### PR TITLE
Colour Scheming: WordPress Social Icon

### DIFF
--- a/client/components/share-button/style.scss
+++ b/client/components/share-button/style.scss
@@ -1,7 +1,7 @@
 
 .share-button.has-color {
 	.wordpress {
-		fill: var( --color-primary );
+		fill: var( --color-wpcom );
 	}
 
 	.facebook {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The social logo component uses a WordPress logo which is currently primary, and therefore changes with the new schemes contradictory to the guidelines in DevDocs, but this would prevent that by switching the variable.

![hgfhgfgfh-1](https://user-images.githubusercontent.com/43215253/54072163-c4f90280-426e-11e9-8ea5-b11c19d6cab3.png)

cc @flootr, @blowery
