### PR TITLE
Signup: Add TrainTracks integration to site vertical suggestions

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { debounce, find, get, noop, startsWith, trim, uniq, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { v4 as uuid } from 'uuid';
 
 /**
  * Internal dependencies
@@ -45,6 +46,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		super( props );
 		this.state = {
 			searchValue: props.initialValue,
+			railcar: this.getNewRailcar(),
 		};
 		props.requestDefaultVertical();
 	}
@@ -63,6 +65,14 @@ export class SiteVerticalsSuggestionSearch extends Component {
 				this.state.searchValue
 			);
 		}
+	}
+
+	getNewRailcar() {
+		return {
+			id: `${ uuid().replace( /-/g, '' ) }-site-vertical-suggestion`,
+			fetch_algo: '/verticals',
+			action: 'site_vertical_selected',
+		};
 	}
 
 	// When a user is keying through the results,
@@ -106,6 +116,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			! result
 		) {
 			this.props.requestVerticals( value, this.props.searchResultsLimit );
+			this.setState( { railcar: this.getNewRailcar() } );
 		}
 
 		this.setState( { searchValue: value } );
@@ -149,6 +160,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 				value={ this.state.searchValue }
 				sortResults={ this.sortSearchResults }
 				autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
+				railcar={ this.state.railcar }
 			/>
 		);
 	}

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -6,6 +6,13 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
   id="siteTopic"
   onChange={[Function]}
   placeholder="e.g. Fashion, travel, design, plumbing"
+  railcar={
+    Object {
+      "action": "site_vertical_selected",
+      "fetch_algo": "/verticals",
+      "id": "fakeuuid-site-vertical-suggestion",
+    }
+  }
   sortResults={[Function]}
   suggestions={
     Array [

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -16,6 +16,10 @@ import { shallow } from 'enzyme';
 import { SiteVerticalsSuggestionSearch } from '../';
 import SuggestionSearch from 'components/suggestion-search';
 
+jest.mock( 'uuid', () => ( {
+	v4: () => 'fake-uuid',
+} ) );
+
 const defaultProps = {
 	onChange: jest.fn(),
 	requestVerticals: jest.fn(),

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -28,6 +28,7 @@ class SuggestionSearch extends Component {
 		suggestions: PropTypes.array,
 		value: PropTypes.string,
 		autoFocus: PropTypes.bool,
+		railcar: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -145,6 +146,7 @@ class SuggestionSearch extends Component {
 					query={ escapeRegExp( this.state.query ) }
 					suggestions={ this.getSuggestions() }
 					suggest={ this.handleSuggestionMouseDown }
+					railcar={ this.props.railcar }
 				/>
 			</div>
 		);

--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -28,6 +28,7 @@ class Suggestions extends Component {
 			} )
 		).isRequired,
 		suggest: PropTypes.func.isRequired,
+		railcar: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -109,7 +110,7 @@ class Suggestions extends Component {
 		} );
 
 	render() {
-		const { query } = this.props;
+		const { query, railcar } = this.props;
 		const showSuggestions = this.getSuggestionsCount() > 0;
 
 		return (
@@ -117,6 +118,7 @@ class Suggestions extends Component {
 				{ showSuggestions && (
 					<div className="suggestions__wrapper">
 						{ map( this.props.suggestions, ( { label }, index ) => (
+							// eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
 							<Item
 								key={ index }
 								hasHighlight={ index === this.state.suggestionPosition }
@@ -124,6 +126,13 @@ class Suggestions extends Component {
 								onMouseDown={ this.handleMouseDown }
 								onMouseOver={ this.handleMouseOver }
 								label={ label }
+								railcar={
+									railcar && {
+										...railcar,
+										railcar: `${ railcar.id }-${ index }`,
+										fetch_position: index,
+									}
+								}
 								ref={ suggestion => {
 									this.refsCollection[ 'suggestion_' + index ] = suggestion;
 								} }

--- a/client/components/suggestions/item.jsx
+++ b/client/components/suggestions/item.jsx
@@ -3,10 +3,15 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { pick } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { tracks } from 'lib/analytics';
 
 class Item extends PureComponent {
 	static propTypes = {
@@ -15,12 +20,23 @@ class Item extends PureComponent {
 		query: PropTypes.string,
 		onMouseDown: PropTypes.func.isRequired,
 		onMouseOver: PropTypes.func.isRequired,
+		railcar: PropTypes.object,
 	};
 
 	static defaultProps = {
 		hasHighlight: false,
 		query: '',
 	};
+
+	componentDidMount() {
+		const { railcar } = this.props;
+		if ( railcar ) {
+			tracks.recordEvent(
+				'calypso_traintracks_render',
+				pick( railcar, [ 'railcar', 'fetch_algo', 'fetch_position' ] )
+			);
+		}
+	}
 
 	/**
 	 * Highlights the part of the text that matches the query.
@@ -48,10 +64,18 @@ class Item extends PureComponent {
 	}
 
 	handleMouseDown = event => {
+		const { railcar } = this.props;
+
 		event.stopPropagation();
 		event.preventDefault();
 
 		this.props.onMouseDown( this.props.label );
+		if ( railcar ) {
+			tracks.recordEvent(
+				'calypso_traintracks_interact',
+				pick( railcar, [ 'railcar', 'action' ] )
+			);
+		}
 	};
 
 	handleMouseOver = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Tracks Events for site vertical suggestions search.
See [the trello card](https://trello.com/c/GNQgnGwq) or `#comment-2993` of p3QzjZ-Tc-p2 for more detail.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Turn on `calypso:analytics:tracks` debug log.
   ```
   localStorage.setItem('debug', 'calypso:analytics:tracks');
   ```
* Try to search site verticals in the `about` step of `main` flow or the `site-type` step of `onboarding` flow.
* The `calypso_traintracks_render` should be triggered when each item renders.
* If you click a suggestion, `calypso_tracktracks_interact` event fires.
<img width="427" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/54374365-524eb380-46c2-11e9-8a1e-ce9e9d24ab51.png">

