### PR TITLE
CI: Prime early, wait less

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,7 +362,6 @@ jobs:
       - save_cache: *save-jest-cache
       - store-artifacts-and-test-results
 
-
   test-server:
     <<: *defaults
     parallelism: 1
@@ -469,7 +468,6 @@ jobs:
     - image: buildpack-deps
     working_directory: ~/wp-calypso
     steps:
-      - prepare
       - run:
           name: Prime calypso.live build
           command: curl "https://hash-$CIRCLE_SHA1.calypso.live"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -540,6 +540,9 @@ workflows:
       - prime-calypso-live:
           requires:
             - setup
+          filters:
+            branches:
+              ignore: master
       - build-jetpack-blocks:
           requires:
             - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,6 +469,13 @@ jobs:
     working_directory: ~/wp-calypso
     steps:
       - run:
+          name: Check external author
+          command: |
+            if [[ ! -z $CIRCLE_PR_USERNAME ]]; then
+              echo 'PRs from external authors cannot run on calypso.live'
+              exit 1
+            fi
+      - run:
           name: Prime calypso.live build
           command: curl "https://hash-$CIRCLE_SHA1.calypso.live"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,17 +455,32 @@ jobs:
                     }'
             fi
 
-  #
   # Prime calypso.live so it has a build ready
   #
   # We can send a request to calypso.live so that it gets a build ready.
-  # This saves time if folks want to test and also saves having e2e jobs wasting container time waiting for the image to build.
+  # This saves time waiting later when waiting for the calypso.live
   #
   # Expected usage:
-  #   - After main tests have passed (test-client, test-server)
+  #   - After setup
   #   - Only on branches (!master)
   #
   prime-calypso-live:
+    docker:
+    - image: buildpack-deps
+    working_directory: ~/wp-calypso
+    steps:
+      - prepare
+      - run:
+          name: Prime calypso.live build
+          command: curl "https://hash-$CIRCLE_SHA1.calypso.live"
+
+  # Wait for calypso.live to be ready
+  #
+  # Expected usage:
+  #   - After main tests have passed (test-client, test-server)
+  #   - Before e2e tests run
+  #
+  wait-calypso-live:
     docker:
     - image: buildpack-deps
     working_directory: ~/wp-calypso
@@ -524,6 +539,9 @@ workflows:
   calypso:
     jobs:
       - setup
+      - prime-calypso-live:
+          requires:
+            - setup
       - build-jetpack-blocks:
           requires:
             - setup
@@ -545,7 +563,7 @@ workflows:
       - test-server:
           requires:
             - setup
-      - prime-calypso-live:
+      - wait-calypso-live:
           requires:
             - test-client
             - test-server
@@ -554,23 +572,23 @@ workflows:
               ignore: master
       - test-e2e-canary:
           requires:
-            - prime-calypso-live
+            - wait-calypso-live
           test-flags: "-C -S $CIRCLE_SHA1"
       - test-e2e-canary:
           name: test-e2e-canary-ie
           requires:
-            - prime-calypso-live
+            - wait-calypso-live
           test-flags: "-z -S $CIRCLE_SHA1"
           test-target: "IE11"
       - test-e2e-canary:
           name: test-e2e-canary-safari
           requires:
-            - prime-calypso-live
+            - wait-calypso-live
           test-flags: "-y -S $CIRCLE_SHA1"
       - test-e2e-canary:
           name: test-e2e-canary-woo
           requires:
-            - prime-calypso-live
+            - wait-calypso-live
           test-flags: "-W -S $CIRCLE_SHA1"
           test-target: "WOO"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,19 +465,15 @@ jobs:
   #
   prime-calypso-live:
     docker:
-    - image: buildpack-deps
+      - image: buildpack-deps
     working_directory: ~/wp-calypso
     steps:
       - run:
-          name: Check external author
+          name: Prime calypso.live
           command: |
-            if [[ ! -z $CIRCLE_PR_USERNAME ]]; then
-              echo 'PRs from external authors cannot run on calypso.live'
-              exit 1
+            if [[ -z $CIRCLE_PR_USERNAME ]]; then
+              curl "https://hash-$CIRCLE_SHA1.calypso.live"
             fi
-      - run:
-          name: Prime calypso.live build
-          command: curl "https://hash-$CIRCLE_SHA1.calypso.live"
 
   # Wait for calypso.live to be ready
   #
@@ -487,7 +483,7 @@ jobs:
   #
   wait-calypso-live:
     docker:
-    - image: buildpack-deps
+      - image: buildpack-deps
     working_directory: ~/wp-calypso
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,7 +472,7 @@ jobs:
           name: Prime calypso.live
           command: |
             if [[ -z $CIRCLE_PR_USERNAME ]]; then
-              curl "https://hash-$CIRCLE_SHA1.calypso.live"
+              curl --silent "https://hash-$CIRCLE_SHA1.calypso.live"
             fi
 
   # Wait for calypso.live to be ready


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Send a request to calypso.live early to start the build
Wait for calypso.live later before e2e runs

Outlined in https://github.com/Automattic/wp-calypso/pull/31300#issue-259411053

#### Testing instructions

* Look at the CI build, do we spend less time waiting? (wait-calypso-live job here, prime-calypso-live job on other branches)
