### PR TITLE
Update/checkout paypal send tax location

### DIFF
--- a/client/components/payment-country-select/index.jsx
+++ b/client/components/payment-country-select/index.jsx
@@ -26,9 +26,10 @@ export class PaymentCountrySelect extends Component {
 	};
 
 	static defaultProps = {
-		onCountrySelected: setTaxCountryCode,
+		onCountrySelected: noop,
 		countryCode: '',
 		updateGlobalCountryCode: noop,
+		updateCartStore: setTaxCountryCode,
 	};
 
 	componentDidMount = () => {
@@ -66,6 +67,7 @@ export class PaymentCountrySelect extends Component {
 
 	handleFieldChange = event => {
 		this.props.updateGlobalCountryCode( event.target.value );
+		this.props.updateCartStore( event.target.value );
 		// Notify the callback function that a new country was selected.
 		this.props.onCountrySelected( event.target.name, event.target.value );
 		// Also notify the standard onChange field handler, if there is one.
@@ -80,6 +82,7 @@ export class PaymentCountrySelect extends Component {
 			// state.
 			'countryCode',
 			'updateGlobalCountryCode',
+			'updateCartStore',
 			// Don't pass down this component's custom props.
 			'onCountrySelected',
 			// Don't pass down standard CountrySelect props that this component

--- a/client/components/payment-country-select/index.jsx
+++ b/client/components/payment-country-select/index.jsx
@@ -14,6 +14,7 @@ import { isFunction, noop, omit, some } from 'lodash';
 import CountrySelect from 'my-sites/domains/components/form/country-select';
 import getPaymentCountryCode from 'state/selectors/get-payment-country-code';
 import { setPaymentCountryCode } from 'state/ui/payment/actions';
+import { setTaxCountryCode } from 'lib/upgrades/actions/cart';
 
 export class PaymentCountrySelect extends Component {
 	static propTypes = {
@@ -25,7 +26,7 @@ export class PaymentCountrySelect extends Component {
 	};
 
 	static defaultProps = {
-		onCountrySelected: noop,
+		onCountrySelected: setTaxCountryCode,
 		countryCode: '',
 		updateGlobalCountryCode: noop,
 	};

--- a/client/components/payment-country-select/test/index.jsx
+++ b/client/components/payment-country-select/test/index.jsx
@@ -18,6 +18,9 @@ import { PaymentCountrySelect } from '../';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
 jest.mock( 'lib/user', () => () => {} );
+jest.mock( 'lib/upgrades/actions/cart', () => ( {
+	setTaxCountryCode: () => {},
+} ) );
 
 describe( 'PaymentCountrySelect', () => {
 	let props;

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -126,6 +126,15 @@ function removeCoupon() {
 	};
 }
 
+export const getTaxCountryCode = ( cart ) =>
+	get( cart, [ 'tax', 'location', 'country_code' ] );
+
+export const getTaxPostalCode = ( cart ) =>
+	get( cart, [ 'tax', 'location', 'postal_code' ] );
+
+export const getTaxLocation	= ( cart ) =>
+	get( cart, [ 'tax', 'location', 'postal_code' ] );
+
 function setTaxCountryCode( countryCode ) {
 	return function( cart ) {
 		return update( cart, {

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -126,14 +126,11 @@ function removeCoupon() {
 	};
 }
 
-export const getTaxCountryCode = ( cart ) =>
-	get( cart, [ 'tax', 'location', 'country_code' ] );
+export const getTaxCountryCode = cart => get( cart, [ 'tax', 'location', 'country_code' ] );
 
-export const getTaxPostalCode = ( cart ) =>
-	get( cart, [ 'tax', 'location', 'postal_code' ] );
+export const getTaxPostalCode = cart => get( cart, [ 'tax', 'location', 'postal_code' ] );
 
-export const getTaxLocation	= ( cart ) =>
-	get( cart, [ 'tax', 'location', 'postal_code' ] );
+export const getTaxLocation = cart => get( cart, [ 'tax', 'location' ], {} );
 
 function setTaxCountryCode( countryCode ) {
 	return function( cart ) {

--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -5,7 +5,7 @@
  */
 import url from 'url';
 import { extend, get, isArray, invert } from 'lodash';
-import update from 'immutability-helper';
+import update, { extend as extendImmutabilityHelper } from 'immutability-helper';
 import i18n from 'i18n-calypso';
 import config from 'config';
 
@@ -14,6 +14,11 @@ import config from 'config';
  */
 import cartItems from './cart-items';
 import { isCredits, isDomainRedemption, whitelistAttributes } from 'lib/products-values';
+
+// Auto-vivification from https://github.com/kolodny/immutability-helper#autovivification
+extendImmutabilityHelper( '$auto', function( value, object ) {
+	return object ? update( object, value ) : update( {}, value );
+} );
 
 // #tax-on-checout-placeholder
 import { injectTaxStateWithPlaceholderValues } from 'lib/tax';
@@ -124,7 +129,19 @@ function removeCoupon() {
 function setTaxCountryCode( countryCode ) {
 	return function( cart ) {
 		return update( cart, {
-			tax: { location: { country_code: { $set: countryCode } } },
+			$auto: {
+				tax: {
+					$auto: {
+						location: {
+							$auto: {
+								country_code: {
+									$set: countryCode,
+								},
+							},
+						},
+					},
+				},
+			},
 		} );
 	};
 }
@@ -132,7 +149,19 @@ function setTaxCountryCode( countryCode ) {
 function setTaxPostalCode( postalCode ) {
 	return function( cart ) {
 		return update( cart, {
-			tax: { location: { postal_code: { $set: postalCode } } },
+			$auto: {
+				tax: {
+					$auto: {
+						location: {
+							$auto: {
+								postal_code: {
+									$set: postalCode,
+								},
+							},
+						},
+					},
+				},
+			},
 		} );
 	};
 }
@@ -140,7 +169,17 @@ function setTaxPostalCode( postalCode ) {
 function setTaxLocation( { postalCode, countryCode } ) {
 	return function( cart ) {
 		return update( cart, {
-			tax: { location: { $set: { postal_code: postalCode, country_code: countryCode } } },
+			$auto: {
+				tax: {
+					$auto: {
+						location: {
+							$auto: {
+								$set: { postal_code: postalCode, country_code: countryCode },
+							},
+						},
+					},
+				},
+			},
 		} );
 	};
 }

--- a/client/lib/cart-values/test/index.js
+++ b/client/lib/cart-values/test/index.js
@@ -41,14 +41,12 @@ describe( 'index', () => {
 	describe( 'cart change functions', () => {
 		describe( 'flow( changeFunctions... )', () => {
 			test( 'should combine multiple cart operations into a single step', () => {
-				let addTwo, newCart;
-
-				addTwo = flow(
+				const addTwo = flow(
 					cartItems.add( PREMIUM_PRODUCT ),
 					cartItems.add( DOMAIN_REGISTRATION_PRODUCT )
 				);
 
-				newCart = addTwo( cartValues.emptyCart( TEST_BLOG_ID ) );
+				const newCart = addTwo( cartValues.emptyCart( TEST_BLOG_ID ) );
 				assert( cartItems.hasProduct( newCart, 'value_bundle' ) );
 				assert( cartItems.hasProduct( newCart, 'dotcom_domain' ) );
 			} );
@@ -56,7 +54,7 @@ describe( 'index', () => {
 
 		describe( 'cartItems.add( cartItem )', () => {
 			test( 'should add the cartItem to the products array', () => {
-				let initialCart = cartValues.emptyCart( TEST_BLOG_ID ),
+				const initialCart = cartValues.emptyCart( TEST_BLOG_ID ),
 					newCart = cartItems.add( PREMIUM_PRODUCT )( initialCart ),
 					expectedCart = {
 						blog_id: TEST_BLOG_ID,
@@ -69,14 +67,12 @@ describe( 'index', () => {
 
 		describe( 'cartItems.remove( cartItem )', () => {
 			test( 'should remove the cartItem from the products array', () => {
-				let initialCart, newCart, expectedCart;
-
-				initialCart = {
+				const initialCart = {
 					blog_id: TEST_BLOG_ID,
 					products: [ PREMIUM_PRODUCT, DOMAIN_REGISTRATION_PRODUCT ],
 				};
-				newCart = cartItems.remove( initialCart.products[ 0 ] )( initialCart );
-				expectedCart = {
+				const newCart = cartItems.remove( initialCart.products[ 0 ] )( initialCart );
+				const expectedCart = {
 					blog_id: TEST_BLOG_ID,
 					products: [ DOMAIN_REGISTRATION_PRODUCT ],
 				};
@@ -88,15 +84,13 @@ describe( 'index', () => {
 
 	describe( 'cartItems.hasProduct( cart, productSlug )', () => {
 		test( 'should return a boolean that says whether the product is in the cart items', () => {
-			let cartWithPremium, cartWithoutPremium;
-
-			cartWithPremium = {
+			const cartWithPremium = {
 				blog_id: TEST_BLOG_ID,
 				products: [ PREMIUM_PRODUCT ],
 			};
 			assert( cartItems.hasProduct( cartWithPremium, 'value_bundle' ) );
 
-			cartWithoutPremium = {
+			const cartWithoutPremium = {
 				blog_id: TEST_BLOG_ID,
 				products: [ DOMAIN_REGISTRATION_PRODUCT ],
 			};
@@ -122,23 +116,21 @@ describe( 'index', () => {
 
 	describe( 'cartItems.hasOnlyProductsOf( cart, productSlug )', () => {
 		test( 'should return a boolean that says whether only products of productSlug are in the cart items', () => {
-			let cartWithSameProductSlugs, cartWithMultipleProductSlugs, emptyCart;
-
-			cartWithMultipleProductSlugs = {
+			const cartWithMultipleProductSlugs = {
 				blog_id: TEST_BLOG_ID,
 				products: [ PREMIUM_PRODUCT, THEME_PRODUCT ],
 			};
 
 			assert( ! cartItems.hasOnlyProductsOf( cartWithMultipleProductSlugs, 'premium_theme' ) );
 
-			cartWithSameProductSlugs = {
+			const cartWithSameProductSlugs = {
 				blog_id: TEST_BLOG_ID,
 				products: [ THEME_PRODUCT, THEME_PRODUCT ],
 			};
 
 			assert( cartItems.hasOnlyProductsOf( cartWithSameProductSlugs, 'premium_theme' ) );
 
-			emptyCart = {};
+			const emptyCart = {};
 			assert( ! cartItems.hasOnlyProductsOf( emptyCart, 'premium_theme' ) );
 		} );
 	} );

--- a/client/lib/cart-values/test/index.js
+++ b/client/lib/cart-values/test/index.js
@@ -154,6 +154,94 @@ describe( 'index', () => {
 			} );
 		} );
 	} );
+
+	describe( 'setTaxCountryCode( countryCode )', () => {
+		test( 'should set the country code', () => {
+			const initialCart = cartValues.emptyCart(),
+				newCart = cartValues.setTaxCountryCode( 'TEST' )( initialCart );
+
+			assert.equal( 'TEST', newCart.tax.location.country_code );
+		} );
+
+		test( 'should clear the countryCode', () => {
+			const initialCart = cartValues.emptyCart(),
+				newCart = cartValues.setTaxCountryCode( null )( initialCart );
+
+			assert.equal( null, newCart.tax.location.country_code );
+		} );
+
+		test( 'should preserve other values', () => {
+			const initialCart = {
+					other: 1,
+					tax: {
+						other: 2,
+						location: {
+							other: 3,
+							country_code: 'JA',
+							postal_code: '88888',
+						},
+					},
+				},
+				newCart = cartValues.setTaxCountryCode( 'RU' )( initialCart ),
+				expectedCart = {
+					other: 1,
+					tax: {
+						other: 2,
+						location: {
+							other: 3,
+							country_code: 'RU',
+							postal_code: '88888',
+						},
+					},
+				};
+
+			assert.deepEqual( newCart, expectedCart );
+		} );
+	} );
+
+	describe( 'setTaxPostalCode( postalCode )', () => {
+		test( 'should set the postal code', () => {
+			const initialCart = cartValues.emptyCart(),
+				newCart = cartValues.setTaxPostalCode( 'TEST' )( initialCart );
+
+			assert.equal( 'TEST', newCart.tax.location.postal_code );
+		} );
+
+		test( 'should clear the postal code', () => {
+			const initialCart = { tax: { location: { postal_code: '4321' } } },
+				newCart = cartValues.setTaxPostalCode( null )( initialCart );
+
+			assert.equal( null, newCart.tax.location.postal_code );
+		} );
+
+		test( 'should preserve other values', () => {
+			const initialCart = {
+					other: 1,
+					tax: {
+						other: 2,
+						location: {
+							other: 3,
+							country_code: 'AI',
+							postal_code: 'clearMe',
+						},
+					},
+				},
+				newCart = cartValues.setTaxPostalCode( '99999' )( initialCart ),
+				expectedCart = {
+					other: 1,
+					tax: {
+						other: 2,
+						location: {
+							other: 3,
+							country_code: 'AI',
+							postal_code: '99999',
+						},
+					},
+				};
+
+			assert.deepEqual( newCart, expectedCart );
+		} );
+	} );
 } );
 
 describe( 'hasPendingPayment()', () => {

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -13,7 +13,8 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
-import cartValues, { getLocationOrigin } from 'lib/cart-values';
+import cartValues, { getLocationOrigin, getTaxPostalCode } from 'lib/cart-values';
+import { setTaxPostalCode } from 'lib/upgrades/actions/cart';
 import Input from 'my-sites/domains/components/form/input';
 import notices from 'notices';
 import PaymentCountrySelect from 'components/payment-country-select';
@@ -36,6 +37,10 @@ export class PaypalPaymentBox extends React.Component {
 		country: null,
 		formDisabled: false,
 	};
+
+	handlePostalCodeChange = event => {
+		setTaxPostalCode( event.target.value );
+	}
 
 	handleChange = event => {
 		this.updateLocalStateWithFieldValue( event.target.name, event.target.value );
@@ -131,7 +136,8 @@ export class PaypalPaymentBox extends React.Component {
 	};
 
 	render = () => {
-		const hasBusinessPlanInCart = some( this.props.cart.products, ( { product_slug } ) =>
+		const { cart } = this.props;
+		const hasBusinessPlanInCart = some( cart.products, ( { product_slug } ) =>
 			overSome( isWpComBusinessPlan, isWpComEcommercePlan )( product_slug )
 		);
 		const showPaymentChatButton = this.props.presaleChatAvailable && hasBusinessPlanInCart;
@@ -154,7 +160,8 @@ export class PaypalPaymentBox extends React.Component {
 								additionalClasses="checkout-field"
 								name="postal-code"
 								label={ this.props.translate( 'Postal Code', { textOnly: true } ) }
-								onChange={ this.handleChange }
+								defaultValue={ getTaxPostalCode( cart ) }
+								onChange={ this.handlePostalCodeChange }
 								disabled={ this.state.formDisabled }
 								eventFormName="Checkout Form"
 							/>

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -40,7 +40,7 @@ export class PaypalPaymentBox extends React.Component {
 
 	handlePostalCodeChange = event => {
 		setTaxPostalCode( event.target.value );
-	}
+	};
 
 	handleChange = event => {
 		this.updateLocalStateWithFieldValue( event.target.name, event.target.value );
@@ -160,7 +160,7 @@ export class PaypalPaymentBox extends React.Component {
 								additionalClasses="checkout-field"
 								name="postal-code"
 								label={ this.props.translate( 'Postal Code', { textOnly: true } ) }
-								defaultValue={ getTaxPostalCode( cart ) }
+								value={ getTaxPostalCode( cart ) || '' }
 								onChange={ this.handlePostalCodeChange }
 								disabled={ this.state.formDisabled }
 								eventFormName="Checkout Form"

--- a/client/my-sites/checkout/checkout/paypal-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/paypal-payment-box.jsx
@@ -88,6 +88,7 @@ export class PaypalPaymentBox extends React.Component {
 			cancelUrl,
 			cart,
 			domainDetails: transaction.domainDetails,
+			"postal-code": getTaxPostalCode( cart ),
 		} );
 
 		// get PayPal Express URL from rest endpoint
@@ -184,7 +185,7 @@ export class PaypalPaymentBox extends React.Component {
 								<button
 									type="submit"
 									className="checkout__pay-button-button button is-primary"
-									disabled={ this.state.formDisabled }
+									disabled={ this.state.formDisabled || cart.hasPendingServerUpdates }
 								>
 									{ this.renderButtonText() }
 								</button>

--- a/client/my-sites/checkout/checkout/test/paypal-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/paypal-payment-box.js
@@ -43,6 +43,7 @@ jest.mock( 'lib/cart-values', () => ( {
 		hasRenewableSubscription: jest.fn( false ),
 		hasRenewalItem: jest.fn( false ),
 	},
+	getTaxPostalCode: () => '12345',
 } ) );
 
 jest.mock( 'i18n-calypso', () => ( {

--- a/client/my-sites/domains/components/form/input.jsx
+++ b/client/my-sites/domains/components/form/input.jsx
@@ -103,7 +103,7 @@ export default class extends React.Component {
 					{ ...valueProp }
 					name={ this.props.name }
 					ref="input"
-					autoFocus={ this.props.autoFocus }
+					autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 					autoComplete={ this.props.autoComplete }
 					disabled={ this.props.disabled }
 					maxLength={ this.props.maxLength }

--- a/client/my-sites/domains/components/form/input.jsx
+++ b/client/my-sites/domains/components/form/input.jsx
@@ -7,6 +7,7 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import classNames from 'classnames';
+import { has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -85,6 +86,10 @@ export default class extends React.Component {
 
 		const validationId = `validation-field-${ this.props.name }`;
 
+		const valueProp = has( this.props, 'defaultValue' )
+			? { defaultValue: this.props.defaultValue }
+			: { value: this.props.value };
+
 		return (
 			<div className={ classes }>
 				<FormLabel htmlFor={ this.props.name } { ...this.props.labelProps }>
@@ -95,7 +100,7 @@ export default class extends React.Component {
 					aria-describedby={ validationId }
 					placeholder={ this.props.placeholder ? this.props.placeholder : this.props.label }
 					id={ this.props.name }
-					value={ this.props.value }
+					{ ...valueProp }
 					name={ this.props.name }
 					ref="input"
 					autoFocus={ this.props.autoFocus }

--- a/client/my-sites/domains/components/form/input.jsx
+++ b/client/my-sites/domains/components/form/input.jsx
@@ -7,7 +7,6 @@
 import ReactDom from 'react-dom';
 import React from 'react';
 import classNames from 'classnames';
-import { has } from 'lodash';
 
 /**
  * Internal dependencies
@@ -86,10 +85,6 @@ export default class extends React.Component {
 
 		const validationId = `validation-field-${ this.props.name }`;
 
-		const valueProp = has( this.props, 'defaultValue' )
-			? { defaultValue: this.props.defaultValue }
-			: { value: this.props.value };
-
 		return (
 			<div className={ classes }>
 				<FormLabel htmlFor={ this.props.name } { ...this.props.labelProps }>
@@ -100,7 +95,7 @@ export default class extends React.Component {
 					aria-describedby={ validationId }
 					placeholder={ this.props.placeholder ? this.props.placeholder : this.props.label }
 					id={ this.props.name }
-					{ ...valueProp }
+					value={ this.props.value }
 					name={ this.props.name }
 					ref="input"
 					autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR connects the PayPal payment form to the CartStore in order to provide location information and enable sales taxes.

#### Testing instructions

Go to Checkout and check that taxes are set appropriately for items according to the paypal location:

- No mention of taxes outside the US
- Tax values where we've got nexus (e.g. 10001(NY))
- Zero tax values where we don't collect taxes (e.g. 90210 (CA))

![paypal tax](https://user-images.githubusercontent.com/5952255/54602095-67de2780-4a8c-11e9-8f42-acaf51311b81.gif)
