### PR TITLE
Move Hot Module Replacement to calypso-build package

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -30,6 +30,7 @@
 		"postcss-loader": "3.0.0",
 		"sass-loader": "7.1.0",
 		"thread-loader": "2.1.2",
+		"webpack": "4.29.6",
 		"webpack-filter-warnings-plugin": "1.2.1",
 		"webpack-rtl-plugin": "1.8.0"
 	}

--- a/packages/calypso-build/webpack/hot-module-replacement.js
+++ b/packages/calypso-build/webpack/hot-module-replacement.js
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+const webpack = require( 'webpack' );
+
+/**
+ * Return an array of hot module reloading relevant webpack plugin object
+ *
+ * @param  {Boolean}   isDeveloment  whether the code is bundled is in development mode
+ *
+ * @return {Object[]}  hot module reloading webpack plugin object
+ */
+module.exports.plugins = isDeveloment => {
+	return isDeveloment ? new webpack.HotModuleReplacementPlugin() : null;
+};
+
+/**
+ * Return an array of hot module reloading entryBuild
+ *
+ * @param  {Boolean}   isDeveloment  whether the code is bundled is in development mode
+ * @param  {Array}     entries  the code entry points.
+ *
+ * @return {Object[]}  hot module reloading webpack plugin object
+ */
+module.exports.entryBuild = ( isDeveloment, entries ) => {
+	return isDeveloment ? entries.unshift( 'webpack-hot-middleware/client' ) : entries;
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpac
 const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' );
 const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
+const HotModuleReplacementConfig = require( '@automattic/calypso-build/webpack/hot-module-replacement' );
 
 /**
  * Internal dependencies
@@ -138,7 +139,11 @@ function getWebpackConfig( {
 	const webpackConfig = {
 		bail: ! isDevelopment,
 		context: __dirname,
-		entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
+		entry: {
+			build: HotModuleReplacementConfig.entryBuild( isDevelopment, [
+				path.join( __dirname, 'client', 'boot', 'app' ),
+			] ),
+		},
 		mode: isDevelopment ? 'development' : 'production',
 		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
 		output: {
@@ -290,6 +295,7 @@ function getWebpackConfig( {
 			new MomentTimezoneDataPlugin( {
 				startYear: 2000,
 			} ),
+			HotModuleReplacementConfig.plugins( isDevelopment ),
 		] ),
 		externals: _.compact( [
 			externalizeWordPressPackages && wordpressExternals,
@@ -309,9 +315,6 @@ function getWebpackConfig( {
 		// also we don't minify so dont name them .min.js
 		webpackConfig.output.filename = '[name].js';
 		webpackConfig.output.chunkFilename = '[name].js';
-
-		webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
-		webpackConfig.entry.build.unshift( 'webpack-hot-middleware/client' );
 	}
 
 	if ( ! config.isEnabled( 'desktop' ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the hot reloading of calypso to `calypso-build`

#### Testing instructions
Switch to this branch do the following
```
npm run distclean
npm ci
npm start
```
Does hot reloading still work as expected?

Fixes https://github.com/Automattic/wp-calypso/issues/31430

Currently it is failing with the following error
```
/Users/enejbajgoric/Projects/wp-calypso/node_modules/webpack/lib/webpack.js:31
		throw new WebpackOptionsValidationError(webpackOptionsValidationErrors);
        ^
WebpackOptionsValidationError: Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration.entry should be one of these:
   function | object { <key>: non-empty string | [non-empty string] } | non-empty string | [non-empty string]
   -> The entry point(s) of the compilation.
   Details:
    * configuration.entry should be an instance of function
      -> A Function returning an entry object, an entry string, an entry array or a promise to these things.
    * configuration.entry['build'] should be a string.
      -> The string is resolved to a module which is loaded upon startup.
    * configuration.entry['build'] should be an array:
      [non-empty string]
    * configuration.entry should be a string.
      -> An entry point without name. The string is resolved to a module which is loaded upon startup.
    * configuration.entry should be an array:
      [non-empty string]
    at webpack (/Users/enejbajgoric/Projects/wp-calypso/node_modules/webpack/lib/webpack.js:31:9)
    at webpack (/Users/enejbajgoric/Projects/wp-calypso/build/webpack:/server/bundler/index.js:20:19)
    at setup (/Users/enejbajgoric/Projects/wp-calypso/build/webpack:/server/boot/index.js:40:3)
    at Object.boot (/Users/enejbajgoric/Projects/wp-calypso/build/webpack:/index.js:22:8)
    at __webpack_require__ (/Users/enejbajgoric/Projects/wp-calypso/build/webpack:/webpack/bootstrap:25:1)
    at /Users/enejbajgoric/Projects/wp-calypso/build/webpack:/webpack/bootstrap:116:1
    at Object.<anonymous> (/Users/enejbajgoric/Projects/wp-calypso/build/bundle.js:121:10)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
 .g/COMMIT_EDITMSG
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:742:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:743:3)
```