### PR TITLE
Slideshow: Replace BUTTONs with DIVs

### DIFF
--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -151,17 +151,20 @@ class Slideshow extends Component {
 						className="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-white"
 						ref={ this.paginationRef }
 					/>
-					<button
+					<div
 						className="wp-block-jetpack-slideshow_button-prev swiper-button-prev swiper-button-white"
 						ref={ this.btnPrevRef }
+						role="button"
 					/>
-					<button
+					<div
 						className="wp-block-jetpack-slideshow_button-next swiper-button-next swiper-button-white"
 						ref={ this.btnNextRef }
+						role="button"
 					/>
-					<button
+					<div
 						aria-label={ __( 'Pause Slideshow' ) }
 						className="wp-block-jetpack-slideshow_button-pause"
+						role="button"
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is one of two PRs that resolve the issue caused by WPCOM stripping out `<button/>` elements, which causes the Slideshow block to become invalid on save. In this one, the `<button/>` elements are replaced by `<div/>`s.

Alternate approach here: https://github.com/Automattic/wp-calypso/pull/31175

#### Testing instructions

- Check out this branch in local `wp-calypso` repo
- From within the `wp-calypso` folder, generate new blocks code targeting your sandbox's `blocks-staging` directory. The SDK command should look like this: `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir={PATH-TO-SANDBOX}/wp-content/mu-plugins/jetpack/_inc/blocks-staging/` 
- Manually upload `blocks-staging` directory to your sandbox.
- From root of `wp-calypso`, start local Calypso: `npm start`.
- Navigate to http://calypso.localhost:3000/
- Create a post, then add Slideshow block.
- Turn on Autoplay, so that you will see all three buttons (prev/next/pause)
- Inspect the block and verify that the three buttons are now `<div/>` elements with `role="button"`
- Save the post and refresh the page. Verify that the block is not invalidated.

Fixes https://github.com/Automattic/wp-calypso/issues/31029
