### PR TITLE
Add learn link to invite accept notices

### DIFF
--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -8,7 +8,7 @@ import i18n from 'i18n-calypso';
 
 export function acceptedNotice( invite, displayOnNextPage = true ) {
 	const site = (
-		<a href={ get( invite, 'site.URL' ) } className="invite-accept__notice-site-link">
+		<a href={ get( invite, 'site.URL' ) } className="invites__notice-site-link">
 			{ get( invite, 'site.title' ) }
 		</a>
 	);
@@ -41,12 +41,12 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 		case 'administrator':
 			return [
 				<div>
-					<h3 className="invite-message__title">
+					<h3 className="invites__title">
 						{ i18n.translate( "You're now an Administrator of: {{site/}}", {
 							components: { site },
 						} ) }
 					</h3>
-					<p className="invite-message__intro">
+					<p className="invites__intro">
 						{ i18n.translate(
 							'This is your site dashboard where you will be able to manage all aspects of %(site)s',
 							{
@@ -69,12 +69,12 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 		case 'editor':
 			return [
 				<div>
-					<h3 className="invite-message__title">
+					<h3 className="invites__title">
 						{ i18n.translate( "You're now an Editor of: {{site/}}", {
 							components: { site },
 						} ) }
 					</h3>
-					<p className="invite-message__intro">
+					<p className="invites__intro">
 						{ i18n.translate(
 							'This is your site dashboard where you can publish and manage your ' +
 								'own posts and the posts of others, as well as upload media.'
@@ -95,12 +95,12 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 		case 'author':
 			return [
 				<div>
-					<h3 className="invite-message__title">
+					<h3 className="invites__title">
 						{ i18n.translate( "You're now an Author of: {{site/}}", {
 							components: { site },
 						} ) }
 					</h3>
-					<p className="invite-message__intro">
+					<p className="invites__intro">
 						{ i18n.translate(
 							'This is your site dashboard where you can publish and ' +
 								'edit your own posts as well as upload media.'
@@ -121,12 +121,12 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 		case 'contributor':
 			return [
 				<div>
-					<h3 className="invite-message__title">
+					<h3 className="invites__title">
 						{ i18n.translate( "You're now a Contributor of: {{site/}}", {
 							components: { site },
 						} ) }
 					</h3>
-					<p className="invite-message__intro">
+					<p className="invites__intro">
 						{ i18n.translate(
 							'This is your site dashboard where you can write and manage your own posts.'
 						) }

--- a/client/my-sites/invites/utils.js
+++ b/client/my-sites/invites/utils.js
@@ -54,6 +54,14 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 							}
 						) }
 					</p>
+					<p>
+						{ i18n.translate(
+							'Not sure where to start? Head on over to {{a}}Learn WordPress{{/a}}.',
+							{
+								components: { a: <a href="http://learn.wordpress.com" /> },
+							}
+						) }
+					</p>
 				</div>,
 				{ displayOnNextPage },
 			];
@@ -72,6 +80,14 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 								'own posts and the posts of others, as well as upload media.'
 						) }
 					</p>
+					<p>
+						{ i18n.translate(
+							'Not sure where to start? Head on over to {{a}}Learn WordPress{{/a}}.',
+							{
+								components: { a: <a href="http://learn.wordpress.com" /> },
+							}
+						) }
+					</p>
 				</div>,
 				{ displayOnNextPage },
 			];
@@ -88,6 +104,14 @@ export function acceptedNotice( invite, displayOnNextPage = true ) {
 						{ i18n.translate(
 							'This is your site dashboard where you can publish and ' +
 								'edit your own posts as well as upload media.'
+						) }
+					</p>
+					<p>
+						{ i18n.translate(
+							'Not sure where to start? Head on over to {{a}}Learn WordPress{{/a}}.',
+							{
+								components: { a: <a href="http://learn.wordpress.com" /> },
+							}
 						) }
 					</p>
 				</div>,

--- a/test/e2e/lib/components/notices-component.js
+++ b/test/e2e/lib/components/notices-component.js
@@ -19,7 +19,7 @@ export default class NoticesComponent extends AsyncBaseContainer {
 	}
 
 	async inviteMessageTitle() {
-		const selector = By.css( '.invite-message__title' );
+		const selector = By.css( '.invites__title' );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		return await this.driver.findElement( selector ).getText();
 	}


### PR DESCRIPTION
When helping a new WordPress.com user out, that was invited to be an Editor to an existing site, I noticed that after creating the new account, the user was just dropped in Calypso with no guidance. She was totally confused, as she had never used WordPress before. An email was sent to the user with a link to the support site, but she didn't see that email until later on.

While a more complete and specific onboarding experience for invited users would be ideal, adding a support link to the existing notice shown after accepting an invite is a quick improvement.

#### Changes proposed in this Pull Request

* Add the same wording and link to support as included in the email sent to the user after accepting an invite ("Not sure where to start? Head on over to Learn WordPress.")

##### Before

<img width="966" alt="ScreenCapture at Fri Mar 29 11:49:30 EDT 2019" src="https://user-images.githubusercontent.com/2098816/55256610-ce550980-5233-11e9-8de2-571dcfe8291e.png">

##### After

<img width="975" alt="ScreenCapture at Fri Mar 29 14:50:54 EDT 2019" src="https://user-images.githubusercontent.com/2098816/55256614-d1e89080-5233-11e9-8e1d-912e17fb66fb.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Invite a new user to be an Administrator/Editor/Author
* Run this branch
* Copy the "Accept Invitation" link in the email you receive. Change "https://wordpress.com" to "http://calypso.localhost:3000" and load link in a private browser window (so that you ensure you aren't already logged into WordPress.com)
* Create new user account
* Verify notice after creating account includes link to "Learn WordPress"
