### PR TITLE
Domains: Search not showing map/transfer option

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -302,9 +302,10 @@ class DomainSearchResults extends React.Component {
 	}
 }
 
-const mapStateToProps = state => {
+const mapStateToProps = ( state, ownProps ) => {
 	return {
-		siteDesignType: getDesignType( state ),
+		// Set site design type only if we're in signup
+		siteDesignType: ownProps.isSignupStep && getDesignType( state ),
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We didn't limit the scope of a prop, so if it got stored
into local storage, it would still be available outside
of NUX, thus hiding the option from regular domain search.

#### Testing instructions

To reproduce:
- Go to https://wpcalypso.wordpress.com/start
- Pick `Sell products`
- Continue
- Make sure you don't see the map/transfer option
- In the same tab, update address to https://wpcalypso.wordpress.com/domains/add
- Search for 'codeden.net'
- It shows `codeden.net is taken.` message
- Now checkout this PR and build calypso locally.
- Repeat the steps above.
- See the call to action to map/transfer
