### PR TITLE
Settings - Writing: fix indentation of custom content type labels

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -78,21 +78,24 @@ class CustomContentTypes extends Component {
 
 		return (
 			<div className="custom-content-types__module-settings">
-				{ hasToggle && (
+				{ hasToggle ? (
 					<CompactFormToggle
 						checked={ !! fields[ name ] }
 						disabled={ this.isFormPending() || activatingCustomContentTypesModule }
 						onChange={ handleAutosavingToggle( name ) }
-					/>
+					>
+						<span className="custom-content-types__label">{ label }</span>
+					</CompactFormToggle>
+				) : (
+					<div
+						id={ numberFieldIdentifier }
+						className={ classnames( 'custom-content-types__label', {
+							'indented-form-field': ! hasToggle,
+						} ) }
+					>
+						{ label }
+					</div>
 				) }
-				<div
-					id={ numberFieldIdentifier }
-					className={ classnames( 'custom-content-types__label', {
-						'indented-form-field': ! hasToggle,
-					} ) }
-				>
-					{ label }
-				</div>
 				<div className="custom-content-types__indented-form-field indented-form-field">
 					{ translate( 'Display {{field /}} per page', {
 						comment:


### PR DESCRIPTION
#### Before

<img width="549" alt="Captura de Pantalla 2019-04-16 a la(s) 08 33 48" src="https://user-images.githubusercontent.com/1041600/56206477-e34ade80-6022-11e9-81f6-0fc274f6923b.png">


#### After

<img width="593" alt="Captura de Pantalla 2019-04-16 a la(s) 08 44 59" src="https://user-images.githubusercontent.com/1041600/56206994-075aef80-6024-11e9-92c4-44cbece03f65.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to Settings > Writing
* check the Content types card
* the toggle labels should be properly aligned


Fixes #32057
