### PR TITLE
Gutenframe: Enable the iframed block editor in all environments.

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -20,7 +20,7 @@
 		"automated-transfer": true,
 		"blogger-plan": false,
 		"calypsoify/gutenberg": true,
-		"calypsoify/iframe": false,
+		"calypsoify/iframe": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -22,7 +22,7 @@
 		"automated-transfer": true,
 		"blogger-plan": false,
 		"calypsoify/gutenberg": true,
-		"calypsoify/iframe": false,
+		"calypsoify/iframe": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/test.json
+++ b/config/test.json
@@ -33,7 +33,7 @@
 		"apple-pay": true,
 		"blogger-plan": false,
 		"calypsoify/gutenberg": true,
-		"calypsoify/iframe": false,
+		"calypsoify/iframe": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
 		"code-splitting": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,7 @@
 		"blogger-plan": false,
 		"comments/management/threaded-view": false,
 		"calypsoify/gutenberg": true,
-		"calypsoify/iframe": false,
+		"calypsoify/iframe": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
Enable the iframed block editor (AKA "Gutenframe") in all environments, including production. This will only affect simple sites, not Atomic or Jetpack sites.

**Testing Instructions**
* Start Calypso locally as if in production: `CALYPSO_ENV=production npm start`.
* Load a new post for a site that has the block editor enabled (`calypso.localhost:3000/block-editor/post/:site`).
* Verify the editor is an iframed `wp-admin` block editor.