### PR TITLE
Revert "Calypso: Update WordPress.com Support Scheduler Description"

### DIFF
--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -42,7 +42,7 @@ class PrimaryHeader extends Component {
 					<FormattedHeader
 						headerText={ translate( 'WordPress.com Support Scheduler' ) }
 						subHeaderText={ translate(
-							'Your Business plan includes two complimentary, half-hour sessions. Use the tool below to schedule. If you need to cancel, let us know ahead of time so we can help you reschedule and preserve the number of sessions available to you.'
+							'Use the tool below to book your in-depth support session.'
 						) }
 					/>
 					<ExternalLink


### PR DESCRIPTION
Reverts Automattic/wp-calypso#30888

This change has to be reverted because the message is shown to all users who book a session with us, which includes Personal, Blogger, and Premium users who can purchase a session. In this case, the "_Your Business plan includes two complimentary, half-hour sessions._" message is totally irrelevant and confusing. 

@Automattic/lannister 

