### PR TITLE
Import: remove site title from descriptive header

### DIFF
--- a/client/my-sites/site-settings/settings-import/descriptive-header.jsx
+++ b/client/my-sites/site-settings/settings-import/descriptive-header.jsx
@@ -15,18 +15,14 @@ import CompactCard from 'components/card/compact';
 
 class DescriptiveHeader extends PureComponent {
 	render() {
-		const { site, translate } = this.props;
-		const { slug, title: siteTitle } = site;
+		const { translate } = this.props;
 
-		const title = siteTitle.length ? siteTitle : slug;
 		const description = translate(
-			'Import content from another site into ' +
-				'{{strong}}%(title)s{{/strong}}. Learn more about ' +
+			'Import content from another site. Learn more about ' +
 				'the import process in our {{a}}support documentation{{/a}}. ' +
 				'Once you start importing, you can visit ' +
 				'this page to check on the progress.',
 			{
-				args: { title },
 				components: {
 					a: <a href="https://support.wordpress.com/import/" />,
 					strong: <strong />,

--- a/client/my-sites/site-settings/settings-import/descriptive-header.jsx
+++ b/client/my-sites/site-settings/settings-import/descriptive-header.jsx
@@ -25,7 +25,6 @@ class DescriptiveHeader extends PureComponent {
 			{
 				components: {
 					a: <a href="https://support.wordpress.com/import/" />,
-					strong: <strong />,
 				},
 			}
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the descriptive header on the import settings page to remove the site title. For new sites, this is often just "Site Title" (the default), and it makes the experience more confusing.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/settings/import/YOURDOMAIN.wordpress.com`
* Verify that the header no longer contains your site title.

Before:
![image](https://user-images.githubusercontent.com/363749/54948863-b0be3200-4f0b-11e9-9fac-3c0a38042c09.png)


After:
![image](https://user-images.githubusercontent.com/363749/54948836-9f752580-4f0b-11e9-9adf-beccfa63ac72.png)



