### PR TITLE
Signup: add sub-header to site type step.

### DIFF
--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -35,8 +35,10 @@ class SiteType extends Component {
 			hasInitializedSitesBackUrl,
 		} = this.props;
 
-		const headerText = translate( 'Start with a site type' );
-		const subHeaderText = '';
+		const headerText = translate( 'What are we building today?' );
+		const subHeaderText = translate(
+			'Choose the best starting point for your site. You can add or change features later on.'
+		);
 
 		return (
 			<StepWrapper


### PR DESCRIPTION
This changes the title of the site-type step in the `/onboarding/` flow and adds a sub-header to be more helpful/encouraging for the user.

**Before:**
<img width="555" alt="Screen Shot 2019-03-14 at 12 37 36 PM" src="https://user-images.githubusercontent.com/942359/54374708-141baa80-4656-11e9-92d9-5bf999c93ebf.png">

**After:**
<img width="668" alt="Screen Shot 2019-03-14 at 12 37 26 PM" src="https://user-images.githubusercontent.com/942359/54374692-082fe880-4656-11e9-9901-b89fba6b6ccf.png">

**To test:**
- visit `/start/onboarding/`
- verify that the title of the site-type step has changed and that a sub-header is shown
