### PR TITLE
Jetpack Connect: Add classname to Layout for mobile flow

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -51,6 +51,7 @@ import SupportUser from 'support/support-user';
 import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
 import { isE2ETest } from 'lib/e2e';
 import BodySectionCssClass from './body-section-css-class';
+import { retrieveMobileRedirect } from 'jetpack-connect/persistence-utils';
 
 class Layout extends Component {
 	static displayName = 'Layout';
@@ -108,7 +109,8 @@ class Layout extends Component {
 				{ 'has-no-sidebar': ! this.props.hasSidebar },
 				{ 'has-chat': this.props.chatIsOpen },
 				{ 'has-no-masterbar': this.props.masterbarIsHidden },
-				{ 'is-jetpack-site': this.props.isJetpack }
+				{ 'is-jetpack-site': this.props.isJetpack },
+				{ 'is-jetpack-mobile-flow': this.props.isJetpackMobileFlow }
 			),
 			loadingClass = classnames( {
 				layout__loader: true,
@@ -179,11 +181,13 @@ export default connect( state => {
 	const noMasterbarForCheckout = isJetpack && startsWith( currentRoute, '/checkout' );
 	const noMasterbarForRoute = currentRoute === '/log-in/jetpack' || noMasterbarForCheckout;
 	const noMasterbarForSection = 'signup' === sectionName || 'jetpack-connect' === sectionName;
+	const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
 
 	return {
 		masterbarIsHidden:
 			! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,
 		isJetpack,
+		isJetpackMobileFlow,
 		isLoading: isSectionLoading( state ),
 		isSupportSession: isSupportSession( state ),
 		sectionGroup,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a `is-jetpack-mobile-flow` class for the Jetpack mobile flow.

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/jetpack/connect
* Verify that `.layout` doesn't have a `.is-jetpack-mobile-flow` class.
* Go to http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection
* Verify that `.layout` has also a `.is-jetpack-mobile-flow` class.

Necessary for excluding mobile app flows from color scheme updates coming in #31141.

This uses the mobile app remote install flow, refer to p7rd6c-1eL-p2 for more details.
