### PR TITLE
Fixes email forwarding link

### DIFF
--- a/client/lib/domains/email-forwarding/index.js
+++ b/client/lib/domains/email-forwarding/index.js
@@ -1,11 +1,49 @@
-/** @format */
 /**
  * External dependencies
  */
-import { mapValues } from 'lodash';
+import { mapValues, includes } from 'lodash';
 import emailValidator from 'email-validator';
 
-export function validateAllFields( fieldValues ) {
+/**
+ * Internal dependencies
+ */
+import { hasGSuite } from 'lib/domains/gsuite';
+import { type as domainTypes } from 'lib/domains/constants';
+
+/**
+ * Retrieves the first domain that is eligible for Email Forwarding either from the current selected site or the list of domains.
+ *
+ * @param {String} selectedDomainName - domain name for the site currently selected by the user
+ * @param {Array} domains - list of domain objects
+ * @returns {String} - Eligible domain name
+ */
+function getEligibleEmailForwardingDomain( selectedDomainName, domains = [] ) {
+	const eligibleDomains = getEmailForwardingSupportedDomains( domains );
+	if ( selectedDomainName ) {
+		eligibleDomains.forEach( function( domain ) {
+			return domain.name === selectedDomainName && selectedDomainName;
+		} );
+	}
+	return ( eligibleDomains.length && eligibleDomains[ 0 ].name ) || '';
+}
+
+/**
+ * Filters a list of domains by the domains that eligible for Email Forwarding
+ *
+ * @param {Array} domains - list of domain objects
+ * @returns {Array} - Array of Email Forwarding supported domans
+ */
+function getEmailForwardingSupportedDomains( domains ) {
+	return domains.filter( function( domain ) {
+		const domainHasGSuite = hasGSuite( domain );
+		const wpcomHosted =
+			includes( [ domainTypes.REGISTERED ], domain.type ) && domain.hasWpcomNameservers;
+		const mapped = includes( [ domainTypes.MAPPED ], domain.type );
+		return ( wpcomHosted || mapped ) && ! domainHasGSuite;
+	} );
+}
+
+function validateAllFields( fieldValues ) {
 	return mapValues( fieldValues, ( value, fieldName ) => {
 		const isValid = validateField( {
 			value,
@@ -26,3 +64,5 @@ function validateField( { name, value } ) {
 			return true;
 	}
 }
+
+export { getEligibleEmailForwardingDomain, getEmailForwardingSupportedDomains, validateAllFields };

--- a/client/lib/domains/email-forwarding/test/index.js
+++ b/client/lib/domains/email-forwarding/test/index.js
@@ -1,0 +1,143 @@
+/**
+ * Internal dependencies
+ */
+import {
+	getEligibleEmailForwardingDomain,
+	getEmailForwardingSupportedDomains,
+} from 'lib/domains/email-forwarding';
+
+jest.mock( 'lib/user/', () => {
+	return () => {
+		return {
+			get: () => {
+				return { is_valid_google_apps_country: true };
+			},
+		};
+	};
+} );
+
+describe( 'index', () => {
+	describe( '#getEligibleEmailForwardingDomain', () => {
+		test( 'Returns an emtpy string if selected domain name is not in domains array', () => {
+			expect( getEligibleEmailForwardingDomain( 'foobar.blog', [] ) ).toEqual( '' );
+		} );
+
+		test( 'Returns selected domain name if that domain is valid for email forwarding', () => {
+			expect(
+				getEligibleEmailForwardingDomain( 'foobar.blog', [
+					{
+						name: 'foobar.blog',
+						type: 'REGISTERED',
+						hasWpcomNameservers: true,
+						googleAppsSubscription: { status: 'no_subscription' },
+					},
+				] )
+			).toEqual( 'foobar.blog' );
+		} );
+
+		test( 'Returns an empty string if selectedt domain name is invalid for email forwarding', () => {
+			expect(
+				getEligibleEmailForwardingDomain( 'foobar.blog', [
+					{
+						name: 'foobar.blog',
+						type: 'REGISTERED',
+						hasWpcomNameservers: false,
+						googleAppsSubscription: { status: 'no_subscription' },
+					},
+				] )
+			).toEqual( '' );
+		} );
+
+		test( 'Returns empty string if no selected site and domains array does not contain a valid domain', () => {
+			expect( getEligibleEmailForwardingDomain( '', [ 'foobar.blog' ] ) ).toEqual( '' );
+		} );
+
+		test( 'Returns first site domain name if it is valid for email forwarding', () => {
+			expect(
+				getEligibleEmailForwardingDomain( '', [
+					{
+						name: 'foobar.blog',
+						type: 'REGISTERED',
+						hasWpcomNameservers: true,
+						googleAppsSubscription: { status: 'no_subscription' },
+					},
+				] )
+			).toEqual( 'foobar.blog' );
+		} );
+	} );
+
+	describe( '#getEmailForwardingSupportedDomains', () => {
+		test( 'returns empty array if give empty array', () => {
+			expect( getEmailForwardingSupportedDomains( [] ) ).toEqual( [] );
+		} );
+
+		test( 'returns empty array if domain has pointed DNS', () => {
+			expect(
+				getEmailForwardingSupportedDomains( [
+					{
+						name: 'foobar.blog',
+						type: 'REGISTERED',
+						hasWpcomNameservers: false,
+						googleAppsSubscription: { status: 'no_subscription' },
+					},
+				] )
+			).toEqual( [] );
+		} );
+
+		test( 'returns empty array if domain has G Suite', () => {
+			expect(
+				getEmailForwardingSupportedDomains( [
+					{
+						name: 'foobar.blog',
+						type: 'REGISTERED',
+						hasWpcomNameservers: false,
+						googleAppsSubscription: { status: 'something' },
+					},
+				] )
+			).toEqual( [] );
+		} );
+
+		test( 'returns empty array if domain has unsupported type', () => {
+			expect(
+				getEmailForwardingSupportedDomains( [
+					{
+						name: 'foobar.blog',
+						type: 'TRANSFER',
+						hasWpcomNameservers: false,
+						googleAppsSubscription: { status: 'something' },
+					},
+				] )
+			).toEqual( [] );
+		} );
+
+		test( 'returns domain object if domain is valid, type of registered, and wpcom nameservers', () => {
+			const registered = {
+				name: 'foo.blog',
+				type: 'REGISTERED',
+				hasWpcomNameservers: true,
+				googleAppsSubscription: { status: 'no_subscription' },
+			};
+			expect( getEmailForwardingSupportedDomains( [ registered ] ) ).toEqual( [ registered ] );
+		} );
+
+		test( 'returns domain object if domain is valid and type of mapped', () => {
+			const mapped = {
+				name: 'foo.blog',
+				type: 'MAPPED',
+				googleAppsSubscription: { status: 'no_subscription' },
+			};
+			expect( getEmailForwardingSupportedDomains( [ mapped ] ) ).toEqual( [ mapped ] );
+		} );
+
+		test( 'returns domain object if domain is valid and type of site redirected', () => {
+			const siteRedirect = {
+				name: 'foo.blog',
+				type: 'SITE_REDIRECT',
+				googleAppsSubscription: { status: 'no_subscription' },
+			};
+			expect( getEmailForwardingSupportedDomains( [ siteRedirect ] ) ).toEqual( [] );
+		} );
+	} );
+} );
+
+// { googleAppsSubscription: { status: 'no_subscription' } }

--- a/client/lib/domains/email-forwarding/test/index.js
+++ b/client/lib/domains/email-forwarding/test/index.js
@@ -139,5 +139,3 @@ describe( 'index', () => {
 		} );
 	} );
 } );
-
-// { googleAppsSubscription: { status: 'no_subscription' } }

--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -16,12 +16,8 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import Header from 'my-sites/domains/domain-management/components/header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import {
-	getEligibleGSuiteDomain,
-	hasGSuite,
-	isGSuiteRestricted,
-	hasGSuiteSupportedDomain,
-} from 'lib/domains/gsuite';
+import { hasGSuite, isGSuiteRestricted, hasGSuiteSupportedDomain } from 'lib/domains/gsuite';
+import { getEligibleEmailForwardingDomain } from 'lib/domains/email-forwarding';
 import { getAnnualPrice, getMonthlyPrice } from 'lib/google-apps';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import GSuitePurchaseCta from 'my-sites/domains/domain-management/gsuite/gsuite-purchase-cta';
@@ -79,6 +75,8 @@ class Email extends React.Component {
 	}
 
 	content() {
+		const { domains, selectedDomainName } = this.props;
+		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
 		if (
 			! (
 				! this.props.isRequestingSiteDomains &&
@@ -88,17 +86,14 @@ class Email extends React.Component {
 		) {
 			return <Placeholder />;
 		}
-
-		const domainList = this.props.selectedDomainName
-			? [ getSelectedDomain( this.props ) ]
-			: this.props.domains;
+		const domainList = selectedDomainName ? [ getSelectedDomain( this.props ) ] : domains;
 
 		if ( domainList.some( hasGSuite ) ) {
 			return this.googleAppsUsersCard();
 		} else if ( hasGSuiteSupportedDomain( domainList ) ) {
 			return this.addGoogleAppsCard();
-		} else if ( isGSuiteRestricted() && this.props.selectedDomainName ) {
-			return this.addEmailForwardingCard();
+		} else if ( emailForwardingDomain && isGSuiteRestricted() && selectedDomainName ) {
+			return this.addEmailForwardingCard( emailForwardingDomain );
 		}
 		return this.emptyContent();
 	}
@@ -150,7 +145,8 @@ class Email extends React.Component {
 	}
 
 	addGoogleAppsCard() {
-		const { currencyCode, products, selectedDomainName, selectedSite } = this.props;
+		const { currencyCode, domains, products, selectedDomainName, selectedSite } = this.props;
+		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
 		const price = get( products, [ 'gapps', 'prices', currencyCode ], 0 );
 		const annualPrice = getAnnualPrice( price, currencyCode );
 		const monthlyPrice = getMonthlyPrice( price, currencyCode );
@@ -163,14 +159,13 @@ class Email extends React.Component {
 					selectedDomainName={ selectedDomainName }
 					selectedSite={ selectedSite }
 				/>
-				{ this.addEmailForwardingCard() }
+				{ emailForwardingDomain && this.addEmailForwardingCard( emailForwardingDomain ) }
 			</Fragment>
 		);
 	}
 
-	addEmailForwardingCard() {
-		const { domains, selectedDomainName, selectedSite, translate } = this.props;
-		const domain = getEligibleGSuiteDomain( selectedDomainName, domains );
+	addEmailForwardingCard( domain ) {
+		const { selectedSite, translate } = this.props;
 		return (
 			<VerticalNav>
 				<VerticalNavItem path={ domainManagementEmailForwarding( selectedSite.slug, domain ) }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds logic to determine if a site can use email forwarding
* Adds new lib functions to decide what screens to show on email page
* Adds tests for new lib functions

#### Testing instructions

* Have site mapped to wpcom
* Have site registered at wpcom but mapped out
* Have site registered at wpcom

* goto sites
* goto domains
* click email tab
* Observe
* Click email forwarding if avail
* Go back
* click on domain then email
* Click email forwarding if avail

If a domain is mapped to wpcom and does not have G Suite you should see email forwarding option
If a domain is registered at wpcom and does not have G Suite you should see email forwarding option
If a domain is registered at wpcom and pointed elsewhere you should not see email forwarding option
If a domain already has G Suite you should not see email forwarding option

