### PR TITLE
Add new AB test to test/e2e/config

### DIFF
--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -76,7 +76,8 @@
 		"builderReferralThemesBanner",
 		"domainSearchButtonStyles",
 		"twoYearPlanByDefault",
-		"pluginFeaturedTitle"
+		"pluginFeaturedTitle",
+		"builderReferralHelpPopover"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],
@@ -93,6 +94,7 @@
 		[ "showConciergeSessionUpsellNonGSuite_20190104", "skip" ],
 		[ "improvedOnboarding_20190214", "main" ],
 		[ "skipBusinessInformation_20190130", "hide" ],
-		[ "twoYearPlanByDefault_20190207", "originalFlavor" ]
+		[ "twoYearPlanByDefault_20190207", "originalFlavor" ],
+		[ "builderReferralHelpPopover_20190227", "original" ]
 	]
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

New AB test is added to `test/e2e/config`. This test is already present in `abtest/active-tests.js`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

When running e2e tests locally you shouldn't see message like `Found an AB Testing key in local storage that isn't known: 'builderReferralHelpPopover'.`

