### PR TITLE
Revert "NUX: extend the NUX SiteType UI component to include a free form text option."

### DIFF
--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -9,12 +9,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Button from 'components/forms/form-button';
 import Card from 'components/card';
-import FormTextInput from 'components/forms/form-text-input';
 import { getAllSiteTypes } from 'lib/signup/site-type';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -34,16 +30,9 @@ class SiteTypeForm extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			otherValue: '',
 			siteType: props.siteType,
 		};
 	}
-
-	onOtherCatChange = event => {
-		this.setState( {
-			otherValue: event.target.value,
-		} );
-	};
 
 	handleSubmit = type => {
 		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_type', {
@@ -55,77 +44,29 @@ class SiteTypeForm extends Component {
 		this.props.submitForm( type );
 	};
 
-	handleSubmitOther = () => {
-		this.handleSubmit( 'other—' + this.state.otherValue );
-	};
-
-	renderBasicCard = () => {
-		return (
-			<Card className="site-type__wrapper">
-				{ getAllSiteTypes().map( siteTypeProperties => (
-					<Card
-						className="site-type__option"
-						key={ siteTypeProperties.id }
-						tagName="button"
-						displayAsLink
-						data-e2e-title={ siteTypeProperties.slug }
-						onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
-					>
-						<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
-					</Card>
-				) ) }
+	renderSegmentOptions() {
+		return getAllSiteTypes().map( siteTypeProperties => (
+			<Card
+				className="site-type__option"
+				key={ siteTypeProperties.id }
+				displayAsLink
+				data-e2e-title={ siteTypeProperties.slug }
+				tagName="button"
+				onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
+			>
+				<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
+				<span className="site-type__option-description">{ siteTypeProperties.description }</span>
 			</Card>
-		);
-	};
-
-	renderOtherInfo = () => {
-		const { translate } = this.props;
-
-		return (
-			<div className="site-type__other-option">
-				<p className="site-type__other-label">{ translate( 'Or type your own' ) }</p>
-
-				<div className="site-type__other-form">
-					<FormTextInput
-						className="site-type__other-input"
-						selectOnFocus
-						placeholder={ translate( 'Other' ) }
-						onChange={ this.onOtherCatChange }
-						value={ this.state.otherValue }
-					/>
-
-					<Button
-						className="site-type__other-submit"
-						disabled={ false }
-						onClick={ this.handleSubmitOther }
-					>
-						{ translate( 'Continue' ) }
-					</Button>
-				</div>
-			</div>
-		);
-	};
+		) );
+	}
 
 	render() {
-		const { isJetpack } = this.props;
-
-		if ( ! isJetpack ) {
-			return <Fragment> { this.renderBasicCard() } </Fragment>;
-		}
-
-		return (
-			<Fragment>
-				{ this.renderBasicCard() }
-				{ this.renderOtherInfo() }
-			</Fragment>
-		);
+		return <Card className="site-type__wrapper">{ this.renderSegmentOptions() }</Card>;
 	}
 }
 
 export default connect(
-	state => ( {
-		isJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
-	} ),
+	null,
 	{
 		recordTracksEvent,
 	}

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -17,6 +17,7 @@
 	margin: 0;
 	font-weight: 400;
 	position: relative;
+	width: 100%;
 	text-align: left;
 	@include elevation ( 0 );
 	border-bottom: 1px solid var( --color-neutral-50 );
@@ -75,54 +76,5 @@
 	&:focus .card__link-indicator {
 		opacity: 1;
 		transform: translateX( 0 );
-	}
-}
-
-.site-type__other-option {
-	text-align: center;
-	max-width: 380px;
-	position: relative;
-	margin: 56px auto 0;
-
-	&::before {
-		content: '';
-		display: block;
-		width: 60px;
-		height: 2px;
-		background: var( --color-white );
-		opacity: 0.2;
-		position: absolute;
-		top: -24px;
-		left: calc( 50% - 30px );
-	}
-
-	.site-type__other-form {
-		position: relative;
-
-	}
-
-	.site-type__other-label {
-		color: var( --color-white );
-		margin: 16px 0;
-	}
-
-	.site-type__other-input {
-		border-radius: 3px;
-		border: none;
-		padding: 11px 100px 11px 24px;
-		@include elevation ( 2dp );
-
-		&:focus,
-		&:focus:hover, // This is weird...
-		&:active {
-			box-shadow: 0 0 0 2px var( --color-accent );
-		}
-	}
-
-	.site-type__other-submit {
-		position: absolute;
-		top: 3px;
-		right: 3px;
-		@include elevation ( 1dp );
 	}
 }


### PR DESCRIPTION
Reverts Automattic/wp-calypso#31524

Brings back the sub-headers of the Site Type NUX step.

<img width="654" alt="Screenshot 2019-04-08 at 15 34 40" src="https://user-images.githubusercontent.com/13561163/55732428-dec76a00-5a13-11e9-9db2-ec9595265ef4.png">
