### PR TITLE
Calypso Build: Bump package version

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"config",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I just published `@automattic/calypso-build@1.0.0-alpha.1`, in which I accidentally included a non-empty `dist/` subdir (leftover from testing something) :roll_eyes: I've unpublished it but cannot re-use the version number. Looks like I need to bump the pacakge version for lerna to let me publish `-alpha.2`
