### PR TITLE
[WIP] Me/Purchases/Billing: Show Upcoming Charges tax estimates

### DIFF
--- a/client/me/billing-history/test/tax.js
+++ b/client/me/billing-history/test/tax.js
@@ -151,6 +151,6 @@ test( 'tax applicable shown if upcoming', () => {
 			{ renderTransactionAmount( upcoming, { translate, addingTax: true, estimated: true } ) }
 		</Provider>
 	);
-	expect( wrapper.last().text() ).toEqual( '$38.48(+%(taxAmount)s tax)' );
+	expect( wrapper.last().text() ).toEqual( '$38.48(+ applicable tax)' );
 	expect( wrapper.find( 'InfoPopover' ) ).toHaveLength( 1 );
 } );

--- a/client/me/billing-history/test/tax.js
+++ b/client/me/billing-history/test/tax.js
@@ -133,16 +133,7 @@ test( 'tax hidden if not available', () => {
 } );
 
 test( 'tax applicable shown if upcoming', () => {
-	const upcoming = {
-		subtotal: '$36.00',
-		tax: '$2.48',
-		amount: '$38.48',
-		items: [
-			{
-				raw_tax: 2.48,
-			},
-		],
-	};
+	const upcoming = { amount: '€38.48' };
 
 	// Provider redux store context required by dep on connected popover
 	const store = createReduxStore();
@@ -151,5 +142,5 @@ test( 'tax applicable shown if upcoming', () => {
 			{ renderTransactionAmount( upcoming, { translate, addingTax: true, estimated: true } ) }
 		</Provider>
 	);
-	expect( wrapper.last().text() ).toEqual( '$38.48(+ applicable tax)' );
+	expect( wrapper.last().text() ).toEqual( '€38.48(+ applicable tax)' );
 } );

--- a/client/me/billing-history/test/tax.js
+++ b/client/me/billing-history/test/tax.js
@@ -152,5 +152,4 @@ test( 'tax applicable shown if upcoming', () => {
 		</Provider>
 	);
 	expect( wrapper.last().text() ).toEqual( '$38.48(+ applicable tax)' );
-	expect( wrapper.find( 'InfoPopover' ) ).toHaveLength( 1 );
 } );

--- a/client/me/billing-history/test/tax.js
+++ b/client/me/billing-history/test/tax.js
@@ -5,12 +5,15 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { renderTransactionAmount, transactionIncludesTax } from '../utils';
+import { createReduxStore } from 'state';
 
 const translate = x => x;
 
@@ -127,4 +130,27 @@ test( 'tax hidden if not available', () => {
 	};
 
 	expect( renderTransactionAmount( transaction, { translate } ) ).toEqual( '$36.00' );
+} );
+
+test( 'tax applicable shown if upcoming', () => {
+	const upcoming = {
+		subtotal: '$36.00',
+		tax: '$2.48',
+		amount: '$38.48',
+		items: [
+			{
+				raw_tax: 2.48,
+			},
+		],
+	};
+
+	// Provider redux store context required by dep on connected popover
+	const store = createReduxStore();
+	const wrapper = mount(
+		<Provider store={ store }>
+			{ renderTransactionAmount( upcoming, { translate, addingTax: true, estimated: true } ) }
+		</Provider>
+	);
+	expect( wrapper.last().text() ).toEqual( '$38.48(+%(taxAmount)s tax)' );
+	expect( wrapper.find( 'InfoPopover' ) ).toHaveLength( 1 );
 } );

--- a/client/me/billing-history/test/tax.js
+++ b/client/me/billing-history/test/tax.js
@@ -5,15 +5,12 @@
 /**
  * External dependencies
  */
-import React from 'react';
 import { mount } from 'enzyme';
-import { Provider } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import { renderTransactionAmount, transactionIncludesTax } from '../utils';
-import { createReduxStore } from 'state';
 
 const translate = x => x;
 
@@ -135,12 +132,9 @@ test( 'tax hidden if not available', () => {
 test( 'tax applicable shown if upcoming', () => {
 	const upcoming = { amount: '€38.48' };
 
-	// Provider redux store context required by dep on connected popover
-	const store = createReduxStore();
 	const wrapper = mount(
-		<Provider store={ store }>
-			{ renderTransactionAmount( upcoming, { translate, addingTax: true, estimated: true } ) }
-		</Provider>
+		renderTransactionAmount( upcoming, { translate, addingTax: true, estimated: true } )
 	);
-	expect( wrapper.last().text() ).toEqual( '€38.48(+ applicable tax)' );
+
+	expect( wrapper.last().text() ).toEqual( '(+ applicable tax)' );
 } );

--- a/client/me/billing-history/test/utils.js
+++ b/client/me/billing-history/test/utils.js
@@ -1,4 +1,7 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment jsdom
+ */
 
 /**
  * External dependencies

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -179,6 +179,7 @@ class TransactionsTable extends React.Component {
 					<td className="billing-history__amount">
 						{ renderTransactionAmount( transaction, {
 							addingTax: transactionType === 'upcoming',
+							estimated: transactionType === 'upcoming',
 							translate,
 						} ) }
 					</td>

--- a/client/me/billing-history/utils.jsx
+++ b/client/me/billing-history/utils.jsx
@@ -66,7 +66,7 @@ export function renderTransactionAmount(
 		return transaction.amount;
 	}
 
-	const taxAmount = addingTax
+	let taxAmount = addingTax
 		? translate( '(+%(taxAmount)s tax)', {
 				args: { taxAmount: transaction.tax },
 				comment: 'taxAmount is a localized price, like $12.34',
@@ -75,6 +75,13 @@ export function renderTransactionAmount(
 				args: { taxAmount: transaction.tax },
 				comment: 'taxAmount is a localized price, like $12.34',
 		  } );
+
+	if ( estimated ) {
+		taxAmount = translate( '(+ applicable tax)', {
+			comment:
+				'Positioned next to a tax exclusive price amount to explain there is potential for an extra tax in addition to the price at sale time',
+		} );
+	}
 
 	return (
 		<Fragment>

--- a/client/me/billing-history/utils.jsx
+++ b/client/me/billing-history/utils.jsx
@@ -62,12 +62,6 @@ export function renderTransactionAmount(
 	transaction,
 	{ translate, addingTax = false, estimated = false }
 ) {
-	if ( estimated ) {
-		// TMP
-		transaction.tax = transaction.tax || '$1.23';
-		transaction.items = transaction.items || [ { raw_tax: 2 } ];
-	}
-
 	if ( ! transactionIncludesTax( transaction ) ) {
 		return transaction.amount;
 	}

--- a/client/me/billing-history/utils.jsx
+++ b/client/me/billing-history/utils.jsx
@@ -51,8 +51,6 @@ export function transactionIncludesTax( transaction ) {
 		return false;
 	}
 
-	// TODO: Make sure that upcoming charges with estimates return true
-
 	// Consider the whole transaction to include tax if any item does
 	return some( transaction.items, 'raw_tax' );
 }

--- a/client/me/billing-history/utils.jsx
+++ b/client/me/billing-history/utils.jsx
@@ -5,6 +5,7 @@
 import { find, map, partition, reduce, some } from 'lodash';
 import React, { Fragment } from 'react';
 import formatCurrency from '@automattic/format-currency';
+import InfoPopover from 'components/info-popover';
 
 export const groupDomainProducts = ( originalItems, translate ) => {
 	const transactionItems = Object.keys( originalItems ).map( key => {
@@ -51,11 +52,22 @@ export function transactionIncludesTax( transaction ) {
 		return false;
 	}
 
+	// TODO: Make sure that upcoming charges with estimates return true
+
 	// Consider the whole transaction to include tax if any item does
 	return some( transaction.items, 'raw_tax' );
 }
 
-export function renderTransactionAmount( transaction, { translate, addingTax = false } ) {
+export function renderTransactionAmount(
+	transaction,
+	{ translate, addingTax = false, estimated = false }
+) {
+	if ( estimated ) {
+		// TMP
+		transaction.tax = transaction.tax || '$1.23';
+		transaction.items = transaction.items || [ { raw_tax: 2 } ];
+	}
+
 	if ( ! transactionIncludesTax( transaction ) ) {
 		return transaction.amount;
 	}
@@ -73,7 +85,17 @@ export function renderTransactionAmount( transaction, { translate, addingTax = f
 	return (
 		<Fragment>
 			<div>{ transaction.amount }</div>
-			<div className="billing-history__transaction-tax-amount">{ taxAmount }</div>
+			<div className="billing-history__transaction-tax-amount">
+				{ taxAmount }
+				{ estimated && (
+					<InfoPopover position="bottom left">
+						{ translate( 'Tax amount is only an estimate', {
+							comment:
+								'Disclaimer indicating uncertaintanty about actual taxes that will be applied in the future',
+						} ) }
+					</InfoPopover>
+				) }
+			</div>
 		</Fragment>
 	);
 }

--- a/client/me/billing-history/utils.jsx
+++ b/client/me/billing-history/utils.jsx
@@ -5,7 +5,6 @@
 import { find, map, partition, reduce, some } from 'lodash';
 import React, { Fragment } from 'react';
 import formatCurrency from '@automattic/format-currency';
-import InfoPopover from 'components/info-popover';
 
 export const groupDomainProducts = ( originalItems, translate ) => {
 	const transactionItems = Object.keys( originalItems ).map( key => {
@@ -86,17 +85,7 @@ export function renderTransactionAmount(
 	return (
 		<Fragment>
 			<div>{ transaction.amount }</div>
-			<div className="billing-history__transaction-tax-amount">
-				{ taxAmount }
-				{ estimated && (
-					<InfoPopover position="bottom left">
-						{ translate( 'Tax amount is only an estimate', {
-							comment:
-								'Disclaimer indicating uncertaintanty about actual taxes that will be applied in the future',
-						} ) }
-					</InfoPopover>
-				) }
-			</div>
+			<div className="billing-history__transaction-tax-amount">{ taxAmount }</div>
 		</Fragment>
 	);
 }

--- a/client/me/billing-history/utils.jsx
+++ b/client/me/billing-history/utils.jsx
@@ -61,7 +61,7 @@ export function renderTransactionAmount(
 	transaction,
 	{ translate, addingTax = false, estimated = false }
 ) {
-	if ( ! transactionIncludesTax( transaction ) ) {
+	if ( ! transactionIncludesTax( transaction ) && ! estimated ) {
 		return transaction.amount;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR displays estimated tax values for upcoming charges when they are available from the backend.

![Billing_History_—_WordPress_com](https://user-images.githubusercontent.com/5952255/55767043-a038ba80-5aba-11e9-9194-6d235797b940.jpg)

#### Testing instructions

1. Get the back end to provide upcoming charges with tax somehow
2. Check that the Upcoming Charges panel at http://calypso.localhost:3000/me/purchases/billing shows tax values only for the appropriate upcoming charges

