### PR TITLE
Fix breakage in classic editor EmbedView.

### DIFF
--- a/client/components/tinymce/plugins/wpcom-view/views/embed/view.jsx
+++ b/client/components/tinymce/plugins/wpcom-view/views/embed/view.jsx
@@ -1,4 +1,5 @@
 /** @format */
+/* eslint-disable react/no-string-refs */
 
 /**
  * External dependencies
@@ -33,6 +34,7 @@ class EmbedView extends Component {
 		//
 		// TODO: Investigate and evaluate whether we need to avoid rendering
 		//       the iframe on the initial render pass
+		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState(
 			{
 				// eslint-disable-line react/no-did-mount-set-state
@@ -115,6 +117,7 @@ class EmbedView extends Component {
 
 	render() {
 		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<div ref="view" className="wpview-content wpview-type-embed">
 				{ this.renderFrame() }
 			</div>
@@ -132,5 +135,20 @@ EmbedView.defaultProps = {
 	onResize: () => {},
 };
 
-const EmbedViewContainer = Container.create( EmbedView, { withProps: true } );
+// Flux does not handle untranspiled ES6 properly (see https://github.com/facebook/flux/issues/351).
+// As such, we need to work around the issue by uglily wrapping the component, to ensure that it
+// works both in the evergreen and fallback builds.
+// The long-term fix is to move this component away from using Flux.
+function wrapComponent( containerClass ) {
+	const Tmp = containerClass;
+	containerClass = function( ...args ) {
+		return new Tmp( ...args );
+	};
+	containerClass.prototype = Tmp.prototype;
+	containerClass.getStores = Tmp.getStores;
+	containerClass.calculateState = Tmp.calculateState;
+	return containerClass;
+}
+
+const EmbedViewContainer = Container.create( wrapComponent( EmbedView ), { withProps: true } );
 export default EmbedViewContainer;


### PR DESCRIPTION
The Embed View in the classic editor is currently breaking as described in #32088.

Due to the move to untranspiled ES6 in evergreen browsers, an issue was exposed in Flux, an old library that doesn't handle untranspiled ES6 properly. The issue was always present, but was only exposed after the build pipeline changes in #30768.

A workaround was put in place and works correctly in both builds (evergreen and fallback).

Fixes #32088.

#### Changes proposed in this Pull Request

* Work around Flux class handling in `EmbedView`

#### Testing instructions

* Open the editor in a modern browser (e.g. latest Chrome)
* Follow the steps in #32088 
* Open the editor in an old browser, or in a modern browser using the `forceFallback=1` URL parameter.
* Follow the steps in #32088 

Fixes #32088 
