### PR TITLE
E2E tests: Add data-e2e attribute to Jetpack connection site types

### DIFF
--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -50,6 +50,7 @@ class SiteTypeForm extends Component {
 				className="site-type__option"
 				key={ siteTypeProperties.id }
 				displayAsLink
+				data-e2e-title={ siteTypeProperties.slug }
 				tagName="button"
 				onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
 			>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* adds `data-e2e-title` attributes to Jetpack connect's site types.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through Jetpack connection flow
* On `jetpack/connect/site-type` check that every site type option has `data-e2e-title` attribue matching type `slug`