### PR TITLE
Onboarding: update site topic suggestions styling

### DIFF
--- a/client/components/site-verticals-suggestion-search/style.scss
+++ b/client/components/site-verticals-suggestion-search/style.scss
@@ -28,6 +28,10 @@
 		background: var( --color-neutral-0 );
 	}
 
+	&:focus {
+		box-shadow: inset 0 0 0 2px var( --color-accent );
+	}
+
 	&:last-child {
 		border-radius: 0 0 4px 4px;
 		border-bottom: 0;

--- a/client/components/site-verticals-suggestion-search/style.scss
+++ b/client/components/site-verticals-suggestion-search/style.scss
@@ -9,7 +9,7 @@
 	font-size: 10px;
 	font-weight: 500;
 	text-transform: uppercase;
-	padding: 12px 24px 8px 40px;
+	padding: 12px 24px 8px 42px;
 	color: var( --color-neutral-400 );
 	border-bottom: 1px solid var( --color-neutral-50 );
 }
@@ -18,7 +18,7 @@
 	font-size: 15px;
 	color: var( --color-text );
 	border-bottom: 1px solid var( --color-neutral-50 );
-	padding: 10px 24px 10px 40px;
+	padding: 10px 24px 10px 42px;
 	text-align: left;
 	width: 100%;
 	display: block;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -938,7 +938,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.site-verticals-suggestion-search__topic-list-item {
-		
 		&:focus {
 			box-shadow: inset 0 0 0 2px var( --color-jetpack );
 		}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -936,6 +936,13 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		background-color: var( --color-white );
 		border-radius: 3px;
 	}
+
+	.site-verticals-suggestion-search__topic-list-item {
+		
+		&:focus {
+			box-shadow: inset 0 0 0 2px var( --color-jetpack );
+		}
+	}
 }
 
 .is-section-checkout.is-jetpack-site {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Onboarding: update site topic suggestions styling introduced in https://github.com/Automattic/wp-calypso/pull/31405:
  * Add focus styles to site topic suggestions.
  * Line up site topic suggestions with placeholder.

### Testing instructions

#### dotcom:
* Go to `/start/onboarding/site-topic`.
* Make sure everything lines up and that focus styles look good.

#### Jetpack:
* Go to `/jetpack/connect/site-topic/SITE_URL` where `SITE_URL` is an existing Jetpack site. Alternatively, you can [create a new site](https://jurassic.ninja/create/?shortlived&jetpack-beta) and connect it to go through the onboarding flow.
* On the site topic step, make sure everything lines up and that focus styles look good.

### Before

![image](https://user-images.githubusercontent.com/390760/54746259-99a5da00-4bc3-11e9-9401-959a199636a5.png)

![image](https://user-images.githubusercontent.com/390760/54746234-8b57be00-4bc3-11e9-9c6d-190d95a9cece.png)

![image](https://user-images.githubusercontent.com/390760/54746522-41230c80-4bc4-11e9-9ac6-5a7685bb1f28.png)


### After

![image](https://user-images.githubusercontent.com/390760/54746456-1fc22080-4bc4-11e9-8d53-f7d3fe896345.png)

![image](https://user-images.githubusercontent.com/390760/54746496-34061d80-4bc4-11e9-9129-5c656c506165.png)

![image](https://user-images.githubusercontent.com/390760/54746534-48e2b100-4bc4-11e9-95d9-4cc0bc1ce00f.png)

