### PR TITLE
Formatted Header: Bumping the subtitle to adhere to the Muriel type scale.

### DIFF
--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -23,7 +23,7 @@
 
 .formatted-header__subtitle {
 	color: var( --color-neutral-500 );
-	font-size: 14px;
+	font-size: 16px;
 
 	@include breakpoint( '<480px' ) {
 		margin: 0;


### PR DESCRIPTION
Material/Muriel recommends a type scale. This PR adjusts the `formattedHeader` component to use `body-1` font site. This will affect <a href="https://github.com/Automattic/wp-calypso/search?l=JSX&p=2&q=formatted-header&type=">all instances of `formattedHeader`</a>, like in `/start/`.