### PR TITLE
Fix/migrate easy me styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -200,7 +200,6 @@
 @import 'me/purchases/manage-purchase/style';
 @import 'me/purchases/manage-purchase/plan-details/style';
 @import 'me/purchases/remove-purchase/style';
-@import 'me/security/style';
 @import 'me/security-account-recovery/style';
 @import 'me/sidebar-navigation/style';
 @import 'me/sidebar/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -204,7 +204,6 @@
 @import 'me/security-account-recovery/style';
 @import 'me/sidebar-navigation/style';
 @import 'me/sidebar/style';
-@import 'me/two-step/style';
 @import 'my-sites/earn/style';
 @import 'my-sites/earn/ads/style';
 @import 'my-sites/checklist/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -173,7 +173,6 @@
 @import 'lib/preferences-helper/style';
 @import 'mailing-lists/style';
 @import 'me/account-password/style';
-@import 'me/account/style';
 @import 'me/account-close/style';
 @import 'me/application-password-item/style';
 @import 'me/application-passwords/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -172,7 +172,6 @@
 @import 'lib/abtest/test-helper/style';
 @import 'lib/preferences-helper/style';
 @import 'mailing-lists/style';
-@import 'me/account-password/style';
 @import 'me/account-close/style';
 @import 'me/application-password-item/style';
 @import 'me/application-passwords/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -194,7 +194,6 @@
 @import 'me/privacy/style';
 @import 'me/purchases/cancel-purchase/style';
 @import 'me/purchases/components/loading-placeholder/style';
-@import 'me/purchases/confirm-cancel-domain/style';
 @import 'me/purchases/purchase-item/style';
 @import 'me/purchases/purchases-site/style';
 @import 'me/purchases/manage-purchase/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -173,8 +173,6 @@
 @import 'lib/preferences-helper/style';
 @import 'mailing-lists/style';
 @import 'me/account-close/style';
-@import 'me/application-password-item/style';
-@import 'me/application-passwords/style';
 @import 'me/billing-history/style';
 @import 'me/get-apps/style';
 @import 'me/happychat/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -191,7 +191,6 @@
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
 @import 'me/pending-payments/style';
-@import 'me/privacy/style';
 @import 'me/purchases/cancel-purchase/style';
 @import 'me/purchases/components/loading-placeholder/style';
 @import 'me/purchases/purchase-item/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -172,7 +172,6 @@
 @import 'lib/abtest/test-helper/style';
 @import 'lib/preferences-helper/style';
 @import 'mailing-lists/style';
-@import 'me/account-close/style';
 @import 'me/billing-history/style';
 @import 'me/get-apps/style';
 @import 'me/happychat/style';

--- a/client/me/account-close/confirm-dialog.jsx
+++ b/client/me/account-close/confirm-dialog.jsx
@@ -17,6 +17,11 @@ import Button from 'components/button';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { closeAccount } from 'state/account/actions';
 
+/**
+ * Style dependencies
+ */
+import './confirm-dialog.scss';
+
 class AccountCloseConfirmDialog extends React.Component {
 	state = {
 		inputValue: '',

--- a/client/me/account-close/confirm-dialog.scss
+++ b/client/me/account-close/confirm-dialog.scss
@@ -1,0 +1,25 @@
+// Confirm dialog
+.account-close__confirm-dialog {
+	max-width: 424px;
+	padding-bottom: 16px;
+}
+
+h1.account-close__confirm-dialog-header {
+	height: auto;
+	margin-bottom: 16px;
+	font-size: 21px;
+	font-weight: 300;
+	line-height: 24px;
+	color: var( --color-neutral-700 );
+}
+
+.account-close__confirm-dialog-label {
+	margin-bottom: 8px;
+	line-height: 24px;
+	color: var( --color-text-subtle );
+	font-weight: normal;
+}
+
+.account-close__confirm-dialog-target-username {
+	color: var( --color-error );
+}

--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -37,6 +37,11 @@ import hasCancelableUserPurchases from 'state/selectors/has-cancelable-user-purc
 import getUserPurchasedPremiumThemes from 'state/selectors/get-user-purchased-premium-themes';
 import userUtils from 'lib/user/utils';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class AccountSettingsClose extends Component {
 	state = {
 		showConfirmDialog: false,

--- a/client/me/account-close/style.scss
+++ b/client/me/account-close/style.scss
@@ -11,32 +11,6 @@
 	margin-bottom: 1em;
 }
 
-// Confirm dialog
-.account-close__confirm-dialog {
-	max-width: 424px;
-	padding-bottom: 16px;
-}
-
-h1.account-close__confirm-dialog-header {
-	height: auto;
-	margin-bottom: 16px;
-	font-size: 21px;
-	font-weight: 300;
-	line-height: 24px;
-	color: var( --color-neutral-700 );
-}
-
-.account-close__confirm-dialog-label {
-	margin-bottom: 8px;
-	line-height: 24px;
-	color: var( --color-text-subtle );
-	font-weight: normal;
-}
-
-.account-close__confirm-dialog-target-username {
-	color: var( --color-error );
-}
-
 // Placeholders
 .account-close.is-loading .account-close__body-copy,
 .account-close.is-loading .account-close__body-copy a,

--- a/client/me/account-password/index.jsx
+++ b/client/me/account-password/index.jsx
@@ -29,6 +29,12 @@ import observe from 'lib/mixins/data-observe';
 import { errorNotice } from 'state/notices/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+/* eslint-disable react/prefer-es6-class */
 const AccountPassword = createReactClass( {
 	displayName: 'AccountPassword',
 
@@ -185,12 +191,7 @@ const AccountPassword = createReactClass( {
 						{ this.state.savingPassword ? translate( 'Saving…' ) : translate( 'Save Password' ) }
 					</FormButton>
 
-					<FormButton
-						className="button"
-						isPrimary={ false }
-						onClick={ this.handleGenerateButtonClick }
-						type="button"
-					>
+					<FormButton isPrimary={ false } onClick={ this.handleGenerateButtonClick } type="button">
 						{ translate( 'Generate strong password' ) }
 					</FormButton>
 				</FormButtonsBar>

--- a/client/me/account/close-link.jsx
+++ b/client/me/account/close-link.jsx
@@ -9,6 +9,11 @@ import { noop } from 'lodash';
 
 import CompactCard from 'components/card/compact';
 
+/**
+ * Style dependencies
+ */
+import './close-link.scss';
+
 class AccountSettingsCloseLink extends React.Component {
 	render() {
 		const { translate } = this.props;

--- a/client/me/account/close-link.scss
+++ b/client/me/account/close-link.scss
@@ -1,0 +1,17 @@
+.account__close-section-title {
+	margin-bottom: 4px;
+	font-size: 14px;
+	line-height: 18px;
+	color: var( --color-neutral-700 );
+
+	&.is-warning {
+		color: var( --color-error );
+	}
+}
+
+.account__close-section-desc {
+	margin-bottom: 0;
+	font-size: 13px;
+	color: var( --color-text-subtle );
+	font-style: italic;
+}

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -23,6 +23,7 @@ import formBase from 'me/form-base';
 import config from 'config';
 import { supportsCssCustomProperties } from 'lib/feature-detection';
 import Card from 'components/card';
+import Button from 'components/button';
 import FormTextInput from 'components/forms/form-text-input';
 import FormTextValidation from 'components/forms/form-input-validation';
 import FormCheckbox from 'components/forms/form-checkbox';
@@ -39,7 +40,7 @@ import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import observe from 'lib/mixins/data-observe';
+import observe from 'lib/mixins/data-observe'; // eslint-disable-line no-restricted-imports
 import Main from 'components/main';
 import SitesDropdown from 'components/sites-dropdown';
 import ColorSchemePicker from 'blocks/color-scheme-picker';
@@ -54,6 +55,11 @@ import AccountSettingsCloseLink from './close-link';
 import { requestGeoLocation } from 'state/data-getters';
 import { withLocalizedMoment } from 'components/localized-moment';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const user = _user();
 const colorSchemeKey = 'calypso_preferences.colorScheme';
 
@@ -62,6 +68,7 @@ const colorSchemeKey = 'calypso_preferences.colorScheme';
  */
 const debug = debugFactory( 'calypso:me:account' );
 
+/* eslint-disable react/prefer-es6-class */
 const Account = createReactClass( {
 	displayName: 'Account',
 
@@ -486,13 +493,12 @@ const Account = createReactClass( {
 
 		if ( ! user.get().visible_site_count ) {
 			return (
-				<a
-					className="button"
+				<Button
 					href={ config( 'signup_url' ) }
 					onClick={ this.getClickHandler( 'Primary Site Add New WordPress Button' ) }
 				>
 					{ translate( 'Add New Site' ) }
-				</a>
+				</Button>
 			);
 		}
 

--- a/client/me/account/style.scss
+++ b/client/me/account/style.scss
@@ -23,22 +23,3 @@
 .account__settings-form select {
 	width: 100%;
 }
-
-/* Account close */
-.account__close-section-title {
-	margin-bottom: 4px;
-	font-size: 14px;
-	line-height: 18px;
-	color: var( --color-neutral-700 );
-
-	&.is-warning {
-		color: var( --color-error );
-	}
-}
-
-.account__close-section-desc {
-	margin-bottom: 0;
-	font-size: 13px;
-	color: var( --color-text-subtle );
-	font-style: italic;
-}

--- a/client/me/application-password-item/index.jsx
+++ b/client/me/application-password-item/index.jsx
@@ -16,6 +16,11 @@ import { deleteApplicationPassword } from 'state/application-passwords/actions';
 import { errorNotice } from 'state/notices/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class ApplicationPasswordsItem extends React.Component {
 	handleRemovePasswordButtonClick = () => {
 		const { password } = this.props;
@@ -28,7 +33,7 @@ class ApplicationPasswordsItem extends React.Component {
 		const { moment, password, translate } = this.props;
 
 		return (
-			<li className="application-password-item__password" key={ password.ID }>
+			<li className="application-password-item">
 				<div className="application-password-item__details">
 					<h2 className="application-password-item__name">{ password.name }</h2>
 					<p className="application-password-item__generated">

--- a/client/me/application-password-item/style.scss
+++ b/client/me/application-password-item/style.scss
@@ -1,4 +1,4 @@
-.application-password-item__password {
+.application-password-item {
 	overflow: auto;
 }
 

--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -31,6 +31,10 @@ import getApplicationPasswords from 'state/selectors/get-application-passwords';
 import getNewApplicationPassword from 'state/selectors/get-new-application-password';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
 class ApplicationPasswords extends Component {
 	static initialState = Object.freeze( {
 		applicationName: '',

--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -19,7 +19,7 @@ import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormToggle from 'components/forms/form-toggle';
 import Main from 'components/main';
-import observe from 'lib/mixins/data-observe';
+import observe from 'lib/mixins/data-observe'; //eslint-disable-line no-restricted-imports
 import { protectForm } from 'lib/protect-form';
 import { localizeUrl } from 'lib/i18n-utils';
 import twoStepAuthorization from 'lib/two-step-authorization';
@@ -29,8 +29,14 @@ import formBase from 'me/form-base';
 import MeSidebarNavigation from 'me/sidebar-navigation';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const TRACKS_OPT_OUT_USER_SETTINGS_KEY = 'tracks_opt_out';
 
+/* eslint-disable react/prefer-es6-class */
 const Privacy = createReactClass( {
 	/**
 	 * `formBase` is used for `getDisabledState` and `submitForm`

--- a/client/me/purchases/confirm-cancel-domain/index.jsx
+++ b/client/me/purchases/confirm-cancel-domain/index.jsx
@@ -43,6 +43,11 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'state/current-user/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class ConfirmCancelDomain extends React.Component {
 	static propTypes = {
 		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,

--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -24,6 +24,11 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 const debug = debugFactory( 'calypso:me:security:password' );
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Security extends React.Component {
 	static displayName = 'Security';
 

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -25,6 +25,11 @@ import SecuritySectionNav from 'me/security-section-nav';
 import twoStepAuthorization from 'lib/two-step-authorization';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const debug = debugFactory( 'calypso:me:two-step' );
 
 class TwoStep extends Component {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate me/account, me/account-password, me/application-passwords, me/application-password-item, me/account-close, me/two-step, me/security, me/privacy, me/purchases/confirm-cancel-domain

#### Testing instructions

* Test the above sections and make sure they still look correct

