### PR TITLE
Fix chunk name for Guided Tours.

### DIFF
--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -20,7 +20,7 @@ function GuidedTours( props ) {
 		return null;
 	}
 
-	return <AsyncLoad require="./component" { ...ownProps } />;
+	return <AsyncLoad require="layout/guided-tours/component" { ...ownProps } />;
 }
 
 export default connect( state => {


### PR DESCRIPTION
Using the full path will provide a better chunk name than "component".

#### Changes proposed in this Pull Request

* Use full path when requiring component in Guided Tours.

#### Testing instructions

* Ensure the build does not break.
