### PR TITLE
Fix typo on e-mail forwarding page

### DIFF
--- a/client/state/data-layer/wpcom/email-forwarding/remove/index.js
+++ b/client/state/data-layer/wpcom/email-forwarding/remove/index.js
@@ -52,7 +52,7 @@ export const removeEmailForwardFailure = ( action, error ) => {
 
 	if ( error && error.message ) {
 		failureMessage = translate(
-			'Failed to remove email forward %(email)s' +
+			'Failed to remove email forward %(email)s ' +
 				'with message "%(message)s". ' +
 				'Please try again or ' +
 				'{{contactSupportLink}}contact support{{/contactSupportLink}}.',


### PR DESCRIPTION
Because of string concattenation this error in screen text is not apparent: `Failed to remove email forward %(email)swith message "%(message)s".` should be `Failed to remove email forward %(email)s with message "%(message)s".`

@cbauerman Could you review and merge yourself? Thanks!