### PR TITLE
Add New Site: Remove hover behavior on cards

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/style.scss
+++ b/client/jetpack-connect/jetpack-new-site/style.scss
@@ -39,15 +39,6 @@
 	flex-direction: column;
 	width: 360px;
 	margin: 0;
-	transition: transform 0.25s ease, box-shadow 0.35s ease, z-index 0.15s ease;
-
-	&:hover {
-		z-index: 3;
-		transform: scale( 1.075 );
-		box-shadow: 0 0 0 1px rgba( var( --color-neutral-100-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 ),
-			0 7px 18px rgba( var( --color-neutral-100-rgb ), 0.5 );
-		transition: transform 0.25s ease, box-shadow 0.35s ease, z-index 0.175s ease;
-	}
 
 	@include breakpoint( '<660px' ) {
 		display: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This isn't a useful design animation pattern; the hover behavior indicates you can click on the card like it were a button, but you can't. This PR removes the hover transform.

***Before**

<img width="779" alt="screen shot 2019-03-06 at 11 45 26 am" src="https://user-images.githubusercontent.com/2124984/53980720-08bd0200-40df-11e9-8ec6-475746a25038.png">

**After**

<img width="753" alt="screen shot 2019-03-07 at 11 15 48 am" src="https://user-images.githubusercontent.com/2124984/53980674-e9be7000-40de-11e9-8065-9f2cc5b7d6b3.png">

#### Testing instructions

* Switch to this PR
* Go to Switch Sites -> Add New Site
* Hover over either of the cards for WordPress.com or Jetpack; neither should increase in size.