### PR TITLE
Inline Popover: Fix/close onboarding welcome prompt

### DIFF
--- a/client/state/inline-help/reducer.js
+++ b/client/state/inline-help/reducer.js
@@ -60,6 +60,7 @@ export const onboardingWelcomePrompt = createReducer(
 	{
 		[ INLINE_HELP_ONBOARDING_WELCOME_PROMPT_SHOW ]: state => ( { ...state, isVisible: true } ),
 		[ INLINE_HELP_ONBOARDING_WELCOME_PROMPT_HIDE ]: state => ( { ...state, isVisible: false } ),
+		[ INLINE_HELP_POPOVER_HIDE ]: state => ( { ...state, isVisible: false } ),
 	}
 );
 

--- a/client/state/inline-help/test/reducer.js
+++ b/client/state/inline-help/test/reducer.js
@@ -9,8 +9,13 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { popover } from '../reducer';
-import { INLINE_HELP_POPOVER_SHOW, INLINE_HELP_POPOVER_HIDE } from 'state/action-types';
+import { popover, onboardingWelcomePrompt } from '../reducer';
+import {
+	INLINE_HELP_POPOVER_SHOW,
+	INLINE_HELP_POPOVER_HIDE,
+	INLINE_HELP_ONBOARDING_WELCOME_PROMPT_SHOW,
+	INLINE_HELP_ONBOARDING_WELCOME_PROMPT_HIDE,
+} from 'state/action-types';
 
 describe( 'reducer', () => {
 	describe( '#popover()', () => {
@@ -26,6 +31,39 @@ describe( 'reducer', () => {
 		test( 'should the existing visible status', () => {
 			const original = deepFreeze( { isVisible: true } );
 			const state = popover( original, {
+				type: INLINE_HELP_POPOVER_HIDE,
+			} );
+
+			expect( state ).to.eql( {
+				isVisible: false,
+			} );
+		} );
+	} );
+
+	describe( '#onboardingWelcomePrompt()', () => {
+		test( 'should set isVisible to true', () => {
+			const state = onboardingWelcomePrompt( null, {
+				type: INLINE_HELP_ONBOARDING_WELCOME_PROMPT_SHOW,
+			} );
+
+			expect( state ).to.eql( {
+				isVisible: true,
+			} );
+		} );
+		test( 'should set isVisible to false', () => {
+			const original = deepFreeze( { isVisible: true } );
+			const state = onboardingWelcomePrompt( original, {
+				type: INLINE_HELP_ONBOARDING_WELCOME_PROMPT_HIDE,
+			} );
+
+			expect( state ).to.eql( {
+				isVisible: false,
+			} );
+		} );
+
+		test( 'should set isVisible to false when the popover is hidden', () => {
+			const original = deepFreeze( { isVisible: true } );
+			const state = onboardingWelcomePrompt( original, {
 				type: INLINE_HELP_POPOVER_HIDE,
 			} );
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

The celebratory prompt persists across pages.

![onboarding](https://user-images.githubusercontent.com/6458278/54974475-4b8c3e80-4fe8-11e9-9a29-15090e790c52.gif)

This PR fixes that by cancelling the welcome prompt whenever the popover action is closed.

![Mar-26-2019 16-48-14](https://user-images.githubusercontent.com/6458278/54974503-652d8600-4fe8-11e9-8a79-b4304cb0076a.gif)

## Testing instructions

Steps to reproduce:
- Go to `http://calypso.localhost:3000/view/{yoursite}?welcome`
- Click on `/stats` or another page
- Open the popover.

Expected behaviour:
The popover should contain the regular help content, not the welcome onboarding content.

