### PR TITLE
Migrate ThemesList styles to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -121,7 +121,6 @@
 @import 'components/sub-masterbar-nav/style';
 @import 'components/text-diff/style';
 @import 'components/theme/style';
-@import 'components/themes-list/style';
 @import 'components/pagination/style';
 @import 'components/tooltip/style';
 @import 'components/upgrades/gsuite/gsuite-dialog/style';

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -17,6 +17,11 @@ import EmptyContent from 'components/empty-content';
 import InfiniteScroll from 'components/infinite-scroll';
 import { DEFAULT_THEME_QUERY } from 'state/themes/constants';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class ThemesList extends React.Component {
 	static propTypes = {
 		themes: PropTypes.array.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/themes` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR