### PR TITLE
Jetpack Manage: All versions above 7.3 are guaranteed to be manageable

### DIFF
--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -698,6 +698,11 @@ export function canJetpackSiteManage( state, siteId ) {
 		return null;
 	}
 
+	// Since Jetpack 7.3, Manage is no longer a module and is baked directly into Jetpack. All will be "Manageable "
+	if ( versionCompare( siteJetpackVersion, '7.3', '>=' ) ) {
+		return true;
+	}
+
 	if ( versionCompare( siteJetpackVersion, '3.4', '>=' ) ) {
 		// if we haven't fetched the modules yet, we default to true
 		const isModuleActive = isJetpackModuleActive( state, siteId, 'manage' );

--- a/client/state/sites/selectors.js
+++ b/client/state/sites/selectors.js
@@ -699,7 +699,7 @@ export function canJetpackSiteManage( state, siteId ) {
 	}
 
 	// Since Jetpack 7.3, Manage is no longer a module and is baked directly into Jetpack. All will be "Manageable "
-	if ( versionCompare( siteJetpackVersion, '7.3', '>=' ) ) {
+	if ( versionCompare( siteJetpackVersion, '7.3-alpha', '>=' ) ) {
 		return true;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Updates the selector to force `true` for all Jetpack sites running Jetpack 7.3 or above. 

Since https://github.com/Automattic/jetpack/pull/9089, Manage is no longer a module. 

IMO we should leave the other checks in place for prior versions because there are so many of them and it would be breaking Calypso experience for many older sites. 

I do think that we should work towards removing this check all together eventually, but that it far out of scope of the intent of this PR. 

#### Testing instructions

Spin up a Jetpack site running latest master https://jurassic.ninja/create?jetpack-beta
Connect and purchase a plan. 
You should not see any warning or error in the "thank you" page. 
