### PR TITLE
Slideshow: Resolve Two Javascript Errors

### DIFF
--- a/packages/jetpack-blocks/src/blocks/slideshow/swiper-callbacks.js
+++ b/packages/jetpack-blocks/src/blocks/slideshow/swiper-callbacks.js
@@ -53,6 +53,9 @@ function swiperResize( swiper ) {
 
 function announceCurrentSlide( swiper ) {
 	const currentSlide = swiper.slides[ swiper.activeIndex ];
+	if ( ! currentSlide ) {
+		return;
+	}
 	const figcaption = currentSlide.getElementsByTagName( 'FIGCAPTION' )[ 0 ];
 	const img = currentSlide.getElementsByTagName( 'IMG' )[ 0 ];
 	const notification = figcaption ? figcaption.innerText : img.alt;

--- a/packages/jetpack-blocks/src/blocks/slideshow/swiper-callbacks.js
+++ b/packages/jetpack-blocks/src/blocks/slideshow/swiper-callbacks.js
@@ -31,6 +31,9 @@ function swiperInit( swiper ) {
 }
 
 function swiperResize( swiper ) {
+	if ( ! swiper || ! swiper.el ) {
+		return;
+	}
 	const img = swiper.el.querySelector( '.swiper-slide[data-swiper-slide-index="0"] img' );
 	if ( ! img ) {
 		return;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Handle two Javascript errors that occur under certain circumstances. 

#### Testing instructions

This PR should be tested in a local Jetpack instance. There is try/catch that was introduced after 7.1.1 shipped which hides these errors. 

- Check out `master`
- Comment out the `catch()` function here: https://github.com/Automattic/wp-calypso/blob/master/packages/jetpack-blocks/src/blocks/slideshow/view.js#L64-L68
- Build blocks locally. 
- You should now be able to reliably reproduce https://github.com/Automattic/wp-calypso/issues/31247 and https://github.com/Automattic/wp-calypso/issues/30876
- Checkout `fix/slideshow-js-errors`, and comment out the same `catch()`
- 31247 and 31247 should now be resolved.

Fixes https://github.com/Automattic/wp-calypso/issues/30876 https://github.com/Automattic/wp-calypso/issues/31247
