### PR TITLE
Billing: Add direction to billing details

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -140,7 +140,9 @@ class BillingReceipt extends React.Component {
 			<li className="billing-history__billing-details">
 				<strong>{ translate( 'Billing Details' ) }</strong>
 				<div contentEditable="true">
-					<span>{ translate( 'Click to add your billing information.' ) }</span>
+					<span className="billing-history__placeholder">
+						{ translate( 'Click to add your billing details.' ) }
+					</span>
 				</div>
 			</li>
 		);

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -140,9 +140,17 @@ class BillingReceipt extends React.Component {
 			<li className="billing-history__billing-details">
 				<strong>{ translate( 'Billing Details' ) }</strong>
 				<div
+					className="billing-history__billing-details-label"
+					id="billing-history__billing-details-label"
+				>
+					{ translate(
+						'Use this field to add your billing information (eg. VAT number, business address) before printing.'
+					) }
+				</div>
+				<div
 					contentEditable="true"
 					className="billing-history__billing-details-editable"
-					placeholder={ translate( 'Add your billing details here…' ) }
+					aria-describedby="billing-history__billing-details-label"
 				/>
 			</li>
 		);

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -139,11 +139,11 @@ class BillingReceipt extends React.Component {
 		return (
 			<li className="billing-history__billing-details">
 				<strong>{ translate( 'Billing Details' ) }</strong>
-				<div contentEditable="true">
-					<span className="billing-history__placeholder">
-						{ translate( 'Click to add your billing details.' ) }
-					</span>
-				</div>
+				<div
+					contentEditable="true"
+					className="billing-history__billing-details-editable"
+					placeholder={ translate( 'Add your billing details here…' ) }
+				/>
 			</li>
 		);
 	}

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -139,7 +139,7 @@ class BillingReceipt extends React.Component {
 
 		return (
 			<li className="billing-history__billing-details">
-				<label for="billing-history__billing-details-textarea">
+				<label htmlFor="billing-history__billing-details-textarea">
 					<strong>{ translate( 'Billing Details' ) }</strong>
 				</label>
 				<div

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -139,7 +139,9 @@ class BillingReceipt extends React.Component {
 		return (
 			<li className="billing-history__billing-details">
 				<strong>{ translate( 'Billing Details' ) }</strong>
-				<div contentEditable="true" />
+				<div contentEditable="true">
+					<span>{ translate( 'Click to add your billing information.' ) }</span>
+				</div>
 			</li>
 		);
 	}

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import TextareaAutosize from 'components/textarea-autosize';
 import DocumentHead from 'components/data/document-head';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
@@ -138,19 +139,22 @@ class BillingReceipt extends React.Component {
 
 		return (
 			<li className="billing-history__billing-details">
-				<strong>{ translate( 'Billing Details' ) }</strong>
+				<label for="billing-history__billing-details-textarea">
+					<strong>{ translate( 'Billing Details' ) }</strong>
+				</label>
 				<div
-					className="billing-history__billing-details-label"
-					id="billing-history__billing-details-label"
+					className="billing-history__billing-details-description"
+					id="billing-history__billing-details-description"
 				>
 					{ translate(
 						'Use this field to add your billing information (eg. VAT number, business address) before printing.'
 					) }
 				</div>
-				<div
-					contentEditable="true"
+				<TextareaAutosize
 					className="billing-history__billing-details-editable"
-					aria-describedby="billing-history__billing-details-label"
+					aria-labelledby="billing-history__billing-details-description"
+					id="billing-history__billing-details-textarea"
+					rows="1"
 				/>
 			</li>
 		);

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -192,15 +192,15 @@
 	min-height: 1.2em;
 }
 
-.billing-history__billing-details-editable {
-	&:hover {
-		outline: 1px black dashed;
-	}
+.billing-history__billing-details-label {
+	font-style: italic;
+}
 
-	&:empty:not( :focus )::before {
-		content: attr( placeholder );
-		font-style: italic;
-	}
+.billing-history__billing-details-editable {
+	outline: 1px solid var( --color-neutral-200 );
+	background: white;
+	margin-top: 5px;
+	padding: 7px 5px;
 }
 
 .billing-history__receipt-details {
@@ -390,13 +390,17 @@
 		.masterbar,
 		.billing-history__receipt-links,
 		.header-cake.card,
-		.inline-help {
+		.inline-help,
+		.billing-history__billing-details-label {
 			display: none;
 		}
 	}
 
-	.billing-history__billing-details-editable:empty:not( :focus )::before {
-		content: '';
+	.billing-history__billing-details-editable {
+		background: transparent;
+		padding: 0;
+		margin: 0;
+		outline: none;
 	}
 }
 

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -199,7 +199,6 @@
 
 	&:empty:not( :focus )::before {
 		content: attr( placeholder );
-		display: block; /* For Firefox */
 		font-style: italic;
 	}
 }
@@ -398,7 +397,6 @@
 
 	.billing-history__billing-details-editable:empty:not( :focus )::before {
 		content: '';
-		display: none;
 	}
 }
 

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -192,8 +192,16 @@
 	min-height: 1.2em;
 }
 
-.billing-history__placeholder {
-	font-style: italic;
+.billing-history__billing-details-editable {
+	&:hover {
+		outline: 1px black dashed;
+	}
+
+	&:empty:not( :focus )::before {
+		content: attr( placeholder );
+		display: block; /* For Firefox */
+		font-style: italic;
+	}
 }
 
 .billing-history__receipt-details {
@@ -225,10 +233,6 @@
 			margin: 0 5px 0 0;
 			text-transform: uppercase;
 		}
-	}
-
-	.billing-history__billing-details div:hover {
-		border: 2px black dashed;
 	}
 }
 
@@ -387,10 +391,14 @@
 		.masterbar,
 		.billing-history__receipt-links,
 		.header-cake.card,
-		.inline-help,
-		.billing-history__placeholder {
+		.inline-help {
 			display: none;
 		}
+	}
+
+	.billing-history__billing-details-editable:empty:not( :focus )::before {
+		content: '';
+		display: none;
 	}
 }
 

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -192,15 +192,14 @@
 	min-height: 1.2em;
 }
 
-.billing-history__billing-details-label {
+.billing-history__billing-details-description {
 	font-style: italic;
 }
 
 .billing-history__billing-details-editable {
-	outline: 1px solid var( --color-neutral-200 );
-	background: white;
+	border: 1px solid var( --color-neutral-200 );
 	margin-top: 5px;
-	padding: 7px 5px;
+	font-size: 13px;
 }
 
 .billing-history__receipt-details {
@@ -391,16 +390,16 @@
 		.billing-history__receipt-links,
 		.header-cake.card,
 		.inline-help,
-		.billing-history__billing-details-label {
+		.billing-history__billing-details-description {
 			display: none;
 		}
 	}
 
 	.billing-history__billing-details-editable {
 		background: transparent;
+		border: 0;
 		padding: 0;
 		margin: 0;
-		outline: none;
 	}
 }
 

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -192,6 +192,10 @@
 	min-height: 1.2em;
 }
 
+.billing-history__placeholder {
+	font-style: italic;
+}
+
 .billing-history__receipt-details {
 	background: var( --color-neutral-0 );
 	list-style: none;
@@ -383,7 +387,8 @@
 		.masterbar,
 		.billing-history__receipt-links,
 		.header-cake.card,
-		.inline-help {
+		.inline-help,
+		.billing-history__placeholder {
 			display: none;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds descriptive text to the billing details section, giving the user indication they can add their own information to the receipt before printing.
* Updates the editable DIV to a Textarea for better accessibility
* The descriptive text will not be shown on the printed receipt.


**Before**

<img width="737" alt="Screen Shot 2019-03-28 at 11 32 28 AM" src="https://user-images.githubusercontent.com/2124984/55170834-a2f7ef00-514d-11e9-8298-8f55fc085c49.png">

**After**

<img width="745" alt="Screen Shot 2019-04-02 at 1 19 06 PM" src="https://user-images.githubusercontent.com/2124984/55422733-52680380-554a-11e9-9f73-a0fd8a8c08b7.png">

#### Testing instructions

* Switch to this PR, navigate to `/me/purchases/billing/` and click on an individual purchase
* You should see the descriptive text under the Billing Details header, and the `div` should be a `textarea` instead .

Fixes #31681
