### PR TITLE
Gutenframe: prevent edit view for empty posts page

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import pageRouter from 'page';
 import { connect } from 'react-redux';
-import { flow, get, includes, noop, partial } from 'lodash';
+import { flow, get, includes, isEmpty, noop, partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -374,9 +374,9 @@ class Page extends Component {
 	undoPostStatus = () => this.updatePostStatus( this.props.shadowStatus.undo );
 
 	render() {
-		const { editorUrl, page, shadowStatus, translate } = this.props;
+		const { editorUrl, page, shadowStatus, translate, preventEditingInGutenberg } = this.props;
 		const title = page.title || translate( 'Untitled' );
-		const canEdit = utils.userCan( 'edit_post', page );
+		const canEdit = utils.userCan( 'edit_post', page ) && ! preventEditingInGutenberg;
 		const depthIndicator = ! this.props.hierarchical && page.parent && '— ';
 
 		const viewItem = this.getViewItem();
@@ -629,6 +629,12 @@ const mapState = ( state, props ) => {
 		isFrontPage: isFrontPage( state, pageSiteId, props.page.ID ),
 		isPostsPage: isPostsPage( state, pageSiteId, props.page.ID ),
 		isPreviewable,
+		// Gutenberg prevents editing of empty posts pages
+		// See https://github.com/Automattic/wp-calypso/issues/31917
+		preventEditingInGutenberg:
+			'gutenberg' === getSelectedEditor( state, pageSiteId ) &&
+			isPostsPage( state, pageSiteId, props.page.ID ) &&
+			isEmpty( props.page.content ),
 		previewURL: utils.getPreviewURL( site, props.page ),
 		site,
 		siteSlugOrId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Core Gutenberg doesn't allow editing of empty posts pages  (see https://github.com/Automattic/wp-calypso/issues/31917 for more details). In those cases it would load the Classic editor view which was causing problems and confusion with our Gutenframe flows.

Since there is no easy way to override this behavior in core, the proposed solution prevents the titles of those posts from linking to the editor.

Looking at the existing behavior, both in case of Classic and Gutenberg editor, we are removing the edit option from the ellipsis menu in pages list. Given that, and the fact that the inserted content is not displayed on posts pages anyway, I'm considering making this approach the default regardless of editor or content.

To clarify, instead of "prevent linking posts pages to editor when it's set to Gutenberg and the content is empty" we'd switch to "prevent linking to editor for posts pages in all cases". Let me know what do you think about this alternative.

#### Testing instructions

1. Use a test site that has opted in to Gutenberg.
2. Create a new page on you site with empty content field.
3. Navigate to Customizer > Homepage Settings and set the above page as a posts page.
4. Go to My Sites > Site Pages.
5. Attempt to edit the above page by clicking on the page title (notice that Edit option is hidden from ellipsis menu).
6. Verify that you are taken to page front end view, instead of iframed wp-admin classic view.

Fixes https://github.com/Automattic/wp-calypso/issues/31917
