### PR TITLE
Fix: Elevation mixin to use `hex-to-rgb` function

### DIFF
--- a/packages/calypso-color-schemes/src/shared/_color-schemes.scss
+++ b/packages/calypso-color-schemes/src/shared/_color-schemes.scss
@@ -61,7 +61,7 @@
 	--color-white: #{$muriel-white};
 	--color-white-rgb: #{hex-to-rgb( $muriel-white )};
 	--color-black: #000000;
-	--color-black-rgb: #000000;
+	--color-black-rgb: #{hex-to-rgb( #000000 )};
 	--color-neutral: #{$muriel-gray-500};
 	--color-neutral-rgb: #{hex-to-rgb( $muriel-gray-500 )};
 	--color-neutral-dark: #{$muriel-gray-700};


### PR DESCRIPTION
Quick fix to the elevation mixin. At some point I accidentally removed the `hex-to-rgb` function from the variable definition. This PR fixes it.