### PR TITLE
Signup: Remove debounce cancel

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -93,12 +93,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		const valueLengthShouldTriggerSearch = valueLength >= this.props.charsToTriggerSearch;
 		const result = this.searchForVerticalMatches( value );
 
-		// Cancel delayed invocations in case of deletion
-		// and make sure the consuming component knows about it.
-		if ( ! hasValue || ! valueLengthShouldTriggerSearch ) {
-			this.props.requestVerticals.cancel();
-		}
-
 		if (
 			hasValue &&
 			valueLengthShouldTriggerSearch &&

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -76,14 +76,6 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 		expect( defaultProps.onChange ).toHaveBeenLastCalledWith( defaultProps.verticals[ 0 ] );
 	} );
 
-	test( 'should cancel debounced invocations when the search value is falsey or has fewer chars than `props.charsToTriggerSearch`', () => {
-		const wrapper = shallow( <SiteVerticalsSuggestionSearch { ...defaultProps } /> );
-		wrapper.instance().onSiteTopicChange( 'b' );
-		expect( defaultProps.requestVerticals.cancel ).toHaveBeenCalledTimes( 1 );
-		wrapper.instance().onSiteTopicChange( null );
-		expect( defaultProps.requestVerticals.cancel ).toHaveBeenCalledTimes( 2 );
-	} );
-
 	describe( 'searchForVerticalMatches()', () => {
 		test( 'should return `undefined` by default', () => {
 			const wrapper = shallow( <SiteVerticalsSuggestionSearch { ...defaultProps } /> );


### PR DESCRIPTION
## Changes proposed in this Pull Request

I r[emoved debounce](https://github.com/Automattic/wp-calypso/pull/31449/files#diff-9553ff7100a8a69d6011c3bc6f8dded2L9), but not the debounce cancel :(

<img width="668" alt="Screen Shot 2019-03-15 at 12 39 55 pm" src="https://user-images.githubusercontent.com/6458278/54402260-78ef0780-471f-11e9-8f86-ba9fc9280dcb.png">

## Testing instructions

Enter some searches in the onboarding flow site vertical search box, then delete characters until there are none left. You shouldn't see the above error.