### PR TITLE
Importers: Improve contrast for service titles

### DIFF
--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -73,7 +73,7 @@
 .importer-header__service-title {
 	font-size: 21px;
 	font-weight: 300;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral-700 );
 
 	@include breakpoint( '>480px' ) {
 		clear: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR looks to improve the contrast of the importer service names in our importer screens.
Previously, the colours were `#969CA1` against `#FFFFFF`, here they're changed to `#2b2d2f` against `#FFFFFF`. `#2b2d2f` is the output of our colour variable `--color-neutral-700`,  the lightest of our colour set that passes WCAG standards ([results here](https://webaim.org/resources/contrastchecker/?fcolor=2B2D2F&bcolor=FFFFFF)).

Before:

<img width="741" alt="screenshot 2019-03-05 at 15 08 15" src="https://user-images.githubusercontent.com/87168/53807649-c49ff500-3f58-11e9-97e7-4bcf0960fdeb.png">


After:
<img width="744" alt="screenshot 2019-03-08 at 11 18 48" src="https://user-images.githubusercontent.com/4335450/54025926-fb158400-4193-11e9-9e53-15e49f1b5174.png">


Fixes #31206 

#### Testing instructions

- Go to calypso.localhost:3000/settings/import
- Take a look at the service titles throughout an import 
  - They should all be consistent in colour throughout
  - They should have good contrast throughout
