### PR TITLE
Fix propTypes definition on EmailCategory component

### DIFF
--- a/client/me/notification-settings/wpcom-settings/email-category.jsx
+++ b/client/me/notification-settings/wpcom-settings/email-category.jsx
@@ -17,14 +17,12 @@ import FormLabel from 'components/forms/form-label';
 import { toggleWPcomEmailSetting } from 'state/notification-settings/actions';
 
 class EmailCategory extends React.Component {
-	static propTypes() {
-		return {
-			name: PropTypes.string,
-			isEnabled: PropTypes.bool,
-			title: PropTypes.string,
-			description: PropTypes.string,
-		};
-	}
+	static propTypes = {
+		name: PropTypes.string,
+		isEnabled: PropTypes.bool,
+		title: PropTypes.string,
+		description: PropTypes.string,
+	};
 
 	toggleSetting = () => {
 		this.props.toggleWPcomEmailSetting( this.props.name );


### PR DESCRIPTION
A trivial bugfix found when grepping for `propTypes` the other day: declaring `propTypes` as a method doesn't make sense. It's an object property.
