### PR TITLE
Podcasting: Auto save category and cover image changes

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -430,16 +430,28 @@ class PodcastingDetails extends Component {
 	};
 
 	onCoverImageRemoved = () => {
-		this.props.updateFields( {
+		const { submitForm } = this.props;
+
+		const fieldsToUpdate = {
 			podcasting_image_id: '0',
 			podcasting_image: '',
+		};
+
+		this.props.updateFields( fieldsToUpdate, () => {
+			submitForm();
 		} );
 	};
 
 	onCoverImageSelected = ( coverId, coverUrl ) => {
-		this.props.updateFields( {
+		const { submitForm } = this.props;
+
+		const fieldsToUpdate = {
 			podcasting_image_id: String( coverId ),
 			podcasting_image: coverUrl,
+		};
+
+		this.props.updateFields( fieldsToUpdate, () => {
+			submitForm();
 		} );
 	};
 

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -398,7 +398,7 @@ class PodcastingDetails extends Component {
 	}
 
 	onCategorySelected = category => {
-		const { settings, fields, isPodcastingEnabled } = this.props;
+		const { settings, fields, isPodcastingEnabled, submitForm } = this.props;
 
 		const fieldsToUpdate = { podcasting_category_id: String( category.ID ) };
 
@@ -415,7 +415,9 @@ class PodcastingDetails extends Component {
 			}
 		}
 
-		this.props.updateFields( fieldsToUpdate );
+		this.props.updateFields( fieldsToUpdate, () => {
+			submitForm();
+		} );
 	};
 
 	onCategoryCleared = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Automatically save changes to podcast category selection or cover image selection/removal.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout the live branch available below.
- Visit http://calypso.localhost:3000/settings/podcasting/
- Choose a site without podcasting setup so far, or choose one that has podcasting setup and disable podcast.
- Click on the category available at the top, or create a new category; notice that the changes are saved on choosing the category.
- Select a new cover image; notice that the changes are saved immediately.
- Remove the existing cover image; notice that the changes are saved immediately.

Fixes https://github.com/Automattic/wp-calypso/issues/29280

@michaeldcain, this goes by the idea you had mentioned here https://github.com/Automattic/wp-calypso/pull/26200#issuecomment-406681966 Or, if we might prefer not to auto-save, but show the publish notice only until the category is saved, I can close this PR and give a shot at a new one.