### PR TITLE
Try a fix for jetpack tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,21 +518,16 @@ jobs:
       slack-webhook:
         type: string
         default: $SLACK_E2E
-      skip-jetpack:
-        type: string
-        default: ""
     steps:
       - prepare
       - run: *set-e2e-variables
-      - when:
-          condition: << parameters.skip-jetpack >>
-          steps:
-            - slack/notify:
-                color: '#FF0000'
-                webhook: << parameters.slack-webhook >>
-                message: Jetpack tests have been skipped
-            - run: |
-                circleci-agent step halt
+      - run:
+          name: Skip Jetpack Tests if needed
+          command: |
+                if [[ $SKIP_JETPACK == 'true' && << parameters.test-target >> == 'JETPACK' ]]
+                  curl curl -X POST -H 'Content-type: application/json' --data '{"text":"Jetpack tests were skipped", "color":"#FF0000"}' << parameters.slack-webhook >>
+                  circleci-agent step halt
+                fi
       - run: npm run decryptconfig
       - run:
           name: Run Canary Tests
@@ -610,7 +605,6 @@ workflows:
           jetpack-host: "PRESSABLEBLEEDINGEDGE"
           test-target: "JETPACK"
           slack-webhook: "$SLACK_JP"
-          skip-jetpack: $SKIP_JETPACK
 
   calypso-nightly:
     jobs:
@@ -683,7 +677,6 @@ workflows:
           jetpack-host: "PRESSABLEBLEEDINGEDGE"
           test-target: "JETPACK"
           slack-webhook: "$SLACK_JP"
-          skip-jetpack: $SKIP_JETPACK
     triggers:
       - schedule:
           cron: "0 7 * * *"
@@ -703,7 +696,6 @@ workflows:
 #        jetpack-host: "PRESSABLE"
 #        test-target: "JETPACK"
 #        slack-webhook: "$SLACK_JP"
-#        skip-jetpack: $SKIP_JETPACK
 #    triggers:
 #    - schedule:
 #        cron: "0 1,13 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -531,7 +531,7 @@ jobs:
                     "{ \
                       \"attachments\": [ \
                         { \
-                          \"text\": \"Jetpack tests were skipped", \
+                          \"text\": \"Jetpack tests were skipped\", \
                           \"fields\": [ \
                             { \
                               \"title\": \"Project\", \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -602,6 +602,15 @@ workflows:
           test-flags: "-W -S $CIRCLE_SHA1"
           test-target: "WOO"
           slack-webhook: "$SLACK_WOO"
+      - test-e2e-canary:
+          name: test-e2e-jetpack
+          requires:
+          - wait-calypso-live
+          test-flags: "-j"
+          jetpack-host: "PRESSABLEBLEEDINGEDGE"
+          test-target: "JETPACK"
+          slack-webhook: "$SLACK_JP"
+          skip-jetpack: $SKIP_JETPACK
 
   calypso-nightly:
     jobs:
@@ -674,7 +683,7 @@ workflows:
           jetpack-host: "PRESSABLEBLEEDINGEDGE"
           test-target: "JETPACK"
           slack-webhook: "$SLACK_JP"
-          skip-jetpack: "$SKIP_JETPACK"
+          skip-jetpack: $SKIP_JETPACK
     triggers:
       - schedule:
           cron: "0 7 * * *"
@@ -694,7 +703,7 @@ workflows:
 #        jetpack-host: "PRESSABLE"
 #        test-target: "JETPACK"
 #        slack-webhook: "$SLACK_JP"
-#        skip-jetpack: "$SKIP_JETPACK"
+#        skip-jetpack: $SKIP_JETPACK
 #    triggers:
 #    - schedule:
 #        cron: "0 1,13 * * *"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,7 +525,7 @@ jobs:
           name: Skip Jetpack Tests if needed
           command: |
               # If the skip jetpack env var is set, notify slack channel and skip the rest of the steps
-              if [[ "$SKIP_JETPACK" == "true" && "<< parameters.test-target >>" == "JETPACK" ]]
+              if [[ "$SKIP_JETPACK" == "true" && "<< parameters.test-target >>" == "JETPACK" ]]; then
                 curl -X POST -H 'Content-type: application/json' \
                     --data \
                     "{ \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -626,14 +626,6 @@ workflows:
           test-flags: "-W -S $CIRCLE_SHA1"
           test-target: "WOO"
           slack-webhook: "$SLACK_WOO"
-      - test-e2e-canary:
-          name: test-e2e-jetpack
-          requires:
-          - wait-calypso-live
-          test-flags: "-j"
-          jetpack-host: "PRESSABLEBLEEDINGEDGE"
-          test-target: "JETPACK"
-          slack-webhook: "$SLACK_JP"
 
   calypso-nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -524,10 +524,39 @@ jobs:
       - run:
           name: Skip Jetpack Tests if needed
           command: |
-                if [[ $SKIP_JETPACK == 'true' && << parameters.test-target >> == 'JETPACK' ]]
-                  curl curl -X POST -H 'Content-type: application/json' --data '{"text":"Jetpack tests were skipped", "color":"#FF0000"}' << parameters.slack-webhook >>
-                  circleci-agent step halt
-                fi
+              # If the skip jetpack env var is set, notify slack channel and skip the rest of the steps
+              if [[ "$SKIP_JETPACK" == "true" && "<< parameters.test-target >>" == "JETPACK" ]]
+                curl -X POST -H 'Content-type: application/json' \
+                    --data \
+                    "{ \
+                      \"attachments\": [ \
+                        { \
+                          \"text\": \"Jetpack tests were skipped", \
+                          \"fields\": [ \
+                            { \
+                              \"title\": \"Project\", \
+                              \"value\": \"$CIRCLE_PROJECT_REPONAME\", \
+                              \"short\": true \
+                            }, \
+                            { \
+                              \"title\": \"Job Number\", \
+                              \"value\": \"$CIRCLE_BUILD_NUM\", \
+                              \"short\": true \
+                            } \
+                          ], \
+                          \"actions\": [ \
+                            { \
+                              \"type\": \"button\", \
+                              \"text\": \"Visit Job\", \
+                              \"url\": \"$CIRCLE_BUILD_URL\" \
+                            } \
+                          ], \
+                          \"color\": \"#FF0000\" \
+                        } \
+                      ] \
+                    }" << parameters.slack-webhook >>
+                circleci-agent step halt
+              fi
       - run: npm run decryptconfig
       - run:
           name: Run Canary Tests


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Jetpack tests were still being skipped even when env var was gone. The conditional wasn't working like I expected so I switched it to using an if statement for the check and a manual curl to the slack webhook for notification

#### Testing instructions

Here are some builds:

Jetpack  with variable (skipped)
https://circleci.com/gh/Automattic/wp-calypso/239047

Jetpack without variable (run)- note that I cancelled to save time, but it started running tests
https://circleci.com/gh/Automattic/wp-calypso/239011

![image](https://user-images.githubusercontent.com/31110506/55492028-c27e9400-55f3-11e9-9ec2-17011c2565e8.png)

