### PR TITLE
Jetpack Connect: Migrate styles to Webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -106,7 +106,6 @@
 @import 'components/wizard/style';
 @import 'components/environment-badge/style';
 @import 'blocks/credit-card-form/style';
-@import 'jetpack-connect/style';
 @import 'layout/guided-tours/style';
 @import 'components/happychat/style';
 @import 'components/happychat/agent-w/style';

--- a/client/jetpack-connect/colors.scss
+++ b/client/jetpack-connect/colors.scss
@@ -9,4 +9,9 @@
 	--color-primary-light:                   var( --color-accent-light );
 	--color-button-primary-background-hover: var( --color-accent-light );
 	--color-accent-600:                      var( --color-accent-dark );
+
+	::selection {
+		color: var( --color-white );
+		background: var( --color-accent );
+	}
 }

--- a/client/jetpack-connect/colors.scss
+++ b/client/jetpack-connect/colors.scss
@@ -1,0 +1,12 @@
+@mixin jetpack-connect-colors() {
+	// Override accent variables with Jetpack colors
+	--color-accent:       var( --color-jetpack );
+	--color-accent-light: var( --color-jetpack-light );
+	--color-accent-dark:  var( --color-jetpack-dark );
+
+	// Override global colors with accent variables
+	--color-primary:                         var( --color-accent-dark );
+	--color-primary-light:                   var( --color-accent-light );
+	--color-button-primary-background-hover: var( --color-accent-light );
+	--color-accent-600:                      var( --color-accent-dark );
+}

--- a/client/jetpack-connect/index.js
+++ b/client/jetpack-connect/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -13,6 +12,11 @@ import * as controller from './controller';
 import { login } from 'lib/paths';
 import { siteSelection } from 'my-sites/controller';
 import { makeLayout, render as clientRender } from 'controller';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export default function() {
 	const user = userFactory();

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -4,14 +4,8 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__main,
 .layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
-.layout.is-jetpack-login,
-.is-section-checkout.is-jetpack-site,
-.is-section-checkout-thank-you.is-jetpack-site {
+.layout.is-jetpack-login {
 	@include jetpack-connect-colors();
-
-	.payment-box-section {
-		--color-primary: var( --color-primary-500 );
-	}
 }
 
 .is-section-jetpack-connect {
@@ -899,51 +893,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	.site-topic__content .form-fieldset {
 		position: relative;
-	}
-}
-
-.is-section-checkout.is-jetpack-site {
-	min-height: 100%;
-	background-color: var( --color-jetpack-onboarding-background );
-
-	.formatted-header {
-		color: var( --color-jetpack-onboarding-text );
-	}
-
-	.card {
-		box-shadow: none;
-		border-radius: 3px;
-
-		&.section-header {
-			border-bottom-left-radius: 0;
-			border-bottom-right-radius: 0;
-		}
-
-		&.payment-box {
-			border-top-left-radius: 0;
-			border-top-right-radius: 0;
-		}
-	}
-}
-
-.is-section-checkout-thank-you.is-jetpack-site {
-	min-height: 100%;
-	background-color: var( --color-jetpack-onboarding-background );
-
-	.checkout-thank-you__jetpack .plan-thank-you-card .thank-you-card,
-	.checkout-thank-you__jetpack .plan-thank-you-card .thank-you-card,
-	.checkout-thank-you__jetpack .plan-thank-you-card .thank-you-card {
-		box-shadow: none;
-	}
-}
-
-.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
-.layout.is-jetpack-login,
-.is-section-checkout.is-jetpack-site,
-.is-section-checkout-thank-you.is-jetpack-site {
-	::selection {
-		color: var( --color-white );
-		background: var( --color-accent );
 	}
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1,3 +1,5 @@
+@import './colors.scss';
+
 $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__main,
@@ -5,16 +7,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 .layout.is-jetpack-login,
 .is-section-checkout.is-jetpack-site,
 .is-section-checkout-thank-you.is-jetpack-site {
-	// Override accent variables with Jetpack colors
-	--color-accent:       var( --color-jetpack );
-	--color-accent-light: var( --color-jetpack-light );
-	--color-accent-dark:  var( --color-jetpack-dark );
-
-	// Override global colors with accent variables
-	--color-primary:                         var( --color-accent-dark );
-	--color-primary-light:                   var( --color-accent-light );
-	--color-button-primary-background-hover: var( --color-accent-light );
-	--color-accent-600:                      var( --color-accent-dark );
+	@include jetpack-connect-colors();
 
 	.payment-box-section {
 		--color-primary: var( --color-primary-500 );

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -600,7 +600,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 	.plan-price.is-original {
 		align-self: center;
-		font-size: 16px;
 		margin-top: 6px;
 	}
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -3,8 +3,7 @@
 $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__main,
-.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
-.layout.is-jetpack-login {
+.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ) {
 	@include jetpack-connect-colors();
 }
 
@@ -761,8 +760,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 /**
  * Onboarding styles
  **/
-.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ),
-.layout.is-jetpack-login {
+.layout.is-section-jetpack-connect:not( .is-add-site-page ):not( .is-jetpack-mobile-flow ) {
 	background-color: var( --color-jetpack-onboarding-background );
 
 	&.layout {
@@ -771,7 +769,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		padding-bottom: $colophon-height;
 	}
 
-	.login__form-header,
 	.formatted-header {
 		color: var( --color-jetpack-onboarding-text );
 	}
@@ -807,14 +804,12 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 	}
 
-	.login__form input:focus,
 	.jetpack-connect__site-address-container input:focus,
 	.logged-out-form input:focus {
 		border-color: var( --color-accent );
 		box-shadow: 0 0 0 2px var( --color-accent-light );
 	}
 
-	.login__form-terms a,
 	.jetpack-connect__tos-link a,
 	.signup-form__terms-of-service-link a,
 	.form-input-validation a {
@@ -826,11 +821,9 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		}
 	}
 
-	.wp-login__links a,
 	.logged-out-form__links a,
 	.logged-out-form__link-item,
 	.jetpack-connect__back-button,
-	.translator-invite__content a,
 	.jetpack-connect__skip-button .button {
 		color: var( --color-neutral-200 );
 		border-bottom-color: var( --color-neutral-700 );
@@ -845,18 +838,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		&:focus {
 			box-shadow: 0 0 0 transparent;
 		}
-	}
-
-	.translator-invite__content a {
-		border: none;
-	}
-
-	.translator-invite__content {
-		color: var( --color-neutral-500 );
-	}
-
-	.wp-login__site-return-link::after {
-		background: linear-gradient( to right, rgba( var( --color-jetpack-onboarding-background ), 0 ), rgba( var( --color-jetpack-onboarding-background ), 1 ) 90% );
 	}
 
 	.plan-features__table-item,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -174,7 +174,7 @@ $image-height: 47px;
 		color: var( --color-neutral-500 );
 	}
 
-	.wp-login__site-return-link:after {
-		background: linear-gradient(to right, rgba( var( --color-jetpack-onboarding-background ) , 0 ), rgba( var( --color-jetpack-onboarding-background ) , 1 ) 90%)
+	.wp-login__site-return-link::after {
+		background: linear-gradient( to right, rgba( var( --color-jetpack-onboarding-background ), 0 ), rgba( var( --color-jetpack-onboarding-background ), 1 ) 90% );
 	}
 }

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -1,3 +1,5 @@
+@import 'jetpack-connect/colors.scss';
+
 $image-height: 47px;
 
 .layout.is-section-login {
@@ -118,4 +120,61 @@ $image-height: 47px;
 
 .wp-login__private-site-button {
 	width: 100%;
+}
+
+.layout.is-jetpack-login {
+	@include jetpack-connect-colors();
+}
+
+.layout.is-jetpack-login {
+	background-color: var( --color-jetpack-onboarding-background );
+
+	.login__form-header {
+		color: var( --color-jetpack-onboarding-text );
+	}
+
+	.jetpack-logo__text {
+		fill: var( --color-jetpack-onboarding-text );
+	}
+
+	.login__form input:focus,
+	.logged-out-form input:focus {
+		border-color: var( --color-accent );
+		box-shadow: 0 0 0 2px var( --color-accent-light );
+	}
+
+	.login__form-terms a,
+	.form-input-validation a {
+		color: var( --color-accent-dark );
+
+		&:hover,
+		&:focus {
+			color: var( --color-accent );
+		}
+	}
+
+	.wp-login__links a,
+	.logged-out-form__links a,
+	.logged-out-form__link-item,
+	.translator-invite__content a {
+		color: var( --color-neutral-200 );
+		border-bottom-color: var( --color-neutral-700 );
+
+		&:hover,
+		&:focus {
+			color: var( --color-primary-200 );
+		}
+	}
+
+	.translator-invite__content a {
+		border: none;
+	}
+
+	.translator-invite__content {
+		color: var( --color-neutral-500 );
+	}
+
+	.wp-login__site-return-link:after {
+		background: linear-gradient(to right, rgba( var( --color-jetpack-onboarding-background ) , 0 ), rgba( var( --color-jetpack-onboarding-background ) , 1 ) 90%)
+	}
 }

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1,25 +1,4 @@
-.is-section-checkout.is-jetpack-site {
-	.layout__content {
-		position: static;
-		// Adjust the padding as we no longer
-		// show the masterbar.
-		padding-top: 48px;
-
-		@include breakpoint( '<660px' ) {
-			padding-top: 0;
-		}
-	}
-
-	// Move the sidebar up top
-	.layout__secondary {
-		top: 0;
-	}
-
-	// Hide the masterbar for real
-	.masterbar {
-		display: none;
-	}
-}
+@import 'jetpack-connect/colors.scss';
 
 .checkout {
 	position: relative;
@@ -1071,4 +1050,71 @@
 	display: block;
 	font-size: 12px;
 	font-style: italic;
+}
+
+.is-section-checkout.is-jetpack-site {
+	.layout__content {
+		position: static;
+		// Adjust the padding as we no longer
+		// show the masterbar.
+		padding-top: 48px;
+
+		@include breakpoint( '<660px' ) {
+			padding-top: 0;
+		}
+	}
+
+	// Move the sidebar up top
+	.layout__secondary {
+		top: 0;
+	}
+
+	// Hide the masterbar for real
+	.masterbar {
+		display: none;
+	}
+}
+
+.is-section-checkout.is-jetpack-site,
+.is-section-checkout-thank-you.is-jetpack-site {
+	@include jetpack-connect-colors();
+
+	.payment-box-section {
+		--color-primary: var( --color-primary-500 );
+	}
+}
+
+.is-section-checkout.is-jetpack-site {
+	min-height: 100%;
+	background-color: var( --color-jetpack-onboarding-background );
+
+	.formatted-header {
+		color: var( --color-jetpack-onboarding-text );
+	}
+
+	.card {
+		box-shadow: none;
+		border-radius: 3px;
+
+		&.section-header {
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
+		}
+
+		&.payment-box {
+			border-top-left-radius: 0;
+			border-top-right-radius: 0;
+		}
+	}
+}
+
+.is-section-checkout-thank-you.is-jetpack-site {
+	min-height: 100%;
+	background-color: var( --color-jetpack-onboarding-background );
+
+	.checkout-thank-you__jetpack .plan-thank-you-card .thank-you-card,
+	.checkout-thank-you__jetpack .plan-thank-you-card .thank-you-card,
+	.checkout-thank-you__jetpack .plan-thank-you-card .thank-you-card {
+		box-shadow: none;
+	}
 }


### PR DESCRIPTION
This PR migrates the style of the Jetpack Connect section to Webpack. Also, some of the styles were bleeding through to other sections (checkout, login) - this PR moves those styles to the appropriate sections for better modularity. 

I promised @jsnajdr I'd take care of this migration, and as I'm moving to a different team with different projects, it only makes sense to take care of this before it falls through the cracks.

The `jetpack-connect` style is a relatively big one, so this migration takes down 5.5% of the gzipped monolithic `style.css`.

See p4TIVU-9dT-p2 for more details on the rationale of this migration.

#### Changes proposed in this Pull Request

* Create a reusable mixin for the custom Jetpack Connect colors.
* Move checkout-related Jetpack Connect styles to the checkout section.
* Move login-related Jetpack Connect styles to the login section.
* Fix some style lint errors in the affected stylesheets.
* Import the Jetpack Connect style in the Jetpack Connect section instead of doing it in the monolithic `style.css`.

#### Testing instructions

* Checkout this branch and build it locally.
* Compare the visual appearance of the page and the elements in each of the steps below between `calypso.localhost:3000` and `wpcalypso.wordpress.com`.
* Start in calypso as a logged out user.
* Spawn a new JN site from this link: https://jurassic.ninja/create?shortlived&jetpack-beta
* Copy the URL of the "Set up" connection button and add `&calypso_env=development` or `&calypso_env=wpcalypso` to it, depending on the environment you want to continue in.
* You'll end up in the login screen. Click the link below to create an account.
* Create an account and continue the authorization process.
* Go through each of the steps - site type, site topic, user type.
* Pick a plan and go through the checkout step.
* Start in calypso as a logged in user.
* Spawn a new JN site from this link: https://jurassic.ninja/create?shortlived&jetpack-beta
* Copy the URL of the "Set up" connection button and add `&calypso_env=development` or `&calypso_env=wpcalypso` to it, depending on the environment you want to continue in.
* Continue the authorization process.
* Go through each of the steps - site type, site topic, user type.
* Pick a plan and go through the checkout step.
* Go to http://calypso.localhost:3000/jetpack/connect
* Try inputting a WP.org site that doesn't have Jetpack yet, or has Jetpack deactivated - you'll end up in the remote install credentials step.
* Try the mobile flow (it should use the light color scheme): http://calypso.localhost:3000/jetpack/connect?mobile_redirect=wordpress://jetpack-connection
* Try the new site step (it should use the light color scheme): http://calypso.localhost:3000/jetpack/new
* Test any other Jetpack connection flow you can think of.