### PR TITLE
Browserlist: Add 'not dead' to query

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "Safari >= 10",
     "iOS >= 10",
     "not ie <= 10",
-    "> 1%"
+    "> 1%",
+    "not dead"
   ],
   "dependencies": {
     "@automattic/format-currency": "file:./packages/format-currency",


### PR DESCRIPTION
We don't need to support dead browsers. This removes transpilation support for IE 10 Mobile and some others. Compare [without not dead](https://browserl.ist/?q=last+2+versions%2C+Safari+%3E%3D+10%2C+++iOS+%3E%3D+10%2C+++not+ie+%3C%3D+10%2C+++%3E+1%25) to [with not dead](https://browserl.ist/?q=last+2+versions%2C+Safari+%3E%3D+10%2C+iOS+%3E%3D+10%2C+not+ie+%3C%3D+10%2C+%3E+1%25%2C+not+dead)

#### Changes proposed in this Pull Request

* Add `not dead` to the browserlist query

#### Testing instructions

* e2e tests should still pass and IE11 canaries.
