### PR TITLE
Checkout: Increase size and contrast of total price

### DIFF
--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -111,9 +111,9 @@
 	}
 
 	.cart__total {
-		color: var( --color-text-subtle );
+		color: var( --color-text );
 		display: table;
-		font-size: 14px;
+		font-size: 16px;
 
 		.cart__total-row.grand-total {
 			display: table-footer-group;
@@ -141,8 +141,6 @@
 
 		.cart__total-amount.grand-total {
 			font-weight: 600;
-			padding-top: 5px;
-			margin-top: 5px;
 		}
 	}
 
@@ -151,8 +149,6 @@
 		height: 0;
 		width: 30%;
 		margin-left: 70%;
-		padding-top: 5px;
-		margin-top: 5px;
 	}
 
 	.cart__coupon {

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -111,9 +111,9 @@
 	}
 
 	.cart__total {
-		color: var( --color-text );
+		color: var( --color-text-subtle );
 		display: table;
-		font-size: 16px;
+		font-size: 20px;
 
 		.cart__total-row.grand-total {
 			display: table-footer-group;
@@ -140,7 +140,7 @@
 		}
 
 		.cart__total-amount.grand-total {
-			font-weight: 600;
+			color: var( --color-text );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Let's make the total price more visible in the Order Summary, since it's a very important facet of this screen and should be the focus of the cart.
* Increases the font size and darkens the text color.

**Before**

<img width="351" alt="screen shot 2019-03-07 at 2 21 46 pm" src="https://user-images.githubusercontent.com/2124984/53983038-5c7e1a00-40e4-11e9-8105-abd888bb340b.png">

**After**

<img width="265" alt="screen shot 2019-03-07 at 4 02 31 pm" src="https://user-images.githubusercontent.com/2124984/53988878-88080100-40f2-11e9-86ef-fa0550314429.png">

#### Testing instructions

* Switch to this PR
* Add various products to your cart (domains, plans, GSuite, etc.) and check out.
* Note the type changes in the Order Summary sidebar.