### PR TITLE
Signup: ensure the sidebar matches the signup default background color

### DIFF
--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -25,6 +25,11 @@ body.is-section-signup {
 			padding: 140px 0 0;
 		}
 	}
+
+	.layout__secondary {
+		background: var( --color-primary );
+		border: 0;
+	}
 }
 
 // Notice the :not(.dops) selector. I've added this to try and


### PR DESCRIPTION
## Changes proposed in this Pull Request

Weary of seeing a white block flash before your eyes each time you refresh a page on the signup journey?

![Mar-27-2019 18-00-33](https://user-images.githubusercontent.com/6458278/55056489-5adbbc80-50ba-11e9-9e05-eb1fde0d62fa.gif)

Your days of torment are over! 

This PR banishes the white, blocky 👻 into the CSS morass from whence it came.

### TL;DR

We're overriding the default layout styles to ensure the secondary layout column matches the default signup background color.

![Mar-27-2019 17-59-18](https://user-images.githubusercontent.com/6458278/55056669-dccbe580-50ba-11e9-9c49-8f696b8d81a8.gif)


## Testing instructions

Fire up the branch and refresh, refresh, refresh.
