### PR TITLE
Sharing: Fix inconsistent heading typography in the connection modal

### DIFF
--- a/client/my-sites/sharing/connections/account-dialog.scss
+++ b/client/my-sites/sharing/connections/account-dialog.scss
@@ -4,7 +4,7 @@
 
 .account-dialog__authorizing-service {
 	font-size: 24px;
-	font-weight: 100;
+	font-weight: 400;
 	margin-bottom: 8px;
 	color: var( --color-neutral-700 );
 }


### PR DESCRIPTION
**Changes proposed in this Pull Request**

From #32223 - The light weight modal title feels out of place.

#### Testing instructions

In your Sharing settings at http://calypso.localhost:3000, try connecting one of the services, for example Twitter. In the modal that appears the service is connected the heading "Connecting Twitter" should use regular font width (400), instead of thin (100).

Before:
![image](https://user-images.githubusercontent.com/4550351/56105644-9a424e00-5f80-11e9-8351-59425f18a2d3.png)

After:
![image](https://user-images.githubusercontent.com/4550351/56105653-aaf2c400-5f80-11e9-8145-20656568fb47.png)
