### PR TITLE
Components: Migrate PlansSkipButton style to Webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -107,7 +107,6 @@
 @import 'components/notice/style';
 @import 'components/payment-logo/style';
 @import 'components/plans/plan-icon/style';
-@import 'components/plans/plans-skip-button/style';
 @import 'blocks/product-purchase-features-list/style';
 @import 'components/popover/style';
 @import 'components/post-excerpt/style';

--- a/client/components/plans/plans-skip-button/index.jsx
+++ b/client/components/plans/plans-skip-button/index.jsx
@@ -12,6 +12,11 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Gridicon from 'gridicons';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export const PlansSkipButton = ( { onClick, translate = identity } ) => (
 	<div className="plans-skip-button">
 		<Button onClick={ onClick }>


### PR DESCRIPTION
This PR migrates the style of the `<PlansSkipButton />` component to Webpack.

See p4TIVU-9dT-p2 for more details on the rationale of this migration.

#### Changes proposed in this Pull Request

* Import the `<PlansSkipButton />` component style with Webpack.

#### Testing instructions

* Checkout this branch.
* Compare http://calypso.localhost:3000/jetpack/connect/store with https://wpcalypso.wordpress.com/jetpack/connect/store and verify the "Start with free" button looks and work the same way.
* Compare http://calypso.localhost:3000/devdocs/design/plans-skip-button with https://wpcalypso.wordpress.com/devdocs/design/plans-skip-button and verify the "Start with free" button looks and work the same way.
