### PR TITLE
Signup: site type options are sometimes not translated

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -10,76 +10,6 @@ import { find, get } from 'lodash';
  */
 
 /**
- * Current list of site types that are displayed in the signup site-type step
- * Some (or all) of these site types will also have landing pages.
- * A user who comes in via a landing page will not see the Site Topic dropdown.
- */
-export const allSiteTypes = [
-	{
-		id: 2,
-		slug: 'blog',
-		label: i18n.translate( 'Blog' ),
-		description: i18n.translate( 'Share and discuss ideas, updates, or creations.' ),
-		theme: 'pub/independent-publisher-2',
-		designType: 'blog',
-		siteTitleLabel: i18n.translate( 'What would you like to call your blog?' ),
-		siteTitlePlaceholder: i18n.translate( "E.g., Stevie's blog " ),
-		siteTopicHeader: i18n.translate( 'Tell us about your blog' ),
-		siteTopicLabel: i18n.translate( 'What will your blog be about?' ),
-	},
-	{
-		id: 1,
-		slug: 'business',
-		label: i18n.translate( 'Business' ),
-		description: i18n.translate( 'Promote products and services.' ),
-		theme: 'pub/professional-business',
-		designType: 'page',
-		siteTitleLabel: i18n.translate( 'What is the name of your business?' ),
-		siteTitlePlaceholder: i18n.translate( 'E.g., Vail Renovations' ),
-		siteTopicHeader: i18n.translate( 'Tell us about your business' ),
-		siteTopicLabel: i18n.translate( 'What type of business do you have?' ),
-		customerType: 'business',
-	},
-	{
-		id: 3,
-		slug: 'professional',
-		label: i18n.translate( 'Professional' ),
-		description: i18n.translate( 'Showcase your portfolio and work.' ),
-		theme: 'pub/altofocus',
-		designType: 'portfolio',
-		siteTitleLabel: i18n.translate( 'What is your name?' ),
-		siteTitlePlaceholder: i18n.translate( 'E.g., John Appleseed' ),
-		siteTopicHeader: i18n.translate( 'Tell us about your website' ),
-		siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
-	},
-	{
-		id: 4,
-		slug: 'education',
-		label: i18n.translate( 'Education' ),
-		description: i18n.translate( 'Share school projects and class info.' ),
-		theme: 'pub/twentyfifteen',
-		designType: 'blog',
-		siteTitleLabel: i18n.translate( 'What is the name of your site?' ),
-		siteTitlePlaceholder: i18n.translate( 'E.g., My class' ),
-		siteTopicHeader: i18n.translate( 'Tell us about your website' ),
-		siteTopicLabel: i18n.translate( 'What will your site be about?' ),
-	},
-	{
-		id: 5,
-		slug: 'online-store',
-		label: i18n.translate( 'Online store' ),
-		description: i18n.translate( 'Sell your collection of products online.' ),
-		theme: 'pub/dara',
-		designType: 'store',
-		siteTitleLabel: i18n.translate( 'What is the name of your store?' ),
-		siteTitlePlaceholder: i18n.translate( "E.g., Mel's Diner" ),
-		siteTopicHeader: i18n.translate( 'Tell us about your website' ),
-		siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
-		customerType: 'business',
-	},
-];
-
-/**
  * Finds in `allSiteTypes` for item match and returns a property value
  *
  * @example
@@ -92,7 +22,81 @@ export const allSiteTypes = [
  * @param {array} siteTypes (optional) A site type collection
  * @return {(string|int)?} value of `property` or `null` if none is found
  */
-export function getSiteTypePropertyValue( key, value, property, siteTypes = allSiteTypes ) {
+export function getSiteTypePropertyValue( key, value, property, siteTypes = getAllSiteTypes() ) {
 	const siteTypeProperties = find( siteTypes, { [ key ]: value } );
 	return get( siteTypeProperties, property, null );
+}
+
+/**
+ * Returns a current list of site types that are displayed in the signup site-type step
+ * Some (or all) of these site types will also have landing pages.
+ * A user who comes in via a landing page will not see the Site Topic dropdown.
+ *
+ * @return {array} current list of site types
+ */
+export function getAllSiteTypes() {
+	return [
+		{
+			id: 2,
+			slug: 'blog',
+			label: i18n.translate( 'Blog' ),
+			description: i18n.translate( 'Share and discuss ideas, updates, or creations.' ),
+			theme: 'pub/independent-publisher-2',
+			designType: 'blog',
+			siteTitleLabel: i18n.translate( 'What would you like to call your blog?' ),
+			siteTitlePlaceholder: i18n.translate( "E.g., Stevie's blog " ),
+			siteTopicHeader: i18n.translate( 'Tell us about your blog' ),
+			siteTopicLabel: i18n.translate( 'What will your blog be about?' ),
+		},
+		{
+			id: 1,
+			slug: 'business',
+			label: i18n.translate( 'Business' ),
+			description: i18n.translate( 'Promote products and services.' ),
+			theme: 'pub/professional-business',
+			designType: 'page',
+			siteTitleLabel: i18n.translate( 'What is the name of your business?' ),
+			siteTitlePlaceholder: i18n.translate( 'E.g., Vail Renovations' ),
+			siteTopicHeader: i18n.translate( 'Tell us about your business' ),
+			siteTopicLabel: i18n.translate( 'What type of business do you have?' ),
+			customerType: 'business',
+		},
+		{
+			id: 3,
+			slug: 'professional',
+			label: i18n.translate( 'Professional' ),
+			description: i18n.translate( 'Showcase your portfolio and work.' ),
+			theme: 'pub/altofocus',
+			designType: 'portfolio',
+			siteTitleLabel: i18n.translate( 'What is your name?' ),
+			siteTitlePlaceholder: i18n.translate( 'E.g., John Appleseed' ),
+			siteTopicHeader: i18n.translate( 'Tell us about your website' ),
+			siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
+		},
+		{
+			id: 4,
+			slug: 'education',
+			label: i18n.translate( 'Education' ),
+			description: i18n.translate( 'Share school projects and class info.' ),
+			theme: 'pub/twentyfifteen',
+			designType: 'blog',
+			siteTitleLabel: i18n.translate( 'What is the name of your site?' ),
+			siteTitlePlaceholder: i18n.translate( 'E.g., My class' ),
+			siteTopicHeader: i18n.translate( 'Tell us about your website' ),
+			siteTopicLabel: i18n.translate( 'What will your site be about?' ),
+		},
+		{
+			id: 5,
+			slug: 'online-store',
+			label: i18n.translate( 'Online store' ),
+			description: i18n.translate( 'Sell your collection of products online.' ),
+			theme: 'pub/dara',
+			designType: 'store',
+			siteTitleLabel: i18n.translate( 'What is the name of your store?' ),
+			siteTitlePlaceholder: i18n.translate( "E.g., Mel's Diner" ),
+			siteTopicHeader: i18n.translate( 'Tell us about your website' ),
+			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
+			customerType: 'business',
+		},
+	];
 }

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -10,10 +10,10 @@ import { find, get } from 'lodash';
  */
 
 /**
- * Finds in `allSiteTypes` for item match and returns a property value
+ * Looks up site types array for item match and returns a property value
  *
  * @example
- * // Find the item in `allSiteTypes` where `id === 2`, and return the value of `slug`
+ * // Find the site type where `id === 2`, and return the value of `slug`
  * const siteTypeValue = getSiteTypePropertyValue( 'id', 2, 'slug' );
  *
  * @param {string} key A property name of a site types item

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -15,7 +15,7 @@ import Card from 'components/card';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
-import { allSiteTypes } from 'lib/signup/site-type';
+import { getAllSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -34,7 +34,8 @@ class SiteTypeForm extends Component {
 
 	constructor( props ) {
 		super( props );
-
+		// eslint-disable-next-line
+		console.log( 'props', props );
 		this.state = {
 			siteType: props.siteType,
 		};
@@ -55,7 +56,7 @@ class SiteTypeForm extends Component {
 	};
 
 	renderRadioOptions() {
-		return allSiteTypes.map( siteTypeProperties => (
+		return getAllSiteTypes().map( siteTypeProperties => (
 			<FormLabel
 				className={ classNames( 'site-type__option', {
 					'is-selected': siteTypeProperties.slug === this.state.siteType,


### PR DESCRIPTION
## Changes proposed in this Pull Request

@southp reported a bug where the site type options were not being updated with a locale change

![before-site-type-changes](https://user-images.githubusercontent.com/6458278/54413123-d77cab80-4748-11e9-933c-e28144d38658.gif)

This PR shifts the former site type list into a function, turning it into a return value with the hope that it retriggers `translate`:

![after-site-type-changes gif](https://user-images.githubusercontent.com/6458278/54413126-da779c00-4748-11e9-80d2-592d00f8ba58.gif)

## Testing instructions

On the http://calypso.localhost:3000/start/onboarding journey, switch to another language when logging in.

Is the site type (mostly^) translated?


_^ I say _mostly_ because some languages may not be 100% translated. Try Spanish!_