### PR TITLE
use enocdeURIComponent to build G Suite TOS Redirect 

### DIFF
--- a/client/lib/google-apps/index.js
+++ b/client/lib/google-apps/index.js
@@ -35,7 +35,7 @@ function getLoginUrlWithTOSRedirect( email, domain ) {
 		`Email=${ encodeURIComponent( email ) }` +
 		`&service=CPanel` +
 		`&continue=${ encodeURIComponent(
-			`https://admin.google.com/${ domain }/AcceptTermsOfService&continue=https://mail.google.com/mail/u/${ email }`
+			`https://admin.google.com/${ domain }/AcceptTermsOfService?continue=https://mail.google.com/mail/u/${ email }`
 		) }`
 	);
 }

--- a/client/lib/google-apps/index.js
+++ b/client/lib/google-apps/index.js
@@ -31,9 +31,12 @@ function formatPrice( cost, currencyCode, options = {} ) {
 
 function getLoginUrlWithTOSRedirect( email, domain ) {
 	return (
-		`https://accounts.google.com/AccountChooser?Email=${ email }&service=CPanel` +
-		`&continue=https%3A%2F%2Fadmin.google.com%2F${ domain }` +
-		`%2FAcceptTermsOfService%3Fcontinue%3Dhttps%3A%2F%2Fmail.google.com%2Fmail%2Fu%2F${ email }`
+		'https://accounts.google.com/AccountChooser?' +
+		`Email=${ encodeURIComponent( email ) }` +
+		`&service=CPanel` +
+		`&continue=${ encodeURIComponent(
+			`https://admin.google.com/${ domain }/AcceptTermsOfService&continue=https://mail.google.com/mail/u/${ email }`
+		) }`
 	);
 }
 


### PR DESCRIPTION
This is a follow-up of https://github.com/Automattic/wp-calypso/pull/31738.

#### Changes proposed in this Pull Request

* All in the title

#### Testing instructions

1. Buy a new G Suite subscription
1. Navigate to `/domains/manage/:domain/email/:siteSlug` for the site and domain of your new G Suite Subscription.
1. Wait to receive your email with your password <img width="400" alt="Password Email" src="https://user-images.githubusercontent.com/2810519/54946797-20292700-4ef6-11e9-9081-dc34d0bae94a.png">
1. Click the "Finish Setup" Button in the notice at the top of the screen <img width="616" alt="The Finish Setup Button" src="https://user-images.githubusercontent.com/2810519/54946941-667e8600-4ef6-11e9-836e-79d794751d1b.png">
1. Navigate through the setup, picking a new password, until you arrive at the "Agree to TOS" screen <img width="400" alt="The TOS Screen" src="https://user-images.githubusercontent.com/2810519/54947076-b6f5e380-4ef6-11e9-8285-d17589ef3c3e.png"> 
1. Inspect the URL and confirm it still has the query arg: `continue=https://mail.google.com/mail/u/[mailbox]@[domain]`
1. Click "Accept Terms of Service"
1. This step of the process can work or not work, I have had it correctly and incorrectly redirect to the right gmail mailbox, so 🤷‍♂️