### PR TITLE
Migrate eligibility warning styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -14,7 +14,6 @@
 @import 'blocks/conversations/style';
 @import 'blocks/domain-to-plan-nudge/style';
 @import 'blocks/follow-button/style';
-@import 'blocks/eligibility-warnings/style';
 @import 'blocks/gdpr-banner/style';
 @import 'blocks/google-my-business-stats-nudge/style';
 @import 'blocks/image-editor/style';

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -29,6 +29,11 @@ import QueryEligibility from 'components/data/query-atat-eligibility';
 import HoldList from './hold-list';
 import WarningList from './warning-list';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export const EligibilityWarnings = ( {
 	backUrl,
 	context,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate the eligibility warning styles to the new CSS pipeline.
* No visual changes.

#### Testing instructions

* Verify the eligibility warning displays just the same
