### PR TITLE
FormToggle: render label only if not empty

### DIFF
--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -148,10 +148,6 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	margin-left: auto;
 }
 
-.post-share__service .form-toggle__label .form-toggle__label-content {
-	margin-left: 0;
-}
-
 .post-share__service-account-social-logo {
 	position: relative;
 	top: 14px;

--- a/client/components/forms/form-toggle/index.jsx
+++ b/client/components/forms/form-toggle/index.jsx
@@ -99,9 +99,11 @@ export default class FormToggle extends PureComponent {
 						aria-label={ this.props[ 'aria-label' ] }
 						tabIndex={ this.props.disabled ? -1 : 0 }
 					/>
-					<span className="form-toggle__label-content" onClick={ this.onLabelClick }>
-						{ this.props.children }
-					</span>
+					{ this.props.children && (
+						/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+						<span className="form-toggle__label-content">{ this.props.children }</span>
+						/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+					) }
 				</label>
 			</span>
 		);

--- a/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
+++ b/client/extensions/woocommerce/app/settings/email/email-settings/style.scss
@@ -35,10 +35,6 @@
 		text-align: center;
 	}
 
-	.form-toggle__label .form-toggle__label-content {
-		margin-left: 0;
-	}
-
 	.list-header {
 		background: var( --color-neutral-0 );
 	}

--- a/client/extensions/woocommerce/app/settings/payments/style.scss
+++ b/client/extensions/woocommerce/app/settings/payments/style.scss
@@ -166,10 +166,6 @@
 	.payments__method-enable-container {
 		width: 20%;
 
-		.form-toggle__label .form-toggle__label-content {
-			margin-left: 0;
-		}
-
 		@include breakpoint( '<660px' ) {
 			width: 30%;
 			padding-left: 0;

--- a/client/extensions/woocommerce/components/extended-header/style.scss
+++ b/client/extensions/woocommerce/components/extended-header/style.scss
@@ -20,9 +20,5 @@
 
 	.section-header__actions {
 		flex-shrink: 0;
-
-		.form-toggle__label .form-toggle__label-content {
-			margin-left: 0;
-		}
 	}
 }

--- a/client/my-sites/domains/domain-management/style.scss
+++ b/client/my-sites/domains/domain-management/style.scss
@@ -263,12 +263,6 @@ input[type='radio'].domain-management-list-item__radio {
 	}
 }
 
-.edit__privacy-protection-toggle {
-	.form-toggle__label-content {
-		margin-left: 0;
-	}
-}
-
 .domain-details-card,
 .edit__domain-details-card {
 	.flag {

--- a/client/post-editor/edit-post-status/style.scss
+++ b/client/post-editor/edit-post-status/style.scss
@@ -81,7 +81,3 @@
 		width: auto;
 	}
 }
-
-.edit-post-status .form-toggle__label .form-toggle__label-content {
-	margin: 0;
-}


### PR DESCRIPTION
The `FormToggle` label has a `margin-left: 12px` style that causes it to be rendered as a visible box even if empty. Many usages in UI have to compensate for that with style overrides.

This PR renders the label element only if there are actual children to be rendered. And removes several CSS styles that are no longer needed.

**How to test:**
The WordPress.com nameservers toggle in domain settings gets a better alignment now:

before:
<img width="502" alt="Screenshot 2019-03-29 at 12 52 53" src="https://user-images.githubusercontent.com/664258/55231583-64ccff00-5223-11e9-9836-0037e5688098.png">

after:
<img width="502" alt="Screenshot 2019-03-29 at 12 53 39" src="https://user-images.githubusercontent.com/664258/55231595-6eeefd80-5223-11e9-9266-90b00dc71609.png">

Other `FormToggle` instance to verify is the "Stick to the top" toggle in Classic Editor Status:

<img width="274" alt="Screenshot 2019-03-29 at 13 07 09" src="https://user-images.githubusercontent.com/664258/55231702-bbd2d400-5223-11e9-835b-98fadb4d7ddb.png">

