### PR TITLE
Signup: Remove radio's and button from `site-type` step

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -105,16 +105,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		box-shadow: 0 0 0 2px var( --color-jetpack-light );
 	}
 
-	.site-type__option.is-selected {
-		box-shadow: 0 0 0 1px var( --color-jetpack ) inset;
-
-		&:first-of-type {
-			border-radius: 3px 3px 0 0;
-		}
-
-		input[type='radio']:checked::before {
-			background-color: var( --color-jetpack );
-		}
+	.site-type__option:focus {
+		box-shadow: inset 0 0 0 2px var( --color-jetpack );
 	}
 	
 	.wpcom-colophon {

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -35,27 +35,27 @@ class SiteTypeForm extends Component {
 		};
 	}
 
-	handleRadioChange = event => this.setState( { siteType: event.currentTarget.value } );
-
-	handleSubmit = event => {
-		const { siteType } = this.state;
-
-		event.preventDefault();
-
+	handleSubmit = type => {
 		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_type', {
-			value: siteType,
+			value: type,
 		} );
 
-		this.props.submitForm( siteType );
+		this.setState( { siteType: type } );
+
+		this.props.submitForm( type );
 	};
 
 	renderRadioOptions() {
 		return getAllSiteTypes().map( siteTypeProperties => (
-			<div className="site-type__option" key={ siteTypeProperties.id }>
+			<button
+				className="site-type__option"
+				key={ siteTypeProperties.id }
+				onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
+			>
 				<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
 				<span className="site-type__option-description">{ siteTypeProperties.description }</span>
 				<Gridicon icon="chevron-right" />
-			</div>
+			</button>
 		) );
 	}
 

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import { getAllSiteTypes } from 'lib/signup/site-type';
-import PlanIcon from 'components/plans/plan-icon';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -50,11 +49,10 @@ class SiteTypeForm extends Component {
 			<Card
 				className="site-type__option"
 				key={ siteTypeProperties.id }
-				displayAsLink={ true }
+				displayAsLink
 				tagName="button"
 				onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
 			>
-				{ siteTypeProperties.icon && <PlanIcon plan={ siteTypeProperties.icon } /> }
 				<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
 				<span className="site-type__option-description">{ siteTypeProperties.description }</span>
 			</Card>

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React, { Component } from 'react';
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -10,13 +9,10 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import Card from 'components/card';
-import FormFieldset from 'components/forms/form-fieldset';
-import FormLabel from 'components/forms/form-label';
-import FormRadio from 'components/forms/form-radio';
 import { getAllSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
+import Gridicon from 'gridicons';
 
 /**
  * Style dependencies
@@ -55,36 +51,18 @@ class SiteTypeForm extends Component {
 
 	renderRadioOptions() {
 		return getAllSiteTypes().map( siteTypeProperties => (
-			<FormLabel
-				className={ classNames( 'site-type__option', {
-					'is-selected': siteTypeProperties.slug === this.state.siteType,
-				} ) }
-				key={ siteTypeProperties.id }
-			>
-				<FormRadio
-					value={ siteTypeProperties.slug }
-					checked={ siteTypeProperties.slug === this.state.siteType }
-					onChange={ this.handleRadioChange }
-				/>
+			<div className="site-type__option" key={ siteTypeProperties.id }>
 				<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
 				<span className="site-type__option-description">{ siteTypeProperties.description }</span>
-			</FormLabel>
+				<Gridicon icon="chevron-right" />
+			</div>
 		) );
 	}
 
 	render() {
-		const { translate } = this.props;
-
 		return (
 			<div className="site-type__wrapper">
-				<form onSubmit={ this.handleSubmit }>
-					<Card>
-						<FormFieldset>{ this.renderRadioOptions() }</FormFieldset>
-						<Button primary={ true } type="submit" disabled={ ! this.state.siteType }>
-							{ translate( 'Continue' ) }
-						</Button>
-					</Card>
-				</form>
+				<Card>{ this.renderRadioOptions() }</Card>
 			</div>
 		);
 	}

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -45,7 +45,7 @@ class SiteTypeForm extends Component {
 		this.props.submitForm( type );
 	};
 
-	renderRadioOptions() {
+	renderSegmentOptions() {
 		return getAllSiteTypes().map( siteTypeProperties => (
 			<Card
 				className="site-type__option"
@@ -62,7 +62,7 @@ class SiteTypeForm extends Component {
 	}
 
 	render() {
-		return <Card className="site-type__wrapper">{ this.renderRadioOptions() }</Card>;
+		return <Card className="site-type__wrapper">{ this.renderSegmentOptions() }</Card>;
 	}
 }
 

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -11,8 +11,8 @@ import { localize } from 'i18n-calypso';
  */
 import Card from 'components/card';
 import { getAllSiteTypes } from 'lib/signup/site-type';
+import PlanIcon from 'components/plans/plan-icon';
 import { recordTracksEvent } from 'state/analytics/actions';
-import Gridicon from 'gridicons';
 
 /**
  * Style dependencies
@@ -47,15 +47,16 @@ class SiteTypeForm extends Component {
 
 	renderRadioOptions() {
 		return getAllSiteTypes().map( siteTypeProperties => (
-			<button
+			<Card
 				className="site-type__option"
 				key={ siteTypeProperties.id }
+				displayAsLink={ true }
 				onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
 			>
+				{ siteTypeProperties.icon && <PlanIcon plan={ siteTypeProperties.icon } /> }
 				<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
 				<span className="site-type__option-description">{ siteTypeProperties.description }</span>
-				<Gridicon icon="chevron-right" />
-			</button>
+			</Card>
 		) );
 	}
 

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -51,6 +51,7 @@ class SiteTypeForm extends Component {
 				className="site-type__option"
 				key={ siteTypeProperties.id }
 				displayAsLink={ true }
+				tagName="button"
 				onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
 			>
 				{ siteTypeProperties.icon && <PlanIcon plan={ siteTypeProperties.icon } /> }
@@ -61,11 +62,7 @@ class SiteTypeForm extends Component {
 	}
 
 	render() {
-		return (
-			<div className="site-type__wrapper">
-				<Card>{ this.renderRadioOptions() }</Card>
-			</div>
-		);
+		return <Card className="site-type__wrapper">{ this.renderRadioOptions() }</Card>;
 	}
 }
 

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -35,8 +35,9 @@ class SiteType extends Component {
 			hasInitializedSitesBackUrl,
 		} = this.props;
 
-		const headerText = translate( 'Start with a site type' );
-		const subHeaderText = '';
+		const headerText = translate( 'What are we building today?' );
+		const subHeaderText =
+			'Choose the best starting point for your site. You can add or change features later on.';
 
 		return (
 			<StepWrapper

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -35,9 +35,8 @@ class SiteType extends Component {
 			hasInitializedSitesBackUrl,
 		} = this.props;
 
-		const headerText = translate( 'What are we building today?' );
-		const subHeaderText =
-			'Choose the best starting point for your site. You can add or change features later on.';
+		const headerText = translate( 'Start with a site type' );
+		const subHeaderText = '';
 
 		return (
 			<StepWrapper

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -16,10 +16,16 @@
 }
 
 .site-type__option {
-	padding: 16px 24px;
+	padding: 16px;
 	margin: 0;
 	font-weight: 400;
 	position: relative;
+	width: 100%;
+	text-align: left;
+
+	@include breakpoint( '>660px' ) {
+		padding: 16px 24px;
+	}
 
 	&:first-child {
 		border-radius: 3px 3px 0 0;
@@ -49,9 +55,13 @@
 		position: absolute;
 		top: calc( 50% - 12px );
 		right: 16px;
-		fill: var( --color-neutral-50 );
-		transform: translateX( -4px );
-		transition: all 200ms cubic-bezier( 0.08, 0.74, 0.44, 1.07 );
+		fill: var( --color-neutral-500 );
+
+		@include breakpoint( '>660px' ) {
+			fill: var( --color-neutral-50 );
+			transform: translateX( -4px );
+			transition: all 200ms cubic-bezier( 0.08, 0.74, 0.44, 1.07 );
+		}
 	}
 
 	&:hover {

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -11,29 +11,22 @@
 	.card {
 		padding: 0;
 		margin: 0;
-	}
-
-	.form-fieldset {
-		margin: 0;
-	}
-
-	.button {
-		margin: 16px;
-		width: calc( 100% - 32px );
+		border-radius: 3px;
 	}
 }
 
 .site-type__option {
-	padding: 13px 24px 13px 48px;
+	padding: 16px 24px;
 	margin: 0;
 	font-weight: 400;
 	position: relative;
 
-	.form-radio {
-		position: absolute;
-		top: 16px;
-		left: 16px;
-		margin: 0;
+	&:first-child {
+		border-radius: 3px 3px 0 0;
+	}
+
+	&:last-child {
+		border-radius: 0 0 3px 3px;
 	}
 
 	.site-type__option-label,
@@ -43,7 +36,8 @@
 	}
 
 	.site-type__option-label {
-		font-size: 16px;
+		font-size: 18px;
+		color: var( --color-text );
 	}
 
 	.site-type__option-description {
@@ -51,15 +45,26 @@
 		color: var( --color-text-subtle );
 	}
 
-	&:hover {
-		cursor: pointer;
-
-		.site-type__option-label {
-			color: var( --color-text );
-		}
+	.gridicon {
+		position: absolute;
+		top: calc( 50% - 12px );
+		right: 16px;
+		fill: var( --color-neutral-50 );
+		transform: translateX( -4px );
+		transition: all 200ms cubic-bezier( 0.08, 0.74, 0.44, 1.07 );
 	}
 
-	&.is-selected {
+	&:hover {
+		cursor: pointer;
 		background: var( --color-neutral-0 );
+
+		.site-type__option-description {
+			color: var( --color-text );
+		}
+
+		.gridicon {
+			fill: var( --color-neutral-500 );
+			transform: translateX( 0 );
+		}
 	}
 }

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -1,30 +1,31 @@
 .site-type__wrapper {
 	margin: auto;
 	width: 380px;
+	padding: 0;
+	border-radius: 3px;
+	box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14),
+				0 3px 1px -2px rgba(0,0,0,0.12),
+				0 1px 5px 0 rgba(0,0,0,0.20);
 
 	// At small screen sizes make the step
 	// full width. -shaun
 	@include breakpoint( '<660px' ) {
 		width: 100%;
 	}
-
-	.card {
-		padding: 0;
-		margin: 0;
-		border-radius: 3px;
-	}
 }
 
 .site-type__option {
-	padding: 16px;
+	padding: 16px 16px 16px 64px;
 	margin: 0;
 	font-weight: 400;
 	position: relative;
 	width: 100%;
 	text-align: left;
+	box-shadow: none;
+	border-bottom: 1px solid var( --color-neutral-50 );
 
 	@include breakpoint( '>660px' ) {
-		padding: 16px 24px;
+		padding-right: 24px;
 	}
 
 	&:first-child {
@@ -33,6 +34,16 @@
 
 	&:last-child {
 		border-radius: 0 0 3px 3px;
+		border-bottom: none;
+	}
+
+	.plan-icon {
+		height: 40px;
+		width: 40px;
+		position: absolute;
+		top: 50%;
+		left: 12px;
+		margin-top: -20px;
 	}
 
 	.site-type__option-label,
@@ -51,14 +62,9 @@
 		color: var( --color-text-subtle );
 	}
 
-	.gridicon {
-		position: absolute;
-		top: calc( 50% - 12px );
-		right: 16px;
-		fill: var( --color-neutral-500 );
-
+	.card__link-indicator {
 		@include breakpoint( '>660px' ) {
-			fill: var( --color-neutral-50 );
+			opacity: 0.5;
 			transform: translateX( -4px );
 			transition: all 200ms cubic-bezier( 0.08, 0.74, 0.44, 1.07 );
 		}
@@ -71,10 +77,15 @@
 		.site-type__option-description {
 			color: var( --color-text );
 		}
+	}
 
-		.gridicon {
-			fill: var( --color-neutral-500 );
-			transform: translateX( 0 );
-		}
+	&:focus {
+		box-shadow: inset 0 0 0 2px var( --color-accent );
+	}
+
+	&:hover .card__link-indicator,
+	&:focus .card__link-indicator {
+		opacity: 1;
+		transform: translateX( 0 );
 	}
 }

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -3,9 +3,9 @@
 	width: 380px;
 	padding: 0;
 	border-radius: 3px;
-	box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14),
-				0 3px 1px -2px rgba(0,0,0,0.12),
-				0 1px 5px 0 rgba(0,0,0,0.20);
+	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ),
+				0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
+				0 1px 5px 0 rgba( 0, 0, 0, 0.20 );
 
 	// At small screen sizes make the step
 	// full width. -shaun
@@ -15,7 +15,7 @@
 }
 
 .site-type__option {
-	padding: 16px 16px 16px 64px;
+	padding: 16px 16px 16px 24px;
 	margin: 0;
 	font-weight: 400;
 	position: relative;
@@ -35,15 +35,6 @@
 	&:last-child {
 		border-radius: 0 0 3px 3px;
 		border-bottom: none;
-	}
-
-	.plan-icon {
-		height: 40px;
-		width: 40px;
-		position: absolute;
-		top: 50%;
-		left: 12px;
-		margin-top: -20px;
 	}
 
 	.site-type__option-label,

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -60,11 +60,10 @@ body.is-section-signup .layout:not(.dops) {
 	// a little strange. Lets try a shadow instead. -shaun
 	.signup-form > .card,
 	.is-about .card,
-	.is-site-type .card,
 	.is-site-information .site-information__wrapper:not(.is-single-fieldset) .card {
-		box-shadow: 0 5px 5px -3px rgba( 0, 0, 0, 0.2),
-					0 8px 10px 1px rgba( 0, 0, 0, 0.14),
-					0 3px 14px 2px rgba( 0, 0, 0, 0.12);
+		box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14),
+					0 3px 1px -2px rgba(0,0,0,0.12),
+					0 1px 5px 0 rgba(0,0,0,0.20);
 
 		.dops & {
 			box-shadow: none;


### PR DESCRIPTION
## Before
The current `site-type` step uses form elements like `radio` and `button` to let customers select a segment — It takes two clicks to pick a choice:

<img width="555" alt="image" src="https://user-images.githubusercontent.com/191598/54219583-31217380-44c6-11e9-80c6-5e776f496a9c.png">

## After
We bet that making it easier, and quicker, to pick an option will lead to higher conversions. This PR updates the UI to be less complex, using clickable rows with a `chevron` icon to select segments:

<img width="678" alt="image" src="https://user-images.githubusercontent.com/191598/54219521-0df6c400-44c6-11e9-8ecb-0f65eedf17c8.png">

## How to test

1. Visit `/start/onboarding/site-type`

