### PR TITLE
Onboarding: Add loading spinner for vertical search

### DIFF
--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -13,6 +13,8 @@ import Gridicon from 'gridicons';
  */
 import FormTextInput from 'components/forms/form-text-input';
 import Suggestions from 'components/suggestions';
+import Spinner from 'components/spinner';
+import { isVerticalSearchPending } from 'components/site-verticals-suggestion-search';
 
 /**
  * Style dependencies
@@ -137,7 +139,7 @@ class SuggestionSearch extends Component {
 
 		return (
 			<div className="suggestion-search">
-				<Gridicon icon="search" />
+				{ isVerticalSearchPending() ? <Spinner /> : <Gridicon icon="search" /> }
 				<FormTextInput
 					id={ id }
 					placeholder={ placeholder }

--- a/client/components/suggestion-search/style.scss
+++ b/client/components/suggestion-search/style.scss
@@ -3,7 +3,8 @@
 	input {
 		padding-left: 42px;
 	}
-	.gridicon {
+	.gridicon,
+	.spinner {
 		position: absolute;
 		top: 10px;
 		left: 10px;
@@ -14,5 +15,9 @@
 		@include breakpoint( '<660px' ) {
 			top: 16px;
 		}
+	}
+
+	.spinner {
+		top: 12px;
 	}
 }

--- a/client/components/suggestion-search/style.scss
+++ b/client/components/suggestion-search/style.scss
@@ -19,5 +19,8 @@
 
 	.spinner {
 		top: 12px;
+		@include breakpoint( '<660px' ) {
+			top: 17px;
+		}
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

To provide visual cues that something, anything, is happening at the vertical search step, we're adding a loading spinner.

![Mar-21-2019 16-56-30](https://user-images.githubusercontent.com/6458278/54735622-54050380-4bfb-11e9-921b-4e66e4aac5ce.gif)

## Testing instructions

Head to http://calypso.localhost:3000/start/onboarding-for-business/site-topic-with-preview and search until your knuckles ache!

The spinner should indicate that a search is taking place.
