### PR TITLE
Importers: restore correct width of importer progress bar

### DIFF
--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -50,7 +50,7 @@
 	&.site-importer {
 		background-color: #faad4d;
 	}
-	
+
 	&.squarespace {
 		background-color: #222;
 	}
@@ -117,7 +117,9 @@
 
 .importer__upload-progress,
 .importer__import-progress {
-	width: 80%;
+	&.progress-bar {
+		width: 80%;
+	}
 
 	.progress-bar__progress {
 		background-color: var( --color-accent );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* It looks like a recent change to the app CSS - perhaps in the order of inclusion of stylesheets - has made the upload/import progress bars too wide.

![image](https://user-images.githubusercontent.com/1647564/54287401-7cf31c00-459d-11e9-97e3-fcfca57c72a7.png)

![image](https://user-images.githubusercontent.com/1647564/54287407-8086a300-459d-11e9-80a2-2276b3688b77.png)

* This PR restores the original width by increasing the specificity of the rule.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Perform a test WordPress import in Calypso. The upload progress bar and import progress bar should both be 80% of the width of their containing pane as shown.

![image](https://user-images.githubusercontent.com/1647564/54287738-289c6c00-459e-11e9-87c8-299f3976e77b.png)

[Related comment](https://github.com/Automattic/wp-calypso/issues/31092#issuecomment-470079372) 