### PR TITLE
Jetpack Checklist: Fix backups completion state when provisioning

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -74,7 +74,7 @@ class JetpackChecklist extends PureComponent {
 			translate,
 			vaultpressFinished,
 		} = this.props;
-		const isRewindActive = rewindState === 'active';
+		const isRewindActive = rewindState === 'active' || rewindState === 'provisioning';
 		const isRewindAvailable = rewindState !== 'uninitialized' && rewindState !== 'unavailable';
 		const isRewindUnAvailable = rewindState === 'unavailable';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Consider Backups task to be "completed" when Rewind is in "provisioning" state. See p9rlnk-1R-p2 for explanation of why.

#### Testing instructions

* Checkout this branch.
* Go to http://calypso.localhost:3000/settings/security/:site where `:site is a Pressable site.
* Make sure your Jetpack Backups credentials are missing, revoke them if you have any.
* Go to http://calypso.localhost:3000/plans/my-plan/:site.
* Click on the "Do it" button on the Backup and Scan task.
* Be very quick about the next clicks.
* Follow through the tour and auto-configure credentials, then quickly go back to the to the checklist by clicking the "Yes, let's do it." button in the last tour step.
* Verify the "Backup and Scan" task is shown as completed.

Previously, if you were quick enough to go back to the checklist while Rewind is still provisioning, the Backup and Scan task would be displayed as unfinished. This behavior has been reported by several folks who tested #32152.

Part of #32248.