### PR TITLE
Packages: Add sideEffects:false to tree-select

### DIFF
--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -11,6 +11,7 @@
 	"license": "GPL-2.0-or-later",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
+	"sideEffects": false,
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Automattic/wp-calypso.git",


### PR DESCRIPTION
Attempt at #31345 (Canary e2e errors on staging / reverted).

Isolating the tree-select package.

## Testing

Verify the Reader works well.