### PR TITLE
Remove gSuiteStatsNudge ab test

### DIFF
--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -12,7 +12,6 @@ import Gridicon from 'gridicons';
 /**
  * Internal Dependencies
  */
-import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import Card from 'components/card';
 import { emailManagement } from 'my-sites/email/paths';
@@ -71,28 +70,6 @@ class GSuiteStatsNudge extends Component {
 		return ! this.props.isDismissed;
 	}
 
-	getHeaderCopy() {
-		const { domainSlug, translate } = this.props;
-
-		switch ( abtest( 'gSuiteStatsNudge' ) ) {
-			case 'copy1':
-				return translate( 'Get a mailbox powered by G Suite' );
-			case 'copy2':
-				return translate(
-					'Get email for your domain powered by G Suite for just {{em}}$6/mo{{/em}} $5/mo – limited time offer!',
-					{ components: { em: <em /> } }
-				);
-			case 'copy3':
-				return translate(
-					'Customers can’t reach you at contact@%s – click here to add a mailbox for just $5/mo',
-					{ args: domainSlug }
-				);
-			case 'copy4':
-				return translate( 'Professional email and so much more' );
-			default:
-		}
-	}
-
 	render() {
 		const { domainSlug, siteSlug, translate } = this.props;
 		const url = emailManagement( siteSlug );
@@ -126,7 +103,9 @@ class GSuiteStatsNudge extends Component {
 					</div>
 
 					<div className="gsuite-stats-nudge__info">
-						<h1 className="gsuite-stats-nudge__title">{ this.getHeaderCopy() }</h1>
+						<h1 className="gsuite-stats-nudge__title">
+							{ translate( 'Get a mailbox powered by G Suite' ) }
+						</h1>
 						{
 							<p>
 								{ translate(

--- a/client/blocks/gsuite-stats-nudge/index.js
+++ b/client/blocks/gsuite-stats-nudge/index.js
@@ -104,7 +104,10 @@ class GSuiteStatsNudge extends Component {
 
 					<div className="gsuite-stats-nudge__info">
 						<h1 className="gsuite-stats-nudge__title">
-							{ translate( 'Get a mailbox powered by G Suite' ) }
+							{ translate(
+								'Customers can’t reach you at contact@%s – click here to add a mailbox',
+								{ args: domainSlug }
+							) }
 						</h1>
 						{
 							<p>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -166,16 +166,6 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
-	gSuiteStatsNudge: {
-		datestamp: '20190308',
-		variations: {
-			copy1: 25,
-			copy2: 25,
-			copy3: 25,
-			copy4: 25,
-		},
-		defaultVariation: 'copy1',
-	},
 	builderReferralHelpBanner: {
 		datestamp: '20190304',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes stats banner copy Ab Test

#### Testing instructions

* Goto Stats page with a site that does not have G Suite.
* Observe banner has the copy: 'Customers can’t reach you at contact@%s – click here to add a mailbox'
![Screen Shot 2019-04-01 at 2 51 58 PM](https://user-images.githubusercontent.com/6817400/55351974-baa4df80-548d-11e9-8bac-53b8541d5edc.png)
