### PR TITLE
Add a starting point for Muriel layout css

### DIFF
--- a/packages/muriel-style/layout.scss
+++ b/packages/muriel-style/layout.scss
@@ -1,0 +1,34 @@
+$layout-grid-columns-large: 12;
+$layout-grid-columns-medium: 8;
+$layout-grid-columns-small: 4;
+
+$layout-grid-gutter-large: 24px;
+$layout-grid-gutter-medium: 24px;
+$layout-grid-gutter-small: 16px; 
+
+$layout-grid-breakpoint-large: 600px;
+$layout-grid-breakpoint-medium: 480px;
+$layout-grid-breakpoint-small: 0;
+
+.layout-grid {
+  @media (min-width: $layout-grid-breakpoint-large) {
+    display: grid;
+    margin: 0;
+    grid-gap: $layout-grid-gutter-large;
+    grid-template-columns: repeat($layout-grid-columns-large, [col-start] minmax(0, 1fr)); 
+  }
+
+  @media (min-width: $layout-grid-breakpoint-medium) and (max-width: $layout-grid-breakpoint-large - 1px) {
+    display: grid;
+    margin: 0;
+    grid-gap: $layout-grid-gutter-medium;
+    grid-template-columns: repeat($layout-grid-columns-medium, [col-start] minmax(0, 1fr)); 
+  }
+
+  @media (max-width: $layout-grid-breakpoint-medium - 1px) {
+    display: grid;
+    margin: 0;
+    grid-gap: $layout-grid-gutter-small;
+    grid-template-columns: repeat($layout-grid-columns-small, [col-start] minmax(0, 1fr)); 
+  }
+}

--- a/packages/muriel-style/layout.scss
+++ b/packages/muriel-style/layout.scss
@@ -1,34 +1,39 @@
 $layout-grid-columns-large: 12;
 $layout-grid-columns-medium: 8;
 $layout-grid-columns-small: 4;
-
 $layout-grid-gutter-large: 24px;
 $layout-grid-gutter-medium: 24px;
 $layout-grid-gutter-small: 16px; 
-
 $layout-grid-breakpoint-large: 600px;
 $layout-grid-breakpoint-medium: 480px;
 $layout-grid-breakpoint-small: 0;
 
 .layout-grid {
-  @media (min-width: $layout-grid-breakpoint-large) {
+
+  @media ( min-width: $layout-grid-breakpoint-large ) {
+
     display: grid;
     margin: 0;
     grid-gap: $layout-grid-gutter-large;
-    grid-template-columns: repeat($layout-grid-columns-large, [col-start] minmax(0, 1fr)); 
+    grid-template-columns: repeat( $layout-grid-columns-large, [col-start] minmax( 0, 1fr ) ); 
+
   }
 
-  @media (min-width: $layout-grid-breakpoint-medium) and (max-width: $layout-grid-breakpoint-large - 1px) {
+  @media ( min-width: $layout-grid-breakpoint-medium ) and ( max-width: $layout-grid-breakpoint-large - 1px ) {
+
     display: grid;
     margin: 0;
     grid-gap: $layout-grid-gutter-medium;
-    grid-template-columns: repeat($layout-grid-columns-medium, [col-start] minmax(0, 1fr)); 
+    grid-template-columns: repeat( $layout-grid-columns-medium, [col-start] minmax( 0, 1fr ) ); 
+
   }
 
-  @media (max-width: $layout-grid-breakpoint-medium - 1px) {
+  @media ( max-width: $layout-grid-breakpoint-medium - 1px ) {
+
     display: grid;
     margin: 0;
     grid-gap: $layout-grid-gutter-small;
-    grid-template-columns: repeat($layout-grid-columns-small, [col-start] minmax(0, 1fr)); 
+    grid-template-columns: repeat( $layout-grid-columns-small, [col-start] minmax( 0, 1fr ) ); 
+
   }
 }

--- a/packages/muriel-style/layout.scss
+++ b/packages/muriel-style/layout.scss
@@ -10,30 +10,30 @@ $layout-grid-breakpoint-small: 0;
 
 .layout-grid {
 
-  @media ( min-width: $layout-grid-breakpoint-large ) {
+	@media ( min-width: $layout-grid-breakpoint-large ) {
 
-    display: grid;
-    margin: 0;
-    grid-gap: $layout-grid-gutter-large;
-    grid-template-columns: repeat( $layout-grid-columns-large, [col-start] minmax( 0, 1fr ) ); 
+		display: grid;
+		margin: 0;
+		grid-gap: $layout-grid-gutter-large;
+		grid-template-columns: repeat( $layout-grid-columns-large, [col-start] minmax( 0, 1fr ) );
 
-  }
+	}
 
-  @media ( min-width: $layout-grid-breakpoint-medium ) and ( max-width: $layout-grid-breakpoint-large - 1px ) {
+	@media ( min-width: $layout-grid-breakpoint-medium ) and ( max-width: $layout-grid-breakpoint-large - 1px ) {
 
-    display: grid;
-    margin: 0;
-    grid-gap: $layout-grid-gutter-medium;
-    grid-template-columns: repeat( $layout-grid-columns-medium, [col-start] minmax( 0, 1fr ) ); 
+		display: grid;
+		margin: 0;
+		grid-gap: $layout-grid-gutter-medium;
+		grid-template-columns: repeat( $layout-grid-columns-medium, [col-start] minmax( 0, 1fr ) );
 
-  }
+	}
 
-  @media ( max-width: $layout-grid-breakpoint-medium - 1px ) {
+	@media ( max-width: $layout-grid-breakpoint-medium - 1px ) {
 
-    display: grid;
-    margin: 0;
-    grid-gap: $layout-grid-gutter-small;
-    grid-template-columns: repeat( $layout-grid-columns-small, [col-start] minmax( 0, 1fr ) ); 
+		display: grid;
+		margin: 0;
+		grid-gap: $layout-grid-gutter-small;
+		grid-template-columns: repeat( $layout-grid-columns-small, [col-start] minmax( 0, 1fr ) );
 
-  }
+	}
 }

--- a/packages/muriel-style/layout.scss
+++ b/packages/muriel-style/layout.scss
@@ -4,20 +4,16 @@ $layout-grid-columns-small: 4;
 $layout-grid-gutter-large: 24px;
 $layout-grid-gutter-medium: 24px;
 $layout-grid-gutter-small: 16px; 
-$layout-grid-breakpoint-large: 600px;
-$layout-grid-breakpoint-medium: 480px;
-$layout-grid-breakpoint-small: 0;
+$layout-grid-breakpoint-large: 1280px;
+$layout-grid-breakpoint-medium: 600px;
+$layout-grid-breakpoint-small: 0px;
 
 .layout-grid {
 
-	@media ( min-width: $layout-grid-breakpoint-large ) {
-
-		display: grid;
-		margin: 0;
-		grid-gap: $layout-grid-gutter-large;
-		grid-template-columns: repeat( $layout-grid-columns-large, [col-start] minmax( 0, 1fr ) );
-
-	}
+	display: grid;
+	margin: 0;
+	grid-gap: $layout-grid-gutter-small;
+	grid-template-columns: repeat( $layout-grid-columns-small, [col-start] minmax( 0, 1fr ) );
 
 	@media ( min-width: $layout-grid-breakpoint-medium ) and ( max-width: $layout-grid-breakpoint-large - 1px ) {
 
@@ -28,12 +24,13 @@ $layout-grid-breakpoint-small: 0;
 
 	}
 
-	@media ( max-width: $layout-grid-breakpoint-medium - 1px ) {
+	@media ( min-width: $layout-grid-breakpoint-large ) {
 
 		display: grid;
 		margin: 0;
-		grid-gap: $layout-grid-gutter-small;
-		grid-template-columns: repeat( $layout-grid-columns-small, [col-start] minmax( 0, 1fr ) );
+		grid-gap: $layout-grid-gutter-large;
+		grid-template-columns: repeat( $layout-grid-columns-large, [col-start] minmax( 0, 1fr ) );
 
 	}
+
 }

--- a/packages/muriel-style/layout.scss
+++ b/packages/muriel-style/layout.scss
@@ -17,8 +17,6 @@ $layout-grid-breakpoint-small: 0px;
 
 	@media ( min-width: $layout-grid-breakpoint-medium ) and ( max-width: $layout-grid-breakpoint-large - 1px ) {
 
-		display: grid;
-		margin: 0;
 		grid-gap: $layout-grid-gutter-medium;
 		grid-template-columns: repeat( $layout-grid-columns-medium, [col-start] minmax( 0, 1fr ) );
 
@@ -26,8 +24,6 @@ $layout-grid-breakpoint-small: 0px;
 
 	@media ( min-width: $layout-grid-breakpoint-large ) {
 
-		display: grid;
-		margin: 0;
 		grid-gap: $layout-grid-gutter-large;
 		grid-template-columns: repeat( $layout-grid-columns-large, [col-start] minmax( 0, 1fr ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a CSS grid layout utility class to the Muriel styles package

#### Testing instructions

* Reference it in a component's styles and use it:
`import "~@automattic/muriel-styles/layout";`

Fixes #
