### PR TITLE
Signup: Disable site type button when no site type is selected

### DIFF
--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -81,7 +81,7 @@ class SiteTypeForm extends Component {
 				<form onSubmit={ this.handleSubmit }>
 					<Card>
 						<FormFieldset>{ this.renderRadioOptions() }</FormFieldset>
-						<Button primary={ true } type="submit">
+						<Button primary={ true } type="submit" disabled={ ! this.state.siteType }>
 							{ translate( 'Continue' ) }
 						</Button>
 					</Card>


### PR DESCRIPTION
This PR disables the "Continue" button on the site type step when there is no site type selected. 

As suggested in https://github.com/Automattic/wp-calypso/pull/31063#issuecomment-468262764 by @folletto.

#### Changes proposed in this Pull Request

* Disable the "Continue" button on the site type step when there is no site type selected.

#### Testing instructions

* Checkout this branch, or spin it up in calypso.live.
* Go to https://wordpress.com/jetpack/connect/site-type/:site where `:site` is one of your connected Jetpack sites.
* Verify that the "Continue" button is disabled.
* Select a site type.
* Verify that the "Continue" button is enabled.
* Go to http://calypso.localhost:3000/start/onboarding-dev
* Input credentials and reach the site type step.
* Verify "blog" is still selected, and this PR basically doesn't affect this step on the WP.com signup flow.
