### PR TITLE
UpgradeNudgeExpanded: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -114,7 +114,6 @@
 @import 'components/section-nav/style';
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
-@import 'blocks/upgrade-nudge-expanded/style';
 @import 'components/signup-site-title/style';
 @import 'components/site-selector/style';
 @import 'components/site-title-example/style';

--- a/client/blocks/upgrade-nudge-expanded/index.jsx
+++ b/client/blocks/upgrade-nudge-expanded/index.jsx
@@ -27,6 +27,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import PlanIcon from 'components/plans/plan-icon';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class UpgradeNudgeExpanded extends Component {
 	constructor( props ) {
 		super( props );

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -242,19 +242,6 @@
 	bottom: 72px;
 }
 
-.media-library__videopress-nudge-container .upgrade-nudge-expanded {
-	position: absolute;
-	left: 0;
-	right: 0;
-	box-shadow: none;
-	margin: 0;
-
-	@include breakpoint( '>960px') {
-		top: 50%;
-		transform: translateY( -50% );
-	}
-}
-
 .empty-content .media-library__videopress-nudge-regular.card.upgrade-nudge {
 	margin-left: auto;
 	margin-right: auto;


### PR DESCRIPTION
- migrates the component CSS to webpack
- removed unused custom styles in Media/VideoPress tab. These served an A/B test that was not successful and got reverted (#8403)

**How to test:**
The expanded upgrade nudge (with plan details and list of features) is used only in the "Earn" section today:

<img width="728" alt="Screenshot 2019-03-26 at 14 18 55" src="https://user-images.githubusercontent.com/664258/55000518-fe51a200-4fd2-11e9-8893-632836c50c93.png">
