### PR TITLE
Checklist: ensure `calypso_checklist_task_display` is only fired when the task is displayed

### DIFF
--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -31,12 +31,20 @@ class Task extends PureComponent {
 		onDismiss: PropTypes.func,
 		title: PropTypes.node.isRequired,
 		translate: PropTypes.func.isRequired,
+		trackTaskDisplay: PropTypes.func,
 	};
+
+	static defaultProps = {
+		trackTaskDisplay: () => {},
+	};
+
+	componentDidMount() {
+		this.props.trackTaskDisplay( this.props.id, this.props.completed, 'checklist' );
+	}
 
 	renderCheckmarkIcon() {
 		const { completed, isWarning, translate } = this.props;
 		const onDismiss = ! completed ? this.props.onDismiss : undefined;
-
 		if ( onDismiss ) {
 			return (
 				<Focusable

--- a/client/my-sites/checklist/wpcom-checklist/checklist-banner/task.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-banner/task.jsx
@@ -21,7 +21,16 @@ class ChecklistBannerTask extends PureComponent {
 		siteSlug: PropTypes.string,
 		title: PropTypes.node.isRequired,
 		translate: PropTypes.func.isRequired,
+		trackTaskDisplay: PropTypes.func,
 	};
+
+	static defaultProps = {
+		trackTaskDisplay: () => {},
+	};
+
+	componentDidMount() {
+		this.props.trackTaskDisplay( this.props.id, this.props.completed, 'banner' );
+	}
 
 	render() {
 		// Banners never render completed Tasks

--- a/client/my-sites/checklist/wpcom-checklist/checklist-prompt/task.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-prompt/task.jsx
@@ -34,6 +34,11 @@ class ChecklistPromptTask extends PureComponent {
 		translate: PropTypes.func.isRequired,
 		closePopover: PropTypes.func.isRequired,
 		onDismiss: PropTypes.func,
+		trackTaskDisplay: PropTypes.func,
+	};
+
+	static defaultProps = {
+		trackTaskDisplay: () => {},
 	};
 
 	componentDidMount() {
@@ -42,6 +47,8 @@ class ChecklistPromptTask extends PureComponent {
 		if ( currentRoute !== targetUrl ) {
 			page( targetUrl );
 		}
+
+		this.props.trackTaskDisplay( this.props.id, this.props.completed, 'prompt' );
 	}
 
 	getExtendedProps() {

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -55,7 +55,6 @@ class WpcomChecklistComponent extends PureComponent {
 		emailSent: false,
 		error: null,
 	};
-	trackedTaskDisplays = {};
 
 	constructor() {
 		super();
@@ -147,11 +146,6 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	trackTaskDisplay = ( id, isCompleted, location ) => {
-		if ( this.trackedTaskDisplays[ id ] ) {
-			return;
-		}
-		this.trackedTaskDisplays[ id ] = true;
-
 		this.props.recordTracksEvent( 'calypso_checklist_task_display', {
 			checklist_name: 'new_blog',
 			site_id: this.props.siteId,

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -146,17 +146,18 @@ class WpcomChecklistComponent extends PureComponent {
 		}
 	};
 
-	trackTaskDisplayOnce = task => {
-		if ( this.trackedTaskDisplays[ task.id ] ) {
+	trackTaskDisplay = ( id, isCompleted, location ) => {
+		if ( this.trackedTaskDisplays[ id ] ) {
 			return;
 		}
-		this.trackedTaskDisplays[ task.id ] = true;
+		this.trackedTaskDisplays[ id ] = true;
 
 		this.props.recordTracksEvent( 'calypso_checklist_task_display', {
 			checklist_name: 'new_blog',
 			site_id: this.props.siteId,
-			step_name: task.id,
-			completed: task.isCompleted,
+			step_name: id,
+			completed: isCompleted,
+			location,
 		} );
 	};
 
@@ -300,15 +301,6 @@ class WpcomChecklistComponent extends PureComponent {
 		);
 	}
 
-	componentDidUpdate() {
-		const taskList = getTaskList( this.props );
-		taskList.getAll().forEach( task => {
-			if ( this.shouldRenderTask( task.id ) ) {
-				this.trackTaskDisplayOnce( task );
-			}
-		} );
-	}
-
 	renderTask( task ) {
 		const { siteSlug, viewMode, closePopover } = this.props;
 
@@ -334,6 +326,7 @@ class WpcomChecklistComponent extends PureComponent {
 			firstIncomplete,
 			buttonPrimary: firstIncomplete && firstIncomplete.id === task.id,
 			closePopover: closePopover,
+			trackTaskDisplay: this.trackTaskDisplay,
 		};
 
 		if ( this.shouldRenderTask( task.id ) ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request 

At the moment, the tracking event `calypso_checklist_task_display` is fired off for every checklist task regardless of whether it's displayed.

See: https://cldup.com/wCyuoZilyF.mp4

I believe this goes against the intention of the author in this PR

https://github.com/Automattic/wp-calypso/pull/29178

By coupling the tracking event to the individual task, we can ensure that the tracking event `calypso_checklist_task_display` is only fired when the task in question is rendered. Adding `location` to the tracking props allows us to know where the task has been rendered, that is, on the stats page in the banner, in the inline help prompt, and so on.

I also remove the caching object `trackedTaskDisplays`, whose purpose, I gather, was to ensure that `calypso_checklist_task_display` was only triggered once per task. 

@cbauerman I might be wildly misguided here, so feel free to set me straight. Thanks!! 🍺  

## Testing

#### 1. Visit `/stats/day/{id}`

Whichever task in the banner should trigger `calypso_checklist_task_display` with the location `'banner'`. For example:

<img width="801" alt="Screen Shot 2019-03-20 at 5 34 02 pm" src="https://user-images.githubusercontent.com/6458278/54663733-6406df80-4b36-11e9-8fe9-0fc319fc8bc5.png">

#### 2. Visit `/checklist/{yoursite.wordpress.com}`

All displayed tasks should trigger `calypso_checklist_task_display` with the location `'checklist'`.

#### 3. Start a task, for example `Add business hours`

Perform the task, then continue onto the next task _within the popover prompt_.

All displayed tasks should trigger `calypso_checklist_task_display` with the location `'prompt'`.


