### PR TITLE
Domains: A/B test different vendors for EN locale

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -183,4 +183,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	domainSuggestionsEnCheck: {
+		datestamp: '20190415',
+		variations: {
+			control: 50,
+			test: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -195,7 +195,7 @@ export default {
 		allowExistingUsers: true,
 		countryCodeTargets: [ 'USD' ],
 	},
-  domainSuggestionsEnCheck: {
+	domainSuggestionsEnCheck: {
 		datestamp: '20190415',
 		variations: {
 			control: 50,
@@ -203,5 +203,5 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
-  },
+	},
 };

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -2,10 +2,14 @@
 /**
  * Internal dependencies
  */
-import { isUsingGivenLocales } from 'lib/abtest';
+import { abtest, isUsingGivenLocales } from 'lib/abtest';
 
 export const getSuggestionsVendor = () => {
 	if ( isUsingGivenLocales( [ 'en' ] ) ) {
+		if ( abtest( 'domainSuggestionsEnCheck' ) === 'test' ) {
+			return 'variation2_front';
+		}
+
 		return 'variation_front';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Check in on conversion rates after a while for different vendors.

#### Testing instructions

- Visit http://calypso.localhost:3000/domains/add
- In the dev tools, switch variations for the test
- Make sure the `/suggestions` endpoint has the proper vendor
