### PR TITLE
Build: Remove build-packages from build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN        bash /tmp/env-config.sh
 # This layer is populated with up-to-date files from
 # Calypso development.
 COPY       . /calypso/
-RUN        npm ci
+RUN        npm ci --unsafe-perm
 
 # Build the final layer
 #

--- a/package.json
+++ b/package.json
@@ -213,7 +213,7 @@
 		"autoprefixer": "postcss -u autoprefixer -r --no-map --config packages/calypso-build/postcss.config.js",
 		"postcss": "postcss -r --config packages/calypso-build/postcss.config.js",
 		"prebuild": "npm run -s install-if-deps-outdated",
-		"build": "npm run build-packages && npm run build-css && run-p -s build-devdocs:* build-server build-client-if-prod build-client-if-desktop",
+		"build": "npm run build-css && run-p -s build-devdocs:* build-server build-client-if-prod build-client-if-desktop",
 		"build-css": "run-p -s build-css:*",
 		"build-css:debug": "node-sass --importer node_modules/node-sass-package-importer/dist/cli.js --include-path client --source-map \"public/style-debug.css.map\" assets/stylesheets/style.scss public/style-debug.css && npm run -s postcss -- public/style-debug.css && rtlcss public/style-debug.css public/style-debug-rtl.css",
 		"build-css:directly": "node-sass --importer node_modules/node-sass-package-importer/dist/cli.js --include-path client assets/stylesheets/directly.scss public/directly.css --output-style compressed && npm run -s postcss -- public/directly.css",


### PR DESCRIPTION
Packages are built on postinstall, should not need to run again for build.

Noticed by @blowery 

#### Changes proposed in this Pull Request

* Required packages are built on install. Don't build again on build

#### Testing instructions

`npm start` and builds should work correctly