### PR TITLE
Post Checkout: Add relative positioning so warning icon appears in the proper area

### DIFF
--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -97,6 +97,7 @@
 	.purchase-detail__notice-icon.gridicon {
 		fill: var( --color-warning );
 		height: 24px;
+		position: relative;
 		right: -26px;
 		top: -3px;
 		width: 24px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I found this while working on #31686; top and right positioning was set on this icon, but no position had been specified so the placement didn't have any effect.

**Before**

<img width="609" alt="Screen Shot 2019-04-15 at 1 26 41 PM" src="https://user-images.githubusercontent.com/2124984/56153691-c2cc4700-5f84-11e9-83fb-ac94d5f424ec.png">

**After**

<img width="697" alt="Screen Shot 2019-04-15 at 1 40 29 PM" src="https://user-images.githubusercontent.com/2124984/56153681-bea02980-5f84-11e9-850a-4aef827d5ed4.png">

#### Testing instructions

* Switch to this PR and purchase a domain with GSuite (**don't forget to cancel the domain right after!**)
* Note the placement of the warning icon after checkout.