### PR TITLE
Change "Add G Suite" Paths

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -51,6 +51,7 @@ import {
 	emailManagement,
 	emailManagementForwarding,
 	emailManagementAddGSuiteUsers,
+	emailManagementNewGSuiteAccount,
 } from 'my-sites/email/paths';
 import SitesComponent from 'my-sites/sites';
 import { warningNotice } from 'state/notices/actions';
@@ -172,6 +173,7 @@ function isPathAllowedForDomainOnlySite( path, slug, primaryDomain ) {
 		domainManagementTransferToOtherSite,
 		emailManagement,
 		emailManagementAddGSuiteUsers,
+		emailManagementNewGSuiteAccount,
 		emailManagementForwarding,
 	];
 

--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -4,17 +4,35 @@
  * External dependencies
  */
 import React from 'react';
+import page from 'page';
 
 /**
  * Internal Dependencies
  */
 import EmailForwarding from 'my-sites/email/email-forwarding';
 import EmailManagement from 'my-sites/email/email-management';
+import { emailManagementAddGSuiteUsers } from 'my-sites/email/paths';
 import GSuiteAddUsers from 'my-sites/email/gsuite-add-users';
 
 export default {
 	emailManagementAddGSuiteUsers( pageContext, next ) {
 		pageContext.primary = <GSuiteAddUsers selectedDomainName={ pageContext.params.domain } />;
+		next();
+	},
+
+	emailManagementAddGSuiteUsersLegacyRedirect( pageContext ) {
+		page.redirect(
+			emailManagementAddGSuiteUsers( pageContext.params.site, pageContext.params.domain )
+		);
+	},
+
+	emailManagementNewGSuiteAccount( pageContext, next ) {
+		pageContext.primary = (
+			<GSuiteAddUsers
+				planType={ pageContext.params.planType }
+				selectedDomainName={ pageContext.params.domain }
+			/>
+		);
 		next();
 	},
 

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -16,7 +16,7 @@ import Button from 'components/button';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import CompactCard from 'components/card/compact';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import { domainManagementAddGSuiteUsers } from 'my-sites/domains/paths';
+import { emailManagementAddGSuiteUsers } from 'my-sites/email/paths';
 import { hasPendingGSuiteUsers } from 'lib/domains/gsuite';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedDomain } from 'lib/domains';
@@ -70,7 +70,7 @@ class GSuiteUsersCard extends React.Component {
 						<Button
 							primary
 							compact
-							href={ domainManagementAddGSuiteUsers( this.props.selectedSiteSlug, domain ) }
+							href={ emailManagementAddGSuiteUsers( this.props.selectedSiteSlug, domain ) }
 							onClick={ this.goToAddGoogleApps }
 						>
 							{ this.props.translate( 'Add G Suite User' ) }
@@ -142,7 +142,7 @@ class GSuiteUsersCard extends React.Component {
 						key="pending-gsuite-tos-notice"
 						siteSlug={ selectedSiteSlug }
 						domains={ pendingDomains }
-						section="gsuite-users-manage-notice"
+						section="google-apps"
 					/>
 				) }
 

--- a/client/my-sites/email/email-management/gsuite-users-card/index.jsx
+++ b/client/my-sites/email/email-management/gsuite-users-card/index.jsx
@@ -142,7 +142,7 @@ class GSuiteUsersCard extends React.Component {
 						key="pending-gsuite-tos-notice"
 						siteSlug={ selectedSiteSlug }
 						domains={ pendingDomains }
-						section="google-apps"
+						section="gsuite-users-manage-notice"
 					/>
 				) }
 

--- a/client/my-sites/email/gsuite-add-users/add-users.jsx
+++ b/client/my-sites/email/gsuite-add-users/add-users.jsx
@@ -33,7 +33,7 @@ import NewUserForm from './new-user-form';
  */
 import './add-users.scss';
 
-function getGoogleAppsCartItems( { domains, fieldsets } ) {
+function getGoogleAppsCartItems( { domains, fieldsets, product_slug } ) {
 	let groups = groupBy( fieldsets, function( fieldset ) {
 		return fieldset.domain.value;
 	} );
@@ -54,7 +54,7 @@ function getGoogleAppsCartItems( { domains, fieldsets } ) {
 		if ( hasGSuite( domainInfo ) ) {
 			item = cartItems.googleAppsExtraLicenses( { domain, users } );
 		} else {
-			item = cartItems.googleApps( { domain, users } );
+			item = cartItems.googleApps( { domain, product_slug, users } );
 		}
 
 		return item;
@@ -258,6 +258,7 @@ class AddEmailAddressesCard extends React.Component {
 
 	addProductsAndGoToCheckout() {
 		const googleAppsCartItems = getGoogleAppsCartItems( {
+			product_slug: 'business' === this.props.planType ? 'gapps_unlimited' : 'gapps',
 			domains: this.props.domains,
 			fieldsets: filterUsers( {
 				users: this.state.fieldsets,
@@ -323,6 +324,7 @@ AddEmailAddressesCard.propTypes = {
 	domains: PropTypes.array.isRequired,
 	isRequestingSiteDomains: PropTypes.bool.isRequired,
 	gsuiteUsers: PropTypes.array.isRequired,
+	planType: PropTypes.oneOf( [ 'basic', 'business' ] ),
 	selectedDomainName: PropTypes.string,
 };
 

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -23,12 +23,15 @@ import {
 import DomainManagementHeader from 'my-sites/domains/domain-management/components/header';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getDecoratedSiteDomains, isRequestingSiteDomains } from 'state/sites/domains/selectors';
+import { getDomainsWithForwards } from 'state/selectors/get-email-forwards';
+import { getGSuiteSupportedDomains, hasGSuiteSupportedDomain } from 'lib/domains/gsuite';
 import { getSelectedSite } from 'state/ui/selectors';
-import { hasGSuiteSupportedDomain } from 'lib/domains/gsuite';
 import Main from 'components/main';
+import Notice from 'components/notice';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QuerySiteDomains from 'components/data/query-site-domains';
 import SectionHeader from 'components/section-header';
+import QueryEmailForwards from 'components/data/query-email-forwards';
 import QueryGSuiteUsers from 'components/data/query-gsuite-users';
 import getGSuiteUsers from 'state/selectors/get-gsuite-users';
 
@@ -61,6 +64,7 @@ class GSuiteAddUsers extends React.Component {
 	renderAddGSuite() {
 		const {
 			domains,
+			domainsWithForwards,
 			gsuiteUsers,
 			planType,
 			isRequestingDomains,
@@ -68,9 +72,27 @@ class GSuiteAddUsers extends React.Component {
 			selectedSite,
 			translate,
 		} = this.props;
+		const gSuiteSupportedDomains = getGSuiteSupportedDomains( domains );
 
 		return (
 			<Fragment>
+				{ domainsWithForwards.length ? (
+					<Notice showDismiss={ false } status="is-warning">
+						{ translate(
+							'Please note that email forwards are not compatible with G Suite, and will be disabled once G Suite is added to this domain. The following domains have forwards:'
+						) }
+						<ul>
+							{ domainsWithForwards.map( domainName => {
+								return <li key={ domainName }>{ domainName }</li>;
+							} ) }
+						</ul>
+					</Notice>
+				) : (
+					''
+				) }
+				{ gSuiteSupportedDomains.map( domain => {
+					return <QueryEmailForwards key={ domain.domain } domainName={ domain.domain } />;
+				} ) }
 				<SectionHeader label={ translate( 'Add G Suite' ) } />
 				{ gsuiteUsers ? (
 					<AddEmailAddressesCard
@@ -134,8 +156,10 @@ GSuiteAddUsers.propTypes = {
 export default connect( state => {
 	const selectedSite = getSelectedSite( state );
 	const siteId = get( selectedSite, 'ID', null );
+	const domains = getDecoratedSiteDomains( state, siteId );
 	return {
-		domains: getDecoratedSiteDomains( state, siteId ),
+		domains,
+		domainsWithForwards: getDomainsWithForwards( state, domains ),
 		gsuiteUsers: getGSuiteUsers( state, siteId ),
 		isRequestingDomains: isRequestingSiteDomains( state, siteId ),
 		selectedSite,

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -14,7 +14,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import config from 'config';
 import CompactCard from 'components/card/compact';
-import { emailManagementAddGSuiteUsers } from 'my-sites/email/paths';
+import { emailManagementNewGSuiteAccount } from 'my-sites/email/paths';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getAnnualPrice } from 'lib/google-apps';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
@@ -49,7 +49,7 @@ export const GSuitePurchaseCta = ( {
 			plan_type: planType,
 		} );
 
-		page( emailManagementAddGSuiteUsers( selectedSiteSlug, domainName ) );
+		page( emailManagementNewGSuiteAccount( selectedSiteSlug, domainName, planType ) );
 	};
 
 	const translate = useTranslate();

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -39,6 +39,22 @@ export default function() {
 		],
 	} );
 
+	registerMultiPage( {
+		paths: [
+			paths.emailManagementAddGSuiteUsersLegacy( ':site', ':domain' ),
+			paths.emailManagementAddGSuiteUsersLegacy( ':site' ),
+		],
+		handlers: [ controller.emailManagementAddGSuiteUsersLegacyRedirect ],
+	} );
+
+	page(
+		paths.emailManagementNewGSuiteAccount( ':site', ':domain', ':planType' ),
+		...commonHandlers,
+		controller.emailManagementNewGSuiteAccount,
+		makeLayout,
+		clientRender
+	);
+
 	page(
 		paths.emailManagementForwarding( ':site', ':domain' ),
 		...commonHandlers,

--- a/client/my-sites/email/paths.js
+++ b/client/my-sites/email/paths.js
@@ -9,12 +9,28 @@ export function emailManagementAddGSuiteUsers( siteName, domainName ) {
 	let path;
 
 	if ( domainName ) {
+		path = emailManagementEdit( siteName, domainName, 'gsuite/add-users' );
+	} else {
+		path = '/email/gsuite/add-users/' + siteName;
+	}
+
+	return path;
+}
+
+export function emailManagementAddGSuiteUsersLegacy( siteName, domainName ) {
+	let path;
+
+	if ( domainName ) {
 		path = emailManagementEdit( siteName, domainName, 'add-gsuite-users' );
 	} else {
 		path = '/email/add-gsuite-users/' + siteName;
 	}
 
 	return path;
+}
+
+export function emailManagementNewGSuiteAccount( siteName, domainName, planType ) {
+	return emailManagementEdit( siteName, domainName, 'gsuite/new/' + planType );
 }
 
 export function emailManagement( siteName, domainName ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Currently we reuse `gsuite-add-users` to get a new G Suite subscription and to add users
* Separates the above into `gsuite/add-users` and `gsuite/new/:plan`
* Allows anyone who knows the right URL to add G Suite Business to a domain

#### Testing instructions

1. Navigate to `/email/:domain/manage/:siteSlug` for a domain and site without G Suite
1. Click the "Add G Suite" Button
1. Confirm you have been taken to the `Add G Suite` Page: <img width="733" alt="Screen Shot 2019-04-05 at 2 58 37 PM" src="https://user-images.githubusercontent.com/2810519/55658665-53e83480-57b3-11e9-8855-06557c950440.png">
1. Inspect the url and confirm it matches `/email/:domain/gsuite/new/basic/:siteSlug`
1. Add G Suite user info and continue to the cart
1. Confirm that the item in the cart is regular "G Suite"
1. Don't complete the purchase, remove all items from cart
1. Navigate back to `/email/:domain/gsuite/new/business/:siteSlug`
1. Confirm you have been taken to the `Add G Suite` Page
1. Inspect the url and confirm it matches `/email/:domain/gsuite/new/business/:siteSlug`
1. Add G Suite user info and continue to the cart
1. Confirm that the item in the cart is "G Suite with Unlimited Storage" and the price is correct
1. Don't complete the purchase, remove all items from cart
1. Navigate to `/email/:domain/manage/:siteSlug` for a site & domain with G Suite
1. Click the "Add G Suite User" button
1. Confirm you have been taken to the `Add G Suite` Page
1. Inspect the url and confirm it matches `/email/:domain/gsuite/add-users/:siteSlug`
1. Change the url to `/email/:domain/add-gsuite-users/:siteSlug`
1. Confirm you are redirected to the same page
1. Add G Suite User info and continue to cart
1. Confirm the item in the cart is "Extra License for G Suite"