### PR TITLE
New description for Medium importer

### DIFF
--- a/client/my-sites/importer/importer-medium.jsx
+++ b/client/my-sites/importer/importer-medium.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import FileImporter from './file-importer';
+import InlineSupportLink from 'components/inline-support-link';
 
 /**
  * Module variables
@@ -29,12 +30,25 @@ class ImporterMedium extends React.PureComponent {
 		);
 
 		importerData.uploadDescription = this.props.translate(
-			'Upload a {{b}}Medium export file{{/b}} to start ' + 'importing into {{b2}}%(title)s{{/b2}}.',
+			'Upload your %(importerName)s export file to start importing into ' +
+				'{{b}}%(siteTitle)s{{/b}}. A %(importerName)s export file is a ZIP ' +
+				'file containing several HTML files with your stories. ' +
+				'Need help {{inlineSupportLink/}}?',
 			{
-				args: { title: this.props.site.title },
+				args: {
+					importerName: importerData.title,
+					siteTitle: this.props.site.title,
+				},
 				components: {
 					b: <strong />,
-					b2: <strong />,
+					inlineSupportLink: (
+						<InlineSupportLink
+							supportPostId={ 93180 }
+							supportLink={ 'https://en.support.wordpress.com/import/import-from-medium/' }
+							text={ this.props.translate( 'exporting your content' ) }
+							showIcon={ false }
+						/>
+					),
 				},
 			}
 		);

--- a/client/my-sites/importer/importer-medium.jsx
+++ b/client/my-sites/importer/importer-medium.jsx
@@ -30,7 +30,7 @@ class ImporterMedium extends React.PureComponent {
 		);
 
 		importerData.uploadDescription = this.props.translate(
-			'Upload your %(importerName)s export file to start importing into ' +
+			'Upload your {{b}}%(importerName)s export file{{/b}} to start importing into ' +
 				'{{b}}%(siteTitle)s{{/b}}. A %(importerName)s export file is a ZIP ' +
 				'file containing several HTML files with your stories. ' +
 				'Need help {{inlineSupportLink/}}?',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update the description of export file to be more helpful for Medium importer. 

#### Testing instructions

* In /settings/import, navigate to Medium and confirm there is a new description on top of the upload box. It should say Medium in all appropriate places and the link "exporting your content" should open up appropriate documentation.

Fixes #30558
