### PR TITLE
Don't offer G Suite in restricted countries during domain purchase flow

### DIFF
--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -189,6 +189,10 @@ const transferDomainPrecheck = ( context, next ) => {
 };
 
 const googleAppsWithRegistration = ( context, next ) => {
+	if ( isGSuiteRestricted() ) {
+		next();
+	}
+
 	const state = context.store.getState();
 	const siteSlug = getSelectedSiteSlug( state ) || '';
 
@@ -204,10 +208,6 @@ const googleAppsWithRegistration = ( context, next ) => {
 	const handleClickSkip = () => {
 		page( '/checkout/' + siteSlug );
 	};
-
-	if ( isGSuiteRestricted() ) {
-		next();
-	}
 
 	context.primary = (
 		<Main>

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -37,6 +37,7 @@ import { isATEnabled } from 'lib/automated-transfer';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { makeLayout, render as clientRender } from 'controller';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { isGSuiteRestricted } from 'lib/domains/gsuite';
 
 /**
  * Module variables
@@ -203,6 +204,10 @@ const googleAppsWithRegistration = ( context, next ) => {
 	const handleClickSkip = () => {
 		page( '/checkout/' + siteSlug );
 	};
+
+	if ( isGSuiteRestricted() ) {
+		next();
+	}
 
 	context.primary = (
 		<Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We should not try to sell G Suite if user is in restricted country

#### Testing instructions

* Goto site
* Goto domains
* Add Domain
* After selecting domain you should see G Suite sales screen

* Make this line return true: https://github.com/Automattic/wp-calypso/blob/master/client/lib/domains/gsuite/index.js#L95
* Goto site
* Goto domains
* Add Domain
* After selecting domain you should see checkout