### PR TITLE
Checklist: set the default headerText to "site created" message.

### DIFF
--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -102,9 +102,9 @@ class ChecklistMain extends PureComponent {
 					/>
 					<FormattedHeader
 						headerText={
-							this.props.siteHasFreePlan
-								? translate( 'Your site has been created!' )
-								: translate( 'Thank you for your purchase!' )
+							! this.props.siteHasFreePlan
+								? translate( 'Thank you for your purchase!' )
+								: translate( 'Your site has been created!' )
 						}
 						subHeaderText={
 							'gsuite' === displayMode

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -15,7 +15,7 @@ import DocumentHead from 'components/data/document-head';
 import EmptyContent from 'components/empty-content';
 import FormattedHeader from 'components/formatted-header';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
+import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 import Main from 'components/main';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
@@ -102,7 +102,7 @@ class ChecklistMain extends PureComponent {
 					/>
 					<FormattedHeader
 						headerText={
-							! this.props.siteHasFreePlan
+							this.props.siteHasPaidPlan
 								? translate( 'Thank you for your purchase!' )
 								: translate( 'Your site has been created!' )
 						}
@@ -179,7 +179,7 @@ export default connect( state => {
 		isAtomic,
 		isJetpack,
 		isNewlyCreatedSite: isNewSite( state, siteId ),
-		siteHasFreePlan: isSiteOnFreePlan( state, siteId ),
+		siteHasPaidPlan: isSiteOnPaidPlan( state, siteId ),
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 		user: getCurrentUser( state ),


### PR DESCRIPTION
When a new user on a free plan visits the checklist, the default header text (while the state loads) reads "Thank you for your purchase!" before updating to "Your site has been created!". This PR switches the default by checking for a paid plan instead of a free plan.

**Before:**
![before](https://user-images.githubusercontent.com/942359/55652901-dfb18f00-57ba-11e9-8cd9-8d81243378cc.gif)

**After:**
![after](https://user-images.githubusercontent.com/942359/55652913-ec35e780-57ba-11e9-9db3-d98144f03212.gif)

**To test:**
- create a new site through the Onboarding flow (`/start/onboarding/`)
- choose a free plan
- verify that the checklist doesn't say "thank you for your purchase" on Signup complete
- create a new site through the Onboarding flow (`/start/onboarding/`)
- choose a paid plan
- verify that the checklist says "thank you for your purchase" after the state loads