### PR TITLE
Fix styles of Jetpack Rewind Credentials setup

### DIFF
--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/index.jsx
@@ -27,14 +27,7 @@ class CredentialsSetupFlow extends Component {
 		siteId: PropTypes.number,
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = {
-			currentStep: 'start',
-			showPopover: false,
-		};
-	}
+	state = { currentStep: 'start' };
 
 	reset = () => this.setState( { currentStep: 'start' } );
 

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.jsx
@@ -18,51 +18,48 @@ import isHappychatAvailable from 'state/happychat/selectors/is-happychat-availab
 import Button from 'components/button';
 import Popover from 'components/popover';
 
-class SetupFooter extends Component {
-	state = {
-		isPopoverVisible: false,
-		popoverContext: null,
-	};
+/**
+ * Style dependencies
+ */
+import './setup-footer.scss';
 
-	setPopoverContext = popoverContext => {
-		if ( popoverContext ) {
-			this.setState( { popoverContext } );
-		}
-	};
+class SetupFooter extends Component {
+	state = { isPopoverVisible: false };
+
+	popoverContext = React.createRef();
+
 	togglePopover = () => this.setState( { isPopoverVisible: ! this.state.isPopoverVisible } );
 	hidePopover = () => this.setState( { isPopoverVisible: false } );
 
 	render() {
 		const { happychatIsAvailable, translate } = this.props;
-		const { isPopoverVisible, popoverContext } = this.state;
+		const { isPopoverVisible } = this.state;
 
 		return (
 			<CompactCard className="credentials-setup-flow__footer">
-				<Button ref={ this.setPopoverContext } onClick={ this.togglePopover } borderless>
+				<Button ref={ this.popoverContext } onClick={ this.togglePopover } borderless>
 					<Gridicon icon="help" />
-					<span className="credentials-setup-flow__help-button-text">
-						{ translate( "Need help finding your site's server credentials?" ) }
-					</span>
+					{ translate( "Need help finding your site's server credentials?" ) }
 				</Button>
-				<Popover
-					context={ popoverContext }
-					isVisible={ isPopoverVisible }
-					onClose={ this.hidePopover }
-					className="credentials-setup-flow__popover"
-					position="top"
-				>
-					{ translate(
-						'You can normally get your credentials from your hosting provider. ' +
-							'Their website should explain how to get or create the credentials you need.'
-					) }
-				</Popover>
+				{ isPopoverVisible && (
+					<Popover
+						isVisible
+						context={ this.popoverContext.current }
+						onClose={ this.hidePopover }
+						className="credentials-setup-flow__footer-popover"
+						position="top"
+					>
+						{ translate(
+							'You can normally get your credentials from your hosting provider. ' +
+								'Their website should explain how to get or create the credentials you need.'
+						) }
+					</Popover>
+				) }
 
 				{ happychatIsAvailable && (
 					<HappychatButton onClick={ this.props.happychatEvent }>
 						<Gridicon icon="chat" />
-						<span className="credentials-setup-flow__happychat-button-text">
-							{ translate( 'Get help' ) }
-						</span>
+						{ translate( 'Get help' ) }
 					</HappychatButton>
 				) }
 			</CompactCard>

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/setup-footer.scss
@@ -1,0 +1,16 @@
+.credentials-setup-flow__footer .button.is-borderless {
+	margin-right: 24px;
+	color: var( --color-primary );
+	padding: 0 0 5px;
+
+	&:hover {
+		color: var( --color-link-dark );
+	}
+}
+
+.credentials-setup-flow__footer-popover .popover__inner {
+	color: var( --color-neutral-500 );
+	font-size: 13px;
+	max-width: 220px;
+	padding: 16px;
+}

--- a/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
+++ b/client/my-sites/site-settings/jetpack-credentials/credentials-setup-flow/style.scss
@@ -45,24 +45,3 @@
 .credentials-setup-flow__tos-buttons .is-borderless {
 	margin-right: 15px;
 }
-
-.credentials-setup-flow__footer .button.is-borderless {
-	margin-right: 24px;
-	color: var( --color-primary );
-	padding: 0 0 5px;
-
-	&:hover {
-		color: var( --color-link-dark );
-	}
-
-	span {
-		margin-left: 6px;
-	}
-}
-
-.credentials-setup-flow__popover .popover__inner {
-	color: var( --color-neutral-500 );
-	font-size: 13px;
-	max-width: 220px;
-	padding: 16px;
-}

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -13,6 +13,7 @@ import { get, includes } from 'lodash';
  */
 import StepWrapper from 'signup/step-wrapper';
 import Card from 'components/card';
+import FormattedHeader from 'components/formatted-header';
 import SignupActions from 'lib/signup/actions';
 import RewindCredentialsForm from 'components/rewind-credentials-form';
 import getRewindState from 'state/selectors/get-rewind-state';
@@ -68,28 +69,24 @@ class RewindFormCreds extends Component {
 	stepContent = () => {
 		const { translate, siteId } = this.props;
 
-		return [
-			<div key="rewind-form-creds__header" className="rewind-form-creds__header">
-				<h3 className="rewind-form-creds__title rewind-switch__heading">
-					{ translate( 'Site credentials' ) }
-				</h3>
-				<p className="rewind-form-creds__description rewind-switch__description">
-					{ translate(
+		return (
+			<Fragment>
+				<FormattedHeader
+					headerText={ translate( 'Site credentials' ) }
+					subHeaderText={ translate(
 						"We'll guide you through the process of finding and entering your site's credentials."
 					) }
-				</p>
-			</div>,
-			<Card
-				key="rewind-form-creds__card"
-				className="rewind-form-creds__card rewind-switch__card rewind-switch__content"
-			>
-				<Card compact className="rewind-form-creds__legend">
-					{ translate( 'Enter your credentials' ) }
+				/>
+				<Card className="rewind-form-creds__card rewind-switch__card rewind-switch__content">
+					<Card compact className="rewind-form-creds__legend">
+						{ translate( 'Enter your credentials' ) }
+					</Card>
+					<RewindCredentialsForm role="main" siteId={ siteId } allowCancel={ false } />
+					<SetupFooter />
 				</Card>
-				<RewindCredentialsForm role="main" siteId={ siteId } allowCancel={ false } />
-				<SetupFooter />
-			</Card>,
-		];
+				,
+			</Fragment>
+		);
 	};
 
 	render() {

--- a/client/signup/steps/rewind-form-creds/style.scss
+++ b/client/signup/steps/rewind-form-creds/style.scss
@@ -1,12 +1,3 @@
-.rewind-form-creds__header {
-	text-align: center;
-	margin-top: 16px;
-
-	.rewind-switch__description {
-		max-width: 100%;
-	}
-}
-
 .rewind-form-creds__card {
 	margin-top: 16px;
 	padding: 0;


### PR DESCRIPTION
Fixes #31700 adding a missing import of `CredentialsSetupFlow`. Regression introduced by #28452 when migrating Site Settings styles to webpack.

Few drive-by fixes:
- SetupFooter: use ref to save `popoverContext` value
- SetupFooter: remove unneeded styling of button text margins
- CredentialsSetupFlow: remove unused `showPopover` state bit


The styles for `SetupFooter` are extracted to separate file, as the module is also imported directly from the `RewindFormCreds` signup step. Without importing the parent module.

The `RewindFormCreds` signup step also gets an updated header that uses `FormattedHeader` and has proper text color.

**How to test:**
1. Check that the "Add Site Credentials" bug reported in #31700 is fixed.
<img width="725" alt="Screenshot 2019-04-01 at 11 22 04" src="https://user-images.githubusercontent.com/664258/55326628-824ed280-5488-11e9-9f18-03c4b4a5f9aa.png">

2. Start the `/start/rewind-setup` signup flow and check the UI of the `rewind-form-creds` step.

Does the header have the correct (white) color? Before this PR, it was black-on-dark-blue:
<img width="695" alt="Screenshot 2019-04-01 at 13 53 33" src="https://user-images.githubusercontent.com/664258/55326683-a3172800-5488-11e9-9355-50ae1ab018a5.png">

In the footer, are the "need help" links in dark-blue and is the popover correctly styled:
<img width="395" alt="Screenshot 2019-04-01 at 11 35 30" src="https://user-images.githubusercontent.com/664258/55326733-bde99c80-5488-11e9-92a9-b3f25b22b99d.png">

Before this PR, the color was gray and the popover was broken (the whole long text on one line etc)
