### PR TITLE
Signup: Updating search field placeholder copy with instructional text

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -163,7 +163,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			<>
 				<SuggestionSearch
 					id="siteTopic"
-					placeholder={ placeholder || translate( 'e.g. Fashion, travel, design, plumbing' ) }
+					placeholder={ placeholder || translate( 'Enter a keyword or select one from below.' ) }
 					onChange={ this.onSiteTopicChange }
 					suggestions={ this.getSuggestions() }
 					value={ this.state.searchValue }

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -6,7 +6,7 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
     autoFocus={false}
     id="siteTopic"
     onChange={[Function]}
-    placeholder="e.g. Fashion, travel, design, plumbing"
+    placeholder="Enter a keyword or select one from below."
     railcar={
       Object {
         "action": "site_vertical_selected",


### PR DESCRIPTION
## Changes proposed in this Pull Request

We're changing the vertical search placeholder copy from `'e.g. Fashion, travel, design, plumbing'` to `'Enter a keyword or select one from below.'`.

The purpose behind the change is to make the text more instructional.