### PR TITLE
Revert "Gutenframe: Allow `/post` to redirect to Gutenframe for Jetpack sites."

### DIFF
--- a/client/state/selectors/is-gutenlypso-enabled.js
+++ b/client/state/selectors/is-gutenlypso-enabled.js
@@ -4,9 +4,14 @@
  */
 import { isEnabled } from 'config';
 import isVipSite from 'state/selectors/is-vip-site';
+import { isJetpackSite } from 'state/sites/selectors';
 
 export const isGutenlypsoEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
+		return false;
+	}
+
+	if ( isJetpackSite( state, siteId ) ) {
 		return false;
 	}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#32051.