### PR TITLE
Prevent editing trashed posts

### DIFF
--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -140,7 +140,8 @@ class PostItem extends React.Component {
 
 		const title = post ? post.title : null;
 		const isPlaceholder = ! globalId;
-		const enabledPostLink = isPlaceholder || multiSelectEnabled ? null : postUrl;
+		const isTrashed = post && 'trash' === post.status;
+		const enabledPostLink = isPlaceholder || multiSelectEnabled || isTrashed ? null : postUrl;
 
 		const panelClasses = classnames( 'post-item__panel', className, {
 			'is-untitled': ! title,

--- a/client/my-sites/post-type-list/post-thumbnail.jsx
+++ b/client/my-sites/post-type-list/post-thumbnail.jsx
@@ -29,7 +29,7 @@ function PostTypeListPostThumbnail( { onClick, thumbnail, postLink } ) {
 		<div className={ classes }>
 			{ thumbnail && (
 				<a href={ postLink } className="post-type-list__post-thumbnail-link">
-					<img
+					<img //eslint-disable-line
 						src={ resizeImageUrl( safeImageUrl( thumbnail ), { h: 80 } ) }
 						className="post-type-list__post-thumbnail"
 						onClick={ onClick }
@@ -60,9 +60,11 @@ export default connect( ( state, ownProps ) => {
 	const postUrl = canCurrentUserEditPost( state, ownProps.globalId )
 		? getEditorPath( state, siteId, postId )
 		: get( post, 'URL' );
+	const isTrashed = post && 'trash' === post.status;
 
 	// Null if the item is a placeholder or bulk edit mode is active.
-	const postLink = ! ownProps.globalId || isMultiSelectEnabled( state ) ? null : postUrl;
+	const postLink =
+		! ownProps.globalId || isMultiSelectEnabled( state ) || isTrashed ? null : postUrl;
 
 	return { thumbnail, postLink };
 } )( PostTypeListPostThumbnail );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the introduction of Gutenframe we lose the Calypso restore dialog when we try to edit a trashed post because core doesn't load items that are in the Trash ([#](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/post.php?rev=44726#L134)).

![screen shot 2019-02-21 at 18 21 26](https://user-images.githubusercontent.com/233601/53202537-87a53b80-3605-11e9-85ee-bf18cc496fa7.png)

This PR prevents loading trashed posts in the editor by disabling the post link used in the Posts list page.

We could also display the restore dialog within the Posts list page if the user attempts to open a trashed post, but I didn't consider that worth it provided we have ability to restore a post from the post actions (by clicking on the ellipsis menu).

<img width="754" alt="screen shot 2019-03-04 at 13 31 03" src="https://user-images.githubusercontent.com/1233880/53733615-c945aa00-3e81-11e9-9753-b4a65574bc62.png">


#### Testing instructions

* Go to the trashed posts list: http://calypso.localhost:3000/posts/trashed
* Make sure you cannot load any post by clicking on it.

Fixes #30946
