### PR TITLE
Jetpack Connect: Fix JP version logic in site topic step

### DIFF
--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -29,8 +29,7 @@ class JetpackSiteTopic extends Component {
 		if ( ! siteJetpackVersion ) {
 			return null;
 		}
-
-		if ( versionCompare( siteJetpackVersion, 7.2 ) < 0 || siteJetpackVersion === '7.2-alpha' ) {
+		if ( versionCompare( siteJetpackVersion, '7.2-alpha', '>=' ) ) {
 			page( `/jetpack/connect/user-type/${ siteSlug }` );
 		} else {
 			page( `/jetpack/connect/plans/${ siteSlug }` );


### PR DESCRIPTION
In #31297 we introduced a new user type step for Jetpack. FWIW, this new step requires at least Jetpack 7.2 alpha or newer. For older Jetpacks, we'd redirect to the plans page instead.

However, the logic we introduced in #31297 works the following way:

* `7.2-alpha` - redirects to user type step - works well ✅ 
* `7.2-beta` - redirects to user type step - works well ✅ 
* `7.2` - redirects to plans - not working well, should redirect to user type step ❌ 
* `7.1` - redirects to user type step - not working well, should redirect to plans ❌ 

This PR fixes this logic, so after the site topic step, we'll redirect:

* To the user type step for Jetpack 7.2-alpha, 7-2-beta, 7.2 and newer.
* To the plans step for older Jetpacks.

The change suggested in this PR also improves the logic's readability a bit IMHO - it makes it easier to understand what we're trying to do here.

#### Changes proposed in this Pull Request

* Fix the logic for redirecting to the right step based on the Jetpack version in the site topic step.

#### Testing instructions

* Checkout this branch.
* Note: to change a JP version, you need to alter the `JETPACK__VERSION` constant in `jetpack.php`.
* Go to http://calypso.localhost:3000/jetpack/connect/site-topic/:site where `:site` is a site with Jetpack `7.2-alpha`. 
* Finish the step and continue; verify it redirects to the new user type step.
* Go to http://calypso.localhost:3000/jetpack/connect/site-topic/:site where `:site` is a site with Jetpack `7.2-beta` (you might have to alter it manually, as this version still doesn't exist). 
* Finish the step and continue; verify it redirects to the new user type step.
* Go to http://calypso.localhost:3000/jetpack/connect/site-topic/:site where `:site` is a site with Jetpack `7.2` or newer (you might have to alter it manually, as this version still doesn't exist). 
* Finish the step and continue; verify it redirects to the new user type step.
* Go to http://calypso.localhost:3000/jetpack/connect/site-topic/:site where `:site` is a site with Jetpack `7.1.1` or older.
* Finish the step and continue; verify it redirects to the plans step.