### PR TITLE
Activity Log Tasklist: Remove Primary Colour for Update Notices

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/update.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/update.jsx
@@ -75,8 +75,7 @@ class ActivityLogTaskUpdate extends Component {
 				</span>
 				<span className="activity-log-tasklist__update-action">
 					<SplitButton
-						compact
-						primary
+						compact					
 						label={ translate( 'Update' ) }
 						onClick={ this.handleEnqueue }
 						disabled={ disable }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This _should_ remove the primary colour from the "Update" split button but not the "Update All" button. That should remain primary:

https://github.com/Automattic/wp-calypso/blob/0c41ed2a304c093f3fa7fcabe02d94962a482d4f/client/my-sites/activity/activity-log-tasklist/index.jsx#L401

Full disclaimer: I've not tested this because I don't have a site with a paid plan, but looking through the code, I'm pretty sure that this is the change. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the instructions in #32114, hopefully that accent colour is gone except for the main "Update All" button. cc @arunsathiya, @flootr, @blowery 

Fixes #32114 
