### PR TITLE
Inline help: Use calypso localization

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -59,7 +59,6 @@ import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import isGutenbergEnabled from '../../state/selectors/is-gutenberg-enabled';
-import { __ } from 'gutenberg/extensions/presets/jetpack/utils/i18n';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -302,10 +301,10 @@ class InlineHelpPopover extends Component {
 	};
 
 	switchToClassicEditor = () => {
-		const { siteId, onClose, optOut, classicUrl } = this.props;
+		const { siteId, onClose, optOut, classicUrl, translate } = this.props;
 		const proceed =
 			typeof window === 'undefined' ||
-			window.confirm( __( 'Are you sure you wish to leave this page?' ) );
+			window.confirm( translate( 'Are you sure you wish to leave this page?' ) );
 		if ( proceed ) {
 			optOut( siteId, classicUrl );
 			onClose();


### PR DESCRIPTION
The popover uses a Jetpack blocks specific `__` wrapper in Calypso Gutenberg. Added in #29431 / @Copons.
Change it to use `i18n-calypso` `translate`.

Spotted in #31199

## Testing

* Test with `?flags=-calypsoify/iframe`
* Navigate to the Gutenberg editor in Calypso (ensure you're not on a WP Admin URL)
* Click the inline help bubble in the lower right (see screens)
* Click "Switch to classic editor"
* The confirmation screen should display the correct (localized) text.

## Screens

### en

![Screen Shot 2019-03-11 at 12 50 13](https://user-images.githubusercontent.com/841763/54122134-85602100-43fc-11e9-8996-1e0b98eaae54.png)
![Screen Shot 2019-03-11 at 12 49 58](https://user-images.githubusercontent.com/841763/54122135-85602100-43fc-11e9-891d-5324f21a1c08.png)


### es

![Screen Shot 2019-03-11 at 12 51 42](https://user-images.githubusercontent.com/841763/54122143-88f3a800-43fc-11e9-847b-7e14d2524832.png)
![Screen Shot 2019-03-11 at 12 51 49](https://user-images.githubusercontent.com/841763/54122142-88f3a800-43fc-11e9-936b-60c60b0462d9.png)
