### PR TITLE
lib/abtest: avoid using moment.js from i18n-calypso

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -7,6 +7,7 @@ import debugFactory from 'debug';
 import { every, get, includes, isArray, keys, reduce, some } from 'lodash';
 import store from 'store';
 import i18n from 'i18n-calypso';
+import moment from 'moment';
 
 /**
  * Internal dependencies
@@ -59,7 +60,7 @@ export const getAllTests = () => keys( activeTests ).map( ABTest );
 const isUserSignedIn = () => user && user.get() !== false;
 
 const parseDateStamp = datestamp => {
-	const date = i18n.moment( datestamp, 'YYYYMMDD' );
+	const date = moment( datestamp, 'YYYYMMDD' );
 
 	if ( ! date.isValid() ) {
 		throw new Error( 'The date ' + datestamp + ' should be in the YYYYMMDD format' );
@@ -249,7 +250,7 @@ ABTest.prototype.isEligibleForAbTest = function() {
 };
 
 ABTest.prototype.hasTestStartedYet = function() {
-	return i18n.moment().isAfter( this.startDate );
+	return moment().isAfter( this.startDate );
 };
 
 ABTest.prototype.hasBeenInPreviousSeriesTest = function() {
@@ -269,7 +270,7 @@ ABTest.prototype.hasBeenInPreviousSeriesTest = function() {
 };
 
 ABTest.prototype.hasRegisteredBeforeTestBegan = function() {
-	return user && user.get() && i18n.moment( user.get().date ).isBefore( this.startDate );
+	return user && user.get() && moment( user.get().date ).isBefore( this.startDate );
 };
 
 ABTest.prototype.getSavedVariation = function() {


### PR DESCRIPTION
Stop relying on `moment` instance provided by `i18n-calypso` and just import the library directly.

`moment` will be eventually removed from `i18n-calypso` and in `lib/abtest`, it's not used for anything i18n-related. It's used for parsing dates in ISO format (`test.startDate` and `user.date`) and comparing timestamps to each other.

**How to test:**
Two use cases are affected by this: users should never be assigned to a test variation
- until the test officially starts (as specified in `startDate`
- if their account was registered before the start data and `allowExistingUsers` test flag is not `true`