### PR TITLE
Webpack: evaluate config.isEnabled( 'desktop' ) at compile time

### DIFF
--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { get, once } from 'lodash';
+import { defer, once } from 'lodash';
 import debugFactory from 'debug';
 import notices from 'notices';
 import page from 'page';
@@ -33,7 +33,7 @@ import hasSitePendingAutomatedTransfer from 'state/selectors/has-site-pending-au
 import isFetchingAutomatedTransferStatus from 'state/selectors/is-fetching-automated-transfer-status';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { getCurrentUser } from 'state/current-user/selectors';
+import { getCurrentUserEmail, getCurrentUserSiteCount } from 'state/current-user/selectors';
 import keyboardShortcuts from 'lib/keyboard-shortcuts';
 import getGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
 import { fetchAutomatedTransferStatus } from 'state/automated-transfer/actions';
@@ -93,15 +93,13 @@ const notifyAboutImmediateLoginLinkEffects = once( ( dispatch, action, getState 
 	if ( ! action.query.immediate_login_success ) {
 		return;
 	}
-	const currentUser = getCurrentUser( getState() );
-	if ( ! currentUser ) {
+	const email = getCurrentUserEmail( getState() );
+	if ( ! email ) {
 		return;
 	}
-	const { email } = currentUser;
 
 	// Let redux process all dispatches that are currently queued and show the message
-	const delay = typeof setImmediate !== 'undefined' ? setImmediate : setTimeout;
-	delay( () => {
+	defer( () => {
 		notices.success( createImmediateLoginMessage( action.query.login_reason, email ) );
 	} );
 } );
@@ -163,8 +161,7 @@ let sitesListeners = [];
 const updateSelectedSiteForAnalytics = ( dispatch, action, getState ) => {
 	const state = getState();
 	const selectedSite = getSelectedSite( state );
-	const user = getCurrentUser( state );
-	const siteCount = get( user, 'site_count', 0 );
+	const siteCount = getCurrentUserSiteCount( state );
 	analytics.setSelectedSite( selectedSite );
 	analytics.setSiteCount( siteCount );
 };

--- a/client/state/lib/middleware.js
+++ b/client/state/lib/middleware.js
@@ -56,11 +56,7 @@ if ( globalKeyBoardShortcutsEnabled ) {
 	globalKeyboardShortcuts = getGlobalKeyboardShortcuts();
 }
 
-const desktopEnabled = config.isEnabled( 'desktop' );
-let desktop;
-if ( desktopEnabled ) {
-	desktop = require( 'lib/desktop' ).default;
-}
+const desktop = config.isEnabled( 'desktop' ) ? require( 'lib/desktop' ).default : null;
 
 /**
  * Notifies user about the fact that they were automatically logged in
@@ -273,7 +269,7 @@ const handler = ( dispatch, action, getState ) => {
 				if ( globalKeyBoardShortcutsEnabled ) {
 					updatedSelectedSiteForKeyboardShortcuts( dispatch, action, getState );
 				}
-				if ( desktopEnabled ) {
+				if ( config.isEnabled( 'desktop' ) ) {
 					updateSelectedSiteForDesktop( dispatch, action, getState );
 				}
 

--- a/server/bundler/config-flag-plugin.js
+++ b/server/bundler/config-flag-plugin.js
@@ -1,0 +1,50 @@
+const BasicEvaluatedExpression = require( 'webpack/lib/BasicEvaluatedExpression' );
+
+// Check that the given call expression is `config.isEnabled( 'flag' )`
+// and return the `flag` literal value.
+const isConfigIsEnabledExpr = expr =>
+	expr.callee.type === 'MemberExpression' &&
+	expr.callee.object.type === 'Identifier' &&
+	expr.callee.object.name === 'config' &&
+	expr.callee.property.type === 'Identifier' &&
+	expr.callee.property.name === 'isEnabled' &&
+	expr.arguments.length === 1 &&
+	expr.arguments[ 0 ].type === 'Literal'
+		? expr.arguments[ 0 ].value
+		: null;
+
+const moduleTypes = [ 'javascript/auto', 'javascript/dynamic', 'javascript/esm' ];
+
+class ConfigFlagPlugin {
+	constructor( flags ) {
+		this.flags = flags;
+	}
+
+	apply( compiler ) {
+		// replace the `config.isEnabled( 'flag' )` expression with the flag's boolean value
+		const handleExpr = expr => {
+			const flag = isConfigIsEnabledExpr( expr );
+			if ( flag && Object.keys( this.flags ).includes( flag ) ) {
+				return new BasicEvaluatedExpression()
+					.setBoolean( this.flags[ flag ] )
+					.setRange( expr.range );
+			}
+		};
+
+		// inspect all function/method calls
+		const handleParser = parser => {
+			parser.hooks.evaluate.for( 'CallExpression' ).tap( 'ConfigFlagPlugin', handleExpr );
+		};
+
+		// inspect all JS modules
+		const handleCompilation = ( compilation, { normalModuleFactory } ) => {
+			moduleTypes.forEach( moduleType => {
+				normalModuleFactory.hooks.parser.for( moduleType ).tap( 'ConfigFlagPlugin', handleParser );
+			} );
+		};
+
+		compiler.hooks.compilation.tap( 'ConfigFlagPlugin', handleCompilation );
+	}
+}
+
+module.exports = ConfigFlagPlugin;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const _ = require( 'lodash' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const AssetsWriter = require( './server/bundler/assets-writer' );
+const ConfigFlagPlugin = require( './server/bundler/config-flag-plugin' );
 const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 const CircularDependencyPlugin = require( 'circular-dependency-plugin' );
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
@@ -252,6 +253,9 @@ function getWebpackConfig( {
 			new MomentTimezoneDataPlugin( {
 				startYear: 2000,
 			} ),
+			new ConfigFlagPlugin( {
+				desktop: config.isEnabled( 'desktop' ),
+			} ),
 		] ),
 		externals: _.compact( [
 			externalizeWordPressPackages && wordpressExternals,
@@ -274,12 +278,6 @@ function getWebpackConfig( {
 
 		webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
 		webpackConfig.entry.build.unshift( 'webpack-hot-middleware/client' );
-	}
-
-	if ( ! config.isEnabled( 'desktop' ) ) {
-		webpackConfig.plugins.push(
-			new webpack.NormalModuleReplacementPlugin( /^lib[/\\]desktop$/, 'lodash/noop' )
-		);
 	}
 
 	return webpackConfig;


### PR DESCRIPTION
Adding a fancy webpack plugin that evaluates statements like
```js
if ( config.isEnabled( 'desktop' ) ) {
  ...
}
```
at compile time, replaces the expression with the boolean value and eliminates the branches that are never executed.

Inspired by `DefinePlugin`, configured as:
```js
new ConfigFlagPlugin( {
  desktop: true
} )
```

The result is that we never create the `jquery` chunk in non-desktop build (the import happens in conditional branch that is eliminated) and that we no longer need to alias the `lib/desktop` module to `noop`.

Impact on webpack build:
http://iscalypsofastyet.com/branch?branch=try/config-desktop-webpack-evaluate
