### PR TITLE
Migrate CardHeading styles to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -39,7 +39,6 @@
 @import 'blocks/user-mentions/style';
 @import 'components/button/style';
 @import 'components/card/style';
-@import 'components/card-heading/style';
 @import 'components/credit-card-form-fields/style';
 @import 'components/date-picker/style';
 @import 'components/date-range/style';

--- a/client/components/card-heading/index.jsx
+++ b/client/components/card-heading/index.jsx
@@ -14,6 +14,11 @@ import classNames from 'classnames';
  */
 import { preventWidows } from 'lib/formatting';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const validTypeSizes = [ 54, 47, 36, 32, 24, 21, 16, 14, 11 ];
 
 function CardHeading( { tagName = 'h1', size = 21, children } ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Import `Card Heading` style with webpack. Details on https://github.com/Automattic/wp-calypso/issues/27515

#### Testing instructions

- Visit `/devdocs/design/card-heading` on the live branch available below
- Ensure the design/visual appearance looks the same as this page's view on `master` branch / before this PR

<img width="1609" alt="Screenshot 2019-04-02 at 11 30 12" src="https://user-images.githubusercontent.com/18581859/55379427-b4b90800-553a-11e9-8850-9d1ceaed1f16.png">