### PR TITLE
Monitor: remove feature flag and enable for 10% of sites.

### DIFF
--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -40,6 +40,16 @@ class SiteSettingsFormJetpackMonitor extends Component {
 		}
 	}
 
+	isNotesEnabledForBlog = () => {
+		const { siteId } = this.props;
+		// Only enable for 10% of users for now (blog IDs that finish by 1).
+		if ( 1 === siteId % 10 ) {
+			return true;
+		}
+
+		return false;
+	};
+
 	recordEvent = event => {
 		return () => {
 			this.props.trackEvent( event );
@@ -151,8 +161,7 @@ class SiteSettingsFormJetpackMonitor extends Component {
 
 					<div className="site-settings__child-settings">
 						{ this.settingsMonitorEmailCheckbox() }
-						{ config.isEnabled( 'settings/security/monitor/wp-note' ) &&
-							this.settingsMonitorWpNoteCheckbox() }
+						{ this.isNotesEnabledForBlog() && this.settingsMonitorWpNoteCheckbox() }
 					</div>
 				</Card>
 			</div>

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -135,7 +135,6 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
 		"signup/onboarding-flow": false,
 		"signup/social": true,

--- a/config/development.json
+++ b/config/development.json
@@ -168,7 +168,6 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,7 +118,6 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": false,
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -136,7 +136,6 @@
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"settings/security/monitor/wp-note": true,
 		"settings/theme-setup": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This depends on D26784-code.

The toggle to enable App / WordPress.com notifications was previously hidden behind a feature flag that was only on for our staging / test environments.
This PR removes the feature flag altogether, and instead enables the toggle for all blog IDs that finish by `1`. This follows the approach we took in D26784-code.

In the coming few days, we'll enable the feature for more and more site owners by making a change here and on WordPress.com.

#### Testing instructions

* Head over to http://calypso.localhost:3000/settings/security/
* Pick different Jetpack sites in the site picker. 
* When picking a site with a site ID that finishes by `1`, you should see this:
![image](https://user-images.githubusercontent.com/426388/55956564-8f2bad00-5c64-11e9-9c42-fbe112785b1b.png)
* When picking any other site, you should see this:
![image](https://user-images.githubusercontent.com/426388/55956606-a4084080-5c64-11e9-9112-87429a8bdef0.png)
