### PR TITLE
Config: Enable iframing Jetpack and Atomic editors in testing environments.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -84,7 +84,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/happychat": true,
-		"jetpack/iframe/editor": true,
+		"jetpack/gutenframe": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"login/magic-login": true,

--- a/config/development.json
+++ b/config/development.json
@@ -84,6 +84,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/happychat": true,
+		"jetpack/iframe/editor": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"login/magic-login": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -46,7 +46,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
-		"jetpack/iframe/editor": true,
+		"jetpack/gutenframe": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"login/native-login-links": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -46,6 +46,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
+		"jetpack/iframe/editor": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,
 		"login/native-login-links": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -62,7 +62,7 @@
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
-		"jetpack/iframe/editor": true,
+		"jetpack/gutenframe": true,
 		"jitms": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -62,6 +62,7 @@
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
+		"jetpack/iframe/editor": true,
 		"jitms": true,
 		"login/magic-login": true,
 		"login/native-login-links": true,


### PR DESCRIPTION
This PR enables iframing Jetpack and Atomic editors in the `development`, `horizon`, and `wpcalypso` testing environments. This is part 3 of 3 to merge #30788, and ready Calypso for wider testing and iteration of iframed Jetpack editors.

See: p7jreA-27X-p2/#comment-1736
See phase 2 work in p3fqKv-6Hh-p2.

**Testing Instructions**
* Apply Automattic/jetpack#11354 to your local test Jetpack site. 
* Load Calypso locally with this branch.
* Load the block editor for your Jetpack site: `/block-editor/post/:JetpackDomain`
* Verify the iframed block editor loads; there should be no `sameorigin` console errors.
* Restart Calypso using `NODE_ENV=horizon` and `NODE_ENV=wpcalypso`; verify the iframing also works.
