### PR TITLE
Slideshow: IE11 Issues

### DIFF
--- a/client/gutenberg/extensions/slideshow/create-swiper.js
+++ b/client/gutenberg/extensions/slideshow/create-swiper.js
@@ -42,7 +42,7 @@ export default async function createSwiper(
 		),
 	};
 	const [ { default: Swiper } ] = await Promise.all( [
-		import( /* webpackChunkName: "swiper" */ 'swiper' ),
+		import( /* webpackChunkName: "swiper" */ 'swiper/dist/js/swiper.js' ),
 		import( /* webpackChunkName: "swiper" */ 'swiper/dist/css/swiper.css' ),
 	] );
 	return new Swiper( container, merge( {}, defaultParams, params ) );

--- a/client/gutenberg/extensions/slideshow/slideshow.js
+++ b/client/gutenberg/extensions/slideshow/slideshow.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 import ResizeObserver from 'resize-observer-polyfill';
 import classnames from 'classnames';
 import { Component, createRef } from '@wordpress/element';

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -79,18 +79,18 @@
 	&.swiper-container-rtl .wp-block-jetpack-slideshow_button-prev,
 	.swiper-button-next.swiper-button-white,
 	.wp-block-jetpack-slideshow_button-next {
-		background-image: url( 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M5.88 4.12L13.76 12l-7.88 7.88L8 22l10-10L8 2z" fill="white"/><path fill="none" d="M0 0h24v24H0z"/></svg>' );
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M5.88 4.12L13.76 12l-7.88 7.88L8 22l10-10L8 2z' fill='white'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E");
 	}
 
 	&.swiper-container-rtl .swiper-button-next.swiper-button-white,
 	&.swiper-container-rtl .wp-block-jetpack-slideshow_button-next,
 	.swiper-button-prev.swiper-button-white,
 	.wp-block-jetpack-slideshow_button-prev {
-		background-image: url( 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M18 4.12L10.12 12 18 19.88 15.88 22l-10-10 10-10z" fill="white"/><path fill="none" d="M0 0h24v24H0z"/></svg>' );
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M18 4.12L10.12 12 18 19.88 15.88 22l-10-10 10-10z' fill='white'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E");
 	}
 
 	.wp-block-jetpack-slideshow_button-pause {
-		background-image: url( 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z" fill="white"/><path d="M0 0h24v24H0z" fill="none"/></svg>' );
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M6 19h4V5H6v14zm8-14v14h4V5h-4z' fill='white'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E");
 		display: none;
 		margin-top: 0;
 		position: absolute;
@@ -100,7 +100,7 @@
 	}
 
 	.wp-block-jetpack-slideshow_autoplay-paused .wp-block-jetpack-slideshow_button-pause {
-		background-image: url( 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M8 5v14l11-7z" fill="white"/><path d="M0 0h24v24H0z" fill="none"/></svg>' );
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M8 5v14l11-7z' fill='white'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E");
 	}
 
 	&[data-autoplay='true'] .wp-block-jetpack-slideshow_button-pause {

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -79,18 +79,18 @@
 	&.swiper-container-rtl .wp-block-jetpack-slideshow_button-prev,
 	.swiper-button-next.swiper-button-white,
 	.wp-block-jetpack-slideshow_button-next {
-		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M5.88 4.12L13.76 12l-7.88 7.88L8 22l10-10L8 2z' fill='white'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E");
+		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M5.88 4.12L13.76 12l-7.88 7.88L8 22l10-10L8 2z' fill='white'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
 
 	&.swiper-container-rtl .swiper-button-next.swiper-button-white,
 	&.swiper-container-rtl .wp-block-jetpack-slideshow_button-next,
 	.swiper-button-prev.swiper-button-white,
 	.wp-block-jetpack-slideshow_button-prev {
-		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M18 4.12L10.12 12 18 19.88 15.88 22l-10-10 10-10z' fill='white'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E");
+		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M18 4.12L10.12 12 18 19.88 15.88 22l-10-10 10-10z' fill='white'/%3E%3Cpath fill='none' d='M0 0h24v24H0z'/%3E%3C/svg%3E" );
 	}
 
 	.wp-block-jetpack-slideshow_button-pause {
-		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M6 19h4V5H6v14zm8-14v14h4V5h-4z' fill='white'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E");
+		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M6 19h4V5H6v14zm8-14v14h4V5h-4z' fill='white'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E" );
 		display: none;
 		margin-top: 0;
 		position: absolute;
@@ -100,7 +100,7 @@
 	}
 
 	.wp-block-jetpack-slideshow_autoplay-paused .wp-block-jetpack-slideshow_button-pause {
-		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M8 5v14l11-7z' fill='white'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E");
+		background-image: url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'%3E%3Cpath d='M8 5v14l11-7z' fill='white'/%3E%3Cpath d='M0 0h24v24H0z' fill='none'/%3E%3C/svg%3E" );
 	}
 
 	&[data-autoplay='true'] .wp-block-jetpack-slideshow_button-pause {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR resolves two IE11 issues:

- Block fails with Syntax Error
- Buttons (previous/next/pause/play) have no background images

The Syntax Error appears to be an issue with importing Swiper, which is resolved by explicitly specifying the file path in the import. Here are two Swiper issues which are possibly related:

https://github.com/nolimits4web/swiper/issues/2282
https://github.com/nolimits4web/Swiper/issues/2237

The button appearance issue is resolved by URL encoding the SVGs. This was done using this utility: https://yoksel.github.io/url-encoder/. 

#### Testing instructions

- Check out this branch on local Jetpack instance
- Build blocks with SDK
- Create new post in IE11 and add Slideshow block. 
- Verify the block works as expected in the editor, and that the buttons appear normal.
- Publish the post and verify the block in the view.

Note: One approach to testing in IE11 is to expose your local instance at a public URL using [Ngrok](https://ngrok.com/), then use [BrowserStack](https://www.browserstack.com/) to test in a virtual machine running IE11.

Fixes https://github.com/Automattic/wp-calypso/issues/31232