### PR TITLE
Don't prime calypso.live for external PR authors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -470,16 +470,17 @@ jobs:
     - image: buildpack-deps
     working_directory: ~/wp-calypso
     steps:
-      - prepare
       - run:
-          name: Prime calypso.live build
+          name: Check external author
           command: |
-            if [[ -z $CIRCLE_PR_USERNAME ]]; then
-              ./test/e2e/scripts/wait-for-running-branch.sh
-            else
+            if [[ ! -z $CIRCLE_PR_USERNAME ]]; then
               echo 'PRs from external authors cannot run on calypso.live'
               exit 1
             fi
+      - prepare
+      - run:
+          name: Wait for calypso.live build
+          command: ./test/e2e/scripts/wait-for-running-branch.sh
 
   test-e2e:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -474,7 +474,7 @@ jobs:
       - run:
           name: Prime calypso.live build
           command: |
-            if [[ ! -z $CIRCLE_PR_USERNAME ]]; then
+            if [[ -z $CIRCLE_PR_USERNAME ]]; then
               ./test/e2e/scripts/wait-for-running-branch.sh
             fi
             echo 'PRs from external authors cannot run on calypso.live'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -476,9 +476,10 @@ jobs:
           command: |
             if [[ -z $CIRCLE_PR_USERNAME ]]; then
               ./test/e2e/scripts/wait-for-running-branch.sh
+            else
+              echo 'PRs from external authors cannot run on calypso.live'
+              exit 1
             fi
-            echo 'PRs from external authors cannot run on calypso.live'
-            exit 1
 
   test-e2e:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,7 +473,12 @@ jobs:
       - prepare
       - run:
           name: Prime calypso.live build
-          command: ./test/e2e/scripts/wait-for-running-branch.sh
+          command: |
+            if [[ ! -z $CIRCLE_PR_USERNAME ]]; then
+              ./test/e2e/scripts/wait-for-running-branch.sh
+            fi
+            echo 'PRs from external authors cannot run on calypso.live'
+            exit 1
 
   test-e2e:
     <<: *defaults


### PR DESCRIPTION
PRs from external authors (forks that submit PRs to this repo) cannot run on calypso.live.
Do not attempt to prime.
Do not attempt to run branch e2e tests against calypso.live.
This will save us waiting for the job to time out (no lost container time).

Unfortunately, it will also fail the tests. This is the same as current behavior. I don't know that there is any way to filter PRs like this where we can't run the e2e suite against the branch.

Examples:
- External PR: https://github.com/Automattic/wp-calypso/pull/31295 (10 minutes wasted wait)
  - prime-calypso-live: https://circleci.com/gh/Automattic/wp-calypso/210830
- Internal PR: https://github.com/Automattic/wp-calypso/pull/31095
  - prime-calypso-live https://circleci.com/gh/Automattic/wp-calypso/209397

#### Testing instructions

* This PR should prime calypso.live successfully. Look at the [`prime-calypso-live` job](https://circleci.com/gh/Automattic/wp-calypso/211054).
* Fork and submit a PR against this branch from another repo. It should fail the same job with an informative message.
  - Example: https://github.com/Automattic/wp-calypso/pull/31301
  - Prime job: https://circleci.com/gh/Automattic/wp-calypso/211069 (Fail at 0s)

#### Follow up

Prime-calypso-live was initially intended to get calypso.live spun up and ready for when e2e tests run (and wait for the build). It would be nice to restore and earlier job just to ping calypso.live so the build can start, then a later job can actually wait for the build to complete so e2e tests can run.