### PR TITLE
Block Editor: Connect to MediaStore in `didMount`

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -60,14 +60,15 @@ class CalypsoifyIframe extends Component {
 		super( props );
 		this.iframeRef = React.createRef();
 		this.mediaSelectPort = null;
-		MediaStore.on( 'change', this.updateImageBlocks );
 	}
 
 	componentDidMount() {
+		MediaStore.on( 'change', this.updateImageBlocks );
 		window.addEventListener( 'message', this.onMessage, false );
 	}
 
 	componentWillUnmount() {
+		MediaStore.off( 'change', this.updateImageBlocks );
 		window.removeEventListener( 'message', this.onMessage, false );
 	}
 


### PR DESCRIPTION
Previously we have been connecting to the `MediaStore` in the editor
iframe's `constructor()` function. As @jsnajdr [pointed out](https://github.com/Automattic/wp-calypso/pull/31902/files#r270860887) (in #31902) this is the
wrong place to do so and in rare circumstances could lead to errors.

In this change we're moving that connection into `componentDidMount()`
and then removing our listener on `componentDidUnmount()` to keep things
tidy and safe.

## Testing

I could use some help understand all the tests we need to run.

To test the basics though open a post on a Simple Site in the block editor at
*My Sites* > *Posts* > *Add*

Insert an image block, ensure that the Calypso media modal opens (it's the
one with the Free Images and Google Photos options), then upload an image.
Select that image and make sure that the post updates once the image is
fully uploaded. It should display as you expect.

We're mainly looking for regressions where something that should update
doesn't.