### PR TITLE
Bump CircleCI API fetch to 100

### DIFF
--- a/bin/get-circle-artifact-url.js
+++ b/bin/get-circle-artifact-url.js
@@ -11,7 +11,7 @@ const baseOptions = {
 };
 
 const basePath = '/api/v1.1/project/github/Automattic/wp-calypso';
-const maxBuilds = 50;
+const maxBuilds = 100;
 
 async function getCircleArtifactUrl( pathMatchRegex ) {
 	if ( ! pathMatchRegex instanceof RegExp ) {


### PR DESCRIPTION
Follow up to #31336

Bump the CircleCI artifact fetch search limit to [100, the maximum](https://circleci.com/docs/api/v1-reference/#recent-builds-project).

## Testing

Test should pass:

```
npm run test-integration
```