### PR TITLE
Remove Babel polyfill from Slideshow block

### DIFF
--- a/packages/jetpack-blocks/src/blocks/slideshow/create-swiper.js
+++ b/packages/jetpack-blocks/src/blocks/slideshow/create-swiper.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { mapValues, merge } from 'lodash';
-import '@babel/polyfill';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Partly resolves https://github.com/Automattic/wp-calypso/issues/31689

Initially, I thought we could remove this dependency when we move blocks to Jetpack, but @jsnajdr is upgrading Babel setup in Calypso and this method of polyfilling is being deprecated.

#### Changes proposed in this Pull Request

*

#### Testing instructions

- Build blocks:
   ```
    npm ci
    npx lerna bootstrap --concurrency=2 --scope='@automattic/jetpack-blocks'
    npx lerna run build --stream --scope='@automattic/jetpack-blocks' -- -- --output-path /path/to/jetpack/_inc/blocks/ --watch
   ```
- Apply https://github.com/Automattic/jetpack/pull/11657 in Jetpack
- Add Slideshow block in the editor (don't add any other blocks to mess up results)
- Open the page with the block
- Note from networks tab how wp-polyfill loads
- Block works in IE11

