### PR TITLE
Make improvements to site-mockup-component

### DIFF
--- a/client/components/site-mockup/index.jsx
+++ b/client/components/site-mockup/index.jsx
@@ -4,7 +4,7 @@
  */
 import React, { PureComponent, Fragment } from 'react';
 import classNames from 'classnames';
-import { isEmpty, noop } from 'lodash';
+import { isEmpty, noop, isFunction } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -39,15 +39,24 @@ function MockupChromeDesktop() {
 	);
 }
 
-function SiteMockupContent( { content, title, tagline } ) {
+function SiteMockupContent( { content, title, tagline, renderContent } ) {
 	/* eslint-disable react/no-danger */
 	return (
 		<Fragment>
-			<div className="site-mockup__site-identity">
-				<div className="site-mockup__title">{ title }</div>
-				<div className="site-mockup__tagline">{ tagline }</div>
-			</div>
-			<div className="site-mockup__entry-content" dangerouslySetInnerHTML={ { __html: content } } />
+			{ ( title || tagline ) && (
+				<div className="site-mockup__site-identity">
+					{ title && <div className="site-mockup__title">{ title }</div> }
+					{ tagline && <div className="site-mockup__tagline">{ tagline }</div> }
+				</div>
+			) }
+			{ isFunction( renderContent ) ? (
+				<div className="site-mockup__entry-content">{ renderContent() }</div>
+			) : (
+				<div
+					className="site-mockup__entry-content"
+					dangerouslySetInnerHTML={ { __html: content } }
+				/>
+			) }
 		</Fragment>
 	);
 	/* eslint-enable react/no-danger */
@@ -78,21 +87,31 @@ export class SiteMockup extends PureComponent {
 	};
 
 	render() {
-		const { size, content, siteType, siteStyle, title, tagline } = this.props;
-		const classes = classNames( 'site-mockup__viewport', `is-${ size }`, {
+		const {
+			size,
+			className,
+			content,
+			renderContent,
+			siteType,
+			siteStyle,
+			title,
+			tagline,
+		} = this.props;
+		const classes = classNames( 'site-mockup__viewport', `is-${ size }`, className, {
 			[ `is-${ siteType }` ]: !! siteType,
 			[ `is-${ siteStyle }` ]: !! siteStyle,
 		} );
+
 		/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
 		return (
 			<div className={ classes } onClick={ this.props.onClick }>
 				{ size === 'mobile' ? <MockupChromeMobile /> : <MockupChromeDesktop /> }
 				<div className="site-mockup__body">
 					<div className="site-mockup__content">
-						{ isEmpty( content ) ? (
+						{ isEmpty( content ) && ! isFunction( renderContent ) ? (
 							<SiteMockupOutlines />
 						) : (
-							<SiteMockupContent { ...{ content, title, tagline } } />
+							<SiteMockupContent { ...{ content, title, tagline, renderContent } } />
 						) }
 					</div>
 				</div>


### PR DESCRIPTION
This PR looks to make some improvements to the freshly extracted SiteMockup component (#31588) in anticipation of requirements by the importer signup flow. 

First, I've allowed for a `className` prop to be passed through.
Second, I've expanded on the ability to show content by adding a `renderContent` prop with the intention to use this to render arbitrary JSX with the `renderProps` pattern. I'm not in love with the idea of having two ways to push content in, but this does mean that we can choose between JSX and regular html.

### Testing instructions

It's not possible to test the `renderContent` prop just yet, but let's make sure that the component still works as it should in it's current location:

- Go to http://calypso.localhost:3000/start/onboarding-dev/site-style-with-preview
- Make sure the site preview renders properly as expected and with proper styling
- Following suite from the test plan of #30749, test that the click handler is still working as expected:
  - filter network events by `calypso_signup_site_preview_mockup_clicked`
  - Click anywhere on the site previews, making sure you see a tracking request in your network pane