### PR TITLE
Avoid re-rendering MomentProvider when mounting with current locale.

### DIFF
--- a/client/components/localized-moment/context.js
+++ b/client/components/localized-moment/context.js
@@ -19,13 +19,13 @@ const debug = debugFactory( 'calypso:localized-moment' );
 const MomentContext = React.createContext( moment );
 
 class MomentProvider extends React.Component {
-	state = { moment, momentLocale: 'en' };
+	state = { moment, momentLocale: moment.locale() };
 
-	async checkAndLoad( previousLocale ) {
+	async checkAndLoad() {
 		const { currentLocale } = this.props;
 
 		// has the requested locale changed?
-		if ( currentLocale === previousLocale ) {
+		if ( currentLocale === this.state.momentLocale ) {
 			return;
 		}
 
@@ -52,11 +52,11 @@ class MomentProvider extends React.Component {
 	}
 
 	componentDidMount() {
-		this.checkAndLoad( 'en' );
+		this.checkAndLoad();
 	}
 
-	componentDidUpdate( prevProps ) {
-		this.checkAndLoad( prevProps.currentLocale );
+	componentDidUpdate() {
+		this.checkAndLoad();
 	}
 
 	render() {


### PR DESCRIPTION
There are some situations in which a new `MomentProvider` gets mounted, e.g. when navigating to Stats. In this situation, it was being rendered once with the hardcoded `'en'` value, and once again with the current locale (if different from `'en'`).

This change initialises `MomentProvider` to the currently active moment locale (`moment.locale()`), effectively reusing the global state rather than a hardcoded default.

This is a small change with no measurable impact in performance that I can track, but it seems valuable to avoid rendering things in the wrong language regardless of how long it stays up on screen.

#### Changes proposed in this Pull Request

* Initialize `MomentProvider` to the current global moment locale, rather than a hardcoded `'en'`

#### Testing instructions

* Use Calypso with a non-`en` locale. Ensure dates are displayed in the correct locale.
