### PR TITLE
Dev builds should always be evergreen.

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
 		"lint:mixedindent": "mixedindentlint --ignore-comments \"client/**/*.scss\" \"assets/**/*.scss\" \"**/*.js\" \"**/*.jsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/config/index.js\"",
 		"prestart": "npx check-node-version --package && npm run -s install-if-deps-outdated && node bin/welcome.js",
 		"start": "npm run -s build",
-		"poststart": "cross-env-shell BROWSERSLIST_ENV=defaults NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS --max_old_space_size=4096 build/bundle.js",
+		"poststart": "cross-env-shell BROWSERSLIST_ENV=evergreen NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS --max_old_space_size=4096 build/bundle.js",
 		"reformat-files": "./node_modules/.bin/prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json}\"",
 		"pretest": "npm run -s install-if-deps-outdated",
 		"test": "run-s -s test-client test-packages test-server",


### PR DESCRIPTION
This fixes a regression in the multiple builds PR. It appears to have come about rebasing on top of other changes to the build process.

#### Changes proposed in this Pull Request

* Make dev builds use the `evergreen` browser configuration.

#### Testing instructions

* `npm run distclean && npm start`
* Ensure that there are no errors when loading `calypso.localhost:3000`
