### PR TITLE
Update/30988 add keyboard shortcut for visit site

### DIFF
--- a/client/lib/keyboard-shortcuts/key-bindings.js
+++ b/client/lib/keyboard-shortcuts/key-bindings.js
@@ -23,9 +23,9 @@ const KEY_BINDINGS = {
 		},
 		{
 			eventName: 'open-selection',
-			keys: [ 'enter' ],
+			keys: [ 'enter', 'v' ],
 			description: {
-				keys: [ 'enter' ],
+				keys: [ 'enter', 'v' ],
 				text: translate( 'Open selection' ),
 			},
 		},

--- a/client/lib/keyboard-shortcuts/key-bindings.js
+++ b/client/lib/keyboard-shortcuts/key-bindings.js
@@ -23,9 +23,9 @@ const KEY_BINDINGS = {
 		},
 		{
 			eventName: 'open-selection',
-			keys: [ 'enter', 'v' ],
+			keys: [ [ 'enter' ], [ 'v' ] ],
 			description: {
-				keys: [ 'enter', 'v' ],
+				keys: [ [ 'enter' ], [ 'v' ] ],
 				text: translate( 'Open selection' ),
 			},
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds a "v" as a keyboard shortcut option for opening Reader site links

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to "Reader"
* Use "j" or "k" to navigate up and down the list of links
* Choose a link you want to open and press "v", which will open the link
* As well, "enter" will also still open posts

Fixes #30988 
