### PR TITLE
Signup: Update site-title singular step

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -457,7 +457,7 @@ export function generateSteps( {
 			stepName: 'site-information',
 			providesDependencies: [ 'title', 'address', 'phone' ],
 			props: {
-				headerText: i18n.translate( 'Give your site a name.' ),
+				headerText: i18n.translate( "Tell us your site's name" ),
 				subHeaderText: i18n.translate(
 					'This will appear at the top of your site and can be changed at anytime.'
 				),
@@ -469,7 +469,7 @@ export function generateSteps( {
 			stepName: 'site-information-title',
 			providesDependencies: [ 'title' ],
 			props: {
-				headerText: i18n.translate( 'Give your site a name.' ),
+				headerText: i18n.translate( "Tell us your site's name" ),
 				subHeaderText: i18n.translate(
 					'This will appear at the top of your site and can be changed at anytime.'
 				),

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -467,6 +467,9 @@ export function generateSteps( {
 			providesDependencies: [ 'title' ],
 			props: {
 				headerText: i18n.translate( "Tell us your site's name" ),
+				subHeaderText: i18n.translate(
+					"Your site's name appears at the top and can be changed at anytime."
+				),
 				informationFields: [ 'title' ],
 			},
 		},
@@ -540,6 +543,9 @@ export function generateSteps( {
 			providesDependencies: [ 'title' ],
 			props: {
 				headerText: i18n.translate( "Tell us your site's name" ),
+				subHeaderText: i18n.translate(
+					"Your site's name appears at the top and can be changed at anytime."
+				),
 				informationFields: [ 'title' ],
 				showSiteMockups: true,
 			},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -457,7 +457,10 @@ export function generateSteps( {
 			stepName: 'site-information',
 			providesDependencies: [ 'title', 'address', 'phone' ],
 			props: {
-				headerText: i18n.translate( 'Help customers find you' ),
+				headerText: i18n.translate( 'Give your site a name.' ),
+				subHeaderText: i18n.translate(
+					'This will appear at the top of your site and can be changed at anytime.'
+				),
 				informationFields: [ 'title', 'address', 'phone' ],
 			},
 		},
@@ -466,9 +469,9 @@ export function generateSteps( {
 			stepName: 'site-information-title',
 			providesDependencies: [ 'title' ],
 			props: {
-				headerText: i18n.translate( "Tell us your site's name" ),
+				headerText: i18n.translate( 'Give your site a name.' ),
 				subHeaderText: i18n.translate(
-					"Your site's name appears at the top and can be changed at anytime."
+					'This will appear at the top of your site and can be changed at anytime.'
 				),
 				informationFields: [ 'title' ],
 			},

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -547,7 +547,7 @@ export function generateSteps( {
 			props: {
 				headerText: i18n.translate( "Tell us your site's name" ),
 				subHeaderText: i18n.translate(
-					"Your site's name appears at the top and can be changed at anytime."
+					'This will appear at the top of your site and can be changed at anytime.'
 				),
 				informationFields: [ 'title' ],
 				showSiteMockups: true,

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -186,6 +186,7 @@ export class SiteInformation extends Component {
 				headerText={ headerText }
 				fallbackHeaderText={ headerText }
 				subHeaderText={ subHeaderText }
+				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
 				showSiteMockups={ this.props.showSiteMockups }

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -42,6 +42,7 @@ export class SiteInformation extends Component {
 		stepName: PropTypes.string,
 		siteType: PropTypes.string,
 		headerText: PropTypes.string,
+		subHeaderText: PropTypes.string,
 		fieldLabel: PropTypes.string,
 		fieldDescription: PropTypes.string,
 		fieldPlaceholder: PropTypes.string,
@@ -53,6 +54,7 @@ export class SiteInformation extends Component {
 
 	static defaultProps = {
 		headerText: '',
+		subHeaderText: '',
 		fieldLabel: '',
 		fieldDescription: '',
 		fieldPlaceholder: '',
@@ -168,7 +170,14 @@ export class SiteInformation extends Component {
 	}
 
 	render() {
-		const { flowName, headerText, positionInFlow, signupProgress, stepName } = this.props;
+		const {
+			flowName,
+			headerText,
+			subHeaderText,
+			positionInFlow,
+			signupProgress,
+			stepName,
+		} = this.props;
 		return (
 			<StepWrapper
 				flowName={ flowName }
@@ -176,6 +185,7 @@ export class SiteInformation extends Component {
 				positionInFlow={ positionInFlow }
 				headerText={ headerText }
 				fallbackHeaderText={ headerText }
+				subHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
 				showSiteMockups={ this.props.showSiteMockups }

--- a/client/signup/steps/site-information/style.scss
+++ b/client/signup/steps/site-information/style.scss
@@ -41,35 +41,44 @@
 		margin: 0 auto;
 	}
 
+	// Mimic a card
+	.form-fieldset {
+		border-radius: 4px;
+		background: var( --color-white );
+		box-shadow: 0 3px 6px rgba( 0, 0, 0, 0.16 ),
+					0 3px 6px rgba( 0, 0, 0, 0.23 );
+	}
+
 	label {
-		// Labels should be white when placed directly
-		// on the primary background color
-		color: var( --color-white );
+		// The label isn't needed when
+		// there's only one input.
+		display: none;
 	}
 
 	input {
-		// Extra padding to account for the button and
-		padding: 10px 100px 10px 10px;
+		// Extra padding to account for the button
+		padding: 10px 100px 13px 16px;
 
-		// Since there's a 1px padding on the container, and
-		// inputs use actual borders (unlike cards, which
-		// use box-shadow), we need to adjust.
-		margin: 0 -1px;
-		width: calc( 100% + 2px );
+		// Match the radious of the fieldset
+		border-radius: 4px;
+
+		// No need for a border here
+		border: none;
 
 		// On smaller screens the buttons get bigger,
 		// so this input needs to get bigger, too.
 		@include breakpoint( '<660px' ) {
 			padding-top: 15px;
 			padding-bottom: 15px;
+
+			// The rounded borders look strange on
+			// smaller screens.
+			border-radius: 0;
 		}
 
-		// Making the border feel a little more "at home"
-		// with signups dark background color.
-		border-color: var( --color-primary-700 );
-
-		// Trying out a rounded input
-		border-radius: 4px;
+		&:focus {
+			box-shadow: 0 0 0 2px var( --color-accent );
+		}
 	}
 
 	.card {

--- a/client/signup/steps/site-information/style.scss
+++ b/client/signup/steps/site-information/style.scss
@@ -57,7 +57,7 @@
 
 	input {
 		// Extra padding to account for the button
-		padding: 10px 100px 13px 16px;
+		padding: 10px 100px 12px 16px;
 
 		// Match the radious of the fieldset
 		border-radius: 4px;

--- a/client/signup/steps/site-information/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-information/test/__snapshots__/index.js.snap
@@ -3,6 +3,7 @@
 exports[`<SiteInformation /> should render 1`] = `
 <Localized(StepWrapper)
   fallbackHeaderText="headerTextoidaliciously"
+  fallbackSubHeaderText="subHeaderTextoidaliciously"
   headerText="headerTextoidaliciously"
   stepContent={
     <div
@@ -126,5 +127,6 @@ exports[`<SiteInformation /> should render 1`] = `
     </div>
   }
   stepName="site-information"
+  subHeaderText="subHeaderTextoidaliciously"
 />
 `;

--- a/client/signup/steps/site-information/test/index.js
+++ b/client/signup/steps/site-information/test/index.js
@@ -29,6 +29,7 @@ describe( '<SiteInformation />', () => {
 		translate: x => x,
 		siteInformation: { title: 'Ho ho ho!' },
 		headerText: 'headerTextoidaliciously',
+		subHeaderText: 'subHeaderTextoidaliciously',
 		formFields: [ 'title', 'address', 'phone' ],
 		stepName: 'site-information',
 	};

--- a/client/signup/steps/site-information/test/index.js
+++ b/client/signup/steps/site-information/test/index.js
@@ -30,6 +30,7 @@ describe( '<SiteInformation />', () => {
 		siteInformation: { title: 'Ho ho ho!' },
 		headerText: 'headerTextoidaliciously',
 		subHeaderText: 'subHeaderTextoidaliciously',
+		fallbackSubHeaderText: 'subHeaderTextoidaliciously',
 		formFields: [ 'title', 'address', 'phone' ],
 		stepName: 'site-information',
 	};


### PR DESCRIPTION
This PR updates the styles of the `site-information` step to match the patterns from the `site-topic` step, updating the :focus style, box-shadow, and spacing. I've also added a subheading, which, ironically, the `site-topic` step doesn't have — yet, it will.

Before:
<img width="954" alt="image" src="https://user-images.githubusercontent.com/191598/54773331-bc45ec00-4bdf-11e9-940e-9768c8ee77f9.png">

After:
<img width="957" alt="image" src="https://user-images.githubusercontent.com/191598/54776482-9cfe8d00-4be6-11e9-9b87-cc2b3b224833.png">

To test, head to `start/onboarding` and work through the steps till you're asked for a title for your site.
