### PR TITLE
Remove @wordpress/editor dependency from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
 		"@wordpress/compose": "3.0.1",
 		"@wordpress/date": "3.0.1",
 		"@wordpress/edit-post": "3.1.11",
-		"@wordpress/editor": "9.0.11",
 		"@wordpress/element": "2.1.9",
 		"@wordpress/hooks": "2.0.5",
 		"@wordpress/i18n": "3.1.1",


### PR DESCRIPTION
The dependency is still defined in `packages/o2-blocks/package.json` so no changes to Shrinkwrap file.

Rest of the `@wordpress/*` dependencies are used mostly by Gutenberg stuff in Devdocs.

#### Changes proposed in this Pull Request

* Remove `@wordpress/editor` dependency

#### Testing instructions

- Confirm that `npm ci` works
- Confirm that only files importing `@wordpress/editor` are in `packages/o2-blocks/src/*`
- Confirm that o2-blocks still have this as a dependency: 
    https://github.com/Automattic/wp-calypso/blob/e61e8d9814ba7b7e50aa9fefea797493829286c4/packages/o2-blocks/package.json#L27
