### PR TITLE
Move the gauge styles to be built by webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -87,7 +87,6 @@
 @import 'components/forms/form-toggle/style';
 @import 'components/forms/range/style';
 @import 'components/forms/sortable-list/style';
-@import 'components/gauge/style';
 @import 'components/global-notices/style';
 @import 'components/happiness-support/style';
 @import 'components/header-button/style';

--- a/client/components/gauge/index.jsx
+++ b/client/components/gauge/index.jsx
@@ -7,6 +7,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+/**
+ * Style Dependencies
+ */
+import './style.scss';
+
 export default class extends React.PureComponent {
 	static displayName = 'Gauge';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This moves the CSS for the gauge component inline

#### Testing instructions

* Check that http://calypso.localhost:3000/devdocs/design/gauge matches http://wpcalypso.wordpress.com/devdocs/design/gauge

