### PR TITLE
Checklist: removing condition that causes the wrong task to appear

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -60,8 +60,7 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 		if (
 			hasTask( 'site_logo_set' ) &&
 			segmentSlug &&
-			( get( taskStatuses, 'site_logo_set.completed' ) ||
-				'logo' === getABTestVariation( 'checklistSiteLogo' ) )
+			'logo' === getABTestVariation( 'checklistSiteLogo' )
 		) {
 			addTask( 'site_logo_set' );
 		} else {


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes the following bug:

> If you're on the **icon** variant of checklistSiteLogo AB test, and then set a logo on customizer, in the checklist, the site icon task is replaced with the site logo task and the logo task is marked completed.

The problem lay in an erroneous condition: `get( taskStatuses, 'site_logo_set.completed' ) ||`

What should be happening is that the site icon task persists, in accordance with the value of the AB Test.

Prop to @niranjan-uma-shankar 

## Testing

### Site logo
1. Apply `D24343-code`
2. Make sure you're using the `icon` variant for the `checklistSiteLogo` AB test.
3. Create a site (not a Business site, since the icon/logo task doesn't show) and **sandbox the site**!
4. Head to the checklist and check that the site icon task is displayed.
5. Go to the Customizer and upload a logo and **Publish**: `http://calypso.localhost:3000/customize/identity/{mysite.com}`
6. Return to the checklist. The site logo task should not appear
