### PR TITLE
Packages: Bump calypso-build version to 1.0.0-alpha.3

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "1.0.0-alpha.2",
+	"version": "1.0.0-alpha.3",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"config",


### PR DESCRIPTION
Mostly for https://github.com/Automattic/jetpack/pull/11802, which needs the package to contain #31513.
Sticking with alpha versioning for a bit longer since there are a few more changes we know we'd like to get in before considering its interface somewhat stable.

#### Changes proposed in this Pull Request

Packages: Bump calypso-build version to 1.0.0-alpha.3

#### Testing instructions

Meh. `npx lerna publish from-package` if you really need to see something.