### PR TITLE
Prevent Jetpack sites displaying WordAds Instant Activation Toggle

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -35,6 +35,7 @@ export function canAccessEarnSection( site ) {
 
 export function isWordadsInstantActivationEligible( site ) {
 	if (
+		! site.jetpack &&
 		( isBusiness( site.plan ) || isPremium( site.plan ) ) &&
 		userCan( 'activate_wordads', site )
 	) {

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -159,9 +159,10 @@ class AdsWrapper extends Component {
 					<p className="ads__activate-description">
 						{ translate(
 							'WordAds allows you to make money from advertising that runs on your site. ' +
-								'Because you have a WordPress.com Premium plan, you can skip the review process and activate WordAds instantly. ' +
+								'Because you have a WordPress.com %(plan)s plan, you can skip the review process and activate WordAds instantly. ' +
 								'{{a}}Learn more about the program.{{/a}}',
 							{
+								args: { plan: this.props.site.plan.product_name_short },
 								components: {
 									a: <a href={ 'http://wordads.co' } />,
 								},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevent Jetpack sites from displaying the WordAds Instant Activation Toggle in the Earn section
* Use the correct plan name when displaying the WordAds Instant Activation Toggle

#### Testing instructions

* Create or re-use test sites with Premium and Business plans, as well as test sites with Jetpack Premium and Professional plans
* Visit the Earn section
* Verify that the WordAds Instant Activation Toggle displays for Premium and Business plans, but not for Jetpack sites
* Verify that the correct plan name is used on the WordAds Instant Activation Toggle