### PR TITLE
Importers: Remove unused logic for clearing import state

### DIFF
--- a/client/my-sites/importer/importer-action-buttons/done-button.jsx
+++ b/client/my-sites/importer/importer-action-buttons/done-button.jsx
@@ -20,7 +20,6 @@ import {
 	setImportOriginSiteDetails,
 } from 'state/importer-nux/actions';
 import { isImportingFromSignupFlow } from 'state/importer-nux/temp-selectors';
-import { SITE_IMPORTER } from 'state/imports/constants';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 export class DoneButton extends React.PureComponent {
@@ -55,7 +54,7 @@ export class DoneButton extends React.PureComponent {
 
 	componentWillUnmount() {
 		const {
-			importerStatus: { importerId, type },
+			importerStatus: { importerId },
 			site: { ID: siteId },
 			isSignup,
 		} = this.props;
@@ -65,11 +64,6 @@ export class DoneButton extends React.PureComponent {
 		 * Otherwise, you see the importers list during the route change
 		 */
 		resetImport( siteId, importerId );
-
-		if ( SITE_IMPORTER === type ) {
-			// Clear out site details, so that importers list isn't filtered
-			this.props.setImportOriginSiteDetails();
-		}
 
 		if ( isSignup ) {
 			this.props.clearImportingFromSignupFlow();


### PR DESCRIPTION
In #31983, the constant `SITE_IMPORTER` from `client/state/import/constants` was renamed to `WIX`. @blowery pointed out that I missed an instance in `client/my-sites/importer/importer-action-buttons/done-button` that was causing a warning in master.

The constant was introduced in #28371 and used to clear the import state when coming from a signup flow. It is no longer needed as there is redundant (and more resilient) clearing of state introduced via #31852.

#### Changes proposed in this Pull Request

* Remove out-dated and unnecessary logic to reset the import state, removing the troublesome constant entirely

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the troublesome constant is now removed
* Start an import from `/start/import` using a Wix site (PCYsg-i88-p2)
* Click "Yes! Start import" and wait for the import to complete
* After the import completes, click "View site" (which is the done-button). It will take you to a site preview.
* Verify that when you click "Import" in the sidebar from your newly-created site, that you see the list of importers as opposed to being drilled in to the Wix importer.

