### PR TITLE
Settings - Writing: add a toggle for Custom CSS

### DIFF
--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
@@ -142,6 +142,29 @@ class ThemeEnhancements extends Component {
 		);
 	}
 
+	renderCustomCSSSettings() {
+		const { selectedSiteId, translate } = this.props;
+		const formPending = this.isFormPending();
+
+		return (
+			<FormFieldset>
+				<SupportInfo
+					text={ translate(
+						"Adds a new panel to the Customizer so you can modify your theme's appearance using custom CSS."
+					) }
+					link="https://jetpack.com/support/custom-css/"
+				/>
+
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="custom-css"
+					label={ translate( "Tweak your site's theme using custom CSS" ) }
+					disabled={ formPending }
+				/>
+			</FormFieldset>
+		);
+	}
+
 	renderMinilevenSettings() {
 		const { selectedSiteId, minilevenModuleActive, translate } = this.props;
 		const formPending = this.isFormPending();
@@ -201,11 +224,13 @@ class ThemeEnhancements extends Component {
 
 				<Card className="theme-enhancements__card site-settings">
 					{ siteIsJetpack ? (
-						<div>
+						<Fragment>
 							{ this.renderJetpackInfiniteScrollSettings() }
 							<hr />
+							{ this.renderCustomCSSSettings() }
+							<hr />
 							{ this.renderMinilevenSettings() }
-						</div>
+						</Fragment>
 					) : (
 						this.renderSimpleSiteInfiniteScrollSettings()
 					) }

--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -150,7 +150,7 @@ class ThemeEnhancements extends Component {
 			<FormFieldset>
 				<SupportInfo
 					text={ translate(
-						"Adds a new panel to the Customizer so you can modify your theme's appearance using custom CSS."
+						"Adds options for CSS preprocessor use, disabling the theme's CSS, or custom image width."
 					) }
 					link="https://jetpack.com/support/custom-css/"
 				/>
@@ -158,7 +158,7 @@ class ThemeEnhancements extends Component {
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
 					moduleSlug="custom-css"
-					label={ translate( "Tweak your site's theme using custom CSS" ) }
+					label={ translate( 'Enhance CSS customization panel' ) }
 					disabled={ formPending }
 				/>
 			</FormFieldset>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* introduces a new toggle for Custom CSS under the Theme Enhancement group

Part of https://github.com/Automattic/jetpack/issues/11932

<img width="753" alt="Captura de Pantalla 2019-04-16 a la(s) 11 01 58" src="https://user-images.githubusercontent.com/1041600/56217336-71ca5a80-6039-11e9-9a9b-2acc9910038e.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to http://calypso.localhost:3000/settings/writing/YOURSITE
verify that the toggle is there and that it looks good
* toggle it on, and verify in https://elio.blog/wp-admin/admin.php?page=jetpack_modules&module_tag=Appearance that Custom CSS is on
* toggle it off, and verify in https://elio.blog/wp-admin/admin.php?page=jetpack_modules&module_tag=Appearance that Custom CSS is off

