### PR TITLE
Jetpack blocks: Fix build transpilation

### DIFF
--- a/packages/jetpack-blocks/bin/build.js
+++ b/packages/jetpack-blocks/bin/build.js
@@ -1,4 +1,7 @@
 /* eslint-disable no-console, import/no-nodejs-modules, no-process-exit */
+
+process.env.TARGET_BROWSER = 'true';
+
 /**
  * External dependencies
  */


### PR DESCRIPTION
This was causing the wrong babel configuration to be used, resulting in
bad transpiled block output.

The line was omitted when the blocks were moved in #31199

Fix the regression.

#### Testing instructions

Are blocks correctly transpiled? - look at the artifacts for the `build-jetpack-blocks` CI job.