### PR TITLE
Even if the site type & site topic dependency data exists, proceed with the data filling and step exluding process.

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -623,14 +623,10 @@ export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) 
 		initialContext: {
 			query: { site_type: siteType },
 		},
-		signupDependencies,
 	} = nextProps;
+
 	const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
 	let fulfilledDependencies = [];
-
-	if ( siteType === get( signupDependencies, 'siteType' ) ) {
-		return;
-	}
 
 	if ( siteTypeValue ) {
 		debug( 'From query string: site_type = %s', siteType );
@@ -658,15 +654,10 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 			query: { vertical },
 		},
 		flowName,
-		signupDependencies,
 	} = nextProps;
 
 	const flowSteps = flows.getFlow( flowName ).steps;
 	let fulfilledDependencies = [];
-
-	if ( vertical && get( signupDependencies, 'surveyQuestion' ) === vertical ) {
-		return;
-	}
 
 	if ( vertical && -1 === flowSteps.indexOf( 'survey' ) ) {
 		debug( 'From query string: vertical = %s', vertical );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently our signup dependency data filling and step excluding process won't happen if the dependency data exist somehow. This causes visiting a step precluding URL like http://calypso.localhost:3000/start/onboarding-for-business?site_type=business&vertical=restaurants while is logged-in and having serialized redux state won't be able to see the site type & site topic steps being excluded. 

#### Testing instructions

1. Visit http://calypso.localhost:3000/start/onboarding-for-business?site_type=business&vertical=restaurants while logged in and make sure the site type and site topic steps are excluded. `getState().signup.steps` also shows that the site type and site topic data are filled.
1. Refresh and the same should happen. Currently this is where the issue could be reproduced.
1. Do the same while logged-out, and you should observe the same behavior.
