### PR TITLE
<StoreConnection> should only compare changes that matters

### DIFF
--- a/client/components/data/store-connection/index.jsx
+++ b/client/components/data/store-connection/index.jsx
@@ -29,7 +29,7 @@ class StoreConnection extends React.Component {
 		if ( ! isEqual( this.state, nextState ) ) {
 			this.removeStoreListeners( this.props.stores );
 			this.addStoreListeners( nextProps.stores );
-			this.setState( nextProps.getStateFromStores( nextProps ) );
+			this.setState( nextState );
 		}
 	}
 

--- a/client/components/data/store-connection/index.jsx
+++ b/client/components/data/store-connection/index.jsx
@@ -24,7 +24,9 @@ class StoreConnection extends React.Component {
 	}
 
 	componentWillReceiveProps( nextProps ) {
-		if ( ! isEqual( this.props, nextProps ) ) {
+		const nextState = nextProps.getStateFromStores( nextProps );
+
+		if ( ! isEqual( this.state, nextState ) ) {
 			this.removeStoreListeners( this.props.stores );
 			this.addStoreListeners( nextProps.stores );
 			this.setState( nextProps.getStateFromStores( nextProps ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The current `<StoreConnection />` is using deep equal to compare if there is anything changes from the received props. However, because `<StoreConnection />` is designed to be a wrapping component, this can be very computational expensive and causes indefinite recursion if there is a self-referring node in one of its children.

In my case, I can consistently reproduce the indefinite recursion by:

1. Run a local calypso instance and make sure the env is set as "development", since that's the way `async-payments` feature flag is opened.
1. Log in as whichever test account. In my case, I use `southptest125`.
1. Set your language as whatever non-en.
1. Access https://calypso.localhost:3000/checklist or https://calypso.localhost:3000/view directly by URL. Note that if you access these pages by navigating the bug somehow would be harder to reproduce.
1. At this point, it's highly probable in my case that the whole tab will be hanged. If not, one or two refreshes would be enough to trigger it.

When that happens, logging `props` in [componentWillReceiveProps()](https://github.com/Automattic/wp-calypso/blob/master/client/components/data/store-connection/index.jsx#L27) gives me this:
![demo-maybe-self-refering-fibernode](https://user-images.githubusercontent.com/1842898/54172693-e568cd00-44b9-11e9-9ce6-ac07896913f0.gif)

I don't know if it is expected on the Fiber layer or if it indicates a deeper problem, but comparing only the properties that matters to `<StoreConnection />` should be reasonable and does resolve this indefinite recursion for me.

The reason that the above test plan could trigger this issue is that the `async-payments` feature enables [current-site/notice](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/current-site/notice.jsx#L182) to render a `<CartData/>` block in both `/checklist` and `/view`, which is just a `<StoreConnection>` filled with the cart data. 
```
<CartData>
    <PendingPaymentNotice />
</CartData>
```
After that, our notification panel will fetch the translations file and set a new locale here: https://github.com/Automattic/wp-calypso/blob/master/client/notifications/src/panel/templates/index.jsx#L115 and cause a "force updates" against all components (this is actually a mistake and I have a PR opened for fixing it: https://github.com/Automattic/wp-calypso/pull/31376). When this happens, if the underlying Fibernode within `<StoreConnection/>` contains that self-referring node as above somehow, the whole calypso will hang and crash eventually because of the indefinite recursion.

#### Testing instructions

1. Put a plan / a domain in the cart, go to the checkout page, and make sure you can see those items as expected.
1. Try to reproduce the above crash in the same way. It shouldn't happen anymore.
