### PR TITLE
Remove G Suite Monthly Prices

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
@@ -24,7 +24,7 @@ import {
 	validate as validateGappsUsers,
 	filter as filterUsers,
 } from 'lib/domains/google-apps-users';
-import { getAnnualPrice, getMonthlyPrice } from 'lib/google-apps';
+import { getAnnualPrice } from 'lib/google-apps';
 import { recordTracksEvent, recordGoogleEvent, composeAnalytics } from 'state/analytics/actions';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import QueryProducts from 'components/data/query-products-list';
@@ -58,14 +58,11 @@ class GoogleAppsDialog extends React.Component {
 		}
 	}
 
-	getPrices( plan ) {
+	getAnnualPrice( plan ) {
 		const { currencyCode, productsList } = this.props;
 		const price = get( productsList, [ plan, 'prices', currencyCode ], 0 );
 
-		return {
-			annualPrice: getAnnualPrice( price, currencyCode ),
-			monthlyPrice: getMonthlyPrice( price, currencyCode ),
-		};
+		return getAnnualPrice( price, currencyCode );
 	}
 
 	render() {
@@ -77,8 +74,6 @@ class GoogleAppsDialog extends React.Component {
 	}
 
 	renderView() {
-		const prices = this.getPrices( gsuitePlanSlug );
-
 		return (
 			<form className="gsuite-dialog__form" onSubmit={ this.handleFormSubmit }>
 				<QueryProducts />
@@ -87,7 +82,7 @@ class GoogleAppsDialog extends React.Component {
 					<GoogleAppsProductDetails
 						domain={ this.props.domain }
 						plan={ gsuitePlanSlug }
-						{ ...prices }
+						annualPrice={ this.getAnnualPrice( gsuitePlanSlug ) }
 					/>
 					{ this.renderGoogleAppsUsers() }
 				</CompactCard>

--- a/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
@@ -15,7 +15,6 @@ import { localize } from 'i18n-calypso';
 class GoogleAppsProductDetails extends Component {
 	static propTypes = {
 		annualPrice: PropTypes.string.isRequired,
-		monthlyPrice: PropTypes.string.isRequired,
 	};
 
 	getStorageText() {
@@ -28,13 +27,7 @@ class GoogleAppsProductDetails extends Component {
 	}
 
 	renderPrice() {
-		return this.props.translate( '%(monthlyPrice)s per user / month', {
-			args: { monthlyPrice: this.props.monthlyPrice },
-		} );
-	}
-
-	renderPeriod() {
-		return this.props.translate( '%(annualPrice)s Billed yearly — get 2 months free!', {
+		return this.props.translate( '%(annualPrice)s per user / year', {
 			args: { annualPrice: this.props.annualPrice },
 		} );
 	}
@@ -58,8 +51,6 @@ class GoogleAppsProductDetails extends Component {
 					</p>
 
 					<div className="gsuite-dialog__price-per-user">{ this.renderPrice() }</div>
-
-					<div className="gsuite-dialog__billing-period">{ this.renderPeriod() }</div>
 				</div>
 
 				<ul className="gsuite-dialog__product-features">

--- a/client/lib/google-apps/index.js
+++ b/client/lib/google-apps/index.js
@@ -12,10 +12,6 @@ function getAnnualPrice( cost, currencyCode ) {
 	return formatPrice( cost, currencyCode );
 }
 
-function getMonthlyPrice( cost, currencyCode ) {
-	return formatPrice( cost / 10, currencyCode );
-}
-
 function googleAppsSettingsUrl( domainName ) {
 	return GOOGLE_APPS_LINK_PREFIX + domainName;
 }
@@ -40,10 +36,4 @@ function getLoginUrlWithTOSRedirect( email, domain ) {
 	);
 }
 
-export {
-	getAnnualPrice,
-	getMonthlyPrice,
-	googleAppsSettingsUrl,
-	formatPrice,
-	getLoginUrlWithTOSRedirect,
-};
+export { getAnnualPrice, googleAppsSettingsUrl, formatPrice, getLoginUrlWithTOSRedirect };

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -18,7 +18,7 @@ import Header from 'my-sites/domains/domain-management/components/header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { hasGSuite, isGSuiteRestricted, hasGSuiteSupportedDomain } from 'lib/domains/gsuite';
 import { getEligibleEmailForwardingDomain } from 'lib/domains/email-forwarding';
-import { getAnnualPrice, getMonthlyPrice } from 'lib/google-apps';
+import { getAnnualPrice } from 'lib/google-apps';
 import getGSuiteUsers from 'state/selectors/get-gsuite-users';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
@@ -176,12 +176,10 @@ class EmailManagement extends React.Component {
 		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
 		const price = get( productsList, [ gsuitePlanSlug, 'prices', currencyCode ], 0 );
 		const annualPrice = getAnnualPrice( price, currencyCode );
-		const monthlyPrice = getMonthlyPrice( price, currencyCode );
 		return (
 			<Fragment>
 				<GSuitePurchaseCta
 					annualPrice={ annualPrice }
-					monthlyPrice={ monthlyPrice }
 					productSlug={ gsuitePlanSlug }
 					selectedDomainName={ selectedDomainName }
 				/>

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -40,7 +40,7 @@ class GSuitePurchaseCta extends React.Component {
 	}
 
 	renderCta() {
-		const { annualPrice, domainName, monthlyPrice, productSlug, translate } = this.props;
+		const { annualPrice, domainName, productSlug, translate } = this.props;
 		const upgradeAvailable = config.isEnabled( 'upgrades/checkout' );
 
 		return (
@@ -72,12 +72,12 @@ class GSuitePurchaseCta extends React.Component {
 							<div className="gsuite-purchase-cta__add-google-apps-card-price">
 								<h4 className="gsuite-purchase-cta__add-google-apps-card-price-per-user">
 									<span>
-										{ translate( '{{strong}}%(price)s{{/strong}} per user / month', {
+										{ translate( '{{strong}}%(price)s{{/strong}} per user / year', {
 											components: {
 												strong: <strong />,
 											},
 											args: {
-												price: monthlyPrice,
+												price: annualPrice,
 											},
 										} ) }
 									</span>
@@ -88,14 +88,6 @@ class GSuitePurchaseCta extends React.Component {
 										{ translate( 'Add G Suite' ) }
 									</Button>
 								) }
-
-								<h5 className="gsuite-purchase-cta__add-google-apps-card-billing-period">
-									{ translate( '%(price)s billed yearly (2 months free!)', {
-										args: {
-											price: annualPrice,
-										},
-									} ) }
-								</h5>
 							</div>
 						</div>
 
@@ -139,7 +131,6 @@ class GSuitePurchaseCta extends React.Component {
 GSuitePurchaseCta.propTypes = {
 	annualPrice: PropTypes.string.isRequired,
 	domainName: PropTypes.string.isRequired,
-	monthlyPrice: PropTypes.string.isRequired,
 	productSlug: PropTypes.string.isRequired,
 	selectedDomainName: PropTypes.string,
 	selectedSiteSlug: PropTypes.string.isRequired,

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -47,9 +47,9 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with basic plan 1`] = `
           >
             <span>
               <strong>
-                $5
+                $72
               </strong>
-               per user / month
+               per user / year
             </span>
           </h4>
           <button
@@ -60,11 +60,6 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with basic plan 1`] = `
           >
             Add G Suite
           </button>
-          <h5
-            className="gsuite-purchase-cta__add-google-apps-card-billing-period"
-          >
-            $50 billed yearly (2 months free!)
-          </h5>
         </div>
       </div>
       <div
@@ -149,9 +144,9 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with business plan 1`] =
           >
             <span>
               <strong>
-                $5
+                $144
               </strong>
-               per user / month
+               per user / year
             </span>
           </h4>
           <button
@@ -162,11 +157,6 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with business plan 1`] =
           >
             Add G Suite
           </button>
-          <h5
-            className="gsuite-purchase-cta__add-google-apps-card-billing-period"
-          >
-            $50 billed yearly (2 months free!)
-          </h5>
         </div>
       </div>
       <div

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -17,16 +17,21 @@ jest.mock( 'my-sites/email/gsuite-purchase-features', () => 'GSuitePurchaseFeatu
 
 describe( 'GSuitePurchaseCta', () => {
 	test( 'it renders GSuitePurchaseCta with basic plan', () => {
-		const store = createReduxStore();
+		const store = createReduxStore( {
+			ui: { selectedSiteId: 123 },
+			sites: {
+				items: {
+					123: {
+						ID: 123,
+						URL: 'https://test.com',
+					},
+				},
+			},
+		} );
 		const tree = renderer
 			.create(
 				<Provider store={ store }>
-					<GSuitePurchaseCta
-						annualPrice={ '$50' }
-						monthlyPrice={ '$5' }
-						productSlug={ 'gapps' }
-						selectedSite={ { ID: 'foo' } }
-					/>
+					<GSuitePurchaseCta annualPrice={ '$72' } productSlug={ 'gapps' } />
 				</Provider>
 			)
 			.toJSON();
@@ -34,16 +39,21 @@ describe( 'GSuitePurchaseCta', () => {
 	} );
 
 	test( 'it renders GSuitePurchaseCta with business plan', () => {
-		const store = createReduxStore();
+		const store = createReduxStore( {
+			ui: { selectedSiteId: 123 },
+			sites: {
+				items: {
+					123: {
+						ID: 123,
+						URL: 'https://test.com',
+					},
+				},
+			},
+		} );
 		const tree = renderer
 			.create(
 				<Provider store={ store }>
-					<GSuitePurchaseCta
-						annualPrice={ '$50' }
-						monthlyPrice={ '$5' }
-						productSlug={ 'gapps_unlimited' }
-						selectedSite={ { ID: 'foo' } }
-					/>
+					<GSuitePurchaseCta annualPrice={ '$144' } productSlug={ 'gapps_unlimited' } />
 				</Provider>
 			)
 			.toJSON();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove G Suite monthly prices

**Email Upsell**
<img width="450" alt="Email Upsell" src="https://user-images.githubusercontent.com/2810519/55361379-ede66f00-548b-11e9-93be-8bb59ec4eeae.png">

**Mobile Email Upsell**
<img width="450" alt="Mobile Email Upsell" src="https://user-images.githubusercontent.com/2810519/55361398-f76fd700-548b-11e9-91e8-df8de3073535.png">

**Domain Upsell**
<img width="450" alt="Domain Upsell" src="https://user-images.githubusercontent.com/2810519/55361406-fa6ac780-548b-11e9-9ade-276740e0da61.png">

**Mobile Domain Upsell**
<img width="450" alt="Mobile Domain Upsell" src="https://user-images.githubusercontent.com/2810519/55361411-fc348b00-548b-11e9-9d2f-a0cdb67c43af.png">

#### Testing instructions

1. Navigate to `/email/:domain/manage/:siteSlug` for a site and domain without G Suite
1. Confirm that this screen matches the **Email Upsell** screenshot above
1. Navigate to `/domains/add/:newDomain/google-apps/:siteSlug` where `:newDomain` is not a domain on the site
1. Confirm that this screen matches the **Domain Upsell** screenshot above
