### PR TITLE
Support Credits in Subscription Length Picker

### DIFF
--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -45,7 +45,8 @@ export class SubscriptionLengthPicker extends React.Component {
 	render() {
 		const { productsWithPrices, translate, shouldShowTax } = this.props;
 		const hasDiscount = productsWithPrices.some(
-			( { priceFullBeforeDiscount, priceFull } ) => priceFull !== priceFullBeforeDiscount
+			( { priceFullBeforeDiscount, priceMinusCredits } ) =>
+				priceMinusCredits !== priceFullBeforeDiscount
 		);
 
 		return (
@@ -67,13 +68,13 @@ export class SubscriptionLengthPicker extends React.Component {
 
 				<div className="subscription-length-picker__options">
 					{ productsWithPrices.map(
-						( { plan, planSlug, priceFullBeforeDiscount, priceFull, priceMonthly } ) => (
+						( { plan, planSlug, priceFullBeforeDiscount, priceMinusCredits, priceMonthly } ) => (
 							<div className="subscription-length-picker__option-container" key={ planSlug }>
 								<SubscriptionLengthOption
 									type={ hasDiscount ? 'upgrade' : 'new-sale' }
 									term={ plan.term }
 									checked={ planSlug === this.props.initialValue }
-									price={ myFormatCurrency( priceFull, this.props.currencyCode ) }
+									price={ myFormatCurrency( priceMinusCredits, this.props.currencyCode ) }
 									priceBeforeDiscount={ myFormatCurrency(
 										priceFullBeforeDiscount,
 										this.props.currencyCode

--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -29,7 +29,7 @@ export class SubscriptionLengthPicker extends React.Component {
 	static propTypes = {
 		initialValue: PropTypes.string,
 		plans: PropTypes.arrayOf( PropTypes.oneOf( Object.keys( PLANS_LIST ) ) ),
-
+		cart: PropTypes.object,
 		currencyCode: PropTypes.oneOf( Object.keys( CURRENCIES ) ).isRequired,
 		onChange: PropTypes.func,
 		translate: PropTypes.func.isRequired,
@@ -109,11 +109,12 @@ export function myFormatCurrency( price, code, options = {} ) {
 	return formatCurrency( price, code, hasCents ? options : { ...options, precision: 0 } );
 }
 
-export const mapStateToProps = ( state, { plans } ) => {
+export const mapStateToProps = ( state, { plans, cart } ) => {
 	const selectedSiteId = getSelectedSiteId( state );
+	const credits = cart.credits;
 	return {
 		currencyCode: getCurrentUserCurrencyCode( state ),
-		productsWithPrices: computeProductsWithPrices( state, selectedSiteId, plans ),
+		productsWithPrices: computeProductsWithPrices( state, selectedSiteId, plans, credits ),
 	};
 };
 

--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -68,27 +68,37 @@ export class SubscriptionLengthPicker extends React.Component {
 
 				<div className="subscription-length-picker__options">
 					{ productsWithPrices.map(
-						( { plan, planSlug, priceFullBeforeDiscount, priceMinusCredits, priceMonthly } ) => (
-							<div className="subscription-length-picker__option-container" key={ planSlug }>
-								<SubscriptionLengthOption
-									type={ hasDiscount ? 'upgrade' : 'new-sale' }
-									term={ plan.term }
-									checked={ planSlug === this.props.initialValue }
-									price={ myFormatCurrency( priceMinusCredits, this.props.currencyCode ) }
-									priceBeforeDiscount={ myFormatCurrency(
-										priceFullBeforeDiscount,
-										this.props.currencyCode
-									) }
-									pricePerMonth={ myFormatCurrency( priceMonthly, this.props.currencyCode ) }
-									savePercent={ Math.round(
-										100 * ( 1 - priceMonthly / this.getHighestMonthlyPrice() )
-									) }
-									value={ planSlug }
-									onCheck={ this.props.onChange }
-									shouldShowTax={ shouldShowTax }
-								/>
-							</div>
-						)
+						( {
+							plan,
+							planSlug,
+							priceFull,
+							priceFullBeforeDiscount,
+							priceMinusCredits,
+							priceMonthly,
+						} ) => {
+							const price = ! priceMinusCredits ? priceFull : priceMinusCredits;
+							return (
+								<div className="subscription-length-picker__option-container" key={ planSlug }>
+									<SubscriptionLengthOption
+										type={ hasDiscount ? 'upgrade' : 'new-sale' }
+										term={ plan.term }
+										checked={ planSlug === this.props.initialValue }
+										price={ myFormatCurrency( price, this.props.currencyCode ) }
+										priceBeforeDiscount={ myFormatCurrency(
+											priceFullBeforeDiscount,
+											this.props.currencyCode
+										) }
+										pricePerMonth={ myFormatCurrency( priceMonthly, this.props.currencyCode ) }
+										savePercent={ Math.round(
+											100 * ( 1 - priceMonthly / this.getHighestMonthlyPrice() )
+										) }
+										value={ planSlug }
+										onCheck={ this.props.onChange }
+										shouldShowTax={ shouldShowTax }
+									/>
+								</div>
+							);
+						}
 					) }
 				</div>
 			</div>

--- a/client/blocks/subscription-length-picker/test/index.js
+++ b/client/blocks/subscription-length-picker/test/index.js
@@ -26,12 +26,14 @@ describe( 'SubscriptionLengthPicker basic tests', () => {
 			planSlug: PLAN_BUSINESS,
 			plan: getPlan( PLAN_BUSINESS ),
 			priceFull: 1200,
+			priceMinusCredits: 1200,
 			priceMonthly: 100,
 		},
 		{
 			planSlug: PLAN_BUSINESS_2_YEARS,
 			plan: getPlan( PLAN_BUSINESS_2_YEARS ),
 			priceFull: 1800,
+			priceMinusCredits: 1800,
 			priceMonthly: 150,
 		},
 	];

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -646,6 +646,7 @@ export class Checkout extends React.Component {
 		return (
 			<React.Fragment>
 				<SubscriptionLengthPicker
+					cart={ this.props.cart }
 					plans={ availableTerms }
 					initialValue={ planInCart.product_slug }
 					onChange={ this.handleTermChange }

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -139,16 +139,17 @@ describe( 'selectors', () => {
 			getPlanRawPrice.mockImplementation( () => 150 );
 
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
-			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan ) ).toEqual( {
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0 ) ).toEqual( {
 				priceFullBeforeDiscount: 150,
 				priceFull: 120,
+				priceMinusCredits: 120,
 				priceMonthly: 10,
 			} );
 		} );
 	} );
 
 	describe( '#computeProductsWithPrices()', () => {
-		const plans = {
+		const testPlans = {
 			plan1: {
 				id: 1,
 				term: TERM_MONTHLY,
@@ -174,7 +175,7 @@ describe( 'selectors', () => {
 				return isMonthly ? 20 : 240;
 			} );
 
-			getPlan.mockImplementation( slug => plans[ slug ] );
+			getPlan.mockImplementation( slug => testPlans[ slug ] );
 		} );
 
 		test( 'Should return list of shapes { priceFull, priceFullBeforeDiscount, priceMonthly, plan, product, planSlug }', () => {
@@ -187,21 +188,23 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
 				{
 					planSlug: 'plan1',
-					plan: plans.plan1,
+					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
+					priceMinusCredits: 120,
 					priceMonthly: 10,
 				},
 				{
 					planSlug: 'plan2',
-					plan: plans.plan2,
+					plan: testPlans.plan2,
 					product: state.productsList.items.plan2,
 					priceFullBeforeDiscount: 150,
 					priceFull: 240,
+					priceMinusCredits: 240,
 					priceMonthly: 20,
 				},
 			] );
@@ -217,12 +220,13 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
 				{
 					planSlug: 'plan1',
-					plan: plans.plan1,
+					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
+					priceMinusCredits: 120,
 					priceFull: 120,
 					priceMonthly: 10,
 				},
@@ -238,13 +242,14 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
 				{
 					planSlug: 'plan1',
-					plan: plans.plan1,
+					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
+					priceMinusCredits: 120,
 					priceMonthly: 10,
 				},
 			] );
@@ -271,13 +276,14 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ] ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
 				{
 					planSlug: 'plan1',
-					plan: plans.plan1,
+					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
+					priceMinusCredits: 120,
 					priceMonthly: 10,
 				},
 			] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The SubscriptionLengthPicker doesn't support credits at the moment. We have three kinds of discounts present at the checkout. Two are applied to the product (coupons and upgrade discounts). One is a property to the shopping cart and historically a cart item. The SubscriptionLengthPicker works perfectly with the first two but ignores the third one. As a result, people who have credits left from different failures, see two prices on checkout.

#### Testing instructions

Try to buy a plan with accounts that have a few free credits (below the price of the 1-year plan), some credits (above 1-year, below 2-year), and a lot of credits (above 2-year). Make sure it makes sense to you.

Note: This is a second attempt for https://github.com/Automattic/wp-calypso/pull/30590
Important projects dragged us to different directions and it slipped into the cracks. I had problems rebasing so it was easier for me to reapply the changes on a new branch.

Fixes #