### PR TITLE
Editor: Use the `frame_nonce_preview` site option for site preview

### DIFF
--- a/client/blocks/site-preview/index.jsx
+++ b/client/blocks/site-preview/index.jsx
@@ -103,7 +103,7 @@ function mapStateToProps( state ) {
 		selectedSite: getPreviewSite( state ),
 		selectedSiteId,
 		selectedSiteUrl: siteUrl.replace( /::/g, '/' ),
-		selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ) || '',
+		selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce_preview' ) || '',
 		previewUrl: getPreviewUrl( state ),
 		isDomainOnlySite: isDomainOnlySite( state, selectedSiteId ),
 	};

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -100,7 +100,7 @@ class PreviewMain extends React.Component {
 			{
 				theme_preview: true,
 				iframe: true,
-				'frame-nonce': this.props.site.options.frame_nonce,
+				'frame-nonce': this.props.site.options.frame_nonce_preview,
 			},
 			baseUrl
 		);

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -566,7 +566,7 @@ export const getPreviewURL = function( site, post, autosavePreviewUrl ) {
 		}
 		if ( site.options.frame_nonce ) {
 			parsed = url.parse( previewUrl, true );
-			parsed.query[ 'frame-nonce' ] = site.options.frame_nonce;
+			parsed.query[ 'frame-nonce' ] = site.options.frame_nonce_preview;
 			delete parsed.search;
 			previewUrl = url.format( parsed );
 		}

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -32,6 +32,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'default_sharing_status',
 	'design_type',
 	'frame_nonce',
+	'frame_nonce_preview',
 	'gmt_offset',
 	'has_pending_automated_transfer',
 	'is_automated_transfer',


### PR DESCRIPTION
_Requires D26364-code to be deployed first._

As preparation for landing iframed Jetpack editors, we need to shift Calypso site previews to use the new `frame_nonce_preview` option introduced in D26364-code. This is the first part of merging #30788 (which can't be safely merged without first dealing with the preview nonces).

See: p7jreA-27X-p2/#comment-1736

**Testing Instructions**
* Sandbox the API with D26364-code applied.
* Open the a Simple Site post in both the Calypso and iframed block editors, and click the Preview button top right.
* Verify the preview modal opens and displays the post successfully.
* Ensure you are logged in to a Jetpack site's `wp-admin` in another tab.
* Edit a post (or any post type) for that Jetpack site in the Calypso editor.
* Click the Preview button top right, and a new tab will open.
* Verify the preview loads in the new tab.
* Log out of the Jetpack `wp-admin`.
* Click Preview again, and verify that the preview still loads properly in the new tab.

The Preview modal is this thing:

<img width="1429" alt="Screen Shot 2019-04-02 at 3 18 41 PM" src="https://user-images.githubusercontent.com/349751/55440030-489acc00-555b-11e9-8ec7-90df66bde8cf.png">
