### PR TITLE
Remove Assumptions From Email Forwards Reducer

### DIFF
--- a/client/state/data-layer/wpcom/email-forwarding/add/index.js
+++ b/client/state/data-layer/wpcom/email-forwarding/add/index.js
@@ -115,3 +115,5 @@ registerHandlers( 'state/data-layer/wpcom/email-forwarding/create/index.js', {
 		} ),
 	],
 } );
+
+export default {};

--- a/client/state/data-layer/wpcom/email-forwarding/get/index.js
+++ b/client/state/data-layer/wpcom/email-forwarding/get/index.js
@@ -41,3 +41,5 @@ registerHandlers( 'state/data-layer/wpcom/email-forwarding/get/index.js', {
 		} ),
 	],
 } );
+
+export default {};

--- a/client/state/data-layer/wpcom/email-forwarding/remove/index.js
+++ b/client/state/data-layer/wpcom/email-forwarding/remove/index.js
@@ -104,3 +104,5 @@ registerHandlers( 'state/data-layer/wpcom/email-forwarding/remove/index.js', {
 		} ),
 	],
 } );
+
+export default {};

--- a/client/state/data-layer/wpcom/email-forwarding/resend-email-verification/index.js
+++ b/client/state/data-layer/wpcom/email-forwarding/resend-email-verification/index.js
@@ -91,3 +91,5 @@ registerHandlers( 'state/data-layer/wpcom/email-forwarding/resend-email-verifica
 		} ),
 	],
 } );
+
+export default {};

--- a/client/state/email-forwarding/reducer.js
+++ b/client/state/email-forwarding/reducer.js
@@ -102,8 +102,9 @@ export const forwards = createReducer(
 	forwardsSchema
 );
 
-export const requestError = createReducer( null, {
-	[ EMAIL_FORWARDING_REQUEST_SUCCESS ]: () => null,
+export const requestError = createReducer( false, {
+	[ EMAIL_FORWARDING_REQUEST ]: () => false,
+	[ EMAIL_FORWARDING_REQUEST_SUCCESS ]: () => false,
 	[ EMAIL_FORWARDING_REQUEST_FAILURE ]: () => true,
 } );
 

--- a/client/state/email-forwarding/reducer.js
+++ b/client/state/email-forwarding/reducer.js
@@ -104,7 +104,7 @@ export const forwards = createReducer(
 
 export const requestError = createReducer( null, {
 	[ EMAIL_FORWARDING_REQUEST_SUCCESS ]: () => null,
-	[ EMAIL_FORWARDING_REQUEST_FAILURE ]: ( state, { message } ) => message,
+	[ EMAIL_FORWARDING_REQUEST_FAILURE ]: () => true,
 } );
 
 export default keyedReducer(

--- a/client/state/email-forwarding/test/reducer.js
+++ b/client/state/email-forwarding/test/reducer.js
@@ -52,6 +52,30 @@ describe( 'emailForwardsReducer', () => {
 			} );
 		} );
 
+		test( 'should set requestError to false', () => {
+			const prevState = {
+				'example.com': {
+					forwards: null,
+					requesting: false,
+					requestError: true,
+				},
+			};
+
+			const state = emailForwardsReducer( prevState, {
+				type: EMAIL_FORWARDING_REQUEST_SUCCESS,
+				domainName: 'example.com',
+				forwards: [ TEST_MAILBOX_EXAMPLE_DOT_COM ],
+			} );
+
+			expect( state ).to.eql( {
+				'example.com': {
+					forwards: [ TEST_MAILBOX_EXAMPLE_DOT_COM ],
+					requesting: false,
+					requestError: false,
+				},
+			} );
+		} );
+
 		test( 'should reset data on request to server', () => {
 			const prevState = {
 				'example.com': {

--- a/client/state/email-forwarding/test/reducer.js
+++ b/client/state/email-forwarding/test/reducer.js
@@ -47,7 +47,7 @@ describe( 'emailForwardsReducer', () => {
 				'example.com': {
 					forwards: [ TEST_MAILBOX_EXAMPLE_DOT_COM ],
 					requesting: false,
-					requestError: null,
+					requestError: false,
 				},
 			} );
 		} );
@@ -57,7 +57,7 @@ describe( 'emailForwardsReducer', () => {
 				'example.com': {
 					forwards: [ TEST_MAILBOX_EXAMPLE_DOT_COM ],
 					requesting: false,
-					requestError: null,
+					requestError: false,
 				},
 			};
 
@@ -70,7 +70,7 @@ describe( 'emailForwardsReducer', () => {
 				'example.com': {
 					forwards: null,
 					requesting: true,
-					requestError: null,
+					requestError: false,
 				},
 			} );
 		} );
@@ -80,12 +80,12 @@ describe( 'emailForwardsReducer', () => {
 				'example.com': {
 					forwards: [ TEST_MAILBOX_EXAMPLE_DOT_COM ],
 					requesting: false,
-					requestError: null,
+					requestError: false,
 				},
 				'test.com': {
 					forwards: [ TEST_MAILBOX_TEST_DOT_COM ],
 					requesting: false,
-					requestError: null,
+					requestError: false,
 				},
 			};
 
@@ -98,12 +98,12 @@ describe( 'emailForwardsReducer', () => {
 				'example.com': {
 					forwards: null,
 					requesting: true,
-					requestError: null,
+					requestError: false,
 				},
 				'test.com': {
 					forwards: [ TEST_MAILBOX_TEST_DOT_COM ],
 					requesting: false,
-					requestError: null,
+					requestError: false,
 				},
 			} );
 		} );
@@ -155,7 +155,7 @@ describe( 'emailForwardsReducer', () => {
 						},
 					],
 					requesting: false,
-					requestError: null,
+					requestError: false,
 				},
 			} );
 		} );
@@ -188,7 +188,7 @@ describe( 'emailForwardsReducer', () => {
 						},
 					],
 					requesting: false,
-					requestError: null,
+					requestError: false,
 				},
 			} );
 		} );

--- a/client/state/email-forwarding/test/reducer.js
+++ b/client/state/email-forwarding/test/reducer.js
@@ -10,8 +10,9 @@ import { expect } from 'chai';
  */
 import emailForwardsReducer from '../reducer';
 import {
-	EMAIL_FORWARDING_REQUEST_SUCCESS,
 	EMAIL_FORWARDING_REQUEST,
+	EMAIL_FORWARDING_REQUEST_SUCCESS,
+	EMAIL_FORWARDING_REQUEST_FAILURE,
 	EMAIL_FORWARDING_ADD_REQUEST,
 } from 'state/action-types';
 
@@ -103,6 +104,23 @@ describe( 'emailForwardsReducer', () => {
 					forwards: [ TEST_MAILBOX_TEST_DOT_COM ],
 					requesting: false,
 					requestError: null,
+				},
+			} );
+		} );
+	} );
+
+	describe( 'requesting email forward error', () => {
+		test( 'should set request error to true', () => {
+			const state = emailForwardsReducer( undefined, {
+				type: EMAIL_FORWARDING_REQUEST_FAILURE,
+				domainName: 'example.com',
+			} );
+
+			expect( state ).to.eql( {
+				'example.com': {
+					forwards: null,
+					requesting: false,
+					requestError: true,
 				},
 			} );
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set `requestError` in email forwards state to true/false instead of saving the message ( and erring if there isn't one )
* test of the above

#### Testing instructions

* run `npm run test-client client/state/email-forwarding/`, confirm all tests pass
