### PR TITLE
Calypso build: Use default babel-loader cacheDirectory

### DIFF
--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -85,7 +85,7 @@ function getWebpackConfig(
 				TranspileConfig.loader( {
 					workerCount,
 					configFile: path.join( __dirname, 'babel.config.js' ),
-					cacheDirectory: path.join( __dirname, '.cache' ),
+					cacheDirectory: true,
 					exclude: /node_modules\//,
 				} ),
 				SassConfig.loader( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use default babel-loader cache directory.

See [docs](https://github.com/babel/babel-loader#options).

#### Testing instructions

1. `npx lerna run prepare --scope="*/o2-blocks"`
1. No `.cache` directory will be created in `packages/calypso-build`.