### PR TITLE
Signup: redirect to block editor after checkout

### DIFF
--- a/client/lib/signup/page-builder.js
+++ b/client/lib/signup/page-builder.js
@@ -21,6 +21,11 @@ export function shouldEnterPageBuilder() {
 	return inTest;
 }
 
+export function getEditHomeUrl( siteSlug ) {
+	// @todo we will need to retrieve the home page ID from site options
+	return `/block-editor/page/${ siteSlug }/2`;
+}
+
 export function isEligibleForPageBuilder( segment, flowName ) {
 	return 'en' === getLocaleSlug() && 1 === segment && 'onboarding-for-business' === flowName;
 }

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -69,6 +69,7 @@ import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { canDomainAddGSuite } from 'lib/domains/gsuite';
 import { getDomainNameFromReceiptOrCart } from 'lib/domains/utils';
 import { fetchSitesAndUser } from 'lib/signup/step-actions';
+import { isInPageBuilderTest, getEditHomeUrl } from 'lib/signup/page-builder';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
 import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
@@ -448,6 +449,9 @@ export class Checkout extends React.Component {
 		}
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
+			if ( isInPageBuilderTest() ) {
+				return getEditHomeUrl( selectedSiteSlug );
+			}
 			const destination = abtest( 'improvedOnboarding' ) === 'main' ? 'checklist' : 'view';
 
 			return `/${ destination }/${ selectedSiteSlug }`;

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -23,6 +23,7 @@ import CompactCard from 'components/card/compact';
 import Button from 'components/button';
 import { addItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
+import { isInPageBuilderTest, getEditHomeUrl } from 'lib/signup/page-builder';
 import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -312,9 +313,11 @@ export class ConciergeSessionNudge extends React.Component {
 			// Send the user to a generic page (not post-purchase related).
 			page( `/stats/day/${ siteSlug }` );
 		} else if ( isEligibleForChecklist ) {
-			const { selectedSiteSlug } = this.props;
+			if ( isInPageBuilderTest() ) {
+				return page( getEditHomeUrl( siteSlug ) );
+			}
 			analytics.tracks.recordEvent( 'calypso_checklist_assign', {
-				site: selectedSiteSlug,
+				site: siteSlug,
 				plan: 'paid',
 			} );
 			page( `/checklist/${ siteSlug }` );

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -17,7 +17,7 @@ import { connect } from 'react-redux';
 import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
 import config from 'config';
 import { getCurrentUser } from 'state/current-user/selectors';
-import { isInPageBuilderTest } from 'lib/signup/page-builder';
+import { isInPageBuilderTest, getEditHomeUrl } from 'lib/signup/page-builder';
 
 /**
  * Style dependencies
@@ -141,7 +141,7 @@ export class SignupProcessingScreen extends Component {
 		// we are hijacking this method slightly because our page builder
 		// test has the same logic for showing, except also being in the test
 		const redirectTo = isInPageBuilderTest()
-			? `/block-editor/page/${ this.state.siteSlug }/2`
+			? getEditHomeUrl( this.state.siteSlug )
 			: `/checklist/${ this.state.siteSlug }`;
 		this.props.loginHandler( { redirectTo } );
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redirect to the block editor after checkout for people in the test

#### Testing instructions

Going through signup, enrolling in the Page Builder, and purchasing a plan should still send you to the block editor. Previously only users who didn't purchase a plan would get there. 

This will **not** work as expected until this is ready to launch, since there are some redirects during checkout that lose the non-persisted state of `inTest` within `lib/signup/page-builder`. Fixing this for temporary code seems a bit silly. If you do want to go through some flows and test this, just set `inTest` to `true` at the top of `lib/signup/page-builder`.

Proper testing can happen when the real abtest PR #31981 is merged.

This also fixes a bug in `ConciergeSessionNudge` where we were trying to use a non-existent `selectedSiteSlug` 