### PR TITLE
Jest: Add per-package Jest config

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -115,11 +115,11 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
-			"integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+			"integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
 			"requires": {
-				"@babel/types": "^7.3.4",
+				"@babel/types": "^7.4.0",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.11",
 				"source-map": "^0.5.0",
@@ -160,36 +160,36 @@
 			}
 		},
 		"@babel/helper-call-delegate": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.1.0.tgz",
-			"integrity": "sha512-YEtYZrw3GUK6emQHKthltKNZwszBcHK58Ygcis+gVUrF4/FmTVr5CCqQNSfmvg2y+YDEANyYoaLz/SHsnusCwQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.0.tgz",
+			"integrity": "sha512-SdqDfbVdNQCBp3WhK2mNdDvHd3BD6qbmIc43CAyjnsfCmgHMeqgDcM3BzY2lchi7HBJGJ2CVdynLWbezaE4mmQ==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.0.0",
-				"@babel/traverse": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-hoist-variables": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.3.4.tgz",
-			"integrity": "sha512-uFpzw6L2omjibjxa8VGZsJUPL5wJH0zzGKpoz0ccBkzIa6C8kWNUbiBmQ0rgOKWlHJ6qzmfa6lTiGchiV8SC+g==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.0.tgz",
+			"integrity": "sha512-2K8NohdOT7P6Vyp23QH4w2IleP8yG3UJsbRKwA4YP6H8fErcLkFuuEEqbF2/BYBKSNci/FWJiqm6R3VhM/QHgw==",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.3.4",
-				"@babel/helper-split-export-declaration": "^7.0.0"
+				"@babel/helper-replace-supers": "^7.4.0",
+				"@babel/helper-split-export-declaration": "^7.4.0"
 			}
 		},
 		"@babel/helper-define-map": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
-			"integrity": "sha512-yPPcW8dc3gZLN+U1mhYV91QU3n5uTbx7DUdf8NnPbjS0RMwBuHi9Xt2MUgppmNz7CJxTBWsGczTiEp1CSOTPRg==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.4.0.tgz",
+			"integrity": "sha512-wAhQ9HdnLIywERVcSvX40CEJwKdAa1ID4neI9NXQPDOHwwA+57DqwLiPEVy2AIyWzAk0CQ8qx4awO0VUURwLtA==",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"lodash": "^4.17.10"
+				"@babel/types": "^7.4.0",
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-explode-assignable-expression": {
@@ -220,11 +220,11 @@
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0.tgz",
-			"integrity": "sha512-Ggv5sldXUeSKsuzLkddtyhyHe2YantsxWKNi7A+7LeD12ExRDWTRk29JCXpaHPAbMaIPZSil7n+lq78WY2VY7w==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.4.0.tgz",
+			"integrity": "sha512-/NErCuoe/et17IlAQFKWM24qtyYYie7sFIrW/tIQXpck6vAu2hhtYYsKLBWQV+BQZMbcIYPU/QMYuTufrY4aQw==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
@@ -290,14 +290,14 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.3.4.tgz",
-			"integrity": "sha512-pvObL9WVf2ADs+ePg0jrqlhHoxRXlOa+SHRHzAXIz2xkYuOHfGl+fKxPMaS4Fq+uje8JQPobnertBBvyrWnQ1A==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
+			"integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
-				"@babel/traverse": "^7.3.4",
-				"@babel/types": "^7.3.4"
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -310,11 +310,11 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-			"integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+			"integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/helper-wrap-function": {
@@ -329,13 +329,13 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.3.1.tgz",
-			"integrity": "sha512-Q82R3jKsVpUV99mgX50gOPCWwco9Ec5Iln/8Vyu4osNIOQgSrd9RFrQeUvmvddFNoLwMyOUWU+5ckioEKpDoGA==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.0.tgz",
+			"integrity": "sha512-2Lfcn74A2WSFUbYJ76ilYE1GnegCKUHTfXxp25EL2zPZHjV7OcDncqNjl295mUH0VnB65mNriXW4J5ROvxsgGg==",
 			"requires": {
-				"@babel/template": "^7.1.2",
-				"@babel/traverse": "^7.1.5",
-				"@babel/types": "^7.3.0"
+				"@babel/template": "^7.4.0",
+				"@babel/traverse": "^7.4.0",
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/highlight": {
@@ -349,9 +349,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
-			"integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ=="
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.0.tgz",
+			"integrity": "sha512-ZmMhJfU/+SXXvy9ALjDZopa3T3EixQtQai89JRC48eM9OUwrxJjYjuM/0wmdl2AekytlzMVhPY8cYdLb13kpKQ=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.2.0",
@@ -400,9 +400,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.3.4.tgz",
-			"integrity": "sha512-j7VQmbbkA+qrzNqbKHrBsW3ddFnOeva6wzSe/zB7T+xaxGc+RCpwo44wCmRixAIGRoIpmVgvzFzNJqQcO3/9RA==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.0.tgz",
+			"integrity": "sha512-uTNi8pPYyUH2eWHyYWWSYJKwKg34hhgl4/dbejEjL+64OhbHjTX7wEVWMQl82tEmdDsGeu77+s8HHLS627h6OQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
@@ -418,13 +418,13 @@
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.2.0.tgz",
-			"integrity": "sha512-LvRVYb7kikuOtIoUeWTkOxQEV1kYvL5B6U3iWEGCzPNRus1MzJweFqORTj+0jkxozkTSYNJozPOddxmqdqsRpw==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.0.tgz",
+			"integrity": "sha512-h/KjEZ3nK9wv1P1FSNb9G079jXrNYR0Ko+7XkOx85+gM24iZbPn0rh4vCftk+5QKY7y1uByFataBTmX7irEF1w==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.2.0"
+				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -500,9 +500,9 @@
 			}
 		},
 		"@babel/plugin-transform-async-to-generator": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.3.4.tgz",
-			"integrity": "sha512-Y7nCzv2fw/jEZ9f678MuKdMo99MFDJMT/PvD9LisrR5JDFcJH6vYeH6RnjVt3p5tceyGRvTtEN0VOlU+rgHZjA==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.4.0.tgz",
+			"integrity": "sha512-EeaFdCeUULM+GPFEsf7pFcNSxM7hYjoj5fiYbyuiXobW4JhFnjAv9OWzNwHyHcKoPNpAfeRDuW6VyaXEDUBa7g==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -518,26 +518,26 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.3.4.tgz",
-			"integrity": "sha512-blRr2O8IOZLAOJklXLV4WhcEzpYafYQKSGT3+R26lWG41u/FODJuBggehtOwilVAcFu393v3OFj+HmaE6tVjhA==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.4.0.tgz",
+			"integrity": "sha512-AWyt3k+fBXQqt2qb9r97tn3iBwFpiv9xdAiG+Gr2HpAZpuayvbL55yWrsV3MyHvXk/4vmSiedhDRl1YI2Iy5nQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.3.4.tgz",
-			"integrity": "sha512-J9fAvCFBkXEvBimgYxCjvaVDzL6thk0j0dBvCeZmIUDBwyt+nv6HfbImsSrWsYXfDNDivyANgJlFXDUWRTZBuA==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.0.tgz",
+			"integrity": "sha512-XGg1Mhbw4LDmrO9rSTNe+uI79tQPdGs0YASlxgweYRLZqo/EQktjaOV4tchL/UZbM0F+/94uOipmdNGoaGOEYg==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
-				"@babel/helper-define-map": "^7.1.0",
+				"@babel/helper-define-map": "^7.4.0",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-optimise-call-expression": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-replace-supers": "^7.3.4",
-				"@babel/helper-split-export-declaration": "^7.0.0",
+				"@babel/helper-replace-supers": "^7.4.0",
+				"@babel/helper-split-export-declaration": "^7.4.0",
 				"globals": "^11.1.0"
 			}
 		},
@@ -550,9 +550,9 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.3.2",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.3.2.tgz",
-			"integrity": "sha512-Lrj/u53Ufqxl/sGxyjsJ2XNtNuEjDyjpqdhMNh5aZ+XFOdThL46KBj27Uem4ggoezSYBxKWAil6Hu8HtwqesYw==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.0.tgz",
+			"integrity": "sha512-HySkoatyYTY3ZwLI8GGvkRWCFrjAGXUHur5sMecmCIdIharnlcWWivOqDJI76vvmVZfzwb6G08NREsrY96RhGQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -585,9 +585,9 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.2.0.tgz",
-			"integrity": "sha512-Kz7Mt0SsV2tQk6jG5bBv5phVbkd0gd27SgYD4hH1aLMJRchM0dzHaXvrWhVZ+WxAlDoAKZ7Uy3jVTW2mKXQ1WQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.0.tgz",
+			"integrity": "sha512-vWdfCEYLlYSxbsKj5lGtzA49K3KANtb8qCPQ1em07txJzsBwY+cKJzBHizj5fl3CCx7vt+WPdgDLTHmydkbQSQ==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -619,9 +619,9 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.2.0.tgz",
-			"integrity": "sha512-V6y0uaUQrQPXUrmj+hgnks8va2L0zcZymeU7TtWEgdRLNkceafKXEduv7QzgQAE4lT+suwooG9dC7LFhdRAbVQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.0.tgz",
+			"integrity": "sha512-iWKAooAkipG7g1IY0eah7SumzfnIT3WNhT4uYB2kIsvHnNSB6MDYVa5qyICSwaTBDBY2c4SnJ3JtEa6ltJd6Jw==",
 			"requires": {
 				"@babel/helper-module-transforms": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -629,11 +629,11 @@
 			}
 		},
 		"@babel/plugin-transform-modules-systemjs": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.3.4.tgz",
-			"integrity": "sha512-VZ4+jlGOF36S7TjKs8g4ojp4MEI+ebCQZdswWb/T9I4X84j8OtFAyjXjt/M16iIm5RIZn0UMQgg/VgIwo/87vw==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.4.0.tgz",
+			"integrity": "sha512-gjPdHmqiNhVoBqus5qK60mWPp1CmYWp/tkh11mvb0rrys01HycEGD7NvvSoKXlWEfSM9TcL36CpsK8ElsADptQ==",
 			"requires": {
-				"@babel/helper-hoist-variables": "^7.0.0",
+				"@babel/helper-hoist-variables": "^7.4.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
@@ -655,9 +655,9 @@
 			}
 		},
 		"@babel/plugin-transform-new-target": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.0.0.tgz",
-			"integrity": "sha512-yin069FYjah+LbqfGeTfzIBODex/e++Yfa0rH0fpfam9uTbuEeEOx5GLGr210ggOV77mVRNoeqSYqeuaqSzVSw==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.4.0.tgz",
+			"integrity": "sha512-6ZKNgMQmQmrEX/ncuCwnnw1yVGoaOW5KpxNhoWI7pCQdA0uZ0HqHGqenCUIENAnxRjy2WwNQ30gfGdIgqJXXqw==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -672,11 +672,11 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.3.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.3.3.tgz",
-			"integrity": "sha512-IrIP25VvXWu/VlBWTpsjGptpomtIkYrN/3aDp4UKm7xK6UxZY88kcJ1UwETbzHAlwN21MnNfwlar0u8y3KpiXw==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.0.tgz",
+			"integrity": "sha512-Xqv6d1X+doyiuCGDoVJFtlZx0onAX0tnc3dY8w71pv/O0dODAbusVv2Ale3cGOwfiyi895ivOBhYa9DhAM8dUA==",
 			"requires": {
-				"@babel/helper-call-delegate": "^7.1.0",
+				"@babel/helper-call-delegate": "^7.4.0",
 				"@babel/helper-get-function-arity": "^7.0.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -718,9 +718,9 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.3.4.tgz",
-			"integrity": "sha512-hvJg8EReQvXT6G9H2MvNPXkv9zK36Vxa1+csAVTpE1J3j0zlHplw76uudEbJxgvqZzAq9Yh45FLD4pk5mKRFQA==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.0.tgz",
+			"integrity": "sha512-SZ+CgL4F0wm4npojPU6swo/cK4FcbLgxLd4cWpHaNXY/NJ2dpahODCqBbAwb2rDmVszVb3SSjnk9/vik3AYdBw==",
 			"requires": {
 				"regenerator-transform": "^0.13.4"
 			}
@@ -868,26 +868,26 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-			"integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+			"integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.2.2",
-				"@babel/types": "^7.2.2"
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
-			"integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+			"integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/generator": "^7.3.4",
+				"@babel/generator": "^7.4.0",
 				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.0.0",
-				"@babel/parser": "^7.3.4",
-				"@babel/types": "^7.3.4",
+				"@babel/helper-split-export-declaration": "^7.4.0",
+				"@babel/parser": "^7.4.0",
+				"@babel/types": "^7.4.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.11"
@@ -904,9 +904,9 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.3.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-			"integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+			"integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
 			"requires": {
 				"esutils": "^2.0.2",
 				"lodash": "^4.17.11",
@@ -2165,9 +2165,9 @@
 			"integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
 		},
 		"@octokit/endpoint": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.3.tgz",
-			"integrity": "sha512-vAWzeoj9Lzpl3V3YkWKhGzmDUoMfKpyxJhpq74/ohMvmLXDoEuAGnApy/7TRi3OmnjyX2Lr+e9UGGAD0919ohA==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.2.3.tgz",
+			"integrity": "sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==",
 			"requires": {
 				"deepmerge": "3.2.0",
 				"is-plain-object": "^2.0.4",
@@ -2183,16 +2183,16 @@
 			}
 		},
 		"@octokit/plugin-enterprise-rest": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.2.0.tgz",
-			"integrity": "sha512-/uXIvjK5bxmMKI1MDZXxVSiheiyvqv7GCWjoN1s43jF3MMrfqnErOwbZkreeL0CgO1R2lNW6dESDV5NbRiWEQA=="
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-2.2.2.tgz",
+			"integrity": "sha512-CTZr64jZYhGWNTDGlSJ2mvIlFsm9OEO3LqWn9I/gmoHI4jRBp4kpHoFYNemG4oA75zUAcmbuWblb7jjP877YZw=="
 		},
 		"@octokit/request": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.1.tgz",
-			"integrity": "sha512-nN8W24ZXEpJQJoVgMsGZeK9FOzxkc39Xn9ykseUpPpPMNEDFSvqfkCeqqKrjUiXRm72ubGLWG1SOz0aJPcgGww==",
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.2.tgz",
+			"integrity": "sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==",
 			"requires": {
-				"@octokit/endpoint": "^3.1.1",
+				"@octokit/endpoint": "^3.2.0",
 				"deprecation": "^1.0.1",
 				"is-plain-object": "^2.0.4",
 				"node-fetch": "^2.3.0",
@@ -2208,11 +2208,11 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.17.1",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.17.1.tgz",
-			"integrity": "sha512-cRosFoYEXraBsXe+FDHFW4b98RM0WuvSv9HUsbV69E+j8aRGAU/4FudEdpgBSIiXv8HvUOLlo6fAdJmmJHSVKw==",
+			"version": "16.19.0",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.19.0.tgz",
+			"integrity": "sha512-mUk/GU2LtV95OAM3FnvK7KFFNzUUzEGFldOhWliJnuhwBqxEag1gW85o//L6YphC9wLoTaZQOhCHmQcsCnt2ag==",
 			"requires": {
-				"@octokit/request": "2.4.1",
+				"@octokit/request": "2.4.2",
 				"before-after-hook": "^1.4.0",
 				"btoa-lite": "^1.0.0",
 				"deprecation": "^1.0.1",
@@ -2451,14 +2451,14 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "11.11.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
-			"integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
+			"version": "11.11.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.4.tgz",
+			"integrity": "sha512-02tIL+QIi/RW4E5xILdoAMjeJ9kYq5t5S2vciUdFPXv/ikFTb0zK8q9vXkg4+WAJuYXGiVT1H28AkD2C+IkXVw=="
 		},
 		"@types/q": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
-			"integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+			"integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
 			"dev": true
 		},
 		"@types/stack-utils": {
@@ -2495,9 +2495,9 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "12.0.9",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.9.tgz",
-			"integrity": "sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA==",
+			"version": "12.0.10",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.10.tgz",
+			"integrity": "sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==",
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
@@ -3616,14 +3616,15 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
 			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+			"dev": true,
 			"requires": {
 				"lodash": "^4.17.11"
 			}
 		},
 		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
+			"integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg=="
 		},
 		"async-foreach": {
 			"version": "0.1.3",
@@ -4382,13 +4383,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.4.2.tgz",
-			"integrity": "sha512-ISS/AIAiHERJ3d45Fz0AVYKkgcy+F/eJHzKEvv1j0wwKGKD9T3BrwKr/5g45L+Y4XIK5PlTqefHciRFcfE1Jxg==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.1.tgz",
+			"integrity": "sha512-/pPw5IAUyqaQXGuD5vS8tcbudyPZ241jk1W5pQBsGDfcjNQt7p8qxZhgMNuygDShte1PibLFexecWUPgmVLfrg==",
 			"requires": {
-				"caniuse-lite": "^1.0.30000939",
-				"electron-to-chromium": "^1.3.113",
-				"node-releases": "^1.1.8"
+				"caniuse-lite": "^1.0.30000949",
+				"electron-to-chromium": "^1.3.116",
+				"node-releases": "^1.1.11"
 			}
 		},
 		"bser": {
@@ -4583,9 +4584,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000946",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000946.tgz",
-			"integrity": "sha512-ZVXtMoZ3Mfq69Ikv587Av+5lwGVJsG98QKUucVmtFBf0tl1kOCfLQ5o6Z2zBNis4Mx3iuH77WxEUpdP6t7f2CQ=="
+			"version": "1.0.30000951",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000951.tgz",
+			"integrity": "sha512-eRhP+nQ6YUkIcNQ6hnvdhMkdc7n3zadog0KXNRxAZTT2kHjUb1yGn71OrPhSn8MOvlX97g5CR97kGVj8fMsXWg=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -6778,9 +6779,9 @@
 			}
 		},
 		"document.contains": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.0.tgz",
-			"integrity": "sha512-zp201O5xAqBop052rDBx1+2N9w2CbPBHvLvAiraigic7vePBr1wQDWvIF1yYjgBclL2z+KmOA0Z9DAXse3kd4Q==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/document.contains/-/document.contains-1.0.1.tgz",
+			"integrity": "sha512-A1KqlZq1w605bwiiLqVZehWE9S9UYlUXPoduFWi64pNVNQ9vy6wwH/7BS+iEfSlF1YyZgcg5PZw5HqDi7FCrUw==",
 			"requires": {
 				"define-properties": "^1.1.3"
 			}
@@ -6950,9 +6951,9 @@
 			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.115",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.115.tgz",
-			"integrity": "sha512-mN2qeapQWdi2B9uddxTZ4nl80y46hbyKY5Wt9Yjih+QZFQLdaujEDK4qJky35WhyxMzHF3ZY41Lgjd2BPDuBhg=="
+			"version": "1.3.116",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.116.tgz",
+			"integrity": "sha512-NKwKAXzur5vFCZYBHpdWjTMO8QptNLNP80nItkSIgUOapPAo9Uia+RvkCaZJtO7fhQaVElSvBPWEc2ku6cKsPA=="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -7363,16 +7364,6 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"eslint-scope": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
-					"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
-					"dev": true,
-					"requires": {
-						"esrecurse": "^4.1.0",
-						"estraverse": "^4.1.1"
-					}
-				},
 				"import-fresh": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
@@ -7623,9 +7614,9 @@
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.5.0.tgz",
-			"integrity": "sha512-iwDuWR2ReRgvJsNm8fXPtTKdg78IVQF8I4+am3ntztPf/+nPnWZfArFu6aXpaC75/iCYRrkqI8nPCYkxJstmpA==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.5.1.tgz",
+			"integrity": "sha512-i3dIrmZ+Ssrm0LrbbtuGcRf7EEpe1FaMuL8XnnpZO0X4tk3dZNzevWxD0/7nMAFa5yZQfNnYkfEP0MmwLvbdHw==",
 			"dev": true
 		},
 		"eslint-plugin-wpcalypso": {
@@ -7633,9 +7624,9 @@
 			"dev": true
 		},
 		"eslint-scope": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
-			"integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+			"integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
 			"requires": {
 				"esrecurse": "^4.1.0",
 				"estraverse": "^4.1.1"
@@ -7654,9 +7645,9 @@
 			"dev": true
 		},
 		"esm": {
-			"version": "3.2.16",
-			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.16.tgz",
-			"integrity": "sha512-iACZMQvYFc66Y7QC+vD3oGA/fFsPA/IQwewRJ3K0gbMV52E59pdko02kF2TfVdtp5aHO62PHxL6fxtHJmhm3NQ=="
+			"version": "3.2.18",
+			"resolved": "https://registry.npmjs.org/esm/-/esm-3.2.18.tgz",
+			"integrity": "sha512-1UENjnnI37UDp7KuOqKYjfqdaMim06eBWnDv37smaxTIzDl0ZWnlgoXwsVwD9+Lidw+q/f1gUf2diVMDCycoVw=="
 		},
 		"espree": {
 			"version": "5.0.1",
@@ -9033,11 +9024,11 @@
 			}
 		},
 		"handlebars": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-			"integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
+			"integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
 			"requires": {
-				"async": "^2.5.0",
+				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
 				"source-map": "^0.6.1",
 				"uglify-js": "^3.1.4"
@@ -9585,9 +9576,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
 					"dev": true
 				},
 				"pify": {
@@ -9869,9 +9860,9 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
 				"strip-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-					"integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					}
@@ -11775,9 +11766,9 @@
 			"integrity": "sha512-EtnfmHsHJTr3u24sito9JctSxej5Ds0SgUD2Lm+qRHyLgM7BGesFlW14eNh1mil0fV5Muh8gf3dBBXzADlUlzQ=="
 		},
 		"macos-release": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
-			"integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.1.0.tgz",
+			"integrity": "sha512-8TCbwvN1mfNxbBv0yBtfyIFMo3m1QsNbKHv7PYIp/abRBKVQBXN7ecu3aeGGgT18VC/Tf397LBDGZF9KBGJFFw=="
 		},
 		"magic-string": {
 			"version": "0.25.2",
@@ -12430,9 +12421,9 @@
 			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
-			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-			"integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+			"version": "2.13.1",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.1.tgz",
+			"integrity": "sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -12671,9 +12662,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.10",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.10.tgz",
-			"integrity": "sha512-KbUPCpfoBvb3oBkej9+nrU0/7xPlVhmhhUJ1PZqwIP5/1dJkRWKWD3OONjo6M2J7tSCBtDCumLwwqeI+DWWaLQ==",
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.11.tgz",
+			"integrity": "sha512-8v1j5KfP+s5WOTa1spNUAOfreajQPN12JXbRR0oDE+YrJBQCXBnNqUDj27EKpPLOoSiU3tKi3xGPB+JaOdUEQQ==",
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -14326,9 +14317,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
 				}
 			}
 		},
@@ -14521,9 +14512,9 @@
 			}
 		},
 		"postcss-less": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.3.tgz",
-			"integrity": "sha512-S0LYoO278GVmyT1uCgr1h95L19dkmzuJDMdpSMCtv+bj15OoJXtFX6c/2AlyL4OEOauGTC7nuqfudVd5kzFtuA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
+			"integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.14"
@@ -17734,9 +17725,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.5.tgz",
-					"integrity": "sha512-kOC8IUb8HSDMVcYrDVezCxpJkzSQWTAzf3olpKM6o9rM5zpojx23O0Fl8Wr4+qJ6ZbPEHqf1fdwev/DS7v7pmA==",
+					"version": "5.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.6.tgz",
+					"integrity": "sha512-/+hp3kUf/Csa32ktIaj0OlRqQxrgs30n62M90UBpNd9k+ENEch5S+hmbW3DtcJGz3sYFTh4F3A6fQ0q7KWsp4w==",
 					"dev": true
 				},
 				"meow": {
@@ -17779,9 +17770,9 @@
 					}
 				},
 				"strip-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-					"integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
@@ -17942,9 +17933,9 @@
 					}
 				},
 				"strip-ansi": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-					"integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
@@ -18555,19 +18546,14 @@
 			"integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
 		},
 		"uglify-js": {
-			"version": "3.4.9",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+			"version": "3.4.10",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
+			"integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
 			"requires": {
-				"commander": "~2.17.1",
+				"commander": "~2.19.0",
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
-				"commander": {
-					"version": "2.17.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-					"integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -19742,9 +19728,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-					"integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
 				},
 				"pump": {
 					"version": "3.0.0",

--- a/packages/calypso-build/jest.config.js
+++ b/packages/calypso-build/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	testEnvironment: 'node',
+	testMatch: [ '<rootDir>/**/test/*.js?(x)', '!**/.eslintrc.*' ],
+	transform: { '^.+\\.jsx?$': 'babel-jest' },
+	verbose: false,
+};

--- a/packages/eslint-config-wpcalypso/jest.config.js
+++ b/packages/eslint-config-wpcalypso/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfig = require( '@automattic/calypso-build/jest.config.js' );
+
+module.exports = { ...jestConfig, rootDir: __dirname };

--- a/packages/eslint-config-wpcalypso/package.json
+++ b/packages/eslint-config-wpcalypso/package.json
@@ -28,5 +28,8 @@
 	},
 	"dependencies": {
 		"eslint-plugin-react-hooks": "^1.5.0"
+	},
+	"devDependencies": {
+		"@automattic/calypso-build": "file:../calypso-build"
 	}
 }

--- a/packages/eslint-plugin-wpcalypso/jest.config.js
+++ b/packages/eslint-plugin-wpcalypso/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfig = require( '@automattic/calypso-build/jest.config.js' );
+
+module.exports = { ...jestConfig, rootDir: __dirname };

--- a/packages/format-currency/jest.config.js
+++ b/packages/format-currency/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfig = require( '@automattic/calypso-build/jest.config.js' );
+
+module.exports = { ...jestConfig, rootDir: __dirname };

--- a/packages/i18n-calypso/jest.config.js
+++ b/packages/i18n-calypso/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfig = require( '@automattic/calypso-build/jest.config.js' );
+
+module.exports = { ...jestConfig, rootDir: __dirname };

--- a/packages/jetpack-blocks/jest.config.js
+++ b/packages/jetpack-blocks/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfig = require( '@automattic/calypso-build/jest.config.js' );
+
+module.exports = { ...jestConfig, rootDir: __dirname };

--- a/packages/photon/jest.config.js
+++ b/packages/photon/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfig = require( '@automattic/calypso-build/jest.config.js' );
+
+module.exports = { ...jestConfig, rootDir: __dirname };

--- a/packages/tree-select/jest.config.js
+++ b/packages/tree-select/jest.config.js
@@ -1,0 +1,3 @@
+const jestConfig = require( '@automattic/calypso-build/jest.config.js' );
+
+module.exports = { ...jestConfig, rootDir: __dirname };

--- a/test/packages/jest.config.js
+++ b/test/packages/jest.config.js
@@ -1,9 +1,6 @@
 /** @format */
 
 module.exports = {
-	rootDir: './../../packages',
-	testEnvironment: 'node',
-	testMatch: [ '<rootDir>/**/test/*.js?(x)', '!**/.eslintrc.*' ],
-	transform: { '^.+\\.jsx?$': 'babel-jest' },
-	verbose: false,
+	rootDir: './../../',
+	projects: [ '<rootDir>/packages/*' ],
 };

--- a/test/packages/jest.config.js
+++ b/test/packages/jest.config.js
@@ -1,4 +1,3 @@
-/** @format */
 
 module.exports = {
 	rootDir: './../../',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use `projects` in the root Jest config, and per-package `jest.config.js` files. The rationale is similar as for per-package build scripts -- greater customizability. One concrete example is different transpilation (`.babelrc.js` files) per package, which will play a role in #31464.

#### Testing instructions

`npm run test-packages`

and verify that all the same tests are run as on `master` with that command.

