### PR TITLE
Profile Settings: Add a Gravatar privacy section

### DIFF
--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -165,13 +165,22 @@ const Profile = createReactClass( {
 					</p>
 				</Card>
 
+				<Card
+					displayAsLink={ true }
+					href="https://en.gravatar.com/profiles/edit/"
+					target="blank"
+					rel="noopener noreferrer"
+				>
+					<p className="me-profile-gravatar__link-title">{ this.props.translate( 'Go to Gravatar.com' ) }</p>
+					<p className="me-profile-gravatar__link-description">{ this.props.translate( 'Access all your Gravatars\' settings' ) }</p>
+				</Card>
+
 				<SectionHeader label={ this.props.translate( 'Profile Privacy' ) } />
 				<Card className="me-profile-privacy">
 					<p>
 						{ this.props.translate(
 							'WordPress.com uses {{link}}Gravatar{{/link}}, a universal avatar service, for your profile. ' +
-								'This enables other sites and services to use your image and profile information when you\'re logged in ' +
-								'with your email address.',
+								'This enables other sites and services to use your image and profile information when using your email address.',
 							{
 								components: {
 									link: <a href="https://gravatar.com" target="_blank" rel="noopener noreferrer" />,
@@ -182,7 +191,7 @@ const Profile = createReactClass( {
 
 					<p>
 						{ this.props.translate(
-							'Each WordPress.com account comes with Gravatar enabled by default. You can change the visibility of your ' +
+							'Your Gravatar profile is public by default. You can change the visibility of your ' +
 								'profile by using the settings below. Go to {{link}}Gravatar.com{{/link}} to access all of your account\'s settings.',
 							{
 								components: {
@@ -211,17 +220,7 @@ const Profile = createReactClass( {
 								</span>
 							</FormLabel>
 							<FormSettingExplanation className="me-profile-privacy__explanation">
-								{ this.props.translate( 'Your profile information is hidden but people can still see your Gravatar image.' ) }
-							</FormSettingExplanation>
-
-							<FormLabel>
-								<FormRadio name="gravatar_public" value="disabled" />
-								<span>
-									{ this.props.translate( 'Disabled' ) }
-								</span>
-							</FormLabel>
-							<FormSettingExplanation className="me-profile-privacy__explanation">
-								{ this.props.translate( 'Your Gravatar images and profile are hidden.' ) }
+								{ this.props.translate( 'Your profile information is hidden but your Gravatar image will still display on third party sites.' ) }
 							</FormSettingExplanation>
 						</FormFieldset>
 
@@ -235,15 +234,25 @@ const Profile = createReactClass( {
 
 				<ProfileLinks />
 
-				<Card
-					displayAsLink={ true }
-					href="https://en.gravatar.com/profiles/edit/"
-					target="blank"
-					rel="noopener noreferrer"
-				>
-					<p className="me-profile-gravatar__link-title">{ this.props.translate( 'Go to Gravatar.com' ) }</p>
-					<p className="me-profile-gravatar__link-description">{ this.props.translate( 'Access all your Gravatars\' settings' ) }</p>
+				<SectionHeader label={ this.props.translate( 'Disable My Gravatar' ) } />
+				<Card>
+					<p>
+						{ this.props.translate(
+							'Disabling your Gravatar will prevent all access to your Gravatar images and profile, and your Gravatar data will be deleted.'
+						) }
+					</p>
+					<ul>
+						<li>{ this.props.translate( 'You will not be able to access Gravatar settings while your account is disabled.' ) }</li>
+						<li>{ this.props.translate( 'You can reenable your account at any time.' ) }</li>
+						<li>{ this.props.translate( 'Reenabling your account within 30 days will automatically restore your data.' ) }</li>
+					</ul>
+					<p>
+						<FormButton scary>
+							{ this.props.translate( 'Disable My Gravatar' ) }
+						</FormButton>
+					</p>
 				</Card>
+
 			</Main>
 		);
 	},

--- a/client/me/profile/index.jsx
+++ b/client/me/profile/index.jsx
@@ -17,6 +17,8 @@ import formBase from 'me/form-base';
 import FormButton from 'components/forms/form-button';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import Main from 'components/main';
@@ -163,7 +165,85 @@ const Profile = createReactClass( {
 					</p>
 				</Card>
 
+				<SectionHeader label={ this.props.translate( 'Profile Privacy' ) } />
+				<Card className="me-profile-privacy">
+					<p>
+						{ this.props.translate(
+							'WordPress.com uses {{link}}Gravatar{{/link}}, a universal avatar service, for your profile. ' +
+								'This enables other sites and services to use your image and profile information when you\'re logged in ' +
+								'with your email address.',
+							{
+								components: {
+									link: <a href="https://gravatar.com" target="_blank" rel="noopener noreferrer" />,
+								},
+							},
+						) }
+					</p>
+
+					<p>
+						{ this.props.translate(
+							'Each WordPress.com account comes with Gravatar enabled by default. You can change the visibility of your ' +
+								'profile by using the settings below. Go to {{link}}Gravatar.com{{/link}} to access all of your account\'s settings.',
+							{
+								components: {
+									link: <a href="https://gravatar.com/profiles/edit/" target="_blank" rel="noopener noreferrer" />
+								},
+							},
+						) }
+					</p>
+
+					<form>
+						<FormFieldset>
+							<FormLabel>
+								<FormRadio name="gravatar_public" value="public" />
+								<span>
+									{ this.props.translate( 'Public' ) }
+								</span>
+							</FormLabel>
+							<FormSettingExplanation className="me-profile-privacy__explanation">
+								{ this.props.translate( 'Your Gravatar and profile information are public.' ) }
+							</FormSettingExplanation>
+
+							<FormLabel>
+								<FormRadio name="gravatar_public" value="private" />
+								<span>
+									{ this.props.translate( 'Hidden' ) }
+								</span>
+							</FormLabel>
+							<FormSettingExplanation className="me-profile-privacy__explanation">
+								{ this.props.translate( 'Your profile information is hidden but people can still see your Gravatar image.' ) }
+							</FormSettingExplanation>
+
+							<FormLabel>
+								<FormRadio name="gravatar_public" value="disabled" />
+								<span>
+									{ this.props.translate( 'Disabled' ) }
+								</span>
+							</FormLabel>
+							<FormSettingExplanation className="me-profile-privacy__explanation">
+								{ this.props.translate( 'Your Gravatar images and profile are hidden.' ) }
+							</FormSettingExplanation>
+						</FormFieldset>
+
+						<p>
+							<FormButton>
+								{ this.props.translate( 'Save Privacy Settings' ) }
+							</FormButton>
+						</p>
+					</form>
+				</Card>
+
 				<ProfileLinks />
+
+				<Card
+					displayAsLink={ true }
+					href="https://en.gravatar.com/profiles/edit/"
+					target="blank"
+					rel="noopener noreferrer"
+				>
+					<p className="me-profile-gravatar__link-title">{ this.props.translate( 'Go to Gravatar.com' ) }</p>
+					<p className="me-profile-gravatar__link-description">{ this.props.translate( 'Access all your Gravatars\' settings' ) }</p>
+				</Card>
 			</Main>
 		);
 	},

--- a/client/me/profile/style.scss
+++ b/client/me/profile/style.scss
@@ -14,3 +14,21 @@
 		clear: right;
 	}
 }
+
+.me-profile-privacy__explanation {
+	margin: 5px 0 5px 25px;
+}
+
+.me-profile-gravatar__link-title {
+	color: var(--color-neutral-700);
+	font-size: 14px;
+	line-height: 18px;
+	margin-bottom: 4px;
+}
+
+.me-profile-gravatar__link-description {
+	color: var(--color-text-subtle);
+	font-size: 13px;
+	font-style: italic;
+	margin-bottom: 0;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

These changes aim to improve user awareness of Gravatar being used for their profiles and to make its privacy settings more accessible by including them on the profile settings page on WordPress.com. See p8Slzc-6j-p2.

This change will require changes in WP.com's API and Gravatar itself to work but I'd like to agree on the functionality and wording before pushing those updates out.

The changes include a new **Profile Privacy** section which allows users to hide their profiles or disable their Gravatars altogether.  
The latter would make users' images and profile information inaccessible to third parties, but not delete it - that'd have to be done manually through Gravatar.com if they so desire.

There's also a link to the account settings on Gravatar.com at the bottom of the page.

![calypso-me-settings](https://user-images.githubusercontent.com/8056203/54748116-07a4ce00-4bd1-11e9-9ddb-df8a5e8cca39.png)

#### Testing instructions

TBA

**Note:** The form doesn't work yet as it requires changes on WP.com which may depend on what interface we end up with.