### PR TITLE
Fix error with wrong react version

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -206,6 +206,7 @@ function getWebpackConfig( {
 					debug: path.resolve( __dirname, 'node_modules/debug' ),
 					store: 'store/dist/store.modern',
 					gridicons$: path.resolve( __dirname, 'client/components/async-gridicons' ),
+					react: path.resolve( __dirname, 'node_modules/react' ),
 				},
 				getAliasesForExtensions( {
 					extensionsDirectory: path.join( __dirname, 'client', 'extensions' ),


### PR DESCRIPTION
I was getting a runtime error due to Webpack somehow pulling in the wrong React version.

First of all, I got this warning during the build:

```
WARNING in react
  Multiple versions of react found:
    0.14.9 ./~/jsx-to-string/~/react
    16.2.0 ./packages/i18n-calypso/~/react
    16.8.4 ./~/react
```

No matter - webpack should automatically choose the highest version number to package. Yet somehow this didn't happen, and I got a runtime error like this:

```
Uncaught TypeError: react__WEBPACK_IMPORTED_MODULE_1___default.a.useState is not a function
    at useTranslate (use-translate.js:22)
(snip)
```

It turns out that if I look at React.version in a breakpoint in use-translate.js, I get `16.2.0`. Whoops.

This change forces webpack to use the top-level React version always, and assumes that this is the React version we want.

#### Changes proposed in this Pull Request

* Force usage of top-level React in `node_modules`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build everything
* Run it
* Looks good?
* Cool
