### PR TITLE
Adds a G Suite stats banner

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -186,6 +186,7 @@ $z-layers: (
 		'.image-selector__item.is-transient::after': 1,
 		'.image-selector__item .spinner': 2,
 		'.upwork-stats-nudge__close-icon': 1,
+		'.gsuite-stats-nudge__close-icon': 1,
 	),
 	'.is-section-signup': (
 		'.is-section-signup::before': -1,

--- a/client/blocks/gsuite-stats-nudge/actions.js
+++ b/client/blocks/gsuite-stats-nudge/actions.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * Internal Dependencies
+ */
+import { getPreference } from 'state/preferences/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { savePreference } from 'state/preferences/actions';
+
+export const dismissNudge = () => ( dispatch, getState ) => {
+	const siteId = getSelectedSiteId( getState() );
+	const preference = getPreference( getState(), 'gsuite-dismissible-nudge' ) || {};
+
+	return dispatch(
+		savePreference(
+			'gsuite-dismissible-nudge',
+			Object.assign( {}, preference, {
+				[ siteId ]: [
+					...( preference[ siteId ] || [] ),
+					{
+						dismissedAt: Date.now(),
+						type: 'dismiss',
+					},
+				],
+			} )
+		)
+	);
+};

--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -1,0 +1,137 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal Dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import isGSuiteStatsNudgeDismissed from 'state/selectors/is-gsuite-stats-nudge-dismissed';
+import QueryPreferences from 'components/data/query-preferences';
+import SectionHeader from 'components/section-header';
+import { dismissNudge } from './actions';
+import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
+import { withEnhancers } from 'state/utils';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class GSuiteStatsNudge extends Component {
+	static propTypes = {
+		isDismissed: PropTypes.bool.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
+		siteId: PropTypes.number.isRequired,
+		siteSlug: PropTypes.string.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	componentDidMount() {
+		this.recordView();
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.siteId && this.props.siteId && this.props.siteId !== prevProps.siteId ) {
+			this.recordView();
+		}
+	}
+
+	recordView() {
+		if ( this.isVisible() ) {
+			this.props.recordTracksEvent( 'calypso_gsuite_stats_nudge_view' );
+		}
+	}
+
+	recordClick = eventName => {
+		this.props.recordTracksEvent( eventName );
+	};
+
+	onDismissClick = () => {
+		this.recordClick( 'calypso_gsuite_stats_nudge_dismiss_icon_click' );
+		this.props.dismissNudge();
+	};
+
+	onStartNowClick = () => {
+		this.recordClick( 'calypso_gsuite_stats_nudge_start_now_button_click' );
+	};
+
+	isVisible() {
+		return ! this.props.isDismissed;
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		if ( ! this.isVisible() ) {
+			return null;
+		}
+
+		return (
+			<Card className="gsuite-stats-nudge">
+				<QueryPreferences />
+
+				<Gridicon
+					icon="cross"
+					className="gsuite-stats-nudge__close-icon"
+					onClick={ this.onDismissClick }
+				/>
+
+				<SectionHeader
+					className="gsuite-stats-nudge__header"
+					label={ translate( 'Recommendations from WordPress.com' ) }
+				/>
+
+				<div className="gsuite-stats-nudge__body">
+					<div className="gsuite-stats-nudge__image-wrapper">
+						<img
+							className="gsuite-stats-nudge__image"
+							src="/calypso/images/gsuite/illustration-builder-referral.svg"
+							alt={ translate( 'Build your dream site with GSuite' ) }
+						/>
+					</div>
+
+					<div className="gsuite-stats-nudge__info">
+						<h1 className="gsuite-stats-nudge__title">
+							{ translate( 'Need an expert to help realize your vision? Hire one!' ) }
+						</h1>
+						<p>
+							{ translate(
+								"We've partnered with GSuite, a network of freelancers with a huge pool of WordPress experts. They know their stuff and they're waiting to help you build your dream site."
+							) }
+						</p>
+						<div className="gsuite-stats-nudge__button-row">
+							<Button
+								href={ '/experts/gsuite?source=stat-banner' }
+								primary
+								onClick={ this.onStartNowClick }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{ translate( 'Find your expert' ) }
+							</Button>
+						</div>
+					</div>
+				</div>
+			</Card>
+		);
+	}
+}
+
+export default connect(
+	( state, ownProps ) => ( {
+		isDismissed: isGSuiteStatsNudgeDismissed( state, ownProps.siteId ),
+	} ),
+	{
+		dismissNudge,
+		recordTracksEvent: withEnhancers( recordTracksEvent, [ enhanceWithSiteType ] ),
+	}
+)( localize( GSuiteStatsNudge ) );

--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -82,7 +82,7 @@ class GSuiteStatsNudge extends Component {
 				);
 			case 'copy3':
 				return translate(
-					'Customers can’t reach you at sales@%s – click here to add a mailbox for just $5/mo”',
+					'Customers can’t reach you at sales@%s – click here to add a mailbox for just $5/mo',
 					{ args: domainSlug }
 				);
 			case 'copy4':

--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -12,6 +12,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal Dependencies
  */
+import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import Card from 'components/card';
 import isGSuiteStatsNudgeDismissed from 'state/selectors/is-gsuite-stats-nudge-dismissed';
@@ -68,8 +69,30 @@ class GSuiteStatsNudge extends Component {
 		return ! this.props.isDismissed;
 	}
 
-	render() {
+	getHeaderCopy() {
 		const { translate } = this.props;
+		switch ( abtest( 'gSuiteStatsNudge' ) ) {
+			case 'copy1':
+				return translate( 'Get a mailbox powered by G Suite' );
+			case 'copy2':
+				return translate(
+					'Get email for your domain powered by G Suite for just $5/mo – limited time offer!'
+				);
+			case 'copy3':
+				return translate(
+					'Customers can’t reach you at sales@yourdomain.com – click here to add a mailbox for just $5/mo”'
+				);
+			case 'copy4':
+				return translate(
+					'Get a mailbox, documents, and (blahblah) for your domain for just $5/mo'
+				);
+			default:
+		}
+	}
+
+	render() {
+		const { siteSlug, translate } = this.props;
+		const url = '/domains/manage/email/' + siteSlug;
 
 		if ( ! this.isVisible() ) {
 			return null;
@@ -94,29 +117,23 @@ class GSuiteStatsNudge extends Component {
 					<div className="gsuite-stats-nudge__image-wrapper">
 						<img
 							className="gsuite-stats-nudge__image"
-							src="/calypso/images/gsuite/illustration-builder-referral.svg"
-							alt={ translate( 'Build your dream site with GSuite' ) }
+							src="/calypso/images/g-suite/g-suite.svg"
+							alt={ translate( 'Get G Suite' ) }
 						/>
 					</div>
 
 					<div className="gsuite-stats-nudge__info">
-						<h1 className="gsuite-stats-nudge__title">
-							{ translate( 'Need an expert to help realize your vision? Hire one!' ) }
-						</h1>
-						<p>
-							{ translate(
-								"We've partnered with GSuite, a network of freelancers with a huge pool of WordPress experts. They know their stuff and they're waiting to help you build your dream site."
-							) }
-						</p>
+						<h1 className="gsuite-stats-nudge__title">{ this.getHeaderCopy() }</h1>
+						{
+							<p>
+								{ translate(
+									"We've partnered with Google to offer you email, storage, docs, calendars, and more integrated with your site."
+								) }
+							</p>
+						}
 						<div className="gsuite-stats-nudge__button-row">
-							<Button
-								href={ '/experts/gsuite?source=stat-banner' }
-								primary
-								onClick={ this.onStartNowClick }
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{ translate( 'Find your expert' ) }
+							<Button href={ url } primary onClick={ this.onStartNowClick }>
+								{ translate( 'Get G Suite' ) }
 							</Button>
 						</div>
 					</div>

--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -29,6 +29,7 @@ import './style.scss';
 
 class GSuiteStatsNudge extends Component {
 	static propTypes = {
+		domainSlug: PropTypes.string.isRequired,
 		isDismissed: PropTypes.bool.isRequired,
 		recordTracksEvent: PropTypes.func.isRequired,
 		siteId: PropTypes.number.isRequired,
@@ -70,7 +71,8 @@ class GSuiteStatsNudge extends Component {
 	}
 
 	getHeaderCopy() {
-		const { translate } = this.props;
+		const { domainSlug, translate } = this.props;
+
 		switch ( abtest( 'gSuiteStatsNudge' ) ) {
 			case 'copy1':
 				return translate( 'Get a mailbox powered by G Suite' );
@@ -80,12 +82,11 @@ class GSuiteStatsNudge extends Component {
 				);
 			case 'copy3':
 				return translate(
-					'Customers can’t reach you at sales@yourdomain.com – click here to add a mailbox for just $5/mo”'
+					'Customers can’t reach you at sales@%s – click here to add a mailbox for just $5/mo”',
+					{ args: domainSlug }
 				);
 			case 'copy4':
-				return translate(
-					'Get a mailbox, documents, and (blahblah) for your domain for just $5/mo'
-				);
+				return translate( 'Professional email and so much more' );
 			default:
 		}
 	}

--- a/client/blocks/gsuite-stats-nudge/style.scss
+++ b/client/blocks/gsuite-stats-nudge/style.scss
@@ -1,0 +1,76 @@
+.card.gsuite-stats-nudge {
+	padding: 0; // allow section header to perfectly sit over the top of the card
+}
+
+.gsuite-stats-nudge__body {
+	align-items: flex-end;
+	display: flex;
+	padding: 11px 24px; // Standard padding
+
+	@include breakpoint( '>960px' ) {
+		max-height: 300px;
+		padding-bottom: 0; // Allow image to go right to the edge of the card
+	}
+}
+
+.gsuite-stats-nudge__info {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+
+	@include breakpoint( '>960px' ) {
+		padding-right: 12px; // The image has about 12 px of whitespace, this helps "balance" the block
+	}
+}
+
+.gsuite-stats-nudge__title {
+	font-size: 21px;
+	font-weight: 400;
+	margin: 10px 0 5px;
+}
+
+.gsuite-stats-nudge__description {
+	font-size: 16px;
+	font-weight: 400;
+}
+
+.gsuite-stats-nudge__button-row {
+	align-content: center;
+	display: flex;
+	margin-bottom: 20px;
+
+	@include breakpoint( '>960px' ) {
+		margin-bottom: 30px;
+	}
+
+	.button {
+		@include breakpoint( '<480px' ) {
+			width: 100%;
+			text-align: center;
+		}
+	}
+}
+
+.gsuite-stats-nudge__image-wrapper {
+	display: none;
+
+	@include breakpoint( '>960px' ) {
+		display: flex;
+		height: 200px;
+		margin-right: 40px;
+		min-width: 260px;
+	}
+}
+
+.gsuite-stats-nudge__image {
+	width: 100%;
+}
+
+.gsuite-stats-nudge__close-icon {
+	position: absolute;
+	top: 14px;
+	right: 18px;
+	color: var( --color-neutral-light );
+	cursor: pointer;
+	z-index: z-index( 'root', '.gsuite-stats-nudge__close-icon' );
+}

--- a/client/blocks/upwork-stats-nudge/actions.js
+++ b/client/blocks/upwork-stats-nudge/actions.js
@@ -12,9 +12,9 @@ export const dismissNudge = () => ( dispatch, getState ) => {
 	const preference = getPreference( getState(), 'upwork-dismissible-nudge' ) || {};
 
 	return dispatch(
-		savePreference(
-			'upwork-dismissible-nudge',
-			Object.assign( {}, preference, {
+		savePreference( 'upwork-dismissible-nudge', {
+			...preference,
+			...{
 				[ siteId ]: [
 					...( preference[ siteId ] || [] ),
 					{
@@ -22,7 +22,7 @@ export const dismissNudge = () => ( dispatch, getState ) => {
 						type: 'dismiss',
 					},
 				],
-			} )
-		)
+			},
+		} )
 	);
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -171,4 +171,14 @@ export default {
 		},
 		defaultVariation: 'icon',
 	},
+	gSuiteStatsNudge: {
+		datestamp: '20190308',
+		variations: {
+			copy1: 25,
+			copy2: 25,
+			copy3: 25,
+			copy4: 25,
+		},
+		defaultVariation: 'copy1',
+	},
 };

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import page from 'page';
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize, translate } from 'i18n-calypso';
 import { parse as parseQs, stringify as stringifyQs } from 'qs';
@@ -13,7 +13,7 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
+
 import DocumentHead from 'components/data/document-head';
 import StatsPeriodNavigation from './stats-period-navigation';
 import Main from 'components/main';
@@ -26,6 +26,7 @@ import StatsModule from './stats-module';
 import statsStrings from './stats-strings';
 import titlecase from 'to-title-case';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import StatsBanners from './stats-banners';
 import StatsFirstView from './stats-first-view';
 import StickyPanel from 'components/sticky-panel';
 import JetpackColophon from 'components/jetpack-colophon';
@@ -34,13 +35,9 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteOption, isJetpackSite, getSitePlanSlug } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
-import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
-import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
-import UpworkStatsNudge from 'blocks/upwork-stats-nudge';
-import ECommerceManageNudge from 'blocks/ecommerce-manage-nudge';
-import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
+
 import memoizeLast from 'lib/memoize-last';
 
 function updateQueryString( query = {} ) {
@@ -128,30 +125,6 @@ class StatsSite extends Component {
 		}
 	};
 
-	displayBanners() {
-		const { isGoogleMyBusinessStatsNudgeVisible, planSlug, siteId, slug } = this.props;
-		return (
-			<Fragment>
-				{ config.isEnabled( 'onboarding-checklist' ) && 'ecommerce-bundle' !== planSlug && (
-					<WpcomChecklist viewMode="banner" />
-				) }
-				{ 'ecommerce-bundle' === planSlug && <ECommerceManageNudge siteId={ siteId } /> }
-				{ config.isEnabled( 'google-my-business' ) &&
-					abtest( 'builderReferralStatsNudge' ) === 'googleMyBusinessBanner' &&
-					siteId && (
-						<GoogleMyBusinessStatsNudge
-							siteSlug={ slug }
-							siteId={ siteId }
-							visible={ isGoogleMyBusinessStatsNudgeVisible }
-						/>
-					) }
-				{ abtest( 'builderReferralStatsNudge' ) === 'builderReferralBanner' && siteId && (
-					<UpworkStatsNudge siteSlug={ slug } siteId={ siteId } />
-				) }
-			</Fragment>
-		);
-	}
-
 	render() {
 		const { date, hasPodcasts, isJetpack, siteId, slug } = this.props;
 
@@ -208,7 +181,7 @@ class StatsSite extends Component {
 					slug={ slug }
 				/>
 				<div id="my-stats-content">
-					{ this.displayBanners() }
+					<StatsBanners siteId={ siteId } slug={ slug } />
 					<ChartTabs
 						activeTab={ getActiveTab( this.props.chartTab ) }
 						activeLegend={ this.state.activeLegend }
@@ -313,10 +286,6 @@ export default connect(
 				!! getSiteOption( state, siteId, 'podcasting_archive' ) ||
 				// Podcasting category ID
 				!! getSiteOption( state, siteId, 'podcasting_category_id' ),
-			isGoogleMyBusinessStatsNudgeVisible: isGoogleMyBusinessStatsNudgeVisibleSelector(
-				state,
-				siteId
-			),
 			siteId,
 			slug: getSelectedSiteSlug( state ),
 			planSlug: getSitePlanSlug( state, siteId ),

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -1,0 +1,133 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+import config from 'config';
+import ECommerceManageNudge from 'blocks/ecommerce-manage-nudge';
+import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
+import { getGSuiteSupportedDomains, hasGSuite } from 'lib/domains/gsuite';
+import GoogleMyBusinessStatsNudge from 'blocks/google-my-business-stats-nudge';
+import GSuiteStatsNudge from 'blocks/gsuite-stats-nudge';
+import isGoogleMyBusinessStatsNudgeVisibleSelector from 'state/selectors/is-google-my-business-stats-nudge-visible';
+import isGSuiteStatsNudgeDismissed from 'state/selectors/is-gsuite-stats-nudge-dismissed';
+import isUpworkStatsNudgeDismissed from 'state/selectors/is-upwork-stats-nudge-dismissed';
+import QuerySiteDomains from 'components/data/query-site-domains';
+import UpworkStatsNudge from 'blocks/upwork-stats-nudge';
+import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
+
+class StatsBanners extends Component {
+	static propTypes = {
+		isGoogleMyBusinessStatsNudgeVisible: PropTypes.bool.isRequired,
+		isGSuiteStatsNudgeVisible: PropTypes.bool.isRequired,
+		isUpworkStatsNudgeVisible: PropTypes.bool.isRequired,
+		siteId: PropTypes.number.isRequired,
+		slug: PropTypes.string.isRequired,
+	};
+
+	shouldComponentUpdate( nextProps ) {
+		if (
+			this.props.isGSuiteStatsNudgeVisible !== nextProps.isGSuiteStatsNudgeVisible ||
+			this.props.isUpworkStatsNudgeVisible !== nextProps.isUpworkStatsNudgeVisible ||
+			this.props.isGoogleMyBusinessStatsNudgeVisible !==
+				nextProps.isGoogleMyBusinessStatsNudgeVisible ||
+			this.props.domains.length !== nextProps.domains.length
+		) {
+			return true;
+		}
+		return false;
+	}
+
+	renderBanner() {
+		if ( this.showUpworkBanner() ) {
+			return this.renderUpworkBanner();
+		} else if ( this.showGSuiteBanner ) {
+			return this.renderGSuiteBanner();
+		} else if ( this.showGoogleMyBusinessBanner ) {
+			return this.renderGoogleMyBusinessBanner();
+		}
+	}
+
+	renderGoogleMyBusinessBanner() {
+		const { isGoogleMyBusinessStatsNudgeVisible, siteId, slug } = this.props;
+		return (
+			<GoogleMyBusinessStatsNudge
+				siteSlug={ slug }
+				siteId={ siteId }
+				visible={ isGoogleMyBusinessStatsNudgeVisible }
+			/>
+		);
+	}
+
+	renderGSuiteBanner() {
+		const { siteId, slug } = this.props;
+		return <GSuiteStatsNudge siteSlug={ slug } siteId={ siteId } />;
+	}
+
+	renderUpworkBanner() {
+		const { siteId, slug } = this.props;
+		return <UpworkStatsNudge siteSlug={ slug } siteId={ siteId } />;
+	}
+
+	showGoogleMyBusinessBanner() {
+		return (
+			config.isEnabled( 'google-my-business' ) && this.props.isGoogleMyBusinessStatsNudgeVisible
+		);
+	}
+
+	showGSuiteBanner() {
+		const { domains } = this.props;
+		return (
+			this.props.isGSuiteStatsNudgeVisible &&
+			getGSuiteSupportedDomains( domains ).filter( function( domain ) {
+				return hasGSuite( domain );
+			} ).length === 0
+		);
+	}
+
+	showUpworkBanner() {
+		return (
+			abtest( 'builderReferralStatsNudge' ) === 'builderReferralBanner' &&
+			this.props.isUpworkStatsNudgeVisible
+		);
+	}
+
+	render() {
+		const { planSlug, siteId } = this.props;
+		if ( ! this.props.domains.length ) {
+			return null;
+		}
+
+		return (
+			<Fragment>
+				{ siteId && <QuerySiteDomains siteId={ siteId } /> }
+				{ config.isEnabled( 'onboarding-checklist' ) && 'ecommerce-bundle' !== planSlug && (
+					<WpcomChecklist viewMode="banner" />
+				) }
+				{ 'ecommerce-bundle' === planSlug && <ECommerceManageNudge siteId={ siteId } /> }
+				{ this.renderBanner() }
+			</Fragment>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	return {
+		domains: getDecoratedSiteDomains( state, ownProps.siteId ),
+		isGoogleMyBusinessStatsNudgeVisible: isGoogleMyBusinessStatsNudgeVisibleSelector(
+			state,
+			ownProps.siteId
+		),
+		isGSuiteStatsNudgeVisible: ! isGSuiteStatsNudgeDismissed( state, ownProps.siteId ),
+		isUpworkStatsNudgeVisible: ! isUpworkStatsNudgeDismissed( state, ownProps.siteId ),
+	};
+} )( localize( StatsBanners ) );

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -50,9 +50,9 @@ class StatsBanners extends Component {
 	renderBanner() {
 		if ( this.showUpworkBanner() ) {
 			return this.renderUpworkBanner();
-		} else if ( this.showGSuiteBanner ) {
+		} else if ( this.showGSuiteBanner() ) {
 			return this.renderGSuiteBanner();
-		} else if ( this.showGoogleMyBusinessBanner ) {
+		} else if ( this.showGoogleMyBusinessBanner() ) {
 			return this.renderGoogleMyBusinessBanner();
 		}
 	}
@@ -86,9 +86,11 @@ class StatsBanners extends Component {
 
 	showGSuiteBanner() {
 		const { domains } = this.props;
+		const supportedDomains = getGSuiteSupportedDomains( domains );
 		return (
 			this.props.isGSuiteStatsNudgeVisible &&
-			getGSuiteSupportedDomains( domains ).filter( function( domain ) {
+			supportedDomains.length > 0 &&
+			supportedDomains.filter( function( domain ) {
 				return hasGSuite( domain );
 			} ).length === 0
 		);

--- a/client/my-sites/stats/stats-banners/index.jsx
+++ b/client/my-sites/stats/stats-banners/index.jsx
@@ -69,8 +69,9 @@ class StatsBanners extends Component {
 	}
 
 	renderGSuiteBanner() {
-		const { siteId, slug } = this.props;
-		return <GSuiteStatsNudge siteSlug={ slug } siteId={ siteId } />;
+		const { domains, siteId, slug } = this.props;
+		const domainSlug = getGSuiteSupportedDomains( domains )[ 0 ].name;
+		return <GSuiteStatsNudge siteSlug={ slug } siteId={ siteId } domainSlug={ domainSlug } />;
 	}
 
 	renderUpworkBanner() {

--- a/client/state/selectors/is-gsuite-stats-nudge-dismissed.js
+++ b/client/state/selectors/is-gsuite-stats-nudge-dismissed.js
@@ -1,0 +1,50 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { last } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getPreference } from 'state/preferences/selectors';
+
+const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Returns the last time the nudge was dismissed by the current user or 0 if it was never dismissed
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId The Id of the site
+ * @return {Number}  Timestamp marking the last time the nudge was dismissed
+ */
+const getLastDismissTime = ( state, siteId ) => {
+	const preference = getPreference( state, 'gsuite-dismissible-nudge' ) || {};
+	const sitePreference = preference[ siteId ] || [];
+	const lastEvent = last( sitePreference.filter( event => 'dismiss' === event.type ) );
+
+	return lastEvent ? lastEvent.dismissedAt : 0;
+};
+
+/**
+ * Returns true if the G Suite nudge has recently been dismissed by the current user
+ * and this action is still effective for this site
+ *
+ * The conditions for it to be effective (and thus make the nudge invisible) are the following:
+ * - The last time it was dismissed must be less than 2 weeks ago
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId The Id of the site
+ * @return {Boolean} True if the nudge has been dismissed
+ */
+export default function isGSuiteStatsNudgeDismissed( state, siteId ) {
+	const lastDismissTime = getLastDismissTime( state, siteId );
+
+	// Return false if it has never been dismissed
+	if ( lastDismissTime === 0 ) {
+		return false;
+	}
+
+	return lastDismissTime > Date.now() - 2 * WEEK_IN_MS;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Factors out stats banner to its own component
* Adds logic to show the next banner if previous is dismissed
* Adds G Suite Banner
* Adds AB Test for G Suite banner text

![image](https://user-images.githubusercontent.com/6817400/54161441-827b2580-4428-11e9-9963-d63f77f76aab.png)

#### Testing instructions

- Goto stats page with a site that does not have G Suite but does have an eligible domain
- If you get the Upwork banner dismiss it.
- Observe G Suite banner
- Click G Suite button
- Observe G Suite CTA
- Goto Stats page for site with G Suite
- Observe no G Suite Banner
- Goto Stats page with domain mapped elsewhere

Testing copy:

- Goto domains page
- Ensure that you are in the test for the copy you want to test. Set variation (copy1, copy2, copy3, copy4): In console run `localStorage.setItem( 'ABTests', '{"gSuiteStatsNudge_20190308":"copy1"}' );`
- Goto stats page
- Observe copy
- Repeat for each variation.
