### PR TITLE
Make sidebar selector more specific

### DIFF
--- a/test/e2e/lib/components/nav-bar-component.js
+++ b/test/e2e/lib/components/nav-bar-component.js
@@ -12,12 +12,21 @@ export default class NavBarComponent extends AsyncBaseContainer {
 	async clickCreateNewPost( { siteURL = null } = {} ) {
 		const postButtonSelector = by.css( 'a.masterbar__item-new' );
 		await driverHelper.clickWhenClickable( this.driver, postButtonSelector );
+		await this.dismissComponentPopover();
 		if ( siteURL !== null ) {
 			return await driverHelper.selectElementByText(
 				this.driver,
 				by.css( '.site__domain' ),
 				siteURL
 			);
+		}
+	}
+	async dismissComponentPopover() {
+		let popoverSelector = by.css( '.components-popover__content' );
+		let dismissPopoverSelector = by.css( '.nux-dot-tip__disable' );
+
+		if ( await driverHelper.isElementPresent( this.driver, popoverSelector ) ) {
+			await driverHelper.clickWhenClickable( dismissPopoverSelector );
 		}
 	}
 	async clickProfileLink() {

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -125,7 +125,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 
 	async ensureSidebarMenuVisible() {
 		const allSitesSelector = By.css( '.current-section a' );
-		const sidebarSelector = By.css( '.sidebar' );
+		const sidebarSelector = By.css( '.sidebar .sidebar__region' );
 		const sidebarVisible = await this.driver.findElement( sidebarSelector ).isDisplayed();
 
 		if ( ! sidebarVisible ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
Waiting and clicking on sidebar should be more reliable. Sometimes it happens that sidebar is opened, test does the click, but it's not actually clicked on the menu item. [Example](https://14895-102822243-gh.circle-artifacts.com/0/home/circleci/wp-calypso/wp-calypso/test/e2e/screenshots/FAILED-EN-MOBILE-can-see-the-post-in-the-activity-log-1552567183860.png) from [CircleCI run](https://circleci.com/gh/Automattic/wp-e2e-tests-for-branches/14895#artifacts/containers/0). 

#### Testing instructions
Make sure that tests are passing in CircleCI. This change can affect many tests. 