### PR TITLE
Jetpack Connect: Add skip button to site type, site topic and user type steps

### DIFF
--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import FormattedHeader from 'components/formatted-header';
 import MainWrapper from './main-wrapper';
+import SkipButton from './skip-button';
 import SiteTopicForm from 'signup/steps/site-topic/form';
 import WpcomColophon from 'components/wpcom-colophon';
 import jetpackOnly from './jetpack-only';
@@ -22,21 +23,27 @@ import { getSiteOption } from 'state/sites/selectors';
 import { saveSiteVertical } from 'state/jetpack-connect/actions';
 
 class JetpackSiteTopic extends Component {
-	handleSubmit = ( { name, slug } ) => {
-		const { siteId, siteSlug } = this.props;
-		const siteVertical = name || slug || '';
+	goToNextStep = () => {
+		const { siteSlug, siteJetpackVersion } = this.props;
 
-		this.props.saveSiteVertical( siteId, siteVertical );
-
-		const jpVersion = this.props.siteJetpackVersion;
-		if ( ! jpVersion ) {
+		if ( ! siteJetpackVersion ) {
 			return null;
 		}
-		if ( versionCompare( jpVersion, 7.2 ) < 0 || jpVersion === '7.2-alpha' ) {
+
+		if ( versionCompare( siteJetpackVersion, 7.2 ) < 0 || siteJetpackVersion === '7.2-alpha' ) {
 			page( `/jetpack/connect/user-type/${ siteSlug }` );
 		} else {
 			page( `/jetpack/connect/plans/${ siteSlug }` );
 		}
+	};
+
+	handleSubmit = ( { name, slug } ) => {
+		const { siteId } = this.props;
+		const siteVertical = name || slug || '';
+
+		this.props.saveSiteVertical( siteId, siteVertical );
+
+		this.goToNextStep();
 	};
 
 	render() {
@@ -53,6 +60,8 @@ class JetpackSiteTopic extends Component {
 					/>
 
 					<SiteTopicForm submitForm={ this.handleSubmit } />
+
+					<SkipButton onClick={ this.goToNextStep } />
 
 					<WpcomColophon />
 				</div>

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -61,7 +61,10 @@ class JetpackSiteTopic extends Component {
 
 					<SiteTopicForm submitForm={ this.handleSubmit } />
 
-					<SkipButton onClick={ this.goToNextStep } />
+					<SkipButton
+						onClick={ this.goToNextStep }
+						tracksEventName="calypso_jpc_skipped_site_topic"
+					/>
 
 					<WpcomColophon />
 				</div>

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 import FormattedHeader from 'components/formatted-header';
 import jetpackOnly from './jetpack-only';
 import MainWrapper from './main-wrapper';
+import SkipButton from './skip-button';
 import SiteTypeForm from 'signup/steps/site-type/form';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomColophon from 'components/wpcom-colophon';
@@ -20,12 +21,18 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { saveSiteType } from 'state/jetpack-connect/actions';
 
 class JetpackSiteType extends Component {
+	goToNextStep = () => {
+		const { siteSlug } = this.props;
+
+		page( `/jetpack/connect/site-topic/${ siteSlug }` );
+	};
+
 	handleSubmit = siteType => {
-		const { siteId, siteSlug } = this.props;
+		const { siteId } = this.props;
 
 		this.props.saveSiteType( siteId, siteType );
 
-		page( `/jetpack/connect/site-topic/${ siteSlug }` );
+		this.goToNextStep();
 	};
 
 	render() {
@@ -44,6 +51,8 @@ class JetpackSiteType extends Component {
 					<FormattedHeader headerText={ translate( 'What kind of site do you have?' ) } />
 
 					<SiteTypeForm submitForm={ this.handleSubmit } />
+
+					<SkipButton onClick={ this.goToNextStep } />
 
 					<WpcomColophon />
 				</div>

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -52,7 +52,10 @@ class JetpackSiteType extends Component {
 
 					<SiteTypeForm submitForm={ this.handleSubmit } />
 
-					<SkipButton onClick={ this.goToNextStep } />
+					<SkipButton
+						onClick={ this.goToNextStep }
+						tracksEventName="calypso_jpc_skipped_site_type"
+					/>
 
 					<WpcomColophon />
 				</div>

--- a/client/jetpack-connect/skip-button.js
+++ b/client/jetpack-connect/skip-button.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -13,6 +14,17 @@ import Gridicon from 'gridicons';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 class SkipButton extends PureComponent {
+	static propTypes = {
+		onClick: PropTypes.func,
+		tracksEventName: PropTypes.string,
+
+		// Connected props
+		recordTracksEvent: PropTypes.func,
+
+		// From localize() HoC
+		translate: PropTypes.func,
+	};
+
 	handleClick = () => {
 		const { onClick, tracksEventName } = this.props;
 
@@ -22,7 +34,9 @@ class SkipButton extends PureComponent {
 			this.props.recordTracksEvent( tracksEventName );
 		}
 
-		onClick();
+		if ( onClick ) {
+			onClick();
+		}
 	};
 
 	render() {

--- a/client/jetpack-connect/skip-button.js
+++ b/client/jetpack-connect/skip-button.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import React from 'react';
-import { identity } from 'lodash';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -10,14 +10,38 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Gridicon from 'gridicons';
+import { recordTracksEvent } from 'state/analytics/actions';
 
-const SkipButton = ( { onClick, translate = identity } ) => (
-	<div className="jetpack-connect__skip-button">
-		<Button onClick={ onClick } borderless>
-			{ translate( 'Skip' ) }
-			<Gridicon icon="arrow-right" size={ 18 } />
-		</Button>
-	</div>
-);
+class SkipButton extends PureComponent {
+	handleClick = () => {
+		const { onClick, tracksEventName } = this.props;
 
-export default localize( SkipButton );
+		this.props.recordTracksEvent( 'calypso_jpc_skip_button_click' );
+
+		if ( tracksEventName ) {
+			this.props.recordTracksEvent( tracksEventName );
+		}
+
+		onClick();
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<div className="jetpack-connect__skip-button">
+				<Button onClick={ this.handleClick } borderless>
+					{ translate( 'Skip' ) }
+					<Gridicon icon="arrow-right" size={ 18 } />
+				</Button>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+	}
+)( localize( SkipButton ) );

--- a/client/jetpack-connect/skip-button.js
+++ b/client/jetpack-connect/skip-button.js
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { identity } from 'lodash';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Gridicon from 'gridicons';
+
+const SkipButton = ( { onClick, translate = identity } ) => (
+	<div className="jetpack-connect__skip-button">
+		<Button onClick={ onClick } borderless>
+			{ translate( 'Skip' ) }
+			<Gridicon icon="arrow-right" size={ 18 } />
+		</Button>
+	</div>
+);
+
+export default localize( SkipButton );

--- a/client/jetpack-connect/skip-button.js
+++ b/client/jetpack-connect/skip-button.js
@@ -22,7 +22,7 @@ class SkipButton extends PureComponent {
 		recordTracksEvent: PropTypes.func.isRequired,
 
 		// From localize() HoC
-		translate: PropTypes.func,
+		translate: PropTypes.func.isRequired,
 	};
 
 	handleClick = () => {

--- a/client/jetpack-connect/skip-button.js
+++ b/client/jetpack-connect/skip-button.js
@@ -19,7 +19,7 @@ class SkipButton extends PureComponent {
 		tracksEventName: PropTypes.string,
 
 		// Connected props
-		recordTracksEvent: PropTypes.func,
+		recordTracksEvent: PropTypes.func.isRequired,
 
 		// From localize() HoC
 		translate: PropTypes.func,

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -864,7 +864,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.logged-out-form__links a,
 	.logged-out-form__link-item,
 	.jetpack-connect__back-button,
-	.translator-invite__content a {
+	.translator-invite__content a,
+	.jetpack-connect__skip-button .button {
 		color: var( --color-neutral-300 );
 		border-bottom-color: var( --color-neutral-700 );
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -875,6 +875,12 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 	}
 
+	.jetpack-connect__skip-button .button {
+		&:focus {
+			box-shadow: 0 0 0 transparent;
+		}
+	}
+
 	.translator-invite__content a {
 		border: none;
 	}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1027,3 +1027,13 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 	}
 }
+
+.jetpack-connect__skip-button {
+	text-align: center;
+	margin: 17px 0;
+
+	.button .gridicon {
+		padding-left: 4px;
+		margin-right: -5px;
+	}
+}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -866,12 +866,12 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.jetpack-connect__back-button,
 	.translator-invite__content a,
 	.jetpack-connect__skip-button .button {
-		color: var( --color-neutral-300 );
+		color: var( --color-neutral-200 );
 		border-bottom-color: var( --color-neutral-700 );
 
 		&:hover,
 		&:focus {
-			color: var( --color-primary-300 );
+			color: var( --color-primary-200 );
 		}
 	}
 

--- a/client/jetpack-connect/user-type/index.js
+++ b/client/jetpack-connect/user-type/index.js
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 import FormattedHeader from 'components/formatted-header';
 import jetpackOnly from '../jetpack-only';
 import MainWrapper from '../main-wrapper';
+import SkipButton from '../skip-button';
 import UserTypeForm from './form';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomColophon from 'components/wpcom-colophon';
@@ -20,12 +21,18 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { saveSiteUserType } from 'state/jetpack-connect/actions';
 
 class JetpackUserType extends Component {
+	goToNextStep = () => {
+		const { siteSlug } = this.props;
+
+		page( `/jetpack/connect/plans/${ siteSlug }` );
+	};
+
 	handleSubmit = userType => {
-		const { siteId, siteSlug } = this.props;
+		const { siteId } = this.props;
 
 		this.props.saveSiteUserType( siteId, userType );
 
-		page( `/jetpack/connect/plans/${ siteSlug }` );
+		this.goToNextStep();
 	};
 
 	render() {
@@ -38,6 +45,10 @@ class JetpackUserType extends Component {
 						headerText={ translate( 'Are you setting up this site for yourself or someone else?' ) }
 					/>
 					<UserTypeForm submitForm={ this.handleSubmit } />
+					<SkipButton
+						onClick={ this.goToNextStep }
+						tracksEventName="calypso_jpc_skipped_user_type"
+					/>
 					<WpcomColophon />
 				</div>
 			</MainWrapper>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce a new `<SkipButton />` component.
* Add a skip button to the Site Type step.
* Add a skip button to the Site Topic step.
* Add a skip button to the User Type step.

#### Preview
Site type step:
![](https://cldup.com/0LA1GZBoYs.png)

Site topic/vertical step:
![](https://cldup.com/SE5xy5jCZt.png)

User type step:
![](https://cldup.com/O-gywMJAn5.png)

#### Testing instructions

* Checkout this branch, or spin it up at calypso.live.
* Create a new JN site with the latest Jetpack.
* Connect the site (adding `&calypso_env=development` to the connection URL if you use local calypso) and reach the site type step.
* Verify skip button on the site type step leads you to the site topic step.
* Verify skip button on the site topic/vertical step leads you to the user type page for the Jetpack bleeding edge, or plans page for older Jetpacks.
* Verify skip button on the user type step leads you to the plans page.
* Verify selecting a site type and continuing still works well.
* Verify selecting a site topic/vertical and continuing still works well.
* Verify selecting a user type and continuing still works well.

We're also recording some tracks events, in case you wish to test those:
* Type `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in your browser console.
* On the site type step, click the skip button.
* Verify `calypso_jpc_skip_button_click` event gets recorded (our generic skip button click event).
* Verify `calypso_jpc_skipped_site_type` event gets recorded (our specific site type skip event).
* On the site topic step, click the skip button.
* Verify `calypso_jpc_skip_button_click` event gets recorded (our generic skip button click event).
* Verify `calypso_jpc_skipped_site_topic` event gets recorded (our specific site topic skip event).
* On the user type step, click the skip button.
* Verify `calypso_jpc_skip_button_click` event gets recorded (our generic skip button click event).
* Verify `calypso_jpc_skipped_user_type` event gets recorded (our specific user type skip event).

Fixes #31115 
Fixes #31784
