### PR TITLE
Experiment: Try limiting what sections are built

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -38,6 +38,15 @@ If your browser is set to block 3rd-party cookies, you should set an exception o
 
 See [Development Workflow](../docs/development-workflow.md) for more.
 
+### Limited builds
+
+Calypso is [broken up into sections](https://github.com/Automattic/wp-calypso/blob/master/client/wordpress-com.js) and by default, every section is built when the development server starts.
+This can take a long time and slow down incremental builds as your work. To speed things up,
+you can choose to build and run specific sections of Calypso using the `SECTION_LIMIT` enviroment variable.
+
+For instance, `SECTION_LIMIT=reader,login npm start` would start Calypso and only build the `reader` and `login` sections.
+
+
 ### Starting the node debugger
 
 The `npm start` command will pass anything set in the `NODE_ARGS` environment variable as an option to the Node command.  This means that if you want to start up the debugger on a specific port you can run `NODE_ARGS="--debug=5858" npm start`.  Starting the built-in inspector can also be done by running `NODE_ARGS="--inspect" npm start`.  In either case, if you would like to debug the build process as well, it might be convenient to have the inspector break on the first line and wait for you.  In that case, you should also pass in the `--debug-brk` option like so `NODE_ARGS="--inspect --debug-brk" npm start`.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,6 +163,7 @@ function getWebpackConfig( {
 		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
 		output: {
 			path: path.join( __dirname, 'public', extraPath ),
+			pathinfo: false,
 			publicPath: `/calypso/${ extraPath }/`,
 			filename: '[name].[chunkhash].min.js', // prefer the chunkhash, which depends on the chunk, not the entire build
 			chunkFilename: '[name].[chunkhash].min.js', // ditto
@@ -226,6 +227,9 @@ function getWebpackConfig( {
 				{
 					include: path.join( __dirname, 'client/sections.js' ),
 					loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),
+					options: {
+						include: process.env.SECTION_LIMIT ? process.env.SECTION_LIMIT.split( ',' ) : null,
+					},
 				},
 				{
 					test: /\.html$/,


### PR DESCRIPTION
This adds the ability to limit what sections are being built (and rebuilt) with an environment variable, SECTION_LIMIT.

Setting SECTION_LIMIT=reader,login would only build the reader and login sections.

This considerably speeds up the overall build when working in a specific section.

To test:
At a command prompt, run `SECTION_LIMIT=reader,login npm start` and try to load reader and log-in. Other routes won't work unless you restart. 
Try changing some code in reader or login and verify that the incremental build works.

No impact on production.


