### PR TITLE
Calypso Build Package: Add @automattic/calypso-color-schemes dep

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -16,6 +16,7 @@
 			"version": "file:packages/calypso-build",
 			"dev": true,
 			"requires": {
+				"@automattic/calypso-color-schemes": "file:packages/calypso-color-schemes",
 				"autoprefixer": "9.4.4",
 				"babel-loader": "8.0.5",
 				"css-loader": "2.1.1",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -23,6 +23,7 @@
 	},
 	"bin": "./bin/build-package.js",
 	"dependencies": {
+		"@automattic/calypso-color-schemes": "file:../calypso-color-schemes",
 		"autoprefixer": "9.4.4",
 		"babel-loader": "8.0.5",
 		"css-loader": "2.1.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Calypso Build Package: Add @automattic/calypso-color-schemes dep

Rationale: The `calypso-build` package depends on the `calypso-color-schemes` package: https://github.com/Automattic/wp-calypso/blob/39202d0e87bb4bdda00cd643261e9aad6e3884dc/packages/calypso-build/postcss.config.js#L4

#### Testing instructions

```
npm run distclean
npm ci
npm start
```

and verify in your browser that Calypso actually works.

Then, build Jetpack blocks

```
npx lerna bootstrap --scope='@automattic/jetpack-blocks'
npx lerna run prepublishOnly --stream --scope='@automattic/jetpack-blocks'
```

and copy them to your local Jetpack Docker instance to test them there.

#### Problem

Attempting to bootstrap for Jetpack blocks currently fails, i.e. `npx lerna bootstrap --scope='@automattic/jetpack-blocks'`.