### PR TITLE
Remove the environment parameter from Apple Pay merchant validation requests, since it's no longer needed by the server

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2372,14 +2372,8 @@ Undocumented.prototype.getDomainConnectSyncUxUrl = function(
 	);
 };
 
-Undocumented.prototype.applePayMerchantValidation = function( validationURL, environment ) {
-	const queries = { validation_url: validationURL };
-
-	if ( environment ) {
-		queries.environment = environment;
-	}
-
-	return this.wpcom.req.get( '/apple-pay/merchant-validation/', queries );
+Undocumented.prototype.applePayMerchantValidation = function( validationURL ) {
+	return this.wpcom.req.get( '/apple-pay/merchant-validation/', { validation_url: validationURL } );
 };
 
 Undocumented.prototype.domainsVerifyRegistrantEmail = function( domain, email, token ) {

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -262,12 +262,10 @@ export class WebPaymentBox extends React.Component {
 			PAYMENT_REQUEST_OPTIONS
 		);
 
-		const environment = 'production' === config( 'env' ) ? undefined : 'sandbox';
-
 		paymentRequest.onmerchantvalidation = event => {
 			wpcom
 				.undocumented()
-				.applePayMerchantValidation( event.validationURL, environment )
+				.applePayMerchantValidation( event.validationURL )
 				.then( json => event.complete( json ) )
 				.catch( error => {
 					debug( 'onmerchantvalidation error', error );


### PR DESCRIPTION
Apple Pay is currently under development as a payment method on WordPress.com.

The server-side code has changed so that the client no longer needs to pass along an `environment` parameter as part of the merchant validation request.  Therefore, this pull request updates the client side code not to send it.

See also: D27024-code