### PR TITLE
Remove google plus logo since google plus is closed

### DIFF
--- a/client/components/share-button/services.js
+++ b/client/components/share-button/services.js
@@ -21,10 +21,6 @@ const twitter = {
 	windowArg: 'width=550,height=420,resizeable,scrollbars',
 };
 
-const googlePlus = {
-	url: 'https://plus.google.com/share?url=<URL>',
-};
-
 const linkedin = {
 	url: 'https://www.linkedin.com/shareArticle?mini=true&url=<URL>&title=<TITLE>',
 };
@@ -50,5 +46,4 @@ export default {
 	tumblr,
 	pinterest,
 	telegram,
-	'google-plus': googlePlus,
 };

--- a/client/my-sites/checklist/share.jsx
+++ b/client/my-sites/checklist/share.jsx
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 import ShareButton from 'components/share-button';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-const services = [ 'facebook', 'twitter', 'linkedin', 'google-plus', 'pinterest' ];
+const services = [ 'facebook', 'twitter', 'linkedin', 'pinterest' ];
 
 class ChecklistShowShare extends PureComponent {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the Google Plus logo from the checklist as Google Plus is closed.

#### Testing instructions

* Open a site with a completed checklist. You should see this at the top of stats:
<img width="1089" alt="Screenshot 2019-03-19 at 14 19 30" src="https://user-images.githubusercontent.com/275961/54613502-b7076680-4a52-11e9-985b-2db7858b2f98.png">

* You should see this at the top of the checklist page
<img width="809" alt="Screenshot 2019-03-19 at 14 19 54" src="https://user-images.githubusercontent.com/275961/54613529-c1c1fb80-4a52-11e9-9f3b-111bdaf703e7.png">


