### PR TITLE
Use the sale_amount field for the renewal pricing if sale pricing applies

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -58,6 +58,7 @@ function createPurchaseObject( purchase ) {
 		// only generate a moment if `renewDate` is present and positive
 		renewMoment:
 			purchase.renew_date && purchase.renew_date > '0' ? i18n.moment( purchase.renew_date ) : null,
+		saleAmount: purchase.sale_amount,
 		siteId: Number( purchase.blog_id ),
 		siteName: purchase.blogname,
 		subscribedDate: purchase.subscribed_date,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -382,6 +382,10 @@ function purchaseType( purchase ) {
 	return null;
 }
 
+function getRenewalPrice( purchase ) {
+	return purchase.saleAmount || purchase.amount;
+}
+
 function showCreditCardExpiringWarning( purchase ) {
 	return (
 		! isIncludedWithPlan( purchase ) &&
@@ -397,6 +401,7 @@ export {
 	getIncludedDomain,
 	getName,
 	getPurchasesBySite,
+	getRenewalPrice,
 	getSubscriptionEndDate,
 	handleRenewNowClick,
 	hasIncludedDomain,

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -22,6 +22,7 @@ import CompactCard from 'components/card/compact';
 import config from 'config';
 import {
 	getName,
+	getRenewalPrice,
 	handleRenewNowClick,
 	isCancelable,
 	isExpired,
@@ -373,7 +374,7 @@ class ManagePurchase extends Component {
 						<div className="manage-purchase__description">{ purchaseType( purchase ) }</div>
 						<div className="manage-purchase__price">
 							<PlanPrice
-								rawPrice={ purchase.amount }
+								rawPrice={ getRenewalPrice( purchase ) }
 								currencyCode={ purchase.currencyCode }
 								taxText={ purchase.taxText }
 							/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to avoid conflicts, the sale price is now present in the `sale_amount` field of the purchase object. We should use this price, if it is present, to show the price of a renewal on the purchases page.


#### Testing instructions

Build this branch and visit the purchase page of a domain that has a renewal sale set. Make sure that the sale price is shown.

Try updating the sale to remove the renewal type from the sale. Make sure that the original price is shown.

Make sure that the correct renewal price is shown for items without a sale at all.

Example:

<img width="741" alt="Screen Shot 2019-03-28 at 12 00 01 PM" src="https://user-images.githubusercontent.com/1379730/55172849-194a2080-5151-11e9-8708-3807b2c6d8ef.png">

