### PR TITLE
Lint fix: twitter-preview: Follow CSS namespace guidelines

### DIFF
--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -200,7 +200,7 @@
 	margin: 20px;
 }
 
-.twitter-card-preview__summary {
+.twitter-preview__summary {
 	width: 506px;
 	height: 125px;
 	margin: 0 auto;
@@ -209,7 +209,7 @@
 	border-radius: 0.42857em;
 }
 
-.twitter-card-preview__large_image_summary {
+.twitter-preview__large_image_summary {
 	width: 506px;
 	height: auto;
 	margin: 0 auto;
@@ -223,14 +223,14 @@
 	background-position: center;
 }
 
-.twitter-card-preview__summary
+.twitter-preview__summary
 .twitter-preview__image {
 	float: left;
 	width: 125px;
 	height: 125px;
 }
 
-.twitter-card-preview__large_image_summary
+.twitter-preview__large_image_summary
 .twitter-preview__image {
 	width: 506px;
 	height: 254px;
@@ -248,14 +248,14 @@
 	overflow: hidden;
 }
 
-.twitter-card-preview__summary
+.twitter-preview__summary
 .twitter-preview__body {
 	margin-left: 125px;
 	border-left: 1px solid #e1e8ed;
 	height: 100%;
 }
 
-.twitter-card-preview__large_image_summary
+.twitter-preview__large_image_summary
 .twitter-preview__body {
 	padding-left: 1em;
 	padding-right: 1em;

--- a/client/components/seo/style.scss
+++ b/client/components/seo/style.scss
@@ -193,7 +193,7 @@
 	}
 }
 
-.twitter-card-preview__container {
+.twitter-preview {
 	width: inherit;
 	overflow-x: auto;
 	-webkit-overflow-scrolling: touch;
@@ -218,26 +218,26 @@
 	border-radius: 0.42857em;
 }
 
-.twitter-card-preview__image {
+.twitter-preview__image {
 	background-size: cover;
 	background-position: center;
 }
 
 .twitter-card-preview__summary
-.twitter-card-preview__image {
+.twitter-preview__image {
 	float: left;
 	width: 125px;
 	height: 125px;
 }
 
 .twitter-card-preview__large_image_summary
-.twitter-card-preview__image {
+.twitter-preview__image {
 	width: 506px;
 	height: 254px;
 	border-bottom: 1px solid #e1e8ed;
 }
 
-.twitter-card-preview__body {
+.twitter-preview__body {
 	padding: 0.75em;
 	text-decoration: none;
 	font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -249,19 +249,19 @@
 }
 
 .twitter-card-preview__summary
-.twitter-card-preview__body {
+.twitter-preview__body {
 	margin-left: 125px;
 	border-left: 1px solid #e1e8ed;
 	height: 100%;
 }
 
 .twitter-card-preview__large_image_summary
-.twitter-card-preview__body {
+.twitter-preview__body {
 	padding-left: 1em;
 	padding-right: 1em;
 }
 
-.twitter-card-preview__title {
+.twitter-preview__title {
 	max-height: 1.3em;
 	white-space: nowrap;
 	font-weight: bold;
@@ -271,14 +271,14 @@
 	text-overflow: ellipsis;
 }
 
-.twitter-card-preview__description {
+.twitter-preview__description {
 	margin-top: 0.32333em;
 	max-height: 3.9em;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
-.twitter-card-preview__url {
+.twitter-preview__url {
 	text-transform: lowercase;
 	color: #8899a6;
 	max-height: 1.3em;

--- a/client/components/seo/twitter-preview/index.jsx
+++ b/client/components/seo/twitter-preview/index.jsx
@@ -22,7 +22,7 @@ export class TwitterPreview extends PureComponent {
 
 		return (
 			<div className="twitter-preview">
-				<div className={ `twitter-card-preview twitter-card-preview__${ type }` }>
+				<div className={ `twitter-preview__${ type }` }>
 					{ image && <div className="twitter-preview__image" style={ previewImageStyle } /> }
 					<div className="twitter-preview__body">
 						<div className="twitter-preview__title">{ title }</div>

--- a/client/components/seo/twitter-preview/index.jsx
+++ b/client/components/seo/twitter-preview/index.jsx
@@ -21,13 +21,13 @@ export class TwitterPreview extends PureComponent {
 		};
 
 		return (
-			<div className="twitter-card-preview__container">
+			<div className="twitter-preview">
 				<div className={ `twitter-card-preview twitter-card-preview__${ type }` }>
-					{ image && <div className="twitter-card-preview__image" style={ previewImageStyle } /> }
-					<div className="twitter-card-preview__body">
-						<div className="twitter-card-preview__title">{ title }</div>
-						<div className="twitter-card-preview__description">{ description }</div>
-						<div className="twitter-card-preview__url">{ baseDomain( url ) }</div>
+					{ image && <div className="twitter-preview__image" style={ previewImageStyle } /> }
+					<div className="twitter-preview__body">
+						<div className="twitter-preview__title">{ title }</div>
+						<div className="twitter-preview__description">{ description }</div>
+						<div className="twitter-preview__url">{ baseDomain( url ) }</div>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Related to https://github.com/Automattic/wp-calypso/issues/24504
- Update class names for `twitter-preview` component
- No functional changes

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Launch the live branch available below
- Visit `/settings/traffic/{site-domain}` (need a WordPress.com Business plan site)
- Fill up the front page meta description and click `Show previews`
- Try the Twitter preview
- Ensure search preview looks same as on `master` branch