### PR TITLE
Signup: Update redirect url to go to checklist after site creation

### DIFF
--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -136,15 +136,8 @@ export class SignupProcessingScreen extends Component {
 			  );
 	}
 
-	showPreviewAfterLogin = () => {
-		const redirectTo = [ 'onboarding', 'onboarding-dev', 'onboarding-for-business' ].includes(
-			this.props.flowName
-		)
-			? `/view/${ this.state.siteSlug }?welcome`
-			: `/checklist/${ this.state.siteSlug }`;
-
-		this.props.loginHandler( { redirectTo } );
-	};
+	showPreviewAfterLogin = () =>
+		this.props.loginHandler( { redirectTo: `/checklist/${ this.state.siteSlug }` } );
 
 	shouldShowChecklist() {
 		const designType = ( this.props.steps || [] ).reduce( function( accumulator, step ) {
@@ -168,7 +161,7 @@ export class SignupProcessingScreen extends Component {
 	componentDidUpdate = () => {
 		const { loginHandler } = this.props;
 
-		if ( !! loginHandler ) {
+		if ( loginHandler ) {
 			this.shouldShowChecklist() ? this.showPreviewAfterLogin() : loginHandler();
 			return null;
 		}

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -136,7 +136,7 @@ export class SignupProcessingScreen extends Component {
 			  );
 	}
 
-	showPreviewAfterLogin = () =>
+	showChecklistAfterLogin = () =>
 		this.props.loginHandler( { redirectTo: `/checklist/${ this.state.siteSlug }` } );
 
 	shouldShowChecklist() {
@@ -162,7 +162,7 @@ export class SignupProcessingScreen extends Component {
 		const { loginHandler } = this.props;
 
 		if ( loginHandler ) {
-			this.shouldShowChecklist() ? this.showPreviewAfterLogin() : loginHandler();
+			this.shouldShowChecklist() ? this.showChecklistAfterLogin() : loginHandler();
 			return null;
 		}
 	};


### PR DESCRIPTION
## Changes proposed in this Pull Request

After our users create new a site,
They're bounced to the preview in spite
of testing, whose outcomes did show
it impedes the onboarding flow.

## Testing instructions

In light of the comments above,
We'll give a congenial shove,
And rather than throw them off piste,
We'll land them on the checklist.

![Mar-26-2019 12-20-13](https://user-images.githubusercontent.com/6458278/54964755-bc6c3000-4fc1-11e9-8a2e-0814a30c7a81.gif)



