### PR TITLE
New description for Blogger.com export format

### DIFF
--- a/client/my-sites/importer/importer-blogger.jsx
+++ b/client/my-sites/importer/importer-blogger.jsx
@@ -65,11 +65,7 @@ class ImporterBlogger extends React.PureComponent {
 								supportLink={
 									'https://en.support.wordpress.com/import/coming-from-blogger/#import'
 								}
-								text={ this.props.translate( 'exporting your content', {
-									args: {
-										importerName,
-									},
-								} ) }
+								text={ this.props.translate( 'exporting your content' ) }
 								showIcon={ false }
 							/>
 						),

--- a/client/my-sites/importer/importer-blogger.jsx
+++ b/client/my-sites/importer/importer-blogger.jsx
@@ -47,11 +47,11 @@ class ImporterBlogger extends React.PureComponent {
 				}
 			),
 			uploadDescription: this.props.translate(
-				'To import content from a %(importerName)s site to ' +
-					'{{b}}%(siteTitle)s{{/b}}, upload your ' +
-					'{{b}}%(importerName)s export file{{/b}} here. ' +
-					"Don't have one, or don't know where to find one? " +
-					'Get step by step instructions in our {{inlineSupportLink/}}.',
+				'Upload a {{b}}%(importerName)s export file{{/b}} ' +
+					'to start importing into {{b}}%(siteTitle)s{{/b}}. ' +
+					'A %(importerName)s export file is an XML file ' +
+					'containing your page and post content. ' +
+					'Need help {{inlineSupportLink/}}?',
 				{
 					args: {
 						importerName,
@@ -65,7 +65,7 @@ class ImporterBlogger extends React.PureComponent {
 								supportLink={
 									'https://en.support.wordpress.com/import/coming-from-blogger/#import'
 								}
-								text={ this.props.translate( '%(importerName)s import guide', {
+								text={ this.props.translate( 'exporting your content', {
 									args: {
 										importerName,
 									},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the description of export file to be more helpful. It uses the exact same wording as #31168 so we can share the translation for both import types. Both operate with XML containing pages & posts.

#### Testing instructions

* In /settings/import, navigate to Blogger.com and confirm there is a new description on top of the upload box. It should say Blogger.com in all appropriate places and the link "exporting your content" should open up appropriate documentation.

Fixes #30557
