### PR TITLE
Colour Scheming: Rewind Signup Flow Headings

### DIFF
--- a/client/signup/steps/rewind-migrate/style.scss
+++ b/client/signup/steps/rewind-migrate/style.scss
@@ -38,12 +38,12 @@
 	font-size: rem( 25px );
 	font-weight: 300;
 	letter-spacing: rem( 1.5px );
-	color: var( --color-neutral-700 );
+	color: var( --color-white );
 }
 
 .rewind-switch__description {
 	max-width: 600px;
-	color: var( --color-text );
+	color: var( --color-white );
 	font-size: rem( 13.5px );
 	font-weight: 100;
 	line-height: rem( 25px );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switches the heading and description text from grey (unreadable) to white, as stated in the original issue and as identical to other flows

#### Testing instructions

Follow the `start/rewind-setup/rewind-form-creds` flow and verify no other styles are adversely affected.

**Before:**

<img width="654" alt="Screenshot 2019-04-02 at 21 42 16" src="https://user-images.githubusercontent.com/43215253/55434756-3a1ad780-5590-11e9-9342-ff619bdb3a48.png">

**After:**

<img width="760" alt="Screenshot 2019-04-02 at 21 41 52" src="https://user-images.githubusercontent.com/43215253/55434765-4010b880-5590-11e9-99ce-bdb52dfee2c6.png">

cc @flootr, @blowery, @joanrho

Fixes #31967
