### PR TITLE
Migrate Billing History styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -130,7 +130,6 @@
 @import 'lib/abtest/test-helper/style';
 @import 'lib/preferences-helper/style';
 @import 'mailing-lists/style';
-@import 'me/billing-history/style';
 @import 'me/happychat/style';
 @import 'me/notification-settings/blogs-settings/style';
 @import 'me/notification-settings/comment-settings/style';

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -23,6 +23,11 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
 import getPastBillingTransactions from 'state/selectors/get-past-billing-transactions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const BillingHistory = ( { pastTransactions, translate } ) => (
 	<Main className="billing-history">
 		<DocumentHead title={ translate( 'Billing History' ) } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate styles to the new CSS pipeline

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure billing history looks just the same

