### PR TITLE
Billing: CSS to fix the height of the textarea

### DIFF
--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -193,7 +193,7 @@
 }
 
 textarea.billing-history__billing-details-editable {
-	min-height: 20px !important;
+	min-height: 20px;
 }
 
 .billing-history__billing-details-description {

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -192,6 +192,10 @@
 	min-height: 1.2em;
 }
 
+textarea.billing-history__billing-details-editable {
+	min-height: 20px !important;
+}
+
 .billing-history__billing-details-description {
 	font-style: italic;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* #31848 should have included this update, but the CSS got left out.
* Reduce the height of the textarea by setting a new `min-height`; we don't need a large text field here, and it will grow as user content is added.

**Before**

<img width="697" alt="Screen Shot 2019-04-03 at 3 03 50 PM" src="https://user-images.githubusercontent.com/2124984/55505713-b5789980-5621-11e9-811f-96f9b6bb77ee.png">

**After**

<img width="683" alt="Screen Shot 2019-04-03 at 2 59 36 PM" src="https://user-images.githubusercontent.com/2124984/55505721-bb6e7a80-5621-11e9-8e31-75cd10b3a6ac.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/me/billing-history` on an account with a purchase and click View Receipt
* Look at the Billing Details field size.