### PR TITLE
Share Button Component: Remove Google+

### DIFF
--- a/client/components/share-button/README.md
+++ b/client/components/share-button/README.md
@@ -1,7 +1,7 @@
 ShareButton (JSX)
 ====================
 
-ShareButton is a component which allows you to open a popup window to share content on various services. Supported services are WordPress, Facebook, Twitter, Linkedin, Tumblr, Pinterest, Telegram, and GooglePlus.
+ShareButton is a component which allows you to open a popup window to share content on various services. Supported services are WordPress, Facebook, Twitter, LinkedIn, Tumblr, Pinterest and Telegram.
 
 -------
 
@@ -36,4 +36,4 @@ function MyButton() {
 * `title`: (string) The title of the content to share
 * `service`: (object) The serice to share on - contains a `url` and `windowArg` to append to the URL
 
-A full list of supported services and associated URLs and windowArgs are at `compnents/share-button/servicesjs`.
+A full list of supported services and associated URLs and windowArgs are at `components/share-button/servicesjs`.

--- a/client/components/share-button/services.js
+++ b/client/components/share-button/services.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -19,10 +18,6 @@ const facebook = {
 const twitter = {
 	url: 'https://twitter.com/intent/tweet?url=<URL>&text=<TITLE>&via=wordpressdotcom',
 	windowArg: 'width=550,height=420,resizeable,scrollbars',
-};
-
-const googlePlus = {
-	url: 'https://plus.google.com/share?url=<URL>',
 };
 
 const linkedin = {
@@ -49,6 +44,5 @@ export default {
 	linkedin,
 	tumblr,
 	pinterest,
-	telegram,
-	'google-plus': googlePlus,
+	telegram,	
 };

--- a/client/components/share-button/style.scss
+++ b/client/components/share-button/style.scss
@@ -11,11 +11,7 @@
 	.twitter {
 		fill: var( --color-twitter );
 	}
-
-	.google-plus {
-		fill: var( --color-gplus );
-	}
-
+	
 	.tumblr {
 		fill: var( --color-tumblr );
 	}

--- a/client/my-sites/checklist/share.jsx
+++ b/client/my-sites/checklist/share.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 import ShareButton from 'components/share-button';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-const services = [ 'facebook', 'twitter', 'linkedin', 'google-plus', 'pinterest' ];
+const services = [ 'facebook', 'twitter', 'linkedin', 'pinterest' ];
 
 class ChecklistShowShare extends PureComponent {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes the Google+ icon from the ShareButton component and the site checklist. The intention was to be able to click to be prompted to post on Google+, but since that's closing, it can go. Not sure if the intention is for that to go in a few weeks instead, but an issue was created on it anyway. 

#### Testing instructions

When you finish the site checklist, does the Google Plus icon appear next to the other icons? Hopefully not. 

![dgffgdfgfdg](https://user-images.githubusercontent.com/43215253/54072418-6170d400-4272-11e9-8c77-35ef24305406.png)

(At least partially) fixes #31299

cc @taggon, @mdawaffe, @eliorivero