### PR TITLE
Jetpack Connect: Skip site type/topic steps for Atomic

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -25,6 +25,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Gravatar from 'components/gravatar';
 import HelpButton from './help-button';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isVipSite from 'state/selectors/is-vip-site';
 import JetpackConnectHappychatButton from './happychat-button';
 import JetpackConnectNotices from './jetpack-connect-notices';
@@ -576,7 +577,7 @@ export class JetpackAuthorize extends Component {
 
 	getRedirectionTarget() {
 		const { clientId, homeUrl, jpVersion, redirectAfterAuth } = this.props.authQuery;
-		const { canManageOptions, partnerSlug } = this.props;
+		const { canManageOptions, isAtomic, partnerSlug } = this.props;
 
 		// Redirect sites hosted on Pressable with a partner plan to some URL.
 		if (
@@ -588,7 +589,9 @@ export class JetpackAuthorize extends Component {
 
 		const isJetpackVersionSupported = versionCompare( jpVersion, '7.1-alpha', '>=' );
 		const nextRoute =
-			isJetpackVersionSupported && canManageOptions ? JPC_PATH_SITE_TYPE : JPC_PATH_PLANS;
+			isJetpackVersionSupported && canManageOptions && ! isAtomic
+				? JPC_PATH_SITE_TYPE
+				: JPC_PATH_PLANS;
 
 		return addQueryArgs(
 			{ redirect: redirectAfterAuth },
@@ -710,6 +713,7 @@ const connectComponent = connect(
 			hasExpiredSecretError: hasExpiredSecretErrorSelector( state ),
 			hasXmlrpcError: hasXmlrpcErrorSelector( state ),
 			isAlreadyOnSitesList: isRemoteSiteOnSitesList( state, authQuery.site ),
+			isAtomic: isSiteAutomatedTransfer( state, authQuery.clientId ),
 			isFetchingAuthorizationSite: isRequestingSite( state, authQuery.clientId ),
 			isFetchingSites: isRequestingSites( state ),
 			isMobileAppFlow,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Skip site type and site topic steps for Atomic sites that are being reconnected.

#### Testing instructions

* Checkout this branch.
* Get a disconnected Atomic site with the latest Jetpack.
* Copy the connection URL from the "Set up" button in Jetpack, add `&calypso_env=development` to it.
* Open the resulting URL.
* Go through the connection flow.
* Verify you don't end up in the site type step anymore.
* Create a JN site with the latest Jetpack: https://jurassic.ninja/create?shortlived&jetpack-beta
* Copy the connection URL from the "Set up" button in Jetpack, add `&calypso_env=development` to it.
* Open the resulting URL.
* Go through the connection flow.
* Verify you still end up in the site type step.

Fixes #31435.