### PR TITLE
People: Swap out select elements for radio buttons for Role

### DIFF
--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -34,7 +34,7 @@ const getWpcomFollowerRole = ( { site, translate } ) => {
 
 const RoleSelect = props => {
 	let { siteRoles } = props;
-	const { site, includeFollower, siteId, id, explanation, translate } = props;
+	const { site, includeFollower, siteId, id, explanation, translate, value } = props;
 	const omitProps = [
 		'site',
 		'key',
@@ -63,7 +63,11 @@ const RoleSelect = props => {
 				map( siteRoles, role => {
 					return (
 						<FormLabel key={ role.name }>
-							<FormRadio value={ role.name } { ...omit( props, omitProps ) } />
+							<FormRadio
+								checked={ role.name === value }
+								value={ role.name }
+								{ ...omit( props, omitProps ) }
+							/>
 							<span>{ role.display_name }</span>
 						</FormLabel>
 					);

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
-import FormSelect from 'components/forms/form-select';
+import FormRadio from 'components/forms/form-radio';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import QuerySites from 'components/data/query-sites';
 import QuerySiteRoles from 'components/data/query-site-roles';
@@ -46,6 +46,8 @@ const RoleSelect = props => {
 		'moment',
 		'numberFormat',
 		'translate',
+		'value',
+		'id',
 	];
 
 	if ( site && siteRoles && includeFollower ) {
@@ -57,16 +59,15 @@ const RoleSelect = props => {
 			{ siteId && <QuerySites siteId={ siteId } /> }
 			{ siteId && <QuerySiteRoles siteId={ siteId } /> }
 			<FormLabel htmlFor={ id }>{ translate( 'Role' ) }</FormLabel>
-			<FormSelect { ...omit( props, omitProps ) }>
-				{ siteRoles &&
-					map( siteRoles, role => {
-						return (
-							<option value={ role.name } key={ role.name }>
-								{ role.display_name }
-							</option>
-						);
-					} ) }
-			</FormSelect>
+			{ siteRoles &&
+				map( siteRoles, role => {
+					return (
+						<FormLabel key={ role.name }>
+							<FormRadio value={ role.name } { ...omit( props, omitProps ) } />
+							<span>{ role.display_name }</span>
+						</FormLabel>
+					);
+				} ) }
 			{ explanation && <FormSettingExplanation>{ explanation }</FormSettingExplanation> }
 		</FormFieldset>
 	);

--- a/client/my-sites/people/role-select/index.jsx
+++ b/client/my-sites/people/role-select/index.jsx
@@ -55,7 +55,7 @@ const RoleSelect = props => {
 	}
 
 	return (
-		<FormFieldset key={ siteId } disabled={ ! siteRoles }>
+		<FormFieldset key={ siteId } disabled={ ! siteRoles } id={ id }>
 			{ siteId && <QuerySites siteId={ siteId } /> }
 			{ siteId && <QuerySiteRoles siteId={ siteId } /> }
 			<FormLabel htmlFor={ id }>{ translate( 'Role' ) }</FormLabel>

--- a/test/e2e/lib/pages/invite-people-page.js
+++ b/test/e2e/lib/pages/invite-people-page.js
@@ -17,7 +17,7 @@ import * as DriverHelper from '../driver-helper.js';
 
 export default class InvitePeoplePage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( 'select#role' ) );
+		super( driver, By.css( 'fieldset#role' ) );
 	}
 
 	async inviteNewUser( email, role, message = '' ) {
@@ -25,7 +25,7 @@ export default class InvitePeoplePage extends AsyncBaseContainer {
 			role = 'follower'; //the select input option uses follower for viewer
 		}
 
-		const roleSelector = By.css( `select#role option[value=${ role }]` );
+		const roleSelector = By.css( `fieldset#role input[value=${ role }]` );
 
 		await DriverHelper.setWhenSettable( this.driver, By.css( 'input.token-field__input' ), email );
 		await DriverHelper.waitTillPresentAndDisplayed( this.driver, roleSelector );

--- a/test/e2e/lib/pages/invite-people-page.js
+++ b/test/e2e/lib/pages/invite-people-page.js
@@ -30,6 +30,7 @@ export default class InvitePeoplePage extends AsyncBaseContainer {
 		await DriverHelper.setWhenSettable( this.driver, By.css( 'input.token-field__input' ), email );
 		await DriverHelper.waitTillPresentAndDisplayed( this.driver, roleSelector );
 		await DriverHelper.clickWhenClickable( this.driver, roleSelector );
+		await DriverHelper.setCheckbox( this.driver, roleSelector );
 		await DriverHelper.setWhenSettable( this.driver, By.css( '#message' ), message );
 		return await DriverHelper.clickWhenClickable(
 			this.driver,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR swaps out the Role select element for radio buttons.
* We'd discussed replacing the select element with the `Dropdown` component, but using a native form element is better for accessibility.
* Since there are five (or fewer) roles, the radio buttons present all of the options upfront rather than hiding four of them behind the select menu.

**Before**

<img width="730" alt="Screen Shot 2019-03-27 at 3 49 10 PM" src="https://user-images.githubusercontent.com/2124984/55113571-046c7f00-50b6-11e9-8b22-e32b0d5cb9a7.png">

<img width="729" alt="Screen Shot 2019-03-27 at 5 58 52 PM" src="https://user-images.githubusercontent.com/2124984/55115610-4815b780-50bb-11e9-9f5d-cdd50f57df4b.png">

**After**

<img width="734" alt="Screen Shot 2019-03-27 at 3 48 43 PM" src="https://user-images.githubusercontent.com/2124984/55113582-0cc4ba00-50b6-11e9-8788-e4971cf280a7.png">

<img width="731" alt="Screen Shot 2019-03-27 at 5 58 22 PM" src="https://user-images.githubusercontent.com/2124984/55115597-40eea980-50bb-11e9-8de3-e2f81eab765b.png">

#### Testing instructions

* Switch to this PR
* Go to `/people/new/` and ensure you can add a new user to your site with the correct role.
* Go to `/people/edit` and edit a user on your site to change their role.

Fixes #31638
