### PR TITLE
Block Editor: End messaging transition

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -85,20 +85,23 @@ class CalypsoifyIframe extends Component {
 		const { action } = data;
 
 		if ( 'loaded' === action ) {
-			const { port1: portToIframe, port2: portForIframe } = new MessageChannel();
+			const { port1: iframePortObject, port2: transferredPortObject } = new MessageChannel();
 
-			this.iframePort = portToIframe;
+			this.iframePort = iframePortObject;
 			this.iframePort.addEventListener( 'message', this.onIframePortMessage, false );
 			this.iframePort.start();
 
 			this.iframeRef.current.contentWindow.postMessage( { action: 'initPort' }, '*', [
-				portForIframe,
+				transferredPortObject,
 			] );
 
 			// Check if we're generating a post via Press This
 			this.pressThis();
 			return;
 		}
+
+		// this message comes from inside TinyMCE and therefore
+		// cannot be controlled like the others
 		if ( 'classicBlockOpenMediaModal' === action ) {
 			if ( data.imageId ) {
 				const { siteId } = this.props;
@@ -111,21 +114,21 @@ class CalypsoifyIframe extends Component {
 				isMediaModalVisible: true,
 			} );
 		}
+
+		// any other message is unknown and may indicate a bug
 	};
 
 	onIframePortMessage = ( { data, ports } ) => {
 		const { action, payload } = data;
 
-		if ( 'openMediaModal' === action ) {
+		if ( 'openMediaModal' === action && ports && ports[ 0 ] ) {
 			const { siteId } = this.props;
 			const { allowedTypes, gallery, multiple, value } = payload;
 
-			if ( ports && ports[ 0 ] ) {
-				// set imperatively on the instance because this is not
-				// the kind of assignment which causes re-renders and we
-				// want it set immediately
-				this.mediaSelectPort = ports[ 0 ];
-			}
+			// set imperatively on the instance because this is not
+			// the kind of assignment which causes re-renders and we
+			// want it set immediately
+			this.mediaSelectPort = ports[ 0 ];
 
 			if ( value ) {
 				const selectedItems = Array.isArray( value )
@@ -184,27 +187,18 @@ class CalypsoifyIframe extends Component {
 	};
 
 	closeMediaModal = media => {
-		if ( ! this.state.classicBlockEditorId && media && this.iframePort ) {
+		if ( ! this.state.classicBlockEditorId && media ) {
 			const { multiple } = this.state;
 			const formattedMedia = map( media.items, item => mediaCalypsoToGutenberg( item ) );
 			const payload = multiple ? formattedMedia : formattedMedia[ 0 ];
 
-			if ( this.mediaSelectPort ) {
-				this.mediaSelectPort.postMessage( payload );
+			this.mediaSelectPort.postMessage( payload );
 
-				// this is a once-only port
-				// after sending our message we want to close it out
-				// and prevent sending more messages (which will be ignored)
-				this.mediaSelectPort.close();
-				this.mediaSelectPort = null;
-			} else {
-				// this to be removed once we are reliably
-				// sending the new MessageChannel from the server
-				this.iframePort.postMessage( {
-					action: 'selectMedia',
-					payload,
-				} );
-			}
+			// this is a once-only port
+			// after sending our message we want to close it out
+			// and prevent sending more messages (which will be ignored)
+			this.mediaSelectPort.close();
+			this.mediaSelectPort = null;
 		}
 
 		this.setState( { classicBlockEditorId: null, isMediaModalVisible: false } );


### PR DESCRIPTION
In #30972 we started sending a custom `MessageChannel` port from
within the `iframe` for sending back media modal messages. We had
to support a transition when some page loads would get that and
others wouldn't.

That transition is over and this change removes the code meant to
support both the old and new systems.

I have also done some minor refactoring to add a few comments and
to rename the `iframePort` to better reflect the fact that we are
_transferring_ ownership of one half of the port into the `iframe`

**Testing**

 1. Open the `iframe` block editor for a Simple Site.
 2. Insert an image block
 3. Select `Media Library` and make sure that the Calypso media model opens
 4. Select an image
 5. Make sure that the image loads as expected.
 6. Go back to the media library and upload an image, repeat tests
 7. Go back to the media library and select a free image, repeat tests