### PR TITLE
Domains: Remove privacy sub grouping from billing history

### DIFF
--- a/client/me/billing-history/test/utils.js
+++ b/client/me/billing-history/test/utils.js
@@ -21,7 +21,7 @@ describe( 'utils', () => {
 			expect( result ).to.eql( items );
 		} );
 
-		test( 'should return a domain item with a groupCount and hasPrivateRegistration added if there is only one', () => {
+		test( 'should return a domain item with a groupCount', () => {
 			const items = deepFreeze( [
 				{ foo: 'bar', product_slug: 'foobar' },
 				{ product_slug: 'wp-domains', domain: 'foo.com', variation_slug: 'none' },
@@ -33,24 +33,10 @@ describe( 'utils', () => {
 					variation_slug: 'none',
 					domain: 'foo.com',
 					groupCount: 1,
-					hasPrivateRegistration: 0,
 				},
 			];
 			const result = groupDomainProducts( items, ident );
 			expect( result ).to.eql( expected );
-		} );
-
-		test( 'should return a domain item with hasPrivateRegistration true if the variation_slug has a private slug', () => {
-			const items = deepFreeze( [
-				{ foo: 'bar', product_slug: 'foobar' },
-				{
-					product_slug: 'wp-domains',
-					domain: 'foo.com',
-					variation_slug: 'wp-private-registration',
-				},
-			] );
-			const result = groupDomainProducts( items, ident );
-			expect( result[ 1 ].hasPrivateRegistration ).to.eql( 1 );
 		} );
 
 		test( 'should not group domain items with different domains', () => {
@@ -77,7 +63,6 @@ describe( 'utils', () => {
 					variation_slug: 'wp-private-registration',
 					domain: 'foo.com',
 					groupCount: 1,
-					hasPrivateRegistration: 1,
 				},
 				{
 					id: '3',
@@ -85,7 +70,6 @@ describe( 'utils', () => {
 					variation_slug: 'wp-private-registration',
 					domain: 'bar.com',
 					groupCount: 1,
-					hasPrivateRegistration: 1,
 				},
 			];
 			const result = groupDomainProducts( items, ident );
@@ -131,26 +115,6 @@ describe( 'utils', () => {
 			] );
 			const result = groupDomainProducts( items, ident );
 			expect( result[ 1 ].groupCount ).to.eql( 2 );
-		} );
-
-		test( 'should set hasPrivateRegistration to a union of multiple items with the same domain', () => {
-			const items = deepFreeze( [
-				{ foo: 'bar', product_slug: 'foobar' },
-				{
-					id: '2',
-					product_slug: 'wp-domains',
-					domain: 'foo.com',
-					variation_slug: 'none',
-				},
-				{
-					id: '3',
-					product_slug: 'wp-domains',
-					domain: 'foo.com',
-					variation_slug: 'wp-private-registration',
-				},
-			] );
-			const result = groupDomainProducts( items, ident );
-			expect( result[ 1 ].hasPrivateRegistration ).to.eql( 1 );
 		} );
 
 		test( 'should sum the raw_amount for multiple items with the same domain', () => {

--- a/client/me/billing-history/utils.jsx
+++ b/client/me/billing-history/utils.jsx
@@ -29,8 +29,7 @@ export const groupDomainProducts = ( originalItems, translate ) => {
 				groups[ product.domain ] = product;
 				groups[ product.domain ].groupCount = 1;
 			}
-			groups[ product.domain ].hasPrivateRegistration |=
-				product.variation_slug === 'wp-private-registration';
+
 			return groups;
 		},
 		{}
@@ -45,9 +44,7 @@ export const groupDomainProducts = ( originalItems, translate ) => {
 			return {
 				...product,
 				amount: formatCurrency( product.raw_amount, product.currency ),
-				variation: product.hasPrivateRegistration
-					? translate( 'Domain Registration with Privacy Protection' )
-					: translate( 'Domain Registration' ),
+				variation: translate( 'Domain Registration' ),
 			};
 		} ),
 	];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Privacy subs are gone. Don't group them anymore.

#### Testing instructions
- Go to billing history.
- Compare results between wpcalypso and this branch.
- You shouldn't see `Domain Registration With Privacy Protection` anymore.
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->