### PR TITLE
Build: No o2-blocks build on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
 		"eslint-branch": "node bin/eslint-branch.js",
 		"install-if-deps-outdated": "node bin/install-if-deps-outdated.js",
 		"install-if-no-packages": "node bin/install-if-no-packages.js",
-		"postinstall": "npm run build-packages",
+		"postinstall": "npm run build-packages -- --ignore='@automattic/o2-blocks'",
 		"lint": "run-s -s lint:*",
 		"lint:config-defaults": "node server/config/validate-config-keys.js",
 		"lint:css": "stylelint \"client/**/*.scss\" --syntax scss",


### PR DESCRIPTION
The o2-blocks aren't used in Calypso, they don't need to be prepared on postinstall. Don't build them there.

## Testing
- `npm run postinstall` does not build o2-blocks package
- Calypso works as before