### PR TITLE
Slideshow: No srcset Experiment

### DIFF
--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -129,9 +129,7 @@ class Slideshow extends Component {
 								<figure>
 									<img
 										alt={ alt }
-										className={
-											`wp-block-jetpack-slideshow_image wp-image-${ id }` /* wp-image-${ id } makes WordPress add a srcset */
-										}
+										className="wp-block-jetpack-slideshow_image"
 										data-id={ id }
 										src={ url }
 									/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove `srcset`. Note: this is purely an experiment, there is no intent to merge this.

https://jurassic.ninja/create/?gutenpack&calypsobranch=try/slideshow-no-wp-image