### PR TITLE
Color Schemes: Fix contrast for sidebar site selector when no results are found

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -147,10 +147,6 @@
 	padding: 10px 20px;
 }
 
-.layout__secondary .site-selector__no-results {
-	color: var( --sidebar-heading-color );
-}
-
 .site-selector__add-new-site {
 	padding: 0;
 	border-top: 1px solid darken( $sidebar-bg-color, 10% );

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -147,6 +147,10 @@
 	padding: 10px 20px;
 }
 
+.layout__secondary .site-selector__no-results {
+	color: var( --sidebar-heading-color );
+}
+
 .site-selector__add-new-site {
 	padding: 0;
 	border-top: 1px solid darken( $sidebar-bg-color, 10% );

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -216,7 +216,11 @@
 		
 		.all-sites {
 			border-color: var( --sidebar-border-color );
-		}				
+		}
+	}
+
+	.site-selector__no-results {
+		color: var( --sidebar-heading-color );
 	}
 	
 	.all-sites .count {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -231,6 +231,50 @@
 }
 
 /*
+ * Color overrides for the site selector in the sidebar
+ */
+
+.layout__secondary {
+
+	.site-selector.is-large .site-selector__sites {
+		border-color: var( --sidebar-border-color );
+	}
+
+	.all-sites .count {
+		color: var( --sidebar-text-color );
+		border-color: var( --sidebar-text-color );
+	}
+
+	.site-selector__sites {
+		background: var( --sidebar-background );
+	}
+
+	.site-selector__no-results {
+		color: var( --sidebar-heading-color );
+	}
+
+	.site-selector__add-new-site {
+		border-color: var( --sidebar-border-color );
+	}
+
+	.site-selector__add-new-site .button {
+		color: var( --sidebar-heading-color );
+
+		&:hover {
+			color: var( --sidebar-text-color );
+		}
+	}
+
+	.site-selector .all-sites {
+		border-color: var( --sidebar-border-color );
+	}
+
+	.site-selector__recent {
+		border-color: var( --sidebar-border-color );
+	}
+}
+
+/*
 	Focus States
 	Sites - Site Selector for those with multiple sites
 	Sidebar - The sidebar is the current focus

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -235,50 +235,6 @@
 }
 
 /*
- * Color overrides for the site selector in the sidebar
- */
-
-.layout__secondary {
-
-	.site-selector.is-large .site-selector__sites {
-		border-color: var( --sidebar-border-color );
-	}
-
-	.all-sites .count {
-		color: var( --sidebar-text-color );
-		border-color: var( --sidebar-text-color );
-	}
-
-	.site-selector__sites {
-		background: var( --sidebar-background );
-	}
-
-	.site-selector__no-results {
-		color: var( --sidebar-heading-color );
-	}
-
-	.site-selector__add-new-site {
-		border-color: var( --sidebar-border-color );
-	}
-
-	.site-selector__add-new-site .button {
-		color: var( --sidebar-heading-color );
-
-		&:hover {
-			color: var( --sidebar-text-color );
-		}
-	}
-
-	.site-selector .all-sites {
-		border-color: var( --sidebar-border-color );
-	}
-
-	.site-selector__recent {
-		border-color: var( --sidebar-border-color );
-	}
-}
-
-/*
 	Focus States
 	Sites - Site Selector for those with multiple sites
 	Sidebar - The sidebar is the current focus


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the sidebar site selector, if you search for a site and no results are found, the resulting message has poor contrast and is not compatible with color schemes.
* This updates this piece of text to use the sidebar heading color for contrast and compatibility with color schemes.

**Before**

<img width="345" alt="Screen Shot 2019-03-19 at 11 40 51 AM" src="https://user-images.githubusercontent.com/2124984/54621589-5c640f80-4a3e-11e9-9ac8-d73285618e36.png">

**After**

<img width="317" alt="Screen Shot 2019-03-19 at 11 53 58 AM" src="https://user-images.githubusercontent.com/2124984/54621590-5c640f80-4a3e-11e9-9204-f2fd894442b9.png">

#### Testing instructions

* Switch to this PR on an account with multiple sites.
* Navigate to `/me/account` and change color scheme to something like Nightfall or Sakura
* Go to the Site Selector in the sidebar (click "Switch Sites" at the top) and search for a site that does not exist.
* Note the "No sites found" message; it should match the color scheme and have contrast with the background.