### PR TITLE
Fix: (Purchases) Make timezone explicit on `moment()` instantiation

### DIFF
--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -99,6 +99,7 @@ describe( 'index', () => {
 					isRefundable: false,
 					refundPeriodInDays: 2,
 					subscribedDate: moment()
+						.utc()
 						.subtract( 1, 'days' )
 						.format(),
 				} )
@@ -110,6 +111,7 @@ describe( 'index', () => {
 					isRefundable: false,
 					refundPeriodInDays: 2,
 					subscribedDate: moment()
+						.utc()
 						.subtract( 2, 'days' )
 						.format(),
 				} )
@@ -122,6 +124,7 @@ describe( 'index', () => {
 					isRefundable: false,
 					refundPeriodInDays: 2,
 					subscribedDate: moment()
+						.utc()
 						.subtract( 71, 'hours' )
 						.format(),
 				} )
@@ -132,7 +135,8 @@ describe( 'index', () => {
 				maybeWithinRefundPeriod( {
 					isRefundable: false,
 					refundPeriodInDays: 2,
-					subscribedDate: moment()
+					subscribedDate: moment
+						.utc()
 						.subtract( 3, 'days' )
 						.format(),
 				} )
@@ -144,6 +148,7 @@ describe( 'index', () => {
 					isRefundable: true,
 					refundPeriodInDays: 2,
 					subscribedDate: moment()
+						.utc()
 						.subtract( 3, 'days' )
 						.format(),
 				} )
@@ -154,6 +159,7 @@ describe( 'index', () => {
 				maybeWithinRefundPeriod( {
 					isRefundable: false,
 					subscribedDate: moment()
+						.utc()
 						.subtract( 1, 'days' )
 						.format(),
 				} )
@@ -176,6 +182,7 @@ describe( 'index', () => {
 			expect(
 				subscribedWithinPastWeek( {
 					subscribedDate: moment()
+						.utc()
 						.subtract( 8, 'days' )
 						.format(),
 				} )
@@ -185,6 +192,7 @@ describe( 'index', () => {
 			expect(
 				subscribedWithinPastWeek( {
 					subscribedDate: moment()
+						.utc()
 						.subtract( 3, 'days' )
 						.format(),
 				} )


### PR DESCRIPTION
@blowery noticed some tests that seemed to be failing because of the
Daylight Saving Time switch. The cause was the use of `moment()` which
implicitly grabs the timezone from the running computer.

In our tests we mix explicit and implicit timezones and so in this patch
I'm updating the tests to be explicit.

Further, our purchasing check relies on a behavior in `moment` that has
changed in version 2.0.0. I've replace that variable behavior with one
that performs the math directly.

---

@DavidRothstein would you be willing to examine this and help follow up
on a code audit to make sure we aren't just fixing the tests and leaving
the client code broken? I'm worried that we're using `moment()` somewhere
which does funny things with the timezone, and also that we're not using
UTC times (because things like DST result in duplicate times one hour of the
year plus a missing hour once a year). I don't really have the time at the
_moment_ to dig deeper 😉 

---

## Testing

Running the unit tests failed for me in `master` when I was in EDT timezone
and when I ran the tests the day after DST switched.

In this branch the tests passed.

We need to formulate testing instructions to verify that this works in the client.