### PR TITLE
Updates to make e2e tests more stable

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -134,16 +134,15 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async removeNUXNotice() {
 		const nuxPopupSelector = By.css( '.nux-dot-tip' );
 		const nuxDisableSelector = By.css( '.nux-dot-tip__disable' );
-		const settingsButtonSelector = By.css( "button[aria-label='Settings']" );
 
-		if (
-			( await driverHelper.isEventuallyPresentAndDisplayed(
-				this.driver,
-				settingsButtonSelector
-			) ) &&
-			( await driverHelper.isElementPresent( this.driver, nuxPopupSelector ) )
-		) {
+		if ( await driverHelper.isElementPresent( this.driver, nuxPopupSelector ) ) {
 			await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );
+			try {
+				await driverHelper.elementIsNotPresent( this.driver, nuxPopupSelector );
+			} catch {
+				await this.closeSidebar();
+				await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );
+			}
 		}
 	}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -134,7 +134,16 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async removeNUXNotice() {
 		const nuxPopupSelector = By.css( '.nux-dot-tip' );
 		const nuxDisableSelector = By.css( '.nux-dot-tip__disable' );
-		if ( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, nuxPopupSelector ) ) {
+		const headerSelector = By.css( '.edit-post-header' );
+
+		if (
+			( await driverHelper.isEventuallyPresentAndDisplayed(
+				this.driver,
+				nuxPopupSelector,
+				this.explicitWaitMS / 2
+			) ) &&
+			( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, headerSelector ) )
+		) {
 			await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );
 		}
 	}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -134,10 +134,13 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async removeNUXNotice() {
 		const nuxPopupSelector = By.css( '.nux-dot-tip' );
 		const nuxDisableSelector = By.css( '.nux-dot-tip__disable' );
-		const headerSelector = By.css( '.edit-post-sidebar-header' );
+		const settingsButtonSelector = By.css( "button[aria-label='Settings']" );
 
 		if (
-			( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, headerSelector ) ) &&
+			( await driverHelper.isEventuallyPresentAndDisplayed(
+				this.driver,
+				settingsButtonSelector
+			) ) &&
 			( await driverHelper.isElementPresent( this.driver, nuxPopupSelector ) )
 		) {
 			await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -134,11 +134,11 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async removeNUXNotice() {
 		const nuxPopupSelector = By.css( '.nux-dot-tip' );
 		const nuxDisableSelector = By.css( '.nux-dot-tip__disable' );
-		const headerSelector = By.css( '.edit-post-header' );
+		const headerSelector = By.css( '.edit-post-sidebar-header' );
 
 		if (
-			( await driverHelper.isElementPresent( this.driver, nuxPopupSelector ) ) &&
-			( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, headerSelector ) )
+			( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, headerSelector ) ) &&
+			( await driverHelper.isElementPresent( this.driver, nuxPopupSelector ) )
 		) {
 			await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );
 		}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -138,7 +138,11 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( await driverHelper.isElementPresent( this.driver, nuxPopupSelector ) ) {
 			await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );
 			try {
-				await driverHelper.elementIsNotPresent( this.driver, nuxPopupSelector );
+				await driverHelper.waitTillNotPresent(
+					this.driver,
+					nuxPopupSelector,
+					this.explicitWaitMS / 2
+				);
 			} catch {
 				await this.closeSidebar();
 				await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -144,7 +144,9 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 					this.explicitWaitMS / 2
 				);
 			} catch {
-				await this.closeSidebar();
+				if ( driverManager.currentScreenSize() === 'mobile' ) {
+					await this.closeSidebar();
+				}
 				await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );
 			}
 		}

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -137,11 +137,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		const headerSelector = By.css( '.edit-post-header' );
 
 		if (
-			( await driverHelper.isEventuallyPresentAndDisplayed(
-				this.driver,
-				nuxPopupSelector,
-				this.explicitWaitMS / 2
-			) ) &&
+			( await driverHelper.isElementPresent( this.driver, nuxPopupSelector ) ) &&
 			( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, headerSelector ) )
 		) {
 			await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -134,7 +134,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async removeNUXNotice() {
 		const nuxPopupSelector = By.css( '.nux-dot-tip' );
 		const nuxDisableSelector = By.css( '.nux-dot-tip__disable' );
-		if ( await driverHelper.isElementPresent( this.driver, nuxPopupSelector ) ) {
+		if ( await driverHelper.isEventuallyPresentAndDisplayed( this.driver, nuxPopupSelector ) ) {
 			await driverHelper.clickWhenClickable( this.driver, nuxDisableSelector );
 		}
 	}

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -13,6 +13,7 @@ import AsyncBaseContainer from '../async-base-container';
 import * as driverHelper from '../driver-helper.js';
 import * as dataHelper from '../data-helper';
 import * as SlackNotifier from '../slack-notifier';
+import * as driverManager from '../driver-manager';
 
 // This is the Calypso WordPress.com login page
 // For the wp-admin login page see /wp-admin/wp-admin-logon-page
@@ -52,6 +53,7 @@ export default class LoginPage extends AsyncBaseContainer {
 				await SlackNotifier.warn( `The login didn't work as expected - retrying now: '${ e }'`, {
 					suppressDuplicateMessages: true,
 				} );
+				await driverManager.ensureNotLoggedIn( this.driver );
 				return await this.login( username, password, { retry: false } );
 			}
 		}

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -62,7 +62,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 
 		step( 'Can enter page title, content and image', async function() {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			await gEditorComponent.removeNUXNotice();
 			await gEditorComponent.enterTitle( pageTitle );
 			await gEditorComponent.enterText( pageQuote );
 			await gEditorComponent.addImage( fileDetails );
@@ -200,7 +199,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, funct
 
 		step( 'Can enter page title and content', async function() {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-			await gEditorComponent.removeNUXNotice();
 			await gEditorComponent.enterTitle( pageTitle );
 			await gEditorComponent.enterText( pageQuote );
 			return await gEditorComponent.ensureSaved();

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -403,7 +403,6 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can enter post title and content', async function() {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
-				await gEditorComponent.removeNUXNotice();
 				await gEditorComponent.enterTitle( blogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
 				return await gEditorComponent.ensureSaved();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR waits for the Nux notice to appear and dismisses it if it does. Before it was checking too quickly and then not dismissing when it showed up. I also added a step to ensure not logged in if the login steps try to retry.  I am hoping this helps with some of the hanging

#### Testing instructions
* Ensure e2e tests pass
