### PR TITLE
Colour Scheming: Unread Notifications Accessibility

### DIFF
--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -383,7 +383,7 @@
 		}
 
 		.unread {
-			background: rgba( var( --color-primary-rgb ), 0.1 );
+			background: rgba( var( --color-primary-rgb ), 0.1 ); // rgba is used to meet AA contrast standard
 		}
 
 		.wpnc__selected-note {

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -383,7 +383,7 @@
 		}
 
 		.unread {
-			background: var( --color-primary-50 );
+			background: rgba( var( --color-primary-rgb ), 0.1);
 		}
 
 		.wpnc__selected-note {

--- a/client/notifications/src/panel/boot/stylesheets/main.scss
+++ b/client/notifications/src/panel/boot/stylesheets/main.scss
@@ -383,7 +383,7 @@
 		}
 
 		.unread {
-			background: rgba( var( --color-primary-rgb ), 0.1);
+			background: rgba( var( --color-primary-rgb ), 0.1 );
 		}
 
 		.wpnc__selected-note {


### PR DESCRIPTION
Fixes #31208

I'm really not sure how to feel about using a primary rgba of 0.1 here, but it's the only thing which I feel has a sufficient visual impact and _just_ meets accessibility requirements. 

To give some context, this is what it was originally. #30267 has discussion on the difference being really difficult to see, but a darker neutral not working. `--primary-50` gets to where it is now though. 

![fgdgfdgfd](https://user-images.githubusercontent.com/43215253/54476797-3a2d8000-47f9-11e9-86f7-8f4d01efa58b.png)

Here's current, clear difference, but not accessible. 

![hgfgfhghffgh](https://user-images.githubusercontent.com/43215253/54476798-41548e00-47f9-11e9-9101-6ba904b1a83d.png)

Here's what I'm proposing: (cc @koke, do you think the difference is still distinct?) 

![gdfdfgfgd](https://user-images.githubusercontent.com/43215253/54476812-5c270280-47f9-11e9-8926-0bd526442614.png)

Color ratio: **4.53:1**
https://webaim.org/resources/contrastchecker/?fcolor=636D75&bcolor=E6EFF3

And in Sakura, ratio of 4.58:1:

![hfghfgfhg](https://user-images.githubusercontent.com/43215253/54476832-8c6ea100-47f9-11e9-8371-0a1c0e9cbce1.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This almost certainly needs design feedback too, but is this assignment correct, and can you compare the difference with an unread notification and a read notification? 

 (cc @flootr, @blowery, @drw158, @simison)