### PR TITLE
Onboarding: add `url` to the close welcome prompt tracking

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/checklist-onboarding-welcome/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-onboarding-welcome/index.jsx
@@ -35,6 +35,7 @@ class ChecklistOnboardingWelcome extends Component {
 	static defaultProps = {
 		hideOnboardingWelcomePrompt: noop,
 		onClose: noop,
+		continueUrl: '',
 	};
 
 	goToChecklist = () => {

--- a/client/my-sites/checklist/wpcom-checklist/checklist-onboarding-welcome/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-onboarding-welcome/index.jsx
@@ -49,6 +49,7 @@ class ChecklistOnboardingWelcome extends Component {
 	closeWelcomePrompt = () => {
 		this.props.recordTracksEvent( 'calypso_onboarding_welcome_click', {
 			action_type: 'close',
+			url: this.props.continueUrl,
 		} );
 		this.onClose();
 	};


### PR DESCRIPTION
## Changes proposed in this Pull Request

In order to know which page the user _doesn't_ wish to visit, let's add the url for context.

## Testing

Visit `http://calypso.localhost:3000/view/{yoursite.wordpress.com}?welcome`

Keep an eye on the tracking event `calypso_onboarding_welcome_click`
Click **Not now**

<img width="320" alt="Screen Shot 2019-03-20 at 5 03 16 pm" src="https://user-images.githubusercontent.com/6458278/54662443-2011db80-4b32-11e9-9a19-c8fc72e7c8f6.png">

Check that the event has the following properties.

```
action_type: "close",
url: "/checklist/yoursite.wordpress.com"
```

Profit. 🎩 