### PR TITLE
Show illustration on checkout for free purchases like standalone domain mapping

### DIFF
--- a/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
@@ -86,7 +86,11 @@ class FreeCartPaymentBox extends React.Component {
 		const cart = this.props.cart;
 
 		if ( ! cart.has_bundle_credit ) {
-			return;
+			return (
+				<span className="checkout__free-stand-alone-domain-mapping-illustration">
+					<img src={ '/calypso/images/upgrades/custom-domain.svg' } alt="" />
+				</span>
+			);
 		}
 
 		const isRestrictedToBlogDomains = isBlogger( this.props.selectedSite.plan );

--- a/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/free-cart-payment-box.jsx
@@ -33,7 +33,7 @@ class FreeCartPaymentBox extends React.Component {
 			<React.Fragment>
 				<form onSubmit={ onSubmit }>
 					{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
-					<div className="payment-box-section">
+					<div className="payment-box-section checkout__free-cart-payment-box">
 						<div className="checkout__payment-box-section-content">
 							{ this.getDomainCreditIllustration() }
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -465,7 +465,8 @@
 				}
 			}
 
-			.checkout__free-domain-credit-illustration {
+			.checkout__free-domain-credit-illustration,
+			.checkout__free-stand-alone-domain-mapping-illustration {
 				max-width: 100%;
 				max-height: 150px;
 				margin: -10px auto 10px;
@@ -483,7 +484,9 @@
 			}
 
 			.checkout__free-domain-credit-illustration + h6,
-			.checkout__free-domain-credit-illustration + h6 + span {
+			.checkout__free-domain-credit-illustration + h6 + span,
+			.checkout__free-stand-alone-domain-mapping-illustration + h6,
+			.checkout__free-stand-alone-domain-mapping-illustration + h6 + span {
 				display: block;
 				padding-left: 20px;
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -470,6 +470,7 @@
 				max-width: 100%;
 				max-height: 150px;
 				margin: 0 auto 10px;
+				display: block;
 
 				img {
 					max-width: 100%;
@@ -479,7 +480,7 @@
 				@include breakpoint( '>960px' ) {
 					float: right;
 					margin-left: 20px;
-					width: calc( 25% - 20px );
+					width: calc( 20% - 20px );
 				}
 			}
 

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -393,7 +393,7 @@
 	.paypal-payment-box,
 	.credits-payment-box,
 	.web-payment-box {
-		.payment-box-section:not(.checkout__free-cart-payment-box),
+		.payment-box-section:not( .checkout__free-cart-payment-box ),
 		.checkout__payment-box-section {
 			background-color: var( --color-white );
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.075 );
@@ -469,7 +469,7 @@
 			.checkout__free-stand-alone-domain-mapping-illustration {
 				max-width: 100%;
 				max-height: 150px;
-				margin: -10px auto 10px;
+				margin: 0 auto 10px;
 
 				img {
 					max-width: 100%;
@@ -477,7 +477,7 @@
 				}
 
 				@include breakpoint( '>960px' ) {
-					float: left;
+					float: right;
 					margin-left: 20px;
 					width: calc( 25% - 20px );
 				}
@@ -492,7 +492,6 @@
 				@include breakpoint( '>960px' ) {
 					clear: none;
 					float: left;
-					padding-left: 20px;
 					width: calc( 75% - 20px );
 				}
 			}

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -393,13 +393,12 @@
 	.paypal-payment-box,
 	.credits-payment-box,
 	.web-payment-box {
-		.payment-box-section,
+		.payment-box-section:not(.checkout__free-cart-payment-box),
 		.checkout__payment-box-section {
 			background-color: var( --color-white );
 			box-shadow: 0 1px 2px rgba( 0, 0, 0, 0.075 );
 
 			@include breakpoint( '>660px' ) {
-				border: 1px solid var( --color-neutral-0 );
 				box-shadow: none;
 			}
 		}
@@ -454,6 +453,7 @@
 			}
 
 			.checkout__payment-box-section-content {
+
 				> h6 {
 					color: var( --color-primary );
 					font-size: 18px;
@@ -473,7 +473,7 @@
 
 				img {
 					max-width: 100%;
-					max-height: 150px;
+					max-height: 100px;
 				}
 
 				@include breakpoint( '>960px' ) {
@@ -488,11 +488,11 @@
 			.checkout__free-stand-alone-domain-mapping-illustration + h6,
 			.checkout__free-stand-alone-domain-mapping-illustration + h6 + span {
 				display: block;
-				padding-left: 20px;
 
 				@include breakpoint( '>960px' ) {
 					clear: none;
 					float: left;
+					padding-left: 20px;
 					width: calc( 75% - 20px );
 				}
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On a checkout page for free purchases like standalone domain mapping with paid plans, we will be showing an illustration. 

Currently there is no illustration for such purchases and the content on the checkout box appears attached to the left in a weird way.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start with a paid WordPress.com plan site
- Start at https://wordpress.com/domains/add to add a [domain mapping](https://en.support.wordpress.com/map-existing-domain/) on it
- Since you have a paid WordPress.com plan, you should be able to checkout for free. This is not the same as paying using WordPress.com credits.

Before:

![Screenshot 2019-03-15 at 22 49 27](https://user-images.githubusercontent.com/18581859/54450129-aebedb00-4775-11e9-9ac2-39df8b566f83.png)

After:

![Screenshot 2019-03-15 at 22 53 13](https://user-images.githubusercontent.com/18581859/54450127-acf51780-4775-11e9-9430-66a766e314a5.png)

Fixes https://github.com/Automattic/wp-calypso/issues/29861

#### Notes:

From what I understand, such type of checkout (free purchases without credits) applies only for domain mapping. Any other free purchases can be triggered only via WordPress.com credits. We do not have any other free products, so this logic for illustration should be fine.

For a credit purchase, the checkout looks like:

![Screenshot 2019-03-15 at 22 47 51](https://user-images.githubusercontent.com/18581859/54450213-e2016a00-4775-11e9-82d6-fc29bb78ccdf.png)

That's an entirely different topic.