### PR TITLE
Remove engines from calypso-color-schemes package

### DIFF
--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -19,10 +19,6 @@
 	"bugs": {
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
-	"engines": {
-		"node": "^10.13.0",
-		"npm": "^6.1.0"
-	},
 	"main": "dist/calypso-color-schemes.css",
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
Remove engines definition from `calypso-color-schemes` package to ensure it works also with Node.js 11.

This was added in https://github.com/Automattic/wp-calypso/commit/32c6921b653d62d14c1dfae6aa76a822b38d1d49#diff-8738703fc0624ea66a290201daedd11aR21

This could also be set to Node.js `>=10` if needed but I'm assuming our Renovate bot setup would just try to keep this in sync with root `package.json`:

https://github.com/Automattic/wp-calypso/blob/5ba8b6e1006453b38af58da6e33ffee5b1189afd/package.json#L205-L208

Came up in p9dueE-Dq-p2 #comment-671

#### Testing instructions

`npm ci` & `npm start` work just fine in Node.js 10, Ci turning green should be enough I suppose.

Not sure how to test Node.js 11 in this case. 🤔 