### PR TITLE
Add "Manage" button to following page.

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -23,6 +23,8 @@ import config from 'config';
 import { getSearchPlaceholderText } from 'reader/search/utils';
 import Banner from 'components/banner';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
+import SectionHeader from 'components/section-header';
+import Button from 'components/button';
 
 /**
  * Style dependencies
@@ -53,6 +55,7 @@ const FollowingStream = props => {
 	const placeholderText = getSearchPlaceholderText();
 	const now = new Date();
 	const showRegistrationMsg = props.userInUSA && now < lastDayForVoteBanner;
+	const { translate } = props;
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -81,6 +84,11 @@ const FollowingStream = props => {
 				/>
 			</CompactCard>
 			<BlankSuggestions suggestions={ suggestionList } />
+			<SectionHeader label={ translate( 'Following' ) }>
+				<Button primary compact className="following__manage" href="/following/manage">
+					{ translate( 'Manage' ) }
+				</Button>
+			</SectionHeader>
 		</Stream>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

With the nav drawer redesign, we'll be dropping the secondary buttons,
such as "Manage", out of the sidebar completely.  To replace it, we
need a primary button on the "Following" page.

Similar PRs have been merged recently for pages and posts
(https://github.com/Automattic/wp-calypso/pull/31783/files).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Click the "Following" item in the Reader sidebar.  Once it is activated, click the "Manage" button on that page.

Fixes #31780
