### PR TITLE
Jetpack blocks: Fix lints

### DIFF
--- a/packages/jetpack-blocks/src/blocks/contact-info/email/save.js
+++ b/packages/jetpack-blocks/src/blocks/contact-info/email/save.js
@@ -7,7 +7,7 @@ import { Fragment } from '@wordpress/element';
 const renderEmail = inputText => {
 	const explodedInput = inputText.split( /(\s+)/ ).map( ( email, i ) => {
 		// Remove and punctuation from the end of the email address.
-		const emailToValidate = email.replace( /([.,\/#!$%\^&\*;:{}=\-_`~()\]\[])+$/g, '' );
+		const emailToValidate = email.replace( /([.,/#!$%^&*;:{}=\-_`~()\][])+$/g, '' );
 		if ( email.indexOf( '@' ) && emailValidator.validate( emailToValidate ) ) {
 			return email === emailToValidate ? (
 				// Email.

--- a/packages/jetpack-blocks/src/blocks/gif/edit.js
+++ b/packages/jetpack-blocks/src/blocks/gif/edit.js
@@ -43,7 +43,7 @@ class GifEdit extends Component {
 		}
 		// https://media.giphy.com/media/gt0hYzKlMpfOg/giphy.gif
 		const match = searchText.match(
-			/http[s]?:\/\/media.giphy.com\/media\/([A-Za-z0-9\-\.]+)\/giphy.gif/
+			/http[s]?:\/\/media.giphy.com\/media\/([A-Za-z0-9\-.]+)\/giphy.gif/
 		);
 		if ( match ) {
 			giphyID = match[ 1 ];

--- a/packages/jetpack-blocks/src/blocks/map/lookup/index.js
+++ b/packages/jetpack-blocks/src/blocks/map/lookup/index.js
@@ -165,7 +165,7 @@ export class Lookup extends Component {
 		if ( ! debouncedSpeak ) {
 			return;
 		}
-		if ( !! filteredOptions.length ) {
+		if ( filteredOptions.length ) {
 			debouncedSpeak(
 				sprintf(
 					_n(

--- a/packages/jetpack-blocks/src/preset/setup/public-path.js
+++ b/packages/jetpack-blocks/src/preset/setup/public-path.js
@@ -6,5 +6,6 @@
  * @see https://webpack.js.org/guides/public-path/#on-the-fly
  */
 if ( typeof window === 'object' && window.Jetpack_Block_Assets_Base_Url ) {
+	// eslint-disable-next-line no-global-assign
 	__webpack_public_path__ = window.Jetpack_Block_Assets_Base_Url;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix existing lints

```sh
npx eslint --ext .js --ext .jsx packages/jetpack-blocks/
```

```
…/packages/jetpack-blocks/src/blocks/contact-info/email/save.js
  10:47  error  Unnecessary escape character: \/  no-useless-escape
  10:53  error  Unnecessary escape character: \^  no-useless-escape
  10:56  error  Unnecessary escape character: \*  no-useless-escape
  10:72  error  Unnecessary escape character: \[  no-useless-escape

…/packages/jetpack-blocks/src/blocks/gif/edit.js
  46:55  error  Unnecessary escape character: \.  no-useless-escape

…/packages/jetpack-blocks/src/blocks/map/lookup/index.js
  168:9  error  Redundant double negation  no-extra-boolean-cast

…/packages/jetpack-blocks/src/preset/setup/public-path.js
  9:2  error  Read-only global '__webpack_public_path__' should not be modified  no-global-assign
```

#### Testing instructions

* No changes
