### PR TITLE
Jetpack Onboarding: Migrate JPO style to Webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -136,7 +136,6 @@
 @import 'components/environment-badge/style';
 @import 'blocks/credit-card-form/style';
 @import 'jetpack-connect/style';
-@import 'jetpack-onboarding/style';
 @import 'layout/guided-tours/style';
 @import 'components/happychat/style';
 @import 'components/happychat/agent-w/style';

--- a/client/jetpack-onboarding/main.jsx
+++ b/client/jetpack-onboarding/main.jsx
@@ -39,6 +39,11 @@ import { isJetpackSite, isRequestingSite, isRequestingSites } from 'state/sites/
 import { saveJetpackSettings } from 'state/jetpack/settings/actions';
 import { setSelectedSiteId } from 'state/ui/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class JetpackOnboardingMain extends React.PureComponent {
 	static propTypes = {
 		stepName: PropTypes.string,
@@ -147,7 +152,7 @@ class JetpackOnboardingMain extends React.PureComponent {
 					title={ analyticsPageTitle }
 				/>
 
-				{ /* It is important to use `<QuerySites siteId={ siteSlug } />` here, however wrong that seems.
+				{ /* It is important to use `<QuerySites siteId={siteSlug} />` here, however wrong that seems.
 				 * The reason is that we rely on an `isRequestingSite()` check to tell whether we've
 				 * finished fetching site details, which will tell us whether the site is connected,
 				 * which we need in turn to conditionally send JPO auth credentials (see below).


### PR DESCRIPTION
This PR migrates the style of Jetpack Onboarding section to Webpack.

See p4TIVU-9dT-p2 for more details on the rationale of this migration.

#### Changes proposed in this Pull Request

* Import the Jetpack Onboarding section style with Webpack.

#### Testing instructions

* Checkout this branch.
* Compare http://calypso.localhost:3000/jetpack/start/:site with https://wpcalypso.wordpress.com/jetpack/start/:site (where `:site` is the slug of a connected Jetpack site) and verify they look and work the same way.
* Verify the selectors in the stylesheet aren't used in any other component (that's easy to check because all selectors are prefixed with `.jetpack-onboarding`).
