### PR TITLE
Block Editor: Update the featured image preview after editing the image file

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -243,9 +243,11 @@ class CalypsoifyIframe extends Component {
 		}
 		const payload = {
 			id: get( action, 'data.ID' ),
-			url: get( action, 'data.URL' ),
-			transientId: get( action, 'id' ),
+			height: get( action, 'data.height' ),
 			status: 'REMOVE_MEDIA_ITEM' === action.type ? 'deleted' : 'updated',
+			transientId: get( action, 'id' ),
+			url: get( action, 'data.URL' ),
+			width: get( action, 'data.width' ),
 		};
 		this.iframePort.postMessage( { action: 'updateImageBlocks', payload } );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the image's `width` and `height` to the update message's payload so that the iframe bridge will be able to recalculate the preview size after the image has been edited.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D26023-code and sandbox a site.
* Open the Block Editor and add a rectangular image as featured image.
* Click on the featured image preview; the Media Modal will open with the featured image selected.
* Edit the image and rotate it; wait for the new image to be uploaded, when the spinner disappears.
* Close the modal and make sure the featured image has been updated and the preview has the correct size (scaled to fit the sidebar), and that it doesn't overlap any neighbouring elements.

Fixes #29829 