### PR TITLE
Use global browserslist config for Babel.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,9 +8,8 @@ const isBrowser = isCalypsoClient || 'true' === process.env.TARGET_BROWSER;
 const modules = isBrowser ? false : 'commonjs'; // Use commonjs for Node
 const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
 
-const targets = isBrowser
-	? { browsers: [ 'last 2 versions', 'Safari >= 10', 'iOS >= 10', 'ie >= 11' ] }
-	: { node: 'current' };
+// Use target configuration in package.json for browser builds.
+const targets = isBrowser ? undefined : { node: 'current' };
 
 const config = {
 	presets: [


### PR DESCRIPTION
Babel had its own target configuration, which was a duplicate of the one
in package.json.

This removes the Babel-specific one, making Babel fall back to the one
in package.json.

#### Changes proposed in this Pull Request

* Remove Babel-specific browser config.

#### Testing instructions

* Ensure browser support remains the same.

Mentioned in #30768 and #31536.
