### PR TITLE
Live Chat: add closure notice for Easter 2019

### DIFF
--- a/client/me/help/help-contact/index.jsx
+++ b/client/me/help/help-contact/index.jsx
@@ -528,18 +528,11 @@ class HelpContact extends React.Component {
 				{ isUserAffectedByLiveChatClosure && (
 					<Fragment>
 						<LiveChatClosureNotice
-							holidayName="Christmas"
+							holidayName="Easter"
 							compact={ compact }
-							displayAt="2018-12-17 00:00Z"
-							closesAt="2018-12-24 00:00Z"
-							reopensAt="2018-12-26 07:00Z"
-						/>
-						<LiveChatClosureNotice
-							holidayName="New Year's Day"
-							compact={ compact }
-							displayAt="2018-12-26 07:00Z"
-							closesAt="2019-01-01 00:00Z"
-							reopensAt="2019-01-02 07:00Z"
+							displayAt="2019-04-18 00:00Z"
+							closesAt="2019-04-21 00:00Z"
+							reopensAt="2019-04-22 00:00Z"
 						/>
 					</Fragment>
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Live Chat closure notice for Easter 2019

#### Testing instructions

1. Go to `/help/contact` with an account that has live chat access.
2. Set clock forward to April 18th or 19th. You should see a notice about closure coming.
3. Set clock forward to April 21st. You should see closure.
4. Set clock beyond April 22nd midnight. You should see open again.
