### PR TITLE
Analytics: Registration, Signup, AddToCart, Purchase events updates

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -176,6 +176,7 @@ if ( typeof window !== 'undefined' ) {
 		setupOutbrainGlobal();
 	}
 
+	// Pinterest
 	if ( isPinterestEnabled ) {
 		setupPinterestGlobal();
 	}
@@ -316,10 +317,6 @@ function setupPinterestGlobal() {
 		n.queue = [];
 		n.version = '3.0';
 	}
-
-	const normalizedHashedEmail = getNormalizedHashedUserEamil();
-	const params = normalizedHashedEmail ? { em: normalizedHashedEmail } : {};
-	window.pintrk( 'load', '2612678247224', params );
 }
 
 /**
@@ -443,6 +440,13 @@ async function loadTrackingScripts( callback ) {
 	// init Quora
 	if ( isQuoraEnabled ) {
 		window.qp( 'init', TRACKING_IDS.quoraPixelId );
+	}
+
+	// init Pinterest
+	if ( isPinterestEnabled ) {
+		const normalizedHashedEmail = getNormalizedHashedUserEamil();
+		const params = normalizedHashedEmail ? { em: normalizedHashedEmail } : {};
+		window.pintrk( 'load', '2612678247224', params );
 	}
 
 	// uses JSON.stringify for consistency with recordOrder()

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -979,16 +979,21 @@ export function recordAddToCart( cartItem ) {
 			ord: floodlightCacheBuster(), // "Counting method" = "Counter/Standard" requires "ord" to be a random number
 			// num: not required
 		};
-		debug( 'recordSignup: [Floodlight]', params );
+		debug( 'recordAddToCart: [Floodlight]', params );
 		recordParamsInFloodlight( params );
 	}
 
 	// Criteo
 
 	if ( isCriteoEnabled ) {
-		recordInCriteo( 'viewItem', {
-			item: cartItem.product_id,
-		} );
+		const params = [
+			'viewItem',
+			{
+				item: cartItem.product_id,
+			},
+		];
+		debug( 'recordAddToCart: [Criteo]', params );
+		recordInCriteo( ...params );
 	}
 
 	// Pinterest

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -335,7 +335,7 @@ let isNanigansConfigured = false;
 function setupNanigansGlobal() {
 	isNanigansConfigured = true;
 
-	const normalizedHashedEmail = getNormalizedHashedUserEamil();
+	const normalizedHashedEmail = getNormalizedHashedUserEamil( user );
 
 	window.NaN_api = [
 		[ TRACKING_IDS.nanigansAppId, normalizedHashedEmail ? hashPii( normalizedHashedEmail ) : '' ],
@@ -444,7 +444,7 @@ async function loadTrackingScripts( callback ) {
 
 	// init Pinterest
 	if ( isPinterestEnabled ) {
-		const normalizedHashedEmail = getNormalizedHashedUserEamil();
+		const normalizedHashedEmail = getNormalizedHashedUserEamil( user );
 		const params = normalizedHashedEmail ? { em: normalizedHashedEmail } : {};
 		window.pintrk( 'load', '2612678247224', params );
 	}
@@ -1824,7 +1824,7 @@ function recordInCriteo( eventName, eventProps ) {
 	events.push( { event: 'setAccount', account: TRACKING_IDS.criteo } );
 	events.push( { event: 'setSiteType', type: criteoSiteType() } );
 
-	const normalizedHashedEmail = getNormalizedHashedUserEamil();
+	const normalizedHashedEmail = getNormalizedHashedUserEamil( user );
 	if ( normalizedHashedEmail ) {
 		events.push( { event: 'setEmail', email: [ normalizedHashedEmail ] } );
 	}
@@ -1992,7 +1992,7 @@ function initFacebook() {
  * See https://developers.facebook.com/docs/facebook-pixel/pixel-with-ads/conversion-tracking#advanced_match
  */
 function initFacebookAdvancedMatching() {
-	const normalizedHashedEmail = getNormalizedHashedUserEamil();
+	const normalizedHashedEmail = getNormalizedHashedUserEamil( user );
 	const advancedMatching = normalizedHashedEmail ? { em: normalizedHashedEmail } : {};
 
 	debug( 'initFacebookAdvancedMatching:', advancedMatching );

--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -15,7 +15,12 @@ import config from 'config';
 import productsValues from 'lib/products-values';
 import userModule from 'lib/user';
 import { loadScript as loadScriptCallback } from 'lib/load-script';
-import { isAdTrackingAllowed, hashPii, costToUSD } from 'lib/analytics/utils';
+import {
+	isAdTrackingAllowed,
+	hashPii,
+	costToUSD,
+	getNormalizedHashedUserEamil,
+} from 'lib/analytics/utils';
 import { promisify } from '../../utils';
 import request from 'superagent';
 
@@ -42,13 +47,11 @@ const isExperianEnabled = true;
 const isLinkedinEnabled = true;
 const isOutbrainEnabled = true;
 const isIconMediaEnabled = true;
-const isYahooEnabled = false;
-let isYandexEnabled = false;
+const isPinterestEnabled = true;
+const isNanigansEnabled = true;
 const isCriteoEnabled = false;
 const isPandoraEnabled = false;
 const isQuoraEnabled = false;
-const isMediaWallahEnabled = false;
-const isNanigansEnabled = true;
 
 // Retargeting events are fired once every `retargetingPeriod` seconds.
 const retargetingPeriod = 60 * 60 * 24;
@@ -82,15 +85,13 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		'https://tags.w55c.net/rs?id=d239e9cb6d164f7299d2dbf7298f930a&t=marketing',
 	ICON_MEDIA_ORDER_PIXEL_URL =
 		'https://tags.w55c.net/rs?id=d299eef42f2d4135a96d0d40ace66f3a&t=checkout',
-	YAHOO_TRACKING_SCRIPT_URL = 'https://s.yimg.com/wi/ytc.js',
 	TWITTER_TRACKING_SCRIPT_URL = 'https://static.ads-twitter.com/uwt.js',
 	DCM_FLOODLIGHT_IFRAME_URL = 'https://6355556.fls.doubleclick.net/activityi',
 	LINKED_IN_SCRIPT_URL = 'https://snap.licdn.com/li.lms-analytics/insight.min.js',
-	MEDIA_WALLAH_SCRIPT_URL = 'https://d3ir0rz7vxwgq5.cloudfront.net/mwData.min.js',
 	QUORA_SCRIPT_URL = 'https://a.quora.com/qevents.js',
-	YANDEX_SCRIPT_URL = 'https://mc.yandex.ru/metrika/watch.js',
 	OUTBRAIN_SCRIPT_URL = 'https://amplify.outbrain.com/cp/obtp.js',
 	NANIGANS_SCRIPT_URL = 'https://cdn.nanigans.com/NaN_tracker.js',
+	PINTEREST_SCRIPT_URL = 'https://s.pinimg.com/ct/core.js',
 	TRACKING_IDS = {
 		bingInit: '4074038',
 		facebookInit: '823166884443641',
@@ -100,8 +101,6 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		googleSignupConversionLabel: 'zKK-CKPG7ocBENbl8_wD',
 		criteo: '31321',
 		quantcast: 'p-3Ma3jHaQMB_bS',
-		yahooProjectId: '10000',
-		yahooPixelId: '10014088',
 		twitterPixelId: 'nvzbs',
 		dcmFloodlightAdvertiserId: '6355556',
 		linkedInPartnerId: '195308',
@@ -109,10 +108,14 @@ const FACEBOOK_TRACKING_SCRIPT_URL = 'https://connect.facebook.net/en_US/fbevent
 		outbrainAdvId: '00f0f5287433c2851cc0cb917c7ff0465e',
 		nanigansAppId: '653793',
 		wpcomGoogleAdsGtag: 'AW-946162814',
-		wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag" event
-		wpcomGoogleAdsGtagSignup: 'AW-946162814/5-NnCKy3xZQBEP6YlcMD', // "All Calypso Signups (WordPress.com)" event
+		wpcomGoogleAdsGtagRegistration: 'AW-946162814/_6cKCK6miZYBEP6YlcMD', // "WordPress.com Registration"
+		wpcomGoogleAdsGtagSignup: 'AW-946162814/5-NnCKy3xZQBEP6YlcMD', // "All Calypso Signups (WordPress.com)"
+		wpcomGoogleAdsGtagAddToCart: 'AW-946162814/MF4yCNi_kZYBEP6YlcMD', // "WordPress.com AddToCart"
+		wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
 		jetpackGoogleAdsGtag: 'AW-937115306',
-		jetpackGoogleAdsGtagPurchase: 'AW-937115306/87huCM-P7ZMBEKr97L4D', // "Jetpack Purchase Plan Gtag" event
+		jetpackGoogleAdsGtagAddToCart: 'AW-937115306/BrwBCIWziZYBEKr97L4D', // "Jetpack AddToCart (Calypso)"
+		jetpackGoogleAdsGtagPurchase: 'AW-937115306/87huCM-P7ZMBEKr97L4D', // "Jetpack Purchase Plan (Calypso)"
+		pinterestInit: '2612678247224',
 	},
 	// This name is something we created to store a session id for DCM Floodlight session tracking
 	DCM_FLOODLIGHT_SESSION_COOKIE_NAME = 'dcmsid',
@@ -159,8 +162,8 @@ if ( typeof window !== 'undefined' ) {
 	}
 
 	// Linkedin
-	if ( isLinkedinEnabled && ! window._linkedin_data_partner_id ) {
-		window._linkedin_data_partner_id = TRACKING_IDS.linkedInPartnerId;
+	if ( isLinkedinEnabled ) {
+		setupLinkedinGlobal();
 	}
 
 	// Quora
@@ -171,6 +174,10 @@ if ( typeof window !== 'undefined' ) {
 	// Outbrain
 	if ( isOutbrainEnabled ) {
 		setupOutbrainGlobal();
+	}
+
+	if ( isPinterestEnabled ) {
+		setupPinterestGlobal();
 	}
 }
 
@@ -212,35 +219,12 @@ function maybeRefreshCountryCodeCookieGdpr( callback ) {
 }
 
 /**
- * Initializes Media Wallah tracking.
- * This is a rework of the obfuscated tracking code provided by Media Wallah.
+ * Initializes Linkedin tracking.
  */
-function initMediaWallah() {
-	const mwOptions = {
-		uid: '',
-		custom: '',
-		account_id: 1015,
-		customer_id: 1012,
-		tag_action: 'visit',
-		timeout: 100, // in milliseconds
-	};
-
-	window.setBrowserAttributeData();
-	let counter = 0;
-	const init = function() {
-		if ( window.mwDataReady() ) {
-			document.body.appendChild( window.mwPixel( mwOptions ) );
-		} else if ( counter === mwOptions.timeout ) {
-			clearTimeout( init );
-		} else {
-			setTimeout( init, 1 );
-			counter++;
-		}
-	};
-
-	window.addEventListener
-		? window.addEventListener( 'load', init, false )
-		: window.attachEvent( 'onload', init );
+function setupLinkedinGlobal() {
+	if ( ! window._linkedin_data_partner_id ) {
+		window._linkedin_data_partner_id = TRACKING_IDS.linkedInPartnerId;
+	}
 }
 
 /**
@@ -323,6 +307,21 @@ function setupOutbrainGlobal() {
 	api.queue = [];
 }
 
+function setupPinterestGlobal() {
+	if ( ! window.pintrk ) {
+		window.pintrk = function() {
+			window.pintrk.queue.push( Array.prototype.slice.call( arguments ) );
+		};
+		const n = window.pintrk;
+		n.queue = [];
+		n.version = '3.0';
+	}
+
+	const normalizedHashedEmail = getNormalizedHashedUserEamil();
+	const params = normalizedHashedEmail ? { em: normalizedHashedEmail } : {};
+	window.pintrk( 'load', '2612678247224', params );
+}
+
 /**
  * For Nanigans, we delay the configuration until an actual purchase is made.
  *
@@ -339,15 +338,13 @@ let isNanigansConfigured = false;
 function setupNanigansGlobal() {
 	isNanigansConfigured = true;
 
-	const currentUser = user.get();
-	const normalizedEmail =
-		currentUser && currentUser.email ? currentUser.email.toLowerCase().replace( /\s/g, '' ) : '';
+	const normalizedHashedEmail = getNormalizedHashedUserEamil();
 
 	window.NaN_api = [
-		[ TRACKING_IDS.nanigansAppId, normalizedEmail ? hashPii( normalizedEmail ) : '' ],
+		[ TRACKING_IDS.nanigansAppId, normalizedHashedEmail ? hashPii( normalizedHashedEmail ) : '' ],
 	];
 
-	debug( 'Nanigans setup: ', window.NaN_api, ', for e-mail: ' + normalizedEmail );
+	debug( 'Nanigans setup: ', window.NaN_api );
 }
 
 const loadScript = promisify( loadScriptCallback );
@@ -386,10 +383,6 @@ async function loadTrackingScripts( callback ) {
 		scripts.push( quantcastAsynchronousTagURL() );
 	}
 
-	if ( isYahooEnabled ) {
-		scripts.push( YAHOO_TRACKING_SCRIPT_URL );
-	}
-
 	if ( isTwitterEnabled ) {
 		scripts.push( TWITTER_TRACKING_SCRIPT_URL );
 	}
@@ -398,20 +391,16 @@ async function loadTrackingScripts( callback ) {
 		scripts.push( LINKED_IN_SCRIPT_URL );
 	}
 
-	if ( isMediaWallahEnabled ) {
-		scripts.push( MEDIA_WALLAH_SCRIPT_URL );
-	}
-
 	if ( isQuoraEnabled ) {
 		scripts.push( QUORA_SCRIPT_URL );
 	}
 
-	if ( isYandexEnabled ) {
-		scripts.push( YANDEX_SCRIPT_URL );
-	}
-
 	if ( isOutbrainEnabled ) {
 		scripts.push( OUTBRAIN_SCRIPT_URL );
+	}
+
+	if ( isPinterestEnabled ) {
+		scripts.push( PINTEREST_SCRIPT_URL );
 	}
 
 	let hasError = false;
@@ -443,7 +432,6 @@ async function loadTrackingScripts( callback ) {
 		if ( typeof UET !== 'undefined' ) {
 			// bing's script creates the UET global for us
 			window.uetq = new UET( bingConfig ); // eslint-disable-line
-			window.uetq.push( 'pageLoad' );
 		}
 	}
 
@@ -452,34 +440,19 @@ async function loadTrackingScripts( callback ) {
 		window.twq( 'init', TRACKING_IDS.twitterPixelId );
 	}
 
-	// init Media Wallah
-	if ( isMediaWallahEnabled ) {
-		initMediaWallah();
-	}
-
 	// init Quora
 	if ( isQuoraEnabled ) {
 		window.qp( 'init', TRACKING_IDS.quoraPixelId );
 	}
 
-	// init Yandex counter
-	if ( isYandexEnabled ) {
-		if ( window.Ya ) {
-			window.yaCounter45268389 = new window.Ya.Metrika( { id: 45268389 } );
-		} else {
-			debug( "Error: Yandex's window.Ya not ready or missing" );
-			isYandexEnabled = false;
-		}
-	}
+	// uses JSON.stringify for consistency with recordOrder()
+	debug( 'loadTrackingScripts: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
 
 	hasFinishedFetchingScripts = true;
 
 	if ( typeof callback === 'function' ) {
 		callback();
 	}
-
-	// uses JSON.stringify for consistency with recordOrder()
-	debug( 'loadTrackingScripts: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
 }
 
 /**
@@ -514,76 +487,105 @@ export function retarget( urlPath ) {
 
 	// Quantcast
 	if ( isQuantcastEnabled ) {
-		window._qevents.push( {
+		const params = {
 			qacct: TRACKING_IDS.quantcast,
 			event: 'refresh',
-		} );
-		debug( 'Retargeting: Quantcast' );
+		};
+		debug( 'retarget: [Quantcast]', params );
+		window._qevents.push( params );
 	}
 
 	// Facebook
 	if ( isFacebookEnabled ) {
-		window.fbq( 'trackSingle', TRACKING_IDS.facebookInit, 'PageView' );
-		debug( 'Retargeting: Facebook' );
+		const params = [ 'trackSingle', TRACKING_IDS.facebookInit, 'PageView' ];
+		debug( 'retarget: [Facebook]', params );
+		window.fbq( ...params );
 	}
 
-	// Rate limited retargeting
-
-	const nowTimestamp = Date.now() / 1000;
-	if ( nowTimestamp < lastRetargetTime + retargetingPeriod ) {
-		return;
+	if ( isBingEnabled ) {
+		debug( 'retarget: [Bing]' );
+		window.uetq.push( 'pageLoad' );
 	}
-	lastRetargetTime = nowTimestamp;
 
-	// Twitter
-	if ( isTwitterEnabled ) {
-		window.twq( 'track', 'PageView' );
-		debug( 'Retargeting: [rate limited] Twitter' );
+	// Wordpress.com Google Ads Gtag
+	if ( isWpcomGoogleAdsGtagEnabled ) {
+		const params = [ 'config', TRACKING_IDS.wpcomGoogleAdsGtag, { page_path: urlPath } ];
+		debug( 'retarget: [Google Ads] WPCom', params );
+		window.gtag( ...params );
+	}
+
+	// Jetpack Google Ads Gtag
+	if ( isJetpackGoogleAdsGtagEnabled ) {
+		const params = [ 'config', TRACKING_IDS.jetpackGoogleAdsGtag, { page_path: urlPath } ];
+		debug( 'retarget: [Google Ads] Jetpack', params );
+		window.gtag( ...params );
 	}
 
 	// AdWords
 	if ( isAdwordsEnabled ) {
+		const params = {
+			google_conversion_id: ADWORDS_CONVERSION_ID,
+			google_remarketing_only: true,
+		};
+		debug( 'retarget: [AdWords]', params );
 		if ( window.google_trackConversion ) {
-			window.google_trackConversion( {
-				google_conversion_id: ADWORDS_CONVERSION_ID,
-				google_remarketing_only: true,
-			} );
+			window.google_trackConversion( params );
 		}
-		debug( 'Retargeting: [rate limited] AdWords' );
 	}
 
 	// Floodlight
 	recordPageViewInFloodlight( urlPath );
 
-	// Yahoo Gemini
-	if ( isGeminiEnabled ) {
-		new Image().src = YAHOO_GEMINI_AUDIENCE_BUILDING_PIXEL_URL;
-		debug( 'Retargeting: [rate limited] Yahoo' );
+	// Pinterest
+	if ( isPinterestEnabled ) {
+		debug( 'retarget: [Pinterest]' );
+		window.pintrk( 'page' );
 	}
 
-	// Quora
-	if ( isQuoraEnabled ) {
-		window.qp( 'track', 'ViewContent' );
-		debug( 'Retargeting: [rate limited] Quora' );
+	// Rate limited retargeting
+
+	const nowTimestamp = Date.now() / 1000;
+	if ( nowTimestamp >= lastRetargetTime + retargetingPeriod ) {
+		lastRetargetTime = nowTimestamp;
+
+		// Outbrain
+		if ( isOutbrainEnabled ) {
+			const params = [ 'track', 'PAGE_VIEW' ];
+			debug( 'retarget: [Outbrain] [rate limited]', params );
+			window.obApi( ...params );
+		}
+
+		// Icon Media
+		if ( isIconMediaEnabled ) {
+			const params = ICON_MEDIA_RETARGETING_PIXEL_URL;
+			debug( 'retarget: [Icon Media] [rate limited]', params );
+			new Image().src = params;
+		}
+
+		// Twitter
+		if ( isTwitterEnabled ) {
+			const params = [ 'track', 'PageView' ];
+			debug( 'retarget: [Twitter] [rate limited]', params );
+			window.twq( ...params );
+		}
+
+		// Yahoo Gemini
+		if ( isGeminiEnabled ) {
+			const params = YAHOO_GEMINI_AUDIENCE_BUILDING_PIXEL_URL;
+			debug( 'retarget: [Yahoo Gemini] [rate limited]', params );
+			new Image().src = params;
+		}
+
+		// Quora
+		if ( isQuoraEnabled ) {
+			const params = [ 'track', 'ViewContent' ];
+			debug( 'retarget: [Quora] [rate limited]', params );
+			window.qp( ...params );
+		}
 	}
 
-	// Yandex
-	if ( isYandexEnabled ) {
-		window.yaCounter45268389.hit( urlPath );
-		debug( 'Retargeting: [rate limited] Yandex' );
-	}
-
-	// Outbrain
-	if ( isOutbrainEnabled ) {
-		window.obApi( 'track', 'PAGE_VIEW' );
-		debug( 'Retargeting: [rate limited] Outbrain' );
-	}
-
-	// Icon Media
-	if ( isIconMediaEnabled ) {
-		new Image().src = ICON_MEDIA_RETARGETING_PIXEL_URL;
-		debug( 'Retargeting: [rate limited] Icon Media' );
-	}
+	// uses JSON.stringify for consistency with recordOrder()
+	debug( 'retarget: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
 }
 
 /**
@@ -641,7 +643,58 @@ function splitWpcomJetpackCartInfo( cart ) {
 }
 
 export function recordRegistration() {
-	// TODO:
+	// Google Ads Gtag
+
+	if ( isWpcomGoogleAdsGtagEnabled ) {
+		const params = [
+			'event',
+			'conversion',
+			{
+				send_to: TRACKING_IDS.wpcomGoogleAdsGtagRegistration,
+			},
+		];
+		debug( 'recordRegistration: [Google Ads Gtag]', params );
+		window.gtag( ...params );
+	}
+
+	// Facebook
+
+	if ( isFacebookEnabled ) {
+		const params = [ 'trackSingle', TRACKING_IDS.facebookInit, 'Lead' ];
+		debug( 'recordRegistration: [Facebook]', params );
+		window.fbq( ...params );
+	}
+
+	// Bing
+
+	if ( isBingEnabled ) {
+		const params = {
+			ec: 'registration',
+		};
+		debug( 'recordRegistration: [Bing]', params );
+		window.uetq.push( params );
+	}
+
+	// DCM Floodlight
+
+	if ( isFloodlightEnabled ) {
+		const params = {
+			type: 'wordp0',
+			cat: 'regis0',
+			ord: 1, // "Counting method" = "Counter/Unique" requires "ord" to be 1
+			num: floodlightCacheBuster(),
+		};
+		debug( 'recordRegistration: [Floodlight]', params );
+		recordParamsInFloodlight( params );
+	}
+
+	// Pinterest
+
+	if ( isPinterestEnabled ) {
+		const params = [ 'track', 'lead' ];
+		debug( 'recordRegistration: [Pinterest]', params );
+		window.pintrk( ...params );
+	}
 
 	debug( 'recordRegistration: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
 }
@@ -693,7 +746,7 @@ export function recordSignup( slug ) {
 
 	if ( isAdwordsEnabled ) {
 		if ( window.google_trackConversion ) {
-			window.google_trackConversion( {
+			const params = {
 				google_conversion_id: ADWORDS_SIGNUP_CONVERSION_ID,
 				google_conversion_label: TRACKING_IDS.googleSignupConversionLabel,
 				google_conversion_value: syntheticCart.total_cost,
@@ -704,33 +757,39 @@ export function recordSignup( slug ) {
 					order_id: syntheticOrderId,
 				},
 				google_remarketing_only: false,
-			} );
+			};
+			debug( 'recordSignup: [AdWords]', params );
+			window.google_trackConversion( params );
 		}
 	}
 
 	// Google Ads Gtag
 
 	if ( isWpcomGoogleAdsGtagEnabled ) {
-		const eventData = {
-			send_to: TRACKING_IDS.wpcomGoogleAdsGtagSignup,
-			value: syntheticCart.total_cost,
-			currency: syntheticCart.currency,
-			transaction_id: syntheticOrderId,
-		};
-		window.gtag( 'event', 'conversion', eventData );
-		debug( 'recordSignup: [Google Ads Gtag] record WPCom signup', eventData );
+		const params = [
+			'event',
+			'conversion',
+			{
+				send_to: TRACKING_IDS.wpcomGoogleAdsGtagSignup,
+				value: syntheticCart.total_cost,
+				currency: syntheticCart.currency,
+				transaction_id: syntheticOrderId,
+			},
+		];
+		debug( 'recordSignup: [Google Ads Gtag]', params );
+		window.gtag( ...params );
 	}
 
 	// Bing
 
 	if ( isBingEnabled ) {
 		if ( null !== usdCost ) {
-			const bingParams = {
+			const params = {
 				ec: 'signup',
 				gv: usdCost,
 			};
-			window.uetq.push( bingParams );
-			debug( 'recordSignup: [Bing] record WPCom signup', bingParams );
+			debug( 'recordSignup: [Bing]', params );
+			window.uetq.push( params );
 		} else {
 			debug( 'recordSignup: [Bing] currency not supported, dropping WPCom pixel' );
 		}
@@ -739,16 +798,20 @@ export function recordSignup( slug ) {
 	// Facebook
 
 	if ( isFacebookEnabled ) {
-		const fbParams = {
-			product_slug: syntheticCart.products.map( product => product.product_slug ).join( ', ' ),
-			value: syntheticCart.total_cost,
-			currency: syntheticCart.currency,
-			user_id: userId,
-			order_id: syntheticOrderId,
-		};
-
-		window.fbq( 'trackSingle', TRACKING_IDS.facebookInit, 'Subscribe', fbParams );
-		debug( 'recordSignup: [Facebook] record WPCom signup', fbParams );
+		const params = [
+			'trackSingle',
+			TRACKING_IDS.facebookInit,
+			'Subscribe',
+			{
+				product_slug: syntheticCart.products.map( product => product.product_slug ).join( ', ' ),
+				value: syntheticCart.total_cost,
+				currency: syntheticCart.currency,
+				user_id: userId,
+				order_id: syntheticOrderId,
+			},
+		];
+		debug( 'recordSignup: [Facebook]', params );
+		window.fbq( ...params );
 	}
 
 	// DCM Floodlight
@@ -758,15 +821,56 @@ export function recordSignup( slug ) {
 			type: 'wordp0',
 			cat: 'signu1',
 			ord: 1, // "Counting method" = "Unique" requires "ord" to be 1
+			num: floodlightCacheBuster(),
 		};
+		debug( 'recordSignup: [Floodlight]', params );
 		recordParamsInFloodlight( params );
-		debug( 'recordSignup: [Floodlight] record signup' );
+	}
+
+	// Quantcast
+
+	if ( isQuantcastEnabled ) {
+		const params = {
+			qacct: TRACKING_IDS.quantcast,
+			labels:
+				'_fp.event.WordPress Signup,_fp.pcat.' +
+				syntheticCart.products.map( product => product.product_slug ).join( ' ' ),
+			orderid: syntheticOrderId,
+			revenue: usdCost,
+			event: 'refresh',
+		};
+		debug( 'recordSignup: [Quantcast]', params );
+		window._qevents.push( params );
 	}
 
 	// Icon Media
 
 	if ( isIconMediaEnabled ) {
+		debug( 'recordSignup: [Icon Media]', ICON_MEDIA_SIGNUP_PIXEL_URL );
 		new Image().src = ICON_MEDIA_SIGNUP_PIXEL_URL;
+	}
+
+	// Pinterest
+
+	if ( isPinterestEnabled ) {
+		const params = [
+			'track',
+			'signup',
+			{
+				value: syntheticCart.total_cost,
+				currency: syntheticCart.currency,
+			},
+		];
+		debug( 'recordSignup: [Pinterest]', params );
+		window.pintrk( ...params );
+	}
+
+	// Twitter
+
+	if ( isTwitterEnabled ) {
+		const params = [ 'track', 'Signup', {} ];
+		debug( 'recordSignup: [Twitter]', params );
+		window.twq( ...params );
 	}
 
 	debug( 'recordSignup: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
@@ -808,22 +912,100 @@ export function recordAddToCart( cartItem ) {
 		debug( 'recordAddToCart: [WPCom]', cartItem );
 	}
 
+	// Google Ads Gtag
+
+	if ( ! isJetpackPlan && isWpcomGoogleAdsGtagEnabled ) {
+		const params = [
+			'event',
+			'conversion',
+			{
+				send_to: TRACKING_IDS.wpcomGoogleAdsGtagAddToCart,
+			},
+		];
+		debug( 'recordAddToCart: [Google Ads Gtag] WPCom', params );
+		window.gtag( ...params );
+	}
+
+	if ( isJetpackPlan && isJetpackGoogleAdsGtagEnabled ) {
+		const params = [
+			'event',
+			'conversion',
+			{
+				send_to: TRACKING_IDS.jetpackGoogleAdsGtagAddToCart,
+			},
+		];
+		debug( 'recordAddToCart: [Google Ads Gtag] Jetpack', params );
+		window.gtag( ...params );
+	}
+
+	// Facebook
+
 	if ( isFacebookEnabled ) {
-		window.fbq(
+		const params = [
 			'trackSingle',
 			isJetpackPlan ? TRACKING_IDS.facebookJetpackInit : TRACKING_IDS.facebookInit,
 			'AddToCart',
 			{
 				product_slug: cartItem.product_slug,
 				free_trial: Boolean( cartItem.free_trial ),
-			}
-		);
+			},
+		];
+		debug( 'recordAddToCart: [Facebook]', params );
+		window.fbq( ...params );
 	}
+
+	// Bing
+
+	if ( isBingEnabled ) {
+		const params = {
+			ec: 'addtocart',
+			el: cartItem.product_slug,
+		};
+		debug( 'recordAddToCart: [Bing]', params );
+		window.uetq.push( params );
+	}
+
+	// DCM Floodlight
+
+	if ( isFloodlightEnabled ) {
+		const params = {
+			type: 'wordp0',
+			cat: 'addto0',
+			u2: cartItem.product_name,
+			ord: floodlightCacheBuster(), // "Counting method" = "Counter/Standard" requires "ord" to be a random number
+			// num: not required
+		};
+		debug( 'recordSignup: [Floodlight]', params );
+		recordParamsInFloodlight( params );
+	}
+
+	// Criteo
 
 	if ( isCriteoEnabled ) {
 		recordInCriteo( 'viewItem', {
 			item: cartItem.product_id,
 		} );
+	}
+
+	// Pinterest
+
+	if ( isPinterestEnabled ) {
+		const params = [
+			'track',
+			'addtocart',
+			{
+				value: cartItem.cost,
+				currency: cartItem.currency,
+				line_items: [
+					{
+						product_name: cartItem.product_name,
+						product_id: cartItem.product_slug,
+					},
+				],
+			},
+		];
+		debug( 'recordAddToCart: [Pinterest]', params );
+		window.pintrk( ...params );
 	}
 
 	debug( 'recordAddToCart: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
@@ -900,27 +1082,73 @@ export function recordOrder( cart, orderId ) {
 
 	// Experian / One 2 One Media
 	if ( isExperianEnabled ) {
+		debug( 'recordOrder: [Experian]', EXPERIAN_CONVERSION_PIXEL_URL );
 		new Image().src = EXPERIAN_CONVERSION_PIXEL_URL;
 	}
 
 	// Yahoo Gemini
 	if ( isGeminiEnabled ) {
-		new Image().src =
+		const params =
 			YAHOO_GEMINI_CONVERSION_PIXEL_URL + ( usdTotalCost !== null ? '&gv=' + usdTotalCost : '' );
+		debug( 'recordOrder: [Yahoo Gemini]', params );
+		new Image().src = params;
 	}
 
 	if ( isPandoraEnabled ) {
+		debug( 'recordOrder: [Pandora]', PANDORA_CONVERSION_PIXEL_URL );
 		new Image().src = PANDORA_CONVERSION_PIXEL_URL;
 	}
 
 	if ( isQuoraEnabled ) {
-		window.qp( 'track', 'Generic' );
+		const params = [ 'track', 'Generic' ];
+		debug( 'recordOrder: [Quora]', params );
+		window.qp( ...params );
 	}
 
 	if ( isIconMediaEnabled ) {
 		const skus = cart.products.map( product => product.product_slug ).join( ',' );
-		new Image().src =
+		const params =
 			ICON_MEDIA_ORDER_PIXEL_URL + `&tx=${ orderId }&sku=${ skus }&price=${ usdTotalCost }`;
+		debug( 'recordOrder: [Icon Media]', params );
+		new Image().src = params;
+	}
+
+	// Twitter
+	if ( isTwitterEnabled ) {
+		const params = [
+			'track',
+			'Purchase',
+			{
+				value: cart.total_cost.toString(),
+				currency: cart.currency,
+				content_name: cart.products.map( product => product.product_name ).join( ',' ),
+				content_type: 'product',
+				content_ids: cart.products.map( product => product.product_slug ),
+				num_items: cart.products.length,
+				order_id: orderId,
+			},
+		];
+		debug( 'recordOrder: [Twitter]', params );
+		window.twq( ...params );
+	}
+
+	// Pinterest
+	if ( isPinterestEnabled ) {
+		const params = [
+			'track',
+			'checkout',
+			{
+				value: cart.total_cost,
+				currency: cart.currency,
+				line_items: cart.products.map( product => ( {
+					product_name: product.product_name,
+					product_id: product.product_slug,
+					product_price: product.price,
+				} ) ),
+			},
+		];
+		debug( 'recordOrder: [Pinterest]', params );
+		window.pintrk( ...params );
 	}
 
 	// Uses JSON.stringify() to print the expanded object because during localhost or .live testing after firing this
@@ -996,54 +1224,6 @@ function recordProduct( product, orderId ) {
 				} );
 			}
 		}
-
-		// Twitter
-		if ( isTwitterEnabled ) {
-			window.twq( 'track', 'Purchase', {
-				value: product.cost.toString(),
-				currency: product.currency,
-				content_name: product.product_name,
-				content_type: 'product',
-				content_ids: [ product.product_slug ],
-				num_items: product.volume,
-				order_id: orderId,
-			} );
-		}
-
-		// Yandex Goal
-		if ( isYandexEnabled ) {
-			window.yaCounter45268389.reachGoal( 'ProductPurchase', {
-				order_id: orderId,
-				product_slug: product.product_slug,
-				order_price: product.cost,
-				currency: product.currency,
-			} );
-		}
-
-		const costUSD = costToUSD( product.cost, product.currency );
-		if ( null !== costUSD ) {
-			// Yahoo
-			if ( isYahooEnabled ) {
-				// Like the Quantcast tracking above, the price has to be passed as a string
-				// See: https://developer.yahoo.com/gemini/guide/dottags/installing-tags/
-				/*global YAHOO*/
-				YAHOO.ywa.I13N.fireBeacon( [
-					{
-						projectId: TRACKING_IDS.yahooProjectId,
-						properties: {
-							pixelId: TRACKING_IDS.yahooPixelId,
-							qstrings: {
-								et: 'custom',
-								ec: 'wordpress.com',
-								ea: 'purchase',
-								el: product.product_slug,
-								gv: costUSD.toString(),
-							},
-						},
-					},
-				] );
-			}
-		}
 	} catch ( err ) {
 		debug( 'Unable to save purchase tracking data', err );
 	}
@@ -1074,8 +1254,8 @@ function recordOrderInQuantcast( cart, orderId, wpcomJetpackCartInfo ) {
 				revenue: wpcomJetpackCartInfo.wpcomCostUSD.toString(),
 				event: 'refresh',
 			};
-			window._qevents.push( params );
 			debug( 'recordOrderInQuantcast: record WPCom purchase', params );
+			window._qevents.push( params );
 		} else {
 			debug(
 				`recordOrderInQuantcast: currency ${ cart.currency } not supported, dropping WPCom pixel`
@@ -1095,8 +1275,8 @@ function recordOrderInQuantcast( cart, orderId, wpcomJetpackCartInfo ) {
 				revenue: wpcomJetpackCartInfo.jetpackCostUSD.toString(),
 				event: 'refresh',
 			};
-			window._qevents.push( params );
 			debug( 'recordOrderInQuantcast: record Jetpack purchase', params );
+			window._qevents.push( params );
 		} else {
 			debug(
 				`recordOrderInQuantcast: currency ${ cart.currency } not supported, dropping Jetpack pixel`
@@ -1120,7 +1300,7 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 
 	debug( 'recordOrderInFloodlight: record purchase' );
 
-	// Legacy "Purchase Confirmation" event
+	// WPCom + Jetpack legacy "Purchase Confirmation" event
 	let params = {
 		type: 'wpsal0',
 		cat: 'wpsale',
@@ -1129,7 +1309,9 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 		u2: cart.products.map( product => product.product_name ).join( ', ' ),
 		u3: cart.currency,
 		ord: orderId,
+		// num: not required
 	};
+	debug( 'recordOrderInFloodlight:', params );
 	recordParamsInFloodlight( params );
 
 	// WPCom
@@ -1142,7 +1324,9 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 			u2: wpcomJetpackCartInfo.wpcomProducts.map( product => product.product_name ).join( ', ' ),
 			u3: cart.currency,
 			ord: orderId,
+			// num: not required
 		};
+		debug( 'recordOrderInFloodlight: WPCom', params );
 		recordParamsInFloodlight( params );
 	}
 
@@ -1156,7 +1340,9 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 			u2: wpcomJetpackCartInfo.jetpackProducts.map( product => product.product_name ).join( ', ' ),
 			u3: cart.currency,
 			ord: orderId,
+			// num: not required
 		};
+		debug( 'recordOrderInFloodlight: Jetpack', params );
 		recordParamsInFloodlight( params );
 	}
 }
@@ -1235,36 +1421,43 @@ function recordOrderInFacebook( cart, orderId, wpcomJetpackCartInfo ) {
 	// WPCom
 
 	if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
-		const fbParams = {
-			product_slug: wpcomJetpackCartInfo.wpcomProducts
-				.map( product => product.product_slug )
-				.join( ', ' ),
-			value: wpcomJetpackCartInfo.wpcomCost,
-			currency: cart.currency,
-			user_id: userId,
-			order_id: orderId,
-		};
-
-		window.fbq( 'trackSingle', TRACKING_IDS.facebookInit, 'Purchase', fbParams );
-		debug( 'recordOrderInFacebook: record WPCom purchase', fbParams );
+		const params = [
+			'trackSingle',
+			TRACKING_IDS.facebookInit,
+			'Purchase',
+			{
+				product_slug: wpcomJetpackCartInfo.wpcomProducts
+					.map( product => product.product_slug )
+					.join( ', ' ),
+				value: wpcomJetpackCartInfo.wpcomCost,
+				currency: cart.currency,
+				user_id: userId,
+				order_id: orderId,
+			},
+		];
+		debug( 'recordOrderInFacebook: WPCom', params );
+		window.fbq( ...params );
 	}
 
 	// Jetpack
 
 	if ( wpcomJetpackCartInfo.containsJetpackProducts ) {
-		const fbParams = {
-			product_slug: wpcomJetpackCartInfo.jetpackProducts
-				.map( product => product.product_slug )
-				.join( ', ' ),
-			value: wpcomJetpackCartInfo.jetpackCost,
-			currency: cart.currency,
-			user_id: userId,
-			order_id: orderId,
-		};
-
-		window.fbq( 'trackSingle', TRACKING_IDS.facebookJetpackInit, 'Purchase', fbParams );
-
-		debug( 'recordOrderInFacebook: record Jetpack purchase', fbParams );
+		const params = [
+			'trackSingle',
+			TRACKING_IDS.facebookJetpackInit,
+			'Purchase',
+			{
+				product_slug: wpcomJetpackCartInfo.jetpackProducts
+					.map( product => product.product_slug )
+					.join( ', ' ),
+				value: wpcomJetpackCartInfo.jetpackCost,
+				currency: cart.currency,
+				user_id: userId,
+				order_id: orderId,
+			},
+		];
+		debug( 'recordOrderInFacebook: Jetpack', params );
+		window.fbq( ...params );
 	}
 }
 
@@ -1283,8 +1476,10 @@ export function recordAliasInFloodlight() {
 	const params = {
 		type: 'wordp0',
 		cat: 'alias0',
+		ord: floodlightCacheBuster(),
+		// num: not required
 	};
-
+	debug( 'recordAliasInFloodlight:', params );
 	recordParamsInFloodlight( params );
 }
 
@@ -1305,12 +1500,12 @@ function recordOrderInBing( cart, orderId, wpcomJetpackCartInfo ) {
 
 	if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
 		if ( null !== wpcomJetpackCartInfo.wpcomCostUSD ) {
-			const bingParams = {
+			const params = {
 				ec: 'purchase',
 				gv: wpcomJetpackCartInfo.wpcomCostUSD,
 			};
-			window.uetq.push( bingParams );
-			debug( 'recordOrderInBing: record WPCom purchase', bingParams );
+			debug( 'recordOrderInBing: record WPCom purchase', params );
+			window.uetq.push( params );
 		} else {
 			debug( `recordOrderInBing: currency ${ cart.currency } not supported, dropping WPCom pixel` );
 		}
@@ -1318,14 +1513,14 @@ function recordOrderInBing( cart, orderId, wpcomJetpackCartInfo ) {
 
 	if ( wpcomJetpackCartInfo.containsJetpackProducts ) {
 		if ( null !== wpcomJetpackCartInfo.jetpackCostUSD ) {
-			const bingParams = {
+			const params = {
 				ec: 'purchase',
 				gv: wpcomJetpackCartInfo.jetpackCostUSD,
 				// NOTE: `el` must be included only for jetpack plans.
 				el: 'jetpack',
 			};
-			window.uetq.push( bingParams );
-			debug( 'recordOrderInBing: record Jetpack purchase', bingParams );
+			debug( 'recordOrderInBing: record Jetpack purchase', params );
+			window.uetq.push( params );
 		} else {
 			debug(
 				`recordOrderInBing: currency ${ cart.currency } not supported, dropping Jetpack pixel`
@@ -1350,8 +1545,9 @@ export function recordSignupStartInFloodlight() {
 		type: 'wordp0',
 		cat: 'pre-p0',
 		ord: 1, // "Counting method" = "Unique" requires "ord" to be 1
+		num: floodlightCacheBuster(),
 	};
-
+	debug( 'recordSignupStartInFloodlight:', params );
 	recordParamsInFloodlight( params );
 }
 
@@ -1371,8 +1567,9 @@ export function recordSignupCompletionInFloodlight() {
 		type: 'wordp0',
 		cat: 'signu0',
 		ord: 1, // "Counting method" = "Unique" requires "ord" to be 1
+		num: floodlightCacheBuster(),
 	};
-
+	debug( 'recordSignupCompletionInFloodlight:', params );
 	recordParamsInFloodlight( params );
 }
 
@@ -1389,27 +1586,32 @@ export function recordPageViewInFloodlight( urlPath ) {
 
 	const sessionId = floodlightSessionId();
 
-	debug( 'Floodlight: [rate limited] recording page view for session ' + sessionId );
-
 	// Set or bump the cookie's expiration date to maintain the session
 	document.cookie = cookie.serialize( DCM_FLOODLIGHT_SESSION_COOKIE_NAME, sessionId, {
 		maxAge: DCM_FLOODLIGHT_SESSION_LENGTH_IN_SECONDS,
 	} );
 
-	recordParamsInFloodlight( {
+	let params = {
 		type: 'wordp0',
 		cat: 'wpvisit',
 		u6: urlPath,
 		u7: sessionId,
 		ord: sessionId,
-	} );
+		// num: not required
+	};
+	debug( 'retarget: recordPageViewInFloodlight: wpvisit', params );
+	recordParamsInFloodlight( params );
 
-	recordParamsInFloodlight( {
+	params = {
 		type: 'wordp0',
 		cat: 'wppv',
 		u6: urlPath,
 		u7: sessionId,
-	} );
+		ord: floodlightCacheBuster(),
+		// num: not required
+	};
+	debug( 'retarget: recordPageViewInFloodlight: wppv', params );
+	recordParamsInFloodlight( params );
 }
 
 /**
@@ -1480,18 +1682,6 @@ function recordParamsInFloodlight( params ) {
 	// As well as the advertiser id
 	params.src = TRACKING_IDS.dcmFloodlightAdvertiserId;
 
-	// The ord is only set for purchases; the rest of the time it should be a random string
-	if ( params.ord === undefined ) {
-		// From the docs:
-		// "For unique user tags, use a constant value."
-		// TODO: Should we use a constant value if it's a unique user? How do we determine a unique user?
-		params.ord = floodlightCacheBuster();
-
-		// From the docs:
-		// "Unique user tags also require a random number as the value of the num= parameter."
-		params.num = floodlightCacheBuster();
-	}
-
 	debug( 'recordParamsInFloodlight:', params );
 
 	// Note that we're not generating a URL with traditional query arguments
@@ -1536,11 +1726,16 @@ function recordOrderInCriteo( cart, orderId ) {
 		return;
 	}
 
-	recordInCriteo( 'trackTransaction', {
-		id: orderId,
-		currency: cart.currency,
-		item: cartToCriteoItems( cart ),
-	} );
+	const params = [
+		'trackTransaction',
+		{
+			id: orderId,
+			currency: cart.currency,
+			item: cartToCriteoItems( cart ),
+		},
+	];
+	debug( 'recordOrderInCriteo:', params );
+	recordInCriteo( ...params );
 }
 
 /**
@@ -1559,10 +1754,15 @@ function recordViewCheckoutInCriteo( cart ) {
 	}
 
 	// Note that unlike `recordOrderInCriteo` above, this doesn't include the order id
-	recordInCriteo( 'viewBasket', {
-		currency: cart.currency,
-		item: cartToCriteoItems( cart ),
-	} );
+	const params = [
+		'viewBasket',
+		{
+			currency: cart.currency,
+			item: cartToCriteoItems( cart ),
+		},
+	];
+	debug( 'recordViewCheckoutInCriteo:', params );
+	recordInCriteo( ...params );
 }
 
 /**
@@ -1589,9 +1789,14 @@ function recordPlansViewInCriteo() {
 		return;
 	}
 
-	recordInCriteo( 'viewItem', {
-		item: '1',
-	} );
+	const params = [
+		'viewItem',
+		{
+			item: '1',
+		},
+	];
+	debug( 'recordPlansViewInCriteo:', params );
+	recordInCriteo( ...params );
 }
 
 /**
@@ -1615,8 +1820,9 @@ function recordInCriteo( eventName, eventProps ) {
 	events.push( { event: 'setAccount', account: TRACKING_IDS.criteo } );
 	events.push( { event: 'setSiteType', type: criteoSiteType() } );
 
-	if ( user.get() ) {
-		events.push( { event: 'setEmail', email: [ hashPii( user.get().email ) ] } );
+	const normalizedHashedEmail = getNormalizedHashedUserEamil();
+	if ( normalizedHashedEmail ) {
+		events.push( { event: 'setEmail', email: [ normalizedHashedEmail ] } );
 	}
 
 	const conversionEvent = clone( eventProps );
@@ -1625,8 +1831,7 @@ function recordInCriteo( eventName, eventProps ) {
 
 	// The deep clone is necessary because the Criteo script modifies the objects in the
 	// array which causes the console to display different data than is originally added
-	debug( 'Track `' + eventName + '` event in Criteo', cloneDeep( events ) );
-
+	debug( 'recordInCriteo: ' + eventName, cloneDeep( events ) );
 	window.criteo_q.push( ...events );
 }
 
@@ -1690,27 +1895,35 @@ function recordOrderInGoogleAds( cart, orderId, wpcomJetpackCartInfo ) {
 
 	if ( isJetpackGoogleAdsGtagEnabled ) {
 		if ( wpcomJetpackCartInfo.containsJetpackProducts ) {
-			const eventData = {
-				send_to: TRACKING_IDS.jetpackGoogleAdsGtagPurchase,
-				value: wpcomJetpackCartInfo.jetpackCost,
-				currency: cart.currency,
-				transaction_id: orderId,
-			};
-			window.gtag( 'event', 'conversion', eventData );
-			debug( 'recordOrderInGoogleAds: Record Jetpack Purchase', eventData );
+			const params = [
+				'event',
+				'conversion',
+				{
+					send_to: TRACKING_IDS.jetpackGoogleAdsGtagPurchase,
+					value: wpcomJetpackCartInfo.jetpackCost,
+					currency: cart.currency,
+					transaction_id: orderId,
+				},
+			];
+			debug( 'recordOrderInGoogleAds: Record Jetpack Purchase', params );
+			window.gtag( ...params );
 		}
 	}
 
 	if ( isWpcomGoogleAdsGtagEnabled ) {
 		if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
-			const eventData = {
-				send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
-				value: wpcomJetpackCartInfo.wpcomCost,
-				currency: cart.currency,
-				transaction_id: orderId,
-			};
-			window.gtag( 'event', 'conversion', eventData );
-			debug( 'recordOrderInGoogleAds: Record WPCom Purchase', eventData );
+			const params = [
+				'event',
+				'conversion',
+				{
+					send_to: TRACKING_IDS.wpcomGoogleAdsGtagPurchase,
+					value: wpcomJetpackCartInfo.wpcomCost,
+					currency: cart.currency,
+					transaction_id: orderId,
+				},
+			];
+			debug( 'recordOrderInGoogleAds: Record WPCom Purchase', params );
+			window.gtag( ...params );
 		}
 	}
 }
@@ -1775,18 +1988,10 @@ function initFacebook() {
  * See https://developers.facebook.com/docs/facebook-pixel/pixel-with-ads/conversion-tracking#advanced_match
  */
 function initFacebookAdvancedMatching() {
-	// All data must be in lowercase. Remove all spaces.
-	const fbRequirementsFormatter = function( str ) {
-		return str.toLowerCase().replace( / /g, '' );
-	};
+	const normalizedHashedEmail = getNormalizedHashedUserEamil();
+	const advancedMatching = normalizedHashedEmail ? { em: normalizedHashedEmail } : {};
 
-	const currentUser = user.get();
-	const advancedMatching = {
-		em: fbRequirementsFormatter( currentUser.email ),
-	};
-
-	debug( 'FB Advanced Matching', advancedMatching );
-
+	debug( 'initFacebookAdvancedMatching:', advancedMatching );
 	window.fbq( 'init', TRACKING_IDS.facebookInit, advancedMatching );
 
 	/*

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -332,9 +332,9 @@ const analytics = {
 	},
 
 	recordPurchase: function( { cart, orderId } ) {
-		// Google Analytics
-		const usdValue = costToUSD( cart.total_cost, cart.currency );
 		if ( cart.total_cost < 0.01 ) {
+			// Google Analytics
+			const usdValue = costToUSD( cart.total_cost, cart.currency );
 			analytics.ga.recordEvent(
 				'Purchase',
 				'calypso_checkout_payment_success',

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -332,7 +332,7 @@ const analytics = {
 	},
 
 	recordPurchase: function( { cart, orderId } ) {
-		if ( cart.total_cost < 0.01 ) {
+		if ( cart.total_cost >= 0.01 ) {
 			// Google Analytics
 			const usdValue = costToUSD( cart.total_cost, cart.currency );
 			analytics.ga.recordEvent(

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -334,14 +334,16 @@ const analytics = {
 	recordPurchase: function( { cart, orderId } ) {
 		// Google Analytics
 		const usdValue = costToUSD( cart.total_cost, cart.currency );
-		analytics.ga.recordEvent(
-			'Purchase',
-			'calypso_checkout_payment_success',
-			'',
-			usdValue ? usdValue : undefined
-		);
-		// Marketing
-		recordOrder( cart, orderId );
+		if ( cart.total_cost < 0.01 ) {
+			analytics.ga.recordEvent(
+				'Purchase',
+				'calypso_checkout_payment_success',
+				'',
+				usdValue ? usdValue : undefined
+			);
+			// Marketing
+			recordOrder( cart, orderId );
+		}
 	},
 
 	timing: {

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -95,10 +95,10 @@ export function hashPii( data ) {
 export function getNormalizedHashedUserEamil() {
 	const currentUser = user.get();
 	if ( currentUser && currentUser.email ) {
-		hashPii( currentUser.email.toLowerCase().replace( /\s/g, '' ) );
-	} else {
-		return false;
+		return hashPii( currentUser.email.toLowerCase().replace( /\s/g, '' ) );
 	}
+
+	return false;
 }
 
 // If this list catches things that are not necessarily forbidden we're ok with

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -13,6 +13,8 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
+import userModule from 'lib/user';
+const user = userModule();
 
 /**
  * Module variables
@@ -84,6 +86,19 @@ export function hashPii( data ) {
 	return sha256()
 		.update( data.toString() )
 		.digest( 'hex' );
+}
+
+/**
+ * Returns the current user email after normalizing it (lowercase without spaces) or `false` if no email or user is available.
+ * @return {false|string} The current user email after normalization
+ */
+export function getNormalizedHashedUserEamil() {
+	const currentUser = user.get();
+	if ( currentUser && currentUser.email ) {
+		hashPii( currentUser.email.toLowerCase().replace( /\s/g, '' ) );
+	} else {
+		return false;
+	}
 }
 
 // If this list catches things that are not necessarily forbidden we're ok with

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -92,7 +92,7 @@ export function hashPii( data ) {
  * @param {Object} user The current user
  * @return {false|string} The current user email after normalization
  */
-export function getNormalizedHashedUserEamil( user ) {
+export function getNormalizedHashedUserEmail( user ) {
 	const currentUser = user.get();
 	if ( currentUser && currentUser.email ) {
 		return hashPii( currentUser.email.toLowerCase().replace( /\s/g, '' ) );

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -13,8 +13,6 @@ import { includes } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
-import userModule from 'lib/user';
-const user = userModule();
 
 /**
  * Module variables
@@ -90,9 +88,11 @@ export function hashPii( data ) {
 
 /**
  * Returns the current user email after normalizing it (lowercase without spaces) or `false` if no email or user is available.
+ *
+ * @param {Object} user The current user
  * @return {false|string} The current user email after normalization
  */
-export function getNormalizedHashedUserEamil() {
+export function getNormalizedHashedUserEamil( user ) {
 	const currentUser = user.get();
 	if ( currentUser && currentUser.email ) {
 		return hashPii( currentUser.email.toLowerCase().replace( /\s/g, '' ) );


### PR DESCRIPTION
### Updates included in this Pull Request

* Pinterest new pixels:
  * Registration: uses `lead` event
  * Signup: uses `signup` event
  * AddToCart: uses `addtocart` event
  * Purchase: uses `checkout` event
  * Pageview/Retarget
* Removed legacy trackers (previously already disabled): 
  * Yandex
  * Yahoo legacy
  * Media Wallah
* Google Ads Gtag:
  * Registration: `AW-946162814/_6cKCK6miZYBEP6YlcMD`
  * AddToCart: [WPCom] `AW-946162814/MF4yCNi_kZYBEP6YlcMD`
  * AddToCart: [Jetpack] `AW-937115306/BrwBCIWziZYBEKr97L4D`
  * Fixed retargeting by implementing virtual page update for both WPCom and Jetpack pixels
* Bing pixels added:
  * Registration
  * AddToCart
  * Retargeting/pageview fixed*
* Facebook pixels:
  * Registration: uses `Lead` FB event.
* Floodlight new pixels:
  * Registration
  * AddToCart
  * Updated `http://` to `https://wordpress.com` in every pixel we have in the Floodlight manger
  * Fixed Alerts in Floodlight configuration due to missing `num` parameters
  * Checked and fixed every single event we have to explicitly set `ord` and `num` according to its event/counter type
* Quantcast new pixel:
  * Signup
* Twitter pixels:
  * Signup new pixel
  * Purchase reconfigured to fire once per purchase
* Google Analytics:
  * Fixed 0-value Purchase events
* Fixed non normalized emails in various trackers
* Fixes the way events are handled while trackers are loaded to enqueue them instead of discarding all events but the first one.
* Fixes potential use of uninitialized trackers (by using the queue).
* Ensures the GDPR cookies and `isAdTrackingAllowed()` are properly checked before all events.
* Debug: moved `debug()` before firing event to provide more meaningful context in case of error
* Debug: print full tracker list of parameters by using `...params` notation where it makes sense
* Debug: dump `dataLayer` also on `retarget()` so we can inspect Gtag proper operation

### Testing WPCom

**Testing Setup**

- Make sure you have the following features enabled in:
  - `development.json`: `gdpr-banner`, `google-analytics`, `ad-tracking` 
  - or via the URL params in the calypso.live URL: https://calypso.live/?branch=add/update-ad-trackers (`?flags=gdpr-banner,google-analytics,ad-tracking`)

- Enable debug logs by entering the following in your browser console:
```
localStorage.setItem( 'debug', 'calypso:analytics:*' );
```
- Set the following to ensure the GDPR logic does not block the trackers:
```
document.cookie = 'sensitive_pixel_option=yes;'
```

- Reload Calypso and make sure you see `isAdTrackingAllowed: true` through out the test in the JS console.

- Make sure to select the options "Preserve Logs" in both Chrome's JS console and Network tab.

- While testing, especially when filtering the JS console make sure to look back at the unfiltered log every now and then to check if there's any suspicious JavaScript error popping up.

**Page view**

- Making sure ad tracking is enabled, clean your JS history and reload ("Empty Cache and Hard Reload") the page. Ghostery should report around 25 trackers.

![image](https://user-images.githubusercontent.com/10284338/53736992-2f7efc80-3e83-11e9-9f32-e1ab3be4fcf5.png)

- Filtering by `retarget` will give you a list of each pixel that's been fired. To double check, look in the Network tab for a corresponding activity. All should have a corresponding activity except the Gtag one which get written in the `dataLayer`.

- Note: some of the trackers are marked with `[rate limited]`, which means that they will not fire in the next 24 hours when clicking on a new page, but they will if you reload Calypso.

**Registration**

- Open a new incognito window, make sure to enable tracking and logging as explained in the beginning (you should see `isAdTrackingAllowed: true` when reloading).

- Create a new user and a new test website with a free plan: `/start/user?flags=gdpr-banner,google-analytics,ad-tracking`.

- After submitting your user and email information filter by `recordRegistration` and you should see something like:

![image](https://user-images.githubusercontent.com/10284338/53738138-4bd06880-3e86-11e9-85c8-26b7f33433eb.png)

- Double check those events have a corresponding entry in the Network tab and the `send_to` parameter in the `dataLayer` for the last event corresponds to the Registration pixel in the code.

**Signup**

- After completing the signup process (select free plan) filter by `recordSignup` and you should see something like this:

![image](https://user-images.githubusercontent.com/10284338/53805031-fe650180-3f40-11e9-8e08-6b4ef03560e5.png)

- Double check those events have a corresponding entry in the Network tab and the last `send_to` parameter in the `dataLayer` for the last event corresponds to the Signup pixel in the code.

**AddToCart**

- Log in to your newly created account and select a paid plan. Filter the JS console with `recordAddToCart`, you should see something like:

![image](https://user-images.githubusercontent.com/10284338/53805821-1fc6ed00-3f43-11e9-81d9-f6be3bac15c5.png)

- The `dataLayer` dump should show a `"send_to": "AW-946162814/MF4yCNi_kZYBEP6YlcMD"` which should correspond to `wpcomGoogleAdsGtagAddToCart` in `ad-tracking.js`.

- Double check those events have a corresponding entry in the Network tab.

**Purchase**

- After purchasing a paid plan you should see the following trackers when filtering by `recordOrder`:

![image](https://user-images.githubusercontent.com/10284338/53827699-9bd92900-3f73-11e9-9998-bce2b78443c7.png)

- If you purchased a WPCom plan you should see something similar to the following entry in the `dataLayer`. The `send_to` param corresponds to the `wpcomGoogleAdsGtagPurchase` in the code.

![image](https://user-images.githubusercontent.com/10284338/53827764-c75c1380-3f73-11e9-8b1d-7b549b517eef.png)


### Testing Jetpack

- Purchase a Jetpack plan, make sure there are no errors in the JS console, filter by `recordOrder`, you should see something like this:

- Make sure those pixels actually exist in the Network tab without errors:

![image](https://user-images.githubusercontent.com/10284338/53829707-a77b1e80-3f78-11e9-9552-81f685d9952d.png)

![image](https://user-images.githubusercontent.com/10284338/53829749-bd88df00-3f78-11e9-8ba2-c7f48c89b579.png)

- Jetpack Gtag `jetpackGoogleAdsGtagPurchase`:

![image](https://user-images.githubusercontent.com/10284338/53829768-ca0d3780-3f78-11e9-9e06-35fada07dc87.png)



