### PR TITLE
Set missing right padding for banners with is-card-link class

### DIFF
--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -70,6 +70,10 @@
 			padding-right: 16px;
 		}
 	}
+
+	&.is-card-link {
+		padding-right: 48px;
+	}
 }
 
 .banner__icons {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix missing right padding for banners with `is-card-link` class. Assigns a padding of 48px, so that the text does not overflow on the gridicon's space.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Launch the Calypso live branch available below. 
- For a WordPress.com Personal plan site, or a free site, visit https://wordpress.com/themes 
- Click on `Premium` theme filter
- Notice that the banner shown has text with a right padding of 48px, so that it does not overlap with the gridicon on the right
- Likewise, click on a premium theme itself and ensure the banner shown has text with right padding of 48px.
- Visit `/settings/performance/` for any WordPress.com site and ensure that the performance card has text with right padding of 48px

#### What is expected 

<img width="1566" alt="Screenshot 2019-04-05 at 23 21 39" src="https://user-images.githubusercontent.com/18581859/55735945-fd435a80-5a3f-11e9-8467-c4ba5afbb57a.png">
<img width="961" alt="Screenshot 2019-04-05 at 23 21 30" src="https://user-images.githubusercontent.com/18581859/55735944-fd435a80-5a3f-11e9-852e-826c42ef212d.png">
<img width="743" alt="Screenshot 2019-04-05 at 23 21 48" src="https://user-images.githubusercontent.com/18581859/55735946-fddbf100-5a3f-11e9-8285-f414141cbb64.png">

#### What is not expected

<img width="1580" alt="Screenshot 2019-04-05 at 23 20 12" src="https://user-images.githubusercontent.com/18581859/55735941-fcaac400-5a3f-11e9-9f46-ad8e50dfc910.png">
<img width="961" alt="Screenshot 2019-04-05 at 23 20 20" src="https://user-images.githubusercontent.com/18581859/55735943-fcaac400-5a3f-11e9-80de-18a266161396.png">
<img width="748" alt="Screenshot 2019-04-05 at 23 33 01" src="https://user-images.githubusercontent.com/18581859/55735947-fddbf100-5a3f-11e9-8cf5-c81b0c7886e4.png">

#### Notes

I am not entirely sure if this is the right fix. If I am wrong with my theory of incorrect stylesheet overrides mentioned on https://github.com/Automattic/wp-calypso/issues/32117 or if I misunderstanding what's actually happening here, please let me know. 

Fixes https://github.com/Automattic/wp-calypso/issues/32117