### PR TITLE
Add: verticals substate tree

### DIFF
--- a/client/state/signup/reducer.js
+++ b/client/state/signup/reducer.js
@@ -9,6 +9,7 @@ import progress from './progress/reducer';
 import optionalDependencies from './optional-dependencies/reducer';
 import steps from './steps/reducer';
 import flow from './flow/reducer';
+import verticals from './verticals/reducer';
 
 export default combineReducers( {
 	dependencyStore,
@@ -16,4 +17,5 @@ export default combineReducers( {
 	progress,
 	steps,
 	flow,
+	verticals,
 } );

--- a/client/state/signup/verticals/reducer.js
+++ b/client/state/signup/verticals/reducer.js
@@ -1,0 +1,13 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { createReducer, keyedReducer } from 'state/utils';
+import { SIGNUP_VERTICALS_SET } from 'state/action-types';
+
+const verticals = createReducer( null, {
+	[ SIGNUP_VERTICALS_SET ]: ( state, action ) => action.verticals,
+} );
+
+export default keyedReducer( 'search', verticals );

--- a/client/state/signup/verticals/selectors.js
+++ b/client/state/signup/verticals/selectors.js
@@ -1,0 +1,9 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export const getVerticals = ( state, searchTerm ) =>
+	get( state, [ 'signup', 'verticals', searchTerm ], null );

--- a/client/state/signup/verticals/test/reducer.js
+++ b/client/state/signup/verticals/test/reducer.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import reducer from '../reducer';
+import { SIGNUP_VERTICALS_SET } from 'state/action-types';
+
+describe( 'state/signup/verticals/reducer', () => {
+	test( 'should default to an empty object.', () => {
+		expect( reducer( undefined, {} ) ).toEqual( {} );
+	} );
+
+	test( 'should associate the search string to the verticals array.', () => {
+		const search = 'Foo';
+		const verticals = [ { id: 0, verticalName: 'Coffee' }, { id: 1, verticalName: 'Tea' } ];
+
+		expect(
+			reducer( undefined, {
+				type: SIGNUP_VERTICALS_SET,
+				search,
+				verticals,
+			} )
+		).toEqual( {
+			[ search ]: verticals,
+		} );
+	} );
+} );

--- a/client/state/signup/verticals/test/selectors.js
+++ b/client/state/signup/verticals/test/selectors.js
@@ -1,0 +1,34 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getVerticals } from '../selectors';
+
+describe( 'state/signup/verticals/selectors', () => {
+	describe( 'getVerticals()', () => {
+		test( 'should default to null.', () => {
+			expect( getVerticals( {}, 'aaa' ) ).toBeNull();
+		} );
+
+		const searchTerm = 'Cool';
+		const state = {
+			signup: {
+				verticals: {
+					[ searchTerm ]: [
+						{ id: 0, verticalName: 'Ah!' },
+						{ id: 1, verticalName: 'I am selected!' },
+					],
+				},
+			},
+		};
+
+		test( 'should return the stored verticals data.', () => {
+			expect( getVerticals( state, searchTerm ) ).toEqual( state.signup.verticals[ searchTerm ] );
+		} );
+
+		test( 'should return null if it does not exist', () => {
+			expect( getVerticals( state, 'Aaa' ) ).toBeNull();
+		} );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR is a continuation on https://github.com/Automattic/wp-calypso/pull/31714, completing the verticals state tree.

To have a more general view of how it would look like in the end, please refer to the PoC integration PR: #31675 .

#### Testing instructions

`npm run test-client signup/verticals` should pass.
