### PR TITLE
Fix: business hours validation

### DIFF
--- a/client/gutenberg/extensions/business-hours/components/day-edit.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-edit.jsx
@@ -14,7 +14,7 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 const defaultOpen = '09:00';
 const defaultClose = '17:00';
 
-class Day extends Component {
+class DayEdit extends Component {
 	renderInterval = ( interval, intervalIndex ) => {
 		const { day } = this.props;
 		const { opening, closing } = interval;
@@ -197,4 +197,4 @@ class Day extends Component {
 	}
 }
 
-export default Day;
+export default DayEdit;

--- a/client/gutenberg/extensions/business-hours/components/day-preview.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-preview.jsx
@@ -7,7 +7,7 @@ import { isEmpty } from 'lodash';
 import { sprintf } from '@wordpress/i18n';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
@@ -45,10 +45,11 @@ class DayPreview extends Component {
 		return (
 			<Fragment>
 				<dt className={ day.name }>{ localization.days[ day.name ] }</dt>
-				{ isEmpty( hours ) ?
-					<dd>{ _x( 'Closed', 'business is closed on a full day' ) }</dd> :
+				{ isEmpty( hours ) ? (
+					<dd>{ _x( 'Closed', 'business is closed on a full day' ) }</dd>
+				) : (
 					hours.map( this.renderInterval )
-				}
+				) }
 			</Fragment>
 		);
 	}

--- a/client/gutenberg/extensions/business-hours/components/day-preview.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-preview.jsx
@@ -6,7 +6,12 @@ import { date } from '@wordpress/date';
 import { isEmpty } from 'lodash';
 import { sprintf } from '@wordpress/i18n';
 
-class DaySave extends Component {
+/**
+ * Internal Dependencies
+ */
+import { _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+
+class DayPreview extends Component {
 	formatTime( time ) {
 		const { timeFormat } = this.props;
 		const [ hours, minutes ] = time.split( ':' );
@@ -20,12 +25,10 @@ class DaySave extends Component {
 	}
 
 	renderInterval = ( interval, key ) => {
-		const { intervalText } = this.props;
-
 		return (
 			<dd key={ key }>
 				{ sprintf(
-					intervalText, // 'From %s to %s'
+					_x( 'From %s to %s', 'from business opening hour to closing hour' ),
 					this.formatTime( interval.opening ),
 					this.formatTime( interval.closing )
 				) }
@@ -34,7 +37,7 @@ class DaySave extends Component {
 	};
 
 	render() {
-		const { closedText, day, localization } = this.props;
+		const { day, localization } = this.props;
 		const hours = day.hours.filter(
 			// remove any malformed or empty intervals
 			interval => this.formatTime( interval.opening ) && this.formatTime( interval.closing )
@@ -42,10 +45,13 @@ class DaySave extends Component {
 		return (
 			<Fragment>
 				<dt className={ day.name }>{ localization.days[ day.name ] }</dt>
-				{ isEmpty( hours ) ? <dd>{ closedText }</dd> : hours.map( this.renderInterval ) }
+				{ isEmpty( hours ) ?
+					<dd>{ _x( 'Closed', 'business is closed on a full day' ) }</dd> :
+					hours.map( this.renderInterval )
+				}
 			</Fragment>
 		);
 	}
 }
 
-export default DaySave;
+export default DayPreview;

--- a/client/gutenberg/extensions/business-hours/components/day-save.jsx
+++ b/client/gutenberg/extensions/business-hours/components/day-save.jsx
@@ -6,11 +6,6 @@ import { date } from '@wordpress/date';
 import { isEmpty } from 'lodash';
 import { sprintf } from '@wordpress/i18n';
 
-/**
- * Internal dependencies
- */
-import { _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
-
 class DaySave extends Component {
 	formatTime( time ) {
 		const { timeFormat } = this.props;
@@ -25,10 +20,12 @@ class DaySave extends Component {
 	}
 
 	renderInterval = ( interval, key ) => {
+		const { intervalText } = this.props;
+
 		return (
 			<dd key={ key }>
 				{ sprintf(
-					_x( 'From %s to %s', 'from business opening hour to closing hour' ),
+					intervalText, // 'From %s to %s'
 					this.formatTime( interval.opening ),
 					this.formatTime( interval.closing )
 				) }
@@ -37,7 +34,7 @@ class DaySave extends Component {
 	};
 
 	render() {
-		const { day, localization } = this.props;
+		const { closedText, day, localization } = this.props;
 		const hours = day.hours.filter(
 			// remove any malformed or empty intervals
 			interval => this.formatTime( interval.opening ) && this.formatTime( interval.closing )
@@ -45,11 +42,7 @@ class DaySave extends Component {
 		return (
 			<Fragment>
 				<dt className={ day.name }>{ localization.days[ day.name ] }</dt>
-				{ isEmpty( hours ) ? (
-					<dd>{ _x( 'Closed', 'business is closed on a full day' ) }</dd>
-				) : (
-					hours.map( this.renderInterval )
-				) }
+				{ isEmpty( hours ) ? <dd>{ closedText }</dd> : hours.map( this.renderInterval ) }
 			</Fragment>
 		);
 	}

--- a/client/gutenberg/extensions/business-hours/edit.jsx
+++ b/client/gutenberg/extensions/business-hours/edit.jsx
@@ -11,10 +11,10 @@ import { __experimentalGetSettings } from '@wordpress/date';
 /**
  * Internal dependencies
  */
-import Day from 'gutenberg/extensions/business-hours/components/day';
-import DaySave from 'gutenberg/extensions/business-hours/components/day-save';
+import DayEdit from 'gutenberg/extensions/business-hours/components/day-edit';
+import DayPreview from 'gutenberg/extensions/business-hours/components/day-preview';
 import { icon } from 'gutenberg/extensions/business-hours/index';
-import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const defaultLocalization = {
 	days: {
@@ -28,7 +28,6 @@ const defaultLocalization = {
 	},
 	startOfWeek: 0,
 };
-const defaultTimeFormat = 'g:i';
 
 class BusinessHours extends Component {
 	state = {
@@ -54,30 +53,11 @@ class BusinessHours extends Component {
 	}
 
 	render() {
-		const { attributes, className, isEdit, isSelected } = this.props;
+		const { attributes, className, isSelected } = this.props;
 		const { days } = attributes;
 		const { localization, hasFetched } = this.state;
 		const { startOfWeek } = localization;
 		const localizedWeek = days.concat( days.slice( 0, startOfWeek ) ).slice( startOfWeek );
-
-		if ( ! isEdit ) {
-			return (
-				<dl className={ classNames( className, 'jetpack-business-hours' ) }>
-					{ localizedWeek.map( ( day, key ) => {
-						return (
-							<DaySave
-								key={ key }
-								day={ day }
-								localization={ defaultLocalization }
-								timeFormat={ defaultTimeFormat }
-								intervalText="From %s to %s"
-								closedText="Closed"
-							/>
-						);
-					} ) }
-				</dl>
-			);
-		}
 
 		if ( ! hasFetched ) {
 			return (
@@ -89,8 +69,6 @@ class BusinessHours extends Component {
 		}
 
 		if ( ! isSelected ) {
-			// Render a preview of the block within the post editor.
-			// The preview will be localized.
 			const settings = __experimentalGetSettings();
 			const {
 				formats: { time },
@@ -99,13 +77,11 @@ class BusinessHours extends Component {
 				<dl className={ classNames( className, 'jetpack-business-hours' ) }>
 					{ localizedWeek.map( ( day, key ) => {
 						return (
-							<DaySave
+							<DayPreview
 								key={ key }
 								day={ day }
 								localization={ localization }
 								timeFormat={ time }
-								intervalText={ _x( 'From %s to %s', 'from business opening hour to closing hour' ) }
-								closedText={ _x( 'Closed', 'business is closed on a full day' ) }
 							/>
 						);
 					} ) }
@@ -116,7 +92,9 @@ class BusinessHours extends Component {
 		return (
 			<div className={ classNames( className, 'is-edit' ) }>
 				{ localizedWeek.map( ( day, key ) => {
-					return <Day key={ key } day={ day } localization={ localization } { ...this.props } />;
+					return (
+						<DayEdit key={ key } day={ day } localization={ localization } { ...this.props } />
+					);
 				} ) }
 			</div>
 		);

--- a/client/gutenberg/extensions/business-hours/edit.jsx
+++ b/client/gutenberg/extensions/business-hours/edit.jsx
@@ -18,13 +18,13 @@ import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const defaultLocalization = {
 	days: {
-		Sun: 'Sunday',
-		Mon: 'Monday',
-		Tue: 'Tuesday',
-		Wed: 'Wednesday',
-		Thu: 'Thursday',
-		Fri: 'Friday',
-		Sat: 'Saturday',
+		Sun: __( 'Sunday' ),
+		Mon: __( 'Monday' ),
+		Tue: __( 'Tuesday' ),
+		Wed: __( 'Wednesday' ),
+		Thu: __( 'Thursday' ),
+		Fri: __( 'Friday' ),
+		Sat: __( 'Saturday' ),
 	},
 	startOfWeek: 0,
 };

--- a/client/gutenberg/extensions/business-hours/edit.jsx
+++ b/client/gutenberg/extensions/business-hours/edit.jsx
@@ -18,13 +18,13 @@ import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const defaultLocalization = {
 	days: {
-		Sun: __( 'Sunday' ),
-		Mon: __( 'Monday' ),
-		Tue: __( 'Tuesday' ),
-		Wed: __( 'Wednesday' ),
-		Thu: __( 'Thursday' ),
-		Fri: __( 'Friday' ),
-		Sat: __( 'Saturday' ),
+		Sun: 'Sunday',
+		Mon: 'Monday',
+		Tue: 'Tuesday',
+		Wed: 'Wednesday',
+		Thu: 'Thursday',
+		Fri: 'Friday',
+		Sat: 'Saturday',
 	},
 	startOfWeek: 0,
 };

--- a/client/gutenberg/extensions/business-hours/edit.jsx
+++ b/client/gutenberg/extensions/business-hours/edit.jsx
@@ -14,7 +14,7 @@ import { __experimentalGetSettings } from '@wordpress/date';
 import Day from 'gutenberg/extensions/business-hours/components/day';
 import DaySave from 'gutenberg/extensions/business-hours/components/day-save';
 import { icon } from 'gutenberg/extensions/business-hours/index';
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
+import { __, _x } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 const defaultLocalization = {
 	days: {
@@ -28,6 +28,7 @@ const defaultLocalization = {
 	},
 	startOfWeek: 0,
 };
+const defaultTimeFormat = 'g:i';
 
 class BusinessHours extends Component {
 	state = {
@@ -59,16 +60,19 @@ class BusinessHours extends Component {
 		const { startOfWeek } = localization;
 		const localizedWeek = days.concat( days.slice( 0, startOfWeek ) ).slice( startOfWeek );
 
-		if ( ! isEdit || ! isSelected ) {
-			const settings = __experimentalGetSettings();
-			const {
-				formats: { time },
-			} = settings;
+		if ( ! isEdit ) {
 			return (
 				<dl className={ classNames( className, 'jetpack-business-hours' ) }>
 					{ localizedWeek.map( ( day, key ) => {
 						return (
-							<DaySave key={ key } day={ day } localization={ localization } timeFormat={ time } />
+							<DaySave
+								key={ key }
+								day={ day }
+								localization={ defaultLocalization }
+								timeFormat={ defaultTimeFormat }
+								intervalText="From %s to %s"
+								closedText="Closed"
+							/>
 						);
 					} ) }
 				</dl>
@@ -81,6 +85,31 @@ class BusinessHours extends Component {
 					icon={ <BlockIcon icon={ icon } /> }
 					label={ __( 'Loading business hours' ) }
 				/>
+			);
+		}
+
+		if ( ! isSelected ) {
+			// Render a preview of the block within the post editor.
+			// The preview will be localized.
+			const settings = __experimentalGetSettings();
+			const {
+				formats: { time },
+			} = settings;
+			return (
+				<dl className={ classNames( className, 'jetpack-business-hours' ) }>
+					{ localizedWeek.map( ( day, key ) => {
+						return (
+							<DaySave
+								key={ key }
+								day={ day }
+								localization={ localization }
+								timeFormat={ time }
+								intervalText={ _x( 'From %s to %s', 'from business opening hour to closing hour' ) }
+								closedText={ _x( 'Closed', 'business is closed on a full day' ) }
+							/>
+						);
+					} ) }
+				</dl>
 			);
 		}
 

--- a/client/gutenberg/extensions/business-hours/index.js
+++ b/client/gutenberg/extensions/business-hours/index.js
@@ -96,7 +96,7 @@ export const settings = {
 		},
 	},
 
-	edit: props => <BusinessHours { ...props } isEdit />,
+	edit: props => <BusinessHours { ...props } />,
 
-	save: props => <BusinessHours { ...props } />,
+	save: () => null,
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, if you create a post with a business hours block, and then change your site's locale or time format, the previously saved post will become invalid when you try to edit it again.

![screen shot 2019-02-28 at 9 57 29 am](https://user-images.githubusercontent.com/2694219/53575305-4948d880-3b3f-11e9-9825-9d8bc0da12ac.png)

This PR ensures we only save un-localize content. We save it in english with a time format of `g:i`
And we only localize on the front end, and when we preview the block in the editor.


#### Testing instructions

* [Try out this Jurassic.ninja link](https://jurassic.ninja/create/?gutenpack&shortlived&jetpack-beta&calypsobranch=fix/11441-business-hours-validation)
* Enable Beta blocks in Settings -> Jetpack Constants
* Create a post with a Business Hours block and save it
* change your site's locale in Settings -> General
* Visit the post on the front end. Is it localized?
* Edit the post, and ensure there are no validation errors
* change your site's time format in Settings -> General
* Visit the post on the front end. Does the time format look right?
* Edit the post again, and ensure there are no validation errors

Fixes #11441
