### PR TITLE
Switch from the globe to the site icon on the default blavatar

### DIFF
--- a/client/blocks/site-icon/index.jsx
+++ b/client/blocks/site-icon/index.jsx
@@ -49,7 +49,7 @@ function SiteIcon( { siteId, site, iconUrl, size, imgSize, isTransientIcon } ) {
 			{ iconSrc ? (
 				<Image className="site-icon__img" src={ iconSrc } alt="" />
 			) : (
-				<Gridicon icon="globe" size={ Math.round( size / 1.3 ) } />
+				<Gridicon icon="site" size={ Math.round( size / 1.3 ) } />
 			) }
 			{ isTransientIcon && <Spinner /> }
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch the icon on the default blavatar (site icon) to the `site`, away from `globe`

#### Testing instructions

* Verify that the default site icon is now the site icon, not the globe

