### PR TITLE
Switch Email and Domain Management Email Paths

### DIFF
--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -15,6 +15,7 @@ import Gridicon from 'gridicons';
 import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import Card from 'components/card';
+import { emailManagement } from 'my-sites/email/paths';
 import isGSuiteStatsNudgeDismissed from 'state/selectors/is-gsuite-stats-nudge-dismissed';
 import QueryPreferences from 'components/data/query-preferences';
 import SectionHeader from 'components/section-header';
@@ -94,7 +95,7 @@ class GSuiteStatsNudge extends Component {
 
 	render() {
 		const { domainSlug, siteSlug, translate } = this.props;
-		const url = '/domains/manage/email/' + siteSlug;
+		const url = emailManagement( siteSlug );
 
 		if ( ! this.isVisible() ) {
 			return null;

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -409,9 +409,11 @@ class SiteSelector extends Component {
 				onMouseLeave={ this.onMouseLeave }
 			>
 				<Search
+					// eslint-disable-next-line react/no-string-refs
 					ref="siteSearch"
 					onSearch={ this.onSearch }
 					delaySearch={ true }
+					// eslint-disable-next-line jsx-a11y/no-autofocus
 					autoFocus={ this.props.autoFocus }
 					disabled={ ! this.props.hasLoadedSites }
 					onSearchClose={ this.props.onClose }
@@ -493,6 +495,10 @@ const navigateToSite = ( siteId, { allSitesPath, allSitesSingleUser, siteBasePat
 
 		if ( path.match( /^\/domains\/manage\// ) ) {
 			path = '/domains/manage';
+		}
+
+		if ( path.match( /^\/email\// ) ) {
+			path = '/email';
 		}
 
 		if ( path.match( /^\/store\/stats\// ) ) {

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -44,6 +44,7 @@ import {
 	setChecklistPromptStep,
 } from 'state/inline-help/actions';
 import getEditorUrl from 'state/selectors/get-editor-url';
+import { emailManagement } from 'my-sites/email/paths';
 
 const userLib = userFactory();
 
@@ -625,7 +626,7 @@ class WpcomChecklistComponent extends PureComponent {
 			: {
 					onClick: () => {
 						this.trackTaskStart( task );
-						page( `/domains/manage/email/${ siteSlug }` );
+						page( emailManagement( siteSlug ) );
 					},
 					onDismiss: this.handleTaskDismiss( task.id ),
 			  };
@@ -662,7 +663,7 @@ class WpcomChecklistComponent extends PureComponent {
 							link: (
 								<a
 									onClick={ () => this.trackTaskStart( task, { clicked_element: 'hyperlink' } ) }
-									href={ `/domains/manage/email/${ siteSlug }` }
+									href={ emailManagement( siteSlug ) }
 								/>
 							),
 						},
@@ -671,7 +672,7 @@ class WpcomChecklistComponent extends PureComponent {
 				completedButtonText={ translate( 'Upgrade' ) }
 				onClick={ () => {
 					this.trackTaskStart( task, { clicked_element: 'button' } );
-					page( `/domains/manage/email/${ siteSlug }` );
+					page( emailManagement( siteSlug ) );
 				} }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 			/>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -78,11 +78,8 @@ import RebrandCitiesThankYou from './rebrand-cities-thank-you';
 import SiteRedirectDetails from './site-redirect-details';
 import Notice from 'components/notice';
 import ThankYouCard from 'components/thank-you-card';
-import {
-	domainManagementEmail,
-	domainManagementList,
-	domainManagementTransferInPrecheck,
-} from 'my-sites/domains/paths';
+import { domainManagementList, domainManagementTransferInPrecheck } from 'my-sites/domains/paths';
+import { emailManagement } from 'my-sites/email/paths';
 import config from 'config';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isRebrandCitiesSiteUrl } from 'lib/rebrand-cities';
@@ -288,7 +285,7 @@ export class CheckoutThankYou extends React.Component {
 			} else if ( purchases.some( isGoogleApps ) ) {
 				const purchase = find( purchases, isGoogleApps );
 
-				return page( domainManagementEmail( this.props.selectedSite.slug, purchase.meta ) );
+				return page( emailManagement( this.props.selectedSite.slug, purchase.meta ) );
 			}
 		}
 

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -413,7 +413,7 @@ export class CheckoutThankYou extends React.Component {
 					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					{ this.renderConfirmationNotice() }
 					{ this.renderVerifiedEmailRequired() }
-					<AtomicStoreThankYou siteId={ this.props.selectedSite.ID } />
+					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
 			);
 		} else if ( wasDotcomPlanPurchased && ( delayedTransferPurchase || this.isNewUser() ) ) {

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -413,13 +413,7 @@ export class CheckoutThankYou extends React.Component {
 					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
 					{ this.renderConfirmationNotice() }
 					{ this.renderVerifiedEmailRequired() }
-					<AtomicStore
-            
-            
-            
-            
-            
-            siteId={ this.props.selectedSite.ID } />
+					<AtomicStoreThankYou siteId={ this.props.selectedSite.ID } />
 				</Main>
 			);
 		} else if ( wasDotcomPlanPurchased && ( delayedTransferPurchase || this.isNewUser() ) ) {

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -36,13 +36,10 @@ import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import canCurrentUser from 'state/selectors/can-current-user';
 import {
-	domainManagementAddGSuiteUsers,
 	domainManagementContactsPrivacy,
 	domainManagementDns,
 	domainManagementEdit,
 	domainManagementEditContactInfo,
-	domainManagementEmail,
-	domainManagementEmailForwarding,
 	domainManagementList,
 	domainManagementNameServers,
 	domainManagementRedirectSettings,
@@ -50,6 +47,11 @@ import {
 	domainManagementTransferOut,
 	domainManagementTransferToOtherSite,
 } from 'my-sites/domains/paths';
+import {
+	emailManagement,
+	emailManagementForwarding,
+	emailManagementAddGSuiteUsers,
+} from 'my-sites/email/paths';
 import SitesComponent from 'my-sites/sites';
 import { warningNotice } from 'state/notices/actions';
 import { makeLayout, render as clientRender } from 'controller';
@@ -158,19 +160,19 @@ function renderSelectedSiteIsDomainOnly( reactContext, selectedSite ) {
 
 function isPathAllowedForDomainOnlySite( path, slug, primaryDomain ) {
 	const allPaths = [
-		domainManagementAddGSuiteUsers,
 		domainManagementContactsPrivacy,
 		domainManagementDns,
 		domainManagementEdit,
 		domainManagementEditContactInfo,
-		domainManagementEmail,
-		domainManagementEmailForwarding,
 		domainManagementList,
 		domainManagementNameServers,
 		domainManagementRedirectSettings,
 		domainManagementTransfer,
 		domainManagementTransferOut,
 		domainManagementTransferToOtherSite,
+		emailManagement,
+		emailManagementAddGSuiteUsers,
+		emailManagementForwarding,
 	];
 
 	let domainManagementPaths = allPaths.map( pathFactory => pathFactory( slug, slug ) );

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
-import { domainManagementEmail } from 'my-sites/domains/paths';
+import { emailManagement } from 'my-sites/email/paths';
 import PendingGSuiteTosNoticeAction from './pending-gsuite-tos-notice-action';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
@@ -91,8 +91,8 @@ class PendingGSuiteTosNotice extends React.PureComponent {
 		const severity = this.getNoticeSeverity();
 		const href =
 			this.props.domains.length === 1
-				? domainManagementEmail( this.props.siteSlug, this.props.domains[ 0 ].name )
-				: domainManagementEmail( this.props.siteSlug );
+				? emailManagement( this.props.siteSlug, this.props.domains[ 0 ].name )
+				: emailManagement( this.props.siteSlug );
 
 		return (
 			<Notice

--- a/client/my-sites/domains/domain-management/README.md
+++ b/client/my-sites/domains/domain-management/README.md
@@ -6,13 +6,10 @@ Supported routes:
 
 - `/domains/manage` - entry point for domains management
 - `/domains/manage/:site` - lists domains for a site
-- `/domains/manage/:site/add-gsuite-users` - adds G Suite for a site
-- `/domains/manage/:domain/add-gsuite-users/:site` - adds G Suite for a domain
 - `/domains/manage/:domain/contacts-privacy/:site` - displays contacts and privacy information for a domain
 - `/domains/manage/:domain/dns/:site` - manages DNS records for a domain
 - `/domains/manage/:domain/edit/:site` - displays domain details
 - `/domains/manage/:domain/edit-contact-info/:site` - manages contact information for a domain
-- `/domains/manage/:domain/email-forwarding/:site` - manages email forwarding information for a domain
 - `/domains/manage/:domain/name-servers/:site` - manages name servers for a domain
 - `/domains/manage/:domain/primary-domain/:site` - changes primary domain for a site
 - `/domains/manage/:domain/redirect-settings/:site` - changes redirect settings for a domain

--- a/client/my-sites/domains/domain-management/controller.jsx
+++ b/client/my-sites/domains/domain-management/controller.jsx
@@ -17,7 +17,6 @@ import {
 	domainManagementDns,
 	domainManagementEdit,
 	domainManagementEditContactInfo,
-	domainManagementEmail,
 	domainManagementList,
 	domainManagementNameServers,
 	domainManagementPrimaryDomain,
@@ -30,10 +29,12 @@ import {
 	domainManagementManageConsent,
 	domainManagementDomainConnectMapping,
 } from 'my-sites/domains/paths';
-import EmailForwarding from 'my-sites/email/email-forwarding';
-import EmailManagement from 'my-sites/email/email-management';
+import {
+	emailManagement,
+	emailManagementAddGSuiteUsers,
+	emailManagementForwarding,
+} from 'my-sites/email/paths';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import GSuiteAddUsers from 'my-sites/email/gsuite-add-users';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { decodeURIComponentIfValid } from 'lib/url';
 
@@ -146,29 +147,14 @@ export default {
 		next();
 	},
 
-	domainManagementEmail( pageContext, next ) {
-		pageContext.primary = (
-			<DomainManagementData
-				analyticsPath={ domainManagementEmail(
-					':site',
-					pageContext.params.domain ? ':domain' : undefined
-				) }
-				analyticsTitle="Domain Management > Email"
-				component={ EmailManagement }
-				context={ pageContext }
-				needsCart
-				needsDomains
-				needsPlans
-				needsProductsList
-				selectedDomainName={ pageContext.params.domain }
-			/>
-		);
-		next();
+	domainManagementEmailRedirect( pageContext ) {
+		page.redirect( emailManagement( pageContext.params.site, pageContext.params.domain ) );
 	},
 
-	domainManagementEmailForwarding( pageContext, next ) {
-		pageContext.primary = <EmailForwarding selectedDomainName={ pageContext.params.domain } />;
-		next();
+	domainManagementEmailForwardingRedirect( pageContext ) {
+		page.redirect(
+			emailManagementForwarding( pageContext.params.site, pageContext.params.domain )
+		);
 	},
 
 	domainManagementDns( pageContext, next ) {
@@ -215,9 +201,10 @@ export default {
 		next();
 	},
 
-	domainManagementAddGSuiteUsers( pageContext, next ) {
-		pageContext.primary = <GSuiteAddUsers selectedDomainName={ pageContext.params.domain } />;
-		next();
+	domainManagementAddGSuiteUsersRedirect( pageContext ) {
+		page.redirect(
+			emailManagementAddGSuiteUsers( pageContext.params.site, pageContext.params.domain )
+		);
 	},
 
 	domainManagementRedirectSettings( pageContext, next ) {

--- a/client/my-sites/domains/domain-management/dns/delete-email-forwards-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/delete-email-forwards-dialog.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
-import { domainManagementEmailForwarding } from 'my-sites/domains/paths';
+import { emailManagementForwarding } from 'my-sites/email/paths';
 
 class DeleteEmailForwardsDialog extends React.Component {
 	static propTypes = {
@@ -51,7 +51,7 @@ class DeleteEmailForwardsDialog extends React.Component {
 				isVisible={ visible }
 				buttons={ buttons }
 				onClose={ this.close }
-				className="cancel-purchase-button__warning-dialog"
+				className="cancel-purchase-button__warning-dialog" // eslint-disable-line wpcalypso/jsx-classname-namespace
 			>
 				<h1>{ translate( 'Are you sure?' ) }</h1>
 				<p>
@@ -72,10 +72,7 @@ class DeleteEmailForwardsDialog extends React.Component {
 	}
 
 	getEmailForwardingPath() {
-		return domainManagementEmailForwarding(
-			this.props.selectedSite.slug,
-			this.props.selectedDomainName
-		);
+		return emailManagementForwarding( this.props.selectedSite.slug, this.props.selectedDomainName );
 	}
 }
 

--- a/client/my-sites/domains/domain-management/edit/mapped-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/mapped-domain.jsx
@@ -17,12 +17,10 @@ import SubscriptionSettings from './card/subscription-settings';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 import DomainWarnings from 'my-sites/domains/components/domain-warnings';
-import {
-	domainManagementDns,
-	domainManagementEmail,
-	domainManagementDomainConnectMapping,
-} from 'my-sites/domains/paths';
+import { domainManagementDns, domainManagementDomainConnectMapping } from 'my-sites/domains/paths';
+import { emailManagement } from 'my-sites/email/paths';
 
+// eslint-disable-next-line react/prefer-es6-class
 const MappedDomain = createReactClass( {
 	displayName: 'MappedDomain',
 	mixins: [ analyticsMixin( 'domainManagement', 'edit' ) ],
@@ -91,6 +89,7 @@ const MappedDomain = createReactClass( {
 		const { domain, selectedSite, translate } = this.props;
 
 		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<div className="domain-details-card">
 				<Header { ...this.props } />
 
@@ -123,7 +122,7 @@ const MappedDomain = createReactClass( {
 	},
 
 	emailNavItem() {
-		const path = domainManagementEmail( this.props.selectedSite.slug, this.props.domain.name );
+		const path = emailManagement( this.props.selectedSite.slug, this.props.domain.name );
 
 		return <VerticalNavItem path={ path }>{ this.props.translate( 'Email' ) }</VerticalNavItem>;
 	},

--- a/client/my-sites/domains/domain-management/edit/registered-domain.jsx
+++ b/client/my-sites/domains/domain-management/edit/registered-domain.jsx
@@ -16,10 +16,10 @@ import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import Header from './card/header';
 import {
 	domainManagementContactsPrivacy,
-	domainManagementEmail,
 	domainManagementNameServers,
 	domainManagementTransfer,
 } from 'my-sites/domains/paths';
+import { emailManagement } from 'my-sites/email/paths';
 import { disablePrivacyProtection, enablePrivacyProtection } from 'lib/upgrades/actions';
 import { errorNotice, successNotice } from 'state/notices/actions';
 import { togglePrivacy } from 'state/sites/domains/actions';
@@ -172,7 +172,7 @@ class RegisteredDomain extends React.Component {
 	}
 
 	emailNavItem() {
-		const path = domainManagementEmail( this.props.selectedSite.slug, this.props.domain.name );
+		const path = emailManagement( this.props.selectedSite.slug, this.props.domain.name );
 
 		return <VerticalNavItem path={ path }>{ this.props.translate( 'Email' ) }</VerticalNavItem>;
 	}

--- a/client/my-sites/domains/domain-management/edit/test/mapped-domain.js
+++ b/client/my-sites/domains/domain-management/edit/test/mapped-domain.js
@@ -44,9 +44,10 @@ describe( 'mapped-domain', () => {
 	} );
 
 	test( 'should use selectedSite.slug for URLs', () => {
-		const paths = require( 'my-sites/domains/paths' );
-		const dnsStub = sinon.stub( paths, 'domainManagementDns' );
-		const emailStub = sinon.stub( paths, 'domainManagementEmail' );
+		const domainPaths = require( 'my-sites/domains/paths' );
+		const dnsStub = sinon.stub( domainPaths, 'domainManagementDns' );
+		const emailPaths = require( 'my-sites/email/paths' );
+		const emailStub = sinon.stub( emailPaths, 'emailManagement' );
 
 		const renderer = new ShallowRenderer();
 		renderer.render( <MappedDomain { ...props } /> );

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -44,10 +44,9 @@ export default function() {
 	page.redirect( '/domains/manage/edit', paths.domainManagementRoot() );
 	page.redirect( '/domains/manage/edit/:site', paths.domainManagementRoot() );
 
-	page( paths.domainManagementEmail(), domainManagementController.domainManagementEmailRedirect );
-
 	registerMultiPage( {
 		paths: [
+			paths.domainManagementEmail(),
 			paths.domainManagementEmail( ':site', ':domain' ),
 			paths.domainManagementEmail( ':site' ),
 		],

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -44,19 +44,14 @@ export default function() {
 	page.redirect( '/domains/manage/edit', paths.domainManagementRoot() );
 	page.redirect( '/domains/manage/edit/:site', paths.domainManagementRoot() );
 
-	page( paths.domainManagementEmail(), siteSelection, sites, makeLayout, clientRender );
+	page( paths.domainManagementEmail(), domainManagementController.domainManagementEmailRedirect );
 
 	registerMultiPage( {
 		paths: [
 			paths.domainManagementEmail( ':site', ':domain' ),
 			paths.domainManagementEmail( ':site' ),
 		],
-		handlers: [
-			...getCommonHandlers( { noSitePath: paths.domainManagementEmail() } ),
-			domainManagementController.domainManagementEmail,
-			makeLayout,
-			clientRender,
-		],
+		handlers: [ domainManagementController.domainManagementEmailRedirect ],
 	} );
 
 	registerMultiPage( {
@@ -64,20 +59,12 @@ export default function() {
 			paths.domainManagementAddGSuiteUsers( ':site', ':domain' ),
 			paths.domainManagementAddGSuiteUsers( ':site' ),
 		],
-		handlers: [
-			...getCommonHandlers(),
-			domainManagementController.domainManagementAddGSuiteUsers,
-			makeLayout,
-			clientRender,
-		],
+		handlers: [ domainManagementController.domainManagementAddGSuiteUsersRedirect ],
 	} );
 
 	page(
 		paths.domainManagementEmailForwarding( ':site', ':domain' ),
-		...getCommonHandlers(),
-		domainManagementController.domainManagementEmailForwarding,
-		makeLayout,
-		clientRender
+		domainManagementController.domainManagementEmailForwardingRedirect
 	);
 
 	page(

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -13,7 +13,7 @@ import EmailManagement from 'my-sites/email/email-management';
 import GSuiteAddUsers from 'my-sites/email/gsuite-add-users';
 
 export default {
-	emailManagementAddGSuiteUsersRedirect( pageContext, next ) {
+	emailManagementAddGSuiteUsers( pageContext, next ) {
 		pageContext.primary = <GSuiteAddUsers selectedDomainName={ pageContext.params.domain } />;
 		next();
 	},

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -3,35 +3,28 @@
 /**
  * External dependencies
  */
-import page from 'page';
+import React from 'react';
 
 /**
  * Internal Dependencies
  */
-import * as domainsPaths from 'my-sites/domains/paths';
+import EmailForwarding from 'my-sites/email/email-forwarding';
+import EmailManagement from 'my-sites/email/email-management';
+import GSuiteAddUsers from 'my-sites/email/gsuite-add-users';
 
 export default {
-	emailManagementAddGSuiteUsersRedirect( pageContext ) {
-		page.redirect(
-			domainsPaths.domainManagementAddGSuiteUsers(
-				pageContext.params.site,
-				pageContext.params.domain
-			)
-		);
+	emailManagementAddGSuiteUsersRedirect( pageContext, next ) {
+		pageContext.primary = <GSuiteAddUsers selectedDomainName={ pageContext.params.domain } />;
+		next();
 	},
 
-	emailManagementForwardingRedirect( pageContext ) {
-		page.redirect(
-			domainsPaths.domainManagementEmailForwarding(
-				pageContext.params.site,
-				pageContext.params.domain
-			)
-		);
+	emailManagementForwarding( pageContext, next ) {
+		pageContext.primary = <EmailForwarding selectedDomainName={ pageContext.params.domain } />;
+		next();
 	},
 
-	emailManagementRedirect( pageContext ) {
-		page.redirect(
-			domainsPaths.domainManagementEmail( pageContext.params.site, pageContext.params.domain )
-		);
+	emailManagement( pageContext, next ) {
+		pageContext.primary = <EmailManagement selectedDomainName={ pageContext.params.domain } />;
+		next();
 	},
 };

--- a/client/my-sites/email/email-forwarding/email-forwarding-gsuite-details.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-gsuite-details.jsx
@@ -11,7 +11,7 @@ import React from 'react';
  * Internal dependencies
  */
 import Card from 'components/card/compact';
-import { domainManagementEmail } from 'my-sites/domains/paths';
+import { emailManagement } from 'my-sites/email/paths';
 
 const EmailForwardingGSuiteDetails = ( { selectedDomainName, siteSlug, translate } ) => {
 	return (
@@ -21,7 +21,7 @@ const EmailForwardingGSuiteDetails = ( { selectedDomainName, siteSlug, translate
 					"You're using G Suite with this domain, so you'll use that to create custom email addresses. {{a}}Manage your G Suite settings.{{/a}}",
 					{
 						components: {
-							a: <a href={ domainManagementEmail( siteSlug, selectedDomainName ) } />,
+							a: <a href={ emailManagement( siteSlug, selectedDomainName ) } />,
 						},
 					}
 				) }

--- a/client/my-sites/email/email-forwarding/index.jsx
+++ b/client/my-sites/email/email-forwarding/index.jsx
@@ -20,7 +20,7 @@ import EmailForwardingDetails from './email-forwarding-details';
 import EmailForwardingCustomMxList from './email-forwarding-custom-mx-list';
 import EmailForwardingGSuiteDetails from './email-forwarding-gsuite-details';
 import EmailForwardingGSuiteDetailsAnotherProvider from './email-forwarding-gsuite-details-another-provider';
-import { domainManagementEmail } from 'my-sites/domains/paths';
+import { emailManagement } from 'my-sites/email/paths';
 import Card from 'components/card/compact';
 import getEmailForwardingLimit from 'state/selectors/get-email-forwarding-limit';
 import getEmailForwardingType from 'state/selectors/get-email-forwarding-type';
@@ -106,7 +106,7 @@ class EmailForwarding extends Component {
 	}
 
 	goToEditEmail = () => {
-		page( domainManagementEmail( this.props.siteSlug, this.props.selectedDomainName ) );
+		page( emailManagement( this.props.siteSlug, this.props.selectedDomainName ) );
 	};
 }
 

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -18,7 +18,9 @@ import CompactCard from 'components/card/compact';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { domainManagementAddGSuiteUsers } from 'my-sites/domains/paths';
 import { hasPendingGSuiteUsers } from 'lib/domains/gsuite';
+import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedDomain } from 'lib/domains';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 import GSuiteUserItem from 'my-sites/email/email-management/gsuite-user-item';
 import Notice from 'components/notice';
 import PendingGSuiteTosNotice from 'my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice';
@@ -68,7 +70,7 @@ class GSuiteUsersCard extends React.Component {
 						<Button
 							primary
 							compact
-							href={ domainManagementAddGSuiteUsers( this.props.selectedSite.slug, domain ) }
+							href={ domainManagementAddGSuiteUsers( this.props.selectedSiteSlug, domain ) }
 							onClick={ this.goToAddGoogleApps }
 						>
 							{ this.props.translate( 'Add G Suite User' ) }
@@ -136,7 +138,7 @@ class GSuiteUsersCard extends React.Component {
 				{ pendingDomains.length !== 0 && (
 					<PendingGSuiteTosNotice
 						key="pending-gsuite-tos-notice"
-						siteSlug={ this.props.selectedSite.slug }
+						siteSlug={ this.props.selectedSiteSlug }
 						domains={ pendingDomains }
 						section="google-apps"
 					/>
@@ -183,11 +185,14 @@ GSuiteUsersCard.propTypes = {
 	domains: PropTypes.array.isRequired,
 	gsuiteUsers: PropTypes.array.isRequired,
 	selectedDomainName: PropTypes.string,
-	selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+	selectedSiteSlug: PropTypes.string.isRequired,
 	user: PropTypes.object.isRequired,
 };
 
 export default connect(
-	null,
+	state => ( {
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+		user: getCurrentUser( state ),
+	} ),
 	{ addGoogleAppsUserClick, manageClick }
 )( localize( GSuiteUsersCard ) );

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -130,23 +130,27 @@ class GSuiteUsersCard extends React.Component {
 	}
 
 	render() {
+		const { gsuiteUsers, selectedDomainName, selectedSiteSlug } = this.props;
 		const pendingDomains = this.getDomainsAsList().filter( hasPendingGSuiteUsers );
-		const usersByDomain = groupBy( this.props.gsuiteUsers, 'domain' );
+		const usersByDomain = groupBy( gsuiteUsers, 'domain' );
 
 		return (
 			<div>
 				{ pendingDomains.length !== 0 && (
 					<PendingGSuiteTosNotice
 						key="pending-gsuite-tos-notice"
-						siteSlug={ this.props.selectedSiteSlug }
+						siteSlug={ selectedSiteSlug }
 						domains={ pendingDomains }
 						section="google-apps"
 					/>
 				) }
 
-				{ Object.keys( usersByDomain ).map( domain =>
-					this.renderDomain( domain, usersByDomain[ domain ] )
-				) }
+				{ Object.keys( usersByDomain )
+					.filter(
+						domain =>
+							! selectedDomainName || ( selectedDomainName && domain === selectedDomainName )
+					)
+					.map( domain => this.renderDomain( domain, usersByDomain[ domain ] ) ) }
 			</div>
 		);
 	}

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -146,10 +146,7 @@ class GSuiteUsersCard extends React.Component {
 				) }
 
 				{ Object.keys( usersByDomain )
-					.filter(
-						domain =>
-							! selectedDomainName || ( selectedDomainName && domain === selectedDomainName )
-					)
+					.filter( domain => ! selectedDomainName || domain === selectedDomainName )
 					.map( domain => this.renderDomain( domain, usersByDomain[ domain ] ) ) }
 			</div>
 		);

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -49,7 +49,7 @@ const gsuitePlanSlug = 'gapps'; // or gapps_unlimited - TODO make this dynamic
 
 class EmailManagement extends React.Component {
 	static propTypes = {
-		currencyCode: PropTypes.string.isRequired,
+		currencyCode: PropTypes.string,
 		domains: PropTypes.array.isRequired,
 		gsuiteUsers: PropTypes.array,
 		isRequestingDomains: PropTypes.bool.isRequired,

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -29,11 +29,8 @@ import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
 import PlansNavigation from 'my-sites/plans/navigation';
 import EmptyContent from 'components/empty-content';
-import {
-	domainManagementEdit,
-	domainManagementList,
-	domainManagementEmailForwarding,
-} from 'my-sites/domains/paths';
+import { domainManagementEdit, domainManagementList } from 'my-sites/domains/paths';
+import { emailManagementForwarding } from 'my-sites/email/paths';
 import { getSelectedDomain } from 'lib/domains';
 import { isPlanFeaturesEnabled } from 'lib/plans';
 import DocumentHead from 'components/data/document-head';
@@ -127,10 +124,7 @@ class EmailManagement extends React.Component {
 				title: translate( 'G Suite is not supported on this domain' ),
 				line: translate( 'Only domains registered with WordPress.com are eligible for G Suite.' ),
 				secondaryAction: translate( 'Add Email Forwarding' ),
-				secondaryActionURL: domainManagementEmailForwarding(
-					selectedSite.slug,
-					selectedDomainName
-				),
+				secondaryActionURL: emailManagementForwarding( selectedSite.slug, selectedDomainName ),
 			};
 		} else {
 			emptyContentProps = {
@@ -188,7 +182,7 @@ class EmailManagement extends React.Component {
 		const { selectedSite, translate } = this.props;
 		return (
 			<VerticalNav>
-				<VerticalNavItem path={ domainManagementEmailForwarding( selectedSite.slug, domain ) }>
+				<VerticalNavItem path={ emailManagementForwarding( selectedSite.slug, domain ) }>
 					{ translate( 'Email Forwarding' ) }
 				</VerticalNavItem>
 			</VerticalNav>

--- a/client/my-sites/email/gsuite-add-users/add-users.jsx
+++ b/client/my-sites/email/gsuite-add-users/add-users.jsx
@@ -22,7 +22,7 @@ import FormLabel from 'components/forms/form-label';
 import { getEligibleGSuiteDomain, hasGSuite } from 'lib/domains/gsuite';
 import getUserSetting from 'state/selectors/get-user-setting';
 import { cartItems } from 'lib/cart-values';
-import { domainManagementEmail } from 'my-sites/domains/paths';
+import { emailManagement } from 'my-sites/email/paths';
 import { addItem } from 'lib/upgrades/actions';
 import { filter as filterUsers, validate as validateUsers } from 'lib/domains/google-apps-users';
 import QueryUserSettings from 'components/data/query-user-settings';
@@ -274,7 +274,7 @@ class AddEmailAddressesCard extends React.Component {
 
 		this.props.cancelClick( this.props.selectedDomainName );
 
-		page( domainManagementEmail( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+		page( emailManagement( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	};
 }
 

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -15,7 +15,7 @@ import React, { Fragment } from 'react';
 
 import AddEmailAddressesCard from './add-users';
 import AddEmailAddressesCardPlaceholder from './add-users-placeholder';
-import { emailManagementAddGSuiteUsers, emailManagement } from 'my-sites/domains/paths';
+import { emailManagementAddGSuiteUsers, emailManagement } from 'my-sites/email/paths';
 import DomainManagementHeader from 'my-sites/domains/domain-management/components/header';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -15,7 +15,7 @@ import React, { Fragment } from 'react';
 
 import AddEmailAddressesCard from './add-users';
 import AddEmailAddressesCardPlaceholder from './add-users-placeholder';
-import { domainManagementAddGSuiteUsers, domainManagementEmail } from 'my-sites/domains/paths';
+import { emailManagementAddGSuiteUsers, emailManagement } from 'my-sites/domains/paths';
 import DomainManagementHeader from 'my-sites/domains/domain-management/components/header';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
@@ -51,7 +51,7 @@ class GSuiteAddUsers extends React.Component {
 	}
 
 	goToEmail = () => {
-		page( domainManagementEmail( this.props.selectedSite.slug, this.props.selectedDomainName ) );
+		page( emailManagement( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	};
 
 	renderAddGSuite() {
@@ -85,7 +85,7 @@ class GSuiteAddUsers extends React.Component {
 	render() {
 		const { translate, selectedDomainName, selectedSite } = this.props;
 
-		const analyticsPath = domainManagementAddGSuiteUsers(
+		const analyticsPath = emailManagementAddGSuiteUsers(
 			':site',
 			selectedDomainName ? ':domain' : undefined
 		);

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -19,6 +19,7 @@ import { domainManagementAddGSuiteUsers } from 'my-sites/domains/paths';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import { getEligibleGSuiteDomain } from 'lib/domains/gsuite';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import GSuitePurchaseFeatures from 'my-sites/email/gsuite-purchase-features';
 
 /**
@@ -28,7 +29,7 @@ import './style.scss';
 
 class GSuitePurchaseCta extends React.Component {
 	goToAddGoogleApps = () => {
-		page( domainManagementAddGSuiteUsers( this.props.selectedSite.slug, this.props.domainName ) );
+		page( domainManagementAddGSuiteUsers( this.props.selectedSiteSlug, this.props.domainName ) );
 	};
 
 	getPlanText() {
@@ -141,14 +142,16 @@ GSuitePurchaseCta.propTypes = {
 	monthlyPrice: PropTypes.string.isRequired,
 	productSlug: PropTypes.string.isRequired,
 	selectedDomainName: PropTypes.string,
-	selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+	selectedSiteSlug: PropTypes.string.isRequired,
 };
 
 export default connect(
-	( state, { selectedDomainName, selectedSite } ) => {
-		const domains = getDomainsBySiteId( state, selectedSite.ID );
+	( state, { selectedDomainName } ) => {
+		const selectedSiteId = getSelectedSiteId( state );
+		const domains = getDomainsBySiteId( state, selectedSiteId );
 		return {
 			domainName: getEligibleGSuiteDomain( selectedDomainName, domains ),
+			selectedSiteSlug: getSelectedSiteSlug( state ),
 		};
 	},
 	null

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -42,7 +42,7 @@ export default function() {
 	page(
 		paths.emailManagementForwarding( ':site', ':domain' ),
 		...commonHandlers,
-		controller.emailManagementForwardingRedirect,
+		controller.emailManagementForwarding,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -15,42 +15,16 @@ import { makeLayout, render as clientRender } from 'controller';
 function registerMultiPage( { paths: givenPaths, handlers } ) {
 	givenPaths.forEach( path => page( path, ...handlers ) );
 }
-function getCommonHandlers() {
-	// function getCommonHandlers( { noSitePath = paths.emailManagement(), warnIfJetpack = true } = {} ) {
-	const handlers = [ siteSelection, navigation ];
 
-	// 	if ( noSitePath ) {
-	// 		handlers.push( domainsController.redirectIfNoSite( noSitePath ) );
-	// 	}
-
-	// 	if ( warnIfJetpack ) {
-	// 		handlers.push( domainsController.jetpackNoDomainsWarning );
-	// 	}
-
-	return handlers;
-}
+const commonHandlers = [ siteSelection, navigation ];
 
 export default function() {
 	page( paths.emailManagement(), siteSelection, sites, makeLayout, clientRender );
-	// page(paths.domainManagementEmail(), siteSelection, sites, makeLayout, clientRender);
 
 	registerMultiPage( {
 		paths: [ paths.emailManagement( ':site', ':domain' ), paths.emailManagement( ':site' ) ],
-		handlers: [ ...getCommonHandlers(), controller.emailManagement, makeLayout, clientRender ],
+		handlers: [ ...commonHandlers, controller.emailManagement, makeLayout, clientRender ],
 	} );
-
-	// registerMultiPage({
-	// 	paths: [
-	// 		paths.domainManagementEmail(':site', ':domain'),
-	// 		paths.domainManagementEmail(':site'),
-	// 	],
-	// 	handlers: [
-	// 		...getCommonHandlers({ noSitePath: paths.domainManagementEmail() }),
-	// 		domainManagementController.domainManagementEmail,
-	// 		makeLayout,
-	// 		clientRender,
-	// 	],
-	// });
 
 	registerMultiPage( {
 		paths: [
@@ -58,39 +32,18 @@ export default function() {
 			paths.emailManagementAddGSuiteUsers( ':site' ),
 		],
 		handlers: [
-			...getCommonHandlers(),
+			...commonHandlers,
 			controller.emailManagementAddGSuiteUsers,
 			makeLayout,
 			clientRender,
 		],
 	} );
 
-	// registerMultiPage({
-	// 	paths: [
-	// 		paths.domainManagementAddGSuiteUsers(':site', ':domain'),
-	// 		paths.domainManagementAddGSuiteUsers(':site'),
-	// 	],
-	// 	handlers: [
-	// 		...getCommonHandlers(),
-	// 		domainManagementController.domainManagementAddGSuiteUsers,
-	// 		makeLayout,
-	// 		clientRender,
-	// 	],
-	// });
-
 	page(
 		paths.emailManagementForwarding( ':site', ':domain' ),
-		...getCommonHandlers(),
+		...commonHandlers,
 		controller.emailManagementForwardingRedirect,
 		makeLayout,
 		clientRender
 	);
-
-	// page(
-	// 	paths.domainManagementEmailForwarding(':site', ':domain'),
-	// 	...getCommonHandlers(),
-	// 	domainManagementController.domainManagementEmailForwarding,
-	// 	makeLayout,
-	// 	clientRender
-	// );
 }

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -7,31 +7,90 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import { navigation, siteSelection, sites } from 'my-sites/controller';
 import controller from './controller';
 import * as paths from './paths';
+import { makeLayout, render as clientRender } from 'controller';
 
 function registerMultiPage( { paths: givenPaths, handlers } ) {
 	givenPaths.forEach( path => page( path, ...handlers ) );
 }
+function getCommonHandlers() {
+	// function getCommonHandlers( { noSitePath = paths.emailManagement(), warnIfJetpack = true } = {} ) {
+	const handlers = [ siteSelection, navigation ];
+
+	// 	if ( noSitePath ) {
+	// 		handlers.push( domainsController.redirectIfNoSite( noSitePath ) );
+	// 	}
+
+	// 	if ( warnIfJetpack ) {
+	// 		handlers.push( domainsController.jetpackNoDomainsWarning );
+	// 	}
+
+	return handlers;
+}
 
 export default function() {
-	page( paths.emailManagement(), controller.emailManagementRedirect );
+	page( paths.emailManagement(), siteSelection, sites, makeLayout, clientRender );
+	// page(paths.domainManagementEmail(), siteSelection, sites, makeLayout, clientRender);
 
 	registerMultiPage( {
 		paths: [ paths.emailManagement( ':site', ':domain' ), paths.emailManagement( ':site' ) ],
-		handlers: [ controller.emailManagementRedirect ],
+		handlers: [ ...getCommonHandlers(), controller.emailManagement, makeLayout, clientRender ],
 	} );
+
+	// registerMultiPage({
+	// 	paths: [
+	// 		paths.domainManagementEmail(':site', ':domain'),
+	// 		paths.domainManagementEmail(':site'),
+	// 	],
+	// 	handlers: [
+	// 		...getCommonHandlers({ noSitePath: paths.domainManagementEmail() }),
+	// 		domainManagementController.domainManagementEmail,
+	// 		makeLayout,
+	// 		clientRender,
+	// 	],
+	// });
 
 	registerMultiPage( {
 		paths: [
 			paths.emailManagementAddGSuiteUsers( ':site', ':domain' ),
 			paths.emailManagementAddGSuiteUsers( ':site' ),
 		],
-		handlers: [ controller.emailManagementAddGSuiteUsersRedirect ],
+		handlers: [
+			...getCommonHandlers(),
+			controller.emailManagementAddGSuiteUsers,
+			makeLayout,
+			clientRender,
+		],
 	} );
+
+	// registerMultiPage({
+	// 	paths: [
+	// 		paths.domainManagementAddGSuiteUsers(':site', ':domain'),
+	// 		paths.domainManagementAddGSuiteUsers(':site'),
+	// 	],
+	// 	handlers: [
+	// 		...getCommonHandlers(),
+	// 		domainManagementController.domainManagementAddGSuiteUsers,
+	// 		makeLayout,
+	// 		clientRender,
+	// 	],
+	// });
 
 	page(
 		paths.emailManagementForwarding( ':site', ':domain' ),
-		controller.emailManagementForwardingRedirect
+		...getCommonHandlers(),
+		controller.emailManagementForwardingRedirect,
+		makeLayout,
+		clientRender
 	);
+
+	// page(
+	// 	paths.domainManagementEmailForwarding(':site', ':domain'),
+	// 	...getCommonHandlers(),
+	// 	domainManagementController.domainManagementEmailForwarding,
+	// 	makeLayout,
+	// 	clientRender
+	// );
 }

--- a/client/my-sites/plans/navigation.jsx
+++ b/client/my-sites/plans/navigation.jsx
@@ -70,7 +70,7 @@ class PlansNavigation extends React.Component {
 			case '/domains/add':
 				return 'Domains';
 
-			case '/domains/manage/email':
+			case '/email':
 				return 'Email';
 
 			default:
@@ -118,10 +118,7 @@ class PlansNavigation extends React.Component {
 							</NavItem>
 						) }
 						{ canManageDomain && (
-							<NavItem
-								path={ `/domains/manage/email/${ site.slug }` }
-								selected={ path === '/domains/manage/email' }
-							>
+							<NavItem path={ `/email/${ site.slug }` } selected={ path === '/email' }>
 								{ translate( 'Email' ) }
 							</NavItem>
 						) }


### PR DESCRIPTION
Some users wish to buy or manage G Suite without necessarily buying or managing their domain on WordPress.com. Currently G Suite is only accessible via (and nested under) the Domains management screens and paths, i.e. `/domains/manage/email/foo.com`. 

We also check that you have a domain when a user tries to visit any of the email management screens directly.

This patch moves email management to its own top-level `/email/foo.com` path and allows it to work without a domain. No other functionality should be affected.

#### Changes

* Email is now managed from `/email` routes. A mostly complete list of these changes are below:
  * `domains/manage/email` *->* `/email`
  * `domains/manage/email/:site` *->* `/email/:site`
  * `domains/manage/add-gsuite-users/:site` ->`email/add-gsuite-users/:site`
  * `domains/manage/:domainName/add-gsuite-users/:site` ->`email/:domainName/add-gsuite-users/:site`
  * `domains/manage/email/:domainName/edit/:site` *->* `/email/:domainName/manage/:site`

#### Testing Instructions

*Prerequisites*
* A site with a domain and GSuite
* A site with a domain and without GSuite ( can be the same as the above site )  
* A site without a domain

*Testing New Routes*
1. Navigate to `/email/:site` for your site with GSuite
1. Confirm you are taken to the email management screen
1. Click one of the "Add GSuite Users" Button
1. Observe the new URL. Confirm it matches `/email/:domain/add-gsuite-users/:site`
1. Observe the page and confirm it is the Add G Suite Users  page 
1. Click the "Back" Button
1. Observe the new URL. Confirm that it matches `/email/:domain/manage/:site`
1. Navigate to `/email/:domain/forwarding/:site` for the site with a domain and without g Suite
1. Observe the page and confirm it is the Email Forwarding  page 
1. Click the Back Button
1. Observe the new URL. Confirm that it matches `/email/:domain/manage/:site`
1. Confirm that you are shown the G Suite CTA
1. Click "Add G Suite"
1. Confirm you are taken to the add G Suite users page again
1. Fill in the info and click continue
1. Confirm G Suite was correctly added to your cart

*Testing Legacy Redirects*
1. Navigate to `/domains/manage/email`
1. Confirm you are taken to `/email` and given a list of sites ( if you have more than one)
1. Navigate to `/domains/manage/email/:site` for your site with G Suite
1. Confirm you are taken to `/email/:site`
1. Navigate to `/domains/manage/:domain/email/:site`
1. Confirm you are taken to `/email/:domain/manage/:site`
1. Navigate to `/domains/manage/:domain/email-forwarding/:site
1. Confirm you are taken to `/email/:domain/forwarding/:site`
1. Navigate to `/domains/manage/add-gsuite-users/:site`
1. Confirm you are taken to `/email/:site`
1. Navigate to `/domains/manage/:domain/add-gsuite-users/:site`
1. Confirm you are taken to `/email/:domain/add-gsuite-users/:site`

 