### PR TITLE
ProfileLinks: fix disabled button, remove code (state, CSS classes)

### DIFF
--- a/client/me/profile-links/add-buttons.jsx
+++ b/client/me/profile-links/add-buttons.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
@@ -21,14 +21,8 @@ class AddProfileLinksButtons extends React.Component {
 	static propTypes = {
 		showingForm: PropTypes.bool,
 		showPopoverMenu: PropTypes.bool,
-	};
-
-	static defaultProps = {
-		showingForm: false,
-	};
-
-	state = {
-		popoverPosition: 'top',
+		onShowAddWordPress: PropTypes.func.isRequired,
+		onShowAddOther: PropTypes.func.isRequired,
 	};
 
 	popoverContext = React.createRef();
@@ -48,32 +42,34 @@ class AddProfileLinksButtons extends React.Component {
 	};
 
 	render() {
-		return (
-			<div>
-				<PopoverMenu
-					isVisible={ this.props.showPopoverMenu }
-					onClose={ this.props.onClosePopoverMenu }
-					position={ this.state.popoverPosition }
-					context={ this.popoverContext.current }
-				>
-					<PopoverMenuItem onClick={ this.handleAddWordPressSiteButtonClick }>
-						{ this.props.translate( 'Add WordPress Site' ) }
-					</PopoverMenuItem>
-					<PopoverMenuItem onClick={ this.handleOtherSiteButtonClick }>
-						{ this.props.translate( 'Add URL' ) }
-					</PopoverMenuItem>
-				</PopoverMenu>
+		const { translate } = this.props;
 
+		return (
+			<Fragment>
 				<Button
-					compact
 					ref={ this.popoverContext }
-					className="popover-icon"
+					compact
+					disabled={ this.props.showingForm }
 					onClick={ this.props.onShowPopoverMenu }
 				>
 					<Gridicon icon="add-outline" />
-					<span>{ this.props.translate( 'Add' ) }</span>
+					<span>{ translate( 'Add' ) }</span>
 				</Button>
-			</div>
+				{ this.props.showPopoverMenu && (
+					<PopoverMenu
+						isVisible
+						onClose={ this.props.onClosePopoverMenu }
+						context={ this.popoverContext.current }
+					>
+						<PopoverMenuItem onClick={ this.handleAddWordPressSiteButtonClick }>
+							{ translate( 'Add WordPress Site' ) }
+						</PopoverMenuItem>
+						<PopoverMenuItem onClick={ this.handleOtherSiteButtonClick }>
+							{ translate( 'Add URL' ) }
+						</PopoverMenuItem>
+					</PopoverMenu>
+				) }
+			</Fragment>
 		);
 	}
 }

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -177,7 +177,7 @@ class ProfileLinks extends React.Component {
 				<QueryProfileLinks />
 				<SectionHeader label={ this.props.translate( 'Profile Links' ) }>
 					<AddProfileLinksButtons
-						showingForm={ !! this.state.showingForm }
+						showingForm={ this.state.showingForm }
 						onShowAddOther={ this.showAddOther }
 						showPopoverMenu={ this.state.showPopoverMenu }
 						onShowAddWordPress={ this.showAddWordPress }
@@ -185,7 +185,7 @@ class ProfileLinks extends React.Component {
 						onClosePopoverMenu={ this.closePopoverMenu }
 					/>
 				</SectionHeader>
-				<Card>{ !! this.state.showingForm ? this.renderForm() : this.renderProfileLinks() }</Card>
+				<Card>{ this.state.showingForm ? this.renderForm() : this.renderProfileLinks() }</Card>
 			</div>
 		);
 	}


### PR DESCRIPTION
A low priority janitorial fix that got left in my stash after reviewing some CSS migrations and `moment-timezone` removal:
- use `showingForm` prop to disable the button while a form is shown (got broken way back in #4611)
- remove `popoverPosition` state that has default (top) value and never changes,
- remove unused `popover-icon` CSS class

**How to test:**
Verify that the button to add profile links in `/me` works as expected:

<img width="478" alt="Screenshot 2019-03-25 at 15 03 12" src="https://user-images.githubusercontent.com/664258/54925715-24157300-4f0f-11e9-968f-34632c85c2fa.png">

Is the button disabled while a form is displayed? Does it get enabled back after clicking "Cancel" in the form?