### PR TITLE
Update monorepo package.jsons and documentation

### DIFF
--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -100,7 +100,11 @@ Using [Lerna](https://lernajs.io/) to publish package(s):
 1. `npm run distclean`
 1. `npm ci`
 1. `npx lerna publish --dist-tag next from-package`
-1. Lerna will confirm which packages and versions will be published. `--dist-tag next` is optional, we used it to avoid publishing a new latest for `i18n-calypso`. Say “no” at the prompt.
+1. Say “no” at the prompt.
+1. Lerna will confirm which packages and versions will be published. If something looks off, abort!
+1. Make sure you're logged in at this point, we're going to publish 🚀
+1. Craft the following command, we'll add `--yes` to skip prompts and save OTP cycle time. `--dist-tag next` is optional, use it when publishing unstable versions.
+1. Wait for your npm OTP (one time password) cycle to start, write it into the command and publish:
 1. If everything looked good, get this command ready and wait for your NPM OTP (one time password) cycle to start. `--yes` is added to then end to skip the prompt, we already verified which packages will be published and don’t want to waste the OTP cycle time at the prompt.
 1. `NPM_CONFIG_OTP=[YOUR_OTP_CODE] npx lerna publish --dist-tag next from-package --yes`
 1. Pat yourself on the back, you published!

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -56,7 +56,8 @@ The only exception are `devDependencies` which _must be declared in the wp-calyp
 	"license": "GPL-2.0-or-later",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Automattic/wp-calypso.git"
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/your-package"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -88,4 +88,19 @@ To run one package's tests:
 
 ## Publishing
 
-We do not use the plain `lerna publish` flow. Instead, use `lerna publish from-package` to publish all packages currently out of date, or `npm publish` within a package to publish an individual package. The standard workflow is too limiting for our needs.
+Please do not use regular [`npm publish`](https://docs.npmjs.com/cli/publish) within a package to publish an individual package; `npx` has issues using this flow.
+
+Using Lerna to publish package(s):
+
+1. Login to NPM: `npm whoami`, `npm login`.
+1. Update packages versions as necessary. We’ll rely on package versions for Lerna to know what to publish. Please be mindful about [semantic versioning](https://semver.org/).
+1. `git checkout master`
+1. `git pull`
+1. `git status` (should be clean!)
+1. `npm run distclean`
+1. `npm ci`
+1. `npx lerna publish --dist-tag next from-package`
+1. Lerna will confirm which packages and versions will be published. `--dist-tag next` is optional, we used it to avoid publishing a new latest for `i18n-calypso`. Say “no” at the prompt.
+1. If everything looked good, get this command ready and wait for your NPM OTP (one time password) cycle to start. `--yes` is added to then end to skip the prompt, we already verified which packages will be published and don’t want to waste the OTP cycle time at the prompt.
+1. `NPM_CONFIG_OTP=[YOUR_OTP_CODE] npx lerna publish --dist-tag next from-package --yes`
+1. Pat yourself on the back, you published!

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -92,7 +92,7 @@ Please do not use regular [`npm publish`](https://docs.npmjs.com/cli/publish) wi
 
 Using [Lerna](https://lernajs.io/) to publish package(s):
 
-1. Might be good to start unlogged, since Lerna doesn't have `--dry-run` option like NPM does: `npm logout`.
+1. Might be good to start un-authenticated, since Lerna doesn't have `--dry-run` option like NPM does: `npm logout`.
 1. Update packages versions as necessary. We’ll rely on package versions for Lerna to know what to publish. Please be mindful about [semantic versioning](https://semver.org/).
 1. `git checkout master`
 1. `git pull`

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -92,7 +92,7 @@ Please do not use regular [`npm publish`](https://docs.npmjs.com/cli/publish) wi
 
 Using [Lerna](https://lernajs.io/) to publish package(s):
 
-1. Login to NPM: `npm whoami`, `npm login`.
+1. Might be good to start unlogged, since Lerna doesn't have `--dry-run` option like NPM does: `npm logout`.
 1. Update packages versions as necessary. We’ll rely on package versions for Lerna to know what to publish. Please be mindful about [semantic versioning](https://semver.org/).
 1. `git checkout master`
 1. `git pull`
@@ -102,7 +102,7 @@ Using [Lerna](https://lernajs.io/) to publish package(s):
 1. `npx lerna publish from-package`
 1. Say “no” at the prompt.
 1. Lerna will confirm which packages and versions will be published. If something looks off, abort!
-1. Make sure you're logged in at this point, we're going to publish 🚀
+1. Make sure you're logged in at this point, we're going to publish 🚀: `npm whoami`, `npm login`.
 1. Craft the following command, we'll add `--yes` to skip prompts and save OTP cycle time. `--dist-tag next` is optional, use it when publishing unstable versions.
 1. Wait for your npm OTP (one time password) cycle to start, write it into the command and publish:
 1. `NPM_CONFIG_OTP=[YOUR_OTP_CODE] npx lerna publish --dist-tag next from-package --yes`

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -42,11 +42,9 @@ The only exception are `devDependencies` which _must be declared in the wp-calyp
 	"name": "@automattic/your-package",
 	"version": "1.0.0",
 	"description": "My new package",
-
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"sideEffects": false,
-
 	"keywords": [
 		"wordpress"
 	],

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -90,7 +90,7 @@ To run one package's tests:
 
 Please do not use regular [`npm publish`](https://docs.npmjs.com/cli/publish) within a package to publish an individual package; `npx` has issues using this flow.
 
-Using Lerna to publish package(s):
+Using [Lerna](https://lernajs.io/) to publish package(s):
 
 1. Login to NPM: `npm whoami`, `npm login`.
 1. Update packages versions as necessary. We’ll rely on package versions for Lerna to know what to publish. Please be mindful about [semantic versioning](https://semver.org/).

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -99,7 +99,7 @@ Using [Lerna](https://lernajs.io/) to publish package(s):
 1. `git status` (should be clean!)
 1. `npm run distclean`
 1. `npm ci`
-1. `npx lerna publish --dist-tag next from-package`
+1. `npx lerna publish from-package`
 1. Say “no” at the prompt.
 1. Lerna will confirm which packages and versions will be published. If something looks off, abort!
 1. Make sure you're logged in at this point, we're going to publish 🚀

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -105,6 +105,5 @@ Using [Lerna](https://lernajs.io/) to publish package(s):
 1. Make sure you're logged in at this point, we're going to publish 🚀
 1. Craft the following command, we'll add `--yes` to skip prompts and save OTP cycle time. `--dist-tag next` is optional, use it when publishing unstable versions.
 1. Wait for your npm OTP (one time password) cycle to start, write it into the command and publish:
-1. If everything looked good, get this command ready and wait for your NPM OTP (one time password) cycle to start. `--yes` is added to then end to skip the prompt, we already verified which packages will be published and don’t want to waste the OTP cycle time at the prompt.
 1. `NPM_CONFIG_OTP=[YOUR_OTP_CODE] npx lerna publish --dist-tag next from-package --yes`
 1. Pat yourself on the back, you published!

--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -13,6 +13,11 @@
 	"publishConfig": {
 		"access": "public"
 	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/babel-plugin-i18n-calypso"
+	},
 	"keywords": [],
 	"author": "Alex Kirk <alex.kirk@automattic.com> (https://automattic.com)",
 	"license": "GPL-2.0+",

--- a/packages/babel-plugin-i18n-calypso/package.json
+++ b/packages/babel-plugin-i18n-calypso/package.json
@@ -20,7 +20,7 @@
 	},
 	"keywords": [],
 	"author": "Alex Kirk <alex.kirk@automattic.com> (https://automattic.com)",
-	"license": "GPL-2.0+",
+	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"clean": "npx rimraf dist",
 		"prepublish": "npm run clean",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -12,7 +12,8 @@
 	"license": "GPL-2.0-or-later",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Automattic/wp-calypso.git"
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/calypso-build"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -13,7 +13,8 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/calypso-color-schemes/README.md",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Automattic/wp-calypso.git"
+		"url": "https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/calypso-color-schemes"
 	},
 	"bugs": {
 		"url": "https://github.com/Automattic/wp-calypso/issues"

--- a/packages/eslint-config-wpcalypso/package.json
+++ b/packages/eslint-config-wpcalypso/package.json
@@ -20,7 +20,8 @@
 	"license": "GPL-2.0-or-later",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Automattic/wp-calypso.git"
+		"url": "https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/eslint-config-wpcalypso"
 	},
 	"peerDependencies": {
 		"eslint": "^3.3.1 || ^4.6.1 || ^5.0.0",

--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -4,7 +4,8 @@
 	"description": "Custom ESLint rules for the WordPress.com Calypso project",
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/Automattic/wp-calypso.git"
+		"url": "https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/eslint-plugin-wpcalypso"
 	},
 	"keywords": [
 		"eslint",

--- a/packages/format-currency/package.json
+++ b/packages/format-currency/package.json
@@ -7,7 +7,8 @@
 	"sideEffects": false,
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/Automattic/wp-calypso.git"
+		"url": "git://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/format-currency"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -7,7 +7,8 @@
 	"sideEffects": false,
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Automattic/wp-calypso.git"
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/i18n-calypso"
 	},
 	"author": "@automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/photon/package.json
+++ b/packages/photon/package.json
@@ -7,7 +7,8 @@
 	"sideEffects": false,
 	"repository": {
 		"type": "git",
-		"url": "git://github.com/Automattic/wp-calypso.git"
+		"url": "git://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/photon"
 	},
 	"keywords": [
 		"wordpress",

--- a/packages/tree-select/package.json
+++ b/packages/tree-select/package.json
@@ -13,7 +13,8 @@
 	"module": "dist/esm/index.js",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Automattic/wp-calypso.git"
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/tree-select"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Updates to monorepo `package.json`s and docs:

- Add `repository.directory` fields:
   npm has added support for packages to declare their directory location within a subdirectory:
    https://github.com/npm/rfcs/blob/latest/implemented/0010-monorepo-subdirectory-declaration.md
    https://github.com/npm/cli/releases/tag/v6.8.0

  It’ll just help http://npmjs.com to link to a correct place in the repo.

- Change deprecated license SPDX to new one https://spdx.org/licenses/GPL-2.0-or-later.html

- Update Publishing monorepo documentation