### PR TITLE
Fix/sharing buttons

### DIFF
--- a/client/my-sites/sharing/buttons/options.jsx
+++ b/client/my-sites/sharing/buttons/options.jsx
@@ -22,6 +22,10 @@ import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
+{
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+}
+
 class SharingButtonsOptions extends Component {
 	static propTypes = {
 		buttons: PropTypes.array,
@@ -224,7 +228,7 @@ class SharingButtonsOptions extends Component {
 
 				<button
 					type="submit"
-					className="button is-primary sharing-buttons__submit"
+					className="button sharing-buttons__submit"
 					disabled={ saving || ! initialized }
 				>
 					{ saving ? translate( 'Saving…' ) : translate( 'Save Changes' ) }

--- a/client/my-sites/sharing/buttons/options.jsx
+++ b/client/my-sites/sharing/buttons/options.jsx
@@ -22,9 +22,7 @@ import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
-{
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
-}
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 class SharingButtonsOptions extends Component {
 	static propTypes = {

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -1056,7 +1056,7 @@
 }
 
 .sharing-buttons-preview__panel-actions {
-	padding: 10px 20px;
+	padding: 10px 16px;
 	text-align: right;
 	border-top: 1px solid var( --color-neutral-0 );
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

### Problem

Two issues:
1) Visually the placement of the Reorder and Cancel buttons doesn't look right.
2) There shouldn't be 2 primary buttons on the same page.

### Before
![](https://d1jfzjx68gj8xs.cloudfront.net/items/021L0b2L3I463m0W2y0V/Screen%20Shot%202019-03-08%20at%201.19.06%20PM.png?X-CloudApp-Visitor-Id=3172841)

### After
![](https://d1jfzjx68gj8xs.cloudfront.net/items/0g1h47060H1p3j00253X/Screen%20Shot%202019-03-08%20at%201.29.12%20PM.png?X-CloudApp-Visitor-Id=3172841)

### Note
When committing the single line primary button fix I ran into a linting nightmare… See: https://cl.ly/4861d9d55dc7 

I started making the recommended changes and the lint errors started to cascade (since the changes affected more than one page)

I spoke with @blowery and opted to exclude this file for now vs. making over a dozen updates to multiple files to fix all of these linting errors.

## Testing instructions

- Check out this branch
- Compile
- Visit http://calypso.localhost:3000/sharing/buttons/YOURSITE.wordpress.com
- Click on `Edit "More" buttons`

Fixes https://trello.com/c/FeLRCAIV/18-fix-button-placement
