### PR TITLE
Tests: Update snapshot for failing Calypso test

### DIFF
--- a/client/signup/steps/site-information/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-information/test/__snapshots__/index.js.snap
@@ -42,8 +42,10 @@ exports[`<SiteInformation /> should render 1`] = `
                 value="Ho ho ho!"
               />
               <Button
+                aria-label="Continue"
                 onClick={[Function]}
                 primary={true}
+                title="Continue"
                 type="submit"
               >
                 <t
@@ -81,8 +83,10 @@ exports[`<SiteInformation /> should render 1`] = `
                 value=""
               />
               <Button
+                aria-label="Continue"
                 onClick={[Function]}
                 primary={true}
+                title="Continue"
                 type="submit"
               >
                 <t
@@ -120,8 +124,10 @@ exports[`<SiteInformation /> should render 1`] = `
                 value=""
               />
               <Button
+                aria-label="Continue"
                 onClick={[Function]}
                 primary={true}
+                title="Continue"
                 type="submit"
               >
                 <t


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update snapshot. Broken by
https://github.com/Automattic/wp-calypso/commit/a29c016a0d26787716a9cf9b59564686e3f74369

#### Testing instructions

```npm run test-client```