### PR TITLE
Sidebar: Fix focus style for links

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -200,6 +200,10 @@ form.sidebar__button input {
 				color: inherit;
 			}
 
+			&:focus {
+				z-index: 1;
+			}
+
 			&:first-child::after {
 				background: overflow-gradient(
 					var( --sidebar-menu-selected-a-first-child-after-background ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a z-index to focus links in the sidebar. This allows the outline to be fully displayed (no white gradient at the bottom or outline not hidden when hovering the previous/next element)

Before: https://cloudup.com/cx7bgcufpnq

After: https://cloudup.com/cJ65VlXufdP

#### Testing instructions

* Open Calypso and click multiple links in the sidebar.
* Does it work properly?
* Do you see the full outline when a link is focused?
