### PR TITLE
Add Reader code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 # Scripts
 /bin @Automattic/team-calypso
 
-# Client initializaton
+# Client initialization
 /client/boot @Automattic/team-calypso
 
 # Client blocks
@@ -44,6 +44,11 @@
 
 # Jetpack Connect
 /client/jetpack-connect @Automattic/luna
+
+# Reader
+/client/reader @Automattic/reader
+/client/blocks/reader-* @Automattic/reader
+/client/state/reader @Automattic/reader
 
 # Server infrastructure
 /server @Automattic/team-calypso


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following the introduction of the CODEOWNERS file in https://github.com/Automattic/wp-calypso/pull/31551, add code owners for Reader, including Redux and blocks.

Even though `Automattic/reader` is essentially just me at this point, I like to keep an eye on what's happening with the Reader codebase and am happy to weigh in on any reviews.

