### PR TITLE
Migrate sub-masterbar-nav to the new style pipeline

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -103,7 +103,6 @@
 @import 'components/sites-popover/style';
 @import 'components/social-icons/style';
 @import 'components/stat-update-indicator/style';
-@import 'components/sub-masterbar-nav/style';
 @import 'components/text-diff/style';
 @import 'components/theme/style';
 @import 'components/pagination/style';

--- a/client/components/sub-masterbar-nav/index.jsx
+++ b/client/components/sub-masterbar-nav/index.jsx
@@ -14,6 +14,11 @@ import { find } from 'lodash';
 import Navbar from './navbar';
 import Dropdown from './dropdown';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const OptionShape = PropTypes.shape( {
 	label: PropTypes.string.isRequired,
 	uri: PropTypes.string.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate the styles for the sub-masterbar-nav component to the new CSS pipeline.
* No visual changes.

#### Testing instructions

* Verify the sub masterbar nav looks the same. Only used in themes.
