### PR TITLE
Build: Centralize runtime config

### DIFF
--- a/server/bundler/babel/babel-loader-cache-identifier/index.js
+++ b/server/bundler/babel/babel-loader-cache-identifier/index.js
@@ -1,9 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-const fs = require( 'fs' ); // eslint-disable-line
+const fs = require( 'fs' );
 const path = require( 'path' );
 
 /**

--- a/server/bundler/babel/babel-loader-cache-identifier/index.js
+++ b/server/bundler/babel/babel-loader-cache-identifier/index.js
@@ -1,7 +1,9 @@
+/** @format */
+
 /**
  * External dependencies
  */
-const fs = require( 'fs' );
+const fs = require( 'fs' ); // eslint-disable-line
 const path = require( 'path' );
 
 /**

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -1,16 +1,15 @@
-/** @format */
 /**
  * Internal dependencies
  */
-
+const { featuresEnabled, featuresDisabled } = require( '../../webpack.common' );
 const configPath = require( 'path' ).resolve( __dirname, '..', '..', 'config' );
 const parser = require( './parser' );
 const createConfig = require( '../../client/lib/create-config' );
 
 const { serverData, clientData } = parser( configPath, {
 	env: process.env.CALYPSO_ENV || process.env.NODE_ENV || 'development',
-	enabledFeatures: process.env.ENABLE_FEATURES,
-	disabledFeatures: process.env.DISABLE_FEATURES,
+	enabledFeatures: featuresEnabled,
+	disabledFeatures: featuresDisabled,
 } );
 
 module.exports = createConfig( serverData );

--- a/server/config/parser.js
+++ b/server/config/parser.js
@@ -1,4 +1,3 @@
-/** @format */
 /*
  * WARNING: ES5 code only here. Used by un-transpiled script!
  */

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -46,6 +46,8 @@ import { setCurrentUserOnReduxStore } from 'lib/redux-helpers';
 import analytics from '../lib/analytics';
 import { getLanguage, filterLanguageRevisions } from 'lib/i18n-utils';
 
+const { commitSha = '(unknown)' } = require( '../../webpack.common' );
+
 const debug = debugFactory( 'calypso:pages' );
 
 const SERVER_BASE_PATH = '/public';
@@ -263,7 +265,7 @@ function getDefaultContext( request ) {
 	}
 
 	const context = Object.assign( {}, request.context, {
-		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
+		commitSha,
 		compileDebug: process.env.NODE_ENV === 'development',
 		urls: generateStaticUrls(),
 		user: false,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-nodejs-modules */
 
+// Number of workers that should be used for a build
 let workerCount;
-
 if ( process.env.CIRCLECI ) {
 	workerCount = 2;
 } else if ( process.env.WORKERS && ! Number.isNaN( parseInt( process.env.WORKERS, 10 ) ) ) {
@@ -10,6 +10,35 @@ if ( process.env.CIRCLECI ) {
 	workerCount = Math.max( 2, Math.floor( require( 'os' ).cpus().length / 2 ) );
 }
 
-module.exports = {
+let useCache = true;
+if ( 'docker' === process.env.CONTAINER ) {
+	useCache = false;
+}
+
+const isCi = !! process.env.CIRCLECI;
+
+// process.env.COMMIT_SHA;
+// process.env.BABEL;
+// process.env.CALYPSO;
+// process.env.CHECK;
+// process.env.CIRCLECI;
+// process.env.COMMIT;
+// process.env.CONTAINER;
+// process.env.DISABLE;
+// process.env.EMIT;
+// process.env.ENABLE;
+// process.env.HOME;
+// process.env.HOST;
+// process.env.MINIFY;
+// process.env.NODE;
+// process.env.PORT;
+// process.env.PROFILE;
+// process.env.PROTOCOL;
+// process.env.SOURCEMAP;
+// process.env.TARGET;
+
+module.exports = Object.freeze( {
+	isCi,
+	useCache,
 	workerCount,
-};
+} );

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -25,11 +25,14 @@ if ( 'docker' === process.env.CONTAINER ) {
  */
 const isCi = !! process.env.CIRCLECI;
 
-// process.env.COMMIT_SHA;
+/**
+ * @type {(string|undefined)} Git commit sha of build
+ */
+const commitSha = process.env.COMMIT_SHA ? process.env.COMMIT_SHA : undefined;
+
 // process.env.BABEL;
 // process.env.CALYPSO;
 // process.env.CHECK;
-// process.env.CIRCLECI;
 // process.env.COMMIT;
 // process.env.CONTAINER;
 // process.env.DISABLE;
@@ -46,6 +49,7 @@ const isCi = !! process.env.CIRCLECI;
 // process.env.TARGET;
 
 module.exports = Object.freeze( {
+	commitSha,
 	isCi,
 	useCache,
 	workerCount,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,60 @@
 /* eslint-disable import/no-nodejs-modules */
 
 /**
+ * @type {(string|undefined)} Git commit sha of build
+ */
+const commitSha = process.env.COMMIT_SHA ? process.env.COMMIT_SHA : undefined;
+
+/**
+ * @type {(string|undefined)} Comma-joined string of disabled features
+ */
+const featuresDisabled = process.env.DISABLE_FEATURES ? process.env.DISABLE_FEATURES : undefined;
+/**
+ * @type {(string|undefined)} Comma-joined string of enabled features
+ */
+const featuresEnabled = process.env.ENABLE_FEATURES ? process.env.ENABLE_FEATURES : undefined;
+
+/**
+ * @type {boolean} Running in CI environment
+ */
+const isCi = !! process.env.CIRCLECI;
+
+/**
+ * @type {boolean} Enable the cyclic dependency checker
+ */
+const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
+
+/**
+ * @type {boolean} Enable build stats
+ */
+const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
+/**
+ * @type {boolean} Enable build stats with reasons
+ */
+const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
+
+/* eslint-disable no-nested-ternary */
+/**
+ * @type {boolean} Should the build be minified
+ *
+ * @TODO: Can we move from `MINIFY_JS` to `MINIFY` and use it for JS and CSS?
+ */
+const shouldMinify =
+	process.env.MINIFY_JS === 'true'
+		? true
+		: process.env.MINIFY_JS === 'false'
+		? false
+		: process.env.CALYPSO_ENV === 'desktop'
+		? false
+		: process.env.NODE_ENV === 'production';
+/* eslint-enable no-nested-ternary */
+
+/**
+ * @type {boolean} Should the build use caching
+ */
+const useCache = 'docker' !== process.env.CONTAINER;
+
+/**
  * @type {number} Number of workers that should be used for a build
  */
 let workerCount;
@@ -12,27 +66,15 @@ if ( process.env.CIRCLECI ) {
 	workerCount = Math.max( 2, Math.floor( require( 'os' ).cpus().length / 2 ) );
 }
 
-/**
- * @type {boolean} Should the build use caching
- */
-let useCache = true;
-if ( 'docker' === process.env.CONTAINER ) {
-	useCache = false;
-}
-
-/**
- * @type {boolean} Running in CI environment
- */
-const isCi = !! process.env.CIRCLECI;
-
-/**
- * @type {(string|undefined)} Git commit sha of build
- */
-const commitSha = process.env.COMMIT_SHA ? process.env.COMMIT_SHA : undefined;
-
 module.exports = Object.freeze( {
 	commitSha,
+	featuresDisabled,
+	featuresEnabled,
 	isCi,
+	shouldCheckForCycles,
+	shouldEmitStats,
+	shouldEmitStatsWithReasons,
+	shouldMinify,
 	useCache,
 	workerCount,
 } );
@@ -42,18 +84,10 @@ module.exports = Object.freeze( {
 // process.env.CALYPSO_CLIENT;
 // process.env.CALYPSO_ENV;
 // process.env.CALYPSO_IS_FORK;
-// process.env.CHECK_CYCLES;
-// process.env.CONTAINER;
-// process.env.DISABLE_FEATURES;
-// process.env.EMIT_STATS;
-// process.env.ENABLE_FEATURES;
-// process.env.HOME;
 // process.env.HOST;
-// process.env.MINIFY_JS;
 // process.env.NODE_ENV;
 // process.env.PORT;
 // process.env.PROFILE;
 // process.env.PROTOCOL;
 // process.env.SOURCEMAP;
 // process.env.TARGET_BROWSER;
-// process.env.WORKERS;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -30,27 +30,30 @@ const isCi = !! process.env.CIRCLECI;
  */
 const commitSha = process.env.COMMIT_SHA ? process.env.COMMIT_SHA : undefined;
 
-// process.env.BABEL;
-// process.env.CALYPSO;
-// process.env.CHECK;
-// process.env.COMMIT;
-// process.env.CONTAINER;
-// process.env.DISABLE;
-// process.env.EMIT;
-// process.env.ENABLE;
-// process.env.HOME;
-// process.env.HOST;
-// process.env.MINIFY;
-// process.env.NODE;
-// process.env.PORT;
-// process.env.PROFILE;
-// process.env.PROTOCOL;
-// process.env.SOURCEMAP;
-// process.env.TARGET;
-
 module.exports = Object.freeze( {
 	commitSha,
 	isCi,
 	useCache,
 	workerCount,
 } );
+
+// @TODO:
+// process.env.BABEL_ENV;
+// process.env.CALYPSO_CLIENT;
+// process.env.CALYPSO_ENV;
+// process.env.CALYPSO_IS_FORK;
+// process.env.CHECK_CYCLES;
+// process.env.CONTAINER;
+// process.env.DISABLE_FEATURES;
+// process.env.EMIT_STATS;
+// process.env.ENABLE_FEATURES;
+// process.env.HOME;
+// process.env.HOST;
+// process.env.MINIFY_JS;
+// process.env.NODE_ENV;
+// process.env.PORT;
+// process.env.PROFILE;
+// process.env.PROTOCOL;
+// process.env.SOURCEMAP;
+// process.env.TARGET_BROWSER;
+// process.env.WORKERS;

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,8 @@
 /* eslint-disable import/no-nodejs-modules */
 
-// Number of workers that should be used for a build
+/**
+ * @type {number} Number of workers that should be used for a build
+ */
 let workerCount;
 if ( process.env.CIRCLECI ) {
 	workerCount = 2;
@@ -10,11 +12,17 @@ if ( process.env.CIRCLECI ) {
 	workerCount = Math.max( 2, Math.floor( require( 'os' ).cpus().length / 2 ) );
 }
 
+/**
+ * @type {boolean} Should the build use caching
+ */
 let useCache = true;
 if ( 'docker' === process.env.CONTAINER ) {
 	useCache = false;
 }
 
+/**
+ * @type {boolean} Running in CI environment
+ */
 const isCi = !! process.env.CIRCLECI;
 
 // process.env.COMMIT_SHA;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,15 @@ const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
  */
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( './server/config' );
-const { isCi, useCache, workerCount } = require( './webpack.common' );
+const {
+	isCi,
+	shouldCheckForCycles,
+	shouldEmitStats,
+	shouldEmitStatsWithReasons,
+	shouldMinify,
+	useCache,
+	workerCount,
+} = require( './webpack.common' );
 
 /**
  * Internal variables
@@ -33,12 +41,6 @@ const { isCi, useCache, workerCount } = require( './webpack.common' );
 const calypsoEnv = config( 'env_id' );
 const bundleEnv = config( 'env' );
 const isDevelopment = bundleEnv !== 'production';
-const shouldMinify =
-	process.env.MINIFY_JS === 'true' ||
-	( process.env.MINIFY_JS !== 'false' && bundleEnv === 'production' && calypsoEnv !== 'desktop' );
-const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
-const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
-const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
  */
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( './server/config' );
-const { workerCount } = require( './webpack.common' );
+const { isCi, useCache, workerCount } = require( './webpack.common' );
 
 /**
  * Internal variables
@@ -187,9 +187,7 @@ function getWebpackConfig( {
 			minimize: shouldMinify,
 			minimizer: [
 				new TerserPlugin( {
-					cache: process.env.CIRCLECI
-						? `${ process.env.HOME }/terser-cache`
-						: 'docker' !== process.env.CONTAINER,
+					cache: useCache && ( isCi ? `${ process.env.HOME }/terser-cache` : true ),
 					parallel: workerCount,
 					sourceMap: Boolean( process.env.SOURCEMAP ),
 					terserOptions: {
@@ -220,7 +218,7 @@ function getWebpackConfig( {
 							options: {
 								configFile: path.resolve( __dirname, 'babel.config.js' ),
 								babelrc: false,
-								cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache' ),
+								cacheDirectory: useCache && path.join( __dirname, 'build', '.babel-client-cache' ),
 								cacheIdentifier,
 							},
 						},

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -20,14 +20,12 @@ const _ = require( 'lodash' );
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( 'config' );
 const bundleEnv = config( 'env' );
-const { useCache, workerCount } = require( './webpack.common' );
+const { commitSha = '(unknown)', useCache, workerCount } = require( './webpack.common' );
 
 /**
  * Internal variables
  */
 const isDevelopment = bundleEnv === 'development';
-
-const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)';
 
 /**
  * This lists modules that must use commonJS `require()`s

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -20,7 +20,7 @@ const _ = require( 'lodash' );
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( 'config' );
 const bundleEnv = config( 'env' );
-const { workerCount } = require( './webpack.common' );
+const { useCache, workerCount } = require( './webpack.common' );
 
 /**
  * Internal variables
@@ -72,7 +72,7 @@ function getExternals() {
 const babelLoader = {
 	loader: 'babel-loader',
 	options: {
-		cacheDirectory: path.join( __dirname, 'build', '.babel-server-cache' ),
+		cacheDirectory: useCache && path.join( __dirname, 'build', '.babel-server-cache' ),
 		cacheIdentifier,
 	},
 };


### PR DESCRIPTION
Centralize the runtime config in a single, immutable atom.

## Feedback please

I'm interested in getting some feedback on the approach here. It overlaps with a lot of the `config` implementation, and I'm wondering if we should just push as much of this into `config` as possible rather than having competing implementations.

Things like code splitting seem like they would be a good fit, but that's currently a config feature. I'm not sure where that direction would stop or if there's value in moving the build-oriented configuration out of config 😕 

https://github.com/Automattic/wp-calypso/blob/d0a3811cc19ecd7610d9cff7cefaf097cd735145/webpack.config.js#L44