### PR TITLE
Email Forwarding: remove styles from the components.scss file

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -311,7 +311,6 @@
 @import 'notices/style';
 @import 'my-sites/domains/domain-management/style';
 @import 'my-sites/domains/domain-management/email/style';
-@import 'my-sites/email/email-forwarding/style';
 @import 'my-sites/domains/domain-management/components/email-verification/style';
 @import 'my-sites/domains/domain-management/components/inbound-transfer-verification/style';
 @import 'my-sites/domains/domain-management/components/icann-verification/style';


### PR DESCRIPTION
After the recent refactorings in #31131 and #31133, the Email Forwarding CSS files somehow ended up being bundled twice: once by the `node-sass` build, once in the webpack build.

This PR removes the unwanted import and leaves only the webpack one.
