### PR TITLE
E2E: Add the Calypso Media Modal to the Gutenframe e2e tests

### DIFF
--- a/test/e2e/lib/gutenberg/blocks/image-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/image-block-component.js
@@ -30,4 +30,36 @@ export class ImageBlockComponent extends GutenbergBlockComponent {
 			By.css( '.wp-block-image .components-spinner' )
 		); // Wait for upload spinner to complete
 	}
+
+	async openMediaModal() {
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.editor-media-placeholder' )
+		);
+		await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.components-form-file-upload + button' )
+		);
+		await this.driver.switchTo().defaultContent();
+		return await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			By.css( '.dialog__content .media-library' )
+		);
+	}
+
+	async insertImageFromMediaModal( fileDetails ) {
+		await this.openMediaModal();
+		const filePathInput = await this.driver.findElement(
+			By.css( '.media-library__upload-button-input' )
+		);
+		await filePathInput.sendKeys( fileDetails.file );
+		await driverHelper.waitTillNotPresent(
+			this.driver,
+			By.css( '.media-library__list-item.is-selected.is-transient' )
+		);
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.button.is-primary[data-tip-target="dialog-base-action-confirm"]' )
+		);
+	}
 }

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -164,6 +164,13 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		return await imageBlock.uploadImage( fileDetails );
 	}
 
+	async addImageFromMediaModal( fileDetails ) {
+		const blockId = await this.addBlock( 'Image' );
+
+		const imageBlock = await ImageBlockComponent.Expect( this.driver, blockId );
+		return await imageBlock.insertImageFromMediaModal( fileDetails );
+	}
+
 	async toggleSidebar( open = true ) {
 		const sidebarSelector = '.edit-post-sidebar-header';
 		const sidebarOpen = await driverHelper.isElementPresent(

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -600,4 +600,24 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 			await driverHelper.ensurePopupsClosed( driver );
 		} );
 	} );
+
+	describe( 'Use the Calypso Media Modal: @parallel', function() {
+		let fileDetails;
+
+		// Create image file for upload
+		before( async function() {
+			fileDetails = await mediaHelper.createFile();
+			return fileDetails;
+		} );
+
+		step( 'Can log in', async function() {
+			const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			return await loginFlow.loginAndStartNewPage( null, true );
+		} );
+
+		step( 'Can insert an image in an Image block with the Media Modal', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			return await gEditorComponent.addImageFromMediaModal( fileDetails );
+		} );
+	} );
 } );

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -1048,6 +1048,26 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 		} );
 	} );
 
+	describe( 'Use the Calypso Media Modal: @parallel', function() {
+		let fileDetails;
+
+		// Create image file for upload
+		before( async function() {
+			fileDetails = await mediaHelper.createFile();
+			return fileDetails;
+		} );
+
+		step( 'Can log in', async function() {
+			const loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
+			return await loginFlow.loginAndStartNewPost( null, true );
+		} );
+
+		step( 'Can insert an image in an Image block with the Media Modal', async function() {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+			return await gEditorComponent.addImageFromMediaModal( fileDetails );
+		} );
+	} );
+
 	describe( 'Revert a post to draft: @parallel', function() {
 		describe( 'Publish a new post', function() {
 			const originalBlogPostTitle = dataHelper.randomPhrase();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a test on the usage of the Calypso Media Modal from the Image block in Gutenframe.

#### Testing instructions

* Setup an e2e testing environment.
* Run `./test/e2e/node_modules/.bin/mocha specs/wp-calypso-gutenberg-post-editor-spec.js`
* Run `./test/e2e/node_modules/.bin/mocha specs/wp-calypso-gutenberg-page-editor-spec.js`
* Make sure they pass all tests.