### PR TITLE
NUX: Jetpack—improve the copy.

### DIFF
--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -35,13 +35,11 @@ class JetpackSiteType extends Component {
 			<MainWrapper isWide>
 				<div className="jetpack-connect__step">
 					<FormattedHeader
-						headerText={ translate( 'High performance. Solid security. Your site, just better.' ) }
+						headerText={ translate( 'What are we building today?' ) }
 						subHeaderText={ translate(
-							'To get started, tell us a little bit about your site goals.'
+							'Choose the best starting point for your site. You can add or change features later.'
 						) }
 					/>
-
-					<FormattedHeader headerText={ translate( 'What kind of site do you have?' ) } />
 
 					<SiteTypeForm submitForm={ this.handleSubmit } />
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Improving the copy of the JP NUX flow, aligning it with the changes to the wpcom flow  ( https://github.com/Automattic/wp-calypso/pull/31467). We keep the definitions separate between JP and wpcom for the time being, in case we want to adapt the former after the research phase.

#### Testing instructions
- for a connected JP site visit 
http://calypso.localhost:3000/jetpack/connect/site-type/:site 
( or spin calypso.live)
and verify the change is effective

before

<img width="560" alt="Screenshot 2019-03-22 at 15 21 54" src="https://user-images.githubusercontent.com/13561163/54879888-e2b59280-4e3e-11e9-9c5a-7c5f855632f1.png">

after

<img width="568" alt="Screenshot 2019-03-24 at 14 06 20" src="https://user-images.githubusercontent.com/13561163/54879885-de897500-4e3e-11e9-9f29-cc65ad34b1b5.png">


