### PR TITLE
Domains: Update button content of a domain added to cart to increase clarity

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -125,9 +125,15 @@ class DomainRegistrationSuggestion extends React.Component {
 		const isAdded = hasDomainInCart( cart, domain );
 
 		let buttonContent;
+		let buttonStyles = this.props.buttonStyles;
 
 		if ( isAdded ) {
-			buttonContent = <Gridicon icon="checkmark" />;
+			buttonContent = translate( '{{checkmark/}} In Cart', {
+				context: 'Domain is already added to shopping cart',
+				components: { checkmark: <Gridicon icon="checkmark" /> },
+			} );
+
+			buttonStyles = { ...buttonStyles, primary: false };
 		} else {
 			buttonContent =
 				! isSignupStep &&
@@ -137,8 +143,6 @@ class DomainRegistrationSuggestion extends React.Component {
 					  } )
 					: translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		}
-
-		let buttonStyles = this.props.buttonStyles;
 
 		if ( this.isUnavailableDomain( suggestion.domain_name ) ) {
 			buttonStyles = { ...buttonStyles, disabled: true };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a label to the button when a domain is in your cart to add clarity. Instead of just a checkmark, indicate what the checkmark actually means.

**Before**
<img width="530" alt="image" src="https://user-images.githubusercontent.com/448298/54027405-66992a80-416f-11e9-811b-32af8c462335.png">

**After**
<img width="535" alt="image" src="https://user-images.githubusercontent.com/448298/54027370-4e291000-416f-11e9-965d-8faea1553d8f.png">

#### Testing instructions

* Checkout this branch or use the calypso.live link
* Click `Domains > Add` to get to domain search
* Search for a domain
* Click `Select` to add the domain to your cart, but don't complete checkout
* Go back to domain search
* Enter the search term that matches the domain in your cart
* Assert the button is secondary and has a label that says `In Cart` next to the checkmark
