### PR TITLE
Themes: use Main as top-level element, remove z-index workarounds

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -72,8 +72,6 @@ $z-layers: (
 		'.stats-popular__empty': 1,
 		'.people-list-item__label': 1,
 		'.is-actionable .theme__thumbnail-label': 1,
-		'.is-section-themes.focus-sidebar #secondary': 1,
-		'.is-section-themes.focus-sites #secondary': 1,
 		'.accessible-focus .current-theme__button:focus': 1,
 		'.signup-processing-screen__processing-step.is-processing:before': 1,
 		'.accessible-focus .theme__more-button button:focus': 1,

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -9,20 +9,25 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Main from 'components/main';
 import ThemeShowcase from './theme-showcase';
 import { connectOptions } from './theme-options';
 
 const ConnectedThemeShowcase = connectOptions( ThemeShowcase );
 
 export default props => (
-	<ConnectedThemeShowcase
-		{ ...props }
-		origin="wpcom"
-		defaultOption="signup"
-		getScreenshotOption={ function() {
-			return 'info';
-		} }
-		source="showcase"
-		showUploadButton={ false }
-	/>
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	<Main className="themes">
+		<ConnectedThemeShowcase
+			{ ...props }
+			origin="wpcom"
+			defaultOption="signup"
+			getScreenshotOption={ function() {
+				return 'info';
+			} }
+			source="showcase"
+			showUploadButton={ false }
+		/>
+	</Main>
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -9,18 +9,21 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThemesSiteSelectorModal from './themes-site-selector-modal';
 import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
 const MultiSiteThemeShowcase = connectOptions( props => (
-	<div>
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	<Main className="themes">
 		<SidebarNavigation />
 		<ThemesSiteSelectorModal { ...props }>
 			<ThemeShowcase source="showcase" showUploadButton={ false } />
 		</ThemesSiteSelectorModal>
-	</div>
+	</Main>
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 ) );
 
 export default props => (

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import Main from 'components/main';
 import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -86,7 +87,8 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 	}
 
 	return (
-		<div>
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		<Main className="themes">
 			<SidebarNavigation />
 			<CurrentTheme siteId={ siteId } />
 			{ ! requestingSitePlans && ! hasUnlimitedPremiumThemes && (
@@ -142,7 +144,8 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 					</div>
 				) }
 			</ThemeShowcase>
-		</div>
+		</Main>
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);
 } );
 

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import Main from 'components/main';
 import CurrentTheme from 'my-sites/themes/current-theme';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ThanksModal from 'my-sites/themes/thanks-modal';
@@ -65,7 +66,8 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 		}
 	}
 	return (
-		<div>
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		<Main className="themes">
 			<SidebarNavigation />
 			<CurrentTheme siteId={ siteId } />
 			{ bannerLocationBelowSearch ? null : upsellBanner }
@@ -80,7 +82,8 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 				{ siteId && <QuerySitePurchases siteId={ siteId } /> }
 				<ThanksModal source={ 'list' } />
 			</ThemeShowcase>
-		</div>
+		</Main>
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);
 } );
 

--- a/client/my-sites/themes/style.scss
+++ b/client/my-sites/themes/style.scss
@@ -58,10 +58,9 @@
 }
 
 .themes__thanks-modal-loading {
-	min-height: 50px;
+	min-height: 90px;
 	display: flex;
 	align-items: center;
-	min-height: 90px;
 
 	.pulsing-dot {
 		margin: 0 auto;
@@ -145,10 +144,4 @@
 	@include banner-dark();
 	margin-top: 15px;
 	margin-bottom: 15px;
-}
-
-// prevent themes panel from appearing on top of the sidebar when you click back
-.is-section-themes.focus-sidebar #secondary,
-.is-section-themes.focus-sites #secondary {
-	z-index: z-index( 'root', '.is-section-themes.focus-sidebar #secondary' );
 }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -16,7 +16,6 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
-import Main from 'components/main';
 import Button from 'components/button';
 import ThemesSelection from './themes-selection';
 import SubMasterbarNav from 'components/sub-masterbar-nav';
@@ -94,7 +93,7 @@ class ThemeShowcase extends React.Component {
 	};
 
 	doSearch = searchBoxContent => {
-		const filterRegex = /([\w-]*)\:([\w-]*)/g;
+		const filterRegex = /([\w-]*):([\w-]*)/g;
 		const { filterToTermTable } = this.props;
 
 		const filters = searchBoxContent.match( filterRegex ) || [];
@@ -221,8 +220,7 @@ class ThemeShowcase extends React.Component {
 
 		// FIXME: Logged-in title should only be 'Themes'
 		return (
-			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-			<Main className="themes">
+			<div>
 				<DocumentHead title={ title } meta={ metas } link={ links } />
 				<PageViewTracker
 					path={ this.props.analyticsPath }
@@ -300,7 +298,7 @@ class ThemeShowcase extends React.Component {
 					<ThemePreview />
 					{ this.props.children }
 				</div>
-			</Main>
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
In #26179, @jancavan fixed an issue where parts of a Theme Showcase UI would overlap the sidebar on mobile:

![screenshot 2018-07-18 14 18 24](https://user-images.githubusercontent.com/4924246/42908523-0595a9c4-8a96-11e8-9c3b-80400f344bd5.png)

The fix, however, didn't address the root cause, but rather patched over it with z-index overrides.

The reason why the UI overlaps the sidebar is that it's not wrapped in the `<Main>` component:

Wrong markup:
```
<div>
  <SidebarNavigation />
  <CurrentTheme />
  <UpsellBanner />
  <Main>
    <ThemeShowcase />
  </Main>
</div>
```

When sidebar or site picker is shown, there is a `main.main` CSS rule that slides the `<main>` content to the right by applying a `transform: translateX( 100% )` style. When there are components outside the `<main>`, they don't slide away.

The correct markup:
```
<Main>
  <SidebarNavigation />
  <CurrentTheme />
  <UpsellBanner />
  <ThemeShowcase />
</Main>
```

This PR does exactly this correction of the component hierarchy and removes the `z-index` overrides.

Found when working on the Themes CSS migration in #32139.