### PR TITLE
Backups: Fix download progress bar

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/downloads/index.js
@@ -10,7 +10,11 @@ import { pick } from 'lodash';
  * Internal dependencies
  */
 import { REWIND_BACKUP } from 'state/action-types';
-import { rewindBackupUpdateError, getRewindBackupProgress } from 'state/activity-log/actions';
+import {
+	rewindBackupUpdateError,
+	updateRewindBackupProgress,
+	getRewindBackupProgress,
+} from 'state/activity-log/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { http } from 'state/data-layer/wpcom-http/actions';
 
@@ -35,10 +39,15 @@ const fromApi = data => {
 		throw new Error( 'Missing downloadId field in response' );
 	}
 
-	return true;
+	return data;
 };
 
-export const receiveBackupSuccess = ( { siteId } ) => getRewindBackupProgress( siteId );
+export const receiveBackupSuccess = ( { siteId }, data ) => {
+	return [
+		getRewindBackupProgress( siteId ),
+		updateRewindBackupProgress( siteId, data.downloadId, data ),
+	];
+};
 
 export const receiveBackupError = ( { siteId }, error ) =>
 	rewindBackupUpdateError( siteId, pick( error, [ 'error', 'status', 'message' ] ) );


### PR DESCRIPTION
Dispatch `updateRewindBackupProgress` on get backup success, which will populate the `downloadId` in state and cause further progress requests to be triggered.

<img width="990" alt="Screenshot 2019-03-26 at 18 53 24" src="https://user-images.githubusercontent.com/7767559/55025529-fa387b00-4ff8-11e9-9572-1f5f88b809d9.png">

<img width="982" alt="Screenshot 2019-03-26 at 18 53 33" src="https://user-images.githubusercontent.com/7767559/55025343-ab8ae100-4ff8-11e9-8e86-1eb9d63a99e8.png">


#### Testing instructions

* Use a site that has backups enabled (wpcom business or ecommerce plan).
* Go to /activity-log.
* Click on the ... on any event that has it.
* Download a backup.
* Check that the progress bar appears, and changes to the "Download" button when complete.


