### PR TITLE
Concierge calendar: add explicit import of moment-timezone

### DIFF
--- a/client/me/concierge/shared/available-time-picker.js
+++ b/client/me/concierge/shared/available-time-picker.js
@@ -5,7 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { moment } from 'i18n-calypso';
+import moment from 'moment-timezone';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Rather from importing moment.js from `i18n-calypso` and assuming it's `moment-timezone`
(it soon won't be), import it explicitly.

**How to test:**
Try to book a concierge session at `/me/concierge/site-with-business-plan.blog/book`. Verify that the offered times are displayed in the requested timezone and that the time closest to the current time (but possibly on another day) is selected by default.
