### PR TITLE
Jetpack Checklist: Update progress text

### DIFF
--- a/client/components/checklist/README.md
+++ b/client/components/checklist/README.md
@@ -9,6 +9,10 @@ Checklist
 
 Render as a placeholder.
 
+### `progressText { string } - default: "Your setup list"`
+
+Displayed in the checklist header, right on top of the progress bar.
+
 ## `Task` props
 
 ### `completed { bool }`

--- a/client/components/checklist/header.js
+++ b/client/components/checklist/header.js
@@ -20,6 +20,7 @@ export class ChecklistHeader extends PureComponent {
 		completed: PropTypes.number.isRequired,
 		hideCompleted: PropTypes.bool,
 		onClick: PropTypes.func,
+		progressText: PropTypes.string,
 	};
 
 	render() {
@@ -27,12 +28,13 @@ export class ChecklistHeader extends PureComponent {
 		const buttonText = hideCompleted
 			? translate( 'Show completed' )
 			: translate( 'Hide completed' );
+		const progressText = this.props.progressText || translate( 'Your setup list' );
 
 		return (
 			<Card compact className="checklist__header">
 				<div className="checklist__header-main">
 					<div className="checklist__header-progress">
-						<h2 className="checklist__header-progress-text">{ translate( 'Your setup list' ) }</h2>
+						<h2 className="checklist__header-progress-text">{ progressText }</h2>
 						<span className="checklist__header-progress-number">{ `${ completed }/${ total }` }</span>
 					</div>
 					<ProgressBar compact total={ total } value={ completed } />

--- a/client/components/checklist/index.js
+++ b/client/components/checklist/index.js
@@ -16,6 +16,7 @@ import TaskPlaceholder from 'components/checklist/task-placeholder';
 export default class Checklist extends PureComponent {
 	static propTypes = {
 		isPlaceholder: PropTypes.bool,
+		progressText: PropTypes.string,
 		updateCompletion: PropTypes.func,
 	};
 
@@ -77,6 +78,7 @@ export default class Checklist extends PureComponent {
 					hideCompleted={ this.state.hideCompleted }
 					onClick={ this.toggleCompleted }
 					total={ total }
+					progressText={ this.props.progressText }
 				/>
 				<div className="checklist__tasks">{ this.props.children }</div>
 			</div>

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -53,7 +53,10 @@ class JetpackChecklist extends PureComponent {
 		return (
 			<Fragment>
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
-				<Checklist isPlaceholder={ ! taskStatuses }>
+				<Checklist
+					isPlaceholder={ ! taskStatuses }
+					progressText={ translate( 'Your Jetpack setup progress' ) }
+				>
 					<Task
 						completed
 						title={ translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce support for `progressText` in `<Checklist />`
* Update the progress text in the Jetpack checklist, as suggested by @jeffgolenski in https://github.com/Automattic/wp-calypso/pull/31963#pullrequestreview-221819865

#### Preview

Before:
![](https://cldup.com/lslrK7seqW.png)

After:
![](https://cldup.com/JlLlVdSeFx.png)

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/my-plan/:site?thank-you where `:site` is a Jetpack site.
* Verify you can see the updated Jetpack progress text "Your Jetpack setup progress".
* Go to https://wordpress.com/checklist/:site where `:site` is a relatively new WP.com site.
* Verify you can see the original progress text "Your setup list".
