### PR TITLE
Migrate CSS of the Theme component

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -106,7 +106,6 @@
 @import 'components/stat-update-indicator/style';
 @import 'components/sub-masterbar-nav/style';
 @import 'components/text-diff/style';
-@import 'components/theme/style';
 @import 'components/pagination/style';
 @import 'components/tooltip/style';
 @import 'components/upgrades/gsuite/gsuite-dialog/style';

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -214,8 +214,7 @@
 	}
 }
 
-.popover__menu-separator,
-.popover__hr {
+.popover__menu-separator {
 	margin: 4px 0;
 	background: var( --color-neutral-0 );
 }

--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -26,8 +26,10 @@ import TrackComponentView from 'lib/analytics/track-component-view';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
- * Component
+ * Style dependencies
  */
+import './style.scss';
+
 export class Theme extends Component {
 	static propTypes = {
 		theme: PropTypes.shape( {
@@ -105,21 +107,23 @@ export class Theme extends Component {
 		}
 	};
 
-	isBeginnerTheme = () => {
+	isBeginnerTheme() {
 		const { theme } = this.props;
 		const skillLevels = get( theme, [ 'taxonomies', 'theme_skill-level' ] );
 		return some( skillLevels, { slug: 'beginner' } );
-	};
+	}
 
-	renderPlaceholder = () => {
+	renderPlaceholder() {
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Card className="theme is-placeholder">
 				<div className="theme__content" />
 			</Card>
 		);
-	};
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
 
-	renderInstalling = () => {
+	renderInstalling() {
 		if ( this.props.installing ) {
 			return (
 				<div className="theme__installing">
@@ -127,7 +131,7 @@ export class Theme extends Component {
 				</div>
 			);
 		}
-	};
+	}
 
 	onUpsellClick = () => {
 		this.props.recordTracksEvent( 'calypso_upgrade_nudge_cta_click', {
@@ -256,10 +260,7 @@ export class Theme extends Component {
 	}
 }
 
-const mapStateToProps = null;
-const mapDispatchToProps = { recordTracksEvent };
-
 export default connect(
-	mapStateToProps,
-	mapDispatchToProps
+	null,
+	{ recordTracksEvent }
 )( localize( Theme ) );

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -18,47 +18,29 @@ import PopoverMenuItem from 'components/popover/menu-item';
 import PopoverMenuSeparator from 'components/popover/menu-separator';
 import { isOutsideCalypso } from 'lib/url';
 
-/**
- * Component
- */
 class ThemeMoreButton extends Component {
-	constructor( props ) {
-		super( props );
-		this.state = { showPopover: false };
-		this.togglePopover = this.togglePopover.bind( this );
-		this.closePopover = this.closePopover.bind( this );
-		this.onClick = this.onClick.bind( this );
-		this.onPopoverActionClick = this.onPopoverActionClick.bind( this );
-	}
+	state = { showPopover: false };
 
-	togglePopover() {
+	moreButtonRef = React.createRef();
+
+	togglePopover = () => {
 		this.setState( { showPopover: ! this.state.showPopover } );
 		! this.state.showPopover &&
 			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_open' );
-	}
+	};
 
-	closePopover( action ) {
+	closePopover = action => {
 		this.setState( { showPopover: false } );
 		if ( isFunction( action ) ) {
 			action();
 		}
-	}
+	};
 
 	popoverAction( action, label ) {
-		action( this.props.themeId );
-		this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + label );
-	}
-
-	onPopoverActionClick( action, label ) {
-		return () => this.popoverAction( action, label );
-	}
-
-	focus( event ) {
-		event.target.focus();
-	}
-
-	onClick( action, label ) {
-		return this.closePopover.bind( this, this.onPopoverActionClick( action, label ) );
+		return () => {
+			action( this.props.themeId );
+			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_' + label );
+		};
 	}
 
 	render() {
@@ -70,42 +52,39 @@ class ThemeMoreButton extends Component {
 
 		return (
 			<span className={ classes }>
-				<button ref="more" onClick={ this.togglePopover }>
+				<button ref={ this.moreButtonRef } onClick={ this.togglePopover }>
 					<Gridicon icon="ellipsis" size={ 24 } />
 				</button>
 
-				<PopoverMenu
-					context={ this.refs && this.refs.more }
-					isVisible={ this.state.showPopover }
-					onClose={ this.closePopover }
-					position="top left"
-				>
-					{ map(
-						this.props.options,
-						function( option, key ) {
+				{ this.state.showPopover && (
+					<PopoverMenu
+						context={ this.moreButtonRef.current }
+						isVisible
+						onClose={ this.closePopover }
+						position="top left"
+					>
+						{ map( this.props.options, ( option, key ) => {
 							if ( option.separator ) {
 								return <PopoverMenuSeparator key={ key } />;
 							}
 							if ( option.getUrl ) {
 								const url = option.getUrl( this.props.themeId );
 								return (
-									<a
-										className="theme__more-button-menu-item popover__menu-item"
-										onMouseOver={ this.focus }
-										onClick={ this.onClick( option.action, option.label ) }
+									<PopoverMenuItem
 										key={ option.label }
+										action={ this.popoverAction( option.action, option.label ) }
 										href={ url }
 										target={ isOutsideCalypso( url ) ? '_blank' : null }
 									>
 										{ option.label }
-									</a>
+									</PopoverMenuItem>
 								);
 							}
 							if ( option.action ) {
 								return (
 									<PopoverMenuItem
 										key={ option.label }
-										action={ this.onPopoverActionClick( option.action, option.label ) }
+										action={ this.popoverAction( option.action, option.label ) }
 									>
 										{ option.label }
 									</PopoverMenuItem>
@@ -113,9 +92,9 @@ class ThemeMoreButton extends Component {
 							}
 							// If neither getUrl() nor action() are specified, filter this option.
 							return null;
-						}.bind( this )
-					) }
-				</PopoverMenu>
+						} ) }
+					</PopoverMenu>
+				) }
 			</span>
 		);
 	}

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -15,6 +15,7 @@ import Gridicon from 'gridicons';
  */
 import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
+import PopoverMenuSeparator from 'components/popover/menu-separator';
 import { isOutsideCalypso } from 'lib/url';
 
 /**
@@ -83,7 +84,7 @@ class ThemeMoreButton extends Component {
 						this.props.options,
 						function( option, key ) {
 							if ( option.separator ) {
-								return <hr key={ key } className="popover__hr" />;
+								return <PopoverMenuSeparator key={ key } />;
 							}
 							if ( option.getUrl ) {
 								const url = option.getUrl( this.props.themeId );

--- a/client/components/theme/style.scss
+++ b/client/components/theme/style.scss
@@ -276,19 +276,6 @@ $theme-info-height: 54px;
 	}
 }
 
-.theme__more-button-menu-item {
-	text-decoration: none;
-
-	&:visited {
-		color: var( --color-neutral-700 );
-	}
-
-	&:hover,
-	&:focus {
-		color: white;
-	}
-}
-
 .theme__ribbon {
 	text-transfrom: capitalize;
 }


### PR DESCRIPTION
Migrate CSS of the `components/theme` component.

Also modernizes the `more-button` code by converting refs to `React.createRef` and using `PopoverMenu` capabilities instead of recreating them:
- `PopoverMenuSeparator` component is available
- `PopoverMenuItem` accepts a `href` prop and will render an `<a href>` element with all the additional bells and whistles (focus management, styling)

**How to test:**
Go to `/themes/:site` and verify that the theme list renders correctly. Focus on the ellipsis button and the popover it shows:

<img width="266" alt="Screenshot 2019-04-16 at 09 46 19" src="https://user-images.githubusercontent.com/664258/56193650-6f640280-6031-11e9-8e3c-88e6e3e7ea90.png">

Test that the mouse-over-ed item is highlighted (this didn't work correctly before this PR: two items could be highlighted at the same time).