### PR TITLE
Sharing: Fix sharing buttons options saving failures

### DIFF
--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { flowRight, get, partial, some, values, xor } from 'lodash';
+import { filter, flowRight, get, partial, some, values, xor } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -242,7 +242,7 @@ const connectComponent = connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const isTwitterButtonAllowed =
 			! isJetpack || isJetpackMinimumVersion( state, siteId, '3.4-dev' );
-		const postTypes = values( getPostTypes( state, siteId ) );
+		const postTypes = filter( values( getPostTypes( state, siteId ) ), 'public' );
 
 		return {
 			buttons: getSharingButtons( state, siteId ),

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -56,7 +56,7 @@ class SharingButtonsOptions extends Component {
 
 	handleMultiCheckboxChange = ( name, event ) => {
 		const delta = xor( this.props.settings.sharing_show, event.value );
-		this.props.onChange( name, event.value.length ? event.value : null );
+		this.props.onChange( name, event.value );
 		if ( delta.length ) {
 			const checked = -1 !== event.value.indexOf( delta[ 0 ] );
 			this.props.recordGoogleEvent(

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -195,31 +195,43 @@ class SharingButtonsOptions extends Component {
 		);
 	}
 
-	render() {
-		const { initialized, saving, settings, siteId, translate } = this.props;
+	getSharingShowOptionsElement = () => {
+		const { initialized, isSharingShowAllowed, settings, translate } = this.props;
+
+		if ( ! isSharingShowAllowed ) {
+			return;
+		}
+
 		const changeSharingPostTypes = partial( this.handleMultiCheckboxChange, 'sharing_show' );
+		return (
+			<fieldset className="sharing-buttons__fieldset">
+				<legend className="sharing-buttons__fieldset-heading">
+					{ translate( 'Show sharing buttons on', {
+						context: 'Sharing options: Header',
+						comment:
+							'Possible values are: "Front page, Archive Pages, and Search Results", "Posts", "Pages", "Media"',
+					} ) }
+				</legend>
+				<MultiCheckbox
+					name="sharing_show"
+					options={ this.getDisplayOptions() }
+					checked={ settings.sharing_show }
+					onChange={ changeSharingPostTypes }
+					disabled={ ! initialized }
+				/>
+			</fieldset>
+		);
+	};
+
+	render() {
+		const { initialized, saving, siteId, translate } = this.props;
 
 		return (
 			<div className="sharing-buttons__panel">
 				{ siteId && <QueryPostTypes siteId={ siteId } /> }
 				<h4>{ translate( 'Options' ) }</h4>
 				<div className="sharing-buttons__fieldset-group">
-					<fieldset className="sharing-buttons__fieldset">
-						<legend className="sharing-buttons__fieldset-heading">
-							{ translate( 'Show sharing buttons on', {
-								context: 'Sharing options: Header',
-								comment:
-									'Possible values are: "Front page, Archive Pages, and Search Results", "Posts", "Pages", "Media"',
-							} ) }
-						</legend>
-						<MultiCheckbox
-							name="sharing_show"
-							options={ this.getDisplayOptions() }
-							checked={ settings.sharing_show }
-							onChange={ changeSharingPostTypes }
-							disabled={ ! initialized }
-						/>
-					</fieldset>
+					{ this.getSharingShowOptionsElement() }
 					{ this.getCommentLikesOptionElement() }
 					{ this.getTwitterViaOptionElement() }
 				</div>
@@ -242,12 +254,15 @@ const connectComponent = connect(
 		const isJetpack = isJetpackSite( state, siteId );
 		const isTwitterButtonAllowed =
 			! isJetpack || isJetpackMinimumVersion( state, siteId, '3.4-dev' );
+		const isSharingShowAllowed = ! isJetpack || isJetpackMinimumVersion( state, siteId, '7.3' );
+
 		const postTypes = filter( values( getPostTypes( state, siteId ) ), 'public' );
 
 		return {
 			buttons: getSharingButtons( state, siteId ),
 			initialized: !! postTypes || !! getSiteSettings( state, siteId ),
 			isJetpack,
+			isSharingShowAllowed,
 			isTwitterButtonAllowed,
 			postTypes,
 			siteId,

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { filter, flowRight, get, partial, some, values, xor } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -13,12 +13,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Banner from 'components/banner';
 import MultiCheckbox from 'components/forms/multi-checkbox';
 import { getPostTypes } from 'state/post-types/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
 import getSharingButtons from 'state/selectors/get-sharing-buttons';
-import { isJetpackSite, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { isJetpackSite, isJetpackMinimumVersion, getSiteAdminUrl } from 'state/sites/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
 import { recordGoogleEvent } from 'state/analytics/actions';
 
@@ -223,27 +224,44 @@ class SharingButtonsOptions extends Component {
 		);
 	};
 
+	getWpAdminBanner = () => {
+		const { isSharingShowAllowed, siteAdminUrl, translate } = this.props;
+		if ( isSharingShowAllowed ) {
+			return;
+		}
+		return (
+			<Banner
+				className="sharing-buttons__banner"
+				href={ `${ siteAdminUrl }options-general.php?page=sharing` }
+				title={ translate( 'Visit WP Admin for more sharing buttons options.' ) }
+			/>
+		);
+	};
+
 	render() {
 		const { initialized, saving, siteId, translate } = this.props;
 
 		return (
-			<div className="sharing-buttons__panel">
-				{ siteId && <QueryPostTypes siteId={ siteId } /> }
-				<h4>{ translate( 'Options' ) }</h4>
-				<div className="sharing-buttons__fieldset-group">
-					{ this.getSharingShowOptionsElement() }
-					{ this.getCommentLikesOptionElement() }
-					{ this.getTwitterViaOptionElement() }
-				</div>
+			<Fragment>
+				<div className="sharing-buttons__panel">
+					{ siteId && <QueryPostTypes siteId={ siteId } /> }
+					<h4>{ translate( 'Options' ) }</h4>
+					<div className="sharing-buttons__fieldset-group">
+						{ this.getSharingShowOptionsElement() }
+						{ this.getCommentLikesOptionElement() }
+						{ this.getTwitterViaOptionElement() }
+					</div>
 
-				<button
-					type="submit"
-					className="button sharing-buttons__submit"
-					disabled={ saving || ! initialized }
-				>
-					{ saving ? translate( 'Saving…' ) : translate( 'Save Changes' ) }
-				</button>
-			</div>
+					<button
+						type="submit"
+						className="button sharing-buttons__submit"
+						disabled={ saving || ! initialized }
+					>
+						{ saving ? translate( 'Saving…' ) : translate( 'Save Changes' ) }
+					</button>
+				</div>
+				{ this.getWpAdminBanner() }
+			</Fragment>
 		);
 	}
 }
@@ -265,6 +283,7 @@ const connectComponent = connect(
 			isSharingShowAllowed,
 			isTwitterButtonAllowed,
 			postTypes,
+			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 			siteId,
 		};
 	},

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -1102,3 +1102,7 @@
 .connections__signup {
 	margin-right: 8px;
 }
+
+.sharing-buttons__banner {
+	margin-top: -20px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Only show `public` post types, which are those that are actually saved by the back end (see D26674-code).
* Always POST the multi-checkbox values array, even if empty, as the intersection happens in the back-end. (Currently, if the array is empty, we send `null`, which eventually gets skipped.)
* These options are largely broken on Jetpack < 7.3 (where Automattic/jetpack#11981 will be merged). This PR also adds a version check and on lower versions shows a "Visit WP Admin" banner instead.

#### Testing instructions

* Apply D26674-code, and sandbox the API.
* Open `/marketing/sharing-buttons`.
* Make sure it only shows the `public` post types. (See example screenshots)
* Try saving: all the options, none of the options, some options.
* Try reloading between each save to make sure the options are really updated
* Switch to a Jetpack site.
* Make sure the sharing options are not shown, and instead there is a "Visit WP Admin" banner at the bottom of the section that opens `options-general.php?page=sharing`.

| Correct | Incorrect |
| - | - |
| ![Screenshot 2019-04-08 at 15 13 22](https://user-images.githubusercontent.com/2070010/55731337-f30a6780-5a11-11e9-8d07-b1b0cc3f64b5.png) | ![Screenshot 2019-04-08 at 15 13 10](https://user-images.githubusercontent.com/2070010/55731358-faca0c00-5a11-11e9-887a-758f11c19709.png) |

Fixes #22811 