### PR TITLE
Settings: checking if `site` is truthy to avoid js error on site deletion

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -45,7 +45,7 @@ export function isWordadsInstantActivationEligible( site ) {
 }
 
 export function canUpgradeToUseWordAds( site ) {
-	if ( ! site.options.wordads && ! isBusiness( site.plan ) && ! isPremium( site.plan ) ) {
+	if ( site && ! site.options.wordads && ! isBusiness( site.plan ) && ! isPremium( site.plan ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

When deleting a site, we see a js error: `Cannot read property of 'options' of null`

The error is triggered by `canUpgradeToUseWordAds` at https://github.com/Automattic/wp-calypso/blob/cafed84/client/lib/ads/utils.js#L47, when it attempt to access the properties of the argument `site`.

![Mar-12-2019 17-58-53](https://user-images.githubusercontent.com/6458278/54181975-50cf9080-44f4-11e9-8997-5cc09bc18c72.gif)

This PR simply checks for the truthiness of `site`.

## Testing instructions

1. Create a site
2. Open the console
3. Delete the site

The error should not appear.
