### PR TITLE
Try adding a basic landing page without redux

### DIFF
--- a/client/document/landingSample.jsx
+++ b/client/document/landingSample.jsx
@@ -5,20 +5,65 @@
  */
 
 import React from 'react';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import Head from 'components/head';
+import getStylesheet from './utils/stylesheet';
 
-function LandingSample( { urls, faviconURL } ) {
+const cssChunkLink = asset => (
+	<link key={ asset } rel="stylesheet" type="text/css" data-webpack={ true } href={ asset } />
+);
+
+function LandingSample( {
+	branchName,
+	inlineScriptNonce,
+	isDebug,
+	env,
+	entrypoint,
+	head,
+	i18nLocaleScript,
+	isRTL,
+	lang,
+	manifest,
+	urls,
+	faviconURL,
+} ) {
+	const csskey = isRTL ? 'css.rtl' : 'css.ltr';
 	return (
-		<html lang="en">
-			<Head faviconURL={ faviconURL } cdn={ '//s1.wp.com' }>
-				<link rel="stylesheet" id="main-css" href={ urls[ 'style.css' ] } type="text/css" />
+		<html lang={ lang } dir={ isRTL ? 'rtl' : 'ltr' }>
+			<Head
+				title={ head.title }
+				faviconURL={ faviconURL }
+				cdn={ '//s1.wp.com' }
+				branchName={ branchName }
+				inlineScriptNonce={ inlineScriptNonce }
+			>
+				{ head.metas.map( ( props, index ) => (
+					<meta { ...props } key={ index } />
+				) ) }
+				{ head.links.map( ( props, index ) => (
+					<link { ...props } key={ index } />
+				) ) }
+
+				<link
+					rel="stylesheet"
+					id="main-css"
+					href={
+						urls[ getStylesheet( { rtl: !! isRTL, debug: isDebug || env === 'development' } ) ]
+					}
+					type="text/css"
+				/>
+				{ entrypoint[ csskey ].map( cssChunkLink ) }
 			</Head>
-			<body>
-				{ /* eslint-disable wpcalypso/jsx-classname-namespace*/ }
+			<body
+				className={ classnames( {
+					rtl: isRTL,
+				} ) }
+			>
+				{ /* eslint-disable wpcalypso/jsx-classname-namespace, react/no-danger */ }
 				<div id="wpcom" className="wpcom-site">
 					<div className="wp has-no-sidebar">
 						<div className="layout__content" id="content">
@@ -28,6 +73,59 @@ function LandingSample( { urls, faviconURL } ) {
 						</div>
 					</div>
 				</div>
+				{ i18nLocaleScript && <script src={ i18nLocaleScript } /> }
+				{ /*
+				 * inline manifest in production, but reference by url for development.
+				 * this lets us have the performance benefit in prod, without breaking HMR in dev
+				 * since the manifest needs to be updated on each save
+				 */ }
+				{ env === 'development' && <script src="/calypso/manifest.js" /> }
+				{ env !== 'development' && (
+					<script
+						nonce={ inlineScriptNonce }
+						dangerouslySetInnerHTML={ {
+							__html: manifest,
+						} }
+					/>
+				) }
+				{ entrypoint.js.map( asset => (
+					<script key={ asset } src={ asset } />
+				) ) }
+				<script
+					nonce={ inlineScriptNonce }
+					dangerouslySetInnerHTML={ {
+						__html: `
+						 (function() {
+							if ( window.console && window.configData && 'development' !== window.configData.env ) {
+								console.log( "%cSTOP!", "color:#f00;font-size:xx-large" );
+								console.log(
+									"%cWait! This browser feature runs code that can alter your website or its security, " +
+									"and is intended for developers. If you've been told to copy and paste something here " +
+									"to enable a feature, someone may be trying to compromise your account. Please make " +
+									"sure you understand the code and trust the source before adding anything here.",
+									"font-size:large;"
+								);
+							}
+						})();
+						 `,
+					} }
+				/>
+				<script
+					nonce={ inlineScriptNonce }
+					dangerouslySetInnerHTML={ {
+						__html: `
+							if ('serviceWorker' in navigator) {
+								window.addEventListener('load', function() {
+									navigator.serviceWorker.register('/service-worker.js');
+								});
+							}
+						 `,
+					} }
+				/>
+				<noscript className="wpcom-site__global-noscript">
+					Please enable JavaScript in your browser to enjoy WordPress.com.
+				</noscript>
+				{ /* eslint-enable wpcalypso/jsx-classname-namespace, react/no-danger */ }
 				{ /* eslint-enable wpcalypso/jsx-classname-namespace*/ }
 			</body>
 		</html>

--- a/client/document/landingSample.jsx
+++ b/client/document/landingSample.jsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ *
+ * @format
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Head from 'components/head';
+
+function LandingSample( { urls, faviconURL } ) {
+	return (
+		<html lang="en">
+			<Head faviconURL={ faviconURL } cdn={ '//s1.wp.com' }>
+				<link rel="stylesheet" id="main-css" href={ urls[ 'style.css' ] } type="text/css" />
+			</Head>
+			<body>
+				{ /* eslint-disable wpcalypso/jsx-classname-namespace*/ }
+				<div id="wpcom" className="wpcom-site">
+					<div className="wp has-no-sidebar">
+						<div className="layout__content" id="content">
+							<div className="layout__primary" id="primary">
+								Oh look, a landing page.
+							</div>
+						</div>
+					</div>
+				</div>
+				{ /* eslint-enable wpcalypso/jsx-classname-namespace*/ }
+			</body>
+		</html>
+	);
+}
+
+export default LandingSample;

--- a/client/landing/sample/index.js
+++ b/client/landing/sample/index.js
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import RenderDom from 'react-dom';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+/**
+ *
+ * Style dependencies
+ */
+import './style.scss';
+
+function LandingPage() {
+	return (
+		<div>
+			<h1 class="heading">Welcome to the landing page</h1>
+			<p class="greeting">
+				Would you like to proceed? <Button>Yes</Button>
+			</p>
+		</div>
+	);
+}
+
+/**
+ * Default export. Boots up the landing page.
+ */
+function boot() {
+	RenderDom.render( <LandingPage />, document.getElementById( 'primary' ) );
+}
+
+boot();

--- a/client/landing/sample/style.scss
+++ b/client/landing/sample/style.scss
@@ -1,0 +1,8 @@
+.heading {
+  font-size: 96px;
+  margin: 32px 0;
+}
+
+.greeting {
+  color: var( --color-text );
+}

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -706,6 +706,12 @@ module.exports = function() {
 		res.redirect( redirectUrl );
 	} );
 
+	app.get( '/landing/sample', function( req, res ) {
+		const ctx = getDefaultContext( req );
+		const pageHtml = renderJsx( 'landingSample', ctx );
+		res.send( pageHtml );
+	} );
+
 	sections
 		.filter( section => ! section.envId || section.envId.indexOf( config( 'env_id' ) ) > -1 )
 		.forEach( section => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -114,7 +114,10 @@ function getWebpackConfig( {
 	const webpackConfig = {
 		bail: ! isDevelopment,
 		context: __dirname,
-		entry: { build: [ path.join( __dirname, 'client', 'boot', 'app' ) ] },
+		entry: {
+			build: [ path.join( __dirname, 'client', 'boot', 'app' ) ],
+			landingSample: [ path.join( __dirname, 'client', 'landing', 'sample' ) ],
+		},
 		mode: isDevelopment ? 'development' : 'production',
 		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
 		output: {


### PR DESCRIPTION
This is a bit of an experiment to add a new entry point into Calypso that doesn't use the normal client/boot/app entry point. Avoiding client/boot/app also avoids all of the transitive dependencies, like redux, the reducer tree, various bits and bobbles from the masterbar and site-selector, abtests, etc, while still using the same webpack build. This may be ideal for logged out landing pages that have very basic data and framework requirements, and may also be a good fit for login and maybe signup. According to ICFY, this setup has a 40k overhead for a very basic react-driven landing page. 

i18n is still an issue though, we still have to load the entire calypso translation set (100k+) for non-EN locales. 

#### Changes proposed in this Pull Request

* Add a landing page that can render react components with translations, but no redux

#### Testing instructions

* Spin this up
* hit /landing/sample
* Enjoy
