### PR TITLE
Dismiss primary domain change notice on switching to another site

### DIFF
--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -1,4 +1,7 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+
 /** @format */
+
 /**
  * External dependencies
  */
@@ -69,7 +72,9 @@ export class List extends React.Component {
 	};
 
 	componentDidUpdate( prevProps ) {
-		if ( get( this.props, 'selectedSite.ID', null ) !== get( prevProps, 'selectedSite.ID', null ) ) {
+		if (
+			get( this.props, 'selectedSite.ID', null ) !== get( prevProps, 'selectedSite.ID', null )
+		) {
 			this.hideNotice();
 		}
 	}
@@ -295,6 +300,8 @@ export class List extends React.Component {
 			return (
 				<Button
 					disabled={ this.state.settingPrimaryDomain }
+					// eslint-disable-next-line react/no-string-refs
+					ref="cancelChangePrimaryButton"
 					borderless
 					compact
 					className="domain-management-list__cancel-change-primary-button"

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -69,7 +69,7 @@ export class List extends React.Component {
 	};
 
 	componentDidUpdate( prevProps ) {
-		if ( get( this.props, 'selectedSite.ID', null ) !== get( prevProps, 'selectedSite.ID', null ) {
+		if ( get( this.props, 'selectedSite.ID', null ) !== get( prevProps, 'selectedSite.ID', null ) ) {
 			this.hideNotice();
 		}
 	}

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -68,6 +68,13 @@ export class List extends React.Component {
 		notice: null,
 	};
 
+	componentDidUpdate( prevProps ) {
+
+		if ( this.props.selectedSite.ID !== prevProps.selectedSite.ID ) {
+			this.hideNotice();
+		}
+	}
+
 	isLoading() {
 		return this.props.isRequestingSiteDomains && this.props.domains.length === 0;
 	}

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -69,8 +69,7 @@ export class List extends React.Component {
 	};
 
 	componentDidUpdate( prevProps ) {
-
-		if ( this.props.selectedSite.ID !== prevProps.selectedSite.ID ) {
+		if ( get( this.props, 'selectedSite.ID', null ) !== get( prevProps, 'selectedSite.ID', null ) {
 			this.hideNotice();
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Dismiss primary domain change notice on switching to another site

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit the live branch available below.
- Open `/domains/manage` for a specific site
- Change the primary domain to a different one
- Use the site switcher on the left to switch to another site
- Ensure that the primary domain change notice (from the previous site) is no longer shown. It should be hidden on switching to the new site.

Fixes https://github.com/Automattic/wp-calypso/issues/31673

#### Notes

I attempted to fix ESLint warnings but there are a few conflicts with E2E tests, and there is a `react/no-string-refs` error (also noted on https://github.com/Automattic/wp-calypso/issues/24504) which I am not sure how to handle. Will read up and attempt those fixes on a new PR.

Thanks @klimeryk for teaching me new stuff that I have implemented on this PR! 