### PR TITLE
Migrate HeaderButton styles to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -76,7 +76,6 @@
 @import 'components/forms/form-toggle/style';
 @import 'components/forms/range/style';
 @import 'components/forms/sortable-list/style';
-@import 'components/header-button/style';
 @import 'components/image/style';
 @import 'components/infinite-list/style';
 @import 'components/info-popover/style';

--- a/client/components/header-button/index.jsx
+++ b/client/components/header-button/index.jsx
@@ -11,6 +11,11 @@ import Gridicon from 'gridicons';
  */
 import Button from 'components/button';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const HeaderButton = ( { icon, label, ...rest } ) => (
 	<Button className="header-button" { ...rest }>
 		{ icon && <Gridicon icon={ icon } size={ 18 } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/header-button` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR
- Additionally check the `Upload plugin` button on `/plugins/{site}` with a WordPress.com Business plan site. Ensure that the cloud gridicon appears the same way as it does on `master` branch.

![Screenshot 2019-03-30 at 20 58 17](https://user-images.githubusercontent.com/18581859/55278575-2a06bc00-5334-11e9-9065-42a364fb473d.png)