### PR TITLE
Migrate HeaderCake styles to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -85,7 +85,6 @@
 @import 'components/forms/sortable-list/style';
 @import 'components/happiness-support/style';
 @import 'components/header-button/style';
-@import 'components/header-cake/style';
 @import 'components/image/style';
 @import 'components/infinite-list/style';
 @import 'components/info-popover/style';

--- a/client/components/header-cake/back.jsx
+++ b/client/components/header-cake/back.jsx
@@ -18,6 +18,11 @@ import Button from 'components/button';
 import { getWindowInnerWidth } from 'lib/viewport';
 
 /**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
  * Module variables
  */
 const HIDE_BACK_CRITERIA = {

--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -39,7 +39,7 @@ export default class HeaderCake extends Component {
 			<Card className={ classes }>
 				<HeaderCakeBack text={ backText } href={ backHref } onClick={ this.props.onClick } />
 
-				<div className="header-cake__title" onClick={ this.props.onTitleClick }>
+				<div className="header-cake__title" role="presentation" onClick={ this.props.onTitleClick }>
 					{ this.props.children }
 				</div>
 

--- a/client/components/header-cake/index.jsx
+++ b/client/components/header-cake/index.jsx
@@ -14,6 +14,11 @@ import classNames from 'classnames';
 import Card from 'components/card';
 import HeaderCakeBack from './back';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class HeaderCake extends Component {
 	render() {
 		const {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit the `/me/account` page on the live branch available below
- Click on the account closure feature
- Test the HeaderCake at the top of this page, and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR
- Additionally test with a RTL language like Hebrew and ensure that the back button (on the same account closure page) points from left to right

**Expected view:**

![Screenshot 2019-03-30 at 21 01 20](https://user-images.githubusercontent.com/18581859/55278622-c630c300-5334-11e9-9975-56bac6108a5c.png)

**Broken view without styling:**

![Screenshot 2019-03-30 at 21 01 23](https://user-images.githubusercontent.com/18581859/55278624-c6c95980-5334-11e9-8f01-f41246555d17.png)