### PR TITLE
Enable `show-tax` feature flag on staging, horizon & wpcalypso

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -103,7 +103,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
-		"show-tax": false,
+		"show-tax": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -119,7 +119,7 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": false,
-		"show-tax": false,
+		"show-tax": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -139,7 +139,7 @@
 		"settings/security/monitor": true,
 		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
-		"show-tax": false,
+		"show-tax": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables taxes on checkout in the US on `staging`, `horizon` and `wpcalypso`, moving the Tax on Checkout project to internal testing.

#### Testing instructions

Check that everything works as expected, showing tax in the US and not outside the US for:

- checkout
- purchase
- manage purchases
- purchase history

A more complete list is available internally at: https://wp.me/p5uIfZ-8Ng
