### PR TITLE
Settings - Writing: introduce a setting for Beautiful Math and Shortcode Embeds in Composing

### DIFF
--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
  */
 import AfterTheDeadline from './after-the-deadline';
 import Latex from './latex';
+import Shortcodes from './shortcodes';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import DateTimeFormat from '../date-time-format';
@@ -58,6 +59,13 @@ const Composing = ( {
 						setFieldValue={ setFieldValue }
 					/>
 					<Latex
+						fields={ fields }
+						handleToggle={ handleToggle }
+						isRequestingSettings={ isRequestingSettings }
+						isSavingSettings={ isSavingSettings }
+						setFieldValue={ setFieldValue }
+					/>
+					<Shortcodes
 						fields={ fields }
 						handleToggle={ handleToggle }
 						isRequestingSettings={ isRequestingSettings }

--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import AfterTheDeadline from './after-the-deadline';
+import Latex from './latex';
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import DateTimeFormat from '../date-time-format';
@@ -48,13 +49,22 @@ const Composing = ( {
 			</CardComponent>
 
 			{ siteIsJetpack && (
-				<AfterTheDeadline
-					fields={ fields }
-					handleToggle={ handleToggle }
-					isRequestingSettings={ isRequestingSettings }
-					isSavingSettings={ isSavingSettings }
-					setFieldValue={ setFieldValue }
-				/>
+				<Fragment>
+					<AfterTheDeadline
+						fields={ fields }
+						handleToggle={ handleToggle }
+						isRequestingSettings={ isRequestingSettings }
+						isSavingSettings={ isSavingSettings }
+						setFieldValue={ setFieldValue }
+					/>
+					<Latex
+						fields={ fields }
+						handleToggle={ handleToggle }
+						isRequestingSettings={ isRequestingSettings }
+						isSavingSettings={ isSavingSettings }
+						setFieldValue={ setFieldValue }
+					/>
+				</Fragment>
 			) }
 
 			<DateTimeFormat

--- a/client/my-sites/site-settings/composing/latex.jsx
+++ b/client/my-sites/site-settings/composing/latex.jsx
@@ -58,7 +58,7 @@ class Latex extends Component {
 					siteId={ selectedSiteId }
 					moduleSlug="latex"
 					label={ translate(
-						'Use the LaTeX markup language to write mathematical equations and formulas.'
+						'Use the LaTeX markup language to write mathematical equations and formulas'
 					) }
 					disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
 				/>

--- a/client/my-sites/site-settings/composing/latex.jsx
+++ b/client/my-sites/site-settings/composing/latex.jsx
@@ -1,0 +1,84 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import SupportInfo from 'components/support-info';
+import Card from 'components/card';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
+import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
+import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
+import QueryJetpackConnection from 'components/data/query-jetpack-connection';
+
+class Latex extends Component {
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+		fields: {},
+	};
+
+	static propTypes = {
+		handleToggle: PropTypes.func.isRequired,
+		setFieldValue: PropTypes.func.isRequired,
+		isSavingSettings: PropTypes.bool,
+		isRequestingSettings: PropTypes.bool,
+		fields: PropTypes.object,
+	};
+
+	render() {
+		const {
+			isRequestingSettings,
+			isSavingSettings,
+			moduleUnavailable,
+			selectedSiteId,
+			translate,
+		} = this.props;
+
+		return (
+			<Card className="composing__card site-settings__card">
+				<QueryJetpackConnection siteId={ selectedSiteId } />
+				<SupportInfo
+					text={ translate(
+						'LaTeX is a powerful markup language for writing complex mathematical equations and formulas.'
+					) }
+					link="https://jetpack.com/support/beautiful-math/"
+				/>
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="latex"
+					label={ translate(
+						'Use the LaTeX markup language to write mathematical equations and formulas.'
+					) }
+					disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
+				/>
+			</Card>
+		);
+	}
+}
+
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+		state,
+		selectedSiteId,
+		'latex'
+	);
+
+	return {
+		selectedSiteId,
+		afterTheDeadlineModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'latex' ),
+		moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+	};
+} )( localize( Latex ) );

--- a/client/my-sites/site-settings/composing/shortcodes.jsx
+++ b/client/my-sites/site-settings/composing/shortcodes.jsx
@@ -1,0 +1,80 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import SupportInfo from 'components/support-info';
+import Card from 'components/card';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
+import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
+import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
+import QueryJetpackConnection from 'components/data/query-jetpack-connection';
+
+class Shortcodes extends Component {
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+		fields: {},
+	};
+
+	static propTypes = {
+		handleToggle: PropTypes.func.isRequired,
+		setFieldValue: PropTypes.func.isRequired,
+		isSavingSettings: PropTypes.bool,
+		isRequestingSettings: PropTypes.bool,
+		fields: PropTypes.object,
+	};
+
+	render() {
+		const {
+			isRequestingSettings,
+			isSavingSettings,
+			moduleUnavailable,
+			selectedSiteId,
+			translate,
+		} = this.props;
+
+		return (
+			<Card className="composing__card site-settings__card">
+				<QueryJetpackConnection siteId={ selectedSiteId } />
+				<SupportInfo
+					text={ translate( 'Embed media from popular sites when you author your content.' ) }
+					link="https://jetpack.com/support/shortcode-embeds/"
+				/>
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="shortcodes"
+					label={ translate( 'Compose using shortcodes to embed media from popular sites.' ) }
+					disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
+				/>
+			</Card>
+		);
+	}
+}
+
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+		state,
+		selectedSiteId,
+		'shortcodes'
+	);
+
+	return {
+		selectedSiteId,
+		afterTheDeadlineModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'shortcodes' ),
+		moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+	};
+} )( localize( Shortcodes ) );

--- a/client/my-sites/site-settings/composing/shortcodes.jsx
+++ b/client/my-sites/site-settings/composing/shortcodes.jsx
@@ -55,7 +55,7 @@ class Shortcodes extends Component {
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="shortcodes"
-					label={ translate( 'Compose using shortcodes to embed media from popular sites.' ) }
+					label={ translate( 'Compose using shortcodes to embed media from popular sites' ) }
 					disabled={ isRequestingSettings || isSavingSettings || moduleUnavailable }
 				/>
 			</Card>

--- a/client/my-sites/site-settings/composing/shortcodes.jsx
+++ b/client/my-sites/site-settings/composing/shortcodes.jsx
@@ -49,7 +49,9 @@ class Shortcodes extends Component {
 			<Card className="composing__card site-settings__card">
 				<QueryJetpackConnection siteId={ selectedSiteId } />
 				<SupportInfo
-					text={ translate( 'Embed media from popular sites when you author your content.' ) }
+					text={ translate(
+						'Shortcodes are WordPress-specific markup that let you add media from popular sites. This feature is no longer necessary as the editor now handles media embeds rather gracefully.'
+					) }
 					link="https://jetpack.com/support/shortcode-embeds/"
 				/>
 				<JetpackModuleToggle

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -446,6 +446,7 @@
 	margin-top: 3px;
 }
 
+.site-settings__card + .site-settings__card,
 .site-settings__foldable-card + .site-settings__card,
 .site-settings__foldable-card + .card.is-compact:last-child,
 .site-settings__card + .card.is-compact:last-child {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -446,6 +446,7 @@
 	margin-top: 3px;
 }
 
+.site-settings__foldable-card + .site-settings__card,
 .site-settings__foldable-card + .card.is-compact:last-child,
 .site-settings__card + .card.is-compact:last-child {
 	margin-top: -16px;


### PR DESCRIPTION
In the upcoming Jetpack release, Beautiful Math–also known as the LaTeX module–and Shortcode Embeds will no longer be enabled by default.
This PR introduces a setting so users can activate them.

Fixes #32183
Part of https://github.com/Automattic/jetpack/issues/11934

#### Changes proposed in this Pull Request

* add toggle for Beautiful Math
* add toggle for Shortcode Embeds
* add negative -16px top margin and 16px margin when a foldable card precedes a regular card or when a regular card precedes a regular card

<img width="751" alt="Captura de Pantalla 2019-04-16 a la(s) 13 41 09" src="https://user-images.githubusercontent.com/1041600/56228201-9d574000-604d-11e9-88b6-ec8fcb34baf3.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to http://calypso.localhost:3000/settings/writing/YOURSITE
* verify that the toggles are there and that they look good
* toggle Beautiful Math **on**, and verify in https://YOURTSITE/wp-admin/admin.php?page=jetpack_modules&module_tag=Writing that Beautiful Math is **on**
* toggle Beautiful Math **off**, and verify in https://YOURTSITE/wp-admin/admin.php?page=jetpack_modules&module_tag=Writing that Beautiful Math is **off**
* toggle Shortcodes **on**, and verify in https://YOURTSITE/wp-admin/admin.php?page=jetpack_modules&module_tag=Writing that Shortcode Embeds is **on**
* toggle Shortcodes **off**, and verify in https://YOURTSITE/wp-admin/admin.php?page=jetpack_modules&module_tag=Writing that Shortcode Embeds is **off**

