### PR TITLE
lib/viewport HOCs: forward refs to the child component

### DIFF
--- a/client/lib/viewport/react.js
+++ b/client/lib/viewport/react.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useEffect } from 'react';
+import React, { forwardRef, useState, useEffect } from 'react';
 import { createHigherOrderComponent } from '@wordpress/compose';
 
 /**
@@ -78,10 +78,11 @@ export function useDesktopBreakpoint() {
  */
 export const withBreakpoint = breakpoint =>
 	createHigherOrderComponent(
-		WrappedComponent => props => {
-			const isBreakpointActive = useBreakpoint( breakpoint );
-			return <WrappedComponent { ...props } isBreakpointActive={ isBreakpointActive } />;
-		},
+		WrappedComponent =>
+			forwardRef( ( props, ref ) => {
+				const isActive = useBreakpoint( breakpoint );
+				return <WrappedComponent { ...props } isBreakpointActive={ isActive } ref={ ref } />;
+			} ),
 		'WithBreakpoint'
 	);
 
@@ -94,10 +95,11 @@ export const withBreakpoint = breakpoint =>
  * @returns {Function} The wrapped component.
  */
 export const withMobileBreakpoint = createHigherOrderComponent(
-	WrappedComponent => props => {
-		const isBreakpointActive = useBreakpoint( MOBILE_BREAKPOINT );
-		return <WrappedComponent { ...props } isBreakpointActive={ isBreakpointActive } />;
-	},
+	WrappedComponent =>
+		forwardRef( ( props, ref ) => {
+			const isActive = useBreakpoint( MOBILE_BREAKPOINT );
+			return <WrappedComponent { ...props } isBreakpointActive={ isActive } ref={ ref } />;
+		} ),
 	'WithMobileBreakpoint'
 );
 
@@ -110,9 +112,10 @@ export const withMobileBreakpoint = createHigherOrderComponent(
  * @returns {Function} The wrapped component.
  */
 export const withDesktopBreakpoint = createHigherOrderComponent(
-	WrappedComponent => props => {
-		const isBreakpointActive = useBreakpoint( DESKTOP_BREAKPOINT );
-		return <WrappedComponent { ...props } isBreakpointActive={ isBreakpointActive } />;
-	},
+	WrappedComponent =>
+		forwardRef( ( props, ref ) => {
+			const isActive = useBreakpoint( DESKTOP_BREAKPOINT );
+			return <WrappedComponent { ...props } isBreakpointActive={ isActive } ref={ ref } />;
+		} ),
 	'WithDesktopBreakpoint'
 );


### PR DESCRIPTION
Fixes a bug where the `withMobileBreakpoint` HOCs wouldn't forward refs to the child components.

Breaks the themes search UI:
<img width="1157" alt="Screenshot 2019-04-16 at 15 48 53" src="https://user-images.githubusercontent.com/664258/56215916-bcab9880-6060-11e9-9d30-74c27a46b042.png">

There is a HOC like this:
```jsx
class Inner extends Component {
  handleClickOutside() {
    ...
  }
  render() {
    return this.props.isBreakpointActive ? <Mobile /> : <Desktop />;
  }
}

export default wrapWithClickOutside( withMobileBreakpoint( Inner ) );
```

The `wrapWithClickOutside` HOC renders the inner component with a ref and then calls the `handleClickOutside` method of the referenced instance. Without `forwardRef`, the ref chain breaks.

**How to test:**
Best tested on the Themes search at `/themes/:site`:
- focus the search box:
<img width="540" alt="Screenshot 2019-04-09 at 11 26 20" src="https://user-images.githubusercontent.com/664258/56216237-570bdc00-6061-11e9-8759-e158c30f7518.png">

- then click outside the search box. It should lose focus. It didn't before this PR.