### PR TITLE
Gutenframe: Add JP version check

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -164,7 +164,7 @@ function waitForSiteIdAndSelectedEditor( context ) {
 	} );
 }
 
-async function loadSelectedEditor( context, next ) {
+async function redirectIfBlockEditor( context, next ) {
 	const tmpState = context.store.getState();
 	const selectedEditor = getSelectedEditor( tmpState, getSelectedSiteId( tmpState ) );
 	if ( ! selectedEditor ) {
@@ -335,6 +335,6 @@ export default {
 			return next();
 		}
 
-		loadSelectedEditor( context, next );
+		redirectIfBlockEditor( context, next );
 	},
 };

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -182,32 +182,32 @@ async function loadSelectedEditor( context, next ) {
 		return next();
 	}
 
-	if ( 'gutenberg' === getSelectedEditor( state, siteId ) ) {
-		const postType = determinePostType( context );
-		const postId = getPostID( context );
-
-		if ( false === isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) ) {
-			const siteAdminUrl = getSiteAdminUrl( state, siteId );
-			let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;
-
-			if ( postId ) {
-				url = `${ siteAdminUrl }post.php?post=${ postId }&action=edit`;
-			}
-
-			if ( isSiteAtomic( state, siteId ) ) {
-				url = addQueryArgs( { calypsoify: '1' }, url );
-			}
-
-			return window.location.replace( addQueryArgs( context.query, url ) );
-		}
-
-		let url = getEditorUrl( state, siteId, postId, postType );
-		// pass along parameters, for example press-this
-		url = addQueryArgs( context.query, url );
-		return window.location.replace( url );
+	if ( 'gutenberg' !== getSelectedEditor( state, siteId ) ) {
+		return next();
 	}
 
-	next();
+	const postType = determinePostType( context );
+	const postId = getPostID( context );
+
+	if ( false === isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) ) {
+		const siteAdminUrl = getSiteAdminUrl( state, siteId );
+		let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;
+
+		if ( postId ) {
+			url = `${ siteAdminUrl }post.php?post=${ postId }&action=edit`;
+		}
+
+		if ( isSiteAtomic( state, siteId ) ) {
+			url = addQueryArgs( { calypsoify: '1' }, url );
+		}
+
+		return window.location.replace( addQueryArgs( context.query, url ) );
+	}
+
+	let url = getEditorUrl( state, siteId, postId, postType );
+	// pass along parameters, for example press-this
+	url = addQueryArgs( context.query, url );
+	return window.location.replace( url );
 }
 
 export default {

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -23,7 +23,7 @@ import PostEditor from './post-editor';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { startEditingNewPost, stopEditingPost } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite } from 'state/sites/selectors';
+import { getSite, isJetpackMinimumVersion } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
@@ -179,6 +179,7 @@ async function maybeCalypsoifyGutenberg( context, next ) {
 		( isCalypsoifyGutenbergEnabled( state, siteId ) ||
 			isGutenlypsoEnabled( state, siteId ) ||
 			isEnabled( 'jetpack/gutenframe' ) ) &&
+		false !== isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) &&
 		'gutenberg' === getSelectedEditor( state, siteId )
 	) {
 		let url = getEditorUrl( state, siteId, postId, postType );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a Jetpack version check, to make sure Gutenframe-related features are available, once the flags are removed.

Still needs work for ineligible sites to redirect to:
 * Jetpack sites: non-Calypsoified WP admin block editor.
 * Atomic sites: Calypsoified WP admin block editor

#### Testing instructions
* Load this branch locally or use calypso.live.
* Apply https://github.com/Automattic/jetpack/pull/11354 to your JP testing site.
* Directly enter the URL `/post/:JPDomain` for a JP site with `gutenberg` as its selected editor (see the User RC if this needs to be set).
* Verify the iframed block editor is loaded.

Fixes #32043
