### PR TITLE
Use named chunks when computing stats, to get stable chunk names

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -181,7 +181,7 @@ function getWebpackConfig( {
 			},
 			runtimeChunk: codeSplit ? { name: 'manifest' } : false,
 			moduleIds: 'named',
-			chunkIds: isDevelopment ? 'named' : 'natural',
+			chunkIds: isDevelopment || shouldEmitStats ? 'named' : 'natural',
 			minimize: shouldMinify,
 			minimizer: Minify( {
 				cache: process.env.CIRCLECI


### PR DESCRIPTION
When calculating stats for ICFY, use the `chunkIds: 'named'` option to give chunks human-readable names rather than numerical IDs.

That makes the chunk names longer, but stable: they don't change when there is an unrelated change that adds or removes a chunk and shifts the whole incrementing-integer ID sequence.

ICFY will start reporting larger sizes after this patch, but we are mainly interested in the deltas anyway, and the reporting will contain much less noise.

The largest size increase comes from the `manifest` chunk, which contains a map from chunk names (now much bigger) to their hashes.

**Some background info about module and chunk IDs:**
We use `moduleIds: 'named'` because that leads to more stable chunk content, more friendly for long-term caching. Module IDs don't get reassigned on unrelated changes.

We use `chunkIds: 'natural'` in production, rather than `named`, in an attempt to make them more stable. There is some [discussion](https://github.com/Automattic/wp-calypso/pull/22860#discussion_r172630481) between @blowery and @samouri from year ago, when we upgraded to Webpack 4. It's stated there that a shared chunk's name changes when it starts to be shared by a different group of chunk groups. I.e., `vendors~domains~checkout` can change to `vendors~domains~checkout~signup` without really changing the chunk content.

I have some doubts if that's really helpful. When webpack reorganizes the shared chunks in such a way, it's very unlikely that their content is unchanged.

**Hashed chunk IDs:**
Webpack 5 introduces `deterministic` module IDs, taking a short numeric hash of the module/chunk full name.

But something similar is already available in webpack 4: the `hashed` algorithm. Conceptually it's the same thing, only the hash algorithm is different:
- `hashed` takes first X characters of a cryptographic MD4 hash. In case of collision, takes the first X+1 characters.
- `deterministic` uses a non-cryptographic hash function (few modulo ops with primes) withing a requested numeric range (e.g., 0-9999).

The `deterministic` algo has probably some better properties, but if we wanted, we could use `hashed` today.