### PR TITLE
 Importers: Tweaks to the BusyImportingButton Component

### DIFF
--- a/client/my-sites/importer/importer-action-buttons/busy-importing-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/busy-importing-button.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import ImporterActionButton from './action-button';
 
 export const BusyImportingButton = ( { translate } ) => (
-	<ImporterActionButton primary busy>
+	<ImporterActionButton primary busy disabled>
 		{ translate( 'Importing…' ) }
 	</ImporterActionButton>
 );

--- a/client/my-sites/importer/importer-action-buttons/busy-importing-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/busy-importing-button.jsx
@@ -10,10 +10,10 @@ import React from 'react';
  */
 import ImporterActionButton from './action-button';
 
-export const StopButton = ( { translate } ) => (
+export const BusyImportingButton = ( { translate } ) => (
 	<ImporterActionButton primary busy>
 		{ translate( 'Importing…' ) }
 	</ImporterActionButton>
 );
 
-export default localize( StopButton );
+export default localize( BusyImportingButton );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the local symbol name `StopButton` => `BusyImportingButton`
* Specify the button is `disabled` so it appears less clickable and clicking does not animate

Before:

Button is clickable (but does nothing)
![before](https://user-images.githubusercontent.com/1587282/55186319-a5b60c80-516c-11e9-993b-3f6bfcc1646b.gif)

After:

Button is not clickable (& looks less like it should be)
![after](https://user-images.githubusercontent.com/1587282/55186330-ac448400-516c-11e9-9774-31317f849a98.gif)

#### Testing instructions

* Browse to `/settings/import`
* Initiate an import flow
* The `Importing...` button should be visible, look "good," and not be clickable
