### PR TITLE
Signup: Update domain search input to match the rest of the flow

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -3,14 +3,27 @@
 	max-width: 720px;
 }
 
-.domains__step-content-enter {
-	opacity: 0.01;
-	transform: translate3d( 0, 32px, 0 );
+.is-section-signup .domains__step-content {
+	.search .search__icon-navigation {
+		background: none;
+	}
 
-	&.domains__step-content-enter-active {
-		opacity: 1;
-		pointer-events: none;
-		transition: all 0.2s ease-in-out;
-		transform: translate3d( 0, 0, 0 );
+	.register-domain-step__search-card {
+		border-radius: 3px;
+		@include elevation( 2dp );
+	}
+
+	.search.is-open.has-focus {
+		border: none;
+		border-radius: 3px;
+		box-shadow: 0 0 0 2px var( --color-accent );
+	}
+
+	.search-filters__dropdown-filters {
+		border-radius: 0 3px 3px 0;
+	}
+
+	.search-filters__dropdown-filters.search-filters__dropdown-filters--is-open {
+		box-shadow: 0 0 0 2px var( --color-accent );
 	}
 }


### PR DESCRIPTION
This PR updates the domain search input inside signup to add border-radii, the `--color-accent` focus border color, and some elevation.

Before:

<img width="1011" alt="image" src="https://user-images.githubusercontent.com/191598/55192282-7c03e200-517a-11e9-9b08-87f5725310cb.png">

After:

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/191598/55192321-8b832b00-517a-11e9-8e6d-71ec2422a0f2.png">

