### PR TITLE
Fix: Typo in a step action function

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -613,9 +613,14 @@ export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) 
 		initialContext: {
 			query: { site_type: siteType },
 		},
+		signupDependencies,
 	} = nextProps;
 	const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
 	let fulfilledDependencies = [];
+
+	if ( siteType === get( signupDependencies, 'siteType' ) ) {
+		return;
+	}
 
 	if ( siteTypeValue ) {
 		debug( 'From query string: site_type = %s', siteType );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -643,10 +643,15 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 			query: { vertical },
 		},
 		flowName,
+		signupDependencies,
 	} = nextProps;
 
 	const flowSteps = flows.getFlow( flowName ).steps;
 	let fulfilledDependencies = [];
+
+	if ( vertical && get( signupDependencies, 'surveyQuestion' ) === vertical ) {
+		return;
+	}
 
 	if ( vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
 		debug( 'From query string: vertical = %s', vertical );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -559,7 +559,7 @@ function shouldExcludeStep( stepName, fulfilledDependencies ) {
 		return false;
 	}
 
-	const stepProvidesDependencies = steps[ stepName ].providedDependencies;
+	const stepProvidesDependencies = steps[ stepName ].providesDependencies;
 	const dependenciesNotProvided = difference( stepProvidesDependencies, fulfilledDependencies );
 	return isEmpty( dependenciesNotProvided );
 }

--- a/client/lib/signup/test/mocks/signup/config/flows-pure.js
+++ b/client/lib/signup/test/mocks/signup/config/flows-pure.js
@@ -29,5 +29,17 @@ const flows = {
 		steps: [ 'stepRequiringSiteSlug' ],
 		providesDependenciesInQuery: [ 'siteSlug' ],
 	},
+
+	flowWithSiteTopic: {
+		steps: [ 'stepA', 'stepB', 'site-topic' ],
+	},
+
+	flowWithSiteTopicAndTitle: {
+		steps: [ 'stepA', 'stepB', 'site-topic-and-title' ],
+	},
+
+	flowWithSiteTopicAndSurvey: {
+		steps: [ 'stepA', 'stepB', 'site-topic', 'survey' ],
+	},
 };
 export default flows;

--- a/client/lib/signup/test/mocks/signup/config/flows.js
+++ b/client/lib/signup/test/mocks/signup/config/flows.js
@@ -11,4 +11,6 @@ export default {
 	getFlow: function( flowName ) {
 		return flows[ flowName ];
 	},
+
+	excludeStep: jest.fn(),
 };

--- a/client/lib/signup/test/mocks/signup/config/steps.js
+++ b/client/lib/signup/test/mocks/signup/config/steps.js
@@ -69,4 +69,14 @@ export default {
 			defer( callback );
 		},
 	},
+
+	'site-topic': {
+		stepName: 'site-topic',
+		providesDependencies: [ 'siteTopic' ],
+	},
+
+	'site-topic-and-title': {
+		stepName: 'site-topic-and-title',
+		providesDependencies: [ 'siteTopic', 'siteTitle' ],
+	},
 };

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -119,7 +119,7 @@ describe( 'isSiteTopicFulfilled()', () => {
 		expect( flows.excludeStep ).toHaveBeenCalledWith( 'site-topic' );
 	} );
 
-	test( 'should not remove any step not unfulfilled', () => {
+	test( 'should not remove any step unfulfilled', () => {
 		const flowName = 'flowWithSiteTopicAndTitle';
 		const stepName = 'site-topic-and-title';
 		const initialContext = { query: { vertical: 'verticalSlug' } };

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -3,8 +3,9 @@
 /**
  * Internal dependencies
  */
-import { createSiteWithCart } from '../step-actions';
+import { createSiteWithCart, isSiteTopicFulfilled } from '../step-actions';
 import { useNock } from 'test/helpers/use-nock';
+import flows from 'signup/config/flows';
 
 jest.mock( 'lib/analytics', () => ( {
 	tracks: { recordEvent() {} },
@@ -16,6 +17,12 @@ jest.mock( 'lib/localforage', () => require( 'lib/localforage/localforage-bypass
 jest.mock( 'lib/abtest', () => ( {
 	abtest: () => '',
 } ) );
+
+jest.mock( 'signup/config/steps', () => require( './mocks/signup/config/steps' ) );
+jest.mock( 'signup/config/steps-pure', () => require( './mocks/signup/config/steps-pure' ) );
+jest.mock( 'signup/config/flows', () => require( './mocks/signup/config/flows' ) );
+jest.mock( 'signup/config/flows-pure', () => require( './mocks/signup/config/flows-pure' ) );
+jest.mock( '../actions' );
 
 describe( 'createSiteWithCart()', () => {
 	// createSiteWithCart() function is not designed to be easy for test at the moment.
@@ -86,5 +93,87 @@ describe( 'createSiteWithCart()', () => {
 			[],
 			fakeStore
 		);
+	} );
+} );
+
+describe( 'isSiteTopicFulfilled()', () => {
+	const setSurvey = jest.fn();
+	const submitSiteVertical = jest.fn();
+
+	beforeEach( () => {
+		flows.excludeStep.mockClear();
+		setSurvey.mockClear();
+		submitSiteVertical.mockClear();
+	} );
+
+	test( 'should remove a step fulfilled', () => {
+		const flowName = 'flowWithSiteTopic';
+		const stepName = 'site-topic';
+		const initialContext = { query: { vertical: 'verticalSlug' } };
+		const nextProps = { initialContext, flowName, submitSiteVertical, setSurvey };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+
+		isSiteTopicFulfilled( stepName, undefined, nextProps );
+
+		expect( flows.excludeStep ).toHaveBeenCalledWith( 'site-topic' );
+	} );
+
+	test( 'should not remove any step not unfulfilled', () => {
+		const flowName = 'flowWithSiteTopicAndTitle';
+		const stepName = 'site-topic-and-title';
+		const initialContext = { query: { vertical: 'verticalSlug' } };
+		const nextProps = { initialContext, flowName, submitSiteVertical, setSurvey };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+
+		isSiteTopicFulfilled( stepName, undefined, nextProps );
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should call both setSurvey() and submitSiteVertical() when vertical query param passed', () => {
+		const flowName = 'flowWithSiteTopic';
+		const stepName = 'site-topic';
+		const initialContext = { query: { vertical: 'verticalSlug' } };
+		const nextProps = { initialContext, flowName, submitSiteVertical, setSurvey };
+
+		expect( setSurvey ).not.toHaveBeenCalled();
+		expect( submitSiteVertical ).not.toHaveBeenCalled();
+
+		isSiteTopicFulfilled( stepName, undefined, nextProps );
+
+		expect( setSurvey ).toHaveBeenCalled();
+		expect( submitSiteVertical ).toHaveBeenCalled();
+	} );
+
+	test( 'should call neither setSurvey() nor submitSiteVertical() when no vertical query param passed', () => {
+		const flowName = 'flowWithSiteTopic';
+		const stepName = 'site-topic';
+		const initialContext = { query: {} };
+		const nextProps = { initialContext, flowName, submitSiteVertical, setSurvey };
+
+		expect( setSurvey ).not.toHaveBeenCalled();
+		expect( submitSiteVertical ).not.toHaveBeenCalled();
+
+		isSiteTopicFulfilled( stepName, undefined, nextProps );
+
+		expect( setSurvey ).not.toHaveBeenCalled();
+		expect( submitSiteVertical ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should call neither setSurvey() nor submitSiteVertical() when the flow contains survey step', () => {
+		const flowName = 'flowWithSiteTopicAndSurvey';
+		const stepName = 'site-topic';
+		const initialContext = { query: { vertical: 'verticalSlug' } };
+		const nextProps = { initialContext, flowName, submitSiteVertical, setSurvey };
+
+		expect( setSurvey ).not.toHaveBeenCalled();
+		expect( submitSiteVertical ).not.toHaveBeenCalled();
+
+		isSiteTopicFulfilled( stepName, undefined, nextProps );
+
+		expect( setSurvey ).not.toHaveBeenCalled();
+		expect( submitSiteVertical ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a typo in `shouldExcludeStep()`.
* Also adds test cases for `isSiteTopicFulfilled()`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the test cases against `step-actions.js`.
   ```
   npm run test-client client/lib/signup/test/step-actions.js
   ```
* The result should be green.

cc @niranjan-uma-shankar 
