### PR TITLE
Importers: Update WordPress file description.

### DIFF
--- a/client/my-sites/importer/importer-wordpress.jsx
+++ b/client/my-sites/importer/importer-wordpress.jsx
@@ -44,9 +44,10 @@ class ImporterWordPress extends React.PureComponent {
 
 		importerData.uploadDescription = this.props.translate(
 			'Upload a {{b}}WordPress export file{{/b}} to start ' +
-				'importing into {{b2}}%(title)s{{/b2}}. Check out our ' +
-				'{{inlineSupportLink/}} if you need ' +
-				'help exporting the file.',
+				'importing into {{b2}}%(title)s{{/b2}}. A WordPress export is ' +
+				'an XML file with your page and post content, or a zip archive ' +
+				'containing several XML files. ' +
+				'Need help {{inlineSupportLink/}}?',
 			{
 				args: { title: this.props.site.title },
 				components: {
@@ -56,7 +57,7 @@ class ImporterWordPress extends React.PureComponent {
 						<InlineSupportLink
 							supportPostId={ 2087 }
 							supportLink={ 'https://en.support.wordpress.com/export/' }
-							text={ this.props.translate( 'WordPress export guide' ) }
+							text={ this.props.translate( 'exporting your content' ) }
 							showIcon={ false }
 						/>
 					),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the intro text of the WordPress importer to 

> Upload a WordPress export file to start importing into example.wordpress.com. A WordPress export is an XML file with your page and post content, or a zip archive containing several XML files. Need help exporting your content?

#### Testing instructions

* Go to http://calypso.localhost:3000/settings/import/[ site ].wordpress.com.
* Click on the WordPress importer. The intro text should read as below.

![image](https://user-images.githubusercontent.com/1647564/54424776-974b0800-470b-11e9-8946-54838bb36df8.png)

Fixes https://github.com/Automattic/wp-calypso/issues/30560
