### PR TITLE
Change the way we handle positioning for guided tours

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -62,7 +62,7 @@ import { getSectionName } from 'state/ui/selectors';
  */
 import './style.scss';
 
-const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 1500,
+const VALIDATION_DELAY_AFTER_FIELD_CHANGES = 2000,
 	debug = debugModule( 'calypso:signup-form:form' );
 
 let usernamesSearched = [],

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -34,11 +34,11 @@ const helpers = {
 	yBelow: bottom => {
 		return bottom + DIALOG_PADDING;
 	},
-	xAboveBelow: ( left, right, width ) => {
+	xAboveBelow: ( left, right ) => {
 		if ( left + DIALOG_WIDTH + DIALOG_PADDING < document.documentElement.clientWidth ) {
 			return left + DIALOG_PADDING;
 		} else if ( right - DIALOG_WIDTH - DIALOG_PADDING > 0 ) {
-			return right - ( DIALOG_WIDTH - width );
+			return right - DIALOG_WIDTH;
 		}
 		return DIALOG_PADDING;
 	},
@@ -147,7 +147,6 @@ export function getStepPosition( {
 			? target.getBoundingClientRect()
 			: window.document.body.getBoundingClientRect();
 	const position = dialogPositioners[ validatePlacement( placement, target ) ]( rect );
-
 	return {
 		x: position.x,
 		y: position.y - scrollDiff + ( scrollDiff !== 0 ? DIALOG_PADDING : 0 ),

--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -46,13 +46,13 @@ const helpers = {
 
 const dialogPositioners = {
 	below: rect => {
-		const x = helpers.xAboveBelow( rect.left, rect.right, rect.width );
+		const x = helpers.xAboveBelow( rect.left, rect.right );
 		const y = helpers.yBelow( rect.bottom );
 
 		return { x, y };
 	},
 	above: rect => {
-		const x = helpers.xAboveBelow( rect.left, rect.right, rect.width );
+		const x = helpers.xAboveBelow( rect.left, rect.right );
 		const y = helpers.yAbove( rect.top );
 
 		return { x, y };

--- a/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-tagline-tour.js
@@ -52,7 +52,7 @@ export const ChecklistSiteTaglineTour = makeTour(
 			) }
 		</Step>
 
-		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
+		<Step name="click-save" target="settings-site-profile-save" arrow="top-right" placement="below">
 			{ ( { translate } ) => (
 				<Fragment>
 					<Continue target="settings-site-profile-save" step="finish" click>

--- a/client/layout/guided-tours/tours/checklist-site-title-tour.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour.js
@@ -53,7 +53,7 @@ export const ChecklistSiteTitleTour = makeTour(
 			) }
 		</Step>
 
-		<Step name="click-save" target="settings-site-profile-save" arrow="top-left" placement="below">
+		<Step name="click-save" target="settings-site-profile-save" arrow="top-right" placement="below">
 			{ ( { translate } ) => (
 				<Fragment>
 					<Continue target="settings-site-profile-save" step="finish" click>


### PR DESCRIPTION
When guided tours overlap the right side of the screen, their position can look strange - see #31688

<img width="1278" alt="54836407-86197280-4c9a-11e9-9212-48292e022d8e" src="https://user-images.githubusercontent.com/275961/55008242-a158ea80-4fd8-11e9-9fc2-69a0ecd80e5d.png">

#### Changes proposed in this Pull Request

This PR makes a change to what happens in these cases, to align the step with the right of the element:

<img width="763" alt="Screenshot 2019-03-26 at 14 54 32" src="https://user-images.githubusercontent.com/275961/55008318-c2b9d680-4fd8-11e9-9915-a3a99c2d3efd.png">
<img width="777" alt="Screenshot 2019-03-26 at 14 54 06" src="https://user-images.githubusercontent.com/275961/55008319-c2b9d680-4fd8-11e9-8616-6221ed41fcff.png">

I've tested all the tours I could find, and this doesn't seem to break them, but there could be others I haven't found.

#### Testing instructions

* Open a site with a checklist
* Go through the checklist task to change your site title
* Go through the checklist task to change your site tagline
* Look for other tours which might be broken

Fixes #31688
