### PR TITLE
NUX: extend the NUX SiteType UI component to include a free form text option.

### DIFF
--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -57,6 +57,11 @@ class SiteTypeForm extends Component {
 
 	handleSubmitOther = () => {
 		const fieldValue = this.state.otherValue ? 'other—' + this.state.otherValue : 'other–other';
+
+		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_type', {
+			value: 'other',
+		} );
+
 		this.handleSubmit( fieldValue );
 	};
 

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -56,7 +56,8 @@ class SiteTypeForm extends Component {
 	};
 
 	handleSubmitOther = () => {
-		this.handleSubmit( 'other—' + this.state.otherValue );
+		const fieldValue = this.state.otherValue ? 'other—' + this.state.otherValue : 'other–other';
+		this.handleSubmit( fieldValue );
 	};
 
 	renderBasicCard = () => {
@@ -72,6 +73,9 @@ class SiteTypeForm extends Component {
 						onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
 					>
 						<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
+						<span className="site-type__option-description">
+							{ siteTypeProperties.description }
+						</span>
 					</Card>
 				) ) }
 			</Card>

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -9,8 +9,8 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import Card from 'components/card';
 import Button from 'components/forms/form-button';
+import Card from 'components/card';
 import FormTextInput from 'components/forms/form-text-input';
 import { getAllSiteTypes } from 'lib/signup/site-type';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -24,17 +24,21 @@ import './style.scss';
 
 class SiteTypeForm extends Component {
 	static propTypes = {
+		siteType: PropTypes.string,
 		submitForm: PropTypes.func.isRequired,
 
 		// from localize() HoC
 		translate: PropTypes.func.isRequired,
 	};
 
-	state = {
-		otherValue: '',
-		siteType: '',
-		hasOtherReasonFocus: false,
-	};
+	constructor( props ) {
+		super( props );
+		this.state = {
+			hasOtherReasonFocus: false,
+			otherValue: '',
+			siteType: props.siteType,
+		};
+	}
 
 	onOtherCatChange = event => {
 		this.setState( {
@@ -53,14 +57,7 @@ class SiteTypeForm extends Component {
 	};
 
 	handleSubmitOther = () => {
-		if ( ! this.state.otherValue || this.state.hasOtherReasonFocus ) {
-			return;
-		}
 		this.handleSubmit( 'other—' + this.state.otherValue );
-	};
-
-	setOtherReasonFocus = focus => () => {
-		this.setState( { hasOtherReasonFocus: focus } );
 	};
 
 	renderBasicCard = () => {
@@ -70,6 +67,7 @@ class SiteTypeForm extends Component {
 					<Card
 						className="site-type__option"
 						key={ siteTypeProperties.id }
+						tagName="button"
 						displayAsLink
 						data-e2e-title={ siteTypeProperties.slug }
 						onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
@@ -91,7 +89,6 @@ class SiteTypeForm extends Component {
 				<div className="site-type__other-form">
 					<FormTextInput
 						className="site-type__other-input"
-						type="text"
 						selectOnFocus
 						placeholder={ translate( 'Other' ) }
 						onChange={ this.onOtherCatChange }
@@ -113,27 +110,23 @@ class SiteTypeForm extends Component {
 	render() {
 		const { isJetpack } = this.props;
 
-		if ( isJetpack === null ) {
-			return <div>{ this.renderBasicCard() }</div>;
+		if ( ! isJetpack ) {
+			return <Fragment> { this.renderBasicCard() } </Fragment>;
 		}
 
 		return (
-			<div>
+			<Fragment>
 				{ this.renderBasicCard() }
 				{ this.renderOtherInfo() }
-			</div>
+			</Fragment>
 		);
 	}
 }
 
 export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-		const isJetpack = isJetpackSite( state, siteId );
-		return {
-			isJetpack,
-		};
-	},
+	state => ( {
+		isJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
+	} ),
 	{
 		recordTracksEvent,
 	}

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -90,7 +90,7 @@ class SiteTypeForm extends Component {
 			<div>
 				<LoggedOutFormLinks className="site-type__links">
 					<LoggedOutFormLinkItem className="site-type__text">
-						Or type your own
+						{ translate( 'Or type your own' ) }
 					</LoggedOutFormLinkItem>
 				</LoggedOutFormLinks>
 

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -10,6 +10,10 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Card from 'components/card';
+import Button from 'components/forms/form-button';
+import FormTextInput from 'components/forms/form-text-input';
+import LoggedOutFormLinks from 'components/logged-out-form/links';
+import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import { getAllSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -20,19 +24,23 @@ import './style.scss';
 
 class SiteTypeForm extends Component {
 	static propTypes = {
-		siteType: PropTypes.string,
 		submitForm: PropTypes.func.isRequired,
 
 		// from localize() HoC
 		translate: PropTypes.func.isRequired,
 	};
 
-	constructor( props ) {
-		super( props );
-		this.state = {
-			siteType: props.siteType,
-		};
-	}
+	state = {
+		otherValue: '',
+		siteType: '',
+		hasOtherReasonFocus: false,
+	};
+
+	onOtherCatChange = event => {
+		this.setState( {
+			otherValue: event.target.value,
+		} );
+	};
 
 	handleSubmit = type => {
 		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_type', {
@@ -44,24 +52,60 @@ class SiteTypeForm extends Component {
 		this.props.submitForm( type );
 	};
 
-	renderSegmentOptions() {
-		return getAllSiteTypes().map( siteTypeProperties => (
-			<Card
-				className="site-type__option"
-				key={ siteTypeProperties.id }
-				displayAsLink
-				data-e2e-title={ siteTypeProperties.slug }
-				tagName="button"
-				onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
-			>
-				<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
-				<span className="site-type__option-description">{ siteTypeProperties.description }</span>
-			</Card>
-		) );
-	}
+	handleSubmitOther = () => {
+		if ( ! this.state.otherValue || this.state.hasOtherReasonFocus ) {
+			return;
+		}
+		this.handleSubmit( 'other—' + this.state.otherValue );
+	};
+
+	setOtherReasonFocus = focus => () => {
+		this.setState( { hasOtherReasonFocus: focus } );
+	};
 
 	render() {
-		return <Card className="site-type__wrapper">{ this.renderSegmentOptions() }</Card>;
+		const { translate } = this.props;
+		return (
+			<div>
+				<Card className="site-type__wrapper">
+					{ getAllSiteTypes().map( siteTypeProperties => (
+						<Card
+							className="site-type__option"
+							key={ siteTypeProperties.id }
+							displayAsLink
+							data-e2e-title={ siteTypeProperties.slug }
+							onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
+						>
+							<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
+						</Card>
+					) ) }
+				</Card>
+				<LoggedOutFormLinks className="site-type__links">
+					<LoggedOutFormLinkItem className="site-type__text">
+						Or type your own
+					</LoggedOutFormLinkItem>
+				</LoggedOutFormLinks>
+
+				<div className="site-type__other-link-item-form">
+					<FormTextInput
+						className="site-type__option-other"
+						type="text"
+						selectOnFocus
+						placeholder={ translate( 'Site profile' ) }
+						onChange={ this.onOtherCatChange }
+						value={ this.state.otherValue }
+					/>
+					<Button
+						className="site-type__other-submit"
+						disabled={ false }
+						onClick={ this.handleSubmitOther }
+						compact
+					>
+						{ translate( 'Continue' ) }
+					</Button>
+				</div>
+			</div>
+		);
 	}
 }
 

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -34,7 +34,6 @@ class SiteTypeForm extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			hasOtherReasonFocus: false,
 			otherValue: '',
 			siteType: props.siteType,
 		};

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -15,6 +15,8 @@ import FormTextInput from 'components/forms/form-text-input';
 import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import { getAllSiteTypes } from 'lib/signup/site-type';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -63,23 +65,29 @@ class SiteTypeForm extends Component {
 		this.setState( { hasOtherReasonFocus: focus } );
 	};
 
-	render() {
+	renderBasicCard = () => {
+		return (
+			<Card className="site-type__wrapper">
+				{ getAllSiteTypes().map( siteTypeProperties => (
+					<Card
+						className="site-type__option"
+						key={ siteTypeProperties.id }
+						displayAsLink
+						data-e2e-title={ siteTypeProperties.slug }
+						onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
+					>
+						<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
+					</Card>
+				) ) }
+			</Card>
+		);
+	};
+
+	renderOtherInfo = () => {
 		const { translate } = this.props;
+
 		return (
 			<div>
-				<Card className="site-type__wrapper">
-					{ getAllSiteTypes().map( siteTypeProperties => (
-						<Card
-							className="site-type__option"
-							key={ siteTypeProperties.id }
-							displayAsLink
-							data-e2e-title={ siteTypeProperties.slug }
-							onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
-						>
-							<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
-						</Card>
-					) ) }
-				</Card>
 				<LoggedOutFormLinks className="site-type__links">
 					<LoggedOutFormLinkItem className="site-type__text">
 						Or type your own
@@ -106,11 +114,32 @@ class SiteTypeForm extends Component {
 				</div>
 			</div>
 		);
+	};
+
+	render() {
+		const { isJetpack } = this.props;
+
+		if ( isJetpack === null ) {
+			return <div>{ this.renderBasicCard() }</div>;
+		}
+
+		return (
+			<div>
+				{ this.renderBasicCard() }
+				{ this.renderOtherInfo() }
+			</div>
+		);
 	}
 }
 
 export default connect(
-	null,
+	state => {
+		const siteId = getSelectedSiteId( state );
+		const isJetpack = isJetpackSite( state, siteId );
+		return {
+			isJetpack,
+		};
+	},
 	{
 		recordTracksEvent,
 	}

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -12,8 +12,6 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import Button from 'components/forms/form-button';
 import FormTextInput from 'components/forms/form-text-input';
-import LoggedOutFormLinks from 'components/logged-out-form/links';
-import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import { getAllSiteTypes } from 'lib/signup/site-type';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -87,27 +85,23 @@ class SiteTypeForm extends Component {
 		const { translate } = this.props;
 
 		return (
-			<div>
-				<LoggedOutFormLinks className="site-type__links">
-					<LoggedOutFormLinkItem className="site-type__text">
-						{ translate( 'Or type your own' ) }
-					</LoggedOutFormLinkItem>
-				</LoggedOutFormLinks>
+			<div className="site-type__other-option">
+				<p className="site-type__other-label">{ translate( 'Or type your own' ) }</p>
 
-				<div className="site-type__other-link-item-form">
+				<div className="site-type__other-form">
 					<FormTextInput
-						className="site-type__option-other"
+						className="site-type__other-input"
 						type="text"
 						selectOnFocus
-						placeholder={ translate( 'Site profile' ) }
+						placeholder={ translate( 'Other' ) }
 						onChange={ this.onOtherCatChange }
 						value={ this.state.otherValue }
 					/>
+
 					<Button
 						className="site-type__other-submit"
 						disabled={ false }
 						onClick={ this.handleSubmitOther }
-						compact
 					>
 						{ translate( 'Continue' ) }
 					</Button>

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -48,22 +48,15 @@ class SiteTypeForm extends Component {
 	handleSubmit = type => {
 		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_type', {
 			value: type,
+			user_input_site_type: this.state.otherValue || null,
 		} );
 
 		this.setState( { siteType: type } );
 
-		this.props.submitForm( type );
+		this.props.submitForm( type + '-' + this.state.otherValue );
 	};
 
-	handleSubmitOther = () => {
-		const fieldValue = this.state.otherValue ? 'other—' + this.state.otherValue : 'other–other';
-
-		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_type', {
-			value: 'other',
-		} );
-
-		this.handleSubmit( fieldValue );
-	};
+	handleSubmitOther = () => this.handleSubmit( 'other' );
 
 	renderBasicCard = () => {
 		return (
@@ -118,14 +111,10 @@ class SiteTypeForm extends Component {
 	render() {
 		const { isJetpack } = this.props;
 
-		if ( ! isJetpack ) {
-			return <Fragment> { this.renderBasicCard() } </Fragment>;
-		}
-
 		return (
 			<Fragment>
 				{ this.renderBasicCard() }
-				{ this.renderOtherInfo() }
+				{ isJetpack && this.renderOtherInfo() }
 			</Fragment>
 		);
 	}

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -53,7 +53,7 @@ class SiteTypeForm extends Component {
 
 		this.setState( { siteType: type } );
 
-		this.props.submitForm( type + '-' + this.state.otherValue );
+		this.props.submitForm( type === 'other' ? type + '-' + this.state.otherValue : type );
 	};
 
 	handleSubmitOther = () => this.handleSubmit( 'other' );

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -12,56 +12,6 @@
 	}
 }
 
-.site-type__other-link-item-form {
-  display: flex;
-	flex-direction: row;
-  align-items: stretch;
-	width: 60%;
-	margin-left: 120px;
-	@include breakpoint( '<660px' ) {
-		margin-left: 50px;
-		width: 100%;
-	}
-
-	.site-type__option-other {
-		width: 80%;
-		@include breakpoint( '<660px' ) {
-			width: 50%;
-		}
-	}
-}
-
-.site-type__other-link-item-form > div {
-  flex: 1;
-}
-
-.site-type__other-submit {
-	transition: none;
-	margin-left: 0;
-
-	&.is-error,
-	&[type='password'] {
-		margin-bottom: 0;
-	}
-
-	&.is-primary {
-		background-color: var( --color-jetpack );
-		border-color: var( --color-jetpack-dark );
-	}
-}
-
-.site-type__links {
-	margin-top: 20px;
-}
-
-.site-type__text {
-	font-size: 14px;
-	color: var( --color-neutral-light );
-	text-align: center;
-	padding-top: 10px;
-	padding-bottom: 20px;
-}
-
 .site-type__option {
 	padding: 16px 16px 16px 24px;
 	margin: 0;
@@ -125,5 +75,47 @@
 	&:focus .card__link-indicator {
 		opacity: 1;
 		transform: translateX( 0 );
+	}
+}
+
+.site-type__other-option {
+	text-align: center;
+	max-width: 380px;
+	position: relative;
+	margin: auto;
+
+	&::before {
+		content: '';
+		display: block;
+		width: 80px;
+		height: 2px;
+		color: var( --primary-light );
+		position: absolute;
+		top: 0;
+		left: calc( 50% - 40px );
+	}
+
+	.site-type__other-form {
+		position: relative;
+
+	}
+
+	.site-type__other-label {
+		color: var( --color-white );
+		margin: 24px 0 16px;
+	}
+
+	.site-type__other-input {
+		border-radius: 3px;
+
+		&:focus {
+			box-shadow: 0 0 0 2px var( --color-accent );
+		}
+	}
+
+	.site-type__other-submit {
+		position: absolute;
+		top: 3px;
+		right: 3px;
 	}
 }

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -82,17 +82,18 @@
 	text-align: center;
 	max-width: 380px;
 	position: relative;
-	margin: auto;
+	margin: 56px auto 0;
 
 	&::before {
 		content: '';
 		display: block;
-		width: 80px;
+		width: 60px;
 		height: 2px;
-		color: var( --primary-light );
+		background: var( --color-white );
+		opacity: 0.2;
 		position: absolute;
-		top: 0;
-		left: calc( 50% - 40px );
+		top: -24px;
+		left: calc( 50% - 30px );
 	}
 
 	.site-type__other-form {
@@ -102,13 +103,18 @@
 
 	.site-type__other-label {
 		color: var( --color-white );
-		margin: 24px 0 16px;
+		margin: 16px 0;
 	}
 
 	.site-type__other-input {
 		border-radius: 3px;
+		border: none;
+		padding: 11px 100px 11px 24px;
+		@include elevation ( 2dp );
 
-		&:focus {
+		&:focus,
+		&:focus:hover, // This is weird...
+		&:active {
 			box-shadow: 0 0 0 2px var( --color-accent );
 		}
 	}
@@ -117,5 +123,6 @@
 		position: absolute;
 		top: 3px;
 		right: 3px;
+		@include elevation ( 1dp );
 	}
 }

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -12,12 +12,61 @@
 	}
 }
 
+.site-type__other-link-item-form {
+  display: flex;
+	flex-direction: row;
+  align-items: stretch;
+	width: 60%;
+	margin-left: 120px;
+	@include breakpoint( '<660px' ) {
+		margin-left: 50px;
+		width: 100%;
+	}
+
+	.site-type__option-other {
+		width: 80%;
+		@include breakpoint( '<660px' ) {
+			width: 50%;
+		}
+	}
+}
+
+.site-type__other-link-item-form > div {
+  flex: 1;
+}
+
+.site-type__other-submit {
+	transition: none;
+	margin-left: 0;
+
+	&.is-error,
+	&[type='password'] {
+		margin-bottom: 0;
+	}
+
+	&.is-primary {
+		background-color: var( --color-jetpack );
+		border-color: var( --color-jetpack-dark );
+	}
+}
+
+.site-type__links {
+	margin-top: 20px;
+}
+
+.site-type__text {
+	font-size: 14px;
+	color: var( --color-neutral-light );
+	text-align: center;
+	padding-top: 10px;
+	padding-bottom: 20px;
+}
+
 .site-type__option {
 	padding: 16px 16px 16px 24px;
 	margin: 0;
 	font-weight: 400;
 	position: relative;
-	width: 100%;
 	text-align: left;
 	@include elevation ( 0 );
 	border-bottom: 1px solid var( --color-neutral-50 );


### PR DESCRIPTION
Bring back the work done in https://github.com/Automattic/wp-calypso/pull/31524 with fixed missing subheaders in the Site Type form categories, which were the reason to revert the work.

TESTING:
- MERGED: the server side changes D26585-code,
- at `.../jetpack/connect/site-type/:connected_JP_site` verify that the site type form has an extra field 
- input some text in the field and submit the form
- in /options.php of the site, verify the that site_topic option contains text `other- your_text` or `other-other` if the form was submitted as empty
- at `.../start/onboarding/site-type` verify that the form has NO extra fields
- verify that the relevant Track event fires with appropriate prop when submitting the user input, e.g. submitting an empty form:
<img width="798" alt="Screenshot 2019-04-08 at 22 34 19" src="https://user-images.githubusercontent.com/13561163/55759653-d68e1f80-5a51-11e9-8bf4-411359b5ff82.png">
