### PR TITLE
Fix React unmounted setState() warning

### DIFF
--- a/client/components/async-load/index.jsx
+++ b/client/components/async-load/index.jsx
@@ -32,12 +32,13 @@ export default class AsyncLoad extends Component {
 		};
 	}
 
-	componentWillMount() {
+	componentDidMount = () => {
+		this.mounted = true;
 		this.require();
-	}
+	};
 
 	componentWillReceiveProps( nextProps ) {
-		if ( this.props.require !== nextProps.require ) {
+		if ( this.mounted && this.props.require !== nextProps.require ) {
 			this.setState( { component: null } );
 		}
 	}
@@ -50,11 +51,15 @@ export default class AsyncLoad extends Component {
 		}
 	}
 
+	componentWillUnmount() {
+		this.mounted = false;
+	}
+
 	require() {
 		const requireFunction = this.props.require;
 
 		requireFunction( component => {
-			if ( this.props.require === requireFunction ) {
+			if ( this.mounted && this.props.require === requireFunction ) {
 				this.setState( { component } );
 			}
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a long-standing react warning about updating an unmounted component `Warning: Can't perform a React state update on an unmounted component.`

![DevTools_-_calypso_localhost_3000_checkout_julesaustest_uk](https://user-images.githubusercontent.com/5952255/55209587-24737e00-522f-11e9-9e05-c233b94d0c7d.jpg)

#### Testing instructions

The error has an element of timing to it, but can be reproduced fairly reliably by navigating directly to `` `http://calypso.localhost:3000/checkout/${SITE}` ``.

If you're having trouble confirming that this problem is occuring but fixed, it may help to check inside the `requireFunction()` callback in [client/components/async-load/index.jsx](client/components/async-load/index.jsx):

```
		requireFunction( component => {
			if ( ! this.mounted ) { console.log( 'gotcha' ) };
			if ( this.mounted && this.props.require === requireFunction ) {
				this.setState( { component } );
			}
		} );
```

Optional ramble:
Firstly, I somehow only just noticed that the settings buttons are missing from checkout, so this might just be a fix for one of a different problem. Still, it's nice to fix warnings like this.

Secondly, I found the AsyncLoad a bit confusing at first, so here's how I understand what's happening:

- AsyncLoad's `require="notifications"` in `client/layout/masterbar/notifications.jsx` is magically being transformed into `require('client/notifications'/index')`
- The module is loaded over the network
- Something very like a react callback ref is injected into the loaded module and set as `this.props.require` in the AsyncLoad(`client/components/async-load/index.jsx`) component. This is the sort of magic webpack is good at, so I'd guess it's happening there.
- That callback-ref-like-thing is called, passing in the new component
- AsyncLoad saves that new component with `setState()`, triggering an update
- AsyncLoad renders the loaded component (`Notifications`), passing down it's own props (e.g. in this example, `isShowing`, `checkToggle` etc are passed through as props to `Notifications` in `client/notifications/index`.

The error occurs when the AsyncLoad is unmounted before the module is finished being loaded, and is triggered by the `setState()` call to save the new component (although the check that the require function hasn't changed catches a number of cases).


