### PR TITLE
Build: Drop cssFilename option from root webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ const Minify = require( '@automattic/calypso-build/webpack/minify' );
 const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
 const WordPressExternalDependenciesPlugin = require( '@automattic/wordpress-external-dependencies-plugin' );
+const { cssNameFromFilename } = require( './webpack/util' );
 
 /**
  * Internal dependencies
@@ -162,8 +163,8 @@ function getWebpackConfig( {
 		outputChunkFilename = '[name].js';
 	}
 
-	const cssFilename = path.parse( outputFilename ).name + '.css';
-	const cssChunkFilename = path.parse( outputChunkFilename ).name + '.css';
+	const cssFilename = cssNameFromFilename( outputFilename );
+	const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 
 	const webpackConfig = {
 		bail: ! isDevelopment,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,7 @@ const Minify = require( '@automattic/calypso-build/webpack/minify' );
 const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
 const WordPressExternalDependenciesPlugin = require( '@automattic/wordpress-external-dependencies-plugin' );
-const { cssNameFromFilename } = require( './webpack/util' );
+const { cssNameFromFilename } = require( '@automattic/calypso-build/webpack/util' );
 
 /**
  * Internal dependencies

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,9 +163,7 @@ function getWebpackConfig( {
 	}
 
 	const cssFilename = path.parse( outputFilename ).name + '.css';
-	const cssChunkFilename = outputChunkFilename
-		? path.parse( outputChunkFilename ).name + '.css'
-		: undefined;
+	const cssChunkFilename = path.parse( outputChunkFilename ).name + '.css';
 
 	const webpackConfig = {
 		bail: ! isDevelopment,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the `cssFilename` option from the Calypso root webpack config, inferring its value from `outputFilename` instead; dito for `cssChunkFilename`. For more background and a rationale, see #32194, which does the same for `calypso-build`'s webpack config.

This also requires some re-arranging of filename logic in the webpack config.

There is one behavioral change: In production, CSS filenames previously followed the `[name].[chunkhash].css` pattern. Since they're now modeled after `outputFilename`, they now include a `min` particle, i.e. `[name].[chunkhash].min.css`. AFAICS, that shouldn't really matter much though.

#### Testing instructions

```
npm run distclean && npm ci
npm start
```

Does Calypso start and build properly?