### PR TITLE
Jetpack Backups: Send Calypso environment ID with all restore requests

### DIFF
--- a/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
+++ b/client/state/data-layer/wpcom/activity-log/rewind/to/index.js
@@ -7,6 +7,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { errorNotice } from 'state/notices/actions';
 import { getRewindRestoreProgress } from 'state/activity-log/actions';
@@ -34,7 +35,9 @@ const requestRewind = ( action, payload ) =>
 			apiVersion: '1',
 			method: 'POST',
 			path: `/activity-log/${ action.siteId }/rewind/to/${ action.timestamp }`,
-			body: payload,
+			body: Object.assign( payload, {
+				calypso_env: config( 'env_id' ),
+			} ),
 		},
 		action
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR sends the Calypso `env_id` with all requests for restores. This will allow us to distinguish production from development environments in the Rewind back end, and test new features based on the environment the request was made from.

#### Testing instructions

* Perform a restore and inspect the network request. You should see `calypso_env` as part of the restore request body. Ensure the restore works correctly.