### PR TITLE
JITM: silence JITMs during the NUX site user type screen

### DIFF
--- a/client/state/data-layer/wpcom/sites/jitm/index.js
+++ b/client/state/data-layer/wpcom/sites/jitm/index.js
@@ -39,7 +39,11 @@ const process = {
 /**
  * Routes in which to specifically prevent from displaying JITMs.
  */
-const routesToIgnore = [ '/jetpack/connect/site-type', '/jetpack/connect/site-topic' ];
+const routesToIgnore = [
+	'/jetpack/connect/user-type',
+	'/jetpack/connect/site-type',
+	'/jetpack/connect/site-topic',
+];
 
 /**
  * Existing libraries do not escape decimal encoded entities that php encodes, this handles that.


### PR DESCRIPTION
Sequel to https://github.com/Automattic/wp-calypso/pull/31024, as we keep NUX free from extra messages.
#### Changes proposed in this Pull Request

* ignore `/user-type` route when fetching JITMs during the JPC flow

#### Testing instructions
- verify that no JITMs are being fetched at `/jetpack/connect/user-type/:connected_JP_site` ( see network requests)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
