### PR TITLE
Colour Scheming: Switch Approved Comment Variable 

### DIFF
--- a/client/blocks/comments/style.scss
+++ b/client/blocks/comments/style.scss
@@ -508,7 +508,7 @@ a.comments__comment-username {
 .comments__comment-actions-approve {
 	.gridicon .gridicon-checkmark,
 	&.is-approved {
-		color: $muriel-green-500;
+		color: var( --color-success );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Just noticed that the approved comment uses a muriel variable for some reason, it's the only one to do so (and I'm assuming that's unintentional). This just switches it to a variable, no visual changes. :) 

cc @flootr, @blowery