### PR TITLE
Colour Scheming: Removes Orange Jazzy

### DIFF
--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -20,8 +20,8 @@ $autobar-height: 20px;
 
 	.is-support-session & {
 		// DO NOT style these with theme colors. We want them to override whatever theme colors the user has picked.
-		background: $orange-jazzy;
-		border-bottom: 1px solid darken( $orange-jazzy, 4% );
+		background: var( --color-hot-orange );
+		border-bottom: 1px solid var( --color-hot-orange-light );
 	}
 
 	.is-section-theme &,
@@ -121,7 +121,7 @@ $autobar-height: 20px;
 	}
 
 	.is-support-session &.is-active {
-		background: darken( $orange-jazzy, 10% );
+		background: var( --color-hot-orange-dark );
 	}
 
 	@include breakpoint( '<480px' ) {
@@ -252,7 +252,7 @@ $autobar-height: 20px;
 	.is-support-session &:focus,
 	.is-support-session &:hover,
 	.is-support-session &:visited {
-		color: $orange-jazzy;
+		color: var( --color-hot-orange );
 	}
 
 	.is-support-session &.is-active {

--- a/packages/calypso-color-schemes/src/shared/_colors.scss
+++ b/packages/calypso-color-schemes/src/shared/_colors.scss
@@ -13,9 +13,6 @@ $gray: $muriel-gray-300;
 
 // See wordpress.com/design-handbook/colors/ for more info.
 
-// Secondary Accent (Oranges)
-$orange-jazzy: #f0821e;
-
 // Essentials
 $transparent: rgba( 255, 255, 255, 0 );
 


### PR DESCRIPTION
Same as #31170, so here's the description copy & pasted:

#### Changes proposed in this Pull Request

Removes $orange-jazzy and replaces all variables which use it.

#### Testing instructions

The problem is that there's a slight difference in colours, mainly for the active state but also just for normal...it may look worse for me though because I've looked at each one at least a dozen times in a row. 

**Current:**

![hjghjgghjgh](https://user-images.githubusercontent.com/43215253/53695552-f7a98380-3db4-11e9-89bb-932db46f61f8.png)

**Proposed:**

![hgfhgfgfh](https://user-images.githubusercontent.com/43215253/53695555-ff692800-3db4-11e9-9ae5-d1218156b634.png)

The intention was to keep the proposed colours as close to the current as possible, whilst also keeping dark at 700 and light at 300. Are those colours okay? cc @drw158 

In order to test, add the `is-support-session` class to the body, and then take a look around the masterbar. They only appear when in a support session...my guess is that means live chat, but no clue.

cc @flootr, @blowery, @drw158 