### PR TITLE
Packages: Fix Tiny MCE handle used as externalized WordPress dependency

### DIFF
--- a/packages/wordpress-external-dependencies-plugin/index.js
+++ b/packages/wordpress-external-dependencies-plugin/index.js
@@ -80,8 +80,8 @@ class WordPressExternalDependenciesPlugin {
 								handle = 'wp-' + userRequest.substring( WORDPRESS_NAMESPACE.length );
 							} else if ( 'tinymce/tinymce' === userRequest ) {
 								// Transform Tiny MCE dep:
-								//   tinyme/tinymce -> tiny_mce
-								handle = 'tiny_mce';
+								//   tinyme/tinymce -> wp-tinymce
+								handle = 'wp-tinymce';
 							} else {
 								// Pass other externalized deps as they are
 								handle = userRequest;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use `wp-tinymce` as handle for the Tiny MCE dependency.

On #32162 I added support for the `tinymce` dependency to the `@automattic/wordpress-external-dependencies-plugin package`, but I realized I was using an incorrect handle for generating the `.deps.json` file.

Currently, the handle is set to `tiny_mce` as per the documentation of the [default scripts included by WordPress](https://developer.wordpress.org/reference/functions/wp_enqueue_script/#default-scripts-included-and-registered-by-wordpress). However, that handle doesn't work since WordPress is using `wp-tinymce` when [it registers the Tiny MCE scripts](https://github.com/WordPress/WordPress/blob/3ab2803af26856db65bab2d4067a812addcd3d4b/wp-includes/script-loader.php#L56-L61).

I already reported that with a note to the docs page ([#](https://developer.wordpress.org/reference/functions/wp_enqueue_script/#comment-3145)).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build a package that has `tinymce` as dependency (i.e. `@automattic/wpcom-block-editor`: `npx lerna run build --scope='@automattic/wpcom-block-editor'`).
* Check the `.deps.json` file generated on the build folder (i.e. `/apps/wpcom-block-editor/dist/iframe-bridge-server.deps.json`).
* Verify the Tiny MCE dependency is included using the `wp-tinymce` handle.
