### PR TITLE
Site Settings: simplify the redirect controllers

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -50,10 +50,6 @@ function canDeleteSite( state, siteId ) {
 	return true;
 }
 
-export function redirectToGeneral() {
-	page.redirect( '/settings/general' );
-}
-
 export function redirectIfCantDeleteSite( context, next ) {
 	const state = context.store.getState();
 	const dispatch = context.store.dispatch;

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -24,7 +24,6 @@ import { isJetpackSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import isVipSite from 'state/selectors/is-vip-site';
-import { SITES_ONCE_CHANGED } from 'state/action-types';
 import { setSection } from 'state/ui/actions';
 import { setImportingFromSignupFlow, setImportOriginSiteDetails } from 'state/importer-nux/actions';
 import { decodeURIComponentIfValid } from 'lib/url';
@@ -52,27 +51,11 @@ function canDeleteSite( state, siteId ) {
 
 export function redirectIfCantDeleteSite( context, next ) {
 	const state = context.store.getState();
-	const dispatch = context.store.dispatch;
-	const siteId = getSelectedSiteId( state );
-	const siteSlug = getSelectedSiteSlug( state );
 
-	if ( siteId && ! canDeleteSite( state, siteId ) ) {
-		return page.redirect( '/settings/general/' + siteSlug );
+	if ( ! canDeleteSite( state, getSelectedSiteId( state ) ) ) {
+		return page.redirect( '/settings/general/' + getSelectedSiteSlug( state ) );
 	}
 
-	if ( ! siteId ) {
-		dispatch( {
-			type: SITES_ONCE_CHANGED,
-			listener: () => {
-				const updatedState = context.store.getState();
-				const updatedSiteId = getSelectedSiteId( updatedState );
-				const updatedSiteSlug = getSelectedSiteSlug( updatedState );
-				if ( ! canDeleteSite( updatedState, updatedSiteId ) ) {
-					return page.redirect( '/settings/general/' + updatedSiteSlug );
-				}
-			},
-		} );
-	}
 	next();
 }
 

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -19,7 +19,6 @@ import {
 	legacyRedirects,
 	manageConnection,
 	redirectIfCantDeleteSite,
-	redirectToGeneral,
 	startOver,
 	themeSetup,
 } from 'my-sites/site-settings/controller';
@@ -29,7 +28,7 @@ import { reasonComponents as reasons } from './disconnect-site';
 import { setScroll, siteSettings } from 'my-sites/site-settings/settings-controller';
 
 export default function() {
-	page( '/settings', siteSelection, redirectToGeneral );
+	page( '/settings', '/settings/general' );
 	page(
 		'/settings/general/:site_id',
 		siteSelection,

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -72,9 +72,9 @@ export default function() {
 	page(
 		'/settings/delete-site/:site_id',
 		siteSelection,
+		redirectIfCantDeleteSite,
 		navigation,
 		setScroll,
-		redirectIfCantDeleteSite,
 		deleteSite,
 		makeLayout,
 		clientRender
@@ -109,9 +109,9 @@ export default function() {
 	page(
 		'/settings/start-over/:site_id',
 		siteSelection,
+		redirectIfCantDeleteSite,
 		navigation,
 		setScroll,
-		redirectIfCantDeleteSite,
 		startOver,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
Simpifies some code I noticed while reviewing #31490.

**the `redirectIfCantDeleteSite` controller**
The controller is always called after `siteSelection`, which ensures that the selected site is in Redux state. No need to duplicate the "load and wait if not loaded" logic.

Also, always call the controller right after `siteSelection`. We should render navigation etc. only after we ensured that we won't redirect.

**the `/settings/general` redirect**
One `page` call with two params is all we need here

**How to test:**
- verify that `/settings` redirects to `/settings/general`
- verify that `/settings/delete-site/jetpack-site.blog` redirects to `/settings/general`, too.