### PR TITLE
Build: Remove webpack ignore props

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -150,7 +150,7 @@ function getWebpackConfig( {
 		module: {
 			// avoids this warning:
 			// https://github.com/localForage/localForage/issues/577
-			noParse: /[\/\\]node_modules[\/\\]localforage[\/\\]dist[\/\\]localforage\.js$/,
+			noParse: /[/\\]node_modules[/\\]localforage[/\\]dist[/\\]localforage\.js$/,
 			rules: [
 				TranspileConfig.loader( {
 					workerCount,
@@ -160,7 +160,7 @@ function getWebpackConfig( {
 					exclude: /node_modules\//,
 				} ),
 				{
-					test: /node_modules[\/\\](redux-form|react-redux)[\/\\]es/,
+					test: /node_modules[/\\](redux-form|react-redux)[/\\]es/,
 					loader: 'babel-loader',
 					options: {
 						babelrc: false,
@@ -200,7 +200,7 @@ function getWebpackConfig( {
 					use: 'exports-loader?window=tinymce',
 				},
 				{
-					test: /node_modules[\/\\]tinymce/,
+					test: /node_modules[/\\]tinymce/,
 					use: 'imports-loader?this=>window',
 				},
 			],
@@ -289,7 +289,7 @@ function getWebpackConfig( {
 
 	if ( ! config.isEnabled( 'desktop' ) ) {
 		webpackConfig.plugins.push(
-			new webpack.NormalModuleReplacementPlugin( /^lib[\/\\]desktop$/, 'lodash/noop' )
+			new webpack.NormalModuleReplacementPlugin( /^lib[/\\]desktop$/, 'lodash/noop' )
 		);
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -231,7 +231,6 @@ function getWebpackConfig( {
 				global: 'window',
 			} ),
 			new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
-			new webpack.IgnorePlugin( /^props$/ ),
 			isCalypsoClient && new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
 			...SassConfig.plugins( { cssFilename, minify: ! isDevelopment } ),
 			new AssetsWriter( {


### PR DESCRIPTION
- Remove webpack `IgnorePlugin( /^props$/ )`
- Remove redundant `\` escapes in Regexes (lint)

> IgnorePlugin prevents generation of modules for import or require calls matching the regular expressions

https://webpack.js.org/plugins/ignore-plugin/

It's unclear why this was introduced, it was part of a larger changeset in 4801-gh-calypso-pre-oss.

I suspect it's not ignoring anything relevant:

```
$ find . -name 'props'

# nothing

$ find . -name 'props*'

./node_modules/ramda/es/props.js
./node_modules/ramda/src/props.js
./node_modules/lodash/fp/props.js
./node_modules/react-day-picker/types/props.d.ts
./node_modules/chai-enzyme/test/props.test.js
./node_modules/chai-enzyme/build/assertions/props.js
./node_modules/chai-enzyme/src/assertions/props.js
./node_modules/bluebird/js/release/props.js
./node_modules/uglify-js/tools/props.html
./node_modules/terser/tools/props.html
./node_modules/eslint-plugin-react/lib/util/props.js

```

#### Testing instructions

* e2e tests pass?
* [ICFY build not impacted](http://iscalypsofastyet.com/branch?branch=remove/webpack-ignore-props) (waiting for build results…)

ICFY report:
```
Latest push in this branch:
Commit: 5b693016004925e402652781872dd98ae07e1310
Author: sirreal
At: 2019-03-18T10:22:49Z
Message: Remove ignore plugin props
Delta:
no changes in production JS
```