### PR TITLE
Signup: show sales team widget in plans step

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -58,14 +58,15 @@ export class PlansStep extends Component {
 			salesTeamStyles.setAttribute( 'rel', 'stylesheet' );
 			salesTeamStyles.setAttribute( 'type', 'text/css' );
 			salesTeamStyles.setAttribute( 'media', 'all' );
-			document.body.appendChild( salesTeamStyles );
+			document.head.appendChild( salesTeamStyles );
 
 			const salesTeamScript = document.createElement( 'script' );
 			salesTeamScript.setAttribute(
 				'src',
-				'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/js/wpcom-salesteam.js?ver=20190221'
+				'//widgets.wp.com/wp-content/a8c-plugins/wpcom-salesteam/js/wpcom-salesteam.js?ver=20190221'
 			);
-			document.body.appendChild( salesTeamScript );
+			salesTeamScript.setAttribute( 'defer', true );
+			document.head.appendChild( salesTeamScript );
 		}
 
 		SignupActions.saveSignupStep( {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -38,6 +38,23 @@ import './style.scss';
 
 export class PlansStep extends Component {
 	componentDidMount() {
+		const salesTeamStyles = document.createElement( 'link' );
+		salesTeamStyles.setAttribute(
+			'href',
+			'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/css/wpcom-salesteam.css?ver=1'
+		);
+		salesTeamStyles.setAttribute( 'rel', 'stylesheet' );
+		salesTeamStyles.setAttribute( 'type', 'text/css' );
+		salesTeamStyles.setAttribute( 'media', 'all' );
+		document.body.appendChild( salesTeamStyles );
+
+		const salesTeamScript = document.createElement( 'script' );
+		salesTeamScript.setAttribute(
+			'src',
+			'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/js/wpcom-salesteam.js?ver=20190221'
+		);
+		document.body.appendChild( salesTeamScript );
+
 		SignupActions.saveSignupStep( {
 			stepName: this.props.stepName,
 		} );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -38,7 +38,13 @@ import './style.scss';
 
 export class PlansStep extends Component {
 	componentDidMount() {
-		if ( document && document.createElement && document.body ) {
+		if (
+			typeof window !== 'undefined' &&
+			window.location &&
+			typeof document !== 'undefined' &&
+			document.createElement &&
+			document.body
+		) {
 			if ( window.location.search ) {
 				// save this so that we can enter debug mode in the widget
 				window.salesteam_initial_search_string = window.location.search;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -38,22 +38,29 @@ import './style.scss';
 
 export class PlansStep extends Component {
 	componentDidMount() {
-		const salesTeamStyles = document.createElement( 'link' );
-		salesTeamStyles.setAttribute(
-			'href',
-			'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/css/wpcom-salesteam.css?ver=1'
-		);
-		salesTeamStyles.setAttribute( 'rel', 'stylesheet' );
-		salesTeamStyles.setAttribute( 'type', 'text/css' );
-		salesTeamStyles.setAttribute( 'media', 'all' );
-		document.body.appendChild( salesTeamStyles );
+		if ( document && document.createElement && document.body ) {
+			if ( window.location.search ) {
+				// save this so that we can enter debug mode in the widget
+				window.salesteam_initial_search_string = window.location.search;
+			}
 
-		const salesTeamScript = document.createElement( 'script' );
-		salesTeamScript.setAttribute(
-			'src',
-			'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/js/wpcom-salesteam.js?ver=20190221'
-		);
-		document.body.appendChild( salesTeamScript );
+			const salesTeamStyles = document.createElement( 'link' );
+			salesTeamStyles.setAttribute(
+				'href',
+				'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/css/wpcom-salesteam.css?ver=1'
+			);
+			salesTeamStyles.setAttribute( 'rel', 'stylesheet' );
+			salesTeamStyles.setAttribute( 'type', 'text/css' );
+			salesTeamStyles.setAttribute( 'media', 'all' );
+			document.body.appendChild( salesTeamStyles );
+
+			const salesTeamScript = document.createElement( 'script' );
+			salesTeamScript.setAttribute(
+				'src',
+				'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/js/wpcom-salesteam.js?ver=20190221'
+			);
+			document.body.appendChild( salesTeamScript );
+		}
 
 		SignupActions.saveSignupStep( {
 			stepName: this.props.stepName,

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -63,7 +63,7 @@ export class PlansStep extends Component {
 			const salesTeamScript = document.createElement( 'script' );
 			salesTeamScript.setAttribute(
 				'src',
-				'//widgets.wp.com/wp-content/a8c-plugins/wpcom-salesteam/js/wpcom-salesteam.js?ver=20190221'
+				'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/js/wpcom-salesteam.js?ver=20190221'
 			);
 			salesTeamScript.setAttribute( 'defer', true );
 			document.head.appendChild( salesTeamScript );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* adds the sales team widget to the "choose a plan" step

#### Testing instructions

* go to the "choose a plan" step and test whether the widget appears, use the query arg to trigger it
* note: Plans step removes query args so you'll need this diff applied also D25357
* also make sure to check sales team hours and URL settings
