### PR TITLE
Implement the debouncing mechnism for the <QueryVerticals /> component,

### DIFF
--- a/client/components/data/query-verticals/test/index.js
+++ b/client/components/data/query-verticals/test/index.js
@@ -65,4 +65,78 @@ describe( 'QueryVerticals', () => {
 
 		expect( requestVerticals ).not.toHaveBeenCalled();
 	} );
+
+	test( 'should create a debounce-wrapped function if debounce time is more than 0 on mount.', () => {
+		const requestVerticals = jest.fn();
+		const debounceFunc = jest.fn();
+		const debounceTime = 100;
+
+		shallow(
+			<QueryVerticals
+				requestVerticals={ requestVerticals }
+				debounceFunc={ debounceFunc }
+				debounceTime={ debounceTime }
+			/>
+		);
+
+		expect( debounceFunc ).toHaveBeenCalledWith( requestVerticals, debounceTime );
+	} );
+
+	test( 'should not create a debounce-wrapped function if debounce time is 0.', () => {
+		const requestVerticals = jest.fn();
+		const debounceFunc = jest.fn();
+
+		shallow(
+			<QueryVerticals
+				requestVerticals={ requestVerticals }
+				debounceFunc={ debounceFunc }
+				debounceTime={ 0 }
+			/>
+		);
+
+		expect( debounceFunc ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should update the debounced function if the debounce time has changed.', () => {
+		const requestVerticals = jest.fn();
+		const debounceFunc = jest.fn();
+
+		const wrapped = shallow(
+			<QueryVerticals
+				requestVerticals={ requestVerticals }
+				debounceFunc={ debounceFunc }
+				debounceTime={ 100 }
+			/>
+		);
+
+		const updatedDebounceTime = 200;
+
+		wrapped.setProps( {
+			debounceTime: updatedDebounceTime,
+		} );
+
+		expect( debounceFunc ).toHaveBeenCalledWith( requestVerticals, updatedDebounceTime );
+	} );
+
+	test( 'should not update the debounced function if the debounce time keeps the same.', () => {
+		const requestVerticals = jest.fn();
+		const debounceFunc = jest.fn();
+		const debounceTime = 100;
+
+		const wrapped = shallow(
+			<QueryVerticals
+				requestVerticals={ requestVerticals }
+				debounceFunc={ debounceFunc }
+				debounceTime={ debounceTime }
+			/>
+		);
+
+		debounceFunc.mockClear();
+
+		wrapped.setProps( {
+			debounceTime,
+		} );
+
+		expect( debounceFunc ).not.toHaveBeenCalled();
+	} );
 } );

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -161,7 +161,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 
 		return (
 			<>
-				<QueryVerticals searchTerm={ this.props.searchValue.trim() } />
+				<QueryVerticals searchTerm={ this.props.searchValue.trim() } debounceTime={ 300 } />
 				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } limit={ 1 } />
 				<SuggestionSearch
 					id="siteTopic"

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -3,6 +3,7 @@
 exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
 <Fragment>
   <Connect(QueryVerticals)
+    debounceTime={300}
     searchTerm=""
   />
   <Connect(QueryVerticals)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following the `debounce` idea from @ramonjd in https://github.com/Automattic/wp-calypso/pull/31746#discussion_r269407620, this PR implements the idea of bringing debouncing to `<QueryVerticals/>` component.

#### Testing instructions

1. `npm run test-client query-verticals` should pass.
1. Go to http://calypso.localhost:3000/start/onboarding and traverse to the site topic step. It should work as expected.
1. Run `getState().signup.verticals`, and the state should contain much less state keys like @ramonjd raised in the comment above.
