### PR TITLE
Chat/Concierge closure notices: don't rely on moment from i18n-calypso 

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -191,7 +191,6 @@
 @import 'me/help/help-happiness-engineers/style';
 @import 'me/help/help-results/style';
 @import 'me/help/help-search/style';
-@import 'me/help/live-chat-closure-notice/style';
 @import 'me/help/style';
 @import 'me/notification-settings/blogs-settings/style';
 @import 'me/notification-settings/comment-settings/style';

--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -5,34 +5,39 @@
  */
 
 import React from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
+import 'moment-timezone'; // monkey patches the existing moment.js
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card/compact';
+import { useLocalizedMoment } from 'components/localized-moment';
 
 const DATE_FORMAT = 'MMMM D h:mma z';
 
-const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt, translate } ) => {
-	const currentDate = i18n.moment();
-	const guessedTimezone = i18n.moment.tz.guess();
+const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt } ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 
-	if ( ! currentDate.isBetween( i18n.moment( displayAt ), i18n.moment( reopensAt ) ) ) {
+	const currentDate = moment();
+	const guessedTimezone = moment.tz.guess();
+
+	if ( ! currentDate.isBetween( displayAt, reopensAt ) ) {
 		return null;
 	}
 
 	let message;
 
-	if ( currentDate.isBefore( i18n.moment.utc( closesAt ) ) ) {
+	if ( currentDate.isBefore( closesAt ) ) {
 		message = translate(
 			'{{strong}}Note:{{/strong}} Support sessions will be closed for %(holidayName)s from %(closesAt)s until %(reopensAt)s. ' +
 				'If you need to get in touch with us, you’ll be able to {{link}}submit a support request{{/link}} and we’ll ' +
 				'get to it as fast as we can. Thank you!',
 			{
 				args: {
-					closesAt: i18n.moment.tz( closesAt, guessedTimezone ).format( DATE_FORMAT ),
-					reopensAt: i18n.moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
+					closesAt: moment.tz( closesAt, guessedTimezone ).format( DATE_FORMAT ),
+					reopensAt: moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
 					holidayName,
 				},
 				components: {
@@ -48,7 +53,7 @@ const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt, translate
 				'get back to you as fast as we can. Thank you!',
 			{
 				args: {
-					reopensAt: i18n.moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
+					reopensAt: moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
 					holidayName,
 				},
 				components: {
@@ -61,4 +66,4 @@ const ClosureNotice = ( { closesAt, displayAt, holidayName, reopensAt, translate
 	return <Card>{ message }</Card>;
 };
 
-export default localize( ClosureNotice );
+export default ClosureNotice;

--- a/client/me/help/live-chat-closure-notice/index.jsx
+++ b/client/me/help/live-chat-closure-notice/index.jsx
@@ -13,6 +13,11 @@ import i18n, { localize } from 'i18n-calypso';
 import FoldableCard from 'components/foldable-card';
 import FormSectionHeading from 'components/forms/form-section-heading';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const DATE_FORMAT = 'MMMM D h:mma z';
 
 const LiveChatClosureNotice = ( {

--- a/client/me/help/live-chat-closure-notice/index.jsx
+++ b/client/me/help/live-chat-closure-notice/index.jsx
@@ -5,13 +5,15 @@
  */
 
 import React from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
+import 'moment-timezone'; // monkey patches the existing moment.js
 
 /**
  * Internal dependencies
  */
 import FoldableCard from 'components/foldable-card';
 import FormSectionHeading from 'components/forms/form-section-heading';
+import { useLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -20,18 +22,14 @@ import './style.scss';
 
 const DATE_FORMAT = 'MMMM D h:mma z';
 
-const LiveChatClosureNotice = ( {
-	closesAt,
-	compact,
-	displayAt,
-	holidayName,
-	reopensAt,
-	translate,
-} ) => {
-	const currentDate = i18n.moment();
-	const guessedTimezone = i18n.moment.tz.guess();
+const LiveChatClosureNotice = ( { closesAt, compact, displayAt, holidayName, reopensAt } ) => {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
 
-	if ( ! currentDate.isBetween( i18n.moment( displayAt ), i18n.moment( reopensAt ) ) ) {
+	const currentDate = moment();
+	const guessedTimezone = moment.tz.guess();
+
+	if ( ! currentDate.isBetween( displayAt, reopensAt ) ) {
 		return null;
 	}
 
@@ -47,8 +45,8 @@ const LiveChatClosureNotice = ( {
 				'You’ll be able to reach us by email and we’ll get back to you as fast as we can. Thank you!',
 			{
 				args: {
-					closesAt: i18n.moment.tz( closesAt, guessedTimezone ).format( DATE_FORMAT ),
-					reopensAt: i18n.moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
+					closesAt: moment.tz( closesAt, guessedTimezone ).format( DATE_FORMAT ),
+					reopensAt: moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
 					holidayName,
 				},
 			}
@@ -59,7 +57,7 @@ const LiveChatClosureNotice = ( {
 				'You can reach us by email below and we’ll get back to you as fast as we can. Thank you!',
 			{
 				args: {
-					reopensAt: i18n.moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
+					reopensAt: moment.tz( reopensAt, guessedTimezone ).format( DATE_FORMAT ),
 					holidayName,
 				},
 			}
@@ -90,4 +88,4 @@ const LiveChatClosureNotice = ( {
 	);
 };
 
-export default localize( LiveChatClosureNotice );
+export default LiveChatClosureNotice;


### PR DESCRIPTION
Changes the `<ClosureNotice>` and `<LiveChatClosureNotice>` components to not rely on `moment-timezone` being supplied by the `i18n-calypso`'s `localize` HOC.

Instead, we use the `useLocalizedMoment` hook that provides `moment` and import the `moment-timezone` module to execute its monkey-patching side-effects: the module adds `tz` static method to the `moment` global and a `tz` method to the `moment` prototype.

The affected components were a great fit for the new `useTranslate` and `useLocalizedMoment` hooks. They were already stateless functional components. And now they don't need to be wrapped in any HOCs.

**How to test:**
One notice is in the help popup's "contact us" section, another one is in `/me/concierge/:site/book`. You'll need to fake the dates a bit to see them. By modifying their props either in source code, or at runtime in React devtools.

`LiveChatClosureNotice` in help popup:
<img width="294" alt="screenshot 2019-03-07 at 10 47 46" src="https://user-images.githubusercontent.com/664258/53948835-fdf77280-40c8-11e9-9ce4-c04dce5ddff3.png">

`ClosureNotice` in Concierge:
<img width="624" alt="screenshot 2019-03-07 at 10 48 19" src="https://user-images.githubusercontent.com/664258/53948846-064fad80-40c9-11e9-845a-491ba512b8d3.png">
