### PR TITLE
Build: Run distclean on stale installs

### DIFF
--- a/bin/install-if-deps-outdated.js
+++ b/bin/install-if-deps-outdated.js
@@ -45,11 +45,21 @@ if ( needsInstall() ) {
 }
 
 function install() {
+	// run a distclean to clean things up. just ci is not enough with the monorepo.
+	const cleanResult = spawnSync( 'npm', [ 'run', 'distclean' ], {
+		shell: true,
+		stdio: 'inherit',
+	} );
+	if ( cleanResult.status ) {
+		console.error( 'failed to clean: %o', cleanResult );
+		process.exit( cleanResult );
+	}
 	const installResult = spawnSync( 'npm', [ 'ci' ], {
 		shell: true,
 		stdio: 'inherit',
 	} ).status;
-	if ( installResult ) {
+	if ( installResult.status ) {
+		console.error( 'failed to install: %o', installResult );
 		process.exit( installResult );
 	}
 	const touchDate = new Date();

--- a/bin/install-if-deps-outdated.js
+++ b/bin/install-if-deps-outdated.js
@@ -52,7 +52,7 @@ function install() {
 	} );
 	if ( cleanResult.status ) {
 		console.error( 'failed to clean: %o', cleanResult );
-		process.exit( cleanResult );
+		process.exit( cleanResult.status );
 	}
 	const installResult = spawnSync( 'npm', [ 'ci' ], {
 		shell: true,
@@ -60,7 +60,7 @@ function install() {
 	} ).status;
 	if ( installResult.status ) {
 		console.error( 'failed to install: %o', installResult );
-		process.exit( installResult );
+		process.exit( installResult.status );
 	}
 	const touchDate = new Date();
 

--- a/bin/install-if-no-packages.js
+++ b/bin/install-if-no-packages.js
@@ -7,7 +7,8 @@ if ( ! fs.existsSync( 'node_modules' ) ) {
 		shell: true,
 		stdio: 'inherit',
 	} ).status;
-	if ( installResult ) {
-		process.exit( installResult );
+	if ( installResult.status ) {
+		console.error( 'Failed install: %o', installResult );
+		process.exit( installResult.status );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Run a `npm run distclean` when installing due to stale deps
* Fix up how we process the return value of `spawnSync`. It's an object, not a plain integer.

#### Testing instructions

* `npm run install-if-deps-outdated` <-- may run a distclean, may not
* `touch -A -990000 node_modules`
* `npm run install-if-deps-outdated` <-- definitely will run a distclean, then an install

