### PR TITLE
Packages: Fix ignore in calypso-color-schemes

### DIFF
--- a/packages/calypso-color-schemes/.npmignore
+++ b/packages/calypso-color-schemes/.npmignore
@@ -1,0 +1,1 @@
+# Include this file so npm does not ignore files in .gitignore

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0-alpha.1",
 	"description": "Calypso Shared Style Bits",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Gitignore was causing required `__color-studio` directory to be removed from the package. Add empty .npmignore so that `.gitignore` is not used.

`@automattic/calypso-color-schemes@1.0.0-alpha.0` has a broken sass file due to missing directory.
