### PR TITLE
Signup: remove default debounce option

### DIFF
--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -59,7 +59,7 @@ class SiteMockups extends Component {
 
 		return true;
 	}
-	updateDebounced = debounce( this.forceUpdate, 777, { leading: false } );
+	updateDebounced = debounce( this.forceUpdate, 777 );
 
 	getNewFontLoaderState( props ) {
 		const state = {


### PR DESCRIPTION
## Changes proposed in this Pull Request

Removing the default debounce option `{leading:false}` since it's the lodash default anyway.

Thanks @southp for the reminder :)