### PR TITLE
Enables engine6 imports in wpcalypso environment

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -74,6 +74,7 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import-in-sidebar": true,
+		"manage/import/engine6": true,
 		"manage/import/medium": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enables Engine 6 imports in wpcalypso environment.

#### Testing instructions

None.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
