### PR TITLE
Import Section: Localize the Section Title in DocumentHead

### DIFF
--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -257,7 +257,6 @@ class SiteSettingsImport extends Component {
 		return (
 			<>
 				<Interval onTick={ this.updateFromAPI } period={ EVERY_FIVE_SECONDS } />
-				<DocumentHead title="Import" />
 				<DescriptiveHeader />
 				{ this.renderImporters() }
 			</>
@@ -270,6 +269,7 @@ class SiteSettingsImport extends Component {
 
 		return (
 			<Main>
+				<DocumentHead title={ translate( 'Import' ) } />
 				<HeaderCake backHref={ '/settings/general/' + siteSlug }>
 					<h1>{ translate( 'Import Content' ) }</h1>
 				</HeaderCake>


### PR DESCRIPTION
...& render it at the top of `Main`

#### Changes proposed in this Pull Request

* Wrap the string in the translate function
* Move the render from the `renderImportersList` fn to the `render` function inside `Main`

#32235 added this, but didn't do the above, so it's unlocalized and only shows when the importers list is shown


#### Testing instructions

* Visit the import section
* You should see `Import` in the title (shown on the tab UI)
* Follow an import signup flow (`/start/import`)
* You should see `Import` in the title (shown on the tab UI)
