### PR TITLE
Settings - Traffic: add a new setting to toggle WP.me shortlinks on Jetpack sites

### DIFF
--- a/client/my-sites/site-settings/settings-traffic/main.jsx
+++ b/client/my-sites/site-settings/settings-traffic/main.jsx
@@ -25,6 +25,7 @@ import JetpackSiteStats from 'my-sites/site-settings/jetpack-site-stats';
 import JetpackAds from 'my-sites/site-settings/jetpack-ads';
 import RelatedPosts from 'my-sites/site-settings/related-posts';
 import Sitemaps from 'my-sites/site-settings/sitemaps';
+import Shortlinks from 'my-sites/site-settings/shortlinks';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -72,6 +73,13 @@ const SiteSettingsTraffic = ( {
 			/>
 		) }
 		<AnalyticsSettings />
+		{ isJetpack && (
+			<Shortlinks
+				isSavingSettings={ isSavingSettings }
+				isRequestingSettings={ isRequestingSettings }
+				fields={ fields }
+			/>
+		) }
 		<Sitemaps
 			isSavingSettings={ isSavingSettings }
 			isRequestingSettings={ isRequestingSettings }

--- a/client/my-sites/site-settings/shortlinks.jsx
+++ b/client/my-sites/site-settings/shortlinks.jsx
@@ -53,7 +53,7 @@ class Shortlinks extends Component {
 					<FormFieldset>
 						<SupportInfo
 							text={ translate(
-								'Create short and simple links for all posts and pages so you can have more space to write on social media sites.'
+								'Generates shorter links so you can have more space to write on social media sites.'
 							) }
 							link="https://jetpack.com/support/shortlinks/"
 						/>
@@ -61,9 +61,7 @@ class Shortlinks extends Component {
 						<JetpackModuleToggle
 							siteId={ selectedSiteId }
 							moduleSlug="shortlinks"
-							label={ translate(
-								'Create short and simple links for all posts and pages so you can have more space to write on social media sites.'
-							) }
+							label={ translate( 'Create short and simple links for all posts and pages' ) }
 							disabled={ formPending }
 						/>
 					</FormFieldset>

--- a/client/my-sites/site-settings/shortlinks.jsx
+++ b/client/my-sites/site-settings/shortlinks.jsx
@@ -1,0 +1,91 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+import FormFieldset from 'components/forms/form-fieldset';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
+import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
+import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
+import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
+import SupportInfo from 'components/support-info';
+
+class Shortlinks extends Component {
+	static defaultProps = {
+		isSavingSettings: false,
+		isRequestingSettings: true,
+		fields: {},
+	};
+
+	static propTypes = {
+		onSubmitForm: PropTypes.func.isRequired,
+		handleAutosavingToggle: PropTypes.func.isRequired,
+		handleAutosavingRadio: PropTypes.func.isRequired,
+		isSavingSettings: PropTypes.bool,
+		isRequestingSettings: PropTypes.bool,
+		fields: PropTypes.object,
+	};
+
+	isFormPending = () => this.props.isRequestingSettings || this.props.isSavingSettings;
+
+	render() {
+		const { selectedSiteId, translate } = this.props;
+		const formPending = this.isFormPending();
+
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
+		return (
+			<div>
+				<SettingsSectionHeader title={ translate( 'WP.me Shortlinks' ) } />
+
+				<Card className="shortlinks__card site-settings site-settings__traffic-settings">
+					<FormFieldset>
+						<SupportInfo
+							text={ translate(
+								'Create short and simple links for all posts and pages so you can have more space to write on social media sites.'
+							) }
+							link="https://jetpack.com/support/shortlinks/"
+						/>
+
+						<JetpackModuleToggle
+							siteId={ selectedSiteId }
+							moduleSlug="shortlinks"
+							label={ translate(
+								'Create short and simple links for all posts and pages so you can have more space to write on social media sites.'
+							) }
+							disabled={ formPending }
+						/>
+					</FormFieldset>
+				</Card>
+			</div>
+		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
+	}
+}
+
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+	const siteInDevMode = isJetpackSiteInDevelopmentMode( state, selectedSiteId );
+	const moduleUnavailableInDevMode = isJetpackModuleUnavailableInDevelopmentMode(
+		state,
+		selectedSiteId,
+		'shortlinks'
+	);
+
+	return {
+		selectedSiteId,
+		shortlinksModuleActive: !! isJetpackModuleActive( state, selectedSiteId, 'shortlinks' ),
+		moduleUnavailable: siteInDevMode && moduleUnavailableInDevMode,
+	};
+} )( localize( Shortlinks ) );


### PR DESCRIPTION
The WP.me shortlinks module will no longer be on by default on the upcoming Jetpack release. Because of this, we need to make a setting for it visible in Calypso settings.

Part of https://github.com/Automattic/jetpack/issues/11935

#### Changes proposed in this Pull Request

* Add a new toggle to activate or deactivate WP.me shortlinks on Jetpack sites

<img width="737" alt="Captura de Pantalla 2019-04-16 a la(s) 14 14 38" src="https://user-images.githubusercontent.com/1041600/56230189-28d2d000-6052-11e9-96f0-cab5c18d3313.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to http://calypso.localhost:3000/settings/traffic/YOURSITE
* verify that the toggle is there and that it looks good
* toggle it on, and verify in https://elio.blog/wp-admin/admin.php?page=jetpack_modules&module_tag=Social that WP.me Shortlinks is on
* toggle it off, and verify in https://elio.blog/wp-admin/admin.php?page=jetpack_modules&module_tag=Social that WP.me Shortlinks is off

