### PR TITLE
Use v1.1 API to fetch post-counts from remote site directly

### DIFF
--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -207,7 +207,7 @@ UndocumentedSite.prototype.postCounts = function( options, callback ) {
 	const query = Object.assign(
 		{
 			type: 'post',
-			apiNamespace: 'wpcom/v2',
+            apiVersion: '1.1',
 		},
 		options
 	);


### PR DESCRIPTION
D25544-code updates v1.1 API's post-counts endpoint to fetch true post counts by fetching from remote site directly. This PR switches from v2 API to v1.1.

Changing v1.1 API behavior was deemed much easier than changing  v2 API. This may change because, while v1.1 API is easier to re-route, it wasn't obvious  how to use shadow tables as alternative source if Jetpack connection is broken.

#### Changes proposed in this Pull Request

Use v1.1 API for post-counts.

#### Testing instructions

Test in the sandbox with D25544-code patch applied.

*

Fixes #

https://github.com/Automattic/jetpack/issues/7848