### PR TITLE
Post List: stop querying post list with context=edit

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -76,7 +76,6 @@ export default class PageList extends Component {
 			search,
 			status: mapStatus( status ),
 			type: 'page',
-			context: 'edit',
 		};
 
 		return (

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -89,7 +89,6 @@ class PostsMain extends React.Component {
 			status,
 			tag,
 			type: 'post',
-			context: 'edit',
 		};
 
 		return (


### PR DESCRIPTION
Will fix issues with loading post list on Atomic sites with reblogged posts. And other, less serious issues described in https://github.com/Automattic/wp-calypso/pull/28180#issuecomment-438991737

Partial revert of #28180.
