### PR TITLE
Checklist: Allow progress bar to go backwards

### DIFF
--- a/client/components/checklist/header.js
+++ b/client/components/checklist/header.js
@@ -37,7 +37,7 @@ export class ChecklistHeader extends PureComponent {
 						<h2 className="checklist__header-progress-text">{ progressText }</h2>
 						<span className="checklist__header-progress-number">{ `${ completed }/${ total }` }</span>
 					</div>
-					<ProgressBar compact total={ total } value={ completed } />
+					<ProgressBar compact canGoBackwards total={ total } value={ completed } />
 				</div>
 				<div className="checklist__header-secondary">
 					{ /* eslint-disable-next-line jsx-a11y/label-has-for */ }


### PR DESCRIPTION
Currently, checklist's progress bar can't go backwards. This causes some weird bugs - to repro:

* Go to http://calypso.localhost:3000/plans/my-plan/:site where `:site` is a Jetpack site where checklist is finished, 6/6.
* Use the site switcher to switch to a Jetpack site, whose checklist is unfinished (5/6 or less).
* Observe that the progress bar inside the checklist header stays at 100%:

![](https://cldup.com/6ws4qmR5wC.png)

#### Changes proposed in this Pull Request

* Allow the progress bar to go backwards.

#### Testing instructions

* Go to http://calypso.localhost:3000/plans/my-plan/:site where `:site` is a Jetpack site where checklist is finished, 6/6.
* Use the site switcher to switch to a Jetpack site, whose checklist is unfinished (5/6 or less).
* Observe that the progress bar inside the checklist header goes back to the right percentage:

![](https://cldup.com/Ju5BE684fH.png)

Noting that this is the behavior that @keoshi noticed a while ago while testing #31684.