### PR TITLE
Signup: Adding a list of common topics to the site-topic search.

### DIFF
--- a/client/components/site-verticals-suggestion-search/README.md
+++ b/client/components/site-verticals-suggestion-search/README.md
@@ -36,7 +36,10 @@ _Optional_ placeholder text for the search input field.
 _Optional_ number of characters before an API search is triggered.
 
 ### _(Function)_ `onChange` 
-The callback function for receiving updated value. 
+The callback function for receiving updated value.
+
+### _(Boolean)_ `showPopular` 
+_Optional_ Informs the component whether to show a list of popular vertical topics when the input field is empty.
 
 Returns _{Object}_:
 

--- a/client/components/site-verticals-suggestion-search/common-topics.jsx
+++ b/client/components/site-verticals-suggestion-search/common-topics.jsx
@@ -1,0 +1,101 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+/*
+	These topics are taken from the most popular for each segment.
+*/
+const COMMON_TOPICS = {
+	business: [
+		translate( 'Digital marketing' ),
+		translate( 'Fitness & exercise' ),
+		translate( 'Health Food' ),
+		translate( 'Photography' ),
+		translate( 'Real estate agency' ),
+		translate( 'Restaurants' ),
+		translate( 'Website designer' ),
+	],
+	blog: [
+		translate( 'Education' ),
+		translate( 'Fashion Designer' ),
+		translate( 'Music' ),
+		translate( 'Photography' ),
+		translate( 'Sport' ),
+		translate( 'Travel & Recreation' ),
+		translate( 'Video Games' ),
+	],
+	professional: [
+		translate( 'Artist' ),
+		translate( 'Architecture' ),
+		translate( 'College' ),
+		translate( 'Computers' ),
+		translate( 'Health & medical' ),
+		translate( 'Photography' ),
+		translate( 'Portfolio' ),
+	],
+	education: [
+		translate( 'Architecture' ),
+		translate( 'Education' ),
+		translate( 'Higher Education & Academy' ),
+		translate( 'Music' ),
+		translate( 'Travel' ),
+		translate( 'School' ),
+		translate( 'Sports' ),
+	],
+};
+
+class CommonTopics extends Component {
+	static propTypes = {
+		commonTopics: PropTypes.array.isRequired,
+		onSelect: PropTypes.func.isRequired,
+	};
+
+	onClick = event => {
+		event.preventDefault();
+		event.stopPropagation();
+		this.props.onSelect( event.currentTarget.value );
+		this.props.recordTracksEvent( 'calypso_signup_common_site_vertical_clicked', {
+			value: event.currentTarget.value,
+		} );
+	};
+	render() {
+		return (
+			<div className="site-verticals-suggestion-search__common-topics">
+				<div className="site-verticals-suggestion-search__heading">Common Topics</div>
+				{ this.props.commonTopics.map( ( topic, index ) => (
+					<button
+						type="button"
+						key={ index }
+						value={ topic }
+						className="site-verticals-suggestion-search__topic-list-item"
+						onClick={ this.onClick }
+						tabIndex="0"
+					>
+						{ topic }
+					</button>
+				) ) }
+			</div>
+		);
+	}
+}
+
+export default connect(
+	state => ( {
+		commonTopics: COMMON_TOPICS[ getSiteType( state ) || 'blog' ],
+	} ),
+	{
+		recordTracksEvent,
+	}
+)( CommonTopics );

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find, get, noop, startsWith, trim, uniq, isEmpty } from 'lodash';
+import { find, get, noop, startsWith, trim, uniq } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { v4 as uuid } from 'uuid';
 
@@ -36,6 +36,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		shouldShowPopularTopics: PropTypes.func,
 		searchResultsLimit: PropTypes.number,
 		verticals: PropTypes.array,
+		defaultVertical: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -48,6 +49,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		shouldShowPopularTopics: noop,
 		searchResultsLimit: 5,
 		verticals: [],
+		defaultVertical: {},
 	};
 
 	constructor( props ) {
@@ -88,7 +90,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	searchForVerticalMatches = ( value = '' ) =>
 		find(
 			this.props.verticals,
-			item => item.verticalName.toLowerCase() === value.toLowerCase() && ! isEmpty( item.preview )
+			item => item.verticalName.toLowerCase() === value.toLowerCase() && !! item.preview
 		);
 
 	updateVerticalData = ( result, value ) =>
@@ -214,7 +216,7 @@ export default localize(
 			};
 		},
 		( dispatch, ownProps ) => ( {
-			shouldShowPopularTopics: searchValue => isEmpty( searchValue ) && ownProps.showPopular,
+			shouldShowPopularTopics: searchValue => ! searchValue && ownProps.showPopular,
 			requestVerticals: requestSiteVerticalHttpData,
 			requestDefaultVertical: ( searchTerm = 'business' ) => {
 				if ( ! get( getHttpData( DEFAULT_SITE_VERTICAL_REQUEST_ID ), 'data', null ) ) {

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -17,7 +17,7 @@ import SuggestionSearch from 'components/suggestion-search';
 import { getHttpData, requestHttpData } from 'state/data-layer/http-data';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { convertToCamelCase } from 'state/data-layer/utils';
-import CommonTopics from 'components/site-verticals-suggestion-search/common-topics';
+import PopularTopics from 'components/site-verticals-suggestion-search/popular-topics';
 
 /**
  * Style dependencies
@@ -33,6 +33,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		placeholder: PropTypes.string,
 		requestDefaultVertical: PropTypes.func,
 		requestVerticals: PropTypes.func,
+		shouldShowPopularTopics: PropTypes.func,
 		searchResultsLimit: PropTypes.number,
 		verticals: PropTypes.array,
 	};
@@ -44,6 +45,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		placeholder: '',
 		requestDefaultVertical: noop,
 		requestVerticals: noop,
+		shouldShowPopularTopics: noop,
 		searchResultsLimit: 5,
 		verticals: [],
 	};
@@ -121,7 +123,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		this.updateVerticalData( result, value );
 	};
 
-	onCommonTopicSelect = value => {
+	onPopularTopicSelect = value => {
 		this.props.requestVerticals( value, 1 );
 		this.setState( { searchValue: value } );
 	};
@@ -153,7 +155,8 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	};
 
 	render() {
-		const { translate, placeholder, autoFocus } = this.props;
+		const { translate, placeholder, autoFocus, shouldShowPopularTopics } = this.props;
+		const showPopularTopics = shouldShowPopularTopics( this.state.searchValue );
 		return (
 			<>
 				<SuggestionSearch
@@ -166,7 +169,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 					autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 					railcar={ this.state.railcar }
 				/>
-				{ ! this.state.searchValue && <CommonTopics onSelect={ this.onCommonTopicSelect } /> }
+				{ showPopularTopics && <PopularTopics onSelect={ this.onPopularTopicSelect } /> }
 			</>
 		);
 	}
@@ -210,7 +213,8 @@ export default localize(
 				defaultVertical: get( defaultVerticalHttpData, 'data[0]', {} ),
 			};
 		},
-		() => ( {
+		( dispatch, ownProps ) => ( {
+			shouldShowPopularTopics: searchValue => isEmpty( searchValue ) && ownProps.showPopular,
 			requestVerticals: requestSiteVerticalHttpData,
 			requestDefaultVertical: ( searchTerm = 'business' ) => {
 				if ( ! get( getHttpData( DEFAULT_SITE_VERTICAL_REQUEST_ID ), 'data', null ) ) {

--- a/client/components/site-verticals-suggestion-search/popular-topics.jsx
+++ b/client/components/site-verticals-suggestion-search/popular-topics.jsx
@@ -17,48 +17,48 @@ import { recordTracksEvent } from 'state/analytics/actions';
 /*
 	These topics are taken from the most popular for each segment.
 */
-const COMMON_TOPICS = {
+const POPULAR_TOPICS = {
 	business: [
-		translate( 'Digital marketing' ),
-		translate( 'Fitness & exercise' ),
-		translate( 'Health Food' ),
-		translate( 'Photography' ),
-		translate( 'Real estate agency' ),
+		translate( 'Travel Agency' ),
+		translate( 'Digital Marketing' ),
+		translate( 'Fashion Designer' ),
+		translate( 'Website Designer' ),
+		translate( 'Real Estate Agent' ),
+		translate( 'Cameras & Photography' ),
 		translate( 'Restaurants' ),
-		translate( 'Website designer' ),
 	],
 	blog: [
+		translate( 'Travel' ),
+		translate( 'Fashion' ),
 		translate( 'Education' ),
-		translate( 'Fashion Designer' ),
+		translate( 'Food' ),
 		translate( 'Music' ),
 		translate( 'Photography' ),
-		translate( 'Sport' ),
-		translate( 'Travel & Recreation' ),
-		translate( 'Video Games' ),
+		translate( 'Sports' ),
 	],
 	professional: [
-		translate( 'Artist' ),
-		translate( 'Architecture' ),
-		translate( 'College' ),
-		translate( 'Computers' ),
-		translate( 'Health & medical' ),
-		translate( 'Photography' ),
+		translate( 'Education' ),
+		translate( 'Higher Education & Academy' ),
+		translate( 'Travel' ),
+		translate( 'School' ),
+		translate( 'Website Designer' ),
+		translate( 'Fashion' ),
 		translate( 'Portfolio' ),
 	],
 	education: [
-		translate( 'Architecture' ),
-		translate( 'Education' ),
 		translate( 'Higher Education & Academy' ),
-		translate( 'Music' ),
-		translate( 'Travel' ),
+		translate( 'Fashion' ),
 		translate( 'School' ),
-		translate( 'Sports' ),
+		translate( 'Website Designer' ),
+		translate( 'Travel' ),
+		translate( 'Design' ),
+		translate( 'Adult Education School' ),
 	],
 };
 
-class CommonTopics extends Component {
+class PopularTopics extends Component {
 	static propTypes = {
-		commonTopics: PropTypes.array.isRequired,
+		popularTopics: PropTypes.array.isRequired,
 		onSelect: PropTypes.func.isRequired,
 	};
 
@@ -73,8 +73,8 @@ class CommonTopics extends Component {
 	render() {
 		return (
 			<div className="site-verticals-suggestion-search__common-topics">
-				<div className="site-verticals-suggestion-search__heading">Common Topics</div>
-				{ this.props.commonTopics.map( ( topic, index ) => (
+				<div className="site-verticals-suggestion-search__heading">{ translate( 'Popular' ) }</div>
+				{ this.props.popularTopics.map( ( topic, index ) => (
 					<button
 						type="button"
 						key={ index }
@@ -93,9 +93,9 @@ class CommonTopics extends Component {
 
 export default connect(
 	state => ( {
-		commonTopics: COMMON_TOPICS[ getSiteType( state ) || 'blog' ],
+		popularTopics: POPULAR_TOPICS[ getSiteType( state ) || 'blog' ],
 	} ),
 	{
 		recordTracksEvent,
 	}
-)( CommonTopics );
+)( PopularTopics );

--- a/client/components/site-verticals-suggestion-search/popular-topics.jsx
+++ b/client/components/site-verticals-suggestion-search/popular-topics.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
 
@@ -56,7 +56,7 @@ const POPULAR_TOPICS = {
 	],
 };
 
-class PopularTopics extends Component {
+class PopularTopics extends PureComponent {
 	static propTypes = {
 		popularTopics: PropTypes.array.isRequired,
 		onSelect: PropTypes.func.isRequired,

--- a/client/components/site-verticals-suggestion-search/style.scss
+++ b/client/components/site-verticals-suggestion-search/style.scss
@@ -1,0 +1,35 @@
+.site-verticals-suggestion-search__common-topics {
+	margin-bottom: 0;
+	box-shadow: none;
+	margin-top: 3px;
+	border-radius: 0 0 4px 4px;
+}
+
+.site-verticals-suggestion-search__heading {
+	font-size: 10px;
+	font-weight: 500;
+	text-transform: uppercase;
+	padding: 12px 24px 8px 40px;
+	color: var( --color-neutral-400 );
+	border-bottom: 1px solid var( --color-neutral-50 );
+}
+
+.site-verticals-suggestion-search__topic-list-item {
+	font-size: 15px;
+	color: var( --color-text );
+	border-bottom: 1px solid var( --color-neutral-50 );
+	padding: 10px 24px 10px 40px;
+	text-align: left;
+	width: 100%;
+	display: block;
+
+	&:hover, &:focus {
+		cursor: pointer;
+		background: var( --color-neutral-0 );
+	}
+
+	&:last-child {
+		border-radius: 0 0 4px 4px;
+		border-bottom: 0;
+	}
+}

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -8,11 +8,11 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
     onChange={[Function]}
     placeholder="e.g. Fashion, travel, design, plumbing"
     railcar={
-	  Object {
-	    "action": "site_vertical_selected",
-	    "fetch_algo": "/verticals",
-	    "id": "fakeuuid-site-vertical-suggestion",
-	  }
+      Object {
+        "action": "site_vertical_selected",
+        "fetch_algo": "/verticals",
+        "id": "fakeuuid-site-vertical-suggestion",
+      }
     }
     sortResults={[Function]}
     suggestions={

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -1,24 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
-<SuggestionSearch
-  autoFocus={false}
-  id="siteTopic"
-  onChange={[Function]}
-  placeholder="e.g. Fashion, travel, design, plumbing"
-  railcar={
-    Object {
-      "action": "site_vertical_selected",
-      "fetch_algo": "/verticals",
-      "id": "fakeuuid-site-vertical-suggestion",
+<Fragment>
+  <SuggestionSearch
+    autoFocus={false}
+    id="siteTopic"
+    onChange={[Function]}
+    placeholder="e.g. Fashion, travel, design, plumbing"
+    railcar={
+	  Object {
+	    "action": "site_vertical_selected",
+	    "fetch_algo": "/verticals",
+	    "id": "fakeuuid-site-vertical-suggestion",
+	  }
     }
-  }
-  sortResults={[Function]}
-  suggestions={
-    Array [
-      "doo",
-    ]
-  }
-  value=""
-/>
+    sortResults={[Function]}
+    suggestions={
+      Array [
+        "doo",
+      ]
+    }
+    value=""
+  />
+</Fragment>
 `;

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -15,6 +15,7 @@ import { shallow } from 'enzyme';
 
 import { SiteVerticalsSuggestionSearch } from '../';
 import SuggestionSearch from 'components/suggestion-search';
+import PopularTopics from 'components/site-verticals-suggestion-search/popular-topics';
 
 jest.mock( 'uuid', () => ( {
 	v4: () => 'fake-uuid',
@@ -45,6 +46,7 @@ const defaultProps = {
 	translate: str => str,
 	charsToTriggerSearch: 2,
 	lastUpdated: 1,
+	shouldShowPopularTopics: jest.fn(),
 };
 
 defaultProps.requestVerticals.cancel = jest.fn();
@@ -78,6 +80,15 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 		wrapper.instance().onSiteTopicChange( 'doo' );
 		wrapper.setProps( { lastUpdated: 2 } );
 		expect( defaultProps.onChange ).toHaveBeenLastCalledWith( defaultProps.verticals[ 0 ] );
+	} );
+
+	test( 'should show common topics', () => {
+		defaultProps.shouldShowPopularTopics.mockReturnValueOnce( true );
+		const wrapper = shallow(
+			<SiteVerticalsSuggestionSearch { ...defaultProps } showPopular={ true } />
+		);
+		expect( defaultProps.shouldShowPopularTopics ).toHaveBeenLastCalledWith( '' );
+		expect( wrapper.find( PopularTopics ) ).toHaveLength( 1 );
 	} );
 
 	describe( 'searchForVerticalMatches()', () => {

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -49,10 +49,17 @@ class SuggestionSearch extends Component {
 			inputValue: props.value,
 		};
 	}
+	componentDidUpdate( prevProps, prevState ) {
+		if ( prevProps.value !== this.props.value && this.props.value !== prevState.inputValue ) {
+			this.updateInputValue( this.props.value );
+		}
+	}
 
 	setSuggestionsRef = ref => ( this.suggestionsRef = ref );
 
 	hideSuggestions = () => this.setState( { query: '' } );
+
+	updateInputValue = inputValue => this.setState( { inputValue } );
 
 	handleSuggestionChangeEvent = ( { target: { value } } ) => {
 		this.setState( { query: value, inputValue: value } );
@@ -100,7 +107,7 @@ class SuggestionSearch extends Component {
 	};
 
 	handleSuggestionMouseDown = position => {
-		this.setState( { inputValue: position.label } );
+		this.updateInputValue( position.label );
 		this.hideSuggestions();
 		this.props.onChange( position.label );
 	};
@@ -121,7 +128,7 @@ class SuggestionSearch extends Component {
 	}
 
 	updateFieldFromSuggestion( newValue ) {
-		this.setState( { inputValue: newValue } );
+		this.updateInputValue( newValue );
 		this.props.onChange( newValue );
 	}
 

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -81,21 +81,22 @@ class SiteTopicForm extends Component {
 							initialValue={ siteTopic }
 							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 						/>
+
+						<div className="site-topic__common-topics">
+							<div className="site-topic__heading">Common Topics</div>
+							<div className="site-topic__topic-list-item">Restaurant</div>
+							<div className="site-topic__topic-list-item">Clothing Store</div>
+							<div className="site-topic__topic-list-item">Bowling Alley</div>
+							<div className="site-topic__topic-list-item">Cafe</div>
+							<div className="site-topic__topic-list-item">Bakery</div>
+							<div className="site-topic__topic-list-item">Child Care</div>
+						</div>
+
 						<Button type="submit" disabled={ isButtonDisabled } primary>
 							{ translate( 'Continue' ) }
 						</Button>
 					</FormFieldset>
 				</form>
-
-				<div className="site-topic__common-topics">
-					<div className="site-topic__heading">Common Topics</div>
-					<div className="site-topic__topic-list-item">Restaurant</div>
-					<div className="site-topic__topic-list-item">Clothing Store</div>
-					<div className="site-topic__topic-list-item">Bowling Alley</div>
-					<div className="site-topic__topic-list-item">Cafe</div>
-					<div className="site-topic__topic-list-item">Bakery</div>
-					<div className="site-topic__topic-list-item">Child Care</div>
-				</div>
 			</div>
 		);
 	}

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -86,6 +86,16 @@ class SiteTopicForm extends Component {
 						</Button>
 					</FormFieldset>
 				</form>
+
+				<div className="site-topic__common-topics">
+					<div className="site-topic__heading">Common Topics</div>
+					<div className="site-topic__topic-list-item">Restaurant</div>
+					<div className="site-topic__topic-list-item">Clothing Store</div>
+					<div className="site-topic__topic-list-item">Bowling Alley</div>
+					<div className="site-topic__topic-list-item">Cafe</div>
+					<div className="site-topic__topic-list-item">Bakery</div>
+					<div className="site-topic__topic-list-item">Child Care</div>
+				</div>
 			</div>
 		);
 	}

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -81,17 +81,6 @@ class SiteTopicForm extends Component {
 							initialValue={ siteTopic }
 							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 						/>
-
-						<div className="site-topic__common-topics">
-							<div className="site-topic__heading">Common Topics</div>
-							<div className="site-topic__topic-list-item">Restaurant</div>
-							<div className="site-topic__topic-list-item">Clothing Store</div>
-							<div className="site-topic__topic-list-item">Bowling Alley</div>
-							<div className="site-topic__topic-list-item">Cafe</div>
-							<div className="site-topic__topic-list-item">Bakery</div>
-							<div className="site-topic__topic-list-item">Child Care</div>
-						</div>
-
 						<Button type="submit" disabled={ isButtonDisabled } primary>
 							{ translate( 'Continue' ) }
 						</Button>

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -78,6 +78,7 @@ class SiteTopicForm extends Component {
 					<FormFieldset>
 						<SiteVerticalsSuggestionSearch
 							onChange={ this.onSiteTopicChange }
+							showPopular={ true }
 							initialValue={ siteTopic }
 							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 						/>

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -2,28 +2,29 @@ body.is-section-signup .step-wrapper .site-topic__content,
 body.is-section-jetpack-connect .site-topic__content {
 	max-width: 480px;
 	margin: 0 auto;
+	border-radius: 4px;
+	background: var( --color-white );
+	box-shadow: 0 3px 6px rgba(0,0,0,0.16),
+				0 3px 6px rgba(0,0,0,0.23);
 
 	.form-fieldset {
 		margin-bottom: 0;
 	}
 
+	.suggestion-search .gridicon {
+		fill: var( --color-neutral-200 );
+	}
+
 	input {
 		// Extra padding to account for the button and
 		// the search icon.
-		padding: 10px 100px 10px 42px;
+		padding: 10px 100px 12px 42px;
 
 		// Trying out a rounded input
 		border-radius: 4px;
 
-		// Making the border feel a little more "at home"
-		// with signups dark background color.
-		border-color: var( --color-primary-700 );
-
-		// Since there's a 1px padding on the container, and
-		// inputs use actual borders (unlike cards, which
-		// use box-shadow), we need to adjust.
-		margin: 0 -1px;
-		width: calc( 100% + 2px );
+		// No need for a border here
+		border: none;
 
 		@include breakpoint( '<660px' ) {
 			// On smaller screens the buttons get bigger,
@@ -35,9 +36,14 @@ body.is-section-jetpack-connect .site-topic__content {
 			// smaller screens.
 			border-radius: 0;
 		}
+
+		&:focus {
+			box-shadow: 0 0 0 3px rgba( var( --color-accent-rgb ), 0.9 );
+		}
 	}
 
 	.suggestions__wrapper {
+		/*
 		// Without the extra padding from the Card, we need
 		// to adjust the position of the suggestions.
 		top: 46px;
@@ -47,11 +53,48 @@ body.is-section-jetpack-connect .site-topic__content {
 		@include breakpoint( '<660px' ) {
 			top: 52px;
 		}
+		*/
+
+		position: relative;
+		top: 0;
+		box-shadow: none;
+		margin-top: 3px;
+		margin-bottom: 10px;
+	}
+
+	.suggestions__item {
+		padding-left: 40px;
 	}
 
 	.button {
 		position: absolute;
 		top: 3px;
 		right: 3px;
+	}
+}
+
+.site-topic__heading {
+	font-size: 12px;
+	font-weight: 500;
+	text-transform: uppercase;
+	padding: 12px 24px 8px 40px;
+	color: var( --color-neutral-500 );
+}
+
+.site-topic__common-topics {}
+
+.site-topic__topic-list-item {
+	font-size: 15px;
+	color: var( --color-text );
+	border-top: 1px solid var( --color-neutral-50 );
+	padding: 10px 24px 10px 40px;
+
+	&:hover {
+		cursor: pointer;
+		background: var( --color-neutral-0 );
+	}
+
+	&:last-child {
+		border-radius: 0 0 4px 4px;
 	}
 }

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -65,42 +65,20 @@ body.is-section-jetpack-connect .site-topic__content {
 		top: 0;
 		box-shadow: none;
 		margin-top: 3px;
-		margin-bottom: 10px;
+		margin-bottom: 0;
+		border-radius: 0 0 4px 4px;
 	}
 
 	.suggestions__item {
 		padding-left: 40px;
+		&:last-child {
+			border-width: 0;
+		}
 	}
 
 	.button {
 		position: absolute;
 		top: 3px;
 		right: 3px;
-	}
-}
-
-.site-topic__heading {
-	font-size: 10px;
-	font-weight: 500;
-	text-transform: uppercase;
-	padding: 12px 24px 8px 40px;
-	color: var( --color-neutral-400 );
-}
-
-.site-topic__common-topics {}
-
-.site-topic__topic-list-item {
-	font-size: 15px;
-	color: var( --color-text );
-	border-top: 1px solid var( --color-neutral-50 );
-	padding: 10px 24px 10px 40px;
-
-	&:hover {
-		cursor: pointer;
-		background: var( --color-neutral-0 );
-	}
-
-	&:last-child {
-		border-radius: 0 0 4px 4px;
 	}
 }

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -74,11 +74,11 @@ body.is-section-jetpack-connect .site-topic__content {
 }
 
 .site-topic__heading {
-	font-size: 12px;
+	font-size: 10px;
 	font-weight: 500;
 	text-transform: uppercase;
 	padding: 12px 24px 8px 40px;
-	color: var( --color-neutral-500 );
+	color: var( --color-neutral-400 );
 }
 
 .site-topic__common-topics {}

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -1,14 +1,20 @@
 body.is-section-signup .step-wrapper .site-topic__content,
 body.is-section-jetpack-connect .site-topic__content {
 	max-width: 480px;
+	min-height: 46px;
 	margin: 0 auto;
-	border-radius: 4px;
-	background: var( --color-white );
-	box-shadow: 0 3px 6px rgba(0,0,0,0.16),
-				0 3px 6px rgba(0,0,0,0.23);
+	position: relative;
 
 	.form-fieldset {
 		margin-bottom: 0;
+		position: absolute;
+		left: 0;
+		right: 0;
+		z-index: 1000; // I know, I know...
+		border-radius: 4px;
+		background: var( --color-white );
+		box-shadow: 0 3px 6px rgba(0,0,0,0.16),
+					0 3px 6px rgba(0,0,0,0.23);
 	}
 
 	.suggestion-search .gridicon {
@@ -38,7 +44,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 3px rgba( var( --color-accent-rgb ), 0.9 );
+			box-shadow: 0 0 0 2px var( --color-accent );
 		}
 	}
 


### PR DESCRIPTION
## What this PR does

We want to make it easier and quicker for people to pick a vertical by showing them some suggestions.

We're drawing the suggestions from the current list of popular topics for each site segment.

![Mar-17-2019 12-31-00](https://user-images.githubusercontent.com/6458278/54483948-97383d00-48b0-11e9-9169-c3afa0406398.gif)

## Testing

1. Fire up the branch and head to the site topic step for **Business**, **Blog**, **Professional** and **Education** site types
2. Select one of the topics, clear the field, select another
3. Create a site for good measure 🍺 

### Expectations

Selecting a popular topic for **Business** site types should load a preview

For all site types, selecting a popular topic should save that topic throughout the flow.

You should be able to tab through the list and select using _Enter_

## Coming up in a future iteration
Keyboard navigation using arrows to make it consistent with the API search results list. 🎈 



