### PR TITLE
e2e: Adding checklist site logo ab test exception

### DIFF
--- a/test/e2e/config/default.json
+++ b/test/e2e/config/default.json
@@ -63,7 +63,7 @@
 		"businessPlanDescriptionAT",
 		"skipThemesSelectionModal",
 		"springSale30PercentOff",
-		"jetpackSignupGoogleTop",		
+		"jetpackSignupGoogleTop",
 		"cartNudgeUpdateToPremium",
 		"signupAtomicStoreVsPressable",
 		"improvedOnboarding",
@@ -78,7 +78,8 @@
 		"twoYearPlanByDefault",
 		"pluginFeaturedTitle",
 		"builderReferralHelpPopover",
-		"jetpackMonthlyPlansOnly"
+		"jetpackMonthlyPlansOnly",
+        "checklistSiteLogo"
 	],
 	"overrideABTests": [
 		[ "businessPlanDescriptionAT_20170605", "original" ],
@@ -96,6 +97,7 @@
 		[ "improvedOnboarding_20190314", "main" ],
 		[ "skipBusinessInformation_20190130", "hide" ],
 		[ "twoYearPlanByDefault_20190207", "originalFlavor" ],
-		[ "builderReferralHelpPopover_20190227", "original" ]
+		[ "builderReferralHelpPopover_20190227", "original" ],
+		[ "checklistSiteLogo_20190305", "icon" ]
 	]
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request
We recently moved the e2e tests from wp-e2e-tests to wp-calypso

See: 
https://github.com/Automattic/wp-calypso/pull/30616
`p6fDka-Bw-p2`

This PR adds the AB Test exceptions already added in https://github.com/Automattic/wp-e2e-tests/pull/1825

