### PR TITLE
Signup: bump the date for the domains step removal test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,7 +98,7 @@ export default {
 		defaultVariation: 'original',
 	},
 	removeDomainsStepFromOnboarding: {
-		datestamp: '20181221',
+		datestamp: '20190412',
 		variations: {
 			keep: 50,
 			remove: 50,


### PR DESCRIPTION
In #32100 we increased the distribution of the `removeDomainsStepFromOnboarding` test to 50/50, but we should also bump the date for cleaner metrics.

**To Test:**
- visually verify that the test date is accurate

**From 32100:**
1. Sign up through the onboarding flow and choose the business segment. The domain step should not be there and you should be able to create a site as expected.
2. Sign up through the onboarding flow and choose the other segments. The domain step should be there and you should be able to create a site as expected.
3. Repeat 2 & 3 as a logged-in user to add new sites. The both should work as expected.
4. The main flow should still work as expected.
