### PR TITLE
Signup: Increase visibility of focus state

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -16,7 +16,7 @@
 	.search.is-open.has-focus {
 		border: none;
 		border-radius: 3px;
-		box-shadow: 0 0 0 2px var( --color-accent );
+		box-shadow: 0 0 0 3px var( --color-accent-light );
 	}
 
 	.search-filters__dropdown-filters {
@@ -24,6 +24,6 @@
 	}
 
 	.search-filters__dropdown-filters.search-filters__dropdown-filters--is-open {
-		box-shadow: 0 0 0 2px var( --color-accent );
+		box-shadow: 0 0 0 3px var( --color-accent-light );
 	}
 }

--- a/client/signup/steps/site-information/style.scss
+++ b/client/signup/steps/site-information/style.scss
@@ -82,7 +82,7 @@
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 2px var( --color-accent );
+			box-shadow: 0 0 0 3px var( --color-accent-light );
 		}
 	}
 

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -43,7 +43,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 2px var( --color-accent );
+			box-shadow: 0 0 0 3px var( --color-accent-light );
 		}
 	}
 

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -69,7 +69,7 @@
 	}
 
 	&:focus {
-		box-shadow: inset 0 0 0 2px var( --color-accent );
+		box-shadow: inset 0 0 0 3px var( --color-accent-light );
 	}
 
 	&:hover .card__link-indicator,


### PR DESCRIPTION
Over in #31857 @danhauk mentioned that the `:focus` state for inputs can be tough to see, especially on some of the alternate color schemes available in Calypso. This PR updates the focus border's color from `--color-accent` to `--color-accent-light` and increases it's size from `2px` to `3px`.

Here's the current focus state:

<img width="554" alt="image" src="https://user-images.githubusercontent.com/191598/55423333-ade6c100-554b-11e9-8a23-cb40f1c41968.png">

And here's what the focus state looks like with this PR:

<img width="520" alt="Screen Shot 2019-04-02 at 1 23 55 PM" src="https://user-images.githubusercontent.com/191598/55423368-bdfea080-554b-11e9-9db0-f9097c2b5aea.png">

To test, append `/start/onboarding` to the calypso.live link below and click around. You should see the new color and sizing for the focus state.