### PR TITLE
Move calypso extensions config to its own file

### DIFF
--- a/config/webpack/extensions.js
+++ b/config/webpack/extensions.js
@@ -1,0 +1,36 @@
+/**
+ **** WARNING: No ES6 modules here. Not transpiled! ****
+ */
+
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+/**
+ * This function scans the /client/extensions directory in order to generate a map that looks like this:
+ * {
+ *   sensei: 'absolute/path/to/wp-calypso/client/extensions/sensei',
+ *   woocommerce: 'absolute/path/to/wp-calypso/client/extensions/woocommerce',
+ *   ....
+ * }
+ *
+ * Providing webpack with these aliases instead of telling it to scan client/extensions for every
+ * module resolution speeds up builds significantly.
+ * @returns {Object} a mapping of extension name to path
+ */
+function getAliasesForExtensions( { extensionsDirectory } ) {
+	const extensionsNames = fs
+		.readdirSync( extensionsDirectory )
+		.filter( filename => filename.indexOf( '.' ) === -1 ); // heuristic for finding directories
+
+	const aliasesMap = {};
+	extensionsNames.forEach(
+		extensionName =>
+			( aliasesMap[ extensionName ] = path.join( extensionsDirectory, extensionName ) )
+	);
+	return aliasesMap;
+}
+
+module.exports = getAliasesForExtensions;

--- a/config/webpack/extensions.js
+++ b/config/webpack/extensions.js
@@ -1,7 +1,7 @@
 /**
  **** WARNING: No ES6 modules here. Not transpiled! ****
  */
-
+/* eslint-disable import/no-nodejs-modules */
 /**
  * External dependencies
  */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,6 +25,7 @@ const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
 const cacheIdentifier = require( './server/bundler/babel/babel-loader-cache-identifier' );
 const config = require( './server/config' );
 const { workerCount } = require( './webpack.common' );
+const getAliasesForExtensions = require( './config/webpack/extensions' );
 
 /**
  * Internal variables
@@ -87,32 +88,6 @@ function createProgressHandler() {
 
 		console.log( message ); // eslint-disable-line no-console
 	};
-}
-
-/**
- * This function scans the /client/extensions directory in order to generate a map that looks like this:
- * {
- *   sensei: 'absolute/path/to/wp-calypso/client/extensions/sensei',
- *   woocommerce: 'absolute/path/to/wp-calypso/client/extensions/woocommerce',
- *   ....
- * }
- *
- * Providing webpack with these aliases instead of telling it to scan client/extensions for every
- * module resolution speeds up builds significantly.
- * @returns {Object} a mapping of extension name to path
- */
-function getAliasesForExtensions() {
-	const extensionsDirectory = path.join( __dirname, 'client', 'extensions' );
-	const extensionsNames = fs
-		.readdirSync( extensionsDirectory )
-		.filter( filename => filename.indexOf( '.' ) === -1 ); // heuristic for finding directories
-
-	const aliasesMap = {};
-	extensionsNames.forEach(
-		extensionName =>
-			( aliasesMap[ extensionName ] = path.join( extensionsDirectory, extensionName ) )
-	);
-	return aliasesMap;
 }
 
 /**
@@ -283,7 +258,9 @@ function getWebpackConfig( {
 					store: 'store/dist/store.modern',
 					gridicons$: path.resolve( __dirname, 'client/components/async-gridicons' ),
 				},
-				getAliasesForExtensions()
+				getAliasesForExtensions( {
+					extensionsDirectory: path.join( __dirname, 'client', 'extensions' ),
+				} )
 			),
 		},
 		node: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the Calypso extensions config to its own file.

#### Testing instructions

Build Calypso, visit the shop page for an Atomic site via http://calypso.localhost:3000 and confirm that the Woo Calypso extension still works.

Fixes #31360
