### PR TITLE
Migrate FormattedHeader styles to JS imports

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -61,7 +61,6 @@
 @import 'components/ellipsis-menu/style';
 @import 'components/faq/style';
 @import 'components/foldable-card/style';
-@import 'components/formatted-header/style';
 @import 'components/forms/form-button/style';
 @import 'components/forms/form-buttons-bar/style';
 @import 'components/forms/form-currency-input/style';

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -34,7 +34,7 @@ function FormattedHeader( { id, headerText, subHeaderText } ) {
 }
 
 FormattedHeader.propTypes = {
-	headerText: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),
+	headerText: PropTypes.node,
 	subHeaderText: PropTypes.node,
 };
 

--- a/client/components/formatted-header/index.jsx
+++ b/client/components/formatted-header/index.jsx
@@ -13,6 +13,11 @@ import classNames from 'classnames';
  */
 import { preventWidows } from 'lib/formatting';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 function FormattedHeader( { id, headerText, subHeaderText } ) {
 	const classes = classNames( 'formatted-header', {
 		'is-without-subhead': ! subHeaderText,

--- a/client/jetpack-connect/plans-placeholder.js
+++ b/client/jetpack-connect/plans-placeholder.js
@@ -10,19 +10,18 @@ import { times, random } from 'lodash';
  * Internal dependencies
  */
 import Main from 'components/main';
+import FormattedHeader from 'components/formatted-header';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const placeholderContent = (
 	<Main className="jetpack-connect__hide-plan-icons" wideLayout>
 		<div className="jetpack-connect__plans placeholder">
-			<header className="formatted-header">
-				<h1 className="formatted-header__title">
-					<span className="placeholder-text">Your site is now connected!</span>
-				</h1>
-				<p className="formatted-header__subtitle">
+			<FormattedHeader
+				headerText={ <span className="placeholder-text">Your site is now connected!</span> }
+				subHeaderText={
 					<span className="placeholder-text">Now pick a plan that's right for you.</span>
-				</p>
-			</header>
+				}
+			/>
 
 			<div className="plans-wrapper">
 				<div className="plan-features plan-features--signup">

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -40,6 +40,7 @@ import { INPUT_VALIDATION, REDIRECTING_FOR_AUTHORIZATION } from 'lib/store-trans
 import { getTld } from 'lib/domains';
 import { displayError, clear } from 'lib/upgrades/notices';
 import { removeNestedProperties } from 'lib/cart/store/cart-analytics';
+import FormattedHeader from 'components/formatted-header';
 
 /**
  * Module variables
@@ -564,16 +565,10 @@ export class SecurePaymentForm extends Component {
 	};
 
 	renderGreatChoiceHeader() {
-		const formatHeaderClass = 'formatted-header',
-			formatHeaderTitleClass = 'formatted-header__title';
+		const { translate } = this.props;
+		const headerText = translate( 'Great choice! How would you like to pay?' );
 
-		return (
-			<header className={ formatHeaderClass }>
-				<h1 className={ formatHeaderTitleClass }>
-					{ this.props.translate( 'Great choice! How would you like to pay?' ) }
-				</h1>
-			</header>
-		);
+		return <FormattedHeader headerText={ headerText } />;
 	}
 
 	render() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Removes individual stylesheet imports and imports them via webpack inside components/blocks. Read https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/formatted-header` on the live branch available below
- Test the feature here and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR

<img width="1541" alt="Screenshot 2019-03-30 at 21 41 39" src="https://user-images.githubusercontent.com/18581859/55278613-a1d4e680-5334-11e9-950f-c8ed92381cc1.png">