### PR TITLE
Themes Search Card: use withMobileBreakpoint to watch viewport size 

### DIFF
--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import wrapWithClickOutside from 'react-click-outside';
 import { connect } from 'react-redux';
-import { debounce, intersection, difference, includes, partial } from 'lodash';
+import { debounce, intersection, difference, includes } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -59,8 +59,9 @@ class ThemesMagicSearchCard extends React.Component {
 		};
 	}
 
-	setSuggestionsRefs = ( key, suggestionComponent ) =>
-		( this.suggestionsRefs[ key ] = suggestionComponent );
+	setSuggestionsRefs = key => suggestionComponent => {
+		this.suggestionsRefs[ key ] = suggestionComponent;
+	};
 
 	setSearchInputRef = search => ( this.searchInputRef = search );
 
@@ -345,7 +346,7 @@ class ThemesMagicSearchCard extends React.Component {
 				<div role="presentation" onClick={ this.handleClickInside }>
 					{ renderSuggestions && (
 						<KeyedSuggestions
-							ref={ partial( this.setSuggestionsRefs, 'suggestions' ) }
+							ref={ this.setSuggestionsRefs( 'suggestions' ) }
 							terms={ this.props.filters }
 							input={ this.state.editedSearchElement }
 							suggest={ this.suggest }
@@ -353,7 +354,7 @@ class ThemesMagicSearchCard extends React.Component {
 					) }
 					{ ! renderSuggestions && (
 						<MagicSearchWelcome
-							ref={ partial( this.setSuggestionsRefs, 'welcome' ) }
+							ref={ this.setSuggestionsRefs( 'welcome' ) }
 							taxonomies={ filtersKeys }
 							topSearches={ [] }
 							suggestionsCallback={ this.insertTextInInput }

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -31,10 +31,17 @@ const preferredOrderOfTaxonomies = [ 'feature', 'layout', 'column', 'subject', '
 
 class ThemesMagicSearchCard extends React.Component {
 	static propTypes = {
+		tier: PropTypes.string,
+		select: PropTypes.func.isRequired,
+		siteId: PropTypes.number,
+		onSearch: PropTypes.func.isRequired,
+		search: PropTypes.string,
+		translate: PropTypes.func.isRequired,
 		showTierThemesControl: PropTypes.bool,
 	};
 
 	static defaultProps = {
+		tier: 'all',
 		showTierThemesControl: true,
 	};
 
@@ -357,19 +364,6 @@ class ThemesMagicSearchCard extends React.Component {
 		);
 	}
 }
-
-ThemesMagicSearchCard.propTypes = {
-	tier: PropTypes.string,
-	select: PropTypes.func.isRequired,
-	siteId: PropTypes.number,
-	onSearch: PropTypes.func.isRequired,
-	search: PropTypes.string,
-	translate: PropTypes.func.isRequired,
-};
-
-ThemesMagicSearchCard.defaultProps = {
-	tier: 'all',
-};
 
 export default connect( state => ( {
 	filters: getThemeFilters( state ),

--- a/client/my-sites/themes/themes-magic-search-card/index.jsx
+++ b/client/my-sites/themes/themes-magic-search-card/index.jsx
@@ -309,6 +309,7 @@ class ThemesMagicSearchCard extends React.Component {
 				<StickyPanel>
 					<div
 						className={ themesSearchCardClass }
+						role="presentation"
 						data-tip-target="themes-search-card"
 						onClick={ this.handleClickInside }
 					>
@@ -334,7 +335,7 @@ class ThemesMagicSearchCard extends React.Component {
 						) }
 					</div>
 				</StickyPanel>
-				<div onClick={ this.handleClickInside }>
+				<div role="presentation" onClick={ this.handleClickInside }>
 					{ renderSuggestions && (
 						<KeyedSuggestions
 							ref={ partial( this.setSuggestionsRefs, 'suggestions' ) }


### PR DESCRIPTION
Implements an improvement discovered when working on #32139 (and is a spinoff from that big PR).

Instead of setting up debounced listeners for `window.resize`, use the recently added `withMobileBreakpoint` HOC that does the same thing, but more concisely and better.

There are few other commits with things like ESLint cleanups. Read the commit messages to see what they do.

**How to test:**
Go to `/themes` and focus the search box. Then verify that when the viewport is wider than the 480px mobile breakpoint, the search box shows an inline segmented control with "price tiers":

<img width="540" alt="Screenshot 2019-04-09 at 11 26 20" src="https://user-images.githubusercontent.com/664258/55789442-a464d800-5aba-11e9-821c-d57dea9ecd6f.png">

When the viewport width is smaller than the 480px mobile breakpoint, the segmented control should not be visible:

<img width="449" alt="Screenshot 2019-04-09 at 11 26 38" src="https://user-images.githubusercontent.com/664258/55789490-bba3c580-5aba-11e9-8739-db9bda318b7a.png">
