### PR TITLE
Map Iterable message type ids to internal category names

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -103,37 +103,63 @@ class MainComponent extends React.Component {
 	};
 
 	getCategoryName = () => {
-		if ( 'marketing' === this.props.category ) {
+		const category = this.getCategoryFromMessageTypeId();
+		if ( 'marketing' === category ) {
 			return this.props.translate( 'Suggestions' );
-		} else if ( 'research' === this.props.category ) {
+		} else if ( 'research' === category ) {
 			return this.props.translate( 'Research' );
-		} else if ( 'community' === this.props.category ) {
+		} else if ( 'community' === category ) {
 			return this.props.translate( 'Community' );
-		} else if ( 'digest' === this.props.category ) {
+		} else if ( 'digest' === category ) {
 			return this.props.translate( 'Digests' );
 		}
 
-		return this.props.category;
+		return category;
 	};
 
 	getCategoryDescription = () => {
-		if ( 'marketing' === this.props.category ) {
+		const category = this.getCategoryFromMessageTypeId();
+		if ( 'marketing' === category ) {
 			return this.props.translate( 'Tips for getting the most out of WordPress.com.' );
-		} else if ( 'research' === this.props.category ) {
+		} else if ( 'research' === category ) {
 			return this.props.translate(
 				'Opportunities to participate in WordPress.com research and surveys.'
 			);
-		} else if ( 'community' === this.props.category ) {
+		} else if ( 'community' === category ) {
 			return this.props.translate(
 				'Information on WordPress.com courses and events (online and in-person).'
 			);
-		} else if ( 'digest' === this.props.category ) {
+		} else if ( 'digest' === category ) {
 			return this.props.translate(
 				'Popular content from the blogs you follow, and reports on your own site and its performance.'
 			);
 		}
 
 		return null;
+	};
+
+	/*
+	 * If category is in the list of those that should be mapped, return the mapped value. Otherwise just return the existing category.
+	 * Some unsubscribe links contain a numeric category.
+	 * These are Iterable message type ids that we need to map to our internal categories.
+	 */
+	getCategoryFromMessageTypeId = () => {
+		switch ( this.props.category ) {
+			case '20659':
+				return 'marketing';
+			case '20784':
+				return 'research';
+			case '20786':
+				return 'community';
+			case '20796':
+				return 'digest';
+			case '20783':
+				return 'promotion';
+			case '20785':
+				return 'news';
+			default:
+				return this.props.category;
+		}
 	};
 
 	onUnsubscribeClick = () => {
@@ -171,7 +197,7 @@ class MainComponent extends React.Component {
 
 	render() {
 		const translate = this.props.translate;
-		let headingLabel = this.state.isSubscribed
+		const headingLabel = this.state.isSubscribed
 				? translate( "You're subscribed" )
 				: translate( "We've unsubscribed your email." ),
 			messageLabel = this.state.isSubscribed


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When an unsubscribe request comes from an Iterable email it'll contain a numeric category value.
This is the id of a message type setup in Iterable that has a one-to-one mapping to our internal mailing list category names.

This is only a display change to make sure we're showing the category name to the user instead of the numeric id.

The backend change to allow for unsubscribes from Iterable is here: D26101-code

--------

Changing `let` to `const` for `headingLabel` is unrelated and due to an error that came up when committing.

--------

#### Testing instructions

* On the backend, apply the patch at D26101-code (if it hasn't already been deployed).
* Visit the following links and confirm that you're successfully unsubscribed from each category (You'll see a message: "Unsubscribed from _CATEGORY_").

These are for a throw-away account created for this purpose.

**marketing (Suggestions)**
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=20659&hmac=367ca60fba2debc155c8c0a77502087bcff5bb89

**research**
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=20784&hmac=0c6e503bdddc36bdf821a93a4be8145a2bba5d5c

**community**
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=20786&hmac=b87f576e240fa2a6e91cb1ccec4d63393a6934b7

**digest**
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=20796&hmac=d16bac929e27a840aefc86f8c9ab7bfc7dad36e0

**promotion**
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=20783&hmac=a23b38e696e89b2599d0b38f5648217b02752369

**news**
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=20785&hmac=0ae5e6d9bf217c9bb64fdba354163b95ad1fb914

