### PR TITLE
Reader: use pointer cursor on tag removal button

### DIFF
--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -268,6 +268,7 @@
 		right: 8px;
 		line-height: 15px;
 		padding: 3px 4px 2px;
+		cursor: pointer;
 
 		.gridicon {
 			position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #32221 @sixhours points out:

"If I want to unfollow a tag by clicking the "x" to the right of each tag, the cursor stays as an arrow rather than a hand; it does not behave like a button or link, so there's no indication you can click on it."

This PR changes the cursor to 'pointer' for this button.

#### Testing instructions

In your Reader at http://calypso.localhost:3000, hover over a 'X' button in the tag list. Ensure it shows a pointer cursor rather than an arrow.

<img width="309" alt="Screen Shot 2019-04-15 at 11 37 17" src="https://user-images.githubusercontent.com/17325/56102835-edad9f80-5f72-11e9-8c92-2d374f685d51.png">

Fixes #32221.
