### PR TITLE
Let <SiteInformation> component fetch the vertical data when it's needed.

### DIFF
--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -18,11 +18,16 @@ import SignupActions from 'lib/signup/actions';
 import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
 import { setSiteInformation } from 'state/signup/steps/site-information/actions';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import {
+	getSiteVerticalName,
+	getSiteVerticalPreview,
+} from 'state/signup/steps/site-vertical/selectors';
 import Button from 'components/button';
 import FormTextInput from 'components/forms/form-text-input';
 import FormLabel from 'components/forms/form-label';
 import FormFieldset from 'components/forms/form-fieldset';
 import InfoPopover from 'components/info-popover';
+import QueryVerticals from 'components/data/query-verticals';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -124,13 +129,19 @@ export class SiteInformation extends Component {
 	);
 
 	renderContent() {
-		const { hasMultipleFieldSets, formFields } = this.props;
+		const {
+			hasMultipleFieldSets,
+			formFields,
+			shouldFetchVerticalData,
+			siteVerticalName,
+		} = this.props;
 		return (
 			<div
 				className={ classNames( 'site-information__wrapper', {
 					'is-single-fieldset': ! hasMultipleFieldSets,
 				} ) }
 			>
+				{ shouldFetchVerticalData && <QueryVerticals searchTerm={ siteVerticalName } /> }
 				<Card>
 					<form>
 						{ formFields.map( ( fieldName, idx ) => {
@@ -198,6 +209,7 @@ export class SiteInformation extends Component {
 export default connect(
 	( state, ownProps ) => {
 		const siteType = getSiteType( state );
+		const siteVerticalName = getSiteVerticalName( state );
 		const isBusiness = 'business' === siteType;
 		// Only business site types may show the full set of fields.
 		// This is a bespoke check until we implement a business-only flow,
@@ -206,10 +218,17 @@ export default connect(
 			! isBusiness && includes( ownProps.informationFields, 'title' )
 				? [ 'title' ]
 				: ownProps.informationFields;
+		const shouldFetchVerticalData =
+			ownProps.showSiteMockups &&
+			getSiteType( state ) === 'business' &&
+			'' === getSiteVerticalPreview( state );
+
 		return {
 			formFields,
 			siteInformation: getSiteInformation( state ),
 			siteType,
+			siteVerticalName,
+			shouldFetchVerticalData,
 			hasMultipleFieldSets: size( formFields ) > 1,
 		};
 	},

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -221,7 +221,7 @@ export default connect(
 		const shouldFetchVerticalData =
 			ownProps.showSiteMockups &&
 			getSiteType( state ) === 'business' &&
-			'' === getSiteVerticalPreview( state );
+			getSiteVerticalPreview( state ) === '';
 
 		return {
 			formFields,


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR addresses the scenario that a user can arrive the site information step without passing the site topic and the site type steps by the query parameters `site_type` and `vertical`. Currently it will cause the preview to not show because the data is not there. This PR embeds a `<QueryVerticals/>` component when this case happens so the data will be automatically fetched.

#### Testing instructions
1. Access `https://calypso.localhost:3000/start/onboarding-for-business/?site_type=business&vertical=restaurants`.
1. Passing the user step will lead you directly to the site information step.
1. Make sure the preview is shown properly.


