### PR TITLE
Colour Scheming: Fix Reader Share Fade

### DIFF
--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -109,7 +109,7 @@
 .reader-share__site-selector .site__title,
 .reader-share__site-selector .site__domain {
 	&::after {
-		background: linear-gradient( to right, rgba( 255, 255, 255, 0 ), var( --color-neutral-0 ) 90% );
+		@include long-content-fade( $color: var( --color-white-rgb ) );
 		border-radius: 50%;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Uses the long fade component for the Reader Share block. 

**Before:**

![beforesdfdfgdfggfd](https://user-images.githubusercontent.com/43215253/54480206-9aceb400-481d-11e9-82cc-104700b9cf91.png)

**After:**

![gfdfdgdfgaf](https://user-images.githubusercontent.com/43215253/54480213-a1f5c200-481d-11e9-9ec9-dd62ca0e245a.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Open the Reader Share menu in the Reader by clicking the share button at the bottom of a post, how do things look? 

Fixes #31368 

cc @flootr, @blowery, @drw158 
