### PR TITLE
Reader: fix padding on notification settings popout

### DIFF
--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -49,7 +49,7 @@
 	border-top: 1px solid var( --color-neutral-100 );
 	color:var( --color-neutral-700 );
 	font-size: 14px;
-	padding: 10px 0 10px 15px;
+	padding: 10px 15px;
 	text-align: left;
 
 	&:first-child {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Due to a CSS regression in an underlying component, the notification settings popover in Reader does not have any right padding.

This PR fixes the right padding. Thanks to @beaulebens for the report.

#### Testing instructions

Visit http://calypso.localhost:3000/following/manage. Choose 'Settings' and ensure that the padding looks correct.

Before:

<img width="359" alt="Screen Shot 2019-04-09 at 12 09 21" src="https://user-images.githubusercontent.com/17325/55764667-b3e71f80-5ac0-11e9-8b1d-a4cde6401c46.png">

After:

<img width="411" alt="Screen Shot 2019-04-09 at 12 09 15" src="https://user-images.githubusercontent.com/17325/55764678-ba759700-5ac0-11e9-8453-3e3142386227.png">
