### PR TITLE
Layout: Do not request all sites on JPC authorize step

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -116,14 +116,7 @@ class Layout extends Component {
 				<BodySectionCssClass group={ this.props.sectionGroup } section={ this.props.sectionName } />
 				<DocumentHead />
 				<QuerySites primaryAndRecent />
-				/* We avoid requesting sites in the Jetpack Connect authorization step, because this would
-				request all sites before authorization has finished. That would cause the "all sites"
-				request to lack the newly authorized site, and when the request finishes after
-				authorization, it would remove the newly connected site that has been fetched separately.
-				See https://github.com/Automattic/wp-calypso/pull/31277 for more details. */
-				{ this.props.currentRoute && this.props.currentRoute !== '/jetpack/connect/authorize' && (
-					<QuerySites allSites />
-				) }
+				{ this.props.shouldQueryAllSites && <QuerySites allSites /> }
 				<QueryPreferences />
 				<QuerySiteSelectedEditor siteId={ this.props.siteId } />
 				<AsyncLoad require="layout/guided-tours" placeholder={ null } />
@@ -181,6 +174,8 @@ class Layout extends Component {
 export default connect( state => {
 	const sectionGroup = getSectionGroup( state );
 	const sectionName = getSectionName( state );
+	const currentRoute = getCurrentRoute( state );
+
 	return {
 		masterbarIsHidden: ! masterbarIsVisible( state ) || 'signup' === sectionName,
 		isLoading: isSectionLoading( state ),
@@ -192,7 +187,13 @@ export default connect( state => {
 		currentLayoutFocus: getCurrentLayoutFocus( state ),
 		chatIsOpen: isHappychatOpen( state ),
 		colorSchemePreference: getPreference( state, 'colorScheme' ),
-		currentRoute: getCurrentRoute( state ),
+		currentRoute,
 		siteId: getSelectedSiteId( state ),
+		/* We avoid requesting sites in the Jetpack Connect authorization step, because this would
+		request all sites before authorization has finished. That would cause the "all sites"
+		request to lack the newly authorized site, and when the request finishes after
+		authorization, it would remove the newly connected site that has been fetched separately.
+		See https://github.com/Automattic/wp-calypso/pull/31277 for more details. */
+		shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
 	};
 } )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -116,7 +116,9 @@ class Layout extends Component {
 				<BodySectionCssClass group={ this.props.sectionGroup } section={ this.props.sectionName } />
 				<DocumentHead />
 				<QuerySites primaryAndRecent />
-				<QuerySites allSites />
+				{ this.props.currentRoute && this.props.currentRoute !== '/jetpack/connect/authorize' && (
+					<QuerySites allSites />
+				) }
 				<QueryPreferences />
 				<QuerySiteSelectedEditor siteId={ this.props.siteId } />
 				<AsyncLoad require="layout/guided-tours" placeholder={ null } />

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -116,6 +116,11 @@ class Layout extends Component {
 				<BodySectionCssClass group={ this.props.sectionGroup } section={ this.props.sectionName } />
 				<DocumentHead />
 				<QuerySites primaryAndRecent />
+				/* We avoid requesting sites in the Jetpack Connect authorization step, because this would
+				request all sites before authorization has finished. That would cause the "all sites"
+				request to lack the newly authorized site, and when the request finishes after
+				authorization, it would remove the newly connected site that has been fetched separately.
+				See https://github.com/Automattic/wp-calypso/pull/31277 for more details. */
 				{ this.props.currentRoute && this.props.currentRoute !== '/jetpack/connect/authorize' && (
 					<QuerySites allSites />
 				) }


### PR DESCRIPTION
Currently, we have hit an interesting race condition when the user has hundreds of sites and wants to connect a new Jetpack site. If you don't have a hundred of sites, sandbox the API and add a 10-20 second delay on the `/me/sites` endpoint to force slower loading of that endpoint. The bug occurs when the things happen in the following order:

- we start connecting a Jetpack site from wp-admin
- we reach the Jetpack Connect authorization page
- Calypso starts requesting ALL the sites of our user
- authorization finishes
- our new site gets loaded
- Calypso finishes requesting ALL the sites

When that happens, the “all sites” we just loaded will overwrite the existing sites we have, and thus will erase the new site we just connected. the new site doesn’t exist in ALL sites, because at the time we made the request, the authorization hadn’t finished.

In order to fix this, this PR suggests that we don't query all sites on the authorization step. This will ensure that we're querying the sites _after_ the authorization has finished.

This will also nicely fix other similar race conditions that we've had with connecting sites to users with hundreds of sites.

#### Changes proposed in this Pull Request

* Do not call `<QuerySites allsites />` on the authorization step.

#### Testing instructions

* Checkout this branch.
* Track the network requests all the time.
* If you don't have over 400 sites in your WP.com account, add a 20 second delay to the `/me/sites` endpoint by adding a `sleep( 20 );` to the beginning of the `get_sites()` method.
* Create a new Jurassic Ninja site from this link: https://jurassic.ninja/create?shortlived&jetpack-beta
* Copy the connection URL and add `&calypso_env=development` to it.
* Open the URL.
* Make sure you don't see a request to `/me/sites`.
* Finish authorization quickly (confirm it if it asks you to do it).
* You'll reach the site type step.
* Verify the `/me/sites` request started when you loaded the site type step.
* Verify that after the `/me/sites` request finished, the step didn't disappear.

I'm pinging @sirreal and @beaulebens specifically, as they were able to reproduce without forcing a delay of the `/me/sites` endpoint.

I'm also pinging @Automattic/team-calypso because this is a change at a framework level - we don't start querying sites before the current route is set.
