### PR TITLE
Build: Move minification logic into a project

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -24,6 +24,7 @@
         "postcss-custom-properties": "8.0.9",
         "postcss-loader": "3.0.0",
         "sass-loader": "7.1.0",
+        "terser-webpack-plugin": "1.2.3",
         "thread-loader": "2.1.2",
         "webpack-filter-warnings-plugin": "1.2.1",
         "webpack-rtl-plugin": "1.8.0"
@@ -2240,17 +2241,19 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.17.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.17.0.tgz",
-      "integrity": "sha512-1RB7e4ptR/M+1Ik3Qn84pbppbSadBaCtpgFqgqsXn6s4ZVE6hqW9SOm6UW5yd3KT7ObVfdYUkhMlgR937oKyDw==",
+      "version": "16.17.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.17.1.tgz",
+      "integrity": "sha512-cRosFoYEXraBsXe+FDHFW4b98RM0WuvSv9HUsbV69E+j8aRGAU/4FudEdpgBSIiXv8HvUOLlo6fAdJmmJHSVKw==",
       "requires": {
         "@octokit/request": "2.4.1",
         "before-after-hook": "^1.4.0",
         "btoa-lite": "^1.0.0",
+        "deprecation": "^1.0.1",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "lodash.uniq": "^4.5.0",
         "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
       }
@@ -2481,9 +2484,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "11.11.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.2.tgz",
-      "integrity": "sha512-iEaHiDNkHv4Jrm9O5T37OYEUwjJesiyt6ZlhLFK0sbo4CLD0jyCOB4Pc2F9iD3MbW2397SLNxZKdDGntGaBjQQ=="
+      "version": "11.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
+      "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
     },
     "@types/q": {
       "version": "1.5.1",
@@ -4608,9 +4611,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000945",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000945.tgz",
-      "integrity": "sha512-PSGwYChNIXJ4FZr9Z9mrVzBCB1TF3yyiRmIDRIdKDHZ6u+1jYH6xeR28XaquxnMwcZVX3f48S9zi7eswO/G1nQ=="
+      "version": "1.0.30000946",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000946.tgz",
+      "integrity": "sha512-ZVXtMoZ3Mfq69Ikv587Av+5lwGVJsG98QKUucVmtFBf0tl1kOCfLQ5o6Z2zBNis4Mx3iuH77WxEUpdP6t7f2CQ=="
     },
     "capture-exit": {
       "version": "1.2.0",
@@ -14577,9 +14580,9 @@
       }
     },
     "postcss-less": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.2.tgz",
-      "integrity": "sha512-66ZBVo1JGkQ7r13M97xcHcyarWpgg21RaqIZWZXHE3XOtb5+ywK1uZWeY1DYkYRkIX/l8Hvxnx9iSKB68nFr+w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.3.tgz",
+      "integrity": "sha512-S0LYoO278GVmyT1uCgr1h95L19dkmzuJDMdpSMCtv+bj15OoJXtFX6c/2AlyL4OEOauGTC7nuqfudVd5kzFtuA==",
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"

--- a/package.json
+++ b/package.json
@@ -190,7 +190,6 @@
     "store": "2.0.12",
     "striptags": "2.2.1",
     "superagent": "3.8.3",
-    "terser-webpack-plugin": "1.2.3",
     "textarea-caret": "3.1.0",
     "tinymce": "4.8.5",
     "to-title-case": "1.0.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -29,6 +29,7 @@
 		"postcss-custom-properties": "8.0.9",
 		"postcss-loader": "3.0.0",
 		"sass-loader": "7.1.0",
+		"terser-webpack-plugin": "1.2.3",
 		"thread-loader": "2.1.2",
 		"webpack-filter-warnings-plugin": "1.2.1",
 		"webpack-rtl-plugin": "1.8.0"

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -3,29 +3,12 @@
  */
 const TerserPlugin = require( 'terser-webpack-plugin' );
 
-const terserDefaults = {
-	ecma: 5,
-	safari10: true,
-	mangle: true,
-};
-
 /**
  * Returns an array containing a Terser plugin object to be used in Webpack minification.
  *
  * @see https://github.com/webpack-contrib/terser-webpack-plugin for complete descriptions of options.
  *
- * @param {Object}           _               Options
- * @param {(Boolean|string)} _.cache         Enable file caching
- * @param {(Boolean|number)} _.parallel      Use multi-process parallel running to improve the build speed
- * @param {Boolean}          _.sourceMap     Use source maps to map error message locations to modules
- * @param {Object}           _.terserOptions Terser minify options
- * @returns {Object[]}                       Terser plugin object to be used in Webpack minification.
+ * @param {Object} options Options passed to the terser plugin
+ * @returns {Object[]}     Terser plugin object to be used in Webpack minification.
  */
-module.exports = ( { cache = true, parallel = false, sourceMap = false, terserOptions = {} } ) => [
-	new TerserPlugin( {
-		cache,
-		parallel,
-		sourceMap,
-		terserOptions: Object.assign( {}, terserDefaults, terserOptions ),
-	} ),
-];
+module.exports = ( options = {} ) => [ new TerserPlugin( options ) ];

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -3,7 +3,5 @@
  */
 const TerserPlugin = require( 'terser-webpack-plugin' );
 
-module.exports = ( { shouldMinify, cache, parallel, sourceMap, terserOptions } ) => ( {
-	minimize: shouldMinify,
-	minimizer: [ new TerserPlugin( { cache, parallel, sourceMap, terserOptions } ) ],
-} );
+module.exports = ( { cache, parallel, sourceMap, terserOptions } ) =>
+	new TerserPlugin( { cache, parallel, sourceMap, terserOptions } );

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -1,0 +1,9 @@
+/**
+ * External Dependencies
+ */
+const TerserPlugin = require( 'terser-webpack-plugin' );
+
+module.exports = ( { shouldMinify, cache, parallel, sourceMap, terserOptions } ) => ( {
+	minimize: shouldMinify,
+	minimizer: [ new TerserPlugin( { cache, parallel, sourceMap, terserOptions } ) ],
+} );

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -3,5 +3,16 @@
  */
 const TerserPlugin = require( 'terser-webpack-plugin' );
 
-module.exports = ( { cache, parallel, sourceMap, terserOptions } ) =>
-	new TerserPlugin( { cache, parallel, sourceMap, terserOptions } );
+const terserDefaults = {
+	ecma: 5,
+	safari10: true,
+	mangle: true,
+};
+
+module.exports = ( { cache = true, parallel = 2, sourceMap = true, terserOptions = {} } ) =>
+	new TerserPlugin( {
+		cache,
+		parallel,
+		sourceMap,
+		terserOptions: Object.assign( {}, terserDefaults, terserOptions ),
+	} );

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -9,10 +9,23 @@ const terserDefaults = {
 	mangle: true,
 };
 
-module.exports = ( { cache = true, parallel = 2, sourceMap = true, terserOptions = {} } ) =>
+/**
+ * Returns an array containing a Terser plugin object to be used in Webpack minification.
+ *
+ * @see https://github.com/webpack-contrib/terser-webpack-plugin for complete descriptions of options.
+ *
+ * @param {Object}           _               Options
+ * @param {(Boolean|string)} _.cache         Enable file caching
+ * @param {(Boolean|number)} _.parallel      Use multi-process parallel running to improve the build speed
+ * @param {Boolean}          _.sourceMap     Use source maps to map error message locations to modules
+ * @param {Object}           _.terserOptions Terser minify options
+ * @returns {Object[]}                       Terser plugin object to be used in Webpack minification.
+ */
+module.exports = ( { cache = true, parallel = false, sourceMap = false, terserOptions = {} } ) => [
 	new TerserPlugin( {
 		cache,
 		parallel,
 		sourceMap,
 		terserOptions: Object.assign( {}, terserDefaults, terserOptions ),
-	} );
+	} ),
+];

--- a/packages/calypso-build/webpack/minify.js
+++ b/packages/calypso-build/webpack/minify.js
@@ -11,4 +11,4 @@ const TerserPlugin = require( 'terser-webpack-plugin' );
  * @param {Object} options Options passed to the terser plugin
  * @returns {Object[]}     Terser plugin object to be used in Webpack minification.
  */
-module.exports = ( options = {} ) => [ new TerserPlugin( options ) ];
+module.exports = options => [ new TerserPlugin( options ) ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -134,14 +134,6 @@ function getWebpackConfig( {
 	cssFilename =
 		cssFilename ||
 		( isDevelopment || calypsoEnv === 'desktop' ? '[name].css' : '[name].[chunkhash].css' );
-	const minifyConfig = Minify( {
-		cache: process.env.CIRCLECI
-			? `${ process.env.HOME }/terser-cache`
-			: 'docker' !== process.env.CONTAINER,
-		parallel: workerCount,
-		sourceMap: Boolean( process.env.SOURCEMAP ),
-		terserOptions: { mangle: calypsoEnv !== 'desktop' },
-	} );
 
 	const webpackConfig = {
 		bail: ! isDevelopment,
@@ -167,7 +159,18 @@ function getWebpackConfig( {
 			moduleIds: 'named',
 			chunkIds: isDevelopment ? 'named' : 'natural',
 			minimize: shouldMinify,
-			minimizer: minifyConfig,
+			minimizer: Minify( {
+				cache: process.env.CIRCLECI
+					? `${ process.env.HOME }/terser-cache`
+					: 'docker' !== process.env.CONTAINER,
+				parallel: workerCount,
+				sourceMap: Boolean( process.env.SOURCEMAP ),
+				terserOptions: {
+					ecma: 5,
+					safari10: true,
+					mangle: calypsoEnv !== 'desktop',
+				},
+			} ),
 		},
 		module: {
 			// avoids this warning:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
 const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' );
-const Minimizer = require( '@automattic/calypso-build/webpack/minify' );
+const Minify = require( '@automattic/calypso-build/webpack/minify' );
 const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
 
@@ -134,7 +134,7 @@ function getWebpackConfig( {
 	cssFilename =
 		cssFilename ||
 		( isDevelopment || calypsoEnv === 'desktop' ? '[name].css' : '[name].[chunkhash].css' );
-	const minimizerConfig = Minimizer( {
+	const minifyConfig = Minify( {
 		cache: process.env.CIRCLECI
 			? `${ process.env.HOME }/terser-cache`
 			: 'docker' !== process.env.CONTAINER,
@@ -145,7 +145,6 @@ function getWebpackConfig( {
 			safari10: true,
 			mangle: calypsoEnv !== 'desktop',
 		},
-		shouldMinify,
 	} );
 
 	const webpackConfig = {
@@ -171,8 +170,8 @@ function getWebpackConfig( {
 			runtimeChunk: codeSplit ? { name: 'manifest' } : false,
 			moduleIds: 'named',
 			chunkIds: isDevelopment ? 'named' : 'natural',
-			minimize: minimizerConfig.minimize,
-			minimizer: minimizerConfig.minimizer,
+			minimize: shouldMinify,
+			minimizer: [ minifyConfig ],
 		},
 		module: {
 			// avoids this warning:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -140,11 +140,7 @@ function getWebpackConfig( {
 			: 'docker' !== process.env.CONTAINER,
 		parallel: workerCount,
 		sourceMap: Boolean( process.env.SOURCEMAP ),
-		terserOptions: {
-			ecma: 5,
-			safari10: true,
-			mangle: calypsoEnv !== 'desktop',
-		},
+		terserOptions: { mangle: calypsoEnv !== 'desktop' },
 	} );
 
 	const webpackConfig = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -167,7 +167,7 @@ function getWebpackConfig( {
 			moduleIds: 'named',
 			chunkIds: isDevelopment ? 'named' : 'natural',
 			minimize: shouldMinify,
-			minimizer: [ minifyConfig ],
+			minimizer: minifyConfig,
 		},
 		module: {
 			// avoids this warning:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves minification logic out of webpack.config and into the calypso-build package

#### Testing instructions

I need help writing testing instructions. So far i've ran:

- `npm start` and verified that calypso.localhost:3000 works

and i've run 
- `SOURCEMAP='source-map' npx lerna run prepublishOnly --stream --scope '**/jetpack-blocks' -- -- --watch` and verified that 'packages/jetpack-blocks/dist/editor.js' is minified

What else should we try?

Fixes #31410 
