### PR TITLE
Mailchimp: error protection

### DIFF
--- a/client/my-sites/sharing/connections/mailchimp-settings.jsx
+++ b/client/my-sites/sharing/connections/mailchimp-settings.jsx
@@ -15,6 +15,7 @@ import QueryMailchimpSettings from 'components/data/query-mailchimp-settings';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
+import { isJetpackMinimumVersion, getSiteSlug } from 'state/sites/selectors';
 
 const MailchimpSettings = ( {
 	siteId,
@@ -22,6 +23,8 @@ const MailchimpSettings = ( {
 	requestSettingsUpdateAction,
 	mailchimpLists,
 	mailchimpListId,
+	isJetpackTooOld,
+	siteSlug,
 	translate,
 } ) => {
 	const chooseMailchimpList = event => {
@@ -47,6 +50,24 @@ const MailchimpSettings = ( {
 			translate( 'Subscriber emails will be saved to the %s Mailchimp list', { args: list.name } )
 		);
 	};
+	if ( isJetpackTooOld ) {
+		return (
+			<div>
+				<Notice
+					status="is-warning"
+					text={ translate(
+						'Please update Jetpack plugin to version 7.1 in order to use the Mailchimp block'
+					) }
+					showDismiss={ false }
+				>
+					<NoticeAction
+						href={ `https://wordpress.com/plugins/jetpack/${ siteSlug }` }
+						icon="external"
+					/>
+				</Notice>
+			</div>
+		);
+	}
 
 	/* eslint-disable jsx-a11y/no-onchange */
 	return (
@@ -126,6 +147,8 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 		return {
 			siteId: siteId,
+			siteSlug: getSiteSlug( state, siteId ),
+			isJetpackTooOld: isJetpackMinimumVersion( state, siteId, '7.1' ) === false,
 			mailchimpLists: get( state, [ 'mailchimp', 'lists', 'items', siteId ], null ),
 			mailchimpListId: get(
 				state,

--- a/client/state/mailchimp/settings/actions.js
+++ b/client/state/mailchimp/settings/actions.js
@@ -60,6 +60,14 @@ export const requestSettingsUpdate = ( siteId, settings, noticeText ) => {
 					siteId,
 					error,
 				} );
+				dispatch( {
+					type: NOTICE_CREATE,
+					notice: {
+						duration: 10000,
+						text: error.message,
+						status: 'is-error',
+					},
+				} );
 			} );
 	};
 };


### PR DESCRIPTION
This reinforces mailchimp settings so that it is harder to introduce bad state.
During the list setup, there is a list of conditions that may lead to the block being not set up properly.

Because selecting a list reaches out to the remote site and uses options api to save data, many problems could arise.

The D25320-code is addressing same issue, but these PRs can be landed seperately.

### What this is doing

a) It shows errors returned by D25320-code
b) It blocks the UI for JP lower than 7.1
c) Blocks UI for disconnected JP

<img width="765" alt="zrzut ekranu 2019-03-8 o 15 32 39" src="https://user-images.githubusercontent.com/3775068/54034741-f662c700-41b7-11e9-807c-6bc527151f3a.png">

### Testing instructions

1. Find a site with old Jetpack version
2. Go to /sharing
3. expand Mailchimp section

Do you know of a way to detect that user is not the connection owner or the user cannot manage options?
