### PR TITLE
 Packages: Bump calypso-color-schemes version, and set o2-blocks to private

### DIFF
--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "1.0.0-alpha.2",
+	"version": "1.0.0",
 	"description": "Calypso Shared Style Bits",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "1.0.0-alpha.1",
+	"version": "1.0.0-alpha.2",
 	"description": "Calypso Shared Style Bits",
 	"author": "Automattic",
 	"license": "GPL-2.0-or-later",

--- a/packages/o2-blocks/package.json
+++ b/packages/o2-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/o2-blocks",
-	"version": "1.0.0",
+	"version": "1.0.0-alpha.0",
 	"description": "Gutenberg extensions for o2 theme.",
 	"main": "dist/editor.js",
 	"sideEffects": false,
@@ -9,9 +9,7 @@
 		"url": "git://github.com/Automattic/wp-calypso.git",
 		"directory": "packages/o2-blocks"
 	},
-	"publishConfig": {
-		"access": "public"
-	},
+	"private": true,
 	"author": "Automattic, Inc.",
 	"license": "GPL-2.0-or-later",
 	"bugs": {

--- a/packages/o2-blocks/package.json
+++ b/packages/o2-blocks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/o2-blocks",
-	"version": "1.0.0-alpha.0",
+	"version": "1.0.0",
 	"description": "Gutenberg extensions for o2 theme.",
 	"main": "dist/editor.js",
 	"sideEffects": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Packages: Bump calypso-color-schemes version to 1.0.0 (to publish a new version)
- Packages: Set o2-blocks to private (we don't intend to publish this one, we only use it internally)

#### Testing instructions

`npx lerna publish from-package` should yield 

```
Found 1 package to publish:
 - @automattic/calypso-color-schemes => 1.0.0
```

(Say no :slightly_smiling_face: at the prompt)