### PR TITLE
Migrate MarkedLines style to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -97,7 +97,6 @@
 @import 'components/language-picker/style';
 @import 'components/locale-suggestions/style';
 @import 'components/main/style';
-@import 'components/marked-lines/style';
 @import 'components/marketing-survey/cancel-purchase-form/style';
 @import 'components/mini-site-preview/style';
 @import 'components/mobile-back-to-sidebar/style';

--- a/client/components/marked-lines/index.jsx
+++ b/client/components/marked-lines/index.jsx
@@ -7,6 +7,11 @@ import classNames from 'classnames';
 import { map } from 'lodash';
 
 /**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
  * Surrounds a text string in a <mark>
  * Just a small helper function
  *

--- a/client/components/marked-lines/style.scss
+++ b/client/components/marked-lines/style.scss
@@ -41,7 +41,7 @@
 
 .marked-lines__mark {
 	background-color: var( --color-error );
-	color: white;
+	color: var( --color-white );
 	border-radius: 4px;
 	padding: 2px 4px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/marked-lines` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR