### PR TITLE
Add finish setup button if user needs to accept G Suite ToS

### DIFF
--- a/client/my-sites/email/email-management/gsuite-user-item/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-user-item/index.jsx
@@ -78,16 +78,6 @@ function GSuiteUserItem( props ) {
 	);
 }
 
-PendingGSuiteTosNoticeDialog.propTypes = {
-	domainName: PropTypes.string.isRequired,
-	isMultipleDomains: PropTypes.bool.isRequired,
-	onClose: PropTypes.func.isRequired,
-	section: PropTypes.string.isRequired,
-	severity: PropTypes.string.isRequired,
-	siteSlug: PropTypes.string.isRequired,
-	user: PropTypes.string.isRequired,
-};
-
 GSuiteUserItem.propTypes = {
 	user: PropTypes.object.isRequired,
 	onClick: PropTypes.func,

--- a/client/my-sites/email/email-management/gsuite-user-item/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-user-item/index.jsx
@@ -2,13 +2,15 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
+import React, { Fragment, useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
-import React from 'react';
 
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import ExternalLink from 'components/external-link';
+import PendingGSuiteTosNoticeDialog from 'my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog';
 
 /**
  * Style dependencies
@@ -17,19 +19,25 @@ import './style.scss';
 
 function GSuiteUserItem( props ) {
 	const translate = useTranslate();
+	const [ dialogVisible, setDialogVisible ] = useState( false );
+	const onFixClickHandler = e => {
+		e.preventDefault();
+		setDialogVisible( true );
+	};
+	const onCloseClickHandler = () => {
+		setDialogVisible( false );
+	};
 
 	const getLoginLink = () => {
 		const { email, domain } = props.user;
 		return `https://accounts.google.com/AccountChooser?Email=${ email }&service=CPanel&continue=https://admin.google.com/a/${ domain }`;
 	};
 
-	return (
-		<li>
-			<span className="gsuite-user-item__email">{ props.user.email }</span>
-
+	const renderManage = () => {
+		return (
 			<ExternalLink
 				icon
-				className="gsuite-user-item__manage-link"
+				className="gsuite-user-item"
 				href={ getLoginLink() }
 				onClick={ props.onClick }
 				target="_blank"
@@ -37,9 +45,48 @@ function GSuiteUserItem( props ) {
 			>
 				{ translate( 'Manage', { context: 'Login to G Suite Manage' } ) }
 			</ExternalLink>
+		);
+	};
+
+	const renderFix = () => {
+		return (
+			<Fragment>
+				<Button className="gsuite-user-item__fix" compact={ true } onClick={ onFixClickHandler }>
+					{ translate( 'Finish Setup' ) }
+				</Button>
+				{ props.siteSlug && (
+					<PendingGSuiteTosNoticeDialog
+						domainName={ props.user.domain }
+						isMultipleDomains={ false }
+						onClose={ onCloseClickHandler }
+						section={ 'gsuite-user-manage' }
+						severity={ 'info' }
+						siteSlug={ props.siteSlug }
+						user={ props.user.email }
+						visible={ dialogVisible }
+					/>
+				) }
+			</Fragment>
+		);
+	};
+
+	return (
+		<li>
+			<span className="gsuite-user-item__email">{ props.user.email }</span>
+			{ props.user.agreed_to_terms ? renderManage() : renderFix() }
 		</li>
 	);
 }
+
+PendingGSuiteTosNoticeDialog.propTypes = {
+	domainName: PropTypes.string.isRequired,
+	isMultipleDomains: PropTypes.bool.isRequired,
+	onClose: PropTypes.func.isRequired,
+	section: PropTypes.string.isRequired,
+	severity: PropTypes.string.isRequired,
+	siteSlug: PropTypes.string.isRequired,
+	user: PropTypes.string.isRequired,
+};
 
 GSuiteUserItem.propTypes = {
 	user: PropTypes.object.isRequired,

--- a/client/my-sites/email/email-management/gsuite-user-item/style.scss
+++ b/client/my-sites/email/email-management/gsuite-user-item/style.scss
@@ -1,6 +1,7 @@
 .email-management .is-placeholder {
 	.gsuite-user-item__email,
-	.gsuite-user-item__manage-link {
+	.gsuite-user-item__manage-link,
+	button {
 		@include placeholder();
 	}
 }
@@ -8,9 +9,11 @@
 .email-management {
 	.gsuite-user-item__email {
 		float: left;
+		line-height: 1.7;
 	}
 	
-	.gsuite-user-item__manage-link {
+	a.gsuite-user-item,
+	.gsuite-user-item__fix {
 		float: right;
 		font-size: 13px;
 	}

--- a/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
@@ -1,6 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GSuiteUserItem renders correctly 1`] = `
+exports[`GSuiteUserItem renders user item finish setup button correctly 1`] = `
+<li>
+  <span
+    className="gsuite-user-item__email"
+  >
+    foo@bar.buzz
+  </span>
+  <button
+    className="button gsuite-user-item__fix is-compact"
+    onClick={[Function]}
+    type="button"
+  >
+    Finish Setup
+  </button>
+</li>
+`;
+
+exports[`GSuiteUserItem renders user item with manage correctly 1`] = `
 <li>
   <span
     className="gsuite-user-item__email"
@@ -8,7 +25,7 @@ exports[`GSuiteUserItem renders correctly 1`] = `
     foo@bar.buzz
   </span>
   <a
-    className="external-link gsuite-user-item__manage-link has-icon"
+    className="external-link gsuite-user-item has-icon"
     href="https://accounts.google.com/AccountChooser?Email=foo@bar.buzz&service=CPanel&continue=https://admin.google.com/a/bar.buzz"
     onClick={[Function]}
     rel="external noopener noreferrer"

--- a/client/my-sites/email/email-management/gsuite-user-item/test/index.js
+++ b/client/my-sites/email/email-management/gsuite-user-item/test/index.js
@@ -13,10 +13,25 @@ import GSuiteUserItem from 'my-sites/email/email-management/gsuite-user-item';
 const noop = () => {};
 
 describe( 'GSuiteUserItem', () => {
-	test( 'renders correctly', () => {
+	test( 'renders user item with manage correctly', () => {
 		const tree = renderer
 			.create(
-				<GSuiteUserItem onClick={ noop } user={ { email: 'foo@bar.buzz', domain: 'bar.buzz' } } />
+				<GSuiteUserItem
+					onClick={ noop }
+					user={ { email: 'foo@bar.buzz', domain: 'bar.buzz', agreed_to_terms: true } }
+				/>
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	test( 'renders user item finish setup button correctly', () => {
+		const tree = renderer
+			.create(
+				<GSuiteUserItem
+					onClick={ noop }
+					user={ { email: 'foo@bar.buzz', domain: 'bar.buzz', agreed_to_terms: false } }
+				/>
 			)
 			.toJSON();
 		expect( tree ).toMatchSnapshot();
@@ -27,9 +42,12 @@ describe( 'GSuiteUserItem', () => {
 			done();
 		} );
 		const instance = renderer.create(
-			<GSuiteUserItem onClick={ callback } user={ { email: 'foo@bar.buzz', domain: 'bar.buzz' } } />
+			<GSuiteUserItem
+				onClick={ callback }
+				user={ { email: 'foo@bar.buzz', domain: 'bar.buzz', agreed_to_terms: true } }
+			/>
 		);
-		const link = instance.root.findByProps( { className: 'gsuite-user-item__manage-link' } );
+		const link = instance.root.findByProps( { className: 'gsuite-user-item' } );
 		// trigger the onClick
 		link.props.onClick( 'buzz' );
 		expect( callback ).toHaveBeenCalledWith( 'buzz' );

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -125,6 +125,7 @@ class GSuiteUsersCard extends React.Component {
 				key={ `google-apps-user-${ user.domain }-${ index }` }
 				user={ user }
 				onClick={ this.generateClickHandler( user ) }
+				siteSlug={ this.props.selectedSiteSlug }
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a user has not accepted ToS change the Manage link to a Finish Setup button that opens the password reset modal

#### Testing instructions

* Have account that has a ToS accepted G Suite user
* Goto Domains -> Email 
* Observe manage link for account with accepted G Suite
* Click manage and ensure it opens up to Google
* Have account that has not accepted G Suite ToS
* Goto Domains -> Email 
* Observe Finish Setup button to the right of email
* Click Finish setup to ensure that dialog opens up

<img width="768" alt="Screen Shot 2019-04-01 at 8 34 33 PM" src="https://user-images.githubusercontent.com/6817400/55368002-b2649880-54bd-11e9-8598-e4be0429ef6d.png">
<img width="782" alt="Screen Shot 2019-04-01 at 8 35 13 PM" src="https://user-images.githubusercontent.com/6817400/55368003-b2649880-54bd-11e9-83dc-5c7098eda665.png">


