### PR TITLE
Mailchimp: Form Element Spacing

### DIFF
--- a/client/gutenberg/extensions/mailchimp/edit.jsx
+++ b/client/gutenberg/extensions/mailchimp/edit.jsx
@@ -191,6 +191,7 @@ class MailchimpSubscribeEdit extends Component {
 			<div className={ blockClasses }>
 				<TextControl
 					aria-label={ emailPlaceholder }
+					className="wp-block-jetpack-mailchimp_text-input"
 					disabled
 					onChange={ () => false }
 					placeholder={ emailPlaceholder }

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -19,7 +19,7 @@
 	}
 
 	.wp-block-jetpack-mailchimp_text-input, .jetpack-submit-button {
-		margin-bottom: 1.5em;
+		margin-bottom: 1.5rem;
 	}
 
 	.wp-block-button .wp-block-button__link {

--- a/client/gutenberg/extensions/mailchimp/editor.scss
+++ b/client/gutenberg/extensions/mailchimp/editor.scss
@@ -18,4 +18,12 @@
 		display: none;
 	}
 
+	.wp-block-jetpack-mailchimp_text-input, .jetpack-submit-button {
+		margin-bottom: 1.5em;
+	}
+
+	.wp-block-button .wp-block-button__link {
+		margin-top: 0;
+	}
+
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR standardizes the spacing between the form elements in the editor, addressing theme-specific spacing issues like these:

<img width="641" alt="screen shot 2019-03-01 at 8 35 55 am" src="https://user-images.githubusercontent.com/1477002/53642489-e79c7300-3bff-11e9-9998-f8b51f3a003f.png">

<img width="670" alt="screen shot 2019-03-01 at 8 36 34 am" src="https://user-images.githubusercontent.com/1477002/53642491-ea976380-3bff-11e9-8931-c92211503798.png">

#### Testing instructions

- Spin up JN instance: https://jurassic.ninja/create/?gutenpack&calypsobranch=fix/mailchimp-spacing
- Connect Jetpack
- Navigate to `Settings->Jetpack Constants` and enable `JETPACK_BETA_BLOCKS`
- Create post, add Mailchimp block.
- Verify spacing between form elements.
- Check in a variety of themes for inconsistencies.