### PR TITLE
Migrate Banner styles to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -37,7 +37,6 @@
 @import 'blocks/video-editor/style';
 @import 'blocks/stats-navigation/style';
 @import 'blocks/user-mentions/style';
-@import 'components/banner/style';
 @import 'components/button/style';
 @import 'components/card/style';
 @import 'components/card-heading/style';

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -34,6 +34,11 @@ import PlanIcon from 'components/plans/plan-icon';
 import PlanPrice from 'my-sites/plan-price';
 import TrackComponentView from 'lib/analytics/track-component-view';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class Banner extends Component {
 	static propTypes = {
 		callToAction: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Import `Banner` style with webpack. Details on https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/banner` on the live branch available below
- Ensure the design/visual appearance for all banners looks the same as this page's view on `master` branch / before this PR