### PR TITLE
Lint: Ignore nested node_modules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,6 +4,6 @@
 /docs/
 /public/
 /packages/*/dist/**/*
-/packages/*/node_modules
+**/node_modules/**/*
 !.eslintrc.js
 /server/devdocs/search-index.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -4,7 +4,7 @@
 /docs/
 /public/
 /packages/*/dist/**/*
-**/node_modules/**/*
+node_modules/
 !.eslintrc.js
 /server/devdocs/search-index.js
 **/presets/**/build/**/*

--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@
 **/node_modules/**/*
 !.eslintrc.js
 /server/devdocs/search-index.js
+**/presets/**/build/**/*


### PR DESCRIPTION
Like those under the e2e tests and in packages.

#### Changes proposed in this Pull Request

* Ignore files under e2e-tests/node_modules when running `npm run lint:js`

#### Testing instructions

* run `npm run lint:js`
* make sure no errors are reported for files inside a node_modules
