### PR TITLE
Lint: Add react hooks lint rules

### DIFF
--- a/client/components/data/query-reader-tag/index.jsx
+++ b/client/components/data/query-reader-tag/index.jsx
@@ -12,10 +12,10 @@ import { connect } from 'react-redux';
  */
 import { requestTags } from 'state/reader/tags/items/actions';
 
-const QueryReaderTag = props => {
+const QueryReaderTag = ( { tag, requestTags: request } ) => {
 	useEffect(() => {
-		props.requestTags( props.tag );
-	}, [ props.tag ]);
+		request( tag );
+	}, [ request, tag ]);
 	return null;
 };
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7425,7 +7425,10 @@
     },
     "eslint-config-wpcalypso": {
       "version": "file:packages/eslint-config-wpcalypso",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eslint-plugin-react-hooks": "^1.5.0"
+      }
     },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
@@ -7639,6 +7642,12 @@
           }
         }
       }
+    },
+    "eslint-plugin-react-hooks": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.5.0.tgz",
+      "integrity": "sha512-iwDuWR2ReRgvJsNm8fXPtTKdg78IVQF8I4+am3ntztPf/+nPnWZfArFu6aXpaC75/iCYRrkqI8nPCYkxJstmpA==",
+      "dev": true
     },
     "eslint-plugin-wpcalypso": {
       "version": "file:packages/eslint-plugin-wpcalypso",

--- a/packages/eslint-config-wpcalypso/package.json
+++ b/packages/eslint-config-wpcalypso/package.json
@@ -25,5 +25,8 @@
   "peerDependencies": {
     "eslint": "^3.3.1 || ^4.6.1 || ^5.0.0",
     "eslint-plugin-wpcalypso": "^3.4.1 || ^4.0.0"
+  },
+  "dependencies": {
+    "eslint-plugin-react-hooks": "^1.5.0"
   }
 }

--- a/packages/eslint-config-wpcalypso/react/index.js
+++ b/packages/eslint-config-wpcalypso/react/index.js
@@ -9,7 +9,7 @@ module.exports = {
 		},
 		sourceType: 'module',
 	},
-	plugins: [ 'react', 'wpcalypso' ],
+	plugins: [ 'react', 'react-hooks', 'wpcalypso' ],
 	rules: {
 		'react/jsx-curly-spacing': [ 2, 'always' ],
 		'react/jsx-no-duplicate-props': 2,
@@ -26,5 +26,7 @@ module.exports = {
 		'react/no-string-refs': 2,
 		'react/prefer-es6-class': 2,
 		'react/react-in-jsx-scope': 2,
+		'react-hooks/rules-of-hooks': 2,
+		'react-hooks/exhaustive-deps': 1,
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add [react-hooks lint rules](https://www.npmjs.com/package/eslint-plugin-react-hooks)

#### Testing instructions

* `npx eslint --ext .js --ext .jsx client packages server | grep react-hooks` should return nothing

