### PR TITLE
Signup: Fix Safari spacing for search results

### DIFF
--- a/client/components/site-verticals-suggestion-search/style.scss
+++ b/client/components/site-verticals-suggestion-search/style.scss
@@ -22,6 +22,7 @@
 	text-align: left;
 	width: 100%;
 	display: block;
+	margin: 0;
 
 	&:hover, &:focus {
 		cursor: pointer;


### PR DESCRIPTION
It might be hard to see, but in Safari there's a little extra spacing between search results:
<img width="136" alt="image" src="https://user-images.githubusercontent.com/191598/54945454-393cd280-4f0c-11e9-8aa2-d96cf25b5046.png">

This PR removes any margins from the result items, and fixes the extra spacing in Safari:
<img width="162" alt="image" src="https://user-images.githubusercontent.com/191598/54945529-730dd900-4f0c-11e9-8d1a-fce73bff8602.png">
