### PR TITLE
Fix how we run lint:js to catch our jsx files

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
     "lint": "run-s -s lint:*",
     "lint:config-defaults": "node server/config/validate-config-keys.js",
     "lint:css": "stylelint \"client/**/*.scss\" --syntax scss",
-    "lint:js": "npm run -s install-if-deps-outdated && eslint .",
+    "lint:js": "npm run -s install-if-deps-outdated && eslint --ext .js --ext .jsx --cache .",
     "lint:mixedindent": "mixedindentlint --ignore-comments \"client/**/*.scss\" \"assets/**/*.scss\" \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/config/index.js\"",
     "prestart": "npx check-node-version --package && npm run -s install-if-deps-outdated && node bin/welcome.js",
     "start": "npm run -s build",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change `npm run lint:js` to include `jsx` files and to use the cache

#### Testing instructions

* Run `npm run lint:js`. Errors should include jsx files now.

Noticed while reviewing https://github.com/Automattic/wp-calypso/pull/31439
