### PR TITLE
Colour Scheming: Fix Gravatar Flow Contrasts

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -638,6 +638,37 @@
 	}
 }
 
+.gravatar {
+    .formatted-header__title {
+        color: var( --color-white );
+    }
+
+    .formatted-header__subtitle {
+        color: var( --color-white );
+			
+			a {
+				color: var( --color-white );
+                text-decoration: underline;
+					
+					&:hover {
+						color: var( --color-neutral-100 );						
+					}
+            }
+    }
+
+    .logged-out-form__links a {
+        color: var( --color-white );
+		
+                &:hover {
+                    color: var( --color-neutral-100 );
+                }
+    }
+
+   .signup-form .logged-out-form__footer {
+        margin: 0;
+    }
+}
+
 // Adding some CSS to cover the --color-primary
 // background color in the signup flow for Akismet.
 .layout.dops.akismet {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -664,7 +664,7 @@
 		}
     }
 
-   .signup-form .logged-out-form__footer {
+    .signup-form .logged-out-form__footer {
         margin: 0;
     }
 }

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -645,23 +645,23 @@
 
     .formatted-header__subtitle {
         color: var( --color-white );
-			
-			a {
-				color: var( --color-white );
-                text-decoration: underline;
-					
-					&:hover {
-						color: var( --color-neutral-100 );						
-					}
-            }
-    }
+		
+		a {
+			color: var( --color-white );
+			text-decoration: underline;
+				
+			&:hover {
+				color: var( --color-neutral-100 );						
+			}		
+		}
+	}
 
     .logged-out-form__links a {
-        color: var( --color-white );
+        color: var( --color-white );		
 		
-                &:hover {
-                    color: var( --color-neutral-100 );
-                }
+		&:hover {
+			color: var( --color-neutral-100 );
+		}
     }
 
    .signup-form .logged-out-form__footer {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds styling to the Gravatar flow so that colours are readable and it doesn't look too odd 
* Mimics the design of the sign-up flow (eg. colour of links) 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the steps in the original issue, how do things look? Are other flows uneffected? Is this PR's formatting okay and does the code look good? 

**Current:**

![gdffgdgfdgfd](https://user-images.githubusercontent.com/43215253/55032934-e0ebfa80-5009-11e9-9c04-9e78229a6ee7.png)

**Proposed:**

![fghfhgghfghf](https://user-images.githubusercontent.com/43215253/55032950-ea756280-5009-11e9-8e4f-2596657214ba.png)

cc @flootr, @blowery, @shaunandrews, @supernovia

Fixes #31785
