### PR TITLE
Masterbar: Prevent a full reload when clicking the Write button

### DIFF
--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -10,7 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 import MasterbarItem from './item';
 import SitesPopover from 'components/sites-popover';
 import { isMobile } from 'lib/viewport';
@@ -22,7 +22,7 @@ import isRtlSelector from 'state/selectors/is-rtl';
 import TranslatableString from 'components/translatable/proptype';
 import { getEditorUrl } from 'state/selectors/get-editor-url';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
-import { reduxGetState } from 'lib/redux-bridge';
+import { navigate } from 'state/ui/actions';
 
 class MasterbarItemNew extends React.Component {
 	static propTypes = {
@@ -75,17 +75,9 @@ class MasterbarItemNew extends React.Component {
 		return 'bottom left';
 	}
 
-	onSiteSelect = siteId => {
-		this.props.recordTracksEvent( 'calypso_masterbar_write_button_clicked' );
-		//To avoid binding in connect, please remove me later.
-		const redirectURL = getEditorUrl( reduxGetState(), siteId, null, 'post' );
-		if ( typeof window !== 'undefined' ) {
-			setTimeout( () => {
-				window.location = redirectURL;
-			}, 0 );
-			return true; // handledByHost = true, don't let the component nav
-		}
-		return false; //otherwise fallback to normal handling
+	onSiteSelect = () => {
+		this.props.openEditor( this.props.editorUrl );
+		return true; // handledByHost = true, don't let the component nav
 	};
 
 	renderPopover() {
@@ -141,7 +133,15 @@ const mapStateToProps = state => {
 	};
 };
 
-const mapDispatchToProps = { recordTracksEvent };
+const mapDispatchToProps = dispatch => ( {
+	openEditor: editorUrl =>
+		dispatch(
+			withAnalytics(
+				recordTracksEvent( 'calypso_masterbar_write_button_clicked' ),
+				navigate( editorUrl )
+			)
+		),
+} );
 
 export default connect(
 	mapStateToProps,

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -22,6 +22,7 @@ import isRtlSelector from 'state/selectors/is-rtl';
 import TranslatableString from 'components/translatable/proptype';
 import { getEditorUrl } from 'state/selectors/get-editor-url';
 import getPrimarySiteId from 'state/selectors/get-primary-site-id';
+import { reduxGetState } from 'lib/redux-bridge';
 import { navigate } from 'state/ui/actions';
 
 class MasterbarItemNew extends React.Component {
@@ -75,8 +76,9 @@ class MasterbarItemNew extends React.Component {
 		return 'bottom left';
 	}
 
-	onSiteSelect = () => {
-		this.props.openEditor( this.props.editorUrl );
+	onSiteSelect = siteId => {
+		const redirectUrl = getEditorUrl( reduxGetState(), siteId, null, 'post' );
+		this.props.openEditor( redirectUrl );
 		return true; // handledByHost = true, don't let the component nav
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace the Masterbar Write button's full reload with a soft `navigate` to the selected editor.

This basically reverts the changes introduced in #29045, as we replaced the Calypsoify Gutenberg approach with Gutenframe, and we don't need a full reload anymore.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso with a user owning multiple sites.
* Enable the analytics logging with: `localStorage.setItem('debug', 'calypso:analytics:tracks');` and filter the console by `calypso_masterbar_write_button_clicked`. Reload.
* Click on the Write button and select a site opted in to Gutenberg.
* Make sure it opens Gutenberg without a full reload, and that a `calypso_masterbar_write_button_clicked` event is tracked.
* Go back to the dashboard, click on the Write button again and select a site opted out from Gutenberg.
* Make sure it opens the Classic Editor without a full reload, and that a `calypso_masterbar_write_button_clicked` event is tracked.