### PR TITLE
Migrate FoldableCard styles to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -46,7 +46,6 @@
 @import 'components/domains/search-filters/style';
 @import 'components/drop-zone/style';
 @import 'components/faq/style';
-@import 'components/foldable-card/style';
 @import 'components/forms/form-button/style';
 @import 'components/forms/form-buttons-bar/style';
 @import 'components/forms/form-currency-input/style';

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -18,6 +18,11 @@ import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
 import ScreenReaderText from 'components/screen-reader-text';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class FoldableCard extends Component {
 	static displayName = 'FoldableCard';
 

--- a/client/components/foldable-card/index.jsx
+++ b/client/components/foldable-card/index.jsx
@@ -95,7 +95,7 @@ class FoldableCard extends Component {
 		const clickAction = ! this.props.clickableHeader ? this.getClickAction() : null;
 		if ( this.props.actionButton ) {
 			return (
-				<div className="foldable-card__action" onClick={ clickAction }>
+				<div className="foldable-card__action" role="presentation" onClick={ clickAction }>
 					{ this.getActionButton() }
 				</div>
 			);
@@ -134,7 +134,7 @@ class FoldableCard extends Component {
 			'has-border': !! this.props.summary,
 		} );
 		return (
-			<div className={ headerClasses } onClick={ headerClickAction }>
+			<div className={ headerClasses } role="presentation" onClick={ headerClickAction }>
 				<span className="foldable-card__main">{ this.props.header } </span>
 				<span className="foldable-card__secondary">
 					{ summary }

--- a/client/components/tinymce/plugins/contact-form/style.scss
+++ b/client/components/tinymce/plugins/contact-form/style.scss
@@ -1,20 +1,3 @@
-.editor-contact-form-modal {
-	padding: 0;
-
-	/* override color of the expanded icon on the foldable card */
-	.editor-contact-form-modal-fields
-		.foldable-card.is-expanded
-		.foldable-card__action.foldable-card__expand
-		.gridicon {
-		fill: var( --color-accent );
-	}
-
-	/* removes the transform on the icon when opening the foldable card */
-	button.foldable-card__action.foldable-card__expand .gridicon.gridicons-pencil {
-		transform: none;
-	}
-}
-
 .editor-contact-form-modal.dialog.card {
 	position: absolute;
 	top: 0;
@@ -73,9 +56,10 @@
 }
 
 .editor-contact-form-modal-fields {
-	.card {
+	.foldable-card.card {
 		border-radius: 4px;
 	}
+
 	.foldable-card__main {
 		min-width: 0;
 		word-wrap: break-word;
@@ -107,21 +91,20 @@
 	}
 }
 
-.editor-contact-form-modal-field__edit-wrapper {
+.editor-contact-form-modal-field__edit-wrapper.foldable-card__expand {
 	height: 100%;
+
+	.editor-contact-form-modal-field__edit {
+		width: 100%;
+		padding-bottom: 6px;
+
+		&.is-expanded {
+			transform: rotate( 0 );
+		}
+	}
 }
 
 .editor-contact-form-modal-field__edit-wrapper-button {
 	width: 100%;
 	height: 100%;
-}
-
-.editor-contact-form-modal-field__edit-wrapper.foldable-card__expand
-	.editor-contact-form-modal-field__edit {
-	width: 100%;
-	padding-bottom: 6px;
-
-	&.is-expanded {
-		transform: rotate( 0 );
-	}
 }

--- a/client/my-sites/activity/activity-log-item/style.scss
+++ b/client/my-sites/activity/activity-log-item/style.scss
@@ -21,7 +21,7 @@
 	}
 }
 
-.activity-log-item .foldable-card {
+.activity-log-item .foldable-card.card {
 	.foldable-card__expand .gridicon {
 		transform: none;
 	}
@@ -42,7 +42,7 @@
 	}
 
 	// TODO: Remove when foldable cards become "expandable"
-	.is-clickable {
+	&.is-clickable {
 		cursor: default;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/foldable-card` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR