### PR TITLE
Cart: Make some cart updates safer

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -250,9 +250,12 @@ function fillInAllCartItemAttributes( cart, products ) {
 	return update( cart, {
 		products: {
 			$apply: function( items ) {
-				return items.map( function( cartItem ) {
-					return fillInSingleCartItemAttributes( cartItem, products );
-				} );
+				return (
+					items &&
+					items.map( function( cartItem ) {
+						return fillInSingleCartItemAttributes( cartItem, products );
+					} )
+				);
 			},
 		},
 	} );

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -104,7 +104,7 @@ function update( changeFunction ) {
 	const previousCart = CartStore.get();
 	const nextCart = wrappedFunction( previousCart );
 
-	_synchronizer.update( wrappedFunction );
+	_synchronizer && _synchronizer.update( wrappedFunction );
 	recordEvents( previousCart, nextCart );
 }
 
@@ -181,7 +181,8 @@ CartStore.dispatchToken = Dispatcher.register( payload => {
 				// typically set one or the other (or neither)
 				const { rawDetails } = action;
 				has( rawDetails, 'country' ) && update( setTaxCountryCode( get( rawDetails, 'country' ) ) );
-				has( rawDetails, 'postal-code' ) && update( setTaxPostalCode( get( rawDetails, 'postal-code' ) ) );
+				has( rawDetails, 'postal-code' ) &&
+					update( setTaxPostalCode( get( rawDetails, 'postal-code' ) ) );
 			}
 			break;
 
@@ -195,11 +196,12 @@ CartStore.dispatchToken = Dispatcher.register( payload => {
 						postalCode = extractStoredCardMetaValue( action, 'card_zip' );
 						countryCode = extractStoredCardMetaValue( action, 'country_code' );
 						break;
-					case 'WPCOM_Billing_MoneyPress_Paygate':
+					case 'WPCOM_Billing_MoneyPress_Paygate': {
 						const paymentDetails = get( action, 'payment.newCardDetails', {} );
 						postalCode = paymentDetails[ 'postal-code' ];
 						countryCode = paymentDetails.country;
 						break;
+					}
 					case 'WPCOM_Billing_WPCOM':
 						postalCode = null;
 						countryCode = null;


### PR DESCRIPTION
These can get triggered when a user adds a new credit card, but has no cart loaded.

Prevents an error from appearing on the add credit card page asking for a country, even though the country has been chosen.

#### Testing instructions
* Load /me/purchases/add-credit-card directly
* Try adding a new credit card
* Add a plan to your cart
* Try to add another credit card

