### PR TITLE
Signup: switch site-information to site-information-title in onboarding flow.

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -102,7 +102,7 @@ export function generateFlows( { getSiteDestination = noop, getPostsDestination 
 		},
 
 		onboarding: {
-			steps: [ 'user', 'site-type', 'site-topic', 'site-information', 'domains', 'plans' ],
+			steps: [ 'user', 'site-type', 'site-topic', 'site-information-title', 'domains', 'plans' ],
 			destination: getSiteDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2019-01-24',


### PR DESCRIPTION
In #31573, we removed the address and phone steps from the `/onboarding-for-business/` flow, but forgot to do the same for the default `/onboarding/` flow.

**Site information step with incorrect fields:**
<img width="435" alt="Screen Shot 2019-04-03 at 8 54 47 PM" src="https://user-images.githubusercontent.com/942359/55522396-c4c40b00-5652-11e9-9659-b98a6a68628f.png">

**To test:**
- visit `/start/onboarding/`
- pick "professional" or "blog" in the site-type step
- continue through the site-topic step
- verify that the site-information-title step is shown and only a title field is available
- finish Signup, the site title you added in the Signup should be available on your new site.