### PR TITLE
Add `lib/track-element-size`.

### DIFF
--- a/client/components/chart/index.jsx
+++ b/client/components/chart/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { useState, useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { noop } from 'lodash';
@@ -11,8 +11,8 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import afterLayoutFlush from 'lib/after-layout-flush';
 import { hasTouch } from 'lib/touch-detect';
+import { useWindowResizeCallback } from 'lib/track-element-size';
 import Tooltip from 'components/tooltip';
 import Notice from 'components/notice';
 import isRtlSelector from 'state/selectors/is-rtl';
@@ -23,195 +23,178 @@ import BarContainer from './bar-container';
  */
 import './style.scss';
 
-class Chart extends React.Component {
-	state = {
-		data: [],
-		isEmptyChart: false,
-		maxBars: 100, // arbitrarily high number. This will be calculated by resize method
-		width: 650,
-		yMax: 0,
-		isTooltipVisible: false,
-		hasResized: false,
-	};
+const isTouch = hasTouch();
 
-	static propTypes = {
-		barClick: PropTypes.func,
-		data: PropTypes.array,
-		isRtl: PropTypes.bool,
-		loading: PropTypes.bool,
-		minBarWidth: PropTypes.number,
-		minTouchBarWidth: PropTypes.number,
-		numberFormat: PropTypes.func,
-		translate: PropTypes.func,
-	};
-
-	static defaultProps = {
-		barClick: noop,
-		minBarWidth: 15,
-		minTouchBarWidth: 42,
-	};
-
-	componentDidMount() {
-		if ( this.props.data && this.props.data.length && ! this.props.loading ) {
-			this.resize();
-		}
-
-		this.resize = afterLayoutFlush( this.resize );
-		window.addEventListener( 'resize', this.resize );
+/**
+ * Auxiliary method to calculate the maximum value for the Y axis, based on a dataset.
+ * @param {Array} values An array of numeric values.
+ *
+ * @return {Number} The maximum value for the Y axis.
+ */
+function getYAxisMax( values ) {
+	// Calculate max value in a dataset.
+	const max = Math.max.apply( null, values );
+	if ( 0 === max ) {
+		return 2;
 	}
 
-	componentDidUpdate( prevProps ) {
-		if ( prevProps.loading && ! this.props.loading ) {
-			return this.resize();
+	const log10 = Math.log10( max );
+	const sign = Math.sign( log10 );
+
+	// Magnitude of the number by a factor fo 10 (e.g. thousands, hundreds, tens, ones, tenths, hundredths, thousandths).
+	const magnitude = Math.ceil( Math.abs( log10 ) ) * sign;
+
+	// Determine the base unit size, based on the magnitude of the number.
+	const unitSize =
+		sign > 0 && 1 < magnitude ? Math.pow( 10, magnitude - sign ) : Math.pow( 10, magnitude );
+
+	// Determine how many units are needed to accommodate the chart's max value.
+	const numberOfUnits = Math.ceil( max / unitSize );
+
+	return unitSize * numberOfUnits;
+}
+
+// The Chart component.
+function Chart( {
+	barClick,
+	data,
+	isRtl,
+	minBarWidth,
+	minTouchBarWidth,
+	numberFormat,
+	translate,
+} ) {
+	const [ tooltip, setTooltip ] = useState( { isTooltipVisible: false } );
+	const [ sizing, setSizing ] = useState( { clientWidth: 650, hasResized: false } );
+
+	const { hasResized } = sizing;
+
+	// Callback to handle tooltip changes.
+	// Needs to be memoized to avoid assigning children a new function every render.
+	const handleTooltipChange = useCallback( ( tooltipContext, tooltipPosition, tooltipData ) => {
+		if ( ! tooltipContext || ! tooltipPosition || ! tooltipData ) {
+			setTooltip( { isTooltipVisible: false } );
+		} else {
+			setTooltip( { tooltipContext, tooltipPosition, tooltipData, isTooltipVisible: true } );
+		}
+	}, [] );
+
+	// Callback to handle element size changes.
+	// Needs to be memoized to avoid causing the `useWindowResizeCallback` custom hook to re-subscribe.
+	const handleContentRectChange = useCallback( contentRect => {
+		setSizing( prevSizing => {
+			const clientWidth = contentRect.width - 82;
+
+			if ( ! prevSizing.hasResized || clientWidth !== prevSizing.clientWidth ) {
+				return { clientWidth, hasResized: true };
+			}
+			return prevSizing;
+		} );
+	}, [] );
+
+	// Subscribe to changes to element size and position.
+	const resizeRef = useWindowResizeCallback( handleContentRectChange );
+
+	const minWidth = isTouch ? minTouchBarWidth : minBarWidth;
+	const width = isTouch && sizing.clientWidth <= 0 ? 350 : sizing.clientWidth; // mobile safari bug with zero width
+	const maxBars = Math.floor( width / minWidth );
+
+	// Memoize data calculations to avoid performing them too often.
+	const { chartData, isEmptyChart, yMax } = useMemo(() => {
+		if ( ! hasResized ) {
+			return {};
 		}
 
-		if ( prevProps.data !== this.props.data ) {
-			this.updateData( this.props.data );
-		}
-	}
-
-	componentWillUnmount() {
-		window.removeEventListener( 'resize', this.resize );
-	}
-
-	resize = () => {
-		if ( ! this.chart ) {
-			return;
-		}
-
-		const isTouch = hasTouch();
-		const clientWidth = this.chart.clientWidth - 82;
-		const minWidth = isTouch ? this.props.minTouchBarWidth : this.props.minBarWidth;
-		const width = isTouch && clientWidth <= 0 ? 350 : clientWidth; // mobile safari bug with zero width
-		const maxBars = Math.floor( width / minWidth );
-
-		const updatedData = this.calculateUpdatedData( this.props.data, maxBars );
-
-		this.setState( { maxBars, width, hasResized: true, ...updatedData } );
-	};
-
-	getYAxisMax = values => {
-		// Calculate max value in the dataset.
-		const max = Math.max.apply( null, values );
-		if ( 0 === max ) {
-			return 2;
-		}
-
-		const log10 = Math.log10( max );
-		const sign = Math.sign( log10 );
-
-		// Magnitude of the number by a factor fo 10 (e.g. thousands, hundreds, tens, ones, tenths, hundredths, thousandths).
-		const magnitude = Math.ceil( Math.abs( log10 ) ) * sign;
-
-		// Determine the base unit size, based on the magnitude of the number.
-		const unitSize =
-			sign > 0 && 1 < magnitude ? Math.pow( 10, magnitude - sign ) : Math.pow( 10, magnitude );
-
-		// Determine how many units are needed to accommodate the chart's max value.
-		const numberOfUnits = Math.ceil( max / unitSize );
-
-		return unitSize * numberOfUnits;
-	};
-
-	storeChart = ref => ( this.chart = ref );
-
-	calculateUpdatedData = ( data, maxBars ) => {
 		const nextData = data.length <= maxBars ? data : data.slice( 0 - maxBars );
 		const nextVals = data.map( ( { value } ) => value );
 
 		return {
-			data: nextData,
+			chartData: nextData,
 			isEmptyChart: Boolean( nextVals.length && ! nextVals.some( a => a > 0 ) ),
-			yMax: this.getYAxisMax( nextVals ),
+			yMax: getYAxisMax( nextVals ),
 		};
-	};
+	}, [ data, maxBars, hasResized ]);
 
-	updateData = data => {
-		this.setState( state => this.calculateUpdatedData( data, state.maxBars ) );
-	};
+	// If we don't have any sizing info yet, render an empty chart with the ref.
+	if ( ! hasResized ) {
+		return <div ref={ resizeRef } className="chart" />;
+	}
 
-	setTooltip = ( tooltipContext, tooltipPosition, tooltipData ) => {
-		if ( ! tooltipContext || ! tooltipPosition || ! tooltipData ) {
-			return this.setState( { isTooltipVisible: false } );
-		}
+	// Otherwise, render full chart.
+	const { isTooltipVisible, tooltipContext, tooltipPosition, tooltipData } = tooltip;
 
-		this.setState( { tooltipContext, tooltipPosition, tooltipData, isTooltipVisible: true } );
-	};
+	return (
+		<div ref={ resizeRef } className="chart">
+			<div className="chart__y-axis-markers">
+				<div className="chart__y-axis-marker is-hundred" />
+				<div className="chart__y-axis-marker is-fifty" />
+				<div className="chart__y-axis-marker is-zero" />
 
-	render() {
-		const { barClick, translate, numberFormat } = this.props;
-		const {
-			data,
-			isEmptyChart,
-			width,
-			yMax,
-			isTooltipVisible,
-			tooltipContext,
-			tooltipPosition,
-			tooltipData,
-			hasResized,
-		} = this.state;
-
-		if ( ! hasResized ) {
-			return <div ref={ this.storeChart } className="chart" />;
-		}
-
-		return (
-			<div ref={ this.storeChart } className="chart">
-				<div className="chart__y-axis-markers">
-					<div className="chart__y-axis-marker is-hundred" />
-					<div className="chart__y-axis-marker is-fifty" />
-					<div className="chart__y-axis-marker is-zero" />
-
-					{ isEmptyChart && (
-						<div className="chart__empty">
-							<Notice
-								className="chart__empty-notice"
-								status="is-warning"
-								isCompact
-								text={ translate( 'No activity this period', {
-									context: 'Message on empty bar chart in Stats',
-									comment: 'Should be limited to 32 characters to prevent wrapping',
-								} ) }
-								showDismiss={ false }
-							/>
-						</div>
-					) }
-				</div>
-				<div className="chart__y-axis">
-					<div className="chart__y-axis-width-fix">{ numberFormat( 100000 ) }</div>
-					<div className="chart__y-axis-label is-hundred">
-						{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
+				{ isEmptyChart && (
+					<div className="chart__empty">
+						<Notice
+							className="chart__empty-notice"
+							status="is-warning"
+							isCompact
+							text={ translate( 'No activity this period', {
+								context: 'Message on empty bar chart in Stats',
+								comment: 'Should be limited to 32 characters to prevent wrapping',
+							} ) }
+							showDismiss={ false }
+						/>
 					</div>
-					<div className="chart__y-axis-label is-fifty">
-						{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
-					</div>
-					<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
-				</div>
-				<BarContainer
-					barClick={ barClick }
-					chartWidth={ width }
-					data={ data }
-					isRtl={ this.props.isRtl }
-					isTouch={ hasTouch() }
-					setTooltip={ this.setTooltip }
-					yAxisMax={ yMax }
-				/>
-				{ isTooltipVisible && (
-					<Tooltip
-						className="chart__tooltip"
-						id="popover__chart-bar"
-						context={ tooltipContext }
-						isVisible={ isTooltipVisible }
-						position={ tooltipPosition }
-					>
-						<ul>{ tooltipData }</ul>
-					</Tooltip>
 				) }
 			</div>
-		);
-	}
+			<div className="chart__y-axis">
+				<div className="chart__y-axis-width-fix">{ numberFormat( 100000 ) }</div>
+				<div className="chart__y-axis-label is-hundred">
+					{ yMax > 1 ? numberFormat( yMax ) : numberFormat( yMax, 2 ) }
+				</div>
+				<div className="chart__y-axis-label is-fifty">
+					{ yMax > 1 ? numberFormat( yMax / 2 ) : numberFormat( yMax / 2, 2 ) }
+				</div>
+				<div className="chart__y-axis-label is-zero">{ numberFormat( 0 ) }</div>
+			</div>
+			<BarContainer
+				barClick={ barClick }
+				chartWidth={ width }
+				data={ chartData }
+				isRtl={ isRtl }
+				isTouch={ hasTouch() }
+				setTooltip={ handleTooltipChange }
+				yAxisMax={ yMax }
+			/>
+			{ isTooltipVisible && (
+				<Tooltip
+					className="chart__tooltip"
+					id="popover__chart-bar"
+					context={ tooltipContext }
+					isVisible={ isTooltipVisible }
+					position={ tooltipPosition }
+				>
+					<ul>{ tooltipData }</ul>
+				</Tooltip>
+			) }
+		</div>
+	);
 }
+
+Chart.propTypes = {
+	barClick: PropTypes.func,
+	data: PropTypes.array,
+	isRtl: PropTypes.bool,
+	loading: PropTypes.bool,
+	minBarWidth: PropTypes.number,
+	minTouchBarWidth: PropTypes.number,
+	numberFormat: PropTypes.func,
+	translate: PropTypes.func,
+};
+
+Chart.defaultProps = {
+	barClick: noop,
+	minBarWidth: 15,
+	minTouchBarWidth: 42,
+};
 
 export default connect( state => ( {
 	isRtl: isRtlSelector( state ),

--- a/client/lib/track-element-size/README.md
+++ b/client/lib/track-element-size/README.md
@@ -21,7 +21,7 @@ import { useWindowResizeRect } from 'lib/track-element-size';
 
 function SampleComponent() {
   // Get ref, rect and subscribe to changes.
-  const [ ref, rect ] = useWindowResizeCallback( ref, resizeCallback );
+  const [ ref, rect ] = useWindowResizeRect();
 
   // Render component, making sure to use the ref.
   // Initial renders will use 'unknown' and wait for updates.

--- a/client/lib/track-element-size/README.md
+++ b/client/lib/track-element-size/README.md
@@ -71,7 +71,7 @@ function SampleComponent() {
   );
 
   // Get ref and subscribe to changes.
-  const ref = useWindowResizeCallback( ref, resizeCallback );
+  const ref = useWindowResizeCallback( resizeCallback );
 
   // Render component, making sure to use the ref.
   // First render will use the initial value in state ('unknown'), since there hasn't been

--- a/client/lib/track-element-size/README.md
+++ b/client/lib/track-element-size/README.md
@@ -1,0 +1,90 @@
+Track Element Size
+==================
+
+This module is designed to provide utilities for tracking an element's size in the DOM.
+
+## Usage
+
+### `useWindowResizeRect`
+
+`useWindowResizeRect` is a React hook that tracks the size of an element's bounding client rect as
+the window is resized. It doesn't track modifications due to other reasons, such as layout changes.
+
+It returns both a ref, to be applied on the element to be measured, and a rect with the element's
+dimensions. This rect will be null at first, but will be updated with the initial values on a later
+render, as well as kept up to date after any window resizes.
+
+Here's a small sample:
+
+```JSX
+import { useWindowResizeRect } from 'lib/track-element-size';
+
+function SampleComponent() {
+  // Get ref, rect and subscribe to changes.
+  const [ ref, rect ] = useWindowResizeCallback( ref, resizeCallback );
+
+  // Render component, making sure to use the ref.
+  // Initial renders will use 'unknown' and wait for updates.
+  return <div ref={ ref }>My width is { rect ? rect.width : 'unknown' }.</div>;
+}
+```
+
+**Note**: The list of properties in the returned rect may vary between browsers. The safe ones to
+use across all of Calypso's supported browsers are:
+- `width`
+- `height`
+- `top`
+- `right`
+- `bottom`
+- `left`
+
+
+### `useWindowResizeCallback`
+
+`useWindowResizeCallback` is a React hook that tracks the size of an element's bounding client rect
+as the window is resized. It doesn't track modifications due to other reasons, such as layout
+changes.
+
+It expects a callback function. When the provided element's bounding client rect changes due to
+window resizes, the callback function gets called with the updated rect, as a plain JavaScript
+object.
+
+It returns a ref, to be applied on the element to be measured.
+
+To help with initialization, the hook always triggers the callback at least once, with the initial
+rect.
+
+Here's a small sample:
+
+```JSX
+import { useWindowResizeCallback } from 'lib/track-element-size';
+
+function SampleComponent() {
+  // Set up state. Starts with an unknown width.
+  const [ width, setWidth ] = useState( 'unknown' );
+
+  // Callback function to be used with hook.
+  // Needs to be memoized to avoid creating new instances on every render.
+  const resizeCallback = useCallback(
+    boundingClientRect => setWidth( boundingClientRect.width ),
+    []
+  );
+
+  // Get ref and subscribe to changes.
+  const ref = useWindowResizeCallback( ref, resizeCallback );
+
+  // Render component, making sure to use the ref.
+  // First render will use the initial value in state ('unknown'), since there hasn't been
+  // a callback yet.
+  return <div ref={ ref }>My width is { width }.</div>;
+}
+```
+
+**Note**: The list of properties in the returned rect may vary between browsers. The safe ones to
+use across all of Calypso's supported browsers are:
+- `width`
+- `height`
+- `top`
+- `right`
+- `bottom`
+- `left`

--- a/client/lib/track-element-size/index.js
+++ b/client/lib/track-element-size/index.js
@@ -1,0 +1,92 @@
+/**
+ * External dependencies
+ */
+import { useRef, useEffect, useState, useCallback } from 'react';
+import { throttle } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import afterLayoutFlush from 'lib/after-layout-flush';
+
+const THROTTLE_RATE = 200;
+
+/**
+ * React hook that subscribes a consumer to changes to the bounding client rect of an element, based
+ * on window resize events.
+ * Does not notify when an element resizes due to reasons other than the window resizing.
+ * Uses throttling on the events, to avoid making changes too often.
+ *
+ * @param {Function} callback The function to call back on changes. Takes a single parameter: `boundingClientRect`.
+ *
+ * @returns {Function} The ref to be set on the consumer component.
+ */
+export function useWindowResizeCallback( callback ) {
+	const lastRect = useRef( {} );
+	const [ element, setElement ] = useState( null );
+
+	const callbackRef = useCallback( node => {
+		if ( node ) {
+			setElement( node );
+		}
+	}, [] );
+
+	useEffect(() => {
+		// Notify consumer of bounding client rect change.
+		const handleRectChange = rect => {
+			if ( rect ) {
+				const jsonRect = rect.toJSON ? rect.toJSON() : rect;
+				// Avoid notifying consumer if nothing's changed.
+				for ( const property of Object.keys( jsonRect ) ) {
+					if ( lastRect.current[ property ] !== jsonRect[ property ] ) {
+						lastRect.current = jsonRect;
+						return callback( jsonRect );
+					}
+				}
+			}
+		};
+
+		// Measure the element in the DOM.
+		// Uses `afterLayoutFlush` to avoid causing layout thrashing.
+		const measureElement = afterLayoutFlush( () => {
+			if ( element.getBoundingClientRect ) {
+				handleRectChange( element.getBoundingClientRect() );
+			}
+		} );
+		const throttledMeasureElement = throttle( measureElement, THROTTLE_RATE );
+
+		// Set up subscription.
+		if ( element && callback ) {
+			// Measure element so that the callback is invoked at least once, even if
+			// there are no window resize events.
+			throttledMeasureElement();
+			window.addEventListener( 'resize', throttledMeasureElement );
+
+			// Unsubscribe.
+			return () => {
+				window.removeEventListener( 'resize', throttledMeasureElement );
+				measureElement.cancel();
+				throttledMeasureElement.cancel();
+			};
+		}
+	}, [ element, callback ]);
+
+	return callbackRef;
+}
+
+/**
+ * React hook that subscribes a consumer to changes to the bounding client rect of an element, based
+ * on window resize events.
+ * Does not notify when an element resizes due to reasons other than the window resizing.
+ * Uses throttling on the events, to avoid making changes too often.
+ *
+ * @returns {Function} The ref to be set on the consumer component.
+ */
+export function useWindowResizeRect() {
+	const [ rect, setRect ] = useState( null );
+
+	const callback = useCallback( boundingClientRect => setRect( boundingClientRect ), [] );
+	const callbackRef = useWindowResizeCallback( callback );
+
+	return [ callbackRef, rect ];
+}

--- a/client/lib/track-element-size/index.ts
+++ b/client/lib/track-element-size/index.ts
@@ -4,10 +4,10 @@
 import React, { useRef, useEffect, useState } from 'react';
 import { throttle } from 'lodash';
 
-const THROTTLE_RATE = 200;
-
 type NullableDOMRect = ClientRect | DOMRect | null;
 type NullableElement = Element | null;
+
+export const THROTTLE_RATE = 200;
 
 function rectIsEqual( prevRect: NullableDOMRect, nextRect: NullableDOMRect ) {
 	if ( prevRect === null ) {
@@ -50,7 +50,7 @@ export function useWindowResizeCallback(
 		}
 
 		// Measure the element in the DOM.
-		const measureElement = throttle( () => {
+		const measureElement = () => {
 			const rect = elementRef.current ? elementRef.current.getBoundingClientRect() : null;
 
 			// Avoid notifying consumer if nothing's changed.
@@ -60,19 +60,21 @@ export function useWindowResizeCallback(
 				// Notify consumer of bounding client rect change.
 				callback( rect );
 			}
-		}, THROTTLE_RATE );
+		};
 
 		// Measure element so that the callback is invoked at least once, even if
 		// there are no window resize events.
 		measureElement();
 
+		const throttledMeasureElement = throttle( measureElement, THROTTLE_RATE );
+
 		// Set up subscription.
-		window.addEventListener( 'resize', measureElement );
+		window.addEventListener( 'resize', throttledMeasureElement );
 
 		// Unsubscribe.
 		return () => {
-			window.removeEventListener( 'resize', measureElement );
-			measureElement.cancel();
+			window.removeEventListener( 'resize', throttledMeasureElement );
+			throttledMeasureElement.cancel();
 		};
 	}, [ elementRef.current, callback ] );
 

--- a/client/lib/track-element-size/test/index.js
+++ b/client/lib/track-element-size/test/index.js
@@ -1,0 +1,325 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import React, { useCallback } from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import _ from 'lodash';
+
+jest.useFakeTimers();
+
+// Mock afterLayoutFlush implementation to avoid asynchronous timers.
+jest.mock( 'lib/after-layout-flush', () =>
+	jest.fn( func => {
+		const ret = ( ...args ) => setTimeout( () => func( ...args ), 0 );
+		ret.cancel = () => null;
+		return ret;
+	} )
+);
+
+jest.mock( 'lodash' );
+
+// Mock Lodash's throttle implementation to avoid issues with Jest's fake timers.
+_.throttle.mockImplementation( func => {
+	const ret = ( ...args ) => setTimeout( () => func( ...args ), 0 );
+	ret.cancel = () => null;
+	return ret;
+} );
+
+import { useWindowResizeCallback, useWindowResizeRect } from '..';
+
+const initialRect = { width: 10, height: 10 };
+
+describe( 'useWindowResizeCallback', () => {
+	let getBoundingClientRectMock;
+	let container;
+	let lastRect;
+	let callback;
+
+	// Auxiliary function to create a test component.
+	function createTestComponent( cb, mock ) {
+		return function() {
+			const resizeCallback = useCallback( cb, [] );
+			const resizeRef = useWindowResizeCallback( resizeCallback );
+			const ref = useCallback(
+				node => {
+					if ( node ) {
+						node.getBoundingClientRect = mock;
+						resizeRef( node );
+					}
+				},
+				[ resizeRef ]
+			);
+
+			return <div ref={ ref } />;
+		};
+	}
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+
+		getBoundingClientRectMock = jest.fn();
+		getBoundingClientRectMock.mockReturnValueOnce( initialRect );
+
+		callback = jest.fn( boundingClientRect => {
+			lastRect = boundingClientRect;
+		} );
+	} );
+
+	afterEach( () => {
+		document.body.removeChild( container );
+		ReactDOM.unmountComponentAtNode( container );
+		container = null;
+	} );
+
+	it( 'does not throw an error there is no callback', () => {
+		const TestComponent = function() {
+			const ref = useWindowResizeCallback();
+			return <div ref={ ref } />;
+		};
+
+		act( () => {
+			ReactDOM.render( <TestComponent />, container );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+	} );
+
+	it( 'triggers an initial callback', () => {
+		const TestComponent = createTestComponent( callback, getBoundingClientRectMock );
+
+		act( () => {
+			ReactDOM.render( <TestComponent />, container );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( lastRect ).toBe( initialRect );
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'triggers a callback when a resize takes place', () => {
+		const secondRect = { height: 100, width: 100 };
+		getBoundingClientRectMock = jest.fn();
+		getBoundingClientRectMock.mockReturnValueOnce( initialRect ).mockReturnValueOnce( secondRect );
+
+		const TestComponent = createTestComponent( callback, getBoundingClientRectMock );
+
+		act( () => {
+			ReactDOM.render( <TestComponent />, container );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( lastRect ).toBe( initialRect );
+
+		// Fire resize event.
+		act( () => {
+			global.dispatchEvent( new Event( 'resize' ) );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( lastRect ).toBe( secondRect );
+		expect( callback ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'does not trigger a callback when a resize returns the same dimensions as before', () => {
+		const secondRect = { height: 10, width: 10 };
+		getBoundingClientRectMock = jest.fn();
+		getBoundingClientRectMock.mockReturnValueOnce( initialRect ).mockReturnValueOnce( secondRect );
+
+		const TestComponent = createTestComponent( callback, getBoundingClientRectMock );
+
+		act( () => {
+			ReactDOM.render( <TestComponent />, container );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( lastRect ).toBe( initialRect );
+
+		// Fire resize event.
+		act( () => {
+			global.dispatchEvent( new Event( 'resize' ) );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( lastRect ).toBe( initialRect );
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'useWindowResizeRect', () => {
+	let getBoundingClientRectMock;
+	let container;
+	let lastRect;
+	let renderTracker;
+
+	// Auxiliary function to create a test component.
+	function createTestComponent( mock ) {
+		return function() {
+			renderTracker();
+
+			const [ resizeRef, rect ] = useWindowResizeRect();
+
+			const ref = useCallback(
+				node => {
+					if ( node ) {
+						node.getBoundingClientRect = mock;
+						resizeRef( node );
+					}
+				},
+				[ resizeRef ]
+			);
+
+			lastRect = rect;
+
+			return <div ref={ ref }>{ rect ? rect.width : 'unknown' }</div>;
+		};
+	}
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+
+		renderTracker = jest.fn();
+
+		getBoundingClientRectMock = jest.fn();
+		getBoundingClientRectMock.mockReturnValueOnce( initialRect );
+	} );
+
+	afterEach( () => {
+		document.body.removeChild( container );
+		ReactDOM.unmountComponentAtNode( container );
+		container = null;
+	} );
+
+	it( 'returns the initial rect', () => {
+		const TestComponent = createTestComponent( getBoundingClientRectMock );
+
+		act( () => {
+			ReactDOM.render( <TestComponent />, container );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( container.textContent ).toBe( initialRect.width.toString() );
+		expect( lastRect ).toBe( initialRect );
+
+		// We expect 3 renders:
+		// - Initial render, where the ref gets applied
+		// - Second render, where the ref callback happens
+		// - Third render, where the rect values get updated after measuring the DOM
+		expect( renderTracker ).toHaveBeenCalledTimes( 3 );
+	} );
+
+	it( 'returns the new rect when a resize takes place', () => {
+		const secondRect = { height: 100, width: 100 };
+		getBoundingClientRectMock = jest.fn();
+		getBoundingClientRectMock.mockReturnValueOnce( initialRect ).mockReturnValueOnce( secondRect );
+
+		const TestComponent = createTestComponent( getBoundingClientRectMock );
+
+		act( () => {
+			ReactDOM.render( <TestComponent />, container );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( container.textContent ).toBe( initialRect.width.toString() );
+		expect( lastRect ).toBe( initialRect );
+
+		// Fire resize event.
+		act( () => {
+			global.dispatchEvent( new Event( 'resize' ) );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( container.textContent ).toBe( secondRect.width.toString() );
+		expect( lastRect ).toBe( secondRect );
+
+		// We expect 4 renders:
+		// - Initial render, where the ref gets applied
+		// - Second render, where the ref callback happens
+		// - Third render, where the rect values get updated after measuring the DOM
+		// - Fourth render, where the new rect values are returned after the resize
+		expect( renderTracker ).toHaveBeenCalledTimes( 4 );
+	} );
+
+	it( 'does not rerender when a resize returns the same dimensions as before', () => {
+		const secondRect = { height: 10, width: 10 };
+		getBoundingClientRectMock = jest.fn();
+		getBoundingClientRectMock.mockReturnValueOnce( initialRect ).mockReturnValueOnce( secondRect );
+
+		const TestComponent = createTestComponent( getBoundingClientRectMock );
+
+		act( () => {
+			ReactDOM.render( <TestComponent />, container );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( container.textContent ).toBe( initialRect.width.toString() );
+		expect( lastRect ).toBe( initialRect );
+
+		// Fire resize event.
+		act( () => {
+			global.dispatchEvent( new Event( 'resize' ) );
+		} );
+
+		// Flush timer queue to trigger callbacks.
+		act( () => {
+			jest.runAllTimers();
+		} );
+
+		expect( container.textContent ).toBe( initialRect.width.toString() );
+		expect( lastRect ).toBe( initialRect );
+
+		// We expect 3 renders:
+		// - Initial render, where the ref gets applied
+		// - Second render, where the ref callback happens
+		// - Third render, where the rect values get updated after measuring the DOM
+		// We do not expect a 4th render, where the rect would get updated, since
+		// the dimensions haven't changed.
+		expect( renderTracker ).toHaveBeenCalledTimes( 3 );
+	} );
+} );


### PR DESCRIPTION
The new library provides React hooks to keep track of an element's size in the DOM.
This PR also rewrites the Chart component to use the new library.

This PR doesn't introduce any performance fixes per se, but rather adds building blocks that encapsulate all of the complexity of tracking a component's size in a performant way, making it easier to build performant new components in the future.

#### Changes proposed in this Pull Request

* Add `lib/track-element-size`
* Rewrite `Chart` to make use of `lib/track-element-size`

#### Testing instructions

* Ensure the unit tests for `lib/track-element-size` pass.
* Ensure that the Chart (in Stats) continues to work normally.
