### PR TITLE
G Suite: ToS dialog updates

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -749,7 +749,7 @@ class WpcomChecklistComponent extends PureComponent {
 					domainName={ domainName }
 					isMultipleDomains={ false }
 					onClose={ this.onCloseGSuiteDialogClickHandler }
-					section={ 'gsuite-user-manage' }
+					section={ 'gsuite-timeline-task' }
 					severity={ 'info' }
 					siteSlug={ this.props.siteSlug }
 					user={ user }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -747,10 +747,8 @@ class WpcomChecklistComponent extends PureComponent {
 
 				<PendingGSuiteTosNoticeDialog
 					domainName={ domainName }
-					isMultipleDomains={ false }
 					onClose={ this.onCloseGSuiteDialogClickHandler }
 					section={ 'gsuite-timeline-task' }
-					severity={ 'info' }
 					siteSlug={ this.props.siteSlug }
 					user={ user }
 					visible={ this.state.gSuiteDialogVisible }

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-action.js
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-action.js
@@ -30,10 +30,8 @@ function PendingGSuiteTosNoticeAction( props ) {
 			</Button>
 			<PendingGSuiteTosNoticeDialog
 				domainName={ props.domainName }
-				isMultipleDomains={ props.isMultipleDomains }
 				onClose={ onCloseClickHandler }
 				section={ props.section }
-				severity={ props.severity }
 				siteSlug={ props.siteSlug }
 				user={ props.user }
 				visible={ dialogVisible }

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
@@ -22,6 +22,7 @@ import wp from 'lib/wp';
 function PendingGSuiteTosNoticeDialog( props ) {
 	const [ password, setPassword ] = useState( false );
 	const [ isCopied, setIsCopied ] = useState( false );
+	const [ openTracked, setOpenTracked ] = useState( false );
 	const translate = useTranslate();
 
 	const trackEvent = ( message, tracksEvent ) => {
@@ -33,6 +34,23 @@ function PendingGSuiteTosNoticeDialog( props ) {
 			tracksEvent,
 			user: props.user,
 		} );
+	};
+
+	if ( props.visible && ! openTracked ) {
+		trackEvent(
+			`Opened G Suite "ToS Dialog" via ${ props.section }`,
+			'calypso_domain_management_gsuite_pending_account_open_dialog'
+		);
+		setOpenTracked( true );
+	}
+
+	const onCloseClick = () => {
+		trackEvent(
+			`Clicked "Close ToS Dialog" link in G Suite pending ToS dialog via ${ props.section }`,
+			'calypso_domain_management_gsuite_pending_account_close_dialog_click'
+		);
+		setOpenTracked( false );
+		props.onClose();
 	};
 
 	const onCopyAction = () => {
@@ -91,7 +109,7 @@ function PendingGSuiteTosNoticeDialog( props ) {
 		<Dialog className="domain-warnings__dialog" isVisible={ props.visible }>
 			<header>
 				<h1>{ translate( 'Log in to G Suite to finish setup' ) }</h1>
-				<button onClick={ props.onClose }>
+				<button onClick={ onCloseClick }>
 					<Gridicon icon="cross" />
 				</button>
 			</header>

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
@@ -24,28 +24,50 @@ function PendingGSuiteTosNoticeDialog( props ) {
 	const [ isCopied, setIsCopied ] = useState( false );
 	const translate = useTranslate();
 
-	const onPasswordClickHandler = e => {
+	const trackEvent = ( message, tracksEvent ) => {
+		props.trackEvent( {
+			domainName: props.domainName,
+			message,
+			tracksEvent,
+			section: props.section,
+			siteSlug: props.siteSlug,
+			user: props.user,
+		} );
+	};
+
+	const onPasswordClick = e => {
 		e.preventDefault();
 		const wpcom = wp.undocumented();
 		const mailbox = props.user.split( '@' )[ 0 ];
 		wpcom.resetPasswordForMailbox( props.domainName, mailbox ).then( data => {
 			setPassword( data.password );
 		} );
+		trackEvent(
+			`Clicked "Get Password" link in G Suite pending ToS dialog via ${ props.section }`,
+			'calypso_domain_management_gsuite_pending_account_get_password_click'
+		);
 	};
 
-	const recordLogInClick = () => {
-		props.pendingAccountLogInClick( {
-			domainName: props.domainName,
-			isMultipleDomains: props.isMultipleDomains,
-			user: props.user,
-			severity: props.severity,
-			section: props.section,
-			siteSlug: props.siteSlug,
-		} );
+	const onLogInClick = () => {
+		trackEvent(
+			`Clicked "Get Password" link in G Suite pending ToS dialog via ${ props.section }`,
+			'calypso_domain_management_gsuite_pending_account_login_click'
+		);
+	};
+
+	const onResetPasswordLogInClick = () => {
+		trackEvent(
+			`Clicked "Login" link after reset in G Suite pending ToS dialog via ${ props.section }`,
+			'calypso_domain_management_gsuite_pending_account_login_after_reset_click'
+		);
 	};
 
 	const onCopyAction = () => {
 		setIsCopied( true );
+		trackEvent(
+			`Clicked "Copy Password" link in G Suite pending ToS dialog via ${ props.section }`,
+			'calypso_domain_management_gsuite_pending_account_copy_password_click'
+		);
 	};
 
 	const renderEntryCopy = () => {
@@ -91,6 +113,7 @@ function PendingGSuiteTosNoticeDialog( props ) {
 					</p>
 					<Button
 						href={ getLoginUrlWithTOSRedirect( props.user, props.domainName ) }
+						onClick={ onResetPasswordLogInClick }
 						primary={ isCopied }
 						rel="noopener noreferrer"
 						target="_blank"
@@ -101,13 +124,13 @@ function PendingGSuiteTosNoticeDialog( props ) {
 			) }
 			{ ! password && (
 				<VerticalNav>
-					<VerticalNavItem onClick={ onPasswordClickHandler } key="0" path={ '#' }>
+					<VerticalNavItem onClick={ onPasswordClick } key="0" path={ '#' }>
 						{ translate( "I {{strong}}don't{{/strong}} have the password", {
 							components: { strong: <strong /> },
 						} ) }
 					</VerticalNavItem>
 					<VerticalNavItem
-						onClick={ recordLogInClick }
+						onClick={ onLogInClick }
 						path={ getLoginUrlWithTOSRedirect( props.user, props.domainName ) }
 						external
 						key="1"
@@ -127,37 +150,24 @@ PendingGSuiteTosNoticeDialog.propTypes = {
 	section: PropTypes.string.isRequired,
 	severity: PropTypes.string.isRequired,
 	siteSlug: PropTypes.string.isRequired,
+	trackEvent: PropTypes.func.isRequired,
 	user: PropTypes.string.isRequired,
 };
 
-const pendingAccountLogInClick = ( {
-	siteSlug,
-	domainName,
-	user,
-	severity,
-	isMultipleDomains,
-	section,
-} ) =>
+const trackEvent = ( { domainName, message, section, siteSlug, tracksEvent, user } ) =>
 	composeAnalytics(
-		recordGoogleEvent(
-			'Domain Management',
-			`Clicked "Log in" link in G Suite pending ToS notice in ${ section }`,
-			'Domain Name',
-			domainName
-		),
-		recordTracksEvent( 'calypso_domain_management_gsuite_pending_account_log_in_click', {
-			site_slug: siteSlug,
+		recordGoogleEvent( 'Domain Management', message, 'Domain Name', domainName ),
+		recordTracksEvent( tracksEvent, {
 			domain_name: domainName,
-			user,
-			severity,
-			is_multiple_domains: isMultipleDomains,
 			section,
+			site_slug: siteSlug,
+			user,
 		} )
 	);
 
 export default connect(
 	null,
 	{
-		pendingAccountLogInClick,
+		trackEvent,
 	}
 )( PendingGSuiteTosNoticeDialog );

--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
@@ -28,11 +28,19 @@ function PendingGSuiteTosNoticeDialog( props ) {
 		props.trackEvent( {
 			domainName: props.domainName,
 			message,
-			tracksEvent,
 			section: props.section,
 			siteSlug: props.siteSlug,
+			tracksEvent,
 			user: props.user,
 		} );
+	};
+
+	const onCopyAction = () => {
+		setIsCopied( true );
+		trackEvent(
+			`Clicked "Copy Password" link in G Suite pending ToS dialog via ${ props.section }`,
+			'calypso_domain_management_gsuite_pending_account_copy_password_click'
+		);
 	};
 
 	const onPasswordClick = e => {
@@ -59,14 +67,6 @@ function PendingGSuiteTosNoticeDialog( props ) {
 		trackEvent(
 			`Clicked "Login" link after reset in G Suite pending ToS dialog via ${ props.section }`,
 			'calypso_domain_management_gsuite_pending_account_login_after_reset_click'
-		);
-	};
-
-	const onCopyAction = () => {
-		setIsCopied( true );
-		trackEvent(
-			`Clicked "Copy Password" link in G Suite pending ToS dialog via ${ props.section }`,
-			'calypso_domain_management_gsuite_pending_account_copy_password_click'
 		);
 	};
 
@@ -145,10 +145,8 @@ function PendingGSuiteTosNoticeDialog( props ) {
 
 PendingGSuiteTosNoticeDialog.propTypes = {
 	domainName: PropTypes.string.isRequired,
-	isMultipleDomains: PropTypes.bool.isRequired,
 	onClose: PropTypes.func.isRequired,
 	section: PropTypes.string.isRequired,
-	severity: PropTypes.string.isRequired,
 	siteSlug: PropTypes.string.isRequired,
 	trackEvent: PropTypes.func.isRequired,
 	user: PropTypes.string.isRequired,

--- a/client/my-sites/email/email-management/gsuite-user-item/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-user-item/index.jsx
@@ -57,10 +57,8 @@ function GSuiteUserItem( props ) {
 				{ props.siteSlug && (
 					<PendingGSuiteTosNoticeDialog
 						domainName={ props.user.domain }
-						isMultipleDomains={ false }
 						onClose={ onCloseClickHandler }
 						section={ 'gsuite-users-manage-user' }
-						severity={ 'info' }
 						siteSlug={ props.siteSlug }
 						user={ props.user.email }
 						visible={ dialogVisible }

--- a/client/my-sites/email/email-management/gsuite-user-item/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-user-item/index.jsx
@@ -59,7 +59,7 @@ function GSuiteUserItem( props ) {
 						domainName={ props.user.domain }
 						isMultipleDomains={ false }
 						onClose={ onCloseClickHandler }
-						section={ 'gsuite-user-manage' }
+						section={ 'gsuite-users-manage-user' }
 						severity={ 'info' }
 						siteSlug={ props.siteSlug }
 						user={ props.user.email }

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -142,7 +142,7 @@ class GSuiteUsersCard extends React.Component {
 						key="pending-gsuite-tos-notice"
 						siteSlug={ selectedSiteSlug }
 						domains={ pendingDomains }
-						section="google-apps"
+						section="gsuite-users-manage-notice"
 					/>
 				) }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds tracking to G Suite ToS dialog

#### Testing instructions

* Turn on tracks logging:  `localStorage.setItem( 'debug', 'calypso:analytics:*' )`
* Observe tracks event fire when:
** Dialog open
** Log In link out clicked
** Get password click
** Copy password click
** Login after password reset click
** Close dialog click
