### PR TITLE
Components: Fix no topics case in PopularTopics

### DIFF
--- a/client/components/site-verticals-suggestion-search/popular-topics.jsx
+++ b/client/components/site-verticals-suggestion-search/popular-topics.jsx
@@ -71,10 +71,16 @@ class PopularTopics extends PureComponent {
 		} );
 	};
 	render() {
+		const { popularTopics } = this.props;
+
+		if ( ! popularTopics.length ) {
+			return null;
+		}
+
 		return (
 			<div className="site-verticals-suggestion-search__common-topics">
 				<div className="site-verticals-suggestion-search__heading">{ translate( 'Popular' ) }</div>
-				{ this.props.popularTopics.map( ( topic, index ) => (
+				{ popularTopics.map( ( topic, index ) => (
 					<button
 						type="button"
 						key={ index }
@@ -93,7 +99,7 @@ class PopularTopics extends PureComponent {
 
 export default connect(
 	state => ( {
-		popularTopics: POPULAR_TOPICS[ getSiteType( state ) || 'blog' ],
+		popularTopics: POPULAR_TOPICS[ getSiteType( state ) || 'blog' ] || [],
 	} ),
 	{
 		recordTracksEvent,


### PR DESCRIPTION
For Jetpack sites, we're not handling the "Online store" site type properly when attempting to display popular topics for the "site vertical" step. The problem is that we always assume that there will be popular topics for the selected site type, but that isn't the case for "online store". 

This PR patches the issue by updating such cases to default to an empty array and render nothing.

#### Changes proposed in this Pull Request

* Fix the case when there are no popular topics for the selected site type

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/jetpack/connect/site-type/:site where `:site` is a connected Jetpack site.
* Click on "Online store".
* You'll end up in the next step properly, without an error. 

Also, make sure to test the WP.com signup flow and verify it's unchanged.

To repro the issue: if you test in master instead of this branch, you'd see the following error in the "site topic" step:

![](https://cldup.com/WT69kMzdGd.png)
