### PR TITLE
Me/Purchases: Improve tax detection

### DIFF
--- a/client/me/billing-history/test/tax.js
+++ b/client/me/billing-history/test/tax.js
@@ -10,15 +10,76 @@ import { mount } from 'enzyme';
 /**
  * Internal dependencies
  */
-import { renderTransactionAmount } from '../utils';
+import { renderTransactionAmount, transactionIncludesTax } from '../utils';
 
 const translate = x => x;
+
+describe( 'transactionIncludesTax', () => {
+	test( 'returns true for a transaction with tax', () => {
+		const transaction = {
+			subtotal: '$36.00',
+			tax: '$2.48',
+			amount: '$38.48',
+			items: [
+				{
+					raw_tax: 2.48,
+				},
+			],
+		};
+
+		expect( transactionIncludesTax( transaction ) ).toBe( true );
+	} );
+
+	test( 'returns false for a transaction without tax values', () => {
+		const transaction = {
+			subtotal: '$36.00',
+			amount: '$38.48',
+			items: [ {} ],
+		};
+
+		expect( transactionIncludesTax( transaction ) ).toBe( false );
+	} );
+
+	test( 'returns false for a transaction with zero tax values', () => {
+		const transaction = {
+			subtotal: '$36.00',
+			tax: '$0.00',
+			amount: '$38.48',
+			items: [
+				{
+					raw_tax: 0,
+				},
+			],
+		};
+		expect( transactionIncludesTax( transaction ) ).toBe( false );
+	} );
+
+	test( 'returns false for a transaction without zero tax values in another currency', () => {
+		const transaction = {
+			subtotal: '€36.00',
+			tax: '€0.00',
+			amount: '€38.48',
+			items: [
+				{
+					raw_tax: 0,
+				},
+			],
+		};
+
+		expect( transactionIncludesTax( transaction ) ).toBe( false );
+	} );
+} );
 
 test( 'tax shown if available', () => {
 	const transaction = {
 		subtotal: '$36.00',
 		tax: '$2.48',
 		amount: '$38.48',
+		items: [
+			{
+				raw_tax: 2.48,
+			},
+		],
 	};
 
 	const wrapper = mount( renderTransactionAmount( transaction, { translate } ) );
@@ -30,6 +91,11 @@ test( 'tax includes', () => {
 		subtotal: '$36.00',
 		tax: '$2.48',
 		amount: '$38.48',
+		items: [
+			{
+				raw_tax: 2.48,
+			},
+		],
 	};
 
 	const wrapper = mount( renderTransactionAmount( transaction, { translate, addingTax: false } ) );
@@ -41,6 +107,11 @@ test( 'tax adding', () => {
 		subtotal: '$36.00',
 		tax: '$2.48',
 		amount: '$38.48',
+		items: [
+			{
+				raw_tax: 2.48,
+			},
+		],
 	};
 
 	const wrapper = mount( renderTransactionAmount( transaction, { translate, addingTax: true } ) );
@@ -52,6 +123,7 @@ test( 'tax hidden if not available', () => {
 		subtotal: '$36.00',
 		tax: '$0.00',
 		amount: '$36.00',
+		items: [ {} ],
 	};
 
 	expect( renderTransactionAmount( transaction, { translate } ) ).toEqual( '$36.00' );

--- a/client/me/billing-history/utils.jsx
+++ b/client/me/billing-history/utils.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { find, map, partition, reduce } from 'lodash';
+import { find, map, partition, reduce, some } from 'lodash';
 import React, { Fragment } from 'react';
 import formatCurrency from '@automattic/format-currency';
 
@@ -47,7 +47,7 @@ export const groupDomainProducts = ( originalItems, translate ) => {
 };
 
 export function renderTransactionAmount( transaction, { translate, addingTax = false } ) {
-	if ( ! transaction.tax || transaction.tax === '$0.00' ) {
+	if ( ! transaction.tax || ! some( transaction.items, 'raw_tax' ) ) {
 		return transaction.amount;
 	}
 

--- a/client/me/billing-history/utils.jsx
+++ b/client/me/billing-history/utils.jsx
@@ -46,8 +46,17 @@ export const groupDomainProducts = ( originalItems, translate ) => {
 	];
 };
 
+export function transactionIncludesTax( transaction ) {
+	if ( ! transaction || ! transaction.tax ) {
+		return false;
+	}
+
+	// Consider the whole transaction to include tax if any item does
+	return some( transaction.items, 'raw_tax' );
+}
+
 export function renderTransactionAmount( transaction, { translate, addingTax = false } ) {
-	if ( ! transaction.tax || ! some( transaction.items, 'raw_tax' ) ) {
+	if ( ! transactionIncludesTax( transaction ) ) {
 		return transaction.amount;
 	}
 


### PR DESCRIPTION
This PR follows up on #29023 by refining tax detection in receipts to account for currencies:

Before:
![Billing_History_—_WordPress_com](https://user-images.githubusercontent.com/5952255/55405608-cc75a800-559d-11e9-8705-1f610b6379f9.jpg)

After:
![Billing_History_—_WordPress_com](https://user-images.githubusercontent.com/5952255/55406044-ac92b400-559e-11e9-9da6-75fdff4beb67.jpg)

#### Testing instructions

1. You'll need a transaction in a non-US currency in your history, so you might need to change your currency using Store Admin and make a purchase
2. Go to https://wordpress.com/me/purchases/billing and check that there are no "(Includes *$0.00)" messages.
