### PR TITLE
SCSS: Add an elevation mixin

### DIFF
--- a/assets/stylesheets/shared/mixins/_elevation.scss
+++ b/assets/stylesheets/shared/mixins/_elevation.scss
@@ -6,7 +6,7 @@
         box-shadow: none
     }
     @else if $dp==1 {
-        box-shadow: 0 1px 1px 0 rgba(0, 0, 0, .14), 0 2px 1px -1px rgba(0, 0, 0, .12), 0 1px 3px 0 rgba(0, 0, 0, .20)
+        box-shadow: 0 1px 1px 0 rgba( var( --color-neutral-900-rgb ), .14), 0 2px 1px -1px rgba( var( --color-neutral-900-rgb ), .12), 0 1px 3px 0 rgba( var( --color-neutral-900-rgb ), .20)
     }
     @else if $dp==2 {
         box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .14), 0 3px 1px -2px rgba(0, 0, 0, .12), 0 1px 5px 0 rgba(0, 0, 0, .20)

--- a/assets/stylesheets/shared/mixins/_elevation.scss
+++ b/assets/stylesheets/shared/mixins/_elevation.scss
@@ -1,0 +1,38 @@
+// A mixin to make it easy to add Material elevation
+// to elements with CSS.
+
+@mixin elevation ( $dp ) {
+    @if $dp==0 {
+        box-shadow: none
+    }
+    @else if $dp==1 {
+        box-shadow: 0 1px 1px 0 rgba(0, 0, 0, .14), 0 2px 1px -1px rgba(0, 0, 0, .12), 0 1px 3px 0 rgba(0, 0, 0, .20)
+    }
+    @else if $dp==2 {
+        box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .14), 0 3px 1px -2px rgba(0, 0, 0, .12), 0 1px 5px 0 rgba(0, 0, 0, .20)
+    }
+    @else if $dp==3 {
+        box-shadow: 0 3px 4px 0 rgba(0, 0, 0, .14), 0 3px 3px -2px rgba(0, 0, 0, .12), 0 1px 8px 0 rgba(0, 0, 0, .20)
+    }
+    @else if $dp==4 {
+        box-shadow: 0 4px 5px 0 rgba(0, 0, 0, .14), 0 1px 10px 0 rgba(0, 0, 0, .12), 0 2px 4px -1px rgba(0, 0, 0, .20)
+    }
+    @else if $dp==6 {
+        box-shadow: 0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12), 0 3px 5px -1px rgba(0, 0, 0, .20)
+    }
+    @else if $dp==8 {
+        box-shadow: 0 8px 10px 1px rgba(0, 0, 0, .14), 0 3px 14px 2px rgba(0, 0, 0, .12), 0 5px 5px -3px rgba(0, 0, 0, .20)
+    }
+    @else if $dp==9 {
+        box-shadow: 0 9px 12px 1px rgba(0, 0, 0, .14), 0 3px 16px 2px rgba(0, 0, 0, .12), 0 5px 6px -3px rgba(0, 0, 0, .20)
+    }
+    @else if $dp==12 {
+        box-shadow: 0 12px 17px 2px rgba(0, 0, 0, .14), 0 5px 22px 4px rgba(0, 0, 0, .12), 0 7px 8px -4px rgba(0, 0, 0, .20)
+    }
+    @else if $dp==16 {
+        box-shadow: 0 16px 24px 2px rgba(0, 0, 0, .14), 0 6px 30px 5px rgba(0, 0, 0, .12), 0 8px 10px -5px rgba(0, 0, 0, .20)
+    }
+    @else if $dp==24 {
+        box-shadow: 0 24px 38px 3px rgba(0, 0, 0, .14), 0 9px 46px 8px rgba(0, 0, 0, .12), 0 11px 15px -7px rgba(0, 0, 0, .20)
+    }
+}

--- a/assets/stylesheets/shared/mixins/_elevation.scss
+++ b/assets/stylesheets/shared/mixins/_elevation.scss
@@ -6,33 +6,53 @@
         box-shadow: none
     }
     @else if $dp==1 {
-        box-shadow: 0 1px 1px 0 rgba( var( --color-neutral-900-rgb ), .14), 0 2px 1px -1px rgba( var( --color-neutral-900-rgb ), .12), 0 1px 3px 0 rgba( var( --color-neutral-900-rgb ), .20)
+        box-shadow: 0 1px 1px 0 rgba( var( --color-black-rgb ), .14),
+                    0 2px 1px -1px rgba( var( --color-black-rgb ), .12),
+                    0 1px 3px 0 rgba( var( --color-black-rgb ), .20)
     }
     @else if $dp==2 {
-        box-shadow: 0 2px 2px 0 rgba(0, 0, 0, .14), 0 3px 1px -2px rgba(0, 0, 0, .12), 0 1px 5px 0 rgba(0, 0, 0, .20)
+        box-shadow: 0 2px 2px 0 rgba( var( --color-black-rgb ), .14),
+                    0 3px 1px -2px rgba( var( --color-black-rgb ), .12),
+                    0 1px 5px 0 rgba( var( --color-black-rgb ), .20)
     }
     @else if $dp==3 {
-        box-shadow: 0 3px 4px 0 rgba(0, 0, 0, .14), 0 3px 3px -2px rgba(0, 0, 0, .12), 0 1px 8px 0 rgba(0, 0, 0, .20)
+        box-shadow: 0 3px 4px 0 rgba( var( --color-black-rgb ), .14),
+                    0 3px 3px -2px rgba( var( --color-black-rgb ), .12),
+                    0 1px 8px 0 rgba( var( --color-black-rgb ), .20)
     }
     @else if $dp==4 {
-        box-shadow: 0 4px 5px 0 rgba(0, 0, 0, .14), 0 1px 10px 0 rgba(0, 0, 0, .12), 0 2px 4px -1px rgba(0, 0, 0, .20)
+        box-shadow: 0 4px 5px 0 rgba( var( --color-black-rgb ), .14),
+                    0 1px 10px 0 rgba( var( --color-black-rgb ), .12),
+                    0 2px 4px -1px rgba( var( --color-black-rgb ), .20)
     }
     @else if $dp==6 {
-        box-shadow: 0 6px 10px 0 rgba(0, 0, 0, .14), 0 1px 18px 0 rgba(0, 0, 0, .12), 0 3px 5px -1px rgba(0, 0, 0, .20)
+        box-shadow: 0 6px 10px 0 rgba( var( --color-black-rgb ), .14),
+                    0 1px 18px 0 rgba( var( --color-black-rgb ), .12),
+                    0 3px 5px -1px rgba( var( --color-black-rgb ), .20)
     }
     @else if $dp==8 {
-        box-shadow: 0 8px 10px 1px rgba(0, 0, 0, .14), 0 3px 14px 2px rgba(0, 0, 0, .12), 0 5px 5px -3px rgba(0, 0, 0, .20)
+        box-shadow: 0 8px 10px 1px rgba( var( --color-black-rgb ), .14),
+                    0 3px 14px 2px rgba( var( --color-black-rgb ), .12),
+                    0 5px 5px -3px rgba( var( --color-black-rgb ), .20)
     }
     @else if $dp==9 {
-        box-shadow: 0 9px 12px 1px rgba(0, 0, 0, .14), 0 3px 16px 2px rgba(0, 0, 0, .12), 0 5px 6px -3px rgba(0, 0, 0, .20)
+        box-shadow: 0 9px 12px 1px rgba( var( --color-black-rgb ), .14),
+                    0 3px 16px 2px rgba( var( --color-black-rgb ), .12),
+                    0 5px 6px -3px rgba( var( --color-black-rgb ), .20)
     }
     @else if $dp==12 {
-        box-shadow: 0 12px 17px 2px rgba(0, 0, 0, .14), 0 5px 22px 4px rgba(0, 0, 0, .12), 0 7px 8px -4px rgba(0, 0, 0, .20)
+        box-shadow: 0 12px 17px 2px rgba( var( --color-black-rgb ), .14),
+                    0 5px 22px 4px rgba( var( --color-black-rgb ), .12),
+                    0 7px 8px -4px rgba( var( --color-black-rgb ), .20)
     }
     @else if $dp==16 {
-        box-shadow: 0 16px 24px 2px rgba(0, 0, 0, .14), 0 6px 30px 5px rgba(0, 0, 0, .12), 0 8px 10px -5px rgba(0, 0, 0, .20)
+        box-shadow: 0 16px 24px 2px rgba( var( --color-black-rgb ), .14),
+                    0 6px 30px 5px rgba( var( --color-black-rgb ), .12),
+                    0 8px 10px -5px rgba( var( --color-black-rgb ), .20)
     }
     @else if $dp==24 {
-        box-shadow: 0 24px 38px 3px rgba(0, 0, 0, .14), 0 9px 46px 8px rgba(0, 0, 0, .12), 0 11px 15px -7px rgba(0, 0, 0, .20)
+        box-shadow: 0 24px 38px 3px rgba( var( --color-black-rgb ), .14),
+                    0 9px 46px 8px rgba( var( --color-black-rgb ), .12),
+                    0 11px 15px -7px rgba( var( --color-black-rgb ), .20)
     }
 }

--- a/assets/stylesheets/shared/mixins/_mixins.scss
+++ b/assets/stylesheets/shared/mixins/_mixins.scss
@@ -5,6 +5,7 @@
 @import 'clear-fix';
 @import 'clear-text';
 @import 'dropdown-menu';
+@import 'elevation';
 @import 'heading';
 @import 'hide-content-accessibly';
 @import 'long-content-fade';

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -3,9 +3,7 @@
 	width: 380px;
 	padding: 0;
 	border-radius: 3px;
-	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ),
-				0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
-				0 1px 5px 0 rgba( 0, 0, 0, 0.20 );
+	@include elevation ( 2dp );
 
 	// At small screen sizes make the step
 	// full width. -shaun

--- a/packages/calypso-color-schemes/src/shared/_color-schemes.scss
+++ b/packages/calypso-color-schemes/src/shared/_color-schemes.scss
@@ -60,6 +60,8 @@
 
 	--color-white: #{$muriel-white};
 	--color-white-rgb: #{hex-to-rgb( $muriel-white )};
+	--color-black: #000000;
+	--color-black-rgb: #000000;
 	--color-neutral: #{$muriel-gray-500};
 	--color-neutral-rgb: #{hex-to-rgb( $muriel-gray-500 )};
 	--color-neutral-dark: #{$muriel-gray-700};


### PR DESCRIPTION
With this mixin we can add Material-style box-shadows to elements using `@include elevation( 2 )`. You can read more about Material's elevation CSS over here: https://material.io/develop/web/components/elevation/