### PR TITLE
Importers: Remove redundant recordTracksEvent from importer-header

### DIFF
--- a/client/my-sites/importer/importer-header/index.jsx
+++ b/client/my-sites/importer/importer-header/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -14,7 +13,6 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import { appStates } from 'state/imports/constants';
-import { recordTracksEvent } from 'state/analytics/actions';
 import ImporterLogo from 'my-sites/importer/importer-logo';
 import StartButton from 'my-sites/importer/importer-header/start-button';
 
@@ -54,9 +52,6 @@ class ImporterHeader extends React.PureComponent {
 	}
 }
 
-export default connect(
-	state => ( {
-		isUploading: get( state, 'imports.uploads.inProgress' ),
-	} ),
-	{ recordTracksEvent }
-)( localize( ImporterHeader ) );
+export default connect( state => ( {
+	isUploading: get( state, 'imports.uploads.inProgress' ),
+} ) )( localize( ImporterHeader ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A simple one here - I noticed that the tracking action is `connect`ed in the importer-header, but not used. This PR removes that.

#### Testing instructions

Just make sure the importer-header can mount without issue. This is easy to do by just patching, hitting http://calypso.localhost:3000/settings/import and ensuring there are no errors in the console :)