### PR TITLE
Guided Tours: Fix JetpackBackupsRewindTour positioning

### DIFF
--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -126,8 +126,6 @@ export const JetpackBackupsRewindTour = makeTour(
 		<Step
 			name="credentials"
 			target=".rewind-credentials-form"
-			placement="beside"
-			arrow="right-top"
 			style={ {
 				display: 'none',
 			} }

--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -57,7 +57,7 @@ const ConnectedContinueToLastStep = connect( state => ( {
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackBackupsRewindTour = makeTour(
 	<Tour { ...meta }>
-		<Step name="init" target=".credentials-setup-flow" placement="beside" arrow="right-top">
+		<Step name="init" target=".credentials-setup-flow" placement="below" arrow="top-left">
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix `JetpackBackupsRewindTour` positioning of first step on a large display.
* Cleanup unnecessary positioning in the hidden step of `JetpackBackupsRewindTour`

#### Preview

Before:
![](https://cldup.com/9gfNXwq6Or.png)

After:
![](https://cldup.com/bk9GF0vQT3.png)

#### Testing instructions

* Checkout this branch or spin it up on calypso.live.
* Start a new Jurassic Ninja site with the latest bleeding edge and connect it to WP.com, pick the free plan.
* Open `/plans/:site` where `:site` is the slug of your site.
* Buy a Premium or Professional plan and wait for the setup to finish.
* Deactivate VaultPress from wp-admin.
* Go to VP MC and enable Rewind for that site.
* Go to `/plans/my-plan/:site` where `:site` is the slug of the site.
* Verify the "Backups & Scanning" task is now not done, and has a "Do it" button.
* Click the "Do it" button of the "Backups & Scanning" task.
* Verify the step is shown as on the "After" screenshot.
