### PR TITLE
Calypso Build Package: Add cssChunkFilename arg to SASS shard, compute from JS counterpart

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "1.0.0-beta.3",
+	"version": "1.0.0-beta.4",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"config",

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -53,7 +53,10 @@ function getWebpackConfig(
 	}
 ) {
 	const workerCount = 1;
-	const cssFilename = '[name].css';
+	const cssFilename = path.parse( outputFilename ).name + '.css';
+	const cssChunkFilename = outputChunkFilename
+		? path.parse( outputChunkFilename ).name + '.css'
+		: undefined;
 
 	const webpackConfig = {
 		bail: ! isDevelopment,
@@ -107,7 +110,7 @@ function getWebpackConfig(
 				global: 'window',
 			} ),
 			new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
-			...SassConfig.plugins( { cssFilename, minify: ! isDevelopment } ),
+			...SassConfig.plugins( { cssChunkFilename, cssFilename, minify: ! isDevelopment } ),
 			new DuplicatePackageCheckerPlugin(),
 			...( env.WP ? [ new WordPressExternalDependenciesPlugin() ] : [] ),
 		],

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -109,7 +109,11 @@ function getWebpackConfig(
 				global: 'window',
 			} ),
 			new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
-			...SassConfig.plugins( { cssChunkFilename, cssFilename, minify: ! isDevelopment } ),
+			...SassConfig.plugins( {
+				chunkFilename: cssChunkFilename,
+				filename: cssFilename,
+				minify: ! isDevelopment,
+			} ),
 			new DuplicatePackageCheckerPlugin(),
 			...( env.WP ? [ new WordPressExternalDependenciesPlugin() ] : [] ),
 		],

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -103,7 +103,6 @@ function getWebpackConfig(
 				} ),
 				SassConfig.loader( {
 					preserveCssCustomProperties: false,
-					includePaths: [ path.join( __dirname, 'client' ) ],
 					prelude: '@import "~@automattic/calypso-color-schemes/src/shared/colors";',
 				} ),
 				FileConfig.loader(),

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -18,6 +18,7 @@ const WordPressExternalDependenciesPlugin = require( '@automattic/wordpress-exte
 /**
  * Internal dependencies
  */
+const { cssNameFromFilename } = require( './webpack/util' );
 // const { workerCount } = require( './webpack.common' ); // todo: shard...
 
 /**
@@ -54,19 +55,8 @@ function getWebpackConfig(
 ) {
 	const workerCount = 1;
 
-	// Determine cssFilename based on the provided `output.filename`
-	const [ cssFilename, filenameQueryString ] = outputFilename.split( '?', 2 );
-	cssFilename.replace(
-		/\.js$/i,
-		'.css' + ( filenameQueryString ? `?${ filenameQueryString }` : '' )
-	);
-
-	// Determine cssChunkFilename based on the provided output.filename
-	const [ cssChunkFilename, chunkQueryString ] = outputChunkFilename.split( '?', 2 );
-	cssChunkFilename.replace(
-		/\.js$/i,
-		'.css' + ( chunkQueryString ? `?${ chunkQueryString }` : '' )
-	);
+	const cssFilename = cssNameFromFilename( outputFilename );
+	const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 
 	const webpackConfig = {
 		bail: ! isDevelopment,

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -53,10 +53,20 @@ function getWebpackConfig(
 	}
 ) {
 	const workerCount = 1;
-	const cssFilename = path.parse( outputFilename ).name + '.css';
-	const cssChunkFilename = outputChunkFilename
-		? path.parse( outputChunkFilename ).name + '.css'
-		: undefined;
+
+	// Determine cssFilename based on the provided `output.filename`
+	const [ cssFilename, filenameQueryString ] = outputFilename.split( '?', 2 );
+	cssFilename.replace(
+		/\.js$/i,
+		'.css' + ( filenameQueryString ? `?${ filenameQueryString }` : '' )
+	);
+
+	// Determine cssChunkFilename based on the provided output.filename
+	const [ cssChunkFilename, chunkQueryString ] = outputChunkFilename.split( '?', 2 );
+	cssChunkFilename.replace(
+		/\.js$/i,
+		'.css' + ( chunkQueryString ? `?${ chunkQueryString }` : '' )
+	);
 
 	const webpackConfig = {
 		bail: ! isDevelopment,

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -50,14 +50,16 @@ module.exports.loader = ( { preserveCssCustomProperties, includePaths, prelude }
 /**
  * Return an array of styling relevant webpack plugin objects.
  *
- * @param  {Object}   _              Options
- * @param  {String}   _.cssFilename  filename pattern to use for CSS files
- * @param  {Boolean}  _.minify       whether to minify CSS
+ * @param  {Object}   _                   Options
+ * @param  {String}   _.chunkCssFilename  filename pattern to use for CSS files
+ * @param  {String}   _.cssFilename       filename pattern to use for CSS chunk files
+ * @param  {Boolean}  _.minify            whether to minify CSS
  *
- * @return {Object[]}                styling relevant webpack plugin objects
+ * @return {Object[]}                     styling relevant webpack plugin objects
  */
-module.exports.plugins = ( { cssFilename, minify } ) => [
+module.exports.plugins = ( { cssChunkFilename, cssFilename, minify } ) => [
 	new MiniCssExtractPluginWithRTL( {
+		chunkFilename: cssChunkFilename,
 		filename: cssFilename,
 		rtlEnabled: true,
 	} ),

--- a/packages/calypso-build/webpack/sass.js
+++ b/packages/calypso-build/webpack/sass.js
@@ -50,17 +50,17 @@ module.exports.loader = ( { preserveCssCustomProperties, includePaths, prelude }
 /**
  * Return an array of styling relevant webpack plugin objects.
  *
- * @param  {Object}   _                   Options
- * @param  {String}   _.chunkCssFilename  filename pattern to use for CSS files
- * @param  {String}   _.cssFilename       filename pattern to use for CSS chunk files
- * @param  {Boolean}  _.minify            whether to minify CSS
+ * @param  {Object}   _                Options
+ * @param  {String}   _.chunkFilename  filename pattern to use for CSS files
+ * @param  {String}   _.filename       filename pattern to use for CSS chunk files
+ * @param  {Boolean}  _.minify         whether to minify CSS
  *
- * @return {Object[]}                     styling relevant webpack plugin objects
+ * @return {Object[]}                  styling relevant webpack plugin objects
  */
-module.exports.plugins = ( { cssChunkFilename, cssFilename, minify } ) => [
+module.exports.plugins = ( { chunkFilename, filename, minify } ) => [
 	new MiniCssExtractPluginWithRTL( {
-		chunkFilename: cssChunkFilename,
-		filename: cssFilename,
+		chunkFilename,
+		filename,
 		rtlEnabled: true,
 	} ),
 	new FilterWarningsPlugin( {

--- a/packages/calypso-build/webpack/test/util.js
+++ b/packages/calypso-build/webpack/test/util.js
@@ -1,0 +1,23 @@
+const { cssNameFromFilename } = require( '../util' );
+
+describe( 'cssNameFromFilename()', () => {
+	test( 'Transforms static string', () => {
+		expect( cssNameFromFilename( 'static.js' ) ).toBe( 'static.css' );
+	} );
+
+	test( 'Passes `undefined` through', () => {
+		expect( cssNameFromFilename() ).toBeUndefined();
+	} );
+
+	test( 'Handles templates', () => {
+		expect( cssNameFromFilename( '[name].[hash].js' ) ).toBe( '[name].[hash].css' );
+	} );
+
+	test( 'Maintains query string', () => {
+		expect( cssNameFromFilename( 'static.js?query=string' ) ).toBe( 'static.css?query=string' );
+	} );
+
+	test( 'Returns other extensions untouched 😬', () => {
+		expect( 'static.jsx' ).toBe( 'static.jsx' );
+	} );
+} );

--- a/packages/calypso-build/webpack/util.js
+++ b/packages/calypso-build/webpack/util.js
@@ -1,0 +1,17 @@
+/**
+ * Transform webpack output.filename and output.chunkFilename to CSS variants
+ *
+ * @param {(string|undefined)} name filename, chunkFilename or undefined
+ * @return {(string|undefined)}     Transformed name or undefined
+ */
+function cssNameFromFilename( name ) {
+	if ( name ) {
+		const [ cssChunkFilename, chunkQueryString ] = name.split( '?', 2 );
+		return cssChunkFilename.replace(
+			/\.js$/i,
+			'.css' + ( chunkQueryString ? `?${ chunkQueryString }` : '' )
+		);
+	}
+}
+
+module.exports = { cssNameFromFilename };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -269,7 +269,7 @@ function getWebpackConfig( {
 			} ),
 			new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
 			isCalypsoClient && new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
-			...SassConfig.plugins( { cssFilename, minify: ! isDevelopment } ),
+			...SassConfig.plugins( { filename: cssFilename, minify: ! isDevelopment } ),
 			isCalypsoClient &&
 				new AssetsWriter( {
 					filename:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to @sirreal's #32192, based on conversation in https://github.com/Automattic/jetpack/pull/12014.

- Add cssChunkFilename arg to SASS shard
- Compute cssFilename and cssChunkFilename from their JS counterparts

The rationale here is that we want our CSS filenames and chunk filenames to reflect their JS counterparts. Fortunately, `mini-css-extract-plugin` supports [options for both](https://github.com/webpack-contrib/mini-css-extract-plugin#minimal-example).

We thus add a `cssChunkFilename` arg to the SASS shard. Furthermore, we change `calypso-build`'s webpack config to compute the CSS filenames (and chunk filenames) from webpack's [`output-filename` and `output-chunk-filename`](https://webpack.js.org/api/cli/#output-options) args.

I'm not a big fan of "being smart" (in this case: determining the CSS filenames from the JS counterparts by removing the `.js`, and adding the `.css` suffix), but it seems like the best option in this case, since
1. It's a reasonable assumption that filenames for both cases should follow the same pattern
2. It's a reasonable assumption that built JS files are suffixed `.js`
3. While webpack supports `output-filename` and `output-chunk-filename` args natively, the CSS counterparts are obviously specific to `mini-css-extract-plugin`.
4. However, they're obviously similar in spirit -- and I don't think it makes sense to add those non-native options as args to `getWepackConfig()`'s signature.

#### Testing instructions

Build `o2-blocks` - no changes. `npx lerna run build`

#### Sidenote

This is also going to come in handy for #32083.