### PR TITLE
Fix WordAds block alignment

### DIFF
--- a/client/gutenberg/extensions/wordads/edit.js
+++ b/client/gutenberg/extensions/wordads/edit.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import classNames from 'classnames';
 import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import { BlockControls } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
@@ -19,10 +18,7 @@ import './editor.scss';
 class WordAdsEdit extends Component {
 	render() {
 		const { attributes, setAttributes } = this.props;
-		const { align, format } = attributes;
-		const classes = classNames( 'wp-block-jetpack-wordads', `jetpack-wordads-${ format }`, {
-			[ `align${ align }` ]: align,
-		} );
+		const { format } = attributes;
 		const selectedFormatObject = AD_FORMATS.filter( ( { tag } ) => tag === format )[ 0 ];
 
 		return (
@@ -33,7 +29,7 @@ class WordAdsEdit extends Component {
 						onChange={ nextFormat => setAttributes( { format: nextFormat } ) }
 					/>
 				</BlockControls>
-				<div className={ classes }>
+				<div className={ `wp-block-jetpack-wordads jetpack-wordads-${ format }` }>
 					<div
 						className="jetpack-wordads__ad"
 						style={ {

--- a/client/gutenberg/extensions/wordads/editor.scss
+++ b/client/gutenberg/extensions/wordads/editor.scss
@@ -1,11 +1,9 @@
 .wp-block-jetpack-wordads {
 	background: var( --color-white );
+}
 
-	&.aligncenter {
-		.jetpack-wordads__ad {
-			margin: 0 auto;
-		}
-	}
+[data-type='jetpack/wordads'][data-align='center'] .jetpack-wordads__ad {
+	margin: 0 auto;
 }
 
 .jetpack-wordads__header,


### PR DESCRIPTION
Remove content floating by removing conflicting align{left,right,center}
classes.

Gutenberg styling handles left/right alignment.

Apply center alignment based on data-align attributes.

## Testing instructions

* Is #31185 improved?
* Add a mixture of WordAds blocks with different alignments and other blocks.
* Does the layout in the editor make sense?
* Test different formats.

## Screens

Four left-aligned rectangles before a paragraph:

![screen shot 2019-03-04 at 16 21 19](https://user-images.githubusercontent.com/841763/53742863-ea19f980-3e99-11e9-87bc-3c966e199f31.png)


Fixes #31185
