### PR TITLE
People: Migrate styles to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -148,7 +148,6 @@
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
 @import 'my-sites/pages/page-card-info/style';
-@import 'my-sites/people/delete-user/style';
 @import 'my-sites/people/edit-team-member-form/style';
 @import 'my-sites/people/invite-people/style';
 @import 'my-sites/people/people-invite-details/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -148,7 +148,6 @@
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
 @import 'my-sites/pages/page-card-info/style';
-@import 'my-sites/people/people-profile/style';
 @import 'my-sites/plan-compare-card/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/plan-interval-discount/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -148,7 +148,6 @@
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
 @import 'my-sites/pages/page-card-info/style';
-@import 'my-sites/people/invite-people/style';
 @import 'my-sites/people/people-invite-details/style';
 @import 'my-sites/people/people-invites/style';
 @import 'my-sites/people/people-list-item/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -148,7 +148,6 @@
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
 @import 'my-sites/pages/page-card-info/style';
-@import 'my-sites/people/edit-team-member-form/style';
 @import 'my-sites/people/invite-people/style';
 @import 'my-sites/people/people-invite-details/style';
 @import 'my-sites/people/people-invites/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -148,7 +148,6 @@
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
 @import 'my-sites/pages/page-card-info/style';
-@import 'my-sites/people/people-invites/style';
 @import 'my-sites/people/people-list-item/style';
 @import 'my-sites/people/people-list-section-header/style';
 @import 'my-sites/people/people-profile/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -148,7 +148,6 @@
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
 @import 'my-sites/pages/page-card-info/style';
-@import 'my-sites/people/people-list-section-header/style';
 @import 'my-sites/people/people-profile/style';
 @import 'my-sites/plan-compare-card/style';
 @import 'my-sites/plan-features/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -148,7 +148,6 @@
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
 @import 'my-sites/pages/page-card-info/style';
-@import 'my-sites/people/people-list-item/style';
 @import 'my-sites/people/people-list-section-header/style';
 @import 'my-sites/people/people-profile/style';
 @import 'my-sites/plan-compare-card/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -148,7 +148,6 @@
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
 @import 'my-sites/pages/page-card-info/style';
-@import 'my-sites/people/people-invite-details/style';
 @import 'my-sites/people/people-invites/style';
 @import 'my-sites/people/people-list-item/style';
 @import 'my-sites/people/people-list-section-header/style';

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -71,7 +71,6 @@ $z-layers: (
 		'.chart__bar-section.is-ghost::after': 1,
 		'.module-content-table::after': 1,
 		'.stats-popular__empty': 1,
-		'.people-list-item__label': 1,
 		'.is-actionable .theme__thumbnail-label': 1,
 		'.accessible-focus .current-theme__button:focus': 1,
 		'.signup-processing-screen__processing-step.is-processing:before': 1,

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -28,6 +28,11 @@ import { localize } from 'i18n-calypso';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class DeleteUser extends React.Component {
 	static displayName = 'DeleteUser';
 

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -259,7 +259,7 @@ class DeleteUser extends React.Component {
 	renderMultisite = () => {
 		return (
 			<CompactCard className="delete-user__multisite">
-				<a className="delete-user__remove-user" onClick={ this.removeUser }>
+				<a className="delete-user__remove-user" role="presentation" onClick={ this.removeUser }>
 					<Gridicon icon="trash" />
 					{ this.getRemoveText() }
 				</a>

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 /** @format */
 
 /**

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Card from 'components/card';
+import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import Gridicon from 'gridicons';
 import FormSectionHeading from 'components/forms/form-section-heading';
@@ -260,10 +261,10 @@ class DeleteUser extends React.Component {
 	renderMultisite = () => {
 		return (
 			<CompactCard className="delete-user__multisite">
-				<a className="delete-user__remove-user" role="presentation" onClick={ this.removeUser }>
+				<Button borderless className="delete-user__remove-user" onClick={ this.removeUser }>
 					<Gridicon icon="trash" />
 					{ this.getRemoveText() }
-				</a>
+				</Button>
 			</CompactCard>
 		);
 	};

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -263,7 +263,7 @@ class DeleteUser extends React.Component {
 			<CompactCard className="delete-user__multisite">
 				<Button borderless className="delete-user__remove-user" onClick={ this.removeUser }>
 					<Gridicon icon="trash" />
-					{ this.getRemoveText() }
+					<span>{ this.getRemoveText() }</span>
 				</Button>
 			</CompactCard>
 		);

--- a/client/my-sites/people/delete-user/style.scss
+++ b/client/my-sites/people/delete-user/style.scss
@@ -15,10 +15,8 @@
 	margin: 0 3px 0 8px;
 }
 
-.delete-user__multisite {
-	.button.is-borderless {
-		&.delete-user__remove-user {
-			color: var( --color-primary );
+.delete-user__remove-user.button.is-borderless {
+	color: var( --color-primary );
 			font-weight: 400;
 		
 			&:active,
@@ -32,6 +30,4 @@
 				margin: -2px 4px 0 0;
 				vertical-align: middle;
 			}
-		}
-	}
 }

--- a/client/my-sites/people/delete-user/style.scss
+++ b/client/my-sites/people/delete-user/style.scss
@@ -15,11 +15,23 @@
 	margin: 0 3px 0 8px;
 }
 
-.delete-user__remove-user .gridicon {
-	margin: -2px 4px 0 0;
-	vertical-align: middle;
-}
-
-.delete-user__remove-user {
-	cursor: pointer;
+.delete-user__multisite {
+	.button.is-borderless {
+		&.delete-user__remove-user {
+			color: var( --color-primary );
+			font-weight: 400;
+		
+			&:active,
+			&:focus,
+			&:hover {
+				color: var( --color-link-dark );
+			}
+		
+			.gridicon {
+				top: 0;
+				margin: -2px 4px 0 0;
+				vertical-align: middle;
+			}
+		}
+	}
 }

--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -22,6 +22,11 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
 /**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
  * Module Variables
  */
 const debug = debugModule( 'calypso:my-sites:people:edit-team-member-form' );

--- a/client/my-sites/people/edit-team-member-form/index.jsx
+++ b/client/my-sites/people/edit-team-member-form/index.jsx
@@ -29,6 +29,11 @@ import EditUserForm from './edit-user-form';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import getPreviousRoute from 'state/selectors/get-previous-route';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class EditTeamMemberForm extends Component {
 	constructor( props ) {
 		super( props );

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -48,6 +48,11 @@ import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/ac
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
 
 /**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
  * Module variables
  */
 const debug = debugModule( 'calypso:my-sites:people:invite' );

--- a/client/my-sites/people/people-invite-details/index.jsx
+++ b/client/my-sites/people/people-invite-details/index.jsx
@@ -33,6 +33,11 @@ import { deleteInvite } from 'state/invites/actions';
 import canCurrentUser from 'state/selectors/can-current-user';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class PeopleInviteDetails extends React.PureComponent {
 	static propTypes = {
 		site: PropTypes.object,

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -38,6 +38,11 @@ import {
 import { deleteInvites } from 'state/invites/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PeopleInvites extends React.PureComponent {
 	static propTypes = {
 		site: PropTypes.object,

--- a/client/my-sites/people/people-invites/invites-list-end.jsx
+++ b/client/my-sites/people/people-invites/invites-list-end.jsx
@@ -14,6 +14,11 @@ import { localize } from 'i18n-calypso';
 import ListEnd from 'components/list-end';
 import { bumpStat } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class InvitesListEnd extends React.PureComponent {
 	static propTypes = {
 		shown: PropTypes.number,

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -26,6 +26,11 @@ import {
 import { resendInvite } from 'state/invites/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PeopleListItem extends React.PureComponent {
 	static displayName = 'PeopleListItem';
 

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -23,33 +23,6 @@
 	}
 }
 
-.people-list-item__checkbox[type=checkbox] {
-	margin-top: 0;
-	position: absolute;
-	top: 48px;
-	left: 2px;
-
-	&::after { // Making tap area larger
-		content: '';
-		position: absolute;
-		top: -20px;
-		left: -19px;
-		width: 56px;
-		height: 55px;
-	}
-}
-
-.people-list-item__label {
-	display: block;
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-	z-index: z-index( 'root', '.people-list-item__label' );
-	cursor: pointer;
-}
-
 .people-list-item__profile-container {
 	display: block;
 	flex-grow: 1;

--- a/client/my-sites/people/people-list-section-header/index.jsx
+++ b/client/my-sites/people/people-list-section-header/index.jsx
@@ -20,6 +20,11 @@ import Button from 'components/button';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PeopleListSectionHeader extends Component {
 	static propTypes = {
 		label: PropTypes.oneOfType( [ PropTypes.string, PropTypes.array ] ),

--- a/client/my-sites/people/people-profile/index.jsx
+++ b/client/my-sites/people/people-profile/index.jsx
@@ -17,6 +17,11 @@ import { decodeEntities } from 'lib/formatting';
  */
 import Gravatar from 'components/gravatar';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PeopleProfile extends React.PureComponent {
 	static displayName = 'PeopleProfile';
 

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -88,7 +88,7 @@
 	border: 1px solid var( --color-neutral-light );
 	border-radius: 2px;
 	color: var( --color-text-subtle );
-	display: inline-block;
+	display: block;
 	font-size: 11px;
 	margin-left: 8px;
 	padding: 2px 6px;

--- a/client/my-sites/people/people-profile/style.scss
+++ b/client/my-sites/people/people-profile/style.scss
@@ -88,7 +88,6 @@
 	border: 1px solid var( --color-neutral-light );
 	border-radius: 2px;
 	color: var( --color-text-subtle );
-	display: block;
 	font-size: 11px;
 	margin-left: 8px;
 	padding: 2px 6px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Import `People:` section styles with webpack. Details on https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/people/team/{site}` on the live branch available below (preferably with a WordPress.com Business plan site)
- Test all the sections available here, and ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR
- In particular, one section would require inviting another WordPress.com user to test.

#### Notes:

- I am not very sure if this is a large PR, but if we might prefer this to be broken down into smaller ones, I can do that.