### PR TITLE
Revert "Gutenframe: Display success message after trashing a post"

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -31,7 +31,6 @@ import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
 import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 import { startEditingPost } from 'state/ui/editor/actions';
 import { Placeholder } from './placeholder';
-import { trashPost } from 'state/posts/actions';
 
 /**
  * Style dependencies
@@ -123,10 +122,8 @@ class CalypsoifyIframe extends Component {
 			}
 		}
 
-		if ( 'trashPost' === action ) {
-			const { siteId, postId, postTypeTrashUrl } = this.props;
-			this.props.trashPost( siteId, postId );
-			this.props.navigate( postTypeTrashUrl );
+		if ( 'postTrashed' === action ) {
+			this.props.navigate( this.props.postTypeTrashUrl );
 		}
 
 		if ( 'goToAllPosts' === action ) {
@@ -252,7 +249,6 @@ const mapDispatchToProps = {
 	navigate,
 	openPostRevisionsDialog,
 	startEditingPost,
-	trashPost,
 };
 
 export default connect(


### PR DESCRIPTION
Reverts Automattic/wp-calypso#31187

This PR adds back the logic changed in #31187 in order to avoid issues when trashing custom types.

**Testing instructions**
- Sandbox a WordPress.com site and apply D25128-code.
- Open a post on the sandboxed site.
- Move the post to the trash by clicking on the "Move to trash" button in the sidebar.
- Make sure you're redirected to the list of trashed posts.
- Repeat with a custom post type (i.e. Testimonial or Portfolio) in draft status.
- Repeat with a custom post type(i.e. Testimonial or Portfolio)  in published status.