### PR TITLE
Migrate Notice styles to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -101,7 +101,6 @@
 @import 'components/marketing-survey/cancel-purchase-form/style';
 @import 'components/mini-site-preview/style';
 @import 'components/mobile-back-to-sidebar/style';
-@import 'components/notice/style';
 @import 'components/payment-logo/style';
 @import 'components/plans/plan-icon/style';
 @import 'blocks/product-purchase-features-list/style';

--- a/client/components/notice/index.jsx
+++ b/client/components/notice/index.jsx
@@ -16,6 +16,11 @@ import Gridicon from 'gridicons';
  */
 import ScreenReaderText from 'components/screen-reader-text';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class Notice extends Component {
 	static defaultProps = {
 		className: '',

--- a/client/components/notice/notice-action.jsx
+++ b/client/components/notice/notice-action.jsx
@@ -8,6 +8,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class extends React.Component {
 	static displayName = 'NoticeAction';
 

--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -135,11 +135,6 @@
 	}
 }
 
-.notice__button {
-	cursor: pointer;
-	margin-left: 0.428em;
-}
-
 // "X" for dismissing a notice
 .notice__dismiss {
 	flex-shrink: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Import `Notice` style with webpack. Details on https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/notice` on the live branch available below
- Ensure the design/visual appearance for all notices looks the same as this page's view on `master` branch / before this PR