### PR TITLE
File Importer: Auto-continue on successful upload

### DIFF
--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import classNames from 'classnames';
 import { numberFormat, localize } from 'i18n-calypso';
-import { get, has, omit } from 'lodash';
+import { defer, get, has, omit } from 'lodash';
 
 /**
  * Internal dependencies
@@ -226,7 +226,7 @@ class ImportingPane extends React.PureComponent {
 	}
 
 	handleOnMap = ( source, target ) =>
-		mapAuthor( get( this.props, 'importerStatus.importerId' ), source, target );
+		defer( () => mapAuthor( get( this.props, 'importerStatus.importerId' ), source, target ) );
 
 	renderActionButtons = () => {
 		if ( this.isProcessing() || this.isMapping() ) {


### PR DESCRIPTION

![calypso-file-import-auto-continue](https://user-images.githubusercontent.com/1587282/56237706-a6024300-605a-11e9-8d91-6fb467e937c2.gif)


#### Changes proposed in this Pull Request

* Remove the `Continue` button from the "uploading pane"
* `defer` calls to `startMappingAuthors` & `mapAuthor` so the dispatcher doesn't error
* When a successful upload is detected, call `startMappingAuthors` (which is what was called on the `Continue` button click previously

#### Testing instructions

* Run this branch
* Test all engines which support file uploads (WordPress, Blogger, Medium, & Squarespace)
* Upon uploading a proper export file, the import should continue to the next step
* You should be able to complete an import as before
* Improper export files should still be handled appropriately
* The UI should be intuitive & you should not be left wondering if the upload succeeded.
* The `DropZone` functionality should still work as well as the file selection