### PR TITLE
Fix the package build when spaces are present in the path

### DIFF
--- a/packages/calypso-build/bin/build-package.js
+++ b/packages/calypso-build/bin/build-package.js
@@ -16,12 +16,15 @@ const outputDirCommon = path.join( dir, 'dist', 'cjs' );
 
 console.log( 'Building %s', dir );
 
-execSync( `npx babel --config-file ${ babelConfigFile } -d ${ outputDirEsm } ${ inputDir }`, {
+execSync( `npx babel --config-file "${ babelConfigFile }" -d "${ outputDirEsm }" "${ inputDir }"`, {
 	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'defaults' } ),
 	cwd: root,
 } );
 
-execSync( `npx babel --config-file ${ babelConfigFile } -d ${ outputDirCommon } ${ inputDir }`, {
-	env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'server' } ),
-	cwd: root,
-} );
+execSync(
+	`npx babel --config-file "${ babelConfigFile }" -d "${ outputDirCommon }" "${ inputDir }"`,
+	{
+		env: Object.assign( {}, process.env, { BROWSERSLIST_ENV: 'server' } ),
+		cwd: root,
+	}
+);


### PR DESCRIPTION
Double quote the paths to support paths with spaces

