### PR TITLE
Billing: Add instructions and input to billing details for users who have transaction information

### DIFF
--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -119,26 +119,10 @@ class BillingReceipt extends React.Component {
 		);
 	}
 
-	renderBillingDetails() {
-		const { transaction, translate } = this.props;
-		if ( ! transaction.cc_name && ! transaction.cc_email ) {
-			return null;
-		}
-
-		return (
-			<li className="billing-history__billing-details">
-				<strong>{ translate( 'Billing Details' ) }</strong>
-				<div contentEditable="true">{ transaction.cc_name }</div>
-				<div contentEditable="true">{ transaction.cc_email }</div>
-			</li>
-		);
-	}
-
-	renderEmptyBillingDetails() {
+	renderBillingDetailsLabels() {
 		const { translate } = this.props;
-
 		return (
-			<li className="billing-history__billing-details">
+			<div>
 				<label htmlFor="billing-history__billing-details-textarea">
 					<strong>{ translate( 'Billing Details' ) }</strong>
 				</label>
@@ -150,6 +134,34 @@ class BillingReceipt extends React.Component {
 						'Use this field to add your billing information (eg. VAT number, business address) before printing.'
 					) }
 				</div>
+			</div>
+		);
+	}
+
+	renderBillingDetails() {
+		const { transaction } = this.props;
+		if ( ! transaction.cc_name && ! transaction.cc_email ) {
+			return null;
+		}
+
+		return (
+			<li className="billing-history__billing-details">
+				{ this.renderBillingDetailsLabels() }
+				<TextareaAutosize
+					className="billing-history__billing-details-editable"
+					aria-labelledby="billing-history__billing-details-description"
+					id="billing-history__billing-details-textarea"
+					rows="1"
+					defaultValue={ transaction.cc_name + '\n' + transaction.cc_email }
+				/>
+			</li>
+		);
+	}
+
+	renderEmptyBillingDetails() {
+		return (
+			<li className="billing-history__billing-details">
+				{ this.renderBillingDetailsLabels() }
 				<TextareaAutosize
 					className="billing-history__billing-details-editable"
 					aria-labelledby="billing-history__billing-details-description"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In #31848 we added a textarea and instructions for how to use it on the Billing Details section of receipts, but I only accounted for users whose billing details were initially empty (which happens to be the case for my test site)
* Sometimes this area is pre-populated with the user's name and email address. This PR adds the same textarea and instruction/label treatment for those users.
* This PR also combines the labels for the textarea into a single function to avoid duplicated code. 
* Kudos to @senff who noticed the discrepancy.

**Before**

<img width="683" alt="Screen Shot 2019-04-10 at 11 00 08 AM" src="https://user-images.githubusercontent.com/2124984/55889975-ea37a400-5b7f-11e9-8128-7de04203c748.png">

**After**

<img width="675" alt="Screen Shot 2019-04-10 at 11 00 33 AM" src="https://user-images.githubusercontent.com/2124984/55889986-edcb2b00-5b7f-11e9-8729-c2bfacf910d4.png">

#### Testing instructions

* Switch to this PR and navigate to a single billing receipt.
* Make sure you're logged into an account that has user information pre-populated with billing details.
* You should see the textarea and label, and the textarea should have the pre-populated data (some variation of name + email).