### PR TITLE
Inline Help: Adding internal Calypso links to inline help search results.

### DIFF
--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -83,7 +83,7 @@ const adminSections = ( siteId, siteSlug ) => [
 		sidebarLabel: 'Import',
 	},
 	{
-		title: 'Earn money from your content and traffic',
+		title: 'Earn money from my content and traffic',
 		description:
 			"By upgrading to the Premium plan, you'll be able to monetize your site through the WordAds program.",
 		link: `/earn/${ siteId }`,
@@ -91,7 +91,7 @@ const adminSections = ( siteId, siteSlug ) => [
 		sidebarLabel: 'Earn',
 	},
 	{
-		title: "Manage your site's users",
+		title: "Manage my site's users",
 		description: '',
 		link: `/people/team/${ siteId }`,
 		synonyms: [ 'administrator', 'editor', 'contributor', 'viewer', 'follower' ],
@@ -105,13 +105,13 @@ const adminSections = ( siteId, siteSlug ) => [
 		sidebarLabel: 'People',
 	},
 	{
-		title: "Change your site's timezone",
+		title: "Change my site's timezone",
 		description: '',
 		link: `/settings/general/${ siteId }`,
 		sidebarLabel: 'Settings',
 	},
 	{
-		title: "Change your site's footer text",
+		title: "Change my site's footer text",
 		description: 'You can customize your website by changing the footer credit in customizer.',
 		link: `/settings/general/${ siteId }`,
 		synonyms: [ 'remove footer', 'update footer' ],

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { includes, words } from 'lodash';
+import { intersection, memoize, words } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -11,126 +11,251 @@ import { includes, words } from 'lodash';
 /**
  * Returns admin section items with site-based urls
  *
- * @param {Int} siteId The currentsite id
  * @param {String} siteSlug The current site slug
  * @returns {Array} An array of admin sections with site-specific URLs
  */
-const adminSections = ( siteId, siteSlug ) => [
+const adminSections = memoize( siteSlug => [
 	{
-		title: 'Add a domain',
+		title: 'Add a new domain',
 		description: 'Set up your domain whether it’s registered with WordPress.com or elsewhere.',
 		link: `/domains/add/${ siteSlug }`,
-		sidebarLabel: 'Domains',
+		icon: 'domains',
 	},
 	{
-		title: 'Domain settings',
+		title: 'Manage my domain settings',
 		description: 'Manage your domain settings',
-		link: `/domains/manage/{site_slug}/edit/${ siteSlug }`,
-		sidebarLabel: 'Domains',
+		link: `/domains/manage/${ siteSlug }`,
+		icon: 'domains',
 	},
 	{
 		title: 'Change my site address',
 		description: '',
-		link: `/domains/manage/{site_slug}/edit/${ siteSlug }`,
+		link: `/domains/manage/${ siteSlug }`,
 		synonyms: [ 'domain' ],
-		sidebarLabel: 'Domains',
+		icon: 'domains',
+	},
+	{
+		title: 'Add a site redirect',
+		description: 'Redirect your site to another domain.',
+		link: `/domains/add/site-redirect/${ siteSlug }`,
+		synonyms: [ 'domain', 'forward' ],
+		icon: 'domains',
 	},
 	{
 		title: 'Change my password',
 		description: '',
 		link: '/me/security',
 		synonyms: [ 'update' ],
-		sidebarLabel: 'Settings',
+		icon: 'cog',
 	},
 	{
 		title: "Change my site's theme",
 		description: '',
 		link: `/themes/${ siteSlug }`,
 		synonyms: [ 'switch' ],
-		sidebarLabel: 'Customize',
+		icon: 'customize',
 	},
 	{
-		title: 'Show me plans to suit my site',
+		title: 'Find a plan to suit my site',
 		description: '',
 		link: `/plans/${ siteSlug }`,
-		sidebarLabel: 'Plan',
+		icon: 'plans',
 	},
 	{
 		title: 'View my site activity',
 		description: '',
 		link: `/activity-log/${ siteSlug }`,
-		sidebarLabel: 'Activity',
+		icon: 'history',
 	},
 	{
 		title: "View my site's latest statistics",
 		description: '',
-		link: `/stats/day/${ siteId }`,
+		link: `/stats/day/${ siteSlug }`,
 		synonyms: [ 'analytics' ],
-		sidebarLabel: 'Stats',
+		icon: 'stats-alt',
 	},
 	{
 		title: 'Upload an image, video, audio or document',
 		description: '',
-		link: `/stats/day/${ siteId }`,
+		link: `/media/${ siteSlug }`,
 		synonyms: [ 'media', 'photo' ],
-		sidebarLabel: 'Media',
+		icon: 'image',
 	},
 	{
 		title: 'Import content from another site',
 		description: '',
-		link: `/settings/import/${ siteId }`,
+		link: `/settings/import/${ siteSlug }`,
 		synonyms: [ 'medium', 'blogger', 'wix', 'squarespace' ],
-		sidebarLabel: 'Import',
+		icon: 'cloud-upload',
 	},
 	{
 		title: 'Earn money from my content and traffic',
 		description:
 			"By upgrading to the Premium plan, you'll be able to monetize your site through the WordAds program.",
-		link: `/earn/${ siteId }`,
+		link: `/earn/${ siteSlug }`,
 		synonyms: [ 'monetize', 'wordads', 'premium' ],
-		sidebarLabel: 'Earn',
+		icon: 'money',
 	},
 	{
 		title: "Manage my site's users",
-		description: '',
-		link: `/people/team/${ siteId }`,
+		description: 'Invite new users and edit existing ones.',
+		link: `/people/team/${ siteSlug }`,
 		synonyms: [ 'administrator', 'editor', 'contributor', 'viewer', 'follower' ],
-		sidebarLabel: 'People',
+		icon: 'user',
 	},
 	{
-		title: 'Invite new users to your site',
+		title: 'Invite new users to my site',
 		description: '',
-		link: `/people/new/${ siteId }`,
+		link: `/people/new/${ siteSlug }`,
 		synonyms: [ 'administrator', 'editor', 'contributor', 'viewer', 'follower' ],
-		sidebarLabel: 'People',
+		icon: 'user',
 	},
 	{
 		title: "Change my site's timezone",
 		description: '',
-		link: `/settings/general/${ siteId }`,
-		sidebarLabel: 'Settings',
+		link: `/settings/general/${ siteSlug }`,
+		synonyms: [ 'time', 'date' ],
+		icon: 'cog',
+	},
+	{
+		title: 'Launch my site',
+		description: 'Switch your site from private to public.',
+		link: `/settings/general/${ siteSlug }`,
+		synonyms: [ 'private', 'public' ],
+		icon: 'cog',
+	},
+	{
+		title: "Delete a site or a site's content",
+		description: 'Remove all posts, pages, and media, or delete a site completely.',
+		link: `/settings/general/${ siteSlug }`,
+		icon: 'cog',
 	},
 	{
 		title: "Change my site's footer text",
 		description: 'You can customize your website by changing the footer credit in customizer.',
-		link: `/settings/general/${ siteId }`,
+		link: `/settings/general/${ siteSlug }`,
 		synonyms: [ 'remove footer', 'update footer' ],
-		sidebarLabel: 'Settings',
+		icon: 'cog',
 	},
-];
+	{
+		title: "Export my site's content and media library",
+		description: 'Export posts, pages and more from your site.',
+		link: `/settings/export/${ siteSlug }`,
+		synonyms: [ 'xml', 'images', 'migration', 'import', 'download' ],
+		icon: 'cog',
+	},
+	{
+		title: 'Manage sharing and social media connections',
+		description: 'You can customize your website by changing the footer credit in customizer.',
+		link: `/sharing/${ siteSlug }`,
+		synonyms: [ 'facebook', 'twitter', 'twitter', 'tumblr', 'eventbrite' ],
+		icon: 'share',
+	},
+	{
+		title: 'Add sharing buttons to my site',
+		description:
+			'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.',
+		link: `/sharing/buttons/${ siteSlug }`,
+		synonyms: [ 'like', 'reblog' ],
+		icon: 'share',
+	},
+	{
+		title: 'Install, manage and search for site plugins',
+		description: 'You can customize your website by changing the footer credit in customizer.',
+		link: `/plugins/${ siteSlug }`,
+		synonyms: [ 'upload' ],
+		icon: 'plugins',
+	},
+	{
+		title: 'Approve or remove comments',
+		description: '',
+		link: `/comments/all/${ siteSlug }`,
+		synonyms: [ 'spam', 'discussion', 'moderation', 'moderate' ],
+		icon: 'chat',
+	},
+	{
+		title: 'Manage how users can comment on my site',
+		link: `/settings/discussion/${ siteSlug }`,
+		synonyms: [ 'discussion', 'moderation', 'blacklist' ],
+		icon: 'cog',
+	},
+	{
+		title: 'Manage SEO and traffic settings',
+		link: `/settings/traffic/${ siteSlug }`,
+		synonyms: [ 'analytics', 'related', 'sitemap' ],
+		icon: 'cog',
+	},
+	{
+		title: 'Update my profile',
+		description: 'Update your name, profile image, and about text.',
+		link: `/me`,
+		synonyms: [ 'avatar' ],
+		icon: 'user',
+	},
+	{
+		title: 'Update my username or email address',
+		description: '',
+		link: `/me/account`,
+		synonyms: [ 'user', 'account' ],
+		icon: 'cog',
+	},
+	{
+		title: 'Change the dashboard color scheme',
+		description: '',
+		link: `/me/account`,
+		synonyms: [ 'theme' ],
+		icon: 'cog',
+	},
+	{
+		title: 'Switch the interface language',
+		description: 'Update the language of the interface you see across WordPress.com as a whole.',
+		link: `/me/account`,
+		synonyms: [ 'dashboard', 'change', 'language' ],
+		icon: 'cog',
+	},
+	{
+		title: 'Close my account permanently',
+		description: 'Delete all of your sites, and close your account completely.',
+		link: `/me/account/close`,
+		synonyms: [ 'delete' ],
+		icon: 'cog',
+	},
+	{
+		title: 'Change my privacy settings',
+		description: '',
+		link: `/me/privacy`,
+		synonyms: [ 'security', 'tracking' ],
+		icon: 'visible',
+	},
+	{
+		title: 'View my purchase and billing history',
+		description: '',
+		link: `/me/purchases`,
+		synonyms: [ 'purchases', 'invoices', 'pending', 'payment', 'credit card' ],
+		icon: 'credit-card',
+	},
+	{
+		title: 'Download the WordPress.com app for my device',
+		description: 'Get WordPress apps for all your screens.',
+		link: `/me/get-apps`,
+		synonyms: [ 'android', 'iphone', 'mobile', 'desktop', 'phone' ],
+		icon: 'my-sites',
+	},
+] );
 
 /**
  * Returns a filtered site admin collection
  *
- * @param {String} searchTerm The search term
- * @param {Array} collection A collection of site admin objects
- * @returns {Array?} An filtered array
+ * @param   {String} searchTerm The search term
+ * @param   {Array}  collection A collection of site admin objects
+ * @param   {Number} limit      The maximum number of results to show
+ * @returns {Array}             A filtered (or empty) array
  */
-export function filterListBySearchTerm( searchTerm = '', collection ) {
+export function filterListBySearchTerm( searchTerm = '', collection = [], limit = 4 ) {
 	const searchTermWords = words( searchTerm ).map( word => word.toLowerCase() );
 
 	if ( searchTermWords.length < 1 ) {
-		return;
+		return [];
 	}
 
 	const searchRegex = new RegExp(
@@ -148,14 +273,26 @@ export function filterListBySearchTerm( searchTerm = '', collection ) {
 	);
 
 	return collection
-		.filter( item => searchRegex.test( item.title ) || includes( item.synonyms, searchTerm ) )
-		.map( item => ( { ...item, type: 'internal' } ) );
+		.filter(
+			item =>
+				searchRegex.test( item.title ) || intersection( item.synonyms, searchTermWords ).length
+		)
+		.map( item => ( { ...item, type: 'internal', key: item.title } ) )
+		.slice( 0, limit );
 }
 
-export function getAdminSectionsResults( searchTerm = '', siteId = '', siteSlug = '' ) {
-	if ( ! siteSlug || ! searchTerm || ! siteId ) {
-		return;
+/**
+ * Returns a filtered site admin collection using the memoized adminSections.
+ *
+ * @param   {String} searchTerm The search term
+ * @param   {String} siteSlug   The current site slug
+ * @param   {Number} limit      The maximum number of results to show
+ * @returns {Array}             A filtered (or empty) array
+ */
+export function getAdminSectionsResults( searchTerm = '', siteSlug, limit ) {
+	if ( ! searchTerm ) {
+		return [];
 	}
 
-	return filterListBySearchTerm( searchTerm, adminSections( siteId, siteSlug ) );
+	return filterListBySearchTerm( searchTerm, adminSections( siteSlug || '' ), limit );
 }

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -1,0 +1,161 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { includes, words } from 'lodash';
+
+/**
+ * Internal Dependencies
+ */
+
+/**
+ * Returns admin section items with site-based urls
+ *
+ * @param {Int} siteId The currentsite id
+ * @param {String} siteSlug The current site slug
+ * @returns {Array} An array of admin sections with site-specific URLs
+ */
+const adminSections = ( siteId, siteSlug ) => [
+	{
+		title: 'Add a domain',
+		description: 'Set up your domain whether it’s registered with WordPress.com or elsewhere.',
+		link: `/domains/add/${ siteSlug }`,
+		sidebarLabel: 'Domains',
+	},
+	{
+		title: 'Domain settings',
+		description: 'Manage your domain settings',
+		link: `/domains/manage/{site_slug}/edit/${ siteSlug }`,
+		sidebarLabel: 'Domains',
+	},
+	{
+		title: 'Change my site address',
+		description: '',
+		link: `/domains/manage/{site_slug}/edit/${ siteSlug }`,
+		synonyms: [ 'domain' ],
+		sidebarLabel: 'Domains',
+	},
+	{
+		title: 'Change my password',
+		description: '',
+		link: '/me/security',
+		synonyms: [ 'update' ],
+		sidebarLabel: 'Settings',
+	},
+	{
+		title: "Change my site's theme",
+		description: '',
+		link: `/themes/${ siteSlug }`,
+		synonyms: [ 'switch' ],
+		sidebarLabel: 'Customize',
+	},
+	{
+		title: 'Show me plans to suit my site',
+		description: '',
+		link: `/plans/${ siteSlug }`,
+		sidebarLabel: 'Plan',
+	},
+	{
+		title: 'View my site activity',
+		description: '',
+		link: `/activity-log/${ siteSlug }`,
+		sidebarLabel: 'Activity',
+	},
+	{
+		title: "View my site's latest statistics",
+		description: '',
+		link: `/stats/day/${ siteId }`,
+		synonyms: [ 'analytics' ],
+		sidebarLabel: 'Stats',
+	},
+	{
+		title: 'Upload an image, video, audio or document',
+		description: '',
+		link: `/stats/day/${ siteId }`,
+		synonyms: [ 'media', 'photo' ],
+		sidebarLabel: 'Media',
+	},
+	{
+		title: 'Import content from another site',
+		description: '',
+		link: `/settings/import/${ siteId }`,
+		synonyms: [ 'medium', 'blogger', 'wix', 'squarespace' ],
+		sidebarLabel: 'Import',
+	},
+	{
+		title: 'Earn money from your content and traffic',
+		description:
+			"By upgrading to the Premium plan, you'll be able to monetize your site through the WordAds program.",
+		link: `/earn/${ siteId }`,
+		synonyms: [ 'monetize', 'wordads', 'premium' ],
+		sidebarLabel: 'Earn',
+	},
+	{
+		title: "Manage your site's users",
+		description: '',
+		link: `/people/team/${ siteId }`,
+		synonyms: [ 'administrator', 'editor', 'contributor', 'viewer', 'follower' ],
+		sidebarLabel: 'People',
+	},
+	{
+		title: 'Invite new users to your site',
+		description: '',
+		link: `/people/new/${ siteId }`,
+		synonyms: [ 'administrator', 'editor', 'contributor', 'viewer', 'follower' ],
+		sidebarLabel: 'People',
+	},
+	{
+		title: "Change your site's timezone",
+		description: '',
+		link: `/settings/general/${ siteId }`,
+		sidebarLabel: 'Settings',
+	},
+	{
+		title: "Change your site's footer text",
+		description: 'You can customize your website by changing the footer credit in customizer.',
+		link: `/settings/general/${ siteId }`,
+		synonyms: [ 'remove footer', 'update footer' ],
+		sidebarLabel: 'Settings',
+	},
+];
+
+/**
+ * Returns a filtered site admin collection
+ *
+ * @param {String} searchTerm The search term
+ * @param {Array} collection A collection of site admin objects
+ * @returns {Array?} An filtered array
+ */
+export function filterListBySearchTerm( searchTerm = '', collection ) {
+	const searchTermWords = words( searchTerm ).map( word => word.toLowerCase() );
+
+	if ( searchTermWords.length < 1 ) {
+		return;
+	}
+
+	const searchRegex = new RegExp(
+		// Join a series of look aheads
+		// matching full and partial works
+		// Example: "Add a dom" => /(?=.*\badd\b)(?=.*\ba\b)(?=.*\bdom).+/gi
+		searchTermWords
+			.map( ( word, i ) =>
+				// if it's the last word, don't look for a end word boundary
+				// otherwise
+				i + 1 === searchTermWords.length ? `(?=.*\\b${ word })` : `(?=.*\\b${ word }\\b)`
+			)
+			.join( '' ) + '.+',
+		'gi'
+	);
+
+	return collection
+		.filter( item => searchRegex.test( item.title ) || includes( item.synonyms, searchTerm ) )
+		.map( item => ( { ...item, type: 'internal' } ) );
+}
+
+export function getAdminSectionsResults( searchTerm = '', siteId = '', siteSlug = '' ) {
+	if ( ! siteSlug || ! searchTerm || ! siteId ) {
+		return;
+	}
+
+	return filterListBySearchTerm( searchTerm, adminSections( siteId, siteSlug ) );
+}

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -19,6 +19,7 @@ const adminSections = memoize( siteSlug => [
 		title: 'Add a new domain',
 		description: 'Set up your domain whether it’s registered with WordPress.com or elsewhere.',
 		link: `/domains/add/${ siteSlug }`,
+		synonyms: [ 'domain' ],
 		icon: 'domains',
 	},
 	{
@@ -59,6 +60,7 @@ const adminSections = memoize( siteSlug => [
 		title: 'Find a plan to suit my site',
 		description: '',
 		link: `/plans/${ siteSlug }`,
+		synonyms: [ 'upgrade', 'business', 'profressional', 'personal' ],
 		icon: 'plans',
 	},
 	{

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -31,7 +31,7 @@ const adminSections = memoize( siteSlug => [
 	{
 		title: 'Change my site address',
 		description: '',
-		link: `/domains/manage/${ siteSlug }`,
+		link: `/domains/manage/${ siteSlug }/edit/${ siteSlug }`,
 		synonyms: [ 'domain' ],
 		icon: 'domains',
 	},
@@ -53,7 +53,14 @@ const adminSections = memoize( siteSlug => [
 		title: "Change my site's theme",
 		description: '',
 		link: `/themes/${ siteSlug }`,
-		synonyms: [ 'switch' ],
+		synonyms: [ 'switch', 'design' ],
+		icon: 'customize',
+	},
+	{
+		title: "Customize my site's theme",
+		description: '',
+		link: `/customize/${ siteSlug }`,
+		synonyms: [ 'color', 'font', 'design', 'css', 'widgets' ],
 		icon: 'customize',
 	},
 	{
@@ -97,6 +104,13 @@ const adminSections = memoize( siteSlug => [
 		link: `/earn/${ siteSlug }`,
 		synonyms: [ 'monetize', 'wordads', 'premium' ],
 		icon: 'money',
+	},
+	{
+		title: 'Learn how to market my site',
+		description: '',
+		link: `/marketing/tools/${ siteSlug }`,
+		synonyms: [ 'marketing', 'brand', 'logo', 'seo', 'tools', 'traffic' ],
+		icon: 'speaker',
 	},
 	{
 		title: "Manage my site's users",

--- a/client/blocks/inline-help/admin-sections.js
+++ b/client/blocks/inline-help/admin-sections.js
@@ -3,6 +3,8 @@
  * External dependencies
  */
 import { intersection, memoize, words } from 'lodash';
+import { translate } from 'i18n-calypso';
+import { getLocaleSlug } from 'lib/i18n-utils';
 
 /**
  * Internal Dependencies
@@ -16,243 +18,237 @@ import { intersection, memoize, words } from 'lodash';
  */
 const adminSections = memoize( siteSlug => [
 	{
-		title: 'Add a new domain',
-		description: 'Set up your domain whether it’s registered with WordPress.com or elsewhere.',
+		title: translate( 'Add a new domain' ),
+		description: translate(
+			'Set up your domain whether it’s registered with WordPress.com or elsewhere.'
+		),
 		link: `/domains/add/${ siteSlug }`,
 		synonyms: [ 'domain' ],
 		icon: 'domains',
 	},
 	{
-		title: 'Manage my domain settings',
-		description: 'Manage your domain settings',
+		title: translate( 'Manage my domain settings' ),
 		link: `/domains/manage/${ siteSlug }`,
 		icon: 'domains',
 	},
 	{
-		title: 'Change my site address',
-		description: '',
+		title: translate( 'Change my site address' ),
 		link: `/domains/manage/${ siteSlug }/edit/${ siteSlug }`,
 		synonyms: [ 'domain' ],
 		icon: 'domains',
 	},
 	{
-		title: 'Add a site redirect',
-		description: 'Redirect your site to another domain.',
+		title: translate( 'Add a site redirect' ),
+		description: translate( 'Redirect your site to another domain.' ),
 		link: `/domains/add/site-redirect/${ siteSlug }`,
 		synonyms: [ 'domain', 'forward' ],
 		icon: 'domains',
 	},
 	{
-		title: 'Change my password',
-		description: '',
+		title: translate( 'Change my password' ),
 		link: '/me/security',
 		synonyms: [ 'update' ],
 		icon: 'cog',
 	},
 	{
-		title: "Change my site's theme",
-		description: '',
+		title: translate( "Change my site's theme" ),
 		link: `/themes/${ siteSlug }`,
 		synonyms: [ 'switch', 'design' ],
 		icon: 'customize',
 	},
 	{
-		title: "Customize my site's theme",
-		description: '',
+		title: translate( "Customize my site's theme" ),
 		link: `/customize/${ siteSlug }`,
 		synonyms: [ 'color', 'font', 'design', 'css', 'widgets' ],
 		icon: 'customize',
 	},
 	{
-		title: 'Find a plan to suit my site',
-		description: '',
+		title: translate( 'Find a plan to suit my site' ),
 		link: `/plans/${ siteSlug }`,
 		synonyms: [ 'upgrade', 'business', 'profressional', 'personal' ],
 		icon: 'plans',
 	},
 	{
-		title: 'View my site activity',
-		description: '',
+		title: translate( 'View my site activity' ),
 		link: `/activity-log/${ siteSlug }`,
 		icon: 'history',
 	},
 	{
-		title: "View my site's latest statistics",
-		description: '',
+		title: translate( "View my site's latest statistics" ),
 		link: `/stats/day/${ siteSlug }`,
 		synonyms: [ 'analytics' ],
 		icon: 'stats-alt',
 	},
 	{
-		title: 'Upload an image, video, audio or document',
-		description: '',
+		title: translate( 'Upload an image, video, audio or document' ),
 		link: `/media/${ siteSlug }`,
 		synonyms: [ 'media', 'photo' ],
 		icon: 'image',
 	},
 	{
-		title: 'Import content from another site',
-		description: '',
+		title: translate( 'Import content from another site' ),
 		link: `/settings/import/${ siteSlug }`,
 		synonyms: [ 'medium', 'blogger', 'wix', 'squarespace' ],
 		icon: 'cloud-upload',
 	},
 	{
-		title: 'Earn money from my content and traffic',
-		description:
-			"By upgrading to the Premium plan, you'll be able to monetize your site through the WordAds program.",
+		title: translate( 'Earn money from my content and traffic' ),
+		description: translate(
+			"By upgrading to the Premium plan, you'll be able to monetize your site through the WordAds program."
+		),
 		link: `/earn/${ siteSlug }`,
 		synonyms: [ 'monetize', 'wordads', 'premium' ],
 		icon: 'money',
 	},
 	{
-		title: 'Learn how to market my site',
-		description: '',
+		title: translate( 'Learn how to market my site' ),
 		link: `/marketing/tools/${ siteSlug }`,
 		synonyms: [ 'marketing', 'brand', 'logo', 'seo', 'tools', 'traffic' ],
 		icon: 'speaker',
 	},
 	{
-		title: "Manage my site's users",
-		description: 'Invite new users and edit existing ones.',
+		title: translate( "Manage my site's users" ),
+		description: translate( 'Invite new users and edit existing ones.' ),
 		link: `/people/team/${ siteSlug }`,
 		synonyms: [ 'administrator', 'editor', 'contributor', 'viewer', 'follower' ],
 		icon: 'user',
 	},
 	{
-		title: 'Invite new users to my site',
-		description: '',
+		title: translate( 'Invite new users to my site' ),
 		link: `/people/new/${ siteSlug }`,
 		synonyms: [ 'administrator', 'editor', 'contributor', 'viewer', 'follower' ],
 		icon: 'user',
 	},
 	{
-		title: "Change my site's timezone",
-		description: '',
+		title: translate( "Change my site's timezone" ),
 		link: `/settings/general/${ siteSlug }`,
 		synonyms: [ 'time', 'date' ],
 		icon: 'cog',
 	},
 	{
-		title: 'Launch my site',
-		description: 'Switch your site from private to public.',
+		title: translate( 'Launch my site' ),
+		description: translate( 'Switch your site from private to public.' ),
 		link: `/settings/general/${ siteSlug }`,
 		synonyms: [ 'private', 'public' ],
 		icon: 'cog',
 	},
 	{
-		title: "Delete a site or a site's content",
-		description: 'Remove all posts, pages, and media, or delete a site completely.',
+		title: translate( "Delete a site or a site's content" ),
+		description: translate( 'Remove all posts, pages, and media, or delete a site completely.' ),
 		link: `/settings/general/${ siteSlug }`,
 		icon: 'cog',
 	},
 	{
-		title: "Change my site's footer text",
-		description: 'You can customize your website by changing the footer credit in customizer.',
+		title: translate( "Change my site's footer text" ),
+		description: translate(
+			'You can customize your website by changing the footer credit in customizer.'
+		),
 		link: `/settings/general/${ siteSlug }`,
 		synonyms: [ 'remove footer', 'update footer' ],
 		icon: 'cog',
 	},
 	{
-		title: "Export my site's content and media library",
-		description: 'Export posts, pages and more from your site.',
+		title: translate( "Export my site's content and media library" ),
+		description: translate( 'Export posts, pages and more from your site.' ),
 		link: `/settings/export/${ siteSlug }`,
 		synonyms: [ 'xml', 'images', 'migration', 'import', 'download' ],
 		icon: 'cog',
 	},
 	{
-		title: 'Manage sharing and social media connections',
-		description: 'You can customize your website by changing the footer credit in customizer.',
+		title: translate( 'Manage sharing and social media connections' ),
+		description: translate(
+			'You can customize your website by changing the footer credit in customizer.'
+		),
 		link: `/sharing/${ siteSlug }`,
 		synonyms: [ 'facebook', 'twitter', 'twitter', 'tumblr', 'eventbrite' ],
 		icon: 'share',
 	},
 	{
-		title: 'Add sharing buttons to my site',
-		description:
-			'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.',
+		title: translate( 'Add sharing buttons to my site' ),
+		description: translate(
+			'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.'
+		),
 		link: `/sharing/buttons/${ siteSlug }`,
 		synonyms: [ 'like', 'reblog' ],
 		icon: 'share',
 	},
 	{
-		title: 'Install, manage and search for site plugins',
-		description: 'You can customize your website by changing the footer credit in customizer.',
+		title: translate( 'Install, manage and search for site plugins' ),
+		description: translate(
+			'You can customize your website by changing the footer credit in customizer.'
+		),
 		link: `/plugins/${ siteSlug }`,
 		synonyms: [ 'upload' ],
 		icon: 'plugins',
 	},
 	{
-		title: 'Approve or remove comments',
-		description: '',
+		title: translate( 'Approve or remove comments' ),
 		link: `/comments/all/${ siteSlug }`,
 		synonyms: [ 'spam', 'discussion', 'moderation', 'moderate' ],
 		icon: 'chat',
 	},
 	{
-		title: 'Manage how users can comment on my site',
+		title: translate( 'Manage how users can comment on my site' ),
 		link: `/settings/discussion/${ siteSlug }`,
 		synonyms: [ 'discussion', 'moderation', 'blacklist' ],
 		icon: 'cog',
 	},
 	{
-		title: 'Manage SEO and traffic settings',
+		title: translate( 'Manage SEO and traffic settings' ),
 		link: `/settings/traffic/${ siteSlug }`,
 		synonyms: [ 'analytics', 'related', 'sitemap' ],
 		icon: 'cog',
 	},
 	{
-		title: 'Update my profile',
-		description: 'Update your name, profile image, and about text.',
+		title: translate( 'Update my profile' ),
+		description: translate( 'Update your name, profile image, and about text.' ),
 		link: `/me`,
 		synonyms: [ 'avatar' ],
 		icon: 'user',
 	},
 	{
-		title: 'Update my username or email address',
-		description: '',
+		title: translate( 'Update my username or email address' ),
 		link: `/me/account`,
 		synonyms: [ 'user', 'account' ],
 		icon: 'cog',
 	},
 	{
-		title: 'Change the dashboard color scheme',
-		description: '',
+		title: translate( 'Change the dashboard color scheme' ),
 		link: `/me/account`,
 		synonyms: [ 'theme' ],
 		icon: 'cog',
 	},
 	{
-		title: 'Switch the interface language',
-		description: 'Update the language of the interface you see across WordPress.com as a whole.',
+		title: translate( 'Switch the interface language' ),
+		description: translate(
+			'Update the language of the interface you see across WordPress.com as a whole.'
+		),
 		link: `/me/account`,
 		synonyms: [ 'dashboard', 'change', 'language' ],
 		icon: 'cog',
 	},
 	{
-		title: 'Close my account permanently',
-		description: 'Delete all of your sites, and close your account completely.',
+		title: translate( 'Close my account permanently' ),
+		description: translate( 'Delete all of your sites, and close your account completely.' ),
 		link: `/me/account/close`,
 		synonyms: [ 'delete' ],
 		icon: 'cog',
 	},
 	{
-		title: 'Change my privacy settings',
-		description: '',
+		title: translate( 'Change my privacy settings' ),
 		link: `/me/privacy`,
 		synonyms: [ 'security', 'tracking' ],
 		icon: 'visible',
 	},
 	{
-		title: 'View my purchase and billing history',
-		description: '',
+		title: translate( 'View my purchase and billing history' ),
 		link: `/me/purchases`,
 		synonyms: [ 'purchases', 'invoices', 'pending', 'payment', 'credit card' ],
 		icon: 'credit-card',
 	},
 	{
-		title: 'Download the WordPress.com app for my device',
-		description: 'Get WordPress apps for all your screens.',
+		title: translate( 'Download the WordPress.com app for my device' ),
+		description: translate( 'Get WordPress apps for all your screens.' ),
 		link: `/me/get-apps`,
 		synonyms: [ 'android', 'iphone', 'mobile', 'desktop', 'phone' ],
 		icon: 'my-sites',
@@ -289,10 +285,15 @@ export function filterListBySearchTerm( searchTerm = '', collection = [], limit 
 	);
 
 	return collection
-		.filter(
-			item =>
-				searchRegex.test( item.title ) || intersection( item.synonyms, searchTermWords ).length
-		)
+		.filter( item => {
+			if ( searchRegex.test( item.title ) ) {
+				return true;
+			}
+			// Until we get the synonyms translated, just check when the language is `'en'`
+			return 'en' === getLocaleSlug()
+				? intersection( item.synonyms, searchTermWords ).length > 0
+				: false;
+		} )
 		.map( item => ( { ...item, type: 'internal', key: item.title } ) )
 		.slice( 0, limit );
 }

--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -113,7 +113,7 @@ class InlineHelpSearchResults extends Component {
 
 		return (
 			<div className="inline-help__find-section">
-				<h2 className="inline-help__view-heading">Go to directly to:</h2>
+				<h2 className="inline-help__view-heading">Go directly to:</h2>
 				<ul className="inline-help__results-list">
 					{ results && results.map( this.renderHelpLink ) }
 				</ul>

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -387,7 +387,7 @@
 	list-style: none;
 	text-align: left;
 	margin: 0;
-	padding: 0 0 8px 0;
+	padding: 0 0 8px;
 
 	.help-contact-form & {
 		padding: 0;
@@ -439,6 +439,10 @@
 				background: none;
 			}
 		}
+	}
+
+	.gridicon {
+		margin: 0 8px -3px 0;
 	}
 }
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -216,6 +216,16 @@
 	.button {
 		vertical-align: middle;
 	}
+
+	.inline-help__search-results,
+	.inline-help__find-section {
+		padding-top: 8px;
+	}
+
+	.inline-help__view-heading {
+		margin: 8px 16px;
+		text-align: left;
+	}
 }
 
 .inline-help__secondary-view {
@@ -377,7 +387,7 @@
 	list-style: none;
 	text-align: left;
 	margin: 0;
-	padding: 8px 0;
+	padding: 0 0 8px 0;
 
 	.help-contact-form & {
 		padding: 0;
@@ -433,11 +443,12 @@
 }
 
 .inline-help__empty-results {
-	padding: 16px 0 0;
+	padding: 0 16px;
 	margin: 0;
 	font-size: 14px;
 	color: var( --color-text-subtle );
 	font-style: italic;
+	text-align: left;
 
 	@include breakpoint( '>660px' ) {
 		font-size: 16px;

--- a/client/blocks/inline-help/test/admin-sections.js
+++ b/client/blocks/inline-help/test/admin-sections.js
@@ -11,9 +11,16 @@
  * Internal dependencies
  */
 
-import { filterListBySearchTerm } from '../admin-sections';
+import * as adminSectionsMethods from '../admin-sections';
 
 describe( 'Admin section search and filters', () => {
+	describe( 'getAdminSectionsResults()', () => {
+		test( 'should return `[]` when there is no search term', () => {
+			const result = adminSectionsMethods.getAdminSectionsResults();
+			expect( result ).toEqual( [] );
+		} );
+	} );
+
 	describe( 'filterListBySearchTerm()', () => {
 		const mockCollection = [
 			{
@@ -21,11 +28,76 @@ describe( 'Admin section search and filters', () => {
 				description: 'Better than that other section.',
 				link: `/best/section/eva`,
 				synonyms: [ 'yolo', 'gud' ],
+				icon: 'beta',
+			},
+			{
+				title: 'Quite a good page',
+				description: 'A rather agreeable page if you ask me.',
+				link: `/acceptable/page`,
+				synonyms: [ 'hi', 'bye' ],
+				icon: 'gamma',
 			},
 		];
-		test( 'should ignore non-word characters', () => {
-			const result = filterListBySearchTerm( "<$(*&#\\\\\\'''''>", mockCollection );
-			expect( result ).toBeUndefined();
+
+		test( 'should ignore non-word characters and return `[]`', () => {
+			const result = adminSectionsMethods.filterListBySearchTerm(
+				"<$(*&#\\\\\\'''''>",
+				mockCollection
+			);
+			expect( result ).toEqual( [] );
+		} );
+
+		test( 'should return `[]` for no matches', () => {
+			const result = adminSectionsMethods.filterListBySearchTerm( 'ciao', mockCollection );
+			expect( result ).toEqual( [] );
+		} );
+
+		test( 'should return a direct match', () => {
+			const result = adminSectionsMethods.filterListBySearchTerm(
+				'The best section',
+				mockCollection
+			);
+			expect( result ).toEqual( [
+				{
+					description: 'Better than that other section.',
+					icon: 'beta',
+					key: 'The best section',
+					link: '/best/section/eva',
+					synonyms: [ 'yolo', 'gud' ],
+					title: 'The best section',
+					type: 'internal',
+				},
+			] );
+		} );
+
+		test( 'should return a partial match', () => {
+			const result = adminSectionsMethods.filterListBySearchTerm( 'best section', mockCollection );
+			expect( result ).toEqual( [
+				{
+					description: 'Better than that other section.',
+					icon: 'beta',
+					key: 'The best section',
+					link: '/best/section/eva',
+					synonyms: [ 'yolo', 'gud' ],
+					title: 'The best section',
+					type: 'internal',
+				},
+			] );
+		} );
+
+		test( 'should return a synonym match', () => {
+			const result = adminSectionsMethods.filterListBySearchTerm( 'yolo', mockCollection );
+			expect( result ).toEqual( [
+				{
+					description: 'Better than that other section.',
+					icon: 'beta',
+					key: 'The best section',
+					link: '/best/section/eva',
+					synonyms: [ 'yolo', 'gud' ],
+					title: 'The best section',
+					type: 'internal',
+				},
+			] );
 		} );
 	} );
 } );

--- a/client/blocks/inline-help/test/admin-sections.js
+++ b/client/blocks/inline-help/test/admin-sections.js
@@ -1,0 +1,31 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+
+import { filterListBySearchTerm } from '../admin-sections';
+
+describe( 'Admin section search and filters', () => {
+	describe( 'filterListBySearchTerm()', () => {
+		const mockCollection = [
+			{
+				title: 'The best section',
+				description: 'Better than that other section.',
+				link: `/best/section/eva`,
+				synonyms: [ 'yolo', 'gud' ],
+			},
+		];
+		test( 'should ignore non-word characters', () => {
+			const result = filterListBySearchTerm( "<$(*&#\\\\\\'''''>", mockCollection );
+			expect( result ).toBeUndefined();
+		} );
+	} );
+} );

--- a/config/development.json
+++ b/config/development.json
@@ -72,6 +72,7 @@
 		"guided-tours/theme-sheet-welcome": true,
 		"gutenberg/opt-in": true,
 		"help": true,
+		"help/admin-section-search": true,
 		"help/courses": true,
 		"i18n/community-translator": false,
 		"jetpack/api-cache": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,6 +53,7 @@
 		"gutenberg/opt-in": true,
 		"happychat": true,
 		"help": true,
+		"help/admin-section-search": true,
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,


### PR DESCRIPTION
## About this PR

This is an experimental feature that enables 'admin section' search results, that is, it surfaces sections of Calypso based on a search in the inline help field.

<img width="347" alt="Screen Shot 2019-04-02 at 5 03 45 pm" src="https://user-images.githubusercontent.com/6458278/55379594-4f304000-5569-11e9-91f5-0a1f21340539.png">

The _down-the-track-some-day-blue-sky_ idea is to create a stand alone filter library that might we employ in other features, for example, to filter the sidebar menu items:

<img width="459" alt="Screen Shot 2019-04-01 at 10 56 11 am" src="https://user-images.githubusercontent.com/6458278/55297148-cfbe4600-546e-11e9-888f-42f2587f9efb.png">

## Testing instructions

This feature is currently behind a development feature flag `help/admin-section-search`.

Open the inline help, making sure you have a site selected. For example, start here:

`http://calypso.localhost:3000/view/{yoursweettestsite}.wordpress.com`

Also search when no site is selected, e.g., `http://calypso.localhost:3000/me` 

You should be asked to select a site should you click on a section that requires one.

The list of admin sections is incomplete, but you can search for terms such as `'Add a domain'`, `'user'`, `'analytics'` and whichever other terms tickle your fancy, bearing in mind the [current definitions](https://github.com/Automattic/wp-calypso/pull/31903/files#diff-5cf1c6b9497fdc569ac7d61cb67e6958R18).

Clicking on a search results should also trigger a tracks event – `calypso_inlinehelp_admin_section_search` – with the following data:

```
{
    link: 'https://the-link-you-clicked-on.com',
    search_term: 'the search term',
}
```

## Notes

We might be able to extend and continue with #27173 (localizing the help text and links) after this PR. At the moment, help text and support doc links are in English.