### PR TITLE
JP Onboarding: update card styles on authorize form

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -684,7 +684,7 @@ export class JetpackAuthorize extends Component {
 							siteIsOnSitesList={ this.props.isAlreadyOnSitesList }
 						/>
 						<AuthFormHeader authQuery={ this.props.authQuery } />
-						<Card className="jetpack-connect__logged-card">
+						<Card className="jetpack-connect__logged-in-card">
 							<Gravatar user={ this.props.user } size={ 64 } />
 							<p className="jetpack-connect__logged-in-form-user-text">{ this.getUserText() }</p>
 							{ this.renderNotices() }

--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -684,7 +684,7 @@ export class JetpackAuthorize extends Component {
 							siteIsOnSitesList={ this.props.isAlreadyOnSitesList }
 						/>
 						<AuthFormHeader authQuery={ this.props.authQuery } />
-						<Card>
+						<Card className="jetpack-connect__logged-card">
 							<Gravatar user={ this.props.user } size={ 64 } />
 							<p className="jetpack-connect__logged-in-form-user-text">{ this.getUserText() }</p>
 							{ this.renderNotices() }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -512,7 +512,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 }
 
 .jetpack-connect__site.card,
-.jetpack-connect__logged-card.card {
+.jetpack-connect__logged-in-card.card {
 	max-width: 360px;
 	margin: 0 auto 16px;
 	border-radius: 3px;

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -509,6 +509,10 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__site.card {
 	padding: 0;
+}
+
+.jetpack-connect__site.card,
+.jetpack-connect__logged-card.card {
 	max-width: 360px;
 	margin: 0 auto 16px;
 	border-radius: 3px;

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -35,6 +35,7 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         }
       />
       <Card
+        className="jetpack-connect__logged-in-card"
         highlight={false}
         tagName="div"
       >


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Jetpack onboarding: update card styles on authorize form.

#### Testing instructions

* Fire up this PR.
* Spin up a [new JN site](https://jurassic.ninja/create/?shortlived&jetpack-beta).
* When prompted to connect, copy the URL from the “Set up Jetpack” button and append `&calypso_env=development` to it.
* Do this while logged in to WordPress.com and you should see the screen below. Make sure it all looks good.

#### Before

![image](https://user-images.githubusercontent.com/390760/55155498-688f5180-514f-11e9-8517-153abf7c166d.png)

#### After

![image](https://user-images.githubusercontent.com/390760/55155506-6af1ab80-514f-11e9-8899-ebe03e10e68b.png)
