### PR TITLE
Gutenframe: Preview posts at multiple screen sizes

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -50,6 +50,7 @@ class CalypsoifyIframe extends Component {
 		isPreviewVisible: false,
 		previewUrl: 'about:blank',
 		postUrl: null,
+		editedPost: null,
 	};
 
 	constructor( props ) {
@@ -227,14 +228,21 @@ class CalypsoifyIframe extends Component {
 		} );
 
 		previewPort.onmessage = message => {
-			const { frameNonce } = this.props;
-			const previewUrl = url.parse( message.data, true );
-			if ( frameNonce ) {
-				previewUrl.query[ 'frame-nonce' ] = frameNonce;
-			}
-			delete previewUrl.search;
-			this.setState( { previewUrl: url.format( previewUrl ) } );
 			previewPort.close();
+
+			const { frameNonce } = this.props;
+			const { previewUrl, editedPost } = message.data;
+
+			const parsedPreviewUrl = url.parse( previewUrl, true );
+			if ( frameNonce ) {
+				parsedPreviewUrl.query[ 'frame-nonce' ] = frameNonce;
+			}
+			delete parsedPreviewUrl.search;
+
+			this.setState( {
+				previewUrl: url.format( parsedPreviewUrl ),
+				editedPost,
+			} );
 		};
 	};
 
@@ -250,6 +258,7 @@ class CalypsoifyIframe extends Component {
 			isPreviewVisible,
 			previewUrl,
 			postUrl,
+			editedPost,
 		} = this.state;
 
 		return (
@@ -281,6 +290,7 @@ class CalypsoifyIframe extends Component {
 				<WebPreview
 					externalUrl={ postUrl }
 					onClose={ this.closePreviewModal }
+					overridePost={ editedPost }
 					previewUrl={ previewUrl }
 					showPreview={ isPreviewVisible }
 				/>

--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -28,6 +28,7 @@ import EditorRevisionsDialog from 'post-editor/editor-revisions/dialog';
 import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 import { startEditingPost } from 'state/ui/editor/actions';
 import { Placeholder } from './placeholder';
+import WebPreview from 'components/web-preview';
 
 /**
  * Style dependencies
@@ -45,6 +46,9 @@ class CalypsoifyIframe extends Component {
 	state = {
 		isMediaModalVisible: false,
 		isIframeLoaded: false,
+		isPreviewVisible: false,
+		previewUrl: 'about:blank',
+		postUrl: null,
 	};
 
 	constructor( props ) {
@@ -141,6 +145,11 @@ class CalypsoifyIframe extends Component {
 		if ( 'openRevisions' === action ) {
 			this.props.openPostRevisionsDialog();
 		}
+
+		if ( 'previewPost' === action ) {
+			const { previewUrl, postUrl } = payload;
+			this.openPreviewModal( { previewUrl, postUrl } );
+		}
 	};
 
 	loadRevision = revision => {
@@ -209,9 +218,28 @@ class CalypsoifyIframe extends Component {
 		this.iframePort.postMessage( { action: 'updateImageBlocks', payload } );
 	};
 
+	openPreviewModal = ( { previewUrl, postUrl } ) => {
+		this.setState( {
+			isPreviewVisible: true,
+			previewUrl,
+			postUrl,
+		} );
+	};
+
+	closePreviewModal = () => this.setState( { isPreviewVisible: false } );
+
+
 	render() {
 		const { iframeUrl, siteId } = this.props;
-		const { isMediaModalVisible, allowedTypes, multiple, isIframeLoaded } = this.state;
+		const {
+			isMediaModalVisible,
+			allowedTypes,
+			multiple,
+			isIframeLoaded,
+			isPreviewVisible,
+			previewUrl,
+			postUrl,
+		} = this.state;
 
 		return (
 			<Fragment>
@@ -239,6 +267,12 @@ class CalypsoifyIframe extends Component {
 					/>
 				</MediaLibrarySelectedData>
 				<EditorRevisionsDialog loadRevision={ this.loadRevision } />
+				<WebPreview
+					externalUrl={ postUrl }
+					onClose={ this.closePreviewModal }
+					previewUrl={ previewUrl }
+					showPreview={ isPreviewVisible }
+				/>
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PRs uses the Calypso's Preview component when previewing a post on Gutenframe so we can check how it will look like in different screen sizes.

| Before | After |
| - | - |
| ![Mar-21-2019 12-36-47](https://user-images.githubusercontent.com/1233880/54732342-92d49280-4bd6-11e9-8fb5-785aa26e1ba6.gif) | ![Mar-21-2019 12-39-25](https://user-images.githubusercontent.com/1233880/54732352-9d8f2780-4bd6-11e9-96b6-3332315ec9f8.gif) |

In D25814-code we send a message to the parent frame that contains a `MessageChannel` port we listen to for knowing when the post has been autosaved and therefore can be previewed. The message of this port will containing the URL we can use for previewing the post and the post data needed for generating the "Search & Social" preview.

_Note_
We also add a frame nonce to the preview URL since they are required by P2 posts.

#### Testing instructions

* Apply D25814-code to your sandbox site.
* Make sure your sandbox site is under a Business plan (needed for testing the "Search & Social" preview).
* Go to `/block-editor` and select your sandbox site.
* Add a title, some content, and a featured image (or a mix-and-match of those).
* Click on the Preview button in the top toolbar.
* Confirm the preview opens up in a modal instead of a different tab.
* Check the preview shows the same content as the editor.
* In the preview modal, select "Search & Social" in the dropdown.
* Make sure the preview is correct for all the available options.
* Sandbox a P2 site and make sure the previews work there too.

Fixes #31278
