### PR TITLE
Update gutenberg tests to use regular page preview

### DIFF
--- a/test/e2e/lib/components/page-preview-component.js
+++ b/test/e2e/lib/components/page-preview-component.js
@@ -38,10 +38,8 @@ export default class PagePreviewComponent extends AsyncBaseContainer {
 
 	async close() {
 		await this.driver.switchTo().defaultContent();
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( 'button.web-preview__close' )
-		);
+		let closeButton = await this.driver.findElement( By.css( 'button.web-preview__close' ) );
+		return await this.driver.executeScript( 'arguments[0].click()', closeButton );
 	}
 
 	async edit() {

--- a/test/e2e/lib/components/post-preview-component.js
+++ b/test/e2e/lib/components/post-preview-component.js
@@ -56,10 +56,8 @@ export default class PostPreviewComponent extends AsyncBaseContainer {
 
 	async close() {
 		await this.driver.switchTo().defaultContent();
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( 'button.web-preview__close' )
-		);
+		let closeButton = await this.driver.findElement( By.css( 'button.web-preview__close' ) );
+		return await this.driver.executeScript( 'arguments[0].click()', closeButton );
 	}
 
 	static async switchToIFrame( driver ) {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -116,7 +116,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const nuxPopupSelector = By.css( '.nux-dot-tip' );
 		const nuxDisableSelector = By.css( '.nux-dot-tip__disable' );
 		if ( await driverHelper.isElementPresent( this.driver, nuxPopupSelector ) ) {
-			driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );
+			await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );
 		}
 	}
 

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -11,7 +11,7 @@ import NotFoundPage from '../lib/pages/not-found-page.js';
 import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
-import GutenbergPagePreviewComponent from '../lib/gutenberg/gutenberg-page-preview-component';
+import PagePreviewComponent from '../lib/components/page-preview-component';
 import SimplePaymentsBlockComponent from '../lib/gutenberg/blocks/payment-block-component';
 
 import * as driverManager from '../lib/driver-manager.js';
@@ -90,9 +90,9 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page title in preview', async function() {
-			const gPagePreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			await gPagePreviewComponent.displayed();
-			let actualPageTitle = await gPagePreviewComponent.pageTitle();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			await pagePreviewComponent.displayed();
+			let actualPageTitle = await pagePreviewComponent.pageTitle();
 			assert.strictEqual(
 				actualPageTitle.toUpperCase(),
 				pageTitle.toUpperCase(),
@@ -101,8 +101,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct page content in preview', async function() {
-			const gPagePreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			let content = await gPagePreviewComponent.pageContent();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			let content = await pagePreviewComponent.pageContent();
 			assert.strictEqual(
 				content.indexOf( pageQuote ) > -1,
 				true,
@@ -115,8 +115,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can see the image uploaded in the preview', async function() {
-			const gPagePreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			const imageDisplayed = await gPagePreviewComponent.imageDisplayed( fileDetails );
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			const imageDisplayed = await pagePreviewComponent.imageDisplayed( fileDetails );
 			return assert.strictEqual(
 				imageDisplayed,
 				true,
@@ -125,8 +125,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 		} );
 
 		step( 'Can close page preview', async function() {
-			const gPagePreviewComponent = await GutenbergPagePreviewComponent.Expect( driver );
-			await gPagePreviewComponent.close();
+			const pagePreviewComponent = await PagePreviewComponent.Expect( driver );
+			await pagePreviewComponent.close();
 		} );
 
 		step( 'Can publish and preview published content', async function() {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -14,7 +14,7 @@ import PaypalCheckoutPage from '../lib/pages/external/paypal-checkout-page';
 
 import SidebarComponent from '../lib/components/sidebar-component.js';
 import NavBarComponent from '../lib/components/nav-bar-component.js';
-import GutenbergPostPreviewComponent from '../lib/gutenberg/gutenberg-post-preview-component';
+import PostPreviewComponent from '../lib/components/post-preview-component';
 import GutenbergEditorComponent from '../lib/gutenberg/gutenberg-editor-component';
 import GutenbergEditorSidebarComponent from '../lib/gutenberg/gutenberg-editor-sidebar-component';
 import SimplePaymentsBlockComponent from '../lib/gutenberg/blocks/payment-block-component';
@@ -121,8 +121,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct post title in preview', async function() {
-			this.gPostPreviewComponent = await GutenbergPostPreviewComponent.Expect( driver );
-			let postTitle = await this.gPostPreviewComponent.postTitle();
+			this.postPreviewComponent = await PostPreviewComponent.Expect( driver );
+			let postTitle = await this.postPreviewComponent.postTitle();
 			assert.strictEqual(
 				postTitle.toLowerCase(),
 				blogPostTitle.toLowerCase(),
@@ -131,7 +131,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see correct post content in preview', async function() {
-			let content = await this.gPostPreviewComponent.postContent();
+			let content = await this.postPreviewComponent.postContent();
 			assert.strictEqual(
 				content.indexOf( blogPostQuote ) > -1,
 				true,
@@ -144,7 +144,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 
 		step( 'Can see the post category in preview', async function() {
-			let categoryDisplayed = await this.gPostPreviewComponent.categoryDisplayed();
+			let categoryDisplayed = await this.postPreviewComponent.categoryDisplayed();
 			assert.strictEqual(
 				categoryDisplayed.toUpperCase(),
 				newCategoryName.toUpperCase(),
@@ -163,12 +163,12 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		// } );
 
 		step( 'Can see the image in preview', async function() {
-			let imageDisplayed = await this.gPostPreviewComponent.imageDisplayed( fileDetails );
+			let imageDisplayed = await this.postPreviewComponent.imageDisplayed( fileDetails );
 			assert.strictEqual( imageDisplayed, true, 'Could not see the image in the web preview' );
 		} );
 
 		step( 'Can close post preview', async function() {
-			await this.gPostPreviewComponent.close();
+			await this.postPreviewComponent.close();
 		} );
 
 		step( 'Can publish and view content', async function() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This test was broken by https://github.com/Automattic/wp-calypso/pull/31610 where the preview for Gutenberg was changed. This changes switches over to using the regular preview.

#### Testing instructions
* Ensure full suite of tests pass in CircleCI. The tests broken were `Calypso Gutenberg Editor: Posts (mobile) Public Posts: Preview and Publish a Public Post` and `Calypso Gutenberg Editor: Pages (mobile) Public Pages`
