### PR TITLE
Gsuite: Increase readability of billing messaging

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-dialog/style.scss
+++ b/client/components/upgrades/gsuite/gsuite-dialog/style.scss
@@ -92,10 +92,9 @@
 }
 
 .gsuite-dialog__billing-period {
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	line-height: 1.6;
-	text-transform: uppercase;
 
 	@include breakpoint( '<480px' ) {
 		margin-top: 15px;


### PR DESCRIPTION
The subtext on the Gsuite screen when purchasing a domain is using a very low-contrast color and uppercase text. These things combined make the messaging hard to read.

Before:
<img width="340" alt="image" src="https://user-images.githubusercontent.com/191598/53972921-bc1cfb00-40cd-11e9-9348-b9bed0e5bcb2.png">

After:
<img width="338" alt="image" src="https://user-images.githubusercontent.com/191598/53972995-ebcc0300-40cd-11e9-8e3d-4f293661a6d7.png">
