### PR TITLE
Sidebar: Remove the 'View Site' menu

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -36,7 +36,7 @@ class Site extends React.Component {
 
 		homeLink: false,
 		// if homeLink is enabled
-		showHomeIcon: true,
+		showHomeIcon: false,
 		compact: false,
 	};
 
@@ -97,7 +97,7 @@ class Site extends React.Component {
 					target={ this.props.externalLink && '_blank' }
 					title={
 						this.props.homeLink
-							? translate( 'View site %(domain)s', {
+							? translate( 'View %(domain)s', {
 									args: { domain: site.domain },
 							  } )
 							: site.domain
@@ -107,7 +107,7 @@ class Site extends React.Component {
 					onMouseLeave={ this.onMouseLeave }
 					aria-label={
 						this.props.homeLink
-							? translate( 'View site %(domain)s', {
+							? translate( 'View %(domain)s', {
 									args: { domain: site.domain },
 							  } )
 							: site.domain
@@ -135,7 +135,13 @@ class Site extends React.Component {
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
 							{ site.title }
 						</div>
-						<div className="site__domain">{ site.domain }</div>
+						<div className="site__domain">
+							{ this.props.homeLink
+								? translate( 'View %(domain)s', {
+										args: { domain: site.domain },
+								  } )
+								: site.domain }
+						</div>
 					</div>
 					{ this.props.homeLink && this.props.showHomeIcon && (
 						<span className="site__home">

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -80,7 +80,7 @@ class CurrentSite extends Component {
 
 				{ selectedSite ? (
 					<div>
-						<Site site={ selectedSite } />
+						<Site site={ selectedSite } homeLink={ true } />
 					</div>
 				) : (
 					<AllSites />

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -79,27 +78,6 @@ export class MySitesSidebar extends Component {
 	onNavigate = () => {
 		this.props.setNextLayoutFocus( 'content' );
 		window.scrollTo( 0, 0 );
-	};
-
-	onViewSiteClick = event => {
-		const { isPreviewable, siteSuffix } = this.props;
-
-		if ( ! isPreviewable ) {
-			this.trackMenuItemClick( 'view_site_unpreviewable' );
-			this.props.recordGoogleEvent( 'Sidebar', 'Clicked View Site | Unpreviewable' );
-			return;
-		}
-
-		if ( event.altKey || event.ctrlKey || event.metaKey || event.shiftKey ) {
-			this.trackMenuItemClick( 'view_site_modifier' );
-			this.props.recordGoogleEvent( 'Sidebar', 'Clicked View Site | Modifier Key' );
-			return;
-		}
-
-		event.preventDefault();
-		this.trackMenuItemClick( 'view_site' );
-		this.props.recordGoogleEvent( 'Sidebar', 'Clicked View Site | Calypso' );
-		page( '/view' + siteSuffix );
 	};
 
 	manage() {
@@ -173,29 +151,6 @@ export class MySitesSidebar extends Component {
 				link={ activityLink }
 				onNavigate={ this.trackActivityClick }
 				icon="history"
-			/>
-		);
-	}
-
-	preview() {
-		const { isPreviewable, path, site, siteId, translate } = this.props;
-
-		if ( ! siteId ) {
-			return null;
-		}
-
-		const siteUrl = ( site && site.URL ) || '';
-
-		return (
-			<SidebarItem
-				tipTarget="sitePreview"
-				label={ translate( 'View Site' ) }
-				selected={ itemLinkMatches( [ '/view' ], path ) }
-				link={ siteUrl }
-				onNavigate={ this.onViewSiteClick }
-				icon="computer"
-				preloadSectionName="preview"
-				forceInternalLink={ isPreviewable }
 			/>
 		);
 	}
@@ -689,7 +644,6 @@ export class MySitesSidebar extends Component {
 			<div>
 				<SidebarMenu>
 					<ul>
-						{ this.preview() }
 						{ this.stats() }
 						{ this.activity() }
 						{ this.plan() }


### PR DESCRIPTION
As part of the upcoming sidebar updates, this change will remove the View Site menu in the sidebar, and instead use the site indicator as a way to view the site. The view site link will link directly to the front end of the site, and not use the site preview.

**Before:**

<img width="273" alt="Screen Shot 2019-03-21 at 8 15 30 AM" src="https://user-images.githubusercontent.com/1464705/54737722-8f7ae000-4bb1-11e9-82c0-c9eda1375a26.png">

**After:**

<img width="273" alt="Screen Shot 2019-03-21 at 8 15 20 AM" src="https://user-images.githubusercontent.com/1464705/54737731-94d82a80-4bb1-11e9-9c34-2b9f23993368.png">

------

**Do not merge** -- this will need to be included as part of the sidebar changes rollout.

#### Testing instructions

Confirm that you do not see the "View Site" menu item at the top of the sidebar.

Check that the site indicator in the sidebar shows a view link, and clicking on it takes you to the front end of the site:

<img width="276" alt="Screen Shot 2019-03-21 at 8 08 57 AM" src="https://user-images.githubusercontent.com/1464705/54737506-aa992000-4bb0-11e9-9102-f864ed948ae8.png">

When viewing the "Switch Site" menu, make sure that sites listed do not include the "View" text next to the domain, and they switch the site, and do not open the front end of the site.

