### PR TITLE
Gutenframe: Display success message after trashing a post - Take 2

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -30,6 +30,8 @@ import { openPostRevisionsDialog } from 'state/posts/revisions/actions';
 import { startEditingPost } from 'state/ui/editor/actions';
 import { Placeholder } from './placeholder';
 import WebPreview from 'components/web-preview';
+import { trashPost } from 'state/posts/actions';
+import { getEditorPostId } from 'state/ui/editor/selectors';
 
 /**
  * Style dependencies
@@ -136,8 +138,10 @@ class CalypsoifyIframe extends Component {
 			}
 		}
 
-		if ( 'postTrashed' === action ) {
-			this.props.navigate( this.props.postTypeTrashUrl );
+		if ( 'trashPost' === action ) {
+			const { siteId, editedPostId, postTypeTrashUrl } = this.props;
+			this.props.trashPost( siteId, editedPostId );
+			this.props.navigate( postTypeTrashUrl );
 		}
 
 		if ( 'goToAllPosts' === action ) {
@@ -333,6 +337,7 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId } ) => {
 		postTypeTrashUrl,
 		siteAdminUrl,
 		frameNonce,
+		editedPostId: getEditorPostId( state ),
 	};
 };
 
@@ -342,6 +347,7 @@ const mapDispatchToProps = {
 	navigate,
 	openPostRevisionsDialog,
 	startEditingPost,
+	trashPost,
 };
 
 export default connect(


### PR DESCRIPTION
### Changes proposed in this Pull Request

Follow-up to https://github.com/Automattic/wp-calypso/pull/30701. 

Move the logic of trashing a post in Guteframe to Calypso. It reuses the available `trashPost` action that, apart from moving a post to the trash, displays a success message when the operation is done with the possibility to undo it.

<img width="876" alt="screen shot 2019-03-04 at 16 08 39" src="https://user-images.githubusercontent.com/1233880/53741946-cc4b9500-3e97-11e9-880a-96c722c20e21.png">

**Note**

This PR adds back the logic we included in #31187 but reverted on #31223. 

At first, we thought it was a problem with the custom post types, but after a further analysis I realized the problem was with draft posts. We were using the `postId` prop when dispatching the `trashPost` action, but `postId` is `undefined` if we are not editing a post. 

I included a new `editedPostId` prop that indicates the post ID for both new posts (after they are saved as drafts) and existing posts. This is the prop we use now on the `trashPost` action.

### Testing instructions

* Apply D25947-code on your sandbox site.
* Open an existing post / page / custom post type on the sandbox site.
* Move the post to the trash by clicking on the "Move to trash" button in the sidebar.
* Make sure you're redirected to the list of trashed posts.
* Make sure you see a success message that includes an "Undo" action.
* Click on the "Undo" action.
* Confirm the post is restored.
* Start writing a new post and save it as a draft.
* Move the post to the trash by clicking on the "Move to trash" button in the sidebar.
* Check the post is trashed.
