### PR TITLE
Migrate taxonomy manager styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -29,7 +29,6 @@
 @import 'blocks/post-likes/style';
 @import 'blocks/sharing-preview-pane/style';
 @import 'blocks/site-address-changer/style';
-@import 'blocks/taxonomy-manager/style';
 @import 'blocks/term-form-dialog/style';
 @import 'blocks/term-tree-selector/style';
 @import 'blocks/upload-image/style';

--- a/client/blocks/taxonomy-manager/index.jsx
+++ b/client/blocks/taxonomy-manager/index.jsx
@@ -21,6 +21,11 @@ import QueryTaxonomies from 'components/data/query-taxonomies';
 import TermFormDialog from 'blocks/term-form-dialog';
 import { recordGoogleEvent, bumpStat } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class TaxonomyManager extends Component {
 	static propTypes = {
 		taxonomy: PropTypes.string,


### PR DESCRIPTION
 #### Changes proposed in this Pull Request

* Migrate taxonomy manager styles to the new CSS pipeline.
* No visual changes.

#### Testing instructions

* Verify the taxonomy manager is visually the same
