### PR TITLE
Extend end date of Jetpack Feb promo nudge to March 8

### DIFF
--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -72,7 +72,7 @@ export default [
 	{
 		name: 'sale_feb_2019_jp',
 		startsAt: new Date( 2019, 1, 25, 0, 0, 0 ),
-		endsAt: new Date( 2019, 2, 1, 0, 0, 0 ),
+		endsAt: new Date( 2019, 2, 8, 0, 0, 0 ),
 		nudgeText: 'Sale! 20% off all plans',
 		ctaText: 'Upgrade',
 		plansPageNoticeText: 'Enter coupon code “JPSALE20” at checkout to claim your 20% discount',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change end date for the Jetpack Feb/Mar promo nudge from Mar 1 to Mar 4
More info: p9jf6J-1s7-p2

#### Testing instructions

* A visual check should be fine
