### PR TITLE
Calypso Build Package: Add webpack.config.js

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -20,12 +20,14 @@
 				"autoprefixer": "9.4.4",
 				"babel-loader": "8.0.5",
 				"css-loader": "2.1.1",
-				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
+				"duplicate-package-checker-webpack-plugin": "3.0.0",
+				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
 				"postcss-custom-properties": "8.0.9",
 				"postcss-loader": "3.0.0",
 				"sass-loader": "7.1.0",
 				"terser-webpack-plugin": "1.2.3",
 				"thread-loader": "2.1.2",
+				"webpack": "4.29.6",
 				"webpack-filter-warnings-plugin": "1.2.1",
 				"webpack-rtl-plugin": "1.8.0"
 			}
@@ -167,9 +169,9 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.0.tgz",
-			"integrity": "sha512-2K8NohdOT7P6Vyp23QH4w2IleP8yG3UJsbRKwA4YP6H8fErcLkFuuEEqbF2/BYBKSNci/FWJiqm6R3VhM/QHgw==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.3.tgz",
+			"integrity": "sha512-UMl3TSpX11PuODYdWGrUeW6zFkdYhDn7wRLrOuNVM6f9L+S9CzmDXYyrp3MTHcwWjnzur1f/Op8A7iYZWya2Yg==",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-member-expression-to-functions": "^7.0.0",
@@ -241,16 +243,16 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.2.2.tgz",
-			"integrity": "sha512-YRD7I6Wsv+IHuTPkAmAS4HhY0dkPobgLftHp0cRGZSdrRvmZY8rFvae/GVu3bD00qscuvK3WPHB3YdNpBXUqrA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.4.3.tgz",
+			"integrity": "sha512-H88T9IySZW25anu5uqyaC1DaQre7ofM+joZtAaO2F8NBdFfupH0SZ4gKjgSFVcvtx/aAirqA9L9Clio2heYbZA==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0",
 				"@babel/helper-split-export-declaration": "^7.0.0",
 				"@babel/template": "^7.2.2",
 				"@babel/types": "^7.2.2",
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
@@ -267,11 +269,11 @@
 			"integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA=="
 		},
 		"@babel/helper-regex": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0.tgz",
-			"integrity": "sha512-TR0/N0NDCcUIUEbqV6dCO+LptmmSQFQ7q70lfcEB4URsjD0E1HzicrwUH+ap6BAQ2jhCX9Q4UqZy4wilujWlkg==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.4.3.tgz",
+			"integrity": "sha512-hnoq5u96pLCfgjXuj8ZLX3QQ+6nAulS+zSgi6HulUwFbEruRAKwbGLU5OvXkE14L8XW6XsQEKsIDfgthKLRAyA==",
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "^4.17.11"
 			}
 		},
 		"@babel/helper-remap-async-to-generator": {
@@ -326,12 +328,12 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.2.tgz",
-			"integrity": "sha512-gQR1eQeroDzFBikhrCccm5Gs2xBjZ57DNjGbqTaHo911IpmSxflOQWMAHPw/TXk8L3isv7s9lYzUkexOeTQUYg==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.3.tgz",
+			"integrity": "sha512-BMh7X0oZqb36CfyhvtbSmcWc3GXocfxv3yNsAEuM0l+fAqSO22rQrUpijr3oE/10jCTrB6/0b9kzmG4VetCj8Q==",
 			"requires": {
 				"@babel/template": "^7.4.0",
-				"@babel/traverse": "^7.4.0",
+				"@babel/traverse": "^7.4.3",
 				"@babel/types": "^7.4.0"
 			}
 		},
@@ -346,9 +348,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.4.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
-			"integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g=="
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+			"integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.2.0",
@@ -397,9 +399,9 @@
 			}
 		},
 		"@babel/plugin-proposal-object-rest-spread": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.0.tgz",
-			"integrity": "sha512-uTNi8pPYyUH2eWHyYWWSYJKwKg34hhgl4/dbejEjL+64OhbHjTX7wEVWMQl82tEmdDsGeu77+s8HHLS627h6OQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz",
+			"integrity": "sha512-xC//6DNSSHVjq8O2ge0dyYlhshsH4T7XdCVoxbi5HzLYWfsC5ooFlJjrXk8RcAT+hjHAK9UjBXdylzSoDK3t4g==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
@@ -524,9 +526,9 @@
 			}
 		},
 		"@babel/plugin-transform-classes": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.0.tgz",
-			"integrity": "sha512-XGg1Mhbw4LDmrO9rSTNe+uI79tQPdGs0YASlxgweYRLZqo/EQktjaOV4tchL/UZbM0F+/94uOipmdNGoaGOEYg==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.4.3.tgz",
+			"integrity": "sha512-PUaIKyFUDtG6jF5DUJOfkBdwAS/kFFV3XFk7Nn0a6vR7ZT8jYw5cGtIlat77wcnd0C6ViGqo/wyNf4ZHytF/nQ==",
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.0.0",
 				"@babel/helper-define-map": "^7.4.0",
@@ -547,21 +549,21 @@
 			}
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.0.tgz",
-			"integrity": "sha512-HySkoatyYTY3ZwLI8GGvkRWCFrjAGXUHur5sMecmCIdIharnlcWWivOqDJI76vvmVZfzwb6G08NREsrY96RhGQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.4.3.tgz",
+			"integrity": "sha512-rVTLLZpydDFDyN4qnXdzwoVpk1oaXHIvPEOkOLyr88o7oHxVc/LyrnDx+amuBWGOwUb7D1s/uLsKBNTx08htZg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-dotall-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.2.0.tgz",
-			"integrity": "sha512-sKxnyHfizweTgKZf7XsXu/CNupKhzijptfTM+bozonIuyVrLWVUvYjE2bhuSBML8VQeMxq4Mm63Q9qvcvUcciQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.4.3.tgz",
+			"integrity": "sha512-9Arc2I0AGynzXRR/oPdSALv3k0rM38IMFyto7kOCwb5F9sLUt2Ykdo3V9yUPR+Bgr4kb6bVEyLkPEiBhzcTeoA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.1.3"
+				"@babel/helper-regex": "^7.4.3",
+				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/plugin-transform-duplicate-keys": {
@@ -582,17 +584,17 @@
 			}
 		},
 		"@babel/plugin-transform-for-of": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.0.tgz",
-			"integrity": "sha512-vWdfCEYLlYSxbsKj5lGtzA49K3KANtb8qCPQ1em07txJzsBwY+cKJzBHizj5fl3CCx7vt+WPdgDLTHmydkbQSQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.4.3.tgz",
+			"integrity": "sha512-UselcZPwVWNSURnqcfpnxtMehrb8wjXYOimlYQPBnup/Zld426YzIhNEvuRsEWVHfESIECGrxoI6L5QqzuLH5Q==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
 		"@babel/plugin-transform-function-name": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.2.0.tgz",
-			"integrity": "sha512-kWgksow9lHdvBC2Z4mxTsvc7YdY7w/V6B2vy9cTIPtLEE9NhwoWivaxdNM/S37elu5bqlLP/qOY906LukO9lkQ==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.4.3.tgz",
+			"integrity": "sha512-uT5J/3qI/8vACBR9I1GlAuU/JqBtWdfCrynuOkrWG6nCDieZd5przB1vfP59FRHBZQ9DC2IUfqr/xKqzOD5x0A==",
 			"requires": {
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-plugin-utils": "^7.0.0"
@@ -616,11 +618,11 @@
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.0.tgz",
-			"integrity": "sha512-iWKAooAkipG7g1IY0eah7SumzfnIT3WNhT4uYB2kIsvHnNSB6MDYVa5qyICSwaTBDBY2c4SnJ3JtEa6ltJd6Jw==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.4.3.tgz",
+			"integrity": "sha512-sMP4JqOTbMJMimqsSZwYWsMjppD+KRyDIUVW91pd7td0dZKAvPmhCaxhOzkzLParKwgQc7bdL9UNv+rpJB0HfA==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.1.0",
+				"@babel/helper-module-transforms": "^7.4.3",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-simple-access": "^7.1.0"
 			}
@@ -669,9 +671,9 @@
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.0.tgz",
-			"integrity": "sha512-Xqv6d1X+doyiuCGDoVJFtlZx0onAX0tnc3dY8w71pv/O0dODAbusVv2Ale3cGOwfiyi895ivOBhYa9DhAM8dUA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.4.3.tgz",
+			"integrity": "sha512-ULJYC2Vnw96/zdotCZkMGr2QVfKpIT/4/K+xWWY0MbOJyMZuk660BGkr3bEKWQrrciwz6xpmft39nA4BF7hJuA==",
 			"requires": {
 				"@babel/helper-call-delegate": "^7.4.0",
 				"@babel/helper-get-function-arity": "^7.0.0",
@@ -715,9 +717,9 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.0.tgz",
-			"integrity": "sha512-SZ+CgL4F0wm4npojPU6swo/cK4FcbLgxLd4cWpHaNXY/NJ2dpahODCqBbAwb2rDmVszVb3SSjnk9/vik3AYdBw==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.3.tgz",
+			"integrity": "sha512-kEzotPuOpv6/iSlHroCDydPkKYw7tiJGKlmYp6iJn4a6C/+b2FdttlJsLKYxolYHgotTJ5G5UY5h0qey5ka3+A==",
 			"requires": {
 				"regenerator-transform": "^0.13.4"
 			}
@@ -776,13 +778,13 @@
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.2.0.tgz",
-			"integrity": "sha512-m48Y0lMhrbXEJnVUaYly29jRXbQ3ksxPrS1Tg8t+MHqzXhtBYAvI51euOBaoAlZLPHsieY9XPVMf80a5x0cPcA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.4.3.tgz",
+			"integrity": "sha512-lnSNgkVjL8EMtnE8eSS7t2ku8qvKH3eqNf/IwIfnSPUqzgqYmRwzdsQWv4mNQAN9Nuo6Gz1Y0a4CSmdpu1Pp6g==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/helper-regex": "^7.0.0",
-				"regexpu-core": "^4.1.3"
+				"@babel/helper-regex": "^7.4.3",
+				"regexpu-core": "^4.5.4"
 			}
 		},
 		"@babel/polyfill": {
@@ -877,15 +879,15 @@
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.4.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
-			"integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+			"version": "7.4.3",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+			"integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"@babel/generator": "^7.4.0",
 				"@babel/helper-function-name": "^7.1.0",
 				"@babel/helper-split-export-declaration": "^7.4.0",
-				"@babel/parser": "^7.4.0",
+				"@babel/parser": "^7.4.3",
 				"@babel/types": "^7.4.0",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
@@ -976,59 +978,11 @@
 				"strip-ansi": "^5.0.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
 				"ansi-regex": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
-				},
-				"camelcase": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
-					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
-					"dev": true
-				},
-				"jest-validate": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.7.0.tgz",
-					"integrity": "sha512-cgai/gts9B2chz1rqVdmLhzYxQbgQurh1PEQSvSgPZ8KGa1AqXsqC45W5wKEwzxKrWqypuQrQxnF4+G9VejJJA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"camelcase": "^5.0.0",
-						"chalk": "^2.0.1",
-						"jest-get-type": "^24.3.0",
-						"leven": "^2.1.0",
-						"pretty-format": "^24.7.0"
-					}
-				},
-				"pretty-format": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
-					"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
 				},
 				"strip-ansi": {
 					"version": "5.2.0",
@@ -1051,24 +1005,6 @@
 				"@jest/transform": "^24.7.0",
 				"@jest/types": "^24.7.0",
 				"jest-mock": "^24.7.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"@jest/fake-timers": {
@@ -1080,24 +1016,6 @@
 				"@jest/types": "^24.7.0",
 				"jest-message-util": "^24.7.0",
 				"jest-mock": "^24.7.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"@jest/reporters": {
@@ -1128,22 +1046,6 @@
 				"string-length": "^2.0.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1186,24 +1088,6 @@
 				"@jest/console": "^24.6.0",
 				"@jest/types": "^24.7.0",
 				"@types/istanbul-lib-coverage": "^2.0.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"@jest/test-sequencer": {
@@ -1241,22 +1125,6 @@
 				"write-file-atomic": "2.4.1"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1277,12 +1145,12 @@
 			}
 		},
 		"@jest/types": {
-			"version": "24.5.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.5.0.tgz",
-			"integrity": "sha512-kN7RFzNMf2R8UDadPOl6ReyI+MT8xfqRuAnuVL+i4gwjv/zubdDK+EDeLHYwq1j0CSSR2W/MmgaRlMZJzXdmVA==",
+			"version": "24.7.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
+			"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
 			"dev": true,
 			"requires": {
-				"@types/istanbul-lib-coverage": "^1.1.0",
+				"@types/istanbul-lib-coverage": "^2.0.0",
 				"@types/yargs": "^12.0.9"
 			}
 		},
@@ -1438,9 +1306,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg=="
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
@@ -1507,9 +1375,9 @@
 					}
 				},
 				"mem": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-					"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
 						"mimic-fn": "^2.0.0",
@@ -1517,9 +1385,9 @@
 					}
 				},
 				"mimic-fn": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-					"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 				},
 				"os-locale": {
 					"version": "3.1.0",
@@ -1548,9 +1416,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -1712,9 +1580,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg=="
 				},
 				"dir-glob": {
 					"version": "2.0.0",
@@ -2409,11 +2277,12 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.21.0",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.21.0.tgz",
-			"integrity": "sha512-4tT+uUPqwOHfPdSSt8RtSZw6vgAbBMTGb+BualKkq3vjpeqmSfmN9h5VxhM4xqV1KAGCeLzBGdH6nwgf18eEPA==",
+			"version": "16.23.2",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.23.2.tgz",
+			"integrity": "sha512-ZxiZMaCuqBG/IsbgNRVfGwYsvBb5DjHuMGjJgOrinT+/b+1j1U7PiGyRkHDJdjTGA6N/PsMC2lP2ZybX9579iA==",
 			"requires": {
 				"@octokit/request": "2.4.2",
+				"atob-lite": "^2.0.0",
 				"before-after-hook": "^1.4.0",
 				"btoa-lite": "^1.0.0",
 				"deprecation": "^1.0.1",
@@ -2633,9 +2502,9 @@
 			}
 		},
 		"@types/istanbul-lib-coverage": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-			"integrity": "sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
+			"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
 			"dev": true
 		},
 		"@types/minimatch": {
@@ -2644,9 +2513,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.12.0.tgz",
-			"integrity": "sha512-Lg00egj78gM+4aE0Erw05cuDbvX9sLJbaaPwwRtdCdAMnIudqrQZ0oZX98Ek0yiSK/A2nubHgJfvII/rTT2Dwg=="
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+			"integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng=="
 		},
 		"@types/q": {
 			"version": "1.5.2",
@@ -2688,9 +2557,9 @@
 			}
 		},
 		"@types/yargs": {
-			"version": "12.0.10",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.10.tgz",
-			"integrity": "sha512-WsVzTPshvCSbHThUduGGxbmnwcpkgSctHGHTqzWyFg4lYAuV5qXlyFPOsP3OWqCINfmg/8VXP+zJaa4OxEsBQQ==",
+			"version": "12.0.11",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.11.tgz",
+			"integrity": "sha512-IsU1TD+8cQCyG76ZqxP0cVFnofvfzT8p/wO8ENT4jbN/KKN3grsHFgHNl/U+08s33ayX4LwI85cEhYXCOlOkMw==",
 			"dev": true
 		},
 		"@webassemblyjs/ast": {
@@ -3834,6 +3703,11 @@
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
 		},
+		"atob-lite": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+			"integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
+		},
 		"autoprefixer": {
 			"version": "9.4.4",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.4.tgz",
@@ -3983,24 +3857,6 @@
 				"babel-preset-jest": "^24.6.0",
 				"chalk": "^2.4.2",
 				"slash": "^2.0.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"babel-loader": {
@@ -4359,9 +4215,9 @@
 			"integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
 		},
 		"binary-extensions": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-			"integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw=="
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
 		},
 		"blob": {
 			"version": "0.0.5",
@@ -4377,9 +4233,9 @@
 			}
 		},
 		"bluebird": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-			"integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+			"integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -4584,13 +4440,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.2.tgz",
-			"integrity": "sha512-zmJVLiKLrzko0iszd/V4SsjTaomFeoVzQGYYOYgRgsbh7WNh95RgDB0CmBdFWYs/3MyFSt69NypjL/h3iaddKQ==",
+			"version": "4.5.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
+			"integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
 			"requires": {
-				"caniuse-lite": "^1.0.30000951",
-				"electron-to-chromium": "^1.3.116",
-				"node-releases": "^1.1.11"
+				"caniuse-lite": "^1.0.30000955",
+				"electron-to-chromium": "^1.3.122",
+				"node-releases": "^1.1.13"
 			}
 		},
 		"bser": {
@@ -4799,9 +4655,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000954",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000954.tgz",
-			"integrity": "sha512-Wopmc0eVSSG1d9/O4JTn0OmGhUfhEHNkHhoCjUrGSImvHI+2YQWkOI1RRNTUFNSHbSAD8J41jbdZrPP4r32cbQ=="
+			"version": "1.0.30000957",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz",
+			"integrity": "sha512-8wxNrjAzyiHcLXN/iunskqQnJquQQ6VX8JHfW5kLgAPRSiSuKZiNfmIkP5j7jgyXqAQBSoXyJxfnbCFS0ThSiQ=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -4994,8 +4850,7 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -5013,13 +4868,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -5032,18 +4885,15 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -5146,8 +4996,7 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -5157,7 +5006,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -5170,20 +5018,17 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -5200,7 +5045,6 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -5273,8 +5117,7 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -5284,7 +5127,6 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -5360,8 +5202,7 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -5391,7 +5232,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -5409,7 +5249,6 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -5448,13 +5287,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						}
 					}
 				}
@@ -5733,9 +5570,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -6258,9 +6095,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
 					"dev": true
 				}
 			}
@@ -7066,9 +6903,9 @@
 			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.119",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.119.tgz",
-			"integrity": "sha512-3mtqcAWa4HgG+Djh/oNXlPH0cOH6MmtwxN1nHSaReb9P0Vn51qYPqYwLeoSuAX9loU1wrOBhFbiX3CkeIxPfgg=="
+			"version": "1.3.122",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.122.tgz",
+			"integrity": "sha512-3RKoIyCN4DhP2dsmleuFvpJAIDOseWH88wFYBzb22CSwoFDSWRc4UAMfrtc9h8nBdJjTNIN3rogChgOy6eFInw=="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -7930,24 +7767,6 @@
 				"jest-matcher-utils": "^24.7.0",
 				"jest-message-util": "^24.7.0",
 				"jest-regex-util": "^24.3.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"exports-loader": {
@@ -9331,9 +9150,9 @@
 			"dev": true
 		},
 		"html-element-map": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.0.tgz",
-			"integrity": "sha512-/SP6aOiM5Ai9zALvCxDubIeez0LvG3qP7R9GcRDnJEP/HBmv0A8A9K0o8+HFudcFt46+i921ANjzKsjPjb7Enw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.0.1.tgz",
+			"integrity": "sha512-BZSfdEm6n706/lBfXKWa4frZRZcT5k1cOusw95ijZsHlI+GdgY0v95h6IzO3iIDf2ROwq570YTwqNPqHcNMozw==",
 			"dev": true,
 			"requires": {
 				"array-filter": "^1.0.0"
@@ -9464,9 +9283,9 @@
 			},
 			"dependencies": {
 				"readable-stream": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-					"integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+					"integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -9661,9 +9480,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
 				"pify": {
@@ -10160,9 +9979,9 @@
 			"dev": true
 		},
 		"is-glob": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-			"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
@@ -10589,28 +10408,6 @@
 				"jest-cli": "^24.7.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
 				"camelcase": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
@@ -10715,20 +10512,6 @@
 						"yargs": "^12.0.2"
 					}
 				},
-				"jest-validate": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.7.0.tgz",
-					"integrity": "sha512-cgai/gts9B2chz1rqVdmLhzYxQbgQurh1PEQSvSgPZ8KGa1AqXsqC45W5wKEwzxKrWqypuQrQxnF4+G9VejJJA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"camelcase": "^5.0.0",
-						"chalk": "^2.0.1",
-						"jest-get-type": "^24.3.0",
-						"leven": "^2.1.0",
-						"pretty-format": "^24.7.0"
-					}
-				},
 				"lcid": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -10800,18 +10583,6 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"pretty-format": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
-					"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				},
 				"yargs": {
 					"version": "12.0.5",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
@@ -10855,22 +10626,6 @@
 				"throat": "^4.0.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -10933,62 +10688,6 @@
 				"micromatch": "^3.1.10",
 				"pretty-format": "^24.7.0",
 				"realpath-native": "^1.1.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"camelcase": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
-					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
-					"dev": true
-				},
-				"jest-validate": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.7.0.tgz",
-					"integrity": "sha512-cgai/gts9B2chz1rqVdmLhzYxQbgQurh1PEQSvSgPZ8KGa1AqXsqC45W5wKEwzxKrWqypuQrQxnF4+G9VejJJA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"camelcase": "^5.0.0",
-						"chalk": "^2.0.1",
-						"jest-get-type": "^24.3.0",
-						"leven": "^2.1.0",
-						"pretty-format": "^24.7.0"
-					}
-				},
-				"pretty-format": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
-					"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				}
 			}
 		},
 		"jest-diff": {
@@ -11001,42 +10700,6 @@
 				"diff-sequences": "^24.3.0",
 				"jest-get-type": "^24.3.0",
 				"pretty-format": "^24.7.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"pretty-format": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
-					"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				}
 			}
 		},
 		"jest-docblock": {
@@ -11059,42 +10722,6 @@
 				"jest-get-type": "^24.3.0",
 				"jest-util": "^24.7.0",
 				"pretty-format": "^24.7.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"pretty-format": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
-					"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				}
 			}
 		},
 		"jest-environment-jsdom": {
@@ -11109,24 +10736,6 @@
 				"jest-mock": "^24.7.0",
 				"jest-util": "^24.7.0",
 				"jsdom": "^11.5.1"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"jest-environment-node": {
@@ -11140,24 +10749,6 @@
 				"@jest/types": "^24.7.0",
 				"jest-mock": "^24.7.0",
 				"jest-util": "^24.7.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"jest-get-type": {
@@ -11186,22 +10777,6 @@
 				"walker": "^1.0.7"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
 				"fsevents": {
 					"version": "1.2.7",
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
@@ -11222,8 +10797,7 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -11244,14 +10818,12 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -11266,20 +10838,17 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -11396,8 +10965,7 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -11409,7 +10977,6 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -11424,7 +10991,6 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -11432,14 +10998,12 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -11458,7 +11022,6 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -11539,8 +11102,7 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -11552,7 +11114,6 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -11638,8 +11199,7 @@
 						"safe-buffer": {
 							"version": "5.1.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -11675,7 +11235,6 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -11695,7 +11254,6 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -11739,14 +11297,12 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"yallist": {
 							"version": "3.0.3",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						}
 					}
 				}
@@ -11774,42 +11330,6 @@
 				"jest-util": "^24.7.0",
 				"pretty-format": "^24.7.0",
 				"throat": "^4.0.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"pretty-format": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
-					"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				}
 			}
 		},
 		"jest-junit": {
@@ -11831,42 +11351,6 @@
 			"dev": true,
 			"requires": {
 				"pretty-format": "^24.7.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"pretty-format": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
-					"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				}
 			}
 		},
 		"jest-matcher-utils": {
@@ -11879,42 +11363,6 @@
 				"jest-diff": "^24.7.0",
 				"jest-get-type": "^24.3.0",
 				"pretty-format": "^24.7.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"pretty-format": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
-					"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				}
 			}
 		},
 		"jest-message-util": {
@@ -11931,24 +11379,6 @@
 				"micromatch": "^3.1.10",
 				"slash": "^2.0.0",
 				"stack-utils": "^1.0.1"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"jest-mock": {
@@ -11958,24 +11388,6 @@
 			"dev": true,
 			"requires": {
 				"@jest/types": "^24.7.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"jest-pnp-resolver": {
@@ -12001,24 +11413,6 @@
 				"chalk": "^2.0.1",
 				"jest-pnp-resolver": "^1.2.1",
 				"realpath-native": "^1.1.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"jest-resolve-dependencies": {
@@ -12030,24 +11424,6 @@
 				"@jest/types": "^24.7.0",
 				"jest-regex-util": "^24.3.0",
 				"jest-snapshot": "^24.7.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"jest-runner": {
@@ -12075,24 +11451,6 @@
 				"jest-worker": "^24.6.0",
 				"source-map-support": "^0.5.6",
 				"throat": "^4.0.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"jest-runtime": {
@@ -12126,28 +11484,6 @@
 				"yargs": "^12.0.2"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
 				"camelcase": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
@@ -12205,20 +11541,6 @@
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
 					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
 					"dev": true
-				},
-				"jest-validate": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.7.0.tgz",
-					"integrity": "sha512-cgai/gts9B2chz1rqVdmLhzYxQbgQurh1PEQSvSgPZ8KGa1AqXsqC45W5wKEwzxKrWqypuQrQxnF4+G9VejJJA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"camelcase": "^5.0.0",
-						"chalk": "^2.0.1",
-						"jest-get-type": "^24.3.0",
-						"leven": "^2.1.0",
-						"pretty-format": "^24.7.0"
-					}
 				},
 				"lcid": {
 					"version": "2.0.0",
@@ -12291,18 +11613,6 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"pretty-format": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
-					"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				},
 				"yargs": {
 					"version": "12.0.5",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
@@ -12359,42 +11669,6 @@
 				"natural-compare": "^1.4.0",
 				"pretty-format": "^24.7.0",
 				"semver": "^5.5.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
-				"ansi-regex": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-					"dev": true
-				},
-				"pretty-format": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
-					"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
-					"dev": true,
-					"requires": {
-						"@jest/types": "^24.7.0",
-						"ansi-regex": "^4.0.0",
-						"ansi-styles": "^3.2.0",
-						"react-is": "^16.8.4"
-					}
-				}
 			}
 		},
 		"jest-util": {
@@ -12417,22 +11691,6 @@
 				"source-map": "^0.6.0"
 			},
 			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				},
 				"callsites": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
@@ -12463,23 +11721,23 @@
 			}
 		},
 		"jest-validate": {
-			"version": "24.5.0",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.5.0.tgz",
-			"integrity": "sha512-gg0dYszxjgK2o11unSIJhkOFZqNRQbWOAB2/LOUdsd2LfD9oXiMeuee8XsT0iRy5EvSccBgB4h/9HRbIo3MHgQ==",
+			"version": "24.7.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.7.0.tgz",
+			"integrity": "sha512-cgai/gts9B2chz1rqVdmLhzYxQbgQurh1PEQSvSgPZ8KGa1AqXsqC45W5wKEwzxKrWqypuQrQxnF4+G9VejJJA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.5.0",
+				"@jest/types": "^24.7.0",
 				"camelcase": "^5.0.0",
 				"chalk": "^2.0.1",
 				"jest-get-type": "^24.3.0",
 				"leven": "^2.1.0",
-				"pretty-format": "^24.5.0"
+				"pretty-format": "^24.7.0"
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
 					"dev": true
 				}
 			}
@@ -12497,24 +11755,6 @@
 				"chalk": "^2.0.1",
 				"jest-util": "^24.7.0",
 				"string-length": "^2.0.0"
-			},
-			"dependencies": {
-				"@jest/types": {
-					"version": "24.7.0",
-					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.7.0.tgz",
-					"integrity": "sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==",
-					"dev": true,
-					"requires": {
-						"@types/istanbul-lib-coverage": "^2.0.0",
-						"@types/yargs": "^12.0.9"
-					}
-				},
-				"@types/istanbul-lib-coverage": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-					"integrity": "sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==",
-					"dev": true
-				}
 			}
 		},
 		"jest-worker": {
@@ -13145,9 +12385,9 @@
 			"integrity": "sha512-swStvEyDqQ85MGpABCMBclZcLI/pBIlu8FFDtmX197+oEgKloJ67QnB+Tidh0340HmLMs39c4GrkPY3cmkXp6Q=="
 		},
 		"macos-release": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.1.0.tgz",
-			"integrity": "sha512-8TCbwvN1mfNxbBv0yBtfyIFMo3m1QsNbKHv7PYIp/abRBKVQBXN7ecu3aeGGgT18VC/Tf397LBDGZF9KBGJFFw=="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+			"integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA=="
 		},
 		"magic-string": {
 			"version": "0.25.2",
@@ -13928,9 +13168,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.11.tgz",
-			"integrity": "sha512-8v1j5KfP+s5WOTa1spNUAOfreajQPN12JXbRR0oDE+YrJBQCXBnNqUDj27EKpPLOoSiU3tKi3xGPB+JaOdUEQQ==",
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.13.tgz",
+			"integrity": "sha512-fKZGviSXR6YvVPyc011NHuJDSD8gFQvLPmc2d2V3BS4gr52ycyQ1Xzs7a8B+Ax3Ni/W+5h1h4SqmzeoA8WZRmA==",
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -15192,9 +14432,9 @@
 			}
 		},
 		"parent-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
-			"integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
@@ -15514,9 +14754,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				}
 			}
 		},
@@ -15616,9 +14856,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg=="
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
@@ -15690,9 +14930,9 @@
 					}
 				},
 				"mem": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-					"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
 						"mimic-fn": "^2.0.0",
@@ -15700,9 +14940,9 @@
 					}
 				},
 				"mimic-fn": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-					"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 				},
 				"os-locale": {
 					"version": "3.1.0",
@@ -15731,9 +14971,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -16304,12 +15544,12 @@
 			}
 		},
 		"pretty-format": {
-			"version": "24.5.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.5.0.tgz",
-			"integrity": "sha512-/3RuSghukCf8Riu5Ncve0iI+BzVkbRU5EeUoArKARZobREycuH5O4waxvaNIloEXdb0qwgmEAed5vTpX1HNROQ==",
+			"version": "24.7.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.7.0.tgz",
+			"integrity": "sha512-apen5cjf/U4dj7tHetpC7UEFCvtAgnNZnBDkfPv3fokzIqyOJckAG9OlAPC1BlFALnqT/lGB2tl9EJjlK6eCsA==",
 			"dev": true,
 			"requires": {
-				"@jest/types": "^24.5.0",
+				"@jest/types": "^24.7.0",
 				"ansi-regex": "^4.0.0",
 				"ansi-styles": "^3.2.0",
 				"react-is": "^16.8.4"
@@ -16644,17 +15884,6 @@
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
 				"scheduler": "^0.13.6"
-			},
-			"dependencies": {
-				"scheduler": {
-					"version": "0.13.6",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-					"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1"
-					}
-				}
 			}
 		},
 		"react-addons-create-fragment": {
@@ -16731,17 +15960,6 @@
 				"object-assign": "^4.1.1",
 				"prop-types": "^15.6.2",
 				"scheduler": "^0.13.6"
-			},
-			"dependencies": {
-				"scheduler": {
-					"version": "0.13.6",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-					"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1"
-					}
-				}
 			}
 		},
 		"react-element-to-jsx-string": {
@@ -16754,9 +15972,9 @@
 			}
 		},
 		"react-is": {
-			"version": "16.8.5",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
-			"integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ=="
+			"version": "16.8.6",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+			"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
 		},
 		"react-lazily-render": {
 			"version": "1.1.0",
@@ -16884,14 +16102,6 @@
 				"prop-types": "^15.6.2",
 				"react-is": "^16.8.6",
 				"scheduler": "^0.13.6"
-			},
-			"dependencies": {
-				"react-is": {
-					"version": "16.8.6",
-					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-					"integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
-					"dev": true
-				}
 			}
 		},
 		"react-transition-group": {
@@ -17367,9 +16577,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
 					"dev": true
 				},
 				"colors": {
@@ -17450,9 +16660,9 @@
 					}
 				},
 				"mem": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-					"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 					"dev": true,
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
@@ -17461,9 +16671,9 @@
 					}
 				},
 				"mimic-fn": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-					"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 					"dev": true
 				},
 				"os-locale": {
@@ -17496,9 +16706,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
 				"yargs": {
@@ -18080,7 +17290,6 @@
 			"version": "0.13.6",
 			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
 			"integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.1.0",
 				"object-assign": "^4.1.1"
@@ -19914,6 +19123,11 @@
 				"source-map": "~0.6.1"
 			},
 			"dependencies": {
+				"commander": {
+					"version": "2.19.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+					"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -20477,9 +19691,9 @@
 			},
 			"dependencies": {
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg=="
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
@@ -20574,9 +19788,9 @@
 					}
 				},
 				"mem": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-					"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
 						"mimic-fn": "^2.0.0",
@@ -20584,9 +19798,9 @@
 					}
 				},
 				"mimic-fn": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-					"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 				},
 				"os-locale": {
 					"version": "3.1.0",
@@ -20615,9 +19829,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -21098,9 +20312,9 @@
 					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
 				},
 				"camelcase": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-					"integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+					"integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg=="
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
@@ -21172,9 +20386,9 @@
 					}
 				},
 				"mem": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-					"integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
 						"mimic-fn": "^2.0.0",
@@ -21182,9 +20396,9 @@
 					}
 				},
 				"mimic-fn": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-					"integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA=="
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
 				},
 				"os-locale": {
 					"version": "3.1.0",
@@ -21213,9 +20427,9 @@
 					}
 				},
 				"p-try": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
-					"integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA=="
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
 				"require-main-filename": {
 					"version": "2.0.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -30,12 +30,14 @@
 		"autoprefixer": "9.4.4",
 		"babel-loader": "8.0.5",
 		"css-loader": "2.1.1",
+		"duplicate-package-checker-webpack-plugin": "3.0.0",
 		"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
 		"postcss-custom-properties": "8.0.9",
 		"postcss-loader": "3.0.0",
 		"sass-loader": "7.1.0",
 		"terser-webpack-plugin": "1.2.3",
 		"thread-loader": "2.1.2",
+		"webpack": "4.29.6",
 		"webpack-filter-warnings-plugin": "1.2.1",
 		"webpack-rtl-plugin": "1.8.0"
 	}

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -34,11 +34,9 @@ function getWebpackConfig(
 	env,
 	{
 		entry,
-		output = {
-			path: path.join( __dirname, 'dist' ),
-			filename: '[name].js',
-			libraryTarget: 'window',
-		},
+		'output-path': outputPath = path.join( __dirname, 'dist' ),
+		'output-filename': outputFilename = '[name].js',
+		'output-libary-target': outputLibraryTarget = 'window',
 	}
 ) {
 	const workerCount = 1;
@@ -50,7 +48,11 @@ function getWebpackConfig(
 		entry,
 		mode: isDevelopment ? 'development' : 'production',
 		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
-		output,
+		output: {
+			path: outputPath,
+			filename: outputFilename,
+			libraryTarget: outputLibraryTarget,
+		},
 		optimization: {
 			minimize: ! isDevelopment,
 			minimizer: Minify( {

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -1,0 +1,105 @@
+/**
+ **** WARNING: No ES6 modules here. Not transpiled! ****
+ */
+/* eslint-disable import/no-nodejs-modules */
+
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const webpack = require( 'webpack' );
+const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
+const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
+const Minify = require( '@automattic/calypso-build/webpack/minify' );
+const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
+const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
+const wordpressExternals = require( '@automattic/calypso-build/webpack/wordpress-externals' );
+
+/**
+ * Internal dependencies
+ */
+// const { workerCount } = require( './webpack.common' ); // todo: shard...
+
+/**
+ * Internal variables
+ */
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+/**
+ * Return a webpack config object
+ *
+ * @return {object} webpack config
+ */
+function getWebpackConfig(
+	env,
+	{
+		entry,
+		output = {
+			path: path.join( __dirname, 'dist' ),
+			filename: '[name].js',
+			libraryTarget: 'window',
+		},
+	}
+) {
+	const workerCount = 1;
+	const cssFilename = '[name].css';
+
+	const webpackConfig = {
+		bail: ! isDevelopment,
+		context: __dirname,
+		entry,
+		mode: isDevelopment ? 'development' : 'production',
+		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
+		output,
+		optimization: {
+			minimize: ! isDevelopment,
+			minimizer: Minify( {
+				cache: process.env.CIRCLECI
+					? `${ process.env.HOME }/terser-cache`
+					: 'docker' !== process.env.CONTAINER,
+				parallel: workerCount,
+				sourceMap: Boolean( process.env.SOURCEMAP ),
+				terserOptions: {
+					ecma: 5,
+					safari10: true,
+					mangle: true,
+				},
+			} ),
+		},
+		module: {
+			rules: [
+				TranspileConfig.loader( {
+					workerCount,
+					configFile: path.join( __dirname, 'babel.config.js' ),
+					cacheDirectory: path.join( __dirname, '.cache' ),
+					exclude: /node_modules\//,
+				} ),
+				SassConfig.loader( {
+					preserveCssCustomProperties: false,
+					includePaths: [ path.join( __dirname, 'client' ) ],
+					prelude: '@import "~@automattic/calypso-color-schemes/src/shared/colors";',
+				} ),
+				FileConfig.loader(),
+			],
+		},
+		resolve: {
+			extensions: [ '.json', '.js', '.jsx' ],
+			modules: [ 'node_modules' ],
+		},
+		node: false,
+		plugins: [
+			new webpack.DefinePlugin( {
+				'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV ),
+				global: 'window',
+			} ),
+			new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
+			...SassConfig.plugins( { cssFilename, minify: ! isDevelopment } ),
+			new DuplicatePackageCheckerPlugin(),
+		],
+		externals: [ wordpressExternals, 'wp', 'lodash' ],
+	};
+
+	return webpackConfig;
+}
+
+module.exports = getWebpackConfig;

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -9,11 +9,11 @@
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
-const FileConfig = require( '@automattic/calypso-build/webpack/file-loader' );
-const Minify = require( '@automattic/calypso-build/webpack/minify' );
-const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
-const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
-const wordpressExternals = require( '@automattic/calypso-build/webpack/wordpress-externals' );
+const FileConfig = require( './webpack/file-loader' );
+const Minify = require( './webpack/minify' );
+const SassConfig = require( './webpack/sass' );
+const TranspileConfig = require( './webpack/transpile' );
+const wordpressExternals = require( './webpack/wordpress-externals' );
 
 /**
  * Internal dependencies

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -28,7 +28,19 @@ const isDevelopment = process.env.NODE_ENV !== 'production';
 /**
  * Return a webpack config object
  *
- * @return {object} webpack config
+ * Arguments to this function replicate webpack's so this config can be used on the command line,
+ * with individual options overridden by command line args.
+ *
+ * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
+ * @see {@link https://webpack.js.org/api/cli/}
+ *
+ * @param  {object}  env                           environment options
+ * @param  {object}  argv                          options map
+ * @param  {object}  argv.entry                    Entry point(s)
+ * @param  {string}  argv.'output-path'            Output path
+ * @param  {string}  argv.'output-filename'        Output filename pattern
+ * @param  {string}  argv.'output-library-target'  Output library target
+ * @return {object}                                webpack config
  */
 function getWebpackConfig(
 	env,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

See pafL3P-oe-p2:

> <h3>Problem: Webpack config re-use is suboptimal</h3>
>
> While we’re able to re-use parts of Calypso’s webpack config thanks to the shards concept (i.e. <a href="https://github.com/Automattic/wp-calypso/tree/924fb2c55b1237d13efacc5248bbc55bb6a0c910/packages/calypso-build/webpack">small files each containing specific parts of the config</a>), the resulting <code>webpack.config.js</code> files are still somewhat <a href="https://github.com/Automattic/wp-calypso/blob/924fb2c55b1237d13efacc5248bbc55bb6a0c910/webpack.config.js">verbose</a> and <a href="https://github.com/Automattic/jetpack/blob/31ce174fb25289c4c238b3f890d7fffbc2ef9c63/webpack.config.extensions.js">redundant</a>. The shards, as we are using them now, have never been the envisioned be-all, end-all, goal for an interface of a re-usable webpack config -- we even had a call with @blowery from +teamcalypsop2 on some options there (tl;dr: It’s complicated).
> 
> <h3>Solution: Parametrized `@automattic/calypso-build/webpack.config.js`</h3>
> 
> I think that as an intermediate step, it makes sense to add a parametrized <code>webpack.config.js</code> to <code>@automattic/calypso-build</code> that can then be less redundantly instantiated by consumers. The interface is still going to be suboptimal (essentially the union of all shards’ parameters), but IMO at least not worse than directly using the shards. Thanks to package versioning, we can release a new version featuring a better interface once we come up with one (and being used by a variety of different projects should help inform that interface).

The file used in here is essentially `webpack.config.extensions.js` minus the entry point magic, and minus `CopyWebpackPlugin` (about which `yarn` complained that it wasn't installed :roll_eyes: -- but we might be able to get rid of that anyway, see https://github.com/Automattic/jetpack/pull/11801).

#### Testing instructions

```
nvm use
cd packages/calypso-build
npm link
cd ../../
cd ../jetpack # Or wherever your local copy of Jetpack is
git checkout update/use-calypso-build-webpack-config
nvm use 10.15.2
yarn distclean && yarn
npm link @automattic/calypso-build
yarn build-extensions
```

Verify that blocks are built in your Jetpack directories `_inc/blocks/` folder.

#### Follow-up (this PR or separately)

Use this config file to build o2 blocks.

/cc @sirreal @simison 