### PR TITLE
Tidy up the flows definition for landing pages

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -102,13 +102,6 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		onboarding: {
-			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'domains', 'plans' ],
-			destination: getSiteDestination,
-			description: 'The improved onboarding flow.',
-			lastModified: '2019-01-24',
-		},
-
-		'onboarding-for-business': {
 			steps: [
 				'user',
 				'site-type',
@@ -118,8 +111,8 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 				'plans',
 			],
 			destination: getSiteDestination,
-			description: 'The improved onboarding flow for business site types.',
-			lastModified: '2019-01-24',
+			description: 'The improved onboarding flow.',
+			lastModified: '2019-03-28',
 		},
 
 		'onboarding-dev': {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -35,6 +35,7 @@ import Notice from 'components/notice';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { setDesignType } from 'state/signup/steps/design-type/actions';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getDomainProductSlug } from 'lib/domains';
 import QueryProductsList from 'components/data/query-products-list';
 import { getAvailableProductsList } from 'state/products-list/selectors';
@@ -599,6 +600,7 @@ export default connect(
 	( state, ownProps ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
+		const siteType = getSiteType( state );
 
 		return {
 			designType: getDesignType( state ),
@@ -611,6 +613,8 @@ export default connect(
 			siteGoals: getSiteGoals( state ),
 			surveyVertical: getSurveyVertical( state ),
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
+			// once we roll out previews to all the segments, this can be removed.
+			showSiteMockups: siteType === 'business' && ownProps.showSiteMockups,
 		};
 	},
 	{

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -230,6 +230,8 @@ export default connect(
 			siteVerticalName,
 			shouldFetchVerticalData,
 			hasMultipleFieldSets: size( formFields ) > 1,
+			// once we roll out previews to all the segments, this can be removed.
+			showSiteMockups: siteType === 'business' && ownProps.showSiteMockups,
 		};
 	},
 	( dispatch, ownProps ) => {

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -94,9 +94,15 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 } );
 
 export default connect(
-	state => ( {
-		siteType: getSiteType( state ),
-		isUserInput: getSiteVerticalIsUserInput( state ),
-	} ),
+	( state, ownProps ) => {
+		const siteType = getSiteType( state );
+
+		return {
+			siteType,
+			isUserInput: getSiteVerticalIsUserInput( state ),
+			// once we roll out previews to all the segments, this can be removed.
+			showSiteMockups: siteType === 'business' && ownProps.showSiteMockups,
+		};
+	},
 	mapDispatchToProps
 )( SiteTopicStep );

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -72,10 +72,6 @@ export default connect(
 				flowName = 'ecommerce-onboarding';
 			}
 
-			if ( 'business' === siteTypeValue ) {
-				flowName = 'onboarding-for-business';
-			}
-
 			goToNextStep( flowName );
 		},
 	} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The primary issue that this PR addresses is that our business landing pages, e.g. the CTA link to https://wordpress.com/start?vertical=Restaurants&site_type=business in https://wordpress.com/websites/create/restaurant/, doesn't show the site preview because it is only enabled in the `onboarding-for-business` flow. 

Now that `onboarding` and `onboarding-for-business` flow is quite closed, this PR attempts to resolve the issue by:

1. Remove the latter
1. Use `*-with-preview` steps in the `onboarding` flow.
1. Further restrict the site preview from showing only for the business segments.

On one hand, I feel this is pretty reasonable since we will roll out previews to all the other segments eventually. On the other hand, I'm also a bit worried that I might jump into the conclusion too soon. 

Thus, please feel free to correct me if I rush deleting code too much :)

#### Testing instructions

1. Visit http://calypso.localhost:3000/start/onboarding and make sure the signup flows for each segment work as expected.
1. Visit http://calypso.localhost:3000/start/onboarding?vertical=Restaurants&site_type=business, and the site preview should appear after the user step.
