### PR TITLE
Tiled gallery block: camel case product name

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/edit.jsx
+++ b/client/gutenberg/extensions/tiled-gallery/edit.jsx
@@ -192,7 +192,7 @@ class TiledGalleryEdit extends Component {
 						icon={ <div className="tiled-gallery__media-placeholder-icon">{ icon }</div> }
 						className={ className }
 						labels={ {
-							title: __( 'Tiled gallery' ),
+							title: __( 'Tiled Gallery' ),
 							name: __( 'images' ),
 						} }
 						onSelect={ this.onSelectImages }
@@ -212,7 +212,7 @@ class TiledGalleryEdit extends Component {
 			<Fragment>
 				{ controls }
 				<InspectorControls>
-					<PanelBody title={ __( 'Tiled gallery settings' ) }>
+					<PanelBody title={ __( 'Tiled Gallery settings' ) }>
 						{ layoutSupportsColumns( layoutStyle ) && images.length > 1 && (
 							<RangeControl
 								label={ __( 'Columns' ) }


### PR DESCRIPTION
Camel case Tiled Gallery product name consistently.

Resolves #30943

#### Testing instructions

- Add tiled gallery block in the editor gutenpack-jn
- Observe _"Tiled Gallery"_ in the media placeholder and in the sidebar as well in the block picker
