### PR TITLE
Updates StatsPostSummary to use module import for css

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -283,7 +283,6 @@
 @import 'my-sites/stats/stats-page-placeholder/style';
 @import 'my-sites/stats/stats-period-navigation/style';
 @import 'my-sites/stats/stats-post-likes/style';
-@import 'my-sites/stats/stats-post-summary/style';
 @import 'my-sites/stats/stats-site-overview/style';
 @import 'my-sites/stats/stats-tabs/style';
 @import 'my-sites/stats/stats-views/style';

--- a/client/my-sites/stats/stats-post-summary/index.jsx
+++ b/client/my-sites/stats/stats-post-summary/index.jsx
@@ -20,6 +20,11 @@ import ControlItem from 'components/segmented-control/item';
 import QueryPostStats from 'components/data/query-post-stats';
 import { getPostStats, isRequestingPostStats } from 'state/stats/posts/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class StatsPostSummary extends Component {
 	static propTypes = {
 		postId: PropTypes.number,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes css from main bundle
* Imports css via an webpack import

#### Testing instructions

* Checkout branch
* Goto stats page for site with posts with stats
* Click into post
* In the inspector search for 'section-nav'
* Look at css that is has the styling from this file: https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/stats/stats-post-summary/style.scss

