### PR TITLE
Add GSuite Price Component

### DIFF
--- a/client/components/gsuite/gsuite-price/index.jsx
+++ b/client/components/gsuite/gsuite-price/index.jsx
@@ -1,0 +1,76 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { getAnnualPrice, getMonthlyPrice } from 'lib/gsuite';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const GSuitePrice = ( { cost, currencyCode, showMonthlyPrice } ) => {
+	const translate = useTranslate();
+
+	const annualPrice = cost && currencyCode ? getAnnualPrice( cost, currencyCode ) : '-';
+	const monthlyPrice = cost && currencyCode ? getMonthlyPrice( cost, currencyCode ) : '-';
+
+	const renderPerUserPerYear = () => {
+		return translate( '{{strong}}%(price)s{{/strong}} per user / year', {
+			components: {
+				strong: <strong />,
+			},
+			args: {
+				price: annualPrice,
+			},
+		} );
+	};
+
+	const renderPerUserPerMonth = () => {
+		return translate( '{{strong}}%(price)s{{/strong}} per user / month', {
+			components: {
+				strong: <strong />,
+			},
+			args: {
+				price: monthlyPrice,
+			},
+		} );
+	};
+
+	return (
+		<div className="gsuite-price">
+			<h4 className="gsuite-price__price-per-user">
+				<span>{ showMonthlyPrice ? renderPerUserPerMonth() : renderPerUserPerYear() }</span>
+			</h4>
+			{ showMonthlyPrice && (
+				<h5 className="gsuite-price__annual-price">
+					{ translate( '%(price)s billed yearly', {
+						args: {
+							price: annualPrice,
+						},
+					} ) }
+				</h5>
+			) }
+		</div>
+	);
+};
+
+GSuitePrice.propTypes = {
+	cost: PropTypes.number,
+	currencyCode: PropTypes.string,
+	showMonthlyPrice: PropTypes.bool.isRequired,
+};
+
+GSuitePrice.defaultProps = {
+	showMonthlyPrice: false,
+};
+
+export default GSuitePrice;

--- a/client/components/gsuite/gsuite-price/style.scss
+++ b/client/components/gsuite/gsuite-price/style.scss
@@ -1,0 +1,19 @@
+.gsuite-price__price-per-user {
+	strong {
+		color: var( --color-text );
+		font-size: 24px;
+		font-weight: 300;
+	}
+
+	span {
+		color: var( --color-text-subtle );
+		font-size: 13px;
+		font-weight: normal;
+	}
+}
+
+.gsuite-price__annual-price {
+	color: var( --color-text-subtle );
+	font-size: 13px;
+	font-style: italic;
+}

--- a/client/components/gsuite/gsuite-price/test/__snapshots__/index.js.snap
+++ b/client/components/gsuite/gsuite-price/test/__snapshots__/index.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GSuitePrice it renders GSuitePrice with monthly prices 1`] = `
+<div
+  className="gsuite-price"
+>
+  <h4
+    className="gsuite-price__price-per-user"
+  >
+    <span>
+      <strong>
+        $12
+      </strong>
+       per user / month
+    </span>
+  </h4>
+  <h5
+    className="gsuite-price__annual-price"
+  >
+    $144 billed yearly
+  </h5>
+</div>
+`;
+
+exports[`GSuitePrice it renders GSuitePrice without monthly prices 1`] = `
+<div
+  className="gsuite-price"
+>
+  <h4
+    className="gsuite-price__price-per-user"
+  >
+    <span>
+      <strong>
+        $72
+      </strong>
+       per user / year
+    </span>
+  </h4>
+</div>
+`;

--- a/client/components/gsuite/gsuite-price/test/index.js
+++ b/client/components/gsuite/gsuite-price/test/index.js
@@ -1,0 +1,25 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import renderer from 'react-test-renderer';
+
+/**
+ * Internal dependencies
+ */
+import GSuitePrice from '../';
+
+describe( 'GSuitePrice', () => {
+	test( 'it renders GSuitePrice without monthly prices', () => {
+		const tree = renderer.create( <GSuitePrice cost={ 72 } currencyCode={ 'USD' } /> ).toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	test( 'it renders GSuitePrice with monthly prices', () => {
+		const tree = renderer
+			.create( <GSuitePrice cost={ 144 } currencyCode={ 'USD' } showMonthlyPrice /> )
+			.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );

--- a/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
@@ -4,53 +4,24 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
-import { getAnnualPrice, getMonthlyPrice } from 'lib/gsuite';
+import GSuitePrice from 'components/gsuite/gsuite-price';
 import GSuiteCompactFeatures from 'components/gsuite/gsuite-features/compact';
 
 function GoogleAppsProductDetails( { currencyCode, cost, domain, plan } ) {
 	const translate = useTranslate();
-	const annualPrice = getAnnualPrice( cost, currencyCode );
-	const monthlyPrice = getMonthlyPrice( cost, currencyCode );
+
 	// currencyCode can safely replace the countryCode, just make sure we have one first
 	const showMonthlyPrice =
 		null !== currencyCode
 			? 'showMonthlyPrice' === abtest( 'gsuiteDomainFlowOptions', currencyCode )
 			: false;
-
-	const renderAnnualPrice = () => {
-		return (
-			<div className="gsuite-dialog__price-per-user">
-				{ translate( '%(annualPrice)s per user / year', {
-					args: { annualPrice },
-				} ) }
-			</div>
-		);
-	};
-
-	const renderMonthlyPrice = () => {
-		return (
-			<Fragment>
-				<div className="gsuite-dialog__price-per-user">
-					{ translate( '%(monthlyPrice)s per user / month', {
-						args: { monthlyPrice },
-					} ) }
-				</div>
-
-				<div className="gsuite-dialog__billing-period">
-					{ translate( '%(annualPrice)s billed yearly', {
-						args: { annualPrice },
-					} ) }
-				</div>
-			</Fragment>
-		);
-	};
 
 	return (
 		<div className="gsuite-dialog__product-details">
@@ -67,7 +38,11 @@ function GoogleAppsProductDetails( { currencyCode, cost, domain, plan } ) {
 					) }
 				</p>
 
-				{ showMonthlyPrice ? renderMonthlyPrice() : renderAnnualPrice() }
+				<GSuitePrice
+					cost={ cost }
+					currencyCode={ currencyCode }
+					showMonthlyPrice={ showMonthlyPrice }
+				/>
 			</div>
 
 			<GSuiteCompactFeatures domainName={ domain } productSlug={ plan } type={ 'list' } />

--- a/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
@@ -14,7 +14,6 @@ import { abtest } from 'lib/abtest';
 import { getAnnualPrice, getMonthlyPrice } from 'lib/gsuite';
 import GSuiteCompactFeatures from 'components/gsuite/gsuite-features/compact';
 
-
 function GoogleAppsProductDetails( { currencyCode, cost, domain, plan } ) {
 	const translate = useTranslate();
 	const annualPrice = getAnnualPrice( cost, currencyCode );

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -13,6 +13,7 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
+import Button from 'components/button';
 import config from 'config';
 import CompactCard from 'components/card/compact';
 import { emailManagementNewGSuiteAccount } from 'my-sites/email/paths';
@@ -22,6 +23,7 @@ import { getProductCost } from 'state/products-list/selectors';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import GSuiteFeatures from 'components/gsuite/gsuite-features';
 import GSuiteLearnMore from 'components/gsuite/gsuite-learn-more';
+import GSuitePrice from 'components/gsuite/gsuite-price';
 import GSuitePurchaseCtaSkuInfo from 'my-sites/email/gsuite-purchase-cta/sku-info';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QueryProductsList from 'components/data/query-products-list';
@@ -74,36 +76,55 @@ export const GSuitePurchaseCta = ( {
 		abTestGroup === 'showBusinessWithMonthlyPrices';
 
 	const renderBasicSku = () => (
-		<GSuitePurchaseCtaSkuInfo
-			currencyCode={ currencyCode }
-			buttonText={
-				showBusinessOption ? translate( 'Add G Suite Basic' ) : translate( 'Add G Suite' )
-			}
-			onButtonClick={ () => {
-				goToAddGSuiteUsers( 'basic' );
-			} }
-			showButton={ upgradeAvailable }
-			showMonthlyPrice={ showMonthlyPrice }
-			skuCost={ gsuiteBasicCost }
-			skuName={ showBusinessOption ? translate( 'G Suite Basic' ) : undefined }
-			storageText={ showBusinessOption ? translate( '30 GB of Storage' ) : undefined }
-		/>
+		<div>
+			{ showBusinessOption && (
+				<GSuitePurchaseCtaSkuInfo
+					skuName={ translate( 'G Suite Basic' ) }
+					storageText={ translate( '30 GB of Storage' ) }
+				/>
+			) }
+			<GSuitePrice
+				cost={ gsuiteBasicCost }
+				currencyCode={ currencyCode }
+				showMonthlyPrice={ showMonthlyPrice }
+			/>
+			{ upgradeAvailable && (
+				<Button
+					className="gsuite-purchase-cta__get-gsuite-button"
+					onClick={ () => {
+						goToAddGSuiteUsers( 'basic' );
+					} }
+					primary
+				>
+					{ showBusinessOption ? translate( 'Add G Suite Basic' ) : translate( 'Add G Suite' ) }
+				</Button>
+			) }
+		</div>
 	);
 
 	const renderBusinessSku = () => (
-		<GSuitePurchaseCtaSkuInfo
-			currencyCode={ currencyCode }
-			buttonText={ translate( 'Add G Suite Business' ) }
-			onButtonClick={ () => {
-				goToAddGSuiteUsers( 'business' );
-			} }
-			showButton={ upgradeAvailable }
-			showMonthlyPrice={ showMonthlyPrice }
-			skuCost={ gsuiteBusinessCost }
-			skuName={ translate( 'G Suite Business' ) }
-			storageText={ translate( 'Unlimited Storage' ) }
-			storageNoticeText={ translate( 'Accounts with fewer than 5 users have 1 TB per user.' ) }
-		/>
+		<div>
+			<GSuitePurchaseCtaSkuInfo
+				skuName={ translate( 'G Suite Business' ) }
+				storageText={ translate( 'Unlimited Storage' ) }
+				storageNoticeText={ translate( 'Accounts with fewer than 5 users have 1 TB per user.' ) }
+			/>
+			<GSuitePrice
+				cost={ gsuiteBusinessCost }
+				currencyCode={ currencyCode }
+				showMonthlyPrice={ showMonthlyPrice }
+			/>
+			{ upgradeAvailable && (
+				<Button
+					className="gsuite-purchase-cta__get-gsuite-button"
+					onClick={ () => {
+						goToAddGSuiteUsers( 'business' );
+					} }
+				>
+					{ translate( 'Add G Suite Business' ) }
+				</Button>
+			) }
+		</div>
 	);
 
 	return (

--- a/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/sku-info.jsx
@@ -3,108 +3,33 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
-import Button from 'components/forms/form-button';
-import { getAnnualPrice, getMonthlyPrice } from 'lib/gsuite';
 import InfoPopover from 'components/info-popover';
 
-function GSuitePurchaseCtaSkuInfo( {
-	buttonText,
-	currencyCode,
-	onButtonClick,
-	showButton,
-	showMonthlyPrice,
-	skuCost,
-	skuName,
-	storageText,
-	storageNoticeText,
-} ) {
-	const translate = useTranslate();
-
-	const annualPrice = skuCost && currencyCode ? getAnnualPrice( skuCost, currencyCode ) : '-';
-	const monthlyPrice = skuCost && currencyCode ? getMonthlyPrice( skuCost, currencyCode ) : '-';
-
+function GSuitePurchaseCtaSkuInfo( { skuName, storageText, storageNoticeText } ) {
 	return (
 		<div className="gsuite-purchase-cta__sku-info">
-			{ skuName && (
-				<div className="gsuite-purchase-cta__sku-info-name-area">
-					<h3>{ skuName }</h3>
-				</div>
-			) }
-			{ storageText && (
-				<div className="gsuite-purchase-cta__sku-info-storage-area">
-					<h4>{ storageText }</h4>
-					{ storageNoticeText && <InfoPopover>{ storageNoticeText }</InfoPopover> }
-				</div>
-			) }
-			<h4 className="gsuite-purchase-cta__sku-info-name-price-per-user">
-				<span>
-					{ ! showMonthlyPrice &&
-						translate( '{{strong}}%(price)s{{/strong}} per user / year', {
-							components: {
-								strong: <strong />,
-							},
-							args: {
-								price: annualPrice,
-							},
-						} ) }
-					{ showMonthlyPrice &&
-						translate( '{{strong}}%(price)s{{/strong}} per user / month', {
-							components: {
-								strong: <strong />,
-							},
-							args: {
-								price: monthlyPrice,
-							},
-						} ) }
-				</span>
-			</h4>
-			{ showMonthlyPrice && (
-				<h5 className="gsuite-purchase-cta__sku-info-annual-price">
-					{ translate( '%(price)s billed yearly', {
-						args: {
-							price: annualPrice,
-						},
-					} ) }
-				</h5>
-			) }
-			{ showButton && (
-				<Button
-					className="gsuite-purchase-cta__sku-info-button"
-					onClick={ onButtonClick }
-					type="button"
-				>
-					{ buttonText }
-				</Button>
-			) }
+			<div className="gsuite-purchase-cta__sku-info-name-area">
+				<h3>{ skuName }</h3>
+			</div>
+
+			<div className="gsuite-purchase-cta__sku-info-storage-area">
+				<h4>{ storageText }</h4>
+				{ storageNoticeText && <InfoPopover>{ storageNoticeText }</InfoPopover> }
+			</div>
 		</div>
 	);
 }
 
 GSuitePurchaseCtaSkuInfo.propTypes = {
-	buttonText: PropTypes.string,
-	currencyCode: PropTypes.string,
-	showButton: PropTypes.bool,
-	showMonthlyPrice: PropTypes.bool,
-	onButtonClick: PropTypes.func,
-	skuCost: PropTypes.number,
-	skuName: PropTypes.string,
-	storageText: PropTypes.string,
+	skuName: PropTypes.string.isRequired,
+	storageText: PropTypes.string.isRequired,
 	storageNoticeText: PropTypes.string,
-};
-
-GSuitePurchaseCtaSkuInfo.defaultProps = {
-	buttonText: 'Click Here',
-	showButton: true,
-	showMonthlyPrice: false,
-	onButtonClick: noop,
 };
 
 export default GSuitePurchaseCtaSkuInfo;

--- a/client/my-sites/email/gsuite-purchase-cta/style.scss
+++ b/client/my-sites/email/gsuite-purchase-cta/style.scss
@@ -96,20 +96,6 @@
 	}
 }
 
-.gsuite-purchase-cta__sku-info-name-price-per-user {
-	strong {
-		color: var( --color-text );
-		font-size: 24px;
-		font-weight: 300;
-	}
-
-	span {
-		color: var( --color-text-subtle );
-		font-size: 13px;
-		font-weight: normal;
-	}
-}
-
 .gsuite-purchase-cta__sku-info-storage-area {
 	display: flex;
 	flex-direction: row;
@@ -128,13 +114,7 @@
 	}
 }
 
-.gsuite-purchase-cta__sku-info-annual-price {
-	color: var( --color-text-subtle );
-	font-size: 13px;
-	font-style: italic;
-}
-
-.gsuite-purchase-cta__sku-info-button {
+.gsuite-purchase-cta__get-gsuite-button {
 	float: none;
 	margin: 1em 0 0.5em;
 	padding-left: 2em;

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -74,64 +74,6 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta 1`] = `
     <div
       className="gsuite-features__grid"
     >
-      <h2
-        className="gsuite-purchase-cta__header-description-title"
-      >
-        Professional email and so much more.
-      </h2>
-      <p
-        className="gsuite-purchase-cta__header-description-sub-title"
-      >
-        We've partnered with Google to offer you email, storage, docs, calendars, and more integrated with your site.
-      </p>
-      <GSuitePurchaseCtaSkuInfo
-        buttonText="Add G Suite"
-        currencyCode="USD"
-        onButtonClick={[Function]}
-        showButton={true}
-        showMonthlyPrice={false}
-        skuCost={72}
-      />
-    </div>
-    <div
-      className="gsuite-purchase-cta__header-image"
-    >
-      <img
-        alt="G Suite Logo"
-        src="/calypso/images/g-suite/g-suite.svg"
-      />
-    </div>
-  </div>
-  <div
-    className="card gsuite-purchase-cta__info is-compact"
-  >
-    <div
-      className="gsuite-features__grid"
-    >
-      <div
-        className="gsuite-features__feature"
-      >
-        <div
-          className="gsuite-features__feature-image"
-        >
-          <img
-            alt="Gmail Logo"
-            src="/calypso/images/g-suite/logo_gmail_48dp.svg"
-          />
-        </div>
-        <div
-          className="gsuite-features__feature-block"
-        >
-          <h5
-            className="gsuite-features__feature-header"
-          >
-            A custom @test.com email address
-          </h5>
-          <p>
-            Professional ad-free email that works with most email clients.
-          </p>
-        </div>
-      </div>
       <div
         className="gsuite-features__feature"
       >

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -35,14 +35,29 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta 1`] = `
       >
         We've partnered with Google to offer you email, storage, docs, calendars, and more integrated with your site.
       </p>
-      <GSuitePurchaseCtaSkuInfo
-        buttonText="Add G Suite"
-        currencyCode="USD"
-        onButtonClick={[Function]}
-        showButton={true}
-        showMonthlyPrice={false}
-        skuCost={72}
-      />
+      <div>
+        <div
+          className="gsuite-price"
+        >
+          <h4
+            className="gsuite-price__price-per-user"
+          >
+            <span>
+              <strong>
+                $72
+              </strong>
+               per user / year
+            </span>
+          </h4>
+        </div>
+        <button
+          className="button gsuite-purchase-cta__get-gsuite-button is-primary"
+          onClick={[Function]}
+          type="button"
+        >
+          Add G Suite
+        </button>
+      </div>
     </div>
     <div
       className="gsuite-purchase-cta__header-image"

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/sku-info.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/sku-info.js.snap
@@ -21,27 +21,10 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCtaSkuInfo with all props 1`
       Accounts with fewer than 5 users have 1 TB per user
     </InfoPopover>
   </div>
-  <h4
-    className="gsuite-purchase-cta__sku-info-name-price-per-user"
-  >
-    <span>
-      <strong>
-        $144
-      </strong>
-       per user / year
-    </span>
-  </h4>
-  <Button
-    className="gsuite-purchase-cta__sku-info-button"
-    onClick={[Function]}
-    type="button"
-  >
-    Add G Suite Business
-  </Button>
 </div>
 `;
 
-exports[`GSuitePurchaseCta it renders GSuitePurchaseCtaSkuInfo with monthly prices 1`] = `
+exports[`GSuitePurchaseCta it renders GSuitePurchaseCtaSkuInfo with all required props 1`] = `
 <div
   className="gsuite-purchase-cta__sku-info"
 >
@@ -59,51 +42,5 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCtaSkuInfo with monthly pric
       Unlimited Storage
     </h4>
   </div>
-  <h4
-    className="gsuite-purchase-cta__sku-info-name-price-per-user"
-  >
-    <span>
-      <strong>
-        $12
-      </strong>
-       per user / month
-    </span>
-  </h4>
-  <h5
-    className="gsuite-purchase-cta__sku-info-annual-price"
-  >
-    $144 billed yearly
-  </h5>
-  <Button
-    className="gsuite-purchase-cta__sku-info-button"
-    onClick={[Function]}
-    type="button"
-  >
-    Add G Suite Business
-  </Button>
-</div>
-`;
-
-exports[`GSuitePurchaseCta it renders GSuitePurchaseCtaSkuInfo with no props 1`] = `
-<div
-  className="gsuite-purchase-cta__sku-info"
->
-  <h4
-    className="gsuite-purchase-cta__sku-info-name-price-per-user"
-  >
-    <span>
-      <strong>
-        -
-      </strong>
-       per user / year
-    </span>
-  </h4>
-  <Button
-    className="gsuite-purchase-cta__sku-info-button"
-    onClick={[Function]}
-    type="button"
-  >
-    Click Here
-  </Button>
 </div>
 `;

--- a/client/my-sites/email/gsuite-purchase-cta/test/sku-info.js
+++ b/client/my-sites/email/gsuite-purchase-cta/test/sku-info.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
 import React from 'react';
 import renderer from 'react-test-renderer';
 
@@ -15,21 +14,10 @@ jest.mock( 'components/forms/form-button', () => 'Button' );
 jest.mock( 'components/info-popover', () => 'InfoPopover' );
 
 describe( 'GSuitePurchaseCta', () => {
-	test( 'it renders GSuitePurchaseCtaSkuInfo with no props', () => {
-		const tree = renderer.create( <GSuitePurchaseCtaSkuInfo /> ).toJSON();
-		expect( tree ).toMatchSnapshot();
-	} );
-
 	test( 'it renders GSuitePurchaseCtaSkuInfo with all props', () => {
 		const tree = renderer
 			.create(
 				<GSuitePurchaseCtaSkuInfo
-					buttonText={ 'Add G Suite Business' }
-					currencyCode={ 'USD' }
-					onButtonClick={ noop }
-					showButton={ true }
-					showMonthlyPrice={ false }
-					skuCost={ 144 }
 					skuName={ 'G Suite Business' }
 					storageText={ 'Unlimited Storage' }
 					storageNoticeText={ 'Accounts with fewer than 5 users have 1 TB per user' }
@@ -39,16 +27,10 @@ describe( 'GSuitePurchaseCta', () => {
 		expect( tree ).toMatchSnapshot();
 	} );
 
-	test( 'it renders GSuitePurchaseCtaSkuInfo with monthly prices', () => {
+	test( 'it renders GSuitePurchaseCtaSkuInfo with all required props', () => {
 		const tree = renderer
 			.create(
 				<GSuitePurchaseCtaSkuInfo
-					buttonText={ 'Add G Suite Business' }
-					currencyCode={ 'USD' }
-					onButtonClick={ noop }
-					showButton={ true }
-					showMonthlyPrice={ true }
-					skuCost={ 144 }
 					skuName={ 'G Suite Business' }
 					storageText={ 'Unlimited Storage' }
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds new common `GSuitePrice` component

#### Testing instructions

1. Enter "Add Domain Flow" on existing sites with branch
1. Get to "Add G Suite" step.
1. Verify that branch version & WordPress.com version are almost the same functionally
1. Navigate to email management  for a site and domain without G Suite