### PR TITLE
Skip localStorage polyfill in evergreen build.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -322,11 +322,21 @@ if ( ! config.isEnabled( 'desktop' ) ) {
 	);
 }
 
-// The SVG external content polyfill (svg4everybody) isn't needed for evergreen browsers, so don't bundle it.
+// List of polyfills that we skip including in the evergreen bundle.
+// CoreJS polyfills are automatically dropped using the browserslist definitions; no need to include them here.
+const polyfillsSkippedInEvergreen = [
+	// Local storage used to throw errors in Safari private mode, but that's no longer the case in Safari >=11.
+	/^lib[/\\]local-storage-polyfill$/,
+	// The SVG external content polyfill (svg4everybody) isn't needed for evergreen browsers.
+	/^svg4everybody$/,
+];
+
 if ( browserslistEnv === 'evergreen' ) {
-	webpackConfig.plugins.push(
-		new webpack.NormalModuleReplacementPlugin( /^svg4everybody$/, 'lodash/noop' )
-	);
+	for ( const polyfill of polyfillsSkippedInEvergreen ) {
+		webpackConfig.plugins.push(
+			new webpack.NormalModuleReplacementPlugin( polyfill, 'lodash/noop' )
+		);
+	}
 }
 
 module.exports = webpackConfig;


### PR DESCRIPTION
All the browsers supported in the evergreen build include support for `localStorage`. This includes Safari, which no longer throws errors when using `localStorage` in private windows.

As such, we can replace the polyfill with a noop in the evergreen build.

This change also adds a generic mechanism to skip other (non-coreJS) polyfills in the evergreen bundle (unnecessary coreJS polyfills are already skipped by the browserslist config).

#### Changes proposed in this Pull Request

* Replace `localStorage` polyfill with a noop in evergreen bundle

#### Testing instructions

* Ensure there are no errors in evergreen browsers, particularly Safari 11+ in private mode. The polyfill is applied very early on and `localStorage` functionality is used liberally across Calypso, so testing a few pages should be enough.