### PR TITLE
Post Scheduler: reorganize moment-timezone usage

### DIFF
--- a/client/components/post-schedule/clock.jsx
+++ b/client/components/post-schedule/clock.jsx
@@ -7,16 +7,18 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
-import { noop } from 'lodash';
+import { localize } from 'i18n-calypso';
+import { noop, flowRight as compose } from 'lodash';
+import 'moment-timezone'; // monkey patches the existing moment.js
 
 /**
  * Internal dependencies
  */
+import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
 import InfoPopover from 'components/info-popover';
+import { withLocalizedMoment } from 'components/localized-moment';
 import getSiteSetting from 'state/selectors/get-site-setting';
-import SegmentedControl from 'components/segmented-control';
 import { isMobile } from 'lib/viewport';
 
 /**
@@ -31,16 +33,15 @@ import {
 } from './utils';
 
 class PostScheduleClock extends Component {
-	constructor() {
-		super( ...arguments );
+	adjustHour = event => this.handleKeyDown( event, 'hour' );
+	adjustMinute = event => this.handleKeyDown( event, 'minute' );
 
-		// bounds
-		this.adjustHour = event => this.handleKeyDown( event, 'hour' );
-		this.adjustMinute = event => this.handleKeyDown( event, 'minute' );
+	setAm = event => this.setAmPm( event, 'AM' );
+	setPm = event => this.setAmPm( event, 'PM' );
 
-		this.setAm = event => this.setAmPm( event, 'AM' );
-		this.setPm = event => this.setAmPm( event, 'PM' );
-	}
+	amPmRef = React.createRef();
+	hourRef = React.createRef();
+	minRef = React.createRef();
 
 	handleKeyDown( event, field ) {
 		const operation = event.keyCode - 39;
@@ -53,7 +54,7 @@ class PostScheduleClock extends Component {
 		let value = Number( event.target.value );
 
 		if ( 'hour' === field ) {
-			if ( this.props.is12hour && this.refs.amPmReference ) {
+			if ( this.props.is12hour && this.amPmRef.current ) {
 				value = this.convertTo24Hour( value );
 			}
 
@@ -73,22 +74,20 @@ class PostScheduleClock extends Component {
 	}
 
 	getTimeValues() {
-		const { amPmReference, hourReference, minuteRef } = this.refs;
-
 		const modifiers = {};
-		const hour = parseAndValidateNumber( hourReference.value );
-		let minute = parseAndValidateNumber( minuteRef.value );
+		const hour = parseAndValidateNumber( this.hourRef.current.value );
+		let minute = parseAndValidateNumber( this.minRef.current.value );
 
 		if ( false !== hour && hour < 24 ) {
 			modifiers.hour = Number( hour );
 		}
 
-		if ( this.props.is12hour && amPmReference ) {
+		if ( this.props.is12hour && this.amPmRef.current ) {
 			if (
 				typeof modifiers.hour === 'undefined' ||
-				( amPmReference.value && modifiers.hour > 12 ) === 'PM'
+				( 'PM' === this.amPmRef.current.value && modifiers.hour > 12 )
 			) {
-				modifiers.hour = Number( hourReference.value.substr( -1 ) );
+				modifiers.hour = Number( this.hourRef.current.value.substr( -1 ) );
 			}
 
 			modifiers.hour = this.convertTo24Hour( modifiers.hour );
@@ -96,7 +95,7 @@ class PostScheduleClock extends Component {
 
 		if ( false !== minute ) {
 			if ( minute > 60 ) {
-				minute = minuteRef.value.substr( -1 );
+				minute = this.hourRef.current.value.substr( -1 );
 			}
 
 			modifiers.minute = Number( minute );
@@ -106,12 +105,12 @@ class PostScheduleClock extends Component {
 	}
 
 	setTime = ( event, modifiers = this.getTimeValues() ) => {
-		const date = moment( this.props.date ).set( modifiers );
+		const date = this.props.moment( this.props.date ).set( modifiers );
 		this.props.onChange( date, modifiers );
 	};
 
 	setAmPm( event, amOrPm ) {
-		this.refs.amPmReference.value = amOrPm;
+		this.amPmRef.current.value = amOrPm;
 		this.setTime( event );
 	}
 
@@ -122,9 +121,9 @@ class PostScheduleClock extends Component {
 	 * @return {Number}      The converted hour.
 	 */
 	convertTo24Hour( hour ) {
-		if ( 'PM' === this.refs.amPmReference.value && hour < 12 ) {
+		if ( 'PM' === this.amPmRef.current.value && hour < 12 ) {
 			hour += 12;
-		} else if ( 'AM' === this.refs.amPmReference.value && 12 === hour ) {
+		} else if ( 'AM' === this.amPmRef.current.value && 12 === hour ) {
 			hour = 0;
 		}
 
@@ -132,7 +131,7 @@ class PostScheduleClock extends Component {
 	}
 
 	renderTimezoneSection() {
-		const { date, gmtOffset, siteId, siteSlug, timezone, translate } = this.props;
+		const { date, gmtOffset, siteId, siteSlug, timezone, moment, translate } = this.props;
 
 		if ( ! ( timezone || isValidGMTOffset( gmtOffset ) ) ) {
 			return;
@@ -155,7 +154,7 @@ class PostScheduleClock extends Component {
 
 		const popoverPosition = isMobile() ? 'top' : 'right';
 		const timezoneText = timezone
-			? `${ timezone.replace( /\_/gi, ' ' ) } ${ tzDateOffset }`
+			? `${ timezone.replace( /_/gi, ' ' ) } ${ tzDateOffset }`
 			: `UTC${ convertHoursToHHMM( gmtOffset ) }`;
 
 		const timezoneInfo = translate(
@@ -192,7 +191,7 @@ class PostScheduleClock extends Component {
 				<input
 					className="post-schedule__clock-time"
 					name="post-schedule__clock_hour"
-					ref="hourReference"
+					ref={ this.hourRef }
 					value={ date.format( is12hour ? 'hh' : 'HH' ) }
 					onChange={ this.setTime }
 					onKeyDown={ this.adjustHour }
@@ -204,7 +203,7 @@ class PostScheduleClock extends Component {
 				<input
 					className="post-schedule__clock-time"
 					name="post-schedule__clock_minute"
-					ref="minuteRef"
+					ref={ this.minRef }
 					value={ date.format( 'mm' ) }
 					onChange={ this.setTime }
 					onKeyDown={ this.adjustMinute }
@@ -215,7 +214,7 @@ class PostScheduleClock extends Component {
 					<span>
 						<input
 							type="hidden"
-							ref="amPmReference"
+							ref={ this.amPmRef }
 							name="post-schedule__clock_am-pm"
 							value={ date.format( 'A' ) }
 						/>
@@ -257,6 +256,10 @@ PostScheduleClock.defaultProps = {
 	onChange: noop,
 };
 
-export default connect( ( state, { siteId } ) => ( {
-	is12hour: is12hr( getSiteSetting( state, siteId, 'time_format' ) ),
-} ) )( localize( PostScheduleClock ) );
+export default compose(
+	connect( ( state, { siteId } ) => ( {
+		is12hour: is12hr( getSiteSetting( state, siteId, 'time_format' ) ),
+	} ) ),
+	localize,
+	withLocalizedMoment
+)( PostScheduleClock );

--- a/client/components/post-schedule/header.jsx
+++ b/client/components/post-schedule/header.jsx
@@ -5,14 +5,14 @@
  */
 
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
 import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Local dependencies
  */
+import { withLocalizedMoment } from 'components/localized-moment';
 import HeaderControl from './header-controls';
-import classNames from 'classnames';
 
 /**
  * Globals
@@ -20,8 +20,6 @@ import classNames from 'classnames';
 const noop = () => {};
 
 class PostScheduleHeader extends React.Component {
-	static displayName = 'PostScheduleHeader';
-
 	static propTypes = {
 		date: PropTypes.object,
 		inputChronoDisplayed: PropTypes.bool,
@@ -38,24 +36,24 @@ class PostScheduleHeader extends React.Component {
 	};
 
 	setToCurrentMonth = () => {
-		const month = this.props.moment().month();
-		this.props.onDateChange( this.props.date.month( month ) );
+		const { moment, date, onDateChange } = this.props;
+		onDateChange( moment( date ).month( moment().month() ) );
 	};
 
 	setToCurrentYear = () => {
-		const year = this.props.moment().year();
-		this.props.onDateChange( this.props.date.year( year ) );
+		const { moment, date,onDateChange } = this.props;
+		onDateChange( moment( date ).year( moment().year() ) );
 	};
 
 	setYear = modifier => {
-		const date = this.props.moment( this.props.date );
-		date.year( date.year() + modifier );
+		const { moment, date,onDateChange } = this.props;
+		const newDate = moment(date).add( modifier, 'y' );
 
-		if ( 0 > date.year() || date.year() > 9999 ) {
+		if ( 0 > newDate.year() || newDate.year() > 9999 ) {
 			return null;
 		}
 
-		this.props.onDateChange( date );
+		onDateChange( newDate );
 	};
 
 	render() {
@@ -63,10 +61,11 @@ class PostScheduleHeader extends React.Component {
 			'is-input-chrono-displayed': this.props.inputChronoDisplayed,
 		} );
 
+		/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
 		return (
 			<div className={ headerClasses }>
 				<span className="post-schedule__header-month" onClick={ this.setToCurrentMonth }>
-					{ this.props.date.format( 'MMM' ) }
+					{ this.props.date.clone().format( 'MMM' ) }
 				</span>
 
 				<div
@@ -78,13 +77,16 @@ class PostScheduleHeader extends React.Component {
 						this.setState( { showYearControls: false } );
 					} }
 				>
-					<span onClick={ this.setToCurrentYear }>{ this.props.date.format( 'YYYY' ) }</span>
+					<span onClick={ this.setToCurrentYear }>
+						{ this.props.date.clone().format( 'YYYY' ) }
+					</span>
 
 					{ this.state.showYearControls && <HeaderControl onYearChange={ this.setYear } /> }
 				</div>
 			</div>
 		);
+		/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
 	}
 }
 
-export default localize( PostScheduleHeader );
+export default withLocalizedMoment( PostScheduleHeader );

--- a/client/components/post-schedule/index.jsx
+++ b/client/components/post-schedule/index.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { moment } from 'i18n-calypso';
+import moment from 'moment';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 

--- a/client/components/post-schedule/style.scss
+++ b/client/components/post-schedule/style.scss
@@ -116,14 +116,7 @@ input[type='text'].post-schedule__clock-time {
 	display: inline-flex;
 	margin: 0 6px;
 	vertical-align: bottom;
-}
-
-.post-schedule__clock .segmented-control__item {
-	display: inline-table;
-}
-
-.post-schedule__clock .segmented-control__link {
-	display: inline-block;
+	line-height: 0;
 }
 
 .info-popover__tooltip.post-schedule__timezone-info,

--- a/client/components/post-schedule/utils.js
+++ b/client/components/post-schedule/utils.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { moment } from 'i18n-calypso';
+import moment from 'moment-timezone';
 
 /**
  * Checks whether the passed time  format is of a 12-hour format.

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -6,6 +6,7 @@ import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { get } from 'lodash';
+import moment from 'moment-timezone';
 
 /**
  * Internal dependencies
@@ -13,7 +14,7 @@ import { get } from 'lodash';
 import PostSchedule from 'components/post-schedule';
 import QueryPosts from 'components/data/query-posts';
 import * as postUtils from 'state/posts/utils';
-import { timezone } from 'lib/site/utils';
+import { timezone, gmtOffset } from 'lib/site/utils';
 import { getPostsForQueryIgnoringPage } from 'state/posts/selectors';
 
 const PostScheduleWithOtherPostsIndicated = connect( ( state, { site, query } ) => ( {
@@ -27,6 +28,8 @@ const PostScheduleWithOtherPostsIndicated = connect( ( state, { site, query } ) 
 			onMonthChange={ onMonthChange }
 			posts={ posts }
 			site={ site }
+			timezone={ timezone( site ) }
+			gmtOffset={ gmtOffset( site ) }
 		/>
 	);
 } );
@@ -39,36 +42,20 @@ export default class PostScheduler extends PureComponent {
 		site: PropTypes.object,
 	};
 
-	state = {
-		firstDayOfTheMonth: this.getFirstDayOfTheMonth( this.props.initialDate ),
-		lastDayOfTheMonth: this.getLastDayOfTheMonth( this.props.initialDate ),
-	};
+	state = this.getFirstAndLastDayOfTheMonth( this.props.initialDate );
 
-	getFirstDayOfTheMonth( date ) {
+	getFirstAndLastDayOfTheMonth( date ) {
 		const tz = timezone( this.props.site );
+		const tzDate = tz ? moment.tz( date, tz ) : moment( date );
 
-		return postUtils.getOffsetDate( date, tz ).set( {
-			year: date.year(),
-			month: date.month(),
-			date: 1,
-			hours: 0,
-			minutes: 0,
-			seconds: 0,
-			milliseconds: 0,
-		} );
-	}
-
-	getLastDayOfTheMonth( date ) {
-		return this.getFirstDayOfTheMonth( date )
-			.add( 1, 'month' )
-			.second( -1 );
+		return {
+			firstDayOfTheMonth: tzDate.clone().startOf( 'month' ),
+			lastDayOfTheMonth: tzDate.clone().endOf( 'month' ),
+		};
 	}
 
 	setCurrentMonth = date => {
-		this.setState( {
-			firstDayOfTheMonth: this.getFirstDayOfTheMonth( date ),
-			lastDayOfTheMonth: this.getLastDayOfTheMonth( date ),
-		} );
+		this.setState( this.getFirstAndLastDayOfTheMonth( date ) );
 	};
 
 	render() {

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -30,7 +30,7 @@ import {
 	find,
 	reject,
 } from 'lodash';
-import { moment } from 'i18n-calypso';
+import moment from 'moment';
 import url from 'url';
 
 /**
@@ -777,20 +777,4 @@ export const getFeaturedImageId = function( post ) {
 		// from the thumbnail object if one exists
 		return post.post_thumbnail.ID;
 	}
-};
-
-/**
- * Return date with timezone offset.
- * If `date` is not defined it returns `now`.
- *
- * @param {String|Date} date - date
- * @param {String} tz - timezone
- * @return {Moment} moment instance
- */
-export const getOffsetDate = function( date, tz ) {
-	if ( ! tz ) {
-		return moment( date );
-	}
-
-	return moment( moment.tz( date, tz ) );
 };

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -52,6 +52,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'signup_is_store',
 	'site_goals',
 	'software_version',
+	'timezone',
 	'upgraded_filetypes_enabled',
 	'unmapped_url',
 	'verification_services_codes',


### PR DESCRIPTION
**`post-schedule/clock.jsx`:**
- uses `moment-timezone` to adjust date to site's timezone and to format hours/minutes/AM/PM
- converted string refs to modern format
- the code that reads and writes the DOM values directy using refs is still horrible, but I didn't rewrite it. Not worth doing in Classic Editor.

Test by setting your site's timezone and date format and then trying to schedule a post. Then test the time setter at the bottom and the timezone notice at the very bottom:
<img width="248" alt="Screenshot 2019-03-15 at 14 02 09" src="https://user-images.githubusercontent.com/664258/54433450-249e5480-472c-11e9-8249-150097910a18.png">

**`post-schedule/header.jsx`:**
Receives date props as moment.js objects, which can have stale locale. Solved by cloning the moment.js objects. Also fixes bugs where prop or state value was mutated by calling moment.js methods on it.

**`post-schedule/index.jsx`:**
`moment` used only for locale-independent parsing and manipulation. Importing the module directly.

**`post-schedule/style.scss`:**
The AM/PM selector's styles were visually broken.

**`post-schedule/utils.js`:**
Uses `moment-timezone` to adjust date to site's timezone. Importing the module directly.

**`post-scheduler.jsx`:**
Uses `moment-timezone` to adjust date to site's timezone and then figure out the correct start and end of month. Refactored the code to use smart methods like `startOf( 'month' )`.

Start passing `timezone` and `gmtOffset` to child components: this was broken for more than a year (!)

Test by checking that Calypso sends a REST request for posts in the displayed month. The `before` and `after` times should be a midnight in the right timezone:
<img width="397" alt="Screenshot 2019-03-15 at 11 48 30" src="https://user-images.githubusercontent.com/664258/54434154-d8ecaa80-472d-11e9-86c7-3fcd46ac52d6.png">

The published posts are then shown in the calendar as circled dates:
<img width="314" alt="Screenshot 2019-03-15 at 11 48 42" src="https://user-images.githubusercontent.com/664258/54434218-05082b80-472e-11e9-9bd2-338d46664377.png">

**`state/posts/utils.js`:**
`moment` used for simple date comparisons using `isSame` or `isBefore`. No timezones there. The `getOffsetDate` function got inlined into its only usage site.

**`state/sites/constants.js`:**
We were not requesting the timezone of the site! Could lead to some suboptimal datetime handling and formatting.

That's all 😆 

The Classic Editor post scheduling has a pretty smart UI that hasn't been matched yet in Gutenberg. It would be nice to bring some of the updates to Core.