### PR TITLE
Pages: prevent editing of latest posts page

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -211,7 +211,11 @@ class Page extends Component {
 		}
 
 		return (
-			<PopoverMenuItem onClick={ this.editPage } onMouseOver={ preloadEditor }>
+			<PopoverMenuItem
+				onClick={ this.editPage }
+				onMouseOver={ preloadEditor }
+				onFocus={ preloadEditor }
+			>
 				<Gridicon icon="pencil" size={ 18 } />
 				{ this.props.translate( 'Edit' ) }
 			</PopoverMenuItem>
@@ -456,6 +460,7 @@ class Page extends Component {
 						}
 						onClick={ this.props.recordPageTitle }
 						onMouseOver={ preloadEditor }
+						onFocus={ preloadEditor }
 						data-tip-target={ 'page-' + page.slug }
 					>
 						{ depthIndicator }
@@ -463,7 +468,7 @@ class Page extends Component {
 						{ latestPostsPage && (
 							<InfoPopover position="right">
 								{ translate(
-									'The content of your latest posts page is automatically generated and it cannot be edited.'
+									'The content of your latest posts page is automatically generated and cannot be edited.'
 								) }
 							</InfoPopover>
 						) }

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import pageRouter from 'page';
 import { connect } from 'react-redux';
-import { flow, get, includes, isEmpty, noop, partial } from 'lodash';
+import { flow, get, includes, noop, partial } from 'lodash';
 
 /**
  * Internal dependencies
@@ -26,6 +26,7 @@ import * as utils from 'state/posts/utils';
 import classNames from 'classnames';
 import MenuSeparator from 'components/popover/menu-separator';
 import PageCardInfo from '../page-card-info';
+import InfoPopover from 'components/info-popover';
 import { preload } from 'sections-helper';
 import { getSite, hasStaticFrontPage, isSitePreviewable } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -374,9 +375,9 @@ class Page extends Component {
 	undoPostStatus = () => this.updatePostStatus( this.props.shadowStatus.undo );
 
 	render() {
-		const { editorUrl, page, shadowStatus, translate, preventEditingInGutenberg } = this.props;
+		const { editorUrl, page, shadowStatus, translate, isPostsPage: latestPostsPage } = this.props;
 		const title = page.title || translate( 'Untitled' );
-		const canEdit = utils.userCan( 'edit_post', page ) && ! preventEditingInGutenberg;
+		const canEdit = utils.userCan( 'edit_post', page ) && ! latestPostsPage;
 		const depthIndicator = ! this.props.hierarchical && page.parent && '— ';
 
 		const viewItem = this.getViewItem();
@@ -459,6 +460,13 @@ class Page extends Component {
 					>
 						{ depthIndicator }
 						{ title }
+						{ latestPostsPage && (
+							<InfoPopover position="right">
+								{ translate(
+									'The content of your latest posts page is automatically generated and it cannot be edited.'
+								) }
+							</InfoPopover>
+						) }
 					</a>
 					<PageCardInfo
 						page={ page }
@@ -629,12 +637,6 @@ const mapState = ( state, props ) => {
 		isFrontPage: isFrontPage( state, pageSiteId, props.page.ID ),
 		isPostsPage: isPostsPage( state, pageSiteId, props.page.ID ),
 		isPreviewable,
-		// Gutenberg prevents editing of empty posts pages
-		// See https://github.com/Automattic/wp-calypso/issues/31917
-		preventEditingInGutenberg:
-			'gutenberg' === getSelectedEditor( state, pageSiteId ) &&
-			isPostsPage( state, pageSiteId, props.page.ID ) &&
-			isEmpty( props.page.content ),
 		previewURL: utils.getPreviewURL( site, props.page ),
 		site,
 		siteSlugOrId,

--- a/client/my-sites/pages/style.scss
+++ b/client/my-sites/pages/style.scss
@@ -141,6 +141,10 @@
 	font-style: italic;
 }
 
+.page__title .info-popover {
+	margin-left: 4px;
+}
+
 .page__actions-toggle {
 	margin-left: 24px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The content of latest post page is dynamically generated and allowing the
option to edit it was causing confusion for the users. This is also making
our UI consistent, since Edit option was hidden from ellipsis menu on the
right in this case.

Follow up to https://github.com/Automattic/wp-calypso/pull/31953
Fixes #31917

#### Visual changes

<img width="738" alt="Screenshot 2019-04-04 at 15 26 32" src="https://user-images.githubusercontent.com/1182160/55560116-de676000-56ef-11e9-9439-a04a43817d70.png">


#### Testing instructions

1. Navigate to Customizer > Homepage Settings and set the some of your test pages as Latest post page.
2. Navigate to http://calypso.localhost:3000/pages
3. Verify that clicking on that page is not showing redirecting to the page's front end view and not the editor.
4. There should be an Info Popover next to the latest post page title.
5. Differences when compared to #31953: this behavior is now applied regardless of editor preference or whether the post's content is empty.

