### PR TITLE
Modernize the component that shows the 2FA backup code list

### DIFF
--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -24,6 +24,7 @@ import Notice from 'components/notice';
 import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
 import Tooltip from 'components/tooltip';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 /**
  * Style dependencies
@@ -379,4 +380,4 @@ class Security2faBackupCodesList extends React.Component {
 	}
 }
 
-export default localize( Security2faBackupCodesList );
+export default localize( withLocalizedMoment( Security2faBackupCodesList ) );

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -9,9 +9,6 @@ import ReactDom from 'react-dom';
 import Clipboard from 'clipboard';
 import userFactory from 'lib/user';
 import Gridicon from 'gridicons';
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:me:security:2fa-backup-codes-list' );
-
 import { saveAs } from 'browser-filesaver';
 
 /**
@@ -54,8 +51,6 @@ class Security2faBackupCodesList extends React.Component {
 	popup = false;
 
 	componentDidMount() {
-		debug( this.constructor.displayName + ' React component is mounted.' );
-
 		// Configure clipboard to be triggered on clipboard button press
 		const button = ReactDom.findDOMNode( this.refs.copyCodesBtn );
 		this.clipboard = new Clipboard( button, {
@@ -65,11 +60,8 @@ class Security2faBackupCodesList extends React.Component {
 	}
 
 	componentWillUnmount() {
-		debug( this.constructor.displayName + ' React component will unmount.' );
-
 		// Cleanup clipboard object
 		this.clipboard.destroy();
-		delete this.clipboard;
 	}
 
 	openPopup = () => {

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -50,9 +50,13 @@ class Security2faBackupCodesList extends React.Component {
 
 	popup = false;
 
+	copyCodesButtonRef = React.createRef();
+	printCodesButtonRef = React.createRef();
+	downloadCodesButtonRef = React.createRef();
+
 	componentDidMount() {
 		// Configure clipboard to be triggered on clipboard button press
-		const button = ReactDom.findDOMNode( this.refs.copyCodesBtn );
+		const button = ReactDom.findDOMNode( this.copyCodesButtonRef.current );
 		this.clipboard = new Clipboard( button, {
 			text: () => this.getBackupCodePlainText( this.props.backupCodes ),
 		} );
@@ -299,11 +303,11 @@ class Security2faBackupCodesList extends React.Component {
 							disabled={ ! this.props.backupCodes.length }
 							onMouseEnter={ this.enableCopyCodesTooltip }
 							onMouseLeave={ this.disableCopyCodesTooltip }
-							ref="copyCodesBtn"
+							ref={ this.copyCodesButtonRef }
 						>
 							<Gridicon icon="clipboard" />
 							<Tooltip
-								context={ this.refs && this.refs.copyCodesBtn }
+								context={ this.copyCodesButtonRef.current }
 								isVisible={ this.state.copyCodesTooltip }
 								position="top"
 							>
@@ -317,11 +321,11 @@ class Security2faBackupCodesList extends React.Component {
 							onClick={ this.onPrint }
 							onMouseEnter={ this.enablePrintCodesTooltip }
 							onMouseLeave={ this.disablePrintCodesTooltip }
-							ref="printCodesBtn"
+							ref={ this.printCodesButtonRef }
 						>
 							<Gridicon icon="print" />
 							<Tooltip
-								context={ this.refs && this.refs.printCodesBtn }
+								context={ this.printCodesButtonRef.current }
 								isVisible={ this.state.printCodesTooltip }
 								position="top"
 							>
@@ -335,11 +339,11 @@ class Security2faBackupCodesList extends React.Component {
 							onClick={ this.saveCodesToFile }
 							onMouseEnter={ this.enableDownloadCodesTooltip }
 							onMouseLeave={ this.disableDownloadCodesTooltip }
-							ref="downloadCodesBtn"
+							ref={ this.downloadCodesButtonRef }
 						>
 							<Gridicon icon="cloud-download" />
 							<Tooltip
-								context={ this.refs && this.refs.downloadCodesBtn }
+								context={ this.downloadCodesButtonRef.current }
 								isVisible={ this.state.downloadCodesTooltip }
 								position="top"
 							>

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -16,7 +16,6 @@ import { flowRight as compose } from 'lodash';
  * Internal dependencies
  */
 import FormButton from 'components/forms/form-button';
-import analytics from 'lib/analytics';
 import FormButtonBar from 'components/forms/form-buttons-bar';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormLabel from 'components/forms/form-label';
@@ -27,6 +26,7 @@ import Button from 'components/button';
 import Tooltip from 'components/tooltip';
 import { withLocalizedMoment } from 'components/localized-moment';
 import { getCurrentUserName } from 'state/current-user/selectors';
+import { recordGoogleEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -86,7 +86,7 @@ class Security2faBackupCodesList extends React.Component {
 	};
 
 	onPrint = () => {
-		analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Print Backup Codes Button' );
+		this.props.recordGoogleEvent( 'Me', 'Clicked On 2fa Print Backup Codes Button' );
 
 		if ( config.isEnabled( 'desktop' ) ) {
 			require( 'lib/desktop' ).print(
@@ -99,12 +99,12 @@ class Security2faBackupCodesList extends React.Component {
 	};
 
 	onCopy = () => {
-		analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Copy to clipboard Button' );
+		this.props.recordGoogleEvent( 'Me', 'Clicked On 2fa Copy to clipboard Button' );
 		this.setState( { isCopied: true } );
 	};
 
 	saveCodesToFile = () => {
-		analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Save Backup Codes Button' );
+		this.props.recordGoogleEvent( 'Me', 'Clicked On 2fa Save Backup Codes Button' );
 
 		const backupCodes = this.props.backupCodes.join( '\n' );
 		const toSave = new Blob( [ backupCodes ], { type: 'text/plain;charset=utf-8' } );
@@ -210,7 +210,7 @@ class Security2faBackupCodesList extends React.Component {
 
 	onNextStep = event => {
 		event.preventDefault();
-		analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Backup Codes Next Step Button' );
+		this.props.recordGoogleEvent( 'Me', 'Clicked On 2fa Backup Codes Next Step Button' );
 		this.props.onNextStep();
 	};
 
@@ -376,7 +376,10 @@ class Security2faBackupCodesList extends React.Component {
 }
 
 export default compose(
-	connect( state => ( { username: getCurrentUserName( state ) } ) ),
+	connect(
+		state => ( { username: getCurrentUserName( state ) } ),
+		{ recordGoogleEvent }
+	),
 	localize,
 	withLocalizedMoment
 )( Security2faBackupCodesList );

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -111,11 +111,11 @@ class Security2faBackupCodesList extends React.Component {
 		saveAs( toSave, `${ username }-backup-codes.txt` );
 	};
 
-	getBackupCodePlainText = backupCodes => {
+	getBackupCodePlainText( backupCodes ) {
 		if ( backupCodes.length > 0 ) {
 			return backupCodes.join( '\n' );
 		}
-	};
+	}
 
 	enableDownloadCodesTooltip = () => {
 		this.setState( { downloadCodesTooltip: true } );
@@ -141,7 +141,7 @@ class Security2faBackupCodesList extends React.Component {
 		this.setState( { copyCodesTooltip: false } );
 	};
 
-	getBackupCodeHTML = codes => {
+	getBackupCodeHTML( codes ) {
 		const datePrinted = this.props.moment().format( 'lll' );
 		let row;
 		let html = '<html><head><title>';
@@ -192,7 +192,7 @@ class Security2faBackupCodesList extends React.Component {
 
 		html += '</div></body></html>';
 		return html;
-	};
+	}
 
 	doPopup = codes => {
 		this.popup.document.open( 'text/html' );
@@ -202,21 +202,19 @@ class Security2faBackupCodesList extends React.Component {
 
 		/* this code takes advantage of setTimeout not running until after the
 	print dialog is dismissed - it is more reliable than using focus tricks */
-		setTimeout(
-			function() {
-				this.popup.close();
-				this.popup = false;
-			}.bind( this ),
-			100
-		);
+		setTimeout( () => {
+			this.popup.close();
+			this.popup = false;
+		}, 100 );
 	};
 
 	onNextStep = event => {
 		event.preventDefault();
+		analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Backup Codes Next Step Button' );
 		this.props.onNextStep();
 	};
 
-	getPlaceholders = () => {
+	getPlaceholders() {
 		let i;
 		const placeholders = [];
 
@@ -225,17 +223,17 @@ class Security2faBackupCodesList extends React.Component {
 		}
 
 		return placeholders;
-	};
+	}
 
 	onUserAgreesChange = event => {
 		this.setState( { userAgrees: event.target.checked } );
 	};
 
-	getSubmitDisabled = () => {
+	isSubmitDisabled() {
 		return ! this.state.userAgrees;
-	};
+	}
 
-	renderList = () => {
+	renderList() {
 		const backupCodes = this.props.backupCodes.length
 			? this.props.backupCodes
 			: this.getPlaceholders();
@@ -249,7 +247,7 @@ class Security2faBackupCodesList extends React.Component {
 					) }
 				</p>
 				<ol className="security-2fa-backup-codes-list__codes">
-					{ backupCodes.map( function( backupCode, index ) {
+					{ backupCodes.map( ( backupCode, index ) => {
 						const spacedCode = backupCode.concat( ' ' );
 						// we add a space to each backup code so that if the user wants to copy and paste the entire list
 						// the backup codes aren't placed in the clipboard as a single long number
@@ -261,7 +259,7 @@ class Security2faBackupCodesList extends React.Component {
 								<span>{ spacedCode }</span>
 							</li>
 						);
-					}, this ) }
+					} ) }
 				</ol>
 
 				<p className="security-2fa-backup-codes-list__warning">
@@ -288,11 +286,8 @@ class Security2faBackupCodesList extends React.Component {
 
 					<FormButton
 						className="security-2fa-backup-codes-list__next"
-						onClick={ function( event ) {
-							analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Backup Codes Next Step Button' );
-							this.onNextStep( event );
-						}.bind( this ) }
-						disabled={ this.getSubmitDisabled() }
+						onClick={ this.onNextStep }
+						disabled={ this.isSubmitDisabled() }
 					>
 						{ this.props.translate( 'All Finished!', {
 							context: 'The user presses the All Finished button at the end of Two-Step setup.',
@@ -355,13 +350,13 @@ class Security2faBackupCodesList extends React.Component {
 				</FormButtonBar>
 			</div>
 		);
-	};
+	}
 
 	clearLastError = () => {
 		this.setState( { lastError: false } );
 	};
 
-	possiblyRenderError = () => {
+	possiblyRenderError() {
 		if ( ! this.state.lastError ) {
 			return null;
 		}
@@ -373,7 +368,7 @@ class Security2faBackupCodesList extends React.Component {
 				text={ this.state.lastError }
 			/>
 		);
-	};
+	}
 
 	render() {
 		return <div className="security-2fa-backup-codes-list">{ this.renderList() }</div>;

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -6,10 +6,11 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
 import ReactDom from 'react-dom';
+import { connect } from 'react-redux';
 import Clipboard from 'clipboard';
-import userFactory from 'lib/user';
 import Gridicon from 'gridicons';
 import { saveAs } from 'browser-filesaver';
+import { flowRight as compose } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,6 +26,7 @@ import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
 import Tooltip from 'components/tooltip';
 import { withLocalizedMoment } from 'components/localized-moment';
+import { getCurrentUserName } from 'state/current-user/selectors';
 
 /**
  * Style dependencies
@@ -103,12 +105,10 @@ class Security2faBackupCodesList extends React.Component {
 
 	saveCodesToFile = () => {
 		analytics.ga.recordEvent( 'Me', 'Clicked On 2fa Save Backup Codes Button' );
-		const user = userFactory();
-		const username = user.get().username;
 
 		const backupCodes = this.props.backupCodes.join( '\n' );
 		const toSave = new Blob( [ backupCodes ], { type: 'text/plain;charset=utf-8' } );
-		saveAs( toSave, `${ username }-backup-codes.txt` );
+		saveAs( toSave, `${ this.props.username }-backup-codes.txt` );
 	};
 
 	getBackupCodePlainText( backupCodes ) {
@@ -375,4 +375,8 @@ class Security2faBackupCodesList extends React.Component {
 	}
 }
 
-export default localize( withLocalizedMoment( Security2faBackupCodesList ) );
+export default compose(
+	connect( state => ( { username: getCurrentUserName( state ) } ) ),
+	localize,
+	withLocalizedMoment
+)( Security2faBackupCodesList );

--- a/client/state/current-user/selectors.js
+++ b/client/state/current-user/selectors.js
@@ -129,6 +129,14 @@ export function getCurrentUserCurrencyCode( state ) {
 export const getCurrentUserDate = createCurrentUserSelector( 'date' );
 
 /**
+ *  Returns the username of the current user.
+ *
+ *  @param {Object} state Global state tree
+ *  @returns {?String} The username of the current user.
+ */
+export const getCurrentUserName = createCurrentUserSelector( 'username' );
+
+/**
  *  Returns the primary email of the current user.
  *
  *  @param {Object} state Global state tree


### PR DESCRIPTION
The main motivation was to wrap the component with `withLocalizedMoment` because it uses `moment`. And there were more modernization opportunities:
- migrate string refs to `React.createRef()`
- remove `debug` statements that only log that the component was mounted and unmounted. No longer an exciting event today.
- replace `lib/user` with Redux selectors
- use Redux analytics instead of `lib/analytics`
- use arrow functions instead of `function() {}.bind( this )`

**How to test:**
Enable 2FA for your testing account, choose "Verify via App", scan the QR code and proceed to the screen with backup codes. Verify that:
- backup codes are generated and displayed
- hovering on any of the copy/print/download buttons shows a tooltip
- clicking on any of the three buttons triggers the copy/print/download action
- when printing, the printed document has a "Printed: Mar 20, 2019 2:27 PM" label
- downloaded file has the username in name: `jsnajdr-backup-codes.txt`
