### PR TITLE
Domains: Don't show upsell for domain-only

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -96,7 +96,7 @@ export class SiteNotice extends React.Component {
 	}
 
 	freeToPaidPlanNotice() {
-		if ( ! this.props.isEligibleForFreeToPaidUpsell || ! this.props.isDomainOnly ) {
+		if ( ! this.props.isEligibleForFreeToPaidUpsell || this.props.isDomainOnly ) {
 			return null;
 		}
 

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -96,7 +96,7 @@ export class SiteNotice extends React.Component {
 	}
 
 	freeToPaidPlanNotice() {
-		if ( ! this.props.isEligibleForFreeToPaidUpsell ) {
+		if ( ! this.props.isEligibleForFreeToPaidUpsell || ! this.props.isDomainOnly ) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The upsell copy makes no sense. The user has a domain, and
we're telling them they get a free domain with a site.

We should either change the copy or hide it, and I went with
hiding it. The link doesn't even work, as domain-only sites have
no access to the `/plans` URL. Also, if you look at the landing page 
for domain-only sites, it's already one big upsell.

<img width="936" alt="Screenshot 2019-04-02 at 15 14 44" src="https://user-images.githubusercontent.com/1103398/55405527-8b0fd900-555a-11e9-8ef8-af3e044d4f13.png">


#### Testing instructions

- Create a domain only site through `wordpress.com/domains` or just visit one you already have
- No upsell on the left