### PR TITLE
[e2e] Dismiss Upsell page

### DIFF
--- a/test/e2e/lib/pages/signup/upsell-page.js
+++ b/test/e2e/lib/pages/signup/upsell-page.js
@@ -1,0 +1,19 @@
+/** @format */
+
+import { By } from 'selenium-webdriver';
+
+import * as driverHelper from '../../driver-helper.js';
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class UpsellPage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.concierge-session-nudge' ) );
+	}
+
+	async declineOffer() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.concierge-session-nudge__decline-offer-button' )
+		);
+	}
+}

--- a/test/e2e/lib/shared-steps/wp-signup-spec.js
+++ b/test/e2e/lib/shared-steps/wp-signup-spec.js
@@ -1,5 +1,6 @@
 /** @format */
 import assert from 'assert';
+import UpsellPage from '../pages/signup/upsell-page';
 import ChecklistPage from '../pages/checklist-page';
 import InlineHelpChecklistComponent from '../components/inline-help-checklist-component.js';
 import SitePreviewComponent from '../components/site-preview-component.js';
@@ -37,6 +38,12 @@ export const canSeeTheInlineHelpCongratulations = () => {
 
 export const canSeeTheOnboardingChecklist = () => {
 	step( 'Can then see the onboarding checklist', async function() {
+		// dismiss upsell page if displayed
+		try {
+			const upsellPage = await UpsellPage.Expect( this.driver );
+			await upsellPage.declineOffer();
+		} catch ( e ) {}
+
 		const checklistPage = await ChecklistPage.Expect( this.driver );
 		const header = await checklistPage.headerExists();
 		const subheader = await checklistPage.subheaderExists();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some of the signup tests are [failing](https://circleci.com/gh/Automattic/wp-calypso/216999) after [Upsell page](https://github.com/Automattic/wp-calypso/pull/31330) was introduced. This fix checks if Upsell page is displayed and dismiss it. 

#### Testing instructions

Make sure that signup tests are passing, mobile and desktop. 


