### PR TITLE
Prevent duplicate gridicons.

### DIFF
--- a/client/components/async-gridicons/index.jsx
+++ b/client/components/async-gridicons/index.jsx
@@ -13,7 +13,7 @@ import FallbackIcon from './fallback';
 const loadedIcons = new Map();
 
 function loadIcon( icon ) {
-	return import( /* webpackChunkName: "gridicons", webpackInclude: /\.js$/, webpackMode: "lazy-once" */
+	return import( /* webpackChunkName: "gridicons", webpackInclude: /\.js$/, webpackExclude: /dist\/(index\.js|example.js)$/, webpackMode: "lazy-once" */
 	`gridicons/dist/${ icon }` ).then(
 		g => {
 			loadedIcons.set( icon, g.default );

--- a/client/components/async-gridicons/index.jsx
+++ b/client/components/async-gridicons/index.jsx
@@ -13,7 +13,7 @@ import FallbackIcon from './fallback';
 const loadedIcons = new Map();
 
 function loadIcon( icon ) {
-	return import( /* webpackChunkName: "gridicons", webpackInclude: /\.js$/, webpackExclude: /dist\/(index\.js|example.js)$/, webpackMode: "lazy-once" */
+	return import( /* webpackChunkName: "gridicons", webpackInclude: /\.js$/, webpackExclude: /dist\/(index\.js|example\.js)$/, webpackMode: "lazy-once" */
 	`gridicons/dist/${ icon }` ).then(
 		g => {
 			loadedIcons.set( icon, g.default );


### PR DESCRIPTION
Gridicons were being loaded more than once:

![image](https://user-images.githubusercontent.com/409615/54627493-7536ea00-4a6b-11e9-9d8e-c723e80d17a3.png)

There was full icon content duplication between these files.

This was caused by the `gridicons` dependency including an `index.js` and an `example.js`, beyond the individual icon files. `index.js` is a bundle of all icons, and `example.js` is a multiple icon demo designed to be included in the devdocs.

These files were being split out to a separate chunk but still loaded, resulting in ~20KB of wasted JS.
The fix is to explicitly exclude `index.js` and `example.js`.

#### Changes proposed in this Pull Request

* Explicitly block `index.js` and `example.js` from being included in the `AsyncGridicons` chunk.

#### Testing instructions

* Open Calypso, check loaded JS chunks. There may be more than one chunk referencing `gridicons`, but there should be no duplicate icons between them.
* Verify that the Gridicons demo still works (`/devdocs/design`).


Huge thanks to @jsnajdr for helping me find and grok the issue!