### PR TITLE
People: Update Followers/Email Followers headings to use sentences for better semantic understanding

### DIFF
--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -37,6 +37,16 @@ const Followers = localize(
 			bulkEditing: false,
 		};
 
+		sendTotalFollowers() {
+			this.props.getFollowers( this.props.totalFollowers );
+		}
+
+		componentDidUpdate( prevProps ) {
+			if ( prevProps.totalFollowers !== this.props.totalFollowers ) {
+				this.sendTotalFollowers();
+			}
+		}
+
 		renderPlaceholders() {
 			return <PeopleListItem key="people-list-item-placeholder" />;
 		}
@@ -260,6 +270,7 @@ const FollowersList = props => {
 			site={ props.site }
 			label={ props.label }
 			type={ props.type }
+			getFollowers={ props.getFollowers }
 		>
 			<Followers />
 		</DataComponent>

--- a/client/my-sites/people/main.jsx
+++ b/client/my-sites/people/main.jsx
@@ -27,6 +27,19 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import titlecase from 'to-title-case';
 
 class People extends React.Component {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			totalFollowers: 0,
+		};
+	}
+
+	getFollowers = count => {
+		if ( count ) {
+			this.setState( { totalFollowers: count } );
+		}
+	};
+
 	renderPeopleList() {
 		const { site, search, filter, translate } = this.props;
 
@@ -34,14 +47,28 @@ class People extends React.Component {
 			case 'team':
 				return <TeamList site={ site } search={ search } />;
 			case 'followers':
-				return <FollowersList site={ site } label={ translate( 'Followers' ) } />;
+				return (
+					<FollowersList
+						site={ site }
+						label={ translate( 'You have %(number)d follower', 'You have %(number)d followers', {
+							count: this.state.totalFollowers,
+							args: { number: this.state.totalFollowers },
+						} ) }
+						getFollowers={ this.getFollowers }
+					/>
+				);
 			case 'email-followers':
 				return (
 					<FollowersList
 						site={ site }
 						search={ search }
-						label={ translate( 'Email Followers' ) }
+						label={ translate(
+							'You have %(number)d email follower',
+							'You have %(number)d email followers',
+							{ count: this.state.totalFollowers, args: { number: this.state.totalFollowers } }
+						) }
 						type="email"
+						getFollowers={ this.getFollowers }
 					/>
 				);
 			case 'viewers':


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR passes the follower counts up from `FollowerList` to the parent `People` component so we can add the count to a full sentence (ie. "You have 123 followers") to make that connection clearer to the user.
* I've labeled this as a "try" because I'm not sure this is the most performant/sensible method for adding the follower count to the heading title. Should we move the `FollowersData` component up into `People` directly? Or something else?
* If we proceed with this change, we'd probably want to apply this logic to the Team and Invites sections as well.

#### Testing instructions

* TBD

Fixes #31635 