### PR TITLE
Signup: Design tweaks to user account step

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -702,7 +702,7 @@ class SignupForm extends Component {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href={ logInUrl }>
-					{ this.props.translate( 'Already have a WordPress.com account? Log in now.' ) }
+					{ this.props.translate( 'Already have a WordPress.com account?' ) }
 				</LoggedOutFormLinkItem>
 				{ this.props.oauth2Client && (
 					<LoggedOutFormBackLink

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -13,7 +13,6 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import config from 'config';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -61,7 +60,7 @@ class SocialSignupForm extends Component {
 		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
 
 		return (
-			<Card className="signup-form__social" compact={ this.props.compact }>
+			<div className="signup-form__social" compact={ this.props.compact }>
 				{ ! this.props.compact && (
 					<p>
 						{ preventWidows(
@@ -79,7 +78,7 @@ class SocialSignupForm extends Component {
 						onClick={ this.trackGoogleLogin }
 					/>
 				</div>
-			</Card>
+			</div>
 		);
 	}
 }

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -30,19 +30,14 @@
 }
 
 .signup-form__social {
-	background: var( --color-neutral-50 );
 	max-width: 400px;
-	margin: 0 auto 32px;
+	margin: 0 auto 16px;
 	padding: 16px;
 	box-sizing: border-box;
-	border-radius: 0 0 3px 3px;
-	box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.14 ),
-				0 2px 1px -1px rgba( 0, 0, 0, 0.12 ),
-				0 1px 3px 0 rgba( 0, 0, 0, 0.20 );
 
 	p {
 		font-size: 13px;
-		color: var( --color-text );
+		color: var( --color-white );
 		margin: 0 0 12px;
 		text-align: center;
 

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -30,8 +30,20 @@
 }
 
 .signup-form__social {
+	background: var( --color-neutral-50 );
+	max-width: 400px;
+	margin: 0 auto 32px;
+	padding: 16px;
+	box-sizing: border-box;
+	border-radius: 0 0 3px 3px;
+	box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.14 ),
+				0 2px 1px -1px rgba( 0, 0, 0, 0.12 ),
+				0 1px 3px 0 rgba( 0, 0, 0, 0.20 );
+
 	p {
-		margin: 0 0 20px;
+		font-size: 13px;
+		color: var( --color-text );
+		margin: 0 0 12px;
 		text-align: center;
 
 		&:last-child {
@@ -42,18 +54,14 @@
 
 .signup-form__social-buttons {
 	button {
-		margin: 0 0 10px;
-		width: 100%;
+		display: block;
+		margin: 0 auto;
+		box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.14 ),
+					0 2px 1px -1px rgba( 0, 0, 0, 0.12 ),
+					0 1px 3px 0 rgba( 0, 0, 0, 0.20 );
 	}
 }
 
 .social-buttons__button-container + .social-buttons__button-container {
 	margin-top: 10px;
-}
-
-.signup-form__social,
-.signup-form__notice.notice {
-	margin-left: auto;
-	margin-right: auto;
-	max-width: 480px;
 }

--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -45,7 +45,7 @@
 		width: 80px;
 		background: rgba( var( --color-white-rgb ), 0.3 );
 		height: 2px;
-		margin: 0 auto 4px;
+		margin: 0 auto 8px;
 	}
 }
 
@@ -53,7 +53,7 @@
 	color: var( --color-neutral-500 );
 	display: block;
 	font-family: $sans;
-	font-size: 14px;
+	font-size: 13px;
 	padding: 8px 16px;
 	cursor: pointer;
 	text-decoration: underline;

--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -1,24 +1,11 @@
 .logged-out-form {
-	margin: 0 auto;
-	max-width: 400px;
+	margin: 0 auto 16px;
+	max-width: 360px;
+	padding: 16px;
 	border-radius: 3px;
 	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ),
 				0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
 				0 1px 5px 0 rgba( 0, 0, 0, 0.20 );
-}
-
-.logged-out-form__links {
-	margin: 0 auto;
-	max-width: 330px;
-	text-align: center;
-
-	body.is-section-signup:not(.is-section-jetpack-connect):not(.is-section-settings) .layout:not(.dops) & a {
-		color: var( --color-white );
-
-		&:hover {
-			color: var( --color-neutral-0 );
-		}
-	}
 }
 
 .logged-out-form__footer {
@@ -47,15 +34,37 @@
 	}
 }
 
+.logged-out-form__links {
+	margin: 0 auto;
+	max-width: 330px;
+	text-align: center;
+
+	&:before {
+		content: '';
+		display: block;
+		width: 80px;
+		background: rgba( var( --color-white-rgb ), 0.3 );
+		height: 2px;
+		margin: 0 auto 4px;
+	}
+}
+
 .logged-out-form__link-item {
-	border-bottom: 1px solid var( --color-neutral-100 );
 	color: var( --color-neutral-500 );
 	display: block;
 	font-family: $sans;
 	font-size: 14px;
-	line-height: 21px;
-	padding: 16px 24px;
+	padding: 8px 16px;
 	cursor: pointer;
+	text-decoration: underline;
+
+	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings ) .layout:not( .dops ) & {
+		color: var( --color-white );
+
+		&:hover {
+			color: var( --color-neutral-100 );
+		}
+	}
 
 	&:last-child {
 		border-bottom: none;

--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -1,6 +1,10 @@
 .logged-out-form {
-	margin: 0 auto 16px auto;
-	max-width: 480px;
+	margin: 0 auto;
+	max-width: 400px;
+	border-radius: 3px;
+	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ),
+				0 3px 1px -2px rgba( 0, 0, 0, 0.12 ),
+				0 1px 5px 0 rgba( 0, 0, 0, 0.20 );
 }
 
 .logged-out-form__links {
@@ -37,6 +41,9 @@
 		float: none;
 		margin: 0;
 		width: 100%;
+		box-shadow: 0 1px 1px 0 rgba( 0, 0, 0, 0.14 ),
+					0 2px 1px -1px rgba( 0, 0, 0, 0.12 ),
+					0 1px 3px 0 rgba( 0, 0, 0, 0.20 );
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -33,16 +33,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 .jetpack-connect__main {
 	max-width: 400px;
 
-	.logged-out-form__links {
-		max-width: 100%;
-
-		/* Move up to the Card above */
-		margin-top: -10px;
-		@include breakpoint( '>480px' ) {
-			margin-top: -16px;
-		}
-	}
-
 	.formatted-header {
 		margin-bottom: 16px;
 	}
@@ -544,6 +534,12 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__site.card {
 	padding: 0;
+	max-width: 360px;
+	margin: 0 auto 16px;
+	border-radius: 3px;
+	box-shadow: 0 5px 5px -3px rgba( 0, 0, 0, 0.2 ),
+				0 8px 10px 1px rgba( 0, 0, 0, 0.14 ),
+				0 3px 14px 2px rgba( 0, 0, 0, 0.12 );
 }
 
 .jetpack-connect__sso-terms-dialog {
@@ -657,7 +653,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		margin-bottom: 8px;
 	}
 
-	.logged-out-form__links,
 	.jetpack-connect__happychat-button {
 		text-align: center;
 	}
@@ -826,20 +821,9 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		color: var( --color-primary-100 );
 	}
 
-	.card,
-	.site-type__wrapper .card,
-	.site-topic__wrapper .card {
-		box-shadow: none;
-		border-radius: 3px;
-	}
-
 	.site__title:after,
 	.site__domain:after {
 		right: 3px;
-	}
-
-	.login__form-social {
-		margin-top: 1px;
 	}
 
 	.site-type__option-label {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -29,7 +29,7 @@ body.is-section-signup {
 
 // Notice the :not(.dops) selector. I've added this to try and
 // avoid stepping on the toes of our oauth users, like Crowdsignal.
-body.is-section-signup .layout:not(.dops) {
+body.is-section-signup .layout:not( .dops ) {
 
 	// Update the logo that appears when loading Calypso
 	// to match the homepage, using primary-dark with opacity.
@@ -46,9 +46,9 @@ body.is-section-signup .layout:not(.dops) {
 			padding-bottom: 16px;
 			margin-bottom: 24px;
 			border-radius: 6px;
-			box-shadow: 0 5px 5px -3px rgba( 0, 0, 0, 0.2),
-						0 8px 10px 1px rgba( 0, 0, 0, 0.14),
-						0 3px 14px 2px rgba( 0, 0, 0, 0.12);
+			box-shadow: 0 5px 5px -3px rgba( 0, 0, 0, 0.2 ),
+						0 8px 10px 1px rgba( 0, 0, 0, 0.14 ),
+						0 3px 14px 2px rgba( 0, 0, 0, 0.12 );
 		}
 
 		.empty-content__title {
@@ -58,12 +58,11 @@ body.is-section-signup .layout:not(.dops) {
 
 	// With the dark background, the border on cards looks a
 	// a little strange. Lets try a shadow instead. -shaun
-	.signup-form > .card,
 	.is-about .card,
 	.is-site-information .site-information__wrapper:not(.is-single-fieldset) .card {
-		box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14),
-					0 3px 1px -2px rgba(0,0,0,0.12),
-					0 1px 5px 0 rgba(0,0,0,0.20);
+		box-shadow: 0 5px 5px -3px rgba( 0, 0, 0, 0.2 ),
+					0 8px 10px 1px rgba( 0, 0, 0, 0.14 ),
+					0 3px 14px 2px rgba( 0, 0, 0, 0.12 );
 
 		.dops & {
 			box-shadow: none;
@@ -151,7 +150,7 @@ body.is-section-signup .layout:not(.dops) .step-wrapper {
 
 // Signup headings
 body.is-section-signup .layout:not(.dops) .formatted-header {
-	margin: 0 0 16px 0;
+	margin: 0 0 16px;
 
 	.formatted-header__title {
 		margin: 0;


### PR DESCRIPTION
The PR adds a border radius to the cards on the user step, and adjust the box-shadows to match Material guidelines.

Before:
<img width="1234" alt="Screen Shot 2019-03-19 at 1 48 16 PM" src="https://user-images.githubusercontent.com/191598/54629299-a99bad80-4a4d-11e9-87a1-84a282a13910.png">

After:
<img width="1106" alt="Screen Shot 2019-03-19 at 4 26 40 PM" src="https://user-images.githubusercontent.com/191598/54639666-541ecb00-4a64-11e9-9bef-0f88762e7943.png">

<img width="1242" alt="Screen Shot 2019-03-19 at 4 26 42 PM" src="https://user-images.githubusercontent.com/191598/54639678-5719bb80-4a64-11e9-8afa-4132f3926424.png">
