### PR TITLE
Move empty content css to the component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -62,7 +62,6 @@
 @import 'components/domains/search-filters/style';
 @import 'components/drop-zone/style';
 @import 'components/ellipsis-menu/style';
-@import 'components/empty-content/style';
 @import 'components/faq/style';
 @import 'components/foldable-card/style';
 @import 'components/formatted-header/style';

--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -9,6 +9,9 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { noop } from 'lodash';
 
+/**
+ * Style Dependencies
+ */
 import './style.scss';
 
 class EmptyContent extends Component {

--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -9,6 +9,8 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import { noop } from 'lodash';
 
+import './style.scss';
+
 class EmptyContent extends Component {
 	static propTypes = {
 		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),

--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -7,7 +7,11 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
-import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
 
 /**
  * Style Dependencies
@@ -37,53 +41,26 @@ class EmptyContent extends Component {
 		title: "You haven't created any content yet.",
 		illustration: '/calypso/images/illustrations/illustration-empty-results.svg',
 		isCompact: false,
-		actionHoverCallback: noop,
 	};
-
-	static displayName = 'EmptyContent';
 
 	primaryAction() {
 		if ( typeof this.props.action !== 'string' ) {
 			return this.props.action;
 		}
 
-		if ( this.props.actionURL && this.props.actionCallback ) {
+		if ( this.props.actionURL || this.props.actionCallback ) {
 			return (
-				<a
-					className="empty-content__action button is-primary"
+				<Button
+					primary
+					className="empty-content__action"
 					onClick={ this.props.actionCallback }
 					href={ this.props.actionURL }
+					target={ this.props.actionTarget }
 					onMouseEnter={ this.props.actionHoverCallback }
 					onTouchStart={ this.props.actionHoverCallback }
 				>
 					{ this.props.action }
-				</a>
-			);
-		} else if ( this.props.actionURL ) {
-			let targetProp = {};
-			if ( this.props.actionTarget ) {
-				targetProp = { target: this.props.actionTarget, rel: 'noopener noreferrer' };
-			}
-
-			return (
-				<a
-					className="empty-content__action button is-primary"
-					href={ this.props.actionURL }
-					onMouseEnter={ this.props.actionHoverCallback }
-					onTouchStart={ this.props.actionHoverCallback }
-					{ ...targetProp }
-				>
-					{ this.props.action }
-				</a>
-			);
-		} else if ( this.props.actionCallback ) {
-			return (
-				<a
-					className="empty-content__action button is-primary"
-					onClick={ this.props.actionCallback }
-				>
-					{ this.props.action }
-				</a>
+				</Button>
 			);
 		}
 	}
@@ -93,36 +70,16 @@ class EmptyContent extends Component {
 			return this.props.secondaryAction;
 		}
 
-		if ( this.props.secondaryActionURL && this.props.secondaryActionCallback ) {
+		if ( this.props.secondaryActionURL || this.props.secondaryActionCallback ) {
 			return (
-				<a
+				<Button
 					className="empty-content__action button"
 					onClick={ this.props.secondaryActionCallback }
 					href={ this.props.secondaryActionURL }
+					target={ this.props.secondaryActionTarget }
 				>
 					{ this.props.secondaryAction }
-				</a>
-			);
-		} else if ( this.props.secondaryActionURL ) {
-			let targetProp = {};
-			if ( this.props.secondaryActionTarget ) {
-				targetProp = { target: this.props.secondaryActionTarget, rel: 'noopener noreferrer' };
-			}
-
-			return (
-				<a
-					className="empty-content__action button"
-					href={ this.props.secondaryActionURL }
-					{ ...targetProp }
-				>
-					{ this.props.secondaryAction }
-				</a>
-			);
-		} else if ( this.props.secondaryActionCallback ) {
-			return (
-				<a className="empty-content__action button" onClick={ this.props.secondaryActionCallback }>
-					{ this.props.secondaryAction }
-				</a>
+				</Button>
 			);
 		}
 	}
@@ -133,6 +90,7 @@ class EmptyContent extends Component {
 		const illustration = this.props.illustration && (
 			<img
 				src={ this.props.illustration }
+				alt=""
 				width={ this.props.illustrationWidth }
 				className="empty-content__illustration"
 			/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This moves the css for the EmptyContent component to the component file

#### Testing instructions

* Check that http://calypso.localhost:3000/devdocs/design/empty-content matches http://wpcalypso.wordpress.com/devdocs/design/empty-content

Fixes #
