### PR TITLE
Build: Add back overrides for Gutenberg blocks to Babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -38,6 +38,27 @@ const config = {
 		],
 		isBrowser && './inline-imports.js',
 	] ),
+	overrides: [
+		{
+			test: [ './client/gutenberg/extensions' ],
+			plugins: [
+				[
+					'@wordpress/import-jsx-pragma',
+					{
+						scopeVariable: 'createElement',
+						source: '@wordpress/element',
+						isDefault: false,
+					},
+				],
+				[
+					'@babel/transform-react-jsx',
+					{
+						pragma: 'createElement',
+					},
+				],
+			],
+		},
+	],
 	env: {
 		test: {
 			presets: [ [ '@babel/env', { targets: { node: 'current' } } ] ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I accidentally removed Babel overrides for the still-remaining Gutenberg blocks in [`client/gutenberg/extensions`](https://github.com/Automattic/wp-calypso/tree/4e9b1086fe5a61afa1cc366915f17e285a5da96d/client/gutenberg/extensions) (o2 preset) . This PR adds 'em back.

#### Testing instructions

Verify that `npm run sdk -- gutenberg client/gutenberg/extensions/presets/o2/` passes, and that there are no references to `React` in the built blocks.

h/t @sirreal for pointing me to this

#### Follow-up

In the long run, I'd like to move o2 blocks to a `packages/` subfolder, so the we can apply the monorepo paradigm (e.g. different build process).