### PR TITLE
Packages: Add node-sass dep to calypso-build

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -34,6 +34,7 @@
 				"css-loader": "2.1.1",
 				"duplicate-package-checker-webpack-plugin": "3.0.0",
 				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
+				"node-sass": "4.11.0",
 				"postcss-custom-properties": "8.0.9",
 				"postcss-loader": "3.0.0",
 				"sass-loader": "7.1.0",
@@ -2100,9 +2101,9 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.23.2",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.23.2.tgz",
-			"integrity": "sha512-ZxiZMaCuqBG/IsbgNRVfGwYsvBb5DjHuMGjJgOrinT+/b+1j1U7PiGyRkHDJdjTGA6N/PsMC2lP2ZybX9579iA==",
+			"version": "16.23.3",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.23.3.tgz",
+			"integrity": "sha512-kwL6gtvWC5j9mXK9O6V7wCwdGDUIoT2im1CfExqCunOHTcs4SPC1V29ajAPJ5sz2sErt0abiQzGORZBZ4GVbEw==",
 			"requires": {
 				"@octokit/request": "2.4.2",
 				"atob-lite": "^2.0.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -44,6 +44,7 @@
 		"css-loader": "2.1.1",
 		"duplicate-package-checker-webpack-plugin": "3.0.0",
 		"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
+		"node-sass": "4.11.0",
 		"postcss-custom-properties": "8.0.9",
 		"postcss-loader": "3.0.0",
 		"sass-loader": "7.1.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "1.0.0-beta.0",
+	"version": "1.0.0-beta.1",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"config",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Discovered while working on https://github.com/Automattic/newspack-blocks/pull/6#issuecomment-481342808. Looks like `sass-loader` needs an npm implementing SASS (either `node-sass` or `sass`) to be present, see https://github.com/webpack-contrib/sass-loader:

> By default the loader resolve the implementation based on your dependencies. Just add required implementation to `package.json` (`node-sass` or `sass` package) and install dependencies.

#### Testing instructions

Can't really test here. I was `npm link`ing to `newspack-blocks` before, but didn't really run into this error. Either I did something wrong, or we just have to release a new version of `calypso-build` and try it with `newspack-blocks` to see if it works.