### PR TITLE
Bug: Remove *.wordpress.com domain suggestion in the launch flow

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -93,6 +93,7 @@ export function generateSteps( {
 			props: {
 				isDomainOnly: false,
 				showExampleSuggestions: false,
+				includeWordPressDotCom: false,
 				showSkipButton: true,
 				headerText: i18n.translate( 'Getting ready to launch, pick a domain' ),
 				subHeaderText: i18n.translate( 'Select a domain name for your website' ),

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -360,6 +360,11 @@ class DomainsStep extends React.Component {
 			showExampleSuggestions = true;
 		}
 
+		let includeWordPressDotCom = this.props.includeWordPressDotCom;
+		if ( 'undefined' === typeof includeWordPressDotCom ) {
+			includeWordPressDotCom = ! this.props.isDomainOnly;
+		}
+
 		return (
 			<RegisterDomainStep
 				key="domainForm"
@@ -377,7 +382,7 @@ class DomainsStep extends React.Component {
 				isDomainOnly={ this.props.isDomainOnly }
 				analyticsSection={ this.getAnalyticsSection() }
 				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-				includeWordPressDotCom={ ! this.props.isDomainOnly }
+				includeWordPressDotCom={ includeWordPressDotCom }
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the wordpress.com subdomain suggestion in the domain step of the launch flow. This is because in the launch flow, the user already has a site and is looking to launch site, so it doesn't make sense to show a *.wordpress.com suggestion. 

#### Testing instructions

1. Create a new site (without purchasing the domain, so it has only a *.wordpress.com account. Then enter the launch flow by clicking the `Launch site` button.

<img width="1400" alt="Screenshot 2019-03-14 at 6 14 09 PM" src="https://user-images.githubusercontent.com/1269602/54357899-16492d80-4685-11e9-85b1-200ba54f3f13.png">

2. In the domain step, verify that the first suggestion is _not_ a wordpress.com subdomain.

**Before**
<img width="1113" alt="Screenshot 2019-03-14 at 6 17 38 PM" src="https://user-images.githubusercontent.com/1269602/54358113-97a0c000-4685-11e9-9316-068b1812e4e8.png">

**After**
![Screenshot 2019-03-14 at 6 25 08 PM](https://user-images.githubusercontent.com/1269602/54358669-ed299c80-4686-11e9-993c-1d603a3503aa.png)

3. Verify that clicking `Already own a domain?` opens the Transfer/mapping page.

4. Now, make sure that the domain step in the signup flow remain unaffected. For this, go through the `onboarding` and `main` variation of the `improvedOnboarding` abtest, both at signup and Adding a new site. Verify that the domain step shows the *.wordpress.com suggestion in these cases.