### PR TITLE
Create a way to skip Jetpack tests with env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,15 +602,6 @@ workflows:
           test-flags: "-W -S $CIRCLE_SHA1"
           test-target: "WOO"
           slack-webhook: "$SLACK_WOO"
-      - test-e2e-canary:
-          name: test-e2e-jetpack
-          requires:
-          - wait-calypso-live
-          test-flags: "-j"
-          jetpack-host: "PRESSABLEBLEEDINGEDGE"
-          test-target: "JETPACK"
-          slack-webhook: "$SLACK_JP"
-          skip-jetpack: "$SKIP_JETPACK"
 
   calypso-nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -521,6 +521,11 @@ jobs:
     steps:
       - prepare
       - run: *set-e2e-variables
+      - run: |
+          if [[ "$SKIP_JETPACK" == "true" ]]; then
+              echo "Jetpack tests have been skipped"
+              circleci-agent step halt
+          fi
       - run: npm run decryptconfig
       - run:
           name: Run Canary Tests
@@ -651,25 +656,26 @@ workflows:
             branches:
               only: master
 
+
+  e2e-jetpack-be-scheduled:
+    jobs:
+      - setup
+      - test-e2e-canary:
+          name: test-e2e-jetpack
+          requires:
+            - setup
+          test-flags: "-j"
+          jetpack-host: "PRESSABLEBLEEDINGEDGE"
+          test-target: "JETPACK"
+          slack-webhook: "$SLACK_JP"
+    triggers:
+      - schedule:
+          cron: "0 7 * * *"
+          filters:
+            branches:
+              only: master
+
 # Temporarily disabling these scheduled test runs
-#  e2e-jetpack-be-scheduled:
-#    jobs:
-#      - setup
-#      - test-e2e-canary:
-#          name: test-e2e-jetpack
-#          requires:
-#            - setup
-#          test-flags: "-j"
-#          jetpack-host: "PRESSABLEBLEEDINGEDGE"
-#          test-target: "JETPACK"
-#          slack-webhook: "$SLACK_JP"
-#    triggers:
-#      - schedule:
-#          cron: "0 7 * * *"
-#          filters:
-#            branches:
-#              only: master
-#
 #  e2e-jetpack-scheduled:
 #    jobs:
 #    - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,14 +518,21 @@ jobs:
       slack-webhook:
         type: string
         default: $SLACK_E2E
+      skip-jetpack:
+        type: string
+        default: ""
     steps:
       - prepare
       - run: *set-e2e-variables
-      - run: |
-          if [[ "$SKIP_JETPACK" == "true" ]]; then
-              echo "Jetpack tests have been skipped"
-              circleci-agent step halt
-          fi
+      - when:
+          condition: << parameters.skip-jetpack >>
+          steps:
+            - slack/notify:
+                color: '#FF0000'
+                webhook: << parameters.slack-webhook >>
+                message: Jetpack tests have been skipped
+            - run: |
+                circleci-agent step halt
       - run: npm run decryptconfig
       - run:
           name: Run Canary Tests
@@ -595,6 +602,15 @@ workflows:
           test-flags: "-W -S $CIRCLE_SHA1"
           test-target: "WOO"
           slack-webhook: "$SLACK_WOO"
+      - test-e2e-canary:
+          name: test-e2e-jetpack
+          requires:
+          - wait-calypso-live
+          test-flags: "-j"
+          jetpack-host: "PRESSABLEBLEEDINGEDGE"
+          test-target: "JETPACK"
+          slack-webhook: "$SLACK_JP"
+          skip-jetpack: "$SKIP_JETPACK"
 
   calypso-nightly:
     jobs:
@@ -656,7 +672,6 @@ workflows:
             branches:
               only: master
 
-
   e2e-jetpack-be-scheduled:
     jobs:
       - setup
@@ -668,6 +683,7 @@ workflows:
           jetpack-host: "PRESSABLEBLEEDINGEDGE"
           test-target: "JETPACK"
           slack-webhook: "$SLACK_JP"
+          skip-jetpack: "$SKIP_JETPACK"
     triggers:
       - schedule:
           cron: "0 7 * * *"
@@ -687,6 +703,7 @@ workflows:
 #        jetpack-host: "PRESSABLE"
 #        test-target: "JETPACK"
 #        slack-webhook: "$SLACK_JP"
+#        skip-jetpack: "$SKIP_JETPACK"
 #    triggers:
 #    - schedule:
 #        cron: "0 1,13 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,25 +651,25 @@ workflows:
             branches:
               only: master
 
-  e2e-jetpack-be-scheduled:
-    jobs:
-      - setup
-      - test-e2e-canary:
-          name: test-e2e-jetpack
-          requires:
-            - setup
-          test-flags: "-j"
-          jetpack-host: "PRESSABLEBLEEDINGEDGE"
-          test-target: "JETPACK"
-          slack-webhook: "$SLACK_JP"
-    triggers:
-      - schedule:
-          cron: "0 7 * * *"
-          filters:
-            branches:
-              only: master
-
 # Temporarily disabling these scheduled test runs
+#  e2e-jetpack-be-scheduled:
+#    jobs:
+#      - setup
+#      - test-e2e-canary:
+#          name: test-e2e-jetpack
+#          requires:
+#            - setup
+#          test-flags: "-j"
+#          jetpack-host: "PRESSABLEBLEEDINGEDGE"
+#          test-target: "JETPACK"
+#          slack-webhook: "$SLACK_JP"
+#    triggers:
+#      - schedule:
+#          cron: "0 7 * * *"
+#          filters:
+#            branches:
+#              only: master
+#
 #  e2e-jetpack-scheduled:
 #    jobs:
 #    - setup

--- a/test/e2e/docs/config.md
+++ b/test/e2e/docs/config.md
@@ -93,3 +93,4 @@ These environment variables are intended for use inside CircleCI, to control whi
 | DISABLE_EMAIL | Setting this to `true` will cause the Invite and Signup tests to be skipped | false | No |
 | SKIP_TEST_REGEX | The value of this variable will be used in the `-i -g *****` parameter, to skip any tests that match the given RegEx.  List multiple keywords separated by a `|` (i.e. `Invite|Domain|Theme`) | `Empty String` | No |
 | SKIP_DOMAIN_TESTS | If this value is set to `true`, the tests that attempt domain registration with be skipped.  | false | No |
+| SKIP_JETPACK | If this value is set to `true`, the Jetpack tests with be skipped. Useful to disable scheduled tests without modifying circleCI config  | false | No |


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds in a step to the config to skip the Jetpack tests if an environment variable is set. If `SKIP_JETPACK` is set in CircleCI, the tests will be skipped. They will show passing in the build, but will alert in the slack channel that they were skipped so that we don't forget to re-enable them 

#### Testing instructions
* See https://circleci.com/gh/Automattic/wp-calypso/236385 for a build where test was skipped.
* See https://circleci.com/gh/Automattic/wp-calypso/236386 for a build that wasn't Jetpack so tests ran even though env var was set.