### PR TITLE
Use military time in the concierge scheduler

### DIFF
--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -172,7 +172,7 @@ class CalendarCard extends Component {
 					>
 						{ times.map( time => (
 							<option value={ time } key={ time }>
-								{ this.withTimezone( time ).format( 'h:mma z' ) }
+								{ this.withTimezone( time ).format( 'HH:mm z' ) }
 							</option>
 						) ) }
 					</FormSelect>

--- a/client/me/concierge/shared/available-time-card.js
+++ b/client/me/concierge/shared/available-time-card.js
@@ -172,7 +172,7 @@ class CalendarCard extends Component {
 					>
 						{ times.map( time => (
 							<option value={ time } key={ time }>
-								{ this.withTimezone( time ).format( 'HH:mm z' ) }
+								{ this.withTimezone( time ).format( 'LT z' ) }
 							</option>
 						) ) }
 					</FormSelect>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the concierge scheduler to use a locale based time:

Before: <img width="1024" alt="Screenshot 2019-03-28 at 14 43 16" src="https://user-images.githubusercontent.com/275961/55167878-ae591380-5169-11e9-80ec-9c2f5846de3d.png">
After: <img width="845" alt="Screenshot 2019-03-28 at 14 55 59" src="https://user-images.githubusercontent.com/275961/55167895-b4e78b00-5169-11e9-904b-996d02ee7797.png">


#### Testing instructions

* Change your language settings to a language that uses military time (e.g. English UK)
* Open the scheduler: https://wordpress.com/me/concierge
* Select a site that has a business plan
* When you have to select a time check that it's in military time

* Change your language settings to a language that uses 12 hour time (e.g. English US)
* Open the scheduler: https://wordpress.com/me/concierge
* Select a site that has a business plan
* When you have to select a time check that it's in 12 hour time

