### PR TITLE
Notification panel doesn't have to fetch its own translations file.

### DIFF
--- a/client/notifications/src/panel/templates/index.jsx
+++ b/client/notifications/src/panel/templates/index.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
-import i18n from 'i18n-calypso';
 import { find, findIndex, matchesProperty } from 'lodash';
 
 import BackButton from './button-back';
@@ -68,24 +67,6 @@ export const findNextNoteId = ( noteId, notes ) => {
 	return notes[ nextIndex ].id;
 };
 
-const fetchLocale = localeSlug => {
-	const xhr = new XMLHttpRequest();
-
-	xhr.open( 'GET', `https://widgets.wp.com/languages/notifications/${ localeSlug }.json`, true );
-
-	xhr.onload = ( { target } ) => {
-		if ( 200 !== target.status ) {
-			return;
-		}
-
-		try {
-			i18n.setLocale( JSON.parse( xhr.response ) );
-		} catch ( e ) {}
-	};
-
-	xhr.send();
-};
-
 class Layout extends React.Component {
 	state = {
 		lastSelectedIndex: 0,
@@ -109,10 +90,6 @@ class Layout extends React.Component {
 				modifierKeyIsActive: this.modifierKeyIsActive,
 				lastInputWasKeyboard: false,
 			};
-		}
-
-		if ( this.props.locale && 'en' !== this.props.locale ) {
-			fetchLocale( this.props.locale );
 		}
 
 		window.addEventListener( 'keydown', this.handleKeyDown, false );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Now the the notification panel doesn't reside in its own repo anymore, its translation strings has been merged into the calypso one so it doesn't have to fetch its own translations file and set the locale anymore.

#### Testing instructions

1. Set the interface language as whatever non-en. To test this properly, I'd suggest to pick a popular language with higher translation rate like de, fr, or ja.
1. Make sure everything in the notification panel is properly translated.