### PR TITLE
Signup: Adding a help tip above the site preview

### DIFF
--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -148,8 +148,9 @@ class SiteMockups extends Component {
 
 				<div className="site-mockup__help-tip">
 					<p>
-						Scroll down to see your website. Once you complete setup you’ll be able to customize it
-						further.
+						{ translate(
+							'Scroll down to see your website. Once you complete setup you’ll be able to customize it further.'
+						) }
 					</p>
 					<Gridicon icon="chevron-down" />
 				</div>

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -18,6 +18,7 @@ import { getSiteVerticalPreview } from 'state/signup/steps/site-vertical/selecto
 import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { loadFont, getCSS } from 'lib/signup/font-loader';
+import Gridicon from 'gridicons';
 
 /**
  * Style dependencies
@@ -144,8 +145,19 @@ class SiteMockups extends Component {
 		return (
 			<div className={ siteMockupClasses }>
 				{ ! this.state.fontError && <style>{ fontStyle }</style> }
-				<SiteMockup size="desktop" { ...otherProps } />
-				<SiteMockup size="mobile" { ...otherProps } />
+
+				<div className="site-mockup__help-tip">
+					<p>
+						Scroll down to see your website. Once you complete setup you’ll be able to customize it
+						further.
+					</p>
+					<Gridicon icon="chevron-down" />
+				</div>
+
+				<div className="site-mockup__devices">
+					<SiteMockup size="desktop" { ...otherProps } />
+					<SiteMockup size="mobile" { ...otherProps } />
+				</div>
 			</div>
 		);
 	}

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -12,8 +12,8 @@
 		align-items: flex-start;
 
 		.site-mockup__viewport {
-			box-shadow: 0 1px 3px rgba(0,0,0,0.12),
-						0 1px 2px rgba(0,0,0,0.24);
+			box-shadow: 0 1px 3px rgba( 0, 0, 0, 0.12 ),
+						0 1px 2px rgba( 0, 0, 0, 0.24 );
 		}
 
 		.site-mockup__viewport.is-desktop {
@@ -43,8 +43,8 @@
 			top: 48px;
 			right: 8px;
 			z-index: 2;
-			box-shadow: 0 3px 6px rgba(0,0,0,0.16),
-						0 3px 6px rgba(0,0,0,0.23);
+			box-shadow: 0 3px 6px rgba( 0, 0, 0, 0.16 ),
+						0 3px 6px rgba( 0, 0, 0, 0.23 );
 
 			.site-mockup__body {
 				height: 440px;
@@ -77,8 +77,8 @@
 	text-align: center;
 	font-size: 13px;
 	font-weight: 300;
-	margin: 24px 0 -8px 0;
-	transition: all 300ms cubic-bezier(.08,.74,.44,1.07);
+	margin: 24px 16px -8px;
+	transition: all 300ms cubic-bezier( 0.08, 0.74, 0.44, 1.07 );
 	transition-delay: 200ms;
 
 	p {
@@ -109,7 +109,7 @@
 	margin: 0 auto;
 	background: var( --color-white );
 	position: relative;
-	transition: all 300ms cubic-bezier(.08,.74,.44,1.07);
+	transition: all 300ms cubic-bezier( 0.08, 0.74, 0.44, 1.07 );
 	transition-delay: 100ms;
 
 	// Hide the mockups until we have vertical

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -1,5 +1,5 @@
-// Mockup wrap
-.site-mockup__wrap {
+// The wrapper around the devices
+.site-mockup__devices {
 	margin: auto;
 	padding: 16px;
 	transition: max-width 200ms ease-in-out;
@@ -10,6 +10,11 @@
 		max-width: 1200px;
 		display: flex;
 		align-items: flex-start;
+
+		.site-mockup__viewport {
+			box-shadow: 0 1px 3px rgba(0,0,0,0.12),
+						0 1px 2px rgba(0,0,0,0.24);
+		}
 
 		.site-mockup__viewport.is-desktop {
 			margin-right: 16px;
@@ -35,11 +40,11 @@
 
 		.site-mockup__viewport.is-mobile {
 			position: absolute;
-			top: 40px;
+			top: 48px;
 			right: 8px;
 			z-index: 2;
-			box-shadow: 0 0 6px 0 rgba( 0, 0, 0, 0.5 ),
-						0 6px 50px 0 rgba( 0, 0, 0, 0.3 );
+			box-shadow: 0 3px 6px rgba(0,0,0,0.16),
+						0 3px 6px rgba(0,0,0,0.23);
 
 			.site-mockup__body {
 				height: 440px;
@@ -66,13 +71,46 @@
 	}
 }
 
+// Some microcopy to help people understand the mockups.
+.site-mockup__help-tip {
+	color: var( --color-primary-50 );
+	text-align: center;
+	font-size: 13px;
+	font-weight: 300;
+	margin: 24px 0 -8px 0;
+	transition: all 300ms cubic-bezier(.08,.74,.44,1.07);
+	transition-delay: 200ms;
+
+	p {
+		margin: 0 auto;
+		max-width: 420px;
+		line-height: 1.4;
+	}
+
+	// Hide the tip until a vertical is selected.
+	.is-empty & {
+		opacity: 0;
+		transform: translateY( 80px );
+	}
+
+	// Hide the tip on all steps.
+	display: none;
+
+	// Display the tip only on these steps.
+	.is-site-topic-with-preview &,
+	.is-site-information-title-with-preview & {
+		display: block;
+	}
+}
+
 // The mockups themselves, both mobile
 // and desktop variants.
 .site-mockup__viewport {
 	margin: 0 auto;
 	background: var( --color-white );
 	position: relative;
-	transition: all 200ms cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
+	transition: all 300ms cubic-bezier(.08,.74,.44,1.07);
+	transition-delay: 100ms;
 
 	// Hide the mockups until we have vertical
 	// data to show.
@@ -89,6 +127,6 @@
 	&.is-mobile {
 		border-radius: 12px;
 		width: 280px;
-		transition-delay: 200ms;
+		transition-delay: 80ms;
 	}
 }


### PR DESCRIPTION
This PR adds a helpful tip above the preview on the `site-topic` and title steps:

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/191598/54213550-f49c4a80-44ba-11e9-8935-c1e05ce9b627.png">

Additionally, I've tweaked the `box-shadow` for the device frames using Material guidelines.

To test, head to `/start/onboarding-dev`, choose the Business segment, and work your way to the `site-topic` step. Once you start typing, the help tip and previews should transition into view. The help tip should go away once you venture past the title step.

--

There's probably a better way to handle the display logic. I used CSS to show it based on step classNames, but this logic should probably be handled by the steps themselves.

The delayed rendering of the search suggestions is a little weird, and kind of hides the help text when its transitioning. We might be able to make this feel better, but its probably best served in a separate PR.