### PR TITLE
Migrate input-chrono styles to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -89,7 +89,6 @@
 @import 'components/image/style';
 @import 'components/infinite-list/style';
 @import 'components/info-popover/style';
-@import 'components/input-chrono/style';
 @import 'components/keyed-suggestions/style';
 @import 'components/legend-item/style';
 @import 'components/list-end/style';

--- a/client/components/input-chrono/index.jsx
+++ b/client/components/input-chrono/index.jsx
@@ -10,6 +10,11 @@ import React from 'react';
 import chrono from 'chrono-node';
 
 /**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
  * Supported languages
  */
 const supportedLanguages = [ 'en', 'jp' ];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/input-chrono` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR

#### Notes

Previously fixed linter warnings here https://github.com/Automattic/wp-calypso/pull/31637