### PR TITLE
Migrate Button styles to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -37,7 +37,6 @@
 @import 'blocks/video-editor/style';
 @import 'blocks/stats-navigation/style';
 @import 'blocks/user-mentions/style';
-@import 'components/button/style';
 @import 'components/card/style';
 @import 'components/card-heading/style';
 @import 'components/checklist/style';

--- a/client/components/button/index.jsx
+++ b/client/components/button/index.jsx
@@ -6,6 +6,11 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class Button extends PureComponent {
 	static propTypes = {
 		compact: PropTypes.bool,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Import `Button` style with webpack. Details on https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/button` on the live branch available below
- Ensure the design/visual appearance for all buttons looks the same as this page's view on `master` branch / before this PR