### PR TITLE
Google Photos: update remaining references

### DIFF
--- a/client/my-sites/marketing/connections/picasa-migration.jsx
+++ b/client/my-sites/marketing/connections/picasa-migration.jsx
@@ -8,10 +8,10 @@ import { localize } from 'i18n-calypso';
 
 const PicasaMigration = ( { translate } ) => (
 	<Fragment>
-		<h3>{ translate( 'Your Photos for Google connection is being upgraded!' ) }</h3>
+		<h3>{ translate( 'Your Google Photos connection is being upgraded!' ) }</h3>
 		<p>
 			{ translate(
-				'We are moving to a new and faster Photos for Google service. You will need to disconnect and reconnect to continue accessing your photos.'
+				'We are moving to a new and faster Google Photos service. You will need to disconnect and reconnect to continue accessing your photos.'
 			) }
 		</p>
 	</Fragment>

--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -179,9 +179,7 @@ class SharingServiceDescription extends Component {
 			'google_photos' === this.props.service.ID &&
 			'must-disconnect' === this.props.status
 		) {
-			description = this.props.translate(
-				'Please connect again to continue using Photos for Google.'
-			);
+			description = this.props.translate( 'Please connect again to continue using Google Photos.' );
 		} else if ( 'reconnect' === this.props.status || 'must-disconnect' === this.props.status ) {
 			description = this.props.translate( 'There is an issue connecting to %(service)s.', {
 				args: { service: this.props.service.label },


### PR DESCRIPTION
Minor change that updates the remaining references to 'Photos for Google' with 'Google Photos'.

<img width="735" alt="s" src="https://user-images.githubusercontent.com/1277682/54214589-69cd4700-44de-11e9-9298-a47b97cdd7ea.png">

## Testing

It's a pure text change, so there's little scope for problems. However, if you do want to test it then:

If you haven't already migrated from Picasa then going to the Sharing page should show the revised text in the Google Photos service.

If you have migrated, or don't have a connection then:

1. Ensure you are connected to Google Photos
2. Edit `client/my-sites/sharing/connections/service.jsx` and changed `getConnectionStatus` so it always returns `must-disconnected`.
3. Load the Sharing page and verify the updated text for Google Photos