### PR TITLE
Gutenframe: Revert "Enable the iframed block editor in all environments."

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -20,7 +20,7 @@
 		"automated-transfer": true,
 		"blogger-plan": false,
 		"calypsoify/gutenberg": true,
-		"calypsoify/iframe": true,
+		"calypsoify/iframe": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -22,7 +22,7 @@
 		"automated-transfer": true,
 		"blogger-plan": false,
 		"calypsoify/gutenberg": true,
-		"calypsoify/iframe": true,
+		"calypsoify/iframe": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,

--- a/config/test.json
+++ b/config/test.json
@@ -33,7 +33,7 @@
 		"apple-pay": true,
 		"blogger-plan": false,
 		"calypsoify/gutenberg": true,
-		"calypsoify/iframe": true,
+		"calypsoify/iframe": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
 		"code-splitting": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -24,7 +24,7 @@
 		"blogger-plan": false,
 		"comments/management/threaded-view": false,
 		"calypsoify/gutenberg": true,
-		"calypsoify/iframe": true,
+		"calypsoify/iframe": false,
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,


### PR DESCRIPTION
Reverts Automattic/wp-calypso#31196.

Use this PR to revert the launch of "Gutenframe" (iframed block editor for simple sites).

See: p7jreA-2aU-p2.

Tests revert: https://github.com/Automattic/wp-e2e-tests/pull/1820