### PR TITLE
Jetpack Connect: Save site type in signup state

### DIFF
--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -19,6 +19,7 @@ import withTrackingTool from 'lib/analytics/with-tracking-tool';
 import WpcomColophon from 'components/wpcom-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { saveSiteType } from 'state/jetpack-connect/actions';
+import { setSiteType } from 'state/signup/steps/site-type/actions';
 
 class JetpackSiteType extends Component {
 	goToNextStep = () => {
@@ -31,6 +32,7 @@ class JetpackSiteType extends Component {
 		const { siteId } = this.props;
 
 		this.props.saveSiteType( siteId, siteType );
+		this.props.setSiteType( siteType );
 
 		this.goToNextStep();
 	};
@@ -69,6 +71,7 @@ const connectComponent = connect(
 	} ),
 	{
 		saveSiteType,
+		setSiteType,
 	}
 );
 


### PR DESCRIPTION
Currently, the popular topics on the site topic step relies on having the selected site type in the Redux store. But for Jetpack Connect, we don't store it there, and this ends up not displaying popular topics at all. This PR changes that so we will save the selected site type in Redux.

#### Changes proposed in this Pull Request

* Save the site type in Redux when submitting the Jetpack site type step.

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/jetpack/connect/site-type/:site where `:site` is a connected Jetpack site.
* Pick a site type, different from "Online store".
* Verify you can see some popular topics in the next "site topic" step.
* Go back to site type step.
* Pick a "Online store" site type.
* Verify you don't see any popular topics in the site topic step.