### PR TITLE
Domains: Update color on unavailable domains

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -30,7 +30,7 @@
 		.domain-suggestion__content {
 			h3,
 			.domain-product-price {
-				color: var( --color-neutral-light );
+				color: var( --color-neutral );
 			}
 		}
 	}
@@ -41,7 +41,7 @@
 		.domain-suggestion__content {
 			h3,
 			.domain-product-price {
-				color: var( --color-neutral-0 );
+				color: var( --color-neutral );
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the text darker on unavailable domains so it can still be read.

Before | After
------------ | -------------
<img width="333" alt="Screen Shot 2019-04-05 at 12 09 09" src="https://user-images.githubusercontent.com/448298/55641426-eaa8f700-579b-11e9-858c-860b07235ed7.png"> | <img width="327" alt="Screen Shot 2019-04-05 at 12 02 54" src="https://user-images.githubusercontent.com/448298/55641444-ef6dab00-579b-11e9-974e-f02891ac2f15.png">
<img width="646" alt="Screen Shot 2019-04-05 at 12 08 24" src="https://user-images.githubusercontent.com/448298/55641454-f4caf580-579b-11e9-9ba9-dcd79e870844.png"> | <img width="647" alt="Screen Shot 2019-04-05 at 11 59 30" src="https://user-images.githubusercontent.com/448298/55641459-fa284000-579b-11e9-9a02-38d97e24d6a8.png">

#### Testing instructions

* Go to `Domains > Add` to get to domain search from any site
* Search for something like `google`
* Select a domain with the exact match of `google` left of the dot
* After the quick availability check it should come up unavailable
* Confirm the domain looks like the **After** screenshots above and you can still read the text

Fixes #32065 
