### PR TITLE
Import styles for upload drop zone

### DIFF
--- a/client/blocks/upload-drop-zone/index.jsx
+++ b/client/blocks/upload-drop-zone/index.jsx
@@ -21,6 +21,11 @@ import notices from 'notices';
 import debugFactory from 'debug';
 import { MAX_UPLOAD_ZIP_SIZE } from 'lib/automated-transfer/constants';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const debug = debugFactory( 'calypso:upload-drop-zone' );
 
 class UploadDropZone extends Component {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Imports styling for the upload drop zone

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the live branch available below.
- Visit `/themes/upload` for a WordPress.com Business plan site
- Ensure that the drop zone's styling is as expected.

Fixes https://github.com/Automattic/wp-calypso/issues/31827

Before:

<img width="769" alt="Screenshot 2019-03-28 at 09 23 18" src="https://user-images.githubusercontent.com/18581859/55128869-265c1500-513b-11e9-9e87-0411d62a8ae7.png">

After:

<img width="773" alt="Screenshot 2019-03-28 at 09 23 16" src="https://user-images.githubusercontent.com/18581859/55128868-25c37e80-513b-11e9-9c90-d7873faef6c4.png">

I haven't looked at the history of this `/assets/stylesheets/_components.scss` file so far, but it looks like this styling was not imported properly; likely due to the recent CSS migrations. 

Noticed while supporting users.