### PR TITLE
Color Schmes: Fix color contrast in checkout when using dark color schemes

### DIFF
--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -1,3 +1,7 @@
+.is-section-checkout .layout__secondary {
+	border-color: var( --color-border-subtle );
+}
+
 .cart__header {
 	border-top: 1px solid var( --color-border-subtle );
 

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -202,6 +202,7 @@
 	background: var( --color-neutral-0 );
 	border: 1px solid var( --color-neutral-0 );
 	border-radius: 4px;
+	color: var( --color-text );
 	font-size: 12px;
 	margin: 15px 15px 0;
 	padding: 10px;

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -166,7 +166,7 @@
 		form {
 			display: block;
 			border-top: 1px solid var( --color-border-subtle );
-			margin: 15px -15px 0 -15px;
+			margin: 15px -15px 0;
 			padding: 15px 15px 0;
 
 			input[type='text'] {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Using a dark color scheme made some parts of the checkout sidebar illegible due to poor contrast. 
* This sets a dark color variable for this area to ensure it retains contrast against the light gray background.
* Also updates the border color to a fixed variable rather than color-scheme-dependent.

**Before**

<img width="379" alt="screen shot 2019-03-07 at 3 52 27 pm" src="https://user-images.githubusercontent.com/2124984/53988239-06fc3a00-40f1-11e9-8785-8a4937a9879b.png">

**After**

<img width="331" alt="screen shot 2019-03-07 at 3 50 53 pm" src="https://user-images.githubusercontent.com/2124984/53988206-f8158780-40f0-11e9-9c6a-fdb21528f719.png">

#### Testing instructions

* Switch to this PR on a site with a Free plan
* Switch your color scheme to Nightfall under Account Settings (/me/account)
* Add a domain to your cart and check out
* Note the upgrade message at the top of the sidebar; it should have contrast with the background