### PR TITLE
Run tests only for packages that have a Jest config

### DIFF
--- a/test/packages/jest.config.js
+++ b/test/packages/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
 	rootDir: './../../',
-	projects: [ '<rootDir>/packages/*' ],
+	// run tests for all packages that have a Jest config file
+	projects: [ '<rootDir>/packages/*/jest.config.js' ],
 };


### PR DESCRIPTION
Avoids the following issue:
1. Have an empty `packages/foo` directory that doesn't have a `jest.config.js` or `package.json`.
2. Because `package/foo` matches the `projects` field in the `packages/jest.config.js`, Jest will try to read a config for it.
3. Jest searches for a config by going up the project's path, looking for `jest.config.js` and `package.json`, and stopping only at the repo's root directory.
4. It finds the Calypso's root `package.json`
5. Because there's no `jest` field there, `packages/foo` Jest config will default to the defaults:

```js
{
  rootDir: '/Users/jsnajdr/src/wp-calypso',
  testMatch: [ '**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[tj]s?(x)' ],
  testPathIgnorePatterns: [NODE_MODULES_REGEXP],
}
```

6. The two files that match are:
```
client/state/data-layer/wpcom-http/pipeline/test/test.js
client/components/plans/plan-icon/test/test.jsx
```

7. The `packages/foo` tests trigger tests from Calypso client! Very unexpected.

These tests will fail to find imports like:
```js
import abtests from 'lib/abtests';
```
because the Jest config doesn't specify module paths, unlike the client config:
```
modulePaths: [ '<rootDir>/client/' ]
```

**How to test:**
1. Create empty directory `packages/ghost`
2. Verify that `npm run test-packages` fails without this PR, and succeeds with it.