### PR TITLE
CI: Generate more readable WP.com block editor build files for debug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ jobs:
           name: Build the block editor in WordPress.com integration utils package
           command: |
             npx lerna run clean --scope='@automattic/wpcom-block-editor'
-            npx lerna run bundle --scope='@automattic/wpcom-block-editor' -- -- --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor
+            SOURCEMAP='inline-cheap-source-map' npx lerna run bundle --scope='@automattic/wpcom-block-editor' -- -- --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor
             NODE_ENV=production npx lerna run bundle --scope='@automattic/wpcom-block-editor' -- -- --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor --output-filename=[name].min.js
       - store-artifacts-and-test-results
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Modify the `build-wpcom-block-editor` CircleCI job to generate the dev build files containing the original source. To accomplish this, we're using the `inline-cheap-source-map` value for the [`devtool` option](https://webpack.js.org/configuration/devtool/#devtool) passed to Webpack (which is got from the [`SOURCEMAP` env var](https://github.com/Automattic/wp-calypso/blob/bb3d9763cf22d285cfdc0f85557ec54f4df2bb27/packages/calypso-build/webpack.config.js#L65)).

This is to make them more readable and easier to review when they are loaded by WordPress.com or Jetpack connected sites (these sites load the unminified files if they are set in `SCRIPT_DEBUG` mode).

#### Testing instructions

- Check the details of the `build-wpcom-block-editor` job on this PR.
<img width="724" alt="Screen Shot 2019-04-16 at 09 44 10" src="https://user-images.githubusercontent.com/1233880/56174173-383f2280-602c-11e9-9edf-ce2fa5d8c49a.png">

- Go to the Artifacts tab.
- Check the unminified `.js` files (those without ending in `.min.js`) and confirm the `eval` syntax is not used and they contain the original source code (example: search for the `transmitDraftId` function on the `iframe-bridge-server.js` file or for `replaceMediaModalOnClassicBlocks` on `tinymce.js`).

| Before | After |
|---|---|
| <img width="1429" alt="Screen Shot 2019-04-16 at 09 49 13" src="https://user-images.githubusercontent.com/1233880/56174380-27db7780-602d-11e9-8fc4-92d1cc3807bc.png"> | <img width="954" alt="Screen Shot 2019-04-16 at 09 48 13" src="https://user-images.githubusercontent.com/1233880/56174388-2c079500-602d-11e9-81c5-ab2966e55926.png"> |

- Apply D26850-code, D26897-code and sandbox `widgets.wp.com`.
- Enable the script debugging on your sandbox site: `define( 'SCRIPT_DEBUG', true )`.
- Go to https://wordpress.com/block-editor and select your sandbox site.
- Check the new more readable unminified scripts are loaded.
- Make sure the Calypso integrations work as expected.


