### PR TITLE
Site Settings: "Content Types" Toggle Spacing

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/style.scss
+++ b/client/my-sites/site-settings/custom-content-types/style.scss
@@ -9,6 +9,7 @@
 		display: inline-block;
 		font-weight: 600;
 		margin-bottom: 5px;
+		margin-left: 12px;
 	}
 
 	.form-toggle__wrapper {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a left margin of 12px to prevent the toggle and the text label looking too close together (12px is the value used throughout that page)

#### Testing instructions

Follow the `/settings/writing/` route and scroll to the "Content Types" section. How do things look?

**Current:**

<img width="709" alt="Screenshot 2019-04-05 at 14 48 43" src="https://user-images.githubusercontent.com/43215253/55632313-f30c2c80-57b1-11e9-9811-faf06fce954c.png">

**Proposed:**

<img width="712" alt="Screenshot 2019-04-05 at 14 47 39" src="https://user-images.githubusercontent.com/43215253/55632283-e25bb680-57b1-11e9-873c-6e237046ef52.png">

cc @simison 

Fixes #32057
