### PR TITLE
Introduce padding above re-Publicize section when it has a notice atop

### DIFF
--- a/client/blocks/post-share/style.scss
+++ b/client/blocks/post-share/style.scss
@@ -15,6 +15,10 @@ $section-border: solid 1px darken( $sidebar-bg-color, 5% );
 	.notice {
 		margin-bottom: 0;
 
+		+ div > .post-share__main {
+			padding-top: 16px;
+		}
+
 		&,
 		.notice__icon-wrapper {
 			border-radius: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Introduce padding of 16px above re-Publicize section when it has a notice atop
* 16px padding is chosen to match the padding used by `post-share__head`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- With a WordPress.com Premium plan or WordPress.com Business plan site, visit https://wordpress.com/posts
- For a specific post, click on the 3 dots' menu available on the right
- Click `Share`
- Share the post with `Share post` button
- When the `Notice` appears (doesn't matter if it's a success, failure, warning or a different notice), ensure that there is a space (16px padding) between the re-Publicize section and the notice.
- Also, without the notice, this padding of 16px should not be shown

**Before:**

<img width="747" alt="Screenshot 2019-04-07 at 14 06 09" src="https://user-images.githubusercontent.com/18581859/55680959-5b881480-593e-11e9-98ab-ead9a5d14449.png">

**After:**

<img width="769" alt="Screenshot 2019-04-07 at 14 04 49" src="https://user-images.githubusercontent.com/18581859/55680958-5aef7e00-593e-11e9-898a-7aff7af1a44f.png">

Fixes #31913