### PR TITLE
Ads Gutenblock: Add "Hide ad on mobile views" toggle

### DIFF
--- a/packages/jetpack-blocks/src/blocks/wordads/constants.js
+++ b/packages/jetpack-blocks/src/blocks/wordads/constants.js
@@ -34,7 +34,7 @@ export const AD_FORMATS = [
 		name: __( 'Leaderboard 728x90' ),
 		tag: 'leaderboard',
 		width: 728,
-		editorPadding: 40,
+		editorPadding: 60,
 	},
 	{
 		height: 50,
@@ -47,7 +47,7 @@ export const AD_FORMATS = [
 		name: __( 'Mobile Leaderboard 320x50' ),
 		tag: 'mobile_leaderboard',
 		width: 320,
-		editorPadding: 60,
+		editorPadding: 100,
 	},
 	{
 		height: 600,

--- a/packages/jetpack-blocks/src/blocks/wordads/edit.js
+++ b/packages/jetpack-blocks/src/blocks/wordads/edit.js
@@ -4,7 +4,7 @@
 import { __ } from '../../utils/i18n';
 import { BlockControls } from '@wordpress/editor';
 import { Component, Fragment } from '@wordpress/element';
-import { Placeholder } from '@wordpress/components';
+import { Placeholder, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -16,9 +16,13 @@ import { icon, title } from './';
 import './editor.scss';
 
 class WordAdsEdit extends Component {
+	handleHideMobileChange = hideMobile => {
+		this.props.setAttributes( { hideMobile: !! hideMobile } );
+	};
+
 	render() {
 		const { attributes, setAttributes } = this.props;
-		const { format } = attributes;
+		const { format, hideMobile } = attributes;
 		const selectedFormatObject = AD_FORMATS.filter( ( { tag } ) => tag === format )[ 0 ];
 
 		return (
@@ -40,6 +44,11 @@ class WordAdsEdit extends Component {
 						<div className="jetpack-wordads__header">{ __( 'Advertisements' ) }</div>
 						<Placeholder icon={ icon } label={ title } />
 						<div className="jetpack-wordads__footer">{ __( 'Report this Ad' ) }</div>
+						<ToggleControl
+							checked={ Boolean( hideMobile ) }
+							label={ __( 'Hide ad on mobile views' ) }
+							onChange={ this.handleHideMobileChange }
+						/>
 					</div>
 				</div>
 			</Fragment>

--- a/packages/jetpack-blocks/src/blocks/wordads/editor.scss
+++ b/packages/jetpack-blocks/src/blocks/wordads/editor.scss
@@ -30,6 +30,14 @@
 	.components-placeholder {
 		flex-grow: 2;
 	}
+
+	.components-toggle-control__label {
+		line-height: 1.4em;
+	}
+
+	.components-base-control__field {
+		padding-left: 5px;
+	}
 }
 
 .jetpack-wordads-leaderboard .components-placeholder {

--- a/packages/jetpack-blocks/src/blocks/wordads/index.js
+++ b/packages/jetpack-blocks/src/blocks/wordads/index.js
@@ -41,6 +41,10 @@ export const settings = {
 			type: 'string',
 			default: DEFAULT_FORMAT,
 		},
+		hideMobile: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 
 	category: 'jetpack',


### PR DESCRIPTION
Sometimes a tall/wide ad unit makes sense on Desktop, but not a mobile impression. It makes sense to include an option to disable the ad on a mobile impression or replace it with one that's more mobile friendly.

Jetpack PR: https://github.com/Automattic/jetpack/pull/11644
Addresses: https://github.com/Automattic/wp-calypso/issues/30870

<img width="782" alt="Screen Shot 2019-03-25 at 11 45 04 AM" src="https://user-images.githubusercontent.com/273708/54945598-7b0d4f00-4ef3-11e9-85c1-29372897a9d2.png">

#### Changes proposed in this Pull Request

* Add "Hide ad on mobile views" toggle

#### Testing instructions

* Before installing the update make a post containing some "old" Ads blocks.
* Download & build Jetpack branch: https://github.com/Automattic/jetpack/tree/update/ad-block-remove-on-mobile
* Open Calypso branch, compile blocks e.g. `npx lerna run build --stream --scope='@automattic/jetpack-blocks' && rsync -a --delete packages/jetpack-blocks/dist/ ../jetpack/_inc/blocks/`
* On WordAds approved site add a unit and toggle `Hide ad on mobile views`
* View page via favorite mobile impression tester, see ad is missing.
* Edit post with "old" blocks and verify the blocks have updated successfully.

Fixes #
