### PR TITLE
Signup Import: Use a notice for the URL input error message

### DIFF
--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -16,9 +16,7 @@ import ExternalLink from 'components/external-link';
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
 import FormButton from 'components/forms/form-button';
-import FormInputValidation from 'components/forms/form-input-validation';
 import FormLabel from 'components/forms/form-label';
-import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextInput from 'components/forms/form-text-input';
 import ScreenReaderText from 'components/screen-reader-text';
 import { infoNotice, removeNotice } from 'state/notices/actions';
@@ -40,6 +38,7 @@ import {
 	SITE_IMPORTER_ERR_INVALID_URL,
 } from 'lib/importers/constants';
 import { prefetchmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
+import Notice from 'components/notice';
 
 /**
  * Style dependencies
@@ -208,6 +207,11 @@ class ImportURLStepComponent extends Component {
 		return (
 			<Fragment>
 				<div className="import-url__wrapper">
+					{ showUrlMessage && urlMessage ? (
+						<Notice className="import-url__url-input-message" status="is-error">
+							{ urlMessage }
+						</Notice>
+					) : null }
 					<form className="import-url__form" onSubmit={ this.handleSubmit }>
 						<ScreenReaderText>
 							<FormLabel htmlFor="url-input">Site URL</FormLabel>
@@ -239,17 +243,6 @@ class ImportURLStepComponent extends Component {
 								: translate( 'Continue' ) }
 						</FormButton>
 					</form>
-					{ showUrlMessage && urlMessage ? (
-						<FormInputValidation
-							className="import-url__url-input-message"
-							text={ urlMessage }
-							isError={ !! urlMessage }
-						/>
-					) : (
-						<FormSettingExplanation className="import-url__url-input-message">
-							{ translate( 'Please enter the full URL of your site.' ) }
-						</FormSettingExplanation>
-					) }
 				</div>
 
 				<div className="import-url__example">

--- a/client/signup/steps/import-url/style.scss
+++ b/client/signup/steps/import-url/style.scss
@@ -3,35 +3,37 @@
 	margin-bottom: 64px;
 }
 
-.import-url__wrapper .form-setting-explanation {
-	color: var( --color-white );
+// The containing element
+.import-url__wrapper {
+	padding: 0;
+	box-shadow: none;
+	border-radius: 3px;
+	max-width: 640px;
+	margin: auto;
+}
+
+// Actual form input for typing the URL
+.import-url__wrapper .import-url__url-input {
+	border: none;
+	border-radius: 3px;
+	padding: 10px 14px;
 
 	@include breakpoint( '<660px' ) {
-		text-align: center;
+		padding: 14px;
 	}
 }
+
+.import-url__wrapper .import-url__url-input-message {
+	max-width: 640px;
+	margin: 16px auto;
+}
+
 
 .import-url {
 	position: relative;
 
 	&__form {
 		position: relative;
-	}
-
-	.import-url__wrapper &__url-input {
-		padding: 9px 14px;
-
-		@include breakpoint( '<660px' ) {
-			padding: 14px;
-		}
-	}
-
-	&__url-input-message {
-		font-size: 14px;
-		margin: 0;
-		padding-top: 6px;
-		// Normalize height with bottom padding so it doesn't change when an error is shown.
-		padding-bottom: 4px;
 	}
 
 	&__submit-button {
@@ -44,6 +46,7 @@
 		display: flex;
 		flex-flow: row wrap;
 		justify-content: center;
+		margin-top: 80px;
 		margin-bottom: 48px;
 		position: relative;
 


### PR DESCRIPTION
This switches to using a Notice component for the error messaging. I've also removed the redundant "full URL" message, and tweaks the styles a bit to fit with the patterns established in the rest of signup.

Before:
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/191598/54444013-44c41880-4718-11e9-9436-817c97a1be15.png">

<img width="1009" alt="image" src="https://user-images.githubusercontent.com/191598/54444328-e3507980-4718-11e9-9f06-885e5904f91f.png">

(Notice the impossible-to-read error message.)

After:
<img width="781" alt="image" src="https://user-images.githubusercontent.com/191598/54444358-f105ff00-4718-11e9-8b9c-b6089db03d39.png">

<img width="717" alt="image" src="https://user-images.githubusercontent.com/191598/54444369-f82d0d00-4718-11e9-81e7-13749b8c34b6.png">

To test, head to `/start/import/from-url` and try to import some random URLs.

Fixes #30422