### PR TITLE
Editor Drawer: Remove Accordion Long Fade

### DIFF
--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -31,7 +31,7 @@
 }
 
 .editor-drawer_accordion.accordion:not(.is-expanded) .accordion__toggle span.accordion__subtitle:after {
-  display: none;
+	display: none;
 }
 
 .editor-drawer__accordion.accordion:not(.is-expanded) .accordion__toggle {

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -11,7 +11,7 @@
 .editor-drawer__accordion.is-loading .accordion__subtitle {
 	position: relative;
 	color: transparent;
-	
+
 	&::before {
 		content: '';
 		position: absolute;

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -8,26 +8,38 @@
 	font-size: 12px;
 }
 
-.editor-drawer__accordion {
-	&.accordion.is-expanded .accordion__subtitle::after {
-		display: none;
-	}
+.editor-drawer__accordion.is-loading .accordion__subtitle {
+	position: relative;
+	color: transparent;
 	
-	&.is-loading .accordion__subtitle {	
-		position: relative;	
-		color: transparent;	
-		
-			&::before {
-				content: '';
-				position: absolute;
+	&::before {
+		content: '';
+		position: absolute;
 				top: 1px;
 				bottom: 1px;
-				width: 60%;
-				background-color: var( --color-neutral-100 );
-				animation: loading-fade 1.6s ease-in-out infinite;
-		}
-	}	
+		width: 60%;
+		background-color: var( --color-neutral-100 );
+		animation: loading-fade 1.6s ease-in-out infinite;
+	}				
 }
+
+.editor-drawer__accordion.accordion .accordion__toggle {
+	span.accordion,
+		&:hover span.accordion__subtitle:after {
+			display: none;
+	}
+}
+
+.editor-drawer_accordion.accordion:not(.is-expanded) .accordion__toggle span.accordion__subtitle:after {
+  display: none;
+}
+
+.editor-drawer__accordion.accordion:not(.is-expanded) .accordion__toggle {
+  span.accordion__subtitle:after, 
+	&:hover span.accordion__subtitle:after {
+		display: none;
+  }
+}  
 
 .editor-drawer__heading {
 	font-weight: 400;

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -8,19 +8,25 @@
 	font-size: 12px;
 }
 
-.editor-drawer__accordion.is-loading .accordion__subtitle {
-	position: relative;
-	color: transparent;
-
-	&::before {
-		content: '';
-		position: absolute;
-		top: 1px;
-		bottom: 1px;
-		width: 60%;
-		background-color: var( --color-neutral-100 );
-		animation: loading-fade 1.6s ease-in-out infinite;
+.editor-drawer__accordion {
+	&.accordion.is-expanded .accordion__subtitle::after {
+		display: none;
 	}
+	
+	&.is-loading .accordion__subtitle {	
+		position: relative;	
+		color: transparent;	
+		
+			&::before {
+				content: '';
+				position: absolute;
+				top: 1px;
+				bottom: 1px;
+				width: 60%;
+				background-color: var( --color-neutral-100 );
+				animation: loading-fade 1.6s ease-in-out infinite;
+		}
+	}	
 }
 
 .editor-drawer__heading {

--- a/client/post-editor/editor-drawer/style.scss
+++ b/client/post-editor/editor-drawer/style.scss
@@ -1,4 +1,3 @@
-
 .editor-drawer {
 	font-size: 13px;
 	background: white;
@@ -7,16 +6,6 @@
 .editor-drawer__description {
 	color: var( --color-neutral-light );
 	font-size: 12px;
-}
-
-.editor-drawer .accordion:not( .is-expanded ) .accordion__toggle {
-	.accordion__subtitle::after {
-		@include long-content-fade();
-	}
-
-	&:hover .accordion__subtitle::after {
-		@include long-content-fade();
-	}
 }
 
 .editor-drawer__accordion.is-loading .accordion__subtitle {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes the Long Fade from the Editor accordion. I'm honestly a bit confused on why it's there, it seems that it was added three years ago in #2388 to ensure there's a visible change in hover state. At some point, it seems that has no longer become necessary anymore. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Activate one of these themes: https://wordpress.com/themes/free/filter/post-formats

Then follow the steps in the original issue and try clicking the tabs around a bit, spot an issue? Hopefully not. 

**Before:**

![gfdgfdfdgfgd](https://user-images.githubusercontent.com/43215253/54234431-060b4400-4507-11e9-8c16-b026e8f32d41.png)

**After:**

![sfdfdsdsfdfs](https://user-images.githubusercontent.com/43215253/54234448-0c012500-4507-11e9-8b5a-ffcc3a5a4a0f.png)

cc @flootr, @sixhours, @blowery 

Fixes #31392
