### PR TITLE
Expect auth cookie in support session

### DIFF
--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -216,7 +216,7 @@ function getAcceptedLanguagesFromHeader( header ) {
  */
 function setupLoggedInContext( req, res, next ) {
 	const isSupportSession = !! req.get( 'x-support-session' );
-	const isLoggedIn = isSupportSession || !! req.cookies.wordpress_logged_in;
+	const isLoggedIn = !! req.cookies.wordpress_logged_in;
 
 	req.context = {
 		...req.context,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -635,13 +635,10 @@ module.exports = function() {
 			return;
 		}
 		if ( 'change-theme' === req.params.section ) {
-			redirectUrl = req.originalUrl.replace(
-				/^\/sites\/[0-9a-zA-Z\-\.]+\/change\-theme/,
-				'/themes'
-			);
+			redirectUrl = req.originalUrl.replace( /^\/sites\/[0-9a-zA-Z\-.]+\/change-theme/, '/themes' );
 		} else {
 			redirectUrl = req.originalUrl.replace(
-				/^\/sites\/[0-9a-zA-Z\-\.]+\/\w+/,
+				/^\/sites\/[0-9a-zA-Z\-.]+\/\w+/,
 				'/' + req.params.section + '/' + req.params.site
 			);
 		}

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -41,6 +41,11 @@ module.exports = function( request ) {
 	const supportSession = request.get( 'x-support-session' );
 
 	return new Promise( ( resolve, reject ) => {
+		if ( ! authCookieValue ) {
+			reject( new Error( 'Cannot bootstrap without an auth cookie' ) );
+			return;
+		}
+
 		// create HTTP Request object
 		const req = superagent.get( url );
 		req.set( 'User-Agent', 'WordPress.com Calypso' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, we did not permit the `wordpress_logged_in` cookie to be present with a support session during user bootstrap, but now, we need to permit and relay that cookie along with the session. (Please feel free to ping me for additional detail.)

This PR updates user bootstrapping to always require the auth cookie and simplifies our `isLoggedIn` condition to rely solely on the cookie's presence.

#### Testing instructions

Enable user bootstrapping locally and test that it works properly for regular logins.

I've tested that it works for both regular logins and support sessions.

cc @jmdodd
