### PR TITLE
Onboarding: remove site verticals debounce

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -157,7 +157,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 const SITE_VERTICALS_REQUEST_ID = 'site-verticals-search-results';
 const DEFAULT_SITE_VERTICAL_REQUEST_ID = 'default-site-verticals-search-results';
 
-const requestSiteVerticalHttpData = ( searchTerm, limit = 5, id = SITE_VERTICALS_REQUEST_ID ) =>
+const requestSiteVerticalHttpData = ( searchTerm, limit = 7, id = SITE_VERTICALS_REQUEST_ID ) =>
 	requestHttpData(
 		id,
 		http( {

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { debounce, find, get, noop, startsWith, trim, uniq, isEmpty } from 'lodash';
+import { find, get, noop, startsWith, trim, uniq, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -179,8 +179,6 @@ const requestSiteVerticalHttpData = ( searchTerm, limit = 5, id = SITE_VERTICALS
 export const isVerticalSearchPending = () =>
 	'pending' === get( getHttpData( SITE_VERTICALS_REQUEST_ID ), 'state', false );
 
-const requestSiteVerticals = debounce( requestSiteVerticalHttpData, 333 );
-
 export default localize(
 	connect(
 		() => {
@@ -193,7 +191,7 @@ export default localize(
 			};
 		},
 		() => ( {
-			requestVerticals: requestSiteVerticals,
+			requestVerticals: requestSiteVerticalHttpData,
 			requestDefaultVertical: ( searchTerm = 'business' ) =>
 				requestSiteVerticalHttpData( searchTerm, 1, DEFAULT_SITE_VERTICAL_REQUEST_ID ),
 		} )


### PR DESCRIPTION
## Changes proposed in this Pull Request

Because we don't trigger a new XHR on a pending httpData request, we can remove the extra debounce.

Result:

![Mar-14-2019 12-48-36](https://user-images.githubusercontent.com/6458278/54325701-b8522100-4657-11e9-97f2-295d881ca4fc.gif)

We're bumping up the results limit from `5` to `7` for more results.

## Testing instructions

Fire up the branch, head to the onboarding flow and start searching for verticals! E.g., at http://calypso.localhost:3000/start/onboarding-for-business/site-topic-with-preview