### PR TITLE
Use ResizeObserver, when available, to monitor Chart size.

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -80,6 +80,7 @@ class Chart extends React.Component {
 			this.resizeObserver.unobserve( this.chart );
 		}
 		window.removeEventListener( 'resize', this.resizeWithLayout );
+		this.resizeWithLayout.cancel();
 	}
 
 	forceResize = () => {


### PR DESCRIPTION
Switch to using `ResizeObserver`, when available, to keep track of changes to sizing of the `Chart` component. This helps avoid expensive synchronous layout passes, even during mount, in most cases.

A polyfill is not needed, since this is a progressive enhancement when the feature is available.

#### Changes proposed in this Pull Request

* Use ResizeObserver, when available, to monitor Chart size.

#### Testing instructions

* Ensure the charts in Stats behave normally in a browser supporting `ResizeObserver` (e.g. recent Chrome).
* Ensure the charts in Stats behave normally in a browser not supporting `ResizeObserver` (any non-Blink browser).
