### PR TITLE
Don't re-render processing screen while adding a new site

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -598,7 +598,7 @@ class Signup extends React.Component {
 
 		// Removes flicker of steps that have been removed from the flow
 		const waitToRenderReturnValue = this.shouldWaitToRender();
-		if ( waitToRenderReturnValue ) {
+		if ( waitToRenderReturnValue && ! this.state.shouldShowLoadingScreen ) {
 			return this.props.siteId && waitToRenderReturnValue;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug wherein the processing screen is shown twice while Adding a new site.

**BEFORE**: 

![giphy](https://user-images.githubusercontent.com/1269602/53779979-53484e00-3f28-11e9-80ea-47c8e16a1cb1.gif)


AFTER:

![giphy 1](https://user-images.githubusercontent.com/1269602/53780100-c3ef6a80-3f28-11e9-8c2f-4c0e23c2de0c.gif)

#### Testing instructions

1. In an existing logged in account, click `ADD NEW SITE` and go through the nux flow.
2. Verify that the processing screen shows only once. 

Fixes one of the issues listed in #31176 
