### PR TITLE
Jetpack: update disconnected site indicator

### DIFF
--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -256,7 +256,7 @@ class SiteIndicator extends Component {
 						borderless
 						compact
 						scary
-						href="https://jetpack.com/support/reconnecting-reinstalling-jetpack/"
+						href="https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/"
 						onClick={ this.props.trackSiteDisconnect }
 						target="_blank"
 					>

--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -251,15 +251,16 @@ class SiteIndicator extends Component {
 		if ( site ) {
 			accessFailedMessage = (
 				<span>
-					{ translate( 'This site cannot be accessed.' ) }
+					{ translate( 'Jetpack is disconnected.' ) }
 					<Button
 						borderless
 						compact
 						scary
-						href={ `/settings/disconnect-site/${ site.slug }` }
+						href="https://jetpack.com/support/reconnecting-reinstalling-jetpack/"
 						onClick={ this.props.trackSiteDisconnect }
+						target="_blank"
 					>
-						{ translate( 'Remove Site' ) }
+						{ translate( 'I’d like to fix this now' ) }
 					</Button>
 				</span>
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update disconnected Jetpack site indicator:
  * Change messaging to make the error more comprehensible.
  * Link to troubleshoot documentation on Jetpack.com.

See: p9dueE-y0-p2

#### Testing instructions

* Fire up this PR.
* Select a disconnected site in the site picker.
* Click the red icon to reveal the warning.
* Make sure the message looks good and that the link works as expected.


#### Before

![image](https://user-images.githubusercontent.com/390760/53817109-b358e780-3f5c-11e9-957c-0b4d5abee42d.png)

#### After

![image](https://user-images.githubusercontent.com/390760/53817135-bce24f80-3f5c-11e9-886f-e0aea7a20dd1.png)
