### PR TITLE
Import Signup Flow: Include import engine in new site endpoint options

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -175,10 +175,12 @@ export function createSiteWithCart(
 
 	const importingFromUrl =
 		'import' === flowName ? normalizeImportUrl( getNuxUrlInputValue( state ) ) : '';
+	const importEngine = 'import' === flowName ? getSelectedImportEngine( state ) : '';
 
 	if ( importingFromUrl ) {
 		newSiteParams.blog_name = importingFromUrl;
 		newSiteParams.find_available_url = true;
+		newSiteParams.options.nux_import_engine = importEngine;
 	} else if (
 		flowName === 'onboarding' &&
 		'remove' === getABTestVariation( 'removeDomainsStepFromOnboarding' )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds the import engine to the options array for the newly created site using the key `nux_import_engine`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
This PR is designed to be used along-side the changes in D26279-code and D26280-code, but can also be tested independently: 

* Open the network inspector (it may be helpful to "Preserve log")
![image](https://user-images.githubusercontent.com/363749/55353962-25541c00-548a-11e9-8e72-4b3c206122ec.png)
* Filter by the phrase "new"
![image](https://user-images.githubusercontent.com/363749/55353980-313fde00-548a-11e9-8c19-b7f0631852f4.png)
* Begin a site-importer import from `/start/import`. Continue through at least site creation.
* Watch for the XHR request to the `/sites/new` endpoint. Verify that the `nux_import_engine` option is present, and that it's value matches the engine of the site you selected


