### PR TITLE
Update monorepo documentation

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -1,0 +1,9 @@
+# Apps
+
+This directory exists to hold a variety of projects that we do not use directly in Calypso and publish as independent outputs or packages.
+
+For packages that are used also in Calypso, see [`/packages`](../packages)
+
+## Adding a new app?
+
+If you want to add a new project into this directory, then add a new directory and follow [Publishing with the Monorepo](../docs/monorepo.md) -documentation.

--- a/apps/README.md
+++ b/apps/README.md
@@ -7,3 +7,13 @@ For packages that are used also in Calypso, see [`/packages`](../packages)
 ## Adding a new app?
 
 If you want to add a new project into this directory, then add a new directory and follow [Publishing with the Monorepo](../docs/monorepo.md) -documentation.
+
+## Building
+
+Apps (unlike packages) are not built on Calypso's `npm install`.
+
+You must manually build apps by running:
+
+```bash
+npx lerna run build --scope="@automattic/app-name"
+```

--- a/apps/README.md
+++ b/apps/README.md
@@ -6,7 +6,7 @@ For packages that we might publish as NPM packages, see [`/packages`](../package
 
 ## Adding a new app?
 
-If you want to add a new project into this directory, then add a new directory and follow [Publishing with the Monorepo](../docs/monorepo.md) -documentation.
+If you want to add a new project into this directory, then add a new directory and follow [monorepo -documentation](../docs/monorepo.md).
 
 ## Building
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,8 +1,8 @@
 # Apps
 
-This directory exists to hold a variety of projects that we do not use directly in Calypso and publish as independent outputs or packages.
+This directory exists to hold a variety of projects that can produce independent, binary-like outputs deployed elsewhere. Typically not published to NPM or build on `npm start`
 
-For packages that are used also in Calypso, see [`/packages`](../packages)
+For packages that we might publish as NPM packages, see [`/packages`](../packages).
 
 ## Adding a new app?
 

--- a/apps/o2-blocks/README.md
+++ b/apps/o2-blocks/README.md
@@ -32,5 +32,5 @@ registerBlockType( 'prefix/name', { /* settings */ } );
 To build bundle in `apps/o2-blocks/dist`, run:
 
 ```bash
-npx lerna run prepare --scope="@automattic/o2-blocks"
+npx lerna run build --scope="*/o2-blocks
 ```

--- a/apps/o2-blocks/README.md
+++ b/apps/o2-blocks/README.md
@@ -26,3 +26,11 @@ Blocks are registered by providing a `name` and `settings` like this:
 ```js
 registerBlockType( 'prefix/name', { /* settings */ } );
 ```
+
+## Building
+
+To build bundle in `apps/o2-blocks/dist`, run:
+
+```bash
+npx lerna run prepare --scope="@automattic/o2-blocks"
+```

--- a/apps/o2-blocks/README.md
+++ b/apps/o2-blocks/README.md
@@ -32,5 +32,5 @@ registerBlockType( 'prefix/name', { /* settings */ } );
 To build bundle in `apps/o2-blocks/dist`, run:
 
 ```bash
-npx lerna run build --scope="*/o2-blocks
+npx lerna run build --scope="@automattic/o2-blocks"
 ```

--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -1,6 +1,6 @@
 # WP.com block editor
 
-This package provides utilities for the WordPress.com block editor integration. 
+This package provides utilities for the WordPress.com block editor integration.
 
 These utilities are intended to be built and then served from `widgets.wp.com`, so they can be loaded by a WordPress.com or a Jetpack connected site.
 

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -78,6 +78,7 @@ The only exception are `devDependencies` which _must be declared in the wp-calyp
 If your package requires compilation, the `package.json` `prepare` script should compile the package. If it contains ES6+ code that needs to be transpiled, use `npx @automattic/calypso-build` which will automatically compile code in `src/` to `dist/cjs` (CommonJS) and `dist/esm` (ECMAScript Modules) by running `babel` over any source files it finds.
 
 ## Running Tests
+
 To run all of the package tests:
 
 `npm run test-packages`
@@ -85,6 +86,22 @@ To run all of the package tests:
 To run one package's tests:
 
 `npm run test-packages [ test file pattern ]`
+
+## Building packages
+
+Packages are automatically build on `npm start` unless they're in `/apps` directory.
+
+You can build packages also by running:
+
+```bash
+npm run build-packages
+```
+
+Or even specific packages:
+
+```bash
+npx lerna run prepare --scope="@automattic/calypso-build"
+```
 
 ## Publishing
 

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -1,11 +1,15 @@
-Publishing Packages with the Monorepo
-=====================================
+# Publishing with the Monorepo
 
 Calypso is a monorepo. In addition to the Calypso application, it also hosts a number of independent modules that are published to NPM.
 
 ## Module Layout
 
-These modules live under the `packages` directory, one folder per module.
+These modules live under the `packages` and `apps` directories, one folder per module.
+
+Two different directories for modules are:
+
+`/packages` — projects and libraries that we use in Calypso but also might publish as independent outputs or packages.
+`/apps` — projects that we _do not_ use directly in Calypso and publish as independent outputs or packages.
 
 Modules should follow our convention for layout:
 ```
@@ -33,7 +37,7 @@ test/
 
 Your `package.json` can have any of the [normal properties](https://docs.npmjs.com/files/package.json) but at a minimum should contain `main`, `module`, and `sideEffects`.
 
-The only exception are `devDependencies` which _must be declared in the wp-calypso root package.json_. `devDependencies` of sub-packages in a monorepo are not reliably installed and cannot be relied on.
+The only exception are `devDependencies` which _must be declared in the wp-calypso root `package.json`_. `devDependencies` of sub-packages in a monorepo are not reliably installed and cannot be relied on.
 
 ### A sample `package.json`
 
@@ -87,11 +91,11 @@ To run one package's tests:
 
 `npm run test-packages [ test file pattern ]`
 
-## Building packages
+## Building packages & apps
 
 Packages will have their `prepare` scripts run automatically on `npm install`.
 
-Independent apps can use `build` instead of `prepare` so avoid unnecessary builds on `npm install`.
+Independent apps in `/apps` directory use `build` instead of `prepare` so avoid unnecessary builds on `npm install`.
 
 You can build packages also by running:
 
@@ -103,6 +107,12 @@ Or even specific packages:
 
 ```bash
 npx lerna run prepare --scope="@automattic/calypso-build"
+```
+
+Or specific apps:
+
+```bash
+npx lerna run build --scope="@automattic/calypso-build"
 ```
 
 ## Publishing

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -89,7 +89,9 @@ To run one package's tests:
 
 ## Building packages
 
-Packages are automatically build on `npm start` unless they're in `/apps` directory.
+Packages will have their `prepare` scripts run automatically on `npm install`.
+
+Independent apps can use `build` instead of `prepare` so avoid unnecessary builds on `npm install`.
 
 You can build packages also by running:
 

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -115,6 +115,16 @@ Or specific apps:
 npx lerna run build --scope="@automattic/calypso-build"
 ```
 
+## Developing packages
+
+When developing packages in Calypso repository that external consumers (like Jetpack repository) depend on, you might want to test them without going through the publishing flow first.
+
+1. Enter the package you're testing
+1. Run [`npm link`](https://docs.npmjs.com/cli/link) — the package will be installed on global scope and symlinked to the folder in Calypso
+1. Enter the consumer's folder (such as Jetpack)
+1. Type `npm link @automattic/package-name` — the package will be symlinked between Calypso and Jetpack and any modifications you make in Calypso, will show up in Jetpack.
+1. Remember to build your changes between modifications in Calypso.
+
 ## Publishing
 
 Please do not use regular [`npm publish`](https://docs.npmjs.com/cli/publish) within a package to publish an individual package; `npx` has issues using this flow.

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -1,4 +1,4 @@
-# Publishing with the Monorepo
+# Working with the Monorepo
 
 Calypso is a monorepo. In addition to the Calypso application, it also hosts a number of independent modules that are published to NPM.
 

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -130,6 +130,8 @@ When developing packages in Calypso repository that external consumers (like Jet
 1. Type `npm link @automattic/package-name` — the package will be symlinked between Calypso and Jetpack and any modifications you make in Calypso, will show up in Jetpack.
 1. Remember to build your changes between modifications in Calypso.
 
+Note that if you're building with Webpack, you may need to turn off [`resolve.symlinks`](https://webpack.js.org/configuration/resolve/#resolvesymlinks) for it to work as expected.
+
 ## Publishing
 
 Please do not use regular [`npm publish`](https://docs.npmjs.com/cli/publish) within a package to publish an individual package; `npx` has issues using this flow.

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -8,8 +8,8 @@ These modules live under the `packages` and `apps` directories, one folder per m
 
 Two different directories for modules are:
 
-`/packages` — projects and libraries that we use in Calypso but also might publish as independent outputs or packages.
-`/apps` — projects that we _do not_ use directly in Calypso and publish as independent outputs or packages.
+`/packages` — projects and libraries that we might publish as [NPM packages](https://docs.npmjs.com/about-packages-and-modules). Typically used also elsewhere in Calypso and build on `npm start`. See "Publishing" below.
+`/apps` — projects that can produce independent, binary-like outputs deployed elsewhere. Typically not published to NPM or build on `npm start`.
 
 Modules should follow our convention for layout:
 ```

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -95,8 +95,6 @@ To run one package's tests:
 
 Packages will have their `prepare` scripts run automatically on `npm install`.
 
-Independent apps in `/apps` directory use `build` instead of `prepare` so avoid unnecessary builds on `npm install`.
-
 You can build packages also by running:
 
 ```bash
@@ -113,6 +111,13 @@ Or specific apps:
 
 ```bash
 npx lerna run build --scope="@automattic/calypso-build"
+```
+
+All `prepare` scripts found in all `package.json`s of apps and packages are always run on Calypso's `npm install`. Therefore independent apps in `/apps` directory can use `build` instead of `prepare` so avoid unnecessary builds.
+
+You can also run other custom `package.json` scripts only for your app or package:
+```bash
+npx lerna run your-script --scope="@automattic/your-package"
 ```
 
 ## Developing packages

--- a/packages/README.md
+++ b/packages/README.md
@@ -7,3 +7,13 @@ For applications that are not used in Calypso, see [`/apps`](../apps)
 ## Adding a new package?
 
 If you want to add a new project or package into this directory, then add a new directory and follow [Publishing with the Monorepo](../docs/monorepo.md) -documentation.
+
+## Building
+
+Packages are built on Calypso's `npm install` so you don't need to build them manually, unless you are working directly on them.
+
+If you must manually build a single package, run:
+
+```bash
+npx lerna run prepare --scope="@automattic/package-name"
+```

--- a/packages/README.md
+++ b/packages/README.md
@@ -2,6 +2,8 @@
 
 This directory exists to hold a variety of projects and libraries that we use in Calypso but also might publish as independent outputs or packages.
 
+For applications that are not used in Calypso, see [`/apps`](../apps)
+
 ## Adding a new package?
 
-If you want to add a new project or package into this directory, then add a new directory and follow [Publishing Packages with the Monorepo](../docs/monorepo.md) -documentation.
+If you want to add a new project or package into this directory, then add a new directory and follow [Publishing with the Monorepo](../docs/monorepo.md) -documentation.

--- a/packages/README.md
+++ b/packages/README.md
@@ -6,7 +6,7 @@ For projects that can produce independent, binary-like outputs deployed elsewher
 
 ## Adding a new package?
 
-If you want to add a new project or package into this directory, then add a new directory and follow [Publishing with the Monorepo](../docs/monorepo.md) -documentation.
+If you want to add a new project or package into this directory, then add a new directory and follow [monorepo -documentation](../docs/monorepo.md).
 
 ## Building
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,8 +1,8 @@
 # Packages
 
-This directory exists to hold a variety of projects and libraries that we use in Calypso but also might publish as independent outputs or packages.
+This directory exists to hold a variety of projects and libraries that we might publish as [NPM packages](https://docs.npmjs.com/about-packages-and-modules). Typically used also elsewhere in Calypso and build on `npm start`.
 
-For applications that are not used in Calypso, see [`/apps`](../apps)
+For projects that can produce independent, binary-like outputs deployed elsewhere, see [`/apps`](../apps).
 
 ## Adding a new package?
 

--- a/packages/babel-plugin-i18n-calypso/README.md
+++ b/packages/babel-plugin-i18n-calypso/README.md
@@ -1,0 +1,3 @@
+# Babel plugin i18n Calypso
+
+A Babel plugin to generate a POT file for translate calls.

--- a/packages/calypso-build/README.md
+++ b/packages/calypso-build/README.md
@@ -1,0 +1,3 @@
+# Calypso build
+
+Shared Calypso build configuration files.

--- a/packages/eslint-config-wpcalypso/README.md
+++ b/packages/eslint-config-wpcalypso/README.md
@@ -1,5 +1,4 @@
-eslint-config-wpcalypso
-=======================
+# Eslint config wpcalypso
 
 An ESLint configuration following WordPress.com's "Calypso" [JavaScript Coding Guidelines](https://github.com/Automattic/wp-calypso/blob/master/docs/coding-guidelines/javascript.md).
 

--- a/packages/eslint-plugin-wpcalypso/README.md
+++ b/packages/eslint-plugin-wpcalypso/README.md
@@ -1,4 +1,4 @@
-# eslint-plugin-wpcalypso
+# Eslint plugin wpcalypso
 
 Custom ESLint rules for the [WordPress.com Calypso project](https://github.com/automattic/wp-calypso).
 

--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -1,0 +1,3 @@
+# @automattic/format-currency
+
+A library for formatting currency.

--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -1,3 +1,3 @@
-# @automattic/format-currency
+# Format currency
 
 A library for formatting currency.

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -1,5 +1,4 @@
-I18n Calypso
-============
+# I18n Calypso
 
 This lib enables translations, exposing three public methods:
 

--- a/packages/material-design-icons/README.md
+++ b/packages/material-design-icons/README.md
@@ -1,4 +1,4 @@
-# material-design-icons
+# Material design icons
 
 This package currently only provides Material icon SVGs required by the Calypso
 nav drawer.  The official `material-design-icons` package (https://github.com/google/material-design-icons)
@@ -27,4 +27,3 @@ https://material.io/tools/icons/
 
 Store the SVG files in the sub-folder matching the category used on
 material.io.
-

--- a/packages/photon/README.md
+++ b/packages/photon/README.md
@@ -1,4 +1,4 @@
-# photon.js
+# Photon.js
 
 JavaScript library for the [WordPress.com][] [Photon][] image manipulation service.
 

--- a/packages/tree-select/README.md
+++ b/packages/tree-select/README.md
@@ -1,4 +1,4 @@
-# `treeSelect`
+# Tree select
 
 This module exports a function which creates a cached state selector for use with the Redux global application state. It is a good idea to use this function over plain selectors whenever either the computation over state or React's rerenders are expensive.
 It is called `treeSelect` because it internally uses a tree of dependencies to allow the gc to free memory without explicitly clearing the cache.

--- a/packages/wordpress-external-dependencies-plugin/README.md
+++ b/packages/wordpress-external-dependencies-plugin/README.md
@@ -1,4 +1,4 @@
-# @automattic/wordpress-external-dependencies-plugin
+# WordPress external dependencies plugin
 
 This webpack plugin serves two purposes:
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add information about building packages to monorepo docs
- Add info about `/apps` and `/packages` difference and how to build them
- Mention `npm link` for easier development of packages
- Document new `/apps` directory (https://github.com/Automattic/wp-calypso/pull/32058)
- Unify title format for packages
- Add more information about some packages
