### PR TITLE
Squarespace Importer: Verbiage Enhancements

### DIFF
--- a/client/my-sites/importer/importer-squarespace.jsx
+++ b/client/my-sites/importer/importer-squarespace.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -47,11 +45,11 @@ class ImporterSquarespace extends React.PureComponent {
 				}
 			),
 			uploadDescription: this.props.translate(
-				'To import content from a %(importerName)s site to ' +
-					'{{b}}%(siteTitle)s{{/b}}, upload your ' +
-					'{{b}}%(importerName)s export file{{/b}} here. ' +
-					"Don't have one, or don't know where to find one? " +
-					'Get step by step instructions in our {{inlineSupportLink/}}.',
+				'Upload a {{b}}%(importerName)s export file{{/b}} ' +
+					'to start importing into {{b}}%(siteTitle)s{{/b}}. ' +
+					'A %(importerName)s export file is an XML file ' +
+					'containing your page and post content. ' +
+					'Need help {{inlineSupportLink/}}?',
 				{
 					args: {
 						importerName,
@@ -63,7 +61,7 @@ class ImporterSquarespace extends React.PureComponent {
 							<InlineSupportLink
 								supportPostId={ 87696 }
 								supportLink={ 'https://en.support.wordpress.com/import/import-from-squarespace' }
-								text={ this.props.translate( '%(importerName)s import guide', {
+								text={ this.props.translate( 'exporting your content', {
 									args: {
 										importerName,
 									},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switches the wording of the Squarespace importer instructions to the one in the original issue in favour of being more clear 

#### Testing instructions

At the `/settings/import/site` route, click "Squarespace". Does the description look identical to the description of the screenshot in the original issues? Here's what it is now, for comparison:

![fgddfgfgd](https://user-images.githubusercontent.com/43215253/53693233-70004c80-3d95-11e9-9e80-b5273c092c46.png)

cc @dezzie, @spen, @dmsnell 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Fixes #30559
