### PR TITLE
Signup: Removing absolute positioning for the form fieldset

### DIFF
--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -7,14 +7,13 @@ body.is-section-jetpack-connect .site-topic__content {
 
 	.form-fieldset {
 		margin-bottom: 0;
-		position: absolute;
 		left: 0;
 		right: 0;
 		z-index: 1000; // I know, I know...
 		border-radius: 4px;
 		background: var( --color-white );
-		box-shadow: 0 3px 6px rgba(0,0,0,0.16),
-					0 3px 6px rgba(0,0,0,0.23);
+		box-shadow: 0 3px 6px rgba( 0, 0, 0, 0.16 ),
+					0 3px 6px rgba( 0, 0, 0, 0.23 );
 	}
 
 	.suggestion-search .gridicon {


### PR DESCRIPTION
## Changes proposed in this Pull Request

[CSS changes](https://github.com/Automattic/wp-calypso/blame/a3c7281bd1c80512cc3a84905f2b96b768f429ff/client/signup/steps/site-topic/style.scss#L10) introduced in #31405 caused some fairly breaky changes to the Jetpack connect flow.

![image](https://user-images.githubusercontent.com/6458278/54723227-0072c580-4bbb-11e9-91c7-84fe44315196.png)

The offending CSS declaration `position: absolute`, applied to the surrounding `<fieldset />` seems to be the problem, and has been duly shown the door:

<img width="300" alt="Screen Shot 2019-03-21 at 9 25 49 am" src="https://user-images.githubusercontent.com/6458278/54723335-60696c00-4bbb-11e9-8fd7-8bf4443a9d32.png">

<img width="300" alt="Screen Shot 2019-03-21 at 9 30 02 am" src="https://user-images.githubusercontent.com/6458278/54723526-f1d8de00-4bbb-11e9-971f-bfa4181dd511.png">

The changes have no effect on the corresponding WordPress.com site topic component:

<img width="300" alt="Screen Shot 2019-03-21 at 9 26 56 am" src="https://user-images.githubusercontent.com/6458278/54723376-7e36d100-4bbb-11e9-9899-a1fc7c6ed498.png">

#### Testing instructions

Got through the WordPress.com flow as usual and check both the popular suggestions and site topic API results (http://calypso.localhost:3000/start/site-topic)

Connect a Jetpack site^ and check the site topic step as well. (http://calypso.localhost:3000/jetpack/connect/site-topic/{yourjetpacksite.whatever})

The popular suggestions and API results should appear as expected.

_^ Create one here: https://jurassic.ninja_
