### PR TITLE
 Signup: Debounce to reduce site preview mockup flashing effect

### DIFF
--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
-import { each, isEmpty } from 'lodash';
+import { debounce, each, isEmpty } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -48,6 +48,18 @@ class SiteMockups extends Component {
 		super( props );
 		this.state = this.getNewFontLoaderState( props );
 	}
+
+	shouldComponentUpdate( nextProps ) {
+		// Debouncing updates to the preview content
+		// prevents the flashing effect.
+		if ( nextProps.verticalPreviewContent !== this.props.verticalPreviewContent ) {
+			this.updateDebounced();
+			return false;
+		}
+
+		return true;
+	}
+	updateDebounced = debounce( this.forceUpdate, 777, { leading: false } );
 
 	getNewFontLoaderState( props ) {
 		const state = {


### PR DESCRIPTION
## Changes proposed in this Pull Request

As noted in https://github.com/Automattic/wp-calypso/pull/31708#issuecomment-480145319, we're trying to reduce the _"flashiness"_ of the site preview whenever we update the vertical state, specifically the vertical content.

And by **reduce the _"flashiness"_**  I don't mean confiscating its glitter body suit and tiger striped scarf.

What we're doing here is debouncing updates to the site mockup preview component whenever the vertical content changes.

**Before:**
![before](https://user-images.githubusercontent.com/6458278/55605200-20130c00-57bf-11e9-96d3-fc300dc8a1ad.gif)

**After:**
![after](https://user-images.githubusercontent.com/6458278/55605199-20130c00-57bf-11e9-9162-f57c7994289c.gif)

## Testing instructions

Head over to http://calypso.localhost:3000/start/onboarding-for-business/site-topic-with-preview and type/select some verticals.

The site mockup shouldn't be so jumpy while typing.
