### PR TITLE
Use only scrollIntoView

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -494,6 +494,15 @@ export async function refreshIfJNError( driver, timeout = 2000 ) {
 	return await refreshIfNeeded();
 }
 
+/**
+ * @description
+ * Scroll element on a page to desired position
+ *
+ * @param {Object} driver WebDriver
+ * @param {Object} selector A element's selector
+ * @param {String} position An element's position. Can be 'start', 'end' and 'center'
+ * @returns {Promise<void>} Promise
+ */
 export async function scrollIntoView( driver, selector, position = 'center' ) {
 	const selectorElement = await driver.findElement( selector );
 

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -494,29 +494,11 @@ export async function refreshIfJNError( driver, timeout = 2000 ) {
 	return await refreshIfNeeded();
 }
 
-export async function scrollIntoView( driver, selector ) {
+export async function scrollIntoView( driver, selector, position = 'center' ) {
 	const selectorElement = await driver.findElement( selector );
 
 	return await driver.executeScript(
-		'arguments[0].scrollIntoView( { block: "center", inline: "center" } )',
-		selectorElement
-	);
-}
-
-export async function scrollToBottom( driver, selector ) {
-	const selectorElement = await driver.findElement( selector );
-
-	return await driver.executeScript(
-		'arguments[0].scrollIntoView( { block: "end", inline: "center" } )',
-		selectorElement
-	);
-}
-
-export async function scrollToTop( driver, selector ) {
-	const selectorElement = await driver.findElement( selector );
-
-	return await driver.executeScript(
-		'arguments[0].scrollIntoView( { block: "start", inline: "center" } )',
+		`arguments[0].scrollIntoView( { block: "${ position }", inline: "center" } )`,
 		selectorElement
 	);
 }

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -152,7 +152,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			`.editor-block-list__block.is-selected[aria-label*='${ name }']`
 		);
 
-		await driverHelper.scrollToTop( this.driver, By.css( '.editor-writing-flow' ) );
+		await driverHelper.scrollIntoView( this.driver, By.css( '.editor-writing-flow' ), 'start' );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, inserterToggleSelector );
 		await driverHelper.clickWhenClickable( this.driver, inserterToggleSelector );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, inserterMenuSelector );

--- a/test/e2e/lib/pages/people-page.js
+++ b/test/e2e/lib/pages/people-page.js
@@ -84,7 +84,7 @@ export default class PeoplePage extends AsyncBaseContainer {
 			if ( displayed ) {
 				break;
 			} else {
-				await DriverHelper.scrollToBottom( this.driver, By.css( '.layout__primary' ) );
+				await DriverHelper.scrollIntoView( this.driver, By.css( '.layout__primary' ), 'end' );
 			}
 		}
 		return displayed;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We had `scrollIntoView`, `scrollToBottom` and `scrollToTop` which do a similar thing. WIth this change we'll have only `scrollIntoView` and call it with proper `positions` argument. 

#### Testing instructions

Make sure that all tests are passing. 

