### PR TITLE
Docs: update packages docs

### DIFF
--- a/packages/README.md
+++ b/packages/README.md
@@ -1,15 +1,7 @@
 # Packages
 
-This directory exists to hold a variety of projects and libraries that we use in Calypso but also might publish as independent outputs or packages. For now it's empty but we expect a number of separate subdirectories soon.
+This directory exists to hold a variety of projects and libraries that we use in Calypso but also might publish as independent outputs or packages.
 
 ## Adding a new package?
 
-If you want to add a new project or package into this directory then follow these guidelines to help others who might stumble upon it later.
-
-1. Create a subdirectory with an appropriate descriptive name for what you are writing; contain all of your code in that subdirectory.
-2. Add a `README.md` file in that subdirectory explaining what the package is, why it exists, how to install it, and how to use it.
-3. Add a terse one-line description and link to the `README.md` file from this page.
-
-## Packages
-
- - who will share the first one?
+If you want to add a new project or package into this directory, then add a new directry and follow [Publishing Packages with the Monorepo](../docs/monorepo.md) -documentation.

--- a/packages/README.md
+++ b/packages/README.md
@@ -4,4 +4,4 @@ This directory exists to hold a variety of projects and libraries that we use in
 
 ## Adding a new package?
 
-If you want to add a new project or package into this directory, then add a new directry and follow [Publishing Packages with the Monorepo](../docs/monorepo.md) -documentation.
+If you want to add a new project or package into this directory, then add a new directory and follow [Publishing Packages with the Monorepo](../docs/monorepo.md) -documentation.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update outdated `packages/README.md` and mainly link to [monorepo docs](https://github.com/Automattic/wp-calypso/blob/ce2493f7fcb3662d16dda09d8885620f0051728b/docs/monorepo.md#readme).

#### Testing instructions

👀 it