### PR TITLE
Import Signup Flow: Remove loading notice

### DIFF
--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -173,23 +173,8 @@ class ImportURLStepComponent extends Component {
 	};
 
 	renderNotice = () => {
-		const { isLoading, translate } = this.props;
 		const { showUrlMessage } = this.state;
 		const urlMessage = this.getUrlMessage();
-
-		if ( isLoading ) {
-			return (
-				<Notice
-					className="import-url__url-input-message"
-					status="is-info"
-					showDismiss={ false }
-					isLoading
-					icon="info"
-				>
-					{ translate( "Please wait, we're checking to see if we can import this site." ) }
-				</Notice>
-			);
-		}
 
 		if ( showUrlMessage && urlMessage ) {
 			return (

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -172,9 +172,38 @@ class ImportURLStepComponent extends Component {
 		} );
 	};
 
+	renderNotice = () => {
+		const { isLoading, translate } = this.props;
+		const { showUrlMessage } = this.state;
+		const urlMessage = this.getUrlMessage();
+
+		if ( isLoading ) {
+			return (
+				<Notice
+					className="import-url__url-input-message"
+					status="is-info"
+					showDismiss={ false }
+					isLoading
+					icon="info"
+				>
+					{ translate( "Please wait, we're checking to see if we can import this site." ) }
+				</Notice>
+			);
+		}
+
+		if ( showUrlMessage && urlMessage ) {
+			return (
+				<Notice className="import-url__url-input-message" status="is-error" showDismiss={ false }>
+					{ urlMessage }
+				</Notice>
+			);
+		}
+
+		return <div className="import-url__notice-placeholder" />;
+	};
+
 	renderContent = () => {
 		const { isLoading, urlInputValue, translate } = this.props;
-		const { showUrlMessage } = this.state;
 		const urlMessage = this.getUrlMessage();
 
 		return (
@@ -211,17 +240,7 @@ class ImportURLStepComponent extends Component {
 								: translate( 'Continue' ) }
 						</FormButton>
 					</form>
-					{ showUrlMessage && urlMessage ? (
-						<Notice
-							className="import-url__url-input-message"
-							status="is-error"
-							showDismiss={ false }
-						>
-							{ urlMessage }
-						</Notice>
-					) : (
-						<div className="import-url__notice-placeholder" />
-					) }
+					{ this.renderNotice() }
 				</div>
 
 				<div className="import-url__example">

--- a/client/state/importer-nux/actions.js
+++ b/client/state/importer-nux/actions.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { translate } from 'i18n-calypso';
 import url from 'url';
 import { trim } from 'lodash';
 
@@ -15,14 +14,11 @@ import {
 	IMPORTER_NUX_URL_INPUT_SET,
 	IMPORT_IS_SITE_IMPORTABLE_START_FETCH,
 } from 'state/action-types';
-import { infoNotice, removeNotice } from 'state/notices/actions';
 import { loadmShotsPreview } from 'my-sites/importer/site-importer/site-preview-actions';
 import wpLib from 'lib/wp';
 import SignupActions from 'lib/signup/actions';
 
 const wpcom = wpLib.undocumented();
-
-const CHECKING_SITE_IMPORTABLE_NOTICE = 'checking-site-importable';
 
 const normalizeUrl = targetUrl => {
 	const siteURL = trim( targetUrl );
@@ -72,16 +68,8 @@ export const fetchIsSiteImportable = site_url => dispatch => {
 		.catch( error => dispatch( { type: IMPORT_IS_SITE_IMPORTABLE_ERROR, error } ) );
 };
 
-export const submitImportUrlStep = ( { stepName, siteUrl: siteUrlFromInput } ) => dispatch => {
-	dispatch(
-		infoNotice( translate( "Please wait, we're checking to see if we can import this site." ), {
-			id: CHECKING_SITE_IMPORTABLE_NOTICE,
-			icon: 'info',
-			isLoading: true,
-		} )
-	);
-
-	return dispatch( fetchIsSiteImportable( siteUrlFromInput ) )
+export const submitImportUrlStep = ( { stepName, siteUrl: siteUrlFromInput } ) => dispatch =>
+	dispatch( fetchIsSiteImportable( siteUrlFromInput ) )
 		.then( async siteDetails => {
 			const { engine, error, favicon, siteTitle, siteUrl: importSiteUrl } = siteDetails;
 
@@ -95,8 +83,6 @@ export const submitImportUrlStep = ( { stepName, siteUrl: siteUrlFromInput } ) =
 				retryTimeout: 1000,
 			} );
 
-			dispatch( removeNotice( CHECKING_SITE_IMPORTABLE_NOTICE ) );
-
 			return SignupActions.submitSignupStep( { stepName }, [], {
 				sitePreviewImageBlob: imageBlob,
 				importEngine: engine,
@@ -107,8 +93,5 @@ export const submitImportUrlStep = ( { stepName, siteUrl: siteUrlFromInput } ) =
 			} );
 		} )
 		.catch( error => {
-			dispatch( removeNotice( CHECKING_SITE_IMPORTABLE_NOTICE ) );
-
 			throw new Error( error );
 		} );
-};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the loading notice in the importer signup flow from the floating top right. We already show the loading state with the busy styling of the input button.
The plan was originally to move the notice to be underneath the URL input - I've left some of the related code changes in place, as they're still an improvement.

#### Testing instructions

- Start at http://calypso.localhost:3000/start/import/from-url
- Enter an invalid URL
  - Make sure that the error notice still shows in the expected place, below the URL
- Enter a valid, parsable URL & hit enter
  - You should not see a notice now, just the busy styled button