### PR TITLE
Login: Add a classname to Jetpack login page

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -19,6 +19,7 @@ import notices from 'notices';
 import OauthClientMasterbar from 'layout/masterbar/oauth-client';
 import { isCrowdsignalOAuth2Client } from 'lib/oauth2-clients';
 import { getCurrentOAuth2Client, showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
+import { getCurrentRoute } from 'state/selectors/get-current-route';
 import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 
@@ -33,6 +34,7 @@ const hasSidebar = section => {
 };
 
 const LayoutLoggedOut = ( {
+	isJetpackLogin,
 	masterbarIsHidden,
 	oauth2Client,
 	primary,
@@ -50,6 +52,7 @@ const LayoutLoggedOut = ( {
 		'focus-content': true,
 		'has-no-sidebar': ! hasSidebar( section ),
 		'has-no-masterbar': masterbarIsHidden,
+		'is-jetpack-login': isJetpackLogin,
 	};
 
 	let masterbar = null;
@@ -111,7 +114,11 @@ LayoutLoggedOut.propTypes = {
 
 export default connect( state => {
 	const section = getSection( state );
+	const currentRoute = getCurrentRoute( state );
+	const isJetpackLogin = currentRoute === '/log-in/jetpack';
+
 	return {
+		isJetpackLogin,
 		masterbarIsHidden: ! masterbarIsVisible( state ) || 'signup' === section.name,
 		section,
 		oauth2Client: getCurrentOAuth2Client( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a `is-jetpack-login` classname on the Jetpack login page. This allows us to apply different color scheme for the Jetpack login page only, excluding the regular login page.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Make sure you're logged out of WP.com.
* Go to `/log-in/jetpack`.
* Verify that `.layout` also has a `.is-jetpack-login` classname.
* Go to `/log-in`.
* Verify that `.layout` does NOT have a `.is-jetpack-login` classname.

Necessary for #31141.
