### PR TITLE
ProfileGravatar: convert to functional component, remove localize HOC

### DIFF
--- a/client/me/profile-gravatar/index.jsx
+++ b/client/me/profile-gravatar/index.jsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 
-import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -18,33 +17,30 @@ import { recordGoogleEvent } from 'state/analytics/actions';
  */
 import './style.scss';
 
-class ProfileGravatar extends Component {
-	recordGravatarMisclick = () => {
-		this.props.recordGoogleEvent( 'Me', 'Clicked on Unclickable Gravatar Image in Sidebar' );
-	};
+// use imgSize = 400 for caching
+// it's the popular value for large Gravatars in Calypso
+const GRAVATAR_IMG_SIZE = 400;
 
-	render() {
-		// use imgSize = 400 for caching
-		// it's the popular value for large Gravatars in Calypso
-		const GRAVATAR_IMG_SIZE = 400;
+// Action creator to record clicks on non-interactive profile picture
+function recordGravatarMisclick() {
+	return recordGoogleEvent( 'Me', 'Clicked on Unclickable Gravatar Image in Sidebar' );
+}
 
-		return (
-			<div className="profile-gravatar">
-				<div onClick={ this.recordGravatarMisclick }>
-					<Animate type="appear">
-						<Gravatar user={ this.props.user } size={ 150 } imgSize={ GRAVATAR_IMG_SIZE } />
-					</Animate>
-				</div>
-				<h2 className="profile-gravatar__user-display-name">{ this.props.user.display_name }</h2>
-				<div className="profile-gravatar__user-secondary-info">@{ this.props.user.username }</div>
+function ProfileGravatar( props ) {
+	return (
+		<div className="profile-gravatar">
+			<div role="presentation" onClick={ props.recordGravatarMisclick }>
+				<Animate type="appear">
+					<Gravatar user={ props.user } size={ 150 } imgSize={ GRAVATAR_IMG_SIZE } />
+				</Animate>
 			</div>
-		);
-	}
+			<h2 className="profile-gravatar__user-display-name">{ props.user.display_name }</h2>
+			<div className="profile-gravatar__user-secondary-info">@{ props.user.username }</div>
+		</div>
+	);
 }
 
 export default connect(
 	null,
-	{
-		recordGoogleEvent,
-	}
-)( localize( ProfileGravatar ) );
+	{ recordGravatarMisclick }
+)( ProfileGravatar );


### PR DESCRIPTION
Another janitorial that appeared in my stash when reviewing usages of `i18n-calypso`: the `ProfileGravatar` doesn't use `translate` at all and can be converted to functional component.

I learned a new trick how to correctly fix the a11y warning about non-interactive static elements having `onClick` listeners: give the `div` a `presentation` role:
```js
<div role="presentation" onClick={ handleClick }>
```

The [jsx-a11y plugin docs](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events) have an example that suggests this. Their use case is different, but I think our case, capturing clicks only for analytics purposes, is also valid.

**How to test:**
Go to `/me` and verify that the big Gravatar circle with your picture in the sidebar works as expected.