### PR TITLE
Block Editor: Add default routes for block editor paths.

### DIFF
--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -57,6 +57,7 @@ export default function() {
 			);
 		}
 
+		page( '/block-editor/**/*', '/block-editor/post' );
 		page( '/block-editor/:site', context =>
 			page.redirect( `/block-editor/post/${ context.params.site }` )
 		);

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -57,7 +57,7 @@ export default function() {
 			);
 		}
 
-		page( '/block-editor/**/*', '/block-editor/post' );
+		page( '/block-editor/*/*', '/block-editor/post' );
 		page( '/block-editor/:site', context =>
 			page.redirect( `/block-editor/post/${ context.params.site }` )
 		);

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -56,6 +56,10 @@ export default function() {
 				clientRender
 			);
 		}
+
+		page( '/block-editor/:site', context =>
+			page.redirect( `/block-editor/post/${ context.params.site }` )
+		);
 	} else {
 		page( '/block-editor', '/post' );
 		page( '/block-editor/*', '/post' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add fallback `page` handlers for the `/block-editor` routes.

* If we have two or more additional segments where the first is unidentified, redirect to the `/block-editor/post` site picker. 
* If we have only one additional unidentified segment, we redirect to `/block-editor/post/:site`; if the site segment is valid, we'll get the iframed editor, and if not, we're redirected to the site picker at `/block-editor/post`.

#### Testing instructions

* Switch to this branch.
* Load `http://calypso.localhost:3000/block-editor/:site`. Verify the redirect to `http://calypso.localhost:3000/block-editor/post/:site`, and the successful iframing of the editor.
* Load `http://calypso.localhost:3000/block-editor/cats/dogs`, and verify the redirect to `/block-editor/post`.
* Load `http://calypso.localhost:3000/block-editor/cats/`, and verify the redirect to `/block-editor/post`.
* Try any and all other valid or invalid routes, and see if you can find any unpredicted behaviour.

Fixes #29822.
Fixes #29864.
