### PR TITLE
Codeowners: Adding Onboarding Dev team for /client/signup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,12 @@
 # Client blocks
 /client/blocks/inline-help @Automattic/onboarding-dev
 
+# Client state
+/client/state/signup @Automattic/onboarding-dev
+
+# Client components
+/client/components/site-verticals-suggestion-search @Automattic/onboarding-dev
+
 # Client framework parts
 /client/config @Automattic/team-calypso
 /client/controller @Automattic/team-calypso

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,10 @@
-# We use codeowners to help keep teams in the loop on changes to code 
-# they typically work on. Even though this file is called CODEOWNERS, 
-# we don't really want to enforce or imply ownership of code, just interest. 
+# We use codeowners to help keep teams in the loop on changes to code
+# they typically work on. Even though this file is called CODEOWNERS,
+# we don't really want to enforce or imply ownership of code, just interest.
 #
-# Anyone can work on anything. 
+# Anyone can work on anything.
 #
-# Prefer associating a "team" with a path rather than an individual. That allows individuals to 
+# Prefer associating a "team" with a path rather than an individual. That allows individuals to
 # move around without having to continually update this file.
 #
 # See https://help.github.com/en/articles/about-code-owners for details on the format of this file
@@ -31,6 +31,9 @@
 
 # Server infrastructure
 /server @Automattic/team-calypso
+
+# Signup
+/client/signup @Automattic/onboarding-dev
 
 # Test infrastructure
 /test @Automattic/team-calypso

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,11 +18,17 @@
 # Client initializaton
 /client/boot @Automattic/team-calypso
 
+# Client blocks
+/client/blocks/inline-help @Automattic/onboarding-dev
+
 # Client framework parts
 /client/config @Automattic/team-calypso
 /client/controller @Automattic/team-calypso
 /client/document @Automattic/team-calypso
 /client/layout @Automattic/team-calypso
+
+# Client sites
+/client/my-sites/checklist @Automattic/onboarding-dev
 
 # Developer guides
 /docs/coding-guidelines @Automattic/team-calypso
@@ -37,3 +43,4 @@
 
 # Test infrastructure
 /test @Automattic/team-calypso
+


### PR DESCRIPTION
## Changes proposed in this Pull Request

Adding @Automattic/onboarding-dev team as codeowners for /client/signup

Also removing whitespace at line ending. ✂️ 