### PR TITLE
Migrate ListEnd styles to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -88,7 +88,6 @@
 @import 'components/info-popover/style';
 @import 'components/keyed-suggestions/style';
 @import 'components/legend-item/style';
-@import 'components/list-end/style';
 @import 'components/logged-out-form/style';
 @import 'components/language-picker/style';
 @import 'components/locale-suggestions/style';

--- a/client/components/list-end/index.js
+++ b/client/components/list-end/index.js
@@ -7,6 +7,11 @@
 import React from 'react';
 import Gridicon from 'gridicons';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default function ListEnd() {
 	return (
 		<div className="list-end">

--- a/client/components/list-end/style.scss
+++ b/client/components/list-end/style.scss
@@ -17,14 +17,4 @@
 		background: var( --color-neutral-0 );
 		padding: 0 8px;
 	}
-
-	// Reader is special since is has a white background, and has lots
-	// of random horizontal lines already.
-	.is-reader-page & {
-		border-top: none;
-
-		.gridicon {
-			background: var( --color-white );
-		}
-	}
 }

--- a/client/reader/components/reader-main/style.scss
+++ b/client/reader/components/reader-main/style.scss
@@ -1,5 +1,12 @@
-
 body.is-reader-page,
 .is-reader-page .layout {
 	background-color: var( --color-surface );
+}
+
+.is-reader-page .list-end {
+	border-top: none;
+	
+	.gridicon {
+	  background: var( --color-white );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/list-end` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR
- Another idea is to check `/posts/my` for a site. There should be a ListEnd at the far end.
- Also check if the ListEnd on a Reader's list looks fine. 