### PR TITLE
Jetpack Checklist: Make task list dynamic

### DIFF
--- a/client/components/data/query-jetpack-product-install-status/README.md
+++ b/client/components/data/query-jetpack-product-install-status/README.md
@@ -1,0 +1,8 @@
+Query Jetpack Product Install Status
+================
+
+`<QueryJetpackProductInstallStatus />` is a React component used in managing network requests for fetching the current Jetpack product installation status.
+
+## Usage
+
+Render the component, passing `siteId`. It does not accept any children, nor does it render any elements to the page.

--- a/client/components/data/query-jetpack-product-install-status/index.js
+++ b/client/components/data/query-jetpack-product-install-status/index.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import { Component } from 'react';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestJetpackProductInstallStatus } from 'state/jetpack-product-install/actions';
+
+class QueryJetpackProductInstallStatus extends Component {
+	static propTypes = {
+		siteId: PropTypes.number.isRequired,
+	};
+
+	componentDidMount() {
+		this.props.requestJetpackProductInstallStatus( this.props.siteId );
+	}
+
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.siteId !== this.props.siteId ) {
+			this.props.requestJetpackProductInstallStatus( this.props.siteId );
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	null,
+	{
+		requestJetpackProductInstallStatus,
+	}
+)( QueryJetpackProductInstallStatus );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+/**
+ * Returns the localized duration of a task in given minutes.
+ *
+ * @param  {Number} minutes Number of minutes.
+ * @return {String} Localized duration.
+ */
+export function getJetpackChecklistTaskDuration( minutes ) {
+	return translate( '%d minute', '%d minutes', { count: minutes, args: [ minutes ] } );
+}
+
+export const JETPACK_CHECKLIST_TASKS = {
+	jetpack_backups: {
+		title: translate( 'Backups & Scanning' ),
+		description: translate(
+			"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
+		),
+		completedButtonText: translate( 'Change' ),
+		completedTitle: translate( 'You turned on backups and scanning.' ),
+		getUrl: siteSlug => `/activity-log/${ siteSlug }`,
+		duration: getJetpackChecklistTaskDuration( 2 ),
+	},
+	jetpack_monitor: {
+		title: translate( 'Jetpack Monitor' ),
+		description: translate(
+			"Monitor your site's uptime and alert you the moment downtime is detected with instant notifications."
+		),
+		completedButtonText: translate( 'Change' ),
+		completedTitle: translate( 'You turned on Jetpack Monitor.' ),
+		getUrl: siteSlug => `/settings/security/${ siteSlug }`,
+		duration: getJetpackChecklistTaskDuration( 3 ),
+		tourId: 'jetpackMonitoring',
+	},
+	jetpack_plugin_updates: {
+		title: translate( 'Automatic Plugin Updates' ),
+		description: translate(
+			'Choose which WordPress plugins you want to keep automatically updated.'
+		),
+		completedButtonText: translate( 'Change' ),
+		completedTitle: translate( 'You turned on automatic plugin updates.' ),
+		getUrl: siteSlug => `/plugins/manage/${ siteSlug }`,
+		duration: getJetpackChecklistTaskDuration( 3 ),
+		tourId: 'jetpackPluginUpdates',
+	},
+	jetpack_sign_in: {
+		title: translate( 'WordPress.com sign in' ),
+		description: translate(
+			'Manage your log in preferences and two-factor authentication settings.'
+		),
+		completedButtonText: translate( 'Change' ),
+		completedTitle: translate( 'You completed your sign in preferences.' ),
+		getUrl: siteSlug => `/settings/security/${ siteSlug }`,
+		duration: getJetpackChecklistTaskDuration( 3 ),
+		tourId: 'jetpackSignIn',
+	},
+};

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -19,7 +19,7 @@ export const JETPACK_CHECKLIST_TASKS = {
 		description: translate(
 			"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
 		),
-		completedButtonText: translate( 'Change' ),
+		completedButtonText: translate( 'Change', { context: 'verb' } ),
 		completedTitle: translate( 'You turned on backups and scanning.' ),
 		getUrl: siteSlug => `/activity-log/${ siteSlug }`,
 		duration: getJetpackChecklistTaskDuration( 2 ),
@@ -29,7 +29,7 @@ export const JETPACK_CHECKLIST_TASKS = {
 		description: translate(
 			"Monitor your site's uptime and alert you the moment downtime is detected with instant notifications."
 		),
-		completedButtonText: translate( 'Change' ),
+		completedButtonText: translate( 'Change', { context: 'verb' } ),
 		completedTitle: translate( 'You turned on Jetpack Monitor.' ),
 		getUrl: siteSlug => `/settings/security/${ siteSlug }`,
 		duration: getJetpackChecklistTaskDuration( 3 ),
@@ -40,7 +40,7 @@ export const JETPACK_CHECKLIST_TASKS = {
 		description: translate(
 			'Choose which WordPress plugins you want to keep automatically updated.'
 		),
-		completedButtonText: translate( 'Change' ),
+		completedButtonText: translate( 'Change', { context: 'verb' } ),
 		completedTitle: translate( 'You turned on automatic plugin updates.' ),
 		getUrl: siteSlug => `/plugins/manage/${ siteSlug }`,
 		duration: getJetpackChecklistTaskDuration( 3 ),
@@ -51,7 +51,7 @@ export const JETPACK_CHECKLIST_TASKS = {
 		description: translate(
 			'Manage your log in preferences and two-factor authentication settings.'
 		),
-		completedButtonText: translate( 'Change' ),
+		completedButtonText: translate( 'Change', { context: 'verb' } ),
 		completedTitle: translate( 'You completed your sign in preferences.' ),
 		getUrl: siteSlug => `/settings/security/${ siteSlug }`,
 		duration: getJetpackChecklistTaskDuration( 3 ),

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -25,12 +25,12 @@ export const JETPACK_CHECKLIST_TASKS = {
 		duration: getJetpackChecklistTaskDuration( 2 ),
 	},
 	jetpack_monitor: {
-		title: translate( 'Jetpack Monitor' ),
+		title: translate( 'Downtime Monitoring' ),
 		description: translate(
 			"Monitor your site's uptime and alert you the moment downtime is detected with instant notifications."
 		),
 		completedButtonText: translate( 'Change', { context: 'verb' } ),
-		completedTitle: translate( 'You turned on Jetpack Monitor.' ),
+		completedTitle: translate( 'You turned on Downtime Monitoring.' ),
 		getUrl: siteSlug => `/settings/security/${ siteSlug }`,
 		duration: getJetpackChecklistTaskDuration( 3 ),
 		tourId: 'jetpackMonitoring',

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
 import Checklist from 'components/checklist';
 import getJetpackProductInstallStatus from 'state/selectors/get-jetpack-product-install-status';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
+import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 import QueryJetpackProductInstallStatus from 'components/data/query-jetpack-product-install-status';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import Task from 'components/checklist/task';
@@ -53,6 +54,7 @@ class JetpackChecklist extends PureComponent {
 	render() {
 		const {
 			akismetFinished,
+			isPaidPlan,
 			productInstallStatus,
 			siteId,
 			siteSlug,
@@ -63,7 +65,7 @@ class JetpackChecklist extends PureComponent {
 		return (
 			<Fragment>
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
-				<QueryJetpackProductInstallStatus siteId={ siteId } />
+				{ isPaidPlan && <QueryJetpackProductInstallStatus siteId={ siteId } /> }
 
 				<Checklist
 					isPlaceholder={ ! taskStatuses }
@@ -75,7 +77,7 @@ class JetpackChecklist extends PureComponent {
 							"We've automatically protected you from brute force login attacks."
 						) }
 					/>
-					{ productInstallStatus && (
+					{ isPaidPlan && productInstallStatus && (
 						<Task
 							title={ translate( "We're automatically turning on spam filtering." ) }
 							completedTitle={ translate( "We've automatically turned on spam filtering." ) }
@@ -125,6 +127,7 @@ export default connect(
 
 		return {
 			akismetFinished: productInstallStatus && productInstallStatus.akismet_status === 'installed',
+			isPaidPlan: isSiteOnPaidPlan( state, siteId ),
 			productInstallStatus,
 			siteId,
 			siteSlug: getSiteSlug( state, siteId ),


### PR DESCRIPTION
Currently, the Jetpack checklist has static tasks. While we'll still have static copy and actions for each task, this PR updates the task list to use the tasks as fetched from the server.

#### Changes proposed in this Pull Request

* Make the Jetpack checklist dynamic.

#### Preview
Some tasks finished:
![](https://cldup.com/G-2S9SJtWr.png)

Akismet setting up:
![](https://cldup.com/aY9ll8RPgX.png)

Akismet finished:
![](https://cldup.com/WxPMCafsiV.png)

Akismet task not available for free plan:
![](https://cldup.com/fVJk-MDCML.png)

#### Testing instructions

* Checkout this branch.
* Create a JN site with the latest bleeding edge.
* Connect a Jetpack site (add `&calypso_env=development` to the connection URL to point it to Calypso).
* Buy a plan.
* You'll end up in the My plan page with the checklist and the plan setup screen.
* Verify the backups, monitor, plugin updates and WP.com sign in tasks work well and reflect the current state of the task.
* Verify Akismet task is in progress while Akismet is being setup, and it gets to a finished state when it finishes installing.
* Test with a site with a free plan and verify Akismet task isn't shown.

#### Next steps

There are still some unfinished things, bugs and edge cases to iron out, for example:
* The VP task doesn't work well yet and needs to be implemented differently for non-Rewind sites.
* Task state gets cached and doesn't get reflected upon uncompletion.

Those will be fixed subsequently in further PRs and diffs.
