### PR TITLE
Migrate ellipsis menu styles to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -58,7 +58,6 @@
 @import 'components/domains/use-your-domain-step/style';
 @import 'components/domains/search-filters/style';
 @import 'components/drop-zone/style';
-@import 'components/ellipsis-menu/style';
 @import 'components/faq/style';
 @import 'components/foldable-card/style';
 @import 'components/formatted-header/style';

--- a/client/components/ellipsis-menu/index.jsx
+++ b/client/components/ellipsis-menu/index.jsx
@@ -17,6 +17,11 @@ import Gridicon from 'gridicons';
 import Button from 'components/button';
 import PopoverMenu from 'components/popover/menu';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class EllipsisMenu extends Component {
 	static propTypes = {
 		translate: PropTypes.func,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/ellipsis-menu` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR