### PR TITLE
SDK: Make SDK Gutenberg more generic

### DIFF
--- a/bin/sdk/gutenberg.js
+++ b/bin/sdk/gutenberg.js
@@ -1,28 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 const fs = require( 'fs' );
-const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const path = require( 'path' );
-const { compact, get } = require( 'lodash' );
-
-const DIRECTORY_DEPTH = '../../'; // Relative path of the extensions to preset directory
-
-function sharedScripts( folderName, inputDir ) {
-	const sharedPath = path.join( inputDir, folderName );
-	return fs
-		.readdirSync( sharedPath )
-		.map( file => path.join( sharedPath, file ) )
-		.filter( fullPathToFile => fullPathToFile.endsWith( '.js' ) );
-}
-
-function blockScripts( type, inputDir, presetBlocks ) {
-	return presetBlocks
-		.map( block => path.join( inputDir, `${ DIRECTORY_DEPTH }${ block }/${ type }.js` ) )
-		.filter( fs.existsSync );
-}
 
 exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 	const baseConfig = getBaseConfig( {
@@ -31,76 +11,15 @@ exports.config = ( { argv: { inputDir, outputDir }, getBaseConfig } ) => {
 		preserveCssCustomProperties: false,
 	} );
 
-	const presetPath = path.join( inputDir, 'index.json' );
-
-	let editorScript;
-	let editorBetaScript;
-	let viewBlocksScripts;
-	let viewScriptEntry;
-	let presetBlocks;
-	let presetBetaBlocks;
-
-	if ( fs.existsSync( presetPath ) ) {
-		const presetIndex = require( presetPath );
-		presetBlocks = get( presetIndex, [ 'production' ], [] );
-		presetBetaBlocks = get( presetIndex, [ 'beta' ], [] );
-		const allPresetBlocks = [ ...presetBlocks, ...presetBetaBlocks ];
-
-		// Find all the shared scripts
-		const sharedUtilsScripts = sharedScripts( 'shared', inputDir );
-
-		// Helps split up each block into its own folder view script
-		viewBlocksScripts = allPresetBlocks.reduce( ( viewBlocks, block ) => {
-			const viewScriptPath = path.join( inputDir, `${ DIRECTORY_DEPTH }${ block }/view.js` );
-			if ( fs.existsSync( viewScriptPath ) ) {
-				viewBlocks[ block + '/view' ] = [ ...sharedUtilsScripts, ...[ viewScriptPath ] ];
-			}
-			return viewBlocks;
-		}, {} );
-
-		// Find all the editor shared scripts
-		const sharedEditorUtilsScripts = sharedScripts( 'editor-shared', inputDir );
-
-		// Combines all the different blocks into one editor.js script
-		editorScript = [
-			...sharedUtilsScripts,
-			...sharedEditorUtilsScripts,
-			...blockScripts( 'editor', inputDir, presetBlocks ),
-		];
-
-		// Combines all the different blocks into one editor-beta.js script
-		editorBetaScript = [
-			...sharedUtilsScripts,
-			...sharedEditorUtilsScripts,
-			...blockScripts( 'editor', inputDir, allPresetBlocks ),
-		];
-
-		// We explicitly don't create a view.js bundle since all the views are
-		// available via the individual folders.
-		viewScriptEntry = null;
-	} else {
-		editorScript = path.join( inputDir, 'editor.js' );
-		const viewScript = path.join( inputDir, 'view.js' );
-		viewScriptEntry = fs.existsSync( viewScript ) ? { view: viewScript } : {};
-	}
+	const editorScript = path.join( inputDir, 'editor.js' );
+	const viewScript = path.join( inputDir, 'view.js' );
+	const viewScriptEntry = fs.existsSync( viewScript ) ? { view: viewScript } : {};
 
 	return {
 		...baseConfig,
-		plugins: compact( [
-			...baseConfig.plugins,
-			fs.existsSync( presetPath ) &&
-				new CopyWebpackPlugin( [
-					{
-						from: presetPath,
-						to: 'index.json',
-					},
-				] ),
-		] ),
 		entry: {
 			editor: editorScript,
-			...( editorBetaScript && { 'editor-beta': editorBetaScript } ),
 			...viewScriptEntry,
-			...viewBlocksScripts,
 		},
 		output: {
 			path: outputDir || path.join( inputDir, 'build' ),


### PR DESCRIPTION
The SDK Gutenberg tool had become overly specific to build the Jetpack
Gutenberg extensions. Said extensions no longer depend on the SDK tool,
instead relying on their own specific build tool.

Should help remove a Webpack plugin only required for building Jetpack blocks (#30904)

## Testing instructions

SDK builds should still work as expected for the only remaining preset:

`npm run sdk gutenberg client/gutenberg/extensions/presets/o2`