### PR TITLE
End concierge upsell test - roll out to all users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -81,15 +81,6 @@ export default {
 		defaultVariation: 'skip',
 		allowExistingUsers: true,
 	},
-	showConciergeSessionUpsellNonGSuite: {
-		datestamp: '20190104',
-		variations: {
-			skip: 50,
-			show: 50,
-		},
-		defaultVariation: 'skip',
-		allowExistingUsers: true,
-	},
 	builderReferralStatsNudge: {
 		datestamp: '20181218',
 		variations: {

--- a/client/my-sites/checkout/checkout/checkout.jsx
+++ b/client/my-sites/checkout/checkout/checkout.jsx
@@ -437,12 +437,9 @@ export class Checkout extends React.Component {
 				cartItems.hasPersonalPlan( cart ) ||
 				cartItems.hasPremiumPlan( cart ) )
 		) {
-			// Assign a test group as late as possible
-			if ( 'show' === abtest( 'showConciergeSessionUpsellNonGSuite' ) ) {
-				// A user just purchased one of the qualifying plans and is in the "show" ab test variation
-				// Show them the concierge session upsell page
-				return `/checkout/${ selectedSiteSlug }/add-support-session/${ receiptId }`;
-			}
+			// A user just purchased one of the qualifying plans
+			// Show them the concierge session upsell page
+			return `/checkout/${ selectedSiteSlug }/add-support-session/${ receiptId }`;
 		}
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Roll out the post-purchase concierge upsell test to all eligible users.

#### Testing instructions

* Purchase a Blogger, Personal, or Premium plan for any wpcom site (don't add a domain to the cart).
* Immediately after the purchase completes, you should see the upsell page.
<img width="770" alt="Screen Shot 2019-03-08 at 4 31 44 PM" src="https://user-images.githubusercontent.com/690843/54063178-bb649180-41bf-11e9-954d-7cb9e6dab59b.png">
