### PR TITLE
Signup: Fix Design Type with Store Flow

### DIFF
--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -21,6 +20,11 @@ import { setDesignType } from 'state/signup/steps/design-type/actions';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import PressableStoreStep from '../design-type-with-store/pressable-store';
 import { getThemeForDesignType } from 'signup/utils';
+
+/**
+ * Style dependencies
+ */
+import '../design-type-with-store/style.scss';
 
 class DesignTypeWithAtomicStoreStep extends Component {
 	state = {

--- a/client/signup/steps/design-type-with-store/style.scss
+++ b/client/signup/steps/design-type-with-store/style.scss
@@ -43,7 +43,7 @@
 .design-type-with-store__disclaimer {
 	text-align: center;
 	padding: 0 15px;
-	color: var( --color-neutral-500 );
+	color: var( --color-neutral-50 );
 	font-size: 0.875em;
 	width: 100%;
 	box-sizing: border-box;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Imports the styling that was currently missing for this flow, causing the issues (cc @jsnajdr)
* Changes the disclaimer text from neutral-500 to neutral-50 (cc @shaunandrews, @drw158)

Old colour ratio in Classic Bright: 1.31:1
New colour ratio in Classic Bright: 5.34:1

#### Testing instructions

Follow the steps in the original issue with the `/start/subdomain/design-type-with-store-nux` flow. Does everything look as expected? No adverse effects?

<img width="881" alt="Screenshot 2019-04-04 at 18 09 10" src="https://user-images.githubusercontent.com/43215253/55574834-4a07f800-5705-11e9-9659-dc08af18aa55.png">

Fixes #30428 and fixes #30429
