### PR TITLE
VideoPress: Disable re-usable block feature for video blocks

### DIFF
--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -95,7 +95,7 @@ const addVideoPressSupport = ( settings, name ) => {
 			},
 
 			supports: {
-				...settings.support,
+				...settings.supports,
 				reusable: false,
 			},
 

--- a/client/gutenberg/extensions/videopress/editor.js
+++ b/client/gutenberg/extensions/videopress/editor.js
@@ -94,6 +94,11 @@ const addVideoPressSupport = ( settings, name ) => {
 				],
 			},
 
+			supports: {
+				...settings.support,
+				reusable: false,
+			},
+
 			edit: withVideoPressEdit( settings.edit ),
 
 			save: withVideoPressSave( settings.save ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR prevents to add the VideoPress-enhanced video blocks to list of the reusable blocks in order to avoid the issue described in #31178 (player not rendered on the published view).

This is a temporary fix for the Jetpack 7.1 release and we should properly support reusable blocks in a follow-up PR.

#### Testing instructions

* Select an environment:
  * Gutenlypso.  
    * Start Calypso with Calypsoify Iframe disabled: `DISABLE_FEATURES=calypsoify/iframe npm start`.
    * Go to `/block-editor`.
    * Select a site under a premium/business plan.
  * Jetpack.
    * [Create a new JN site using the extensions from this branch](https://jurassic.ninja/create?gutenpack&calypsobranch=update/videopress-gutenberg-disable-reusable&jetpack-beta&shortlived&wp-debug-log).
    * Connect to WP.com using a premium/business subscription.
    * Go to Settings → Jetpack Constants in the site’s wp-admin and set `JETPACK_BETA_BLOCKS` to true.
    * Go to Jetpack → Settings and activate the VideoPress module (by enabling the "Enable high-speed, ad-free video player" option).
    * Go to Posts → New.
* Insert a video block.
* Make sure you cannot add it to Reusable Blocks.

<img width="655" alt="screen shot 2019-03-04 at 15 29 51" src="https://user-images.githubusercontent.com/1233880/53739638-83451200-3e92-11e9-8cd1-3171cd614485.png">

Fixes #31178
