### PR TITLE
Remove "Two Months Free" G Suite Copy

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
@@ -34,7 +34,7 @@ class GoogleAppsProductDetails extends Component {
 	}
 
 	renderPeriod() {
-		return this.props.translate( '%(annualPrice)s Billed yearly — get 2 months free!', {
+		return this.props.translate( '%(annualPrice)s Billed yearly', {
 			args: { annualPrice: this.props.annualPrice },
 		} );
 	}

--- a/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
@@ -34,8 +34,8 @@ class GoogleAppsProductDetails extends Component {
 	}
 
 	renderPeriod() {
-		return this.props.translate( '%(annualPrice)s Billed yearly', {
-			args: { annualPrice: this.props.annualPrice },
+		return this.props.translate( '%(price)s billed yearly', {
+			args: { price: this.props.annualPrice },
 		} );
 	}
 

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -90,7 +90,7 @@ class GSuitePurchaseCta extends React.Component {
 								) }
 
 								<h5 className="gsuite-purchase-cta__add-google-apps-card-billing-period">
-									{ translate( '%(price)s billed yearly (2 months free!)', {
+									{ translate( '%(price)s billed yearly', {
 										args: {
 											price: annualPrice,
 										},

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -63,7 +63,7 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with basic plan 1`] = `
           <h5
             className="gsuite-purchase-cta__add-google-apps-card-billing-period"
           >
-            $50 billed yearly (2 months free!)
+            $50 billed yearly
           </h5>
         </div>
       </div>
@@ -165,7 +165,7 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with business plan 1`] =
           <h5
             className="gsuite-purchase-cta__add-google-apps-card-billing-period"
           >
-            $50 billed yearly (2 months free!)
+            $50 billed yearly
           </h5>
         </div>
       </div>

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -17,16 +17,21 @@ jest.mock( 'my-sites/email/gsuite-purchase-features', () => 'GSuitePurchaseFeatu
 
 describe( 'GSuitePurchaseCta', () => {
 	test( 'it renders GSuitePurchaseCta with basic plan', () => {
-		const store = createReduxStore();
+		const store = createReduxStore( {
+			ui: { selectedSiteId: 123 },
+			sites: {
+				items: {
+					123: {
+						ID: 123,
+						URL: 'https://test.com',
+					},
+				},
+			},
+		} );
 		const tree = renderer
 			.create(
 				<Provider store={ store }>
-					<GSuitePurchaseCta
-						annualPrice={ '$50' }
-						monthlyPrice={ '$5' }
-						productSlug={ 'gapps' }
-						selectedSite={ { ID: 'foo' } }
-					/>
+					<GSuitePurchaseCta annualPrice={ '$50' } monthlyPrice={ '$5' } productSlug={ 'gapps' } />
 				</Provider>
 			)
 			.toJSON();
@@ -34,7 +39,17 @@ describe( 'GSuitePurchaseCta', () => {
 	} );
 
 	test( 'it renders GSuitePurchaseCta with business plan', () => {
-		const store = createReduxStore();
+		const store = createReduxStore( {
+			ui: { selectedSiteId: 123 },
+			sites: {
+				items: {
+					123: {
+						ID: 123,
+						URL: 'https://test.com',
+					},
+				},
+			},
+		} );
 		const tree = renderer
 			.create(
 				<Provider store={ store }>
@@ -42,7 +57,7 @@ describe( 'GSuitePurchaseCta', () => {
 						annualPrice={ '$50' }
 						monthlyPrice={ '$5' }
 						productSlug={ 'gapps_unlimited' }
-						selectedSite={ { ID: 'foo' } }
+						selectedSiteSlug={ 'test.com' }
 					/>
 				</Provider>
 			)

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -57,7 +57,6 @@ describe( 'GSuitePurchaseCta', () => {
 						annualPrice={ '$50' }
 						monthlyPrice={ '$5' }
 						productSlug={ 'gapps_unlimited' }
-						selectedSiteSlug={ 'test.com' }
 					/>
 				</Provider>
 			)


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove "2 months free" from G Suite CTAs

#### Testing instructions

1. navigate to `/email/:domain/manage/:siteSlug`
1. confirm that "2 months free" is gone <img width="500" alt="Screen Shot 2019-03-28 at 9 50 24 PM" src="https://user-images.githubusercontent.com/2810519/55210218-969e8100-51a3-11e9-8b3b-48f12fa8366b.png">
1. navigate to `domains/add/:newDomain/google-apps/:siteSlug` where `:newDomain` is not a domain on the site
1. confirm that "2 months free" is gone <img width="500" alt="Screen Shot 2019-03-28 at 9 54 00 PM" src="https://user-images.githubusercontent.com/2810519/55210349-2a704d00-51a4-11e9-9e90-5ca826716771.png">

