### PR TITLE
Jetpack Blocks: remove Babel Polyfill dependency from package.json

### DIFF
--- a/packages/jetpack-blocks/package.json
+++ b/packages/jetpack-blocks/package.json
@@ -8,7 +8,6 @@
 	],
 	"dependencies": {
 		"@automattic/format-currency": "file:../format-currency",
-		"@babel/polyfill": "7.2.5",
 		"@wordpress/api-fetch": "2.2.8",
 		"@wordpress/blob": "2.1.0",
 		"@wordpress/blocks": "6.0.7",


### PR DESCRIPTION
The only usage got removed in #31690. Not needed any more in Jetpack Blocks.