### PR TITLE
Update uses of text that fail contrast (mostly Reader)

### DIFF
--- a/assets/stylesheets/shared/_typography.scss
+++ b/assets/stylesheets/shared/_typography.scss
@@ -18,7 +18,7 @@ $signup-sans: 'Noto Sans', $sans;
 	font-weight: 400;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-	color: var( --color-neutral-600 );
+	color: var( --color-text );
 }
 
 // ======================================================================

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -88,7 +88,7 @@
 }
 
 .author-compact-profile__follow-count {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	padding: 5px;
 }
 

--- a/client/blocks/author-compact-profile/style.scss
+++ b/client/blocks/author-compact-profile/style.scss
@@ -88,7 +88,7 @@
 }
 
 .author-compact-profile__follow-count {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	padding: 5px;
 }
 

--- a/client/blocks/author-selector/style.scss
+++ b/client/blocks/author-selector/style.scss
@@ -72,5 +72,5 @@
 	width: 168px;
 	font-size: 14px;
 	font-style: italic;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 }

--- a/client/blocks/author-selector/style.scss
+++ b/client/blocks/author-selector/style.scss
@@ -72,5 +72,5 @@
 	width: 168px;
 	font-size: 14px;
 	font-style: italic;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 }

--- a/client/blocks/author-selector/style.scss
+++ b/client/blocks/author-selector/style.scss
@@ -15,7 +15,7 @@
 	&.is-open {
 		.gridicon,
 		.editor-author__name {
-			color: var( --color-neutral-600 );
+			color: var( --color-text );
 		}
 	}
 }

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -1,7 +1,7 @@
 .comment-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;

--- a/client/blocks/comment-button/style.scss
+++ b/client/blocks/comment-button/style.scss
@@ -1,7 +1,7 @@
 .comment-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;

--- a/client/blocks/comments/comment-actions.scss
+++ b/client/blocks/comments/comment-actions.scss
@@ -1,13 +1,13 @@
 // Actions for Individual Comments
 .comments__comment-actions {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	font-size: 14px;
 	list-style: none;
 	margin-top: -6px;
 
 	button {
 		display: inline-block;
-		color: var( --color-neutral-light );
+		color: var( --color-neutral );
 		padding: 4px;
 		margin-right: 8px;
 		margin-top: 0;

--- a/client/blocks/comments/comment-actions.scss
+++ b/client/blocks/comments/comment-actions.scss
@@ -1,13 +1,13 @@
 // Actions for Individual Comments
 .comments__comment-actions {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	font-size: 14px;
 	list-style: none;
 	margin-top: -6px;
 
 	button {
 		display: inline-block;
-		color: var( --color-neutral );
+	color: var( --color-text-subtle );
 		padding: 4px;
 		margin-right: 8px;
 		margin-top: 0;

--- a/client/blocks/comments/comment-count.scss
+++ b/client/blocks/comments/comment-count.scss
@@ -1,5 +1,5 @@
 .comments__comment-count {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	font-size: 14px;
 	font-weight: 600;
 	line-height: 1;

--- a/client/blocks/comments/comment-count.scss
+++ b/client/blocks/comments/comment-count.scss
@@ -1,5 +1,5 @@
 .comments__comment-count {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	font-size: 14px;
 	font-weight: 600;
 	line-height: 1;

--- a/client/blocks/comments/comment-edit-form.scss
+++ b/client/blocks/comments/comment-edit-form.scss
@@ -57,7 +57,7 @@
 		font-size: 12px;
 		font-weight: 600;
 		text-transform: uppercase;
-		color: var( --color-neutral );
+	color: var( --color-text-subtle );
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {

--- a/client/blocks/comments/comment-edit-form.scss
+++ b/client/blocks/comments/comment-edit-form.scss
@@ -57,7 +57,7 @@
 		font-size: 12px;
 		font-weight: 600;
 		text-transform: uppercase;
-		color: var( --color-neutral-200 );
+		color: var( --color-neutral );
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -65,7 +65,7 @@
 		font-size: 12px;
 		font-weight: 600;
 		text-transform: uppercase;
-		color: var( --color-neutral-200 );
+		color: var( --color-neutral );
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
@@ -90,7 +90,7 @@
 }
 
 .comments__form-closed {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	margin-top: 20px;
 	margin-bottom: -3px;
 	font-family: $sans;

--- a/client/blocks/comments/form.scss
+++ b/client/blocks/comments/form.scss
@@ -65,7 +65,7 @@
 		font-size: 12px;
 		font-weight: 600;
 		text-transform: uppercase;
-		color: var( --color-neutral );
+	color: var( --color-text-subtle );
 		transition: all 0.2s ease-in-out;
 
 		&.is-active {
@@ -90,7 +90,7 @@
 }
 
 .comments__form-closed {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	margin-top: 20px;
 	margin-bottom: -3px;
 	font-family: $sans;

--- a/client/blocks/comments/post-comment-content.scss
+++ b/client/blocks/comments/post-comment-content.scss
@@ -40,7 +40,7 @@
 	word-break: break-word;
 
 	p {
-		color: var( --color-neutral-600 );
+		color: var( --color-text );
 
 		&:last-child {
 			margin-bottom: 0;
@@ -51,7 +51,7 @@
 		background: var( --color-neutral-0 );
 		border-left: 2px solid var( --color-neutral-0 );
 		border-radius: 0;
-		color: var( --color-neutral-600 );
+		color: var( --color-text );
 		margin: 8px 0 16px;
 		padding: 8px 16px;
 	}

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -25,7 +25,7 @@
 }
 
 .comments__view-more {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	cursor: pointer;
 	display: block !important; // to overwrite inline-block rule
 	font-size: 14px;

--- a/client/blocks/comments/post-comment-list.scss
+++ b/client/blocks/comments/post-comment-list.scss
@@ -25,7 +25,7 @@
 }
 
 .comments__view-more {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	cursor: pointer;
 	display: block !important; // to overwrite inline-block rule
 	font-size: 14px;

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -56,7 +56,7 @@
 }
 
 .comments__comment-author {
-	color: var( --color-neutral-600 );
+	color: var( --color-text );
 	display: flex;
 	flex-wrap: wrap;
 	font-size: 14px;
@@ -71,7 +71,7 @@
 }
 
 .comments__comment-username {
-	color: var( --color-neutral-600 );
+	color: var( --color-text );
 	height: 21px;
 	margin-right: 7px;
 }

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -120,7 +120,7 @@ a.comments__comment-username {
 }
 
 .comments__comment-respondee {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	margin-right: 12px;
 
 	.gridicon {
@@ -132,7 +132,7 @@ a.comments__comment-username {
 }
 
 .comments__comment-respondee .comments__comment-respondee-link {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	font-weight: normal;
 	margin-left: -2px;
 
@@ -142,7 +142,7 @@ a.comments__comment-username {
 }
 
 .comments__comment-timestamp a {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	font-weight: normal;
 	text-decoration: none;
 
@@ -152,7 +152,7 @@ a.comments__comment-username {
 }
 
 .comments__comment-moderation {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;
 	font-size: 12px;

--- a/client/blocks/comments/post-comment.scss
+++ b/client/blocks/comments/post-comment.scss
@@ -120,7 +120,7 @@ a.comments__comment-username {
 }
 
 .comments__comment-respondee {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	margin-right: 12px;
 
 	.gridicon {
@@ -132,7 +132,7 @@ a.comments__comment-username {
 }
 
 .comments__comment-respondee .comments__comment-respondee-link {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	font-weight: normal;
 	margin-left: -2px;
 
@@ -142,7 +142,7 @@ a.comments__comment-username {
 }
 
 .comments__comment-timestamp a {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	font-weight: normal;
 	text-decoration: none;
 
@@ -152,7 +152,7 @@ a.comments__comment-username {
 }
 
 .comments__comment-moderation {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;
 	font-size: 12px;

--- a/client/blocks/dismissible-card/style.scss
+++ b/client/blocks/dismissible-card/style.scss
@@ -2,6 +2,6 @@
 	position: absolute;
 	top: 16px;
 	right: 16px;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	cursor: pointer;
 }

--- a/client/blocks/dismissible-card/style.scss
+++ b/client/blocks/dismissible-card/style.scss
@@ -2,6 +2,6 @@
 	position: absolute;
 	top: 16px;
 	right: 16px;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	cursor: pointer;
 }

--- a/client/blocks/ecommerce-manage-nudge/style.scss
+++ b/client/blocks/ecommerce-manage-nudge/style.scss
@@ -11,7 +11,7 @@
 	position: absolute;
 	top: 14px;
 	right: 18px;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	cursor: pointer;
 }
 

--- a/client/blocks/ecommerce-manage-nudge/style.scss
+++ b/client/blocks/ecommerce-manage-nudge/style.scss
@@ -11,7 +11,7 @@
 	position: absolute;
 	top: 14px;
 	right: 18px;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	cursor: pointer;
 }
 

--- a/client/blocks/ecommerce-manage-nudge/style.scss
+++ b/client/blocks/ecommerce-manage-nudge/style.scss
@@ -11,7 +11,7 @@
 	position: absolute;
 	top: 14px;
 	right: 18px;
-	color: var( --color-text-subtle );
+	color: var( --color-neutral-light );
 	cursor: pointer;
 }
 

--- a/client/blocks/image-selector/style.scss
+++ b/client/blocks/image-selector/style.scss
@@ -205,7 +205,7 @@
 
 		&:hover {
 			.gridicon {
-				color: var( --color-neutral-600 );
+				color: var( --color-text );
 			}
 		}
 	}
@@ -282,7 +282,7 @@
 
 	&:hover {
 		.gridicon {
-			color: var( --color-neutral-600 );
+			color: var( --color-text );
 		}
 	}
 }

--- a/client/blocks/image-selector/style.scss
+++ b/client/blocks/image-selector/style.scss
@@ -162,10 +162,10 @@
 	width: 24px;
 	height: 24px;
 	margin: 0;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 
 	&:hover {
-		color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	}
 }
 

--- a/client/blocks/image-selector/style.scss
+++ b/client/blocks/image-selector/style.scss
@@ -162,10 +162,10 @@
 	width: 24px;
 	height: 24px;
 	margin: 0;
-	color: var( --color-text-subtle );
+	color: var( --color-neutral-200 );
 
 	&:hover {
-	color: var( --color-text-subtle );
+	color: var( --color-neutral-light );
 	}
 }
 
@@ -205,7 +205,7 @@
 
 		&:hover {
 			.gridicon {
-				color: var( --color-text );
+				color: var( --color-neutral-600 );
 			}
 		}
 	}
@@ -282,7 +282,7 @@
 
 	&:hover {
 		.gridicon {
-			color: var( --color-text );
+			color: var( --color-neutral-600 );
 		}
 	}
 }

--- a/client/blocks/image-selector/style.scss
+++ b/client/blocks/image-selector/style.scss
@@ -162,10 +162,10 @@
 	width: 24px;
 	height: 24px;
 	margin: 0;
-	color: var( --color-neutral-200 );
+	color: var( --color-neutral );
 
 	&:hover {
-		color: var( --color-neutral-light );
+		color: var( --color-neutral );
 	}
 }
 

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -435,7 +435,7 @@
 	padding: 16px 0 0;
 	margin: 0;
 	font-size: 14px;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	font-style: italic;
 
 	@include breakpoint( '>660px' ) {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -435,7 +435,7 @@
 	padding: 16px 0 0;
 	margin: 0;
 	font-size: 14px;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	font-style: italic;
 
 	@include breakpoint( '>660px' ) {

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -4,7 +4,7 @@
 	align-items: center;
 	display: inline-flex;
 	padding: 4px;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	position: relative;
 	box-sizing: border-box;
 

--- a/client/blocks/like-button/style.scss
+++ b/client/blocks/like-button/style.scss
@@ -4,7 +4,7 @@
 	align-items: center;
 	display: inline-flex;
 	padding: 4px;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	position: relative;
 	box-sizing: border-box;
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -88,7 +88,7 @@
 		a,
 		a:hover {
 			pointer-events: none;
-			color: var( --color-neutral );
+	color: var( --color-text-subtle );
 		}
 	}
 }
@@ -184,7 +184,7 @@
 
 	span {
 		background: var( --color-white );
-		color: var( --color-neutral );
+	color: var( --color-text-subtle );
 		font-size: 14px;
 		padding-left: 8px;
 		padding-right: 8px;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -88,7 +88,7 @@
 		a,
 		a:hover {
 			pointer-events: none;
-	color: var( --color-text-subtle );
+		color: var( --color-text-subtle );
 		}
 	}
 }
@@ -184,7 +184,7 @@
 
 	span {
 		background: var( --color-white );
-	color: var( --color-text-subtle );
+		color: var( --color-text-subtle );
 		font-size: 14px;
 		padding-left: 8px;
 		padding-right: 8px;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -88,7 +88,7 @@
 		a,
 		a:hover {
 			pointer-events: none;
-			color: var( --color-neutral-light );
+			color: var( --color-neutral );
 		}
 	}
 }
@@ -184,7 +184,7 @@
 
 	span {
 		background: var( --color-white );
-		color: var( --color-neutral-light );
+		color: var( --color-neutral );
 		font-size: 14px;
 		padding-left: 8px;
 		padding-right: 8px;

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -113,5 +113,5 @@
 	top: 0;
 }
 .nps-survey__close-button.button.is-borderless {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 }

--- a/client/blocks/nps-survey/style.scss
+++ b/client/blocks/nps-survey/style.scss
@@ -113,5 +113,5 @@
 	top: 0;
 }
 .nps-survey__close-button.button.is-borderless {
-	color: var( --color-neutral-200 );
+	color: var( --color-neutral );
 }

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -27,7 +27,7 @@
 	}
 
 	.post-edit-button__label {
-	color: var( --color-text-subtle );
+		color: var( --color-text-subtle );
 
 		@include breakpoint( '<480px' ) {
 			display: none;

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -1,7 +1,7 @@
 .post-edit-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;
@@ -27,7 +27,7 @@
 	}
 
 	.post-edit-button__label {
-		color: var( --color-neutral );
+	color: var( --color-text-subtle );
 
 		@include breakpoint( '<480px' ) {
 			display: none;

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -1,7 +1,7 @@
 .post-edit-button {
 	align-items: center;
 	box-sizing: border-box;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	cursor: pointer;
 	display: inline-flex;
 	list-style-type: none;
@@ -27,7 +27,7 @@
 	}
 
 	.post-edit-button__label {
-		color: var( --color-neutral-light );
+		color: var( --color-neutral );
 
 		@include breakpoint( '<480px' ) {
 			display: none;

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -46,7 +46,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	cursor: pointer;
 
 	&:hover .form-checkbox {
-	color: var( --color-text-subtle );
+		border-color: var( --color-neutral-200 );
 	}
 
 	padding: 16px 16px 0;
@@ -97,7 +97,7 @@ a.post-item__title-link:visited {
 	}
 
 	.post-item__panel.is-untitled & {
-	color: var( --color-text-subtle );
+		color: var( --color-text-subtle );
 		font-style: italic;
 	}
 

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -46,7 +46,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	cursor: pointer;
 
 	&:hover .form-checkbox {
-		border-color: var( --color-neutral-200 );
+		border-color: var( --color-neutral );
 	}
 
 	padding: 16px 16px 0;
@@ -97,7 +97,7 @@ a.post-item__title-link:visited {
 	}
 
 	.post-item__panel.is-untitled & {
-		color: var( --color-neutral-light );
+		color: var( --color-neutral );
 		font-style: italic;
 	}
 

--- a/client/blocks/post-item/style.scss
+++ b/client/blocks/post-item/style.scss
@@ -46,7 +46,7 @@ $expanded-post-item-outline: 4px solid $post-item-border-color;
 	cursor: pointer;
 
 	&:hover .form-checkbox {
-		border-color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	}
 
 	padding: 16px 16px 0;
@@ -97,7 +97,7 @@ a.post-item__title-link:visited {
 	}
 
 	.post-item__panel.is-untitled & {
-		color: var( --color-neutral );
+	color: var( --color-text-subtle );
 		font-style: italic;
 	}
 

--- a/client/blocks/reader-author-link/style.scss
+++ b/client/blocks/reader-author-link/style.scss
@@ -1,5 +1,5 @@
 .reader-author-link {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 }
 
 .reader-author-link:hover,
@@ -8,5 +8,5 @@
 }
 
 .reader-author-link:focus {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 }

--- a/client/blocks/reader-author-link/style.scss
+++ b/client/blocks/reader-author-link/style.scss
@@ -1,5 +1,5 @@
 .reader-author-link {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 }
 
 .reader-author-link:hover,
@@ -8,5 +8,5 @@
 }
 
 .reader-author-link:focus {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 }

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -200,7 +200,7 @@
 	&:focus,
 	&:link,
 	&:visited {
-	color: var( --color-text-subtle );
+		color: var( --color-text-subtle );
 	}
 
 	&:hover,

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -36,7 +36,7 @@
 }
 
 .reader-combined-card__header-post-count {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	margin-bottom: 0;
 	line-height: 1em;
 	margin-top: 4px;
@@ -173,7 +173,7 @@
 
 .reader-combined-card__post-author-and-time {
 	font-size: 13px;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	font-family: $sans;
 	overflow: hidden;
 	max-height: 13px * 1.4 * 1;
@@ -194,13 +194,13 @@
 .reader-combined-card .reader-visit-link,
 .reader-combined-card .reader-author-link,
 .reader-combined-card__timestamp-link {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	cursor: pointer;
 
 	&:focus,
 	&:link,
 	&:visited {
-		color: var( --color-neutral-light );
+		color: var( --color-neutral );
 	}
 
 	&:hover,

--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -36,7 +36,7 @@
 }
 
 .reader-combined-card__header-post-count {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	margin-bottom: 0;
 	line-height: 1em;
 	margin-top: 4px;
@@ -173,7 +173,7 @@
 
 .reader-combined-card__post-author-and-time {
 	font-size: 13px;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	font-family: $sans;
 	overflow: hidden;
 	max-height: 13px * 1.4 * 1;
@@ -194,13 +194,13 @@
 .reader-combined-card .reader-visit-link,
 .reader-combined-card .reader-author-link,
 .reader-combined-card__timestamp-link {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	cursor: pointer;
 
 	&:focus,
 	&:link,
 	&:visited {
-		color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	}
 
 	&:hover,

--- a/client/blocks/reader-export-button/style.scss
+++ b/client/blocks/reader-export-button/style.scss
@@ -19,6 +19,6 @@
 
 .reader-export-button__label {
 	font-size: 14px;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	padding-left: 4px;
 }

--- a/client/blocks/reader-export-button/style.scss
+++ b/client/blocks/reader-export-button/style.scss
@@ -19,6 +19,6 @@
 
 .reader-export-button__label {
 	font-size: 14px;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	padding-left: 4px;
 }

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -15,7 +15,7 @@
 }
 
 .reader-feed-header .reader-feed-header__site-badge {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	padding-right: 4px;
 	line-height: 0;
 	position: relative;
@@ -86,7 +86,7 @@
 	}
 
 	.reader-feed-header__follow-count {
-		color: var( --color-neutral-light );
+		color: var( --color-neutral );
 		font-size: 14px;
 		margin-right: 15px;
 

--- a/client/blocks/reader-feed-header/style.scss
+++ b/client/blocks/reader-feed-header/style.scss
@@ -15,7 +15,7 @@
 }
 
 .reader-feed-header .reader-feed-header__site-badge {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	padding-right: 4px;
 	line-height: 0;
 	position: relative;
@@ -86,7 +86,7 @@
 	}
 
 	.reader-feed-header__follow-count {
-		color: var( --color-neutral );
+		color: var( --color-text-subtle );
 		font-size: 14px;
 		margin-right: 15px;
 

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -469,7 +469,7 @@
 
 .reader-full-post__header-date-link,
 .reader-full-post__header-date-link:visited {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 
 	&:hover {
 		color: var( --color-primary-light );
@@ -494,7 +494,7 @@
 }
 
 .reader-full-post__header-tag-list {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -508,7 +508,7 @@
 }
 
 .reader-full-post__header-tag-list-item {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	display: inline;
 	margin-right: 5px;
 
@@ -527,7 +527,7 @@
 
 .reader-full-post__header-tag-list-item-link,
 .reader-full-post__header-tag-list-item-link:visited {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 
 	&:hover {
 		color: var( --color-primary-light );

--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -469,7 +469,7 @@
 
 .reader-full-post__header-date-link,
 .reader-full-post__header-date-link:visited {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 
 	&:hover {
 		color: var( --color-primary-light );
@@ -494,7 +494,7 @@
 }
 
 .reader-full-post__header-tag-list {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -508,7 +508,7 @@
 }
 
 .reader-full-post__header-tag-list-item {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	display: inline;
 	margin-right: 5px;
 
@@ -527,7 +527,7 @@
 
 .reader-full-post__header-tag-list-item-link,
 .reader-full-post__header-tag-list-item-link:visited {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 
 	&:hover {
 		color: var( --color-primary-light );

--- a/client/blocks/reader-import-button/style.scss
+++ b/client/blocks/reader-import-button/style.scss
@@ -19,6 +19,6 @@
 
 .reader-import-button__label {
 	font-size: 14px;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	padding-left: 4px;
 }

--- a/client/blocks/reader-import-button/style.scss
+++ b/client/blocks/reader-import-button/style.scss
@@ -19,6 +19,6 @@
 
 .reader-import-button__label {
 	font-size: 14px;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	padding-left: 4px;
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -165,7 +165,7 @@
 		}
 
 		.reader-post-card__timestamp-link {
-			color: var( --color-neutral );
+	color: var( --color-text-subtle );
 		}
 
 		.reader-post-options-menu {
@@ -266,7 +266,7 @@
 // Need .reader__content to override .reader__content a
 .reader__content .reader-post-card__timestamp-link,
 .reader__content .reader-post-card__tag-link {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	margin-top: 2px;
 	cursor: pointer;
 	&:hover {
@@ -315,7 +315,7 @@
 }
 
 .reader-post-card__tags {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	display: flex;
 	flex-direction: row;
 	height: 20px;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -165,7 +165,7 @@
 		}
 
 		.reader-post-card__timestamp-link {
-			color: var( --color-neutral-light );
+			color: var( --color-neutral );
 		}
 
 		.reader-post-options-menu {
@@ -266,7 +266,7 @@
 // Need .reader__content to override .reader__content a
 .reader__content .reader-post-card__timestamp-link,
 .reader__content .reader-post-card__tag-link {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	margin-top: 2px;
 	cursor: pointer;
 	&:hover {
@@ -315,7 +315,7 @@
 }
 
 .reader-post-card__tags {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	display: flex;
 	flex-direction: row;
 	height: 20px;

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -165,7 +165,7 @@
 		}
 
 		.reader-post-card__timestamp-link {
-	color: var( --color-text-subtle );
+			color: var( --color-text-subtle );
 		}
 
 		.reader-post-options-menu {

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -1,7 +1,7 @@
 .reader-post-options-menu,
 .reader-post-options-menu .ellipsis-menu {
 	.button.is-borderless {
-		color: var( --color-neutral );
+		color: var( --color-text-subtle );
 
 		&:hover,
 		&:active {

--- a/client/blocks/reader-post-options-menu/style.scss
+++ b/client/blocks/reader-post-options-menu/style.scss
@@ -1,7 +1,7 @@
 .reader-post-options-menu,
 .reader-post-options-menu .ellipsis-menu {
 	.button.is-borderless {
-		color: var( --color-neutral-light );
+		color: var( --color-neutral );
 
 		&:hover,
 		&:active {

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -5,7 +5,7 @@
 }
 
 .reader-recommended-sites__header {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	font-size: 14px;
 	font-weight: 600;
 	letter-spacing: 0.01em;

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -5,7 +5,7 @@
 }
 
 .reader-recommended-sites__header {
-	color: var( --color-neutral-200 );
+	color: var( --color-neutral );
 	font-size: 14px;
 	font-weight: 600;
 	letter-spacing: 0.01em;

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -1,5 +1,5 @@
 .reader-related-card__heading {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	font-size: 14px;
 	font-weight: 600;
 	margin-bottom: 20px;

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -1,5 +1,5 @@
 .reader-related-card__heading {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	font-size: 14px;
 	font-weight: 600;
 	margin-bottom: 20px;

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -1,7 +1,7 @@
 .reader-share__button {
 	align-items: center;
 	box-sizing: border-box;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	display: inline-flex;
 	padding: 4px;
 	position: relative;

--- a/client/blocks/reader-share/style.scss
+++ b/client/blocks/reader-share/style.scss
@@ -1,7 +1,7 @@
 .reader-share__button {
 	align-items: center;
 	box-sizing: border-box;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	display: inline-flex;
 	padding: 4px;
 	position: relative;

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -1,5 +1,5 @@
 .reader-site-notification-settings__button {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 
 	&:hover {
 		cursor: pointer;
@@ -70,7 +70,7 @@
 
 .reader-site-notification-settings__popout-hint,
 .reader-site-notification-settings__popout-instructions-hint {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	font-size: 12px;
 	margin-bottom: 0;
 }

--- a/client/blocks/reader-site-notification-settings/style.scss
+++ b/client/blocks/reader-site-notification-settings/style.scss
@@ -1,5 +1,5 @@
 .reader-site-notification-settings__button {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 
 	&:hover {
 		cursor: pointer;
@@ -70,7 +70,7 @@
 
 .reader-site-notification-settings__popout-hint,
 .reader-site-notification-settings__popout-instructions-hint {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	font-size: 12px;
 	margin-bottom: 0;
 }

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -72,7 +72,7 @@
 .reader-subscription-list-item__site-url,
 .reader-subscription-list-item__site-url:visited,
 .reader-subscription-list-item__timestamp {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 }
 
 .reader-subscription-list-item__site-title,

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -4,7 +4,7 @@
 }
 
 .reader-subscription-list-item__byline {
-	color: var( --color-neutral-600 );
+	color: var( --color-text );
 	margin-right: 16px;
 	flex: 1 1 0;
 }
@@ -44,7 +44,7 @@
 }
 
 .reader-subscription-list-item__by-text .reader-subscription-list-item__link {
-	color: var( --color-neutral-600 );
+	color: var( --color-text );
 }
 
 .reader-subscription-list-item .gravatar {

--- a/client/blocks/reader-subscription-list-item/style.scss
+++ b/client/blocks/reader-subscription-list-item/style.scss
@@ -72,7 +72,7 @@
 .reader-subscription-list-item__site-url,
 .reader-subscription-list-item__site-url:visited,
 .reader-subscription-list-item__timestamp {
-	color: var( --color-neutral-200 );
+	color: var( --color-neutral );
 }
 
 .reader-subscription-list-item__site-title,

--- a/client/blocks/reader-visit-link/style.scss
+++ b/client/blocks/reader-visit-link/style.scss
@@ -3,7 +3,7 @@
 }
 
 .reader-visit-link__label {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 }
 
 .reader-visit-link:hover,

--- a/client/blocks/reader-visit-link/style.scss
+++ b/client/blocks/reader-visit-link/style.scss
@@ -3,7 +3,7 @@
 }
 
 .reader-visit-link__label {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 }
 
 .reader-visit-link:hover,

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -41,7 +41,7 @@
 	width: 48px;
 	height: 49px;
 	cursor: pointer;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 
 	&:hover {
 		color: var( --color-neutral-700 );

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -41,7 +41,7 @@
 	width: 48px;
 	height: 49px;
 	cursor: pointer;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 
 	&:hover {
 		color: var( --color-neutral-700 );

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -23,7 +23,7 @@
 }
 
 .site-address-changer__select-icon {
-	color: var( --color-text-subtle );
+	color: var( --color-neutral-light );
 	margin-left: 6px;
 	align-self: center;
 }

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -23,7 +23,7 @@
 }
 
 .site-address-changer__select-icon {
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 	margin-left: 6px;
 	align-self: center;
 }

--- a/client/blocks/site-address-changer/style.scss
+++ b/client/blocks/site-address-changer/style.scss
@@ -23,7 +23,7 @@
 }
 
 .site-address-changer__select-icon {
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 	margin-left: 6px;
 	align-self: center;
 }

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -102,7 +102,7 @@
 
 	.subscription-length-picker__option-credit-info {
 		float: right;
-		color: var( --color-neutral );
+		color: var( --color-text-subtle );
 	}
 
 	.subscription-length-picker__option-old-price {

--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -102,7 +102,7 @@
 
 	.subscription-length-picker__option-credit-info {
 		float: right;
-		color: var( --color-neutral-light );
+		color: var( --color-neutral );
 	}
 
 	.subscription-length-picker__option-old-price {

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -103,7 +103,7 @@
 		.ellipsis-menu__toggle.button.is-borderless {
 			cursor: pointer;
 			font-size: 24px;
-			color: var( --color-neutral-light );
+			color: var( --color-neutral );
 			padding: 15px 24px;
 			min-width: 24px;
 			.gridicon {

--- a/client/blocks/taxonomy-manager/style.scss
+++ b/client/blocks/taxonomy-manager/style.scss
@@ -103,7 +103,7 @@
 		.ellipsis-menu__toggle.button.is-borderless {
 			cursor: pointer;
 			font-size: 24px;
-			color: var( --color-neutral );
+			color: var( --color-text-subtle );
 			padding: 15px 24px;
 			min-width: 24px;
 			.gridicon {

--- a/client/blocks/term-tree-selector/style.scss
+++ b/client/blocks/term-tree-selector/style.scss
@@ -102,7 +102,7 @@ input[type=checkbox].term-tree-selector__input {
 	margin-left: 8px;
 	font-size: 11px;
 	text-transform: uppercase;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 
 	.term-tree-selector.is-type-labels-visible & {
 		display: block;

--- a/client/blocks/term-tree-selector/style.scss
+++ b/client/blocks/term-tree-selector/style.scss
@@ -102,7 +102,7 @@ input[type=checkbox].term-tree-selector__input {
 	margin-left: 8px;
 	font-size: 11px;
 	text-transform: uppercase;
-	color: var( --color-neutral-light );
+	color: var( --color-neutral );
 
 	.term-tree-selector.is-type-labels-visible & {
 		display: block;

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -101,7 +101,7 @@
 	width: 20px;
 	height: 20px;
 	margin: 0;
-	color: var( --color-neutral );
+	color: var( --color-text-subtle );
 
 	&:hover {
 		color: var( --color-neutral-400 );

--- a/client/blocks/upload-image/style.scss
+++ b/client/blocks/upload-image/style.scss
@@ -101,7 +101,7 @@
 	width: 20px;
 	height: 20px;
 	margin: 0;
-	color: var( --color-neutral-200 );
+	color: var( --color-neutral );
 
 	&:hover {
 		color: var( --color-neutral-400 );

--- a/client/reader/discover/site-attribution.scss
+++ b/client/reader/discover/site-attribution.scss
@@ -1,7 +1,7 @@
 .is-reader-page .discover-attribution {
 	align-items: flex-start;
 	display: flex;
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	font-size: 13px;
 	font-family: $sans;
 	margin-bottom: 8px;

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -36,7 +36,7 @@
 	border-top: 0;
 	border-top-left-radius: 0;
 	border-top-right-radius: 0;
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	font-size: 11px;
 	padding: 2px 9px 6px 11px;
 	position: relative;
@@ -103,7 +103,7 @@
 	}
 
 	.following-manage__subscriptions-sort .following-manage__sort-controls {
-		color: var( --color-neutral-light );
+		color: var( --color-text-subtle );
 		font-size: 12px;
 		font-weight: normal;
 		padding-top: 8px;

--- a/client/reader/list-stream/style.scss
+++ b/client/reader/list-stream/style.scss
@@ -56,7 +56,7 @@
 
 .list-stream__header-description {
 	margin: 0;
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 }
 
 .list-stream__header-title,

--- a/client/reader/post-excerpt-link/style.scss
+++ b/client/reader/post-excerpt-link/style.scss
@@ -45,7 +45,7 @@
 	max-height: 0;
 	overflow: hidden;
 	font-size: 14px;
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	margin: 0;
 	transition: all 0.15s ease-in-out;
 }

--- a/client/reader/reading-time/style.scss
+++ b/client/reader/reading-time/style.scss
@@ -1,5 +1,5 @@
 .reading-time {
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	font-weight: 400;
 }
 

--- a/client/reader/search-stream/style.scss
+++ b/client/reader/search-stream/style.scss
@@ -183,7 +183,7 @@
 
 // Post and Sites static headers
 .search-stream__headers {
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	display: flex;
 	font-size: 14px;
 	font-weight: 600;

--- a/client/reader/site-stream/featured.scss
+++ b/client/reader/site-stream/featured.scss
@@ -17,7 +17,7 @@
 
 .reader__featured-description {
 	font-size: 13px;
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 }
 
 .reader__featured-posts {

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -371,7 +371,7 @@
 .reader__x-post-to {
 	font-size: 13px;
 	font-family: $sans;
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	position: relative;
 }
 

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -194,7 +194,7 @@
 	margin: 16px 0 0 -4px;
 	list-style: none;
 	font-size: 14px;
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	display: flex;
 	align-items: center;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to up the contrast for several locations that fail. These instances don't use the text variables as they should. **I avoided anything that might be an icon or something that might not be against a white background.** My goal was to only address text. I'm not too co

I performed 3 searches/updates:

- **Blocks** folder: 
    - replaced `var( --color-neutral-light )` with `var( --color-text-subtle)`
    - replaced `var( --color-neutral-600 )` with `var( --color-text)` 
    - replaced `var( --color-neutral-200 )` with `var( --color-text-subtle)`
- **client/reader folder**: 
    - replaced `var( --color-neutral-light )` with `var( --color-text-subtle)`
- [Updated](https://github.com/Automattic/wp-calypso/pull/32284/files#diff-ae6da2cd3efe0b8333294aea604b19b0L21) a less frequently used extend called `content-font`, mostly used by the Reader. The color of that extend now uses --color-text.

#### Testing instructions

Sorry for the big PR. I don't think this needs involved testing other than a smoke test of the [Blocks](http://calypso.localhost:3000/devdocs/blocks) page and the Reader itself.

Make sure all text is readable and there are no unintended effects.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before|After
---|---
![image](https://user-images.githubusercontent.com/618551/56160226-4e95a180-5f8c-11e9-990a-8700558d7189.png)|![image](https://user-images.githubusercontent.com/618551/56160193-2d34b580-5f8c-11e9-9e65-b479b58a6435.png)


