### PR TITLE
Import Section: Pull isHydrated & state data from the server into redux

### DIFF
--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -68,8 +68,8 @@ const apiSuccess = data => {
 
 	Dispatcher.handleViewAction( apiFetchCompleteAction );
 	reduxDispatch( {
-		...data,
 		...apiFetchCompleteAction,
+		data,
 	} );
 
 	return data;

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -60,7 +60,10 @@ const clearOrder = ( siteId, importerId ) =>
 const importOrder = importerStatus =>
 	toApi( Object.assign( {}, importerStatus, { importerState: appStates.IMPORTING } ) );
 
-const apiStart = () => Dispatcher.handleViewAction( { type: IMPORTS_FETCH } );
+const apiStart = () => {
+	Dispatcher.handleViewAction( { type: IMPORTS_FETCH } );
+	reduxDispatch( { type: IMPORTS_FETCH } );
+};
 const apiSuccess = data => {
 	const apiFetchCompleteAction = {
 		type: IMPORTS_FETCH_COMPLETED,
@@ -76,7 +79,7 @@ const apiSuccess = data => {
 };
 const apiFailure = data => {
 	Dispatcher.handleViewAction( { type: IMPORTS_FETCH_FAILED } );
-
+	reduxDispatch( { type: IMPORTS_FETCH_FAILED } );
 	return data;
 };
 const setImportLock = ( shouldEnableLock, importerId ) => {

--- a/client/lib/importer/actions.js
+++ b/client/lib/importer/actions.js
@@ -62,7 +62,15 @@ const importOrder = importerStatus =>
 
 const apiStart = () => Dispatcher.handleViewAction( { type: IMPORTS_FETCH } );
 const apiSuccess = data => {
-	Dispatcher.handleViewAction( { type: IMPORTS_FETCH_COMPLETED } );
+	const apiFetchCompleteAction = {
+		type: IMPORTS_FETCH_COMPLETED,
+	};
+
+	Dispatcher.handleViewAction( apiFetchCompleteAction );
+	reduxDispatch( {
+		...data,
+		...apiFetchCompleteAction,
+	} );
 
 	return data;
 };

--- a/client/lib/importer/store.js
+++ b/client/lib/importer/store.js
@@ -37,8 +37,6 @@ const initialState = Object.freeze( {
 	importers: {},
 	importerLocks: {},
 	api: {
-		isHydrated: false,
-		isFetching: false,
 		retryCount: 0,
 	},
 } );
@@ -59,7 +57,6 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 				...state,
 				api: {
 					...state.api,
-					isFetching: true,
 				},
 			};
 
@@ -68,7 +65,6 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 				...state,
 				api: {
 					...state.api,
-					isFetching: false,
 					retryCount: get( state, 'api.retryCount', 0 ) + 1,
 				},
 			};
@@ -78,8 +74,6 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 				...state,
 				api: {
 					...state.api,
-					isFetching: false,
-					isHydrated: true,
 					retryCount: 0,
 				},
 			};
@@ -164,7 +158,6 @@ const ImporterStore = createReducerStore( function( state, payload ) {
 				...state,
 				api: {
 					...state.api,
-					isHydrated: true,
 				},
 			};
 			const importerId = get( action, 'importerStatus.importerId' );

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -216,11 +216,8 @@ class SiteSettingsImport extends Component {
 	 * @returns {Array} Importer react elements
 	 */
 	renderImporters() {
-		const {
-			api: { isHydrated },
-			importers: imports,
-		} = this.state;
-		const { engine, site } = this.props;
+		const { importers: imports } = this.state;
+		const { engine, isHydrated, site } = this.props;
 		const { slug, title } = site;
 		const siteTitle = title.length ? title : slug;
 
@@ -284,6 +281,7 @@ export default flow(
 	connect( state => ( {
 		engine: getSelectedImportEngine( state ),
 		fromSite: getImporterSiteUrl( state ),
+		isHydrated: !! get( state, 'imports.isHydrated' ),
 		site: getSelectedSite( state ),
 		siteSlug: getSelectedSiteSlug( state ),
 	} ) ),

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { filter, find, flow, get, isEmpty, memoize, once } from 'lodash';
+import { defer, filter, find, flow, get, isEmpty, isEqual, memoize, once } from 'lodash';
 
 /**
  * Internal dependencies
@@ -113,7 +113,7 @@ class SiteSettingsImport extends Component {
 			return;
 		}
 
-		startImport( site.ID, getImporterTypeForEngine( engine ) );
+		defer( () => startImport( site.ID, getImporterTypeForEngine( engine ) ) );
 	} );
 
 	componentDidMount() {
@@ -247,7 +247,13 @@ class SiteSettingsImport extends Component {
 	};
 
 	updateState = () => {
-		this.setState( getImporterState() );
+		const newState = getImporterState();
+		if ( isEqual( this.state, newState ) ) {
+			// Don't trigger a re-render if nothing has changed
+			return;
+		}
+
+		this.setState( newState );
 	};
 
 	renderImportersList() {

--- a/client/my-sites/site-settings/section-import.jsx
+++ b/client/my-sites/site-settings/section-import.jsx
@@ -33,6 +33,7 @@ import {
 } from 'state/imports/constants';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
+import isImportDataHydrated from 'state/selectors/is-import-data-hydrated';
 import { getSelectedImportEngine, getImporterSiteUrl } from 'state/importer-nux/temp-selectors';
 import Main from 'components/main';
 import HeaderCake from 'components/header-cake';
@@ -281,7 +282,7 @@ export default flow(
 	connect( state => ( {
 		engine: getSelectedImportEngine( state ),
 		fromSite: getImporterSiteUrl( state ),
-		isHydrated: !! get( state, 'imports.isHydrated' ),
+		isHydrated: isImportDataHydrated( state ),
 		site: getSelectedSite( state ),
 		siteSlug: getSelectedSiteSlug( state ),
 	} ) ),

--- a/client/state/imports/reducer.js
+++ b/client/state/imports/reducer.js
@@ -4,9 +4,10 @@
  */
 import { combineReducers, createReducer } from 'state/utils';
 import uploadsReducer from 'state/imports/uploads/reducer';
-import { IMPORTS_FETCH_COMPLETED } from 'state/action-types';
+import { IMPORTS_FETCH_COMPLETED, SELECTED_SITE_SET } from 'state/action-types';
 
 const isHydrated = createReducer( false, {
+	[ SELECTED_SITE_SET ]: () => false,
 	[ IMPORTS_FETCH_COMPLETED ]: () => true,
 } );
 

--- a/client/state/imports/reducer.js
+++ b/client/state/imports/reducer.js
@@ -6,12 +6,23 @@ import { combineReducers, createReducer } from 'state/utils';
 import uploadsReducer from 'state/imports/uploads/reducer';
 import { IMPORTS_FETCH_COMPLETED, SELECTED_SITE_SET } from 'state/action-types';
 
-const isHydrated = createReducer( false, {
-	[ SELECTED_SITE_SET ]: () => false,
-	[ IMPORTS_FETCH_COMPLETED ]: () => true,
+// @TODO better name than serverData
+const serverData = createReducer( null, {
+	[ SELECTED_SITE_SET ]: () => null,
+	[ IMPORTS_FETCH_COMPLETED ]: (
+		state,
+		{ customData, importId, importStatus, progress, siteId, type }
+	) => ( {
+		customData,
+		importId,
+		importStatus,
+		progress,
+		siteId,
+		type,
+	} ),
 } );
 
 export default combineReducers( {
-	isHydrated,
+	serverData,
 	uploads: uploadsReducer,
 } );

--- a/client/state/imports/reducer.js
+++ b/client/state/imports/reducer.js
@@ -2,9 +2,15 @@
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, createReducer } from 'state/utils';
 import uploadsReducer from 'state/imports/uploads/reducer';
+import { IMPORTS_FETCH_COMPLETED } from 'state/action-types';
+
+const isHydrated = createReducer( false, {
+	[ IMPORTS_FETCH_COMPLETED ]: () => true,
+} );
 
 export default combineReducers( {
+	isHydrated,
 	uploads: uploadsReducer,
 } );

--- a/client/state/imports/reducer.js
+++ b/client/state/imports/reducer.js
@@ -4,7 +4,19 @@
  */
 import { combineReducers, createReducer } from 'state/utils';
 import uploadsReducer from 'state/imports/uploads/reducer';
-import { IMPORTS_FETCH_COMPLETED, SELECTED_SITE_SET } from 'state/action-types';
+import {
+	IMPORTS_FETCH,
+	IMPORTS_FETCH_COMPLETED,
+	IMPORTS_FETCH_FAILED,
+	SELECTED_SITE_SET,
+} from 'state/action-types';
+
+const isFetching = createReducer( false, {
+	[ IMPORTS_FETCH ]: () => true,
+	[ IMPORTS_FETCH_COMPLETED ]: () => false,
+	[ IMPORTS_FETCH_FAILED ]: () => false,
+	[ SELECTED_SITE_SET ]: () => false,
+} );
 
 // @TODO better name than serverData
 const serverData = createReducer( null, {
@@ -23,6 +35,7 @@ const serverData = createReducer( null, {
 } );
 
 export default combineReducers( {
+	isFetching,
 	serverData,
 	uploads: uploadsReducer,
 } );

--- a/client/state/selectors/get-import-server-data.js
+++ b/client/state/selectors/get-import-server-data.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
+/**
+ * Returns importer state data if it's been successfully fetched from the API
+ *
+ * @param {Object} state Global state tree
+ * @return {Object|null} Data if it has been fetched -- null, if not
+ */
+export default function getImportServerData( state ) {
+	return get( state, 'imports.serverData', null );
+}

--- a/client/state/selectors/is-import-data-fetching.js
+++ b/client/state/selectors/is-import-data-fetching.js
@@ -1,0 +1,16 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Returns true if importer state is fetching from the API
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if data is being fetched
+ */
+export default function isImportDataFetching( state ) {
+	return !! get( state, 'imports.isFetching' );
+}

--- a/client/state/selectors/is-import-data-hydrated.js
+++ b/client/state/selectors/is-import-data-hydrated.js
@@ -3,8 +3,12 @@
 /**
  * External dependencies
  */
+import { isEmpty } from 'lodash';
 
-import { get } from 'lodash';
+/**
+ * Internal dependencies
+ */
+import getImportServerData from 'state/selectors/get-import-server-data';
 
 /**
  * Returns true if importer state has been successfully fetched from the API
@@ -13,5 +17,5 @@ import { get } from 'lodash';
  * @return {Boolean} True if data has been fetched
  */
 export default function isImportDataHydrated( state ) {
-	return !! get( state, 'imports.isHydrated' );
+	return ! isEmpty( getImportServerData( state ) );
 }

--- a/client/state/selectors/is-import-data-hydrated.js
+++ b/client/state/selectors/is-import-data-hydrated.js
@@ -1,0 +1,17 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { get } from 'lodash';
+
+/**
+ * Returns true if importer state has been successfully fetched from the API
+ *
+ * @param {Object} state Global state tree
+ * @return {Boolean} True if data has been fetched
+ */
+export default function isImportDataHydrated( state ) {
+	return !! get( state, 'imports.isHydrated' );
+}


### PR DESCRIPTION
Another step at pulling state out of flux for the import section. Currently the fetching state toggling is causing a re-render of the whole subtree.  This should help with that and let us iterate on the data flow for this section.

#### Changes proposed in this Pull Request

* Use the redux bridge to dispatch an action when the fetch completes
* Include the data in the action so we can start working with it in redux
* New reducer node `state.imports.serverData` (naming help appreciated!)
* New selectors for the data & derived state of it being hydrated or not.

#### Testing instructions

* TBD
