### PR TITLE
Jetpack Onboarding: override styles for buttons that are disabled

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1037,6 +1037,11 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			background: var( --color-white );
 			border-color: var( --color-neutral-50 );
 			color: var( --color-neutral-50 );
+
+			&:hover,
+			&:focus {
+				background: var( --color-white );
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Jetpack Onboarding: override styles for buttons that are disabled

#### Testing instructions

* Fire up this PR.
* Create a [new Jetpack site](https://jurassic.ninja/create/?shortlived&jetpack-beta).
* Copy this link from the `Set up Jetpack` button and append `&calypso_env=development` to it.
* Ensure that the primary buttons that are disabled don't have `hover` or `focus` styles.

#### Before

![button-disabled-before](https://user-images.githubusercontent.com/390760/54602373-72230600-4a39-11e9-857c-12b2cc0eb4fb.gif)

#### After

![button-disabled-after](https://user-images.githubusercontent.com/390760/54602377-764f2380-4a39-11e9-9d7c-a515f070f269.gif)

