### PR TITLE
Signup: enable page builder mvp test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -174,4 +174,12 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
+	pageBuilderMVP: {
+		datestamp: '20190402',
+		variations: {
+			control: 50,
+			test: 50,
+		},
+		defaultVariation: 'control',
+	},
 };

--- a/client/lib/signup/page-builder.js
+++ b/client/lib/signup/page-builder.js
@@ -1,24 +1,15 @@
 /**
  * Internal dependencies
  */
-import config from 'config';
+import { abtest, getABTestVariation } from 'lib/abtest';
 import { getLocaleSlug } from 'lib/i18n-utils';
 
-// temp
-let inTest = false;
-
 export function isInPageBuilderTest() {
-	// This will check an already-set abtest value with
-	// `getABTestVariation` when ready to launch
-	return inTest;
+	return 'test' === getABTestVariation( 'pageBuilderMVP' );
 }
 
 export function shouldEnterPageBuilder() {
-	// This will become an abtest when we are ready to launch
-	inTest = config.isEnabled( 'signup/page-builder' );
-	// using `inTest` this way ensures that `isInPageBuilderTest` will only
-	// return true after this, like assigning the test and later checking `getABTestVariation`
-	return inTest;
+	return 'test' === abtest( 'pageBuilderMVP' );
 }
 
 export function isEligibleForPageBuilder( segment, flowName ) {

--- a/config/development.json
+++ b/config/development.json
@@ -177,7 +177,6 @@
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": true,
 		"signup/onboarding-flow": true,
-		"signup/page-builder": true,
 		"signup/social": true,
 		"signup/social-management": true,
 		"signup/wpcc": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -122,7 +122,6 @@
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,
 		"signup/onboarding-flow": true,
-		"signup/page-builder": true,
 		"signup/social": true,
 		"signup/social-management": true,
 		"signup/wpcc": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* enable the Page Builder test in production

#### Testing instructions

Check this out locally and visit http://calypso.localhost:3000/start/onboarding or https://calypso.live/start/onboarding?branch=add/page-builder-test

Paste the following into your console to enter the test

```
localStorage.setItem( 'ABTests', '{"pageBuilderMVP_20190402":"test"}' );
```

Choose Business. Ensure your interface language is English. After completing signup, you should land in the block editor like this:

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/195089/55500934-003ce600-560f-11e9-8888-22d99c6573db.png">

You should have an editable Site Header block at the top of the editor.

---

To test the non-test variant, visit the same URL as above, but this time paste the following into your console:

```
localStorage.setItem( 'ABTests', '{"pageBuilderMVP_20190402":"control"}' );
```

Verify that you land in the checklist after signup, otherwise following the same instructions.