### PR TITLE
Color Schemes: Sakura, Use variation of pink rather than gray for profile gravatar username

### DIFF
--- a/packages/calypso-color-schemes/src/shared/_color-schemes.scss
+++ b/packages/calypso-color-schemes/src/shared/_color-schemes.scss
@@ -1184,7 +1184,7 @@
 		--button-is-borderless-color: #{$muriel-gray-500};
 		--count-border-color: #{$muriel-gray-500};
 		--count-color: #{$muriel-gray-500};
-		--profile-gravatar-user-secondary-info-color: #{$muriel-gray-600};
+		--profile-gravatar-user-secondary-info-color: #{$muriel-pink-700};
 	}
 
 	&.is-laser-black {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use a dark pink variation rather than gray for the profile name in the sidebar. This makes for better color harmony in the Sakura color scheme.

**Before**

<img width="271" alt="Screen Shot 2019-03-12 at 3 48 55 PM" src="https://user-images.githubusercontent.com/2124984/54232526-35a75580-44e1-11e9-897d-b7d1c135c38d.png">


**After**

<img width="272" alt="Screen Shot 2019-03-12 at 3 52 12 PM" src="https://user-images.githubusercontent.com/2124984/54231391-d34d5580-44de-11e9-8440-802006732265.png">

#### Testing instructions

* Switch to this PR and go to `/me/account/`
* Activate Sakura color scheme.
* Check profile name color underneath the Gravatar for color change.
