### PR TITLE
Color Schemes: Fix contrast on selected menu items in the mobile sidebar

### DIFF
--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -13,16 +13,16 @@
 			.menu-link-icon,
 			.sidebar__menu-action .gridicon,
 			.sidebar-dynamic-menu-action-icon {
-				fill: var( --color-neutral-light );
+				fill: var( --sidebar-gridicon-fill );
 			}
 
 			.sidebar-streams__edit-icon {
-				fill: var( --color-white );
+				fill: var( --sidebar-gridicon-fill );
 			}
 
 			.gridicon {
 				@include breakpoint( '<660px' ) {
-					fill: var( --color-primary );
+					fill: var( --sidebar-gridicon-fill );
 				}
 			}
 
@@ -30,7 +30,7 @@
 			li > a:visited,
 			:not( .sidebar__button ) {
 				@include breakpoint( '<660px' ) {
-					color: var( --color-primary );
+					color: var( --sidebar-menu-selected-a-color );
 				}
 			}
 		}

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -30,7 +30,7 @@
 			li > a:visited,
 			:not( .sidebar__button ) {
 				@include breakpoint( '<660px' ) {
-					color: var( --sidebar-menu-selected-a-color );
+					color: var( --sidebar-text-color );
 				}
 			}
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes color contrast for the selected menu item in the Reader sidebar on mobile devices. Swaps out default color values for sidebar-specific values for compatibility with color schemes.

**Before**

<img width="487" alt="Screen Shot 2019-04-03 at 4 56 42 PM" src="https://user-images.githubusercontent.com/2124984/55569253-3b9ee980-56cf-11e9-993b-bb109870737c.png">

**After**

<img width="293" alt="Screen Shot 2019-04-04 at 11 45 43 AM" src="https://user-images.githubusercontent.com/2124984/55569246-393c8f80-56cf-11e9-8e42-e8cd40d70c7e.png">


#### Testing instructions

* Switch to this PR on a mobile device, ensure you're using a color palette like Nightfall or Sakura.
* Navigate to the Reader sidebar and note the color of the selected menu item. It should have proper contrast with the sidebar background.

Fixes #32028
