### PR TITLE
Signup: give Page Builder MVP to all eligible sites

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -177,8 +177,8 @@ export default {
 	pageBuilderMVP: {
 		datestamp: '20190402',
 		variations: {
-			control: 50,
-			test: 50,
+			control: 0,
+			test: 1,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,

--- a/client/lib/signup/page-builder.js
+++ b/client/lib/signup/page-builder.js
@@ -4,6 +4,7 @@
 import { abtest, getABTestVariation } from 'lib/abtest';
 import { getLocaleSlug } from 'lib/i18n-utils';
 import { getSectionGroup } from 'state/ui/selectors';
+import { getSiteOption } from 'state/sites/selectors';
 
 export function isInPageBuilderTest() {
 	return 'test' === getABTestVariation( 'pageBuilderMVP' );
@@ -24,4 +25,15 @@ export function isEligibleForPageBuilder( segment, flowName ) {
 
 export function isBlockEditorSectionInTest( state ) {
 	return 'gutenberg' === getSectionGroup( state ) && isInPageBuilderTest();
+}
+
+/**
+ * This is only to be used once there is a `site` object post-signup
+ * @param {object} state  Redux state
+ * @param {number} siteId Current site ID
+ * @returns {bool}        Is the site qualified?
+ */
+export function siteQualifiesForPageBuilder( state, siteId ) {
+	const segment = getSiteOption( state, siteId, 'site_segment' );
+	return isEligibleForPageBuilder( segment, 'onboarding-for-business' );
 }

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -69,7 +69,7 @@ import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { canDomainAddGSuite } from 'lib/domains/gsuite';
 import { getDomainNameFromReceiptOrCart } from 'lib/domains/utils';
 import { fetchSitesAndUser } from 'lib/signup/step-actions';
-import { isInPageBuilderTest, getEditHomeUrl } from 'lib/signup/page-builder';
+import { siteQualifiesForPageBuilder, getEditHomeUrl } from 'lib/signup/page-builder';
 import { getProductsList, isProductsListFetching } from 'state/products-list/selectors';
 import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
@@ -449,7 +449,7 @@ export class Checkout extends React.Component {
 		}
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
-			if ( isInPageBuilderTest() ) {
+			if ( this.props.redirectToPageBuilder ) {
 				return getEditHomeUrl( selectedSiteSlug );
 			}
 			const destination = abtest( 'improvedOnboarding' ) === 'main' ? 'checklist' : 'view';
@@ -771,6 +771,7 @@ export default connect(
 				selectedSiteId,
 				props.cart
 			),
+			redirectToPageBuilder: siteQualifiesForPageBuilder( state, selectedSiteId ),
 			productsList: getProductsList( state ),
 			isProductsListFetching: isProductsListFetching( state ),
 			isPlansListFetching: isRequestingPlans( state ),

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -23,7 +23,7 @@ import CompactCard from 'components/card/compact';
 import Button from 'components/button';
 import { addItem } from 'lib/upgrades/actions';
 import { cartItems } from 'lib/cart-values';
-import { isInPageBuilderTest, getEditHomeUrl } from 'lib/signup/page-builder';
+import { siteQualifiesForPageBuilder, getEditHomeUrl } from 'lib/signup/page-builder';
 import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
@@ -305,7 +305,13 @@ export class ConciergeSessionNudge extends React.Component {
 	}
 
 	handleClickDecline = () => {
-		const { siteSlug, receiptId, isEligibleForChecklist, trackUpsellButtonClick } = this.props;
+		const {
+			siteSlug,
+			receiptId,
+			isEligibleForChecklist,
+			trackUpsellButtonClick,
+			redirectToPageBuilder,
+		} = this.props;
 
 		trackUpsellButtonClick( 'decline' );
 
@@ -313,7 +319,7 @@ export class ConciergeSessionNudge extends React.Component {
 			// Send the user to a generic page (not post-purchase related).
 			page( `/stats/day/${ siteSlug }` );
 		} else if ( isEligibleForChecklist ) {
-			if ( isInPageBuilderTest() ) {
+			if ( redirectToPageBuilder ) {
 				return page( getEditHomeUrl( siteSlug ) );
 			}
 			analytics.tracks.recordEvent( 'calypso_checklist_assign', {
@@ -356,6 +362,7 @@ export default connect(
 			hasSitePlans: sitePlans && sitePlans.length > 0,
 			siteSlug: getSiteSlug( state, selectedSiteId ),
 			isEligibleForChecklist: isEligibleForDotcomChecklist( state, selectedSiteId ),
+			redirectToPageBuilder: siteQualifiesForPageBuilder( state, selectedSiteId ),
 			productCost: getProductCost( state, 'concierge-session' ),
 			productDisplayCost: getProductDisplayCost( state, 'concierge-session' ),
 		};

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -140,9 +140,10 @@ export class SignupProcessingScreen extends Component {
 	showChecklistAfterLogin = () => {
 		// we are hijacking this method slightly because our page builder
 		// test has the same logic for showing, except also being in the test
-		const redirectTo = isInPageBuilderTest()
-			? getEditHomeUrl( this.state.siteSlug )
-			: `/checklist/${ this.state.siteSlug }`;
+		const redirectTo =
+			isInPageBuilderTest() && this.props.signupDependencies.siteType === 'business'
+				? getEditHomeUrl( this.state.siteSlug )
+				: `/checklist/${ this.state.siteSlug }`;
 		this.props.loginHandler( { redirectTo } );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*Roll out Page Builder MVP to all eligible (onboarding flow, business segment, english) sites

#### Testing instructions

In an incognitio window and this PR built, visit `http://calypso.localhost:3000/start/onboarding`

1. Create a new user
1. Choose business and create a site: verify you're redirected to the block editor
2. With the **same user**, start the onboarding flow again. Choose a non-business segment. At the end, verify that you're redirected to the checklist.
3. Try both of the above while purchasing a plan through signup. Verify that the redirects happen properly
