### PR TITLE
Change coupon code shown in Feb/March sale banner to MARCH20

### DIFF
--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -61,7 +61,7 @@ export default [
 		endsAt: new Date( 2019, 2, 8, 0, 0, 0 ),
 		nudgeText: 'Sale! 20% off all plans',
 		ctaText: 'Upgrade',
-		plansPageNoticeText: 'Enter coupon code “FEBRUARY20” at checkout to claim your 20% discount',
+		plansPageNoticeText: 'Enter coupon code “MARCH20” at checkout to claim your 20% discount',
 		targetPlans: [
 			{ type: TYPE_FREE, group: GROUP_WPCOM },
 			{ type: TYPE_BLOGGER, group: GROUP_WPCOM },


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change coupon code from "FEBRUARY20" to "MARCH20".

#### Testing instructions

* A visual check should be fine
