### PR TITLE
Jetpack blocks: Remove CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,16 +200,6 @@ jobs:
           paths:
             - wp-calypso
 
-  build-jetpack-blocks:
-    <<: *defaults
-    parallelism: 1
-    steps:
-      - prepare
-      - run: npx lerna bootstrap --concurrency=2 --scope '@automattic/jetpack-blocks'
-      - run: npx lerna run prepublishOnly --stream --scope '@automattic/jetpack-blocks'
-      - run: mv packages/jetpack-blocks/dist $CIRCLE_ARTIFACTS/jetpack-blocks
-      - store-artifacts-and-test-results
-
   lint-and-translate:
     <<: *defaults
     parallelism: 1
@@ -552,9 +542,6 @@ workflows:
           filters:
             branches:
               ignore: master
-      - build-jetpack-blocks:
-          requires:
-            - setup
       - build-notifications:
           requires:
             - setup


### PR DESCRIPTION
It's not longer used.

## Testing

Verify the `build-jetpack-blocks` job doesn't run and the rest do.