### PR TITLE
Slideshow: Update mobile styles

### DIFF
--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -4,6 +4,10 @@ $break-small: 600px;
 	margin-bottom: 1.5em;
 	position: relative;
 
+	[tabindex="-1"]:focus {
+		outline: 0;
+	}
+
 	.wp-block-jetpack-slideshow_container {
 		width: 100%;
 		overflow: hidden;
@@ -76,7 +80,7 @@ $break-small: 600px;
 			outline-offset: -4px;
 		}
 	}
-	
+
 	.wp-block-jetpack-slideshow_button-prev,
 	.wp-block-jetpack-slideshow_button-next {
 		display: none;
@@ -132,7 +136,7 @@ $break-small: 600px;
 			color: inherit;
 		}
 	}
-	
+
 	&[data-autoplay='true'] .wp-block-jetpack-slideshow_caption.gallery-caption {
 		max-height: calc( 100% - 68px );
 	}

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -1,3 +1,5 @@
+$break-small: 600px;
+
 .wp-block-jetpack-slideshow {
 	margin-bottom: 1.5em;
 	position: relative;
@@ -74,6 +76,11 @@
 			outline-offset: -4px;
 		}
 	}
+	
+	.wp-block-jetpack-slideshow_button-prev,
+	.wp-block-jetpack-slideshow_button-next {
+		display: none;
+	}
 
 	&.swiper-container-rtl .swiper-button-prev.swiper-button-white,
 	&.swiper-container-rtl .wp-block-jetpack-slideshow_button-prev,
@@ -115,6 +122,7 @@
 		cursor: text;
 		left: 0;
 		margin: 0 !important;
+		max-height: 100%;
 		padding: 0.75em;
 		position: absolute;
 		right: 0;
@@ -122,6 +130,12 @@
 		z-index: 1;
 		a {
 			color: inherit;
+		}
+	}
+	
+	.swiper-container-fade .wp-block-jetpack-slideshow_slide {
+		.wp-block-jetpack-slideshow_caption.gallery-caption {
+			max-height: calc( 100% - 68px );
 		}
 	}
 
@@ -156,6 +170,15 @@
 			background-color: currentColor;
 			opacity: 1;
 			transform: scale( 1 );
+		}
+	}
+}
+
+@media ( min-width: $break-small ) {
+	.wp-block-jetpack-slideshow {
+		.wp-block-jetpack-slideshow_button-prev,
+		.wp-block-jetpack-slideshow_button-next {
+			display: block;
 		}
 	}
 }

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -133,10 +133,8 @@ $break-small: 600px;
 		}
 	}
 	
-	.swiper-container-fade .wp-block-jetpack-slideshow_slide {
-		.wp-block-jetpack-slideshow_caption.gallery-caption {
-			max-height: calc( 100% - 68px );
-		}
+	&[data-autoplay='true'] .wp-block-jetpack-slideshow_caption.gallery-caption {
+		max-height: calc( 100% - 68px );
 	}
 
 	.wp-block-jetpack-slideshow_pagination.swiper-pagination-bullets {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Only display prev/next arrows when viewport is >= 600px
* Make sure captions fit properly within the slide and don't overflow the play/pause button.

#### Testing instructions

* [Try out this Jurassic.ninja link](https://jurassic.ninja/create/?jetpack-beta&gutenpack&calypsobranch=update/slideshow-mobile-styles)
* Enable Beta blocks in Settings -> Jetpack Constants
* Create a post with a Slideshow block
* Add a few images with a very very long caption
* How does the block look like?
* Enable autoplay
* How does the block look like?
* Resize your screen (or check the side on mobile), do you see the arrows?
* On on your desktop, do you see the arrows?
