### PR TITLE
Jetpack Connect: Fix spacing and sizes on mobile site topic step

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -109,7 +109,8 @@ $colophon-height: 50px;
 	}
 
 	.site-topic__content {
-		
+		padding-bottom: 2px;
+
 		.form-fieldset {
 			position: relative;
 		}
@@ -120,6 +121,12 @@ $colophon-height: 50px;
 			&:focus {
 				box-shadow: 0 0 0 2px var( --color-jetpack-light );
 			}
+		}
+
+		.button {
+			font-size: 16px;
+			padding-top: 12px;
+			padding-bottom: 14px;
 		}
 	}
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -123,10 +123,12 @@ $colophon-height: 50px;
 			}
 		}
 
-		.button {
-			font-size: 16px;
-			padding-top: 12px;
-			padding-bottom: 14px;
+		@include breakpoint( '<660px' ) {
+			.button {
+				font-size: 16px;
+				padding-top: 12px;
+				padding-bottom: 14px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Jetpack Connect site topic step currently looks a bit off on mobile devices. This PR updates the spacing so it looks well on mobile, and aligns with how it looks for the .com signup site topic step.

#### Changes proposed in this Pull Request

* Fix spacing of button in the site topic step.
* Add some space below the form so the outer glow on focus would be visible.

#### Preview

Before:
![](https://cldup.com/HptGxz8Tfw.png)

After:
![](https://cldup.com/4bld8fIEtC.png)

#### Testing instructions

* Use a mobile device, or resize your screen to <660px width.
* Checkout this branch, or spin it up at calypso.live.
* Go to `/jetpack/connect/site-topic/:site` where `:site` is one of your connected Jetpack sites.
* Verify the form looks like the "after" screenshot.
