### PR TITLE
Fix fetching Circle Artifacts

### DIFF
--- a/bin/get-circle-artifact-url.js
+++ b/bin/get-circle-artifact-url.js
@@ -11,7 +11,7 @@ const baseOptions = {
 };
 
 const basePath = '/api/v1.1/project/github/Automattic/wp-calypso';
-const maxBuilds = 30;
+const maxBuilds = 50;
 
 async function getCircleArtifactUrl( pathMatchRegex ) {
 	if ( ! pathMatchRegex instanceof RegExp ) {


### PR DESCRIPTION
As noted in p4TIVU-9dY-p2 we were having trouble finding specific artifacts like translated strings and jetpack block bundles. This is a temporary fix to find related items. This is likely a side effect of adding new workflows from moving E2E tests to wp-calypso. Folks are welcome to follow up with a more robust patch.

To Test:
`npm run test-integration` is green on this branch

`npm run test-integration` is red on master