### PR TITLE
useLocalizedMoment hook: return just moment object, not array

### DIFF
--- a/client/components/formatted-date/index.js
+++ b/client/components/formatted-date/index.js
@@ -10,7 +10,7 @@ import { useLocalizedMoment } from 'components/localized-moment';
 import toCurrentLocale from './to-current-locale';
 
 export default function FormattedDate( { date, format } ) {
-	const [ moment ] = useLocalizedMoment();
+	const moment = useLocalizedMoment();
 
 	if ( ! moment.isMoment( date ) ) {
 		// only make a new moment if we were passed something else

--- a/client/components/localized-moment/README.md
+++ b/client/components/localized-moment/README.md
@@ -32,8 +32,8 @@ automatically rerendered.
 # `useLocalizedMoment`
 
 Is a React hook that can be used inside stateless functional components. The function returns
-an array with two elements: `moment` and `momentLocale`. Their meaning is the same as in the
-`withLocalizedMoment`. It's just a different implementation of the same concept.
+the moment.js instance that can be used to parse and format dates. Its meaning is the same as
+in `withLocalizedMoment`. It's just a different implementation of the same concept.
 
 ## Usage
 
@@ -42,7 +42,7 @@ import React from 'react';
 import { useLocalizedMoment } from 'components/localized-moment';
 
 export default function Label( { date } ) {
-	const [ moment ] = useLocalizedMoment();
+	const moment = useLocalizedMoment();
 	return <span>{ moment( date ).format( 'LLLL' ) }</span>;
 }
 ```

--- a/client/components/localized-moment/index.js
+++ b/client/components/localized-moment/index.js
@@ -23,6 +23,6 @@ export const withLocalizedMoment = createHigherOrderComponent( Wrapped => {
 }, 'WithLocalizedMoment' );
 
 export const useLocalizedMoment = () => {
-	const { moment, momentLocale } = React.useContext( MomentContext );
-	return [ moment, momentLocale ];
+	const { moment } = React.useContext( MomentContext );
+	return moment;
 };

--- a/client/components/localized-moment/test/index.js
+++ b/client/components/localized-moment/test/index.js
@@ -43,7 +43,7 @@ const LabelWithMomentHOC = withLocalizedMoment( Label );
 
 // The same Label component, but this time a stateless functional one that uses hooks
 const LabelWithMomentHook = ( { date } ) => {
-	const [ moment ] = useLocalizedMoment();
+	const moment = useLocalizedMoment();
 	return moment( date ).format( 'dddd MMMM' );
 };
 


### PR DESCRIPTION
When implementing the `useTranslate` hook, we eventually decided to return just the `translate` function instead of an array. This PR makes the same change in `useLocalizedMoment`. The hook now returns just the `moment` object, not an array.