### PR TITLE
Signup: Show business site tab first for non .blog domain in launch site flow.

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -132,12 +132,21 @@ export class PlansStep extends Component {
 	}
 
 	getCustomerType() {
+		if ( this.props.customerType ) {
+			return this.props.customerType;
+		}
+
 		const siteGoals = this.props.siteGoals.split( ',' );
-		return (
-			this.props.customerType ||
+		let customerType =
 			getSiteTypePropertyValue( 'slug', this.props.siteType, 'customerType' ) ||
-			( intersection( siteGoals, [ 'sell', 'promote' ] ).length > 0 ? 'business' : 'personal' )
-		);
+			( intersection( siteGoals, [ 'sell', 'promote' ] ).length > 0 ? 'business' : 'personal' );
+
+		// Default to 'business' when the blogger plan is not available.
+		if ( customerType === 'personal' && this.props.disableBloggerPlanWithNonBlogDomain ) {
+			customerType = 'business';
+		}
+
+		return customerType;
 	}
 
 	handleFreePlanButtonClick = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We default to showing the blog/personal site plans in launch flow if you don't have a .blog domain. This PR shows business site plans first unless you have .blog domain.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a private website from `/start/private`.
* You will see _Lunch Site_ button in the banner on top of the site preview.
  <img width="600" alt="Your_Site_‹_Site_Title_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/54680819-2d3cc380-4b4e-11e9-9886-4971012b15e7.png">
* Note that the URL always heads for `wordpress.com`. Replace the host name with your local calypso or .live one.
* Follow the `launch-site` flow.
  * When you pick a `.blog` domain, you will see _Blogs and Personal Sites_ tab first.
  * Otherwise, _Business Sites and Online Stores_ tab will be displayed.

