### PR TITLE
Guided Tours: Add Jetpack Backups Rewind tour to config

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -20,6 +20,7 @@ import checklistSiteTagline from 'layout/guided-tours/tours/checklist-site-tagli
 import checklistSiteTitle from 'layout/guided-tours/tours/checklist-site-title-tour/meta';
 import checklistUserAvatar from 'layout/guided-tours/tours/checklist-user-avatar-tour/meta';
 import jetpack from 'layout/guided-tours/tours/jetpack-basic-tour/meta';
+import jetpackBackupsRewind from 'layout/guided-tours/tours/jetpack-backups-rewind-tour/meta';
 import jetpackMonitoring from 'layout/guided-tours/tours/jetpack-monitoring-tour/meta';
 import jetpackPluginUpdates from 'layout/guided-tours/tours/jetpack-plugin-updates-tour/meta';
 import jetpackSignIn from 'layout/guided-tours/tours/jetpack-sign-in-tour/meta';
@@ -38,6 +39,7 @@ export default {
 	checklistSiteTitle,
 	checklistUserAvatar,
 	jetpack,
+	jetpackBackupsRewind,
 	jetpackMonitoring,
 	jetpackPluginUpdates,
 	jetpackSignIn,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* As suggested by @sgomes in https://github.com/Automattic/wp-calypso/pull/32152#issuecomment-483207480 this PR registers the Jetpack Backups Rewind tour as a valid guided tour.

#### Testing instructions

* Verify changes are sane and Jetpack Backups Rewind tour continues to work well (follow instructions in #32152)
