### PR TITLE
Simple Payments: increase the number of posts

### DIFF
--- a/client/lib/simple-payments/constants.js
+++ b/client/lib/simple-payments/constants.js
@@ -1,6 +1,8 @@
 /** @format */
 export const SIMPLE_PAYMENTS_PRODUCT_POST_TYPE = 'jp_pay_product';
 
+export const NUMBER_OF_POSTS_BY_REQUEST = 100;
+
 export const DEFAULT_CURRENCY = 'USD';
 
 // https://developer.paypal.com/docs/integration/direct/rest/currency-codes/

--- a/client/state/data-layer/wpcom/sites/simple-payments/index.js
+++ b/client/state/data-layer/wpcom/sites/simple-payments/index.js
@@ -15,7 +15,10 @@ import { getFeaturedImageId } from 'state/posts/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { isValidSimplePaymentsProduct } from 'lib/simple-payments/utils';
 import { metaKeyToSchemaKeyMap, metadataSchema } from 'state/simple-payments/product-list/schema';
-import { SIMPLE_PAYMENTS_PRODUCT_POST_TYPE } from 'lib/simple-payments/constants';
+import {
+	SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
+	NUMBER_OF_POSTS_BY_REQUEST,
+} from 'lib/simple-payments/constants';
 import { TransformerError } from 'lib/make-json-schema-parser';
 import {
 	SIMPLE_PAYMENTS_PRODUCT_GET,
@@ -169,6 +172,7 @@ export const handleProductList = dispatchRequest( {
 				query: {
 					type: SIMPLE_PAYMENTS_PRODUCT_POST_TYPE,
 					status: 'publish',
+					number: NUMBER_OF_POSTS_BY_REQUEST,
 				},
 			},
 			action


### PR DESCRIPTION
This commit increases the number of posts (buttons) by request from `20` (default value) to `100`.

# Testing instructions

Try to find a site with more than 20 Simple Payments buttons. Before these changes, the customer should be able to see only 20 buttons as maximum.
After applying these changes, confirm that the customer sees the buttons (maximum 100).

Fixes #24436
