### PR TITLE
Import In Signup: Properly set site title & tidy up

### DIFF
--- a/client/my-sites/importer/importer-godaddy-gocentral.jsx
+++ b/client/my-sites/importer/importer-godaddy-gocentral.jsx
@@ -31,7 +31,6 @@ class ImporterGoDaddyGoCentral extends React.PureComponent {
 				type: PropTypes.string.isRequired,
 				description: PropTypes.string.isRequired,
 			} ),
-			siteTitle: PropTypes.string.isRequired,
 			statusMessage: PropTypes.string,
 		} ),
 	};

--- a/client/my-sites/importer/site-importer/index.jsx
+++ b/client/my-sites/importer/site-importer/index.jsx
@@ -55,7 +55,6 @@ export default class extends React.PureComponent {
 			filename: PropTypes.string,
 			importerState: PropTypes.string.isRequired,
 			percentComplete: PropTypes.number,
-			siteTitle: PropTypes.string.isRequired,
 			statusMessage: PropTypes.string,
 		} ),
 	};

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -435,9 +435,9 @@ export function generateSteps( {
 			providesDependencies: [
 				'importEngine',
 				'importFavicon',
-				'importSiteTitle',
 				'importSiteUrl',
 				'sitePreviewImageBlob',
+				'siteTitle',
 				'themeSlugWithRepo',
 			],
 		},

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -18,15 +18,10 @@ import FormButton from 'components/forms/form-button';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import ScreenReaderText from 'components/screen-reader-text';
-import {
-	setImportOriginSiteDetails,
-	setNuxUrlInputValue,
-	submitImportUrlStep,
-} from 'state/importer-nux/actions';
+import { setNuxUrlInputValue, submitImportUrlStep } from 'state/importer-nux/actions';
 import {
 	getNuxUrlError,
 	getNuxUrlInputValue,
-	getSiteDetails,
 	isUrlInputDisabled,
 } from 'state/importer-nux/temp-selectors';
 import { validateImportUrl } from 'lib/importers/url-validation';
@@ -289,12 +284,10 @@ export default flow(
 		state => ( {
 			isSiteImportableError: getNuxUrlError( state ),
 			urlInputValue: getNuxUrlInputValue( state ),
-			siteDetails: getSiteDetails( state ),
 			isLoading: isUrlInputDisabled( state ),
 		} ),
 		{
 			setNuxUrlInputValue,
-			setImportOriginSiteDetails,
 			recordTracksEvent,
 			submitImportUrlStep,
 		}

--- a/client/state/importer-nux/actions.js
+++ b/client/state/importer-nux/actions.js
@@ -19,6 +19,7 @@ import {
 import { loadmShotsPreview } from 'lib/mshots';
 import wpLib from 'lib/wp';
 import SignupActions from 'lib/signup/actions';
+import { setSiteTitle } from 'state/signup/steps/site-title/actions';
 
 const wpcom = wpLib.undocumented();
 
@@ -79,6 +80,8 @@ export const submitImportUrlStep = ( { stepName, siteUrl: siteUrlFromInput } ) =
 				throw new Error( error );
 			}
 
+			dispatch( setSiteTitle( siteTitle ) );
+
 			const imageBlob = await loadmShotsPreview( {
 				url: normalizeUrl( siteUrlFromInput ),
 				maxRetries: 30,
@@ -89,8 +92,8 @@ export const submitImportUrlStep = ( { stepName, siteUrl: siteUrlFromInput } ) =
 				sitePreviewImageBlob: imageBlob,
 				importEngine: engine,
 				importFavicon: favicon,
-				importSiteTitle: siteTitle,
 				importSiteUrl,
+				siteTitle,
 				themeSlugWithRepo: 'pub/modern-business',
 			} );
 		} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Call `setSiteTitle` with the value received from the API -- that value is pulled in as the new `blog_title` / site title [here](https://github.com/Automattic/wp-calypso/blob/c493a630688209b218dc0d64524a342d17a30bc6/client/lib/signup/step-actions.js#L159)
* Declare that the signup step provides `siteTitle`
* Pull out some invalid propType entries calling for a `siteTitle` property key
* Remove unused "Import Site Details" functions from the signup step component

#### Testing instructions

##### Confirm existing behavior

* Go through an import flow in prod or on master `/start/import`
* Notice the site created does not pull in the site title, but instead is called `Site Title`

##### Confirm fix

* Run this branch
* Repeat the above
* Notice the site created **does** pull in the site title
* The entire flow should work for all supported engines
