### PR TITLE
Analytics: set ad_details cookie and AMP analytics support

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -45,6 +45,9 @@ import {
 	recordAddToCart,
 	recordOrder,
 } from 'lib/analytics/ad-tracking';
+
+import { updateSEM } from 'lib/analytics/sem';
+
 import { statsdTimingUrl } from 'lib/analytics/statsd';
 
 /**
@@ -77,7 +80,7 @@ if ( typeof window !== 'undefined' ) {
 }
 
 function getUrlParameter( name ) {
-	name = name.replace( /[\[]/, '\\[' ).replace( /[\]]/, '\\]' );
+	name = name.replace( /[[]/, '\\[' ).replace( /[\]]/, '\\]' );
 	const regex = new RegExp( '[\\?&]' + name + '=([^&#]*)' );
 	const results = regex.exec( location.search );
 	return results === null ? '' : decodeURIComponent( results[ 1 ].replace( /\+/g, ' ' ) );
@@ -262,6 +265,7 @@ const analytics = {
 				pathCounter++;
 				params.this_pageview_path_with_count = urlPath + '(' + pathCounter.toString() + ')';
 				analytics.tracks.recordPageView( urlPath, params );
+				updateSEM();
 				retarget( urlPath ); // Fire page-view/retargeting pixels.
 				analytics.ga.recordPageView( urlPath, pageTitle );
 				analytics.emit( 'page-view', urlPath, pageTitle );
@@ -543,6 +547,7 @@ const analytics = {
 					window.ga( 'set', 'dimension3', clientId );
 				} );
 				window.ga( 'set', 'anonymizeIp', true );
+				window.ga( 'set', 'useAmpClientId', true );
 				analytics.ga.initialized = true;
 			}
 		},

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -46,7 +46,7 @@ import {
 	recordOrder,
 } from 'lib/analytics/ad-tracking';
 
-import { updateSEM } from 'lib/analytics/sem';
+import { updateQueryParamsTracking } from 'lib/analytics/sem';
 
 import { statsdTimingUrl } from 'lib/analytics/statsd';
 
@@ -265,7 +265,7 @@ const analytics = {
 				pathCounter++;
 				params.this_pageview_path_with_count = urlPath + '(' + pathCounter.toString() + ')';
 				analytics.tracks.recordPageView( urlPath, params );
-				updateSEM();
+				updateQueryParamsTracking();
 				retarget( urlPath ); // Fire page-view/retargeting pixels.
 				analytics.ga.recordPageView( urlPath, pageTitle );
 				analytics.emit( 'page-view', urlPath, pageTitle );

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -80,7 +80,7 @@ if ( typeof window !== 'undefined' ) {
 }
 
 function getUrlParameter( name ) {
-	name = name.replace( /[[]/, '\\[' ).replace( /[\]]/, '\\]' );
+	name = name.replace( /[[]/g, '\\[' ).replace( /[\]]/g, '\\]' );
 	const regex = new RegExp( '[\\?&]' + name + '=([^&#]*)' );
 	const results = regex.exec( location.search );
 	return results === null ? '' : decodeURIComponent( results[ 1 ].replace( /\+/g, ' ' ) );

--- a/client/lib/analytics/sem.js
+++ b/client/lib/analytics/sem.js
@@ -43,9 +43,10 @@ const URL_PARAM_WHITELIST = [
 	'ref',
 	'format', // amp/non-amp
 ];
+const VALID_UTM_SOURCE_CAMPAIGN = new RegExp( '^[a-zA-Z\\d_\\-]{1,' + MAX_UTM_LENGTH + '}$' );
 
-function isValidUtmSurceOrCampaign( value ) {
-	return null !== value.match( new RegExp( '^[a-zA-Z\\d_\\-]{1,' + MAX_UTM_LENGTH + '}$' ) );
+function isValidUtmSourceOrCampaign( value ) {
+	return VALID_UTM_SOURCE_CAMPAIGN.test( value );
 }
 
 function isValidOtherUrlParamValue( key, value ) {
@@ -62,7 +63,7 @@ function isValidWhitelistedUrlParamValue( key, value ) {
 	if ( -1 === URL_PARAM_WHITELIST.indexOf( key ) ) {
 		return false;
 	} else if ( 'utm_source' === key || 'utm_campaign' === value ) {
-		return isValidUtmSurceOrCampaign( value );
+		return isValidUtmSourceOrCampaign( value );
 	}
 
 	return isValidOtherUrlParamValue( key, value );

--- a/client/lib/analytics/sem.js
+++ b/client/lib/analytics/sem.js
@@ -81,8 +81,12 @@ function setUtmCookie( name, value ) {
  * Updates tracking based on URL query parameters.
  */
 export function updateQueryParamsTracking() {
-	const parsedUrl = urlParseAmpCompatible( document.location.href );
-	const query = parsedUrl.query;
+	if ( ! document.location.search ) {
+		debug( 'No query data in URL.' );
+		return;
+	}
+
+	const query = urlParseAmpCompatible( document.location.href ).query;
 
 	// Sanitize query params
 	const sanitized_query = {};

--- a/client/lib/analytics/sem.js
+++ b/client/lib/analytics/sem.js
@@ -78,9 +78,9 @@ function setUtmCookie( name, value ) {
 }
 
 /**
- * Initializes the cookies for SEM attribution `ad_details` and `ad_timestamp`.
+ * Updates tracking based on URL query parameters.
  */
-export function updateSEM() {
+export function updateQueryParamsTracking() {
 	const parsedUrl = urlParseAmpCompatible( document.location.href );
 	const query = parsedUrl.query;
 

--- a/client/lib/analytics/sem.js
+++ b/client/lib/analytics/sem.js
@@ -1,0 +1,121 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import cookie from 'cookie';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies.
+ */
+import { urlParseAmpCompatible } from 'lib/analytics/utils';
+
+/**
+ * Const variables.
+ */
+const debug = debugFactory( 'calypso:analytics:sem' );
+const UTM_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+const MAX_UTM_LENGTH = 128;
+const MAX_URL_PARAM_VALUE_LENGTH = 50;
+const MAX_KEYWORD_PARAM_VALUE_LENGTH = 80;
+const MAX_GCLID_PARAM_VALUE_LENGTH = 100;
+// These are the URL params that end up in the `ad_details` cookie
+const URL_PARAM_WHITELIST = [
+	'adgroupid',
+	'campaignid',
+	'device',
+	'gclid',
+	'gclsrc',
+	'fbclid',
+	'keyword',
+	'matchtype',
+	'network',
+	'type',
+	'term',
+	'utm_campaign',
+	'utm_content',
+	'utm_medium',
+	'utm_source',
+	'utm_term',
+	'targetid', // QuanticMind
+	'locationid', // QuanticMind
+	'ref',
+	'format', // amp/non-amp
+];
+
+function isValidUtmSurceOrCampaign( value ) {
+	return null !== value.match( new RegExp( '^[a-zA-Z\\d_\\-]{1,' + MAX_UTM_LENGTH + '}$' ) );
+}
+
+function isValidOtherUrlParamValue( key, value ) {
+	if ( 'gclid' === key ) {
+		return value.length <= MAX_GCLID_PARAM_VALUE_LENGTH;
+	} else if ( 'keyword' === key ) {
+		return value.length <= MAX_KEYWORD_PARAM_VALUE_LENGTH;
+	}
+
+	return value.length <= MAX_URL_PARAM_VALUE_LENGTH;
+}
+
+function isValidWhitelistedUrlParamValue( key, value ) {
+	if ( -1 === URL_PARAM_WHITELIST.indexOf( key ) ) {
+		return false;
+	} else if ( 'utm_source' === key || 'utm_campaign' === value ) {
+		return isValidUtmSurceOrCampaign( value );
+	}
+
+	return isValidOtherUrlParamValue( key, value );
+}
+
+function setUtmCookie( name, value ) {
+	document.cookie = cookie.serialize( name, value, {
+		path: '/',
+		maxAge: UTM_COOKIE_MAX_AGE,
+		// domain: '.wordpress.com',
+	} );
+}
+
+/**
+ * Initializes the cookies for SEM attribution `ad_details` and `ad_timestamp`.
+ */
+export function updateSEM() {
+	const parsedUrl = urlParseAmpCompatible( document.location.href );
+	const query = parsedUrl.query;
+
+	// Sanitize query params
+	const sanitized_query = {};
+	Object.keys( query ).forEach( key => {
+		const value = query[ key ];
+		if ( isValidWhitelistedUrlParamValue( key, value ) ) {
+			sanitized_query[ key ] = value;
+		}
+	} );
+
+	// Cross domain tracking for Tracks
+	if ( query.client_id ) {
+		window._tkq.push( [ 'identifyAnonUser', query.client_id ] );
+	}
+
+	// Drop SEM cookie update if either of these is missing
+	if ( ! sanitized_query.utm_source || ! sanitized_query.utm_campaign ) {
+		debug( 'Missing utm_source or utm_campaign.' );
+		return;
+	}
+
+	// Regenerate sanitized query string
+	let sanitized_query_string = [];
+	Object.keys( sanitized_query ).forEach( key => {
+		sanitized_query_string.push(
+			encodeURIComponent( key ) + '=' + encodeURIComponent( sanitized_query[ key ] )
+		);
+	} );
+
+	sanitized_query_string = sanitized_query_string.join( '&' );
+
+	if ( sanitized_query_string ) {
+		debug( 'ad_details: ' + sanitized_query_string );
+		setUtmCookie( 'ad_details', sanitized_query_string );
+		setUtmCookie( 'ad_timestamp', Math.floor( new Date().getTime() / 1000 ) );
+	}
+}

--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -7,7 +7,8 @@
 import cookie from 'cookie';
 import debugFactory from 'debug';
 import sha256 from 'hash.js/lib/hash/sha/256';
-import { includes } from 'lodash';
+import { assign, includes } from 'lodash';
+import { parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -272,6 +273,71 @@ export function isCurrentUserMaybeInGdprZone() {
 	];
 
 	return includes( gdprCountries, countryCode );
+}
+
+/**
+ * Decodes a url-safe base64 encoded string.
+ *
+ * @param {String} str The url-safe base64 encoded string
+ * @return {String} The decoded string
+ */
+function urlSafeBase64DecodeString( str ) {
+	const decodeMap = {
+		'-': '+',
+		_: '/',
+		'.': '=',
+	};
+
+	return atob( str.replace( /[-_.]/g, ch => decodeMap[ ch ] ) );
+}
+
+/**
+ * Decodes a URL param encoded by AMP's linker.js
+ * See also https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/linker-id-receiving.md
+ *
+ * @param {String} value Value to be decoded
+ * @return {null|Object} null or and object containing key/value pairs
+ */
+function parseAmpEncodedParams( value ) {
+	value = value
+		.split( '*' )
+		.filter( val => val.length )
+		.slice( 2 );
+	// return null if empty or we have an odd number of elements
+	if ( 0 === value.length || 0 !== value.length % 2 ) {
+		return null;
+	}
+	const keyValMap = {};
+	for ( let i = 0; i < value.length; i += 2 ) {
+		keyValMap[ value[ i ] ] = urlSafeBase64DecodeString( value[ i + 1 ] );
+	}
+
+	return keyValMap;
+}
+
+/**
+ * Returns an object equivalent to what url.parse( url, true ) would return plus the data extracted from `tk_amp`.
+ * URL parameters explicitly present in the URL take precedence over the ones extracted from `tk_amp`.
+ * This function is used to support AMP-compatible tracking.
+ *
+ * @param {String} url URL to be parsed like `document.location.href`.
+ * @return {Object} An object equivalent to what url.parse( url, true ) would return plus the data extracted from in `tk_amp`
+ */
+export function urlParseAmpCompatible( url ) {
+	const parsedUrl = parseUrl( url, true );
+	const query = parsedUrl.query;
+
+	debug( 'urlParseAmpCompatible: original query:', query );
+
+	if ( 'tk_amp' in query ) {
+		const tk_amp = parseAmpEncodedParams( query.tk_amp );
+		debug( 'urlParseAmpCompatible: tk_amp:', tk_amp );
+		parsedUrl.query = assign( {}, tk_amp, query );
+	}
+
+	debug( 'urlParseAmpCompatible: merged query:', parsedUrl.query );
+
+	return parsedUrl;
 }
 
 const SITE_FRAGMENT_REGEX = /\/(:site|:site_id|:siteid|:blogid|:blog_id|:siteslug)(\/|$|\?)/i;

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -7,7 +7,6 @@ import debugModule from 'debug';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
-import url from 'url';
 import {
 	assign,
 	defer,
@@ -29,6 +28,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import config from 'config';
+import { urlParseAmpCompatible } from 'lib/analytics/utils';
 
 /**
  * Style dependencies
@@ -237,7 +237,7 @@ class Signup extends React.Component {
 
 	recordReferralVisit() {
 		const urlPath = location.href;
-		const parsedUrl = url.parse( urlPath, true );
+		const parsedUrl = urlParseAmpCompatible( urlPath );
 		const affiliateId = parsedUrl.query.aff;
 		const campaignId = parsedUrl.query.cid;
 		const subId = parsedUrl.query.sid;


### PR DESCRIPTION
### Description

- Sets the `ad_details` and `ad_timestamp` cookie based on present UTM parameters so SEM attribution works also when users land in Calypso with UTM parameters.
- Parses the encoded `tk_amp` parameter and uses its UTM and affiliate params if present.
- Passes the `client_id` to Tracks' `identifyAnonUser`.

### Test

- `localStorage.setItem( 'debug', 'calypso:analytics:*' );`
- `document.cookie = 'sensitive_pixel_option=yes;'`
- Enable `Preserve log` in JS console.
- Visit the following in incognito window:
- http://calypso.localhost:3000/start/about?ref=calypso-selector&myparam=myvalue&utm_source=test_source&utm_campaign=test_campaign&tk_amp=1*5epghs*cid*YW1wLVNsQjJnZmlpXzExZFdxdFNyM3pUNHc.*uid*MTIzNA..*aff*MTIz*client_id*bXktY2xpZW50LWlkLTEyMzQ.*utm_campaign*dGVzdF9jYW1wYWlnbl9hbXA.
- In the JS console filter by "urlParseAmpCompatible" and you should see the following:

![image](https://user-images.githubusercontent.com/10284338/55736509-bfd0d400-5a23-11e9-889d-461287873433.png)

- You should see an `ad_details` cookie being created: `ref%3Dcalypso-selector%26utm_source%3Dtest_source%26utm_campaign%3Dtest_campaign` with one year expiration time and set to `/`.
- You should see an `ad_timestamp` cookie being created the current timestamp in seconds (can be tested here https://www.unixtimestamp.com/).


- If you are logged-out:
  - You should see a `tk_ai` cookie set to `my-client-id-1234`
  - You should see a `tk_aip` set to your previous `tk_ai`.


- If you are logged in:
  - You should see Tracks call to `_aliasUser` begin fired with `anonId: my-client-id-1234`.
  - You will not have the `tk_ai` and `tk_aip` cookies.
![Following ‹ Reader — WordPress com - Google Chrome 2019-04-08 13 46 12](https://user-images.githubusercontent.com/10284338/55721840-bdab4d00-5a04-11e9-8617-1b12167b172a.png)


### Referrals

- In the Network tab filter by `refer.wordpress.com/clicks/67402` and you should see the referral request being successful:

![image](https://user-images.githubusercontent.com/10284338/55737179-04a93a80-5a25-11e9-9834-fd78686658d9.png)

Returning the following response:

`{"success":true,"data":{"affiliate_id":123,"referrer":"http:\/\/calypso.localhost:3000\/start\/about?ref=calypso-selector&myparam=myvalue&utm_source=test_source&utm_campaign=test_campaign&tk_amp=1*5epghs*cid*YW1wLVNsQjJnZmlpXzExZFdxdFNyM3pUNHc.*aff*MTIz*client_id*bXktY2xpZW50LWlkLTEyMzQ.*utm_campaign*dGVzdF9jYW1wYWlnbl9hbXA.","campaign_id":null,"sub_id":null,"cookie_id":"7615ca7c101c526c2.21789060","vendor_id":67402}}`


- You should see the Tracks event `calypso_refer_visit`:

![image](https://user-images.githubusercontent.com/10284338/55736982-ad0acf00-5a24-11e9-9e56-d15c47ee4ad2.png)


- You should see the Tracks event `calypso_refer_visit_response`:

![image](https://user-images.githubusercontent.com/10284338/55737056-cca1f780-5a24-11e9-8fa5-f046b7bb0d96.png)


### Other

- Try encoding and testing other `tk_amp` values based on https://github.com/ampproject/amphtml/blob/master/extensions/amp-analytics/linker-id-receiving.md
for example encoding the client_id and utm parameters.



