### PR TITLE
Gutenframe: Allow `/post` to redirect to Gutenframe for Jetpack sites.

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -15,6 +15,7 @@ import { get, has, startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
+import { isEnabled } from 'config';
 import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/actions';
 import { addQueryArgs, addSiteFragment } from 'lib/route';
@@ -175,7 +176,9 @@ async function maybeCalypsoifyGutenberg( context, next ) {
 	const postId = getPostID( context );
 
 	if (
-		( isCalypsoifyGutenbergEnabled( state, siteId ) || isGutenlypsoEnabled( state, siteId ) ) &&
+		( isCalypsoifyGutenbergEnabled( state, siteId ) ||
+			isGutenlypsoEnabled( state, siteId ) ||
+			isEnabled( 'jetpack/gutenframe' ) ) &&
 		'gutenberg' === getSelectedEditor( state, siteId )
 	) {
 		let url = getEditorUrl( state, siteId, postId, postType );


### PR DESCRIPTION
Iframed editors for Jetpack are currently behind the `jetpack/gutenframe` feature flag, meaning the `/post` route doesn't get redirected to `/block-editor/post` on testing environments. This PR allows the redirect if the flag is present.

This is take 2 of #32051 , which caused an infinite loop on staging (so it was reverted before deploying to prod).

**Testing Instructions**
* Load this branch locally or use calypso.live.
* Apply https://github.com/Automattic/jetpack/pull/11354 to your JP testing site.
* Directly enter the URL `/post/:JPDomain` for a JP site with `gutenberg` as its selected editor (see the User RC if this needs to be set).
* Verify the iframed block editor is loaded.
* Directly enter the URL `/post/:JPDomain?flags=-jetpack/gutenframe` for the same JP site (to replicate staging/prod behaviour).
* Verify the Calypso editor loads instead.