### PR TITLE
Me: Migrate "Get Apps" CSS to Webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -137,7 +137,6 @@
 @import 'lib/preferences-helper/style';
 @import 'mailing-lists/style';
 @import 'me/billing-history/style';
-@import 'me/get-apps/style';
 @import 'me/happychat/style';
 @import 'me/notification-settings/blogs-settings/style';
 @import 'me/notification-settings/comment-settings/style';

--- a/client/me/get-apps/index.jsx
+++ b/client/me/get-apps/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -16,6 +14,11 @@ import DesktopDownloadCard from './desktop-download-card.jsx';
 import MobileDownloadCard from './mobile-download-card.jsx';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import config from 'config';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export const GetApps = () => {
 	return (


### PR DESCRIPTION
This PR migrates the style of the `/me/get-apps` page to Webpack.

See p4TIVU-9dT-p2 for more details on the rationale of this migration.

#### Changes proposed in this Pull Request

* Import the `/me/get-apps` style with Webpack.

#### Testing instructions

* Checkout this branch.
* Compare http://calypso.localhost:3000/me/get-apps with https://wpcalypso.wordpress.com/me/get-apps and verify there are no differences.
* Verify the selectors in the stylesheet aren't used in any other component (that's easy to check because all selectors are prefixed with `.get-apps`).
