### PR TITLE
Settings: adjust Publish confirmation for Gutenberg enabled sites

### DIFF
--- a/client/my-sites/site-settings/composing/publish-confirmation.jsx
+++ b/client/my-sites/site-settings/composing/publish-confirmation.jsx
@@ -54,8 +54,9 @@ class PublishConfirmation extends Component {
 					<FormLabel>{ translate( 'Show publish confirmation' ) }</FormLabel>
 					<FormSettingExplanation isIndented>
 						{ translate(
-							'Publish confirmation setting is now handled by the Block Editor. ' +
-								"You can access it by opening the Options item in Editor's ellipsis menu."
+							'The Block Editor handles the Publish confirmation setting. ' +
+								'To enable it, go to Options under the Ellipses menu in the Editor ' +
+								'and check "Enable Pre-publish checks."'
 						) }
 					</FormSettingExplanation>
 				</FormFieldset>

--- a/client/my-sites/site-settings/composing/publish-confirmation.jsx
+++ b/client/my-sites/site-settings/composing/publish-confirmation.jsx
@@ -54,11 +54,8 @@ class PublishConfirmation extends Component {
 					<FormLabel>{ translate( 'Show publish confirmation' ) }</FormLabel>
 					<FormSettingExplanation isIndented>
 						{ translate(
-							'The confirmation step for double-checking your content before publishing ' +
-								'now is handled by the new block editor.' +
-								'To show the publish confirmation with the block editor, ' +
-								'click the editor menu, then "Options", ' +
-								'and check "Enable Pre-publish Checks".'
+							'Publish confirmation setting is now handled by the Block Editor. ' +
+								"You can access it by opening the Options item in Editor's ellipsis menu."
 						) }
 					</FormSettingExplanation>
 				</FormFieldset>

--- a/client/my-sites/site-settings/composing/publish-confirmation.jsx
+++ b/client/my-sites/site-settings/composing/publish-confirmation.jsx
@@ -15,12 +15,15 @@ import { bindActionCreators } from 'redux';
  */
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import QueryPreferences from 'components/data/query-preferences';
 import { isFetchingPreferences } from 'state/preferences/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isConfirmationSidebarEnabled } from 'state/ui/editor/selectors';
 import { saveConfirmationSidebarPreference } from 'state/ui/editor/actions';
+import { isGutenbergEnabled } from 'state/selectors/is-gutenberg-enabled';
+import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 
 class PublishConfirmation extends Component {
 	constructor( props ) {
@@ -43,7 +46,24 @@ class PublishConfirmation extends Component {
 	}
 
 	render() {
-		const { fetchingPreferences, translate } = this.props;
+		const { fetchingPreferences, translate, showPublishFlow } = this.props;
+
+		if ( showPublishFlow ) {
+			return (
+				<FormFieldset>
+					<FormLabel>{ translate( 'Show publish confirmation' ) }</FormLabel>
+					<FormSettingExplanation isIndented>
+						{ translate(
+							'The confirmation step for double-checking your content before publishing ' +
+								'now is handled by the new block editor.' +
+								'To show the publish confirmation with the block editor, ' +
+								'click the editor menu, then "Options", ' +
+								'and check "Enable Pre-publish Checks".'
+						) }
+					</FormSettingExplanation>
+				</FormFieldset>
+			);
+		}
 
 		return (
 			<FormFieldset className="composing__publish-confirmation has-divider is-bottom-only">
@@ -87,6 +107,8 @@ export default connect(
 			siteId,
 			fetchingPreferences: isFetchingPreferences( state ),
 			publishConfirmationEnabled: isConfirmationSidebarEnabled( state, siteId ),
+			showPublishFlow:
+				isGutenbergEnabled( state, siteId ) && getSelectedEditor( state, siteId ) === 'gutenberg',
 		};
 	},
 	dispatch => {


### PR DESCRIPTION
It replaces the "Show publish confirmation" toggle option from the `Settings/Writing` with an informative text whether the current editor of the site is the Block Editor, delegating the control of this feature to the editor.

Fixes #29627 


## Testing

### Classic Editor

If the Classic editor is the current one, the Settings/Writing page should show:

<img src="https://user-images.githubusercontent.com/77539/54942396-c46a9800-4f0d-11e9-9587-64762fc25686.png" width="600px" />

and when the post is going to be published it should show the following advice:

<img src="https://user-images.githubusercontent.com/77539/54942513-01cf2580-4f0e-11e9-9f96-714e0f41d31c.png" width="300px" />

### Block Editor

If the Block Editor is activated, the Settings/Writing page should show just a message:

![image](https://user-images.githubusercontent.com/77539/54942733-773af600-4f0e-11e9-89b4-6cb2965e815c.png)

_(Adding `Needs Design Review` and `Needs Copy Review` )

So now when it's going to be published the Block editor will take over of warning to customers:

<img src="https://user-images.githubusercontent.com/77539/54943010-2081ec00-4f0f-11e9-8121-136b70dbba73.png" width="300px" />