### PR TITLE
Clean up logic for detecting invalid TLDs for G Suite

### DIFF
--- a/client/lib/domains/gsuite/index.js
+++ b/client/lib/domains/gsuite/index.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { get, includes, some } from 'lodash';
+import { get, includes, some, endsWith } from 'lodash';
 import { type as domainTypes } from 'lib/domains/constants';
 import userFactory from 'lib/user';
 
@@ -12,18 +12,16 @@ import userFactory from 'lib/user';
  * @returns {Boolean} -Can a domain add G Suite
  */
 function canDomainAddGSuite( domainName ) {
-	const GOOGLE_APPS_INVALID_TLDS = [ 'in' ];
-	const GOOGLE_APPS_BANNED_PHRASES = [ 'google', 'wpcomstaging' ];
-	const tld = domainName.split( '.' )[ 1 ],
-		includesBannedPhrase = some( GOOGLE_APPS_BANNED_PHRASES, function( phrase ) {
-			return includes( domainName, phrase );
-		} );
-
-	return ! (
-		includes( GOOGLE_APPS_INVALID_TLDS, tld ) ||
-		includesBannedPhrase ||
-		isGSuiteRestricted()
+	const GOOGLE_APPS_INVALID_SUFFIXES = [ '.in', '.wpcomstaging.com' ];
+	const GOOGLE_APPS_BANNED_PHRASES = [ 'google' ];
+	const includesBannedPhrase = some( GOOGLE_APPS_BANNED_PHRASES, bannedPhrase =>
+		includes( domainName, bannedPhrase )
 	);
+	const hasInvalidSuffix = some( GOOGLE_APPS_INVALID_SUFFIXES, invalidSuffix =>
+		endsWith( domainName, invalidSuffix )
+	);
+
+	return ! ( hasInvalidSuffix || includesBannedPhrase || isGSuiteRestricted() );
 }
 
 /**


### PR DESCRIPTION
Our current logic for detecting `canDomainAddGSuite` is to see if `domainName.split( '.' )[ 1 ]` matches any banned TLD

However, not all domains contain a TLD as their second element. Some have multi-part TLDs, or long strings of subdomains. While these are rare cases, it's worth correcting this logic so that bugs aren't accidentally introduced in the future. 

This PR does this by treating the TLD as a string suffix that begins with a `.`

#### Changes proposed in this Pull Request

* Make TLD detection more robust by treating it as a string suffix

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that Indian TLDs are still banned and WPCOM non-custom-domains are still banned.

