### PR TITLE
Disallow domains with wpcomstaging in them from G Suite purchase

### DIFF
--- a/client/lib/domains/gsuite/index.js
+++ b/client/lib/domains/gsuite/index.js
@@ -13,7 +13,7 @@ import userFactory from 'lib/user';
  */
 function canDomainAddGSuite( domainName ) {
 	const GOOGLE_APPS_INVALID_TLDS = [ 'in' ];
-	const GOOGLE_APPS_BANNED_PHRASES = [ 'google' ];
+	const GOOGLE_APPS_BANNED_PHRASES = [ 'google', 'wpcomstaging' ];
 	const tld = domainName.split( '.' )[ 1 ],
 		includesBannedPhrase = some( GOOGLE_APPS_BANNED_PHRASES, function( phrase ) {
 			return includes( domainName, phrase );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disallow domains that contain 'wpcomstaging' from purchasing G Suite.

#### Testing instructions

* Have site with business plan and no custom domain
* Add plugin
* Goto domains
* Click email
* Observe you are not given G Suite CTA
