### PR TITLE
Slideshow: Replace Buttons With A Tags

### DIFF
--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -156,23 +156,17 @@ class Slideshow extends Component {
 						className="wp-block-jetpack-slideshow_button-prev swiper-button-prev swiper-button-white"
 						ref={ this.btnPrevRef }
 						role="button"
-					>
-						{ __( 'Previous Slide' ) }
-					</a>
+					/>
 					<a
 						className="wp-block-jetpack-slideshow_button-next swiper-button-next swiper-button-white"
 						ref={ this.btnNextRef }
 						role="button"
-					>
-						{ __( 'Next Slide' ) }
-					</a>
+					/>
 					<a
 						aria-label={ __( 'Pause Slideshow' ) }
 						className="wp-block-jetpack-slideshow_button-pause"
 						role="button"
-					>
-						{ __( 'Pause Slideshow' ) }
-					</a>
+					/>
 				</div>
 			</div>
 		);

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -105,6 +105,7 @@ class Slideshow extends Component {
 		const { autoplay, className, delay, effect, images } = this.props;
 		// Note: React omits the data attribute if the value is null, but NOT if it is false.
 		// This is the reason for the unusual logic related to autoplay below.
+		/* eslint-disable jsx-a11y/anchor-is-valid */
 		return (
 			<div
 				className={ className }
@@ -151,21 +152,31 @@ class Slideshow extends Component {
 						className="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-white"
 						ref={ this.paginationRef }
 					/>
-					<button
+					<a
 						className="wp-block-jetpack-slideshow_button-prev swiper-button-prev swiper-button-white"
 						ref={ this.btnPrevRef }
-					/>
-					<button
+						role="button"
+					>
+						{ __( 'Previous Slide' ) }
+					</a>
+					<a
 						className="wp-block-jetpack-slideshow_button-next swiper-button-next swiper-button-white"
 						ref={ this.btnNextRef }
-					/>
-					<button
+						role="button"
+					>
+						{ __( 'Next Slide' ) }
+					</a>
+					<a
 						aria-label={ __( 'Pause Slideshow' ) }
 						className="wp-block-jetpack-slideshow_button-pause"
-					/>
+						role="button"
+					>
+						{ __( 'Pause Slideshow' ) }
+					</a>
 				</div>
 			</div>
 		);
+		/* eslint-enable jsx-a11y/anchor-is-valid */
 	}
 
 	prefersReducedMotion = () => {

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -3,7 +3,6 @@
  */
 import ResizeObserver from 'resize-observer-polyfill';
 import classnames from 'classnames';
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { Component, createRef } from '@wordpress/element';
 import { isBlobURL } from '@wordpress/blob';
 import { isEqual } from 'lodash';
@@ -159,7 +158,7 @@ class Slideshow extends Component {
 						role="button"
 					/>
 					<a
-						aria-label={ __( 'Pause Slideshow' ) }
+						aria-label="Pause Slideshow"
 						className="wp-block-jetpack-slideshow_button-pause"
 						role="button"
 					/>

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -148,10 +148,6 @@ class Slideshow extends Component {
 							</li>
 						) ) }
 					</ul>
-					<div
-						className="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-white"
-						ref={ this.paginationRef }
-					/>
 					<a
 						className="wp-block-jetpack-slideshow_button-prev swiper-button-prev swiper-button-white"
 						ref={ this.btnPrevRef }
@@ -166,6 +162,10 @@ class Slideshow extends Component {
 						aria-label={ __( 'Pause Slideshow' ) }
 						className="wp-block-jetpack-slideshow_button-pause"
 						role="button"
+					/>
+					<div
+						className="wp-block-jetpack-slideshow_pagination swiper-pagination swiper-pagination-white"
+						ref={ this.paginationRef }
 					/>
 				</div>
 			</div>

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -49,6 +49,7 @@
 		object-fit: contain;
 	}
 
+	/* Approach to hiding text in the buttons from http://www.zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement/ */
 	.wp-block-jetpack-slideshow_button-prev,
 	.wp-block-jetpack-slideshow_button-next,
 	.wp-block-jetpack-slideshow_button-pause {
@@ -60,8 +61,11 @@
 		border-radius: 4px;
 		height: 48px;
 		margin: -24px 0 0;
+		overflow: hidden;
 		padding: 0;
+		text-indent: 100%;
 		transition: background-color 250ms;
+		white-space: nowrap;
 		width: 48px;
 
 		&:focus,

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -49,7 +49,6 @@
 		object-fit: contain;
 	}
 
-	/* Approach to hiding text in the buttons from http://www.zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement/ */
 	.wp-block-jetpack-slideshow_button-prev,
 	.wp-block-jetpack-slideshow_button-next,
 	.wp-block-jetpack-slideshow_button-pause {
@@ -61,11 +60,8 @@
 		border-radius: 4px;
 		height: 48px;
 		margin: -24px 0 0;
-		overflow: hidden;
 		padding: 0;
-		text-indent: 100%;
 		transition: background-color 250ms;
-		white-space: nowrap;
 		width: 48px;
 
 		&:focus,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is one of two PRs that resolve the issue caused by WPCOM stripping out `<button/>` elements, which causes the Slideshow block to become invalid on save. In this one, the `<button/>` elements are replaced by `<a/>`s.

The alternate approach is here: https://github.com/Automattic/wp-calypso/pull/31174

#### Testing instructions

- Check out this branch in local `wp-calypso` repo
- From within the `wp-calypso` folder, generate new blocks code targeting your sandbox's `blocks-staging` directory. The SDK command should look like this: `npm run sdk gutenberg client/gutenberg/extensions/presets/jetpack -- --output-dir={PATH-TO-SANDBOX}/wp-content/mu-plugins/jetpack/_inc/blocks-staging/` 
- Manually upload `blocks-staging` directory to your sandbox.
- From root of `wp-calypso`, start local Calypso: `npm start`.
- Navigate to http://calypso.localhost:3000/
- Create a post, then add Slideshow block.
- Turn on Autoplay, so that you will see all three buttons (prev/next/pause)
- Inspect the block and verify that the three buttons are now `<a/>` elements
- Save the post and refresh the page. Verify that the block is not invalidated.

Fixes https://github.com/Automattic/wp-calypso/issues/31029
