### PR TITLE
Checklist: Add a site logo checklist task

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -173,4 +173,12 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
+	checklistSiteLogo: {
+		datestamp: '20190226',
+		variations: {
+			icon: 50,
+			logo: 50,
+		},
+		defaultVariation: 'icon',
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -174,7 +174,7 @@ export default {
 		defaultVariation: 'original',
 	},
 	checklistSiteLogo: {
-		datestamp: '20190226',
+		datestamp: '20190305',
 		variations: {
 			icon: 50,
 			logo: 50,

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -66,6 +66,7 @@ class WpcomChecklistComponent extends PureComponent {
 			address_picked: this.renderAddressPickedTask,
 			blogname_set: this.renderBlogNameSetTask,
 			site_icon_set: this.renderSiteIconSetTask,
+			site_logo_set: this.renderSiteLogoSetTask,
 			blogdescription_set: this.renderBlogDescriptionSetTask,
 			avatar_uploaded: this.renderAvatarUploadedTask,
 			contact_page_updated: this.renderContactPageUpdatedTask,
@@ -443,6 +444,27 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Upload a site icon' ) }
+			/>
+		);
+	};
+
+	renderSiteLogoSetTask = ( TaskComponent, baseProps, task ) => {
+		const { translate, siteSlug } = this.props;
+
+		return (
+			<TaskComponent
+				{ ...baseProps }
+				bannerImageSrc="/calypso/images/stats/tasks/upload-icon.svg"
+				completedButtonText={ translate( 'Change' ) }
+				completedTitle={ translate( 'You uploaded a logo' ) }
+				description={ translate( 'Help people recognize your brand!' ) }
+				duration={ translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ) }
+				onClick={ this.handleTaskStart( {
+					task,
+					url: `/customize/identity/${ siteSlug }`,
+				} ) }
+				onDismiss={ this.handleTaskDismiss( task.id ) }
+				title={ translate( 'Upload your logo' ) }
 			/>
 		);
 	};

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -11,6 +11,7 @@ import config from 'config';
  */
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { getVerticalTaskList } from './vertical-task-list';
+import { getABTestVariation } from 'lib/abtest';
 
 const debug = debugModule( 'calypso:wpcom-task-list' );
 
@@ -41,7 +42,6 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 		getVerticalTaskList( siteVerticals ).forEach( addTask );
 	} else {
 		addTask( 'blogname_set' );
-		addTask( 'site_icon_set' );
 		addTask( 'blogdescription_set' );
 
 		if ( designType === 'blog' ) {
@@ -52,6 +52,19 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 
 		if ( designType === 'blog' ) {
 			addTask( 'post_published' );
+		}
+
+		// If there is a site segment and
+		// the user has already completed the logo task or
+		// if it's the AB variant
+		if (
+			segmentSlug &&
+			( get( taskStatuses, 'site_logo_set.completed' ) ||
+				'logo' === getABTestVariation( 'checklistSiteLogo' ) )
+		) {
+			addTask( 'site_logo_set' );
+		} else {
+			addTask( 'site_icon_set' );
 		}
 	}
 

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -58,6 +58,7 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 		// the user has already completed the logo task or
 		// if it's the AB variant
 		if (
+			hasTask( 'site_logo_set' ) &&
 			segmentSlug &&
 			( get( taskStatuses, 'site_logo_set.completed' ) ||
 				'logo' === getABTestVariation( 'checklistSiteLogo' ) )


### PR DESCRIPTION
## Changes proposed in this Pull Request

For sites created with a valid site type (segment), we're creating a 50/50 AB Test to replace the site icon task with an _Upload a site logo_ task:

<img width="780" alt="screen shot 2019-03-06 at 2 41 32 pm" src="https://user-images.githubusercontent.com/6458278/53854545-fcbd3b80-401d-11e9-919a-dafdb5700a6a.png">

Clicking on the logo task will take the user to the Customizer page and open the **Site Identity** panel

<img width="737" alt="screen shot 2019-03-05 at 6 44 38 pm" src="https://user-images.githubusercontent.com/6458278/53788766-c7114780-3f76-11e9-9215-420be209a9e0.png">

## Testing

### Site logo
1. Prepare a tea or a nice drink. 🍵You deserve it.
2. Apply `D24343-code`
3. Switch to the  `logo` variant for the `checklistSiteLogo` AB test.
4. Create a site (not a Business site, since the icon/logo task doesn't show) and **sandbox it**!
5. Head to the checklist and click on the **Upload your logo** task.
6. Ask yourself: _Have I been redirection to `http://calypso.localhost:3000/customize/identity/{mysite.com}` and does the **Site Identity** panel open?_
7. Return to the checklist. The site logo task is marked as completed, right?
7. Now upload a logo and **Publish**
8. Return to the checklist. Is the site logo task marked as completed?

### Site icon
1. Switch to the  `icon` variant for the `checklistSiteLogo` AB test.
2. Complete the site icon task^, and make sure it persists in the list.


^ _Just in case you were wondering, for private sites the site icon link will also [take you to the Customizer](https://github.com/Automattic/wp-calypso/blob/add/onboarding/ab-test-site-logo-checklist-task/client/my-sites/site-settings/site-icon-setting/index.jsx#L260)_