### PR TITLE
Move Repeat visitor block from beta to production

### DIFF
--- a/packages/jetpack-blocks/src/preset/index.json
+++ b/packages/jetpack-blocks/src/preset/index.json
@@ -9,6 +9,7 @@
     "markdown",
     "publicize",
     "related-posts",
+    "repeat-visitor",
     "shortlinks",
     "simple-payments",
     "slideshow",
@@ -18,7 +19,6 @@
     "wordads"
   ],
   "beta": [
-    "repeat-visitor",
     "seo",
     "vr"
   ]


### PR DESCRIPTION
In preparation for the Jetpack 7.2 build.

## Testing

Build blocks from Calypso root folder:
```bash
npm ci
npx lerna bootstrap --concurrency=2 --scope='@automattic/jetpack-blocks'
npx lerna run build --stream --scope='@automattic/jetpack-blocks' -- -- --output-path /PATH_TO_YOUR/jetpack/_inc/blocks/
```

Confirm Jetpack  with Gutenberg now has repeat visitor block even if `JETPACK_BETA_BLOCKS` is `false`

---

cc @Automattic/opportunity just to let you know that @Automattic/gutenpack is handling moving this to Jetpack v7.2 release this time around — no action or review required from your side. :-)