### PR TITLE
Migrate CSS for my-sites/checkout

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -233,13 +233,6 @@
 @import 'my-sites/themes/themes-selection-header/style';
 @import 'my-sites/themes/themes-banner/style';
 @import 'my-sites/upgrade-nudge/style';
-@import 'my-sites/checkout/cart/style';
-@import 'my-sites/checkout/checkout/style';
-@import 'my-sites/checkout/checkout/subscription-text';
-@import 'my-sites/checkout/checkout-thank-you/style';
-@import 'my-sites/checkout/checkout-thank-you/google-voucher/style';
-@import 'my-sites/checkout/concierge-session-nudge/style';
-@import 'my-sites/checkout/gsuite-nudge/style';
 @import 'my-sites/domains/domain-management/components/designated-agent-notice/style';
 @import 'my-sites/domains/domain-management/transfer/transfer-out/style';
 @import 'my-sites/domains/domain-management/transfer/transfer-to-other-user/style';

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -1,4 +1,4 @@
-/** @format */
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 /**
  * External dependencies
@@ -26,6 +26,12 @@ import CartPlanAd from './cart-plan-ad';
 import { isCredits } from 'lib/products-values';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+// eslint-disable-next-line react/prefer-es6-class
 const PopoverCart = createReactClass( {
 	displayName: 'PopoverCart',
 
@@ -38,6 +44,13 @@ const PopoverCart = createReactClass( {
 		pinned: PropTypes.bool.isRequired,
 		showKeepSearching: PropTypes.bool.isRequired,
 		onKeepSearchingClick: PropTypes.func.isRequired,
+	},
+
+	toggleButton: React.createRef(),
+	hasUnmounted: false,
+
+	componentWillUnmount: function() {
+		this.hasUnmounted = true;
 	},
 
 	itemCount: function() {
@@ -69,7 +82,11 @@ const PopoverCart = createReactClass( {
 			<div>
 				<CartMessages cart={ cart } selectedSite={ selectedSite } />
 				<div className={ classes }>
-					<button className="cart-toggle-button" ref="toggleButton" onClick={ this.onToggle }>
+					<button
+						className="cart-toggle-button"
+						ref={ this.toggleButton }
+						onClick={ this.onToggle }
+					>
 						<div className="popover-cart__label">{ this.props.translate( 'Cart' ) }</div>
 						<Gridicon icon="cart" size={ 24 } />
 						{ countBadge }
@@ -89,7 +106,7 @@ const PopoverCart = createReactClass( {
 					isVisible={ this.props.visible }
 					position="bottom left"
 					onClose={ this.onClose }
-					context={ this.refs.toggleButton }
+					context={ this.toggleButton.current }
 				>
 					{ this.cartBody() }
 					<TrackComponentView
@@ -149,7 +166,7 @@ const PopoverCart = createReactClass( {
 	onClose: function() {
 		// Since this callback can fire after the user navigates off the page, we
 		// we need to check if it's mounted to prevent errors.
-		if ( ! this.isMounted() ) {
+		if ( this.hasUnmounted ) {
 			return;
 		}
 

--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -29,6 +29,11 @@ import { isJetpackSite } from 'state/sites/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import JetpackLogo from 'components/jetpack-logo';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class SecondaryCart extends Component {
 	static propTypes = {
 		cart: PropTypes.object.isRequired,

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -26,6 +26,11 @@ import { assignSiteVoucher as assignVoucher } from 'state/sites/vouchers/actions
 import { GOOGLE_CREDITS } from 'state/sites/vouchers/service-types';
 import { getVouchersBySite, getGoogleAdCredits } from 'state/sites/vouchers/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const [ INITIAL_STEP, TERMS_AND_CONDITIONS, CODE_REDEEMED ] = [
 	'INITIAL_STEP',
 	'TERMS_AND_CONDITIONS',

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -93,6 +93,11 @@ import isFetchingTransfer from 'state/selectors/is-fetching-atomic-transfer';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 function getPurchases( props ) {
 	return [
 		...get( props, 'receipt.data.purchases', [] ),

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -78,6 +78,12 @@ import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import config from 'config';
 import { abtest } from 'lib/abtest';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+
 export class Checkout extends React.Component {
 	static propTypes = {
 		cards: PropTypes.array.isRequired,

--- a/client/my-sites/checkout/checkout/package.json
+++ b/client/my-sites/checkout/checkout/package.json
@@ -1,6 +1,0 @@
-{
-	"name": "checkout",
-	"version": "0.0.0",
-	"private": true,
-	"main": "checkout.jsx"
-}

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -258,7 +258,7 @@
 		font-size: 12px;
 	}
 
-	.checkout-terms,
+	.checkout__terms,
 	.checkout__domain-refund-policy {
 		color: var( --color-text-subtle );
 		margin: 16px 0;

--- a/client/my-sites/checkout/checkout/subscription-text.jsx
+++ b/client/my-sites/checkout/checkout/subscription-text.jsx
@@ -14,6 +14,11 @@ import { isMonthly, isYearly, isBiennially } from 'lib/products-values';
  */
 import { cartItems } from 'lib/cart-values';
 
+/**
+ * Style dependencies
+ */
+import './subscription-text.scss';
+
 class SubscriptionText extends React.Component {
 	render() {
 		const { cart, translate } = this.props;
@@ -36,7 +41,7 @@ class SubscriptionText extends React.Component {
 				} );
 			}
 
-			return <span className="subscription-text">{ informative_text }</span>;
+			return <span className="checkout__subscription-text">{ informative_text }</span>;
 		}
 
 		return null;

--- a/client/my-sites/checkout/checkout/subscription-text.scss
+++ b/client/my-sites/checkout/checkout/subscription-text.scss
@@ -1,4 +1,4 @@
-.subscription-text {
+.checkout__subscription-text {
 	color: var( --color-neutral-light );
 	font-size: 14px;
 	font-style: italic;

--- a/client/my-sites/checkout/checkout/terms-of-service.jsx
+++ b/client/my-sites/checkout/checkout/terms-of-service.jsx
@@ -23,7 +23,7 @@ class TermsOfService extends React.Component {
 		analytics.ga.recordEvent( 'Upgrades', 'Clicked Terms and Conditions Link' );
 	};
 
-	renderTerms = () => {
+	renderTerms() {
 		let message = this.props.translate(
 			'By checking out, you agree to our {{link}}terms and conditions{{/link}}.',
 			{
@@ -64,11 +64,15 @@ class TermsOfService extends React.Component {
 		}
 
 		return message;
-	};
+	}
 
 	render() {
 		return (
-			<div className="checkout-terms" onClick={ this.recordTermsAndConditionsClick }>
+			<div
+				className="checkout__terms"
+				role="presentation"
+				onClick={ this.recordTermsAndConditionsClick }
+			>
 				<Gridicon icon="info-outline" size={ 18 } />
 				<p>{ this.renderTerms() }</p>
 			</div>

--- a/client/my-sites/checkout/checkout/test/checkout.js
+++ b/client/my-sites/checkout/checkout/test/checkout.js
@@ -13,7 +13,7 @@ import { identity } from 'lodash';
 /**
  * Internal dependencies
  */
-import { Checkout } from '../checkout';
+import { Checkout } from '../';
 import { hasPendingPayment } from 'lib/cart-values';
 import { isEnabled } from 'config';
 

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -37,6 +37,11 @@ import { localize } from 'i18n-calypso';
 import { isRequestingSitePlans, getPlansBySiteId } from 'state/sites/plans/selectors';
 import analytics from 'lib/analytics';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class ConciergeSessionNudge extends React.Component {
 	static propTypes = {
 		receiptId: PropTypes.number,

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -26,6 +26,11 @@ import { isDotComPlan } from 'lib/products-values';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { abtest } from 'lib/abtest';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class GSuiteNudge extends React.Component {
 	static propTypes = {
 		domain: PropTypes.string.isRequired,


### PR DESCRIPTION
This is a quick and dirty migration, just porting the import statements from _components.scss to the corresponding root components. We could go further and break up the styles to match their components, but I'm not sure it's worth the additional complexity and risk with something as mission critical as the shopping cart.

#### Testing instructions

* Visit the plans page for a site.
* Add a plan to your cart
* Verify that all cart-related styles still apply and work
