### PR TITLE
Colour Scheming: Remove Orange Jazzy

### DIFF
--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -175,7 +175,11 @@
 	--color-error-800-rgb: #{hex-to-rgb( $muriel-hot-red-800 )};
 	--color-error-900: #{$muriel-hot-red-900};
 	--color-error-900-rgb: #{hex-to-rgb( $muriel-hot-red-900 )};
-
+	
+	--color-orange: #{$muriel-hot-orange-500};	
+	--color-orange-dark: #{$muriel-hot-orange-700};
+	--color-orange-light: #{$muriel-hot-orange-300};
+	
 	--color-surface: #{$muriel-white};
 	--color-surface-backdrop: #{$muriel-gray-0};
 	--color-surface-backdrop-rgb: #{hex-to-rgb( $muriel-gray-0 )};

--- a/assets/stylesheets/shared/_color-schemes.scss
+++ b/assets/stylesheets/shared/_color-schemes.scss
@@ -176,9 +176,9 @@
 	--color-error-900: #{$muriel-hot-red-900};
 	--color-error-900-rgb: #{hex-to-rgb( $muriel-hot-red-900 )};
 	
-	--color-orange: #{$muriel-hot-orange-500};	
-	--color-orange-dark: #{$muriel-hot-orange-700};
-	--color-orange-light: #{$muriel-hot-orange-300};
+	--color-hot-orange: #{$muriel-hot-orange-500};	
+	--color-hot-orange-dark: #{$muriel-hot-orange-700};
+	--color-hot-orange-light: #{$muriel-hot-orange-300};
 	
 	--color-surface: #{$muriel-white};
 	--color-surface-backdrop: #{$muriel-gray-0};

--- a/assets/stylesheets/shared/_colors.scss
+++ b/assets/stylesheets/shared/_colors.scss
@@ -24,9 +24,6 @@ $gray-lighten-20: $muriel-gray-100; // #c8d7e1
 //
 // See wordpress.com/design-handbook/colors/ for more info.
 
-// Secondary Accent (Oranges)
-$orange-jazzy: #f0821e;
-
 // Essentials
 $white: $muriel-white;
 $transparent: rgba( 255, 255, 255, 0 );

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -20,8 +20,8 @@ $autobar-height: 20px;
 
 	.is-support-session & {
 		// DO NOT style these with theme colors. We want them to override whatever theme colors the user has picked.
-		background: $orange-jazzy;
-		border-bottom: 1px solid darken( $orange-jazzy, 4% );
+		background: var( --color-orange );
+		border-bottom: 1px solid var( --color-orange-light );
 	}
 
 	.is-section-theme &,
@@ -121,7 +121,7 @@ $autobar-height: 20px;
 	}
 
 	.is-support-session &.is-active {
-		background: darken( $orange-jazzy, 10% );
+		background: var( --color-orange-dark );
 	}
 
 	@include breakpoint( '<480px' ) {
@@ -252,7 +252,7 @@ $autobar-height: 20px;
 	.is-support-session &:focus,
 	.is-support-session &:hover,
 	.is-support-session &:visited {
-		color: $orange-jazzy;
+		color: var( --color-orange );
 	}
 
 	.is-support-session &.is-active {

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -20,8 +20,8 @@ $autobar-height: 20px;
 
 	.is-support-session & {
 		// DO NOT style these with theme colors. We want them to override whatever theme colors the user has picked.
-		background: var( --color-orange );
-		border-bottom: 1px solid var( --color-orange-light );
+		background: var( --color-hot-orange );
+		border-bottom: 1px solid var( --color-hot-orange-light );
 	}
 
 	.is-section-theme &,
@@ -121,7 +121,7 @@ $autobar-height: 20px;
 	}
 
 	.is-support-session &.is-active {
-		background: var( --color-orange-dark );
+		background: var( --color-hot-orange-dark );
 	}
 
 	@include breakpoint( '<480px' ) {
@@ -252,7 +252,7 @@ $autobar-height: 20px;
 	.is-support-session &:focus,
 	.is-support-session &:hover,
 	.is-support-session &:visited {
-		color: var( --color-orange );
+		color: var( --color-hot-orange );
 	}
 
 	.is-support-session &.is-active {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes $orange-jazzy and replaces all variables which use it.

#### Testing instructions

The problem is that there's a slight difference in colours, mainly for the active state but also just for normal...it may look worse for me though because I've looked at each one at least a dozen times in a row. 

**Current:**

![hjghjgghjgh](https://user-images.githubusercontent.com/43215253/53695552-f7a98380-3db4-11e9-89bb-932db46f61f8.png)

**Proposed:**

![hgfhgfgfh](https://user-images.githubusercontent.com/43215253/53695555-ff692800-3db4-11e9-9ae5-d1218156b634.png)

The intention was to keep the proposed colours as close to the current as possible, whilst also keeping dark at 700 and light at 300. Are those colours okay? cc @drw158 

In order to test, add the `is-support-session` class to the body, and then take a look around the masterbar. They only appear when in a support session...my guess is that means live chat, but no clue.

cc @flootr, @blowery, @drw158 