### PR TITLE
ABTest: Updating site logo AB test for existing users and all locales

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -163,6 +163,8 @@ export default {
 			logo: 50,
 		},
 		defaultVariation: 'icon',
+		allowExistingUsers: true,
+		localeTargets: 'any',
 	},
 	gSuiteStatsNudge: {
 		datestamp: '20190308',

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -11,7 +11,7 @@ import config from 'config';
  */
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { getVerticalTaskList } from './vertical-task-list';
-import { getABTestVariation } from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 
 const debug = debugModule( 'calypso:wpcom-task-list' );
 
@@ -57,11 +57,7 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 		// If there is a site segment and
 		// the user has already completed the logo task or
 		// if it's the AB variant
-		if (
-			hasTask( 'site_logo_set' ) &&
-			segmentSlug &&
-			'logo' === getABTestVariation( 'checklistSiteLogo' )
-		) {
+		if ( hasTask( 'site_logo_set' ) && segmentSlug && 'logo' === abtest( 'checklistSiteLogo' ) ) {
 			addTask( 'site_logo_set' );
 		} else {
 			addTask( 'site_icon_set' );


### PR DESCRIPTION
## Changes proposed in this Pull Request

We're widening the net to include existing users and all locales for the site logo checklist task AB test.

Original PR: https://github.com/Automattic/wp-calypso/pull/31198

## Testing instructions

On a newly-created site, head to `http://calypso.localhost:3000/checklist/{yournewsite.wordpress.com}` and check that `checklistSiteLogo_20190305` is set in `localStorage.ABTests`.

Clear `localStorage.ABTests` and refresh to check if the `logo/icon` variations are being set.

Thank you! 🍻 

