### PR TITLE
Skipping broken import test

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1506,7 +1506,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Import a site while signing up @parallel', function() {
+	describe.skip( 'Import a site while signing up @parallel', function() {
 		// Currently must use a Wix site to be importable through this flow.
 		const siteURL = 'https://hi6822.wixsite.com/eat-here-its-good';
 		const userName = dataHelper.getNewBlogName();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This skips an import e2e test until https://github.com/Automattic/wp-calypso/issues/31570 is fixed

#### Testing instructions
 Ensure `Import a site while signing up ` is skipped when running

