### PR TITLE
eslint-config-wpcalypso: Extend eslint:recommended

### DIFF
--- a/packages/eslint-config-wpcalypso/index.js
+++ b/packages/eslint-config-wpcalypso/index.js
@@ -4,6 +4,7 @@ module.exports = {
 	env: {
 		es6: true,
 	},
+	extends: 'eslint:recommended',
 	parserOptions: {
 		ecmaVersion: 7,
 		sourceType: 'module',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add `extends: 'eslint:recommended',` to `packages/eslint-config-wpcalypso/index.js` in order to base our ruleset on ESLint's recommendedations :upside_down_face: 

The reason for this is 209e8-pb (further reading: p1552496116159300-slack-calypso, p1552498887067600-slack-devops), which was fixed by #31438. One of the takeaways from that issue is that WP.com's `.eslintrc.json` is stricter than Calypso's -- it will cause code to fail to build that Calypso lets through.

One way to fix this would be to simply add that one rule (`no-empty-pattern`) to `eslint-config-wpcalypso`. However, WP.com's `.eslintrc.json` doesn't reference that rule explicitly, but includes it through `"extends": "eslint:recommended"`. Also, it seems like there might be other rules in `eslint:recommended` that we might inadvertently violate in Calypso, while they will cause errors on WP.com.

It is thus arguable that `eslint-config-wpcalypso` should do the same as WP.com's eslint config. I'm not sure if we decided against basing Calypso's on `eslint:recommended` in the past in order to maintain a rigid ruleset, but it seems to make sense to me to base ours on the recommended one since that recommendation might change with time (and become smarter). I think it'd make sense to remove rules that are part of `eslint:recommended` from `eslint-config-wpcalypso` and only keep the ones that we override in there (as a subsequent PR).

A cursory glance seems to indicate that this change doesn't introduce too many new/different lint errors.

#### Testing instructions

`npm run lint:js`