### PR TITLE
Earn section: fix links from plans

### DIFF
--- a/client/blocks/product-purchase-features-list/monetize-site.jsx
+++ b/client/blocks/product-purchase-features-list/monetize-site.jsx
@@ -15,7 +15,7 @@ import PurchaseDetail from 'components/purchase-detail';
 export default localize( ( { selectedSite, translate } ) => {
 	const adSettingsUrl = selectedSite.jetpack
 		? '/settings/traffic/' + selectedSite.slug
-		: '/ads/settings/' + selectedSite.slug;
+		: '/earn/ads-settings/' + selectedSite.slug;
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail

--- a/client/my-sites/earn/controller.js
+++ b/client/my-sites/earn/controller.js
@@ -17,7 +17,10 @@ export default {
 		page.redirect( '/earn/ads-earnings/' + context.params.site_id );
 		return;
 	},
-
+	redirectToAdsSettings: function( context ) {
+		page.redirect( '/earn/ads-settings/' + context.params.site_id );
+		return;
+	},
 	layout: function( context, next ) {
 		// Scroll to the top
 		if ( typeof window !== 'undefined' ) {

--- a/client/my-sites/earn/index.js
+++ b/client/my-sites/earn/index.js
@@ -14,6 +14,10 @@ import { makeLayout, render as clientRender } from 'controller';
 export default function() {
 	page( '/earn', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/:site_id', earnController.redirect, makeLayout, clientRender );
+	// These 2 are legacy URLs to redirect if they are present anywhere on the web.
+	page( '/ads/earnings/:site_id', earnController.redirect, makeLayout, clientRender );
+	page( '/ads/settings/:site_id', earnController.redirectToAdsSettings, makeLayout, clientRender );
+
 	page(
 		'/earn/:section/:site_id',
 		siteSelection,

--- a/client/wordpress-com.js
+++ b/client/wordpress-com.js
@@ -274,7 +274,7 @@ const sections = [
 	},
 	{
 		name: 'earn',
-		paths: [ '/earn' ],
+		paths: [ '/earn', '/ads' ],
 		module: 'my-sites/earn',
 		secondary: true,
 		group: 'sites',


### PR DESCRIPTION
Fixes a bug introduct in #29001 . The path has changed to wordads settings and there was one place where URL was not updated.

- URL gets updated
- legacy URLs are now redirected to new URLs

#### Testing instructions

A) On a premium+ site, go to /plans, you should see this button:
![](https://cld.wthms.co/jI41Tu+)
When you click it, you should  NOT get 404

B) Try `http://calypso.localhost:3000/ads/settings/[your-site]`. It should redirect you to /earn/ads-settings

C) Profit!

