### PR TITLE
Don't offer G Suite in restricted countries after checkout

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -21,6 +21,7 @@ import SecondaryCart from './cart/secondary-cart';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
 import ConciergeSessionNudge from './concierge-session-nudge';
+import { isGSuiteRestricted } from 'lib/domains/gsuite';
 
 export function checkout( context, next ) {
 	const { feature, plan, product } = context.params;
@@ -119,6 +120,10 @@ export function gsuiteNudge( context, next ) {
 
 	if ( ! selectedSite ) {
 		return null;
+	}
+
+	if ( isGSuiteRestricted() ) {
+		next();
 	}
 
 	context.primary = (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We should not try to sell G Suite if user is in restricted country

#### Testing instructions

* Create new site with domain
* Checkout
* After checkout you should see G Suite sales screen

* Make this line return true: https://github.com/Automattic/wp-calypso/blob/master/client/lib/domains/gsuite/index.js#L95
* Create new site with domain
* Checkout
* After checkout you should see not see G Suite sales screen, should be something else