### PR TITLE
Allow purchase of extra seats for existing G Suite customers with mapped out domains

### DIFF
--- a/client/lib/domains/gsuite/index.js
+++ b/client/lib/domains/gsuite/index.js
@@ -50,7 +50,8 @@ function getEligibleGSuiteDomain( selectedDomainName, domains ) {
 function getGSuiteSupportedDomains( domains ) {
 	return domains.filter( function( domain ) {
 		const wpcomHosted =
-			includes( [ domainTypes.REGISTERED ], domain.type ) && domain.hasWpcomNameservers;
+			includes( [ domainTypes.REGISTERED ], domain.type ) &&
+			( domain.hasWpcomNameservers || hasGSuite( domain ) );
 		const mapped = includes( [ domainTypes.MAPPED ], domain.type );
 		return ( wpcomHosted || mapped ) && canDomainAddGSuite( domain.name );
 	} );

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -21,7 +21,7 @@ import { fetchBySiteId } from 'state/google-apps-users/actions';
 import { getBySite, isLoaded } from 'state/google-apps-users/selectors';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { hasGSuite, hasGSuiteSupportedDomain } from 'lib/domains/gsuite';
+import { hasGSuiteSupportedDomain } from 'lib/domains/gsuite';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySiteDomains from 'components/data/query-site-domains';
@@ -29,29 +29,22 @@ import SectionHeader from 'components/section-header';
 
 class GSuiteAddUsers extends React.Component {
 	componentDidMount() {
-		const { domains, isRequestingDomains, selectedDomainName, selectedSite } = this.props;
-		this.redirectIfCannotAddEmail( domains, isRequestingDomains, selectedDomainName );
+		const { domains, isRequestingDomains, selectedSite } = this.props;
+		this.redirectIfCannotAddEmail( domains, isRequestingDomains );
 		this.props.fetchGoogleAppsUsers( selectedSite.ID );
 	}
 
 	shouldComponentUpdate( nextProps ) {
-		const { domains, isRequestingDomains, selectedDomainName } = nextProps;
-		this.redirectIfCannotAddEmail( domains, isRequestingDomains, selectedDomainName );
+		const { domains, isRequestingDomains } = nextProps;
+		this.redirectIfCannotAddEmail( domains, isRequestingDomains );
 		if ( isRequestingDomains || ! domains.length ) {
 			return false;
 		}
 		return true;
 	}
 
-	redirectIfCannotAddEmail( domains, isRequestingDomains, selectedDomainName ) {
-		let selectedDomainHasGSuite = false;
-		if ( selectedDomainName ) {
-			const selectedDomain = domains.reduce( function( selected, domain ) {
-				return domain.name === selectedDomainName ? domain.name : selected;
-			}, '' );
-			selectedDomainHasGSuite = hasGSuite( selectedDomain );
-		}
-		if ( selectedDomainHasGSuite || isRequestingDomains || hasGSuiteSupportedDomain( domains ) ) {
+	redirectIfCannotAddEmail( domains, isRequestingDomains ) {
+		if ( isRequestingDomains || hasGSuiteSupportedDomain( domains ) ) {
 			return;
 		}
 		this.goToEmail();

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -21,7 +21,7 @@ import { fetchBySiteId } from 'state/google-apps-users/actions';
 import { getBySite, isLoaded } from 'state/google-apps-users/selectors';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { hasGSuiteSupportedDomain } from 'lib/domains/gsuite';
+import { hasGSuite, hasGSuiteSupportedDomain } from 'lib/domains/gsuite';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySiteDomains from 'components/data/query-site-domains';
@@ -29,22 +29,29 @@ import SectionHeader from 'components/section-header';
 
 class GSuiteAddUsers extends React.Component {
 	componentDidMount() {
-		const { domains, isRequestingDomains, selectedSite } = this.props;
-		this.redirectIfCannotAddEmail( domains, isRequestingDomains );
+		const { domains, isRequestingDomains, selectedDomainName, selectedSite } = this.props;
+		this.redirectIfCannotAddEmail( domains, isRequestingDomains, selectedDomainName );
 		this.props.fetchGoogleAppsUsers( selectedSite.ID );
 	}
 
 	shouldComponentUpdate( nextProps ) {
-		const { domains, isRequestingDomains } = nextProps;
-		this.redirectIfCannotAddEmail( domains, isRequestingDomains );
+		const { domains, isRequestingDomains, selectedDomainName } = nextProps;
+		this.redirectIfCannotAddEmail( domains, isRequestingDomains, selectedDomainName );
 		if ( isRequestingDomains || ! domains.length ) {
 			return false;
 		}
 		return true;
 	}
 
-	redirectIfCannotAddEmail( domains, isRequestingDomains ) {
-		if ( isRequestingDomains || hasGSuiteSupportedDomain( domains ) ) {
+	redirectIfCannotAddEmail( domains, isRequestingDomains, selectedDomainName ) {
+		let selectedDomainHasGSuite = false;
+		if ( selectedDomainName ) {
+			const selectedDomain = domains.reduce( function( selected, domain ) {
+				return domain.name === selectedDomainName ? domain.name : selected;
+			}, '' );
+			selectedDomainHasGSuite = hasGSuite( selectedDomain );
+		}
+		if ( selectedDomainHasGSuite || isRequestingDomains || hasGSuiteSupportedDomain( domains ) ) {
 			return;
 		}
 		this.goToEmail();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Allows purchase of extra G Suite seats if user has a mapped out domain but already has at least one seat.

#### Testing instructions

* DO NOT checkout branch yet.
* Have a site with a domain that has G Suite
* Ensure that you can purchase an extra seat, or at least get to checkout
* Map the domain out to another host
* Observe that clicking the button to add another seat takes you back to the G Suite user list
* Check out this branch
* Observe that you can now go to checkout with an additional seat.
