### PR TITLE
Block Editor: Add an update image event on Media Modal changes

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { map, pickBy, endsWith } from 'lodash';
+import { endsWith, get, map, pickBy, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 
 /**
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
 import MediaModal from 'post-editor/media-modal';
 import MediaActions from 'lib/media/actions';
+import MediaStore from 'lib/media/store';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteOption, getSiteAdminUrl } from 'state/sites/selectors';
 import { addQueryArgs } from 'lib/route';
@@ -50,6 +51,7 @@ class CalypsoifyIframe extends Component {
 		super( props );
 		this.iframeRef = React.createRef();
 		this.mediaSelectPort = null;
+		MediaStore.on( 'change', this.updateImageBlocks );
 	}
 
 	componentDidMount() {
@@ -187,6 +189,18 @@ class CalypsoifyIframe extends Component {
 				payload: pressThis,
 			} );
 		}
+	};
+
+	updateImageBlocks = action => {
+		if ( ! action || startsWith( action.data.URL, 'blob:' ) ) {
+			return;
+		}
+		const payload = {
+			id: get( action, 'data.ID' ),
+			url: get( action, 'data.URL' ),
+			transientId: get( action, 'id' ),
+		};
+		this.iframePort.postMessage( { action: 'updateImageBlocks', payload } );
 	};
 
 	render() {

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -193,6 +193,7 @@ class CalypsoifyIframe extends Component {
 
 	updateImageBlocks = action => {
 		if (
+			! this.iframePort ||
 			! action ||
 			! startsWith( action.data.mime_type, 'image/' ) ||
 			startsWith( action.data.URL, 'blob:' )

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -192,7 +192,11 @@ class CalypsoifyIframe extends Component {
 	};
 
 	updateImageBlocks = action => {
-		if ( ! action || startsWith( action.data.URL, 'blob:' ) ) {
+		if (
+			! action ||
+			! startsWith( action.data.mime_type, 'image/' ) ||
+			startsWith( action.data.URL, 'blob:' )
+		) {
 			return;
 		}
 		const payload = {

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -199,6 +199,7 @@ class CalypsoifyIframe extends Component {
 			id: get( action, 'data.ID' ),
 			url: get( action, 'data.URL' ),
 			transientId: get( action, 'id' ),
+			status: 'REMOVE_MEDIA_ITEM' === action.type ? 'deleted' : 'updated',
 		};
 		this.iframePort.postMessage( { action: 'updateImageBlocks', payload } );
 	};

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -122,11 +122,8 @@ MediaStore.dispatchToken = Dispatcher.register( function( payload ) {
 				receiveSingle( action.siteId, action.data, action.id );
 			}
 
-			if ( 'RECEIVE_MEDIA_ITEM' === action.type ) {
-				MediaStore.emit( 'change', action );
-			} else {
-				MediaStore.emit( 'change' );
-			}
+			// `action` used by CalypsoifyIframe
+			MediaStore.emit( 'change', 'RECEIVE_MEDIA_ITEM' === action.type && action );
 			break;
 
 		case 'REMOVE_MEDIA_ITEM':
@@ -140,7 +137,8 @@ MediaStore.dispatchToken = Dispatcher.register( function( payload ) {
 				removeSingle( action.siteId, action.data );
 			}
 
-			MediaStore.emit( 'change', action );
+			// `action` used by CalypsoifyIframe
+			MediaStore.emit( 'change', 'deleted' === action.data.status && action );
 			break;
 
 		case 'FETCH_MEDIA_ITEM':

--- a/client/lib/media/store.js
+++ b/client/lib/media/store.js
@@ -122,7 +122,11 @@ MediaStore.dispatchToken = Dispatcher.register( function( payload ) {
 				receiveSingle( action.siteId, action.data, action.id );
 			}
 
-			MediaStore.emit( 'change' );
+			if ( 'RECEIVE_MEDIA_ITEM' === action.type ) {
+				MediaStore.emit( 'change', action );
+			} else {
+				MediaStore.emit( 'change' );
+			}
 			break;
 
 		case 'REMOVE_MEDIA_ITEM':
@@ -136,7 +140,7 @@ MediaStore.dispatchToken = Dispatcher.register( function( payload ) {
 				removeSingle( action.siteId, action.data );
 			}
 
-			MediaStore.emit( 'change' );
+			MediaStore.emit( 'change', action );
 			break;
 
 		case 'FETCH_MEDIA_ITEM':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Emit an `updateImageBlocks` event whenever an image has been updated or deleted in the Media Modal, so that the server can update accordingly all the blocks containing it.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test 1

* Apply D25703-code and sandbox a site.
* Open the Block Editor.
* Insert an Image block and, through the Media Modal, add an image from an external source (Pexels or Google Photos).
* Wait a bit until the image is uploaded. There should be no visual clues, but opening the image in a new tab should show a WP.com url instead of a Pexels or Google one).
* Save and reload.
* Make sure the image is displayed correctly.

Test 2

* Add the same image in other blocks (e.g. a File or Gallery block, and try also nesting them into other blocks like Columns).
* Open the Media Modal by editing any of these blocks, and edit the image.
* Rotate the image and confirm. Wait for the new version of the image to be uploaded successfully (the image should not be faded out and loading anymore).
* Instead of inserting it, cancel to close the modal.
* Make sure all the blocks containing the image have been updated correctly with the rotated image.

Test 3

* Open the Media Modal and delete the image.
* Make sure all the blocks containing it have been updated correctly by removing the image.

Fixes #29928