### PR TITLE
Importer: Change the text of the `Done` button to `View Site`

### DIFF
--- a/client/my-sites/importer/importer-action-buttons/done-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/done-button.jsx
@@ -83,7 +83,7 @@ export class DoneButton extends React.PureComponent {
 
 		return (
 			<ImporterActionButton primary onClick={ this.handleClick }>
-				{ translate( 'Done', { context: 'adjective' } ) }
+				{ translate( 'View Site' ) }
 			</ImporterActionButton>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the text of the `Done` button to `View Site` (as [suggested](https://github.com/Automattic/wp-calypso/pull/31852#discussion_r270095752) in #31852).

Before:

![Screen Shot 2019-04-01 at 1 44 55 PM](https://user-images.githubusercontent.com/1587282/55348107-719c5d80-5484-11e9-8101-318b6a138a63.png)

After:

![Screen Shot 2019-04-01 at 1 45 26 PM](https://user-images.githubusercontent.com/1587282/55348121-77923e80-5484-11e9-9bd2-55ac91ad679f.png)

#### Testing instructions

* Follow instructions in #31817 & #31852 
  * Everything should "still work"
* The `Done` button text should be representative of what clicking it will do