### PR TITLE
Checkout: update checkout terms text contrast

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -248,7 +248,6 @@
 
 		p {
 			font-size: 12px;
-			font-weight: 100;
 			margin: 0;
 
 			@include breakpoint( '>660px' ) {

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -237,7 +237,7 @@
 
 	.checkout-terms,
 	.checkout__domain-refund-policy {
-		color: var( --color-neutral-400 );
+		color: var( --color-text-subtle );
 		margin: 16px 0;
 		padding: 0;
 
@@ -457,7 +457,7 @@
 				}
 
 				> span {
-					color: var( --color-neutral-400 );
+					color: var( --color-text-subtle );
 					font-size: 15px;
 				}
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increases text contrast

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/domains/add
* Add a domain to your cart
* Continue checkout until you get to the purchase screen

Notice the "terms" text. Shouldn't matter if you have credits or real $$$

Before
<img width="749" alt="screen shot 2019-03-07 at 4 01 06 pm" src="https://user-images.githubusercontent.com/618551/53989409-e386be80-40f3-11e9-9605-fea327885f10.png">

After
<img width="750" alt="screen shot 2019-03-07 at 4 04 26 pm" src="https://user-images.githubusercontent.com/618551/53989422-f00b1700-40f3-11e9-8b2d-0c657dc75b0c.png">


