### PR TITLE
Fix unstable payment button test and change e2e schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -601,7 +601,7 @@ workflows:
         - setup
     triggers:
     - schedule:
-        cron: "0 * * * *"
+        cron: "0 3,15 * * *"
         filters:
           branches:
             only: master

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,20 +20,35 @@
         "autoprefixer": "9.4.4",
         "babel-loader": "8.0.5",
         "css-loader": "2.1.1",
-        "mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
         "postcss-custom-properties": "8.0.9",
         "postcss-loader": "3.0.0",
         "sass-loader": "7.1.0",
         "thread-loader": "2.1.2",
         "webpack-filter-warnings-plugin": "1.2.1",
         "webpack-rtl-plugin": "1.8.0"
+      },
+      "dependencies": {
+        "mini-css-extract-plugin-with-rtl": {
+          "version": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
+          "from": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
+          "bundled": true,
+          "requires": {
+            "loader-utils": "^1.1.0",
+            "schema-utils": "^1.0.0",
+            "webpack-sources": "^1.1.0"
+          }
+        }
       }
     },
     "@automattic/calypso-color-schemes": {
       "version": "file:packages/calypso-color-schemes",
       "dev": true,
-      "requires": {
-        "color-studio": "github:automattic/color-studio#279f6ae4eacb15bc4f8f75856101aa4d0f4fd4a7"
+      "dependencies": {
+        "color-studio": {
+          "version": "github:automattic/color-studio#279f6ae4eacb15bc4f8f75856101aa4d0f4fd4a7",
+          "from": "github:automattic/color-studio#279f6ae4eacb15bc4f8f75856101aa4d0f4fd4a7",
+          "bundled": true
+        }
       }
     },
     "@automattic/format-currency": {
@@ -5457,11 +5472,6 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
-    },
-    "color-studio": {
-      "version": "github:automattic/color-studio#279f6ae4eacb15bc4f8f75856101aa4d0f4fd4a7",
-      "from": "github:automattic/color-studio#1.0.1",
-      "dev": true
     },
     "colors": {
       "version": "0.6.2",
@@ -12153,16 +12163,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
-    },
-    "mini-css-extract-plugin-with-rtl": {
-      "version": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
-      "from": "github:Automattic/mini-css-extract-plugin-with-rtl",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.1.0",
-        "schema-utils": "^1.0.0",
-        "webpack-sources": "^1.1.0"
-      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,35 +20,20 @@
         "autoprefixer": "9.4.4",
         "babel-loader": "8.0.5",
         "css-loader": "2.1.1",
+        "mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
         "postcss-custom-properties": "8.0.9",
         "postcss-loader": "3.0.0",
         "sass-loader": "7.1.0",
         "thread-loader": "2.1.2",
         "webpack-filter-warnings-plugin": "1.2.1",
         "webpack-rtl-plugin": "1.8.0"
-      },
-      "dependencies": {
-        "mini-css-extract-plugin-with-rtl": {
-          "version": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
-          "from": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
-          "bundled": true,
-          "requires": {
-            "loader-utils": "^1.1.0",
-            "schema-utils": "^1.0.0",
-            "webpack-sources": "^1.1.0"
-          }
-        }
       }
     },
     "@automattic/calypso-color-schemes": {
       "version": "file:packages/calypso-color-schemes",
       "dev": true,
-      "dependencies": {
-        "color-studio": {
-          "version": "github:automattic/color-studio#279f6ae4eacb15bc4f8f75856101aa4d0f4fd4a7",
-          "from": "github:automattic/color-studio#279f6ae4eacb15bc4f8f75856101aa4d0f4fd4a7",
-          "bundled": true
-        }
+      "requires": {
+        "color-studio": "github:automattic/color-studio#279f6ae4eacb15bc4f8f75856101aa4d0f4fd4a7"
       }
     },
     "@automattic/format-currency": {
@@ -5472,6 +5457,11 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "color-studio": {
+      "version": "github:automattic/color-studio#279f6ae4eacb15bc4f8f75856101aa4d0f4fd4a7",
+      "from": "github:automattic/color-studio#1.0.1",
+      "dev": true
     },
     "colors": {
       "version": "0.6.2",
@@ -12163,6 +12153,16 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+    },
+    "mini-css-extract-plugin-with-rtl": {
+      "version": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
+      "from": "github:Automattic/mini-css-extract-plugin-with-rtl",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "schema-utils": "^1.0.0",
+        "webpack-sources": "^1.1.0"
+      }
     },
     "minimalistic-assert": {
       "version": "1.0.1",

--- a/test/e2e/lib/components/payment-button-front-end-component.js
+++ b/test/e2e/lib/components/payment-button-front-end-component.js
@@ -10,6 +10,12 @@ export default class PaymentButtonFrontEndComponent extends AsyncBaseContainer {
 		super( driver, by.css( '.jetpack-simple-payments-wrapper' ) );
 	}
 
+	async _preInit() {
+		// The payment button doesn't always show on the page right away. Waiting a few seconds and refreshing fixes it.
+		await this.driver.sleep( 5000 );
+		return await this.driver.navigate().refresh();
+	}
+
 	async clickPaymentButton() {
 		const payPalPayButtonSelector = by.css( '.paypal-button-card' );
 		await this.driver.wait(

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -114,9 +114,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async removeNUXNotice() {
 		const nuxPopupSelector = By.css( '.nux-dot-tip' );
+		const nuxDisableSelector = By.css( '.nux-dot-tip__disable' );
 		if ( await driverHelper.isElementPresent( this.driver, nuxPopupSelector ) ) {
-			const element = await this.driver.findElement( nuxPopupSelector );
-			await this.driver.executeScript( "return arguments[0].style.visibility='hidden';", element );
+			driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );
 		}
 	}
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1088,7 +1088,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
-	xdescribe( 'Insert embeds: @parallel', function() {
+	describe.skip( 'Insert embeds: @parallel', function() {
 		step( 'Can log in', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
 			return await this.loginFlow.loginAndStartNewPost( null, true );

--- a/test/e2e/specs/wp-reader-spec.js
+++ b/test/e2e/specs/wp-reader-spec.js
@@ -29,7 +29,7 @@ describe( 'Reader: (' + screenSize + ') @parallel', function() {
 	describe( 'Log in as commenting user', function() {
 		step( 'Can log in as commenting user', async function() {
 			this.loginFlow = new LoginFlow( driver, 'commentingUser' );
-			return await this.loginFlow.login();
+			return await this.loginFlow.login( { useFreshLogin: true } );
 		} );
 
 		describe( 'Leave a comment on the latest post in the Reader', function() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This changes the scheduled job to only run twice a day instead of hourly and also adds some fixes for the `Calypso Gutenberg Editor: Pages Insert a payment button into a page` test. The first issue fixed is that it would often times exit the editor right away. This seems to have been fixed by having the test click the 'X' to close the tips box rather than using JS. The other part fixed is that the payment button doesn't always show up right away. I added a sleep (I know, I know) and a refresh to make it show up. 

#### Testing instructions
-Ensure that the test passes locally and in CI
