### PR TITLE
Signup: store the vertical results objects under trimmed and lowercase keys

### DIFF
--- a/client/components/data/query-verticals/index.jsx
+++ b/client/components/data/query-verticals/index.jsx
@@ -15,17 +15,19 @@ import { getVerticals } from 'state/signup/verticals/selectors';
 
 export class QueryVerticals extends Component {
 	static propTypes = {
+		isFetched: PropTypes.bool,
 		searchTerm: PropTypes.string,
 		limit: PropTypes.number,
 	};
 
 	static defaultProps = {
+		isFetched: false,
 		limit: 7,
 		searchTerm: '',
 	};
 
 	componentDidMount() {
-		const { searchTerm, limit } = this.props;
+		const { searchTerm = '', limit } = this.props;
 		const trimmedSearchTerm = searchTerm.trim();
 
 		if ( trimmedSearchTerm ) {
@@ -34,7 +36,7 @@ export class QueryVerticals extends Component {
 	}
 
 	componentDidUpdate() {
-		const { isFetched, searchTerm, limit } = this.props;
+		const { isFetched, searchTerm = '', limit } = this.props;
 		const trimmedSearchTerm = searchTerm.trim();
 
 		if ( ! isFetched && trimmedSearchTerm ) {
@@ -49,7 +51,7 @@ export class QueryVerticals extends Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		isFetched: null !== getVerticals( ownProps.searchTerm ),
+		isFetched: null !== getVerticals( state, ownProps.searchTerm ),
 	} ),
 	{
 		requestVerticals,

--- a/client/components/data/query-verticals/test/index.js
+++ b/client/components/data/query-verticals/test/index.js
@@ -34,20 +34,18 @@ describe( 'QueryVerticals', () => {
 		expect( requestVerticals ).not.toHaveBeenCalled();
 	} );
 
-	test( 'should call request on update if isFetched is false.', () => {
+	test( 'should not call request on mount if search term is falsey.', () => {
 		const requestVerticals = jest.fn();
-
 		const wrapped = shallow( <QueryVerticals requestVerticals={ requestVerticals } /> );
-
 		const updatedProps = {
-			searchTerm: 'Foo',
+			searchTerm: undefined,
 			limit: 7,
-			isFetched: false,
+			isFetched: true,
 		};
 
 		wrapped.setProps( updatedProps );
 
-		expect( requestVerticals ).toHaveBeenCalledWith( updatedProps.searchTerm, updatedProps.limit );
+		expect( requestVerticals ).not.toHaveBeenCalled();
 	} );
 
 	test( 'should not call request on update if isFetched is true.', () => {

--- a/client/components/data/query-verticals/test/index.js
+++ b/client/components/data/query-verticals/test/index.js
@@ -34,18 +34,20 @@ describe( 'QueryVerticals', () => {
 		expect( requestVerticals ).not.toHaveBeenCalled();
 	} );
 
-	test( 'should not call request on mount if search term is falsey.', () => {
+	test( 'should call request on update if isFetched is false.', () => {
 		const requestVerticals = jest.fn();
+
 		const wrapped = shallow( <QueryVerticals requestVerticals={ requestVerticals } /> );
+
 		const updatedProps = {
-			searchTerm: undefined,
+			searchTerm: 'Foo',
 			limit: 7,
-			isFetched: true,
+			isFetched: false,
 		};
 
 		wrapped.setProps( updatedProps );
 
-		expect( requestVerticals ).not.toHaveBeenCalled();
+		expect( requestVerticals ).toHaveBeenCalledWith( updatedProps.searchTerm, updatedProps.limit );
 	} );
 
 	test( 'should not call request on update if isFetched is true.', () => {

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -183,11 +183,8 @@ export class SiteVerticalsSuggestionSearch extends Component {
 export default localize(
 	connect(
 		( state, ownProps ) => {
-			const { searchValue } = ownProps;
-			const trimmedSearchValue = searchValue.trim();
-			const verticals = getVerticals( state, trimmedSearchValue );
-			const isVerticalSearchPending = trimmedSearchValue && null == verticals;
-
+			const verticals = getVerticals( state, ownProps.searchValue );
+			const isVerticalSearchPending = ownProps.searchValue && null == verticals;
 			return {
 				verticals: verticals || [],
 				isVerticalSearchPending,

--- a/client/state/signup/verticals/reducer.js
+++ b/client/state/signup/verticals/reducer.js
@@ -1,8 +1,4 @@
 /** @format */
-/**
- * External dependencies
- */
-import { toLower, trim } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,7 +12,7 @@ const verticals = createReducer(
 		[ SIGNUP_VERTICALS_SET ]: ( state, action ) => {
 			return {
 				...state,
-				[ trim( toLower( action.search ) ) ]: action.verticals,
+				[ action.search.trim().toLowerCase() ]: action.verticals,
 			};
 		},
 	}

--- a/client/state/signup/verticals/reducer.js
+++ b/client/state/signup/verticals/reducer.js
@@ -1,13 +1,25 @@
 /** @format */
+/**
+ * External dependencies
+ */
+import { toLower, trim } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { createReducer, keyedReducer } from 'state/utils';
+import { createReducer } from 'state/utils';
 import { SIGNUP_VERTICALS_SET } from 'state/action-types';
 
-const verticals = createReducer( null, {
-	[ SIGNUP_VERTICALS_SET ]: ( state, action ) => action.verticals,
-} );
+const verticals = createReducer(
+	{},
+	{
+		[ SIGNUP_VERTICALS_SET ]: ( state, action ) => {
+			return {
+				...state,
+				[ trim( toLower( action.search ) ) ]: action.verticals,
+			};
+		},
+	}
+);
 
-export default keyedReducer( 'search', verticals );
+export default verticals;

--- a/client/state/signup/verticals/selectors.js
+++ b/client/state/signup/verticals/selectors.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get, toLower, trim } from 'lodash';
+import { get } from 'lodash';
 
-export const getVerticals = ( state, searchTerm ) =>
-	get( state, [ 'signup', 'verticals', trim( toLower( searchTerm ) ) ], null );
+export const getVerticals = ( state, searchTerm = '' ) =>
+	get( state, [ 'signup', 'verticals', searchTerm.trim().toLowerCase() ], null );

--- a/client/state/signup/verticals/selectors.js
+++ b/client/state/signup/verticals/selectors.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { get, toLower, trim } from 'lodash';
 
 export const getVerticals = ( state, searchTerm ) =>
-	get( state, [ 'signup', 'verticals', searchTerm ], null );
+	get( state, [ 'signup', 'verticals', trim( toLower( searchTerm ) ) ], null );

--- a/client/state/signup/verticals/test/reducer.js
+++ b/client/state/signup/verticals/test/reducer.js
@@ -11,7 +11,7 @@ describe( 'state/signup/verticals/reducer', () => {
 		expect( reducer( undefined, {} ) ).toEqual( {} );
 	} );
 
-	test( 'should associate the search string to the verticals array.', () => {
+	test( 'should associate a trimmed and lowercase search string to the verticals array.', () => {
 		const search = 'Foo';
 		const verticals = [ { id: 0, verticalName: 'Coffee' }, { id: 1, verticalName: 'Tea' } ];
 
@@ -22,7 +22,7 @@ describe( 'state/signup/verticals/reducer', () => {
 				verticals,
 			} )
 		).toEqual( {
-			[ search ]: verticals,
+			foo: verticals,
 		} );
 	} );
 } );

--- a/client/state/signup/verticals/test/selectors.js
+++ b/client/state/signup/verticals/test/selectors.js
@@ -11,7 +11,7 @@ describe( 'state/signup/verticals/selectors', () => {
 			expect( getVerticals( {}, 'aaa' ) ).toBeNull();
 		} );
 
-		const searchTerm = 'Cool';
+		const searchTerm = 'cool';
 		const state = {
 			signup: {
 				verticals: {
@@ -29,6 +29,10 @@ describe( 'state/signup/verticals/selectors', () => {
 
 		test( 'should return null if it does not exist', () => {
 			expect( getVerticals( state, 'Aaa' ) ).toBeNull();
+		} );
+
+		test( 'should return correct results from mixed case and untrimmed value', () => {
+			expect( getVerticals( state, ' COOL ' ) ).toEqual( state.signup.verticals[ searchTerm ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Changes proposed in this Pull Request

I hereby propose that we trim and _lowercase_ vertical query keys before we store them to avoid duplicate values, for example, `DESIGNER: {}` **and** `designer: {}` **and** `deSIGner: {}`.

#### Before
<img width="574" alt="Screen Shot 2019-03-28 at 3 28 34 pm" src="https://user-images.githubusercontent.com/6458278/55130326-91730f00-516e-11e9-9a82-025a141b6f16.png">

#### After
<img width="456" alt="Screen Shot 2019-03-28 at 4 41 11 pm" src="https://user-images.githubusercontent.com/6458278/55133211-fb90b180-5178-11e9-82b5-3946cd54590f.png">

This is an enhancement on the work in #31746

## Testing instructions

At the site topic step, _SeARch FOr similAR TeRmS_, mixing case and adding spaces at the end or the start of your query. 

The state should contain only unique keys, ignoring case. Searching for already-fetched queries should not trigger another search, but fetch it from the state! 🤠 