### PR TITLE
Classic Post Schedule: query posts that are in different month but still in a displayed week

### DIFF
--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -49,8 +49,14 @@ export default class PostScheduler extends PureComponent {
 		const tzDate = tz ? moment.tz( date, tz ) : moment( date );
 
 		return {
-			firstDayOfTheMonth: tzDate.clone().startOf( 'month' ),
-			lastDayOfTheMonth: tzDate.clone().endOf( 'month' ),
+			firstDayOfTheMonth: tzDate
+				.clone()
+				.startOf( 'month' )
+				.startOf( 'week' ),
+			lastDayOfTheMonth: tzDate
+				.clone()
+				.endOf( 'month' )
+				.endOf( 'week' ),
 		};
 	}
 

--- a/client/post-editor/editor-publish-date/post-scheduler.jsx
+++ b/client/post-editor/editor-publish-date/post-scheduler.jsx
@@ -44,6 +44,10 @@ export default class PostScheduler extends PureComponent {
 
 	state = this.getFirstAndLastDayOfTheMonth( this.props.initialDate );
 
+	// Calculates the start and end of the period shown by a monthly calendar UI
+	// for the specified `date`:
+	// - first day of the week containing the first day of the month
+	// - last day of the week containing the last day of the month
 	getFirstAndLastDayOfTheMonth( date ) {
 		const tz = timezone( this.props.site );
 		const tzDate = tz ? moment.tz( date, tz ) : moment( date );


### PR DESCRIPTION
Fixes #1035 by expanding the post query `before` and `after` dates to include the start of the first and end of the last week.

Not a big priority in Gutenberg era, but:
- I recently touched that code when working on `moment-timezone` usages, so I immediately knew that there is a easy fix
- this neat feature is missing in Gutenberg. Maybe an idea for @Automattic/lannister?

**How to test:**
Verify that the scheduling calendar in Classic Editor shows published posts outside the current month (note the posts on Apr 29 and Jun 1):
<img width="242" alt="Screenshot 2019-04-01 at 14 38 19" src="https://user-images.githubusercontent.com/664258/55328908-bb3d7600-548d-11e9-89cc-5731895f024e.png">

and that the query parameters for the REST request have the correct dates. Example for May 2018:
<img width="424" alt="Screenshot 2019-04-01 at 14 43 29" src="https://user-images.githubusercontent.com/664258/55328897-b4aefe80-548d-11e9-8db6-c8fd9be1db55.png">
