### PR TITLE
Gsuite: Change label on button to make it clear there is a cost involved

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
@@ -141,7 +141,7 @@ class GoogleAppsDialog extends React.Component {
 					className="gsuite-dialog__continue-button"
 					onClick={ this.handleFormSubmit }
 				>
-					{ translate( 'Yes, Add Email \u00BB' ) }
+					{ translate( 'Purchase G Suite' ) }
 				</Button>
 			</footer>
 		);

--- a/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
@@ -13,6 +13,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import { cartItems } from 'lib/cart-values';
 import CompactCard from 'components/card/compact';
@@ -128,8 +129,17 @@ class GoogleAppsDialog extends React.Component {
 		);
 	}
 
+	renderButtonCopy() {
+		const { translate } = this.props;
+		if ( abtest( 'gSuiteContinueButtonCopy' ) === 'purchase' ) {
+			return translate( 'Purchase G Suite' );
+		}
+		return translate( 'Purchase G Suite' );
+	}
+
 	footer() {
 		const { translate } = this.props;
+
 		return (
 			<footer className="gsuite-dialog__footer">
 				<Button className="gsuite-dialog__checkout-button" onClick={ this.handleFormCheckout }>
@@ -141,7 +151,7 @@ class GoogleAppsDialog extends React.Component {
 					className="gsuite-dialog__continue-button"
 					onClick={ this.handleFormSubmit }
 				>
-					{ translate( 'Purchase G Suite' ) }
+					{ this.renderButtonCopy() }
 				</Button>
 			</footer>
 		);

--- a/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
@@ -134,7 +134,7 @@ class GoogleAppsDialog extends React.Component {
 		if ( abtest( 'gSuiteContinueButtonCopy' ) === 'purchase' ) {
 			return translate( 'Purchase G Suite' );
 		}
-		return translate( 'Purchase G Suite' );
+		return translate( 'Yes, Add Email \u00BB' );
 	}
 
 	footer() {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -173,4 +173,12 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
+	gSuiteContinueButtonCopy: {
+		datestamp: '20190307',
+		variations: {
+			purchase: 50,
+			original: 50,
+		},
+		defaultVariation: 'original',
+	},
 };


### PR DESCRIPTION
It's not totally obvious that adding mail to your domain purchase involved additional fees. This PR adds an A/B test to analyze what effect changing the copy will have.

Original:
<img width="233" alt="image" src="https://user-images.githubusercontent.com/191598/53974030-d35ce800-40cf-11e9-97b2-1cdb1ce0473d.png">

Variation:
<img width="258" alt="image" src="https://user-images.githubusercontent.com/191598/53974082-ea033f00-40cf-11e9-91b4-7b890abb5007.png">

Testing Instructions:

- In the chrome dev console: localStorage.setItem( 'ABTests', '{"gSuiteContinueButtonCopy_20190307":"purchase"}' );
- Refresh
- Goto a site
- Click domains in left menu
- Click "Add domain"
- Choose domain
- Observe G Suite up sell

- In the chrome dev console: localStorage.setItem( 'ABTests', '{"gSuiteContinueButtonCopy_20190307":"original"}' );
- Follow test plan above

