### PR TITLE
Importers: Navigate to View Site when clicking Done

### DIFF
--- a/client/my-sites/importer/importer-action-buttons/done-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/done-button.jsx
@@ -7,6 +7,7 @@ import { localize } from 'i18n-calypso';
 import React from 'react';
 import { flow } from 'lodash';
 import { connect } from 'react-redux';
+import page from 'page';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import { resetImport } from 'lib/importer/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { setImportOriginSiteDetails } from 'state/importer-nux/actions';
 import { SITE_IMPORTER } from 'state/imports/constants';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 export class DoneButton extends React.PureComponent {
 	static displayName = 'DoneButton';
@@ -32,23 +34,38 @@ export class DoneButton extends React.PureComponent {
 
 	handleClick = () => {
 		const {
+			importerStatus: { type },
+			site: { ID: siteId },
+			siteSlug,
+		} = this.props;
+
+		const tracksType = type.endsWith( 'site-importer' ) ? type + '-wix' : type;
+
+		this.props.recordTracksEvent( 'calypso_importer_main_done_clicked', {
+			blog_id: siteId,
+			importer_id: tracksType,
+		} );
+
+		page( '/view/' + siteSlug );
+	};
+
+	componentWillUnmount() {
+		const {
 			importerStatus: { importerId, type },
 			site: { ID: siteId },
 		} = this.props;
-		const tracksType = type.endsWith( 'site-importer' ) ? type + '-wix' : type;
 
+		/**
+		 * Calling `resetImport` in unmount defers until the redirect is in progress
+		 * Otherwise, you see the importers list during the route change
+		 */
 		resetImport( siteId, importerId );
 
 		if ( SITE_IMPORTER === type ) {
 			// Clear out site details, so that importers list isn't filtered
 			this.props.setImportOriginSiteDetails();
 		}
-
-		this.props.recordTracksEvent( 'calypso_importer_main_done_clicked', {
-			blog_id: siteId,
-			importer_id: tracksType,
-		} );
-	};
+	}
 
 	render() {
 		const { translate } = this.props;
@@ -63,7 +80,9 @@ export class DoneButton extends React.PureComponent {
 
 export default flow(
 	connect(
-		null,
+		state => ( {
+			siteSlug: getSelectedSiteSlug( state ),
+		} ),
 		{ setImportOriginSiteDetails, recordTracksEvent }
 	),
 	localize


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `connect` the component to the selected `siteSlug`
* In `onClick`, use page.js to navigate to `'/view/' + siteSlug`
* Move `resetImport` & `setImportOriginSiteDetails` calls to `componentWillUnmount` lifecycle method to avoid showing the importers list during the route change

#### Testing instructions

* Browse to `/settings/import/*.wordpress.com` (where `*` is your wpcom simple site slug)
* Run a WordPress import flow
* When it completes, click the `Done` button
  * You should be taken to `View Site` for your selected site
  * You should not see the list of importers while your browser navigates to the new route
  * The `calypso_importer_main_done_clicked` tracks event should be recorded as before
* Navigate back to the import section
  * You should see the importers list (an import engine should not be selected & an import should not appear to be in progress)
* Repeat the above for each import engine
