### PR TITLE
Migrate manage-purchase styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -142,7 +142,6 @@
 @import 'me/purchases/components/loading-placeholder/style';
 @import 'me/purchases/purchase-item/style';
 @import 'me/purchases/purchases-site/style';
-@import 'me/purchases/manage-purchase/style';
 @import 'me/purchases/manage-purchase/plan-details/style';
 @import 'me/purchases/remove-purchase/style';
 @import 'me/security-account-recovery/style';

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -77,6 +77,11 @@ import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import CartStore from 'lib/cart/store';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class ManagePurchase extends Component {
 	static propTypes = {
 		hasLoadedSites: PropTypes.bool.isRequired,


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Migrate manage-purchase styles to the new CSS pipeline. 
* No visual changes

#### Testing instructions

* Verify that manage-purchase (under /me) looks just the same as before

