### PR TITLE
Fix Monthly Billing Logic for G Suite

### DIFF
--- a/client/lib/google-apps/index.js
+++ b/client/lib/google-apps/index.js
@@ -13,7 +13,7 @@ function getAnnualPrice( cost, currencyCode ) {
 }
 
 function getMonthlyPrice( cost, currencyCode ) {
-	return formatPrice( cost / 10, currencyCode );
+	return formatPrice( cost / 12, currencyCode );
 }
 
 function googleAppsSettingsUrl( domainName ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch billing logic divided by 12

#### Testing instructions

1. navigate to `/email/:domain/manage/:siteSlug`
1. confirm that it says "$4.17 per user / month"
1. navigate to `domains/add/:newDomain/google-apps/:siteSlug` where `:newDomain` is not a domain on the site
1. confirm that it says "$4.17 per user / month"