### PR TITLE
Updates button class for importing to fix import in signup e2e test

### DIFF
--- a/test/e2e/lib/pages/import-page.js
+++ b/test/e2e/lib/pages/import-page.js
@@ -35,8 +35,7 @@ export default class ImportPage extends AsyncBaseContainer {
 	async siteImporterCanStartImport() {
 		await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
-			// @TODO use a specific classname for this button
-			By.css( '.site-importer__site-importer-confirm-actions .button.is-primary' )
+			By.css( '.importer-action-buttons__action-button.is-primary' )
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates button class in import in signup e2e test.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run e2e tests and make sure they pass, particularly wp-signup-spec "Import a site while signing up"
