### PR TITLE
Use ESM version of react-virtualized and import modules individually

### DIFF
--- a/client/reader/components/reader-infinite-stream/index.jsx
+++ b/client/reader/components/reader-infinite-stream/index.jsx
@@ -5,13 +5,11 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {
-	List,
-	WindowScroller,
-	CellMeasurerCache,
-	CellMeasurer,
-	InfiniteLoader,
-} from 'react-virtualized';
+import List from 'react-virtualized/List';
+import WindowScroller from 'react-virtualized/WindowScroller';
+import { CellMeasurer, CellMeasurerCache } from 'react-virtualized/CellMeasurer';
+import InfiniteLoader from 'react-virtualized/InfiniteLoader';
+
 import { debounce, noop, get, pickBy } from 'lodash';
 
 /**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -211,7 +211,7 @@ function getWebpackConfig( {
 			alias: Object.assign(
 				{
 					'gridicons/example': 'gridicons/dist/example',
-					'react-virtualized': 'react-virtualized/dist/commonjs',
+					'react-virtualized': 'react-virtualized/dist/es',
 					'social-logos/example': 'social-logos/build/example',
 					debug: path.resolve( __dirname, 'node_modules/debug' ),
 					store: 'store/dist/store.modern',


### PR DESCRIPTION
Update the webpack config bit that imported the CommonJS version to import ES modules.

The reason why we need the webpack alias at all is that the `module` field in `package.json` doesn't work well when resolving subpackages like `react-virtualized/List`.

Because the package doesn't have the `sideEffect: false` flag (see also bvaughn/react-virtualized#1163), importing from the top-level package is not efficient and we need to import the subpackages individually, 

The result is a big size decrease of the chunks that bundle `react-virtualized`:
```
vendors~async-load-design-blocks~async-load-reader-following-manage~async-load-reader-search-stream  -20207 B (-13.6%) -14882 B (-26.4%)  -2057 B (-17.1%)
vendors~async-load-reader-following-manage~async-load-reader-search-stream                          -202112 B (-84.2%) -86589 B (-86.2%) -15777 B (-80.2%)
```