### PR TITLE
Jetpack Connect: Fix colophon alignment on user type step

### DIFF
--- a/client/jetpack-connect/user-type/index.js
+++ b/client/jetpack-connect/user-type/index.js
@@ -33,7 +33,7 @@ class JetpackUserType extends Component {
 
 		return (
 			<MainWrapper isWide>
-				<div className="user-type__connect-step">
+				<div className="user-type__connect-step jetpack-connect__step">
 					<FormattedHeader
 						headerText={ translate( 'Are you setting up this site for yourself or someone else?' ) }
 					/>


### PR DESCRIPTION
This is a follow up to #31297 to fix the alignment of the colophon in the footer of the user type step.

#### Changes proposed in this Pull Request

* Fix the alignment of the colophon in the user type step.

#### Preview

Before:
![](https://cldup.com/4Km0ZyD357.png)

After:
![](https://cldup.com/rES8VY6erc.png)

#### Testing instructions

* Checkout this branch.
* Head to http://calypso.localhost:3000/jetpack/connect/user-type/:site where `:site` is a connected Jetpack site.
* Verify colophon is aligned to the footer like the rest of the steps (site type, site vertical).