### PR TITLE
Try implementing a query component using hooks

### DIFF
--- a/client/components/data/query-reader-tag/index.jsx
+++ b/client/components/data/query-reader-tag/index.jsx
@@ -3,9 +3,8 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -13,26 +12,19 @@ import { connect } from 'react-redux';
  */
 import { requestTags } from 'state/reader/tags/items/actions';
 
-/**
- *  QueryReaderTag takes 1 parameter (the tag ) and will fetch it
- *  and add to the state tree
- */
-class QueryReaderTag extends Component {
-	static propTypes = {
-		requestTag: PropTypes.func.isRequired,
-		tag: PropTypes.string.isRequired,
-	};
+const QueryReaderTag = props => {
+	useEffect(() => {
+		props.requestTags( props.tag );
+	}, [ props.tag ]);
+	return null;
+};
 
-	componentDidMount() {
-		this.props.requestTag( this.props.tag );
-	}
-
-	render() {
-		return null;
-	}
-}
+QueryReaderTag.propTypes = {
+	requestTags: PropTypes.func.isRequired,
+	tag: PropTypes.string.isRequired,
+};
 
 export default connect(
 	null,
-	{ requestTag: requestTags }
+	{ requestTags }
 )( QueryReaderTag );


### PR DESCRIPTION
Fixes a bug where the component would not requery if the tag changed.

@jsnajdr and I were talking about places we might like to use hooks in the codebase and query components seemed like an obvious fit. Hooks have one big advantage over our Component based implementations: they deal with component updates natively.. Many of our components will request on mount, but do not re-request on update when a dependency updates. This component is an example.

#### Changes proposed in this Pull Request

* Change the reader query tag component to use hooks

#### Testing instructions

* Pull up a tag stream in the Reader. Validate that every looks good.
