### PR TITLE
Gutenframe: Check origin against site admin URL

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -64,15 +64,17 @@ class CalypsoifyIframe extends Component {
 	}
 
 	onMessage = ( { data, origin } ) => {
-		if ( ! data || origin.indexOf( this.props.siteSlug ) < 0 ) {
+		if ( ! data || 'gutenbergIframeMessage' !== data.type ) {
 			return;
 		}
 
-		const { action, type } = data;
+		const isValidOrigin = this.props.siteAdminUrl.indexOf( origin ) === 0;
 
-		if ( 'gutenbergIframeMessage' !== type ) {
+		if ( ! isValidOrigin ) {
 			return;
 		}
+
+		const { action } = data;
 
 		if ( 'loaded' === action ) {
 			const { port1: portToIframe, port2: portForIframe } = new MessageChannel();
@@ -228,10 +230,9 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId } ) => {
 		queryArgs = wpcom.addSupportParams( queryArgs );
 	}
 
-	const iframeUrl = addQueryArgs(
-		queryArgs,
-		getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' )
-	);
+	const siteAdminUrl = getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
+
+	const iframeUrl = addQueryArgs( queryArgs, siteAdminUrl );
 
 	return {
 		allPostsUrl: getPostTypeAllPostsUrl( state, postType ),
@@ -240,6 +241,7 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId } ) => {
 		currentRoute,
 		iframeUrl,
 		postTypeTrashUrl,
+		siteAdminUrl,
 	};
 };
 

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -15,7 +15,7 @@ import MediaLibrarySelectedData from 'components/data/media-library-selected-dat
 import MediaModal from 'post-editor/media-modal';
 import MediaActions from 'lib/media/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteOption, getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
+import { getSiteOption, getSiteAdminUrl } from 'state/sites/selectors';
 import { addQueryArgs } from 'lib/route';
 import {
 	getEnabledFilters,
@@ -210,7 +210,6 @@ class CalypsoifyIframe extends Component {
 
 const mapStateToProps = ( state, { postId, postType, duplicatePostId } ) => {
 	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSiteSlug( state, siteId );
 	const currentRoute = getCurrentRoute( state );
 	const postTypeTrashUrl = getPostTypeTrashUrl( state, postType );
 
@@ -237,7 +236,6 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId } ) => {
 	return {
 		allPostsUrl: getPostTypeAllPostsUrl( state, postType ),
 		siteId,
-		siteSlug,
 		currentRoute,
 		iframeUrl,
 		postTypeTrashUrl,


### PR DESCRIPTION
Previously when we were attempting to validate the origin
for incoming messages from the Gutenberg iframe we were
assuming that site slug would represent the proper domain.

This was wrong. On sites with mapped domains we get a mismatch
with the domain and the site admin URL.

In this patch, we updated the check in order to verify that
the origin comes from the site admin URL.

This fixes an issue where the core media modal was showing
instead of the Calypso media modal because the iframe
communication was not established.

#### Testing instructions

- Select a site with a mapped domain
- Create a new post by visiting `/block-editor`
- Insert a image block
- Make sure that the Calypso Media Modal is opened

![Screen Shot 2019-03-11 at 10 37 06](https://user-images.githubusercontent.com/1233880/54144766-a3705600-43e9-11e9-80ef-1d0d879795d6.png)


Fixes #31298
Fixes #31338