### PR TITLE
Add notice that informs user email forwards stop working with G Suite

### DIFF
--- a/client/my-sites/email/email-forwarding/index.jsx
+++ b/client/my-sites/email/email-forwarding/index.jsx
@@ -24,7 +24,7 @@ import { emailManagement } from 'my-sites/email/paths';
 import Card from 'components/card/compact';
 import getEmailForwardingLimit from 'state/selectors/get-email-forwarding-limit';
 import getEmailForwardingType from 'state/selectors/get-email-forwarding-type';
-import getEmailForwards from 'state/selectors/get-email-forwards';
+import { getEmailForwards } from 'state/selectors/get-email-forwards';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryEmailForwards from 'components/data/query-email-forwards';
 import SectionHeader from 'components/section-header';

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -74,7 +74,7 @@ class GSuiteAddUsers extends React.Component {
 				{ domainsWithForwards.length ? (
 					<Notice showDismiss={ false } status="is-warning">
 						{ translate(
-							'This site has domains with email forwards. If you add G Suite those forwards will stop working. The following domains have forwards:'
+							'Please note that email forwards are not compatible with G Suite, and will be disabled once G Suite is added to this domain. The following domains have forwards:'
 						) }
 						<ul>
 							{ domainsWithForwards.map( domainName => {

--- a/client/state/selectors/get-email-forwards.js
+++ b/client/state/selectors/get-email-forwards.js
@@ -21,7 +21,7 @@ export function getEmailForwards( state, domainName ) {
  *
  * @param  {Object} state   Global state tree
  * @param  {String} domains domains to filter
- * @return {Object}         EmailForwards list
+ * @return {Object}         list of domains with forwards
  */
 export function getDomainsWithForwards( state, domains ) {
 	if ( ! domains || ! domains.length ) {

--- a/client/state/selectors/get-email-forwards.js
+++ b/client/state/selectors/get-email-forwards.js
@@ -12,6 +12,26 @@ import { get } from 'lodash';
  * @param  {String} domainName domainName to request email forwards for
  * @return {Object}          EmailForwards list
  */
-export default function getEmailForwards( state, domainName ) {
+export function getEmailForwards( state, domainName ) {
 	return get( state.emailForwarding, [ domainName, 'forwards' ], null );
+}
+
+/**
+ * Retrieve a list domains that have forwards
+ *
+ * @param  {Object} state   Global state tree
+ * @param  {String} domains domains to filter
+ * @return {Object}         EmailForwards list
+ */
+export function getDomainsWithForwards( state, domains ) {
+	if ( ! domains || ! domains.length ) {
+		return [];
+	}
+	return domains.reduce( ( accumulator, domain ) => {
+		const forwards = getEmailForwards( state, domain.domain );
+		if ( forwards && forwards.length ) {
+			accumulator.push( domain.domain );
+		}
+		return accumulator;
+	}, [] );
 }

--- a/client/state/selectors/get-email-forwards.js
+++ b/client/state/selectors/get-email-forwards.js
@@ -21,7 +21,7 @@ export function getEmailForwards( state, domainName ) {
  *
  * @param  {Object} state   Global state tree
  * @param  {String} domains domains to filter
- * @return {Object}         list of domains with forwards
+ * @return {Array}          list of domains with forwards
  */
 export function getDomainsWithForwards( state, domains ) {
 	if ( ! domains || ! domains.length ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds notice if a user has email forwards that they will stop working if they add G Suite

#### Testing instructions

* have site with email forwards
* goto site
* got to domains->email
* Click "Add G Suite"
* Observe banner

<img width="749" alt="Screen Shot 2019-04-04 at 1 33 28 PM" src="https://user-images.githubusercontent.com/6817400/55576171-a9064680-56de-11e9-9297-440e1c10fab3.png">
