### PR TITLE
NUX Signup: Retire the skip button test.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -72,16 +72,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	skipBusinessInformation: {
-		datestamp: '20190130',
-		variations: {
-			hide: 50,
-			show: 50,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	showConciergeSessionUpsell: {
 		datestamp: '20181214',
 		variations: {

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -25,7 +25,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import InfoPopover from 'components/info-popover';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -86,17 +85,6 @@ export class SiteInformation extends Component {
 		this.props.submitStep( this.props.siteInformation );
 	};
 
-	handleSkip = event => {
-		event.preventDefault();
-
-		const emptySiteInformation = {};
-		each( this.props.informationFields, key => {
-			emptySiteInformation[ key ] = '';
-		} );
-
-		this.props.submitStep( emptySiteInformation );
-	};
-
 	getFieldTexts( informationType ) {
 		const { translate, siteType } = this.props;
 		switch ( informationType ) {
@@ -127,22 +115,11 @@ export class SiteInformation extends Component {
 		}
 	}
 
-	renderSubmitButton = () => {
-		const { translate } = this.props;
-
-		return (
-			<>
-				<Button primary type="submit" onClick={ this.handleSubmit }>
-					{ translate( 'Continue' ) }
-				</Button>
-				{ abtest( 'skipBusinessInformation' ) === 'show' && (
-					<Button className="site-information__skip-button" borderless onClick={ this.handleSkip }>
-						{ translate( 'Skip' ) }
-					</Button>
-				) }
-			</>
-		);
-	};
+	renderSubmitButton = () => (
+		<Button primary type="submit" onClick={ this.handleSubmit }>
+			{ this.props.translate( 'Continue' ) }
+		</Button>
+	);
 
 	renderContent() {
 		const { hasMultipleFieldSets, formFields } = this.props;

--- a/client/signup/steps/site-information/style.scss
+++ b/client/signup/steps/site-information/style.scss
@@ -30,27 +30,9 @@
 
 	.button {
 		position: absolute;
-		top: 29px;
+		bottom: 3px;
 		right: 3px;
 		width: auto;
-	}
-
-	.site-information__skip-button {
-		left: calc( 100% );
-		width: 80px;
-		color: var( --color-white );
-		text-decoration: underline;
-
-		&:hover {
-			color: var( --color-white );
-		}
-
-		@include breakpoint( '<660px' ) {
-			position: relative;
-			margin: 0 auto;
-			left: 0;
-			top: 0;
-		}
 	}
 }
 

--- a/client/signup/steps/site-information/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-information/test/__snapshots__/index.js.snap
@@ -4,7 +4,6 @@ exports[`<SiteInformation /> should render 1`] = `
 <Localized(StepWrapper)
   fallbackHeaderText="headerTextoidaliciously"
   headerText="headerTextoidaliciously"
-  positionInFlow={0}
   stepContent={
     <div
       className="site-information__wrapper is-single-fieldset"
@@ -41,15 +40,13 @@ exports[`<SiteInformation /> should render 1`] = `
                 placeholder="E.g., Vail Renovations"
                 value="Ho ho ho!"
               />
-              <React.Fragment>
-                <Button
-                  onClick={[Function]}
-                  primary={true}
-                  type="submit"
-                >
-                  Continue
-                </Button>
-              </React.Fragment>
+              <Button
+                onClick={[Function]}
+                primary={true}
+                type="submit"
+              >
+                Continue
+              </Button>
             </FormFieldset>
           </div>
           <div
@@ -79,15 +76,13 @@ exports[`<SiteInformation /> should render 1`] = `
                 placeholder="E.g., 60 29th St, San Francisco, CA 94110"
                 value=""
               />
-              <React.Fragment>
-                <Button
-                  onClick={[Function]}
-                  primary={true}
-                  type="submit"
-                >
-                  Continue
-                </Button>
-              </React.Fragment>
+              <Button
+                onClick={[Function]}
+                primary={true}
+                type="submit"
+              >
+                Continue
+              </Button>
             </FormFieldset>
           </div>
           <div
@@ -117,15 +112,13 @@ exports[`<SiteInformation /> should render 1`] = `
                 placeholder="E.g., (555) 555-5555"
                 value=""
               />
-              <React.Fragment>
-                <Button
-                  onClick={[Function]}
-                  primary={true}
-                  type="submit"
-                >
-                  Continue
-                </Button>
-              </React.Fragment>
+              <Button
+                onClick={[Function]}
+                primary={true}
+                type="submit"
+              >
+                Continue
+              </Button>
             </FormFieldset>
           </div>
         </form>

--- a/client/signup/steps/site-information/test/index.js
+++ b/client/signup/steps/site-information/test/index.js
@@ -20,23 +20,17 @@ jest.mock( 'lib/signup/actions', () => ( {
 	saveSignupStep: jest.fn(),
 } ) );
 
-jest.mock( 'lib/abtest', () => ( {
-	abtest: () => '',
-} ) );
-
 describe( '<SiteInformation />', () => {
 	const defaultProps = {
 		siteType: 'business',
 		submitStep: jest.fn(),
 		updateStep: jest.fn(),
-		goToNextStep: jest.fn(),
 		informationType: 'title',
 		translate: x => x,
 		siteInformation: { title: 'Ho ho ho!' },
 		headerText: 'headerTextoidaliciously',
 		formFields: [ 'title', 'address', 'phone' ],
 		stepName: 'site-information',
-		positionInFlow: 0,
 	};
 
 	afterEach( () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We've concluded that there is no significant impact on adding a skip button this way, so it's time to retire the test. This PR is a direct revert of the commit introducing the test, d69efc2f07461b3f80f900522cf1e4f108e7d48a.

#### Testing instructions

* Make sure the site information step works as expected, without the skip button.
* The `skipBusinessInformation` test should be removed completely.
