### PR TITLE
Remove Confusing "Remove G Suite Purchase" Wait State

### DIFF
--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -179,8 +179,6 @@ class GSuiteCancelPurchaseDialog extends Component {
 				},
 			];
 		}
-		// these buttons are returned in the "removing" state to maintain
-		// visual continuity
 		return [
 			{
 				action: 'cancel',

--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/index.jsx
@@ -239,7 +239,6 @@ GSuiteCancelPurchaseDialog.propTypes = {
 	domain: PropTypes.string.isRequired,
 	isVisible: PropTypes.bool.isRequired,
 	onClose: PropTypes.func.isRequired,
-	onRemovePurchase: PropTypes.func.isRequired,
 	productName: PropTypes.string.isRequired,
 	purchase: PropTypes.object.isRequired,
 	purchasesError: PropTypes.string,

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -480,10 +480,8 @@ class RemovePurchase extends Component {
 		if ( isGoogleApps( purchase ) ) {
 			return (
 				<GSuiteCancellationPurchaseDialog
-					disabled={ this.state.isRemoving }
 					isVisible={ this.state.isDialogVisible }
 					onClose={ this.closeDialog }
-					onRemovePurchase={ this.removePurchase }
 					purchase={ purchase }
 					site={ this.props.site }
 				/>

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -101,17 +101,13 @@ class RemovePurchase extends Component {
 		);
 	};
 
-	closeDialog = type => {
+	closeDialog = () => {
 		this.recordEvent( 'calypso_purchases_cancel_form_close' );
 		this.setState( {
 			isDialogVisible: false,
 			surveyStep: INITIAL_STEP,
 			survey: initialSurveyState(),
 		} );
-
-		if ( 'remove' === type ) {
-			page( purchasesRoot );
-		}
 	};
 
 	chatInitiated = () => {

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -101,13 +101,17 @@ class RemovePurchase extends Component {
 		);
 	};
 
-	closeDialog = () => {
+	closeDialog = type => {
 		this.recordEvent( 'calypso_purchases_cancel_form_close' );
 		this.setState( {
 			isDialogVisible: false,
 			surveyStep: INITIAL_STEP,
 			survey: initialSurveyState(),
 		} );
+
+		if ( 'remove' === type ) {
+			page( purchasesRoot );
+		}
 	};
 
 	chatInitiated = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `Busy` button while G Suite Purchase is being removed
* Move remove purchase logic to G Suite Cancellation Dialog

![Screen Shot 2019-03-21 at 20 46 17](https://user-images.githubusercontent.com/2810519/54801768-aa873780-4c25-11e9-93c2-205185d0e2d3.png)

#### Testing instructions

1. Acquire G Suite Subscription
1. Navigate to `/me/purchases`
1. Select the G Suite Sub to remove
1. Click "Remove Purchase"
1. Click "Next Step"
1. Click "Remove Now"
1. Verify that button switches to busy state
1. Verify the G Suite Cancelation survey is shown, and that it is now disabled


1. Verify that when purchase is deleted success notice is displayed, the dialog closes, and you are redirected to the purchases root page