### PR TITLE
Onboarding: Add tracking events to welcome prompt

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/checklist-onboarding-welcome/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-onboarding-welcome/index.jsx
@@ -26,7 +26,7 @@ import './style.scss';
 
 class ChecklistOnboardingWelcome extends Component {
 	static propTypes = {
-		checkListUrl: PropTypes.string.isRequired,
+		continueUrl: PropTypes.string.isRequired,
 		hideOnboardingWelcomePrompt: PropTypes.func,
 		onClose: PropTypes.func,
 		recordTracksEvent: PropTypes.func.isRequired,
@@ -39,10 +39,11 @@ class ChecklistOnboardingWelcome extends Component {
 
 	goToChecklist = () => {
 		this.props.recordTracksEvent( 'calypso_onboarding_welcome_click', {
-			action_type: 'checklist',
+			action_type: 'continue',
+			url: this.props.continueUrl,
 		} );
 		this.onClose();
-		page( this.props.checkListUrl );
+		page( this.props.continueUrl );
 	};
 
 	closeWelcomePrompt = () => {
@@ -80,7 +81,7 @@ class ChecklistOnboardingWelcome extends Component {
 					</p>
 				</div>
 				<div className="checklist-onboarding-welcome__buttons">
-					<Button primary={ true } href={ this.props.checkListUrl } onClick={ this.goToChecklist }>
+					<Button primary={ true } href={ this.props.continueUrl } onClick={ this.goToChecklist }>
 						{ translate( 'Start customizing' ) }
 					</Button>
 					<Button onClick={ this.closeWelcomePrompt }>{ translate( 'Not now' ) }</Button>
@@ -92,7 +93,7 @@ class ChecklistOnboardingWelcome extends Component {
 
 export default connect(
 	state => ( {
-		checkListUrl: `/checklist/${ getSiteSlug( state, getSelectedSiteId( state ) ) }`,
+		continueUrl: `/checklist/${ getSiteSlug( state, getSelectedSiteId( state ) ) }`,
 	} ),
 	{
 		hideOnboardingWelcomePrompt,

--- a/client/my-sites/checklist/wpcom-checklist/checklist-onboarding-welcome/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-onboarding-welcome/index.jsx
@@ -17,6 +17,7 @@ import Button from 'components/button';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { hideOnboardingWelcomePrompt } from 'state/inline-help/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -28,6 +29,7 @@ class ChecklistOnboardingWelcome extends Component {
 		checkListUrl: PropTypes.string.isRequired,
 		hideOnboardingWelcomePrompt: PropTypes.func,
 		onClose: PropTypes.func,
+		recordTracksEvent: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -36,8 +38,18 @@ class ChecklistOnboardingWelcome extends Component {
 	};
 
 	goToChecklist = () => {
+		this.props.recordTracksEvent( 'calypso_onboarding_welcome_click', {
+			action_type: 'checklist',
+		} );
 		this.onClose();
 		page( this.props.checkListUrl );
+	};
+
+	closeWelcomePrompt = () => {
+		this.props.recordTracksEvent( 'calypso_onboarding_welcome_click', {
+			action_type: 'close',
+		} );
+		this.onClose();
 	};
 
 	onClose = () => {
@@ -71,7 +83,7 @@ class ChecklistOnboardingWelcome extends Component {
 					<Button primary={ true } href={ this.props.checkListUrl } onClick={ this.goToChecklist }>
 						{ translate( 'Start customizing' ) }
 					</Button>
-					<Button onClick={ this.onClose }>{ translate( 'Not now' ) }</Button>
+					<Button onClick={ this.closeWelcomePrompt }>{ translate( 'Not now' ) }</Button>
 				</div>
 			</div>
 		);
@@ -82,5 +94,8 @@ export default connect(
 	state => ( {
 		checkListUrl: `/checklist/${ getSiteSlug( state, getSelectedSiteId( state ) ) }`,
 	} ),
-	{ hideOnboardingWelcomePrompt }
+	{
+		hideOnboardingWelcomePrompt,
+		recordTracksEvent,
+	}
 )( ChecklistOnboardingWelcome );


### PR DESCRIPTION
## Changes proposed in this Pull Request
We're currently not tracking if people interact with the first inline popup that shows right after a site is created. 

This PR adds tracking if someone clicks continue or dismisses the popup.

<img width="340" alt="screen shot 2019-03-06 at 1 51 24 am" src="https://user-images.githubusercontent.com/6458278/53813706-60aa1a80-3fb2-11e9-9748-584c25daf4aa.png">

## Testing instructions

Trigger the welcome popup by adding the `welcome` query param: `/view/{yoursite.wordpress.com}?welcome`

Filter image network requests by `calypso_onboarding_welcome_click`. 

Click on **Not now** and check the event. 

```
		action_type: 'close',
```

Click on **Start Customizing** and check the event. 

```
		action_type: 'continue',
		url: '/checklist/{yoursite.wordpress.com}',
```
