### PR TITLE
Fix broken Twitter preview styling

### DIFF
--- a/client/components/seo/twitter-preview/style.scss
+++ b/client/components/seo/twitter-preview/style.scss
@@ -9,14 +9,14 @@
  * @blame: dmsnell
 */
 
-.twitter-card-preview__container {
+.twitter-preview__container {
 	width: inherit;
 	overflow-x: auto;
 	-webkit-overflow-scrolling: touch;
 	margin: 20px;
 }
 
-.twitter-card-preview__summary {
+.twitter-preview__summary {
 	width: 506px;
 	height: 125px;
 	margin: 0 auto;
@@ -25,7 +25,7 @@
 	border-radius: 0.42857em;
 }
 
-.twitter-card-preview__large_image_summary {
+.twitter-preview__large_image_summary {
 	width: 506px;
 	height: auto;
 	margin: 0 auto;
@@ -34,26 +34,26 @@
 	border-radius: 0.42857em;
 }
 
-.twitter-card-preview__image {
+.twitter-preview__image {
 	background-size: cover;
 	background-position: center;
 }
 
-.twitter-card-preview__summary
-.twitter-card-preview__image {
+.twitter-preview__summary
+.twitter-preview__image {
 	float: left;
 	width: 125px;
 	height: 125px;
 }
 
-.twitter-card-preview__large_image_summary
-.twitter-card-preview__image {
+.twitter-preview__large_image_summary
+.twitter-preview__image {
 	width: 506px;
 	height: 254px;
 	border-bottom: 1px solid #e1e8ed;
 }
 
-.twitter-card-preview__body {
+.twitter-preview__body {
 	padding: 0.75em;
 	text-decoration: none;
 	font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
@@ -64,20 +64,20 @@
 	overflow: hidden;
 }
 
-.twitter-card-preview__summary
-.twitter-card-preview__body {
+.twitter-preview__summary
+.twitter-preview__body {
 	margin-left: 125px;
 	border-left: 1px solid #e1e8ed;
 	height: 100%;
 }
 
-.twitter-card-preview__large_image_summary
-.twitter-card-preview__body {
+.twitter-preview__large_image_summary
+.twitter-preview__body {
 	padding-left: 1em;
 	padding-right: 1em;
 }
 
-.twitter-card-preview__title {
+.twitter-preview__title {
 	max-height: 1.3em;
 	white-space: nowrap;
 	font-weight: bold;
@@ -87,14 +87,14 @@
 	text-overflow: ellipsis;
 }
 
-.twitter-card-preview__description {
+.twitter-preview__description {
 	margin-top: 0.32333em;
 	max-height: 3.9em;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
-.twitter-card-preview__url {
+.twitter-preview__url {
 	text-transform: lowercase;
 	color: #8899a6;
 	max-height: 1.3em;

--- a/client/components/seo/twitter-preview/style.scss
+++ b/client/components/seo/twitter-preview/style.scss
@@ -9,7 +9,7 @@
  * @blame: dmsnell
 */
 
-.twitter-preview__container {
+.twitter-preview {
 	width: inherit;
 	overflow-x: auto;
 	-webkit-overflow-scrolling: touch;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes broken Twitter preview styling that was introduced in https://github.com/Automattic/wp-calypso/pull/31733

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Get a WordPress.com Business plan site
- Visit `/settings/traffic` on the live branch available below
- Add front page meta description
- Click `Show previews`
- Ensure Twitter preview styling is fine
