### PR TITLE
Settings: reorder Security tab

### DIFF
--- a/client/my-sites/site-settings/navigation.jsx
+++ b/client/my-sites/site-settings/navigation.jsx
@@ -57,6 +57,16 @@ export class SiteSettingsNavigation extends Component {
 						{ strings.general }
 					</NavItem>
 
+					{ config.isEnabled( 'manage/security' ) && site.jetpack && (
+						<NavItem
+							path={ `/settings/security/${ site.slug }` }
+							preloadSectionName="settings-security"
+							selected={ section === 'security' }
+						>
+							{ strings.security }
+						</NavItem>
+					) }
+
 					<NavItem
 						path={ `/settings/performance/${ site.slug }` }
 						preloadSectionName="settings-performance"
@@ -88,16 +98,6 @@ export class SiteSettingsNavigation extends Component {
 					>
 						{ strings.traffic }
 					</NavItem>
-
-					{ config.isEnabled( 'manage/security' ) && site.jetpack && (
-						<NavItem
-							path={ `/settings/security/${ site.slug }` }
-							preloadSectionName="settings-security"
-							selected={ section === 'security' }
-						>
-							{ strings.security }
-						</NavItem>
-					) }
 				</NavTabs>
 			</SectionNav>
 		);


### PR DESCRIPTION
Twin PR for Jetpack: https://github.com/Automattic/jetpack/pull/11538

#### Changes proposed in this Pull Request

* Reorder Security tab in Settings.
  * Moves the tab from the last place to second place, right after General and before Performance.

**Notes**:
* This change only applies to Jetpack sites.
* Might need updated tests.

#### Testing instructions

* Fire up this PR.
* Visit your Jetpack site settings.
* Make sure the Security tab appears in the right spot.

#### Before

![wordpress com_settings_security_mutelife com(Calypso)](https://user-images.githubusercontent.com/390760/54141771-36c37e80-441e-11e9-8ff4-a2acc89162e2.png)


#### After

![calypso localhost_3000_settings_security_mutelife com(Calypso)](https://user-images.githubusercontent.com/390760/54141768-33c88e00-441e-11e9-8aa1-afa58316145c.png)

