### PR TITLE
Jetpack Checklist: Introduce header component

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/header.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/header.js
@@ -1,0 +1,32 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import CardHeading from 'components/card-heading';
+
+const JetpackChecklistHeader = ( { translate } ) => (
+	<Card compact className="jetpack-checklist__header">
+		<img
+			className="jetpack-checklist__header-illustration"
+			alt=""
+			aria-hidden="true"
+			src="/calypso/images/illustrations/security.svg"
+		/>
+		<div className="jetpack-checklist__header-content">
+			<CardHeading>
+				{ translate( "Let's start by securing your site with a few essential security features" ) }
+			</CardHeading>
+			<p>
+				{ translate( 'These security features ensure that your site is secured and backed up.' ) }
+			</p>
+		</div>
+	</Card>
+);
+
+export default localize( JetpackChecklistHeader );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -16,6 +16,7 @@ import Checklist from 'components/checklist';
 import getJetpackProductInstallStatus from 'state/selectors/get-jetpack-product-install-status';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
+import JetpackChecklistHeader from './header';
 import QueryJetpackProductInstallStatus from 'components/data/query-jetpack-product-install-status';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
 import Task from 'components/checklist/task';
@@ -25,6 +26,11 @@ import { isDesktop } from 'lib/viewport';
 import { JETPACK_CHECKLIST_TASKS } from './constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class JetpackChecklist extends PureComponent {
 	isComplete( taskId ) {
@@ -66,6 +72,8 @@ class JetpackChecklist extends PureComponent {
 			<Fragment>
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 				{ isPaidPlan && <QueryJetpackProductInstallStatus siteId={ siteId } /> }
+
+				<JetpackChecklistHeader />
 
 				<Checklist
 					isPlaceholder={ ! taskStatuses }

--- a/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
@@ -1,0 +1,27 @@
+.jetpack-checklist__header {
+	display: flex;
+}
+
+.jetpack-checklist__header-illustration {
+	max-width: 128px;
+	margin-right: 20px;
+}
+
+.jetpack-checklist__header-content {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}
+
+@include breakpoint( '<660px' ) {
+	.jetpack-checklist__header {
+		display: block;
+	}
+
+	.jetpack-checklist__header-illustration {
+		max-width: 80%;
+		display: block;
+		margin: 20px auto;
+	}
+}


### PR DESCRIPTION
This PR introduces a new header component that is displayed directly above the Jetpack checklist. This follows the initial mockups in p5XAZ9-2c7-p2.

#### Changes proposed in this Pull Request

* Introduce a new header component for the Jetpack Checklist.

#### Preview

![](https://cldup.com/bd046dgmGR.png)

#### Testing instructions

* Checkout this branch locally and build Calypso.
* Go to http://calypso.localhost:3000/plans/my-plan/:site where `:site` is a connected Jetpack site.
* Take a look at the header and verify it looks well on large and small displays.
