### PR TITLE
Gutenframe: Display success message after trashing a post

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -31,6 +31,7 @@ import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
 import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 import { startEditingPost } from 'state/ui/editor/actions';
 import { Placeholder } from './placeholder';
+import { trashPost } from 'state/posts/actions';
 
 /**
  * Style dependencies
@@ -125,8 +126,10 @@ class CalypsoifyIframe extends Component {
 			}
 		}
 
-		if ( 'postTrashed' === action ) {
-			this.props.navigate( this.props.postTypeTrashUrl );
+		if ( 'trashPost' === action ) {
+			const { siteId, postId, postTypeTrashUrl } = this.props;
+			this.props.trashPost( siteId, postId );
+			this.props.navigate( postTypeTrashUrl );
 		}
 
 		if ( 'goToAllPosts' === action ) {
@@ -252,6 +255,7 @@ const mapDispatchToProps = {
 	navigate,
 	openPostRevisionsDialog,
 	startEditingPost,
+	trashPost,
 };
 
 export default connect(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to https://github.com/Automattic/wp-calypso/pull/30701. 

This PR moves the logic of trashing a post in Guteframe to Calypso. It reuses the available `trashPost` action that, apart from moving a post to the trash, displays a success message when the operation is done with the possibility to undo it.

<img width="876" alt="screen shot 2019-03-04 at 16 08 39" src="https://user-images.githubusercontent.com/1233880/53741946-cc4b9500-3e97-11e9-880a-96c722c20e21.png">


#### Testing instructions

* Sandbox a WordPress.com site and apply D25077-code.
* Open a post on the sandboxed site.
* Move the post to the trash by clicking on the "Move to trash" button in the sidebar.
* Make sure you're redirected to the list of trashed posts.
* Make sure you see a success message that includes an "Undo" action.
* Click on the "Undo" action.
* Confirm the post is restored.