### PR TITLE
Clean up support for G Suite Business

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
@@ -30,6 +30,8 @@ import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import QueryProducts from 'components/data/query-products-list';
 import { getProductsList } from 'state/products-list/selectors';
 
+const gsuitePlanSlug = 'gapps'; // or gapps_unlimited - TODO make this dynamic
+
 class GoogleAppsDialog extends React.Component {
 	static propTypes = {
 		domain: PropTypes.string.isRequired,
@@ -75,14 +77,18 @@ class GoogleAppsDialog extends React.Component {
 	}
 
 	renderView() {
-		const prices = this.getPrices( 'gapps' );
+		const prices = this.getPrices( gsuitePlanSlug );
 
 		return (
 			<form className="gsuite-dialog__form" onSubmit={ this.handleFormSubmit }>
 				<QueryProducts />
 				<CompactCard>{ this.header() }</CompactCard>
 				<CompactCard>
-					<GoogleAppsProductDetails domain={ this.props.domain } plan={ 'gapps' } { ...prices } />
+					<GoogleAppsProductDetails
+						domain={ this.props.domain }
+						plan={ gsuitePlanSlug }
+						{ ...prices }
+					/>
 					{ this.renderGoogleAppsUsers() }
 				</CompactCard>
 				<CompactCard>{ this.footer() }</CompactCard>
@@ -225,7 +231,7 @@ class GoogleAppsDialog extends React.Component {
 
 		return cartItems.googleApps( {
 			domain: this.props.domain,
-			product_slug: 'gapps',
+			product_slug: gsuitePlanSlug,
 			users,
 		} );
 	}

--- a/client/my-sites/checkout/cart/cart-item.jsx
+++ b/client/my-sites/checkout/cart/cart-item.jsx
@@ -248,6 +248,7 @@ export class CartItem extends React.Component {
 		} else if ( cartItem.volume === 1 ) {
 			switch ( cartItem.product_slug ) {
 				case 'gapps':
+				case 'gapps_unlimited':
 					return translate( '%(productName)s (1 User)', {
 						args: {
 							productName: cartItem.product_name,
@@ -260,6 +261,7 @@ export class CartItem extends React.Component {
 		} else {
 			switch ( cartItem.product_slug ) {
 				case 'gapps':
+				case 'gapps_unlimited':
 					return translate(
 						'%(productName)s (%(volume)s User)',
 						'%(productName)s (%(volume)s Users)',

--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -87,7 +87,7 @@ class Email extends React.Component {
 			! (
 				! this.props.isRequestingSiteDomains &&
 				null !== this.props.gsuiteUsers &&
-				get( this.props, 'products.' + gsuitePlanSlug, false )
+				get( this.props, [ 'products', gsuitePlanSlug ], false )
 			)
 		) {
 			return <Placeholder />;

--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -39,7 +39,7 @@ import { isPlanFeaturesEnabled } from 'lib/plans';
 import DocumentHead from 'components/data/document-head';
 import QueryGSuiteUsers from 'components/data/query-gsuite-users';
 
-const gsuitePlanSlug = 'gapps_unlimited'; // or gapps_unlimited - TODO make this dynamic
+const gsuitePlanSlug = 'gapps'; // or gapps_unlimited - TODO make this dynamic
 
 class Email extends React.Component {
 	static propTypes = {

--- a/client/my-sites/domains/domain-management/email/index.jsx
+++ b/client/my-sites/domains/domain-management/email/index.jsx
@@ -39,6 +39,8 @@ import { isPlanFeaturesEnabled } from 'lib/plans';
 import DocumentHead from 'components/data/document-head';
 import QueryGSuiteUsers from 'components/data/query-gsuite-users';
 
+const gsuitePlanSlug = 'gapps_unlimited'; // or gapps_unlimited - TODO make this dynamic
+
 class Email extends React.Component {
 	static propTypes = {
 		currencyCode: PropTypes.string.isRequired,
@@ -85,7 +87,7 @@ class Email extends React.Component {
 			! (
 				! this.props.isRequestingSiteDomains &&
 				null !== this.props.gsuiteUsers &&
-				get( this.props, 'products.gapps', false )
+				get( this.props, 'products.' + gsuitePlanSlug, false )
 			)
 		) {
 			return <Placeholder />;
@@ -151,7 +153,7 @@ class Email extends React.Component {
 	addGoogleAppsCard() {
 		const { currencyCode, domains, products, selectedDomainName, selectedSite } = this.props;
 		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
-		const price = get( products, [ 'gapps', 'prices', currencyCode ], 0 );
+		const price = get( products, [ gsuitePlanSlug, 'prices', currencyCode ], 0 );
 		const annualPrice = getAnnualPrice( price, currencyCode );
 		const monthlyPrice = getMonthlyPrice( price, currencyCode );
 		return (
@@ -159,7 +161,7 @@ class Email extends React.Component {
 				<GSuitePurchaseCta
 					annualPrice={ annualPrice }
 					monthlyPrice={ monthlyPrice }
-					productSlug={ 'gapps' }
+					productSlug={ gsuitePlanSlug }
 					selectedDomainName={ selectedDomainName }
 					selectedSite={ selectedSite }
 				/>

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -33,7 +33,7 @@ class GSuitePurchaseCta extends React.Component {
 
 	getPlanText() {
 		const { productSlug, translate } = this.props;
-		if ( 'gappsbusiness' === productSlug ) {
+		if ( 'gapps_unlimited' === productSlug ) {
 			return translate( 'Business' );
 		}
 	}

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -1,6 +1,6 @@
 .gsuite-purchase-cta__add-google-apps-card-product-logo {
 	font-size: 150%;
-    color: #757575;
+	color: #757575;
 
 	@include breakpoint( '<660px' ) {
 		width: 236px;

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -1,4 +1,7 @@
 .gsuite-purchase-cta__add-google-apps-card-product-logo {
+	font-size: 150%;
+    color: #757575;
+
 	@include breakpoint( '<660px' ) {
 		width: 236px;
 	}
@@ -10,8 +13,9 @@
 	strong {
 		background: url( '/calypso/images/upgrades/g-suite-logo.png' ) no-repeat left;
 		background-size: 73px;
+		background-position-y: 5px;
 		display: inline-block;
-		height: 19px;
+		height: 23px;
 		margin: 0 6px 0 0;
 		text-indent: -999999px;
 		vertical-align: text-top;

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -184,7 +184,7 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with business plan 1`] =
   >
     <GSuitePurchaseFeatures
       domainName=""
-      productSlug="gappsbusiness"
+      productSlug="gapps_unlimited"
       type="grid"
     />
     <div

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -41,7 +41,7 @@ describe( 'GSuitePurchaseCta', () => {
 					<GSuitePurchaseCta
 						annualPrice={ '$50' }
 						monthlyPrice={ '$5' }
-						productSlug={ 'gappsbusiness' }
+						productSlug={ 'gapps_unlimited' }
 						selectedSite={ { ID: 'foo' } }
 					/>
 				</Provider>

--- a/client/my-sites/email/gsuite-purchase-features/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-features/index.jsx
@@ -29,7 +29,7 @@ class GSuitePurchaseFeatures extends React.Component {
 		const { productSlug, translate } = this.props;
 		if ( 'gapps' === productSlug ) {
 			return translate( 'Get 30GB of storage for all your files synced across devices.' );
-		} else if ( 'gappsbusiness' === productSlug ) {
+		} else if ( 'gapps_unlimited' === productSlug ) {
 			return translate( 'Get unlimited storage for all your files synced across devices.' );
 		}
 	}

--- a/client/my-sites/email/gsuite-purchase-features/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-features/test/index.js
@@ -30,7 +30,10 @@ describe( 'GSuitePurchaseFeatures', () => {
 		const tree = renderer
 			.create(
 				<Provider store={ store }>
-					<GSuitePurchaseFeatures domainName={ 'testing123.com' } productSlug={ 'gappsbusiness' } />
+					<GSuitePurchaseFeatures
+						domainName={ 'testing123.com' }
+						productSlug={ 'gapps_unlimited' }
+					/>
 				</Provider>
 			)
 			.toJSON();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Clean up styling of "Business" to match logo in domains CTA page
* Virtualise G Suite Plan in the G Suite Dialog since it was hard-coded in multiple places
* Replace references to incorrect plan slug "gappsbusiness" with "gapps_unlimited"

Here's an example of the unstyled logo in the Domains Email CTA:

Unstyled logo:

<img width="200" alt="before-style-changes" src="https://user-images.githubusercontent.com/51896/54779155-ba762b80-4bd3-11e9-8f54-6d8764c86ba9.png">

Full new version:

<img width="949" alt="business-cta-domains" src="https://user-images.githubusercontent.com/51896/54779820-5ce2de80-4bd5-11e9-8033-5441e2848bb7.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since we don't actually offer Business right now, everything should be the same as before
* But if you change `gapps` to `gapps_unlimited` in `GoogleAppsDialog` or the `Email` component, the correct prices and text for G Suite Business should be displayed
