### PR TITLE
Add costToUnbundle and costToUnbundleText to the purchase object for calculating plan refunds

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -24,6 +24,12 @@ function createPurchaseObject( purchase ) {
 			: null,
 		canDisableAutoRenew: Boolean( purchase.can_disable_auto_renew ),
 		canExplicitRenew: Boolean( purchase.can_explicit_renew ),
+		costToUnbundle: purchase.cost_to_unbundle
+			? Number( purchase.cost_to_unbundle )
+			: Number( purchase.amount ),
+		costToUnbundleText: purchase.cost_to_unbundle_display
+			? purchase.cost_to_unbundle_display
+			: purchase.price_text,
 		currencyCode: purchase.currency_code,
 		currencySymbol: purchase.currency_symbol,
 		description: purchase.description,

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -115,7 +115,7 @@ class CancelPurchase extends React.Component {
 				const { precision } = getCurrencyDefaults( currency );
 				const fullRefundText =
 					currencySymbol +
-					parseFloat( refundAmount + this.props.includedDomainPurchase.amount ).toFixed(
+					parseFloat( refundAmount + this.props.includedDomainPurchase.costToUnbundle ).toFixed(
 						precision
 					);
 				return this.props.translate( '%(refundText)s to be refunded', {

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -110,7 +110,9 @@ const CancelPurchaseRefundInformation = ( {
 				const { precision } = getCurrencyDefaults( purchase.currencyCode );
 				const planCostText =
 					purchase.currencySymbol +
-					parseFloat( purchase.refundAmount + includedDomainPurchase.amount ).toFixed( precision );
+					parseFloat( purchase.refundAmount + includedDomainPurchase.costToUnbundle ).toFixed(
+						precision
+					);
 				if ( isRefundable( includedDomainPurchase ) ) {
 					text.push(
 						i18n.translate(
@@ -145,7 +147,7 @@ const CancelPurchaseRefundInformation = ( {
 									{
 										args: {
 											productName: getName( purchase ),
-											domainCost: includedDomainPurchase.priceText,
+											domainCost: includedDomainPurchase.costToUnbundleText,
 											refundAmount: purchase.refundText,
 										},
 									}

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -79,6 +79,8 @@ describe( 'selectors', () => {
 				attachedToPurchaseId: NaN,
 				canExplicitRenew: false,
 				canDisableAutoRenew: false,
+				costToUnbundle: NaN,
+				costToUnbundleText: undefined,
 				currencyCode: undefined,
 				currencySymbol: undefined,
 				description: undefined,


### PR DESCRIPTION
Add `costToUnbundle` and `costToUnbundleText` to the purchase object for use when refunding plans with bundled domains.  The `amount` property is not clear whether it is for the previous purchase, renewal, pre/post tax etc.  This sets aside a property specifically for the refund of bundled domains.

#### Changes proposed in this Pull Request

* Adds new properties to purchases specifically for the calculated refund values when dealing with bundled domains.  

#### Testing instructions

* Add a plan and domain with taxes enabled
* Try to cancel/refund the plan. 
* The description and calculations in the explanation of the refund should be correct

![Screen Shot 2019-03-27 at 2 17 52 PM](https://user-images.githubusercontent.com/103718/55101754-345a5900-509b-11e9-9c30-0b5fd42ab35f.png)
