### PR TITLE
Fix possible race conditions with localized-moment.

### DIFF
--- a/client/components/localized-moment/context.js
+++ b/client/components/localized-moment/context.js
@@ -21,11 +21,11 @@ const MomentContext = React.createContext( moment );
 class MomentProvider extends React.Component {
 	state = { moment, momentLocale: moment.locale() };
 
-	async checkAndLoad() {
+	async checkAndLoad( previousLocale ) {
 		const { currentLocale } = this.props;
 
 		// has the requested locale changed?
-		if ( currentLocale === this.state.momentLocale ) {
+		if ( currentLocale === previousLocale ) {
 			return;
 		}
 
@@ -45,18 +45,22 @@ class MomentProvider extends React.Component {
 			debug( 'Loaded moment locale for %s', currentLocale );
 		}
 
-		if ( moment.locale() !== currentLocale ) {
-			moment.locale( currentLocale );
+		// Since this is an async function that may await on a dynamic import,
+		// we need to check if the props haven't changed in the meantime.
+		if ( currentLocale === this.props.currentLocale ) {
+			if ( moment.locale() !== currentLocale ) {
+				moment.locale( currentLocale );
+			}
+			this.setState( { momentLocale: currentLocale } );
 		}
-		this.setState( { momentLocale: currentLocale } );
 	}
 
 	componentDidMount() {
-		this.checkAndLoad();
+		this.checkAndLoad( moment.locale() );
 	}
 
-	componentDidUpdate() {
-		this.checkAndLoad();
+	componentDidUpdate( prevProps ) {
+		this.checkAndLoad( prevProps.currentLocale );
 	}
 
 	render() {


### PR DESCRIPTION
Fix possible race conditions with `localized-moment`, following review by @jsnajdr in #31645.

#### Changes proposed in this Pull Request

* Revert to previous state management logic
* Add check to ensure out-of-order import responses don't lead to a race condition.

#### Testing instructions

* Use Calypso with a non-`en` locale. Ensure dates are displayed in the correct locale.
