### PR TITLE
Move Secondary Layout Overrides

### DIFF
--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -41,8 +41,3 @@
 		text-decoration: underline;
 	}
 }
-
-.layout__secondary .app-promo .app-promo__link {
-	box-shadow: 0 0 0 1px var( --sidebar-border-color ),
-		0 1px 2px var( --sidebar-border-color );
-}

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -102,20 +102,12 @@
 	line-height: 1.4;
 }
 
-.layout__secondary .site__title {
-	color: var( --sidebar-text-color );
-}
-
 .site__domain {
 	color: var( --color-text-subtle );
 	display: block;
 	max-width: 95%;
 	font-size: 11px;
 	line-height: 1.4;
-}
-
-.layout__secondary .site__domain {
-	color: var( --sidebar-heading-color );
 }
 
 .site__title,
@@ -125,11 +117,6 @@
 	&::after {
 		@include long-content-fade( $color: var( --sidebar-secondary-background-gradient ) );
 	}
-}
-
-.layout__secondary .site__title::after,
-.layout__secondary .site__domain::after {
-	@include long-content-fade( $color: var( --sidebar-background-gradient ) );
 }
 
 .site__home {
@@ -177,8 +164,4 @@
 	line-height: 0;
 	position: relative;
 	vertical-align: middle;
-}
-
-.layout__secondary .site__badge {
-	color: var( --sidebar-gridicon-fill );
 }

--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -33,10 +33,6 @@
 	}
 }
 
-.layout__secondary .site-selector.is-large .site-selector__sites {
-	border-color: var( --sidebar-border-color );
-}
-
 // Styles for Site elements within the Selector
 .site-selector .site,
 .site-selector .all-sites {
@@ -69,11 +65,6 @@
 			color: var( --sidebar-menu-selected-a-color );
 		}
 	}
-}
-
-.layout__secondary .all-sites .count {
-	color: var( --sidebar-text-color );
-	border-color: var( --sidebar-text-color );
 }
 
 // Highlight & hover effects
@@ -150,10 +141,6 @@
 	}
 }
 
-.layout__secondary .site-selector__sites {
-	background: var( --sidebar-background );
-}
-
 .site-selector__no-results {
 	color: var( --color-neutral-light );
 	font-style: italic;
@@ -167,10 +154,6 @@
 	display: flex;
 	flex-direction: row;
 	padding-left: 10px;
-}
-
-.layout__secondary .site-selector__add-new-site {
-	border-color: var( --sidebar-border-color );
 }
 
 .site-selector__add-new-site .button {
@@ -200,14 +183,6 @@
 	}
 }
 
-.layout__secondary .site-selector__add-new-site .button {
-	color: var( --sidebar-heading-color );
-
-	&:hover {
-		color: var( --sidebar-text-color );
-	}
-}
-
 // Containers in the list of sites are larger
 .site-selector .site-action {
 	padding-top: 15px;
@@ -217,20 +192,12 @@
 	border-bottom: 1px solid var( --color-neutral-100 );
 }
 
-.layout__secondary .site-selector .all-sites {
-	border-color: var( --sidebar-border-color );
-}
-
 .site-selector__recent {
 	border-bottom: 1px solid var( --color-neutral-0 );
 
 	&:empty {
 		border-bottom-width: 0;
 	}
-}
-
-.layout__secondary .site-selector__recent {
-	border-color: var( --sidebar-border-color );
 }
 
 .site-selector__hidden-sites-message {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -223,6 +223,11 @@
 	.all-sites .count {
 		color: var( --sidebar-text-color );	
 		border-color: var( --sidebar-text-color );
+	}
+	
+	.app-promo .app-promo__link {
+		box-shadow: 0 0 0 1px var( --sidebar-border-color ),
+			0 1px 2px var( --sidebar-border-color );
 	} 
 }
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -171,6 +171,26 @@
 	}
 }
 
+// Secondary Layout overrides
+.layout__secondary {	
+	.site__title {
+		color: var( --sidebar-text-color );
+	}
+	
+	.site__domain {
+		color: var( --sidebar-heading-color );
+	}
+	
+	.site__title::after,
+	.site__domain::after {
+		@include long-content-fade( $color: var( --sidebar-background-gradient ) );
+	}
+	
+	.site__badge {
+		color: var( --sidebar-gridicon-fill );
+	}
+}
+
 /*
 	Focus States
 	Sites - Site Selector for those with multiple sites

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -189,6 +189,39 @@
 	.site__badge {
 		color: var( --sidebar-gridicon-fill );
 	}
+	
+	.site-selector.is-large .site-selector__sites {
+		border-color: var( --sidebar-border-color );
+	}
+	
+	.all-sites .count {
+		color: var( --sidebar-text-color );	
+		border-color: var( --sidebar-text-color );
+	} 
+	
+	.site-selector__sites {
+		background: var( --sidebar-background );
+	}
+	
+	.site-selector__add-new-site {
+		border-color: var( --sidebar-border-color );
+	}
+	
+	.site-selector__add-new-site .button {		
+		color: var( --sidebar-heading-color );
+		
+		&:hover {
+			color: var( --sidebar-text-color );
+		}
+	}
+	
+	.site-selector .all-sites {
+		border-color: var( --sidebar-border-color );
+	}
+	
+	.site-selector__recent {
+		border-color: var( --sidebar-border-color );
+	}
 }
 
 /*

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -190,38 +190,40 @@
 		color: var( --sidebar-gridicon-fill );
 	}
 	
-	.site-selector.is-large .site-selector__sites {
+	.site-selector {		
+		&.is-large .site-selector__sites {
+			border-color: var( --sidebar-border-color );
+		}
+		
+		&__sites {
+			background: var( --sidebar-background );		
+		}
+	
+		&__add-new-site {
+			border-color: var( --sidebar-border-color );
+		
+			.button {		
+				color: var( --sidebar-heading-color );
+			
+				&:hover {
+					color: var( --sidebar-text-color );	
+				} 
+			}	
+		}
+	
+	.all-sites {
 		border-color: var( --sidebar-border-color );
 	}
+	
+	&__recent {
+		border-color: var( --sidebar-border-color );
+	}		  
+}
 	
 	.all-sites .count {
 		color: var( --sidebar-text-color );	
 		border-color: var( --sidebar-text-color );
 	} 
-	
-	.site-selector__sites {
-		background: var( --sidebar-background );
-	}
-	
-	.site-selector__add-new-site {
-		border-color: var( --sidebar-border-color );
-	}
-	
-	.site-selector__add-new-site .button {		
-		color: var( --sidebar-heading-color );
-		
-		&:hover {
-			color: var( --sidebar-text-color );
-		}
-	}
-	
-	.site-selector .all-sites {
-		border-color: var( --sidebar-border-color );
-	}
-	
-	.site-selector__recent {
-		border-color: var( --sidebar-border-color );
-	}
 }
 
 /*

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -1,7 +1,7 @@
 /**
  * /*
  * 	Layout Elements
- * 	.layout__loading - Displays when loading Claypso
+ * 	.layout__loading - Displays when loading Calypso
  * 	.layout__content - Contains primary and secondary elements
  * 		.layout__primary - Where the main content lives
  * 		.layout__secondary - Contains the site selector and sidebar elements
@@ -203,21 +203,20 @@
 			border-color: var( --sidebar-border-color );
 		
 			.button {		
-				color: var( --sidebar-heading-color );
-			
+				color: var( --sidebar-heading-color );			
 				&:hover {
 					color: var( --sidebar-text-color );	
 				} 
 			}	
 		}
 		
-		.all-sites {
-			border-color: var( --sidebar-border-color );
-		}
-		
 		&__recent {
 			border-color: var( --sidebar-border-color );
 		}		  
+		
+		.all-sites {
+			border-color: var( --sidebar-border-color );
+		}				
 	}
 	
 	.all-sites .count {

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -210,15 +210,15 @@
 				} 
 			}	
 		}
-	
-	.all-sites {
-		border-color: var( --sidebar-border-color );
+		
+		.all-sites {
+			border-color: var( --sidebar-border-color );
+		}
+		
+		&__recent {
+			border-color: var( --sidebar-border-color );
+		}		  
 	}
-	
-	&__recent {
-		border-color: var( --sidebar-border-color );
-	}		  
-}
 	
 	.all-sites .count {
 		color: var( --sidebar-text-color );	


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Moves all secondary layout overrides to `layout/style.scss`, see #31604 for context. 

cc @blowery 

#### Testing instructions

Firstly, is this scss compiled and formatted correctly? Visually, verify nothing has changed when checking out the sidebar, for example in the "My Sites" view. 