### PR TITLE
Temporarily make build sequential.

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
 		"build-client": "npm run build-client-evergreen",
 		"build-client-fallback": "cross-env-shell BROWSERSLIST_ENV=defaults NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
 		"build-client-evergreen": "cross-env-shell BROWSERSLIST_ENV=evergreen NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
-		"build-client-both": "concurrently -c cyan -n \"fallback ,evergreen\" \"npm run build-client-fallback\" \"npm run build-client-evergreen\"",
+		"build-client-both": "npm run build-client-fallback && npm run build-client-evergreen",
 		"build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client-both",
 		"build-client-if-desktop": "node -e \"process.env.CALYPSO_ENV === 'desktop' && process.exit(1)\" || npm run build-client",
 		"build-packages": "npx lerna run prepare --stream",


### PR DESCRIPTION
`moment-timezone-data-webpack-plugin` is sometimes causing a race condition when trying to write results to a cache dir. Since we start two builds in parallel, sometimes one build tries to access an incomplete set of results that the other build is still preparing.

While we work on an upstream fix, we're making builds happen in sequence rather than in parallel. This will slow things down, but should remove any race conditions.

#### Changes proposed in this Pull Request

* Make build happen in sequence.

#### Testing instructions

* Ensure the build finishes correctly.
