### PR TITLE
Reader: strip HTML from feed descriptions

### DIFF
--- a/client/lib/post-normalizer/rule-strip-html.js
+++ b/client/lib/post-normalizer/rule-strip-html.js
@@ -5,7 +5,7 @@
 import { forEach } from 'lodash';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { stripHTML } from 'lib/formatting';
 

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -15,7 +15,7 @@ import {
 	SERIALIZE,
 } from 'state/action-types';
 import { combineReducers, createReducer } from 'state/utils';
-import { decodeEntities } from 'lib/formatting';
+import { decodeEntities, stripHTML } from 'lib/formatting';
 import { itemsSchema } from './schema';
 import { safeLink } from 'lib/post-normalizer/utils';
 
@@ -46,7 +46,7 @@ function adaptFeed( feed ) {
 		feed_URL: safeLink( feed.feed_URL ),
 		is_following: feed.is_following,
 		subscribers_count: feed.subscribers_count,
-		description: feed.description && decodeEntities( feed.description ),
+		description: feed.description && decodeEntities( stripHTML( feed.description ) ),
 		last_update: feed.last_update,
 		image: feed.image,
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/issues/31858, @alisterscott discovered that we display encoded HTML if a feed description contains it.

This PR removes any HTML from a feed description before it is stored in Redux.

#### Testing instructions

Visit http://calypso.localhost:3000/read/feeds/50155126.

<img width="887" alt="Screen Shot 2019-03-29 at 18 37 21" src="https://user-images.githubusercontent.com/17325/55211622-b8564180-5251-11e9-9c4a-577762a28c81.png">

Compare with https://wordpress.com/read/feeds/50155126:

<img width="843" alt="Screen Shot 2019-03-29 at 18 35 19" src="https://user-images.githubusercontent.com/17325/55211583-8ba22a00-5251-11e9-983d-c88421cffec2.png">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Fixes #31858.
