### PR TITLE
Blocks: Migrate EditGravatar CSS to Webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -14,7 +14,6 @@
 @import 'blocks/conversation-follow-button/style';
 @import 'blocks/conversations/style';
 @import 'blocks/domain-to-plan-nudge/style';
-@import 'blocks/edit-gravatar/style';
 @import 'blocks/follow-button/style';
 @import 'blocks/eligibility-warnings/style';
 @import 'blocks/gdpr-banner/style';

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -35,6 +35,11 @@ import VerifyEmailDialog from 'components/email-verification/email-verification-
 import DropZone from 'components/drop-zone';
 import { recordTracksEvent, recordGoogleEvent, composeAnalytics } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class EditGravatar extends Component {
 	state = {
 		isEditingImage: false,
@@ -174,6 +179,8 @@ export class EditGravatar extends Component {
 		const buttonText = user.email_verified
 			? translate( 'Click to change photo' )
 			: translate( 'Verify your email' );
+		/* eslint-disable jsx-a11y/click-events-have-key-events */
+		/* eslint-disable jsx-a11y/no-static-element-interactions */
 		return (
 			<div
 				className={ classnames(
@@ -243,6 +250,8 @@ export class EditGravatar extends Component {
 				</div>
 			</div>
 		);
+		/* eslint-enable jsx-a11y/click-events-have-key-events */
+		/* eslint-enable jsx-a11y/no-static-element-interactions */
 	}
 }
 

--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classnames from 'classnames';


### PR DESCRIPTION
This PR migrates the style of the `EditGravatar` block to Webpack.

See p4TIVU-9dT-p2 for more details on the rationale of this migration.

#### Changes proposed in this Pull Request

* Import the Edit Gravatar block style with Webpack.

#### Testing instructions

* Checkout this branch.
* Compare http://calypso.localhost:3000/me with https://wpcalypso.wordpress.com/me and verify they look and work the same way.
* Verify the selectors in the stylesheet aren't used in any other component that we're not testing here (that's easy to check because all selectors are prefixed with `.edit-gravatar`). 

Note: I'd like to avoid adding `eslint-disable`s but this one really should be done outside of this PR.
