### PR TITLE
Misc: add Lannister Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,10 +37,16 @@
 # Client sites
 /client/my-sites/checklist @Automattic/onboarding-dev
 
+# Comments management
+/client/my-sites/comment* @Automattic/lannister
+
 # Developer guides
 /docs/coding-guidelines @Automattic/team-calypso
 /docs/guide @Automattic/team-calypso
 /docs/testing @Automattic/team-calypso
+
+# Gutenberg editor (Gutenframe)
+/client/gutenberg @Automattic/lannister
 
 # Jetpack Connect
 /client/jetpack-connect @Automattic/luna


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following @Copons's suggestion (https://github.com/Automattic/wp-calypso/pull/31551#issuecomment-474356021) I'm starting a PR to mark some Calypso areas that we'd like to review in the future. @Automattic/lannister are you aware of any other folders that we should add here?

#### Testing instructions

*  🦉 
