### PR TITLE
Signup: Hide the continue button on the `site-topic` step when disabled

### DIFF
--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -80,5 +80,11 @@ body.is-section-jetpack-connect .site-topic__content {
 		position: absolute;
 		top: 3px;
 		right: 3px;
+		transition: all 150ms ease-in-out;
+		transition-delay: 400ms;
+
+		&[disabled] {
+			opacity: 0;
+		}
 	}
 }

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -49,18 +49,6 @@ body.is-section-jetpack-connect .site-topic__content {
 	}
 
 	.suggestions__wrapper {
-		/*
-		// Without the extra padding from the Card, we need
-		// to adjust the position of the suggestions.
-		top: 46px;
-
-		// On smaller screens the input gets bigger,
-		// so the suggestions need to move down a little.
-		@include breakpoint( '<660px' ) {
-			top: 52px;
-		}
-		*/
-
 		position: relative;
 		top: 0;
 		box-shadow: none;
@@ -81,7 +69,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		top: 3px;
 		right: 3px;
 		transition: all 150ms ease-in-out;
-		transition-delay: 400ms;
+		transition-delay: 150ms;
 
 		&[disabled] {
 			opacity: 0;


### PR DESCRIPTION
When the step first loads, the continue button is now hidden:

<img width="538" alt="image" src="https://user-images.githubusercontent.com/191598/54229363-7d76ae80-44da-11e9-9399-e7795d20a5bb.png">

Once you start typing or choose a vertical, the continue button transitions into place:

<img width="517" alt="image" src="https://user-images.githubusercontent.com/191598/54229425-9d0dd700-44da-11e9-9065-30a63cd7294a.png">
