### PR TITLE
Slideshow: Handle Swiper Load Failure

### DIFF
--- a/client/gutenberg/extensions/slideshow/edit.js
+++ b/client/gutenberg/extensions/slideshow/edit.js
@@ -196,6 +196,7 @@ class SlideshowEdit extends Component {
 					delay={ delay }
 					effect={ effect }
 					images={ images }
+					onError={ noticeOperations.createErrorNotice }
 				/>
 				<DropZone onFilesDrop={ this.addFiles } />
 				{ isSelected && (

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -38,10 +38,15 @@ class Slideshow extends Component {
 	}
 
 	componentDidMount() {
-		this.buildSwiper().then( swiper => {
-			this.swiperInstance = swiper;
-			this.initializeResizeObserver( swiper );
-		} );
+		const { onError } = this.props;
+		this.buildSwiper()
+			.then( swiper => {
+				this.swiperInstance = swiper;
+				this.initializeResizeObserver( swiper );
+			} )
+			.catch( () => {
+				onError( __( 'The Swiper library could not be loaded.' ) );
+			} );
 	}
 
 	componentWillUnmount() {
@@ -50,7 +55,7 @@ class Slideshow extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { align, autoplay, delay, effect, images } = this.props;
+		const { align, autoplay, delay, effect, images, onError } = this.props;
 
 		/* A change in alignment or images only needs an update */
 		if ( align !== prevProps.align || ! isEqual( images, prevProps.images ) ) {
@@ -68,10 +73,14 @@ class Slideshow extends Component {
 					? this.swiperInstance.realIndex
 					: prevProps.images.length;
 			this.swiperInstance && this.swiperInstance.destroy( true, true );
-			this.buildSwiper( realIndex ).then( swiper => {
-				this.swiperInstance = swiper;
-				this.initializeResizeObserver( swiper );
-			} );
+			this.buildSwiper( realIndex )
+				.then( swiper => {
+					this.swiperInstance = swiper;
+					this.initializeResizeObserver( swiper );
+				} )
+				.catch( () => {
+					onError( __( 'The Swiper library could not be loaded.' ) );
+				} );
 		}
 	}
 

--- a/client/gutenberg/extensions/slideshow/view.js
+++ b/client/gutenberg/extensions/slideshow/view.js
@@ -48,17 +48,23 @@ typeof window !== 'undefined' &&
 					paginationRender: swiperPaginationRender,
 					transitionEnd: swiperApplyAria,
 				}
-			).then( swiper => {
-				new ResizeObserver( () => {
-					if ( pendingRequestAnimationFrame ) {
-						cancelAnimationFrame( pendingRequestAnimationFrame );
-						pendingRequestAnimationFrame = null;
-					}
-					pendingRequestAnimationFrame = requestAnimationFrame( () => {
-						swiperResize( swiper );
-						swiper.update();
-					} );
-				} ).observe( swiper.el );
-			} );
+			)
+				.then( swiper => {
+					new ResizeObserver( () => {
+						if ( pendingRequestAnimationFrame ) {
+							cancelAnimationFrame( pendingRequestAnimationFrame );
+							pendingRequestAnimationFrame = null;
+						}
+						pendingRequestAnimationFrame = requestAnimationFrame( () => {
+							swiperResize( swiper );
+							swiper.update();
+						} );
+					} ).observe( swiper.el );
+				} )
+				.catch( () => {
+					slideshowBlock
+						.querySelector( '.wp-block-jetpack-slideshow_container' )
+						.classList.add( 'wp-swiper-initialized' );
+				} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR catches and responds to the case where the Swiper library fails to load. 

#### Testing instructions

It's easiest to test this functionality in local Jetpack docker instances.

- Checkout this branch, and run an SDK build.
- In Jetpack repo, navigate to `_inc/blocks`, and rename (or delete) `swiper.js`
- Add a Slideshow block and add or pick a few images.
- You should see a typical editor notification that reads "The Swiper library could not be loaded."
- Publish the post and view it.
- You should see a fairly normal representation of the block which is non-functional: buttons don't work, etc. 
