### PR TITLE
Block Editor: Fix inline help notifications dot size

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -104,12 +104,6 @@
 	}
 }
 
-//border-box in the gutenberg section makes the dot too small, update width/height to compensate
-.is-section-gutenberg-editor .button.is-borderless.inline-help__button.has-notification::before {
-	width: 14px;
-	height: 14px;
-}
-
 @keyframes wiggle {
 	0% {
 		transform: rotate( 0 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove unnecessary dimensions for the inline help notifications dot.

Back in the Gutenlypso days, we needed to adjust some components styles to account for the different `box-sizing` of Gutenberg compared to Calypso.
After switching to Gutenframe, these adjustments weren't needed anymore.

| Before (Calypso; expected look) | Before (Gutenframe) | After (Gutenframe) |
| - | - | - |
| ![Screenshot 2019-04-12 at 13 02 36](https://user-images.githubusercontent.com/2070010/56036065-cca33f80-5d23-11e9-8572-71af0e363fc0.png) | ![Screenshot 2019-04-12 at 13 02 19](https://user-images.githubusercontent.com/2070010/56036072-d2008a00-5d23-11e9-800e-b28b356578ba.png) | ![Screenshot 2019-04-12 at 13 02 27](https://user-images.githubusercontent.com/2070010/56036079-d5941100-5d23-11e9-81d1-473e596d7cae.png) |

#### Testing instructions

* Open Calypso on a site with inline help notifications (e.g. a site that has a site setup checklist to clear).
* Note how the notifications dot looks like outside of the editor.
* Open the block editor (Gutenframe) and make sure the notifications dot looks the same.

Fix #32216