### PR TITLE
Fix subdomains test by using vertical name

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1299,7 +1299,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 				StartPage.getStartURL( {
 					culture: locale,
 					flow: 'subdomain',
-					query: 'vertical=a8c.1',
+					query: 'vertical=art',
 				} )
 			);
 			const designTypePage = await DesignTypePage.Expect( driver );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use vertical name now that the old code format doesn't work

#### Testing instructions
* Ensure `Sign up for free subdomain site` test works
