### PR TITLE
Gutenframe: Allow `/post` to redirect to Gutenframe for Jetpack sites.

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -15,6 +15,7 @@ import { get, has, startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/actions';
 import { addQueryArgs, addSiteFragment } from 'lib/route';
@@ -175,7 +176,9 @@ async function maybeCalypsoifyGutenberg( context, next ) {
 	const postId = getPostID( context );
 
 	if (
-		( isCalypsoifyGutenbergEnabled( state, siteId ) || isGutenlypsoEnabled( state, siteId ) ) &&
+		( isCalypsoifyGutenbergEnabled( state, siteId ) ||
+			isGutenlypsoEnabled( state, siteId ) ||
+			isEnabled( 'jetpack/gutenframe' ) ) &&
 		'gutenberg' === getSelectedEditor( state, siteId )
 	) {
 		let url = getEditorUrl( state, siteId, postId, postType );

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -15,7 +15,6 @@ import { get, has, startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/actions';
 import { addQueryArgs, addSiteFragment } from 'lib/route';
@@ -176,9 +175,7 @@ async function maybeCalypsoifyGutenberg( context, next ) {
 	const postId = getPostID( context );
 
 	if (
-		( isCalypsoifyGutenbergEnabled( state, siteId ) ||
-			isGutenlypsoEnabled( state, siteId ) ||
-			isEnabled( 'jetpack/gutenframe' ) ) &&
+		( isCalypsoifyGutenbergEnabled( state, siteId ) || isGutenlypsoEnabled( state, siteId ) ) &&
 		'gutenberg' === getSelectedEditor( state, siteId )
 	) {
 		let url = getEditorUrl( state, siteId, postId, postType );

--- a/client/state/selectors/is-gutenlypso-enabled.js
+++ b/client/state/selectors/is-gutenlypso-enabled.js
@@ -4,14 +4,9 @@
  */
 import { isEnabled } from 'config';
 import isVipSite from 'state/selectors/is-vip-site';
-import { isJetpackSite } from 'state/sites/selectors';
 
 export const isGutenlypsoEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
-		return false;
-	}
-
-	if ( isJetpackSite( state, siteId ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Iframed editors for Jetpack are currently behind the `jetpack/gutenframe` feature flag, meaning the `/post` route doesn't get redirected to `/block-editor/post` on testing environments. This PR removes that block by having the `isGutenlypsoEnabled` selector not fail early on Jetpack sites.