### PR TITLE
Jetpack Connect: Reset vertical when auth starts

### DIFF
--- a/client/state/signup/steps/site-vertical/reducer.js
+++ b/client/state/signup/steps/site-vertical/reducer.js
@@ -7,9 +7,11 @@ import { omit } from 'lodash';
 /**
  * Internal dependencies
  */
-
-import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_SITE_VERTICAL_SET } from 'state/action-types';
-
+import {
+	JETPACK_CONNECT_AUTHORIZE,
+	SIGNUP_COMPLETE_RESET,
+	SIGNUP_STEPS_SITE_VERTICAL_SET,
+} from 'state/action-types';
 import { createReducer } from 'state/utils';
 import { siteVerticalSchema } from './schema';
 
@@ -32,6 +34,9 @@ export default createReducer(
 			};
 		},
 		[ SIGNUP_COMPLETE_RESET ]: () => {
+			return {};
+		},
+		[ JETPACK_CONNECT_AUTHORIZE ]: () => {
 			return {};
 		},
 	},

--- a/client/state/signup/steps/site-vertical/test/reducer.js
+++ b/client/state/signup/steps/site-vertical/test/reducer.js
@@ -4,7 +4,7 @@
  * Internal dependencies
  */
 import reducer from '../reducer';
-import { SIGNUP_STEPS_SITE_VERTICAL_SET } from 'state/action-types';
+import { JETPACK_CONNECT_AUTHORIZE, SIGNUP_STEPS_SITE_VERTICAL_SET } from 'state/action-types';
 
 describe( 'reducer', () => {
 	test( 'should return default  state', () => {} );
@@ -28,5 +28,15 @@ describe( 'reducer', () => {
 			...state,
 			...siteVertical,
 		} );
+	} );
+
+	test( 'should reset the site vertical when Jetpack authorization starts', () => {
+		const state = {
+			isUserInput: true,
+			name: 'glücklich',
+			slug: 'happy',
+			preview: '<ho>ho</ho>',
+		};
+		expect( reducer( state, { type: JETPACK_CONNECT_AUTHORIZE } ) ).toEqual( {} );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reset the stored site vertical when authorization for a new site starts.

#### Testing instructions

* Checkout this branch, or get it going on calypso.live.
* Create 2 JN sites.
* Connect 1 of the sites.
* In the site vertical step, input something.
* Connect the 2 site.
* Verify the site vertical is empty.
* Verify tests pass:

```
npm run test-client client/state/signup/steps/site-vertical/test/reducer.js
```

Fixes #31072.