### PR TITLE
Packages: Set muriel-style to private

### DIFF
--- a/packages/muriel-style/package.json
+++ b/packages/muriel-style/package.json
@@ -20,5 +20,6 @@
 	"bugs": {
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},
-	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/muriel-style#readme"
+	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/muriel-style#readme",
+	"private": true
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Per https://github.com/Automattic/wp-calypso/pull/32201#issuecomment-482354511:

> Hmm, holding off publishing [of `@automattic/calypso-build`] because `lerna` also wants to publish `@automattic/muriel-style@1.0.0`, and I'm not sure that's ready for primetime yet  (Introduced per #32076)

#### Testing instructions

`npx lerna publish from-package` should _not_ list `@automattic/muriel-style`
