### PR TITLE
styles: use css custom props in placeholder() mixin

### DIFF
--- a/assets/stylesheets/shared/mixins/_placeholder.scss
+++ b/assets/stylesheets/shared/mixins/_placeholder.scss
@@ -4,9 +4,9 @@
 // Adds animation to placeholder section
 // ==========================================================================
 
-@mixin placeholder( $lighten-value: 0 ) {
+@mixin placeholder( $value: 0 ) {
 	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: var( --color-neutral-#{$lighten-value} );
+	background-color: var( --color-neutral-#{$value} );
 	color: transparent;
 
 	&::after {

--- a/assets/stylesheets/shared/mixins/_placeholder.scss
+++ b/assets/stylesheets/shared/mixins/_placeholder.scss
@@ -4,19 +4,9 @@
 // Adds animation to placeholder section
 // ==========================================================================
 
-@mixin placeholder( $lighten-percentage: 30% ) {
+@mixin placeholder( $lighten-value: 0 ) {
 	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: lighten( $gray, $lighten-percentage );
-	color: transparent;
-
-	&::after {
-		content: '\00a0';
-	}
-}
-
-@mixin placeholder-dark( $darken-percentage: 30% ) {
-	animation: loading-fade 1.6s ease-in-out infinite;
-	background-color: darken( $gray, $darken-percentage );
+	background-color: var( --color-neutral-#{$lighten-value} );
 	color: transparent;
 
 	&::after {

--- a/client/blocks/image-editor/style.scss
+++ b/client/blocks/image-editor/style.scss
@@ -63,7 +63,7 @@
 	top: 50%;
 	left: 50%;
 	&.is-placeholder {
-		@include placeholder-dark();
+		@include placeholder( 600 );
 	}
 }
 

--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -1,7 +1,7 @@
 .happiness-support.is-placeholder {
 	.happiness-support__heading,
 	.happiness-support__text {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 	}
 
 	.happiness-support__heading {
@@ -18,7 +18,7 @@
 
 	.happiness-support__buttons {
 		.button {
-			@include placeholder( 23% );
+			@include placeholder( 50 );
 		}
 	}
 }

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -24,7 +24,7 @@
 		.purchase-detail__button,
 		.purchase-detail__description,
 		.purchase-detail__title {
-			@include placeholder( 23% );
+			@include placeholder( 50 );
 
 			display: block;
 		}

--- a/client/components/vertical-nav/item/style.scss
+++ b/client/components/vertical-nav/item/style.scss
@@ -12,7 +12,7 @@
 
 .vertical-nav-item.is-placeholder {
 	span {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 
 		display: inline-block;
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -588,7 +588,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .jetpack-connect__sso-placeholder {
-	@include placeholder( 23% );
+	@include placeholder( 50 );
 	background-color: transparent;
 }
 

--- a/client/me/help/help-courses/style.scss
+++ b/client/me/help/help-courses/style.scss
@@ -1,6 +1,6 @@
 .help-courses__course-list {
 	&.is-placeholder {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 		height: 300px;
 	}
 }
@@ -9,7 +9,7 @@
 	margin-top: 16px;
 
 	&.is-placeholder {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 	}
 
 	.help__help-teaser-button-icon {

--- a/client/me/purchases/manage-purchase/plan-details/style.scss
+++ b/client/me/purchases/manage-purchase/plan-details/style.scss
@@ -8,7 +8,7 @@
 .plan-details__wrapper.is-placeholder {
 	.section-header__label-text,
 	.plan-details__plugin-key {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 
 		display: block;
 	}

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -35,7 +35,7 @@
 		.manage-purchase__settings-link,
 		.manage-purchase__detail-label,
 		.manage-purchase__detail {
-			@include placeholder( 23% );
+			@include placeholder( 50 );
 
 			display: block;
 		}

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -28,7 +28,7 @@
 	.purchase-item__title,
 	.purchase-item__purchase-date,
 	.purchase-item__purchase-type {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 	}
 
 	.purchase-item__plan-icon {

--- a/client/me/purchases/purchases-site/style.scss
+++ b/client/me/purchases/purchases-site/style.scss
@@ -30,7 +30,7 @@
 		.site-icon,
 		.site__title,
 		.site__domain {
-			@include placeholder( 23% );
+			@include placeholder( 50 );
 		}
 	}
 

--- a/client/me/security-2fa-enable/style.scss
+++ b/client/me/security-2fa-enable/style.scss
@@ -13,7 +13,7 @@
 	margin: 0 auto;
 
 	&.is-placeholder {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 	}
 }
 

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -104,7 +104,7 @@
 
 	.cart-item__loading-placeholder {
 		.cart__remove-item {
-			@include placeholder( 23% );
+			@include placeholder( 50 );
 			border-radius: 0;
 			width: 25px;
 		}
@@ -431,7 +431,7 @@ div.popover-cart__popover {
 
 .cart-item__loading-placeholder {
 	span {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 		margin-bottom: 1px;
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -75,7 +75,7 @@
 	}
 
 	&.is-placeholder {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 
 		margin-left: auto;
 		margin-right: auto;
@@ -164,7 +164,7 @@
 
 	.checkout-thank-you__header-heading,
 	.checkout-thank-you__header-text {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 
 		display: block;
 

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -1,6 +1,6 @@
 .domain-main-placeholder {
 	.domain-management-header__children {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 
 		@include breakpoint( '>480px' ) {
 			max-width: 60%;
@@ -11,7 +11,7 @@
 
 .domain-main-placeholder__card {
 	p {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 		margin-bottom: 0.5em;
 
 		&:first-child {
@@ -143,12 +143,12 @@
 	}
 
 	.domain-management-list-item__title {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 		width: 60%;
 	}
 
 	.domain-management-list-item__type {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 		display: inline-block;
 		width: 40%;
 	}
@@ -426,7 +426,7 @@ input[type='radio'].domain-management-list-item__radio {
 
 	.domain-connect__is-placeholder {
 		span {
-			@include placeholder( 23% );
+			@include placeholder( 50 );
 
 			display: block;
 			margin: 0.8em 0;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -330,7 +330,7 @@ $plan-features-sidebar-width: 272px;
 	line-height: normal;
 
 	&.is-placeholder {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 		width: 140px;
 		height: 12px;
 		margin-bottom: 15px;
@@ -419,7 +419,7 @@ $plan-features-sidebar-width: 272px;
 
 .plan-features__price {
 	&.is-placeholder {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 			width: 45px;
 			height: 25px;
 			margin-top: 9px;
@@ -428,7 +428,7 @@ $plan-features-sidebar-width: 272px;
 }
 .plan-features__price-jetpack {
 	&.is-placeholder {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 			width: 140px;
 			height: 32px;
 			margin-top: 5px;

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -5,7 +5,7 @@
 	color: var( --color-neutral-700 );
 
 	&.is-placeholder {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 		width: 60px;
 		margin: 10px 0;
 		height: 21px;

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -61,7 +61,7 @@
 
 	.current-plan__header-heading,
 	.current-plan__header-text {
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 
 		display: block;
 

--- a/client/post-editor/editor-diff-viewer/style.scss
+++ b/client/post-editor/editor-diff-viewer/style.scss
@@ -90,7 +90,7 @@
 	display: inline-block;
 	width: 50%;
 	height: 38px;
-	@include placeholder( 23% );
+	@include placeholder( 50 );
 }
 
 .editor-diff-viewer__content {
@@ -111,7 +111,7 @@
 		width: 100%;
 		height: 20px;
 		margin-top: 6px;
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 	}
 
 	&::before {

--- a/client/post-editor/editor-revisions-list/style.scss
+++ b/client/post-editor/editor-revisions-list/style.scss
@@ -53,7 +53,7 @@
 			width: 50%;
 			height: $editor-revisions-list-header-font-size;
 			align-self: center;
-			@include placeholder( 23% );
+			@include placeholder( 50 );
 		}
 	}
 }
@@ -212,7 +212,7 @@
 		content: '';
 		display: block;
 		box-sizing: border-box;
-		@include placeholder( 23% );
+		@include placeholder( 50 );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR migrates the `placeholder()` mixin from using percentage to lighten or darken a gray value to using CSS custom props and absolute values from our color scaling (0 - 900). The current version is less stable as the previous one as we rely on the user knowing about which colors are available. I'm not sure this is a solution we want to go with but I'd appreciate feedback

/cc @blowery @drw158 

#### Testing instructions

* code: make sure migration to css custom prop values are correct
* visually: do placeholder usages still look okay?

