### PR TITLE
Layout: AsyncLoad NpsSurveyNotice

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -41,7 +41,6 @@ import SupportArticleDialog from 'blocks/support-article-dialog';
 import { getCurrentLayoutFocus } from 'state/ui/layout-focus/selectors';
 import { getCurrentRoute } from 'state/selectors/get-current-route';
 import DocumentHead from 'components/data/document-head';
-import NpsSurveyNotice from 'layout/nps-survey-notice';
 import AppBanner from 'blocks/app-banner';
 import GdprBanner from 'blocks/gdpr-banner';
 import { getPreference } from 'state/preferences/selectors';
@@ -126,7 +125,9 @@ class Layout extends Component {
 				<QueryPreferences />
 				<QuerySiteSelectedEditor siteId={ this.props.siteId } />
 				<AsyncLoad require="layout/guided-tours" placeholder={ null } />
-				{ config.isEnabled( 'nps-survey/notice' ) && ! isE2ETest() && <NpsSurveyNotice /> }
+				{ config.isEnabled( 'nps-survey/notice' ) && ! isE2ETest() && (
+					<AsyncLoad require="layout/nps-survey-notice" placeholder={ null } />
+				) }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				<MasterbarLoggedIn
 					section={ this.props.sectionGroup }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Load NpsSurveyNotice asynchronously to reduce some of the `build` size.

#### Testing instructions

* Checkout this branch.
* Load Calypso.
* Use React Dev Tools and play with `NpsSurveyNotice` to make it show by enabling `isSectionAndSessionEligible` and `isNpsSurveyDialogShowing` props.
* Verify survey looks good and works well.

