### PR TITLE
Start with visible mobile cart summary

### DIFF
--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -41,7 +41,7 @@ class SecondaryCart extends Component {
 	};
 
 	state = {
-		cartVisible: false,
+		cartVisible: true,
 	};
 
 	UNSAFE_componentWillMount() {

--- a/client/my-sites/checkout/checkout/cart-toggle.jsx
+++ b/client/my-sites/checkout/checkout/cart-toggle.jsx
@@ -15,7 +15,7 @@ import { showCartOnMobile } from 'lib/upgrades/actions';
 class CartToggle extends Component {
 	constructor( props ) {
 		super( props );
-		this.state = { isShowingCartOnMobile: false };
+		this.state = { isShowingCartOnMobile: true };
 	}
 
 	toggleCartOnMobile = event => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR tweaks the mobile cart UI to make the cart summary default to being visible:

#### Testing instructions

Check `` `http://calypso.localhost:3000/checkout/${SITE}` `` in mobile view


