### PR TITLE
Post/Page List: add section headers with 'add new' buttons

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -33,6 +33,8 @@ import {
 } from 'state/posts/selectors';
 import { getSite } from 'state/sites/selectors';
 import getEditorUrl from 'state/selectors/get-editor-url';
+import SectionHeader from 'components/section-header';
+import Button from 'components/button';
 
 function preloadEditor() {
 	preload( 'post-editor' );
@@ -293,6 +295,18 @@ class Pages extends Component {
 		return this.props.lastPage && ! this.props.loading ? <ListEnd /> : null;
 	}
 
+	renderSectionHeader() {
+		const { newPageLink, translate } = this.props;
+
+		return (
+			<SectionHeader label={ translate( 'Pages' ) }>
+				<Button primary compact className="pages__add-page" href={ newPageLink }>
+					{ translate( 'Add New Page' ) }
+				</Button>
+			</SectionHeader>
+		);
+	}
+
 	renderPagesList( { pages } ) {
 		const { site, lastPage, query } = this.props;
 
@@ -330,6 +344,7 @@ class Pages extends Component {
 		return (
 			<div id="pages" className="pages__page-list">
 				<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
+				{ this.renderSectionHeader() }
 				{ rows }
 				{ this.renderListEnd() }
 			</div>
@@ -371,6 +386,7 @@ class Pages extends Component {
 				{ showBlogPostsPage && (
 					<BlogPostsPage key="blog-posts-page" site={ site } pages={ pages } />
 				) }
+				{ this.renderSectionHeader() }
 				{ rows }
 				<InfiniteScroll nextPageMethod={ this.fetchPages } />
 				{ this.renderListEnd() }


### PR DESCRIPTION
As part of the upcoming sidebar changes, this adds a section header to the top of the page, posts, and custom post type lists with a button to 'Add New {Post Label}'.

**Changes:**

<img width="976" alt="post-list" src="https://user-images.githubusercontent.com/942359/55027726-550fa980-4fdc-11e9-9690-ef9fb0b09074.png">
<img width="975" alt="page-list-hierarchical" src="https://user-images.githubusercontent.com/942359/55027727-550fa980-4fdc-11e9-889f-fcd7b62940a6.png">
<img width="990" alt="page-list-chronological" src="https://user-images.githubusercontent.com/942359/55027728-550fa980-4fdc-11e9-8e18-8c25dc699734.png">

**To test:**

- visit `/pages/`
- verify that the section header is shown above the page list, with an 'Add New Page' button that links to the correct editor for a new page
- visit `/posts/`
- verify that the section header is shown above the post list, with an 'Add New Post' button that links to the correct editor for a new post
- enable a custom post type (portfolio or testimonial) in Settings > Writing > Content Types
- visit the custom post type list from the sidebar
- verify that the section header is shown above the post type list, with an 'Add New {Post Type}' button that links to the correct editor for a new post of that type