### PR TITLE
Fix: Domain Transfer/Mapping not working in the launch flow

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -91,7 +91,7 @@ export function generateSteps( {
 			fulfilledStepCallback: isDomainFulfilled,
 			providesDependencies: [ 'domainItem' ],
 			props: {
-				isDomainOnly: true,
+				isDomainOnly: false,
 				showExampleSuggestions: false,
 				showSkipButton: true,
 				headerText: i18n.translate( 'Getting ready to launch, pick a domain' ),

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -514,7 +514,7 @@ class DomainsStep extends React.Component {
 			return null;
 		}
 
-		const { translate } = this.props;
+		const { translate, hasSelectedSiteBackUrl } = this.props;
 		let backUrl = undefined;
 
 		if ( 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName ) {
@@ -526,6 +526,8 @@ class DomainsStep extends React.Component {
 			);
 		} else if ( this.props.stepSectionName ) {
 			backUrl = getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() );
+		} else if ( 0 === this.props.positionInFlow && hasSelectedSiteBackUrl ) {
+			backUrl = hasSelectedSiteBackUrl;
 		}
 
 		const fallbackSubHeaderText = this.getSubHeaderText();
@@ -548,6 +550,7 @@ class DomainsStep extends React.Component {
 					</div>
 				}
 				showSiteMockups={ this.props.showSiteMockups }
+				allowBackFirstStep={ !! hasSelectedSiteBackUrl }
 			/>
 		);
 	}
@@ -589,6 +592,7 @@ export default connect(
 	( state, ownProps ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
+		const selectedSite = getSite( state, ownProps.signupDependencies.siteSlug );
 
 		return {
 			designType: getDesignType( state ),
@@ -600,7 +604,8 @@ export default connect(
 			productsLoaded,
 			siteGoals: getSiteGoals( state ),
 			surveyVertical: getSurveyVertical( state ),
-			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
+			selectedSite,
+			hasSelectedSiteBackUrl: selectedSite ? '/view/' + selectedSite.slug : false,
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -515,8 +515,7 @@ class DomainsStep extends React.Component {
 		}
 
 		const { translate, selectedSite } = this.props;
-		let backUrl = undefined,
-			backLabelText = null;
+		let backUrl, backLabelText;
 
 		if ( 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName ) {
 			backUrl = getStepUrl(
@@ -528,7 +527,7 @@ class DomainsStep extends React.Component {
 		} else if ( this.props.stepSectionName ) {
 			backUrl = getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() );
 		} else if ( 0 === this.props.positionInFlow && selectedSite ) {
-			backUrl = '/view/' + selectedSite.slug;
+			backUrl = `/view/${ selectedSite.slug }`;
 			backLabelText = translate( 'Back to Site' );
 		}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -514,7 +514,7 @@ class DomainsStep extends React.Component {
 			return null;
 		}
 
-		const { translate, hasSelectedSiteBackUrl } = this.props;
+		const { translate } = this.props;
 		let backUrl = undefined;
 
 		if ( 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName ) {
@@ -526,8 +526,6 @@ class DomainsStep extends React.Component {
 			);
 		} else if ( this.props.stepSectionName ) {
 			backUrl = getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() );
-		} else if ( 0 === this.props.positionInFlow && hasSelectedSiteBackUrl ) {
-			backUrl = hasSelectedSiteBackUrl;
 		}
 
 		const fallbackSubHeaderText = this.getSubHeaderText();
@@ -550,7 +548,6 @@ class DomainsStep extends React.Component {
 					</div>
 				}
 				showSiteMockups={ this.props.showSiteMockups }
-				allowBackFirstStep={ !! hasSelectedSiteBackUrl }
 			/>
 		);
 	}
@@ -592,7 +589,6 @@ export default connect(
 	( state, ownProps ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
-		const selectedSite = getSite( state, ownProps.signupDependencies.siteSlug );
 
 		return {
 			designType: getDesignType( state ),
@@ -604,8 +600,7 @@ export default connect(
 			productsLoaded,
 			siteGoals: getSiteGoals( state ),
 			surveyVertical: getSurveyVertical( state ),
-			selectedSite,
-			hasSelectedSiteBackUrl: selectedSite ? '/view/' + selectedSite.slug : false,
+			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -514,8 +514,9 @@ class DomainsStep extends React.Component {
 			return null;
 		}
 
-		const { translate } = this.props;
-		let backUrl = undefined;
+		const { translate, selectedSite } = this.props;
+		let backUrl = undefined,
+			backLabelText = null;
 
 		if ( 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName ) {
 			backUrl = getStepUrl(
@@ -526,6 +527,9 @@ class DomainsStep extends React.Component {
 			);
 		} else if ( this.props.stepSectionName ) {
 			backUrl = getStepUrl( this.props.flowName, this.props.stepName, undefined, getLocaleSlug() );
+		} else if ( 0 === this.props.positionInFlow && selectedSite ) {
+			backUrl = '/view/' + selectedSite.slug;
+			backLabelText = translate( 'Back to Site' );
 		}
 
 		const fallbackSubHeaderText = this.getSubHeaderText();
@@ -548,6 +552,8 @@ class DomainsStep extends React.Component {
 					</div>
 				}
 				showSiteMockups={ this.props.showSiteMockups }
+				allowBackFirstStep={ !! selectedSite }
+				backLabelText={ backLabelText }
 			/>
 		);
 	}

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -169,9 +169,8 @@ export class PlansStep extends Component {
 
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
 		const subHeaderText = this.props.subHeaderText;
+		let backUrl, backLabelText;
 
-		let backUrl = undefined,
-			backLabelText = null;
 		if ( 0 === positionInFlow && selectedSite ) {
 			backUrl = '/view/' + siteSlug;
 			backLabelText = translate( 'Back to Site' );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -150,7 +150,15 @@ export class PlansStep extends Component {
 	}
 
 	plansFeaturesSelection = () => {
-		const { flowName, stepName, positionInFlow, signupProgress, translate } = this.props;
+		const {
+			flowName,
+			stepName,
+			positionInFlow,
+			signupProgress,
+			translate,
+			selectedSite,
+			siteSlug,
+		} = this.props;
 
 		let headerText = this.props.headerText || translate( "Pick a plan that's right for you." );
 
@@ -161,6 +169,13 @@ export class PlansStep extends Component {
 
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
 		const subHeaderText = this.props.subHeaderText;
+
+		let backUrl = undefined,
+			backLabelText = null;
+		if ( 0 === positionInFlow && selectedSite ) {
+			backUrl = '/view/' + siteSlug;
+			backLabelText = translate( 'Back to Site' );
+		}
 
 		return (
 			<StepWrapper
@@ -173,6 +188,9 @@ export class PlansStep extends Component {
 				signupProgress={ signupProgress }
 				isWideLayout={ true }
 				stepContent={ this.plansFeaturesList() }
+				allowBackFirstStep={ !! selectedSite }
+				backUrl={ backUrl }
+				backLabelText={ backLabelText }
 			/>
 		);
 	};
@@ -227,4 +245,5 @@ export default connect( ( state, { path, signupDependencies: { siteSlug, domainI
 	customerType: parseQs( path.split( '?' ).pop() ).customerType,
 	siteGoals: getSiteGoals( state ) || '',
 	siteType: getSiteType( state ),
+	siteSlug,
 } ) )( localize( PlansStep ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR:
* fixes the issue of the Domain Transfer/Mapping option not working in the Private by Default launch flow.
    To reproduce the issue:
    1. Create a new site, apply the backend patch D23389-code, sandbox the new site and click the `Launch Site` button (in 
    Calypso preview) to enter the launch flow.
    2. Click `Use a domain I own` and nothing happens. It is expected that we're taken  to the Transfers/Mapping page.

        <img width="1163" alt="screenshot 2019-03-05 at 7 37 37 pm" src="https://user-images.githubusercontent.com/1269602/53854734-a259b600-3ff0-11e9-9465-e2277b975f28.png">

* adds a back button to the first step of the launch flow (which could either be the Domain step or Plan step)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site, apply the backend patch D23389-code, sandbox the new site, and click the `Launch Site` button (in Calypso preview) to enter the launch flow.
* Clicking `Use a domain I own` should take to the Transfers/Mapping page.
* Verify that the launch flow otherwise works fine.
* Verify the Back button works in the Transfer and Mappings pages
* Verify the Back button in the first step of the launch flow takes you back to Calypso preview. Test this on a site with a domain(the Plan step is the first step in the launch flow), and without a domain(the domain step is the first step in the launch flow).



Fixes one of the issues listed in #31176
