### PR TITLE
Jetpack Checklist: Move all tasks to constants

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -49,6 +49,11 @@ export const JETPACK_CHECKLIST_TASKS = {
 	},
 };
 
+export const JETPACK_CHECKLIST_TASK_AKISMET = {
+	title: translate( "We're automatically turning on spam filtering." ),
+	completedTitle: translate( "We've automatically turned on spam filtering." ),
+};
+
 export const JETPACK_CHECKLIST_TASK_PROTECT = {
 	title: translate( "We've automatically protected you from brute force login attacks." ),
 };

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -49,6 +49,10 @@ export const JETPACK_CHECKLIST_TASKS = {
 	},
 };
 
+export const JETPACK_CHECKLIST_TASK_PROTECT = {
+	title: translate( "We've automatically protected you from brute force login attacks." ),
+};
+
 export const JETPACK_CHECKLIST_TASK_BACKUPS_REWIND = {
 	title: translate( 'Backup and Scan' ),
 	description: translate(

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -28,6 +28,7 @@ import {
 	JETPACK_CHECKLIST_TASKS,
 	JETPACK_CHECKLIST_TASK_BACKUPS_REWIND,
 	JETPACK_CHECKLIST_TASK_BACKUPS_VAULTPRESS,
+	JETPACK_CHECKLIST_TASK_PROTECT,
 } from './constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
@@ -90,12 +91,7 @@ class JetpackChecklist extends PureComponent {
 					isPlaceholder={ ! taskStatuses }
 					progressText={ translate( 'Your Jetpack setup progress' ) }
 				>
-					<Task
-						completed
-						title={ translate(
-							"We've automatically protected you from brute force login attacks."
-						) }
-					/>
+					<Task completed { ...JETPACK_CHECKLIST_TASK_PROTECT } />
 					{ isPaidPlan && isRewindAvailable && (
 						<Task
 							{ ...JETPACK_CHECKLIST_TASK_BACKUPS_REWIND }

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -26,6 +26,7 @@ import { getSiteSlug } from 'state/sites/selectors';
 import { isDesktop } from 'lib/viewport';
 import {
 	JETPACK_CHECKLIST_TASKS,
+	JETPACK_CHECKLIST_TASK_AKISMET,
 	JETPACK_CHECKLIST_TASK_BACKUPS_REWIND,
 	JETPACK_CHECKLIST_TASK_BACKUPS_VAULTPRESS,
 	JETPACK_CHECKLIST_TASK_PROTECT,
@@ -112,8 +113,7 @@ class JetpackChecklist extends PureComponent {
 					) }
 					{ isPaidPlan && productInstallStatus && (
 						<Task
-							title={ translate( "We're automatically turning on spam filtering." ) }
-							completedTitle={ translate( "We've automatically turned on spam filtering." ) }
+							{ ...JETPACK_CHECKLIST_TASK_AKISMET }
 							completed={ akismetFinished }
 							inProgress={ ! akismetFinished }
 						/>


### PR DESCRIPTION
As @simison suggested in https://github.com/Automattic/wp-calypso/pull/31547#discussion_r272494191 this PR moves the remaining tasks to the constants file so they'll all live in the same place.

#### Changes proposed in this Pull Request

* Move Protect task definition to constants
* Move Akismet task definition to constants

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/plans/my-plan/:site where `:site` is a Jetpack site.
* Verify everything works the same way as it does on wpcalypso.
