### PR TITLE
Domains: Remove a/b test and make one primary button the default

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -21,7 +21,6 @@ import {
 	hasDomainInCart,
 } from 'lib/cart-values/cart-items';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { abtest } from 'lib/abtest';
 import {
 	parseMatchReasons,
 	VALID_MATCH_REASONS,
@@ -140,10 +139,7 @@ class DomainRegistrationSuggestion extends React.Component {
 					: translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		}
 
-		let buttonStyles = { primary: true };
-		if ( abtest( 'domainSearchButtonStyles' ) === 'onePrimary' ) {
-			buttonStyles = ! isFeatured ? {} : this.props.buttonStyles;
-		}
+		let buttonStyles = ! isFeatured ? {} : this.props.buttonStyles;
 
 		if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
 			buttonStyles = { ...buttonStyles, disabled: true };

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -120,7 +120,6 @@ class DomainRegistrationSuggestion extends React.Component {
 			suggestion,
 			translate,
 			pendingCheckSuggestion,
-			isFeatured,
 		} = this.props;
 		const { domain_name: domain } = suggestion;
 		const isAdded = hasDomainInCart( cart, domain );
@@ -139,7 +138,7 @@ class DomainRegistrationSuggestion extends React.Component {
 					: translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		}
 
-		let buttonStyles = ! isFeatured ? {} : this.props.buttonStyles;
+		let buttonStyles = this.props.buttonStyles;
 
 		if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
 			buttonStyles = { ...buttonStyles, disabled: true };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,14 +124,6 @@ export default {
 		},
 		defaultVariation: 'keep',
 	},
-	domainSearchButtonStyles: {
-		datestamp: '20190119',
-		variations: {
-			allPrimary: 50,
-			onePrimary: 50,
-		},
-		defaultVariation: 'allPrimary',
-	},
 	twoYearPlanByDefault: {
 		datestamp: '20190207',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the domain search results default to only using one primary button. All others are outlined secondary buttons.
* Remove the `domainSearchButtonStyles` test.

#### Before
<img width="1062" alt="screen shot 2019-03-07 at 14 23 13" src="https://user-images.githubusercontent.com/448298/53983290-e4fcba80-40e4-11e9-8348-d267f73375f1.png">

#### After
<img width="1063" alt="screen shot 2019-03-07 at 14 19 28" src="https://user-images.githubusercontent.com/448298/53983303-eb8b3200-40e4-11e9-8b3d-aed243c35f87.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click `Add` next to the `Domains` sidebar item.
* Enter a term to search for a domain.
* Confirm the only primary button is the `Best Match` first featured result.
