### PR TITLE
Gutenframe: prevent lock takeover from disabling integrations

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -85,9 +85,6 @@ class CalypsoifyIframe extends Component {
 				portForIframe,
 			] );
 
-			//once the iframe is loaded and the port exchanged, we no longer need to listen for message
-			window.removeEventListener( 'message', this.onMessage, false );
-
 			// Check if we're generating a post via Press This
 			this.pressThis();
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When clicking the _Take Over_ button on the _This post is already being edited_ dialog, the refresh of the iframe disables **all** integrations (Media Modal, Revisions, etc).

![screen shot 2019-02-26 at 13 15 50](https://user-images.githubusercontent.com/233601/53427971-ab330200-39c8-11e9-8f02-64c1c9dc6dbc.png)

This PR makes the `CalypsoifyIframe` component to keep listening for `loaded` events from the Block Editor iframe, in case it gets refreshed by an action.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test this action you'll need a test site with two users, and either two different browsers or the same browser on a regular and an incognito sessions. We'll call them _Browser A_ and _Browser B_.

* Sandbox the site and apply this patch: D24835-code.
* Edit a post on _Browser A_.
* Edit the same post on _Browser B_.
* On _Browser B_, click the _Take Over_ button on the _This post is already being edited_ dialog.
* Switch to _Browser A_ and wait for the _Someone else has taken over this post._ dialog.
* Click _All Posts_ on _Browser A_.
* Edit the post again on _Browser A_, then  click the _Take Over_ button on the _This post is already being edited_ dialog.
* Switch to _Browser B_ and wait for the _Someone else has taken over this post._ dialog.
* Click _All Posts_ on _Browser B_.

Also, verify that there are no regressions for other integrations (like opening and closing the media modal multiple times after taking over a post).


