### PR TITLE
Memoize the last active discount.

### DIFF
--- a/client/state/selectors/get-active-discount.js
+++ b/client/state/selectors/get-active-discount.js
@@ -49,8 +49,6 @@ const composeActiveDiscount = memoizeLast( ( discount, activeVariation ) => ( {
 	...activeVariation,
 } ) );
 
-const NO_VARIATION = {};
-
 /**
  * Returns info whether the site is eligible for spring discount or not.
  *
@@ -58,14 +56,18 @@ const NO_VARIATION = {};
  * @return {Object|null}  Promo description
  */
 export default state => {
-	const discount = activeDiscounts.filter( p => isDiscountActive( p, state ) )[ 0 ];
+	const discount = activeDiscounts.find( p => isDiscountActive( p, state ) );
 	if ( ! discount ) {
 		return null;
 	}
 
 	const activeVariation = discount.variations
 		? discount.variations[ abtest( discount.abTestName ) ]
-		: NO_VARIATION;
+		: null;
+
+	if ( ! activeVariation ) {
+		return discount;
+	}
 
 	return composeActiveDiscount( discount, activeVariation );
 };

--- a/client/state/selectors/get-active-discount.js
+++ b/client/state/selectors/get-active-discount.js
@@ -9,6 +9,7 @@ import { planMatches } from 'lib/plans';
 import { hasActivePromotion } from 'state/active-promotions/selectors';
 import { getSitePlanSlug } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import memoizeLast from 'lib/memoize-last';
 
 export const isDiscountActive = ( discount, state ) => {
 	const now = new Date();
@@ -42,6 +43,14 @@ export const isDiscountActive = ( discount, state ) => {
 	return true;
 };
 
+// Some simple last value memoization to avoid constant re-renders.
+const composeActiveDiscount = memoizeLast( ( discount, activeVariation ) => ( {
+	...discount,
+	...activeVariation,
+} ) );
+
+const NO_VARIATION = {};
+
 /**
  * Returns info whether the site is eligible for spring discount or not.
  *
@@ -56,9 +65,7 @@ export default state => {
 
 	const activeVariation = discount.variations
 		? discount.variations[ abtest( discount.abTestName ) ]
-		: {};
-	return {
-		...discount,
-		...activeVariation,
-	};
+		: NO_VARIATION;
+
+	return composeActiveDiscount( discount, activeVariation );
 };


### PR DESCRIPTION
Lack of memoization in `getActiveDiscount` was causing the `SiteNotice` component to re-render needlessly at a high rate.

This PR adds simple last value memoization in the `getActiveDiscount` selector so that the previously returned value is reused if nothing's changed. Preserving the reference avoids a component re-render when nothing else has changed.

#### Changes proposed in this Pull Request

* Add simple last value memoization in the `getActiveDiscount` selector

#### Testing instructions

* Ensure that the active discount functionality correctly results in site notices being displayed.
