### PR TITLE
Allow users to cancel and refund a domain renewal within 96 hours

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -5,7 +5,7 @@
  */
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { moment, localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
@@ -225,8 +225,15 @@ class ManagePurchase extends Component {
 		} else if ( isRefundable( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
 				if ( isRenewal( purchase ) ) {
-					text = translate( 'Contact Support to Cancel Domain and Refund' );
-					link = CALYPSO_CONTACT;
+					const hoursSinceRenewal = Math.ceil(
+						moment().diff( purchase.mostRecentRenewMoment, 'hours', true )
+					);
+					if ( hoursSinceRenewal < 96 ) {
+						text = translate( 'Cancel Domain and Refund' );
+					} else {
+						text = translate( 'Contact Support to Cancel Domain and Refund' );
+						link = CALYPSO_CONTACT;
+					}
 				} else {
 					text = translate( 'Cancel Domain and Refund' );
 				}


### PR DESCRIPTION
Context: https://trello.com/c/EtzhEeYW/59-allow-refunds-for-domain-renewals

This will need further testing per the discussion here:

https://trello.com/c/uGqdSJKh/970-allow-users-to-refund-domains-after-a-renewal

