### PR TITLE
Import in Signup: Remove Godaddy subdomain from new site slug

### DIFF
--- a/client/state/importer-nux/utils.js
+++ b/client/state/importer-nux/utils.js
@@ -7,6 +7,7 @@ import { memoize } from 'lodash';
 export const normalizeImportUrl = memoize( ( url = '' ) =>
 	url
 		.replace( /^https?:\/\/(www)?/gi, '' )
+		.replace( /godaddysites(\.com)?/i, '' )
 		.replace( /wixsite(\.com)?/i, '' )
 		.replace( /[^a-z0-9]/gi, '' )
 		.trim()


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* replace godaddysites.com with an empty string in `normalizeImportUrl`

#### Testing instructions

* Go through an import signup flow `/start/import` with a `*.godaddysites.com` url.
* Your new WPCOM site should not include a `godaddysitescom` suffix
* Verify there are no other usages (except [here](https://github.com/Automattic/wp-calypso/blob/c493a630688209b218dc0d64524a342d17a30bc6/client/lib/signup/step-actions.js#L177)) which will be affected by changing the behavior of this function