### PR TITLE
Fix a warning that's a result from a previous refactoring

### DIFF
--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -60,7 +60,7 @@ class SocialSignupForm extends Component {
 		const redirectUri = uxMode === 'redirect' ? `https://${ window.location.host }/start` : null;
 
 		return (
-			<div className="signup-form__social" compact={ this.props.compact }>
+			<div className="signup-form__social">
 				{ ! this.props.compact && (
 					<p>
 						{ preventWidows(


### PR DESCRIPTION
There's a warning when I visit some signup flows.

#### Changes proposed in this Pull Request

A past change turned a Card component to a div. Divs don't have a compact attribute and don't have boolean attributes. Here's the change that introduced it:

https://github.com/Automattic/wp-calypso/commit/fbe9c9af608893f8f0fedfbb08ee29f9bde5b5ca


#### Testing instructions

Visit
http://calypso.localhost:3000/start/user?vertical=Restaurants&site_type=business

No warnings should be visible. No design changes should be visible. Everything should work fine.
