### PR TITLE
Signup: change loading fallback for mockup images

### DIFF
--- a/client/components/site-mockup/style.scss
+++ b/client/components/site-mockup/style.scss
@@ -139,6 +139,12 @@
 
 }
 
+@keyframes pulse {
+	0%   { background-color: rgba( var( --color-neutral-500-rgb ), 0.7 ); }
+	50%  { background-color: rgba( var( --color-neutral-500-rgb ), 1 ); }
+	100% { background-color: rgba( var( --color-neutral-500-rgb ), 0.7 ); }
+}
+
 // Gutenberg Content
 .site-mockup__entry-content {
 	color: #1e1e1e;
@@ -146,6 +152,7 @@
 	.wp-block-cover {
 		position: relative;
 		background-color: var( --color-neutral-500 );
+		animation: pulse 1.5s infinite;
 		background-size: cover;
 		background-position: center center;
 		display: flex;
@@ -237,6 +244,7 @@
 
 			img {
 				background-color: var( --color-neutral-500 );
+				animation: pulse 1.5s infinite;
 				height: auto;
 				max-width: unset;
 				width: 100%;

--- a/client/components/site-mockup/style.scss
+++ b/client/components/site-mockup/style.scss
@@ -145,7 +145,7 @@
 
 	.wp-block-cover {
 		position: relative;
-		background-color: #000;
+		background-color: var( --color-neutral-500 );
 		background-size: cover;
 		background-position: center center;
 		display: flex;
@@ -236,6 +236,7 @@
 			margin: 0;
 
 			img {
+				background-color: var( --color-neutral-500 );
 				height: auto;
 				max-width: unset;
 				width: 100%;


### PR DESCRIPTION
This replaces the stark black image background with something lighter that shows progress while images are loading on slow connections.

**To Test:**
- visit `/start/onboarding/`
- using devtools > performance, throttle your connection to "slow 3G"
- pick "business" for the site type
- pick a common topic
- verify that the preview shows and that as the images load, their background is grey with a nice soothing pulse animation