### PR TITLE
Slideshow Block: Override Themes' Box Shadow

### DIFF
--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -12,7 +12,7 @@
 		}
 
 		// High specifity to override theme styles
-		.wp-block-jetpack-slideshow_swiper-wrappper,
+		.wp-block-jetpack-slideshow_swiper-wrapper,
 		.wp-block-jetpack-slideshow_slide {
 			padding: 0;
 			margin: 0;
@@ -58,6 +58,7 @@
 		background-size: 24px;
 		border: 0;
 		border-radius: 4px;
+		box-shadow: none;
 		height: 48px;
 		margin: -24px 0 0;
 		padding: 0;

--- a/client/gutenberg/extensions/slideshow/style.scss
+++ b/client/gutenberg/extensions/slideshow/style.scss
@@ -12,7 +12,7 @@
 		}
 
 		// High specifity to override theme styles
-		.wp-block-jetpack-slideshow_swiper-wrapper,
+		.wp-block-jetpack-slideshow_swiper-wrappper,
 		.wp-block-jetpack-slideshow_slide {
 			padding: 0;
 			margin: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since the Slideshow Block arrow underlines are links, it isn't unreasonable to expect themes to style them with a box-shadow (which is what Twenty Sixteen does). This PR would override that, and also fix a typo in a selector. (Never mind, that's actually the class name) 

#### Testing instructions

Add a Slideshow Block and notice no difference with most themes, except with the Twenty Sixteen theme in regards to that blue underline. 

**Current:**

![gdfgfdfgdgf](https://user-images.githubusercontent.com/43215253/53992378-9707a700-4124-11e9-93cc-f0cc16e82dca.png)

**Proposed:**

![gdffgdgdf](https://user-images.githubusercontent.com/43215253/53992395-9f5fe200-4124-11e9-8b39-7c1db54570a9.png)

cc @simison, @jeffersonrabb

Fixes #31227 