### PR TITLE
Migrate HappinessSupport styles webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -83,7 +83,6 @@
 @import 'components/forms/form-toggle/style';
 @import 'components/forms/range/style';
 @import 'components/forms/sortable-list/style';
-@import 'components/happiness-support/style';
 @import 'components/header-button/style';
 @import 'components/header-cake/style';
 @import 'components/image/style';

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -25,6 +25,11 @@ import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection-connected';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class HappinessSupport extends Component {
 	static propTypes = {
 		isJetpack: PropTypes.bool,

--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -46,11 +46,6 @@
 	}
 }
 
-.happiness-support__gravatar-name {
-	color: var( --color-neutral-light );
-	font-size: 14px;
-}
-
 .happiness-support__buttons {
 	clear: both;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Import `HappinessSupport` style with webpack. Details on https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/plans/my-plan/{site}` on the live branch available below (preferably with a WordPress.com Business plan site)
- Ensure the design/visual appearance of the support (Happiness) card looks the same as this page's view on `master` branch / before this PR

<img width="552" alt="Screenshot 2019-04-01 at 10 40 07" src="https://user-images.githubusercontent.com/18581859/55304722-8966e800-546a-11e9-976e-74a0863f64bc.png">