### PR TITLE
Domains: Sort the TLDs in the "More Extensions" popup alphabetically

### DIFF
--- a/client/components/domains/search-filters/tld-filter-bar.jsx
+++ b/client/components/domains/search-filters/tld-filter-bar.jsx
@@ -177,7 +177,7 @@ export class TldFilterBar extends Component {
 						maxSuggestions={ 500 }
 						onChange={ this.handleTokenChange }
 						placeholder={ translate( 'Select an extension' ) }
-						suggestions={ this.props.availableTlds }
+						suggestions={ [ ...this.props.availableTlds ].sort() }
 						tokenizeOnSpace
 						value={ this.props.filters.tlds }
 					/>


### PR DESCRIPTION
The "More Extensions" popup shows all the TLDs ordered by the suggestion provider ordering mechanism. However that makes searching in the list unintuitive. This PR will order the list alphabetically which will make it easier to find specific TLDs.

#### Changes proposed in this Pull Request

* order the list in the "More Extensions" alphabetically

#### Testing instructions

Apply the PR, then search for a domain in the domain search and click on the "More Extensions" button. Check if the list is sorted appropriately and try searching for different TLDs in there. The TLD buttons next to the "More Extensions" button should still be sorted according to the search term.
