### PR TITLE
Editor: Sync Sticky Posts Copy with Gutenberg

### DIFF
--- a/client/post-editor/edit-post-status/index.jsx
+++ b/client/post-editor/edit-post-status/index.jsx
@@ -100,7 +100,7 @@ export class EditPostStatus extends Component {
 				{ showSticky && (
 					<label className="edit-post-status__sticky">
 						<span className="edit-post-status__label-text">
-							{ translate( 'Stick to the top' ) }
+							{ translate( 'Stick to the top of the blog' ) }
 							<InfoPopover position="top right" gaEventCategory="Editor" popoverName="Sticky Post">
 								{ translate( 'Sticky posts will appear at the top of your posts page.' ) }
 							</InfoPopover>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In #29799, the sticky posts copy was updated to "Stick to the top" after #28125 noted that the "front page" was not always accurate
* When syncing this change to Gutenberg, it was agreed that "Stick to the top of the blog" is probably a better compromise between clarity (WordPress/gutenberg#13120)
* This change was never synced back to the Calypso editor, this PR proposes that 

cc @michelleweber & @kristastevens on this

#### Testing instructions

See the sticky posts label when creating a post in the editor

cc @cecoates

Fixes #31970 for the classic Calypso editor
