### PR TITLE
Add non-tabbed plans presentation abtest

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -94,6 +94,7 @@
 @import 'components/mobile-back-to-sidebar/style';
 @import 'components/notice/style';
 @import 'components/payment-logo/style';
+@import 'components/plans/plan-pill/style';
 @import 'components/plans/plan-icon/style';
 @import 'blocks/product-purchase-features-list/style';
 @import 'components/popover/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -52,6 +52,7 @@ $z-layers: (
 		'.is-section-signup': 1,
 		'.media-library .search.is-expanded-to-container': 1,
 		'.ribbon': 1,
+		'.plan-pill': 1,
 		'.reader__featured-post-title': 1,
 		'.reader-list-gap__button': 1,
 		'.reader-following-search': 1,
@@ -193,6 +194,10 @@ $z-layers: (
 	'.ribbon': (
 		'.ribbon__title::before': -1,
 		'.ribbon__title::after': -1
+	),
+	'.plan-pill': (
+		'.plan-pill__title::before': -1,
+		'.plan-pill__title::after': -1
 	),
 	'.environment-badge': (
 		'.environment-badge .environment::before': -1,

--- a/client/components/plans/plan-pill/index.jsx
+++ b/client/components/plans/plan-pill/index.jsx
@@ -1,0 +1,18 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+export default props => (
+	<div
+		className={ classNames( {
+			'plan-pill': true,
+		} ) }
+	>
+		{ props.children }
+	</div>
+);

--- a/client/components/plans/plan-pill/style.scss
+++ b/client/components/plans/plan-pill/style.scss
@@ -1,0 +1,16 @@
+.plan-pill {
+	position: absolute;
+	bottom: -10px;
+	left: 14px;
+	z-index: z-index( 'root', '.plan-pill' );
+	
+	padding: 4px;
+	border-radius: 3px;
+	background: var( --color-accent );
+	
+	font-size: 11px;
+	text-align: center;
+	line-height: 1;
+	color: var( --color-white );
+	text-transform: uppercase;
+}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -183,12 +183,4 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	plansPresentation: {
-		datestamp: '20190410',
-		variations: {
-			tab: 50,
-			scroll: 50,
-		},
-		defaultVariation: 'tab',
-	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -183,4 +183,12 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	plansPresentation: {
+		datestamp: '201904010',
+		variations: {
+			tab: 50,
+			scroll: 50,
+		},
+		defaultVariation: 'tab',
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -184,7 +184,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	plansPresentation: {
-		datestamp: '201904010',
+		datestamp: '20190410',
 		variations: {
 			tab: 50,
 			scroll: 50,

--- a/client/lib/discounts/active-discounts.js
+++ b/client/lib/discounts/active-discounts.js
@@ -82,6 +82,11 @@ export default [
 			{ type: TYPE_PREMIUM, group: GROUP_JETPACK },
 		],
 	},
+	{
+		name: 'plans_no_tabs',
+		startsAt: new Date( 2018, 2, 7, 0, 0, 0 ),
+		endsAt: new Date( 2120, 9, 26, 0, 0, 0 ),
+	},
 	// NOTE: These two (new_plans and default_plans_tab_business) should remain at the bottom.
 	// It's a temporary hack and will be removed shortly.
 	{

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -186,8 +186,7 @@ export const TYPE_PREMIUM = 'TYPE_PREMIUM';
 export const TYPE_BUSINESS = 'TYPE_BUSINESS';
 export const TYPE_ECOMMERCE = 'TYPE_ECOMMERCE';
 
-const WPComGetBillingTimeframe = () =>
-	i18n.translate( '/month, billed annually or every two years' );
+const WPComGetBillingTimeframe = () => i18n.translate( 'per month, billed annually' );
 const WPComGetBiennialBillingTimeframe = () => i18n.translate( '/month, billed every two years' );
 
 const getPlanBloggerDetails = () => ( {
@@ -209,6 +208,10 @@ const getPlanBloggerDetails = () => ( {
 					),
 				},
 			}
+		),
+	getShortDescription: () =>
+		i18n.translate(
+			'Brand your blog with a custom .blog domain name, and remove all WordPress.com advertising. Receive additional storage space and email support.'
 		),
 	// }}}
 	getPlanCompareFeatures: () => [
@@ -261,6 +264,11 @@ const getPlanPersonalDetails = () => ( {
 				},
 			}
 		),
+	getShortDescription: () =>
+		i18n.translate(
+			'Boost your website with a custom domain name, and remove all WordPress.com advertising. ' +
+				'Get access to high-quality email and live chat support.'
+		),
 	getPlanCompareFeatures: () => [
 		// pay attention to ordering, shared features should align on /plan page
 		FEATURE_CUSTOM_DOMAIN,
@@ -310,6 +318,11 @@ const getPlanPremiumDetails = () => ( {
 					),
 				},
 			}
+		),
+	getShortDescription: () =>
+		i18n.translate(
+			'Build a unique website with advanced design tools, CSS editing, lots of space for audio and video,' +
+				' and the ability to monetize your site with ads.'
 		),
 	getPlanCompareFeatures: () =>
 		compact( [
@@ -389,6 +402,12 @@ const getPlanBusinessDetails = () => ( {
 			}
 		);
 	},
+	getShortDescription: () =>
+		i18n.translate(
+			'Power your business website with custom plugins and themes, unlimited premium and business theme templates,' +
+				' Google Analytics support, unlimited' +
+				' storage, and the ability to remove WordPress.com branding.'
+		),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with Business and take advantage of its professional features.'
@@ -468,6 +487,12 @@ const getPlanEcommerceDetails = () => ( {
 			}
 		);
 	},
+	getShortDescription: () =>
+		i18n.translate(
+			'Sell products or services with this powerful, ' +
+				'all-in-one online store experience. This plan includes premium integrations and is extendable, ' +
+				'so it’ll grow with you as your business grows.'
+		),
 	getTagline: () =>
 		i18n.translate(
 			'Learn more about everything included with eCommerce and take advantage of its powerful marketplace features.'

--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -188,6 +188,12 @@ export const TYPE_ECOMMERCE = 'TYPE_ECOMMERCE';
 
 const WPComGetBillingTimeframe = () => i18n.translate( 'per month, billed annually' );
 const WPComGetBiennialBillingTimeframe = () => i18n.translate( '/month, billed every two years' );
+const WPComGetTwoLinesBillingTimeframe = () =>
+	i18n.translate( 'per month,{{br/}}billed annually', {
+		components: {
+			br: <br />,
+		},
+	} );
 
 const getPlanBloggerDetails = () => ( {
 	group: GROUP_WPCOM,
@@ -604,6 +610,7 @@ export const PLANS_LIST = {
 		...getPlanBloggerDetails(),
 		term: TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
+		getTwoLinesBillingTimeFrame: WPComGetTwoLinesBillingTimeframe,
 		availableFor: plan => includes( [ PLAN_FREE ], plan ),
 		getProductId: () => 1010,
 		getStoreSlug: () => PLAN_BLOGGER,
@@ -614,6 +621,7 @@ export const PLANS_LIST = {
 		...getPlanBloggerDetails(),
 		term: TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
+		getTwoLinesBillingTimeFrame: WPComGetTwoLinesBillingTimeframe,
 		availableFor: plan => includes( [ PLAN_FREE, PLAN_BLOGGER ], plan ),
 		getProductId: () => 1030,
 		getStoreSlug: () => PLAN_BLOGGER_2_YEARS,
@@ -624,6 +632,7 @@ export const PLANS_LIST = {
 		...getPlanPersonalDetails(),
 		term: TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
+		getTwoLinesBillingTimeFrame: WPComGetTwoLinesBillingTimeframe,
 		availableFor: plan => includes( [ PLAN_FREE, PLAN_BLOGGER, PLAN_BLOGGER_2_YEARS ], plan ),
 		getProductId: () => 1009,
 		getStoreSlug: () => PLAN_PERSONAL,
@@ -634,6 +643,7 @@ export const PLANS_LIST = {
 		...getPlanPersonalDetails(),
 		term: TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
+		getTwoLinesBillingTimeFrame: WPComGetTwoLinesBillingTimeframe,
 		availableFor: plan =>
 			includes( [ PLAN_FREE, PLAN_BLOGGER, PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL ], plan ),
 		getProductId: () => 1029,
@@ -645,6 +655,7 @@ export const PLANS_LIST = {
 		...getPlanPremiumDetails(),
 		term: TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
+		getTwoLinesBillingTimeFrame: WPComGetTwoLinesBillingTimeframe,
 		availableFor: plan =>
 			includes(
 				[ PLAN_FREE, PLAN_BLOGGER, PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL, PLAN_PERSONAL_2_YEARS ],
@@ -659,6 +670,7 @@ export const PLANS_LIST = {
 		...getPlanPremiumDetails(),
 		term: TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
+		getTwoLinesBillingTimeFrame: WPComGetTwoLinesBillingTimeframe,
 		availableFor: plan =>
 			includes(
 				[
@@ -703,6 +715,7 @@ export const PLANS_LIST = {
 		...getPlanBusinessDetails(),
 		term: TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
+		getTwoLinesBillingTimeFrame: WPComGetTwoLinesBillingTimeframe,
 		availableFor: plan =>
 			includes(
 				[
@@ -726,6 +739,7 @@ export const PLANS_LIST = {
 		...getPlanBusinessDetails(),
 		term: TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
+		getTwoLinesBillingTimeFrame: WPComGetTwoLinesBillingTimeframe,
 		availableFor: plan =>
 			includes(
 				[
@@ -750,6 +764,7 @@ export const PLANS_LIST = {
 		...getPlanEcommerceDetails(),
 		term: TERM_ANNUALLY,
 		getBillingTimeFrame: WPComGetBillingTimeframe,
+		getTwoLinesBillingTimeFrame: WPComGetTwoLinesBillingTimeframe,
 		availableFor: plan =>
 			includes(
 				[
@@ -775,6 +790,7 @@ export const PLANS_LIST = {
 		...getPlanEcommerceDetails(),
 		term: TERM_BIENNIALLY,
 		getBillingTimeFrame: WPComGetBiennialBillingTimeframe,
+		getTwoLinesBillingTimeFrame: WPComGetTwoLinesBillingTimeframe,
 		availableFor: plan =>
 			includes(
 				[

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -358,7 +358,7 @@ export class PlanFeaturesHeader extends Component {
 PlanFeaturesHeader.propTypes = {
 	availableForPurchase: PropTypes.bool,
 	bestValue: PropTypes.bool,
-	billingTimeFrame: PropTypes.oneOf( [ PropTypes.string, PropTypes.array ] ).isRequired,
+	billingTimeFrame: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ).isRequired,
 	currencyCode: PropTypes.string,
 	current: PropTypes.bool,
 	discountPrice: PropTypes.number,

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -17,7 +17,7 @@ import InfoPopover from 'components/info-popover';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import PlanPrice from 'my-sites/plan-price';
 import PlanIntervalDiscount from 'my-sites/plan-interval-discount';
-import Ribbon from 'components/ribbon';
+import PlanPill from 'components/plans/plan-pill';
 import PlanIcon from 'components/plans/plan-icon';
 import { TYPE_FREE, PLANS_LIST, getPlanClass } from 'lib/plans/constants';
 import { getYearlyPlanByMonthly, planMatches } from 'lib/plans';
@@ -27,14 +27,20 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { isMobile } from 'lib/viewport';
 import { planLevelsMatch } from 'lib/plans/index';
+import { requestGeoLocation } from 'state/data-getters';
 import { abtest } from 'lib/abtest';
 
 export class PlanFeaturesHeader extends Component {
 	render() {
-		const { isInSignup } = this.props;
-		const content = isInSignup ? this.renderSignupHeader() : this.renderPlansHeader();
+		const { isInSignup, plansWithScroll } = this.props;
+		// Do not use the signup-specific header, unify plans for the plansWithScroll test
+		if ( plansWithScroll ) {
+			return this.renderPlansHeaderNoTabs();
+		} else if ( isInSignup ) {
+			return this.renderSignupHeader();
+		}
 
-		return content;
+		return this.renderPlansHeader();
 	}
 
 	renderPlansHeader() {
@@ -44,13 +50,6 @@ export class PlanFeaturesHeader extends Component {
 
 		return (
 			<header className={ headerClasses }>
-				{ planLevelsMatch( selectedPlan, planType ) && (
-					<Ribbon>{ translate( 'Suggested' ) }</Ribbon>
-				) }
-				{ popular && ! selectedPlan && <Ribbon>{ translate( 'Popular' ) }</Ribbon> }
-				{ newPlan && ! selectedPlan && <Ribbon>{ translate( 'New' ) }</Ribbon> }
-				{ bestValue && ! selectedPlan && <Ribbon>{ translate( 'Best Value' ) }</Ribbon> }
-				{ this.isPlanCurrent() && <Ribbon>{ translate( 'Your Plan' ) }</Ribbon> }
 				<div className="plan-features__header-figure">
 					<PlanIcon plan={ planType } />
 				</div>
@@ -59,7 +58,49 @@ export class PlanFeaturesHeader extends Component {
 					{ this.getPlanFeaturesPrices() }
 					{ this.getBillingTimeframe() }
 				</div>
+				{ planLevelsMatch( selectedPlan, planType ) && (
+					<PlanPill>{ translate( 'Suggested' ) }</PlanPill>
+				) }
+				{ popular && ! selectedPlan && <PlanPill>{ translate( 'Popular' ) }</PlanPill> }
+				{ newPlan && ! selectedPlan && <PlanPill>{ translate( 'New' ) }</PlanPill> }
+				{ bestValue && ! selectedPlan && <PlanPill>{ translate( 'Best Value' ) }</PlanPill> }
+				{ this.isPlanCurrent() && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
 			</header>
+		);
+	}
+
+	renderPlansHeaderNoTabs() {
+		const {
+			newPlan,
+			bestValue,
+			planType,
+			popular,
+			selectedPlan,
+			title,
+			audience,
+			translate,
+		} = this.props;
+
+		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
+
+		return (
+			<>
+				<header className={ headerClasses }>
+					<h4 className="plan-features__header-title">{ title }</h4>
+					<div className="plan-features__audience">{ audience }</div>
+					{ planLevelsMatch( selectedPlan, planType ) && (
+						<PlanPill>{ translate( 'Suggested' ) }</PlanPill>
+					) }
+					{ popular && ! selectedPlan && <PlanPill>{ translate( 'Popular' ) }</PlanPill> }
+					{ newPlan && ! selectedPlan && <PlanPill>{ translate( 'New' ) }</PlanPill> }
+					{ bestValue && ! selectedPlan && <PlanPill>{ translate( 'Best Value' ) }</PlanPill> }
+					{ this.isPlanCurrent() && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
+				</header>
+				<div className="plan-features__pricing">
+					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
+					{ this.getIntervalDiscount() }
+				</div>
+			</>
 		);
 	}
 
@@ -80,13 +121,13 @@ export class PlanFeaturesHeader extends Component {
 		return (
 			<div className="plan-features__header-wrapper">
 				<header className={ headerClasses }>
-					{ newPlan && <Ribbon>{ translate( 'New' ) }</Ribbon> }
-					{ popular && <Ribbon>{ translate( 'Popular' ) }</Ribbon> }
-					{ bestValue && <Ribbon>{ translate( 'Best Value' ) }</Ribbon> }
 					<div className="plan-features__header-text">
 						<h4 className="plan-features__header-title">{ title }</h4>
 						{ audience }
 					</div>
+					{ newPlan && <PlanPill>{ translate( 'New' ) }</PlanPill> }
+					{ popular && <PlanPill>{ translate( 'Popular' ) }</PlanPill> }
+					{ bestValue && <PlanPill>{ translate( 'Best Value' ) }</PlanPill> }
 				</header>
 				<div className="plan-features__graphic">
 					<PlanIcon plan={ planType } />
@@ -126,6 +167,7 @@ export class PlanFeaturesHeader extends Component {
 			isJetpack,
 			hideMonthly,
 			isInSignup,
+			plansWithScroll,
 		} = this.props;
 
 		const isDiscounted = !! discountPrice;
@@ -134,11 +176,11 @@ export class PlanFeaturesHeader extends Component {
 			'is-placeholder': isPlaceholder,
 		} );
 
-		if ( isInSignup ) {
+		if ( isInSignup || plansWithScroll ) {
 			return (
-				<span>
+				<div className={ 'plan-features__header-billing-info' }>
 					<span>{ billingTimeFrame }</span>
-				</span>
+				</div>
 			);
 		}
 
@@ -215,7 +257,8 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	renderPriceGroup( fullPrice, discountedPrice = null ) {
-		const { currencyCode, isInSignup } = this.props;
+		const { currencyCode, isInSignup, plansWithScroll } = this.props;
+		const displayFlatPrice = isInSignup && ! plansWithScroll;
 
 		if ( fullPrice && discountedPrice ) {
 			return (
@@ -224,23 +267,27 @@ export class PlanFeaturesHeader extends Component {
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ fullPrice }
-							isInSignup={ isInSignup }
+							isInSignup={ displayFlatPrice }
 							original
 						/>
 						<PlanPrice
 							currencyCode={ currencyCode }
 							rawPrice={ discountedPrice }
-							isInSignup={ isInSignup }
+							isInSignup={ displayFlatPrice }
 							discounted
 						/>
 					</div>
-					{ this.renderCreditLabel() }
+					{ plansWithScroll ? null : this.renderCreditLabel() }
 				</span>
 			);
 		}
 
 		return (
-			<PlanPrice currencyCode={ currencyCode } rawPrice={ fullPrice } isInSignup={ isInSignup } />
+			<PlanPrice
+				currencyCode={ currencyCode }
+				rawPrice={ fullPrice }
+				isInSignup={ displayFlatPrice }
+			/>
 		);
 	}
 
@@ -311,7 +358,7 @@ export class PlanFeaturesHeader extends Component {
 PlanFeaturesHeader.propTypes = {
 	availableForPurchase: PropTypes.bool,
 	bestValue: PropTypes.bool,
-	billingTimeFrame: PropTypes.string.isRequired,
+	billingTimeFrame: PropTypes.oneOf( [ PropTypes.string, PropTypes.array ] ).isRequired,
 	currencyCode: PropTypes.string,
 	current: PropTypes.bool,
 	discountPrice: PropTypes.number,
@@ -328,7 +375,6 @@ PlanFeaturesHeader.propTypes = {
 	siteSlug: PropTypes.string,
 	title: PropTypes.string.isRequired,
 	translate: PropTypes.func,
-	countryCode: PropTypes.string,
 
 	// Connected props
 	currentSitePlan: PropTypes.object,
@@ -363,5 +409,6 @@ export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) 
 		isYearly,
 		relatedYearlyPlan: isYearly ? null : getPlanBySlug( state, getYearlyPlanByMonthly( planType ) ),
 		siteSlug: getSiteSlug( state, selectedSiteId ),
+		countryCode: requestGeoLocation().data || 'US',
 	};
 } )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -79,7 +79,9 @@ export class PlanFeatures extends Component {
 			'plan-features--signup': isInSignup,
 		} );
 		const planWrapperClasses = classNames( { 'plans-wrapper': isInSignup } );
-		const mobileView = <div className="plan-features__mobile">{ this.renderMobileView() }</div>;
+		const mobileView = ! withScroll && (
+			<div className="plan-features__mobile">{ this.renderMobileView() }</div>
+		);
 		let planDescriptions;
 		let bottomButtons = null;
 
@@ -96,7 +98,11 @@ export class PlanFeatures extends Component {
 					{ this.renderNotice() }
 					<div ref={ this.contentRef } className="plan-features__content">
 						{ mobileView }
-						<PlanFeaturesScroller withScroll={ withScroll } planCount={ planProperties.length }>
+						<PlanFeaturesScroller
+							withScroll={ withScroll }
+							planCount={ planProperties.length }
+							cellSelector=".plan-features__table-item"
+						>
 							<table className={ tableClasses }>
 								<tbody>
 									<tr>{ this.renderPlanHeaders() }</tr>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -66,10 +66,11 @@ import {
 	TYPE_BUSINESS,
 	GROUP_WPCOM,
 } from 'lib/plans/constants';
+import PlanFeaturesScroller from './scroller';
 
 export class PlanFeatures extends Component {
 	render() {
-		const { isInSignup, planProperties } = this.props;
+		const { isInSignup, planProperties, withScroll } = this.props;
 		const tableClasses = classNames(
 			'plan-features__table',
 			`has-${ planProperties.length }-cols`
@@ -93,17 +94,19 @@ export class PlanFeatures extends Component {
 				<QueryActivePromotions />
 				<div className={ planClasses }>
 					{ this.renderNotice() }
-					<div className="plan-features__content">
+					<div ref={ this.contentRef } className="plan-features__content">
 						{ mobileView }
-						<table className={ tableClasses }>
-							<tbody>
-								<tr>{ this.renderPlanHeaders() }</tr>
-								{ planDescriptions }
-								<tr>{ this.renderTopButtons() }</tr>
-								{ this.renderPlanFeatureRows() }
-								{ bottomButtons }
-							</tbody>
-						</table>
+						<PlanFeaturesScroller withScroll={ withScroll } planCount={ planProperties.length }>
+							<table className={ tableClasses }>
+								<tbody>
+									<tr>{ this.renderPlanHeaders() }</tr>
+									{ planDescriptions }
+									<tr>{ this.renderTopButtons() }</tr>
+									{ this.renderPlanFeatureRows() }
+									{ bottomButtons }
+								</tbody>
+							</table>
+						</PlanFeaturesScroller>
 					</div>
 				</div>
 			</div>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -85,7 +85,7 @@ export class PlanFeatures extends Component {
 		let planDescriptions;
 		let bottomButtons = null;
 
-		if ( ! isInSignup ) {
+		if ( withScroll || ! isInSignup ) {
 			planDescriptions = <tr>{ this.renderPlanDescriptions() }</tr>;
 
 			bottomButtons = <tr>{ this.renderBottomButtons() }</tr>;
@@ -106,10 +106,11 @@ export class PlanFeatures extends Component {
 							<table className={ tableClasses }>
 								<tbody>
 									<tr>{ this.renderPlanHeaders() }</tr>
-									{ planDescriptions }
+									{ ! withScroll && planDescriptions }
 									<tr>{ this.renderTopButtons() }</tr>
+									{ withScroll && planDescriptions }
 									{ this.renderPlanFeatureRows() }
-									{ bottomButtons }
+									{ ! withScroll && ! isInSignup && bottomButtons }
 								</tbody>
 							</table>
 						</PlanFeaturesScroller>
@@ -358,6 +359,7 @@ export class PlanFeatures extends Component {
 			siteType,
 			showPlanCreditsApplied,
 			countryCode,
+			withScroll,
 		} = this.props;
 
 		return map( planProperties, properties => {
@@ -402,6 +404,10 @@ export class PlanFeatures extends Component {
 				}
 			}
 
+			if ( withScroll && planConstantObj.getTwoLinesBillingTimeFrame ) {
+				billingTimeFrame = planConstantObj.getTwoLinesBillingTimeFrame();
+			}
+
 			if ( isInSignup && displayJetpackPlans ) {
 				billingTimeFrame = planConstantObj.getSignupBillingTimeFrame();
 			}
@@ -430,6 +436,7 @@ export class PlanFeatures extends Component {
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
 						title={ planConstantObj.getTitle() }
 						countryCode={ countryCode }
+						plansWithScroll={ withScroll }
 					/>
 				</td>
 			);
@@ -437,20 +444,28 @@ export class PlanFeatures extends Component {
 	}
 
 	renderPlanDescriptions() {
-		const { planProperties } = this.props;
+		const { planProperties, withScroll } = this.props;
 
 		return map( planProperties, properties => {
 			const { planName, planConstantObj, isPlaceholder } = properties;
 
 			const classes = classNames( 'plan-features__table-item', {
 				'is-placeholder': isPlaceholder,
+				'is-description': withScroll,
 			} );
+
+			let description = null;
+			if ( withScroll ) {
+				description = planConstantObj.getShortDescription( abtest );
+			} else {
+				description = planConstantObj.getDescription( abtest );
+			}
 
 			return (
 				<td key={ planName } className={ classes }>
 					{ isPlaceholder ? <SpinnerLine /> : null }
 
-					<p className="plan-features__description">{ planConstantObj.getDescription( abtest ) }</p>
+					<p className="plan-features__description">{ description }</p>
 				</td>
 			);
 		} );
@@ -558,6 +573,7 @@ export class PlanFeatures extends Component {
 				key={ index }
 				description={ description }
 				hideInfoPopover={ feature.hideInfoPopover }
+				hideGridicon={ this.props.withScroll }
 			>
 				<span className="plan-features__item-info">
 					<span className="plan-features__item-title">{ feature.getTitle() }</span>
@@ -567,7 +583,7 @@ export class PlanFeatures extends Component {
 	}
 
 	renderPlanFeatureColumns( rowIndex ) {
-		const { planProperties, selectedFeature } = this.props;
+		const { planProperties, selectedFeature, withScroll } = this.props;
 
 		return map( planProperties, properties => {
 			const { features, planName } = properties;
@@ -577,7 +593,7 @@ export class PlanFeatures extends Component {
 				currentFeature = features[ key ];
 
 			const classes = classNames( 'plan-features__table-item', getPlanClass( planName ), {
-				'has-partial-border': rowIndex + 1 < featureKeys.length,
+				'has-partial-border': ! withScroll && rowIndex + 1 < featureKeys.length,
 				'is-highlighted':
 					selectedFeature && currentFeature && selectedFeature === currentFeature.getSlug(),
 			} );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -8,7 +8,7 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { compact, get, last, map, noop, reduce } from 'lodash';
+import { compact, get, findIndex, last, map, noop, reduce } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import formatCurrency from '@automattic/format-currency';
@@ -102,6 +102,7 @@ export class PlanFeatures extends Component {
 							withScroll={ withScroll }
 							planCount={ planProperties.length }
 							cellSelector=".plan-features__table-item"
+							initialSelectedIndex={ findIndex( planProperties, { popular: true } ) }
 						>
 							<table className={ tableClasses }>
 								<tbody>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -53,6 +53,7 @@ import {
 	isJetpackSite,
 } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
 import {
 	isBestValue,
 	isMonthly,
@@ -98,23 +99,25 @@ export class PlanFeatures extends Component {
 					{ this.renderNotice() }
 					<div ref={ this.contentRef } className="plan-features__content">
 						{ mobileView }
-						<PlanFeaturesScroller
-							withScroll={ withScroll }
-							planCount={ planProperties.length }
-							cellSelector=".plan-features__table-item"
-							initialSelectedIndex={ findIndex( planProperties, { popular: true } ) }
-						>
-							<table className={ tableClasses }>
-								<tbody>
-									<tr>{ this.renderPlanHeaders() }</tr>
-									{ ! withScroll && planDescriptions }
-									<tr>{ this.renderTopButtons() }</tr>
-									{ withScroll && planDescriptions }
-									{ this.renderPlanFeatureRows() }
-									{ ! withScroll && ! isInSignup && bottomButtons }
-								</tbody>
-							</table>
-						</PlanFeaturesScroller>
+						{ ! this.props.isRequestingActivePromotions && (
+							<PlanFeaturesScroller
+								withScroll={ withScroll }
+								planCount={ planProperties.length }
+								cellSelector=".plan-features__table-item"
+								initialSelectedIndex={ findIndex( planProperties, { popular: true } ) }
+							>
+								<table className={ tableClasses }>
+									<tbody>
+										<tr>{ this.renderPlanHeaders() }</tr>
+										{ ! withScroll && planDescriptions }
+										<tr>{ this.renderTopButtons() }</tr>
+										{ withScroll && planDescriptions }
+										{ this.renderPlanFeatureRows() }
+										{ ! withScroll && ! isInSignup && bottomButtons }
+									</tbody>
+								</table>
+							</PlanFeaturesScroller>
+						) }
 					</div>
 				</div>
 			</div>
@@ -894,6 +897,7 @@ export default connect(
 			sitePlan,
 			siteType,
 			planCredits,
+			isRequestingActivePromotions: isRequestingActivePromotions( state ),
 			hasPlaceholders: hasPlaceholders( planProperties ),
 			showPlanCreditsApplied:
 				sitePlan &&

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -594,6 +594,7 @@ export class PlanFeatures extends Component {
 
 			const classes = classNames( 'plan-features__table-item', getPlanClass( planName ), {
 				'has-partial-border': ! withScroll && rowIndex + 1 < featureKeys.length,
+				'is-last-feature': rowIndex + 1 === featureKeys.length,
 				'is-highlighted':
 					selectedFeature && currentFeature && selectedFeature === currentFeature.getSlug(),
 			} );

--- a/client/my-sites/plan-features/item.jsx
+++ b/client/my-sites/plan-features/item.jsx
@@ -13,12 +13,19 @@ import Gridicon from 'gridicons';
 import InfoPopover from 'components/info-popover';
 import { useMobileBreakpoint } from 'lib/viewport/react';
 
-export default function PlanFeaturesItem( { children, description, hideInfoPopover } ) {
+export default function PlanFeaturesItem( {
+	children,
+	description,
+	hideInfoPopover,
+	hideGridicon = false,
+} ) {
 	const isMobile = useMobileBreakpoint();
 
 	return (
 		<div className="plan-features__item">
-			<Gridicon className="plan-features__item-checkmark" size={ 18 } icon="checkmark" />
+			{ ! hideGridicon && (
+				<Gridicon className="plan-features__item-checkmark" size={ 18 } icon="checkmark" />
+			) }
 			{ children }
 			{ hideInfoPopover ? null : (
 				<InfoPopover

--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -1,0 +1,201 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Gridicon from 'gridicons';
+import { clamp, range, inRange } from 'lodash';
+import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+
+const MIN_CELL_WIDTH = 220; // px
+const SIDE_PANE_RATIO = 0.12; // 12% of full width
+
+export default class PlanFeaturesScroller extends PureComponent {
+	static propTypes = {
+		withScroll: PropTypes.bool.isRequired,
+		planCount: PropTypes.number.isRequired,
+	};
+
+	static defaultProps = {
+		withScroll: false,
+		planCount: 0,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.containerElement = null;
+		this.state = { viewportWidth: 0, scrollPos: 0 };
+	}
+
+	componentDidMount() {
+		if ( typeof window !== 'undefined' ) {
+			window.addEventListener( 'resize', this.handleWindowResize );
+		}
+	}
+
+	componentWillUnmount() {
+		if ( typeof window !== 'undefined' ) {
+			window.removeEventListener( 'resize', this.handleWindowResize );
+		}
+		if ( this.containerElement ) {
+			this.containerElement.removeEventListener( 'scroll', this.handleScroll );
+		}
+	}
+
+	setContainerRef = element => {
+		this.containerElement = element;
+		element.addEventListener( 'scroll', this.handleScroll );
+		this.updateViewportWidth();
+	};
+
+	scrollLeft = event => {
+		event.preventDefault();
+		this.scroll( -1 );
+	};
+
+	scrollRight = event => {
+		event.preventDefault();
+		this.scroll( 1 );
+	};
+
+	scroll( direction ) {
+		const { cellWidth, borderSpacing, visibleIndex } = this.computeStyleVars();
+		if ( this.containerElement ) {
+			this.containerElement.scrollLeft =
+				( visibleIndex + direction ) * ( cellWidth + borderSpacing );
+		}
+	}
+
+	handleWindowResize = () => {
+		cancelAnimationFrame( this.updateViewportWidthRaf );
+		this.updateViewportWidthRaf = window.requestAnimationFrame( this.updateViewportWidth );
+	};
+
+	handleScroll = () => {
+		cancelAnimationFrame( this.updateScrollPositionRaf );
+		this.updateScrollPositionRaf = window.requestAnimationFrame( this.updateScrollPosition );
+	};
+
+	updateViewportWidth = () => {
+		this.updateViewportWidthRaf = null;
+		if ( this.containerElement ) {
+			this.setState( { viewportWidth: this.containerElement.offsetWidth } );
+		}
+	};
+
+	updateScrollPosition = () => {
+		this.updateScrollPositionRaf = null;
+		if ( this.containerElement ) {
+			this.setState( { scrollPos: this.containerElement.scrollLeft } );
+		}
+	};
+
+	computeStyleVars() {
+		const { viewportWidth: vpw } = this.state;
+		const { planCount } = this.props;
+		const borderSpacing = clamp( vpw * 0.015, 5, 15 );
+		let paneWidth = '0';
+		let visibleCount = planCount;
+		let visibleIndex = 0;
+		let cellWidth = ( vpw - borderSpacing * ( visibleCount + 1 ) ) / visibleCount;
+		let scrollerWidth = 'auto';
+		let scrollerPadding = '0';
+
+		if ( vpw && cellWidth < MIN_CELL_WIDTH ) {
+			// Each cell should be wider than MIN_CELL_WIDTH
+			do {
+				visibleCount--;
+				cellWidth = ( vpw * ( 1 - SIDE_PANE_RATIO * 2 ) ) / visibleCount - borderSpacing;
+			} while ( cellWidth < MIN_CELL_WIDTH );
+
+			paneWidth = SIDE_PANE_RATIO * vpw;
+			scrollerWidth = ( cellWidth + borderSpacing ) * planCount + borderSpacing;
+			scrollerPadding = `0 ${ paneWidth }px`;
+			visibleIndex = Math.floor( this.state.scrollPos / cellWidth );
+		}
+
+		return {
+			cellWidth,
+			paneWidth,
+			scrollerWidth,
+			scrollerPadding,
+			borderSpacing,
+			visibleCount,
+			visibleIndex,
+			showIndicator: planCount > visibleCount,
+		};
+	}
+
+	renderIndicator( { visibleCount, visibleIndex } ) {
+		const dotClass = 'plan-features__scroll-indicator-dot';
+		const start = visibleIndex;
+		const end = start + visibleCount;
+
+		return (
+			<div className="plan-features__scroll-indicator">
+				{ range( 0, this.props.planCount ).map( index => (
+					<span
+						key={ index }
+						className={ classNames( dotClass, { 'is-highlighted': inRange( index, start, end ) } ) }
+					/>
+				) ) }
+			</div>
+		);
+	}
+
+	render() {
+		const { children, withScroll, planCount } = this.props;
+
+		if ( ! withScroll ) {
+			return <>{ children }</>;
+		}
+
+		const vars = this.computeStyleVars();
+
+		return (
+			/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+			<div className="plan-features__scroller-container" ref={ this.setContainerRef }>
+				<div
+					className="plan-features__scroll-left"
+					style={ { width: vars.paneWidth } }
+					onClick={ this.scrollLeft }
+				>
+					<Button
+						className="plan-features__scroll-button"
+						disabled={ 0 === vars.visibleIndex }
+						onClick={ this.scrollLeft }
+						tabIndex="0"
+					>
+						<Gridicon icon="arrow-left" size={ 24 } />
+					</Button>
+				</div>
+				<div
+					className="plan-features__scroller"
+					style={ { width: vars.scrollerWidth, padding: vars.scrollerPadding } }
+				>
+					{ children }
+				</div>
+				<div
+					className="plan-features__scroll-right"
+					style={ { width: vars.paneWidth } }
+					onClick={ this.scrollRight }
+				>
+					<Button
+						className="plan-features__scroll-button"
+						disabled={ planCount === vars.visibleIndex + vars.visibleCount }
+						onClick={ this.scrollRight }
+					>
+						<Gridicon icon="arrow-right" size={ 24 } />
+					</Button>
+				</div>
+				{ vars.showIndicator && this.renderIndicator( vars ) }
+			</div>
+			/* eslint-enable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
+		);
+	}
+}

--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -77,6 +77,7 @@ export default class PlanFeaturesScroller extends PureComponent {
 			// when scroll-snap is turned on.
 			this.setState( { scrollSnapDisabled: true }, () => {
 				this.containerElement.scrollLeft = xPos;
+				this.setState( { scrollSnapDisabled: false } );
 			} );
 		}
 	}
@@ -103,10 +104,7 @@ export default class PlanFeaturesScroller extends PureComponent {
 	updateScrollPosition = () => {
 		this.updateScrollPositionRaf = null;
 		if ( this.containerElement ) {
-			this.setState( {
-				scrollPos: this.containerElement.scrollLeft,
-				scrollSnapDisabled: false,
-			} );
+			this.setState( { scrollPos: this.containerElement.scrollLeft } );
 		}
 	};
 
@@ -176,8 +174,7 @@ export default class PlanFeaturesScroller extends PureComponent {
 		return (
 			<>
 				<style>
-					{ `.plan-features__header-wrapper::before { left: ${ -paneWidth -
-						borderSpacing / 2 }px }` }
+					{ `.plan-features__header::before { left: ${ -paneWidth - borderSpacing / 2 }px }` }
 				</style>
 				{ styleWeights.map( ( weight, index ) => {
 					const selector = `${ cellSelector }:nth-child(${ index + 1 })`;

--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -231,6 +231,7 @@ export default class PlanFeaturesScroller extends PureComponent {
 		return (
 			<>
 				<style>
+					{ `.signup__step.is-plans { overflow-x: hidden; }` }
 					{ `.plan-features__header::before { left: ${ -paneWidth - borderSpacing / 2 }px }` }
 				</style>
 				{ styleWeights.map( ( weight, index ) => {
@@ -283,6 +284,8 @@ export default class PlanFeaturesScroller extends PureComponent {
 		}
 
 		const vars = this.computeStyleVars();
+		const disabledLeft = 0 === vars.visibleIndex;
+		const disabledRight = planCount === vars.visibleIndex + vars.visibleCount;
 		const containerClass = classNames( 'plan-features__scroller-container', {
 			'scroll-snap-disabled': this.state.scrollSnapDisabled,
 		} );
@@ -292,13 +295,13 @@ export default class PlanFeaturesScroller extends PureComponent {
 			<div className={ containerClass }>
 				{ this.renderStyle( vars ) }
 				<div
-					className="plan-features__scroll-left"
+					className={ classNames( 'plan-features__scroll-left', { disabled: disabledLeft } ) }
 					style={ { width: vars.paneWidth } }
 					onClick={ this.scrollLeft }
 				>
 					<Button
 						className="plan-features__scroll-button"
-						disabled={ 0 === vars.visibleIndex }
+						disabled={ disabledLeft }
 						onClick={ this.scrollLeft }
 						tabIndex="0"
 					>
@@ -314,13 +317,13 @@ export default class PlanFeaturesScroller extends PureComponent {
 					</div>
 				</div>
 				<div
-					className="plan-features__scroll-right"
+					className={ classNames( 'plan-features__scroll-right', { disabled: disabledRight } ) }
 					style={ { width: vars.paneWidth } }
 					onClick={ this.scrollRight }
 				>
 					<Button
 						className="plan-features__scroll-button"
-						disabled={ planCount === vars.visibleIndex + vars.visibleCount }
+						disabled={ disabledRight }
 						onClick={ this.scrollRight }
 					>
 						<Gridicon icon="arrow-right" size={ 24 } />

--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -58,8 +58,10 @@ export default class PlanFeaturesScroller extends PureComponent {
 
 	setWrapperRef = element => {
 		this.scrollWrapperDOM = element;
-		element.addEventListener( 'scroll', this.handleScroll );
-		this.updateViewportWidth();
+		if ( element ) {
+			element.addEventListener( 'scroll', this.handleScroll );
+			this.updateViewportWidth();
+		}
 	};
 
 	scrollLeft = event => {
@@ -148,8 +150,8 @@ export default class PlanFeaturesScroller extends PureComponent {
 					index = clamp( round( initialSelectedIndex - visibleCount / 2 ), minIndex, maxIndex );
 				}
 
-				this.initialized = true;
 				this.scrollBy( index );
+				this.initialized = true;
 			} );
 		}
 	};

--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -231,7 +231,6 @@ export default class PlanFeaturesScroller extends PureComponent {
 		return (
 			<>
 				<style>
-					{ `.signup__step.is-plans { overflow-x: hidden; }` }
 					{ `.plan-features__header::before { left: ${ -paneWidth - borderSpacing / 2 }px }` }
 				</style>
 				{ styleWeights.map( ( weight, index ) => {
@@ -293,6 +292,7 @@ export default class PlanFeaturesScroller extends PureComponent {
 		return (
 			/* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
 			<div className={ containerClass }>
+				<style>{ `.signup__step.is-plans { overflow-x: hidden; }` }</style>
 				{ this.renderStyle( vars ) }
 				<div
 					className={ classNames( 'plan-features__scroll-left', { disabled: disabledLeft } ) }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -268,6 +268,11 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
+.plan-features__audience {
+	display: block;
+	color: var( --color-text-subtle );
+}
+
 .plan-features__header-price-group,
 .plan-features__header-price-group-prices {
 	display: flex;
@@ -612,124 +617,13 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		}
 
 		@include breakpoint( '>1040px' ) {
-			border-spacing: 15px 0 !important;
+			border-spacing: 15px 0;
 			padding: 0;
 		}
 	}
 
 	.plan-features__content {
 		margin: -16px 0 0 0;
-	}
-
-	.plan-features__scroller-container {
-		overflow: auto;
-		-ms-overflow-style: none;
-		scrollbar-width: none;
-		scroll-snap-type: x mandatory;
-		scroll-behavior: smooth;
-		padding: 0 0 30px;
-
-		&.scroll-snap-disabled {
-			scroll-snap-type: none;
-		}
-
-		&::-webkit-scrollbar {
-			height: 0;
-		}
-
-		.plan-features__table {
-			display: table;
-			padding: 0;
-			margin: 0 auto;
-			width: 100%;
-		}
-
-		.plan-features__header-wrapper {
-			position: relative;
-		}
-
-		/* scroll stops */
-		.plan-features__header-wrapper::before {
-			content: '';
-			position: absolute;
-			top: 0;
-			height: 0;
-			width: 1px;
-			overflow: hidden;
-			scroll-snap-align: start;
-		}
-	}
-
-	.plan-features__scroller {
-		position: relative;
-		margin: 0 auto;
-	}
-
-	.plan-features__scroll-left,
-	.plan-features__scroll-right {
-		display: flex;
-		position: absolute;
-		top: 24px;
-		bottom: 40px;
-		width: 12%;
-		background-color: rgba( var( --color-primary-rgb ), 0.01 );
-		cursor: pointer;
-		overflow: hidden;
-		z-index: 1;
-	}
-
-	.plan-features__scroll-left {
-		left: 0;
-		cursor: w-resize;
-	}
-
-	.plan-features__scroll-right {
-		right: 0;
-		cursor: e-resize;
-	}
-
-	.plan-features__scroll-button {
-		align-self: center;
-		margin: 0 auto;
-		width: 30px;
-		height: 30px;
-		padding: 0;
-		background: var( --color-white );
-		border: 0;
-		border-radius: 15px;
-		color: var( --color-primary );
-		cursor: pointer;
-
-		:root body.is-section-signup & {
-			padding: 0;
-		}
-
-		&:disabled, &[disabled] {
-			opacity: 0.5;
-		}
-	}
-
-	.plan-features__scroll-indicator {
-		position: absolute;
-		width: auto;
-		bottom: 0;
-		left: 50%;
-		transform: translateX(-50%);
-		white-space: nowrap;
-	}
-
-	.plan-features__scroll-indicator-dot {
-		display: inline-block;
-		background: var( --color-white );
-		opacity: 0.5;
-		width: 10px;
-		height: 10px;
-		margin: 0 2px;
-		border-radius: 5px;
-
-		&.is-highlighted {
-			opacity: 1;
-		}
 	}
 
 	.plan-features__header {
@@ -835,5 +729,250 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 	.plan-features__header-price-group-prices {
 		display: inline;
+	}
+}
+
+.plans-features-main__group.is-scrollable {
+	position: relative;
+}
+
+.plan-features__scroller-container {
+	overflow: auto;
+	-ms-overflow-style: none;
+	scrollbar-width: none;
+	scroll-snap-type: x mandatory;
+	scroll-behavior: smooth;
+	padding: 0 0 30px;
+
+	&::-webkit-scrollbar {
+		height: 0;
+	}
+
+	&.scroll-snap-disabled .plan-features__header::before {
+		display: none;
+	}
+}
+
+.plan-features__scroller {
+	position: relative;
+	margin: 0 auto;
+
+	.plan-features__table {
+		display: table;
+		padding: 0;
+		margin: 0 auto;
+		width: 100%;
+		border-spacing: 7px 0;
+	}
+
+	.plan-features__header {
+		display: block;
+		position: relative;
+		text-align: left;
+		box-sizing: border-box;
+		margin: -1px -1px 0;
+		border-top: solid 8px;
+		padding-bottom: 12px;
+
+		.plans-features-main__group.is-wpcom & {
+			border-bottom: none;
+		}
+
+		&.is-blogger-plan {
+			border-color: var( --color-plan-blogger );
+		}
+
+		&.is-personal-plan {
+			border-color: var( --color-plan-personal );
+		}
+
+		&.is-premium-plan {
+			border-color: var( --color-plan-premium );
+		}
+
+		&.is-business-plan {
+			border-color: var( --color-plan-business );
+		}
+
+		&.is-ecommerce-plan {
+			border-color: var( --color-plan-ecommerce );
+		}
+	}
+
+	/* scroll stops */
+	.plan-features__header::before {
+		content: '';
+		position: absolute;
+		top: 0;
+		height: 0;
+		width: 1px;
+		overflow: hidden;
+		scroll-snap-align: start;
+	}
+
+	.plan-features__header-title {
+		color: var( --color-text );
+		font-weight: 700;
+		font-size: 24px;
+		margin-bottom: 6px;
+	}
+
+	.plan-features__header-billing-info {
+		display: flex;
+		color: var( --color-text-subtle );
+		align-items: center;
+		text-align: initial;
+	}
+
+	.plan-features__pricing {
+		display: flex;
+		flex-direction: row;
+		padding: 8px 16px;
+		margin: 0;
+		border-top: solid 1px lighten( $gray, 27% );
+
+		.plan-price {
+			font-weight: bold;
+			margin-right: 10px;
+			font-size: 52px;
+			font-family: 'Helvetica Neue', helvetica, arial, sans-serif;
+		}
+
+		.plan-price__currency-symbol {
+			font-size: 50%;
+			font-weight: 400;
+		}
+
+		.plan-price__integer {
+			font-weight: 600;
+		}
+	}
+
+	.plan-features__table-item {
+		border-top: solid 1px var( --color-neutral-50 );
+		vertical-align: middle;
+		padding: 7px 0;
+
+		&:empty {
+			background: transparent;
+			border-top: none;
+		}
+
+		&.has-border-top, &.is-top-buttons, &.is-description {
+			border-top: none;
+			border-bottom: none;
+			padding-top: 0;
+		}
+
+		&.is-description {
+			vertical-align: top;
+		}
+	}
+
+	.plan-features__actions {
+		padding-bottom: 12px;
+	}
+
+	.plan-features__item {
+		align-items: center;
+		font-size: inherit;
+		font-weight: 500;
+		min-height: 42px;
+		margin: 0;
+		padding: 0 8px 0 16px;
+	}
+
+	.plan-features__item-title {
+		padding: 0;
+	}
+
+	.plan-features__description {
+		text-align: initial;
+		padding: 0 24px;
+	}
+
+	.plan-features__item-tip-info {
+		margin-left: 10px;
+	}
+}
+
+.plan-features__scroll-left,
+.plan-features__scroll-right {
+	display: flex;
+	position: absolute;
+	top: 24px;
+	bottom: 40px;
+	width: 12%;
+	background-color: rgba( var( --color-primary-rgb ), 0.01 );
+	cursor: pointer;
+	overflow: hidden;
+	z-index: 1;
+}
+
+.plan-features__scroll-left {
+	left: 0;
+	cursor: w-resize;
+}
+
+.plan-features__scroll-right {
+	right: 0;
+	cursor: e-resize;
+}
+
+button.plan-features__scroll-button {
+	align-self: start;
+	margin: 180px auto 0;
+	width: 30px;
+	height: 30px;
+	padding: 0;
+	background-color: var( --color-white );
+	border: 0;
+	border-radius: 15px;
+	color: var( --color-primary );
+	cursor: pointer;
+
+	.gridicon {
+		width: 24px;
+		height: 24px;
+	}
+
+	:root body.is-section-signup .plan-features__scroller-container & {
+		padding: 0;
+	}
+
+	&:disabled, &[disabled] {
+		background-color: rgba( var( --color-white-rgb ), 0.5 );
+		color: var( --color-primary );
+	}
+
+	.plan-features__scroll-right & {
+		margin-left: 20px;
+	}
+
+	.plan-features__scroll-left & {
+		margin-right: 20px;
+	}
+}
+
+.plan-features__scroll-indicator {
+	position: absolute;
+	width: auto;
+	bottom: 0;
+	left: 50%;
+	transform: translateX(-50%);
+	white-space: nowrap;
+}
+
+.plan-features__scroll-indicator-dot {
+	display: inline-block;
+	background: var( --color-white );
+	opacity: 0.5;
+	width: 10px;
+	height: 10px;
+	margin: 0 2px;
+	border-radius: 5px;
+
+	&.is-highlighted {
+		opacity: 1;
 	}
 }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -900,7 +900,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		vertical-align: middle;
 		padding: 7px 0;
 
-		.is-signup-section & {
+		.is-section-signup & {
 			border-right: none;
 			border-left: none;
 		}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -111,10 +111,6 @@ $plan-features-sidebar-width: 272px;
 	}
 }
 
-.plan-features__row {
-	background: var( --color-white );
-}
-
 .plan-features__table-item {
 	border-right: solid 1px var( --color-neutral-50 );
 	border-left: solid 1px var( --color-neutral-50 );
@@ -627,15 +623,40 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 	.plan-features__scroller-container {
 		overflow: auto;
-		overflow: -moz-scrollbars-none;
 		-ms-overflow-style: none;
+		scrollbar-width: none;
 		scroll-snap-type: x mandatory;
 		scroll-behavior: smooth;
-		overscroll-behavior: contain;
 		padding: 0 0 30px;
+
+		&.scroll-snap-disabled {
+			scroll-snap-type: none;
+		}
 
 		&::-webkit-scrollbar {
 			height: 0;
+		}
+
+		.plan-features__table {
+			display: table;
+			padding: 0;
+			margin: 0 auto;
+			width: 100%;
+		}
+
+		.plan-features__header-wrapper {
+			position: relative;
+		}
+
+		/* scroll stops */
+		.plan-features__header-wrapper::before {
+			content: '';
+			position: absolute;
+			top: 0;
+			height: 0;
+			width: 1px;
+			overflow: hidden;
+			scroll-snap-align: start;
 		}
 	}
 
@@ -651,7 +672,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		top: 24px;
 		bottom: 40px;
 		width: 12%;
-		background-color: rgba( var( --color-primary-rgb ), 0.5 );
+		background-color: rgba( var( --color-primary-rgb ), 0.01 );
 		cursor: pointer;
 		overflow: hidden;
 		z-index: 1;
@@ -678,6 +699,10 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		border-radius: 15px;
 		color: var( --color-primary );
 		cursor: pointer;
+
+		:root body.is-section-signup & {
+			padding: 0;
+		}
 
 		&:disabled, &[disabled] {
 			opacity: 0.5;
@@ -718,6 +743,7 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 	.plan-features__table-item {
 		text-align: center;
+		transition: opacity 0.05s
 	}
 
 	.plan-features__table-item.has-border-bottom {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -734,22 +734,42 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 .plans-features-main__group.is-scrollable {
 	position: relative;
+
+	.is-section-signup & {
+		width: 100vw;
+		margin-left: calc(50% - 50vw);
+	}
+
+	.is-section-plans & {
+		overflow: hidden;
+		width: calc(100vw - 273px);
+		margin-left: calc(50% - 50vw + 136px);
+	}
+
+	.signup__steps & .plan-features--signup {
+		max-width: 100%;
+	}
+
+	.plan-features__content {
+		margin-left: 0;
+		margin-right: 0;
+	}
 }
 
 .plan-features__scroller-container {
+	padding: 0 0 30px;
+	margin: 0 0 40px;
+}
+
+.plan-features__scroller-wrapper {
 	overflow: auto;
 	-ms-overflow-style: none;
 	scrollbar-width: none;
 	scroll-snap-type: x mandatory;
-	scroll-behavior: smooth;
-	padding: 0 0 30px;
+	-webkit-overflow-scrolling: touch;
 
 	&::-webkit-scrollbar {
 		height: 0;
-	}
-
-	&.scroll-snap-disabled .plan-features__header::before {
-		display: none;
 	}
 }
 
@@ -805,9 +825,14 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		position: absolute;
 		top: 0;
 		height: 0;
-		width: 1px;
-		overflow: hidden;
+		width: 0;
 		scroll-snap-align: start;
+		scroll-snap-coordinate: 0% 0%;
+
+		.scroll-snap-disabled & {
+			content: none;
+			overflow: hidden;
+		}
 	}
 
 	.plan-features__header-title {
@@ -867,6 +892,10 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		&.is-description {
 			vertical-align: top;
 		}
+
+		&.is-last-feature {
+			border-bottom: solid 1px var( --color-neutral-50 );
+		}
 	}
 
 	.plan-features__actions {
@@ -893,6 +922,10 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 	.plan-features__item-tip-info {
 		margin-left: 10px;
+	}
+
+	.plan-features__row:last-child .plan-features__table-item{
+		border-bottom: solid 1px var( --color-neutral-50 );
 	}
 }
 
@@ -925,10 +958,10 @@ button.plan-features__scroll-button {
 	width: 30px;
 	height: 30px;
 	padding: 0;
-	background-color: var( --color-white );
+	background-color: var( --color-neutral );
 	border: 0;
 	border-radius: 15px;
-	color: var( --color-primary );
+	color: var( --color-white );
 	cursor: pointer;
 
 	.gridicon {
@@ -937,10 +970,17 @@ button.plan-features__scroll-button {
 	}
 
 	:root body.is-section-signup .plan-features__scroller-container & {
+		background-color: var( --color-white );
+		color: var( --color-primary );
 		padding: 0;
 	}
 
 	&:disabled, &[disabled] {
+		background-color: rgba( var( --color-neutral-rgb ), 0.5 );
+		color: var( --color-neutral-50 );
+	}
+
+	:root body.is-section-signup &:disabled, .is-section-signup &[disabled] {
 		background-color: rgba( var( --color-white-rgb ), 0.5 );
 		color: var( --color-primary );
 	}
@@ -961,16 +1001,25 @@ button.plan-features__scroll-button {
 	left: 50%;
 	transform: translateX(-50%);
 	white-space: nowrap;
+
+	.is-section-plans & {
+		bottom: 20px;
+	}
 }
 
 .plan-features__scroll-indicator-dot {
 	display: inline-block;
-	background: var( --color-white );
-	opacity: 0.5;
+	background: var( --color-neutral-dark );
+	opacity: 0.3;
 	width: 10px;
 	height: 10px;
 	margin: 0 2px;
 	border-radius: 5px;
+
+	.is-section-signup & {
+		background: var( --color-white );
+		opacity: 0.5;
+	}
 
 	&.is-highlighted {
 		opacity: 1;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -777,6 +777,10 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 .plan-features__scroller-container {
 	padding: 0 0 30px;
+
+	.is-section-plans & {
+		margin: 0 0 30px;
+	}
 }
 
 .plan-features__scroller-wrapper {
@@ -893,10 +897,13 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 	.plan-features__table-item {
 		border-top: solid 1px var( --color-neutral-50 );
-		border-right: none;
-		border-left: none;
 		vertical-align: middle;
 		padding: 7px 0;
+
+		.is-signup-section & {
+			border-right: none;
+			border-left: none;
+		}
 
 		&:empty {
 			background: transparent;
@@ -964,7 +971,6 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	top: 24px;
 	bottom: 40px;
 	width: 12%;
-	background-color: rgba( var( --color-primary-rgb ), 0.01 );
 	cursor: pointer;
 	overflow: hidden;
 	z-index: 1;

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -744,6 +744,11 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		overflow: hidden;
 		width: calc(100vw - 273px);
 		margin-left: calc(50% - 50vw + 136px);
+
+		@include breakpoint( '<660px' ) {
+			margin-left: 0;
+			width: 100%;
+		}
 	}
 
 	.signup__steps & .plan-features--signup {

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -625,6 +625,88 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		margin: -16px 0 0 0;
 	}
 
+	.plan-features__scroller-container {
+		overflow: auto;
+		overflow: -moz-scrollbars-none;
+		-ms-overflow-style: none;
+		scroll-snap-type: x mandatory;
+		scroll-behavior: smooth;
+		overscroll-behavior: contain;
+		padding: 0 0 30px;
+
+		&::-webkit-scrollbar {
+			height: 0;
+		}
+	}
+
+	.plan-features__scroller {
+		position: relative;
+		margin: 0 auto;
+	}
+
+	.plan-features__scroll-left,
+	.plan-features__scroll-right {
+		display: flex;
+		position: absolute;
+		top: 24px;
+		bottom: 40px;
+		width: 12%;
+		background-color: rgba( var( --color-primary-rgb ), 0.5 );
+		cursor: pointer;
+		overflow: hidden;
+		z-index: 1;
+	}
+
+	.plan-features__scroll-left {
+		left: 0;
+		cursor: w-resize;
+	}
+
+	.plan-features__scroll-right {
+		right: 0;
+		cursor: e-resize;
+	}
+
+	.plan-features__scroll-button {
+		align-self: center;
+		margin: 0 auto;
+		width: 30px;
+		height: 30px;
+		padding: 0;
+		background: var( --color-white );
+		border: 0;
+		border-radius: 15px;
+		color: var( --color-primary );
+		cursor: pointer;
+
+		&:disabled, &[disabled] {
+			opacity: 0.5;
+		}
+	}
+
+	.plan-features__scroll-indicator {
+		position: absolute;
+		width: auto;
+		bottom: 0;
+		left: 50%;
+		transform: translateX(-50%);
+		white-space: nowrap;
+	}
+
+	.plan-features__scroll-indicator-dot {
+		display: inline-block;
+		background: var( --color-white );
+		opacity: 0.5;
+		width: 10px;
+		height: 10px;
+		margin: 0 2px;
+		border-radius: 5px;
+
+		&.is-highlighted {
+			opacity: 1;
+		}
+	}
+
 	.plan-features__header {
 		padding-bottom: 12px;
 	}

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -738,16 +738,30 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	.is-section-signup & {
 		width: 100vw;
 		margin-left: calc(50% - 50vw);
+
+		@media ( min-width: 1600px ) {
+			max-width: 1600px;
+			margin-left: -280px;
+		}
+
+		@include breakpoint('<1040px') {
+			padding-top: 12px;
+		}
 	}
 
 	.is-section-plans & {
 		overflow: hidden;
-		width: calc(100vw - 273px);
-		margin-left: calc(50% - 50vw + 136px);
+		width: calc(100vw - 278px);
+		margin-left: calc(50% - 50vw + 138px);
 
 		@include breakpoint( '<660px' ) {
 			margin-left: 0;
 			width: 100%;
+		}
+
+		@media ( min-width: 1800px ) {
+			max-width: 1520px;
+			margin-left: -240px;
 		}
 	}
 
@@ -763,7 +777,6 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 .plan-features__scroller-container {
 	padding: 0 0 30px;
-	margin: 0 0 40px;
 }
 
 .plan-features__scroller-wrapper {
@@ -795,8 +808,8 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		position: relative;
 		text-align: left;
 		box-sizing: border-box;
-		margin: -1px -1px 0;
 		border-top: solid 8px;
+		border-radius: 3px 3px 0 0;
 		padding-bottom: 12px;
 
 		.plans-features-main__group.is-wpcom & {
@@ -880,6 +893,8 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 
 	.plan-features__table-item {
 		border-top: solid 1px var( --color-neutral-50 );
+		border-right: none;
+		border-left: none;
 		vertical-align: middle;
 		padding: 7px 0;
 
@@ -901,6 +916,14 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		&.is-last-feature {
 			border-bottom: solid 1px var( --color-neutral-50 );
 		}
+	}
+
+	tr:first-child .plan-features__table-item {
+		border-radius: 3px 3px 0 0;
+	}
+
+	tr:last-child .plan-features__table-item {
+		border-radius: 0 0 3px 3px;
 	}
 
 	.plan-features__actions {
@@ -950,11 +973,19 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 .plan-features__scroll-left {
 	left: 0;
 	cursor: w-resize;
+
+	&.disabled {
+		cursor: default;
+	}
 }
 
 .plan-features__scroll-right {
 	right: 0;
 	cursor: e-resize;
+
+	&.disabled {
+		cursor: default;
+	}
 }
 
 button.plan-features__scroll-button {
@@ -968,6 +999,10 @@ button.plan-features__scroll-button {
 	border-radius: 15px;
 	color: var( --color-white );
 	cursor: pointer;
+
+	&:hover, &:active, &:focus {
+		color: var( --color-white );
+	}
 
 	.gridicon {
 		width: 24px;
@@ -992,10 +1027,18 @@ button.plan-features__scroll-button {
 
 	.plan-features__scroll-right & {
 		margin-left: 20px;
+
+		@include breakpoint( '<480px' ) {
+			margin-left: 5px;
+		}
 	}
 
 	.plan-features__scroll-left & {
 		margin-right: 20px;
+
+		@include breakpoint( '<480px' ) {
+			margin-right: 5px;
+		}
 	}
 }
 
@@ -1016,10 +1059,10 @@ button.plan-features__scroll-button {
 	display: inline-block;
 	background: var( --color-neutral-dark );
 	opacity: 0.3;
-	width: 10px;
-	height: 10px;
+	width: 8px;
+	height: 8px;
 	margin: 0 2px;
-	border-radius: 5px;
+	border-radius: 4px;
 
 	.is-section-signup & {
 		background: var( --color-white );

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -55,7 +55,7 @@
 
 .plan-price__currency-symbol,
 .plan-price__tax-amount {
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 }
 
 .plan-price__integer {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -91,6 +91,7 @@ export class PlansFeaturesMain extends Component {
 					'is-' + ( displayJetpackPlans ? 'jetpack' : 'wpcom' ),
 					{
 						[ `is-customer-${ customerType }` ]: ! displayJetpackPlans,
+						'is-scrollable': plansWithScroll,
 					}
 				) }
 				data-e2e-plans={ displayJetpackPlans ? 'jetpack' : 'wpcom' }
@@ -112,7 +113,7 @@ export class PlansFeaturesMain extends Component {
 					withDiscount={ withDiscount }
 					withScroll={ plansWithScroll }
 					popularPlanSpec={ {
-						type: customerType === 'personal' ? TYPE_PREMIUM : TYPE_BUSINESS,
+						type: customerType === 'personal' || plansWithScroll ? TYPE_PREMIUM : TYPE_BUSINESS,
 						group: GROUP_WPCOM,
 					} }
 					siteId={ siteId }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -113,7 +113,7 @@ export class PlansFeaturesMain extends Component {
 					withDiscount={ withDiscount }
 					withScroll={ plansWithScroll }
 					popularPlanSpec={ {
-						type: customerType === 'personal' || plansWithScroll ? TYPE_PREMIUM : TYPE_BUSINESS,
+						type: customerType === 'personal' ? TYPE_PREMIUM : TYPE_BUSINESS,
 						group: GROUP_WPCOM,
 					} }
 					siteId={ siteId }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -78,6 +78,7 @@ export class PlansFeaturesMain extends Component {
 			selectedPlan,
 			withDiscount,
 			siteId,
+			plansWithScroll,
 		} = this.props;
 
 		const plans = this.getPlansForPlanFeatures();
@@ -108,6 +109,7 @@ export class PlansFeaturesMain extends Component {
 					selectedFeature={ selectedFeature }
 					selectedPlan={ selectedPlan }
 					withDiscount={ withDiscount }
+					withScroll={ plansWithScroll }
 					popularPlanSpec={ {
 						type: customerType === 'personal' ? TYPE_PREMIUM : TYPE_BUSINESS,
 						group: GROUP_WPCOM,
@@ -190,13 +192,25 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getVisiblePlansForPlanFeatures( plans ) {
-		const { displayJetpackPlans, customerType, withWPPlanTabs } = this.props;
+		const { displayJetpackPlans, customerType, plansWithScroll, withWPPlanTabs } = this.props;
 
 		const isPlanOneOfType = ( plan, types ) =>
 			types.filter( type => planMatches( plan, { type } ) ).length > 0;
 
 		if ( displayJetpackPlans ) {
 			return plans;
+		}
+
+		if ( plansWithScroll ) {
+			return plans.filter( plan =>
+				isPlanOneOfType( plan, [
+					TYPE_BLOGGER,
+					TYPE_PERSONAL,
+					TYPE_PREMIUM,
+					TYPE_BUSINESS,
+					TYPE_ECOMMERCE,
+				] )
+			);
 		}
 
 		if ( ! withWPPlanTabs ) {
@@ -295,7 +309,7 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	render() {
-		const { displayJetpackPlans, isInSignup, siteId } = this.props;
+		const { displayJetpackPlans, isInSignup, siteId, plansWithScroll } = this.props;
 		let faqs = null;
 
 		if ( ! isInSignup ) {
@@ -306,7 +320,7 @@ export class PlansFeaturesMain extends Component {
 			<div className="plans-features-main">
 				<HappychatConnection />
 				<div className="plans-features-main__notice" />
-				{ this.renderToggle() }
+				{ ! plansWithScroll && this.renderToggle() }
 				<QueryPlans />
 				<QuerySitePlans siteId={ siteId } />
 				{ this.getPlanFeatures() }
@@ -347,6 +361,7 @@ PlansFeaturesMain.propTypes = {
 	siteId: PropTypes.number,
 	siteSlug: PropTypes.string,
 	withWPPlanTabs: PropTypes.bool,
+	plansWithScroll: PropTypes.bool,
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -358,6 +373,7 @@ PlansFeaturesMain.defaultProps = {
 	siteId: null,
 	siteSlug: '',
 	withWPPlanTabs: false,
+	plansWithScroll: false,
 };
 
 const guessCustomerType = ( state, props ) => {
@@ -389,13 +405,18 @@ const guessCustomerType = ( state, props ) => {
 export default connect(
 	( state, props ) => {
 		const siteId = get( props.site, [ 'ID' ] );
+		const isNewPlanDiscountActive = isDiscountActive( getDiscountByName( 'new_plans' ), state );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and
 			// during the signup, and we're going to remove the code soon after the test. Also, since this endpoint is
 			// pretty versatile, we could rename it from discounts to flags/features/anything else and make it more
 			// universal.
-			withWPPlanTabs: isDiscountActive( getDiscountByName( 'new_plans' ), state ),
+			withWPPlanTabs: isNewPlanDiscountActive,
+			plansWithScroll:
+				isNewPlanDiscountActive &&
+				! props.displayJetpackPlans &&
+				abtest( 'plansPresentation' ) === 'scroll',
 			customerType: guessCustomerType( state, props ),
 			domains: getDecoratedSiteDomains( state, siteId ),
 			isChatAvailable: isHappychatAvailable( state ),

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -430,18 +430,16 @@ const guessCustomerType = ( state, props ) => {
 export default connect(
 	( state, props ) => {
 		const siteId = get( props.site, [ 'ID' ] );
-		const isNewPlanDiscountActive = isDiscountActive( getDiscountByName( 'new_plans' ), state );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and
 			// during the signup, and we're going to remove the code soon after the test. Also, since this endpoint is
 			// pretty versatile, we could rename it from discounts to flags/features/anything else and make it more
 			// universal.
-			withWPPlanTabs: isNewPlanDiscountActive,
+			withWPPlanTabs: isDiscountActive( getDiscountByName( 'new_plans' ), state ),
 			plansWithScroll:
-				isNewPlanDiscountActive &&
 				! props.displayJetpackPlans &&
-				abtest( 'plansPresentation' ) === 'scroll',
+				isDiscountActive( getDiscountByName( 'plans_no_tabs' ), state ),
 			customerType: guessCustomerType( state, props ),
 			domains: getDecoratedSiteDomains( state, siteId ),
 			isChatAvailable: isHappychatAvailable( state ),

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -34,6 +34,7 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isEnabled } from 'config';
 import { plansLink, planMatches, findPlansKeys, getPlan } from 'lib/plans';
+import Button from 'components/button';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
 import PaymentMethods from 'blocks/payment-methods';
@@ -294,6 +295,28 @@ export class PlansFeaturesMain extends Component {
 		);
 	}
 
+	handleFreePlanButtonClick = () => {
+		const { onUpgradeClick } = this.props;
+		onUpgradeClick && onUpgradeClick( null );
+	};
+
+	renderFreePlanBanner() {
+		if ( this.props.hideFreePlan ) {
+			return null;
+		}
+
+		return (
+			<div className="plans-features-main__banner">
+				<div className="plans-features-main__banner-content">
+					Don’t need a plan yet?
+					<Button onClick={ this.handleFreePlanButtonClick } borderless>
+						Start for Free
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
 	renderToggle() {
 		const { displayJetpackPlans, withWPPlanTabs, countryCode } = this.props;
 		if ( displayJetpackPlans ) {
@@ -321,6 +344,7 @@ export class PlansFeaturesMain extends Component {
 				<HappychatConnection />
 				<div className="plans-features-main__notice" />
 				{ ! plansWithScroll && this.renderToggle() }
+				{ plansWithScroll && this.renderFreePlanBanner() }
 				<QueryPlans />
 				<QuerySitePlans siteId={ siteId } />
 				{ this.getPlanFeatures() }

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -21,3 +21,22 @@
 		color: var( --color-primary );
 	}
 }
+
+.plans-features-main__banner {
+	text-align: center;
+	padding: 5px 0;
+}
+
+.plans-features-main__banner-content {
+	display: inline-block;
+	background: var( --color-white );
+	border-radius: 5px;
+	padding: 5px 20px;
+
+	button.is-borderless {
+		color: var( --color-accent );
+		text-decoration: underline;
+		vertical-align: baseline;
+		margin-left: 0.75em;
+	}
+}

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -30,8 +30,9 @@
 .plans-features-main__banner-content {
 	display: inline-block;
 	background: var( --color-white );
-	border-radius: 5px;
-	padding: 5px 20px;
+	border-radius: 3px;
+	padding: 2px 12px;
+	@include elevation ( 2dp );
 
 	button.is-borderless {
 		color: var( --color-accent );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an a/b test for non-tabbed plans presentation. See p8Eqe3-wP-p2 for more details.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D24045-code to your sandboxed `public-api.wordpress.com`.
* The plans should be scrollable both in signup and `/plans/YOUR_SITE` page.
   <img width="700" alt="Create_a_site_—_WordPress_com_및_Slack_-_A8C" src="https://user-images.githubusercontent.com/212034/55733661-291f0a00-5a59-11e9-9a1e-ae12d00a9e57.png"> 
   <img width="350" alt="Create_a_site_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/55734734-0f7ec200-5a5b-11e9-8ac7-60039967394c.png">
   <img width="1276" alt="Plans_‹_Taggon_on_wordpress_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/55734484-9bdcb500-5a5a-11e9-85ad-a805d5c06e43.png">
   <img width="350" alt="붙여넣은_이미지_2019__4__9__오전_12_04" src="https://user-images.githubusercontent.com/212034/55734798-2b826380-5a5b-11e9-9498-7ae4be610a3c.png">


