### PR TITLE
Packages: format-currency no sideEffects

### DIFF
--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -1,28 +1,29 @@
 {
-	"name": "@automattic/format-currency",
-	"version": "1.0.0",
-	"description": "JavaScript library for formatting currency",
-	"main": "dist/cjs/index.js",
-	"module": "dist/esm/index.js",
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/Automattic/wp-calypso.git"
-	},
-	"keywords": [
-		"currency",
-		"internationalization"
-	],
-	"author": "Automattic, Inc.",
-	"license": "GPL-2.0-or-later",
-	"bugs": {
-		"url": "https://github.com/Automattic/wp-calypso/issues"
-	},
-	"homepage": "https://github.com/Automattic/wp-calypso",
-	"dependencies": {
-		"i18n-calypso": "file:../i18n-calypso"
-	},
-	"scripts": {
-		"build": "node ../../bin/build-package",
-		"clean": "npx rimraf dist"
-	}
+  "name": "@automattic/format-currency",
+  "version": "1.0.0",
+  "description": "JavaScript library for formatting currency",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/Automattic/wp-calypso.git"
+  },
+  "keywords": [
+    "currency",
+    "internationalization"
+  ],
+  "author": "Automattic, Inc.",
+  "license": "GPL-2.0-or-later",
+  "bugs": {
+    "url": "https://github.com/Automattic/wp-calypso/issues"
+  },
+  "homepage": "https://github.com/Automattic/wp-calypso",
+  "dependencies": {
+    "i18n-calypso": "file:../i18n-calypso"
+  },
+  "scripts": {
+    "build": "node ../../bin/build-package",
+    "clean": "npx rimraf dist"
+  }
 }

--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -11,6 +11,7 @@
   "license": "GPL-2.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Automattic/wp-calypso.git"

--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -11,7 +11,6 @@
   "license": "GPL-2.0-or-later",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Automattic/wp-calypso.git"


### PR DESCRIPTION
Add `sideEffects: false` to format-currency package.

> A "side effect" is defined as code that performs a special behavior when imported, other than exposing one or more exports. An example of this are polyfills, which affect the global scope and usually do not provide an export.

https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

Use spaces in `packages.json`

Follow-up from #31229

## Testing
- Simple payments currency formatting in the Calypso classic editor for format-currency

Second attempt at https://github.com/Automattic/wp-calypso/pull/31345
Reverts Automattic/wp-calypso#31348 (Canary e2e errors on staging / reverted)