### PR TITLE
Jetpack: fix ublock geo-block

### DIFF
--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -132,11 +132,17 @@ const connectComponent = connect(
 	( state, { url } ) => {
 		const rawSite = url ? getJetpackSiteByUrl( state, url ) : null;
 		const site = rawSite ? getSite( state, rawSite.ID ) : null;
+		const geo = requestGeoLocation();
+		let countryCode = geo.data;
+		if ( ! countryCode && geo.state === 'failure' ) {
+			// if our geo requests are being blocked, we default to US
+			countryCode = 'US';
+		}
 
 		return {
 			requestingSites: isRequestingSites( state ),
 			site,
-			countryCode: requestGeoLocation().data,
+			countryCode: countryCode,
 		};
 	},
 	{

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -240,7 +240,12 @@ const connectComponent = connect(
 		const user = getCurrentUser( state );
 		const selectedSite = getSelectedSite( state );
 		const selectedSiteSlug = selectedSite ? selectedSite.slug : '';
-
+		const geo = requestGeoLocation();
+		let countryCode = geo.data;
+		if ( ! countryCode && geo.state === 'failure' ) {
+			// if our geo requests are being blocked, we default to US
+			countryCode = 'US';
+		}
 		const selectedPlanSlug = retrievePlan();
 		const selectedPlan = getPlanBySlug( state, selectedPlanSlug );
 		return {
@@ -257,7 +262,7 @@ const connectComponent = connect(
 			selectedSite,
 			selectedSiteSlug,
 			userId: user ? user.ID : null,
-			countryCode: props.countryCode || requestGeoLocation().data,
+			countryCode: props.countryCode || countryCode,
 		};
 	},
 	{


### PR DESCRIPTION
Ublock is blocking our geolocation requests, breaking the connection flow (which now requests your geolocation to check for your eligibility for an A/B test). This PR adds a fallback to make sure that those requests fail gracefully and users can still connect.

How to test
======
0. Install uBlock in your chrome
1. http://calypso.localhost:3000/jetpack/connect/store and make sure you can see the plans (after a brief rendering of some placeholders)
2. connect a jetpack site. Once you get to the plans step, change WordPress.com for calypso.localhost:3000 and check everything renders ok there too

