### PR TITLE
Login: Hide Jetpack colophon from Jetpack login, fix a spacing bug

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -15,6 +15,7 @@ import { startCase } from 'lodash';
  */
 import DocumentHead from 'components/data/document-head';
 import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import getCurrentRoute from 'state/selectors/get-current-route';
 import LocaleSuggestions from 'components/locale-suggestions';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import TranslatorInvite from 'components/translator-invite';
@@ -106,8 +107,13 @@ export class Login extends React.Component {
 	}
 
 	renderFooter() {
-		const { translate } = this.props;
+		const { currentRoute, translate } = this.props;
 		const isOauthLogin = !! this.props.oauth2Client;
+
+		if ( currentRoute === '/log-in/jetpack' ) {
+			return null;
+		}
+
 		return (
 			<div
 				className={ classNames( 'wp-login__footer', {
@@ -119,7 +125,8 @@ export class Login extends React.Component {
 					<LoggedOutFormBackLink
 						classes={ { 'logged-out-form__link-item': false } }
 						oauth2Client={ this.props.oauth2Client }
-						recordClick={ this.recordBackToWpcomLinkClick } />
+						recordClick={ this.recordBackToWpcomLinkClick }
+					/>
 				) }
 
 				{ isOauthLogin ? (
@@ -236,6 +243,7 @@ export class Login extends React.Component {
 
 export default connect(
 	( state, props ) => ( {
+		currentRoute: getCurrentRoute( state ),
 		isLoggedIn: Boolean( getCurrentUserId( state ) ),
 		locale: getCurrentLocaleSlug( state ),
 		oauth2Client: getCurrentOAuth2Client( state ),

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -1,6 +1,6 @@
 $image-height: 47px;
 
-.is-section-login {
+.layout.is-section-login {
 	padding-bottom: $image-height;
 	position: relative;
 	min-height: calc( 100% - #{$image-height} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide the Jetpack colophon from the `/log-in/jetpack` page.
* Fix a weird spacing bug below the colophon on the login page that allows us to scroll bottom and see spacing below the "powered by Jetpack" colophon in the footer.

#### Testing instructions

* Checkout this branch, or spin it up at calypso.live.
* Make sure you're logged out of WP.com.
* Go to http://calypso.localhost:3000/log-in/jetpack
* Verify you don't see the "Powered by Jetpack" colophon in the footer.
* Verify you can't scroll bottom to more than expected on a big screen.
* Go to http://calypso.localhost:3000/log-in
* Verify you can see the "Powered by Jetpack" colophon in the footer.
* Verify you can't scroll bottom on a big screen and you don't see empty space below the Jetpack colophon.

Fixes #31113
