### PR TITLE
Ads Gutenblock: Remove header/footer from placeholder

### DIFF
--- a/packages/jetpack-blocks/src/blocks/wordads/edit.js
+++ b/packages/jetpack-blocks/src/blocks/wordads/edit.js
@@ -41,9 +41,7 @@ class WordAdsEdit extends Component {
 							height: selectedFormatObject.height + selectedFormatObject.editorPadding,
 						} }
 					>
-						<div className="jetpack-wordads__header">{ __( 'Advertisements' ) }</div>
 						<Placeholder icon={ icon } label={ title } />
-						<div className="jetpack-wordads__footer">{ __( 'Report this Ad' ) }</div>
 						<ToggleControl
 							checked={ Boolean( hideMobile ) }
 							label={ __( 'Hide ad on mobile views' ) }

--- a/packages/jetpack-blocks/src/blocks/wordads/editor.scss
+++ b/packages/jetpack-blocks/src/blocks/wordads/editor.scss
@@ -6,21 +6,6 @@
 	margin: 0 auto;
 }
 
-.jetpack-wordads__header,
-.jetpack-wordads__footer {
-	font-size: 10px;
-	font-family: sans-serif;
-}
-
-.jetpack-wordads__header {
-	text-align: left;
-}
-
-.jetpack-wordads__footer {
-	text-transform: uppercase;
-	text-align: right;
-}
-
 .jetpack-wordads__ad {
 	display: flex;
 	overflow: hidden;
@@ -36,7 +21,7 @@
 	}
 
 	.components-base-control__field {
-		padding-left: 5px;
+		padding: 7px;
 	}
 }
 


### PR DESCRIPTION
Removing the `Advertisements` and `Report this Ad` copy from placeholder per @thomasguillot's comment: https://github.com/Automattic/wp-calypso/pull/31608#issuecomment-476331818

#### Testing instructions

* Open Calypso branch, compile blocks e.g. `npx lerna run build --stream --scope='@automattic/jetpack-blocks' && rsync -a --delete packages/jetpack-blocks/dist/ ../jetpack/_inc/blocks/`
* On WordAds approved site add an add

**Before**
<img width="773" alt="Screen Shot 2019-03-25 at 11 33 03 AM" src="https://user-images.githubusercontent.com/273708/54947863-9038ac80-4ef8-11e9-98c2-22f4bacf3094.png">

**After**
<img width="790" alt="Screen Shot 2019-03-25 at 12 17 35 PM" src="https://user-images.githubusercontent.com/273708/54947867-93cc3380-4ef8-11e9-84e3-40ffa4bef710.png">
