### PR TITLE
Update Blogger importer name

### DIFF
--- a/client/my-sites/importer/importer-blogger.jsx
+++ b/client/my-sites/importer/importer-blogger.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
 import FileImporter from './file-importer';
 import InlineSupportLink from 'components/inline-support-link';
 
-const importerName = 'Blogger.com';
+const importerName = 'Blogger';
 
 class ImporterBlogger extends React.PureComponent {
 	static displayName = 'ImporterBlogger';


### PR DESCRIPTION
Dropping the .com in Blogger.com since they refer to themselves as Blogger. This change is part of my weekly trash pickup, and my first commit/PR to calypso: be gentle but firm!

