### PR TITLE
Jetpack Onboarding: add accent color, clean up styles

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -796,6 +796,13 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
  * Onboarding styles
  **/
 .layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
+.layout.is-jetpack-login,
+.is-section-checkout.is-jetpack-site,
+.is-section-checkout-thank-you.is-jetpack-site {
+	--color-accent: var( --color-jetpack );
+}
+
+.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
 .layout.is-jetpack-login {
 	background-color: var( --color-jetpack-onboarding-background );
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -816,14 +816,14 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.jetpack-connect__site-address-container input:focus,
 	.logged-out-form input:focus {
 		border-color: var( --color-accent );
-		box-shadow: 0 0 0 2px var( --color-jetpack-light );
+		box-shadow: 0 0 0 2px var( --color-accent-light );
 	}
 
 	.login__form-terms a,
 	.jetpack-connect__tos-link a,
 	.signup-form__terms-of-service-link a,
 	.form-input-validation a {
-		color: var( --color-jetpack-dark );
+		color: var( --color-accent-dark );
 
 		&:hover,
 		&:focus {
@@ -863,11 +863,11 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	}
 
 	.plan-features__item-checkmark {
-		fill: var( --color-jetpack-dark );
+		fill: var( --color-accent-dark );
 	}
 
 	.plan-features__item-title a {
-		color: var( --color-jetpack-dark );
+		color: var( --color-accent-dark );
 
 		&:hover,
 		&:focus {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1,5 +1,22 @@
 $colophon-height: 50px; // wpcomColophon element at the bottom
 
+.jetpack-connect__main,
+.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
+.layout.is-jetpack-login,
+.is-section-checkout.is-jetpack-site,
+.is-section-checkout-thank-you.is-jetpack-site {
+	// Override accent variables with Jetpack colors
+	--color-accent:       var( --color-jetpack );
+	--color-accent-light: var( --color-jetpack-light );
+	--color-accent-dark:  var( --color-jetpack-dark );
+
+	// Override global colors with accent variables
+	--color-primary:                         var( --color-accent-dark );
+	--color-primary-light:                   var( --color-accent-light );
+	--color-button-primary-background-hover: var( --color-accent-light );
+	--color-accent-600:                      var( --color-accent-dark );
+}
+
 .is-section-jetpack-connect {
 
 	.layout__content {
@@ -787,13 +804,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 /**
  * Onboarding styles
  **/
-.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
-.layout.is-jetpack-login,
-.is-section-checkout.is-jetpack-site,
-.is-section-checkout-thank-you.is-jetpack-site {
-	--color-accent: var( --color-jetpack );
-}
-
 .layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
 .layout.is-jetpack-login {
 	background-color: var( --color-jetpack-onboarding-background );

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -95,10 +95,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		box-shadow: 0 0 0 2px var( --color-jetpack-light );
 	}
 
-	.site-type__option:focus {
-		box-shadow: inset 0 0 0 2px var( --color-jetpack );
-	}
-
 	.wpcom-colophon {
 		position: absolute;
 			bottom: 0;
@@ -116,10 +112,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		input[type='text'] {
 			border-color: var( --color-jetpack-dark );
-
-			&:focus {
-				box-shadow: 0 0 0 2px var( --color-jetpack-light );
-			}
 		}
 
 		@include breakpoint( '<660px' ) {
@@ -1012,7 +1004,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.button {
 
 		&.is-primary {
-			background-color: var( --color-jetpack );
 			border-color: var( --color-jetpack-dark );
 
 			&:hover,

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -851,7 +851,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.login__form input:focus,
 	.jetpack-connect__site-address-container input:focus,
 	.logged-out-form input:focus {
-		border-color: var( --color-jetpack );
+		border-color: var( --color-accent );
 		box-shadow: 0 0 0 2px var( --color-jetpack-light );
 	}
 
@@ -863,7 +863,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		&:hover,
 		&:focus {
-			color: var( --color-jetpack );
+			color: var( --color-accent );
 		}
 	}
 
@@ -891,15 +891,15 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	.spinner__inner,
 	.spinner__outer {
-		border-top-color: var( --color-jetpack );
+		border-top-color: var( --color-accent );
 	}
 
 	.spinner__inner {
-		border-right-color: var( --color-jetpack );
+		border-right-color: var( --color-accent );
 	}
 
 	.segmented-control.is-primary .segmented-control__item.is-selected .segmented-control__link {
-		background-color: var( --color-jetpack );
+		background-color: var( --color-accent );
 		border-color: var( --color-jetpack-dark );
 
 		&:hover,
@@ -926,7 +926,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		&:hover,
 		&:focus {
-			color: var( --color-jetpack );
+			color: var( --color-accent );
 		}
 	}
 
@@ -993,8 +993,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		background-image: linear-gradient(
 			-45deg,
 			var( --color-jetpack-dark ) 28%,
-			var( --color-jetpack ) 28%,
-			var( --color-jetpack ) 72%,
+			var( --color-accent ) 28%,
+			var( --color-accent ) 72%,
 			var( --color-jetpack-dark ) 72%
 		);
 	}
@@ -1006,7 +1006,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 .is-section-checkout-thank-you.is-jetpack-site {
 	::selection {
 		color: var( --color-white );
-		background: var( --color-jetpack );
+		background: var( --color-accent );
 	}
 
 	.button {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -15,6 +15,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	--color-primary-light:                   var( --color-accent-light );
 	--color-button-primary-background-hover: var( --color-accent-light );
 	--color-accent-600:                      var( --color-accent-dark );
+
+	.payment-box-section {
+		--color-primary: var( --color-primary-500 );
+	}
 }
 
 .is-section-jetpack-connect {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -63,44 +63,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 			display: none;
 		}
 	}
-
-	.ribbon .ribbon__title {
-		background-color: var( --color-jetpack );
-
-		&::before,
-		&::after {
-			border-top-color: var( --color-jetpack-dark );
-		}
-
-		&::before {
-			border-left-color: var( --color-jetpack-dark );
-		}
-
-		&::after {
-			border-right-color: var( --color-jetpack-dark );
-		}
-	}
-
-	.button.is-primary {
-		background-color: var( --color-jetpack );
-		border-color: var( --color-jetpack-dark );
-
-		&:hover,
-		&:focus {
-			background-color: var( --color-jetpack-400 );
-		}
-
-		&:focus {
-			box-shadow: 0 0 0 2px var( --color-jetpack-light );
-		}
-
-		&[disabled],
-		&:disabled {
-			background: var( --color-white );
-			border-color: var( --color-neutral-50 );
-			color: var( --color-neutral-50 );
-		}
-	}
 }
 
 .jetpack-connect__step {
@@ -891,25 +853,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		color: var( --color-neutral-500 );
 	}
 
-	.spinner__inner,
-	.spinner__outer {
-		border-top-color: var( --color-accent );
-	}
-
-	.spinner__inner {
-		border-right-color: var( --color-accent );
-	}
-
-	.segmented-control.is-primary .segmented-control__item.is-selected .segmented-control__link {
-		background-color: var( --color-accent );
-		border-color: var( --color-jetpack-dark );
-
-		&:hover,
-		&:focus {
-			background-color: var( --color-jetpack-light );
-		}
-	}
-
 	.wp-login__site-return-link:after {
 		background: linear-gradient(to right, rgba( var( --color-jetpack-onboarding-background ) , 0 ), rgba( var( --color-jetpack-onboarding-background ) , 1 ) 90%)
 	}
@@ -944,12 +887,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		padding-bottom: 24px;
 		background-color: var( --color-white );
 		border-radius: 3px;
-	}
-
-	.site-verticals-suggestion-search__topic-list-item {
-		&:focus {
-			box-shadow: inset 0 0 0 2px var( --color-jetpack );
-		}
 	}
 
 	.site-topic__content .form-fieldset {
@@ -990,16 +927,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	.checkout-thank-you__jetpack .plan-thank-you-card .thank-you-card {
 		box-shadow: none;
 	}
-
-	.progress-bar.is-pulsing .progress-bar__progress {
-		background-image: linear-gradient(
-			-45deg,
-			var( --color-jetpack-dark ) 28%,
-			var( --color-accent ) 28%,
-			var( --color-accent ) 72%,
-			var( --color-jetpack-dark ) 72%
-		);
-	}
 }
 
 .layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
@@ -1009,33 +936,5 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	::selection {
 		color: var( --color-white );
 		background: var( --color-accent );
-	}
-
-	.button {
-
-		&.is-primary {
-			border-color: var( --color-jetpack-dark );
-
-			&:hover,
-			&:focus {
-				background-color: var( --color-jetpack-400 );
-			}
-		}
-
-		&:focus {
-			box-shadow: 0 0 0 2px var( --color-jetpack-light );
-		}
-
-		&[disabled],
-		&:disabled {
-			background: var( --color-white );
-			border-color: var( --color-neutral-50 );
-			color: var( --color-neutral-50 );
-
-			&:hover,
-			&:focus {
-				background: var( --color-white );
-			}
-		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With this change, we've stopped overriding classes — often multiple and chained — on the Jetpack onboarding flow. Instead, we're using `var()` to override colors in these flows, which means we don't have to keep duplicating the code from dotcom and can remove whatever we have now.

* Add accent and primary color variables to Jetpack Onboarding.
* Removes unused styles.

This should only affect the Jetpack flow, **not** the dotcom one.

Note: cherry-picks a commit from #31619 — kudos @tyxla for teaching me the ropes! 🙌

#### Testing instructions

* Spin up this PR.
* Create a [new Jurassic Ninja site](https://jurassic.ninja/create/?shortlived&jetpack-beta).
* Copy the link from the `Set up Jetpack` button and append `&calypso_env=development` to it.
* Go through all onboarding flows: log in, sign up, onboarding, checkout, etc.
* Make sure **everything looks the same** as before. You're not expected to find any visual changes.
