### PR TITLE
Wiring the new `verticals` state tree to the related components

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -98,9 +98,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			this.setState( { railcar: this.getNewRailcar() } );
 		}
 
-		this.props.onChange( {
-			verticalName: value,
-		} );
+		this.updateVerticalData( result, value );
 
 		this.setState( {
 			isNavigating,

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -17,6 +17,7 @@ import SuggestionSearch from 'components/suggestion-search';
 import PopularTopics from 'components/site-verticals-suggestion-search/popular-topics';
 import QueryVerticals from 'components/data/query-verticals';
 import { getVerticals } from 'state/signup/verticals/selectors';
+import { DEFAULT_VERTICAL_KEY } from 'state/signup/verticals/constants';
 
 /**
  * Style dependencies
@@ -162,7 +163,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		return (
 			<>
 				<QueryVerticals searchTerm={ this.props.searchValue.trim() } />
-				<QueryVerticals searchTerm={ 'business' } limit={ 1 } />
+				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } limit={ 1 } />
 				<SuggestionSearch
 					id="siteTopic"
 					placeholder={ placeholder || translate( 'Enter a keyword or select one from below.' ) }

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find, get, noop, startsWith, trim, uniq } from 'lodash';
+import { find, get, noop, startsWith, uniq } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { v4 as uuid } from 'uuid';
 
@@ -14,10 +14,9 @@ import { v4 as uuid } from 'uuid';
  * Internal dependencies
  */
 import SuggestionSearch from 'components/suggestion-search';
-import { getHttpData, requestHttpData } from 'state/data-layer/http-data';
-import { http } from 'state/data-layer/wpcom-http/actions';
-import { convertToCamelCase } from 'state/data-layer/utils';
 import PopularTopics from 'components/site-verticals-suggestion-search/popular-topics';
+import QueryVerticals from 'components/data/query-verticals';
+import { getVerticals } from 'state/signup/verticals/selectors';
 
 /**
  * Style dependencies
@@ -31,8 +30,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		lastUpdated: PropTypes.number,
 		onChange: PropTypes.func,
 		placeholder: PropTypes.string,
-		requestDefaultVertical: PropTypes.func,
-		requestVerticals: PropTypes.func,
 		shouldShowPopularTopics: PropTypes.func,
 		searchResultsLimit: PropTypes.number,
 		verticals: PropTypes.array,
@@ -44,8 +41,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		initialValue: '',
 		onChange: noop,
 		placeholder: '',
-		requestDefaultVertical: noop,
-		requestVerticals: noop,
 		shouldShowPopularTopics: noop,
 		searchResultsLimit: 5,
 		verticals: [],
@@ -55,26 +50,8 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			searchValue: props.initialValue,
 			railcar: this.getNewRailcar(),
 		};
-		props.requestDefaultVertical();
-	}
-
-	componentDidMount() {
-		// If we have a stored vertical, grab the preview
-		this.props.initialValue && this.props.requestVerticals( this.props.initialValue, 1 );
-	}
-
-	componentDidUpdate( prevProps ) {
-		// Check if there's a direct match for any subsequent
-		// HTTP requests
-		if ( prevProps.lastUpdated !== this.props.lastUpdated ) {
-			this.updateVerticalData(
-				this.searchForVerticalMatches( this.state.searchValue ),
-				this.state.searchValue
-			);
-		}
 	}
 
 	getNewRailcar() {
@@ -117,16 +94,13 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			// Don't trigger a search if there's already an exact, non-user-defined match from the API
 			! result
 		) {
-			this.props.requestVerticals( value, this.props.searchResultsLimit );
 			this.setState( { railcar: this.getNewRailcar() } );
 		}
 
-		this.setState( { searchValue: value } );
 		this.updateVerticalData( result, value );
 	};
 
 	onPopularTopicSelect = value => {
-		this.props.requestVerticals( value, 1 );
 		this.setState( { searchValue: value } );
 	};
 
@@ -158,71 +132,35 @@ export class SiteVerticalsSuggestionSearch extends Component {
 
 	render() {
 		const { translate, placeholder, autoFocus, shouldShowPopularTopics } = this.props;
-		const showPopularTopics = shouldShowPopularTopics( this.state.searchValue );
+		const showPopularTopics = shouldShowPopularTopics( this.props.searchValue );
 		return (
 			<>
+				<QueryVerticals searchTerm={ this.props.searchValue } />
+				<QueryVerticals searchTerm={ 'business' } limit={ 1 } />
 				<SuggestionSearch
 					id="siteTopic"
 					placeholder={ placeholder || translate( 'Enter a keyword or select one from below.' ) }
 					onChange={ this.onSiteTopicChange }
 					suggestions={ this.getSuggestions() }
-					value={ this.state.searchValue }
+					value={ this.props.searchValue }
 					sortResults={ this.sortSearchResults }
 					autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 					railcar={ this.state.railcar }
 				/>
-				{ showPopularTopics && <PopularTopics onSelect={ this.onPopularTopicSelect } /> }
+				{ showPopularTopics && <PopularTopics onSelect={ this.onSiteTopicChange } /> }
 			</>
 		);
 	}
 }
 
-const SITE_VERTICALS_REQUEST_ID = 'site-verticals-search-results';
-const DEFAULT_SITE_VERTICAL_REQUEST_ID = 'default-site-verticals-search-results';
-
-const requestSiteVerticalHttpData = ( searchTerm, limit = 7, id = SITE_VERTICALS_REQUEST_ID ) => {
-	searchTerm = trim( searchTerm );
-	requestHttpData(
-		id,
-		http( {
-			apiNamespace: 'wpcom/v2',
-			method: 'GET',
-			path: '/verticals',
-			query: {
-				search: searchTerm,
-				limit,
-				include_preview: true,
-			},
-		} ),
-		{
-			fromApi: () => data => [ [ id, convertToCamelCase( data ) ] ],
-			freshness: -Infinity,
-		}
-	);
-};
-
-export const isVerticalSearchPending = () =>
-	'pending' === get( getHttpData( SITE_VERTICALS_REQUEST_ID ), 'state', false );
-
 export default localize(
 	connect(
-		() => {
-			const siteVerticalHttpData = getHttpData( SITE_VERTICALS_REQUEST_ID );
-			const defaultVerticalHttpData = getHttpData( DEFAULT_SITE_VERTICAL_REQUEST_ID );
-			return {
-				lastUpdated: get( siteVerticalHttpData, 'lastUpdated', 0 ),
-				verticals: get( siteVerticalHttpData, 'data', [] ),
-				defaultVertical: get( defaultVerticalHttpData, 'data[0]', {} ),
-			};
-		},
+		( state, ownProps ) => ( {
+			verticals: getVerticals( state, ownProps.searchValue ) || [],
+			defaultVertical: get( getVerticals( state, 'business' ), '0', {} ),
+		} ),
 		( dispatch, ownProps ) => ( {
 			shouldShowPopularTopics: searchValue => ! searchValue && ownProps.showPopular,
-			requestVerticals: requestSiteVerticalHttpData,
-			requestDefaultVertical: ( searchTerm = 'business' ) => {
-				if ( ! get( getHttpData( DEFAULT_SITE_VERTICAL_REQUEST_ID ), 'data', null ) ) {
-					requestSiteVerticalHttpData( searchTerm, 1, DEFAULT_SITE_VERTICAL_REQUEST_ID );
-				}
-			},
 		} )
 	)( SiteVerticalsSuggestionSearch )
 );

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -164,7 +164,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 
 		return (
 			<>
-				<QueryVerticals searchTerm={ this.props.searchValue } />
+				<QueryVerticals searchTerm={ this.props.searchValue.trim() } />
 				<QueryVerticals searchTerm={ 'business' } limit={ 1 } />
 				<SuggestionSearch
 					id="siteTopic"
@@ -186,8 +186,10 @@ export class SiteVerticalsSuggestionSearch extends Component {
 export default localize(
 	connect(
 		( state, ownProps ) => {
-			const verticals = getVerticals( state, ownProps.searchValue );
-			const isVerticalSearchPending = null == verticals;
+			const { searchValue } = ownProps;
+			const trimmedSearchValue = searchValue.trim();
+			const verticals = getVerticals( state, trimmedSearchValue );
+			const isVerticalSearchPending = trimmedSearchValue && null == verticals;
 
 			return {
 				verticals: verticals || [],

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -31,7 +31,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		onChange: PropTypes.func,
 		placeholder: PropTypes.string,
 		shouldShowPopularTopics: PropTypes.func,
-		searchResultsLimit: PropTypes.number,
+		searchValue: PropTypes.string,
 		verticals: PropTypes.array,
 		defaultVertical: PropTypes.object,
 	};
@@ -42,7 +42,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		onChange: noop,
 		placeholder: '',
 		shouldShowPopularTopics: noop,
-		searchResultsLimit: 5,
+		searchValue: '',
 		verticals: [],
 		defaultVertical: {},
 	};
@@ -119,10 +119,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			} );
 		}
 	}
-
-	onPopularTopicSelect = value => {
-		this.setState( { searchValue: value } );
-	};
 
 	getSuggestions = () => this.state.candidateVerticals.map( vertical => vertical.verticalName );
 

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -51,6 +51,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		super( props );
 		this.state = {
 			railcar: this.getNewRailcar(),
+			candidateVerticals: [],
 		};
 	}
 
@@ -82,7 +83,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			}
 		);
 
-	onSiteTopicChange = value => {
+	onSiteTopicChange = ( value, isNavigating ) => {
 		const hasValue = !! value;
 		const valueLength = value.length || 0;
 		const valueLengthShouldTriggerSearch = valueLength >= this.props.charsToTriggerSearch;
@@ -97,14 +98,35 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			this.setState( { railcar: this.getNewRailcar() } );
 		}
 
-		this.updateVerticalData( result, value );
+		this.props.onChange( {
+			verticalName: value,
+		} );
+
+		this.setState( {
+			isNavigating,
+		} );
 	};
+
+	componentDidUpdate( prevProps ) {
+		// The suggestion list should only be updated when a user is not navigating the list through keying.
+		// Note: it's intentional to use object reference comparison here.
+		// Since `verticals` props is connected from a redux state here, if the two references are identical,
+		// we can safely say that the two content are identical, thanks to the immutability invariant of redux.
+		if ( prevProps.verticals !== this.props.verticals && ! this.state.isNavigating ) {
+			// It's safe here to call setState() because we prevent the indefinite loop by the wrapping condition.
+			// See the official doc here: https://reactjs.org/docs/react-component.html#componentdidupdate
+			// eslint-disable-next-line react/no-did-update-set-state
+			this.setState( {
+				candidateVerticals: this.props.verticals,
+			} );
+		}
+	}
 
 	onPopularTopicSelect = value => {
 		this.setState( { searchValue: value } );
 	};
 
-	getSuggestions = () => this.props.verticals.map( vertical => vertical.verticalName );
+	getSuggestions = () => this.state.candidateVerticals.map( vertical => vertical.verticalName );
 
 	sortSearchResults = ( suggestionsArray, queryString ) => {
 		let queryMatch;

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -153,8 +153,15 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	};
 
 	render() {
-		const { translate, placeholder, autoFocus, shouldShowPopularTopics } = this.props;
+		const {
+			translate,
+			placeholder,
+			autoFocus,
+			shouldShowPopularTopics,
+			isVerticalSearchPending,
+		} = this.props;
 		const showPopularTopics = shouldShowPopularTopics( this.props.searchValue );
+
 		return (
 			<>
 				<QueryVerticals searchTerm={ this.props.searchValue } />
@@ -167,6 +174,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 					value={ this.props.searchValue }
 					sortResults={ this.sortSearchResults }
 					autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
+					isSearching={ isVerticalSearchPending }
 					railcar={ this.state.railcar }
 				/>
 				{ showPopularTopics && <PopularTopics onSelect={ this.onSiteTopicChange } /> }
@@ -177,10 +185,16 @@ export class SiteVerticalsSuggestionSearch extends Component {
 
 export default localize(
 	connect(
-		( state, ownProps ) => ( {
-			verticals: getVerticals( state, ownProps.searchValue ) || [],
-			defaultVertical: get( getVerticals( state, 'business' ), '0', {} ),
-		} ),
+		( state, ownProps ) => {
+			const verticals = getVerticals( state, ownProps.searchValue );
+			const isVerticalSearchPending = null == verticals;
+
+			return {
+				verticals: verticals || [],
+				isVerticalSearchPending,
+				defaultVertical: get( getVerticals( state, 'business' ), '0', {} ),
+			};
+		},
 		( dispatch, ownProps ) => ( {
 			shouldShowPopularTopics: searchValue => ! searchValue && ownProps.showPopular,
 		} )

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -71,6 +71,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			item => item.verticalName.toLowerCase() === value.toLowerCase() && !! item.preview
 		);
 
+	// TODO: once the siteVertical state got simplified, this can be removed.
 	updateVerticalData = ( result, value ) =>
 		this.props.onChange(
 			result || {
@@ -89,6 +90,8 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		const valueLengthShouldTriggerSearch = valueLength >= this.props.charsToTriggerSearch;
 		const result = this.searchForVerticalMatches( value );
 
+		// TODO:
+		// Where to put the railcar code will be reconsidered.
 		if (
 			hasValue &&
 			valueLengthShouldTriggerSearch &&

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -28,7 +28,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	static propTypes = {
 		charsToTriggerSearch: PropTypes.number,
 		initialValue: PropTypes.string,
-		lastUpdated: PropTypes.number,
 		onChange: PropTypes.func,
 		placeholder: PropTypes.string,
 		shouldShowPopularTopics: PropTypes.func,

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -2,6 +2,13 @@
 
 exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
 <Fragment>
+  <Connect(QueryVerticals)
+    searchTerm=""
+  />
+  <Connect(QueryVerticals)
+    limit={1}
+    searchTerm="business"
+  />
   <SuggestionSearch
     autoFocus={false}
     id="siteTopic"
@@ -15,11 +22,7 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
       }
     }
     sortResults={[Function]}
-    suggestions={
-      Array [
-        "doo",
-      ]
-    }
+    suggestions={Array []}
     value=""
   />
 </Fragment>

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -23,7 +23,6 @@ jest.mock( 'uuid', () => ( {
 
 const defaultProps = {
 	onChange: jest.fn(),
-	requestVerticals: jest.fn(),
 	verticals: [
 		{
 			verticalName: 'doo',
@@ -34,7 +33,6 @@ const defaultProps = {
 			verticalId: 'hoodoo',
 		},
 	],
-	requestDefaultVertical: jest.fn(),
 	defaultVertical: {
 		verticalName: 'eeek',
 		verticalSlug: 'ooofff',
@@ -45,11 +43,9 @@ const defaultProps = {
 	},
 	translate: str => str,
 	charsToTriggerSearch: 2,
-	lastUpdated: 1,
 	shouldShowPopularTopics: jest.fn(),
+	searchValue: '',
 };
-
-defaultProps.requestVerticals.cancel = jest.fn();
 
 describe( '<SiteVerticalsSuggestionSearch />', () => {
 	afterEach( () => {
@@ -62,23 +58,9 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 		expect( wrapper ).toMatchSnapshot();
 	} );
 
-	test( 'should make an API call onMount where there is a valid initial value', () => {
-		shallow( <SiteVerticalsSuggestionSearch { ...defaultProps } initialValue="scooby" /> );
-		expect( defaultProps.requestVerticals ).toHaveBeenLastCalledWith( 'scooby', 1 );
-	} );
-
-	test( 'should trigger search after > `charsToTriggerSearch` characters and call `onChange` prop', () => {
-		const wrapper = shallow( <SiteVerticalsSuggestionSearch { ...defaultProps } /> );
-		wrapper.instance().onSiteTopicChange( 'b' );
-		expect( defaultProps.requestVerticals ).not.toHaveBeenCalled();
-		wrapper.instance().onSiteTopicChange( 'bo' );
-		expect( defaultProps.requestVerticals ).toHaveBeenLastCalledWith( 'bo', 5 );
-	} );
-
 	test( 'should pass an exact non-user vertical match to the `onChange` prop', () => {
 		const wrapper = shallow( <SiteVerticalsSuggestionSearch { ...defaultProps } /> );
 		wrapper.instance().onSiteTopicChange( 'doo' );
-		wrapper.setProps( { lastUpdated: 2 } );
 		expect( defaultProps.onChange ).toHaveBeenLastCalledWith( defaultProps.verticals[ 0 ] );
 	} );
 

--- a/client/components/suggestion-search/README.md
+++ b/client/components/suggestion-search/README.md
@@ -8,8 +8,8 @@ SuggestionSearch is a bundled component of FormTextInput and Suggestions which e
 ```es6
 import SuggestionSearch from 'components/suggestion-search';
 
-onChange( newValue ) {
-	console.log( 'New value: ', newValue );
+onChange( newValue, isNavigating ) {
+	console.log( 'New value: ', newValue, 'isNavigating:', isNavigating );
 }
 
 render() {
@@ -36,7 +36,7 @@ It's common that this component is used in a form. This `id` prop is passed to t
 The placeholder text to show if there has nothing been entered yet.
 
 ### `{Func} onChange`
-The callback function for receiving updated value, whether it's by typing, autocompletion, or suggestion picking.
+The callback function for receiving updated value, whether it's by typing, autocompletion, or suggestion picking. If a user is navigating through the list, it will pass an additional `true` as the 2nd argument.
 
 ### `{Func} sortResults` 
 An optional method for sorting the results that we display in the suggestion list.

--- a/client/components/suggestion-search/README.md
+++ b/client/components/suggestion-search/README.md
@@ -33,7 +33,7 @@ It's common that this component is used in a form. This `id` prop is passed to t
 
 
 ### `{String} placeholder`
-The placeholder text to show if there has nothing been entered yet.
+The placeholder text to show if nothing has been entered yet.
 
 ### `{Func} onChange`
 The callback function for receiving updated value, whether it's by typing, autocompletion, or suggestion picking. If a user is navigating through the list, it will pass an additional `true` as the 2nd argument.

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -14,7 +14,6 @@ import Gridicon from 'gridicons';
 import FormTextInput from 'components/forms/form-text-input';
 import Suggestions from 'components/suggestions';
 import Spinner from 'components/spinner';
-import { isVerticalSearchPending } from 'components/site-verticals-suggestion-search';
 
 /**
  * Style dependencies
@@ -135,11 +134,11 @@ class SuggestionSearch extends Component {
 	}
 
 	render() {
-		const { id, placeholder, autoFocus } = this.props;
+		const { id, placeholder, autoFocus, isSearching } = this.props;
 
 		return (
 			<div className="suggestion-search">
-				{ isVerticalSearchPending() ? <Spinner /> : <Gridicon icon="search" /> }
+				{ isSearching ? <Spinner /> : <Gridicon icon="search" /> }
 				<FormTextInput
 					id={ id }
 					placeholder={ placeholder }

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -131,7 +131,7 @@ class SuggestionSearch extends Component {
 
 	updateFieldFromSuggestion( newValue ) {
 		this.updateInputValue( newValue );
-		this.props.onChange( newValue );
+		this.props.onChange( newValue, true );
 	}
 
 	render() {

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -479,13 +479,9 @@ class AboutStep extends Component {
 	}
 
 	renderContent() {
-		const {
-			translate,
-			siteTitle,
-			shouldHideSiteTitle,
-			shouldHideSiteGoals,
-			siteTopic,
-		} = this.props;
+		const { translate, siteTitle, shouldHideSiteTitle, shouldHideSiteGoals } = this.props;
+
+		const { siteTopicValue } = this.state;
 
 		const pressableWrapperClassName = classNames( 'about__pressable-wrapper', {
 			'about__wrapper-is-hidden': ! this.state.showStore,
@@ -542,7 +538,7 @@ class AboutStep extends Component {
 									</FormLabel>
 									<SiteVerticalsSuggestionSearch
 										onChange={ this.onSiteTopicChange }
-										initialValue={ siteTopic }
+										searchValue={ siteTopicValue }
 									/>
 								</FormFieldset>
 							) }

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -13,9 +13,8 @@ import { connect } from 'react-redux';
  */
 import Button from 'components/button';
 import FormFieldset from 'components/forms/form-fieldset';
-import SiteVerticalsSuggestionSearch, {
-	isVerticalSearchPending,
-} from 'components/site-verticals-suggestion-search';
+import SiteVerticalsSuggestionSearch from // isVerticalSearchPending,
+'components/site-verticals-suggestion-search';
 import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
 import {
 	getSiteVerticalName,
@@ -25,6 +24,7 @@ import {
 	getSiteVerticalParentId,
 } from 'state/signup/steps/site-vertical/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getVerticals } from 'state/signup/verticals/selectors';
 
 /**
  * Style dependencies
@@ -79,7 +79,7 @@ class SiteTopicForm extends Component {
 						<SiteVerticalsSuggestionSearch
 							onChange={ this.onSiteTopicChange }
 							showPopular={ true }
-							initialValue={ siteTopic }
+							searchValue={ siteTopic }
 							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 						/>
 						<Button type="submit" disabled={ isButtonDisabled } primary>
@@ -95,7 +95,8 @@ class SiteTopicForm extends Component {
 export default connect(
 	state => {
 		const siteTopic = getSiteVerticalName( state );
-		const isButtonDisabled = ! siteTopic || isVerticalSearchPending();
+		const isVerticalSearchPending = null == getVerticals( state, siteTopic );
+		const isButtonDisabled = ! siteTopic || isVerticalSearchPending;
 
 		return {
 			siteTopic,

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -13,8 +13,7 @@ import { connect } from 'react-redux';
  */
 import Button from 'components/button';
 import FormFieldset from 'components/forms/form-fieldset';
-import SiteVerticalsSuggestionSearch from // isVerticalSearchPending,
-'components/site-verticals-suggestion-search';
+import SiteVerticalsSuggestionSearch from 'components/site-verticals-suggestion-search';
 import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
 import {
 	getSiteVerticalName,

--- a/client/state/signup/steps/site-vertical/reducer.js
+++ b/client/state/signup/steps/site-vertical/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { omit } from 'lodash';
+// import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -28,9 +28,12 @@ export default createReducer(
 	initialState,
 	{
 		[ SIGNUP_STEPS_SITE_VERTICAL_SET ]: ( state, siteVerticalData ) => {
+			// return {
+			// 	...state,
+			// 	...omit( siteVerticalData, 'type' ),
+			// };
 			return {
-				...state,
-				...omit( siteVerticalData, 'type' ),
+				name: siteVerticalData.name,
 			};
 		},
 		[ SIGNUP_COMPLETE_RESET ]: () => {

--- a/client/state/signup/steps/site-vertical/reducer.js
+++ b/client/state/signup/steps/site-vertical/reducer.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-// import { omit } from 'lodash';
+import { omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -24,16 +24,16 @@ const initialState = {
 	preview: '',
 };
 
+// TODO:
+// This reducer can be further simplify since the verticals data can be
+// found in `signup.verticals`, so it only needs to store the site vertical name.
 export default createReducer(
 	initialState,
 	{
 		[ SIGNUP_STEPS_SITE_VERTICAL_SET ]: ( state, siteVerticalData ) => {
-			// return {
-			// 	...state,
-			// 	...omit( siteVerticalData, 'type' ),
-			// };
 			return {
-				name: siteVerticalData.name,
+				...state,
+				...omit( siteVerticalData, 'type' ),
 			};
 		},
 		[ SIGNUP_COMPLETE_RESET ]: () => {

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -4,7 +4,12 @@
  * External dependencies
  */
 
-import { get } from 'lodash';
+import { get, find } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getVerticals } from 'state/signup/verticals/selectors';
 
 export function getSiteVerticalName( state ) {
 	return get( state, 'signup.steps.siteVertical.name', '' );
@@ -26,6 +31,34 @@ export function getSiteVerticalIsUserInput( state ) {
 	return get( state, 'signup.steps.siteVertical.isUserInput', true );
 }
 
+export function getSiteVerticalData( state ) {
+	const verticalName = get( state, 'signup.steps.siteVertical.name', '' );
+
+	const verticals = getVerticals( state, verticalName );
+
+	// TODO: this can be optimized
+	const match = find(
+		verticals,
+		item => item.verticalName.toLowerCase() === verticalName.toLowerCase()
+	);
+
+	if ( match ) {
+		return match;
+	}
+
+	// TODO: ARRRGHHH. I'm running out of time ...
+	const defaultVerticalData = get( verticals, 'business[0]', {} );
+
+	return {
+		isUserInputVertical: true,
+		parent: '',
+		preview: defaultVerticalData.preview,
+		verticalId: '',
+		verticalName,
+		verticalSlug: verticalName,
+	};
+}
+
 export function getSiteVerticalPreview( state ) {
-	return get( state, 'signup.steps.siteVertical.preview', '' );
+	return get( getSiteVerticalData( state ), 'preview', '' );
 }

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -15,22 +15,6 @@ export function getSiteVerticalName( state ) {
 	return get( state, 'signup.steps.siteVertical.name', '' );
 }
 
-export function getSiteVerticalId( state ) {
-	return get( state, 'signup.steps.siteVertical.id', '' );
-}
-
-export function getSiteVerticalParentId( state ) {
-	return get( state, 'signup.steps.siteVertical.parentId', '' );
-}
-
-export function getSiteVerticalSlug( state ) {
-	return get( state, 'signup.steps.siteVertical.slug', '' );
-}
-
-export function getSiteVerticalIsUserInput( state ) {
-	return get( state, 'signup.steps.siteVertical.isUserInput', true );
-}
-
 export function getSiteVerticalData( state ) {
 	const verticalName = get( state, 'signup.steps.siteVertical.name', '' );
 
@@ -61,4 +45,21 @@ export function getSiteVerticalData( state ) {
 
 export function getSiteVerticalPreview( state ) {
 	return get( getSiteVerticalData( state ), 'preview', '' );
+}
+
+// TODO: All the following selectors will be updated to use getSiteVerticalData like getSiteVerticalPreview() does.
+export function getSiteVerticalId( state ) {
+	return get( state, 'signup.steps.siteVertical.id', '' );
+}
+
+export function getSiteVerticalParentId( state ) {
+	return get( state, 'signup.steps.siteVertical.parentId', '' );
+}
+
+export function getSiteVerticalSlug( state ) {
+	return get( state, 'signup.steps.siteVertical.slug', '' );
+}
+
+export function getSiteVerticalIsUserInput( state ) {
+	return get( state, 'signup.steps.siteVertical.isUserInput', true );
 }

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -10,6 +10,7 @@ import { get, find } from 'lodash';
  * Internal dependencies
  */
 import { getVerticals } from 'state/signup/verticals/selectors';
+import { DEFAULT_VERTICAL_KEY } from 'state/signup/verticals/constants';
 
 export function getSiteVerticalName( state ) {
 	return get( state, 'signup.steps.siteVertical.name', '' );
@@ -20,7 +21,6 @@ export function getSiteVerticalData( state ) {
 
 	const verticals = getVerticals( state, verticalName );
 
-	// TODO: this can be optimized
 	const match = find(
 		verticals,
 		item => item.verticalName.toLowerCase() === verticalName.toLowerCase()
@@ -30,13 +30,12 @@ export function getSiteVerticalData( state ) {
 		return match;
 	}
 
-	// TODO: ARRRGHHH. I'm running out of time ...
-	const defaultVerticalData = get( verticals, 'business[0]', {} );
+	const defaultVerticalData = get( verticals, [ DEFAULT_VERTICAL_KEY, 0 ], {} );
 
 	return {
 		isUserInputVertical: true,
 		parent: '',
-		preview: defaultVerticalData.preview,
+		preview: defaultVerticalData.preview || '',
 		verticalId: '',
 		verticalName,
 		verticalSlug: verticalName,

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -17,8 +17,7 @@ export function getSiteVerticalName( state ) {
 }
 
 export function getSiteVerticalData( state ) {
-	const verticalName = get( state, 'signup.steps.siteVertical.name', '' );
-
+	const verticalName = getSiteVerticalName( state );
 	const verticals = getVerticals( state, verticalName );
 
 	const match = find(

--- a/client/state/signup/steps/site-vertical/test/selectors.js
+++ b/client/state/signup/steps/site-vertical/test/selectors.js
@@ -13,6 +13,12 @@ import {
 } from '../selectors';
 
 describe( 'selectors', () => {
+	const verticals = {
+		felice: [
+			{ verticalName: 'felice', preview: '<!--gutenberg-besties-forever <p>Fist bump!</p>-->' },
+		],
+	};
+
 	const state = {
 		signup: {
 			steps: {
@@ -21,12 +27,13 @@ describe( 'selectors', () => {
 					name: 'felice',
 					slug: 'happy',
 					isUserInput: false,
-					preview: '<!--gutenberg-besties-forever <p>Fist bump!</p>-->',
 					parentId: 'gluecklich',
 				},
 			},
+			verticals,
 		},
 	};
+
 	describe( 'getSiteVerticalName', () => {
 		test( 'should return empty string as a default state', () => {
 			expect( getSiteVerticalName( {} ) ).toEqual( '' );
@@ -62,7 +69,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return site vertical from the state', () => {
-			expect( getSiteVerticalPreview( state ) ).toEqual( state.signup.steps.siteVertical.preview );
+			expect( getSiteVerticalPreview( state ) ).toEqual( verticals.felice[ 0 ].preview );
 		} );
 	} );
 	describe( '', () => {

--- a/client/state/signup/verticals/constants.js
+++ b/client/state/signup/verticals/constants.js
@@ -1,0 +1,3 @@
+/** @format */
+
+export const DEFAULT_VERTICAL_KEY = 'business';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR wires the new `verticals` state tree introduced by #31714, #31716 and #31718 to the related components, most notably `<SiteVerticalsSuggestionSearch/>`. 

In general, it means:

1. No more `http-data` since all the `GET /verticals` endpoint interaction has been moved into the data-layer.
1. `signup.steps.siteVertical` state tree can be further simplified. Now that all the verticals data can be found in the `verticals` state tree, the site vertical data can be derived by a vertical name string and the `verticals` state tree. This PR has only done it for the preview data to demonstrate the idea. A major clean-up will be in an upcoming PR to not further bloat this one.

#### Testing instructions
1. `npm run test-client vertical` should pass.
1. Creating a site via the onboarding flow, i.e. http://calypso.localhost:3000/start/onboarding should work as expected. Especially, please play around the site topic step to see if it works, e.g. the loading spinner, the suggestion list, auto-completion, keyboard navigation.
1. Creating a site via the main flow, i.e. http://calypso.localhost:3000/start/main should work as expected. Please do the same as the above to the site topic field.
