### PR TITLE
Revert "Import Signup Flow: Support "drilling in" to all importers via query args"

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -333,7 +333,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		destination: ( { importSiteDetails, importUrl, siteSlug } ) =>
 			addQueryArgs(
 				{
-					engine: importSiteDetails.engine || null,
+					engine: importSiteDetails.engine === 'wix' ? 'wix' : null,
 					'from-site': ( importUrl && encodeURIComponent( importUrl ) ) || null,
 				},
 				`/settings/import/${ siteSlug }`

--- a/client/state/importer-nux/reducer.js
+++ b/client/state/importer-nux/reducer.js
@@ -29,12 +29,15 @@ export const isUrlInputDisabled = createReducer( false, {
 } );
 
 export const siteDetails = createReducer( null, {
-	[ IMPORT_IS_SITE_IMPORTABLE_RECEIVE ]: ( state, { engine, favicon, siteTitle, siteUrl } ) => ( {
-		engine,
-		favicon,
-		siteTitle,
-		siteUrl,
-	} ),
+	[ IMPORT_IS_SITE_IMPORTABLE_RECEIVE ]: ( state, { engine, favicon, siteTitle, siteUrl } ) =>
+		engine && siteUrl
+			? {
+					engine,
+					favicon,
+					siteTitle,
+					siteUrl,
+			  }
+			: null,
 	[ IMPORT_IS_SITE_IMPORTABLE_ERROR ]: () => null,
 	[ 'FLUX_IMPORTS_IMPORT_CANCEL' ]: () => null,
 } );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#31462

---

Existing flow did not work with this change.