### PR TITLE
ImportersInSignup: Move action logic to action file

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -432,7 +432,12 @@ export function generateSteps( {
 		/* Imports */
 		'from-url': {
 			stepName: 'from-url',
-			providesDependencies: [ 'importSiteDetails', 'importUrl', 'themeSlugWithRepo' ],
+			providesDependencies: [
+				'importSiteDetails',
+				'importUrl',
+				'sitePreviewImageBlob',
+				'themeSlugWithRepo',
+			],
 		},
 
 		'reader-landing': {

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -45,7 +45,6 @@ import Notice from 'components/notice';
  */
 import './style.scss';
 
-const CHECKING_SITE_IMPORTABLE_NOTICE = 'checking-site-importable';
 const IMPORT_HELP_LINK = 'https://en.support.wordpress.com/import/';
 const EXAMPLE_WIX_URL = 'https://username.wixsite.com/my-site';
 
@@ -62,7 +61,7 @@ class ImportURLStepComponent extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { isSiteImportableError, goToNextStep, stepName, siteDetails, isLoading } = this.props;
+		const { isSiteImportableError, goToNextStep, stepName, siteDetails } = this.props;
 
 		// isSiteImportable error, focus input to revise url.
 		if (
@@ -70,17 +69,6 @@ class ImportURLStepComponent extends Component {
 			isSiteImportableError
 		) {
 			this.focusInput();
-		}
-
-		if ( isLoading !== prevProps.isLoading ) {
-			if ( isLoading ) {
-				this.props.infoNotice(
-					this.props.translate( "Please wait, we're checking to see if we can import this site." ),
-					{ id: CHECKING_SITE_IMPORTABLE_NOTICE, icon: 'info', isLoading: true }
-				);
-			} else {
-				this.props.removeNotice( CHECKING_SITE_IMPORTABLE_NOTICE );
-			}
 		}
 
 		if ( isEqual( prevProps.siteDetails, siteDetails ) || isEmpty( pickBy( siteDetails ) ) ) {

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -5,7 +5,7 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { flow, get, invoke, isEmpty, isEqual, pickBy } from 'lodash';
+import { flow, get, invoke, isEqual } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,16 +14,14 @@ import Button from 'components/button';
 import ExampleDomainBrowser from 'components/domains/example-domain-browser';
 import ExternalLink from 'components/external-link';
 import StepWrapper from 'signup/step-wrapper';
-import SignupActions from 'lib/signup/actions';
 import FormButton from 'components/forms/form-button';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import ScreenReaderText from 'components/screen-reader-text';
-import { infoNotice, removeNotice } from 'state/notices/actions';
 import {
-	fetchIsSiteImportable,
 	setImportOriginSiteDetails,
 	setNuxUrlInputValue,
+	submitImportUrlStep,
 } from 'state/importer-nux/actions';
 import {
 	getNuxUrlError,
@@ -37,7 +35,6 @@ import {
 	SITE_IMPORTER_ERR_BAD_REMOTE,
 	SITE_IMPORTER_ERR_INVALID_URL,
 } from 'lib/importers/constants';
-import { prefetchmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
 import Notice from 'components/notice';
 
 /**
@@ -61,7 +58,7 @@ class ImportURLStepComponent extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { isSiteImportableError, goToNextStep, stepName, siteDetails } = this.props;
+		const { isSiteImportableError } = this.props;
 
 		// isSiteImportable error, focus input to revise url.
 		if (
@@ -70,22 +67,6 @@ class ImportURLStepComponent extends Component {
 		) {
 			this.focusInput();
 		}
-
-		if ( isEqual( prevProps.siteDetails, siteDetails ) || isEmpty( pickBy( siteDetails ) ) ) {
-			return;
-		}
-
-		// We have a verified, importable site url.
-		SignupActions.submitSignupStep( { stepName }, [], {
-			importSiteDetails: siteDetails,
-			importUrl: siteDetails.siteUrl,
-			themeSlugWithRepo: 'pub/radcliffe-2',
-		} );
-
-		goToNextStep();
-
-		// Defer the mshot call as to not compete with the flow transition
-		setTimeout( () => prefetchmShotsPreview( siteDetails.siteUrl ), 200 );
 	}
 
 	handleInputChange = event => {
@@ -111,10 +92,14 @@ class ImportURLStepComponent extends Component {
 			return;
 		}
 
-		// Clear out the site details so the step knows when to progress
-		this.props.setImportOriginSiteDetails();
+		const { urlInputValue, stepName } = this.props;
 
-		this.props.fetchIsSiteImportable( this.props.urlInputValue );
+		this.props
+			.submitImportUrlStep( {
+				siteUrl: urlInputValue,
+				stepName,
+			} )
+			.then( this.props.goToNextStep );
 	};
 
 	setInputValueFromProps = () => {
@@ -302,12 +287,10 @@ export default flow(
 			isLoading: isUrlInputDisabled( state ),
 		} ),
 		{
-			fetchIsSiteImportable,
 			setNuxUrlInputValue,
 			setImportOriginSiteDetails,
 			recordTracksEvent,
-			infoNotice,
-			removeNotice,
+			submitImportUrlStep,
 		}
 	),
 	localize

--- a/client/state/importer-nux/actions.js
+++ b/client/state/importer-nux/actions.js
@@ -3,6 +3,8 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
+import url from 'url';
+import { get, trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,10 +16,31 @@ import {
 	IMPORT_IS_SITE_IMPORTABLE_START_FETCH,
 } from 'state/action-types';
 import { infoNotice, removeNotice } from 'state/notices/actions';
+import { loadmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
 import wpLib from 'lib/wp';
+import SignupActions from 'lib/signup/actions';
+
 const wpcom = wpLib.undocumented();
 
 const CHECKING_SITE_IMPORTABLE_NOTICE = 'checking-site-importable';
+
+const normalizeUrl = targetUrl => {
+	const siteURL = trim( targetUrl );
+
+	if ( ! siteURL ) {
+		return;
+	}
+
+	const { hostname, pathname } = url.parse(
+		siteURL.startsWith( 'http' ) ? siteURL : 'https://' + siteURL
+	);
+
+	if ( ! hostname ) {
+		return;
+	}
+
+	return hostname + pathname;
+};
 
 export const setNuxUrlInputValue = value => ( {
 	type: IMPORTER_NUX_URL_INPUT_SET,
@@ -34,6 +57,22 @@ export const fetchIsSiteImportable = site_url => dispatch => {
 		type: IMPORT_IS_SITE_IMPORTABLE_START_FETCH,
 	} );
 
+	return wpcom
+		.isSiteImportable( site_url )
+		.then( ( { engine, favicon, site_title: siteTitle, site_url: siteUrl } ) =>
+			dispatch(
+				setImportOriginSiteDetails( {
+					engine,
+					favicon,
+					siteTitle,
+					siteUrl,
+				} )
+			)
+		)
+		.catch( error => dispatch( { type: IMPORT_IS_SITE_IMPORTABLE_ERROR, error } ) );
+};
+
+export const submitImportUrlStep = ( { stepName, siteUrl } ) => dispatch => {
 	dispatch(
 		infoNotice( translate( "Please wait, we're checking to see if we can import this site." ), {
 			id: CHECKING_SITE_IMPORTABLE_NOTICE,
@@ -42,23 +81,32 @@ export const fetchIsSiteImportable = site_url => dispatch => {
 		} )
 	);
 
-	return wpcom
-		.isSiteImportable( site_url )
-		.then( ( { engine, favicon, site_title: siteTitle, site_url: siteUrl } ) => {
+	return dispatch( fetchIsSiteImportable( siteUrl ) )
+		.then( async siteDetails => {
+			const error = get( siteDetails, 'error' );
+
+			if ( error ) {
+				throw new Error( error );
+			}
+
+			const imageBlob = await loadmShotsPreview( {
+				url: normalizeUrl( siteUrl ),
+				maxRetries: 30,
+				retryTimeout: 1000,
+			} );
+
 			dispatch( removeNotice( CHECKING_SITE_IMPORTABLE_NOTICE ) );
 
-			return dispatch(
-				setImportOriginSiteDetails( {
-					engine,
-					favicon,
-					siteTitle,
-					siteUrl,
-				} )
-			);
+			return SignupActions.submitSignupStep( { stepName }, [], {
+				sitePreviewImageBlob: imageBlob,
+				importSiteDetails: siteDetails,
+				importUrl: siteDetails.siteUrl,
+				themeSlugWithRepo: 'pub/radcliffe-2',
+			} );
 		} )
 		.catch( error => {
 			dispatch( removeNotice( CHECKING_SITE_IMPORTABLE_NOTICE ) );
 
-			return dispatch( { type: IMPORT_IS_SITE_IMPORTABLE_ERROR, error } );
+			throw new Error( error );
 		} );
 };


### PR DESCRIPTION
Before adding extra state work to the import-url sign-up flow, I wanted to pick apart some of what we have that could end up hindering us in the future.

in `steps/import-url`'s `componentDidUpdate` we have some implicit state management, where we're looking at differences between the previous props and new props to determine if an action has taken place. 
In English, These checks would sound a bit like this:
```
Has the value of isLoading changed?
	If so, is the new value of isLoading true?
		Then we can assume that we have just started loading and we show a notice.
		Otherwise we can assume that we've just stopped loading and we hide a notice.

Is the new siteDetails the same as the old siteDetails?
	If so, do nothing, return early so that we don't continue with the step submission logic below
	If not, we must have done something to change them
		If siteDetails are empty, we've cleared them (this is sort of a hack/workaround, imo), do nothing.
		If different but not empty, we assume that we've just fetched `isSiteImportable`, which we assume means it's time to submit the step.
```

I've tried to show that there's a lot of assumption in the code here, a result of our logic being implicit. Assumptions in logic lead to the code being unreliable and buggy, so, imo, efforts should always be made to be explicit where possible. If we find ourselves having to 'trick' the logic with [tricks such as the one below](https://github.com/Automattic/wp-calypso/blob/master/client/signup/steps/import-url/index.jsx#L126), where we are unsetting some state in order for a component to notice new state, we should take this as a sign that something isn't right and the problem needs more thought.

```js
// Clear out the site details so the step knows when to progress
this.props.setImportOriginSiteDetails();

this.props.fetchIsSiteImportable( this.props.urlInputValue );
```

This PR seeks to pull any logic from the `componentDidUpdate` that would be better suited to being an action, or part of another action.
Even though I've talked about the reasons above, I'm keen to hear other opinions on this - do you agree? Do you disagree?

### Testing Instructions

There should be no major change in behaviour with this branch applied, other than the `sitePreviewImageBlob` property being passed via the step submission and the loading notice now covering the time it takes to fetch that mShot image, so let's test and just make sure the experience still works:

1. Visit `/start/import/from-url`
1. Try submitting a url that is a valid wix site (example: `https://smt593.wixsite.com/wowz`)
1. You should see a notice while we check if the site is importable and while we generate the mShot. Then you'll be taken to the next step, which is currently the user details form.
1. Try submitting a url that is not a valid wix site (example: `https://smt593.wixsite.com/wowzxx`)
1. You should see a notice while we check if the site is importable and while we generate the mShot. Then you'll see an error stating "We're not able to reach that site at this time, or it's not compatible with our URL importer.", and you should stay in that first step
