### PR TITLE
Signup: Hiding the site style input elements for larger screen widths

### DIFF
--- a/client/signup/steps/site-style/style.scss
+++ b/client/signup/steps/site-style/style.scss
@@ -116,7 +116,11 @@
 
 	input[type='radio'] {
 		position: absolute;
-		left: -1000px;
+		left: -10000px;
+		top: auto;
+		width: 1px;
+		height: 1px;
+		overflow: hidden;
 	}
 
 	svg {


### PR DESCRIPTION
## Changes proposed in this Pull Request

We're hiding the radio inputs for larger screen widths while keeping it accessible, mainly for those poor souls who prefer to view web content at a million pixel resolution on their fancy cinema screens .

![Screen Shot 2019-04-09 at 11](https://user-images.githubusercontent.com/6458278/55773929-58c02780-5ad6-11e9-931a-4b09597eec3b.jpg)

## Testing instructions

Head to http://calypso.localhost:3000/start/onboarding-dev/site-style-with-preview and view with a page width `>1700px` wide.

The radio buttons shouldn't be there.

Pacman should definitely not be there.
