### PR TITLE
Turn off autoCapitalize and autoCorrect on username fields

### DIFF
--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -686,6 +686,9 @@ const Account = createReactClass( {
 						} ) }
 					</FormLabel>
 					<FormTextInput
+						autoCapitalize="off"
+						autoComplete="off"
+						autoCorrect="off"
 						id="username_confirm"
 						name="username_confirm"
 						onFocus={ this.getFocusHandler( 'Username Confirm Field' ) }
@@ -790,7 +793,9 @@ const Account = createReactClass( {
 						<FormFieldset>
 							<FormLabel htmlFor="user_login">{ translate( 'Username' ) }</FormLabel>
 							<FormTextInput
+								autoCapitalize="off"
 								autoComplete="off"
+								autoCorrect="off"
 								className="account__username"
 								disabled={
 									this.getDisabledState() || ! this.getUserSetting( 'user_login_can_be_changed' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Turns off auto capitalization, auto correct, and auto complete for the username fields at `/me/account`. The username must be lower case, so it makes no sense to auto capitalize this field. Ran into this when helping a user attempt to change their username.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run branch on an iOS device and verify that username fields at `/me/account` do not automatically capitalize the first character of the username when typing into an empty username field
