### PR TITLE
Import: Modern Business theme for sites created while importing in signup

### DIFF
--- a/client/state/importer-nux/actions.js
+++ b/client/state/importer-nux/actions.js
@@ -103,7 +103,7 @@ export const submitImportUrlStep = ( { stepName, siteUrl: siteUrlFromInput } ) =
 				importFavicon: favicon,
 				importSiteTitle: siteTitle,
 				importSiteUrl,
-				themeSlugWithRepo: 'pub/radcliffe-2',
+				themeSlugWithRepo: 'pub/modern-business',
 			} );
 		} )
 		.catch( error => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sites created while importing in signup default to the Modern Business theme. Data indicates that this is most popular theme activated after finishing signup.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit `/start/import`
1. Enter a Wix url such as https://hi6822.wixsite.com/eat-here-its-good and continue
1. Create a new account, if needed
1. When finished with the signup flow, verify that the new site has the "Modern Business" theme activated
