### PR TITLE
Business Hours: Add small UI fixes to the editor

### DIFF
--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -42,6 +42,7 @@ $break-small: 600px;
 
 			.components-base-control {
 				display: inline-block;
+				margin-bottom: 0;
 				width: 48%;
 
 				&.business-hours__open {
@@ -62,11 +63,8 @@ $break-small: 600px;
 		width: 10%;
 	}
 
-	.business-hours-row__add button {
-		text-decoration: none;
-		svg {
-			pointer-events: none;
-		}
+	.business-hours-row__add button:hover {
+		box-shadow: none;
 	}
 
 	.business-hours__remove button {

--- a/client/gutenberg/extensions/business-hours/editor.scss
+++ b/client/gutenberg/extensions/business-hours/editor.scss
@@ -64,7 +64,7 @@ $break-small: 600px;
 	}
 
 	.business-hours-row__add button:hover {
-		box-shadow: none;
+		box-shadow: none !important;
 	}
 
 	.business-hours__remove button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Have the "Add hour" button to look like a proper link with text-description and no box-shadow on hover
* Fix misalignment of opening/closing divs

#### Testing instructions

* [Try out this Jurassic.ninja link](https://jurassic.ninja/create/?jetpack-beta&gutenpack&calypsobranch=update/business-hours-editor-visual-fixes)
* Enable Beta blocks in Settings -> Jetpack Constants
* Create a post with a Business hours block
* How does the block look like?

Before:

![screenshot 2019-03-06 at 17 31 34](https://user-images.githubusercontent.com/177929/53901330-a9a3b280-4036-11e9-8372-e737380fb6c6.png)

After:

![screenshot 2019-03-06 at 17 38 13](https://user-images.githubusercontent.com/177929/53901347-b0cac080-4036-11e9-8c2f-94a37c234a73.png)

