### PR TITLE
Happychat: Update user message link color to accent

### DIFF
--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -276,8 +276,12 @@
 
 	p {
 		margin: 8px 0;
-		&:first-child { margin-top: 0; }
-		&:last-child { margin-bottom: 0; }
+		&:first-child {
+			margin-top: 0;
+		}
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	&::after {

--- a/client/components/happychat/style.scss
+++ b/client/components/happychat/style.scss
@@ -338,7 +338,7 @@
 		margin-right: 0;
 
 		a {
-			color: var( --color-primary-100 );
+			color: var( --color-accent );
 		}
 
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Links sent by users on Happychat have the accent color with this change
* Also addressed a few stylelint warnings

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit https://wordpress.com/help/contact 
* Start a Happychat 
* Sent a link as an user
* Notice that the link color is pink/orange (accent)

Before:

![Screenshot 2019-03-15 at 12 55 43](https://user-images.githubusercontent.com/18581859/54417812-37fbf080-4729-11e9-91c6-7f080214168a.png)

After:

![Screenshot 2019-03-15 at 13 49 40](https://user-images.githubusercontent.com/18581859/54417806-33373c80-4729-11e9-97d8-40e65cf2b35e.png)
