### PR TITLE
Import in Signup: Split step dependencies so tracks event records

### DIFF
--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -25,10 +25,22 @@ const SignupActions = {
 	},
 
 	submitSignupStep( step, errors, providedDependencies ) {
+		const { stepName } = step;
+
 		// Transform the keys since tracks events only accept snaked prop names.
 		const inputs = keys( providedDependencies ).reduce( ( props, name ) => {
 			let propName = snakeCase( name );
 			let propValue = providedDependencies[ name ];
+
+			if ( stepName === 'from-url' && propName === 'site_preview_image_blob' ) {
+				/**
+				 * There's no need to include a resource ID in our event.
+				 * Just record that a preview was fetched
+				 * @see the `sitePreviewImageBlob` dependency
+				 */
+				propName = 'site_preview_image_fetched';
+				propValue = !! propValue;
+			}
 
 			// Ensure we don't capture identifiable user data we don't need.
 			if ( includes( [ 'email', 'address', 'phone' ], propName ) ) {
@@ -43,7 +55,7 @@ const SignupActions = {
 		}, {} );
 
 		analytics.tracks.recordEvent( 'calypso_signup_actions_submit_step', {
-			step: step.stepName,
+			step: stepName,
 			...inputs,
 		} );
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -326,11 +326,11 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 
 	flows.import = {
 		steps: [ 'from-url', 'user', 'domains' ],
-		destination: ( { importSiteDetails, importUrl, siteSlug } ) =>
+		destination: ( { importEngine, importSiteUrl, siteSlug } ) =>
 			addQueryArgs(
 				{
-					engine: importSiteDetails.engine || null,
-					'from-site': ( importUrl && encodeURIComponent( importUrl ) ) || null,
+					engine: importEngine || null,
+					'from-site': ( importSiteUrl && encodeURIComponent( importSiteUrl ) ) || null,
 				},
 				`/settings/import/${ siteSlug }`
 			),

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -433,8 +433,10 @@ export function generateSteps( {
 		'from-url': {
 			stepName: 'from-url',
 			providesDependencies: [
-				'importSiteDetails',
-				'importUrl',
+				'importEngine',
+				'importFavicon',
+				'importSiteTitle',
+				'importSiteUrl',
 				'sitePreviewImageBlob',
 				'themeSlugWithRepo',
 			],

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -72,14 +72,14 @@ class DomainsStep extends React.Component {
 		super( props );
 
 		const { flowName, signupDependencies } = props;
-		const importUrl = get( signupDependencies, 'importUrl' );
+		const importSiteUrl = get( signupDependencies, 'importSiteUrl' );
 
-		if ( flowName === 'import' && importUrl ) {
+		if ( flowName === 'import' && importSiteUrl ) {
 			this.skipRender = true;
 
 			SignupActions.submitSignupStep( {
 				flowName,
-				siteUrl: importUrl,
+				siteUrl: importSiteUrl,
 				stepName: props.stepName,
 				stepSectionName: props.stepSectionName,
 			} );

--- a/client/state/importer-nux/actions.js
+++ b/client/state/importer-nux/actions.js
@@ -4,7 +4,7 @@
  */
 import { translate } from 'i18n-calypso';
 import url from 'url';
-import { get, trim } from 'lodash';
+import { trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -72,7 +72,7 @@ export const fetchIsSiteImportable = site_url => dispatch => {
 		.catch( error => dispatch( { type: IMPORT_IS_SITE_IMPORTABLE_ERROR, error } ) );
 };
 
-export const submitImportUrlStep = ( { stepName, siteUrl } ) => dispatch => {
+export const submitImportUrlStep = ( { stepName, siteUrl: siteUrlFromInput } ) => dispatch => {
 	dispatch(
 		infoNotice( translate( "Please wait, we're checking to see if we can import this site." ), {
 			id: CHECKING_SITE_IMPORTABLE_NOTICE,
@@ -81,16 +81,16 @@ export const submitImportUrlStep = ( { stepName, siteUrl } ) => dispatch => {
 		} )
 	);
 
-	return dispatch( fetchIsSiteImportable( siteUrl ) )
+	return dispatch( fetchIsSiteImportable( siteUrlFromInput ) )
 		.then( async siteDetails => {
-			const error = get( siteDetails, 'error' );
+			const { engine, error, favicon, siteTitle, siteUrl: importSiteUrl } = siteDetails;
 
 			if ( error ) {
 				throw new Error( error );
 			}
 
 			const imageBlob = await loadmShotsPreview( {
-				url: normalizeUrl( siteUrl ),
+				url: normalizeUrl( siteUrlFromInput ),
 				maxRetries: 30,
 				retryTimeout: 1000,
 			} );
@@ -99,8 +99,10 @@ export const submitImportUrlStep = ( { stepName, siteUrl } ) => dispatch => {
 
 			return SignupActions.submitSignupStep( { stepName }, [], {
 				sitePreviewImageBlob: imageBlob,
-				importSiteDetails: siteDetails,
-				importUrl: siteDetails.siteUrl,
+				importEngine: engine,
+				importFavicon: favicon,
+				importSiteTitle: siteTitle,
+				importSiteUrl,
 				themeSlugWithRepo: 'pub/radcliffe-2',
 			} );
 		} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Instead of "nested" `importSiteDetails`, have the `from-url` step provide flat dependencies:
  * `importEngine`
  * `importFavicon`
  * `importSiteTitle`
  * `importSiteUrl` (this was already split out -- renaming from `importUrl` for consistency)
* Adjust the `import` flow destination for the above
* Adjust the `domains` step for the above
* Adjust the `submitImportUrlStep` action for the above and disambiguate the local variables

#### Testing instructions

* Confirm existing behavior:
  * Run http://calypso.localhost:3000/start/import in an incognito window against the `master` branch
  * Notice an error in the console about not being able to record `calypso_signup_actions_submit_step because nested properties are not supported...`
* Confirm fix
  * Repeat the above against this branch
  * Notice no error is shown in the console
  * Confirm the `calypso_signup_actions_submit_step` event is recorded
  * Confirm the signup flow completes successfully as before
  * Confirm you land "drilled in" to the appropriate import section with the provided URL being confirmed
