### PR TITLE
Layout: Add a classname for Jetpack new site page

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -102,6 +102,7 @@ class Layout extends Component {
 				`is-group-${ this.props.sectionGroup }`,
 				`is-section-${ this.props.sectionName }`,
 				`focus-${ this.props.currentLayoutFocus }`,
+				{ 'is-add-site-page': this.props.currentRoute === '/jetpack/new' },
 				{ 'is-support-session': this.props.isSupportSession },
 				{ 'has-no-sidebar': ! this.props.hasSidebar },
 				{ 'has-chat': this.props.chatIsOpen },

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -34,6 +34,7 @@ const hasSidebar = section => {
 };
 
 const LayoutLoggedOut = ( {
+	currentRoute,
 	isJetpackLogin,
 	masterbarIsHidden,
 	oauth2Client,
@@ -49,6 +50,7 @@ const LayoutLoggedOut = ( {
 	const classes = {
 		[ 'is-group-' + sectionGroup ]: sectionGroup,
 		[ 'is-section-' + sectionName ]: sectionName,
+		'is-add-site-page': currentRoute === '/jetpack/new',
 		'focus-content': true,
 		'has-no-sidebar': ! hasSidebar( section ),
 		'has-no-masterbar': masterbarIsHidden,
@@ -106,6 +108,7 @@ LayoutLoggedOut.propTypes = {
 	primary: PropTypes.element,
 	secondary: PropTypes.element,
 	// Connected props
+	currentRoute: PropTypes.string,
 	masterbarIsHidden: PropTypes.bool,
 	section: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 	redirectUri: PropTypes.string,
@@ -118,6 +121,7 @@ export default connect( state => {
 	const isJetpackLogin = currentRoute === '/log-in/jetpack';
 
 	return {
+		currentRoute,
 		isJetpackLogin,
 		masterbarIsHidden: ! masterbarIsVisible( state ) || 'signup' === section.name,
 		section,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a `is-add-site-page` classname to the `/jetpack/new` page. This allows us to apply different color schemes for specific flows and pages that exclude that specific page.

#### Testing instructions

* Checkout this branch, or spin it up on calypso.live.
* Go to `/jetpack/new`.
* Verify that `.layout` also has a `.is-add-site-page` classname.
* Go to any other page in Calypso.
* Verify that `.layout` does NOT have a `.is-add-site-page` classname.

Necessary for #31141.
