### PR TITLE
Framework: Remove references to client/gutenberg/extensions from .*ignore files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,9 +7,6 @@ node_modules/
 !.eslintrc.js
 /server/devdocs/search-index.js
 
-# Gutenberg preset builds
-/client/gutenberg/extensions/presets/*/build
-
 # Built packages
 /packages/*/dist/
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,8 +56,5 @@ cover.html
 
 cached-requests.json
 
-# Gutenberg extensions
-/client/gutenberg/extensions/**/build
-
 # package output
 /packages/*/dist/


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Framework: Remove references to client/gutenberg/extensions from .*ignore files

#### Testing instructions

:man_shrugging: Nothing to see here really.

Remaining references to `client/gutenberg/extensions` in the codebase will be taken care of by #32024 and a TBD PR to remove `/bin/sdk-cli.js`.
