### PR TITLE
Gutenframe: Fix non-production flows.

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -187,6 +187,7 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId } ) => {
 		'block-editor': 1,
 		'frame-nonce': getSiteOption( state, siteId, 'frame_nonce' ) || '',
 		'jetpack-copy': duplicatePostId,
+		origin: window.location.origin,
 	} );
 
 	// needed for loading the editor in SU sessions


### PR DESCRIPTION
This PR adds the current origin as a query param to the iframe URL, allowing us to correct the Back button and Switch to Classic Editor flows server-side.

Requires D24978-code.

Fixes #31099 .

**Testing Instructions**
* Apply D24978-code to your sandbox, and load this branch locally.
* Follow testing instructions in D24978-code.