### PR TITLE
Signup: refactor search results logic

### DIFF
--- a/client/components/site-verticals-suggestion-search/README.md
+++ b/client/components/site-verticals-suggestion-search/README.md
@@ -15,9 +15,9 @@ onChange( { vertical_name, vertical_slug, vertical_id } ) {
 render() {
 	return (
 		<SiteVerticalsSuggestionSearch
-			onChange={ this.onChange }
-			initialValue={ this.state.initialValue }
-			charsToTriggerSearch={ 3 }
+			autoFocus={ true }
+			onChange={ onChange }
+			searchValue={ stateValue }
 		/>
 	);
 }
@@ -26,20 +26,14 @@ render() {
 
 ## Props
 
-### _(String)_ `initialValue`
-An _optional_ initial value of the search input field. Default is `''`;
+### _(String)_ `searchValue`
+The value with which we conduct a vertical API search, and also the initial search field value to display when the component loads.
 
 ### _(String)_ `placeholder`
-_Optional_ placeholder text for the search input field.
-
-### _(Integer)_ `charsToTriggerSearch`
-_Optional_ number of characters before an API search is triggered.
+_Optional_ placeholder text for the search input field. Default: `''`
 
 ### _(Function)_ `onChange` 
 The callback function for receiving updated value.
-
-### _(Boolean)_ `showPopular` 
-_Optional_ Informs the component whether to show a list of popular vertical topics when the input field is empty.
 
 Returns _{Object}_:
 
@@ -58,4 +52,9 @@ Returns _{Object}_:
 
 ```
 
+### _(Boolean)_ `showPopular` 
+_Optional_ Informs the component whether to show a list of popular vertical topics when the input field is empty. Default: `false`
+
+### _(Boolean)_ `autoFocus` 
+_Optional_ When set to `true` gives immediate focus to the search input field. Default: `false`
 

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { debounce, find, get } from 'lodash';
+import { find, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { v4 as uuid } from 'uuid';
 
@@ -29,7 +29,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		autoFocus: PropTypes.bool,
 		defaultVertical: PropTypes.object,
 		onChange: PropTypes.func,
-		onChangeDebounceFn: PropTypes.func,
 		placeholder: PropTypes.string,
 		searchValue: PropTypes.string,
 		showPopular: PropTypes.bool,
@@ -40,8 +39,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		autoFocus: false,
 		defaultVertical: {},
 		onChange: () => {},
-		// For unit test dependency injection
-		onChangeDebounceFn: fn => debounce( fn, 1000 ),
 		placeholder: '',
 		searchValue: '',
 		showPopular: false,
@@ -56,7 +53,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			isSuggestionSelected: false,
 			inputValue: props.searchValue,
 		};
-		this.updateVerticalDataDebounced = props.onChangeDebounceFn( this.updateVerticalData );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -174,7 +170,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 
 		// We debounce the update on the vertical while the user is typing
 		// to prevent unnecessary site preview updates
-		this.updateVerticalDataDebounced( this.searchForVerticalMatches( value ), value );
+		this.updateVerticalData( this.searchForVerticalMatches( value ), value );
 	};
 
 	/*

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find, get, noop, startsWith, uniq } from 'lodash';
+import { debounce, find, get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { v4 as uuid } from 'uuid';
 
@@ -26,25 +26,28 @@ import './style.scss';
 
 export class SiteVerticalsSuggestionSearch extends Component {
 	static propTypes = {
-		charsToTriggerSearch: PropTypes.number,
-		initialValue: PropTypes.string,
-		onChange: PropTypes.func,
-		placeholder: PropTypes.string,
-		shouldShowPopularTopics: PropTypes.func,
-		searchValue: PropTypes.string,
-		verticals: PropTypes.array,
+		autoFocus: PropTypes.bool,
 		defaultVertical: PropTypes.object,
+		onChange: PropTypes.func,
+		onChangeDebounceFn: PropTypes.func,
+		placeholder: PropTypes.string,
+		searchValue: PropTypes.string,
+		showPopular: PropTypes.bool,
+		shouldShowPopularTopics: PropTypes.func,
+		verticals: PropTypes.array,
 	};
 
 	static defaultProps = {
-		charsToTriggerSearch: 1,
-		initialValue: '',
-		onChange: noop,
-		placeholder: '',
-		shouldShowPopularTopics: noop,
-		searchValue: '',
-		verticals: [],
+		autoFocus: false,
 		defaultVertical: {},
+		onChange: () => {},
+		// For unit test dependency injection
+		onChangeDebounceFn: fn => debounce( fn, 1000 ),
+		placeholder: '',
+		searchValue: '',
+		showPopular: false,
+		shouldShowPopularTopics: () => {},
+		verticals: [],
 	};
 
 	constructor( props ) {
@@ -52,29 +55,97 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		this.state = {
 			railcar: this.getNewRailcar(),
 			candidateVerticals: [],
+			isSuggestionSelected: false,
+			inputValue: props.searchValue,
 		};
+		this.updateVerticalDataDebounced = props.onChangeDebounceFn( this.updateVerticalData );
 	}
 
-	getNewRailcar() {
-		return {
-			id: `${ uuid().replace( /-/g, '' ) }-site-vertical-suggestion`,
-			fetch_algo: '/verticals',
-			action: 'site_vertical_selected',
-		};
+	componentDidUpdate( prevProps ) {
+		// The suggestion list should only be updated when the vertical suggestions results change.
+		// Note: it's intentional to use object reference comparison here.
+		// Since `verticals` props is connected from a redux state here, if the two references are identical,
+		// we can safely say that the two content are identical, thanks to the immutability invariant of redux.
+		if ( prevProps.verticals !== this.props.verticals ) {
+			// It's safe here to call setState() because we prevent the indefinite loop by the wrapping condition.
+			// See the official doc here: https://reactjs.org/docs/react-component.html#componentdidupdate
+			this.setSearchResults( this.props.verticals );
+		}
 	}
 
-	// When a user is keying through the results,
-	// only update the vertical when they select a result.
+	/**
+	 * Show the popular topics component when the search field is empty and
+	 * `props.showPopular` tell us to.
+	 *
+	 * @returns {Bool} Whether we should display the popular topics component.
+	 */
+	shouldShowPopularTopics = () => ! this.state.inputValue && this.props.showPopular;
+
+	/**
+	 * Checks for the existence of vertical results. If there are none we assume
+	 *
+	 * @returns {Bool} Whether we should display the popular topics component.
+	 */
+	isVerticalSearchPending = () => this.state.inputValue && 0 === this.props.verticals.length;
+
+	/**
+	 * Sets `state.results` with incoming vertical results, retaining previous non-user vertical search results
+	 * if the incoming vertical results contain only user-defined results.
+	 *
+	 * This function could better be performed in the backend eventually.
+	 *
+	 * @param {Array} results Incoming vertical results
+	 */
+	setSearchResults = results => {
+		if ( results && results.length ) {
+			const { candidateVerticals, inputValue, isSuggestionSelected } = this.state;
+			// If the user is typing
+			// and the only result is a user input (non-vertical),
+			// and we have some previous results
+			// then concat that with the previous results and remove the last user input
+			if (
+				! isSuggestionSelected &&
+				! find( results, item => ! item.isUserInputVertical ) &&
+				1 < candidateVerticals.length
+			) {
+				results = candidateVerticals.filter( item => ! item.isUserInputVertical ).concat( results );
+			}
+
+			this.setState( { candidateVerticals: results }, () =>
+				this.updateVerticalData( this.searchForVerticalMatches( inputValue ), inputValue )
+			);
+		}
+	};
+
+	getNewRailcar = () => ( {
+		id: `${ uuid().replace( /-/g, '' ) }-site-vertical-suggestion`,
+		fetch_algo: '/verticals',
+		action: 'site_vertical_selected',
+	} );
+
+	/**
+	 * Searches the API results for a direct match on the user search query.
+	 *
+	 * @param {String} value Search query array
+	 * @returns {Object?} An object from the vertical results array
+	 */
 	searchForVerticalMatches = ( value = '' ) =>
 		find(
 			this.props.verticals,
-			item => item.verticalName.toLowerCase() === value.toLowerCase() && !! item.preview
+			item => item.verticalName.toLowerCase() === value.toLowerCase().trim() && !! item.preview
 		);
 
-	// TODO: once the siteVertical state got simplified, this can be removed.
-	updateVerticalData = ( result, value ) =>
+	/**
+	 * Callback to be passed to consuming component when the search value is updated.
+	 * TODO: once the siteVertical state got simplified, this can be removed.
+	 *
+	 * @param {Object} verticalData An object from the vertical results array
+	 * @param {String} value Search query array
+	 */
+	updateVerticalData = ( verticalData, value = '' ) => {
+		value = value.trim();
 		this.props.onChange(
-			result || {
+			verticalData || {
 				isUserInputVertical: true,
 				parent: '',
 				preview: get( this.props.defaultVertical, 'preview', '' ),
@@ -83,98 +154,63 @@ export class SiteVerticalsSuggestionSearch extends Component {
 				verticalSlug: value,
 			}
 		);
+	};
 
-	onSiteTopicChange = ( value, isNavigating ) => {
-		const hasValue = !! value;
-		const valueLength = value.length || 0;
-		const valueLengthShouldTriggerSearch = valueLength >= this.props.charsToTriggerSearch;
-		const result = this.searchForVerticalMatches( value );
-
-		// TODO:
-		// Where to put the railcar code will be reconsidered.
-		if (
-			hasValue &&
-			valueLengthShouldTriggerSearch &&
-			// Don't trigger a search if there's already an exact, non-user-defined match from the API
-			! result
-		) {
+	/**
+	 * Callback to be passed to consuming component when the search field is updated.
+	 *
+	 * @param {String} value The new search value
+	 * @param {Bool} isSuggestionSelected Whether the user has selected a suggestion
+	 */
+	onSiteTopicChange = ( value, isSuggestionSelected = false ) => {
+		if ( value && value !== this.props.searchValue ) {
 			this.setState( { railcar: this.getNewRailcar() } );
 		}
 
-		this.updateVerticalData( result, value );
-
-		this.setState( {
-			isNavigating,
-		} );
+		// We debounce the update on the vertical while the user is typing
+		// to prevent unnecessary site preview updates
+		this.setState(
+			{
+				isSuggestionSelected,
+				inputValue: value,
+			},
+			() => this.updateVerticalDataDebounced( this.searchForVerticalMatches( value ), value )
+		);
 	};
 
-	componentDidUpdate( prevProps ) {
-		// The suggestion list should only be updated when a user is not navigating the list through keying.
-		// Note: it's intentional to use object reference comparison here.
-		// Since `verticals` props is connected from a redux state here, if the two references are identical,
-		// we can safely say that the two content are identical, thanks to the immutability invariant of redux.
-		if ( prevProps.verticals !== this.props.verticals && ! this.state.isNavigating ) {
-			// It's safe here to call setState() because we prevent the indefinite loop by the wrapping condition.
-			// See the official doc here: https://reactjs.org/docs/react-component.html#componentdidupdate
-			// eslint-disable-next-line react/no-did-update-set-state
-			this.setState( {
-				candidateVerticals: this.props.verticals,
-			} );
-		}
-	}
+	/*
+	 * Because this is a 'click' selection, we call `this.onSiteTopicChange`
+	 * setting `isSuggestionSelected` to true.
+	 */
+	onSelectPopularTopic = value => this.onSiteTopicChange( value, true );
 
+	/**
+	 * Returns an array of vertical values - suggestions - that is consumable by `<SuggestionSearch />`
+	 *
+	 * @returns {Array} The array of vertical values.
+	 */
 	getSuggestions = () => this.state.candidateVerticals.map( vertical => vertical.verticalName );
 
-	sortSearchResults = ( suggestionsArray, queryString ) => {
-		let queryMatch;
-
-		// first do the search, omit and cache exact matches
-		queryString = queryString.trim().toLocaleLowerCase();
-		const lazyResults = suggestionsArray.filter( val => {
-			if ( val.toLocaleLowerCase() === queryString ) {
-				queryMatch = val;
-				return false;
-			}
-			return val.toLocaleLowerCase().includes( queryString );
-		} );
-
-		// second find the words that start with the search
-		const startsWithResults = lazyResults.filter( val =>
-			startsWith( val.toLocaleLowerCase(), queryString )
-		);
-
-		// merge, dedupe, bye
-		return uniq(
-			startsWithResults.concat( lazyResults.concat( queryMatch ? [ queryMatch ] : [] ) )
-		);
-	};
-
 	render() {
-		const {
-			translate,
-			placeholder,
-			autoFocus,
-			shouldShowPopularTopics,
-			isVerticalSearchPending,
-		} = this.props;
-		const showPopularTopics = shouldShowPopularTopics( this.props.searchValue );
-
+		const { autoFocus, placeholder, translate } = this.props;
+		const { inputValue, railcar } = this.state;
 		return (
 			<>
-				<QueryVerticals searchTerm={ this.props.searchValue.trim() } debounceTime={ 300 } />
+				<QueryVerticals searchTerm={ inputValue.trim() } debounceTime={ 300 } />
 				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } limit={ 1 } />
 				<SuggestionSearch
 					id="siteTopic"
 					placeholder={ placeholder || translate( 'Enter a keyword or select one from below.' ) }
 					onChange={ this.onSiteTopicChange }
 					suggestions={ this.getSuggestions() }
-					value={ this.props.searchValue }
-					sortResults={ this.sortSearchResults }
+					value={ inputValue }
 					autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
-					isSearching={ isVerticalSearchPending }
-					railcar={ this.state.railcar }
+					isSearching={ this.isVerticalSearchPending() }
+					railcar={ railcar }
 				/>
-				{ showPopularTopics && <PopularTopics onSelect={ this.onSiteTopicChange } /> }
+				{ this.shouldShowPopularTopics() && (
+					<PopularTopics onSelect={ this.onSelectPopularTopic } />
+				) }
 			</>
 		);
 	}
@@ -182,17 +218,10 @@ export class SiteVerticalsSuggestionSearch extends Component {
 
 export default localize(
 	connect(
-		( state, ownProps ) => {
-			const verticals = getVerticals( state, ownProps.searchValue );
-			const isVerticalSearchPending = ownProps.searchValue && null == verticals;
-			return {
-				verticals: verticals || [],
-				isVerticalSearchPending,
-				defaultVertical: get( getVerticals( state, 'business' ), '0', {} ),
-			};
-		},
-		( dispatch, ownProps ) => ( {
-			shouldShowPopularTopics: searchValue => ! searchValue && ownProps.showPopular,
-		} )
+		( state, ownProps ) => ( {
+			verticals: getVerticals( state, ownProps.searchValue ) || [],
+			defaultVertical: get( getVerticals( state, 'business' ), '0', {} ),
+		} ),
+		null
 	)( SiteVerticalsSuggestionSearch )
 );

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -33,7 +33,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		placeholder: PropTypes.string,
 		searchValue: PropTypes.string,
 		showPopular: PropTypes.bool,
-		shouldShowPopularTopics: PropTypes.func,
 		verticals: PropTypes.array,
 	};
 
@@ -46,7 +45,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		placeholder: '',
 		searchValue: '',
 		showPopular: false,
-		shouldShowPopularTopics: () => {},
 		verticals: [],
 	};
 
@@ -126,8 +124,8 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	/**
 	 * Searches the API results for a direct match on the user search query.
 	 *
-	 * @param {String} value Search query array
-	 * @returns {Object?} An object from the vertical results array
+	 * @param {String} value       Search query array
+	 * @returns {Object|undefined} An object from the vertical results array
 	 */
 	searchForVerticalMatches = ( value = '' ) =>
 		find(
@@ -143,15 +141,15 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	 * @param {String} value Search query array
 	 */
 	updateVerticalData = ( verticalData, value = '' ) => {
-		value = value.trim();
+		const trimmedValue = value.trim();
 		this.props.onChange(
 			verticalData || {
 				isUserInputVertical: true,
 				parent: '',
 				preview: get( this.props.defaultVertical, 'preview', '' ),
 				verticalId: '',
-				verticalName: value,
-				verticalSlug: value,
+				verticalName: trimmedValue,
+				verticalSlug: trimmedValue,
 			}
 		);
 	};
@@ -159,23 +157,24 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	/**
 	 * Callback to be passed to consuming component when the search field is updated.
 	 *
-	 * @param {String} value The new search value
-	 * @param {Bool} isSuggestionSelected Whether the user has selected a suggestion
+	 * @param {String}  value                The new search value
+	 * @param {Boolean} isSuggestionSelected Whether the user has selected a suggestion
 	 */
 	onSiteTopicChange = ( value, isSuggestionSelected = false ) => {
+		const newState = {
+			isSuggestionSelected,
+			inputValue: value,
+		};
+
 		if ( value && value !== this.props.searchValue ) {
-			this.setState( { railcar: this.getNewRailcar() } );
+			newState.railcar = this.getNewRailcar();
 		}
+
+		this.setState( { ...newState } );
 
 		// We debounce the update on the vertical while the user is typing
 		// to prevent unnecessary site preview updates
-		this.setState(
-			{
-				isSuggestionSelected,
-				inputValue: value,
-			},
-			() => this.updateVerticalDataDebounced( this.searchForVerticalMatches( value ), value )
-		);
+		this.updateVerticalDataDebounced( this.searchForVerticalMatches( value ), value );
 	};
 
 	/*

--- a/client/components/site-verticals-suggestion-search/popular-topics.jsx
+++ b/client/components/site-verticals-suggestion-search/popular-topics.jsx
@@ -16,6 +16,8 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 /*
 	These topics are taken from the most popular for each segment.
+	They should match the translated vertical names, so that they
+	return meaningful results from the verticals API.
 */
 const POPULAR_TOPICS = {
 	business: [

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -13,7 +13,9 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
   <SuggestionSearch
     autoFocus={false}
     id="siteTopic"
+    isSearching=""
     onChange={[Function]}
+    onSelect={[Function]}
     placeholder="Enter a keyword or select one from below."
     railcar={
       Object {
@@ -22,7 +24,6 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
         "id": "fakeuuid-site-vertical-suggestion",
       }
     }
-    sortResults={[Function]}
     suggestions={Array []}
     value=""
   />

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -12,7 +12,6 @@ import { shallow } from 'enzyme';
 /**
  * Internal dependencies
  */
-
 import { SiteVerticalsSuggestionSearch } from '../';
 import SuggestionSearch from 'components/suggestion-search';
 import PopularTopics from 'components/site-verticals-suggestion-search/popular-topics';
@@ -41,15 +40,18 @@ const defaultProps = {
 		parent: 'whoops',
 		verticalId: 'argh',
 	},
+	onChangeDebounceFn: fn => fn,
 	translate: str => str,
-	charsToTriggerSearch: 2,
-	shouldShowPopularTopics: jest.fn(),
 	searchValue: '',
 };
 
 describe( '<SiteVerticalsSuggestionSearch />', () => {
 	afterEach( () => {
 		jest.resetAllMocks();
+	} );
+
+	beforeEach( () => {
+		//SiteVerticalsSuggestionSearch.bindDebounce = jest.fn().mockImplementation( fn => fn );
 	} );
 
 	test( 'should render', () => {
@@ -64,12 +66,10 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 		expect( defaultProps.onChange ).toHaveBeenLastCalledWith( defaultProps.verticals[ 0 ] );
 	} );
 
-	test( 'should show common topics', () => {
-		defaultProps.shouldShowPopularTopics.mockReturnValueOnce( true );
+	test( 'should show popular topics', () => {
 		const wrapper = shallow(
 			<SiteVerticalsSuggestionSearch { ...defaultProps } showPopular={ true } />
 		);
-		expect( defaultProps.shouldShowPopularTopics ).toHaveBeenLastCalledWith( '' );
 		expect( wrapper.find( PopularTopics ) ).toHaveLength( 1 );
 	} );
 
@@ -102,8 +102,8 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 		test( 'should return default vertical object', () => {
 			wrapper.instance().updateVerticalData();
 			expect( defaultProps.onChange ).toHaveBeenLastCalledWith( {
-				verticalName: undefined,
-				verticalSlug: undefined,
+				verticalName: '',
+				verticalSlug: '',
 				isUserInputVertical: true,
 				preview: defaultProps.defaultVertical.preview,
 				verticalId: '',
@@ -126,36 +126,6 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 		test( 'should return result', () => {
 			wrapper.instance().updateVerticalData( { deal: 'nodeal' }, 'ciao' );
 			expect( defaultProps.onChange ).toHaveBeenLastCalledWith( { deal: 'nodeal' } );
-		} );
-	} );
-
-	describe( 'sortSearchResults()', () => {
-		const wrapper = shallow( <SiteVerticalsSuggestionSearch { ...defaultProps } /> );
-		test( 'should return sorted results with `startsWith` matches at the start and exact match at the end', () => {
-			const sortedResults = wrapper
-				.instance()
-				.sortSearchResults( [ 'Bar', 'Bari Beaches', 'Bartender', 'Foobar', 'Crowbar' ], ' bar ' );
-			expect( sortedResults ).toEqual( [
-				'Bari Beaches',
-				'Bartender',
-				'Foobar',
-				'Crowbar',
-				'Bar',
-			] );
-		} );
-
-		test( 'should omit non-matches', () => {
-			const sortedResults = wrapper
-				.instance()
-				.sortSearchResults( [ 'Bar', 'Bartender', 'Foobar', 'Terminal spiv' ], 'spiv' );
-			expect( sortedResults ).toEqual( [ 'Terminal spiv' ] );
-		} );
-
-		test( 'should not sort when no `startsWith` suggestions', () => {
-			const sortedResults = wrapper
-				.instance()
-				.sortSearchResults( [ 'Stammabschnitt', 'Tim Tam', '123 Tam', 'Tam' ], 'tam' );
-			expect( sortedResults ).toEqual( [ 'Stammabschnitt', 'Tim Tam', '123 Tam', 'Tam' ] );
 		} );
 	} );
 } );

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -40,7 +40,6 @@ const defaultProps = {
 		parent: 'whoops',
 		verticalId: 'argh',
 	},
-	onChangeDebounceFn: fn => fn,
 	translate: str => str,
 	searchValue: '',
 };

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -50,10 +50,6 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 		jest.resetAllMocks();
 	} );
 
-	beforeEach( () => {
-		//SiteVerticalsSuggestionSearch.bindDebounce = jest.fn().mockImplementation( fn => fn );
-	} );
-
 	test( 'should render', () => {
 		const wrapper = shallow( <SiteVerticalsSuggestionSearch { ...defaultProps } /> );
 		expect( wrapper.find( SuggestionSearch ) ).toHaveLength( 1 );

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -25,7 +25,7 @@ class SuggestionSearch extends Component {
 		id: PropTypes.string,
 		placeholder: PropTypes.string,
 		onChange: PropTypes.func,
-		sortResults: PropTypes.func,
+		onSelect: PropTypes.func,
 		suggestions: PropTypes.array,
 		value: PropTypes.string,
 		autoFocus: PropTypes.bool,
@@ -36,7 +36,7 @@ class SuggestionSearch extends Component {
 		id: '',
 		placeholder: '',
 		onChange: noop,
-		sortResults: null,
+		onSelect: noop,
 		suggestions: [],
 		value: '',
 		autoFocus: false,
@@ -118,10 +118,7 @@ class SuggestionSearch extends Component {
 			return [];
 		}
 
-		return ( 'function' === typeof this.props.sortResults
-			? this.props.sortResults( this.props.suggestions, this.state.query )
-			: this.props.suggestions
-		).map( hint => ( { label: hint } ) );
+		return this.props.suggestions.map( hint => ( { label: hint } ) );
 	}
 
 	getSuggestionLabel( suggestionPosition ) {

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -110,7 +110,7 @@ class SuggestionSearch extends Component {
 	handleSuggestionMouseDown = position => {
 		this.updateInputValue( position.label );
 		this.hideSuggestions();
-		this.props.onChange( position.label );
+		this.props.onChange( position.label, true );
 	};
 
 	getSuggestions() {

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -101,8 +101,7 @@ class SiteTopicForm extends Component {
 export default connect(
 	state => {
 		const siteTopic = getSiteVerticalName( state );
-		const isVerticalSearchPending = null == getVerticals( state, siteTopic );
-		const isButtonDisabled = ! siteTopic || isVerticalSearchPending;
+		const isButtonDisabled = ! siteTopic || null == getVerticals( state, siteTopic );
 
 		return {
 			siteTopic,

--- a/client/state/signup/verticals/reducer.js
+++ b/client/state/signup/verticals/reducer.js
@@ -6,16 +6,9 @@
 import { createReducer } from 'state/utils';
 import { SIGNUP_VERTICALS_SET } from 'state/action-types';
 
-const verticals = createReducer(
-	{},
-	{
-		[ SIGNUP_VERTICALS_SET ]: ( state, action ) => {
-			return {
-				...state,
-				[ action.search.trim().toLowerCase() ]: action.verticals,
-			};
-		},
-	}
-);
-
-export default verticals;
+export default createReducer( null, {
+	[ SIGNUP_VERTICALS_SET ]: ( state, action ) => ( {
+		...state,
+		[ action.search.trim().toLowerCase() ]: action.verticals,
+	} ),
+} );

--- a/client/state/signup/verticals/test/reducer.js
+++ b/client/state/signup/verticals/test/reducer.js
@@ -7,8 +7,8 @@ import reducer from '../reducer';
 import { SIGNUP_VERTICALS_SET } from 'state/action-types';
 
 describe( 'state/signup/verticals/reducer', () => {
-	test( 'should default to an empty object.', () => {
-		expect( reducer( undefined, {} ) ).toEqual( {} );
+	test( 'should default to `null`', () => {
+		expect( reducer( undefined, {} ) ).toEqual( null );
 	} );
 
 	test( 'should associate a trimmed and lowercase search string to the verticals array.', () => {


### PR DESCRIPTION
⚠️ This PR is a little on the large side, so if it works okay I can split it up :)

## Changes proposed in this Pull Request

This is an attempt to incorporate many of the suggestions we received in our spike PR #31378, including, but not limited to:

### ~~Debouncing the site preview update so that we don't get 'flashes' of the default site preview as the user types~~

_Update_: We will address this in ~~a future PR~~ https://github.com/Automattic/wp-calypso/pull/32055. See comment: https://github.com/Automattic/wp-calypso/pull/31708#issuecomment-480145319

![debounce](https://user-images.githubusercontent.com/6458278/55216081-ed619480-524f-11e9-9adb-6cc0fd81186b.gif)

### Caching previous results, which we can display to the user if their query yields none (probably should be migrated to the backend eventually)
![no-match](https://user-images.githubusercontent.com/6458278/55216120-05391880-5250-11e9-8a32-f42cd5bd72c2.gif)

### Removing sorting on the clientside
No GIF 🕶 

## Testing instructions
Fire up the branch and search for a vertical. In particular:

* Select a popular category, clear the field, select another
* Enter text, slow and fast
* _More scenarios to come..._
