### PR TITLE
Checkout Length Picker: Show generic message rather than tax amount

### DIFF
--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -6,7 +6,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { isNumber } from 'lodash';
 import formatCurrency, { CURRENCIES } from '@automattic/format-currency';
 
 /**
@@ -20,9 +19,6 @@ import { PLANS_LIST } from 'lib/plans/constants';
 import QueryPlans from 'components/data/query-plans';
 import QueryProductsList from 'components/data/query-products-list';
 import SubscriptionLengthOption from './option';
-import getPaymentCountryCode from 'state/selectors/get-payment-country-code';
-import getPaymentPostalCode from 'state/selectors/get-payment-postal-code';
-import { requestTaxRate } from 'state/data-getters';
 
 /**
  * Style dependencies
@@ -46,33 +42,8 @@ export class SubscriptionLengthPicker extends React.Component {
 		onChange: () => null,
 	};
 
-	formatTax( taxRate, price, currencyCode ) {
-		const { translate } = this.props;
-
-		// taxRate unknown
-		if ( ! isNumber( taxRate ) ) {
-			return translate( '+tax', {
-				comment:
-					'This string is displayed immediately next to a localized price with a currency symbol, and is indicating that there may be an additional charge on top of the displayed price.',
-			} );
-		}
-
-		// a zero tax rate - don't display anything
-		if ( ! taxRate ) {
-			return '';
-		}
-
-		return translate( '+%(taxAmount)s tax', {
-			args: {
-				taxAmount: myFormatCurrency( price * taxRate, currencyCode, { symbol: '' } ),
-			},
-			comment:
-				'taxAmount is a price with localised formatting but not currency symbol, like 1.234,56 or 1,234.56. The string is displayed immediately next to a price with a currency symbol, and is showing the amount of local sales tax added to that "sticker price".',
-		} );
-	}
-
 	render() {
-		const { productsWithPrices, translate, taxRate, shouldShowTax } = this.props;
+		const { productsWithPrices, translate, shouldShowTax } = this.props;
 		const hasDiscount = productsWithPrices.some(
 			( { priceFullBeforeDiscount, priceFull } ) => priceFull !== priceFullBeforeDiscount
 		);
@@ -114,7 +85,6 @@ export class SubscriptionLengthPicker extends React.Component {
 									value={ planSlug }
 									onCheck={ this.props.onChange }
 									shouldShowTax={ shouldShowTax }
-									taxDisplay={ this.formatTax( taxRate, priceFull, this.props.currencyCode ) }
 								/>
 							</div>
 						)
@@ -141,12 +111,9 @@ export function myFormatCurrency( price, code, options = {} ) {
 
 export const mapStateToProps = ( state, { plans } ) => {
 	const selectedSiteId = getSelectedSiteId( state );
-	const paymentCountryCode = getPaymentCountryCode( state );
-	const paymentPostalCode = getPaymentPostalCode( state );
 	return {
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		productsWithPrices: computeProductsWithPrices( state, selectedSiteId, plans ),
-		taxRate: requestTaxRate( paymentCountryCode, paymentPostalCode ).data,
 	};
 };
 

--- a/client/blocks/subscription-length-picker/option.jsx
+++ b/client/blocks/subscription-length-picker/option.jsx
@@ -34,7 +34,6 @@ export class SubscriptionLengthOption extends React.Component {
 		onCheck: PropTypes.func,
 		translate: PropTypes.func.isRequired,
 		shouldShowTax: PropTypes.bool,
-		taxDisplay: PropTypes.oneOfType( [ PropTypes.string, PropTypes.bool ] ),
 	};
 
 	static defaultProps = {
@@ -43,7 +42,6 @@ export class SubscriptionLengthOption extends React.Component {
 		savePercent: 0,
 		onCheck: () => null,
 		shouldShowTax: false,
-		taxDisplay: '',
 	};
 
 	constructor( props ) {
@@ -76,7 +74,8 @@ export class SubscriptionLengthOption extends React.Component {
 	}
 
 	renderNewSaleContent() {
-		const { checked, price, savePercent, shouldShowTax, term, translate, taxDisplay } = this.props;
+		const { checked, price, savePercent, term, translate } = this.props;
+
 		return (
 			<React.Fragment>
 				<div className="subscription-length-picker__option-header">
@@ -97,9 +96,7 @@ export class SubscriptionLengthOption extends React.Component {
 				</div>
 				<div className="subscription-length-picker__option-description">
 					<div className="subscription-length-picker__option-price">{ price }</div>
-					{ shouldShowTax && (
-						<sup className="subscription-length-picker__option-tax">{ taxDisplay }</sup>
-					) }
+					{ this.renderPlusTax() }
 					<div className="subscription-length-picker__option-side-note">
 						{ term !== TERM_MONTHLY ? this.renderPricePerMonth() : false }
 					</div>
@@ -109,7 +106,7 @@ export class SubscriptionLengthOption extends React.Component {
 	}
 
 	renderUpgradeContent() {
-		const { price, priceBeforeDiscount, shouldShowTax, taxDisplay, translate } = this.props;
+		const { price, priceBeforeDiscount, translate } = this.props;
 		const hasDiscount = priceBeforeDiscount && priceBeforeDiscount !== price;
 		return (
 			<React.Fragment>
@@ -124,9 +121,7 @@ export class SubscriptionLengthOption extends React.Component {
 					) }
 					<div className="subscription-length-picker__option-price">
 						{ price }
-						{ shouldShowTax && (
-							<sup className="subscription-length-picker__option-tax">{ taxDisplay }</sup>
-						) }
+						{ this.renderPlusTax() }
 					</div>
 					{ hasDiscount && (
 						<div className="subscription-length-picker__option-credit-info">
@@ -142,13 +137,25 @@ export class SubscriptionLengthOption extends React.Component {
 		const { term, translate } = this.props;
 		switch ( term ) {
 			case TERM_BIENNIALLY:
-				return translate( '%s year', '%s years', { count: 2, args: '2', context: 'subscription length' } );
+				return translate( '%s year', '%s years', {
+					count: 2,
+					args: '2',
+					context: 'subscription length',
+				} );
 
 			case TERM_ANNUALLY:
-				return translate( '%s year', '%s years', { count: 1, args: '1', context: 'subscription length' } );
+				return translate( '%s year', '%s years', {
+					count: 1,
+					args: '1',
+					context: 'subscription length',
+				} );
 
 			case TERM_MONTHLY:
-				return translate( '%s month', '%s months', { count: 1, args: '1', context: 'subscription length' } );
+				return translate( '%s month', '%s months', {
+					count: 1,
+					args: '1',
+					context: 'subscription length',
+				} );
 		}
 	}
 
@@ -159,6 +166,23 @@ export class SubscriptionLengthOption extends React.Component {
 		return savePercent
 			? translate( 'only %(price)s / month', args )
 			: translate( '%(price)s / month', args );
+	}
+
+	renderPlusTax() {
+		const { shouldShowTax, translate } = this.props;
+
+		if ( ! shouldShowTax ) {
+			return null;
+		}
+
+		return (
+			<sup className="subscription-length-picker__option-tax">
+				{ translate( '+tax', {
+					comment:
+						'This string is displayed immediately next to a localized price with a currency symbol, and is indicating that there may be an additional charge on top of the displayed price.',
+				} ) }
+			</sup>
+		);
 	}
 
 	handleChange = e => {


### PR DESCRIPTION
This PR simplifies the Subscription length picker to use a simple "+tax" message rather than an amount:

![Checkout_‹_My_Test_Blog_—_WordPress_com](https://user-images.githubusercontent.com/5952255/54254455-81b8cf80-459f-11e9-93f2-690c4b540d21.jpg)

Given that the actual tax amount is presented on the same screen, we don't need to show the detail right there, and it looks a lot nicer than cramming it in

e.g. *Before*:

![Checkout_‹_julesauspremiumtest_—_WordPress_com](https://user-images.githubusercontent.com/5952255/54253335-5089d080-459a-11e9-9338-e0fcf109a298.jpg)

#### Testing instructions

- Check out http://calypso.localhost:3000/checkout/julesaustest.wordpress.com/example with and without tax enabled

Bonus: Demo Time!

![checkout tax demo](https://user-images.githubusercontent.com/5952255/54254434-6d74d280-459f-11e9-8ad7-6b2064f69a8d.gif)
