### PR TITLE
Jetpack Onboarding: update intro messaging

### DIFF
--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -35,9 +35,7 @@ class JetpackSiteType extends Component {
 			<MainWrapper isWide>
 				<div className="jetpack-connect__step">
 					<FormattedHeader
-						headerText={ translate(
-							'High performance. Solid security. Your website, just better.'
-						) }
+						headerText={ translate( 'High performance. Solid security. Your site, just better.' ) }
 						subHeaderText={ translate(
 							'To get started, tell us a little bit about your site goals.'
 						) }

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -35,9 +35,7 @@ class JetpackSiteType extends Component {
 			<MainWrapper isWide>
 				<div className="jetpack-connect__step">
 					<FormattedHeader
-						headerText={ translate(
-							'Boost your WordPress site with Security, Performance, and Customization features all in one service.'
-						) }
+						headerText={ translate( 'Boost your site with Security and Performance tools.' ) }
 						subHeaderText={ translate(
 							'To get started, tell us a little bit about your site goals.'
 						) }

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -35,7 +35,9 @@ class JetpackSiteType extends Component {
 			<MainWrapper isWide>
 				<div className="jetpack-connect__step">
 					<FormattedHeader
-						headerText={ translate( 'Boost your site with Security and Performance tools.' ) }
+						headerText={ translate(
+							'High performance. Solid security. Your website, just better.'
+						) }
 						subHeaderText={ translate(
 							'To get started, tell us a little bit about your site goals.'
 						) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Jetpack Onboarding: update intro messaging to be more Security and Performance focused.
* `Boost your WordPress site with Security, Performance, and Customization features all in one service.` => `High performance. Solid security. Your site, just better.`

#### Testing instructions

* Fire up this PR.
* Try adding a new Jetpack site or go to `/jetpack/connect/site-type/SITE_URL`.
* Check if the title on the site type step is correct.

#### Before

![wordpress com_jetpack_connect_site-type_mutelife com(Calypso)](https://user-images.githubusercontent.com/390760/54220963-7192e880-44ea-11e9-976b-a096512bfcdd.png)


#### After

![image](https://user-images.githubusercontent.com/390760/54269134-acd9f980-4574-11e9-8831-ad662cdb63ad.png)


Fixes https://github.com/Automattic/wp-calypso/issues/31354
