### PR TITLE
PopoverMenu: remove action prop passed to PopoverMenuItem

### DIFF
--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { over } from 'lodash';
 
 /**
  * Internal dependencies
@@ -85,15 +84,14 @@ class PopoverMenu extends Component {
 			return child;
 		}
 
-		const boundOnClose = this._onClose.bind( this, child.props.action );
-		let onClick = boundOnClose;
-
-		if ( child.props.onClick ) {
-			onClick = over( [ child.props.onClick, boundOnClose ] );
-		}
+		const { action, onClick } = child.props;
 
 		return React.cloneElement( child, {
-			onClick: onClick,
+			action: null,
+			onClick: () => {
+				onClick && onClick();
+				this._onClose( action );
+			},
 		} );
 	};
 


### PR DESCRIPTION
When `PopoverMenu` renders its children:
```jsx
<PopoverMenu>
  <PopoverMenuItem action={ action } />
</PopoverMenu>
```
it converts the `action` prop to a `onClick` handler and uses `React.cloneElement` to add it:
```jsx
<PopoverMenuItem onClick={ handlerGeneratedFrom( action ) } />
```
The `PopoverMenuItem` is then rendered as a `button` element:
```jsx
<button onClick={ handler } />
```

There is a bug however, that the `action` prop is passed down, too:
```jsx
<PopoverMenuItem action onClick />
```
and an invalid `action` prop is added to the DOM `button`:
```jsx
<button action onClick />
```

We don't want to pass the `action` down: it's been completely consumed by converting it to the `onClick` handler. And it causes React warning about invalid DOM attributes.

<img width="833" alt="Screenshot 2019-04-16 at 10 07 43" src="https://user-images.githubusercontent.com/664258/56193348-b69dc380-6030-11e9-8c0a-bfd4c2c749a6.png">

I fix this by passing `action: null` to the cloned element.

I also refactored the `onClick` handler to be more readable. Use normal function calls instead of `bind` and `over`.

**How to test:**
Best reviewed together with #32296 🙂 Go to `/themes/:site` and click on the ellipsis button of a theme:
<img width="266" alt="Screenshot 2019-04-16 at 09 46 19" src="https://user-images.githubusercontent.com/664258/56193322-a71e7a80-6030-11e9-9af1-4ee8d9cc72b5.png">

Verify that the menu still works as expected and the React warning in console (dev version only) disappeared.
