### PR TITLE
Domains: Update messaging for editing contact info

### DIFF
--- a/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
@@ -57,8 +57,8 @@ class EditContactInfo extends React.Component {
 	};
 
 	getCard = () => {
-		const domain = getSelectedDomain( this.props ),
-			{ OPENHRS, OPENSRS } = registrarNames;
+		const domain = getSelectedDomain( this.props );
+		const { OPENHRS, OPENSRS } = registrarNames;
 
 		if ( ! domain.currentUserCanManage ) {
 			return <NonOwnerCard { ...this.props } />;
@@ -69,7 +69,12 @@ class EditContactInfo extends React.Component {
 		}
 
 		if ( ! includes( [ OPENHRS, OPENSRS ], domain.registrar ) && domain.privateDomain ) {
-			return <EditContactInfoPrivacyEnabledCard />;
+			return (
+				<EditContactInfoPrivacyEnabledCard
+					selectedDomainName={ this.props.selectedDomainName }
+					selectedSite={ this.props.selectedSite }
+				/>
+			);
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/edit-contact-info/privacy-enabled-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/privacy-enabled-card.jsx
@@ -3,28 +3,39 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-
 import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Card from 'components/card';
-import { CALYPSO_CONTACT } from 'lib/url/support';
+import { domainManagementEdit } from 'my-sites/domains/paths';
+import PropTypes from 'prop-types';
 
-class EditContactInfoPrivacyEnabledCard extends React.Component {
+class EditContactInfoPrivacyEnabledCard extends React.PureComponent {
+	static propTypes = {
+		selectedDomainName: PropTypes.string.isRequired,
+		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
+	};
+
 	render() {
+		const { selectedDomainName, selectedSite, translate } = this.props;
+
 		return (
-			<Card className="edit-contact-info-privacy-enabled-card">
-				<p className="edit-contact-info-privacy-enabled-card__settings-explanation">
-					{ this.props.translate(
+			<Card className="edit-contact-info__privacy-enabled-card">
+				<p className="edit-contact-info__privacy-enabled-card-settings-explanation">
+					{ translate(
 						'This domain is currently using Privacy Protection to keep your information from showing up in public record searches. ' +
-							"If you need to make a change to your domain's contact info, please {{a}}contact support{{/a}}.",
+							"If you need to make a change to your domain's contact info, please {{a}}turn privacy off{{/a}} first.",
 						{
 							components: {
-								a: <a href={ CALYPSO_CONTACT } target="_blank" rel="noopener noreferrer" />,
+								a: (
+									<a
+										href={ domainManagementEdit( selectedSite.slug, selectedDomainName ) }
+										rel="noopener noreferrer"
+									/>
+								),
 							},
 						}
 					) }

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -356,7 +356,7 @@ input[type='radio'].domain-management-list-item__radio {
 	}
 }
 
-.edit-contact-info-privacy-enabled-card__settings-explanation {
+.edit-contact-info__privacy-enabled-card-settings-explanation {
 	color: var( --color-text-subtle );
 	display: block;
 	font-size: 13px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If a domain requires the privacy protection off to be
updated, point users how to turn it off themselves instead of
contacting support.

#### Testing instructions

- You must have a WWD domain OR you can hack to show `EditContactInfoPrivacyEnabledCard`
- Make sure the copy is good
- Make sure the link works properly

