### PR TITLE
WP.com block editor: Remove semicolon from the switch to classic button

### DIFF
--- a/apps/wpcom-block-editor/src/common/switch-to-classic.js
+++ b/apps/wpcom-block-editor/src/common/switch-to-classic.js
@@ -18,7 +18,7 @@ function addSwitchToClassicButton() {
 				<button type="button" aria-label="${ wpcomGutenberg.switchToClassic.label }" role="menuitem"
 					class="components-button components-menu-item__button components-menu-item__button-switch">
 					${ wpcomGutenberg.switchToClassic.label }
-				</button>;
+				</button>
 			` );
 			$( '.components-menu-item__button-switch' ).on( 'click', () => {
 				$.wpcom_proxy_request( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove an unintended semicolon I noticed while testing D26970-code I noticed on the "Switch to Classic" button introduced by #32294.

<img width="265" alt="Screen Shot 2019-04-17 at 14 24 24" src="https://user-images.githubusercontent.com/1233880/56263160-ceeb0c80-611c-11e9-9938-0c6374808200.png">

#### Testing instructions

Check D26970-code
