### PR TITLE
Components: Migrate CardHeading CSS to Webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -39,7 +39,6 @@
 @import 'blocks/user-mentions/style';
 @import 'components/button/style';
 @import 'components/card/style';
-@import 'components/card-heading/style';
 @import 'components/checklist/style';
 @import 'components/credit-card-form-fields/style';
 @import 'components/date-picker/style';

--- a/client/components/card-heading/index.jsx
+++ b/client/components/card-heading/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -13,6 +11,11 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { preventWidows } from 'lib/formatting';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const validTypeSizes = [ 54, 47, 36, 32, 24, 21, 16, 14, 11 ];
 


### PR DESCRIPTION
This PR migrates the style of the `<CardHeading />` component to Webpack.

See p4TIVU-9dT-p2 for more details on the rationale of this migration.

#### Changes proposed in this Pull Request

* Import the `<CardHeading />` component style with Webpack.

#### Testing instructions

* Checkout this branch.
* Compare http://calypso.localhost:3000/devdocs/design/card-heading with https://wpcalypso.wordpress.com/devdocs/design/card-heading and verify there are no differences.
* Verify the selectors in the stylesheet aren't used in any other component (that's easy to check because all selectors are prefixed with `.card-heading`).
