### PR TITLE
Post Checkout: Update "Learn more" button for domain waiting period

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -29,6 +29,7 @@ export const CUSTOM_DNS = `${ root }/domains/custom-dns`;
 export const DESIGNATED_AGENT = `${ root }/designated-agent/`;
 export const DOMAIN_HELPER_PREFIX = `${ root }/domain-helper/?host=`;
 export const DOMAIN_REGISTRATION_AGREEMENTS = `${ root }/domain-registration-agreements/`;
+export const DOMAIN_WAITING = `${ root }/domains/register-domain/#waiting-for-domain-changes`;
 export const DOMAINS = `${ root }/domains`;
 export const DOMAIN_CONNECT = `${ root }/domain-connect`;
 export const INCOMING_DOMAIN_TRANSFER_STATUSES_PENDING_CONFIRMATION = `${ root }/incoming-domain-transfer/status-and-failed-transfers/#confirmation`;

--- a/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-registration-details.jsx
@@ -16,7 +16,7 @@ import { getDomainManagementUrl } from './utils';
 import GoogleAppsDetails from './google-apps-details';
 import { isGoogleApps, isBlogger } from 'lib/products-values';
 import PurchaseDetail from 'components/purchase-detail';
-import { EMAIL_VALIDATION_AND_VERIFICATION, REGISTER_DOMAIN } from 'lib/url/support';
+import { EMAIL_VALIDATION_AND_VERIFICATION, DOMAIN_WAITING } from 'lib/url/support';
 
 const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 	const googleAppsWasPurchased = purchases.some( isGoogleApps ),
@@ -58,7 +58,7 @@ const DomainRegistrationDetails = ( { selectedSite, domain, purchases } ) => {
 					'Your domain should start working immediately, but may be unreliable during the first 72 hours.'
 				) }
 				buttonText={ i18n.translate( 'Learn more about your domain' ) }
-				href={ REGISTER_DOMAIN }
+				href={ DOMAIN_WAITING }
 				target="_blank"
 				rel="noopener noreferrer"
 			/>


### PR DESCRIPTION
<img width="1118" alt="54836236-30dd6100-4c9a-11e9-89a6-f32e8a60b51f" src="https://user-images.githubusercontent.com/2124984/55428620-72ea8a80-5557-11e9-9e17-3110f4e99b86.png">

#### Changes proposed in this Pull Request

* Update the "Learn more about your domain" button on the post-purchase screen to point to information on the waiting period rather than general domain registration information.

**Before**

The button pointed to https://en.support.wordpress.com/domains/register-domain/

**After**

The button points to https://en.support.wordpress.com/domains/register-domain/#waiting-for-domain-changes

#### Testing instructions

* Switch to this PR and purchase a `.blog` domain (if you're not using the store sandbox, don't forget to cancel it immediately afterward!)
* Test the "Learn more about your domain" button on the post-checkout screen. It should go to this doc: https://en.support.wordpress.com/domains/register-domain/#waiting-for-domain-changes

Fixes #31687
