### PR TITLE
Domain search: Increase text contrast

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -1,6 +1,6 @@
 
 .domain-product-price {
-	color: var( --color-neutral-600 );
+	color: var( --color-text );
 	font-weight: 400;
     font-size: 0.875em;
 	line-height: 1;
@@ -32,7 +32,7 @@
 	}
 
 	small {
-		opacity: 0.6;
+		color: var( --color-text-subtle )
 	}
 
 	&.domain-product-price__is-with-plans-only {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This increases text contrast for places that use the domain search component

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to http://calypso.localhost:3000/start/domain/domain-only
* search for a domain
* note the color of the "/year" text

Before

<img width="961" alt="screen shot 2019-03-07 at 3 52 33 pm" src="https://user-images.githubusercontent.com/618551/53988341-3e6ae680-40f1-11e9-8d1c-1dcced3a71c9.png">

After

<img width="966" alt="screen shot 2019-03-07 at 3 52 03 pm" src="https://user-images.githubusercontent.com/618551/53988366-4aef3f00-40f1-11e9-82ac-530cd7670c2a.png">

