### PR TITLE
Editor: Add Jetpack iframed editors behind a feature flag.

### DIFF
--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -1,4 +1,10 @@
 /** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -6,6 +12,7 @@ import { isEnabled } from 'config';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import getSiteOptions from 'state/selectors/get-site-options';
 import getWordPressVersion from 'state/selectors/get-wordpress-version';
 import versionCompare from 'lib/version-compare';
 import isPluginActive from 'state/selectors/is-plugin-active';
@@ -16,7 +23,11 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 	}
 
 	if ( isEnabled( 'jetpack/gutenframe' ) ) {
-		return false;
+		if (
+			versionCompare( get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ), '7.3', '>=' )
+		) {
+			return false;
+		}
 	}
 
 	// We do want Calypsoify flows for Atomic sites

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -15,6 +15,10 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 		return false;
 	}
 
+	if ( isEnabled( 'jetpack/iframe/editor' ) ) {
+		return false;
+	}
+
 	// We do want Calypsoify flows for Atomic sites
 	if ( isSiteAutomatedTransfer( state, siteId ) ) {
 		const wpVersion = getWordPressVersion( state, siteId );

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -24,7 +24,11 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 
 	if ( isEnabled( 'jetpack/gutenframe' ) ) {
 		if (
-			versionCompare( get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ), '7.3', '>=' )
+			versionCompare(
+				get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ),
+				'7.3-alpha',
+				'>='
+			)
 		) {
 			return false;
 		}

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -15,7 +15,7 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 		return false;
 	}
 
-	if ( isEnabled( 'jetpack/iframe/editor' ) ) {
+	if ( isEnabled( 'jetpack/gutenframe' ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -11,9 +11,15 @@ export const isGutenbergEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
 		return false;
 	}
+
 	if ( isCalypsoifyGutenbergEnabled( state, siteId ) ) {
 		return true;
 	}
+
+	if ( isEnabled( 'jetpack/iframe/editor' ) ) {
+		return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
+	}
+
 	return (
 		isEnabled( 'gutenberg' ) && ! isJetpackSite( state, siteId ) && ! isVipSite( state, siteId )
 	);

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -26,7 +26,11 @@ export const isGutenbergEnabled = ( state, siteId ) => {
 
 	if ( isEnabled( 'jetpack/gutenframe' ) ) {
 		if (
-			versionCompare( get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ), '7.3', '>=' )
+			versionCompare(
+				get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ),
+				'7.3-alpha',
+				'>='
+			)
 		) {
 			return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
 		}

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -1,11 +1,19 @@
 /** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
 /**
  * Internal dependencies
  */
 import { isEnabled } from 'config';
+import getSiteOptions from 'state/selectors/get-site-options';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import isVipSite from 'state/selectors/is-vip-site';
 import { isJetpackSite } from 'state/sites/selectors';
+import versionCompare from 'lib/version-compare';
 
 export const isGutenbergEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
@@ -17,7 +25,11 @@ export const isGutenbergEnabled = ( state, siteId ) => {
 	}
 
 	if ( isEnabled( 'jetpack/gutenframe' ) ) {
-		return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
+		if (
+			versionCompare( get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ), '7.3', '>=' )
+		) {
+			return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
+		}
 	}
 
 	return (

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -16,7 +16,7 @@ export const isGutenbergEnabled = ( state, siteId ) => {
 		return true;
 	}
 
-	if ( isEnabled( 'jetpack/iframe/editor' ) ) {
+	if ( isEnabled( 'jetpack/gutenframe' ) ) {
 		return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
 	}
 


### PR DESCRIPTION
This PR adds iframing Jetpack block editors behind the `jetpack/gutenframe` feature flag. It is part 2 of 3 for landing #30788. Part 1 is #31980 . 

See: p7jreA-27X-p2/#comment-1736
See phase 2 work in p3fqKv-6Hh-p2.

**Testing Instructions**
* Apply https://github.com/Automattic/jetpack/pull/11354 to your local test Jetpack site.
* Disconnect and reconnect your site to WordPress.com to force the auto-activation of the module.
* Load the block editor for your Jetpack site: `/block-editor/post/:JetpackDomain?flags=jetpack/gutenframe`
* Verify the iframed block editor loads; there should be no `sameorigin` console errors.