### PR TITLE
Signup: hide checklist dot for people in the page builder test

### DIFF
--- a/client/lib/signup/page-builder.js
+++ b/client/lib/signup/page-builder.js
@@ -27,6 +27,5 @@ export function isEligibleForPageBuilder( segment, flowName ) {
 }
 
 export function isBlockEditorSectionInTest( state ) {
-	const isGutenberg = getSectionGroup( state ) === 'gutenberg';
-	return isGutenberg && isInPageBuilderTest();
+	return 'gutenberg' === getSectionGroup( state ) && isInPageBuilderTest();
 }

--- a/client/lib/signup/page-builder.js
+++ b/client/lib/signup/page-builder.js
@@ -3,6 +3,7 @@
  */
 import config from 'config';
 import { getLocaleSlug } from 'lib/i18n-utils';
+import { getSectionGroup } from 'state/ui/selectors';
 
 // temp
 let inTest = false;
@@ -23,4 +24,9 @@ export function shouldEnterPageBuilder() {
 
 export function isEligibleForPageBuilder( segment, flowName ) {
 	return 'en' === getLocaleSlug() && 1 === segment && 'onboarding-for-business' === flowName;
+}
+
+export function isBlockEditorSectionInTest( state ) {
+	const isGutenberg = getSectionGroup( state ) === 'gutenberg';
+	return isGutenberg && isInPageBuilderTest();
 }

--- a/client/my-sites/checklist/wpcom-checklist/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/index.jsx
@@ -58,7 +58,13 @@ class WpcomChecklist extends Component {
 	}
 }
 
-function shouldChecklistRender( viewMode, isEligibleForChecklist, taskList, isSection, siteId ) {
+function shouldChecklistRender(
+	viewMode,
+	isEligibleForChecklist,
+	taskList,
+	isSectionEligible,
+	siteId
+) {
 	// Render nothing in notification mode.
 	if ( viewMode === 'notification' ) {
 		return false;
@@ -75,7 +81,7 @@ function shouldChecklistRender( viewMode, isEligibleForChecklist, taskList, isSe
 	}
 
 	// Render nothing in navigation mode if the current section is not site-specific.
-	if ( ! isSection && viewMode === 'navigation' ) {
+	if ( ! isSectionEligible && viewMode === 'navigation' ) {
 		return false;
 	}
 
@@ -91,7 +97,7 @@ function shouldChecklistShowNotification(
 	taskList,
 	storedTask,
 	isEligibleForChecklist,
-	isSection
+	isSectionEligible
 ) {
 	const firstIncomplete = taskList && taskList.getFirstIncompleteTask();
 
@@ -99,7 +105,7 @@ function shouldChecklistShowNotification(
 		firstIncomplete &&
 		( storedTask !== firstIncomplete.id || storedTask === null ) &&
 		isEligibleForChecklist &&
-		isSection
+		isSectionEligible
 	) {
 		return true;
 	}
@@ -111,7 +117,7 @@ export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 	const designType = getSiteOption( state, siteId, 'design_type' );
 	const isEligibleForChecklist = isEligibleForDotcomChecklist( state, siteId );
-	const isSection = isSiteSection( state ) && ! isBlockEditorSectionInTest( state );
+	const isSectionEligible = isSiteSection( state ) && ! isBlockEditorSectionInTest( state );
 	const siteChecklist = getSiteChecklist( state, siteId );
 	const siteSegment = get( siteChecklist, 'segment' );
 	const siteVerticals = get( siteChecklist, 'vertical' );
@@ -132,14 +138,14 @@ export default connect( ( state, ownProps ) => {
 			viewMode,
 			isEligibleForChecklist,
 			taskList,
-			isSection,
+			isSectionEligible,
 			siteId
 		),
 		shouldShowNotification: shouldChecklistShowNotification(
 			taskList,
 			storedTask,
 			isEligibleForChecklist,
-			isSection
+			isSectionEligible
 		),
 	};
 } )( WpcomChecklist );

--- a/client/my-sites/checklist/wpcom-checklist/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/index.jsx
@@ -18,6 +18,7 @@ import { getSiteOption } from 'state/sites/selectors';
 import AsyncLoad from 'components/async-load';
 import { getNeverShowBannerStatus } from 'my-sites/checklist/wpcom-checklist/checklist-banner/never-show';
 import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { isBlockEditorSectionInTest } from 'lib/signup/page-builder';
 
 class WpcomChecklist extends Component {
 	static propTypes = {
@@ -110,7 +111,7 @@ export default connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 	const designType = getSiteOption( state, siteId, 'design_type' );
 	const isEligibleForChecklist = isEligibleForDotcomChecklist( state, siteId );
-	const isSection = isSiteSection( state );
+	const isSection = isSiteSection( state ) && ! isBlockEditorSectionInTest( state );
 	const siteChecklist = getSiteChecklist( state, siteId );
 	const siteSegment = get( siteChecklist, 'segment' );
 	const siteVerticals = get( siteChecklist, 'vertical' );


### PR DESCRIPTION
Users in the Site Builder test should not see the dot. The dot is a lie.

#### Changes proposed in this Pull Request

* The checklist dot on the lower right help circle will not be shown in the block editor for users in the page builder test

#### Testing instructions

As with #31975 this will not work until this is ready to launch and the AB tests are properly set up. See #31981 for abtest setup.

Verify that this does _not_ hide the dot in the block editor. 

Then change `inTest` to `true` on top of `lib/signup/page-builder` to simulate being in the test. Verify that the dot on the help button does not show, as below:

<img width="844" alt="image" src="https://user-images.githubusercontent.com/195089/55437856-9b798100-5565-11e9-95f3-0e19d28cdaba.png">
