### PR TITLE
Add GoDaddy GoCentral to Site Import related copy in signup

### DIFF
--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -43,7 +43,9 @@ import Notice from 'components/notice';
 import './style.scss';
 
 const IMPORT_HELP_LINK = 'https://en.support.wordpress.com/import/';
+const EXAMPLE_CUSTOM_DOMAIN_URL = 'https://example.com';
 const EXAMPLE_WIX_URL = 'https://username.wixsite.com/my-site';
+const EXAMPLE_GOCENTRAL_URL = 'https://example.godaddysites.com';
 
 class ImportURLStepComponent extends Component {
 	state = {
@@ -202,7 +204,7 @@ class ImportURLStepComponent extends Component {
 						<FormTextInput
 							id="url-input"
 							className="import-url__url-input"
-							placeholder={ EXAMPLE_WIX_URL }
+							placeholder={ EXAMPLE_CUSTOM_DOMAIN_URL }
 							disabled={ isLoading }
 							defaultValue={ urlInputValue }
 							onChange={ this.handleInputChange }
@@ -233,16 +235,16 @@ class ImportURLStepComponent extends Component {
 						{ translate( 'Example URLs', {
 							comment: 'Title for list of example urls, such as "example.com"',
 						} ) }
-						<li className="import-url__example-url">https://example.com</li>
-
+						<li className="import-url__example-url">{ EXAMPLE_CUSTOM_DOMAIN_URL }</li>
 						<li className="import-url__example-url">{ EXAMPLE_WIX_URL }</li>
+						<li className="import-url__example-url">{ EXAMPLE_GOCENTRAL_URL }</li>
 					</ul>
 					<ExampleDomainBrowser className="import-url__example-browser" />
 				</div>
 
 				<div className="import-url__escape">
 					{ translate(
-						"Don't have a Wix site? We also support importing from {{a}}other sources{{/a}}.",
+						"Don't have a Wix or GoDaddy GoCentral site? We also support importing from {{a}}other sources{{/a}}.",
 						{
 							components: {
 								a: (
@@ -275,7 +277,7 @@ class ImportURLStepComponent extends Component {
 				positionInFlow={ positionInFlow }
 				headerText={ translate( 'Where can we find your old site?' ) }
 				subHeaderText={ translate(
-					"Enter your Wix site's URL, sometimes called a domain name or site address."
+					'Enter your Wix or GoDaddy GoCentral site URL, sometimes called a domain name or site address.'
 				) }
 				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With site-parsing support for GoDaddy GoCentral sites coming soon, this PR adds the relevant copy to our import signup flow to better communicate the import abilities.

Note: This is not to be merged until we're ready to 🚀- so I've left it as a draft for now.

#### Testing instructions

- Starting at http://calypso.localhost:3000/start/import/from-url
- Check the copy, is there any copy missed where only Wix is mentioned?
- Does the copy still all make sense with 2 services mentioned?