### PR TITLE
Refactor G Suite Purchase CTA

### DIFF
--- a/client/my-sites/activity/activity-log-tasklist/update.jsx
+++ b/client/my-sites/activity/activity-log-tasklist/update.jsx
@@ -75,8 +75,7 @@ class ActivityLogTaskUpdate extends Component {
 				</span>
 				<span className="activity-log-tasklist__update-action">
 					<SplitButton
-						compact
-						primary
+						compact					
 						label={ translate( 'Update' ) }
 						onClick={ this.handleEnqueue }
 						disabled={ disable }

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -97,7 +97,7 @@ class EmailManagement extends React.Component {
 		if ( domainList.some( hasGSuite ) ) {
 			return this.googleAppsUsersCard();
 		} else if ( hasGSuiteSupportedDomain( domainList ) ) {
-			return this.addGSuiteCta( getEligibleGSuiteDomain( selectedDomainName, domainList ) );
+			return this.addGSuiteCta();
 		} else if ( emailForwardingDomain && isGSuiteRestricted() && selectedDomainName ) {
 			return this.addEmailForwardingCard( emailForwardingDomain );
 		}
@@ -154,12 +154,13 @@ class EmailManagement extends React.Component {
 		);
 	}
 
-	addGSuiteCta( domainName ) {
+	addGSuiteCta() {
 		const { domains, selectedDomainName } = this.props;
 		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
+		const gsuiteDomainName = getEligibleGSuiteDomain( selectedDomainName, domains );
 		return (
 			<Fragment>
-				<GSuitePurchaseCta domainName={ domainName } />
+				<GSuitePurchaseCta domainName={ gsuiteDomainName } />
 				{ emailForwardingDomain && this.addEmailForwardingCard( emailForwardingDomain ) }
 			</Fragment>
 		);

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -89,7 +89,7 @@ class EmailManagement extends React.Component {
 	content() {
 		const { domains, gsuiteUsers, isRequestingDomains, selectedDomainName } = this.props;
 		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
-		if ( ! ( ! isRequestingDomains && null !== gsuiteUsers ) ) {
+		if ( isRequestingDomains || ! gsuiteUsers ) {
 			return <Placeholder />;
 		}
 		const domainList = selectedDomainName ? [ getSelectedDomain( this.props ) ] : domains;

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { Fragment } from 'react';
 import page from 'page';
@@ -18,11 +17,8 @@ import Header from 'my-sites/domains/domain-management/components/header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { hasGSuite, isGSuiteRestricted, hasGSuiteSupportedDomain } from 'lib/domains/gsuite';
 import { getEligibleEmailForwardingDomain } from 'lib/domains/email-forwarding';
-import { getAnnualPrice } from 'lib/google-apps';
 import getGSuiteUsers from 'state/selectors/get-gsuite-users';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
-import { getProductsList } from 'state/products-list/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import GSuitePurchaseCta from 'my-sites/email/gsuite-purchase-cta';
 import GSuiteUsersCard from 'my-sites/email/email-management/gsuite-users-card';
@@ -38,22 +34,17 @@ import { isPlanFeaturesEnabled } from 'lib/plans';
 import DocumentHead from 'components/data/document-head';
 import QueryGSuiteUsers from 'components/data/query-gsuite-users';
 import QuerySiteDomains from 'components/data/query-site-domains';
-import QueryProductsList from 'components/data/query-products-list';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const gsuitePlanSlug = 'gapps'; // or gapps_unlimited - TODO make this dynamic
-
 class EmailManagement extends React.Component {
 	static propTypes = {
-		currencyCode: PropTypes.string,
 		domains: PropTypes.array.isRequired,
 		gsuiteUsers: PropTypes.array,
 		isRequestingDomains: PropTypes.bool.isRequired,
-		productsList: PropTypes.object,
 		selectedSiteId: PropTypes.number.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
 		selectedDomainName: PropTypes.string,
@@ -65,7 +56,6 @@ class EmailManagement extends React.Component {
 			<Main className="email-management" wideLayout={ isPlanFeaturesEnabled() }>
 				{ selectedSiteId && <QueryGSuiteUsers siteId={ selectedSiteId } /> }
 				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
-				<QueryProductsList />
 				<DocumentHead title={ this.props.translate( 'Email' ) } />
 				<SidebarNavigation />
 				{ this.headerOrPlansNavigation() }
@@ -92,21 +82,9 @@ class EmailManagement extends React.Component {
 	}
 
 	content() {
-		const {
-			domains,
-			gsuiteUsers,
-			isRequestingDomains,
-			selectedDomainName,
-			productsList,
-		} = this.props;
+		const { domains, gsuiteUsers, isRequestingDomains, selectedDomainName } = this.props;
 		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
-		if (
-			! (
-				! isRequestingDomains &&
-				null !== gsuiteUsers &&
-				get( productsList, [ gsuitePlanSlug ], false )
-			)
-		) {
+		if ( ! ( ! isRequestingDomains && null !== gsuiteUsers ) ) {
 			return <Placeholder />;
 		}
 		const domainList = selectedDomainName ? [ getSelectedDomain( this.props ) ] : domains;
@@ -172,17 +150,11 @@ class EmailManagement extends React.Component {
 	}
 
 	addGoogleAppsCard() {
-		const { currencyCode, domains, productsList, selectedDomainName } = this.props;
+		const { domains, selectedDomainName } = this.props;
 		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
-		const price = get( productsList, [ gsuitePlanSlug, 'prices', currencyCode ], 0 );
-		const annualPrice = getAnnualPrice( price, currencyCode );
 		return (
 			<Fragment>
-				<GSuitePurchaseCta
-					annualPrice={ annualPrice }
-					productSlug={ gsuitePlanSlug }
-					selectedDomainName={ selectedDomainName }
-				/>
+				<GSuitePurchaseCta selectedDomainName={ selectedDomainName } />
 				{ emailForwardingDomain && this.addEmailForwardingCard( emailForwardingDomain ) }
 			</Fragment>
 		);
@@ -213,11 +185,9 @@ export default connect(
 	state => {
 		const selectedSiteId = getSelectedSiteId( state );
 		return {
-			currencyCode: getCurrentUserCurrencyCode( state ),
 			domains: getDecoratedSiteDomains( state, selectedSiteId ),
 			gsuiteUsers: getGSuiteUsers( state, selectedSiteId ),
 			isRequestingDomains: isRequestingSiteDomains( state, selectedSiteId ),
-			productsList: getProductsList( state ),
 			selectedSiteId,
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 		};

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -15,7 +15,12 @@ import { localize } from 'i18n-calypso';
 import Main from 'components/main';
 import Header from 'my-sites/domains/domain-management/components/header';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import { hasGSuite, isGSuiteRestricted, hasGSuiteSupportedDomain } from 'lib/domains/gsuite';
+import {
+	hasGSuite,
+	isGSuiteRestricted,
+	hasGSuiteSupportedDomain,
+	getEligibleGSuiteDomain,
+} from 'lib/domains/gsuite';
 import { getEligibleEmailForwardingDomain } from 'lib/domains/email-forwarding';
 import getGSuiteUsers from 'state/selectors/get-gsuite-users';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
@@ -92,7 +97,7 @@ class EmailManagement extends React.Component {
 		if ( domainList.some( hasGSuite ) ) {
 			return this.googleAppsUsersCard();
 		} else if ( hasGSuiteSupportedDomain( domainList ) ) {
-			return this.addGoogleAppsCard();
+			return this.addGSuiteCta( getEligibleGSuiteDomain( selectedDomainName, domainList ) );
 		} else if ( emailForwardingDomain && isGSuiteRestricted() && selectedDomainName ) {
 			return this.addEmailForwardingCard( emailForwardingDomain );
 		}
@@ -149,12 +154,12 @@ class EmailManagement extends React.Component {
 		);
 	}
 
-	addGoogleAppsCard() {
+	addGSuiteCta( domainName ) {
 		const { domains, selectedDomainName } = this.props;
 		const emailForwardingDomain = getEligibleEmailForwardingDomain( selectedDomainName, domains );
 		return (
 			<Fragment>
-				<GSuitePurchaseCta selectedDomainName={ selectedDomainName } />
+				<GSuitePurchaseCta domainName={ domainName } />
 				{ emailForwardingDomain && this.addEmailForwardingCard( emailForwardingDomain ) }
 			</Fragment>
 		);

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -19,12 +19,10 @@ import { emailManagementAddGSuiteUsers } from 'my-sites/email/paths';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getAnnualPrice } from 'lib/google-apps';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getDomainsBySiteId } from 'state/sites/domains/selectors';
-import { getEligibleGSuiteDomain } from 'lib/domains/gsuite';
 import { getProductsList } from 'state/products-list/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 import GSuitePurchaseFeatures from 'my-sites/email/gsuite-purchase-features';
-import GSuitePurchaseCtaSkuInfo from './sku-info';
+import GSuitePurchaseCtaSkuInfo from 'my-sites/email/gsuite-purchase-cta/sku-info';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QueryProductsList from 'components/data/query-products-list';
 
@@ -112,19 +110,16 @@ class GSuitePurchaseCta extends Component {
 }
 
 GSuitePurchaseCta.propTypes = {
+	currencyCode: PropTypes.string.isRequired,
 	domainName: PropTypes.string.isRequired,
 	productsList: PropTypes.object,
-	selectedDomainName: PropTypes.string,
 	selectedSiteSlug: PropTypes.string.isRequired,
 };
 
 export default connect(
-	( state, { selectedDomainName } ) => {
-		const selectedSiteId = getSelectedSiteId( state );
-		const domains = getDomainsBySiteId( state, selectedSiteId );
+	state => {
 		return {
 			currencyCode: getCurrentUserCurrencyCode( state ),
-			domainName: getEligibleGSuiteDomain( selectedDomainName, domains ),
 			productsList: getProductsList( state ),
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 		};

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -31,9 +31,10 @@ import QueryProductsList from 'components/data/query-products-list';
 import './style.scss';
 
 class GSuitePurchaseCta extends Component {
-	goToAddGSuiteUsers = () => {
+	goToAddGSuiteUsers = planType => {
 		this.props.recordTracksEvent( 'calypso_email_gsuite_purchase_cta_get_gsuite_click', {
 			domain: this.props.domainName,
+			plan_type: planType,
 		} );
 
 		page( emailManagementAddGSuiteUsers( this.props.selectedSiteSlug, this.props.domainName ) );
@@ -81,7 +82,9 @@ class GSuitePurchaseCta extends Component {
 								<GSuitePurchaseCtaSkuInfo
 									annualPrice={ gsuiteBasicAnnualCost }
 									buttonText={ translate( 'Add G Suite' ) }
-									onButtonClick={ this.goToAddGSuiteUsers }
+									onButtonClick={ () => {
+										this.goToAddGSuiteUsers( 'basic' );
+									} }
 									showButton={ upgradeAvailable }
 								/>
 							</div>

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -4,134 +4,116 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
  */
-import Button from 'components/forms/form-button';
 import CompactCard from 'components/card/compact';
 import config from 'config';
-import { domainManagementAddGSuiteUsers } from 'my-sites/domains/paths';
+import { emailManagementAddGSuiteUsers } from 'my-sites/email/paths';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
+import { getAnnualPrice } from 'lib/google-apps';
+import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 import { getEligibleGSuiteDomain } from 'lib/domains/gsuite';
+import { getProductsList } from 'state/products-list/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import GSuitePurchaseFeatures from 'my-sites/email/gsuite-purchase-features';
+import GSuitePurchaseCtaSkuInfo from './sku-info';
+import { recordTracksEvent } from 'state/analytics/actions';
+import QueryProductsList from 'components/data/query-products-list';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-class GSuitePurchaseCta extends React.Component {
-	goToAddGoogleApps = () => {
-		page( domainManagementAddGSuiteUsers( this.props.selectedSiteSlug, this.props.domainName ) );
+class GSuitePurchaseCta extends Component {
+	goToAddGSuiteUsers = () => {
+		this.props.recordTracksEvent( 'calypso_email_gsuite_purchase_cta_get_gsuite_click', {
+			domain: this.props.domainName,
+		} );
+
+		page( emailManagementAddGSuiteUsers( this.props.selectedSiteSlug, this.props.domainName ) );
 	};
 
-	getPlanText() {
-		const { productSlug, translate } = this.props;
-		if ( 'gapps_unlimited' === productSlug ) {
-			return translate( 'Business' );
-		}
+	componentDidMount() {
+		this.props.recordTracksEvent( 'calypso_email_gsuite_purchase_cta_view', {
+			domain: this.props.domainName,
+		} );
 	}
 
-	renderCta() {
-		const { annualPrice, domainName, productSlug, translate } = this.props;
+	render() {
+		const { currencyCode, domainName, productsList, translate } = this.props;
 		const upgradeAvailable = config.isEnabled( 'upgrades/checkout' );
 
+		const annualPrice = get( productsList, [ 'gapps', 'prices', currencyCode ], null );
+		const annualPriceFormatted =
+			null === annualPrice ? '-' : getAnnualPrice( annualPrice, currencyCode );
+
 		return (
-			<Fragment>
+			<EmailVerificationGate
+				noticeText={ this.props.translate( 'You must verify your email to purchase G Suite.' ) }
+				noticeStatus="is-info"
+			>
+				<QueryProductsList />
 				<CompactCard>
-					<header className="gsuite-purchase-cta__add-google-apps-card-header">
-						<h3 className="gsuite-purchase-cta__add-google-apps-card-product-logo">
+					<header>
+						<h3 className="gsuite-purchase-cta__product-logo">
 							{ /* Intentionally not translated */ }
 							<strong>G Suite</strong>
-							{ this.getPlanText() }
 						</h3>
 					</header>
 				</CompactCard>
-
 				<CompactCard>
-					<div className="gsuite-purchase-cta__add-google-apps-card-product-details">
-						<div className="gsuite-purchase-cta__add-google-apps-card-description">
-							<h2 className="gsuite-purchase-cta__add-google-apps-card-title">
+					<div className="gsuite-purchase-cta__header">
+						<div className="gsuite-purchase-cta__header-description">
+							<h2 className="gsuite-purchase-cta__header-description-title">
 								{ translate( 'Professional email and so much more.' ) }
 							</h2>
 
-							<p className="gsuite-purchase-cta__add-google-apps-card-sub-title">
+							<p className="gsuite-purchase-cta__header-description-sub-title">
 								{ translate(
 									"We've partnered with Google to offer you email, " +
 										'storage, docs, calendars, and more integrated with your site.'
 								) }
 							</p>
 
-							<div className="gsuite-purchase-cta__add-google-apps-card-price">
-								<h4 className="gsuite-purchase-cta__add-google-apps-card-price-per-user">
-									<span>
-										{ translate( '{{strong}}%(price)s{{/strong}} per user / year', {
-											components: {
-												strong: <strong />,
-											},
-											args: {
-												price: annualPrice,
-											},
-										} ) }
-									</span>
-								</h4>
-
-								{ upgradeAvailable && (
-									<Button type="button" onClick={ this.goToAddGoogleApps }>
-										{ translate( 'Add G Suite' ) }
-									</Button>
-								) }
+							<div className="gsuite-purchase-cta__skus">
+								<GSuitePurchaseCtaSkuInfo
+									annualPrice={ annualPriceFormatted }
+									buttonText={ translate( 'Add G Suite' ) }
+									onButtonClick={ this.goToAddGSuiteUsers }
+									showButton={ upgradeAvailable }
+								/>
 							</div>
 						</div>
 
-						<div className="gsuite-purchase-cta__add-google-apps-card-logos">
+						<div className="gsuite-purchase-cta__header-image">
 							<img alt="G Suite Logo" src="/calypso/images/g-suite/g-suite.svg" />
 						</div>
 					</div>
 				</CompactCard>
-
 				<CompactCard>
 					<GSuitePurchaseFeatures
 						domainName={ domainName }
-						productSlug={ productSlug }
 						type={ 'grid' }
+						productSlug={ 'gapps' }
 					/>
-
-					<div className="gsuite-purchase-cta__add-google-apps-card-secondary-button">
-						{ upgradeAvailable && (
-							<Button type="button" onClick={ this.goToAddGoogleApps }>
-								{ translate( 'Add G Suite' ) }
-							</Button>
-						) }
-					</div>
 				</CompactCard>
-			</Fragment>
-		);
-	}
-
-	render() {
-		return (
-			<EmailVerificationGate
-				noticeText={ this.props.translate( 'You must verify your email to purchase G Suite.' ) }
-				noticeStatus="is-info"
-			>
-				{ this.renderCta() }
 			</EmailVerificationGate>
 		);
 	}
 }
 
 GSuitePurchaseCta.propTypes = {
-	annualPrice: PropTypes.string.isRequired,
 	domainName: PropTypes.string.isRequired,
-	productSlug: PropTypes.string.isRequired,
+	productsList: PropTypes.object,
 	selectedDomainName: PropTypes.string,
 	selectedSiteSlug: PropTypes.string.isRequired,
 };
@@ -141,9 +123,11 @@ export default connect(
 		const selectedSiteId = getSelectedSiteId( state );
 		const domains = getDomainsBySiteId( state, selectedSiteId );
 		return {
+			currencyCode: getCurrentUserCurrencyCode( state ),
 			domainName: getEligibleGSuiteDomain( selectedDomainName, domains ),
+			productsList: getProductsList( state ),
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 		};
 	},
-	null
+	{ recordTracksEvent }
 )( localize( GSuitePurchaseCta ) );

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -54,7 +54,7 @@ export const GSuitePurchaseCta = ( {
 
 	const translate = useTranslate();
 	const upgradeAvailable = config.isEnabled( 'upgrades/checkout' );
-	// display '-' instead of 0 if we don;t have a price yet
+	// display '-' instead of 0 if we don't have a price yet
 	const gsuiteBasicAnnualCost =
 		gsuiteBasicCost && currencyCode ? getAnnualPrice( gsuiteBasicCost, currencyCode ) : '-';
 

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -4,7 +4,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
@@ -19,7 +18,7 @@ import { emailManagementAddGSuiteUsers } from 'my-sites/email/paths';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getAnnualPrice } from 'lib/google-apps';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
-import { getProductsList } from 'state/products-list/selectors';
+import { getProductCost } from 'state/products-list/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import GSuitePurchaseFeatures from 'my-sites/email/gsuite-purchase-features';
 import GSuitePurchaseCtaSkuInfo from 'my-sites/email/gsuite-purchase-cta/sku-info';
@@ -47,12 +46,8 @@ class GSuitePurchaseCta extends Component {
 	}
 
 	render() {
-		const { currencyCode, domainName, productsList, translate } = this.props;
+		const { domainName, gsuiteBasicAnnualCost, translate } = this.props;
 		const upgradeAvailable = config.isEnabled( 'upgrades/checkout' );
-
-		const annualPrice = get( productsList, [ 'gapps', 'prices', currencyCode ], null );
-		const annualPriceFormatted =
-			null === annualPrice ? '-' : getAnnualPrice( annualPrice, currencyCode );
 
 		return (
 			<EmailVerificationGate
@@ -84,7 +79,7 @@ class GSuitePurchaseCta extends Component {
 
 							<div className="gsuite-purchase-cta__skus">
 								<GSuitePurchaseCtaSkuInfo
-									annualPrice={ annualPriceFormatted }
+									annualPrice={ gsuiteBasicAnnualCost }
 									buttonText={ translate( 'Add G Suite' ) }
 									onButtonClick={ this.goToAddGSuiteUsers }
 									showButton={ upgradeAvailable }
@@ -110,17 +105,18 @@ class GSuitePurchaseCta extends Component {
 }
 
 GSuitePurchaseCta.propTypes = {
-	currencyCode: PropTypes.string.isRequired,
 	domainName: PropTypes.string.isRequired,
-	productsList: PropTypes.object,
+	gsuiteBasicAnnualCost: PropTypes.string.isRequired,
 	selectedSiteSlug: PropTypes.string.isRequired,
 };
 
 export default connect(
 	state => {
+		const gappsCost = getProductCost( state, 'gapps' );
+		const currencyCode = getCurrentUserCurrencyCode( state );
 		return {
-			currencyCode: getCurrentUserCurrencyCode( state ),
-			productsList: getProductsList( state ),
+			gsuiteBasicAnnualCost:
+				gappsCost && currencyCode ? getAnnualPrice( gappsCost, currencyCode ) : '-',
 			selectedSiteSlug: getSelectedSiteSlug( state ),
 		};
 	},

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -7,21 +7,21 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import CompactCard from 'components/card/compact';
 import config from 'config';
+import CompactCard from 'components/card/compact';
 import { emailManagementAddGSuiteUsers } from 'my-sites/email/paths';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getAnnualPrice } from 'lib/google-apps';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getProductCost } from 'state/products-list/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
-import GSuitePurchaseFeatures from 'my-sites/email/gsuite-purchase-features';
 import GSuitePurchaseCtaSkuInfo from 'my-sites/email/gsuite-purchase-cta/sku-info';
+import GSuitePurchaseFeatures from 'my-sites/email/gsuite-purchase-features';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QueryProductsList from 'components/data/query-products-list';
 
@@ -30,7 +30,15 @@ import QueryProductsList from 'components/data/query-products-list';
  */
 import './style.scss';
 
-class GSuitePurchaseCta extends Component {
+export class GSuitePurchaseCta extends React.Component {
+	static propTypes = {
+		domainName: PropTypes.string.isRequired,
+		gsuiteBasicAnnualCost: PropTypes.string.isRequired,
+		recordTracksEvent: PropTypes.func.isRequired,
+		selectedSiteSlug: PropTypes.string.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
 	goToAddGSuiteUsers = planType => {
 		this.props.recordTracksEvent( 'calypso_email_gsuite_purchase_cta_get_gsuite_click', {
 			domain: this.props.domainName,
@@ -106,12 +114,6 @@ class GSuitePurchaseCta extends Component {
 		);
 	}
 }
-
-GSuitePurchaseCta.propTypes = {
-	domainName: PropTypes.string.isRequired,
-	gsuiteBasicAnnualCost: PropTypes.string.isRequired,
-	selectedSiteSlug: PropTypes.string.isRequired,
-};
 
 export default connect(
 	state => {

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -3,11 +3,11 @@
 /**
  * External dependencies
  */
-import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -54,6 +54,9 @@ export const GSuitePurchaseCta = ( {
 
 	const translate = useTranslate();
 	const upgradeAvailable = config.isEnabled( 'upgrades/checkout' );
+	// display '-' instead of 0 if we don;t have a price yet
+	const gsuiteBasicAnnualCost =
+		gsuiteBasicCost && currencyCode ? getAnnualPrice( gsuiteBasicCost, currencyCode ) : '-';
 
 	return (
 		<EmailVerificationGate
@@ -85,11 +88,7 @@ export const GSuitePurchaseCta = ( {
 
 						<div className="gsuite-purchase-cta__skus">
 							<GSuitePurchaseCtaSkuInfo
-								annualPrice={
-									gsuiteBasicCost && currencyCode
-										? getAnnualPrice( gsuiteBasicCost, currencyCode )
-										: '-'
-								}
+								annualPrice={ gsuiteBasicAnnualCost }
 								buttonText={ translate( 'Add G Suite' ) }
 								onButtonClick={ () => {
 									goToAddGSuiteUsers( 'basic' );

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -3,11 +3,11 @@
 /**
  * External dependencies
  */
+import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -30,90 +30,88 @@ import QueryProductsList from 'components/data/query-products-list';
  */
 import './style.scss';
 
-export class GSuitePurchaseCta extends React.Component {
-	static propTypes = {
-		domainName: PropTypes.string.isRequired,
-		gsuiteBasicAnnualCost: PropTypes.string.isRequired,
-		recordTracksEvent: PropTypes.func.isRequired,
-		selectedSiteSlug: PropTypes.string.isRequired,
-		translate: PropTypes.func.isRequired,
-	};
+export const GSuitePurchaseCta = ( {
+	domainName,
+	gsuiteBasicAnnualCost,
+	recordTracksEvent: recordEvent,
+	selectedSiteSlug,
+} ) => {
+	useEffect(() => {
+		recordEvent( 'calypso_email_gsuite_purchase_cta_view', {
+			domain_name: domainName,
+		} );
+	}, [ domainName ]);
 
-	goToAddGSuiteUsers = planType => {
-		this.props.recordTracksEvent( 'calypso_email_gsuite_purchase_cta_get_gsuite_click', {
-			domain: this.props.domainName,
+	const goToAddGSuiteUsers = planType => {
+		recordEvent( 'calypso_email_gsuite_purchase_cta_get_gsuite_click', {
+			domain_name: domainName,
 			plan_type: planType,
 		} );
 
-		page( emailManagementAddGSuiteUsers( this.props.selectedSiteSlug, this.props.domainName ) );
+		page( emailManagementAddGSuiteUsers( selectedSiteSlug, domainName ) );
 	};
 
-	componentDidMount() {
-		this.props.recordTracksEvent( 'calypso_email_gsuite_purchase_cta_view', {
-			domain: this.props.domainName,
-		} );
-	}
+	const translate = useTranslate();
+	const upgradeAvailable = config.isEnabled( 'upgrades/checkout' );
 
-	render() {
-		const { domainName, gsuiteBasicAnnualCost, translate } = this.props;
-		const upgradeAvailable = config.isEnabled( 'upgrades/checkout' );
+	return (
+		<EmailVerificationGate
+			noticeText={ translate( 'You must verify your email to purchase G Suite.' ) }
+			noticeStatus="is-info"
+		>
+			<QueryProductsList />
+			<CompactCard>
+				<header>
+					<h3 className="gsuite-purchase-cta__product-logo">
+						{ /* Intentionally not translated */ }
+						<strong>G Suite</strong>
+					</h3>
+				</header>
+			</CompactCard>
+			<CompactCard>
+				<div className="gsuite-purchase-cta__header">
+					<div className="gsuite-purchase-cta__header-description">
+						<h2 className="gsuite-purchase-cta__header-description-title">
+							{ translate( 'Professional email and so much more.' ) }
+						</h2>
 
-		return (
-			<EmailVerificationGate
-				noticeText={ this.props.translate( 'You must verify your email to purchase G Suite.' ) }
-				noticeStatus="is-info"
-			>
-				<QueryProductsList />
-				<CompactCard>
-					<header>
-						<h3 className="gsuite-purchase-cta__product-logo">
-							{ /* Intentionally not translated */ }
-							<strong>G Suite</strong>
-						</h3>
-					</header>
-				</CompactCard>
-				<CompactCard>
-					<div className="gsuite-purchase-cta__header">
-						<div className="gsuite-purchase-cta__header-description">
-							<h2 className="gsuite-purchase-cta__header-description-title">
-								{ translate( 'Professional email and so much more.' ) }
-							</h2>
+						<p className="gsuite-purchase-cta__header-description-sub-title">
+							{ translate(
+								"We've partnered with Google to offer you email, " +
+									'storage, docs, calendars, and more integrated with your site.'
+							) }
+						</p>
 
-							<p className="gsuite-purchase-cta__header-description-sub-title">
-								{ translate(
-									"We've partnered with Google to offer you email, " +
-										'storage, docs, calendars, and more integrated with your site.'
-								) }
-							</p>
-
-							<div className="gsuite-purchase-cta__skus">
-								<GSuitePurchaseCtaSkuInfo
-									annualPrice={ gsuiteBasicAnnualCost }
-									buttonText={ translate( 'Add G Suite' ) }
-									onButtonClick={ () => {
-										this.goToAddGSuiteUsers( 'basic' );
-									} }
-									showButton={ upgradeAvailable }
-								/>
-							</div>
-						</div>
-
-						<div className="gsuite-purchase-cta__header-image">
-							<img alt="G Suite Logo" src="/calypso/images/g-suite/g-suite.svg" />
+						<div className="gsuite-purchase-cta__skus">
+							<GSuitePurchaseCtaSkuInfo
+								annualPrice={ gsuiteBasicAnnualCost }
+								buttonText={ translate( 'Add G Suite' ) }
+								onButtonClick={ () => {
+									goToAddGSuiteUsers( 'basic' );
+								} }
+								showButton={ upgradeAvailable }
+							/>
 						</div>
 					</div>
-				</CompactCard>
-				<CompactCard>
-					<GSuitePurchaseFeatures
-						domainName={ domainName }
-						type={ 'grid' }
-						productSlug={ 'gapps' }
-					/>
-				</CompactCard>
-			</EmailVerificationGate>
-		);
-	}
-}
+
+					<div className="gsuite-purchase-cta__header-image">
+						<img alt="G Suite Logo" src="/calypso/images/g-suite/g-suite.svg" />
+					</div>
+				</div>
+			</CompactCard>
+			<CompactCard>
+				<GSuitePurchaseFeatures domainName={ domainName } type={ 'grid' } productSlug={ 'gapps' } />
+			</CompactCard>
+		</EmailVerificationGate>
+	);
+};
+
+GSuitePurchaseCta.propTypes = {
+	domainName: PropTypes.string.isRequired,
+	gsuiteBasicAnnualCost: PropTypes.string.isRequired,
+	recordTracksEvent: PropTypes.func.isRequired,
+	selectedSiteSlug: PropTypes.string.isRequired,
+};
 
 export default connect(
 	state => {
@@ -126,4 +124,4 @@ export default connect(
 		};
 	},
 	{ recordTracksEvent }
-)( localize( GSuitePurchaseCta ) );
+)( GSuitePurchaseCta );

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -31,8 +31,9 @@ import QueryProductsList from 'components/data/query-products-list';
 import './style.scss';
 
 export const GSuitePurchaseCta = ( {
+	currencyCode,
 	domainName,
-	gsuiteBasicAnnualCost,
+	gsuiteBasicCost,
 	recordTracksEvent: recordEvent,
 	selectedSiteSlug,
 } ) => {
@@ -84,7 +85,11 @@ export const GSuitePurchaseCta = ( {
 
 						<div className="gsuite-purchase-cta__skus">
 							<GSuitePurchaseCtaSkuInfo
-								annualPrice={ gsuiteBasicAnnualCost }
+								annualPrice={
+									gsuiteBasicCost && currencyCode
+										? getAnnualPrice( gsuiteBasicCost, currencyCode )
+										: '-'
+								}
 								buttonText={ translate( 'Add G Suite' ) }
 								onButtonClick={ () => {
 									goToAddGSuiteUsers( 'basic' );
@@ -107,21 +112,18 @@ export const GSuitePurchaseCta = ( {
 };
 
 GSuitePurchaseCta.propTypes = {
+	currencyCode: PropTypes.string.isRequired,
 	domainName: PropTypes.string.isRequired,
-	gsuiteBasicAnnualCost: PropTypes.string.isRequired,
+	gsuiteBasicCost: PropTypes.number.isRequired,
 	recordTracksEvent: PropTypes.func.isRequired,
 	selectedSiteSlug: PropTypes.string.isRequired,
 };
 
 export default connect(
-	state => {
-		const gappsCost = getProductCost( state, 'gapps' );
-		const currencyCode = getCurrentUserCurrencyCode( state );
-		return {
-			gsuiteBasicAnnualCost:
-				gappsCost && currencyCode ? getAnnualPrice( gappsCost, currencyCode ) : '-',
-			selectedSiteSlug: getSelectedSiteSlug( state ),
-		};
-	},
+	state => ( {
+		gsuiteBasicCost: getProductCost( state, 'gapps' ),
+		currencyCode: getCurrentUserCurrencyCode( state ),
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+	} ),
 	{ recordTracksEvent }
 )( GSuitePurchaseCta );

--- a/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
@@ -67,8 +67,8 @@ GSuitePurchaseCtaSkuInfo.propTypes = {
 	showButton: PropTypes.bool.isRequired,
 	onButtonClick: PropTypes.func.isRequired,
 	skuName: PropTypes.string,
-	skuSubNoticeText: PropTypes.string,
-	skuSubText: PropTypes.string,
+	skuStorage: PropTypes.string,
+	skuStorageNotice: PropTypes.string,
 };
 
 export default GSuitePurchaseCtaSkuInfo;

--- a/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
@@ -19,8 +19,8 @@ function GSuitePurchaseCtaSkuInfo( {
 	onButtonClick,
 	showButton,
 	skuName,
-	skuStorage,
-	skuStorageNotice,
+	storageText,
+	storageNoticeText,
 } ) {
 	const translate = useTranslate();
 	return (
@@ -42,10 +42,10 @@ function GSuitePurchaseCtaSkuInfo( {
 					} ) }
 				</span>
 			</h4>
-			{ skuStorage && (
+			{ storageText && (
 				<div className="gsuite-purchase-cta__sku-info-storage-area">
-					<h5>{ skuStorage }</h5>
-					{ skuStorageNotice && <InfoPopover>{ skuStorageNotice }</InfoPopover> }
+					<h5>{ storageText }</h5>
+					{ storageNoticeText && <InfoPopover>{ storageNoticeText }</InfoPopover> }
 				</div>
 			) }
 			{ showButton && (
@@ -67,8 +67,8 @@ GSuitePurchaseCtaSkuInfo.propTypes = {
 	showButton: PropTypes.bool.isRequired,
 	onButtonClick: PropTypes.func.isRequired,
 	skuName: PropTypes.string,
-	skuStorage: PropTypes.string,
-	skuStorageNotice: PropTypes.string,
+	storageText: PropTypes.string,
+	storageNoticeText: PropTypes.string,
 };
 
 export default GSuitePurchaseCtaSkuInfo;

--- a/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
@@ -16,11 +16,11 @@ import InfoPopover from 'components/info-popover';
 function GSuitePurchaseCtaSkuInfo( {
 	annualPrice,
 	buttonText,
-	showButton,
 	onButtonClick,
+	showButton,
 	skuName,
-	skuSubNoticeText,
-	skuSubText,
+	skuStorage,
+	skuStorageNotice,
 	translate,
 } ) {
 	return (
@@ -42,10 +42,10 @@ function GSuitePurchaseCtaSkuInfo( {
 					} ) }
 				</span>
 			</h4>
-			{ skuSubText && (
-				<div className="gsuite-purchase-cta__sku-info-sub-text-area">
-					<h5>{ skuSubText }</h5>
-					{ skuSubNoticeText && <InfoPopover>{ skuSubNoticeText }</InfoPopover> }
+			{ skuStorage && (
+				<div className="gsuite-purchase-cta__sku-info-storage-area">
+					<h5>{ skuStorage }</h5>
+					{ skuStorageNotice && <InfoPopover>{ skuStorageNotice }</InfoPopover> }
 				</div>
 			) }
 			{ showButton && (

--- a/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
@@ -3,9 +3,9 @@
 /**
  * External dependencies
  */
-import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -21,8 +21,8 @@ function GSuitePurchaseCtaSkuInfo( {
 	skuName,
 	skuStorage,
 	skuStorageNotice,
-	translate,
 } ) {
+	const translate = useTranslate();
 	return (
 		<div className="gsuite-purchase-cta__sku-info">
 			{ skuName && (
@@ -69,7 +69,6 @@ GSuitePurchaseCtaSkuInfo.propTypes = {
 	skuName: PropTypes.string,
 	skuSubNoticeText: PropTypes.string,
 	skuSubText: PropTypes.string,
-	translate: PropTypes.func.isRequired,
 };
 
-export default localize( GSuitePurchaseCtaSkuInfo );
+export default GSuitePurchaseCtaSkuInfo;

--- a/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
@@ -1,0 +1,75 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/forms/form-button';
+import InfoPopover from 'components/info-popover';
+
+function GSuitePurchaseCtaSkuInfo( {
+	annualPrice,
+	buttonText,
+	showButton,
+	onButtonClick,
+	skuName,
+	skuSubNoticeText,
+	skuSubText,
+	translate,
+} ) {
+	return (
+		<div className="gsuite-purchase-cta__sku-info">
+			{ skuName && (
+				<div className="gsuite-purchase-cta__sku-info-name-area">
+					<h3>{ skuName }</h3>
+				</div>
+			) }
+			<h4 className="gsuite-purchase-cta__sku-info-name-price-per-user">
+				<span>
+					{ translate( '{{strong}}%(price)s{{/strong}} per user / year', {
+						components: {
+							strong: <strong />,
+						},
+						args: {
+							price: annualPrice,
+						},
+					} ) }
+				</span>
+			</h4>
+			{ skuSubText && (
+				<div className="gsuite-purchase-cta__sku-info-sub-text-area">
+					<h5>{ skuSubText }</h5>
+					{ skuSubNoticeText && <InfoPopover>{ skuSubNoticeText }</InfoPopover> }
+				</div>
+			) }
+			{ showButton && (
+				<Button
+					className="gsuite-purchase-cta__sku-info-button"
+					onClick={ onButtonClick }
+					type="button"
+				>
+					{ buttonText }
+				</Button>
+			) }
+		</div>
+	);
+}
+
+GSuitePurchaseCtaSkuInfo.propTypes = {
+	annualPrice: PropTypes.string.isRequired,
+	buttonText: PropTypes.string.isRequired,
+	showButton: PropTypes.bool.isRequired,
+	onButtonClick: PropTypes.func.isRequired,
+	skuName: PropTypes.string,
+	skuSubNoticeText: PropTypes.string,
+	skuSubText: PropTypes.string,
+	translate: PropTypes.func.isRequired,
+};
+
+export default localize( GSuitePurchaseCtaSkuInfo );

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -101,7 +101,7 @@
 	}
 }
 
-.gsuite-purchase-cta__sku-info-sub-text-area {
+.gsuite-purchase-cta__sku-info-storage-area {
 	display: flex;
 	direction: row;
 	// the InfoPopover will try to make this div bigger when it is rendered

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -1,6 +1,6 @@
 .gsuite-purchase-cta__product-logo {
-	font-size: 150%;
 	color: #757575;
+	font-size: 150%;
 
 	@include breakpoint( '<660px' ) {
 		width: 236px;
@@ -29,9 +29,9 @@
 }
 
 .gsuite-purchase-cta__header-description {
+	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	box-sizing: border-box;
 	font-size: 14px;
 
 	@include breakpoint( '>1040px' ) {
@@ -58,8 +58,8 @@
 		align-items: center;
 		display: flex;
 		flex-grow: 1;
-		margin-left: 20px;
 		justify-content: center;
+		margin-left: 20px;
 	}
 }
 
@@ -74,16 +74,16 @@
 }
 
 .gsuite-purchase-cta__sku-info {
+	align-items: flex-start;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;
-	align-items: flex-start;
 }
 
 .gsuite-purchase-cta__sku-info-name-area {
 	h3 {
-		font-size: 150%;
 		color: #757575;
+		font-size: 150%;
 	}
 }
 
@@ -103,7 +103,7 @@
 
 .gsuite-purchase-cta__sku-info-storage-area {
 	display: flex;
-	direction: row;
+	flex-direction: row;
 	// the InfoPopover will try to make this div bigger when it is rendered
 	// we want them to always be the same size for when they appear side-by-side
 	height: 19.5px;

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -1,4 +1,4 @@
-.gsuite-purchase-cta__add-google-apps-card-product-logo {
+.gsuite-purchase-cta__product-logo {
 	font-size: 150%;
 	color: #757575;
 
@@ -15,7 +15,7 @@
 		background-size: 73px;
 		background-position-y: 5px;
 		display: inline-block;
-		height: 23px;
+		height: 32px;
 		margin: 0 6px 0 0;
 		text-indent: -999999px;
 		vertical-align: text-top;
@@ -23,96 +23,109 @@
 	}
 }
 
-.gsuite-purchase-cta__add-google-apps-card-product-details {
-	@include breakpoint( '>960px' ) {
-		display: flex;
-	}
+.gsuite-purchase-cta__header {
+	display: flex;
+	flex-direction: row;
 }
 
-.gsuite-purchase-cta__add-google-apps-card-description {
+.gsuite-purchase-cta__header-description {
+	display: flex;
+	flex-direction: column;
 	box-sizing: border-box;
 	font-size: 14px;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint( '>1040px' ) {
 		flex-basis: 100%;
 		max-width: 400px;
 	}
-
-	.button {
-		float: none;
-		margin: 1em 0 0.5em;
-		padding-left: 2em;
-		padding-right: 2em;
-
-		@include breakpoint( '<960px' ) {
-			width: 100%;
-		}
-	}
 }
 
-.gsuite-purchase-cta__add-google-apps-card-title {
+.gsuite-purchase-cta__header-description-title {
 	color: var( --color-text );
 	font-size: 24px;
 	line-height: 120%;
 	margin: 0 0 10px;
 }
 
-.gsuite-purchase-cta__add-google-apps-card-sub-title {
+.gsuite-purchase-cta__header-description-sub-title {
 	font-size: 18px;
 }
 
-.gsuite-purchase-cta__add-google-apps-card-price {
-	margin: 2em 0 1em;
-
-	.gsuite-purchase-cta__add-google-apps-card-price-per-user {
-		strong {
-			color: var( --color-text );
-			font-size: 24px;
-			font-weight: 300;
-		}
-
-		span {
-			color: var( --color-text-subtle );
-			font-size: 13px;
-			font-weight: normal;
-		}
-	}
-
-	.gsuite-purchase-cta__add-google-apps-card-billing-period {
-		color: var( --color-text-subtle );
-		font-size: 13px;
-		font-style: italic;
-
-		@include breakpoint( '<960px' ) {
-			text-align: center;
-		}
-	}
-}
-
-.gsuite-purchase-cta__add-google-apps-card-logos {
+.gsuite-purchase-cta__header-image {
 	display: none;
 
-	@include breakpoint( '>960px' ) {
-		align-items: flex-start;
+	@include breakpoint( '>1040px' ) {
+		align-items: center;
 		display: flex;
 		flex-grow: 1;
 		margin-left: 20px;
 		justify-content: center;
 	}
+}
 
-	@include breakpoint( '>1040px' ) {
-		align-items: center;
+.gsuite-purchase-cta__skus {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+
+	@include breakpoint( '>960px' ) {
+		flex-direction: row;
 	}
 }
 
-.gsuite-purchase-cta__add-google-apps-card-secondary-button {
-	.button {
-		float: none;
-		margin: 1em 0;
-		width: 100%;
+.gsuite-purchase-cta__sku-info {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: flex-start;
+}
 
-		@include breakpoint( '>660px' ) {
-			display: none;
-		}
+.gsuite-purchase-cta__sku-info-name-area {
+	h3 {
+		font-size: 150%;
+		color: #757575;
+	}
+}
+
+.gsuite-purchase-cta__sku-info-name-price-per-user {
+	strong {
+		color: var( --color-text );
+		font-size: 24px;
+		font-weight: 300;
+	}
+
+	span {
+		color: var( --color-text-subtle );
+		font-size: 13px;
+		font-weight: normal;
+	}
+}
+
+.gsuite-purchase-cta__sku-info-sub-text-area {
+	display: flex;
+	direction: row;
+	// the InfoPopover will try to make this div bigger when it is rendered
+	// we want them to always be the same size for when they appear side-by-side
+	height: 19.5px;
+
+	h5 {
+		color: var( --color-text-subtle );
+		font-size: 13px;
+		font-style: italic;
+	}
+
+	.info-popover {
+		margin-left: 3px;
+	}
+}
+
+.gsuite-purchase-cta__sku-info-button {
+	float: none;
+	margin: 1em 0 0.5em;
+	padding-left: 2em;
+	padding-right: 2em;
+
+	@include breakpoint( '<480px' ) {
+		width: 100%;
 	}
 }

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -8,11 +8,9 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with basic plan 1`] = `
   <div
     className="card is-compact"
   >
-    <header
-      className="gsuite-purchase-cta__add-google-apps-card-header"
-    >
+    <header>
       <h3
-        className="gsuite-purchase-cta__add-google-apps-card-product-logo"
+        className="gsuite-purchase-cta__product-logo"
       >
         <strong>
           G Suite
@@ -24,46 +22,34 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with basic plan 1`] = `
     className="card is-compact"
   >
     <div
-      className="gsuite-purchase-cta__add-google-apps-card-product-details"
+      className="gsuite-purchase-cta__header"
     >
       <div
-        className="gsuite-purchase-cta__add-google-apps-card-description"
+        className="gsuite-purchase-cta__header-description"
       >
         <h2
-          className="gsuite-purchase-cta__add-google-apps-card-title"
+          className="gsuite-purchase-cta__header-description-title"
         >
           Professional email and so much more.
         </h2>
         <p
-          className="gsuite-purchase-cta__add-google-apps-card-sub-title"
+          className="gsuite-purchase-cta__header-description-sub-title"
         >
           We've partnered with Google to offer you email, storage, docs, calendars, and more integrated with your site.
         </p>
         <div
-          className="gsuite-purchase-cta__add-google-apps-card-price"
+          className="gsuite-purchase-cta__skus"
         >
-          <h4
-            className="gsuite-purchase-cta__add-google-apps-card-price-per-user"
-          >
-            <span>
-              <strong>
-                $72
-              </strong>
-               per user / year
-            </span>
-          </h4>
-          <button
-            className="button form-button is-primary"
-            locale="en"
-            onClick={[Function]}
-            type="button"
-          >
-            Add G Suite
-          </button>
+          <GSuitePurchaseCtaSkuInfo
+            annualPrice="$72"
+            buttonText="Add G Suite"
+            onButtonClick={[Function]}
+            showButton={true}
+          />
         </div>
       </div>
       <div
-        className="gsuite-purchase-cta__add-google-apps-card-logos"
+        className="gsuite-purchase-cta__header-image"
       >
         <img
           alt="G Suite Logo"
@@ -76,119 +62,10 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with basic plan 1`] = `
     className="card is-compact"
   >
     <GSuitePurchaseFeatures
-      domainName=""
+      domainName="test.com"
       productSlug="gapps"
       type="grid"
     />
-    <div
-      className="gsuite-purchase-cta__add-google-apps-card-secondary-button"
-    >
-      <button
-        className="button form-button is-primary"
-        locale="en"
-        onClick={[Function]}
-        type="button"
-      >
-        Add G Suite
-      </button>
-    </div>
-  </div>
-</EmailVerificationGate>
-`;
-
-exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with business plan 1`] = `
-<EmailVerificationGate
-  noticeStatus="is-info"
-  noticeText="You must verify your email to purchase G Suite."
->
-  <div
-    className="card is-compact"
-  >
-    <header
-      className="gsuite-purchase-cta__add-google-apps-card-header"
-    >
-      <h3
-        className="gsuite-purchase-cta__add-google-apps-card-product-logo"
-      >
-        <strong>
-          G Suite
-        </strong>
-        Business
-      </h3>
-    </header>
-  </div>
-  <div
-    className="card is-compact"
-  >
-    <div
-      className="gsuite-purchase-cta__add-google-apps-card-product-details"
-    >
-      <div
-        className="gsuite-purchase-cta__add-google-apps-card-description"
-      >
-        <h2
-          className="gsuite-purchase-cta__add-google-apps-card-title"
-        >
-          Professional email and so much more.
-        </h2>
-        <p
-          className="gsuite-purchase-cta__add-google-apps-card-sub-title"
-        >
-          We've partnered with Google to offer you email, storage, docs, calendars, and more integrated with your site.
-        </p>
-        <div
-          className="gsuite-purchase-cta__add-google-apps-card-price"
-        >
-          <h4
-            className="gsuite-purchase-cta__add-google-apps-card-price-per-user"
-          >
-            <span>
-              <strong>
-                $144
-              </strong>
-               per user / year
-            </span>
-          </h4>
-          <button
-            className="button form-button is-primary"
-            locale="en"
-            onClick={[Function]}
-            type="button"
-          >
-            Add G Suite
-          </button>
-        </div>
-      </div>
-      <div
-        className="gsuite-purchase-cta__add-google-apps-card-logos"
-      >
-        <img
-          alt="G Suite Logo"
-          src="/calypso/images/g-suite/g-suite.svg"
-        />
-      </div>
-    </div>
-  </div>
-  <div
-    className="card is-compact"
-  >
-    <GSuitePurchaseFeatures
-      domainName=""
-      productSlug="gapps_unlimited"
-      type="grid"
-    />
-    <div
-      className="gsuite-purchase-cta__add-google-apps-card-secondary-button"
-    >
-      <button
-        className="button form-button is-primary"
-        locale="en"
-        onClick={[Function]}
-        type="button"
-      >
-        Add G Suite
-      </button>
-    </div>
   </div>
 </EmailVerificationGate>
 `;

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -5,6 +5,7 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta 1`] = `
   noticeStatus="is-info"
   noticeText="You must verify your email to purchase G Suite."
 >
+  <QueryProductsList />
   <div
     className="card is-compact"
   >

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GSuitePurchaseCta it renders GSuitePurchaseCta with basic plan 1`] = `
+exports[`GSuitePurchaseCta it renders GSuitePurchaseCta 1`] = `
 <EmailVerificationGate
   noticeStatus="is-info"
   noticeText="You must verify your email to purchase G Suite."

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/sku-info.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/sku-info.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GSuitePurchaseCta it renders GSuitePurchaseCtaSkuInfo with all props 1`] = `
+<div
+  className="gsuite-purchase-cta__sku-info"
+>
+  <div
+    className="gsuite-purchase-cta__sku-info-name-area"
+  >
+    <h3>
+      G Suite Business
+    </h3>
+  </div>
+  <h4
+    className="gsuite-purchase-cta__sku-info-name-price-per-user"
+  >
+    <span>
+      <strong>
+        $144
+      </strong>
+       per user / year
+    </span>
+  </h4>
+  <div
+    className="gsuite-purchase-cta__sku-info-storage-area"
+  >
+    <h5>
+      Unlimited Storage
+    </h5>
+    <InfoPopover>
+      Accounts with fewer than 5 users have 1 TB per user
+    </InfoPopover>
+  </div>
+  <Button
+    className="gsuite-purchase-cta__sku-info-button"
+    onClick={[Function]}
+    type="button"
+  >
+    Add G Suite Business
+  </Button>
+</div>
+`;
+
+exports[`GSuitePurchaseCta it renders GSuitePurchaseCtaSkuInfo with all required props 1`] = `
+<div
+  className="gsuite-purchase-cta__sku-info"
+>
+  <h4
+    className="gsuite-purchase-cta__sku-info-name-price-per-user"
+  >
+    <span>
+      <strong>
+        $72
+      </strong>
+       per user / year
+    </span>
+  </h4>
+  <Button
+    className="gsuite-purchase-cta__sku-info-button"
+    onClick={[Function]}
+    type="button"
+  >
+    Add G Suite
+  </Button>
+</div>
+`;

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -12,6 +12,7 @@ import renderer from 'react-test-renderer';
 import { createReduxStore } from 'state';
 import GSuitePurchaseCta from '../';
 
+// components to mock
 jest.mock( 'components/email-verification/email-verification-gate', () => 'EmailVerificationGate' );
 jest.mock( 'my-sites/email/gsuite-purchase-features', () => 'GSuitePurchaseFeatures' );
 jest.mock( 'my-sites/email/gsuite-purchase-cta/sku-info', () => 'GSuitePurchaseCtaSkuInfo' );
@@ -24,14 +25,10 @@ describe( 'GSuitePurchaseCta', () => {
 		productsList: {
 			items: {
 				gapps: {
-					prices: {
-						USD: 72,
-					},
+					cost: 72,
 				},
 				gapps_unlimited: {
-					prices: {
-						USD: 144,
-					},
+					cost: 144,
 				},
 			},
 		},
@@ -46,7 +43,7 @@ describe( 'GSuitePurchaseCta', () => {
 		ui: { selectedSiteId: 123 },
 	} );
 
-	test( 'it renders GSuitePurchaseCta with basic plan', () => {
+	test( 'it renders GSuitePurchaseCta', () => {
 		const tree = renderer
 			.create(
 				<Provider store={ testStore }>

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -2,53 +2,33 @@
 /**
  * External dependencies
  */
-import { Provider } from 'react-redux';
+import { noop } from 'lodash';
 import React from 'react';
 import renderer from 'react-test-renderer';
 
 /**
  * Internal dependencies
  */
-import { createReduxStore } from 'state';
-import GSuitePurchaseCta from '../';
+
+import { GSuitePurchaseCta } from '../';
 
 // components to mock
 jest.mock( 'components/email-verification/email-verification-gate', () => 'EmailVerificationGate' );
-jest.mock( 'my-sites/email/gsuite-purchase-features', () => 'GSuitePurchaseFeatures' );
 jest.mock( 'my-sites/email/gsuite-purchase-cta/sku-info', () => 'GSuitePurchaseCtaSkuInfo' );
+jest.mock( 'my-sites/email/gsuite-purchase-features', () => 'GSuitePurchaseFeatures' );
+jest.mock( 'components/data/query-products-list', () => 'QueryProductsList' );
 
 describe( 'GSuitePurchaseCta', () => {
-	const testStore = createReduxStore( {
-		currentUser: {
-			currencyCode: 'USD',
-		},
-		productsList: {
-			items: {
-				gapps: {
-					cost: 72,
-				},
-				gapps_unlimited: {
-					cost: 144,
-				},
-			},
-		},
-		sites: {
-			items: {
-				123: {
-					ID: 123,
-					URL: 'https://test.com',
-				},
-			},
-		},
-		ui: { selectedSiteId: 123 },
-	} );
-
 	test( 'it renders GSuitePurchaseCta', () => {
 		const tree = renderer
 			.create(
-				<Provider store={ testStore }>
-					<GSuitePurchaseCta domainName={ 'test.com' } />
-				</Provider>
+				<GSuitePurchaseCta
+					domainName={ 'test.com' }
+					gsuiteBasicAnnualCost={ '$72' }
+					recordTracksEvent={ noop }
+					selectedSiteSlug={ 'test.wordpress.com' }
+					translate={ text => text }
+				/>
 			)
 			.toJSON();
 		expect( tree ).toMatchSnapshot();

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -23,8 +23,9 @@ describe( 'GSuitePurchaseCta', () => {
 		const tree = renderer
 			.create(
 				<GSuitePurchaseCta
+					currencyCode={ 'USD' }
 					domainName={ 'test.com' }
-					gsuiteBasicAnnualCost={ '$72' }
+					gsuiteBasicCost={ 72 }
 					recordTracksEvent={ noop }
 					selectedSiteSlug={ 'test.wordpress.com' }
 				/>

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -27,7 +27,6 @@ describe( 'GSuitePurchaseCta', () => {
 					gsuiteBasicAnnualCost={ '$72' }
 					recordTracksEvent={ noop }
 					selectedSiteSlug={ 'test.wordpress.com' }
-					translate={ text => text }
 				/>
 			)
 			.toJSON();

--- a/client/my-sites/email/gsuite-purchase-cta/test/index.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/index.js
@@ -14,46 +14,43 @@ import GSuitePurchaseCta from '../';
 
 jest.mock( 'components/email-verification/email-verification-gate', () => 'EmailVerificationGate' );
 jest.mock( 'my-sites/email/gsuite-purchase-features', () => 'GSuitePurchaseFeatures' );
+jest.mock( 'my-sites/email/gsuite-purchase-cta/sku-info', () => 'GSuitePurchaseCtaSkuInfo' );
 
 describe( 'GSuitePurchaseCta', () => {
-	test( 'it renders GSuitePurchaseCta with basic plan', () => {
-		const store = createReduxStore( {
-			ui: { selectedSiteId: 123 },
-			sites: {
-				items: {
-					123: {
-						ID: 123,
-						URL: 'https://test.com',
+	const testStore = createReduxStore( {
+		currentUser: {
+			currencyCode: 'USD',
+		},
+		productsList: {
+			items: {
+				gapps: {
+					prices: {
+						USD: 72,
+					},
+				},
+				gapps_unlimited: {
+					prices: {
+						USD: 144,
 					},
 				},
 			},
-		} );
-		const tree = renderer
-			.create(
-				<Provider store={ store }>
-					<GSuitePurchaseCta annualPrice={ '$72' } productSlug={ 'gapps' } />
-				</Provider>
-			)
-			.toJSON();
-		expect( tree ).toMatchSnapshot();
+		},
+		sites: {
+			items: {
+				123: {
+					ID: 123,
+					URL: 'https://test.com',
+				},
+			},
+		},
+		ui: { selectedSiteId: 123 },
 	} );
 
-	test( 'it renders GSuitePurchaseCta with business plan', () => {
-		const store = createReduxStore( {
-			ui: { selectedSiteId: 123 },
-			sites: {
-				items: {
-					123: {
-						ID: 123,
-						URL: 'https://test.com',
-					},
-				},
-			},
-		} );
+	test( 'it renders GSuitePurchaseCta with basic plan', () => {
 		const tree = renderer
 			.create(
-				<Provider store={ store }>
-					<GSuitePurchaseCta annualPrice={ '$144' } productSlug={ 'gapps_unlimited' } />
+				<Provider store={ testStore }>
+					<GSuitePurchaseCta domainName={ 'test.com' } />
 				</Provider>
 			)
 			.toJSON();

--- a/client/my-sites/email/gsuite-purchase-cta/test/sku-info.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/sku-info.js
@@ -37,8 +37,8 @@ describe( 'GSuitePurchaseCta', () => {
 					buttonText={ 'Add G Suite Business' }
 					onButtonClick={ noop }
 					skuName={ 'G Suite Business' }
-					skuStorage={ 'Unlimited Storage' }
-					skuStorageNotice={ 'Accounts with fewer than 5 users have 1 TB per user' }
+					storageText={ 'Unlimited Storage' }
+					storageNoticeText={ 'Accounts with fewer than 5 users have 1 TB per user' }
 					showButton={ true }
 				/>
 			)

--- a/client/my-sites/email/gsuite-purchase-cta/test/sku-info.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/sku-info.js
@@ -1,0 +1,50 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { noop } from 'lodash';
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import GSuitePurchaseCtaSkuInfo from '../sku-info';
+
+jest.mock( 'components/forms/form-button', () => 'Button' );
+jest.mock( 'components/info-popover', () => 'InfoPopover' );
+
+describe( 'GSuitePurchaseCta', () => {
+	test( 'it renders GSuitePurchaseCtaSkuInfo with all required props', () => {
+		expect(
+			renderer
+				.create(
+					<GSuitePurchaseCtaSkuInfo
+						annualPrice={ '$72' }
+						buttonText={ 'Add G Suite' }
+						onButtonClick={ noop }
+						showButton={ true }
+					/>
+				)
+				.toJSON()
+		).toMatchSnapshot();
+	} );
+
+	test( 'it renders GSuitePurchaseCtaSkuInfo with all props', () => {
+		expect(
+			renderer
+				.create(
+					<GSuitePurchaseCtaSkuInfo
+						annualPrice={ '$144' }
+						buttonText={ 'Add G Suite Business' }
+						onButtonClick={ noop }
+						skuName={ 'G Suite Business' }
+						skuStorage={ 'Unlimited Storage' }
+						skuStorageNotice={ 'Accounts with fewer than 5 users have 1 TB per user' }
+						showButton={ true }
+					/>
+				)
+				.toJSON()
+		).toMatchSnapshot();
+	} );
+} );

--- a/client/my-sites/email/gsuite-purchase-cta/test/sku-info.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/sku-info.js
@@ -16,35 +16,33 @@ jest.mock( 'components/info-popover', () => 'InfoPopover' );
 
 describe( 'GSuitePurchaseCta', () => {
 	test( 'it renders GSuitePurchaseCtaSkuInfo with all required props', () => {
-		expect(
-			renderer
-				.create(
-					<GSuitePurchaseCtaSkuInfo
-						annualPrice={ '$72' }
-						buttonText={ 'Add G Suite' }
-						onButtonClick={ noop }
-						showButton={ true }
-					/>
-				)
-				.toJSON()
-		).toMatchSnapshot();
+		const tree = renderer
+			.create(
+				<GSuitePurchaseCtaSkuInfo
+					annualPrice={ '$72' }
+					buttonText={ 'Add G Suite' }
+					onButtonClick={ noop }
+					showButton={ true }
+				/>
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
 	} );
 
 	test( 'it renders GSuitePurchaseCtaSkuInfo with all props', () => {
-		expect(
-			renderer
-				.create(
-					<GSuitePurchaseCtaSkuInfo
-						annualPrice={ '$144' }
-						buttonText={ 'Add G Suite Business' }
-						onButtonClick={ noop }
-						skuName={ 'G Suite Business' }
-						skuStorage={ 'Unlimited Storage' }
-						skuStorageNotice={ 'Accounts with fewer than 5 users have 1 TB per user' }
-						showButton={ true }
-					/>
-				)
-				.toJSON()
-		).toMatchSnapshot();
+		const tree = renderer
+			.create(
+				<GSuitePurchaseCtaSkuInfo
+					annualPrice={ '$144' }
+					buttonText={ 'Add G Suite Business' }
+					onButtonClick={ noop }
+					skuName={ 'G Suite Business' }
+					skuStorage={ 'Unlimited Storage' }
+					skuStorageNotice={ 'Accounts with fewer than 5 users have 1 TB per user' }
+					showButton={ true }
+				/>
+			)
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* New Sub Component For Rendering G Suite SKUs Info on CTA
* Move connections from Email Management only used with CTA to CTA
* Minor Style Tweaks
* Refactor G Suite Purchase CTA into Functional Component
* Tracks Events when CTA is viewed and "Add G Suite" Button is clicked
* Tests

#### The Component is Visually Unchanged
<img width="500" alt="Current Preview" src="https://user-images.githubusercontent.com/2810519/55842213-5914ee80-5ae7-11e9-818e-0c1082067ba8.png">

#### Preview of both SKUs ( changes not in this PR )
<img width="500" alt="Two SKU Preview" src="https://user-images.githubusercontent.com/2810519/55846780-c599e880-5afb-11e9-876d-f729c57d3697.png">

#### Testing instructions

1. Enable Analytics logging by typing `localStorage.setItem( 'debug', 'calypso:analytics:*' )` into the console of your browser dev tools
1. Make sure your Dev Tools are open so you can confirm Tracks events are correct ( clearing it would probably help )
1. Navigate to `/email/:domain/manage/:siteSlug` for a domain and site without G Suite
1. Confirm that what you see almost exactly matches the WordPress.com version of the same path
1. Confirm that a `calypso_email_gsuite_purchase_cta_view` event was logged with the correct `domain_name`
1. Press "Add G Suite"
1. Confirm you were taken to `/email/:domain/add-gsuite-users/:site`
1. Confirm that a `calypso_email_gsuite_purchase_cta_get_gsuite_click` event was logged with the correct `domain_name` and `plan_type: "basic"`
1. run `npm run test-client client/my-sites/email/gsuite-purchase-cta/` and confirm the tests pass