### PR TITLE
Layout: AsyncLoad community translator

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -17,7 +17,6 @@ import AsyncLoad from 'components/async-load';
 import MasterbarLoggedIn from 'layout/masterbar/logged-in';
 import GlobalNotices from 'components/global-notices';
 import notices from 'notices';
-import TranslatorLauncher from './community-translator/launcher';
 import config from 'config';
 import PulsingDot from 'components/pulsing-dot';
 import OfflineStatus from 'layout/offline-status';
@@ -150,7 +149,7 @@ class Layout extends Component {
 				{ config.isEnabled( 'i18n/community-translator' ) ? (
 					isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
 				) : (
-					<TranslatorLauncher />
+					<AsyncLoad require="layout/community-translator/launcher" placeholder={ null } />
 				) }
 				{ this.props.sectionGroup === 'sites' && <SitePreview /> }
 				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Load community translator asynchronously to reduce some of the `build` size.

#### Testing instructions

* Checkout this branch.
* Load Calypso.
* Make sure you've picked a different interface language than English in your WP.com profile.
* Load any WP.com page.
* Verify community translator loads properly and works like it did before.

