### PR TITLE
Importer UI fixes - make cancel button secondary to fix colour clashes

### DIFF
--- a/client/components/button/index.jsx
+++ b/client/components/button/index.jsx
@@ -10,6 +10,7 @@ export default class Button extends PureComponent {
 	static propTypes = {
 		compact: PropTypes.bool,
 		primary: PropTypes.bool,
+		secondary: PropTypes.bool,
 		scary: PropTypes.bool,
 		busy: PropTypes.bool,
 		type: PropTypes.string,
@@ -27,13 +28,14 @@ export default class Button extends PureComponent {
 		const className = classNames( 'button', this.props.className, {
 			'is-compact': this.props.compact,
 			'is-primary': this.props.primary,
+			'is-secondary': this.props.secondary,
 			'is-scary': this.props.scary,
 			'is-busy': this.props.busy,
 			'is-borderless': this.props.borderless,
 		} );
 
 		if ( this.props.href ) {
-			const { compact, primary, scary, busy, borderless, type, ...props } = this.props;
+			const { compact, primary, secondary, scary, busy, borderless, type, ...props } = this.props;
 
 			// block referrers when external link
 			const rel = props.target
@@ -43,7 +45,17 @@ export default class Button extends PureComponent {
 			return <a { ...props } rel={ rel } className={ className } />;
 		}
 
-		const { compact, primary, scary, busy, borderless, target, rel, ...props } = this.props;
+		const {
+			compact,
+			primary,
+			secondary,
+			scary,
+			busy,
+			borderless,
+			target,
+			rel,
+			...props
+		} = this.props;
 
 		return <button { ...props } className={ className } />;
 	}

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -160,6 +160,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       className="contact-details-form-fields__submit-button"
       disabled={false}
       isPrimary={true}
+      isSecondary={false}
       isSubmitting={false}
       onClick={[Function]}
       type="submit"

--- a/client/components/forms/form-button/index.jsx
+++ b/client/components/forms/form-button/index.jsx
@@ -18,6 +18,7 @@ class FormButton extends React.Component {
 	static defaultProps = {
 		isSubmitting: false,
 		isPrimary: true,
+		isSecondary: false,
 		type: 'submit',
 	};
 
@@ -28,13 +29,14 @@ class FormButton extends React.Component {
 	};
 
 	render() {
-		const { children, className, isPrimary, ...props } = this.props,
+		const { children, className, isPrimary, isSecondary, ...props } = this.props,
 			buttonClasses = classNames( className, 'form-button' );
 
 		return (
 			<Button
 				{ ...omit( props, [ 'isSubmitting', 'moment', 'numberFormat', 'translate' ] ) }
 				primary={ isPrimary }
+				secondary={ isSecondary }
 				className={ buttonClasses }
 			>
 				{ Children.count( children ) ? children : this.getDefaultButtonAction() }

--- a/client/my-sites/importer/importer-header/close-button.jsx
+++ b/client/my-sites/importer/importer-header/close-button.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Button from 'components/forms/form-button';
+import FormButton from 'components/forms/form-button';
 import { appStates } from 'state/imports/constants';
 import { cancelImport } from 'lib/importer/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -59,15 +59,15 @@ export class CloseButton extends React.PureComponent {
 		const disabled = ! isEnabled || isUploading || appStates.UPLOADING === importerState;
 
 		return (
-			<Button
+			<FormButton
 				className="importer-header__action-button"
 				disabled={ disabled }
-				isPrimary
-				scary
+				isPrimary={ false }
+				isSecondary={ true }
 				onClick={ this.handleClick }
 			>
-				{ translate( 'Close', { context: 'verb, to Close a dialog' } ) }
-			</Button>
+				{ translate( 'Cancel', { context: 'verb, to Close a dialog' } ) }
+			</FormButton>
 		);
 	}
 }

--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -50,7 +50,7 @@
 	&.site-importer {
 		background-color: #faad4d;
 	}
-	
+
 	&.squarespace {
 		background-color: #222;
 	}
@@ -117,7 +117,9 @@
 
 .importer__upload-progress,
 .importer__import-progress {
-	width: 80%;
+	&.progress-bar {
+		width: 80%;
+	}
 
 	.progress-bar__progress {
 		background-color: var( --color-accent );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR addresses some of the UX issues detailed in #30564. It consists of the first few commits in @getdave's PR https://github.com/Automattic/wp-calypso/pull/31302. The colours of the `Continue` and `Close` buttons in some of the importers were clashing following the introduction of a new colour scheme. The PR fixes this by making the `Close` button a secondary button. It also changes the text to `Cancel` to be more consistent with buttons elsewhere.
* It also addresses the issue mentioned in https://github.com/Automattic/wp-calypso/issues/31092#issuecomment-470079372, where the import file progress bar is too wide.

#### Testing instructions

* Go to https://wordpress.com/settings/import/[ your-site ].wordpress.com.
* Click on the `Start Import` button in the Wix importer. You should see this:

![image](https://user-images.githubusercontent.com/1647564/54036881-a2a2ae80-41b4-11e9-9419-023fd63a8b48.png)

* Apply this branch to your local Calypso instance and open the Wix importer as described above. You should see this:

![image](https://user-images.githubusercontent.com/1647564/54036945-c7972180-41b4-11e9-979e-eb2ef1e14db5.png)

* Go to the WordPress importer on production and upload a large import file. You'll see that the progress bar is too wide:

![image](https://user-images.githubusercontent.com/1647564/54041443-a556d100-41bf-11e9-89bd-f39a64502d3d.png)

* Repeat the action in this branch. The progress bar should be its proper width:

![image](https://user-images.githubusercontent.com/1647564/54041478-b869a100-41bf-11e9-941a-05b0488c0c88.png)


Partially fixes #30564
