### PR TITLE
Refactor Email Forwarding Components

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -314,6 +314,7 @@
 @import 'notices/style';
 @import 'my-sites/domains/domain-management/style';
 @import 'my-sites/domains/domain-management/email/style';
+@import 'my-sites/email/email-forwarding/style';
 @import 'my-sites/domains/domain-management/components/email-verification/style';
 @import 'my-sites/domains/domain-management/components/inbound-transfer-verification/style';
 @import 'my-sites/domains/domain-management/components/icann-verification/style';

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -63,33 +63,6 @@ const EVENTS = {
 		},
 
 		emailForwarding: {
-			cancelClick( domainName ) {
-				analytics.ga.recordEvent(
-					'Domain Management',
-					'Clicked "Cancel" Button in Email Forwarding',
-					'Domain Name',
-					domainName
-				);
-
-				analytics.tracks.recordEvent( 'calypso_domain_management_email_forwarding_cancel_click', {
-					domain_name: domainName,
-				} );
-			},
-
-			inputFocus( domainName, fieldName ) {
-				analytics.ga.recordEvent(
-					'Domain Management',
-					`Focused On "${ fieldName }" Input in Email Forwarding`,
-					'Domain Name',
-					domainName
-				);
-
-				analytics.tracks.recordEvent(
-					`calypso_domain_management_email_forwarding_${ snakeCase( fieldName ) }_focus`,
-					{ domain_name: domainName }
-				);
-			},
-
 			learnMoreClick( domainName ) {
 				analytics.ga.recordEvent(
 					'Domain Management',

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -61,22 +61,6 @@ const EVENTS = {
 				} );
 			},
 		},
-
-		emailForwarding: {
-			learnMoreClick( domainName ) {
-				analytics.ga.recordEvent(
-					'Domain Management',
-					'Clicked "Learn more" link in Email Forwarding',
-					'Domain Name',
-					domainName
-				);
-
-				analytics.tracks.recordEvent(
-					'calypso_domain_management_email_forwarding_learn_more_click',
-					{ domain_name: domainName }
-				);
-			},
-		},
 	},
 };
 

--- a/client/lib/mixins/analytics/index.js
+++ b/client/lib/mixins/analytics/index.js
@@ -63,24 +63,6 @@ const EVENTS = {
 		},
 
 		emailForwarding: {
-			addNewEmailForwardClick( domainName, mailbox, destination ) {
-				analytics.ga.recordEvent(
-					'Domain Management',
-					'Clicked "Add New Email Forward" Button in Email Forwarding',
-					'Domain Name',
-					domainName
-				);
-
-				analytics.tracks.recordEvent(
-					'calypso_domain_management_email_forwarding_add_new_email_forward_click',
-					{
-						destination,
-						domain_name: domainName,
-						mailbox,
-					}
-				);
-			},
-
 			cancelClick( domainName ) {
 				analytics.ga.recordEvent(
 					'Domain Management',

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new.jsx
@@ -40,7 +40,17 @@ class EmailForwardingAddNew extends React.Component {
 		selectedDomainName: PropTypes.string.isRequired,
 	};
 
-	getInitialState() {
+	state = {
+		fields: { destination: '', mailbox: '' },
+		formSubmitting: false,
+		showForm: false,
+	};
+
+	getInitialFields() {
+		return { destination: '', mailbox: '' };
+	}
+
+	getInitialFormState() {
 		return {
 			fields: { destination: '', mailbox: '' },
 			formSubmitting: false,
@@ -50,7 +60,7 @@ class EmailForwardingAddNew extends React.Component {
 
 	componentWillMount() {
 		this.formStateController = formState.Controller( {
-			initialFields: this.getInitialState().fields,
+			initialFields: this.getInitialFields(),
 			onNewState: this.setFormState,
 			validatorFunction: ( fieldValues, onComplete ) => {
 				onComplete( null, validateAllFields( fieldValues ) );
@@ -68,7 +78,7 @@ class EmailForwardingAddNew extends React.Component {
 		return this.props.emailForwards.length >= this.props.emailForwardingLimit;
 	}
 
-	addEmailForwardClick = event => {
+	addNewEmailForwardClick = event => {
 		event.preventDefault();
 
 		if ( this.state.formSubmitting ) {
@@ -83,19 +93,21 @@ class EmailForwardingAddNew extends React.Component {
 				return;
 			}
 
-			const { mailbox, destination, selectedDomainName } = formState.getAllFieldValues(
-				this.state.fields
-			);
+			const { mailbox, destination } = formState.getAllFieldValues( this.state.fields );
 
-			this.props.addNewEmailForwardWithAnalytics( selectedDomainName, mailbox, destination );
-			this.props.this.formStateController.resetFields( this.getInitialState().fields );
+			this.props.addNewEmailForwardWithAnalytics(
+				this.props.selectedDomainName,
+				mailbox,
+				destination
+			);
+			this.formStateController.resetFields( this.getInitialFields() );
 			this.setState( { formSubmitting: false, showForm: true } );
 		} );
 	};
 
-	setFormState( fields ) {
+	setFormState = fields => {
 		this.setState( { fields } );
-	}
+	};
 
 	onShowForm = event => {
 		event.preventDefault();
@@ -103,7 +115,7 @@ class EmailForwardingAddNew extends React.Component {
 	};
 
 	addButton() {
-		const handler = this.shouldShowForm() ? this.onAddEmailForward : this.onShowForm;
+		const handler = this.shouldShowForm() ? this.addNewEmailForwardClick : this.onShowForm;
 
 		return (
 			<FormButton
@@ -226,10 +238,10 @@ class EmailForwardingAddNew extends React.Component {
 
 	cancelClick = () => {
 		this.setState( { showForm: false } );
-		this.trackCancelClick( this.props.selectedDomainName );
+		this.props.trackCancelClick( this.props.selectedDomainName );
 	};
 
-	onChange( event ) {
+	onChange = event => {
 		const { name } = event.target;
 		let { value } = event.target;
 
@@ -243,14 +255,10 @@ class EmailForwardingAddNew extends React.Component {
 			name,
 			value,
 		} );
-	}
+	};
 
 	isValid( fieldName ) {
 		return ! formState.isFieldInvalid( this.state.fields, fieldName );
-	}
-
-	handleFieldFocus( fieldName ) {
-		this.recordEvent( 'inputFocus', this.props.selectedDomainName, fieldName );
 	}
 
 	destinationFieldFocus = () => {
@@ -262,7 +270,7 @@ class EmailForwardingAddNew extends React.Component {
 	};
 }
 
-const addNewEmailForwardWithAnalytics = ( domainName, mailbox, destination ) => {
+const addNewEmailForwardWithAnalytics = ( domainName, mailbox, destination ) =>
 	withAnalytics(
 		composeAnalytics(
 			recordGoogleEvent(
@@ -279,9 +287,8 @@ const addNewEmailForwardWithAnalytics = ( domainName, mailbox, destination ) => 
 		),
 		addEmailForward( domainName, mailbox, destination )
 	);
-};
 
-const trackCancelClick = domainName => {
+const trackCancelClick = domainName =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Management',
@@ -293,9 +300,8 @@ const trackCancelClick = domainName => {
 			domain_name: domainName,
 		} )
 	);
-};
 
-const trackDestinationFieldFocus = domainName => {
+const trackDestinationFieldFocus = domainName =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Management',
@@ -307,9 +313,8 @@ const trackDestinationFieldFocus = domainName => {
 			domain_name: domainName,
 		} )
 	);
-};
 
-const trackMailboxFieldFocus = domainName => {
+const trackMailboxFieldFocus = domainName =>
 	composeAnalytics(
 		recordGoogleEvent(
 			'Domain Management',
@@ -321,7 +326,6 @@ const trackMailboxFieldFocus = domainName => {
 			domain_name: domainName,
 		} )
 	);
-};
 
 export default connect(
 	null,

--- a/client/my-sites/email/email-forwarding/email-forwarding-add-new.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-add-new.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
-import createReactClass from 'create-react-class';
 
 /**
  * Internal dependencies
@@ -21,22 +20,16 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
 import FormInputValidation from 'components/forms/form-input-validation';
 import formState from 'lib/form-state';
-import analyticsMixin from 'lib/mixins/analytics';
 import { addEmailForward } from 'state/email-forwarding/actions';
 
-// eslint-disable-next-line react/prefer-es6-class
-const EmailForwardingAddNew = createReactClass( {
-	displayName: 'EmailForwardingAddNew',
-
-	propTypes: {
+class EmailForwardingAddNew extends React.Component {
+	static propTypes = {
 		initialShowForm: PropTypes.bool,
 		addEmailForward: PropTypes.func.isRequired,
 		emailForwards: PropTypes.array,
 		emailForwardingLimit: PropTypes.number.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
-	},
-
-	mixins: [ analyticsMixin( 'domainManagement', 'emailForwarding' ) ],
+	};
 
 	getInitialState() {
 		return {
@@ -44,7 +37,7 @@ const EmailForwardingAddNew = createReactClass( {
 			formSubmitting: false,
 			showForm: false,
 		};
-	},
+	}
 
 	componentWillMount() {
 		this.formStateController = formState.Controller( {
@@ -56,15 +49,15 @@ const EmailForwardingAddNew = createReactClass( {
 		} );
 
 		this.setFormState( this.formStateController.getInitialState() );
-	},
+	}
 
 	hasForwards() {
 		return this.props.emailForwards.length > 0;
-	},
+	}
 
 	hasReachedLimit() {
 		return this.props.emailForwards.length >= this.props.emailForwardingLimit;
-	},
+	}
 
 	onAddEmailForward( event ) {
 		event.preventDefault();
@@ -94,16 +87,16 @@ const EmailForwardingAddNew = createReactClass( {
 			this.formStateController.resetFields( this.getInitialState().fields );
 			this.setState( { formSubmitting: false, showForm: true } );
 		} );
-	},
+	}
 
 	setFormState( fields ) {
 		this.setState( { fields } );
-	},
+	}
 
 	onShowForm( event ) {
 		event.preventDefault();
 		this.setState( { showForm: true } );
-	},
+	}
 
 	addButton() {
 		const handler = this.shouldShowForm() ? this.onAddEmailForward : this.onShowForm;
@@ -116,7 +109,7 @@ const EmailForwardingAddNew = createReactClass( {
 				{ this.props.translate( 'Add New Email Forward' ) }
 			</FormButton>
 		);
-	},
+	}
 
 	cancelButton() {
 		if ( ! this.shouldShowForm() || ! this.hasForwards() ) {
@@ -133,7 +126,7 @@ const EmailForwardingAddNew = createReactClass( {
 				{ this.props.translate( 'Cancel' ) }
 			</FormButton>
 		);
-	},
+	}
 
 	formFooter() {
 		return (
@@ -142,7 +135,7 @@ const EmailForwardingAddNew = createReactClass( {
 				{ this.cancelButton() }
 			</FormFooter>
 		);
-	},
+	}
 
 	formFields() {
 		if ( ! this.shouldShowForm() ) {
@@ -206,11 +199,11 @@ const EmailForwardingAddNew = createReactClass( {
 				</FormFieldset>
 			</div>
 		);
-	},
+	}
 
 	shouldShowForm() {
 		return ! this.hasReachedLimit() && ( ! this.hasForwards() || this.state.showForm );
-	},
+	}
 
 	render() {
 		const { emailForwards, emailForwardingLimit } = this.props;
@@ -226,13 +219,13 @@ const EmailForwardingAddNew = createReactClass( {
 				{ this.formFooter() }
 			</form>
 		);
-	},
+	}
 
 	onCancel() {
 		this.setState( { showForm: false } );
 
 		this.recordEvent( 'cancelClick', this.props.selectedDomainName );
-	},
+	}
 
 	onChange( event ) {
 		const { name } = event.target;
@@ -248,16 +241,16 @@ const EmailForwardingAddNew = createReactClass( {
 			name,
 			value,
 		} );
-	},
+	}
 
 	isValid( fieldName ) {
 		return ! formState.isFieldInvalid( this.state.fields, fieldName );
-	},
+	}
 
 	handleFieldFocus( fieldName ) {
 		this.recordEvent( 'inputFocus', this.props.selectedDomainName, fieldName );
-	},
-} );
+	}
+}
 
 export default connect(
 	null,

--- a/client/my-sites/email/email-forwarding/email-forwarding-details.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-details.jsx
@@ -3,25 +3,24 @@
 /**
  * External dependencies
  */
-
-import React from 'react';
-
-import createReactClass from 'create-react-class';
-
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
+import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { EMAIL_FORWARDING } from 'lib/url/support';
-import analyticsMixin from 'lib/mixins/analytics';
 
-// eslint-disable-next-line react/prefer-es6-class
-const EmailForwardingDetails = createReactClass( {
-	displayName: 'EmailForwardingDetails',
-	mixins: [ analyticsMixin( 'domainManagement', 'emailForwarding' ) ],
+class EmailForwardingDetails extends React.Component {
+	static propTypes = {
+		selectedDomainName: PropTypes.string.isRequired,
+		trackLearnMoreClick: PropTypes.func.isRequired,
+	};
 
-	render: function() {
+	render() {
 		return (
 			<p className="email-forwarding__explanation">
 				{ this.props.translate(
@@ -31,17 +30,35 @@ const EmailForwardingDetails = createReactClass( {
 					href={ EMAIL_FORWARDING }
 					target="_blank"
 					rel="noopener noreferrer"
-					onClick={ this.handleLearnMoreClick }
+					onClick={ this.learnMoreClick }
 				>
 					{ this.props.translate( 'Learn more.' ) }
 				</a>
 			</p>
 		);
-	},
+	}
 
-	handleLearnMoreClick() {
-		this.recordEvent( 'learnMoreClick', this.props.selectedDomainName );
-	},
-} );
+	learnMoreClick = () => {
+		this.props.trackLearnMoreClick( this.props.selectedDomainName );
+	};
+}
 
-export default localize( EmailForwardingDetails );
+const trackLearnMoreClick = domainName =>
+	composeAnalytics(
+		recordTracksEvent( 'calypso_domain_management_email_forwarding_learn_more_click', {
+			domain_name: domainName,
+		} ),
+		recordGoogleEvent(
+			'Domain Management',
+			'Clicked "Learn more" link in Email Forwarding',
+			'Domain Name',
+			domainName
+		)
+	);
+
+export default connect(
+	null,
+	{
+		trackLearnMoreClick,
+	}
+)( localize( EmailForwardingDetails ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor `EmailForwardingAddNew` to an es6 class
Refactor `EmailForwardingDetails` to an es6 class
* Remove unused analytics from above

#### Testing instructions

1. Navigate to `/domains/manage/:domainName/email-forwarding/:siteSlug` for a site and domain without G Suite
1. Enable analytics logging by running `localStorage.setItem( 'debug', 'calypso:analytics:*' )` in the console
1. Click the `Learn More` link <img width="768" alt="screen shot 2019-02-28 at 4 12 23 pm" src="https://user-images.githubusercontent.com/2810519/53607473-bb3b1500-3b73-11e9-8eb8-a15870e5005e.png">
1. Verify in the console that a `calypso_domain_management_email_forwarding_learn_more_click` event was emitted
1. Click `Add New Email Forward`
1. Verify that the form appears
1. Click in the mailbox field <img width="783" alt="screen shot 2019-02-28 at 3 50 44 pm" src="https://user-images.githubusercontent.com/2810519/53606869-3cdd7380-3b71-11e9-916b-f493bc019376.png">
1. Verify in the console that a `calypso_domain_management_email_forwarding_mailbox_focus` event was emitted
1. Click in the destination field <img width="779" alt="screen shot 2019-02-28 at 3 55 32 pm" src="https://user-images.githubusercontent.com/2810519/53606917-757d4d00-3b71-11e9-8643-00d103a4ec96.png">
1. Verify in the console that a `calypso_domain_management_email_forwarding_destination_focus` event was emitted
1. Click the `Cancel` Button
1. Verify in the console that a `calypso_domain_management_email_forwarding_cancel_click` event was emitted
1. Show the form again
1. Verify the validation fields work by inserting unusual symbols into both fields
1. Fill out the fields with a correct forward
1. Click the `Add New Email Forward` button
1. Verify in the console that a `calypso_domain_management_email_forwarding_add_new_email_forward_click` event was emitted
1. Verify that the new forward was successfully added