### PR TITLE
ClipboardButton: update to React Hooks

### DIFF
--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -7,8 +7,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { omit } from 'lodash';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
@@ -24,85 +23,46 @@ import { recordTracksEvent } from 'state/analytics/actions';
  */
 import './style.scss';
 
-class ClipboardButtonInputExport extends React.Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			isCopied: false,
-			disabled: false,
-		};
-	}
-	static propTypes = {
-		value: PropTypes.string,
-		disabled: PropTypes.bool,
-		className: PropTypes.string,
-		hideHttp: PropTypes.bool,
-		moment: PropTypes.func,
-		numberFormat: PropTypes.func,
-		translate: PropTypes.func,
+function ClipboardButtonInput( { value = '', className, disabled, hideHttp, dispatch, ...rest } ) {
+	const translate = useTranslate();
+
+	const [ isCopied, setCopied ] = React.useState( false );
+
+	// toggle the `isCopied` flag back to `false` after 4 seconds
+	React.useEffect(() => {
+		if ( isCopied ) {
+			const confirmationTimeout = setTimeout( () => setCopied( false ), 4000 );
+			return () => clearTimeout( confirmationTimeout );
+		}
+	}, [ isCopied ]);
+
+	const showConfirmation = () => {
+		setCopied( true );
+		dispatch( recordTracksEvent( 'calypso_editor_clipboard_url_button_click' ) );
 	};
 
-	static defaultProps = {
-		value: '',
-	};
-
-	componentWillUnmount() {
-		clearTimeout( this.confirmationTimeout );
-		delete this.confirmationTimeout;
-	}
-
-	showConfirmation = () => {
-		this.setState( {
-			isCopied: true,
-		} );
-
-		this.confirmationTimeout = setTimeout( () => {
-			this.setState( {
-				isCopied: false,
-			} );
-		}, 4000 );
-		this.props.recordTracksEvent( 'calypso_editor_clipboard_url_button_click' );
-	};
-
-	render() {
-		const { value, className, disabled, hideHttp, translate } = this.props;
-		const classes = classnames( 'clipboard-button-input', className );
-
-		return (
-			<span className={ classes }>
-				<FormTextInput
-					{ ...omit(
-						this.props,
-						'className',
-						'hideHttp',
-						'moment',
-						'numberFormat',
-						'translate',
-						'recordTracksEvent'
-					) }
-					value={ hideHttp ? withoutHttp( value ) : value }
-					type="text"
-					selectOnFocus
-					readOnly
-				/>
-				<ClipboardButton
-					text={ value }
-					onCopy={ this.showConfirmation }
-					disabled={ disabled }
-					compact
-				>
-					{ this.state.isCopied
-						? translate( 'Copied!' )
-						: translate( 'Copy', { context: 'verb' } ) }
-				</ClipboardButton>
-			</span>
-		);
-	}
+	return (
+		<span className={ classnames( 'clipboard-button-input', className ) }>
+			<FormTextInput
+				{ ...rest }
+				disabled={ disabled }
+				value={ hideHttp ? withoutHttp( value ) : value }
+				type="text"
+				selectOnFocus
+				readOnly
+			/>
+			<ClipboardButton text={ value } onCopy={ showConfirmation } disabled={ disabled } compact>
+				{ isCopied ? translate( 'Copied!' ) : translate( 'Copy', { context: 'verb' } ) }
+			</ClipboardButton>
+		</span>
+	);
 }
 
-export default connect(
-	null,
-	{
-		recordTracksEvent,
-	}
-)( localize( ClipboardButtonInputExport ) );
+ClipboardButtonInput.propTypes = {
+	value: PropTypes.string,
+	disabled: PropTypes.bool,
+	className: PropTypes.string,
+	hideHttp: PropTypes.bool,
+};
+
+export default connect()( ClipboardButtonInput );

--- a/client/components/forms/clipboard-button/index.jsx
+++ b/client/components/forms/clipboard-button/index.jsx
@@ -6,10 +6,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
 import ReactDom from 'react-dom';
 import Clipboard from 'clipboard';
-import { omit, noop } from 'lodash';
+import { noop } from 'lodash';
 import classNames from 'classnames';
 
 /**
@@ -17,55 +16,40 @@ import classNames from 'classnames';
  */
 import Button from 'components/button';
 
-class ClipboardButton extends React.Component {
-	static propTypes = {
-		className: PropTypes.string,
-		text: PropTypes.string,
-		onCopy: PropTypes.func,
-		// from localize()
-		moment: PropTypes.func,
-		numberFormat: PropTypes.func,
-		translate: PropTypes.func,
-	};
+function ClipboardButton( { className, text, onCopy = noop, ...rest } ) {
+	const buttonRef = React.useRef();
 
-	static defaultProps = {
-		onCopy: noop,
-	};
+	const textCallback = React.useRef();
+	const successCallback = React.useRef();
 
-	buttonReference = React.createRef();
+	// update the callbacks on rerenders that change `text` or `onCopy`
+	React.useEffect(() => {
+		textCallback.current = () => text;
+		successCallback.current = onCopy;
+	}, [ text, onCopy ]);
 
-	componentDidMount() {
-		const button = ReactDom.findDOMNode( this.buttonReference.current );
-		this.clipboard = new Clipboard( button, {
-			text: () => this.props.text,
-		} );
-		this.clipboard.on( 'success', this.props.onCopy );
-		this.clipboard.on( 'error', this.displayPrompt );
-	}
+	// create the `Clipboard` object on mount and destroy on unmount
+	React.useEffect(() => {
+		const buttonEl = ReactDom.findDOMNode( buttonRef.current );
+		const clipboard = new Clipboard( buttonEl, { text: () => textCallback.current() } );
+		clipboard.on( 'success', () => successCallback.current() );
 
-	componentWillUnmount() {
-		this.clipboard.destroy();
-		delete this.clipboard;
-	}
+		return () => clipboard.destroy();
+	}, []);
 
-	displayPrompt = () => {
-		window.prompt(
-			this.props.translate( 'Highlight and copy the following text to your clipboard:' ),
-			this.props.text
-		);
-	};
-
-	render() {
-		const classes = classNames( 'clipboard-button', this.props.className );
-
-		return (
-			<Button
-				ref={ this.buttonReference }
-				{ ...omit( this.props, Object.keys( this.constructor.propTypes ) ) }
-				className={ classes }
-			/>
-		);
-	}
+	return (
+		<Button
+			{ ...rest }
+			ref={ buttonRef }
+			className={ classNames( 'clipboard-button', className ) }
+		/>
+	);
 }
 
-export default localize( ClipboardButton );
+ClipboardButton.propTypes = {
+	className: PropTypes.string,
+	text: PropTypes.string,
+	onCopy: PropTypes.func,
+};
+
+export default ClipboardButton;


### PR DESCRIPTION
Another janitorial I did when inspecting usages of `i18n-calypso` and moment.js. Refactors `ClipboardButton` and `ClipboardButtonInput` to hooks.

The main motivation was to avoid code like:
```jsx
const passedProps = omit( this.props, Object.keys( this.constructor.propTypes ) );
<WrappedComponent { ...passedProps } />
```
and replace it with object destructuring.

I'd like to remove all production usages of `propTypes` and the remove them from production builds with [babel-plugin-transform-react-remove-prop-types](https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types).

From `ClipboardButton` I removed the error handler that uses `window.prompt` and `i18n-calypso` to show a localized message. The error can happen only when `document.execCommand( 'copy' )` fails. And that doesn't happen in any reasonably recent browser today.

Hooks code, especially saving the up-to-date versions of callbacks to refs, is heavily inspired by [Dan Abramov's `useInterval` hook](https://overreacted.io/making-setinterval-declarative-with-react-hooks/).

**How to test:**
Both components can be tested in devdocs. There are also many usages in Classic Editor UI:

<img width="530" alt="Screenshot 2019-03-25 at 16 29 51" src="https://user-images.githubusercontent.com/664258/54935469-a6f2f980-4f20-11e9-9513-41d7c67dbcd8.png">
