### PR TITLE
People: migrate React component to ES6 and remove Jetpack version checks

### DIFF
--- a/client/my-sites/people/controller.js
+++ b/client/my-sites/people/controller.js
@@ -11,7 +11,6 @@ import i18n from 'i18n-calypso';
  */
 import PeopleList from './main';
 import EditTeamMember from './edit-team-member-form';
-import PeopleLogStore from 'lib/people/log-store';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import InvitePeople from './invite-people';
 import PeopleInvites from './people-invites';
@@ -71,7 +70,6 @@ function renderPeopleList( context, next ) {
 	context.store.dispatch( setTitle( i18n.translate( 'People', { textOnly: true } ) ) );
 
 	context.primary = React.createElement( PeopleList, {
-		peopleLog: PeopleLogStore,
 		filter: filter,
 		search: context.query.s,
 	} );

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -5,9 +5,7 @@
  */
 
 import React from 'react';
-import createReactClass from 'create-react-class';
 import { localize } from 'i18n-calypso';
-import debugModule from 'debug';
 import { connect } from 'react-redux';
 
 /**
@@ -18,82 +16,53 @@ import FollowersList from './followers-list';
 import ViewersList from './viewers-list';
 import TeamList from 'my-sites/people/team-list';
 import EmptyContent from 'components/empty-content';
-import observe from 'lib/mixins/data-observe';
 import PeopleNotices from 'my-sites/people/people-notices';
-import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import PeopleSectionNav from 'my-sites/people/people-section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isPrivateSite from 'state/selectors/is-private-site';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import titlecase from 'to-title-case';
 
-/**
- * Module variables
- */
-const debug = debugModule( 'calypso:my-sites:people:main' );
+class People extends React.Component {
+	renderPeopleList() {
+		const { site, search, filter, translate } = this.props;
 
-// TODO: port to es6 once we remove the last observe
-export const People = createReactClass( {
-	// eslint-disable-line react/prefer-es6-class
-
-	displayName: 'People',
-
-	mixins: [ observe( 'peopleLog' ) ],
-
-	componentDidMount: function() {
-		debug( 'PeopleList React component mounted.' );
-	},
-
-	renderPeopleList: function( site ) {
-		switch ( this.props.filter ) {
+		switch ( filter ) {
 			case 'team':
-				return <TeamList site={ site } search={ this.props.search } />;
+				return <TeamList site={ site } search={ search } />;
 			case 'followers':
-				return <FollowersList site={ site } label={ this.props.translate( 'Followers' ) } />;
+				return <FollowersList site={ site } label={ translate( 'Followers' ) } />;
 			case 'email-followers':
 				return (
 					<FollowersList
 						site={ site }
-						search={ this.props.search }
-						label={ this.props.translate( 'Email Followers' ) }
+						search={ search }
+						label={ translate( 'Email Followers' ) }
 						type="email"
 					/>
 				);
 			case 'viewers':
-				return <ViewersList site={ site } label={ this.props.translate( 'Viewers' ) } />;
+				return <ViewersList site={ site } label={ translate( 'Viewers' ) } />;
 			default:
 				return null;
 		}
-	},
+	}
 
-	render: function() {
+	render() {
 		const {
 			isJetpack,
-			jetpackPeopleSupported,
 			canViewPeople,
 			siteId,
 			site,
 			search,
 			filter,
 			isPrivate,
+			translate,
 		} = this.props;
 
-		// Jetpack 3.7 is necessary to manage people
-		if ( isJetpack && ! jetpackPeopleSupported ) {
-			return (
-				<Main>
-					<PageViewTracker
-						path={ `/people/${ filter }/:site` }
-						title={ `People > ${ titlecase( filter ) }` }
-					/>
-					<SidebarNavigation />
-					<JetpackManageErrorPage template="updateJetpack" siteId={ siteId } version="3.7" />
-				</Main>
-			);
-		}
 		if ( siteId && ! canViewPeople ) {
 			return (
 				<Main>
@@ -103,7 +72,7 @@ export const People = createReactClass( {
 					/>
 					<SidebarNavigation />
 					<EmptyContent
-						title={ this.props.translate( 'You are not authorized to view this page' ) }
+						title={ translate( 'You are not authorized to view this page' ) }
 						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
 					/>
 				</Main>
@@ -121,7 +90,6 @@ export const People = createReactClass( {
 						<PeopleSectionNav
 							isJetpack={ isJetpack }
 							isPrivate={ isPrivate }
-							jetpackPeopleSupported={ jetpackPeopleSupported }
 							canViewPeople={ canViewPeople }
 							search={ search }
 							filter={ filter }
@@ -129,12 +97,12 @@ export const People = createReactClass( {
 						/>
 					}
 					<PeopleNotices />
-					{ this.renderPeopleList( site ) }
+					{ this.renderPeopleList() }
 				</div>
 			</Main>
 		);
-	},
-} );
+	}
+}
 
 export default connect( state => {
 	const siteId = getSelectedSiteId( state );
@@ -144,6 +112,5 @@ export default connect( state => {
 		isJetpack: isJetpackSite( state, siteId ),
 		isPrivate: isPrivateSite( state, siteId ),
 		canViewPeople: canCurrentUser( state, siteId, 'list_users' ),
-		jetpackPeopleSupported: isJetpackMinimumVersion( state, siteId, '3.7.0-beta' ),
 	};
 } )( localize( People ) );

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -25,7 +25,7 @@ import QuerySiteInvites from 'components/data/query-site-invites';
 import Dialog from 'components/dialog';
 import InvitesListEnd from './invites-list-end';
 import { getSelectedSite } from 'state/ui/selectors';
-import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isPrivateSite from 'state/selectors/is-private-site';
 import {
@@ -68,7 +68,7 @@ class PeopleInvites extends React.PureComponent {
 	};
 
 	render() {
-		const { site, canViewPeople, isJetpack, isPrivate, jetpackPeopleSupported } = this.props;
+		const { site, canViewPeople, isJetpack, isPrivate } = this.props;
 		const siteId = site && site.ID;
 
 		if ( siteId && ! canViewPeople ) {
@@ -94,7 +94,6 @@ class PeopleInvites extends React.PureComponent {
 					site={ site }
 					isJetpack={ isJetpack }
 					isPrivate={ isPrivate }
-					jetpackPeopleSupported={ jetpackPeopleSupported }
 				/>
 				{ this.renderInvitesList() }
 			</Main>
@@ -243,7 +242,6 @@ export default connect(
 			site,
 			isJetpack: isJetpackSite( state, siteId ),
 			isPrivate: isPrivateSite( state, siteId ),
-			jetpackPeopleSupported: isJetpackMinimumVersion( state, siteId, '3.7.0-beta' ),
 			requesting: isRequestingInvitesForSite( state, siteId ),
 			pendingInvites: getPendingInvitesForSite( state, siteId ),
 			acceptedInvites: getAcceptedInvitesForSite( state, siteId ),

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -123,16 +123,15 @@ class PeopleSectionNav extends Component {
 	}
 
 	render() {
-		let selectedText,
-			hasPinnedItems = false,
-			search = null;
+		let hasPinnedItems = false;
+		let search = null;
 
 		if ( this.canSearch() ) {
 			hasPinnedItems = true;
 			search = <PeopleSearch { ...this.props } />;
 		}
 
-		selectedText = find( this.getFilters(), { id: this.props.filter } ).title;
+		const selectedText = find( this.getFilters(), { id: this.props.filter } ).title;
 		return (
 			<SectionNav selectedText={ selectedText } hasPinnedItems={ hasPinnedItems }>
 				<PeopleNavTabs

--- a/client/my-sites/people/people-section-nav/index.jsx
+++ b/client/my-sites/people/people-section-nav/index.jsx
@@ -40,7 +40,7 @@ class PeopleNavTabs extends React.Component {
 
 class PeopleSectionNav extends Component {
 	canSearch() {
-		const { isJetpack, jetpackPeopleSupported, filter } = this.props;
+		const { filter } = this.props;
 		if ( ! this.props.site ) {
 			return false;
 		}
@@ -50,16 +50,6 @@ class PeopleSectionNav extends Component {
 			if ( 'followers' === filter || 'viewers' === filter || 'invites' === filter ) {
 				return false;
 			}
-		}
-
-		if ( ! isJetpack ) {
-			// wpcom sites will always support search
-			return true;
-		}
-
-		if ( 'team' === filter && ! jetpackPeopleSupported ) {
-			// Jetpack sites can only search team on versions of 3.7.0-beta or later
-			return false;
 		}
 
 		return true;


### PR DESCRIPTION
Janitorial opportunity I noticed when reviewing #31153:
- the `People` component can be migrated to ES6, as it doesn't need the `observe( 'peopleLog' )` mixin at all
- legacy Jetpack version checks can be removed, too.

**How to test:**
Click around the "People" section and verify that it works: Simple sites, Jetpack sites, private sites... Pay attention to the navigation toolbar:

<img width="729" alt="Screenshot 2019-03-14 at 10 49 35" src="https://user-images.githubusercontent.com/664258/54347394-3e19a080-4647-11e9-80b3-fe11d14682cc.png">

It should display the "Viewers" tab only on private non-Jetpack sites.