### PR TITLE
Add domain transfer products to agreement list.

### DIFF
--- a/client/my-sites/checkout/checkout/domain-registration-agreement.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-agreement.jsx
@@ -93,10 +93,12 @@ class DomainRegistrationAgreement extends React.Component {
 	};
 
 	getDomainsByRegistrationAgreement() {
-		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
+		const { cart } = this.props;
+		const domainItems = cartItems.getDomainRegistrations( cart );
+		domainItems.push( ...cartItems.getDomainTransfers( cart ) );
 		const agreementUrls = [
 			...new Set(
-				map( domainRegistrations, registration =>
+				map( domainItems, registration =>
 					get( registration, 'extra.domain_registration_agreement_url' )
 				)
 			),
@@ -106,10 +108,10 @@ class DomainRegistrationAgreement extends React.Component {
 			agreementUrls,
 			( domainsByAgreement, url ) => {
 				const domainsList = reduce(
-					domainRegistrations,
-					( domains, registration ) => {
-						if ( registration.extra.domain_registration_agreement_url === url ) {
-							domains.push( registration.meta );
+					domainItems,
+					( domains, domainItem ) => {
+						if ( domainItem.extra.domain_registration_agreement_url === url ) {
+							domains.push( domainItem.meta );
 						}
 						return domains;
 					},
@@ -126,7 +128,8 @@ class DomainRegistrationAgreement extends React.Component {
 	}
 
 	render() {
-		if ( ! cartItems.hasDomainRegistration( this.props.cart ) ) {
+		const { cart } = this.props;
+		if ( ! ( cartItems.hasDomainRegistration( cart ) || cartItems.hasTransferProduct( cart ) ) ) {
 			return null;
 		}
 

--- a/client/my-sites/checkout/checkout/domain-registration-agreement.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-agreement.jsx
@@ -82,8 +82,7 @@ class DomainRegistrationAgreement extends React.Component {
 	};
 
 	renderAgreements = () => {
-		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
-		const agreementsList = this.getDomainsByRegistrationAgreement( domainRegistrations );
+		const agreementsList = this.getDomainsByRegistrationAgreement();
 
 		if ( agreementsList.length > 1 ) {
 			return this.renderMultipleAgreements( agreementsList );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On the checkout page we need to show the Domain Registration Agreements that will apply to domains that are transferred in.

#### Testing instructions

Add one or more domain transfers to the cart. Go to the checkout page and make sure that the link to the correct domain registration agreement is shown.

Make sure that the correct links are shown when just domain registrations are in the cart.

Make sure that the links are not shown when there are no domain products in the cart as well.

Check the console to make sure there are no errors.

<img width="1359" alt="Screen Shot 2019-04-06 at 3 21 04 PM" src="https://user-images.githubusercontent.com/1379730/55674394-274f1e00-5882-11e9-903d-b025088904b8.png">

<img width="1362" alt="Screen Shot 2019-04-06 at 3 24 34 PM" src="https://user-images.githubusercontent.com/1379730/55674399-2cac6880-5882-11e9-895b-31a7fb0528fe.png">
