### PR TITLE
Update tax value usage in billing history

### DIFF
--- a/client/me/billing-history/test/tax.js
+++ b/client/me/billing-history/test/tax.js
@@ -1,0 +1,81 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import { mount } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { renderTransactionAmount } from '../utils';
+import config from 'config';
+
+jest.mock( 'config', () => {
+	const mock = () => 'development';
+	mock.isEnabled = jest.fn();
+	return mock;
+} );
+
+const translate = x => x;
+
+test( 'tax shown if available', () => {
+	config.isEnabled.mockImplementation( flag => flag === 'show-tax' );
+
+	const transaction = {
+		subtotal: '$36.00',
+		tax: '$2.48',
+		amount: '$38.48',
+	};
+
+	const wrapper = mount( renderTransactionAmount( transaction, { translate } ) );
+	expect( wrapper.last().text() ).toContain( 'tax' );
+} );
+
+test( 'tax includes', () => {
+	const transaction = {
+		subtotal: '$36.00',
+		tax: '$2.48',
+		amount: '$38.48',
+	};
+
+	const wrapper = mount( renderTransactionAmount( transaction, { translate, addingTax: false } ) );
+	expect( wrapper.last().text() ).toEqual( '(includes %(taxAmount)s tax)' );
+} );
+
+test( 'tax adding', () => {
+	const transaction = {
+		subtotal: '$36.00',
+		tax: '$2.48',
+		amount: '$38.48',
+	};
+
+	const wrapper = mount( renderTransactionAmount( transaction, { translate, addingTax: true } ) );
+	expect( wrapper.last().text() ).toEqual( '(+%(taxAmount)s tax)' );
+} );
+
+test( 'tax hidden if not available', () => {
+	config.isEnabled.mockImplementation( flag => flag === 'show-tax' );
+
+	const transaction = {
+		subtotal: '$36.00',
+		tax: '$0.00',
+		amount: '$36.00',
+	};
+
+	expect( renderTransactionAmount( transaction, { translate } ) ).toEqual( '$36.00' );
+} );
+
+test( 'respects show-tax config flag', () => {
+	config.isEnabled.mockImplementation( () => false );
+
+	const transaction = {
+		subtotal: '$36.00',
+		tax: '$2.48',
+		amount: '$38.48',
+	};
+
+	expect( renderTransactionAmount( transaction, { translate } ) ).toEqual( '$38.48' );
+} );

--- a/client/me/billing-history/utils.jsx
+++ b/client/me/billing-history/utils.jsx
@@ -22,6 +22,7 @@ export const groupDomainProducts = ( originalItems, translate ) => {
 	const groupedDomainProducts = reduce(
 		domainProducts,
 		( groups, product ) => {
+			// eslint-disable-next-line no-extra-boolean-cast
 			if ( !! groups[ product.domain ] ) {
 				groups[ product.domain ].raw_amount += product.raw_amount;
 				groups[ product.domain ].groupCount++;
@@ -51,17 +52,17 @@ export const groupDomainProducts = ( originalItems, translate ) => {
 };
 
 export function renderTransactionAmount( transaction, { translate, addingTax = false } ) {
-	if ( ! config.isEnabled( 'show-tax' ) || ! transaction.tax_amount ) {
+	if ( ! config.isEnabled( 'show-tax' ) || ! transaction.tax || transaction.tax === '$0.00' ) {
 		return transaction.amount;
 	}
 
 	const taxAmount = addingTax
 		? translate( '(+%(taxAmount)s tax)', {
-				args: { taxAmount: transaction.tax_amount },
+				args: { taxAmount: transaction.tax },
 				comment: 'taxAmount is a localized price, like $12.34',
 		  } )
 		: translate( '(includes %(taxAmount)s tax)', {
-				args: { taxAmount: transaction.tax_amount },
+				args: { taxAmount: transaction.tax },
 				comment: 'taxAmount is a localized price, like $12.34',
 		  } );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update tax value references in billing history after backend support was added in D26222-code

#### Testing instructions

* View billing history for a receipt http://calypso.localhost:3000/me/purchases/billing/19227401
* View billing history list: http://calypso.localhost:3000/me/purchases/billing
* run tests `npm run test-client client/me/billing-history/test`

#### List After
![list-after](https://user-images.githubusercontent.com/811776/55304455-4b33ed80-5497-11e9-94e4-112a78a83de8.png)

#### Receipt After
![receipt-after](https://user-images.githubusercontent.com/811776/55304457-4c651a80-5497-11e9-8c0d-ca9f460b641a.png)


