### PR TITLE
Calypso build: Accept output-chunk-filename cli arg

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "1.0.0-beta.2",
+	"version": "1.0.0-beta.3",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"config",

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -46,6 +46,7 @@ function getWebpackConfig(
 	env = {}, // eslint-disable-line no-unused-vars
 	{
 		entry,
+		'output-chunk-filename': outputChunkFilename,
 		'output-path': outputPath = path.join( __dirname, 'dist' ),
 		'output-filename': outputFilename = '[name].js',
 		'output-libary-target': outputLibraryTarget = 'window',
@@ -60,6 +61,7 @@ function getWebpackConfig(
 		mode: isDevelopment ? 'development' : 'production',
 		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
 		output: {
+			chunkFilename: outputChunkFilename,
 			path: outputPath,
 			filename: outputFilename,
 			libraryTarget: outputLibraryTarget,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Accept and pass in [webpack cli](https://webpack.js.org/api/cli/#output-options) arg for [`output.chunkFilename`](https://webpack.js.org/configuration/output#outputchunkfilename)

#### Testing instructions

Build `o2-blocks` - no changes. `npx lerna run build`