### PR TITLE
Jetpack Checklist: Support skipping of VP installation

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -6,7 +6,7 @@
 import page from 'page';
 import React, { Fragment, PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { get, map } from 'lodash';
+import { get, includes, map } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -162,7 +162,8 @@ export default connect(
 		return {
 			akismetFinished: productInstallStatus && productInstallStatus.akismet_status === 'installed',
 			vaultpressFinished:
-				productInstallStatus && productInstallStatus.vaultpress_status === 'installed',
+				productInstallStatus &&
+				includes( [ 'installed', 'skipped' ], productInstallStatus.vaultpress_status ),
 			isPaidPlan: isSiteOnPaidPlan( state, siteId ),
 			rewindState,
 			productInstallStatus,

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.js
@@ -34,6 +34,7 @@ const NON_ERROR_STATES = [
 	'option_name_not_in_whitelist', // Plugin is installed but not activated
 	'key_not_set', // Plugin is installed and activated, but not configured
 	'installed', // Plugin is installed, activated and configured
+	'skipped', // Plugin installation is skipped as unnecessary
 ];
 /**
  * Those errors are any of the following:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR updates the Jetpack Checklist to support VaultPress installation skipping - this will happen in case Rewind is available. 

#### Testing instructions

* Apply D26922-code and sandbox `public-api.wordpress.com`.
* Load http://calypso.localhost:3000/plans/my-plan/:site?thank-you where :site is the slug of a Jetpack site with a paid plan and Rewind available.
* Verify VP didn't install on that site, and you see the success message.
* Load http://calypso.localhost:3000/plans/my-plan/:site?thank-you where :site is the slug of a Jetpack site with a paid plan and Rewind unavailable.
* Verify VP installed and configured properly on that site, and you see the success message.
