### PR TITLE
Jetpack Connect: Migrate /jetpack/new style to Webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -156,7 +156,6 @@
 @import 'components/environment-badge/style';
 @import 'blocks/credit-card-form/style';
 @import 'jetpack-connect/style';
-@import 'jetpack-connect/jetpack-new-site/style';
 @import 'jetpack-onboarding/style';
 @import 'layout/guided-tours/style';
 @import 'components/happychat/style';

--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -22,6 +22,11 @@ import { cleanUrl } from '../utils';
 import { persistSession } from '../persistence-utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class JetpackNewSite extends Component {
 	constructor() {
 		super();


### PR DESCRIPTION
This PR migrates the style of `/jetpack/new` to Webpack.

See p4TIVU-9dT-p2 for more details on the rationale of this migration.

#### Changes proposed in this Pull Request

* Import the `/jetpack/new` style with Webpack.

#### Testing instructions

* Checkout this branch.
* Compare http://calypso.localhost:3000/jetpack/new with https://wpcalypso.wordpress.com/jetpack/new and verify they look and work the same way.
* Verify the selectors in the stylesheet aren't used in any other component (that's easy to check because all selectors are prefixed with `.jetpack-new-site`).
