### PR TITLE
Jetpack Connect: Add `data-e2e-slug` to user type cards

### DIFF
--- a/client/jetpack-connect/user-type/form.jsx
+++ b/client/jetpack-connect/user-type/form.jsx
@@ -60,6 +60,7 @@ class UserTypeForm extends Component {
 				className="user-type__option"
 				key={ userTypeProperties.id }
 				displayAsLink
+				data-e2e-slug={ userTypeProperties.slug }
 				tagName="button"
 				onClick={ this.handleSubmit.bind( this, userTypeProperties.slug ) }
 			>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `data-e2e-slug` attribute to UserType cards to be used by e2e tests

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through Jetpack connection. 
* On User Type step you should see  `data-e2e-slug` added to type Cards with correct values

Blocker for #31668