### PR TITLE
Jetpack Checklist: Implement Jetpack Backups task

### DIFF
--- a/client/layout/guided-tours/all-tours.js
+++ b/client/layout/guided-tours/all-tours.js
@@ -21,6 +21,7 @@ import { ChecklistSiteIconTour } from 'layout/guided-tours/tours/checklist-site-
 import { ChecklistSiteTaglineTour } from 'layout/guided-tours/tours/checklist-site-tagline-tour';
 import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site-title-tour';
 import { ChecklistUserAvatarTour } from 'layout/guided-tours/tours/checklist-user-avatar-tour';
+import { JetpackBackupsRewindTour } from 'layout/guided-tours/tours/jetpack-backups-rewind-tour';
 import { JetpackBasicTour } from 'layout/guided-tours/tours/jetpack-basic-tour';
 import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
 import { JetpackPluginUpdatesTour } from 'layout/guided-tours/tours/jetpack-plugin-updates-tour';
@@ -40,6 +41,7 @@ export default combineTours( {
 	checklistSiteTitle: ChecklistSiteTitleTour,
 	checklistUserAvatar: ChecklistUserAvatarTour,
 	jetpack: JetpackBasicTour,
+	jetpackBackupsRewind: JetpackBackupsRewindTour,
 	jetpackMonitoring: JetpackMonitoringTour,
 	jetpackPluginUpdates: JetpackPluginUpdatesTour,
 	jetpackSignIn: JetpackSignInTour,

--- a/client/layout/guided-tours/config-elements/site-link.js
+++ b/client/layout/guided-tours/config-elements/site-link.js
@@ -20,10 +20,12 @@ class SiteLink extends Component {
 	static propTypes = {
 		href: PropTypes.string,
 		isButton: PropTypes.bool,
+		isPrimaryButton: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isButton: false,
+		isPrimaryButton: true,
 	};
 
 	static contextTypes = contextTypes;
@@ -35,12 +37,12 @@ class SiteLink extends Component {
 	};
 
 	render() {
-		const { children, href, siteSlug, isButton } = this.props;
+		const { children, href, siteSlug, isButton, isPrimaryButton } = this.props;
 		const siteHref = href.replace( ':site', siteSlug );
 
 		if ( isButton ) {
 			return (
-				<Button primary onClick={ this.onClick } href={ siteHref }>
+				<Button primary={ isPrimaryButton } onClick={ this.onClick } href={ siteHref }>
 					{ children }
 				</Button>
 			);

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -124,10 +124,15 @@
 	.button {
 		min-width: 48%;
 	}
-	.guided-tours__quit-button {
+	.guided-tours__quit-button,
+	a.button {
 		color: var( --color-neutral-100 );
 		background: none;
 		border: 1px rgba( var( --color-white-rgb ), 0.2 ) solid;
+	}
+
+	a.button {
+		text-decoration: none;
 	}
 }
 

--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -29,6 +29,15 @@ function whenWeCanAutoconfigure( state ) {
 	return canAutoconfigure || credentials.some( c => c.type === 'auto' );
 }
 
+const JetpackBackupsRewindTourButtons = ( { backText, translate } ) => (
+	<Fragment>
+		<SiteLink isButton href="/plans/my-plan/:site">
+			{ backText || translate( 'Return to the checklist' ) }
+		</SiteLink>
+		<Quit>{ translate( 'No, thanks.' ) }</Quit>
+	</Fragment>
+);
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackBackupsRewindTour = makeTour(
 	<Tour { ...meta }>
@@ -57,10 +66,7 @@ export const JetpackBackupsRewindTour = makeTour(
 							click
 							hidden
 						/>
-						<SiteLink href="/plans/my-plan/:site">
-							{ translate( 'Return to the checklist' ) }
-						</SiteLink>
-						<Quit>{ translate( 'No, thanks.' ) }</Quit>
+						<JetpackBackupsRewindTourButtons translate={ translate } />
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -91,10 +97,7 @@ export const JetpackBackupsRewindTour = makeTour(
 								click
 								hidden
 							/>
-							<SiteLink href="/plans/my-plan/:site">
-								{ translate( 'Return to the checklist' ) }
-							</SiteLink>
-							<Quit>{ translate( 'No, thanks.' ) }</Quit>
+							<JetpackBackupsRewindTourButtons translate={ translate } />
 						</ButtonRow>
 					</ConditionalBlock>
 					<ConditionalBlock when={ not( whenWeCanAutoconfigure ) }>
@@ -110,10 +113,7 @@ export const JetpackBackupsRewindTour = makeTour(
 								click
 								hidden
 							/>
-							<SiteLink href="/plans/my-plan/:site">
-								{ translate( 'Return to the checklist' ) }
-							</SiteLink>
-							<Quit>{ translate( 'No, thanks.' ) }</Quit>
+							<JetpackBackupsRewindTourButtons translate={ translate } />
 						</ButtonRow>
 					</ConditionalBlock>
 				</Fragment>
@@ -149,10 +149,10 @@ export const JetpackBackupsRewindTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href="/plans/my-plan/:site">
-							{ translate( "Yes, let's do it." ) }
-						</SiteLink>
-						<Quit>{ translate( 'No thanks.' ) }</Quit>
+						<JetpackBackupsRewindTourButtons
+							translate={ translate }
+							backText={ translate( "Yes, let's do it." ) }
+						/>
 					</ButtonRow>
 				</Fragment>
 			) }

--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -41,16 +41,7 @@ const JetpackBackupsRewindTourButtons = ( { backText, translate } ) => (
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackBackupsRewindTour = makeTour(
 	<Tour { ...meta }>
-		<Step
-			name="init"
-			target=".credentials-setup-flow"
-			placement="beside"
-			arrow="right-top"
-			style={ {
-				animationDelay: '0.7s',
-				zIndex: 1,
-			} }
-		>
+		<Step name="init" target=".credentials-setup-flow" placement="beside" arrow="right-top">
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>
@@ -77,10 +68,6 @@ export const JetpackBackupsRewindTour = makeTour(
 			target=".credentials-setup-flow__tos .is-primary"
 			placement="beside"
 			arrow="right-top"
-			style={ {
-				animationDelay: '0.7s',
-				zIndex: 1,
-			} }
 		>
 			{ ( { translate } ) => (
 				<Fragment>

--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -68,30 +68,53 @@ export const JetpackBackupsRewindTour = makeTour(
 
 		<Step
 			name="autoconfigureOrConfirm"
-			target=".credentials-setup-flow__tos"
+			target=".credentials-setup-flow__tos .is-primary"
 			placement="beside"
 			arrow="right-top"
 			style={ {
-				display: 'none',
+				animationDelay: '0.7s',
+				zIndex: 1,
 			} }
 		>
-			{ () => (
+			{ ( { translate } ) => (
 				<Fragment>
 					<ConditionalBlock when={ whenWeCanAutoconfigure }>
-						<Continue
-							target=".credentials-setup-flow__tos-buttons .is-primary"
-							step="finish"
-							click
-							hidden
-						/>
+						<p>
+							{ translate(
+								"You can click this button to provide WordPress.com with access to your host's server."
+							) }
+						</p>
+						<ButtonRow>
+							<Continue
+								target=".credentials-setup-flow__tos-buttons .is-primary"
+								step="finish"
+								click
+								hidden
+							/>
+							<SiteLink href="/plans/my-plan/:site">
+								{ translate( 'Return to the checklist' ) }
+							</SiteLink>
+							<Quit>{ translate( 'No, thanks.' ) }</Quit>
+						</ButtonRow>
 					</ConditionalBlock>
 					<ConditionalBlock when={ not( whenWeCanAutoconfigure ) }>
-						<Continue
-							target=".credentials-setup-flow__tos-buttons .is-primary"
-							step="credentials"
-							click
-							hidden
-						/>
+						<p>
+							{ translate(
+								'You can click the button in order to agree and continue to the credentials form.'
+							) }
+						</p>
+						<ButtonRow>
+							<Continue
+								target=".credentials-setup-flow__tos-buttons .is-primary"
+								step="credentials"
+								click
+								hidden
+							/>
+							<SiteLink href="/plans/my-plan/:site">
+								{ translate( 'Return to the checklist' ) }
+							</SiteLink>
+							<Quit>{ translate( 'No, thanks.' ) }</Quit>
+						</ButtonRow>
 					</ConditionalBlock>
 				</Fragment>
 			) }
@@ -111,7 +134,7 @@ export const JetpackBackupsRewindTour = makeTour(
 			) }
 		</Step>
 
-		<Step name="finish" target=".credentials-configured" placement="beside" arrow="right-top">
+		<Step name="finish" target=".credentials-configured" placement="right">
 			{ ( { translate } ) => (
 				<Fragment>
 					<h1 className="tours__title">

--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -7,6 +7,7 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
+import getJetpackCredentialsUpdateStatus from 'state/selectors/get-jetpack-credentials-update-status';
 import getRewindState from 'state/selectors/get-rewind-state';
 import meta from './meta';
 import {
@@ -27,6 +28,12 @@ function whenWeCanAutoconfigure( state ) {
 	const { canAutoconfigure, credentials = [] } = getRewindState( state, siteId );
 
 	return canAutoconfigure || credentials.some( c => c.type === 'auto' );
+}
+
+// @ TODO: debug why this doesn't listen to state changes properly
+function siteHasCredentials( state ) {
+	const siteId = getSelectedSiteId( state );
+	return getJetpackCredentialsUpdateStatus( state, siteId ) === 'success';
 }
 
 const JetpackBackupsRewindTourButtons = ( { backText, translate } ) => (
@@ -66,8 +73,8 @@ export const JetpackBackupsRewindTour = makeTour(
 		<Step
 			name="autoconfigureOrConfirm"
 			target=".credentials-setup-flow__tos .is-primary"
-			placement="beside"
-			arrow="right-top"
+			placement="below"
+			arrow="top-left"
 		>
 			{ ( { translate } ) => (
 				<Fragment>
@@ -117,7 +124,13 @@ export const JetpackBackupsRewindTour = makeTour(
 			} }
 		>
 			{ () => (
-				<Continue target=".rewind-credentials-form .is-primary" step="finish" click hidden />
+				<Continue
+					target=".rewind-credentials-form .is-primary"
+					step="finish"
+					when={ siteHasCredentials }
+					click
+					hidden
+				/>
 			) }
 		</Step>
 

--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -1,0 +1,138 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import getRewindState from 'state/selectors/get-rewind-state';
+import meta from './meta';
+import {
+	ButtonRow,
+	ConditionalBlock,
+	Continue,
+	makeTour,
+	Quit,
+	SiteLink,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+import { not } from 'layout/guided-tours/utils';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+function whenWeCanAutoconfigure( state ) {
+	const siteId = getSelectedSiteId( state );
+	const { canAutoconfigure, credentials = [] } = getRewindState( state, siteId );
+
+	return canAutoconfigure || credentials.some( c => c.type === 'auto' );
+}
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+export const JetpackBackupsRewindTour = makeTour(
+	<Tour { ...meta }>
+		<Step
+			name="init"
+			target=".credentials-setup-flow"
+			placement="beside"
+			arrow="right-top"
+			style={ {
+				animationDelay: '0.7s',
+				zIndex: 1,
+			} }
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"Let's enable Jetpack backups and restores " +
+								'by adding access credentials for your site.'
+						) }
+					</p>
+					<ButtonRow>
+						<Continue
+							target=".credentials-setup-flow__setup-start"
+							step="autoconfigureOrConfirm"
+							click
+							hidden
+						/>
+						<SiteLink href="/plans/my-plan/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
+						<Quit>{ translate( 'No, thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step
+			name="autoconfigureOrConfirm"
+			target=".credentials-setup-flow__tos"
+			placement="beside"
+			arrow="right-top"
+			style={ {
+				display: 'none',
+			} }
+		>
+			{ () => (
+				<Fragment>
+					<ConditionalBlock when={ whenWeCanAutoconfigure }>
+						<Continue
+							target=".credentials-setup-flow__tos-buttons .is-primary"
+							step="finish"
+							click
+							hidden
+						/>
+					</ConditionalBlock>
+					<ConditionalBlock when={ not( whenWeCanAutoconfigure ) }>
+						<Continue
+							target=".credentials-setup-flow__tos-buttons .is-primary"
+							step="credentials"
+							click
+							hidden
+						/>
+					</ConditionalBlock>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step
+			name="credentials"
+			target=".rewind-credentials-form"
+			placement="beside"
+			arrow="right-top"
+			style={ {
+				display: 'none',
+			} }
+		>
+			{ () => (
+				<Continue target=".rewind-credentials-form .is-primary" step="finish" click hidden />
+			) }
+		</Step>
+
+		<Step name="finish" target=".credentials-configured" placement="beside" arrow="right-top">
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Excellent, you’re done!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Jetpack Backups has been enabled. Would you like to continue setting up the security essential features for your site?'
+						) }
+					</p>
+					<ButtonRow>
+						<SiteLink isButton href="/plans/my-plan/:site">
+							{ translate( "Yes, let's do it." ) }
+						</SiteLink>
+						<Quit>{ translate( 'No thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -3,6 +3,7 @@
  */
 import React, { Fragment } from 'react';
 import Gridicon from 'gridicons';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -30,12 +31,6 @@ function whenWeCanAutoconfigure( state ) {
 	return canAutoconfigure || credentials.some( c => c.type === 'auto' );
 }
 
-// @ TODO: debug why this doesn't listen to state changes properly
-function siteHasCredentials( state ) {
-	const siteId = getSelectedSiteId( state );
-	return getJetpackCredentialsUpdateStatus( state, siteId ) === 'success';
-}
-
 const JetpackBackupsRewindTourButtons = ( { backText, translate } ) => (
 	<Fragment>
 		<SiteLink isButton href="/plans/my-plan/:site">
@@ -44,6 +39,20 @@ const JetpackBackupsRewindTourButtons = ( { backText, translate } ) => (
 		<Quit>{ translate( 'No, thanks.' ) }</Quit>
 	</Fragment>
 );
+
+const ContinueToLastStep = ( { siteHasCredentials } ) => (
+	<Continue
+		target=".rewind-credentials-form .is-primary"
+		step="finish"
+		when={ () => siteHasCredentials }
+		click
+		hidden
+	/>
+);
+const ConnectedContinueToLastStep = connect( state => ( {
+	siteHasCredentials:
+		getJetpackCredentialsUpdateStatus( state, getSelectedSiteId( state ) ) === 'success',
+} ) )( ContinueToLastStep );
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackBackupsRewindTour = makeTour(
@@ -123,15 +132,7 @@ export const JetpackBackupsRewindTour = makeTour(
 				display: 'none',
 			} }
 		>
-			{ () => (
-				<Continue
-					target=".rewind-credentials-form .is-primary"
-					step="finish"
-					when={ siteHasCredentials }
-					click
-					hidden
-				/>
-			) }
+			{ () => <ConnectedContinueToLastStep /> }
 		</Step>
 
 		<Step name="finish" target=".credentials-configured" placement="right">

--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -33,7 +33,7 @@ function whenWeCanAutoconfigure( state ) {
 
 const JetpackBackupsRewindTourButtons = ( { backText, translate } ) => (
 	<Fragment>
-		<SiteLink isButton href="/plans/my-plan/:site">
+		<SiteLink isButton isPrimaryButton={ false } href="/plans/my-plan/:site">
 			{ backText || translate( 'Return to the checklist' ) }
 		</SiteLink>
 		<Quit>{ translate( 'No, thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/meta.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/meta.js
@@ -1,0 +1,4 @@
+export default {
+	name: 'jetpackBackupsRewind',
+	version: '20190409',
+};

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -14,16 +14,6 @@ export function getJetpackChecklistTaskDuration( minutes ) {
 }
 
 export const JETPACK_CHECKLIST_TASKS = {
-	jetpack_backups: {
-		title: translate( 'Backups & Scanning' ),
-		description: translate(
-			"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
-		),
-		completedButtonText: translate( 'Change', { context: 'verb' } ),
-		completedTitle: translate( 'You turned on backups and scanning.' ),
-		getUrl: siteSlug => `/activity-log/${ siteSlug }`,
-		duration: getJetpackChecklistTaskDuration( 2 ),
-	},
 	jetpack_monitor: {
 		title: translate( 'Downtime Monitoring' ),
 		description: translate(
@@ -57,4 +47,20 @@ export const JETPACK_CHECKLIST_TASKS = {
 		duration: getJetpackChecklistTaskDuration( 3 ),
 		tourId: 'jetpackSignIn',
 	},
+};
+
+export const JETPACK_CHECKLIST_TASK_BACKUPS_REWIND = {
+	title: translate( 'Backups & Scanning' ),
+	description: translate(
+		"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
+	),
+	completedButtonText: translate( 'Change', { context: 'verb' } ),
+	completedTitle: translate( 'You turned on backups and scanning.' ),
+	getUrl: siteSlug => `/settings/security/${ siteSlug }`,
+	duration: getJetpackChecklistTaskDuration( 3 ),
+};
+
+export const JETPACK_CHECKLIST_TASK_BACKUPS_VAULTPRESS = {
+	title: translate( "We're automatically turning on backups and scanning." ),
+	completedTitle: translate( "We've automatically turned on backups and scanning." ),
 };

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -52,7 +52,7 @@ export const JETPACK_CHECKLIST_TASKS = {
 export const JETPACK_CHECKLIST_TASK_BACKUPS_REWIND = {
 	title: translate( 'Backup and Scan' ),
 	description: translate(
-		"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
+		"Connect your site's server to Jetpack to perform backups, restores, and security scans."
 	),
 	completedButtonText: translate( 'Change', { context: 'verb' } ),
 	completedTitle: translate( 'You turned on backups and scanning.' ),

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -50,7 +50,7 @@ export const JETPACK_CHECKLIST_TASKS = {
 };
 
 export const JETPACK_CHECKLIST_TASK_BACKUPS_REWIND = {
-	title: translate( 'Backups & Scanning' ),
+	title: translate( 'Backup and Scan' ),
 	description: translate(
 		"Connect your site's server to Jetpack to perform backups, rewinds, and security scans."
 	),

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -55,7 +55,7 @@ export const JETPACK_CHECKLIST_TASK_BACKUPS_REWIND = {
 		"Connect your site's server to Jetpack to perform backups, restores, and security scans."
 	),
 	completedButtonText: translate( 'Change', { context: 'verb' } ),
-	completedTitle: translate( 'You turned on backups and scanning.' ),
+	completedTitle: translate( 'You turned on Backup and Scan.' ),
 	getUrl: siteSlug => `/settings/security/${ siteSlug }`,
 	duration: getJetpackChecklistTaskDuration( 3 ),
 };

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -61,6 +61,6 @@ export const JETPACK_CHECKLIST_TASK_BACKUPS_REWIND = {
 };
 
 export const JETPACK_CHECKLIST_TASK_BACKUPS_VAULTPRESS = {
-	title: translate( "We're automatically turning on backups and scanning." ),
-	completedTitle: translate( "We've automatically turned on backups and scanning." ),
+	title: translate( "We're automatically turning on Backup and Scan." ),
+	completedTitle: translate( "We've automatically turned on Backup and Scan." ),
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Implements the Jetpack Backups task for all use cases.

#### Previews

Note: primary buttons in the guided tour steps are no longer primary, and there might be small textual changes as feedback is addressed in the PR.

Pre-Rewind sites install and configure backups (VaultPress) automatically:
![](https://cldup.com/sINyGmEX3D.png)

Rewind sites require credentials, so there's a manual task for that:
![](https://cldup.com/Q63POyn9MH.png)

Clicking the "Do it" button leads to the Security Settings page:
![](https://cldup.com/9I5pupUdvx.png)

Clicking the "Add site credentials" button displays a confirmation section if the credentials have to be input manually:
![](https://cldup.com/kX2jQhCzuz.png)

Clicking the "Add site credentials" button displays a confirmation section if the credentials can be auto-provisioned (for example in Pressable):
![](https://cldup.com/WUt2goQ1EC.png)

After inputting credentials or auto-provisioning them successfuly, user gets a success message and a nudge to go back:
![](https://cldup.com/_Nz2NYAgrg.png)

Users can use the checklist to change credentials if they want:
![](https://cldup.com/6GdMysRgZZ.png)

Users can't do anything with the VP task, it's passive:
![](https://cldup.com/DQWd-hPdzb.png)

#### Testing instructions

* Checkout this branch or spin it up on calypso.live.
* Start a new Jurassic Ninja site with the latest bleeding edge and connect it to WP.com, pick the free plan.
* Open `/plans/:site` where `:site` is the slug of your site.
* Buy a Premium or Professional plan.
* Wait for the setup to finish, and verify that the Backups task is automatically setup - first displayed as "in progress", and when finished, displayed as "finished".
* Deactivate VaultPress from wp-admin.
* Go to VP MC and enable Rewind for that site.
* Go to `/plans/my-plan/:site` where `:site` is the slug of the site.
* Verify the "Backups & Scanning" task is now not done, and has a "Do it" button.
* Click the button.
* Verify the guided tour leads you to add credentials, as shown on the screenshots (for manual credentials entry).
* Verify the after you add credentials, and you click the button to go back to the checklist, the Backups and Scanning task is now displayed as complete.
* Pick a Pressable site.
* Go to `/settings/security/:site` where `:site` is the slug of the Pressable site.
* If you already have credentials for backups, click the green icon to edit them, and click "Revoke credentials" to remove them.
* Go to `/plans/my-plan/:site` where `:site` is the slug of the site.
* Verify the "Backups & Scanning" task is now not done, and has a "Do it" button.
* Click the button.
* Verify the guided tour leads you to add credentials, as shown on the screenshots (for auto provisioning).
* Verify the after credentials are auto-provisioned, and you click the button to go back to the checklist, the Backups and Scanning task is now displayed as complete.
