### PR TITLE
Tiled gallery: Add safety for mangled block output

### DIFF
--- a/packages/jetpack-blocks/src/blocks/tiled-gallery/layout/mosaic/resize.js
+++ b/packages/jetpack-blocks/src/blocks/tiled-gallery/layout/mosaic/resize.js
@@ -33,23 +33,17 @@ function getRowRatio( row ) {
 }
 
 export function getGalleryRows( gallery ) {
-	return typeof gallery.querySelectorAll === 'function'
-		? Array.from( gallery.querySelectorAll( '.tiled-gallery__row' ) )
-		: [];
+	return Array.from( gallery.querySelectorAll( '.tiled-gallery__row' ) );
 }
 
 function getRowCols( row ) {
-	return typeof row.querySelectorAll === 'function'
-		? Array.from( row.querySelectorAll( '.tiled-gallery__col' ) )
-		: [];
+	return Array.from( row.querySelectorAll( '.tiled-gallery__col' ) );
 }
 
 function getColImgs( col ) {
-	return typeof col.querySelectorAll === 'function'
-		? Array.from(
-				col.querySelectorAll( '.tiled-gallery__item > img, .tiled-gallery__item > a > img' )
-		  )
-		: [];
+	return Array.from(
+		col.querySelectorAll( '.tiled-gallery__item > img, .tiled-gallery__item > a > img' )
+	);
 }
 
 function getColumnRatio( col ) {

--- a/packages/jetpack-blocks/src/blocks/tiled-gallery/layout/mosaic/resize.js
+++ b/packages/jetpack-blocks/src/blocks/tiled-gallery/layout/mosaic/resize.js
@@ -33,17 +33,23 @@ function getRowRatio( row ) {
 }
 
 export function getGalleryRows( gallery ) {
-	return Array.from( gallery.querySelectorAll( '.tiled-gallery__row' ) );
+	return typeof gallery.querySelectorAll === 'function'
+		? Array.from( gallery.querySelectorAll( '.tiled-gallery__row' ) )
+		: [];
 }
 
 function getRowCols( row ) {
-	return Array.from( row.querySelectorAll( '.tiled-gallery__col' ) );
+	return typeof row.querySelectorAll === 'function'
+		? Array.from( row.querySelectorAll( '.tiled-gallery__col' ) )
+		: [];
 }
 
 function getColImgs( col ) {
-	return Array.from(
-		col.querySelectorAll( '.tiled-gallery__item > img, .tiled-gallery__item > a > img' )
-	);
+	return typeof col.querySelectorAll === 'function'
+		? Array.from(
+				col.querySelectorAll( '.tiled-gallery__item > img, .tiled-gallery__item > a > img' )
+		  )
+		: [];
 }
 
 function getColumnRatio( col ) {

--- a/packages/jetpack-blocks/src/blocks/tiled-gallery/view.js
+++ b/packages/jetpack-blocks/src/blocks/tiled-gallery/view.js
@@ -18,7 +18,8 @@ function handleObservedResize( galleries ) {
 		handleObservedResize.pendingRaf = null;
 		for ( const gallery of galleries ) {
 			const { width: galleryWidth } = gallery.contentRect;
-			const rows = Array.from( gallery.target.childNodes );
+			// We can't use childNodes becuase post content may contain unexpected text nodes
+			const rows = Array.from( gallery.target.querySelectorAll( '.tiled-gallery__row' ) );
 			rows.forEach( row => handleRowResize( row, galleryWidth ) );
 		}
 	} );


### PR DESCRIPTION
The Tiled Gallery block view script expects a very rigid output which may be mangled in some situations. Received a report (p1552469945108900-slack-jetpack-gutenberg) of broken display and the issue was tracked down to additional, unexpected text nodes being present in the block's HTML structure. These unexpected text nodes were then treated as elements (only Gallery rows were expected), which lead to calling methods which are undefined on text nodes.

```
Uncaught TypeError: t.querySelectorAll is not a function
```

Rather than using `childNode` which may match text nodes, use `querySelectorAll` to match gallery rows and ignore the text nodes.

#### Testing instructions

* Build the blocks and test in Jetpack (editor and frontend)
* For easy sandbox testing: D25497-code