### PR TITLE
Reader stripAutoPlays: handle an array of values

### DIFF
--- a/client/lib/post-normalizer/rule-content-disable-autoplay.js
+++ b/client/lib/post-normalizer/rule-content-disable-autoplay.js
@@ -16,6 +16,9 @@ function stripAutoPlays( query ) {
 			query[ key ] = '0';
 		} else if ( val === 'true' ) {
 			query[ key ] = 'false';
+		} else {
+			// force a singular value
+			query[ key ] = val;
 		}
 	} );
 	return query;

--- a/client/lib/post-normalizer/rule-content-disable-autoplay.js
+++ b/client/lib/post-normalizer/rule-content-disable-autoplay.js
@@ -1,22 +1,17 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import { forEach } from 'lodash';
+import { forEach, isArray } from 'lodash';
 import url from 'url';
-
-/**
- * Internal Dependencies
- */
 
 function stripAutoPlays( query ) {
 	const keys = Object.keys( query ).filter( function( k ) {
 		return /^auto_?play$/i.test( k );
 	} );
 	forEach( keys, key => {
-		const val = query[ key ].toLowerCase();
+		// In the rare case that we're handed an array of values, use the first one
+		const firstValue = isArray( query[ key ] ) ? query[ key ][ 0 ] : query[ key ];
+		const val = firstValue.toLowerCase();
 		if ( val === '1' ) {
 			query[ key ] = '0';
 		} else if ( val === 'true' ) {

--- a/client/lib/post-normalizer/rule-content-disable-autoplay.js
+++ b/client/lib/post-normalizer/rule-content-disable-autoplay.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { forEach, isArray } from 'lodash';
+import { forEach } from 'lodash';
 import url from 'url';
 
 function stripAutoPlays( query ) {
@@ -10,7 +10,7 @@ function stripAutoPlays( query ) {
 	} );
 	forEach( keys, key => {
 		// In the rare case that we're handed an array of values, use the first one
-		const firstValue = isArray( query[ key ] ) ? query[ key ][ 0 ] : query[ key ];
+		const firstValue = Array.isArray( query[ key ] ) ? query[ key ][ 0 ] : query[ key ];
 		const val = firstValue.toLowerCase();
 		if ( val === '1' ) {
 			query[ key ] = '0';

--- a/client/lib/post-normalizer/test/index.js
+++ b/client/lib/post-normalizer/test/index.js
@@ -355,6 +355,48 @@ describe( 'index', () => {
 				}
 			);
 		} );
+
+		test( 'should strip autoplay like attributes from iframes', done => {
+			normalizer(
+				{ content: '<iframe src="https://example.com/?autoplay=1"></iframe>' },
+				[ normalizer.withContentDOM( [ normalizer.content.disableAutoPlayOnEmbeds ] ) ],
+				function( err, normalized ) {
+					assert.strictEqual(
+						normalized.content,
+						'<iframe src="https://example.com/?autoplay=0"></iframe>'
+					);
+					done( err );
+				}
+			);
+		} );
+
+		test( 'should strip multiple autoplay like attributes from iframes', done => {
+			normalizer(
+				{ content: '<iframe src="https://example.com/?autoplay=1&autoplay=2"></iframe>' },
+				[ normalizer.withContentDOM( [ normalizer.content.disableAutoPlayOnEmbeds ] ) ],
+				function( err, normalized ) {
+					assert.strictEqual(
+						normalized.content,
+						'<iframe src="https://example.com/?autoplay=0"></iframe>'
+					);
+					done( err );
+				}
+			);
+		} );
+
+		test( 'should reduce multiple autoplay like attributes to one value', done => {
+			normalizer(
+				{ content: '<iframe src="https://example.com/?autoplay=0&autoplay=2"></iframe>' },
+				[ normalizer.withContentDOM( [ normalizer.content.disableAutoPlayOnEmbeds ] ) ],
+				function( err, normalized ) {
+					assert.strictEqual(
+						normalized.content,
+						'<iframe src="https://example.com/?autoplay=0"></iframe>'
+					);
+					done( err );
+				}
+			);
+		} );
 	} );
 
 	describe( 'the content normalizer (withContentDOM)', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We have a post normalizer rule called `stripAutoplays`, which sets the "autoplay" attribute to off for videos in the Reader stream.

One user had encountered an edge case where the `stripAutoplays` rule received an array of attributes when it didn't expect it:

<img width="681" alt="Screen Shot 2019-04-08 at 10 34 34" src="https://user-images.githubusercontent.com/17325/55690903-a3b14080-59eb-11e9-9974-eb2e5054d47f.png">

This caused a type error:

<img width="773" alt="screen-shot-2019-04-07-at-10 45 02" src="https://user-images.githubusercontent.com/17325/55690914-baf02e00-59eb-11e9-867d-c0905e3e5cd3.png">

This PR adds handling for the unusual scenario where we receive an array of values.

#### Testing instructions

Switch to the user account mentioned in the p2 post: p5PDj3-4KG-p2. Verify that you can load several pages of their Reader stream and do not encounter any console errors like the one above.
