### PR TITLE
Activity Log: Allow `fail` status in ProgressBanner component

### DIFF
--- a/client/my-sites/activity/activity-log-banner/progress-banner.jsx
+++ b/client/my-sites/activity/activity-log-banner/progress-banner.jsx
@@ -115,7 +115,7 @@ ProgressBanner.propTypes = {
 	applySiteOffset: PropTypes.func.isRequired,
 	percent: PropTypes.number,
 	siteId: PropTypes.number,
-	status: PropTypes.oneOf( [ 'queued', 'running' ] ),
+	status: PropTypes.oneOf( [ 'queued', 'running', 'fail' ] ),
 	timestamp: PropTypes.string,
 	action: PropTypes.oneOf( [ 'restore', 'backup' ] ),
 };


### PR DESCRIPTION
In certain circumstances, a `fail` status might be pushed to the ProgressBanner component. This fixes by allowing `fail` as one of the `status` propTypes.

**Testing**

Do a restore. Ensure the progress banner works start-to-finish.