### PR TITLE
Gutenframe: Add support for Press This/Reblog

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -42,6 +42,7 @@ class CalypsoifyIframe extends Component {
 		postId: PropTypes.number,
 		postType: PropTypes.string,
 		duplicatePostId: PropTypes.number,
+		pressThis: PropTypes.object,
 	};
 
 	state = {
@@ -158,6 +159,16 @@ class CalypsoifyIframe extends Component {
 		}
 
 		this.setState( { isMediaModalVisible: false } );
+	};
+
+	pressThis = () => {
+		const { pressThis } = this.props;
+		if ( pressThis ) {
+			this.iframePort.postMessage( {
+				action: 'pressThis',
+				payload: pressThis,
+			} );
+		}
 	};
 
 	render() {

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -87,6 +87,9 @@ class CalypsoifyIframe extends Component {
 
 			//once the iframe is loaded and the port exchanged, we no longer need to listen for message
 			window.removeEventListener( 'message', this.onMessage, false );
+
+			// Check if we're generating a post via Press This
+			this.pressThis();
 		}
 	};
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -147,6 +147,11 @@ export const redirect = ( { store: { getState } }, next ) => {
 	return page.redirect( `/post/${ getSelectedSiteSlug( state ) }` );
 };
 
+function getPressThisData( query ) {
+	const { text, url, title, image, embed } = query;
+	return url ? { text, url, title, image, embed } : null;
+}
+
 export const post = ( context, next ) => {
 	//see post-editor/controller.js for reference
 
@@ -171,6 +176,7 @@ export const post = ( context, next ) => {
 				postId={ postId }
 				postType={ postType }
 				duplicatePostId={ duplicatePostId }
+				pressThis={ pressThis }
 			/>
 		);
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -167,6 +167,7 @@ export const post = ( context, next ) => {
 	if ( config.isEnabled( 'calypsoify/iframe' ) ) {
 		const state = context.store.getState();
 		const siteId = getSelectedSiteId( state );
+		const pressThis = getPressThisData( context.query );
 
 		// Set postId on state.ui.editor.postId, so components like editor revisions can read from it.
 		context.store.dispatch( { type: EDITOR_START, siteId, postId } );

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -17,7 +17,7 @@ import { get, has, startsWith } from 'lodash';
  */
 import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/actions';
-import { addSiteFragment } from 'lib/route';
+import { addQueryArgs, addSiteFragment } from 'lib/route';
 import PostEditor from './post-editor';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { startEditingNewPost, stopEditingPost } from 'state/ui/editor/actions';
@@ -178,7 +178,10 @@ async function maybeCalypsoifyGutenberg( context, next ) {
 		( isCalypsoifyGutenbergEnabled( state, siteId ) || isGutenlypsoEnabled( state, siteId ) ) &&
 		'gutenberg' === getSelectedEditor( state, siteId )
 	) {
-		return window.location.replace( getEditorUrl( state, siteId, postId, postType ) );
+		let url = getEditorUrl( state, siteId, postId, postType );
+		// pass along parameters, for example press-this
+		url = addQueryArgs( context.query, url );
+		return window.location.replace( url );
 	}
 	next();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add support for sharing posts from the reader or using the Press This bookmarklet.

<img width="855" alt="screen shot 2019-03-01 at 18 27 45" src="https://user-images.githubusercontent.com/1233880/53655172-c82d3680-3c4f-11e9-9908-cd77eb4248e6.png">
<img width="1270" alt="screen shot 2019-03-01 at 18 27 56" src="https://user-images.githubusercontent.com/1233880/53655166-c4011900-3c4f-11e9-86a6-5e9556200492.png">
<img width="1191" alt="screen shot 2019-03-01 at 18 15 03" src="https://user-images.githubusercontent.com/1233880/53654409-fc9ff300-3c4d-11e9-8599-1ac802f331d9.png">


#### Testing instructions

**Pre-requisites**
* Apply D25028-code

**Share a post from the reader**

* Go to the reader http://calypso.localhost:3000.
* Select a post and click on the share post icon.
* Select your sandbox site.
* Make sure the new post automatically contains blocks based on the content of the shared post:
  * An image block for the first image previewed on the reader.
  * A quote block with the excerpt of the post and a link to the original post as citation.
  * An embed block if the post contains embeds such as YouTube videos or tweets.
* Check that the post title is generated with the title of the original post and the site name when the original post has been published.

![mar-01-2019 18-35-36](https://user-images.githubusercontent.com/1233880/53655596-e9daed80-3c50-11e9-97c3-f4e7c16719d0.gif)

**Share a post from the Press This bookmarklet**

* Go to the writing settings of your site http://calypso.localhost:3000/settings/writing/example.wordpress.com.
* Save the Press This bookmarklet.
* Use the bookmarklet on another URL.
* Make sure the new post automatically contains blocks based on the content of the shared page:
  ** A quote block with the selected text (if you selected any text before using the bookmarklet) and a link to the original post as citation.
* Check that the post title is generated by the title of the original page.

![mar-01-2019 18-39-41](https://user-images.githubusercontent.com/1233880/53655766-6ec60700-3c51-11e9-8fba-e2dab8d01604.gif)

Fixes #28973 
Fixes #28548
