### PR TITLE
Plans: Update customer-type-toggle styling

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -342,70 +342,8 @@ $plan-features-sidebar-width: 272px;
 }
 
 .segmented-control.is-customer-type-toggle {
-	background-color: transparent;
-	margin: 50px auto 20px;
-	max-width: 100%;
-	width: 580px;
-
-	.segmented-control__item {
-		background-color: var( --color-neutral-0 );
-		min-width: 50%;
-
-		&:first-of-type {
-			margin-right: 5px;
-
-			@include breakpoint( '<660px' ) {
-				margin: 0 15px 10px;
-			}
-		}
-
-		&:last-of-type {
-			margin-right: 5px;
-
-			@include breakpoint( '<660px' ) {
-				margin: 0 15px;
-			}
-		}
-
-		&.is-selected + .segmented-control__item .segmented-control__link {
-			border-left-color: var( --color-neutral-200 );
-
-			&:hover {
-				border-left-color: var( --color-neutral-700 );
-			}
-		}
-	}
-
-	.segmented-control__link {
-		border-radius: 6px;
-		border: 2px solid --color-neutral-200;
-		color: var( --color-neutral-700 );
-		font-size: 15px;
-		font-weight: 500;
-		padding: 15px;
-
-		&:hover {
-			background-color: transparent;
-			border: 2px solid var( --color-neutral-700 );
-		}
-	}
-
-	@include breakpoint( '<660px' ) {
-		flex-wrap: wrap;
-	}
-
-	@include breakpoint( '<480px' ) {
-		flex-wrap: wrap;
-		margin-bottom: 9px;
-
-		.segmented-control__item {
-			width: 100%;
-		}
-	}
-
-	&.is-primary .segmented-control__link:hover {
-		background-color: transparent;
-	}
+	max-width: 520px;
+	margin: 8px auto 16px;
 }
 
 .info-popover.plan-features__header-tip-info {
@@ -588,30 +526,13 @@ $plan-features-sidebar-width: 272px;
 // and override some of the segmented-control styles.
 // This UI should really use buttons instead.
 body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
+	margin: 0 auto;
+
 	.segmented-control__item {
-		background: none;
-
-		&:hover,
-		&:focus {
-			background: none;
-		}
-
-		a,
-		a:hover,
-		a:focus {
-			background: none;
-			border: none;
-			color: var( --color-white );
-			text-decoration: underline;
-		}
-
 		&.is-selected a,
 		&.is-selected a:hover,
 		&.is-selected a:focus {
-			background: var( --color-white );
-			color: var( --color-text );
-			text-decoration: none;
-			cursor: default;
+		    background-color: var(--color-primary-700);
 		}
 	}
 }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -344,6 +344,15 @@ $plan-features-sidebar-width: 272px;
 .segmented-control.is-customer-type-toggle {
 	max-width: 520px;
 	margin: 8px auto 16px;
+
+	@include breakpoint( '<480px' ) {
+		flex-wrap: wrap;
+		border-radius: 0;
+
+		.segmented-control__link {
+			border-radius: 0;
+		}
+	}
 }
 
 .info-popover.plan-features__header-tip-info {
@@ -526,12 +535,45 @@ $plan-features-sidebar-width: 272px;
 // and override some of the segmented-control styles.
 // This UI should really use buttons instead.
 body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
-	margin: 0 auto;
+	margin: 0 auto 16px;
+	box-shadow: 0 1px 1px 0 rgba(0,0,0,0.14),
+				0 2px 1px -1px rgba(0,0,0,0.12),
+				0 1px 3px 0 rgba(0,0,0,0.20);
 
-	.segmented-control__item {
-		&.is-selected a,
-		&.is-selected a:hover,
-		&.is-selected a:focus {
+	.segmented-control__item a {
+		text-decoration: underline;
+		border: none;
+	}
+
+	.segmented-control__item.is-selected {
+		position: relative;
+
+		// This adds a little pointer arrow to the bottom
+		// of the selected segment item. It relies on the
+		// relative positioning above.
+		@include breakpoint( '>480px' ) {
+			&:after {
+				display: block;
+				content: '';
+				width: 0;
+				height: 0;
+				border-left: 10px solid transparent;
+				border-right: 10px solid transparent;
+				border-top: 10px solid var(--color-primary-700);
+				position: absolute;
+				bottom: -10px;
+				left: calc(50% - 10px);
+			}
+		}
+
+		a,
+		a:hover,
+		a:focus {
+			@include breakpoint( '<660px' ) {
+				flex-wrap: wrap;
+			}
+			cursor: default;
+			text-decoration: none;
 		    background-color: var(--color-primary-700);
 		}
 	}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -259,7 +259,7 @@ export class PlansFeaturesMain extends Component {
 		const segmentClasses = classNames( 'plan-features__interval-type', 'is-customer-type-toggle' );
 
 		return (
-			<SegmentedControl compact className={ segmentClasses } primary={ true }>
+			<SegmentedControl className={ segmentClasses } primary={ true }>
 				<SegmentedControlItem
 					selected={ customerType === 'personal' }
 					path={ '?customerType=personal' }


### PR DESCRIPTION
This PR removes the custom styling of the segment control uses to toggle between plan types. The current "button-like, but not-button-like" styling doesn't fit with out current patterns and is hard to use in signup.

Before Signup:
<img width="716" alt="image" src="https://user-images.githubusercontent.com/191598/55012217-6f865a80-4fbd-11e9-8552-e7681ac6051c.png">

Before Signed In:
<img width="1078" alt="image" src="https://user-images.githubusercontent.com/191598/55012239-790fc280-4fbd-11e9-969f-5a51b3551823.png">

After Signup:
<img width="616" alt="image" src="https://user-images.githubusercontent.com/191598/55021668-93529c00-4fcf-11e9-8e14-83c4c3f50310.png">


After Signed In:
<img width="616" alt="image" src="https://user-images.githubusercontent.com/191598/55012149-5a113080-4fbd-11e9-83dc-8d40ec440cda.png">
