### PR TITLE
Gutenframe: Warn if unsaved changes on the client side

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.jsx
+++ b/client/gutenberg/editor/calypsoify-iframe.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { endsWith, get, map, pickBy, startsWith } from 'lodash';
+import { endsWith, flow, get, map, pickBy, startsWith } from 'lodash';
 import PropTypes from 'prop-types';
 import url from 'url';
 
@@ -32,6 +32,7 @@ import { Placeholder } from './placeholder';
 import WebPreview from 'components/web-preview';
 import { trashPost } from 'state/posts/actions';
 import { getEditorPostId } from 'state/ui/editor/selectors';
+import { protectForm } from 'lib/protect-form';
 
 /**
  * Style dependencies
@@ -44,6 +45,8 @@ class CalypsoifyIframe extends Component {
 		postType: PropTypes.string,
 		duplicatePostId: PropTypes.number,
 		pressThis: PropTypes.object,
+		markChanged: PropTypes.func.isRequired,
+		markSaved: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -164,6 +167,12 @@ class CalypsoifyIframe extends Component {
 		}
 
 		if ( 'goToAllPosts' === action ) {
+			const { unsavedChanges = false } = payload;
+			if ( unsavedChanges ) {
+				this.props.markChanged();
+			} else {
+				this.props.markSaved();
+			}
 			this.props.navigate( this.props.allPostsUrl );
 		}
 
@@ -400,7 +409,12 @@ const mapDispatchToProps = {
 	trashPost,
 };
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( CalypsoifyIframe );
+const enhance = flow(
+	protectForm,
+	connect(
+		mapStateToProps,
+		mapDispatchToProps
+	)
+);
+
+export default enhance( CalypsoifyIframe );


### PR DESCRIPTION
### Changes proposed in this Pull Request

On this PR we protect a user from navigating away from the iframed editor to the list of posts when there are unsaved changes.

This was previously handled on the server side, but we can get some benefits by moving it to Calypso (client side):
- We can perform any redirect to `/posts/:site` on the client side, making the navigation much faster since we avoid a full page load.
- We fix a bug on the desktop app caused by a conflict on how the `beforeunload` event behaves on the web and on Electron apps. [Gutenberg uses the `beforeunload` event](https://github.com/WordPress/gutenberg/blob/580fedd587962304f21964a64778298be2f88511/packages/editor/src/components/unsaved-changes-warning/index.js#L14-L36) to ask the user if they really want to leave the page when there are unsaved changes. But Electron [cancels the close](https://github.com/electron/electron/blob/7c6cedb1191ef9071dc80ca2dc475d76914c4926/docs/api/browser-window.md#event-close) (without showing any warning dialog) when we return any non-void value on the `beforeunload` event. Provided the navigation is moved to Calypso, we can use now the same `protectForm` HOC [we use on the Calypso classic editor](https://github.com/Automattic/wp-calypso/blob/7bf6a37f599d3e35dad482cee2cd8cd73dca5466/client/post-editor/post-editor.jsx#L1131), which is [based on `window.confirm`](https://github.com/Automattic/wp-calypso/blob/7bf6a37f599d3e35dad482cee2cd8cd73dca5466/client/lib/protect-form/index.jsx#L115-L122) (and compatible with Electron).

### Testing instructions

#### Pre-requisites
* Apply D26381-code to your sandboxed site.

#### Web
* Go to `/block-editor` and select your sandboxed site.
* Add some content to the post.
* Click on the "View Posts" button before the post is autosaved.
<img width="256" alt="Screen Shot 2019-04-03 at 12 55 10" src="https://user-images.githubusercontent.com/1233880/55453445-e7d0c980-5616-11e9-916c-14a934019ac5.png">

* Make sure you see a warning dialog asking if you really want to leave the page.
  * Accept the dialog and check you are redirect to the list of posts. Try with other post types (pages, custom post types) and confirm you are redirected to the appropriate page (list of pages, list of testimonial, etc).
  * Dismiss the dialog and confirm you stay on the editor.
* Save the post as draft or publish it.
* Click again on the "View Posts" button.
* Make sure you don't see any warning dialog now.

#### Desktop
* Make sure you have the dev environment [installed and running](https://github.com/Automattic/wp-desktop/blob/b729377828ec53f4469ed27a15c1fbc6e9b3a1cf/docs/install.md) (more info about how to set up the secrets in paaHJt-7y-p2).
* In the desktop repo, point the calypso submodule to this branch.
* Create a build: `make build`.
* Open the built app in the `release` folder.
* Repeat the same steps under the **Web** section above.

