### PR TITLE
Settings - Writing: add a settings group for Widgets

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -27,6 +27,7 @@ import PodcastingLink from 'my-sites/site-settings/podcasting-details/link';
 import Masterbar from './masterbar';
 import MediaSettingsWriting from './media-settings-writing';
 import ThemeEnhancements from './theme-enhancements';
+import Widgets from './widgets';
 import PublishingTools from './publishing-tools';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
@@ -158,6 +159,15 @@ class SiteSettingsFormWriting extends Component {
 					isRequestingSettings={ isRequestingSettings }
 					fields={ fields }
 				/>
+
+				{ siteIsJetpack && (
+					<Widgets
+						onSubmitForm={ handleSubmitForm }
+						isSavingSettings={ isSavingSettings }
+						isRequestingSettings={ isRequestingSettings }
+						fields={ fields }
+					/>
+				) }
 
 				{ siteIsJetpack && config.isEnabled( 'press-this' ) && (
 					<PublishingTools

--- a/client/my-sites/site-settings/widgets.jsx
+++ b/client/my-sites/site-settings/widgets.jsx
@@ -1,0 +1,119 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import FormFieldset from 'components/forms/form-fieldset';
+import { getCustomizerUrl, isJetpackSite } from 'state/sites/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
+import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
+import SupportInfo from 'components/support-info';
+
+class Widgets extends Component {
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+		fields: {},
+	};
+
+	static propTypes = {
+		onSubmitForm: PropTypes.func.isRequired,
+		handleAutosavingToggle: PropTypes.func.isRequired,
+		handleAutosavingRadio: PropTypes.func.isRequired,
+		isSavingSettings: PropTypes.bool,
+		isRequestingSettings: PropTypes.bool,
+		fields: PropTypes.object,
+	};
+
+	isFormPending = () => this.props.isRequestingSettings || this.props.isSavingSettings;
+
+	renderWidgetsSettings() {
+		const { selectedSiteId, translate } = this.props;
+		const formPending = this.isFormPending();
+
+		return (
+			<FormFieldset>
+				<SupportInfo
+					text={ translate( 'Provides additional widgets for use on your site.' ) }
+					link="https://jetpack.com/support/extra-sidebar-widgets/"
+				/>
+
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="widget-visibility"
+					label={ translate(
+						'Make extra widgets available for use on your site including images and Twitter streams'
+					) }
+					disabled={ formPending }
+				/>
+			</FormFieldset>
+		);
+	}
+
+	renderWidgetVisibilitySettings() {
+		const { selectedSiteId, translate } = this.props;
+		const formPending = this.isFormPending();
+
+		return (
+			<FormFieldset>
+				<SupportInfo
+					text={ translate( 'Configure widgets to appear only on certain posts or pages.' ) }
+					link="https://jetpack.com/support/widget-visibility"
+				/>
+
+				<JetpackModuleToggle
+					siteId={ selectedSiteId }
+					moduleSlug="widgets"
+					label={ translate( 'Control where widgets appear on your site' ) }
+					disabled={ formPending }
+				/>
+			</FormFieldset>
+		);
+	}
+
+	render() {
+		const { translate } = this.props;
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<Fragment>
+				<SettingsSectionHeader title={ translate( 'Widgets' ) } />
+
+				<Card className="site-settings">
+					{ this.renderWidgetsSettings() }
+					<hr />
+					{ this.renderWidgetVisibilitySettings() }
+				</Card>
+			</Fragment>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
+}
+
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+
+	return {
+		customizeUrl: getCustomizerUrl( state, selectedSiteId ),
+		selectedSiteId,
+		siteIsJetpack: isJetpackSite( state, selectedSiteId ),
+		widgetsModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'widgets' ),
+		widgetVisibilityModuleActive: !! isJetpackModuleActive(
+			state,
+			selectedSiteId,
+			'widget-visibility'
+		),
+	};
+} )( localize( Widgets ) );

--- a/client/my-sites/site-settings/widgets.jsx
+++ b/client/my-sites/site-settings/widgets.jsx
@@ -52,7 +52,7 @@ class Widgets extends Component {
 
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
-					moduleSlug="widget-visibility"
+					moduleSlug="widgets"
 					label={ translate(
 						'Make extra widgets available for use on your site including images and Twitter streams'
 					) }
@@ -75,7 +75,7 @@ class Widgets extends Component {
 
 				<JetpackModuleToggle
 					siteId={ selectedSiteId }
-					moduleSlug="widgets"
+					moduleSlug="widget-visibility"
 					label={ translate( 'Control where widgets appear on your site' ) }
 					disabled={ formPending }
 				/>


### PR DESCRIPTION
This PR introduces a new group of settings under the Writing tab in the Settings page. The controls available in this group allow users of a Jetpack site to activate the Extra Sidebar Widgets and Widget Visibility modules.

#### Changes proposed in this Pull Request

* add new settings group titled "Widgets" for Jetpack sites
* add toggle to activate additional widgets
* add toggle to activate Widget Visibility

<img width="752" alt="Captura de Pantalla 2019-04-16 a la(s) 12 15 46" src="https://user-images.githubusercontent.com/1041600/56222725-e81f8a80-6042-11e9-878e-dcf8fc73b22d.png">

<img width="765" alt="Captura de Pantalla 2019-04-16 a la(s) 12 32 17" src="https://user-images.githubusercontent.com/1041600/56223365-fc17bc00-6043-11e9-8db5-920818e3b15f.png">


#### Testing instructions

* go to http://calypso.localhost:3000/settings/writing/YOURSITE
* verify that the toggles are there and that they look good
* turn the Widgets toggle on, and verify in https://elio.blog/wp-admin/admin.php?page=jetpack_modules&module_tag=Appearance that Extra Sidebar Widgets is on
* turn the Widgets toggle off, and verify in https://elio.blog/wp-admin/admin.php?page=jetpack_modules&module_tag=Appearance that Extra Sidebar Widgets is off
* turn the Widget Visibility toggle on, and verify in https://elio.blog/wp-admin/admin.php?page=jetpack_modules&module_tag=Appearance that Widget Visibility is on
* turn the Widget Visibility toggle off, and verify in https://elio.blog/wp-admin/admin.php?page=jetpack_modules&module_tag=Appearance that Widget Visibility is off

Part of https://github.com/Automattic/jetpack/issues/11933 and https://github.com/Automattic/jetpack/issues/11936
