### PR TITLE
Tiled gallery block: add babel-polyfill

### DIFF
--- a/client/gutenberg/extensions/tiled-gallery/editor.js
+++ b/client/gutenberg/extensions/tiled-gallery/editor.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import '@babel/polyfill';
+
+/**
  * Internal dependencies
  */
 import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';

--- a/client/gutenberg/extensions/tiled-gallery/editor.js
+++ b/client/gutenberg/extensions/tiled-gallery/editor.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import '@babel/polyfill';
-
-/**
  * Internal dependencies
  */
 import registerJetpackBlock from 'gutenberg/extensions/presets/jetpack/utils/register-jetpack-block';

--- a/client/gutenberg/extensions/tiled-gallery/view.js
+++ b/client/gutenberg/extensions/tiled-gallery/view.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import '@babel/polyfill';
+
+/**
  * Internal dependencies
  */
 import './view.scss';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add [Babel polyfill](https://babeljs.io/docs/en/babel-polyfill) to view -side script

#### Testing instructions

- Spin up jurassic ninja with this branch gutenpack-jn
- Add Tiled gallery to a page where no other blocks are not present (to ensure you're not loading `wp-polyfill` to cover the issue, 
- open the saved page in IE11 and observe no more  fatal errors in debugger

Fixes #31224
