### PR TITLE
Migrate easy blocks styles to imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -14,9 +14,6 @@
 @import 'blocks/conversation-caterpillar/style';
 @import 'blocks/conversation-follow-button/style';
 @import 'blocks/conversations/style';
-@import 'blocks/daily-post-button/style';
-@import 'blocks/disconnect-jetpack/style';
-@import 'blocks/dismissible-card/style';
 @import 'blocks/domain-to-plan-nudge/style';
 @import 'blocks/edit-gravatar/style';
 @import 'blocks/follow-button/style';
@@ -27,12 +24,9 @@
 @import 'blocks/inline-help/style';
 @import 'blocks/support-article-dialog/style';
 @import 'blocks/like-button/style';
-@import 'blocks/location-search/style';
 @import 'blocks/nps-survey/style';
-@import 'blocks/plan-storage/style';
 @import 'blocks/login/style';
 @import 'blocks/payment-methods/style';
-@import 'blocks/plan-thank-you-card/style';
 @import 'blocks/post-edit-button/style';
 @import 'blocks/post-item/style';
 @import 'blocks/post-likes/style';
@@ -42,7 +36,6 @@
 @import 'blocks/taxonomy-manager/style';
 @import 'blocks/term-form-dialog/style';
 @import 'blocks/term-tree-selector/style';
-@import 'blocks/upload-drop-zone/style';
 @import 'blocks/upload-image/style';
 @import 'blocks/video-editor/style';
 @import 'blocks/stats-navigation/style';

--- a/client/blocks/daily-post-button/index.jsx
+++ b/client/blocks/daily-post-button/index.jsx
@@ -25,6 +25,11 @@ import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUser } from 'state/current-user/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 function getPingbackAttributes( post ) {
 	const typeTitles = {
 		prompt: translate( 'Daily Prompt: ' ),

--- a/client/blocks/disconnect-jetpack/index.jsx
+++ b/client/blocks/disconnect-jetpack/index.jsx
@@ -30,6 +30,11 @@ import { getPlanClass } from 'lib/plans/constants';
 import { getSiteSlug, getSiteTitle, getSitePlanSlug } from 'state/sites/selectors';
 import getRewindState from 'state/selectors/get-rewind-state';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class DisconnectJetpack extends PureComponent {
 	static propTypes = {
 		disconnectHref: PropTypes.string,

--- a/client/blocks/disconnect-jetpack/style.scss
+++ b/client/blocks/disconnect-jetpack/style.scss
@@ -1,4 +1,3 @@
-
 .disconnect-jetpack__block {
 	text-align: center;
 	max-width: 400px;

--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -19,6 +19,11 @@ import QueryPreferences from 'components/data/query-preferences';
 import { savePreference, setPreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const PREFERENCE_PREFIX = 'dismissible-card-';
 
 class DismissibleCard extends Component {

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -15,6 +15,11 @@ import { getLocaleSlug } from 'i18n-calypso';
 import SearchCard from 'components/search-card';
 import Prediction from './prediction';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 let autocompleteService = null;
 
 class LocationSearch extends Component {

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -19,6 +19,11 @@ import { planHasFeature } from 'lib/plans';
 import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
 import PlanStorageBar from './bar';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class PlanStorage extends Component {
 	static propTypes = {
 		className: PropTypes.string,

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -22,6 +22,11 @@ import ThankYouCard from 'components/thank-you-card';
 import PlanIcon from 'components/plans/plan-icon';
 import { getPlanClass } from 'lib/plans/constants';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PlanThankYouCard extends Component {
 	getPlanClass() {
 		const { plan } = this.props;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrates the easy blocks scss to webpack imports

#### Testing instructions

* Goto http://calypso.localhost:3000/devdocs/blocks/
* Search for each block
* Observe styles are correct
