### PR TITLE
Migrate styles for gsuite-dialog in upgrades

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -108,7 +108,6 @@
 @import 'components/theme/style';
 @import 'components/pagination/style';
 @import 'components/tooltip/style';
-@import 'components/upgrades/gsuite/gsuite-dialog/style';
 @import 'components/web-preview/style';
 @import 'components/wizard/style';
 @import 'components/environment-badge/style';

--- a/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/index.jsx
@@ -28,6 +28,11 @@ import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import QueryProducts from 'components/data/query-products-list';
 import { getProductCost } from 'state/products-list/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const gsuitePlanSlug = 'gapps'; // or gapps_unlimited - TODO make this dynamic
 
 class GoogleAppsDialog extends React.Component {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate styles in gsuite-dialog in upgrades to the new CSS pipeline.
* No visual changes.

#### Testing instructions

* Verify that the gsuite dialog looks the same as before
