### PR TITLE
ImportSignupFlow: Fix whitespace issues around the error notice

### DIFF
--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -246,7 +246,9 @@ class ImportURLStepComponent extends Component {
 						>
 							{ urlMessage }
 						</Notice>
-					) : null }
+					) : (
+						<div className="import-url__notice-placeholder" />
+					) }
 				</div>
 
 				<div className="import-url__example">

--- a/client/signup/steps/import-url/style.scss
+++ b/client/signup/steps/import-url/style.scss
@@ -46,7 +46,6 @@
 		display: flex;
 		flex-flow: row wrap;
 		justify-content: center;
-		margin-top: 80px;
 		margin-bottom: 48px;
 		position: relative;
 
@@ -90,4 +89,9 @@
 			vertical-align: middle;
 		}
 	}
+}
+
+.import-url__notice-placeholder {
+	height: 47px;
+	margin: 16px auto;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a placeholder in place of the error notice that we see in the import signup flow when a bad URL is given. Previously the error notice would nudge the example URLs section down the page, leaving a large gap. With this placeholder, the whitespace is replaced with the error notice when it's shown:

<img width="751" alt="Screenshot 2019-03-25 at 13 02 50" src="https://user-images.githubusercontent.com/4335450/54921729-58346800-4efe-11e9-8f7e-a9a9e177a703.png">

<img width="776" alt="Screenshot 2019-03-25 at 13 02 59" src="https://user-images.githubusercontent.com/4335450/54921728-58346800-4efe-11e9-8dcd-079130ce7624.png">


#### Testing instructions


1. Visit `/start/import/from-url`
1. Try submitting a url that is not valid (example: `invalid-url`)
1. You should see the notice fill up the existing whitespace, with no jumping of the rest of the UI. 
