### PR TITLE
Domains: Populate the currentUser currencyCode from the productList

### DIFF
--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -92,7 +92,7 @@ export const currencyCode = createReducer(
 export function capabilities( state = {}, action ) {
 	switch ( action.type ) {
 		case SITE_RECEIVE:
-		case SITES_RECEIVE:
+		case SITES_RECEIVE: {
 			const sites = action.site ? [ action.site ] : action.sites;
 			return reduce(
 				sites,
@@ -110,6 +110,7 @@ export function capabilities( state = {}, action ) {
 				},
 				state
 			);
+		}
 	}
 
 	return state;

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { get, isEqual, reduce } from 'lodash';
+import { get, isEqual, reduce, keys, first } from 'lodash';
 
 /**
  * Internal dependencies
@@ -15,6 +15,7 @@ import {
 	SITE_PLANS_FETCH_COMPLETED,
 	SITES_RECEIVE,
 	PLANS_RECEIVE,
+	PRODUCTS_LIST_RECEIVE,
 } from 'state/action-types';
 import { combineReducers, createReducer } from 'state/utils';
 import { idSchema, capabilitiesSchema, currencyCodeSchema, flagsSchema } from './schema';
@@ -62,11 +63,18 @@ export const flags = createReducer(
 export const currencyCode = createReducer(
 	null,
 	{
+		[ PRODUCTS_LIST_RECEIVE ]: ( state, action ) => {
+			return get(
+				action.productsList,
+				[ first( keys( action.productsList ) ), 'currency_code' ],
+				state
+			);
+		},
 		[ PLANS_RECEIVE ]: ( state, action ) => {
-			return get( action.plans[ 0 ], 'currency_code', state );
+			return get( action.plans, [ 0, 'currency_code' ], state );
 		},
 		[ SITE_PLANS_FETCH_COMPLETED ]: ( state, action ) => {
-			return get( action.plans[ 0 ], 'currencyCode', state );
+			return get( action.plans, [ 0, 'currencyCode' ], state );
 		},
 	},
 	currencyCodeSchema


### PR DESCRIPTION
The current user currencyCode is populated from the plans API endpoint. However in domains-only flow we don't load the plans at all since there is no need for them to load and this makes the prices shown in the domain search component to be paired with the wrong currency (if you're in India you'll see the prices in USD but the actual price will be in rupee - so it'll look like more than 1000 USD for domain). This PR should populate the currentUser.currency even when you open the domains-only flow.

Depends on D26748-code

#### Changes proposed in this Pull Request

* Populate the currentUser.currencyCode when the productList is populated

#### Testing instructions

* Apply D26748-code
* Open http://calypso.localhost:3000/start/domain/domain-only in incognito window
* In the console check that `state.currentUser.currencyCode` has value
* search for a domain and make sure the prices are in the correct currency
* Also change your user default currency
* Open http://calypso.localhost:3000/start/domain/domain-only logged in as yourself
* Verify that the prices are in the correct currency (try different currencies as INR and etc)

Fixes #

https://core.trac.wordpress.org/ticket/46756
