### PR TITLE
Plans: Update copy of Jetpack thank you card skip link

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/index.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/index.js
@@ -73,9 +73,7 @@ export class CurrentPlanThankYouCard extends Component {
 									<ProgressBar isPulsing total={ 100 } value={ progressComplete || 0 } />
 
 									<p>
-										<a href={ this.getMyPlanRoute() }>
-											{ translate( 'Skip setup. I’ll do this later.' ) }
-										</a>
+										<a href={ this.getMyPlanRoute() }>{ translate( 'Hide message' ) }</a>
 									</p>
 								</Fragment>
 							) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the copy of the "skip" link to properly reflect its real behavior.

#### Preview

Before:
![](https://cldup.com/bx1alY__1d.png)

After:
![](https://cldup.com/CY6Cpf3Eru.png)


#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/my-plan/:site?thank-you where `:site` is a Jetpack site with a paid plan that needs VP or AK to be installed/activated/configured.
* Verify the skip button still works/looks well

This enhancement was suggested by @jeffgolenski while testing the security checklist: https://cloudup.com/cqK-IkaWi3O

#manual-testing
