### PR TITLE
Colour Scheming: Fix Hidden Site Lock

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -172,9 +172,13 @@
 }
 
 .site__badge {
-	color: var( --sidebar-gridicon-fill );
+	color: var( --color-neutral );
 	padding-right: 4px;
 	line-height: 0;
 	position: relative;
 	vertical-align: middle;
+}
+
+.layout__secondary .site__badge {
+	color: var( --sidebar-gridicon-fill );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Ensures that the site lock only uses the sidebar gridicon fill variable if it's actually in the sidebar, otherwise it can be hidden elsewhere. Placing the override here instead of the layout file because it seems that's the common trend with this. 

#### Testing instructions

Follow the steps in the original issue, how do things look?

Hover:
![fdfsdfs3](https://user-images.githubusercontent.com/43215253/54719107-f5387f00-4b53-11e9-85f1-5821356dc1fe.png)

Normal:
![gfdgfdgfd-1](https://user-images.githubusercontent.com/43215253/54719108-f5d11580-4b53-11e9-9723-5838a182dd5d.png)

Notice how it still remains pink in Sakura's sidebar:

![gdfdgfgfgf](https://user-images.githubusercontent.com/43215253/54719125-03869b00-4b54-11e9-8e2f-9fe5229f1e48.png)

cc @flootr, @blowery 

Fixes #31574 

