### PR TITLE
Add email button to domain only flow

### DIFF
--- a/client/components/empty-content/index.jsx
+++ b/client/components/empty-content/index.jsx
@@ -108,6 +108,7 @@ class EmptyContent extends Component {
 				{ this.props.line ? <h3 className="empty-content__line">{ this.props.line }</h3> : null }
 				{ action }
 				{ secondaryAction }
+				{ this.props.children }
 			</div>
 		);
 	}

--- a/client/my-sites/domains/domain-management/list/domain-only.jsx
+++ b/client/my-sites/domains/domain-management/list/domain-only.jsx
@@ -12,9 +12,12 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import EmptyContent from 'components/empty-content';
+import { hasGSuite } from 'lib/domains/gsuite';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import { domainManagementEdit } from 'my-sites/domains/paths';
+import { emailManagement } from 'my-sites/email/paths';
 import getPrimaryDomainBySiteId from 'state/selectors/get-primary-domain-by-site-id';
 import { getSiteSlug } from 'state/sites/selectors';
 
@@ -51,7 +54,16 @@ const DomainOnly = ( { primaryDomain, hasNotice, siteId, slug, translate } ) => 
 				secondaryAction={ translate( 'Manage Domain' ) }
 				secondaryActionURL={ domainManagementEdit( slug, domainName ) }
 				illustration={ '/calypso/images/drake/drake-browser.svg' }
-			/>
+			>
+				<Button
+					className="empty-content__action button"
+					href={ emailManagement( slug, domainName ) }
+					primary
+				>
+					{ hasGSuite( primaryDomain ) ? translate( 'Manage Email' ) : translate( 'Add Email' ) }
+				</Button>
+			</EmptyContent>
+
 			{ hasNotice && (
 				<div className="domain-only-site__settings-notice">
 					{ translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a "Manage Email" or "Add Email" button to the domain only screen.

#### Testing instructions

* Have domain only with G Suite
* Goto that site
* Observe "Manage Email" button
* Button should take you to email manage page

* Have domain only without G Suite
* Goto that site
* Observe "Add Email" button
* Button should take you to G Suite CTA

![Screen Shot 2019-04-02 at 4 55 43 PM](https://user-images.githubusercontent.com/6817400/55435780-936f1080-5568-11e9-897f-17d68735985f.png)

![Screen Shot 2019-04-02 at 2 30 16 PM](https://user-images.githubusercontent.com/6817400/55426913-ea1e1f80-5553-11e9-8e2e-343586a90aed.png)

