### PR TITLE
Checkout: refactor ebanx.js to be more generic

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -19,7 +19,7 @@ import CountrySpecificPaymentFields from 'my-sites/checkout/checkout/country-spe
 import { Input } from 'my-sites/domains/components/form';
 import InfoPopover from 'components/info-popover';
 import { maskField, unmaskField, getCreditCardType } from 'lib/checkout';
-import { shouldRenderAdditionalCountryFields } from 'lib/checkout/ebanx';
+import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
 
 export class CreditCardFormFields extends React.Component {
 	static propTypes = {

--- a/client/components/credit-card-form-fields/test/index.js
+++ b/client/components/credit-card-form-fields/test/index.js
@@ -14,13 +14,13 @@ import { identity, noop } from 'lodash';
  * Internal dependencies
  */
 import { CreditCardFormFields } from '../';
-import { shouldRenderAdditionalCountryFields } from 'lib/checkout/ebanx';
+import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
 } ) );
 
-jest.mock( 'lib/checkout/ebanx', () => {
+jest.mock( 'lib/checkout/processor-specific', () => {
 	return {
 		shouldRenderAdditionalCountryFields: jest.fn( false ),
 	};

--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -60,6 +60,35 @@ export function isValidCNPJ( cnpj = '' ) {
 	return CNPJ.isValid( cnpj );
 }
 
+export function fullAddressFieldsRules() {
+	return {
+		'street-number': {
+			description: i18n.translate( 'Street Number' ),
+			rules: [ 'required', 'validStreetNumber' ],
+		},
+
+		'address-1': {
+			description: i18n.translate( 'Address' ),
+			rules: [ 'required' ],
+		},
+
+		state: {
+			description: i18n.translate( 'State' ),
+			rules: [ 'required' ],
+		},
+
+		city: {
+			description: i18n.translate( 'City' ),
+			rules: [ 'required' ],
+		},
+
+		'postal-code': {
+			description: i18n.translate( 'Postal Code' ),
+			rules: [ 'required' ],
+		},
+	}
+}
+
 /**
  * Returns ebanx validation rule sets for defined fields. Ebanx required fields may vary according to country
  * See: https://developers.ebanx.com/api-reference/full-api-documentation/ebanx-payment-2/ebanx-payment-guide/guide-create-a-payment/
@@ -70,30 +99,10 @@ export function ebanxFieldRules( country ) {
 	const ebanxFields = PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ country ].fields || [];
 
 	return pick(
-		{
+		Object.assign( {
 			document: {
 				description: i18n.translate( 'Taxpayer Identification Number' ),
 				rules: [ 'validBrazilTaxId' ],
-			},
-
-			'street-number': {
-				description: i18n.translate( 'Street Number' ),
-				rules: [ 'required', 'validStreetNumber' ],
-			},
-
-			'address-1': {
-				description: i18n.translate( 'Address' ),
-				rules: [ 'required' ],
-			},
-
-			state: {
-				description: i18n.translate( 'State' ),
-				rules: [ 'required' ],
-			},
-
-			city: {
-				description: i18n.translate( 'City' ),
-				rules: [ 'required' ],
 			},
 
 			'phone-number': {
@@ -105,7 +114,7 @@ export function ebanxFieldRules( country ) {
 				description: i18n.translate( 'Postal Code' ),
 				rules: [ 'required' ],
 			},
-		},
+		}, fullAddressFieldsRules() ),
 		ebanxFields
 	);
 }

--- a/client/lib/checkout/test/ebanx.js
+++ b/client/lib/checkout/test/ebanx.js
@@ -15,7 +15,7 @@ import {
 	isValidCPF,
 	isValidCNPJ,
 	shouldRenderAdditionalCountryFields,
-} from '../ebanx';
+} from '../processor-specific';
 import { isPaymentMethodEnabled } from 'lib/cart-values';
 
 jest.mock( 'lib/cart-values', () => {

--- a/client/lib/checkout/test/validation.js
+++ b/client/lib/checkout/test/validation.js
@@ -18,7 +18,7 @@ import {
 	getCreditCardFieldRules,
 	mergeValidationRules,
 } from '../validation';
-import * as ebanxMethods from '../ebanx';
+import * as processorSpecificMethods from '../processor-specific';
 
 describe( 'validation', () => {
 	const validCard = {
@@ -171,10 +171,10 @@ describe( 'validation', () => {
 
 		describe( 'validate ebanx non-credit card details', () => {
 			beforeAll( () => {
-				ebanxMethods.isEbanxCreditCardProcessingEnabledForCountry = jest
+				processorSpecificMethods.isEbanxCreditCardProcessingEnabledForCountry = jest
 					.fn()
 					.mockImplementation( () => true );
-				ebanxMethods.isValidCPF = jest.fn().mockImplementation( () => true );
+				processorSpecificMethods.isValidCPF = jest.fn().mockImplementation( () => true );
 			} );
 
 			test( 'should return no errors when details are valid', () => {
@@ -250,7 +250,7 @@ describe( 'validation', () => {
 			} );
 
 			test( 'should return error when CPF is invalid', () => {
-				ebanxMethods.isValidCPF = jest.fn().mockImplementation( () => false );
+				processorSpecificMethods.isValidCPF = jest.fn().mockImplementation( () => false );
 				const invalidCPF = { ...validBrazilianEbanxCard, document: 'blah' };
 				const result = validatePaymentDetails( invalidCPF );
 				expect( result ).toEqual( {

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -15,7 +15,7 @@ import {
 	isValidCPF,
 	isValidCNPJ,
 	ebanxFieldRules,
-} from 'lib/checkout/ebanx';
+} from 'lib/checkout/processor-specific';
 
 /**
  * Returns the credit card validation rule set

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -26,7 +26,7 @@ import wp from 'lib/wp';
 import {
 	isEbanxCreditCardProcessingEnabledForCountry,
 	translatedEbanxError,
-} from 'lib/checkout/ebanx';
+} from 'lib/checkout/processor-specific';
 import analytics from 'lib/analytics';
 
 const wpcom = wp.undocumented();

--- a/client/my-sites/checkout/checkout/README.md
+++ b/client/my-sites/checkout/checkout/README.md
@@ -14,10 +14,10 @@ Domain contact details data flow (2017-06-07):
 
 ## Components
 
-### Ebanx - country-specific-payment-fields.jsx
+### Processor/country - country-specific-payment-fields.jsx
 
 Processing payments in countries such as Brazil via Ebanx require us to collect extra information from the user.
 
 See: `PAYMENT_PROCESSOR_COUNTRIES_FIELDS.BR.fields` in `client/lib/checkout/constants.js`
 
-Most prominent is the tax identification number, for which unique validation exists. See: `client/lib/checkout/ebanx.js`
+Most prominent is the tax identification number, for which unique validation exists. See: `client/lib/checkout/processor-specific.js`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Renaming `ebanx` to a more generic `processor-specific`, and extracting the address fields validation into own function so that it can be reused by other payment methods

#### Testing instructions
I think this is well covered by existing tests.
You can also manually test by selecting Brazil as the country for a credit card payment, and making sure the validation still works.
