### PR TITLE
Remove domain only purchase Thank You screen

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -441,7 +441,7 @@ export class CheckoutThankYou extends React.Component {
 
 		if ( this.props.domainOnlySiteFlow && purchases.length > 0 && ! failedPurchases.length ) {
 			const domainName = find( purchases, isDomainRegistration ).meta;
-
+			// page( domainManagementList( domainName ) );
 			return (
 				<Main className="checkout-thank-you">
 					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -272,7 +272,7 @@ export class CheckoutThankYou extends React.Component {
 		if ( props.domainOnlySiteFlow && get( props, 'receipt.hasLoadedFromServer', false ) ) {
 			const purchases = getPurchases( props );
 			const failedPurchases = getFailedPurchases( props );
-			if ( props.domainOnlySiteFlow && purchases.length > 0 && ! failedPurchases.length ) {
+			if ( purchases.length > 0 && ! failedPurchases.length ) {
 				const domainName = find( purchases, isDomainRegistration ).meta;
 				page( domainManagementList( domainName ) );
 			}

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -133,6 +133,7 @@ export class CheckoutThankYou extends React.Component {
 
 	componentDidMount() {
 		this.redirectIfThemePurchased();
+		this.redirectIfDomainOnly( this.props );
 
 		const {
 			gsuiteReceipt,
@@ -173,6 +174,7 @@ export class CheckoutThankYou extends React.Component {
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		this.redirectIfThemePurchased();
+		this.redirectIfDomainOnly( nextProps );
 
 		if (
 			! this.props.receipt.hasLoadedFromServer &&
@@ -264,6 +266,17 @@ export class CheckoutThankYou extends React.Component {
 			this.props.activatedTheme( 'premium/' + themeId, this.props.selectedSite.ID );
 
 			page.redirect( '/themes/' + this.props.selectedSite.slug );
+		}
+	};
+
+	redirectIfDomainOnly = props => {
+		if ( props.domainOnlySiteFlow && get( props, 'receipt.hasLoadedFromServer', false ) ) {
+			const purchases = getPurchases( props );
+			const failedPurchases = getFailedPurchases( props );
+			if ( props.domainOnlySiteFlow && purchases.length > 0 && ! failedPurchases.length ) {
+				const domainName = find( purchases, isDomainRegistration ).meta;
+				page( domainManagementList( domainName ) );
+			}
 		}
 	};
 
@@ -440,25 +453,7 @@ export class CheckoutThankYou extends React.Component {
 		}
 
 		if ( this.props.domainOnlySiteFlow && purchases.length > 0 && ! failedPurchases.length ) {
-			const domainName = find( purchases, isDomainRegistration ).meta;
-			// page( domainManagementList( domainName ) );
-			return (
-				<Main className="checkout-thank-you">
-					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
-					{ this.renderConfirmationNotice() }
-
-					<ThankYouCard
-						name={ domainName }
-						price={ this.props.receipt.data.displayPrice }
-						heading={ translate( 'Thank you for your purchase!' ) }
-						description={ translate(
-							"That looks like a great domain. Now it's time to get it all set up."
-						) }
-						buttonUrl={ domainManagementList( domainName ) }
-						buttonText={ translate( 'Go To Your Domain' ) }
-					/>
-				</Main>
-			);
+			return null;
 		}
 
 		const goBackText = this.props.selectedSite

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -77,7 +77,6 @@ import {
 import RebrandCitiesThankYou from './rebrand-cities-thank-you';
 import SiteRedirectDetails from './site-redirect-details';
 import Notice from 'components/notice';
-import ThankYouCard from 'components/thank-you-card';
 import {
 	domainManagementEmail,
 	domainManagementList,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the Thank You splash view in the domain only purchase flow

![image](https://user-images.githubusercontent.com/6817400/54778981-6fb4dd80-4bec-11e9-9ec7-c4649a9421de.png)

#### Testing instructions

* Checkout branch
* Goto: http://calypso.localhost:3000/start/domain/domain-only
* Buy domain
* You should be taken directly to the domain page.  See screenshot below:

<img width="898" alt="Screen Shot 2019-03-21 at 3 18 31 PM" src="https://user-images.githubusercontent.com/6817400/54779061-a854b700-4bec-11e9-89e5-ea66ff5a5c14.png">

