### PR TITLE
Color Schemes: Use correct background color for the Switch Sites hover state

### DIFF
--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -76,10 +76,11 @@
 	}
 
 	&:hover {
-		background-color: var( --sidebar-background );
+		background-color: var( --sidebar-menu-hover-background );
 
 		.button.is-borderless:hover,
 		.button.is-borderless:focus {
+			background-color: var( --sidebar-menu-hover-background );
 			color: var( --sidebar-menu-hover-color );
 
 			.gridicon {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the menu item hover background color on the Switch Sites button for contrast.
* I thought this was fixed in #30867, but apparently not!

**Before**

<img width="294" alt="screen shot 2019-02-28 at 6 22 05 pm" src="https://user-images.githubusercontent.com/2124984/53605538-c72fd280-3b85-11e9-8d05-c275ce4ab896.png">

**After**

<img width="377" alt="screen shot 2019-02-28 at 5 58 04 pm" src="https://user-images.githubusercontent.com/2124984/53605537-c72fd280-3b85-11e9-8ee7-bae334bd09f6.png">


#### Testing instructions

* Switch to this PR and change color schemes to one where this issue will be obvious, like Nightfall or Sakura
* Check out the Switch Sites button under My Sites.