### PR TITLE
Replace editor dependency with block-editor

### DIFF
--- a/apps/o2-blocks/package.json
+++ b/apps/o2-blocks/package.json
@@ -22,9 +22,9 @@
 		"build": "webpack --config='../../packages/calypso-build/webpack.config.js' --output-path='./dist' --env.WP='true' editor='./src/editor.js' "
 	},
 	"dependencies": {
+		"@wordpress/block-editor": "1.0.0",
 		"@wordpress/blocks": "6.0.7",
 		"@wordpress/components": "7.0.8",
-		"@wordpress/editor": "9.0.11",
 		"@wordpress/element": "2.1.9",
 		"@wordpress/i18n": "3.1.1",
 		"classnames": "2.2.6"

--- a/apps/o2-blocks/src/editor-notes/editor.js
+++ b/apps/o2-blocks/src/editor-notes/editor.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { RichText } from '@wordpress/editor';
+import { RichText } from '@wordpress/block-editor';
 
 import './editor.scss';
 

--- a/apps/o2-blocks/src/todo/editor.js
+++ b/apps/o2-blocks/src/todo/editor.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { Button, Dashicon } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
-import { RichText } from '@wordpress/editor';
+import { RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies

--- a/apps/o2-blocks/src/todo/item.js
+++ b/apps/o2-blocks/src/todo/item.js
@@ -5,7 +5,7 @@
  */
 import { Button, Dashicon } from '@wordpress/components';
 import { Component } from '@wordpress/element';
-import { RichText } from '@wordpress/editor';
+import { RichText } from '@wordpress/block-editor';
 
 export const ItemEditor = class extends Component {
 	constructor() {


### PR DESCRIPTION
Once WP 5.2 is out and `@wordpress/block-editor` published, this can be merged:

https://make.wordpress.org/core/2019/04/09/the-block-editor-javascript-module-in-5-2/

#### Changes proposed in this Pull Request

* Switch `@wordpress/editor` dependency to `@wordpress/block-editor`

#### Testing instructions

Build blocks:
```
npx lerna run build --scope="*/o2-blocks
```

Place `editor.js` and `editor.css` to Jetpack in `_inc/blocks` and observe a few extra internal. blocks appear when Jetpack is connected.