### PR TITLE
Import Signup Flow: Support "drilling in" to all importers via query args

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -333,7 +333,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		destination: ( { importSiteDetails, importUrl, siteSlug } ) =>
 			addQueryArgs(
 				{
-					engine: importSiteDetails.engine === 'wix' ? 'wix' : null,
+					engine: importSiteDetails.engine || null,
 					'from-site': ( importUrl && encodeURIComponent( importUrl ) ) || null,
 				},
 				`/settings/import/${ siteSlug }`

--- a/client/state/importer-nux/reducer.js
+++ b/client/state/importer-nux/reducer.js
@@ -29,15 +29,12 @@ export const isUrlInputDisabled = createReducer( false, {
 } );
 
 export const siteDetails = createReducer( null, {
-	[ IMPORT_IS_SITE_IMPORTABLE_RECEIVE ]: ( state, { engine, favicon, siteTitle, siteUrl } ) =>
-		engine && siteUrl
-			? {
-					engine,
-					favicon,
-					siteTitle,
-					siteUrl,
-			  }
-			: null,
+	[ IMPORT_IS_SITE_IMPORTABLE_RECEIVE ]: ( state, { engine, favicon, siteTitle, siteUrl } ) => ( {
+		engine,
+		favicon,
+		siteTitle,
+		siteUrl,
+	} ),
 	[ IMPORT_IS_SITE_IMPORTABLE_ERROR ]: () => null,
 	[ 'FLUX_IMPORTS_IMPORT_CANCEL' ]: () => null,
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't check for particular values for `importSiteDetails.engine` in the signup flow
* Pass it along and let the destination determine if it's a valid engine
* When the currently-selected engine is in the "supported" list, render it (vs. just checking for a single engine)
* Always set `state.importerNux.siteDetails` for the action -- not just when engine & url are present

#### Testing instructions

* Run this branch
* Make sure you have no "active" import
* Browse to `/settings/import/<yourtestsite.wordpress.com>/?engine=engine6`
  * You should be taken to the engine6 importer
* Repeat with a `from-site=<yourengine6url>` as well
  * You should be taken to the engine6 importer with the provided URL in place and checking

**Existing importers & flows should "still work"**