### PR TITLE
Redirect to launch flow from Settings and Checklist

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -26,7 +26,12 @@ import Task from 'components/checklist/task';
 import { successNotice } from 'state/notices/actions';
 import { getPostsForQuery } from 'state/posts/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteOption, getSiteSlug, getSiteFrontPage } from 'state/sites/selectors';
+import {
+	getSiteOption,
+	getSiteSlug,
+	getSiteFrontPage,
+	isCurrentPlanPaid,
+} from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
@@ -186,9 +191,13 @@ class WpcomChecklistComponent extends PureComponent {
 			return;
 		}
 
-		const { siteId } = this.props;
+		const { siteId, domains, isPaidPlan, siteSlug } = this.props;
 
-		this.props.launchSite( siteId );
+		if ( isPaidPlan && domains.length > 1 ) {
+			this.props.launchSite( siteId );
+		} else {
+			location.href = `/start/launch-site?siteSlug=${ siteSlug }`;
+		}
 	};
 
 	verificationTaskButtonText() {
@@ -1009,6 +1018,7 @@ export default connect(
 			needsVerification: ! isCurrentUserEmailVerified( state ),
 			isSiteUnlaunched: isUnlaunchedSite( state, siteId ),
 			domains: getDomainsBySiteId( state, siteId ),
+			isPaidPlan: isCurrentPlanPaid( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -640,7 +640,7 @@ const getFormSettings = settings => {
 	const gmt_offset = settings.gmt_offset;
 
 	if ( ! settings.timezone_string && typeof gmt_offset === 'string' && gmt_offset.length ) {
-		formSettings.timezone_string = 'UTC' + ( /\-/.test( gmt_offset ) ? '' : '+' ) + gmt_offset;
+		formSettings.timezone_string = 'UTC' + ( /-/.test( gmt_offset ) ? '' : '+' ) + gmt_offset;
 	}
 
 	return formSettings;

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -35,13 +35,15 @@ import Banner from 'components/banner';
 import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
-import { isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite, isCurrentPlanPaid } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
 import scrollTo from 'lib/scroll-to';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
 import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
 import { launchSite } from 'state/sites/launch/actions';
+import { getDomainsBySiteId } from 'state/sites/domains/selectors';
+import QuerySiteDomains from 'components/data/query-site-domains';
 
 export class SiteSettingsFormGeneral extends Component {
 	componentWillMount() {
@@ -391,7 +393,26 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	renderLaunchSite() {
-		const { translate } = this.props;
+		const { translate, siteDomains, siteSlug, siteId, isPaidPlan } = this.props;
+
+		const launchSiteClasses = classNames( 'site-settings__general-settings-launch-site-button', {
+			'site-settings__disable-privacy-settings': ! siteDomains.length,
+		} );
+		const btnText = translate( 'Launch site' );
+		let querySiteDomainsComponent, btnComponent;
+
+		if ( 0 === siteDomains.length ) {
+			querySiteDomainsComponent = <QuerySiteDomains siteId={ siteId } />;
+			btnComponent = <Button>{ btnText }</Button>;
+		} else if ( isPaidPlan && siteDomains.length > 1 ) {
+			btnComponent = <Button onClick={ this.props.launchSite }>{ btnText }</Button>;
+			querySiteDomainsComponent = '';
+		} else {
+			btnComponent = (
+				<Button href={ `/start/launch-site?siteSlug=${ siteSlug }` }>{ btnText }</Button>
+			);
+			querySiteDomainsComponent = '';
+		}
 
 		return (
 			<>
@@ -404,10 +425,10 @@ export class SiteSettingsFormGeneral extends Component {
 							) }
 						</p>
 					</div>
-					<div className="site-settings__general-settings-launch-site-button">
-						<Button onClick={ this.props.launchSite }>{ translate( 'Launch site' ) }</Button>
-					</div>
+					<div className={ launchSiteClasses }>{ btnComponent }</div>
 				</Card>
+
+				{ querySiteDomainsComponent }
 			</>
 		);
 	}
@@ -567,7 +588,9 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 	const { site } = ownProps;
 
 	return {
-		launchSite: () => dispatch( launchSite( site.ID ) ),
+		launchSite: () => {
+			dispatch( launchSite( site.ID ) );
+		},
 	};
 };
 
@@ -583,6 +606,8 @@ const connectComponent = connect(
 			siteIsJetpack,
 			siteSlug: getSelectedSiteSlug( state ),
 			selectedSite,
+			isPaidPlan: isCurrentPlanPaid( state, siteId ),
+			siteDomains: getDomainsBySiteId( state, siteId ),
 		};
 	},
 	mapDispatchToProps,

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -588,9 +588,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => {
 	const { site } = ownProps;
 
 	return {
-		launchSite: () => {
-			dispatch( launchSite( site.ID ) );
-		},
+		launchSite: () => dispatch( launchSite( site.ID ) ),
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The `Launch Site` button in /settings and the `Launch your site` checklist item in /checklist will now redirect to the launch flow for eligible sites(i.e the site needs to either be on a free plan or free domain).

<img width="752" alt="Screenshot 2019-03-25 at 12 41 59 PM" src="https://user-images.githubusercontent.com/1269602/54901121-88c6d280-4efb-11e9-8d89-0a37aac6b963.png">

<img width="744" alt="Screenshot 2019-03-25 at 12 41 47 PM" src="https://user-images.githubusercontent.com/1269602/54901127-8c5a5980-4efb-11e9-8548-893b77f45316.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**

_Verify Settings page_
* Create a new site with no custom domain
* Head to the settings page(`/settings/general/{siteSlug}`) and click the `Launch Site` button
* You should be taken to launch flow. Complete the flow and verify your site is launched.
* Head back to the Settings page and verify that the Launch Site button is no longer there, the privacy options have been enabled (Public / Hidden / Private).

_Verify Checklist page_ 
* Create a new site with no custom domain
* Head to the checklist page(`/checklist/{siteSlug}`) and click the `Launch your site` checklist action
* You should be taken to launch flow. Complete the flow and verify your site is launched.
* Head back to the Checklist  page and verify that the Launch Site action is no longer there.

**Scenario 2**

_Verify Settings page_
* Create a new site with both a paid plan and a custom domain
* Head to the settings page(`/settings/general/{siteSlug}`) and click the `Launch Site` button
* The site should launch in the background and **not** take you to the launch flow

_Verify Checklist page_ 
* Create a new site with both a paid plan and a custom domain
* Head to the settings page(`/checklist/{siteSlug}`) and click the `Launch your site` action
* The site should launch in the background and **not** take you to the launch flow


Fixes one of the issues listed in #31176
