### PR TITLE
Components: Migrate HrWithText CSS to Webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -87,7 +87,6 @@
 @import 'components/happiness-support/style';
 @import 'components/header-button/style';
 @import 'components/header-cake/style';
-@import 'components/hr-with-text/style';
 @import 'components/image/style';
 @import 'components/infinite-list/style';
 @import 'components/info-popover/style';

--- a/client/components/hr-with-text/index.jsx
+++ b/client/components/hr-with-text/index.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/components/hr-with-text/index.jsx
+++ b/client/components/hr-with-text/index.jsx
@@ -4,6 +4,11 @@
  */
 import React from 'react';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const HrWithText = ( { children } ) => (
 	<div className="hr-with-text">
 		<div>{ children }</div>


### PR DESCRIPTION
This PR migrates the style of the `<HrWithText />` component to Webpack.

See p4TIVU-9dT-p2 for more details on the rationale of this migration.

#### Changes proposed in this Pull Request

* Import the `<HrWithText />` component style with Webpack.

#### Testing instructions

* Checkout this branch.
* Insert this component somewhere and rebuild (this component isn't used anywhere at this time):
```
import HrWithText from 'components/hr-with-text';

...

<HrWithText>
	Something!
</HrWithText>
```
* Verify the selectors in the stylesheet aren't used in any other component (that's easy to check because all selectors are prefixed with `.hr-with-text`).

We could also remove this component as it's not used at all, but I say let's keep it for now - it might be useful at some point.
