### PR TITLE
Importers: merge both isSiteImportable calls

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -6,6 +6,7 @@
  */
 import debugFactory from 'debug';
 import { camelCase, isPlainObject, omit, pick, reject, snakeCase } from 'lodash';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies.
@@ -1817,7 +1818,20 @@ Undocumented.prototype.googleAppsFilterBySiteId = function( siteId, fn ) {
 	return this.wpcom.req.get( { path: '/sites/' + siteId + '/google-apps' }, fn );
 };
 
-Undocumented.prototype.isSiteImportable = function( site_url ) {
+Undocumented.prototype.isSiteImportable = function( site_url, siteId, params ) {
+	// Note: There are 2 different is-site-importable endpoints.
+	// One is done within the context of a site, the other doesn't require a site.
+	if ( siteId ) {
+		const path = `/sites/${ siteId }/site-importer/is-site-importable?${ stringify( params ) }`;
+
+		debug( path );
+
+		return this.wpcom.req.get( {
+			path,
+			apiNamespace: 'wpcom/v2',
+		} );
+	}
+
 	debug( `/wpcom/v2/site-importer-global/is-site-importable?${ site_url }` );
 
 	return this.wpcom.req.get(

--- a/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
+++ b/client/my-sites/importer/site-importer/site-importer-input-pane.jsx
@@ -249,13 +249,8 @@ class SiteImporterInputPane extends React.Component {
 		const params = this.getApiParams();
 		params.site_url = urlForImport;
 
-		wpcom.wpcom.req
-			.get( {
-				path: `/sites/${ this.props.site.ID }/site-importer/is-site-importable?${ stringify(
-					params
-				) }`,
-				apiNamespace: 'wpcom/v2',
-			} )
+		wpcom
+			.isSiteImportable( urlForImport, this.props.site.ID, params )
 			.then( resp => {
 				this.setState( {
 					importStage: 'importable',


### PR DESCRIPTION
This PR looks to make `undocumented. isSiteImportable` useful for both of our `is-site-importable` endpoints so as to help discoverability.

The hope is to continue to consolidate this call, to make debugging and improvements easier to make.

### To Test

- Go through a Wix importing flow (An example site: https://smt593.wixsite.com/wowz)
- Make sure you still see the correct site preview, with the "We will import:" list being shown as expected.