### PR TITLE
Build: Use BROWSERSLIST_ENV instead of CALYPSO_CLIENT and TARGET_BROWSER

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ jobs:
           name: Build Stats
           environment:
             NODE_ENV: "production"
-            CALYPSO_CLIENT: "true"
+            BROWSERSLIST_ENV: "defaults"
           command: |
             #
             # This block should not cause a test failure and block PRs.

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,13 +5,12 @@ const _ = require( 'lodash' );
 const path = require( 'path' );
 
 const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
-const isBrowser = isCalypsoClient || 'true' === process.env.TARGET_BROWSER;
 
-const modules = isBrowser ? false : 'commonjs'; // Use commonjs for Node
+const modules = isCalypsoClient ? false : 'commonjs'; // Use commonjs for Node
 const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
 
 // Use target configuration in package.json for browser builds.
-const targets = isBrowser ? undefined : { node: 'current' };
+const targets = isCalypsoClient ? undefined : { node: 'current' };
 
 const config = {
 	extends: require.resolve( '@automattic/calypso-build/babel.config.js' ),

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,13 +4,12 @@
 const _ = require( 'lodash' );
 const path = require( 'path' );
 
-const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
+const isBrowser = process.env.BROWSERSLIST_ENV !== 'server';
 
-const modules = isCalypsoClient ? false : 'commonjs'; // Use commonjs for Node
+const modules = isBrowser ? false : 'commonjs'; // Use commonjs for Node
 const codeSplit = require( './server/config' ).isEnabled( 'code-splitting' );
 
-// Use target configuration in package.json for browser builds.
-const targets = isCalypsoClient ? undefined : { node: 'current' };
+// We implicitly use browserslist configuration in package.json for build targets.
 
 const config = {
 	extends: require.resolve( '@automattic/calypso-build/babel.config.js' ),
@@ -19,7 +18,6 @@ const config = {
 			'@babel/env',
 			{
 				modules,
-				targets,
 				useBuiltIns: 'entry',
 				corejs: 2,
 				// Exclude transforms that make all code slower, see https://github.com/facebook/create-react-app/pull/5278
@@ -36,9 +34,9 @@ const config = {
 				'babel',
 				'babel-plugin-transform-wpcalypso-async'
 			),
-			{ async: isCalypsoClient && codeSplit },
+			{ async: isBrowser && codeSplit },
 		],
-		isCalypsoClient && './inline-imports.js',
+		isBrowser && './inline-imports.js',
 	] ),
 	env: {
 		test: {

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -3,7 +3,7 @@
 /** @format */
 
 // SDK bundles are for the browser. Ensure that babel preset reflects this.
-process.env.TARGET_BROWSER = 'true';
+process.env.CALYPSO_CLIENT = 'true';
 
 /**
  * External dependencies

--- a/bin/sdk-cli.js
+++ b/bin/sdk-cli.js
@@ -1,10 +1,5 @@
 #!/usr/bin/env node
 
-/** @format */
-
-// SDK bundles are for the browser. Ensure that babel preset reflects this.
-process.env.CALYPSO_CLIENT = 'true';
-
 /**
  * External dependencies
  */

--- a/config/test.json
+++ b/config/test.json
@@ -35,7 +35,7 @@
 		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
-		"code-splitting": true,
+		"code-splitting": false,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,

--- a/package.json
+++ b/package.json
@@ -12,9 +12,14 @@
 	"bin": {
 		"calypso-sdk": "./bin/sdk-cli.js"
 	},
-	"browserslist": [
-		"extends @wordpress/browserslist-config"
-	],
+	"browserslist": {
+		"defaults": [
+			"extends @wordpress/browserslist-config"
+		],
+		"server": [
+			"current node"
+		]
+	},
 	"dependencies": {
 		"@automattic/format-currency": "file:./packages/format-currency",
 		"@automattic/tree-select": "file:./packages/tree-select",
@@ -225,8 +230,8 @@
 		"build-devdocs:index:_env": "node server/devdocs/bin/generate-devdocs-index",
 		"build-docker": "node bin/build-docker.js",
 		"prebuild-server": "mkdirp build",
-		"build-server": "cross-env-shell CALYPSO_SERVER=true NODE_PATH=$NODE_PATH:server:client:. webpack --display errors-only --config webpack.config.node.js",
-		"build-client": "cross-env-shell CALYPSO_CLIENT=true NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
+		"build-server": "cross-env-shell BROWSERSLIST_ENV=server NODE_PATH=$NODE_PATH:server:client:. webpack --display errors-only --config webpack.config.node.js",
+		"build-client": "cross-env-shell BROWSERSLIST_ENV=defaults NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
 		"build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client",
 		"build-client-if-desktop": "node -e \"process.env.CALYPSO_ENV === 'desktop' && process.exit(1)\" || npm run build-client",
 		"build-packages": "npx lerna run prepare --stream",
@@ -249,7 +254,7 @@
 		"lint:mixedindent": "mixedindentlint --ignore-comments \"client/**/*.scss\" \"assets/**/*.scss\" \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/config/index.js\"",
 		"prestart": "npx check-node-version --package && npm run -s install-if-deps-outdated && node bin/welcome.js",
 		"start": "npm run -s build",
-		"poststart": "cross-env-shell CALYPSO_CLIENT=true NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS --max_old_space_size=4096 build/bundle.js",
+		"poststart": "cross-env-shell BROWSERSLIST_ENV=defaults NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS --max_old_space_size=4096 build/bundle.js",
 		"reformat-files": "./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json}\"",
 		"pretest": "npm run -s install-if-deps-outdated",
 		"test": "run-s -s test-client test-packages test-server",

--- a/packages/calypso-build/bin/build-package.js
+++ b/packages/calypso-build/bin/build-package.js
@@ -17,11 +17,11 @@ const outputDirCommon = path.join( dir, 'dist', 'cjs' );
 console.log( 'Building %s', dir );
 
 execSync( `npx babel --config-file ${ babelConfigFile } -d ${ outputDirEsm } ${ inputDir }`, {
-	env: Object.assign( {}, process.env, { CALYPSO_CLIENT: 'true' } ),
+	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'defaults' } ),
 	cwd: root,
 } );
 
 execSync( `npx babel --config-file ${ babelConfigFile } -d ${ outputDirCommon } ${ inputDir }`, {
-	env: Object.assign( {}, process.env, { CALYPSO_CLIENT: 'false' } ),
+	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'server' } ),
 	cwd: root,
 } );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,7 @@ const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'fa
 const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
-const isCalypsoClient = process.env.CALYPSO_CLIENT === 'true';
+const isCalypsoClient = process.env.BROWSERSLIST_ENV !== 'server';
 
 /*
  * Create reporter for ProgressPlugin (used with EMIT_STATS)


### PR DESCRIPTION
Drop our obscure `TARGET_BROWSERS` and `CALYPSO_CLIENT` env vars in favor of a somwhat more standard approach based on `BROWSERSLIST_ENV`. Inspired by @sgomes' #30768.

#### Changes proposed in this Pull Request

- Ditch `TARGET_BROWSERS` env in favor of `CALYPSO_CLIENT` (that env var was purely redundant)
- Use `BROWSERSLIST_ENV` instead of `CALYPSO_CLIENT`

#### Testing instructions

Verify that Calypso builds and runs as before

#### Next steps

Make `bin/sdk-cli.js` use `@automattic/calypso-build`'s webpack and babel configs, make declarative. 