### PR TITLE
Jetpack Connect: Preserve history for site type and topic pages

### DIFF
--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -26,7 +26,7 @@ class JetpackSiteTopic extends Component {
 
 		this.props.saveSiteVertical( siteId, siteVertical );
 
-		page.redirect( `/jetpack/connect/plans/${ siteSlug }` );
+		page( `/jetpack/connect/plans/${ siteSlug }` );
 	};
 
 	render() {

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -25,7 +25,7 @@ class JetpackSiteType extends Component {
 
 		this.props.saveSiteType( siteId, siteType );
 
-		page.redirect( `/jetpack/connect/site-topic/${ siteSlug }` );
+		page( `/jetpack/connect/site-topic/${ siteSlug }` );
 	};
 
 	render() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Preserve history for site type and site topic pages.

#### Testing instructions

* Checkout this branch.
* Connect a Jetpack site, but add `&calypso_env=development` to the connection URL of the green button in Jetpack.
* You'll end up in the site type step. Pick a site type and continue.
* You'll end up in the site topic step. Input a site topic and continue.
* You'll end up in the plans page.
* Hit the browser's back. Verify you end up in the site topic page.
* Hit the browser's back again. Verify you end up in the site type page.

cc @eliorivero who initially reported this in p1HpG7-6qP-p2.
