### PR TITLE
Asynchronously load Jetpack header partner logos and social connect

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -283,7 +283,12 @@ class Login extends Component {
 		}
 
 		if ( socialConnect ) {
-			return <AsyncLoad require="./social-connect-prompt" onSuccess={ this.handleValidLogin } />;
+			return (
+				<AsyncLoad
+					require="blocks/login/social-connect-prompt"
+					onSuccess={ this.handleValidLogin }
+				/>
+			);
 		}
 
 		return (

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -213,6 +213,7 @@ class Login extends Component {
 				<div className="login__jetpack-logo">
 					<AsyncLoad
 						require="components/jetpack-header"
+						placeholder={ null }
 						partnerSlug={ this.props.partnerSlug }
 						darkColorScheme
 					/>

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -35,7 +35,6 @@ import { login } from 'lib/paths';
 import Notice from 'components/notice';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
 import userFactory from 'lib/user';
-import SocialConnectPrompt from './social-connect-prompt';
 import AsyncLoad from 'components/async-load';
 
 const user = userFactory();
@@ -284,7 +283,7 @@ class Login extends Component {
 		}
 
 		if ( socialConnect ) {
-			return <SocialConnectPrompt onSuccess={ this.handleValidLogin } />;
+			return <AsyncLoad require="./social-connect-prompt" onSuccess={ this.handleValidLogin } />;
 		}
 
 		return (

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -28,7 +28,6 @@ import { wasManualRenewalImmediateLoginAttempted } from 'state/immediate-login/s
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
-import JetpackHeader from 'components/jetpack-header';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
 import VerificationCodeForm from './two-factor-authentication/verification-code-form';
 import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';
@@ -37,6 +36,7 @@ import Notice from 'components/notice';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
 import userFactory from 'lib/user';
 import SocialConnectPrompt from './social-connect-prompt';
+import AsyncLoad from 'components/async-load';
 
 const user = userFactory();
 
@@ -212,7 +212,11 @@ class Login extends Component {
 			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack.' );
 			preHeader = (
 				<div className="login__jetpack-logo">
-					<JetpackHeader partnerSlug={ this.props.partnerSlug } darkColorScheme />
+					<AsyncLoad
+						require="components/jetpack-header"
+						partnerSlug={ this.props.partnerSlug }
+						darkColorScheme
+					/>
 				</div>
 			);
 		}

--- a/client/components/jetpack-header/index.jsx
+++ b/client/components/jetpack-header/index.jsx
@@ -37,7 +37,10 @@ export class JetpackHeader extends PureComponent {
 						viewBox="0 0 1270 170"
 						partnerName="DreamHost"
 					>
-						<AsyncLoad require="./dreamhost" darkColorScheme={ darkColorScheme } />
+						<AsyncLoad
+							require="components/jetpack-header/dreamhost"
+							darkColorScheme={ darkColorScheme }
+						/>
 					</JetpackPartnerLogoGroup>
 				);
 
@@ -48,7 +51,10 @@ export class JetpackHeader extends PureComponent {
 						viewBox="0 0 1150 170"
 						partnerName="Pressable"
 					>
-						<AsyncLoad require="./pressable" darkColorScheme={ darkColorScheme } />
+						<AsyncLoad
+							require="components/jetpack-header/pressable"
+							darkColorScheme={ darkColorScheme }
+						/>
 					</JetpackPartnerLogoGroup>
 				);
 
@@ -59,7 +65,10 @@ export class JetpackHeader extends PureComponent {
 						viewBox="0 0 1128 170"
 						partnerName="Bluehost"
 					>
-						<AsyncLoad require="./bluehost" darkColorScheme={ darkColorScheme } />
+						<AsyncLoad
+							require="components/jetpack-header/bluehost"
+							darkColorScheme={ darkColorScheme }
+						/>
 					</JetpackPartnerLogoGroup>
 				);
 
@@ -70,13 +79,21 @@ export class JetpackHeader extends PureComponent {
 						viewBox="0 0 936 151"
 						partnerName="InMotion"
 					>
-						<AsyncLoad require="./inmotion" darkColorScheme={ darkColorScheme } />
+						<AsyncLoad
+							require="components/jetpack-header/inmotion"
+							darkColorScheme={ darkColorScheme }
+						/>
 					</JetpackPartnerLogoGroup>
 				);
 
 			case 'milesweb':
 				// This is a raster logo that contains the Jetpack logo already.
-				return <AsyncLoad require="./milesweb" darkColorScheme={ darkColorScheme } />;
+				return (
+					<AsyncLoad
+						require="components/jetpack-header/milesweb"
+						darkColorScheme={ darkColorScheme }
+					/>
+				);
 
 			case 'liquidweb':
 				return (
@@ -85,7 +102,10 @@ export class JetpackHeader extends PureComponent {
 						viewBox="0 0 1034 150"
 						partnerName="Liquid Web"
 					>
-						<AsyncLoad require="./liquidweb" darkColorScheme={ darkColorScheme } />
+						<AsyncLoad
+							require="components/jetpack-header/liquidweb"
+							darkColorScheme={ darkColorScheme }
+						/>
 					</JetpackPartnerLogoGroup>
 				);
 			default:

--- a/client/components/jetpack-header/index.jsx
+++ b/client/components/jetpack-header/index.jsx
@@ -7,13 +7,9 @@ import React, { PureComponent } from 'react';
 /**
  * Internal dependencies
  */
-import JetpackBluehostLogo from './bluehost';
-import JetpackDreamhostLogo from './dreamhost';
-import JetpackInmotionLogo from './inmotion';
+import AsyncLoad from 'components/async-load';
+
 import JetpackLogo from 'components/jetpack-logo';
-import JetpackMileswebLogo from './milesweb';
-import JetpackPressableLogo from './pressable';
-import JetpackLiquidWebLogo from './liquidweb';
 import JetpackPartnerLogoGroup from './partner-logo-group';
 
 /**
@@ -41,7 +37,7 @@ export class JetpackHeader extends PureComponent {
 						viewBox="0 0 1270 170"
 						partnerName="DreamHost"
 					>
-						<JetpackDreamhostLogo darkColorScheme={ darkColorScheme } />
+						<AsyncLoad require="./dreamhost" darkColorScheme={ darkColorScheme } />
 					</JetpackPartnerLogoGroup>
 				);
 
@@ -52,7 +48,7 @@ export class JetpackHeader extends PureComponent {
 						viewBox="0 0 1150 170"
 						partnerName="Pressable"
 					>
-						<JetpackPressableLogo darkColorScheme={ darkColorScheme } />
+						<AsyncLoad require="./pressable" darkColorScheme={ darkColorScheme } />
 					</JetpackPartnerLogoGroup>
 				);
 
@@ -63,7 +59,7 @@ export class JetpackHeader extends PureComponent {
 						viewBox="0 0 1128 170"
 						partnerName="Bluehost"
 					>
-						<JetpackBluehostLogo darkColorScheme={ darkColorScheme } />
+						<AsyncLoad require="./bluehost" darkColorScheme={ darkColorScheme } />
 					</JetpackPartnerLogoGroup>
 				);
 
@@ -74,13 +70,13 @@ export class JetpackHeader extends PureComponent {
 						viewBox="0 0 936 151"
 						partnerName="InMotion"
 					>
-						<JetpackInmotionLogo darkColorScheme={ darkColorScheme } />
+						<AsyncLoad require="./inmotion" darkColorScheme={ darkColorScheme } />
 					</JetpackPartnerLogoGroup>
 				);
 
 			case 'milesweb':
 				// This is a raster logo that contains the Jetpack logo already.
-				return <JetpackMileswebLogo darkColorScheme={ darkColorScheme } />;
+				return <AsyncLoad require="./milesweb" darkColorScheme={ darkColorScheme } />;
 
 			case 'liquidweb':
 				return (
@@ -89,7 +85,7 @@ export class JetpackHeader extends PureComponent {
 						viewBox="0 0 1034 150"
 						partnerName="Liquid Web"
 					>
-						<JetpackLiquidWebLogo darkColorScheme={ darkColorScheme } />
+						<AsyncLoad require="./liquidweb" darkColorScheme={ darkColorScheme } />
 					</JetpackPartnerLogoGroup>
 				);
 			default:

--- a/client/components/jetpack-header/index.jsx
+++ b/client/components/jetpack-header/index.jsx
@@ -40,6 +40,7 @@ export class JetpackHeader extends PureComponent {
 						<AsyncLoad
 							require="components/jetpack-header/dreamhost"
 							darkColorScheme={ darkColorScheme }
+							placeholder={ null }
 						/>
 					</JetpackPartnerLogoGroup>
 				);
@@ -54,6 +55,7 @@ export class JetpackHeader extends PureComponent {
 						<AsyncLoad
 							require="components/jetpack-header/pressable"
 							darkColorScheme={ darkColorScheme }
+							placeholder={ null }
 						/>
 					</JetpackPartnerLogoGroup>
 				);
@@ -68,6 +70,7 @@ export class JetpackHeader extends PureComponent {
 						<AsyncLoad
 							require="components/jetpack-header/bluehost"
 							darkColorScheme={ darkColorScheme }
+							placeholder={ null }
 						/>
 					</JetpackPartnerLogoGroup>
 				);
@@ -82,6 +85,7 @@ export class JetpackHeader extends PureComponent {
 						<AsyncLoad
 							require="components/jetpack-header/inmotion"
 							darkColorScheme={ darkColorScheme }
+							placeholder={ null }
 						/>
 					</JetpackPartnerLogoGroup>
 				);
@@ -92,6 +96,7 @@ export class JetpackHeader extends PureComponent {
 					<AsyncLoad
 						require="components/jetpack-header/milesweb"
 						darkColorScheme={ darkColorScheme }
+						placeholder={ null }
 					/>
 				);
 
@@ -105,6 +110,7 @@ export class JetpackHeader extends PureComponent {
 						<AsyncLoad
 							require="components/jetpack-header/liquidweb"
 							darkColorScheme={ darkColorScheme }
+							placeholder={ null }
 						/>
 					</JetpackPartnerLogoGroup>
 				);

--- a/client/components/jetpack-header/test/index.js
+++ b/client/components/jetpack-header/test/index.js
@@ -7,7 +7,7 @@
  * External dependencies
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 /**
  * Internal dependencies
@@ -37,18 +37,18 @@ describe( 'JetpackHeader', () => {
 	} );
 
 	test( 'should render a co-branded logo when passed a known partner slug', () => {
-		const wrapper = shallow( <JetpackHeader partnerSlug="dreamhost" /> );
+		const wrapper = mount( <JetpackHeader partnerSlug="dreamhost" /> );
 		expect( wrapper.find( 'Localized(JetpackPartnerLogoGroup)' ) ).toHaveLength( 1 );
 		expect( wrapper.find( 'JetpackDreamhostLogo' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should override width on JetpackLogo when width provided but no partner slug', () => {
-		const wrapper = shallow( <JetpackHeader width={ 60 } /> );
+		const wrapper = mount( <JetpackHeader width={ 60 } /> );
 		expect( wrapper.find( 'JetpackLogo' ).props().size ).toEqual( 60 );
 	} );
 
 	test( 'should override width on logo group when width and known partner slug provided', () => {
-		const wrapper = shallow( <JetpackHeader width={ 60 } partnerSlug="dreamhost" /> );
+		const wrapper = mount( <JetpackHeader width={ 60 } partnerSlug="dreamhost" /> );
 		expect( wrapper.find( 'Localized(JetpackPartnerLogoGroup)' ).props().width ).toEqual( 60 );
 	} );
 } );


### PR DESCRIPTION
All partner logos were being bundled together, when there will never be more than one (if any) shown. After this change, only the required logo will be loaded. In addition, the Jetpack header itself only needs to be shown on Jetpack sites, so after this change it too will be lazily loaded, conditionally.
A nice future improvement would be to move the SVG data out of JSX to static SVG files.

This PR also lazily loads the social connect components only when they're needed.

This PR appears to save ~36KB of compressed JS in total on `/log-in`.

#### Changes proposed in this Pull Request

* Lazily load partner logos with `AsyncLoad`.
* Lazily load `JetpackHeader` itself (only needed when site is Jetpack).
* Lazily load social connect component.

#### Testing instructions

* Test correct presence and behaviour of Jetpack header in Jetpack site login.
* Test correct behaviour of non-Jetpack site login.
* Test correct behaviour of social connect prompt.

