### PR TITLE
color-schemes: remove $gray-dark

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -588,9 +588,9 @@
 		--sidebar-menu-hover-color: #{$muriel-gray-50};
 
 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
-		--button-is-borderless-color: #{$gray-dark};
-		--count-border-color: #{$gray-dark};
-		--count-color: #{$gray-dark};
+		--button-is-borderless-color: #{$muriel-gray-700};
+		--count-border-color: #{$muriel-gray-700};
+		--count-color: #{$muriel-gray-700};
 		--profile-gravatar-user-secondary-info-color: #{$muriel-gray-50};
 	}
 

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -273,8 +273,8 @@
 	--sidebar-text-color: #{$muriel-gray-800};
 	--sidebar-gridicon-fill: #{$muriel-gray-500};
 	--sidebar-heading-color: #{$muriel-gray-500};
-	--sidebar-footer-button-color: #{$gray-dark};
-	--sidebar-menu-link-secondary-text-color: #{$gray-dark};
+	--sidebar-footer-button-color: #{$muriel-gray-700};
+	--sidebar-menu-link-secondary-text-color: #{$muriel-gray-700};
 	--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-white )};
 	--sidebar-menu-selected-background-color: #{$muriel-blue-50};
 	--sidebar-menu-selected-a-color: var( --color-primary );
@@ -286,7 +286,7 @@
 	--color-podcasting: #9b4dd5;
 
 	// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
-	--profile-gravatar-user-secondary-info-color: #{$gray-dark};
+	--profile-gravatar-user-secondary-info-color: #{$muriel-gray-700};
 }
 
 //additional color schemes
@@ -796,8 +796,8 @@
 		--sidebar-text-color: #{$muriel-gray-100};
 		--sidebar-gridicon-fill: #{$muriel-gray-400};
 		--sidebar-heading-color: #{$muriel-gray-400};
-		--sidebar-footer-button-color: #{$gray-dark};
-		--sidebar-menu-link-secondary-text-color: #{$gray-dark};
+		--sidebar-footer-button-color: #{$muriel-gray-700};
+		--sidebar-menu-link-secondary-text-color: #{$muriel-gray-700};
 		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-900 )};
 		--sidebar-menu-selected-background-color: #{$muriel-hot-blue-700};
 		--sidebar-menu-selected-a-color: #{$muriel-hot-blue-200};
@@ -807,6 +807,6 @@
 		--sidebar-menu-hover-color: #{$muriel-gray-100};
 
 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
-		--profile-gravatar-user-secondary-info-color: #{$gray-dark};
+		--profile-gravatar-user-secondary-info-color: #{$muriel-gray-700};
 	}
 }

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -17,7 +17,6 @@ $green-jetpack: #00be28;
 // Grays
 $gray: $muriel-gray-300;
 $gray-light: $muriel-gray-0;
-$gray-dark: $muriel-gray-700;
 
 // Shades of gray
 $gray-lighten-20: $muriel-gray-100; // #c8d7e1

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -86,7 +86,7 @@
 	padding: 12px;
 	border-top: 1px solid var( --color-neutral-100 );
 	color: var( --color-white );
-	background-color: lighten( $gray-dark, 20% );
+	background-color: var( --color-neutral );
 	margin: 0;
 }
 

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -212,7 +212,7 @@ $theme-info-height: 54px;
 }
 
 .theme__installing {
-	background: transparentize( $gray-dark, 0.5 );
+	background: rgba( var( --color-neutral-dark-rgb ), 0.5 );
 	width: 100%;
 	left: 0;
 	top: 0;

--- a/client/components/upgrades/gsuite/gsuite-dialog/style.scss
+++ b/client/components/upgrades/gsuite/gsuite-dialog/style.scss
@@ -39,7 +39,7 @@
 }
 
 .gsuite-dialog__no-setup-required {
-	color: lighten( $gray-dark, 20% );
+	color: var( --color-neutral );
 }
 
 .gsuite-dialog__product-features {

--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -125,7 +125,7 @@ $devdocs-max-width: 720px;
 	.docs-example__wrapper-content {
 		background: var( --color-surface-backdrop );
 		padding: 16px;
-		--docs-example-grid: #{hex-to-rgb( $gray-dark )};
+		--docs-example-grid: #{hex-to-rgb( $muriel-gray-700 )};
 		box-shadow: inset 0 2px 1px rgba( var( --docs-example-grid ), 0.075 );
 
 		// Grid background

--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -79,7 +79,7 @@
 
 .jetpack-new-site__card-description {
 	margin-bottom: 1em;
-	color: lighten( $gray-dark, 25% );
+	color: var( --color-neutral-400 );
 }
 
 .jetpack-new-site__button-holder {

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -244,7 +244,7 @@ input[type='radio'].domain-management-list-item__radio {
 
 		.contact-display-content {
 			border: 1px solid var( --color-neutral-0 );
-			color: lighten( $gray-dark, 20% );
+			color: var( --color-neutral );
 			font-size: 12px;
 			line-height: 140%;
 			margin: 0;

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -28,7 +28,7 @@
 .plan-compare-card__title {
 	font-size: 16px;
 	font-weight: 500;
-	color: lighten( $gray-dark, 10% );
+	color: var( --color-neutral-600 );
 }
 
 .plan-compare-card__line {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -487,7 +487,7 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__targeted-description-heading {
 	display: block;
-	color: lighten( $gray-dark, 25% );
+	color: var( --color-neutral-400 );
 }
 
 .plan-features__item {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -107,7 +107,7 @@
 	margin-top: -156px;
 	width: 98%;
 	z-index: 1;
-	box-shadow: 0 0 0 1px $transparent, 0 2px 8px 0 transparentize( $gray-dark, 0.5 );
+	box-shadow: 0 0 0 1px $transparent, 0 2px 8px 0 rgba( var( --color-neutral-dark-rgb ), 0.5 );
 	background-color: transparentize( white, 0.5 );
 	transition: all 200ms ease-in-out;
 
@@ -143,7 +143,7 @@
 	@include breakpoint( '>960px' ) {
 		&.is-active:hover {
 			cursor: pointer;
-			box-shadow: 0 0 0 1px $gray, 0 2px 10px 0 transparentize( $gray-dark, 0.5 );
+			box-shadow: 0 0 0 1px $gray, 0 2px 10px 0 rgba( var( --color-neutral-dark-rgb ), 0.5 );
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove remaining usages of `$gray-dark`

#### Testing instructions

**code**:

- make sure each assignment is correct and there are no typos
- make sure there are no occurrences left of `$gray-dark` in Calypso code

**visually:**:

- smoke test Calypso and make sure none of the new gray usages look wrong