### PR TITLE
JP Onboarding: round the corners on the user type step

### DIFF
--- a/client/jetpack-connect/user-type/style.scss
+++ b/client/jetpack-connect/user-type/style.scss
@@ -51,11 +51,11 @@
 		box-shadow: inset 0 0 0 2px var( --color-accent );
 	}
 
-	&:first-of-type {
+	&:first-child {
 		border-radius: 3px 3px 0 0;
 	}
 
-	&:last-of-type {
+	&:last-child {
 		border-bottom: none;
 		border-radius: 0 0 3px 3px;
 	}

--- a/client/jetpack-connect/user-type/style.scss
+++ b/client/jetpack-connect/user-type/style.scss
@@ -50,6 +50,14 @@
 	&:focus {
 		box-shadow: inset 0 0 0 2px var( --color-accent );
 	}
+
+	&:first-of-type {
+		border-radius: 3px 3px 0 0;
+	}
+
+	&:last-of-type {
+		border-radius: 0 0 3px 3px;
+	}
 }
 
 .user-type__connect-step {

--- a/client/jetpack-connect/user-type/style.scss
+++ b/client/jetpack-connect/user-type/style.scss
@@ -56,6 +56,7 @@
 	}
 
 	&:last-of-type {
+		border-bottom: none;
 		border-radius: 0 0 3px 3px;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Round the corners on the user type step of Jetpack onboarding.

#### Testing instructions

* Spin up this PR.
* Go to `/jetpack/connect/user-type/SITE_URL`.
* Ensure the first and last options (the only two for now) have rounded corners that match the site type and site topic steps.

#### Before

![image](https://user-images.githubusercontent.com/390760/54909361-ed753380-4ee1-11e9-9b39-887892b4e889.png)


#### After

![image](https://user-images.githubusercontent.com/390760/54909983-4f826880-4ee3-11e9-8311-5acda92aa0a8.png)
