### PR TITLE
Importers: Remove feature flags for Medium and Engine6

### DIFF
--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { isEnabled } from 'config';
 import { filter, find, flow, get, isEmpty, memoize, once } from 'lodash';
 
 /**
@@ -59,12 +58,12 @@ const importers = [
 	},
 	{
 		type: GODADDY_GOCENTRAL,
-		isImporterEnabled: isEnabled( 'manage/import/engine6' ),
+		isImporterEnabled: true,
 		component: GoDaddyGoCentralImporter,
 	},
 	{
 		type: MEDIUM,
-		isImporterEnabled: isEnabled( 'manage/import/medium' ),
+		isImporterEnabled: true,
 		component: MediumImporter,
 	},
 	{

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -70,7 +70,6 @@
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/import/medium": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/people": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -52,7 +52,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import-in-sidebar": true,
-		"manage/import/medium": true,
 		"manage/pages": true,
 		"manage/plan-features": false,
 		"manage/plugins": true,

--- a/config/development.json
+++ b/config/development.json
@@ -96,8 +96,6 @@
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/import/engine6": true,
-		"manage/import/medium": true,
 		"manage/import-in-sidebar": true,
 		"manage/import-to-jetpack": true,
 		"manage/pages": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,7 +58,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import-in-sidebar": true,
-		"manage/import/medium": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,

--- a/config/production.json
+++ b/config/production.json
@@ -57,7 +57,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import-in-sidebar": true,
-		"manage/import/medium": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -60,8 +60,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/import-in-sidebar": true,
-		"manage/import/engine6": true,
-		"manage/import/medium": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,

--- a/config/test.json
+++ b/config/test.json
@@ -56,7 +56,6 @@
 		"mailchimp": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/import/medium": true,
 		"manage/pages": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -74,8 +74,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/import-in-sidebar": true,
-		"manage/import/engine6": true,
-		"manage/import/medium": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Removes the feature flag `manage/import/medium`. Medium is launched in every environment, and this flag had no effect.
* Removes the feature flag `manage/import/engine6`. This PR should be merged once we're ready to launch the GoDaddy GoCentral importer.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that both the Medium and GoDaddy GoCentral importers continue to work with this PR applied

