### PR TITLE
Contact Info: Fix lint error

### DIFF
--- a/packages/jetpack-blocks/src/blocks/contact-info/edit.js
+++ b/packages/jetpack-blocks/src/blocks/contact-info/edit.js
@@ -34,10 +34,7 @@ const ALLOWED_BLOCKS = [
 const TEMPLATE = [ [ 'jetpack/email' ], [ 'jetpack/phone' ], [ 'jetpack/address' ] ];
 
 const ContactInfoEdit = props => {
-	const {
-		attributes: {},
-		isSelected,
-	} = props;
+	const { isSelected } = props;
 
 	return (
 		<div


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove an unused line that was causing an `Unexpected empty object pattern. (no-empty-pattern)` error on WP.com servers.

Reported here: 209e8-pb. Further reading: p1552496116159300-slack-calypso, p1552498887067600-slack-devops

#### Testing instructions

- Wait for the `jetpack-blocks` artifact to be built, than run `eslint` on `editor-beta.js`.
- Verify that the Contact Info block still works.
