### PR TITLE
icfy-analyze: get the sizes of public/style.css file and report it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,7 @@ jobs:
             npm run build-css                                      \
               && npm run preanalyze-bundles                        \
               && node bin/icfy-analyze.js                          \
-              && mv stats.json chart.json "$CIRCLE_ARTIFACTS/icfy" \
+              && mv stats.json chart.json style.json "$CIRCLE_ARTIFACTS/icfy" \
               || rm -fr build/.babel-client-cache # In case of failure do not save a potentially bad cache
             exit 0
       - save_cache: *save-terser-cache

--- a/bin/icfy-analyze.js
+++ b/bin/icfy-analyze.js
@@ -1,7 +1,8 @@
 /** @format */
 
 const { getViewerData, readStatsFromFile } = require( 'webpack-bundle-analyzer/lib/analyzer' );
-const { writeFileSync } = require( 'fs' );
+const { statSync, writeFileSync } = require( 'fs' );
+const gzip = require( 'gzip-size' );
 
 analyzeBundle();
 
@@ -12,5 +13,14 @@ function analyzeBundle() {
 	const chart = getViewerData( stats, './public' );
 	console.log( 'Analyze: writing chart.json file' );
 	writeFileSync( 'chart.json', JSON.stringify( chart, null, 2 ) );
+	console.log( 'Analyze: analyzing the style.css file' );
+	analyzeStylesheet( './public/style.css', 'style.json' );
 	console.log( 'Analyze: finished' );
+}
+
+function analyzeStylesheet( inputCSSFile, outputJSONFile ) {
+	const parsedSize = statSync( inputCSSFile ).size;
+	const gzipSize = gzip.fileSync( inputCSSFile );
+	const styleStats = { statSize: parsedSize, parsedSize, gzipSize };
+	writeFileSync( outputJSONFile, JSON.stringify( styleStats, null, 2 ) );
 }

--- a/bin/icfy-analyze.js
+++ b/bin/icfy-analyze.js
@@ -1,7 +1,8 @@
 /** @format */
 
 const { getViewerData, readStatsFromFile } = require( 'webpack-bundle-analyzer/lib/analyzer' );
-const { statSync, writeFileSync } = require( 'fs' );
+const { statSync, readFileSync, writeFileSync } = require( 'fs' );
+const { createHash } = require( 'crypto' );
 const gzip = require( 'gzip-size' );
 
 analyzeBundle();
@@ -18,9 +19,17 @@ function analyzeBundle() {
 	console.log( 'Analyze: finished' );
 }
 
+function hashFile( inputFile ) {
+	const sha = createHash( 'sha1' );
+	const data = readFileSync( inputFile );
+	sha.update( data );
+	return sha.digest( 'hex' ).slice( 0, 20 );
+}
+
 function analyzeStylesheet( inputCSSFile, outputJSONFile ) {
 	const parsedSize = statSync( inputCSSFile ).size;
 	const gzipSize = gzip.fileSync( inputCSSFile );
-	const styleStats = { statSize: parsedSize, parsedSize, gzipSize };
+	const hash = hashFile( inputCSSFile );
+	const styleStats = { statSize: parsedSize, parsedSize, gzipSize, hash };
 	writeFileSync( outputJSONFile, JSON.stringify( styleStats, null, 2 ) );
 }


### PR DESCRIPTION
The stylesheet is built outside webpack and therefore not a part of reported stats. This patch adds code to analyze the file and report the stats as a separate artifact file, `style.json`.

Enables us to start showing an ICFY chart of `style.css` getting smaller.

(The `gzip-size` package is already used by the `bin/loader-stats.js` script and also internally by `webpack-bundle-analyzer`)

**How to test:**
Look at the `icfy-stats` CircleCI task for this branch. Verify that the `style.json` artifact is there and contains valid data.
