### PR TITLE
Business hours block: use blockIcon in placeholder

### DIFF
--- a/client/gutenberg/extensions/business-hours/edit.jsx
+++ b/client/gutenberg/extensions/business-hours/edit.jsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { BlockIcon } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
 import { Placeholder } from '@wordpress/components';
 import apiFetch from '@wordpress/api-fetch';
@@ -75,7 +76,12 @@ class BusinessHours extends Component {
 		}
 
 		if ( ! hasFetched ) {
-			return <Placeholder icon={ icon } label={ __( 'Loading business hours' ) } />;
+			return (
+				<Placeholder
+					icon={ <BlockIcon icon={ icon } /> }
+					label={ __( 'Loading business hours' ) }
+				/>
+			);
 		}
 
 		return (


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/issues/30903 for context.

#### Changes proposed in this Pull Request

* Use `BlockIcon` in the placeholder

#### Testing instructions

Add business hours block and observe icon have more space next to "loading" text

Before
<img width="682" alt="screenshot 2019-03-01 at 17 12 46" src="https://user-images.githubusercontent.com/87168/53647678-b6936100-3c46-11e9-8551-7d80ac23dfe9.png">

After
<img width="662" alt="screenshot 2019-03-01 at 17 13 08" src="https://user-images.githubusercontent.com/87168/53647677-b5faca80-3c46-11e9-9350-c504a67f28ef.png">
