### PR TITLE
2FA Reauth Required Screen: Design Improvements

### DIFF
--- a/client/components/forms/form-verification-code-input/index.jsx
+++ b/client/components/forms/form-verification-code-input/index.jsx
@@ -46,7 +46,7 @@ export default class FormVerificationCodeInput extends React.Component {
 		if ( method === 'backup' ) {
 			placeholder = constants.eightDigitBackupCodePlaceholder;
 		} else if ( method === 'sms' ) {
-			placeholder = constants.sevenDigit2faPlaceholder;
+			placeholder = constants.sixDigit2faPlaceholder;
 		}
 
 		return (

--- a/client/components/forms/form-verification-code-input/index.jsx
+++ b/client/components/forms/form-verification-code-input/index.jsx
@@ -46,7 +46,7 @@ export default class FormVerificationCodeInput extends React.Component {
 		if ( method === 'backup' ) {
 			placeholder = constants.eightDigitBackupCodePlaceholder;
 		} else if ( method === 'sms' ) {
-			placeholder = constants.sixDigit2faPlaceholder;
+			placeholder = constants.sevenDigit2faPlaceholder;
 		}
 
 		return (

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -14,7 +14,6 @@ const debug = debugFactory( 'calypso:me:reauth-required' );
  */
 import Dialog from 'components/dialog';
 import FormButton from 'components/forms/form-button';
-import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInputValidation from 'components/forms/form-input-validation';

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -14,6 +14,7 @@ const debug = debugFactory( 'calypso:me:reauth-required' );
  */
 import Dialog from 'components/dialog';
 import FormButton from 'components/forms/form-button';
+import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormCheckbox from 'components/forms/form-checkbox';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormInputValidation from 'components/forms/form-input-validation';
@@ -279,10 +280,11 @@ const ReauthRequired = createReactClass( {
 
 					{ this.renderSMSResendThrottled() }
 					
+					<FormButtonsBar>
 					{ this.renderVerifyButton() }
-					
+
 					{ this.renderBottomSendSMSButton() }
-								
+					</FormButtonsBar>		
 				</form>
 			</Dialog>
 		);

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -254,6 +254,7 @@ const ReauthRequired = createReactClass( {
 						<FormVerificationCodeInput
 							autoFocus
 							id="code"
+							disabled={ ! this.state.smsCodeSent && this.props.twoStepAuthorization.isTwoStepSMSEnabled() }
 							isError={ this.props.twoStepAuthorization.codeValidationFailed() }
 							name="code"
 							method={ method }
@@ -265,7 +266,7 @@ const ReauthRequired = createReactClass( {
 						{ this.renderFailedValidationMsg() }
 					</FormFieldset>
 
-					<FormFieldset>
+					<FormFieldset className="reauth-required__remember-checkbox">
 						<FormLabel>
 							<FormCheckbox
 								id="remember2fa"
@@ -280,7 +281,7 @@ const ReauthRequired = createReactClass( {
 
 					{ this.renderSMSResendThrottled() }
 
-					<FormButtonsBar>
+					<FormButtonsBar className="reauth-required__buttons">
 					{ this.renderVerifyButton() }
 
 					{ this.renderBottomSendSMSButton() }

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -279,12 +279,12 @@ const ReauthRequired = createReactClass( {
 					</FormFieldset>
 
 					{ this.renderSMSResendThrottled() }
-					
+
 					<FormButtonsBar>
 					{ this.renderVerifyButton() }
 
 					{ this.renderBottomSendSMSButton() }
-					</FormButtonsBar>		
+					</FormButtonsBar>
 				</form>
 			</Dialog>
 		);

--- a/client/me/reauth-required/style.scss
+++ b/client/me/reauth-required/style.scss
@@ -10,6 +10,14 @@
 	max-width: 400px;
 }
 
+.reauth-required__remember-checkbox {
+	margin-bottom: 0;
+}
+
+.reauth-required__buttons {
+	margin-top: 10px;
+}
+
 .reauth-required__sign-out {
 	cursor: pointer;
 }

--- a/client/me/reauth-required/style.scss
+++ b/client/me/reauth-required/style.scss
@@ -2,6 +2,10 @@
 	margin-bottom: 1em;
 }
 
+.reauth-required__send-sms-code-top {
+	margin-top: -8px;
+}
+
 .reauth-required__dialog {
 	max-width: 400px;
 }

--- a/client/me/reauth-required/style.scss
+++ b/client/me/reauth-required/style.scss
@@ -2,7 +2,7 @@
 	margin-bottom: 1em;
 }
 
-.reauth-required__send-sms-code-top {
+.reauth-required__send-sms-code.is-sms-only {
 	margin-top: -8px;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This provides a series of design enhancements to the Reauth Required flow, so fixes #23549. (cc @cafenoirdesign, @drw158)

## SMS Flow

### _First opening the screen_

> Why is the "Send SMS" button, below the empty "Verification Code" field?

It isn't anymore with this PR! :) 

> It would be better to have the SMS button alone in the panel first

This PR proposes this, it doesn't make sense to offer the option of verifying a code which the user doesn't have access to yet. 

> It's especially confusing because the empty field has focus and not the button. Could we make this a bit more intuitive?

I'd strongly argue that the best way to do this is to make this a primary button. To proceed, the user **must** press the button to enter that page of Calypso, and that feels like a pretty reasonable usage for a primary button.

As such, throughout this flow, I feel like that there should be a button which is primary (see below this screenshot)

> I would expect just one button, "Send SMS Code", maybe with the input field disabled, or not shown at all.

Disabled in this screen - after all, the user doesn't have the information to input. They need to click the button itself to get it, which they're more likely to do now that it's primary. 

<img width="478" alt="Screenshot 2019-04-06 at 23 11 30" src="https://user-images.githubusercontent.com/43215253/55675873-69e41b00-58c1-11e9-8618-f1cb303bcaa3.png">

FWIW, here's a comparison without the buttons changing position. This isn't currently what's proposed in this PR, but it can be easily switched to this.

<img width="498" alt="Screenshot 2019-04-07 at 10 52 22" src="https://user-images.githubusercontent.com/43215253/55681914-1951d980-5924-11e9-8591-8608599fedc7.png">


### _Requesting a code_

The Resend Button will be disabled for sixty seconds until the next code is entered. The Verify code button will also be disabled until the moment the user enters the digits required for the code to be valid.

Once the minimum required digits has been entered, it turns primary.

<img width="470" alt="Screenshot 2019-04-06 at 23 14 43" src="https://user-images.githubusercontent.com/43215253/55675912-d7904700-58c1-11e9-8797-e20f2a3bba05.png">

### _Requesting a resend of the code_

After sixty seconds, the Resend Button will *not* be primary again. I feel that it seems odd to have two primary buttons on one screen. 

<img width="483" alt="Screenshot 2019-04-06 at 23 15 42" src="https://user-images.githubusercontent.com/43215253/55675929-ef67cb00-58c1-11e9-8439-62d36be62cc4.png">

**Other:** This PR also proposes following removing the additional space between the four digits and the comma which is currently the case - this has seemed odd to me for a while, and I'm assuming it's unintentional since the four digits themselves are already bold.

## Authenticator Flow

> if those two components need to be in the same panel for some reason

This is a flow where the two components need to be in the same panel, as the user doesn't need to request a verification code to proceed unlike with the SMS flow - they could just obtain one from their authenticator app.

As such, the Authenticator Flow is not touched by these changes, since there's no need to receive a code.

<img width="482" alt="Screenshot 2019-04-06 at 23 19 15" src="https://user-images.githubusercontent.com/43215253/55675966-9482a380-58c2-11e9-8b00-4317b285f5ef.png">


And of course, with either flow, the code should still work.

#### Testing instructions

Visit `/me/notifications` to trigger the reauth flow and try both. Try triggering an error as well (eg. wrong code) and ensure nothing is broken. Are codes still received? (I filled my text messages inbox working on this 😅)

This is pretty much my first time doing something like this, so I've almost certainly done something wrong! I'd appreciate any feedback on this! 

Not quite sure who to ping, but going to cc @rodrigoi, @gwwar, @kwight and @vindl as involved in #22195.

Fixes #23549
