### PR TITLE
Packages: Add `@automattic/wpcom-block-editor` documentation

### DIFF
--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -1,0 +1,49 @@
+# @automattic/wpcom-block-editor
+
+This package provides utilities for the WordPress.com block editor integration. 
+
+These utilities are intended to be built and then served from `widgets.wp.com`, so they can be loaded by a WordPress.com or a Jetpack connected site.
+
+## File architecture
+
+### `iframe-bridge-server.js`
+
+Server-side handlers of the different communication channels we establish with the client-side when Calypso loads the iframed block editor. See [`calypsoify-iframe.jsx`](https://github.com/Automattic/wp-calypso/blob/master/client/gutenberg/editor/calypsoify-iframe.jsx).
+
+### `tinymce.js`
+
+Tiny MCE plugin that overrides the core media modal used on classic blocks with the Calypso media modal.
+
+### `utils.js`
+
+Shared utilities to be used across the package.
+
+## Build
+
+### Manual
+
+To manually build the package, execute the command below:
+
+```
+npx lerna run build --scope='@automattic/wpcom-block-editor'
+```
+
+This will generate the distributable files under the `dist` folder.
+
+If you want to generate the build in a different folder, you can use the `bundle` script instead:
+
+```
+npx lerna run bundle --scope='@automattic/wpcom-block-editor' -- -- --output-path=/path-to-folder
+```
+
+_Wonky double `--` is needed for first skipping Lerna args and then NPM args to reach Webpack._
+
+### Automatic
+
+The `build-wpcom-block-editor` CircleCI job automatically generates a build on every Calypso PR.
+
+<img alt="CircleCI job" width="700" src="https://cldup.com/hpfqhRKU0i-1200x1200.png" />
+
+The build files are stored as artifacts of the job. 
+
+<img alt="Artifacts" width="700" src="https://cldup.com/W1yGG6MCsM-1200x1200.png" />

--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -1,4 +1,4 @@
-# @automattic/wpcom-block-editor
+# WP.com block editor
 
 This package provides utilities for the WordPress.com block editor integration. 
 
@@ -44,6 +44,8 @@ The `build-wpcom-block-editor` CircleCI job automatically generates a build on e
 
 <img alt="CircleCI job" width="700" src="https://cldup.com/hpfqhRKU0i-1200x1200.png" />
 
-The build files are stored as artifacts of the job. 
+The build files are stored as artifacts of the job.
 
 <img alt="Artifacts" width="700" src="https://cldup.com/W1yGG6MCsM-1200x1200.png" />
+
+_You must be logged in to CircleCI for the Artifacts tab to be displayed._


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a README file to the `@automattic/wpcom-block-editor` package with documentation about the file architecture and how to build it.

#### Testing instructions

Just check the [README file](https://github.com/Automattic/wp-calypso/blob/94548d6a54010eff20c1e1657dfb0a58edb0b050/apps/wpcom-block-editor/README.md) and make sure it is clear and understandable :).
