### PR TITLE
Site Settings: import moment-timezone directly rather than from i18n-calypso

### DIFF
--- a/client/my-sites/site-settings/date-time-format/utils.js
+++ b/client/my-sites/site-settings/date-time-format/utils.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { moment } from 'i18n-calypso';
+import moment from 'moment-timezone';
 import { has, startsWith } from 'lodash';
 
 /**

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import { flowRight, get, has } from 'lodash';
+import moment from 'moment-timezone';
 
 /**
  * Internal dependencies
@@ -350,7 +351,7 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	Timezone() {
-		const { fields, isRequestingSettings, translate, moment } = this.props;
+		const { fields, isRequestingSettings, translate } = this.props;
 		const guessedTimezone = moment.tz.guess();
 		const setGuessedTimezone = this.onTimezoneSelect.bind( this, guessedTimezone );
 


### PR DESCRIPTION
`moment-timezone` is used in Site Settings for two purposes:

- to guess user's time zone and provide a hint when configuring site's timezone:

<img width="565" alt="Screenshot 2019-03-14 at 15 17 53" src="https://user-images.githubusercontent.com/664258/54364669-a67b7880-466d-11e9-9018-9b054b6e202e.png">

- to adjust a moment to site's time zone when configuring datetime format for site. That 06:43 time in the screenshot below? That's not my local time, but the time in the configured site's timezone:

<img width="726" alt="Screenshot 2019-03-14 at 14 45 07" src="https://user-images.githubusercontent.com/664258/54364763-d3c82680-466d-11e9-85d4-0a0891350f2a.png">

None of these are locale-specific. This change will let us remove `moment-timezone` from `i18n-calypso` and make Calypso bundle smaller.
