### PR TITLE
Add a sale badge to the renewal pricing on the purchase page

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -386,6 +386,7 @@ class ManagePurchase extends Component {
 								rawPrice={ getRenewalPrice( purchase ) }
 								currencyCode={ purchase.currencyCode }
 								taxText={ purchase.taxText }
+								isOnSale={ !! purchase.saleAmount }
 							/>
 						</div>
 					</header>

--- a/client/my-sites/plan-price/README.md
+++ b/client/my-sites/plan-price/README.md
@@ -32,7 +32,8 @@ export default class extends React.Component {
 | ----         | -------| -----------                                               |
 | rawPrice     | number | Price of the plan                                         |
 | original     | bool   | Is the price discounted and this is the original one?     |
-| discounted     | bool   | Is the price discounted and this is the discounted one?   |
+| discounted   | bool   | Is the price discounted and this is the discounted one?   |
+| isOnSale     | bool   | Is the product this price is for on sale?                 |
 | currencyCode | string | Currency of the price                                     |
 | className    | string | If you need to add additional classes                     |
 

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -10,6 +10,11 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { getCurrencyObject } from '@automattic/format-currency';
 
+/**
+ * Internal dependencies
+ */
+import Badge from 'components/badge';
+
 export class PlanPrice extends Component {
 	render() {
 		const {
@@ -19,6 +24,7 @@ export class PlanPrice extends Component {
 			discounted,
 			className,
 			isInSignup,
+			isOnSale,
 			taxText,
 			translate,
 		} = this.props;
@@ -41,6 +47,10 @@ export class PlanPrice extends Component {
 			);
 		}
 
+		const saleBadgeText = translate( 'Sale', {
+			comment: 'Shown next to a domain that has a special discounted sale price',
+		} );
+
 		return (
 			<h4 className={ classes }>
 				<sup className="plan-price__currency-symbol">{ price.symbol }</sup>
@@ -53,6 +63,7 @@ export class PlanPrice extends Component {
 						{ translate( '(+%(taxText)s tax)', { args: { taxText } } ) }
 					</sup>
 				) }
+				{ isOnSale && <Badge>{ saleBadgeText }</Badge> }
 			</h4>
 		);
 	}
@@ -66,6 +77,7 @@ PlanPrice.propTypes = {
 	discounted: PropTypes.bool,
 	currencyCode: PropTypes.string,
 	className: PropTypes.string,
+	isOnSale: PropTypes.bool,
 	taxText: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 };
@@ -75,4 +87,5 @@ PlanPrice.defaultProps = {
 	original: false,
 	discounted: false,
 	className: '',
+	isOnSale: false,
 };

--- a/client/my-sites/plan-price/style.scss
+++ b/client/my-sites/plan-price/style.scss
@@ -11,6 +11,11 @@
 		height: 21px;
 	}
 
+	.badge {
+		margin-left: 8px;
+		vertical-align: super;
+	}
+
 	@include breakpoint( '<960px' ) {
 		font-size: 24px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a `Sale` badge in `/me/purchases` if a domain is on sale. Otherwise, the two prices listed on that page are confusing.

This was noticed while reviewing https://github.com/Automattic/wp-calypso/pull/31850.

#### Testing instructions

You need to have a sandbox and enable the Store Sandbox to make .live domains go on sale.

Before:
<img width="743" alt="Screenshot 2019-04-05 at 11 34 20" src="https://user-images.githubusercontent.com/3392497/55625468-6a34c700-5798-11e9-8fa3-4c802461ebe8.png">

After:
<img width="743" alt="Screenshot 2019-04-05 at 11 53 31" src="https://user-images.githubusercontent.com/3392497/55625850-75d4bd80-5799-11e9-9e6e-0d5c5a0a6668.png">

