### PR TITLE
Block Editor: use Calypso Media Modal in Classic Blocks

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -13,7 +13,6 @@ import url from 'url';
  * Internal dependencies
  */
 import MediaLibrarySelectedData from 'components/data/media-library-selected-data';
-import MediaModal from 'post-editor/media-modal';
 import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
 import EditorMediaModal from 'post-editor/editor-media-modal';
@@ -48,14 +47,13 @@ class CalypsoifyIframe extends Component {
 	};
 
 	state = {
+		classicBlockEditorId: null,
 		isMediaModalVisible: false,
-		isClassicBlockMediaModalVisible: false,
 		isIframeLoaded: false,
 		isPreviewVisible: false,
 		previewUrl: 'about:blank',
 		postUrl: null,
 		editedPost: null,
-		classicBlockEditorId: null,
 	};
 
 	constructor( props ) {
@@ -103,8 +101,8 @@ class CalypsoifyIframe extends Component {
 		}
 		if ( 'classicBlockOpenMediaModal' === action ) {
 			this.setState( {
-				isClassicBlockMediaModalVisible: true,
 				classicBlockEditorId: data.editorId,
+				isMediaModalVisible: true,
 			} );
 		}
 	};
@@ -180,7 +178,7 @@ class CalypsoifyIframe extends Component {
 	};
 
 	closeMediaModal = media => {
-		if ( media && this.iframePort ) {
+		if ( ! this.state.classicBlockEditorId && media && this.iframePort ) {
 			const { multiple } = this.state;
 			const formattedMedia = map( media.items, item => mediaCalypsoToGutenberg( item ) );
 			const payload = multiple ? formattedMedia : formattedMedia[ 0 ];
@@ -203,13 +201,11 @@ class CalypsoifyIframe extends Component {
 			}
 		}
 
-		this.setState( { isMediaModalVisible: false } );
+		this.setState( { classicBlockEditorId: null, isMediaModalVisible: false } );
 	};
 
-	closeClassicBlockMediaModal = () => this.setState( { isClassicBlockMediaModalVisible: false } );
-
 	insertClassicBlockMedia = markup => {
-		if ( this.iframePort ) {
+		if ( !! this.state.classicBlockEditorId && this.iframePort ) {
 			this.iframePort.postMessage( {
 				action: 'insertClassicBlockMedia',
 				payload: {
@@ -279,6 +275,7 @@ class CalypsoifyIframe extends Component {
 	render() {
 		const { iframeUrl, siteId } = this.props;
 		const {
+			classicBlockEditorId,
 			isMediaModalVisible,
 			allowedTypes,
 			multiple,
@@ -287,7 +284,6 @@ class CalypsoifyIframe extends Component {
 			previewUrl,
 			postUrl,
 			editedPost,
-			isClassicBlockMediaModalVisible,
 		} = this.state;
 
 		return (
@@ -305,22 +301,16 @@ class CalypsoifyIframe extends Component {
 					/>
 				</div>
 				<MediaLibrarySelectedData siteId={ siteId }>
-					<MediaModal
+					<EditorMediaModal
 						disabledDataSources={ getDisabledDataSources( allowedTypes ) }
 						enabledFilters={ getEnabledFilters( allowedTypes ) }
 						galleryViewEnabled={ false }
+						isGutenberg={ ! classicBlockEditorId }
 						onClose={ this.closeMediaModal }
+						onInsertMedia={ this.insertClassicBlockMedia }
 						single={ ! multiple }
 						source=""
 						visible={ isMediaModalVisible }
-					/>
-					<EditorMediaModal
-						galleryViewEnabled={ false }
-						onClose={ this.closeClassicBlockMediaModal }
-						onInsertMedia={ this.insertClassicBlockMedia }
-						single
-						source=""
-						visible={ isClassicBlockMediaModalVisible }
 					/>
 				</MediaLibrarySelectedData>
 				<EditorRevisionsDialog loadRevision={ this.loadRevision } />

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -100,6 +100,12 @@ class CalypsoifyIframe extends Component {
 			return;
 		}
 		if ( 'classicBlockOpenMediaModal' === action ) {
+			if ( data.imageId ) {
+				const { siteId } = this.props;
+				const image = MediaStore.get( siteId, data.imageId );
+				MediaActions.setLibrarySelectedItems( siteId, [ image ] );
+			}
+
 			this.setState( {
 				classicBlockEditorId: data.editorId,
 				isMediaModalVisible: true,

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -16,6 +16,7 @@ import MediaLibrarySelectedData from 'components/data/media-library-selected-dat
 import MediaModal from 'post-editor/media-modal';
 import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
+import EditorMediaModal from 'post-editor/editor-media-modal';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteOption, getSiteAdminUrl } from 'state/sites/selectors';
 import { addQueryArgs } from 'lib/route';
@@ -48,11 +49,13 @@ class CalypsoifyIframe extends Component {
 
 	state = {
 		isMediaModalVisible: false,
+		isClassicBlockMediaModalVisible: false,
 		isIframeLoaded: false,
 		isPreviewVisible: false,
 		previewUrl: 'about:blank',
 		postUrl: null,
 		editedPost: null,
+		classicBlockEditorId: null,
 	};
 
 	constructor( props ) {
@@ -96,6 +99,13 @@ class CalypsoifyIframe extends Component {
 
 			// Check if we're generating a post via Press This
 			this.pressThis();
+			return;
+		}
+		if ( 'classicBlockOpenMediaModal' === action ) {
+			this.setState( {
+				isClassicBlockMediaModalVisible: true,
+				classicBlockEditorId: data.editorId,
+			} );
 		}
 	};
 
@@ -196,6 +206,20 @@ class CalypsoifyIframe extends Component {
 		this.setState( { isMediaModalVisible: false } );
 	};
 
+	closeClassicBlockMediaModal = () => this.setState( { isClassicBlockMediaModalVisible: false } );
+
+	insertClassicBlockMedia = markup => {
+		if ( this.iframePort ) {
+			this.iframePort.postMessage( {
+				action: 'insertClassicBlockMedia',
+				payload: {
+					editorId: this.state.classicBlockEditorId,
+					media: markup,
+				},
+			} );
+		}
+	};
+
 	pressThis = () => {
 		const { pressThis } = this.props;
 		if ( pressThis ) {
@@ -263,6 +287,7 @@ class CalypsoifyIframe extends Component {
 			previewUrl,
 			postUrl,
 			editedPost,
+			isClassicBlockMediaModalVisible,
 		} = this.state;
 
 		return (
@@ -288,6 +313,14 @@ class CalypsoifyIframe extends Component {
 						single={ ! multiple }
 						source=""
 						visible={ isMediaModalVisible }
+					/>
+					<EditorMediaModal
+						galleryViewEnabled={ false }
+						onClose={ this.closeClassicBlockMediaModal }
+						onInsertMedia={ this.insertClassicBlockMedia }
+						single
+						source=""
+						visible={ isClassicBlockMediaModalVisible }
 					/>
 				</MediaLibrarySelectedData>
 				<EditorRevisionsDialog loadRevision={ this.loadRevision } />

--- a/client/post-editor/editor-media-modal/index.jsx
+++ b/client/post-editor/editor-media-modal/index.jsx
@@ -72,10 +72,9 @@ class EditorMediaModal extends Component {
 
 	onClose = value => {
 		if ( value ) {
-			this.insertMedia( value );
-		} else {
-			this.props.onClose();
+			return this.props.isGutenberg ? this.props.onClose( value ) : this.insertMedia( value );
 		}
+		this.props.onClose();
 	};
 
 	render() {

--- a/client/post-editor/editor-media-modal/index.jsx
+++ b/client/post-editor/editor-media-modal/index.jsx
@@ -25,6 +25,7 @@ class EditorMediaModal extends Component {
 		site: PropTypes.object,
 		onInsertMedia: PropTypes.func,
 		onClose: PropTypes.func,
+		isGutenberg: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -72,6 +73,10 @@ class EditorMediaModal extends Component {
 
 	onClose = value => {
 		if ( value ) {
+			// `isGutenberg` means that the Media Modal has been opened by a Gutenberg media block,
+			// as opposed to the Classic editor or the Classic block in Gutenberg.
+			// This is needed because `insertMedia` returns the media markup, used by TinyMCE,
+			// while `onClose` returns the media object, used by Gutenberg media blocks.
 			return this.props.isGutenberg ? this.props.onClose( value ) : this.insertMedia( value );
 		}
 		this.props.onClose();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new Media Modal instance to be used in Classic blocks.
* Make Calypso listen to `classicBlockOpenMediaModal` messages and respond with `insertClassicBlockMedia` ones.

#### Testing instructions

* Apply D25790-code and sandbox a site.
* Open the Block Editor and insert a Classic block.
* Click "Add media" in the toolbar, choose an item and insert it.
* The item should have been inserted appropriately in the editor.
* Select the item and click on the Edit icon in the contextual sidebar.
* The media modal should be open, with that item selected.
* Pick another item and insert it.
* Make sure it replaced the previous item.

Fixes #31294
