### PR TITLE
Adding lerna-debug.log to the .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ test-results*.xml
 /stats.json
 spec-xunit-reporter-0.0.1.tgz
 *xunit_*.xml
+lerna-debug.log
 
 # added during build
 /config/secrets.json


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds lerna-debug.log to the `.gitignore` file

#### Testing instructions

Does git ignore files called `lerna-debug.log`?
