### PR TITLE
Packages: Add Rich Text extensions to WP.com block editor package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,9 +284,8 @@ jobs:
       - run:
           name: Build the block editor in WordPress.com integration utils package
           command: |
-            npx lerna run clean --scope='@automattic/wpcom-block-editor'
-            SOURCEMAP='inline-cheap-source-map' npx lerna run bundle --scope='@automattic/wpcom-block-editor' -- -- --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor
-            NODE_ENV=production npx lerna run bundle --scope='@automattic/wpcom-block-editor' -- -- --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor --output-filename=[name].min.js
+            SOURCEMAP='inline-cheap-source-map' npx lerna run build --scope='@automattic/wpcom-block-editor' -- -- --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor
+            NODE_ENV=production npx lerna run build --scope='@automattic/wpcom-block-editor' -- -- --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor --output-filename=[name].min.js
       - store-artifacts-and-test-results
 
   test-client:

--- a/apps/wpcom-block-editor/.eslintrc.js
+++ b/apps/wpcom-block-editor/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
 	rules: {
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: __dirname } ],
+		'react/react-in-jsx-scope': 0,
 	},
 };

--- a/apps/wpcom-block-editor/README.md
+++ b/apps/wpcom-block-editor/README.md
@@ -10,6 +10,10 @@ These utilities are intended to be built and then served from `widgets.wp.com`, 
 
 Server-side handlers of the different communication channels we establish with the client-side when Calypso loads the iframed block editor. See [`calypsoify-iframe.jsx`](https://github.com/Automattic/wp-calypso/blob/master/client/gutenberg/editor/calypsoify-iframe.jsx).
 
+### `rich-text.js`
+
+Extensions for the Rich Text toolbar with the Calypso buttons missing on Core (i.e. underline, justify).
+
 ### `tinymce.js`
 
 Tiny MCE plugin that overrides the core media modal used on classic blocks with the Calypso media modal.
@@ -22,18 +26,10 @@ Shared utilities to be used across the package.
 
 ### Manual
 
-To manually build the package, execute the command below:
+To manually build the package, execute the command below passing the directory where the distributable files will be generated:
 
 ```
-npx lerna run build --scope='@automattic/wpcom-block-editor'
-```
-
-This will generate the distributable files under the `dist` folder.
-
-If you want to generate the build in a different folder, you can use the `bundle` script instead:
-
-```
-npx lerna run bundle --scope='@automattic/wpcom-block-editor' -- -- --output-path=/path-to-folder
+npx lerna run build --scope='@automattic/wpcom-block-editor' -- -- --output-path=/path-to-folder
 ```
 
 _Wonky double `--` is needed for first skipping Lerna args and then NPM args to reach Webpack._

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -16,15 +16,19 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
-		"clean": "npx rimraf dist",
-		"prebuild": "npm run clean",
-		"bundle": "webpack --config='../../packages/calypso-build/webpack.config.js' --env.WP='true' iframe-bridge-server='./src/iframe-bridge-server.js' tinymce='./src/tinymce.js'",
-		"build": "npm run bundle -- --output-path=./dist"
+		"bundle": "webpack --config='../../packages/calypso-build/webpack.config.js' --env.WP='true'",
+		"build:iframe-bridge-server": "npm run bundle -- iframe-bridge-server='./src/iframe-bridge-server.js'",
+		"build:tinymce": "npm run bundle -- tinymce='./src/tinymce.js'",
+		"build:rich-text": "npm run bundle -- rich-text='./src/rich-text.js'",
+		"build": "npm-run-all --parallel \"build:* -- {@}\" --"
 	},
 	"dependencies": {
 		"@wordpress/data": "4.4.0",
 		"@wordpress/blocks": "6.0.7",
+		"@wordpress/compose": "3.2.0",
+		"@wordpress/editor": "9.2.2",
 		"@wordpress/hooks": "2.0.5",
+		"@wordpress/rich-text": "3.2.2",
 		"@wordpress/url": "2.3.3",
 		"jquery": "^1.12",
 		"lodash": "4.17.11",

--- a/apps/wpcom-block-editor/src/rich-text.js
+++ b/apps/wpcom-block-editor/src/rich-text.js
@@ -1,0 +1,77 @@
+/* global wpcomGutenberg */
+
+/**
+ * External dependencies
+ */
+import { compose, ifCondition } from '@wordpress/compose';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { RichTextToolbarButton } from '@wordpress/editor';
+import { toggleFormat, registerFormatType } from '@wordpress/rich-text';
+import { get } from 'lodash';
+
+registerFormatType( 'wpcom/underline', {
+	title: wpcomGutenberg.richTextToolbar.underline,
+	tagName: 'span',
+	className: null,
+	attributes: { style: 'style' },
+	edit( { isActive, value, onChange } ) {
+		const onToggle = () =>
+			onChange(
+				toggleFormat( value, {
+					type: 'wpcom/underline',
+					attributes: {
+						style: 'text-decoration: underline;',
+					},
+				} )
+			);
+
+		return (
+			<RichTextToolbarButton
+				icon="editor-underline"
+				title={ wpcomGutenberg.richTextToolbar.underline }
+				onClick={ onToggle }
+				isActive={ isActive }
+			/>
+		);
+	},
+} );
+
+const RichTextJustifyButton = ( { blockId, isBlockJustified, updateBlockAttributes } ) => {
+	const onToggle = () =>
+		updateBlockAttributes( blockId, { align: isBlockJustified ? null : 'justify' } );
+
+	return (
+		<RichTextToolbarButton
+			icon="editor-justify"
+			title={ wpcomGutenberg.richTextToolbar.justify }
+			onClick={ onToggle }
+			isActive={ isBlockJustified }
+		/>
+	);
+};
+
+const ConnectedRichTextJustifyButton = compose(
+	withSelect( select => {
+		const selectedBlock = select( 'core/editor' ).getSelectedBlock();
+		if ( ! selectedBlock ) {
+			return {};
+		}
+		return {
+			blockId: selectedBlock.clientId,
+			blockName: selectedBlock.name,
+			isBlockJustified: 'justify' === get( selectedBlock, 'attributes.align' ),
+		};
+	} ),
+	withDispatch( dispatch => ( {
+		updateBlockAttributes: dispatch( 'core/editor' ).updateBlockAttributes,
+	} ) ),
+	ifCondition( props => 'core/paragraph' === props.blockName )
+)( RichTextJustifyButton );
+
+registerFormatType( 'wpcom/justify', {
+	title: wpcomGutenberg.richTextToolbar.justify,
+	tagName: 'p',
+	className: null,
+	attributes: { style: 'style' },
+	edit: ConnectedRichTextJustifyButton,
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a new `rich-text.js` file the `@automattic/wpcom-block-editor` package with all the extensions registering the Calypso format types missing on Core (justify, underline).

It contains the same logic that the `gutenberg-wpcom.js` file currently maintained on WP.com, but using ES2015+ syntax.

Given that this is adding a new entry file to the build script, I decided to split the `bundle` script into 3 smaller `build` scripts (one for each entry file), so we don't have a very long script command. The `build` scripts runs now all the smaller build scripts in parallel (using `npm-run-all`) and requires an explicit output path (reason why the `clean` script is not needed anymore).

#### Testing instructions

Check D26899-code
