### PR TITLE
Vertical search: ensure results float over site preview

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -7,7 +7,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		// Adjust the padding as we no longer
 		// show the masterbar.
 		padding-top: 48px;
-
+		overflow: visible;
 		& > .banner {
 			max-width: 600px;
 		}

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -7,7 +7,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		// Adjust the padding as we no longer
 		// show the masterbar.
 		padding-top: 48px;
-		overflow: visible;
+
 		& > .banner {
 			max-width: 600px;
 		}
@@ -941,6 +941,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		&:focus {
 			box-shadow: inset 0 0 0 2px var( --color-jetpack );
 		}
+	}
+
+	.site-topic__content .form-fieldset {
+		position: relative;
 	}
 }
 

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -7,6 +7,7 @@ body.is-section-jetpack-connect .site-topic__content {
 
 	.form-fieldset {
 		margin-bottom: 0;
+		position: absolute;
 		left: 0;
 		right: 0;
 		z-index: 1000; // I know, I know...


### PR DESCRIPTION
## Changes proposed in this Pull Request

#31609 introduced a hotfix to prevent Jetpack connect site vertical results from being cut off. 

The fix was to remove `position: absolute` on the fieldset. It worked! Well, sort of.

It seems as though this little declaration had a purpose after all, that is, to ensure we're not pushing down site preview. 

<img width="500" alt="Screen Shot 2019-03-22 at 3 09 13 pm" src="https://user-images.githubusercontent.com/6458278/54800217-fd5c0000-4cb4-11e9-8562-aa28b0182290.png">

This PR reinstates the `position: absolute` so that the fieldset floats over the site preview, but also sets the layout overflow to `visible` on Jetpack to avoid cutting off the results list.

### Results:

<img width="500" alt="Screen Shot 2019-03-22 at 3 09 19 pm" src="https://user-images.githubusercontent.com/6458278/54800259-21b7dc80-4cb5-11e9-9b06-e4b4911483be.png">

<img width="500" alt="Screen Shot 2019-03-22 at 3 09 26 pm" src="https://user-images.githubusercontent.com/6458278/54800260-241a3680-4cb5-11e9-9836-72e4bf72310d.png">

## Testing instructions

Run through the WordPress.com flow as usual and check both the popular suggestions and site topic API results (http://calypso.localhost:3000/start/site-topic)

Connect a Jetpack site^ and check the site topic step as well. (http://calypso.localhost:3000/jetpack/connect/site-topic/{yourjetpacksite.whatever})

The popular suggestions and API results should appear as expected in desktop- and smaller screen widths.

^ Create one here: https://jurassic.ninja