### PR TITLE
Revert "Packages: format-currency no sideEffects"

### DIFF
--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -4,7 +4,6 @@
   "description": "JavaScript library for formatting currency",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
-  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git://github.com/Automattic/wp-calypso.git"


### PR DESCRIPTION
Reverts Automattic/wp-calypso#31349