### PR TITLE
Update the domain step removal code to match the current status.

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -100,8 +100,8 @@ export default {
 	removeDomainsStepFromOnboarding: {
 		datestamp: '20181221',
 		variations: {
-			keep: 100,
-			remove: 0,
+			keep: 50,
+			remove: 50,
 		},
 		defaultVariation: 'keep',
 	},

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -182,7 +182,7 @@ export function createSiteWithCart(
 		newSiteParams.find_available_url = true;
 		newSiteParams.options.nux_import_engine = importEngine;
 	} else if (
-		flowName === 'onboarding' &&
+		flowName === 'onboarding-for-business' &&
 		'remove' === getABTestVariation( 'removeDomainsStepFromOnboarding' )
 	) {
 		newSiteParams.blog_name = get( user.get(), 'username', siteTitle ) || siteType || siteVertical;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -12,7 +12,7 @@ import i18n from 'i18n-calypso';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
-import { abtest, getABTestVariation } from 'lib/abtest';
+import { abtest } from 'lib/abtest';
 import { generateFlows } from './flows-pure';
 
 const user = userFactory();
@@ -245,12 +245,16 @@ const Flows = {
 	 */
 	getABTestFilteredFlow( flowName, flow ) {
 		if (
-			'onboarding' === flowName &&
-			'onboarding' === getABTestVariation( 'improvedOnboarding' ) &&
+			'onboarding-for-business' === flowName &&
 			'remove' === abtest( 'removeDomainsStepFromOnboarding' )
 		) {
-			flow = Flows.removeStepFromFlow( 'domains', flow );
-			flow = replaceStepInFlow( flow, 'site-information', 'site-information-without-domains' );
+			flow = Flows.removeStepFromFlow( 'domains-with-preview', flow );
+			flow = replaceStepInFlow(
+				flow,
+				'site-information-title-with-preview',
+				'site-information-without-domains'
+			);
+
 			return flow;
 		}
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -507,18 +507,14 @@ export function generateSteps( {
 			apiRequestFunction: createSiteWithCart,
 			delayApiRequestUntilComplete: true,
 			dependencies: [ 'themeSlugWithRepo' ],
-			providesDependencies: [
-				'title',
-				'address',
-				'phone',
-				'siteId',
-				'siteSlug',
-				'domainItem',
-				'themeItem',
-			],
+			providesDependencies: [ 'title', 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
 			props: {
-				headerText: i18n.translate( 'Help customers find you' ),
-				informationFields: [ 'title', 'address', 'phone' ],
+				headerText: i18n.translate( "Tell us your site's name" ),
+				subHeaderText: i18n.translate(
+					'This will appear at the top of your site and can be changed at anytime.'
+				),
+				informationFields: [ 'title' ],
+				showSiteMockups: true,
 			},
 		},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to revive the domain step removal test from the new onboarding flow. In general, it consists of:

1. Update the a/b test allocation from 100/0 to 50/50.
1. Update the code accordingly so the domain step removal code works again. It's mainly about updating conditions expecting the flow name to be `onboarding` as `onboarding-for-business`. 

#### Testing instructions

1. Set a/b test variation of `removeDomainsStepFromOnboarding` as `remove`.
1. Sign up through the onboarding flow and choose the business segment. The domain step should not be there and you should be able to create a site as expected.
1. Sign up through the onboarding flow and choose the other segments. The domain step should be there and you should be able to create a site as expected.
1. Repeat 2 & 3 as a logged-in user to add new sites. The both should work as expected.
1. The main flow should still work as expected.
