### PR TITLE
Build: Simplify Webpack Config

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -34,7 +34,7 @@
 				"caniuse-api": "3.0.0",
 				"css-loader": "2.1.1",
 				"duplicate-package-checker-webpack-plugin": "3.0.0",
-				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
+				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
 				"node-sass": "4.11.0",
 				"postcss-custom-properties": "8.0.9",
 				"postcss-loader": "3.0.0",
@@ -48,8 +48,7 @@
 			"dependencies": {
 				"autoprefixer": {
 					"version": "9.4.4",
-					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.4.tgz",
-					"integrity": "sha512-7tpjBadJyHKf+gOJEmKhZIksWxdZCSrnKbbTJNsw+/zX9+f//DLELRQPWjjjVoDbbWlCuNRkN7RfmZwDVgWMLw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"browserslist": "^4.3.7",
@@ -80,6 +79,7 @@
 		},
 		"@automattic/wordpress-external-dependencies-plugin": {
 			"version": "file:packages/wordpress-external-dependencies-plugin",
+			"dev": true,
 			"requires": {
 				"webpack": "^4.29.6",
 				"webpack-sources": "^1.3.0"
@@ -144,14 +144,6 @@
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"requires": {
 						"ms": "^2.1.1"
-					}
-				},
-				"json5": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-					"requires": {
-						"minimist": "^1.2.0"
 					}
 				},
 				"source-map": {
@@ -982,6 +974,14 @@
 			"requires": {
 				"exec-sh": "^0.3.2",
 				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
 			}
 		},
 		"@jest/console": {
@@ -1388,6 +1388,14 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
 				"get-stream": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -1407,6 +1415,15 @@
 					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 					"requires": {
 						"invert-kv": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"mem": {
@@ -1433,6 +1450,27 @@
 						"lcid": "^2.0.0",
 						"mem": "^4.0.0"
 					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -1732,6 +1770,11 @@
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -1947,6 +1990,11 @@
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -2281,9 +2329,9 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.23.4",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.23.4.tgz",
-			"integrity": "sha512-fQuYQ0vgNLkzeN0KEsqN0aS6EPzcuaePT5M5cE5qnKayaxFwRIQOMhNR/rTmEqo/zDK/20ZAcHsgLKodSsJtww==",
+			"version": "16.24.3",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.24.3.tgz",
+			"integrity": "sha512-fBr2ziN4WT9G9sYTfnNVI/0wCb68ZI5isNU48lfWXQDyAy4ftlrh0SkIbhL7aigXUjcY0cX5J46ypyRPH0/U0g==",
 			"requires": {
 				"@octokit/request": "3.0.0",
 				"atob-lite": "^2.0.0",
@@ -2778,19 +2826,19 @@
 			}
 		},
 		"@wordpress/block-editor": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-1.1.2.tgz",
-			"integrity": "sha512-kD7qo/1WAZW+a9bNP4cKK0l2iSvcYrmUA8op2brrPpR5tQw8TDpd/RJ7bU5Uo1bZe7nvB9caM3/8wJGec3uhkw==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-2.0.0.tgz",
+			"integrity": "sha512-jg1cafln21pteFrPdI/pbShuml3aMFiF9FFN+9+hZhluACJyHhz1rb3FKPNqK3baF+IGSPrh7x8WPJ5oZPJn6w==",
 			"requires": {
 				"@babel/runtime": "^7.0.0",
 				"@wordpress/a11y": "^2.2.0",
 				"@wordpress/blob": "^2.3.0",
-				"@wordpress/blocks": "^6.2.2",
-				"@wordpress/components": "^7.2.2",
+				"@wordpress/blocks": "^6.2.3",
+				"@wordpress/components": "^7.3.0",
 				"@wordpress/compose": "^3.2.0",
 				"@wordpress/core-data": "^2.2.2",
 				"@wordpress/data": "^4.4.0",
-				"@wordpress/dom": "^2.2.2",
+				"@wordpress/dom": "^2.2.3",
 				"@wordpress/element": "^2.3.0",
 				"@wordpress/hooks": "^2.2.0",
 				"@wordpress/html-entities": "^2.2.0",
@@ -2838,9 +2886,9 @@
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.2.2",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.2.2.tgz",
-					"integrity": "sha512-6wA+wlJ7bnnGuefURWDrqgWNx8mkqLJ8xcsQ9jJ+/XrGyi9IcxaBONHQJe+S5zpxMXf9NKzf7Vzc2K1aJh40+A==",
+					"version": "6.2.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.2.3.tgz",
+					"integrity": "sha512-gEctuxOxSnOoZjp8BumjAms59PEmx3ZZlVKegU6bq6iaW6DwRJMdF4Pu9O54uevPgaVT1pzcI2nSRxDhFLumZQ==",
 					"requires": {
 						"@babel/runtime": "^7.3.1",
 						"@wordpress/autop": "^2.2.0",
@@ -2848,7 +2896,7 @@
 						"@wordpress/block-serialization-default-parser": "^3.1.0",
 						"@wordpress/block-serialization-spec-parser": "^3.0.0",
 						"@wordpress/data": "^4.4.0",
-						"@wordpress/dom": "^2.2.2",
+						"@wordpress/dom": "^2.2.3",
 						"@wordpress/element": "^2.3.0",
 						"@wordpress/hooks": "^2.2.0",
 						"@wordpress/html-entities": "^2.2.0",
@@ -2865,15 +2913,15 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "7.2.2",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.2.2.tgz",
-					"integrity": "sha512-EChv0PPWia8+OXq9m4zRaKRgc1mvC1wl24jRxqJ2sfn3OFlnCn5oBo77VZcDfdQiRK2Sn+nfMbA+4pbgCS38Mg==",
+					"version": "7.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.3.0.tgz",
+					"integrity": "sha512-TMaL5TSHhSPjwbyM/K8ME0RmCiXoQapfac0So0g+KbVXWCWa3IAfJDAsdKGfoV6WA/naiLwU6Dxv6VSM+kor3Q==",
 					"requires": {
 						"@babel/runtime": "^7.3.1",
 						"@wordpress/a11y": "^2.2.0",
 						"@wordpress/api-fetch": "^3.1.2",
 						"@wordpress/compose": "^3.2.0",
-						"@wordpress/dom": "^2.2.2",
+						"@wordpress/dom": "^2.2.3",
 						"@wordpress/element": "^2.3.0",
 						"@wordpress/hooks": "^2.2.0",
 						"@wordpress/i18n": "^3.3.0",
@@ -2945,21 +2993,21 @@
 			}
 		},
 		"@wordpress/block-library": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.4.2.tgz",
-			"integrity": "sha512-AN1kwaFfZIPQpLJMkOEpyeYvOuA+SdTC9CX3PBuq6KHOKobJL9DIF006lqfL+aVEtxCURCvotPId5xUToF4Yww==",
+			"version": "2.4.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.4.3.tgz",
+			"integrity": "sha512-syHN7+4z/UCBzCO3AvRzK/ytHGfE4uV1KpOxX/Txg2RNLogwLWXRNOrtJPUQODrvViubR1xOuyuDCOm84jaxfw==",
 			"requires": {
 				"@babel/runtime": "^7.3.1",
 				"@wordpress/autop": "^2.2.0",
 				"@wordpress/blob": "^2.3.0",
-				"@wordpress/block-editor": "^1.1.2",
-				"@wordpress/blocks": "^6.2.2",
-				"@wordpress/components": "^7.2.2",
+				"@wordpress/block-editor": "^2.0.0",
+				"@wordpress/blocks": "^6.2.3",
+				"@wordpress/components": "^7.3.0",
 				"@wordpress/compose": "^3.2.0",
 				"@wordpress/core-data": "^2.2.2",
 				"@wordpress/data": "^4.4.0",
 				"@wordpress/deprecated": "^2.2.0",
-				"@wordpress/editor": "^9.2.2",
+				"@wordpress/editor": "^9.2.3",
 				"@wordpress/element": "^2.3.0",
 				"@wordpress/html-entities": "^2.2.0",
 				"@wordpress/i18n": "^3.3.0",
@@ -2999,9 +3047,9 @@
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.2.2",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.2.2.tgz",
-					"integrity": "sha512-6wA+wlJ7bnnGuefURWDrqgWNx8mkqLJ8xcsQ9jJ+/XrGyi9IcxaBONHQJe+S5zpxMXf9NKzf7Vzc2K1aJh40+A==",
+					"version": "6.2.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.2.3.tgz",
+					"integrity": "sha512-gEctuxOxSnOoZjp8BumjAms59PEmx3ZZlVKegU6bq6iaW6DwRJMdF4Pu9O54uevPgaVT1pzcI2nSRxDhFLumZQ==",
 					"requires": {
 						"@babel/runtime": "^7.3.1",
 						"@wordpress/autop": "^2.2.0",
@@ -3009,7 +3057,7 @@
 						"@wordpress/block-serialization-default-parser": "^3.1.0",
 						"@wordpress/block-serialization-spec-parser": "^3.0.0",
 						"@wordpress/data": "^4.4.0",
-						"@wordpress/dom": "^2.2.2",
+						"@wordpress/dom": "^2.2.3",
 						"@wordpress/element": "^2.3.0",
 						"@wordpress/hooks": "^2.2.0",
 						"@wordpress/html-entities": "^2.2.0",
@@ -3026,15 +3074,15 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "7.2.2",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.2.2.tgz",
-					"integrity": "sha512-EChv0PPWia8+OXq9m4zRaKRgc1mvC1wl24jRxqJ2sfn3OFlnCn5oBo77VZcDfdQiRK2Sn+nfMbA+4pbgCS38Mg==",
+					"version": "7.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.3.0.tgz",
+					"integrity": "sha512-TMaL5TSHhSPjwbyM/K8ME0RmCiXoQapfac0So0g+KbVXWCWa3IAfJDAsdKGfoV6WA/naiLwU6Dxv6VSM+kor3Q==",
 					"requires": {
 						"@babel/runtime": "^7.3.1",
 						"@wordpress/a11y": "^2.2.0",
 						"@wordpress/api-fetch": "^3.1.2",
 						"@wordpress/compose": "^3.2.0",
-						"@wordpress/dom": "^2.2.2",
+						"@wordpress/dom": "^2.2.3",
 						"@wordpress/element": "^2.3.0",
 						"@wordpress/hooks": "^2.2.0",
 						"@wordpress/i18n": "^3.3.0",
@@ -3306,9 +3354,9 @@
 			}
 		},
 		"@wordpress/dom": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.2.2.tgz",
-			"integrity": "sha512-p0y6sb0E1+lsAeoYOopK9D2LSco1Ycc+8Ps2uqZssK5MKawU+ntBWEwX5nW9gzsRoqhpzQwXz711vh0/+lxnAQ==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.2.3.tgz",
+			"integrity": "sha512-KqdR9YB+dap+spAr6NhwLacKN8xDn6b2iWl5qOvMCSNv1Sg1qC7Dtmzq0hun3chEPiO2Y7Vx0ACxiORha8MQLw==",
 			"requires": {
 				"@babel/runtime": "^7.3.1",
 				"lodash": "^4.17.11"
@@ -3352,16 +3400,16 @@
 			}
 		},
 		"@wordpress/editor": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.2.2.tgz",
-			"integrity": "sha512-WQmwUO3XMgBNhTLT+OdifdoPx1lzXtY4VIzTyydUC3RgZp0UAS39SZU1A+ZQ14658WyngMj16JIiwDXX65UYWQ==",
+			"version": "9.2.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.2.3.tgz",
+			"integrity": "sha512-wxCrOswsnYThmRny4j+SHjqlkk4D11PUnuNRnno+KcT/KOhCD3RPFG+1fuNvmXnQPcveBZQwZt+4vTK75WNrng==",
 			"requires": {
 				"@babel/runtime": "^7.3.1",
 				"@wordpress/api-fetch": "^3.1.2",
 				"@wordpress/blob": "^2.3.0",
-				"@wordpress/block-editor": "^1.1.2",
-				"@wordpress/blocks": "^6.2.2",
-				"@wordpress/components": "^7.2.2",
+				"@wordpress/block-editor": "^2.0.0",
+				"@wordpress/blocks": "^6.2.3",
+				"@wordpress/components": "^7.3.0",
 				"@wordpress/compose": "^3.2.0",
 				"@wordpress/core-data": "^2.2.2",
 				"@wordpress/data": "^4.4.0",
@@ -3373,7 +3421,7 @@
 				"@wordpress/i18n": "^3.3.0",
 				"@wordpress/keycodes": "^2.2.0",
 				"@wordpress/notices": "^1.3.0",
-				"@wordpress/nux": "^3.2.2",
+				"@wordpress/nux": "^3.2.3",
 				"@wordpress/url": "^2.5.0",
 				"@wordpress/viewport": "^2.3.0",
 				"@wordpress/wordcount": "^2.2.0",
@@ -3416,9 +3464,9 @@
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.2.2",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.2.2.tgz",
-					"integrity": "sha512-6wA+wlJ7bnnGuefURWDrqgWNx8mkqLJ8xcsQ9jJ+/XrGyi9IcxaBONHQJe+S5zpxMXf9NKzf7Vzc2K1aJh40+A==",
+					"version": "6.2.3",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.2.3.tgz",
+					"integrity": "sha512-gEctuxOxSnOoZjp8BumjAms59PEmx3ZZlVKegU6bq6iaW6DwRJMdF4Pu9O54uevPgaVT1pzcI2nSRxDhFLumZQ==",
 					"requires": {
 						"@babel/runtime": "^7.3.1",
 						"@wordpress/autop": "^2.2.0",
@@ -3426,7 +3474,7 @@
 						"@wordpress/block-serialization-default-parser": "^3.1.0",
 						"@wordpress/block-serialization-spec-parser": "^3.0.0",
 						"@wordpress/data": "^4.4.0",
-						"@wordpress/dom": "^2.2.2",
+						"@wordpress/dom": "^2.2.3",
 						"@wordpress/element": "^2.3.0",
 						"@wordpress/hooks": "^2.2.0",
 						"@wordpress/html-entities": "^2.2.0",
@@ -3443,15 +3491,15 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "7.2.2",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.2.2.tgz",
-					"integrity": "sha512-EChv0PPWia8+OXq9m4zRaKRgc1mvC1wl24jRxqJ2sfn3OFlnCn5oBo77VZcDfdQiRK2Sn+nfMbA+4pbgCS38Mg==",
+					"version": "7.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.3.0.tgz",
+					"integrity": "sha512-TMaL5TSHhSPjwbyM/K8ME0RmCiXoQapfac0So0g+KbVXWCWa3IAfJDAsdKGfoV6WA/naiLwU6Dxv6VSM+kor3Q==",
 					"requires": {
 						"@babel/runtime": "^7.3.1",
 						"@wordpress/a11y": "^2.2.0",
 						"@wordpress/api-fetch": "^3.1.2",
 						"@wordpress/compose": "^3.2.0",
-						"@wordpress/dom": "^2.2.2",
+						"@wordpress/dom": "^2.2.3",
 						"@wordpress/element": "^2.3.0",
 						"@wordpress/hooks": "^2.2.0",
 						"@wordpress/i18n": "^3.3.0",
@@ -3543,14 +3591,14 @@
 			}
 		},
 		"@wordpress/format-library": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/format-library/-/format-library-1.4.2.tgz",
-			"integrity": "sha512-seEct9YGWornxibNXzc/XLyXhY8cnlYC1qGIz417LsN0CK7x9phzuEHbtiBdYq2jL7zREss1vv0rorOLUemskA==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/format-library/-/format-library-1.4.3.tgz",
+			"integrity": "sha512-Go7JHFqBwIn86OwLmL4o1Txx8kQNAaPHQ9geH0W6srg6X9/TtRAD3aoKH31ysx6N6yXhnPje4tm9FtC0bfREVg==",
 			"requires": {
 				"@babel/runtime": "^7.3.1",
-				"@wordpress/block-editor": "^1.1.2",
-				"@wordpress/components": "^7.2.2",
-				"@wordpress/editor": "^9.2.2",
+				"@wordpress/block-editor": "^2.0.0",
+				"@wordpress/components": "^7.3.0",
+				"@wordpress/editor": "^9.2.3",
 				"@wordpress/element": "^2.3.0",
 				"@wordpress/i18n": "^3.3.0",
 				"@wordpress/keycodes": "^2.2.0",
@@ -3569,15 +3617,15 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "7.2.2",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.2.2.tgz",
-					"integrity": "sha512-EChv0PPWia8+OXq9m4zRaKRgc1mvC1wl24jRxqJ2sfn3OFlnCn5oBo77VZcDfdQiRK2Sn+nfMbA+4pbgCS38Mg==",
+					"version": "7.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.3.0.tgz",
+					"integrity": "sha512-TMaL5TSHhSPjwbyM/K8ME0RmCiXoQapfac0So0g+KbVXWCWa3IAfJDAsdKGfoV6WA/naiLwU6Dxv6VSM+kor3Q==",
 					"requires": {
 						"@babel/runtime": "^7.3.1",
 						"@wordpress/a11y": "^2.2.0",
 						"@wordpress/api-fetch": "^3.1.2",
 						"@wordpress/compose": "^3.2.0",
-						"@wordpress/dom": "^2.2.2",
+						"@wordpress/dom": "^2.2.3",
 						"@wordpress/element": "^2.3.0",
 						"@wordpress/hooks": "^2.2.0",
 						"@wordpress/i18n": "^3.3.0",
@@ -3722,12 +3770,12 @@
 			}
 		},
 		"@wordpress/nux": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-3.2.2.tgz",
-			"integrity": "sha512-G+M30GOiBtlKu7IA5QLaL+sTWI9zvaUbYyS2tUVvUPe830G18NqoxA+hITVp3AD97umYuhnTKak5dEpvh58VDg==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-3.2.3.tgz",
+			"integrity": "sha512-P05TiUjKn4rb+BFowUUh6b6daRHRoT0YW95kKZLqnTr3XmjAvDrMnbYLsEyl5K/LLRcf8k+6sC4kEXJvjzzFnw==",
 			"requires": {
 				"@babel/runtime": "^7.3.1",
-				"@wordpress/components": "^7.2.2",
+				"@wordpress/components": "^7.3.0",
 				"@wordpress/compose": "^3.2.0",
 				"@wordpress/data": "^4.4.0",
 				"@wordpress/element": "^2.3.0",
@@ -3747,15 +3795,15 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "7.2.2",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.2.2.tgz",
-					"integrity": "sha512-EChv0PPWia8+OXq9m4zRaKRgc1mvC1wl24jRxqJ2sfn3OFlnCn5oBo77VZcDfdQiRK2Sn+nfMbA+4pbgCS38Mg==",
+					"version": "7.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.3.0.tgz",
+					"integrity": "sha512-TMaL5TSHhSPjwbyM/K8ME0RmCiXoQapfac0So0g+KbVXWCWa3IAfJDAsdKGfoV6WA/naiLwU6Dxv6VSM+kor3Q==",
 					"requires": {
 						"@babel/runtime": "^7.3.1",
 						"@wordpress/a11y": "^2.2.0",
 						"@wordpress/api-fetch": "^3.1.2",
 						"@wordpress/compose": "^3.2.0",
-						"@wordpress/dom": "^2.2.2",
+						"@wordpress/dom": "^2.2.3",
 						"@wordpress/element": "^2.3.0",
 						"@wordpress/hooks": "^2.2.0",
 						"@wordpress/i18n": "^3.3.0",
@@ -4043,9 +4091,9 @@
 			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
 		},
 		"acorn-globals": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
-			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.1.tgz",
+			"integrity": "sha512-gJSiKY8dBIjV/0jagZIFBdVMtfQyA5QHCvAT48H2q8REQoW8Fs5AOjqBql1LgSXgrMWdevcE+8cdZ33NtVbIBA==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
@@ -4441,9 +4489,9 @@
 			}
 		},
 		"async-each": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
-			"integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ=="
 		},
 		"async-foreach": {
 			"version": "0.1.3",
@@ -4577,14 +4625,59 @@
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz",
-			"integrity": "sha512-RNNVv2lsHAXJQsEJ5jonQwrJVWK8AcZpG1oxhnjCUaAjL7xahYLANhPUZbzEQHjKy1NMYUwn+0NPKQc8iSY4xQ==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.2.tgz",
+			"integrity": "sha512-U3ZVajC+Z69Gim7ZzmD4Wcsq76i/1hqDamBfowc1tWzWjybRy70iWfngP2ME+1CrgcgZ/+muIbPY/Yi0dxdIkQ==",
 			"dev": true,
 			"requires": {
 				"find-up": "^3.0.0",
-				"istanbul-lib-instrument": "^3.0.0",
-				"test-exclude": "^5.0.0"
+				"istanbul-lib-instrument": "^3.2.0",
+				"test-exclude": "^5.2.2"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				}
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -5021,6 +5114,13 @@
 				"minimist": "^1.2.0",
 				"os-homedir": "^1.0.1",
 				"regexpu-core": "^4.5.4"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
 			}
 		},
 		"buffer": {
@@ -5087,6 +5187,26 @@
 				"ssri": "^6.0.1",
 				"unique-filename": "^1.1.1",
 				"y18n": "^4.0.0"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+				}
 			}
 		},
 		"cache-base": {
@@ -5173,9 +5293,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000957",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz",
-			"integrity": "sha512-8wxNrjAzyiHcLXN/iunskqQnJquQQ6VX8JHfW5kLgAPRSiSuKZiNfmIkP5j7jgyXqAQBSoXyJxfnbCFS0ThSiQ=="
+			"version": "1.0.30000960",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000960.tgz",
+			"integrity": "sha512-7nK5qs17icQaX6V3/RYrJkOsZyRNnroA4+ZwxaKJzIKy+crIy0Mz5CBlLySd2SNV+4nbUZeqeNfiaEieUBu3aA=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -5303,6 +5423,14 @@
 				"object.assign": "^4.0.4",
 				"run-parallel": "^1.1.4",
 				"semver": "^5.0.3"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				}
 			}
 		},
 		"check-types": {
@@ -5344,13 +5472,13 @@
 			},
 			"dependencies": {
 				"fsevents": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-					"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+					"version": "1.2.8",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
+					"integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
 					"optional": true,
 					"requires": {
-						"nan": "^2.9.2",
-						"node-pre-gyp": "^0.10.0"
+						"nan": "^2.12.1",
+						"node-pre-gyp": "^0.12.0"
 					},
 					"dependencies": {
 						"abbrev": {
@@ -5360,8 +5488,7 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -5379,13 +5506,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -5398,18 +5523,15 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -5417,11 +5539,11 @@
 							"optional": true
 						},
 						"debug": {
-							"version": "2.6.9",
+							"version": "4.1.1",
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"ms": "2.0.0"
+								"ms": "^2.1.1"
 							}
 						},
 						"deep-extend": {
@@ -5512,8 +5634,7 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -5523,7 +5644,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -5536,20 +5656,17 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -5566,28 +5683,27 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
 						},
 						"ms": {
-							"version": "2.0.0",
+							"version": "2.1.1",
 							"bundled": true,
 							"optional": true
 						},
 						"needle": {
-							"version": "2.2.4",
+							"version": "2.3.0",
 							"bundled": true,
 							"optional": true,
 							"requires": {
-								"debug": "^2.1.2",
+								"debug": "^4.1.0",
 								"iconv-lite": "^0.4.4",
 								"sax": "^1.2.4"
 							}
 						},
 						"node-pre-gyp": {
-							"version": "0.10.3",
+							"version": "0.12.0",
 							"bundled": true,
 							"optional": true,
 							"requires": {
@@ -5613,12 +5729,12 @@
 							}
 						},
 						"npm-bundled": {
-							"version": "1.0.5",
+							"version": "1.0.6",
 							"bundled": true,
 							"optional": true
 						},
 						"npm-packlist": {
-							"version": "1.2.0",
+							"version": "1.4.1",
 							"bundled": true,
 							"optional": true,
 							"requires": {
@@ -5639,8 +5755,7 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -5650,7 +5765,6 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -5726,8 +5840,7 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -5740,7 +5853,7 @@
 							"optional": true
 						},
 						"semver": {
-							"version": "5.6.0",
+							"version": "5.7.0",
 							"bundled": true,
 							"optional": true
 						},
@@ -5757,7 +5870,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -5775,7 +5887,6 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -5814,13 +5925,11 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						}
 					}
 				}
@@ -6147,9 +6256,9 @@
 			}
 		},
 		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+			"integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
 		},
 		"component-event": {
 			"version": "0.1.4",
@@ -6264,6 +6373,15 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
 				"get-stream": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -6294,6 +6412,16 @@
 						"invert-kv": "^2.0.0"
 					}
 				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
 				"mem": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -6321,6 +6449,30 @@
 						"lcid": "^2.0.0",
 						"mem": "^4.0.0"
 					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
 				},
 				"pify": {
 					"version": "3.0.0",
@@ -6467,9 +6619,9 @@
 			}
 		},
 		"conventional-changelog-preset-loader": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.2.tgz",
-			"integrity": "sha512-pBY+qnUoJPXAXXqVGwQaVmcye05xi6z231QM98wHWamGAmu/ghkBprQAwmF5bdmyobdVxiLhPY3PrCfSeUNzRQ=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.1.1.tgz",
+			"integrity": "sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA=="
 		},
 		"conventional-changelog-writer": {
 			"version": "4.0.3",
@@ -6512,18 +6664,72 @@
 			}
 		},
 		"conventional-recommended-bump": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.0.4.tgz",
-			"integrity": "sha512-9mY5Yoblq+ZMqJpBzgS+RpSq+SUfP2miOR3H/NR9drGf08WCrY9B6HAGJZEm6+ThsVP917VHAahSOjM6k1vhPg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-4.1.1.tgz",
+			"integrity": "sha512-JT2vKfSP9kR18RXXf55BRY1O3AHG8FPg5btP3l7LYfcWJsiXI6MCf30DepQ98E8Qhowvgv7a8iev0J1bEDkTFA==",
 			"requires": {
-				"concat-stream": "^1.6.0",
-				"conventional-changelog-preset-loader": "^2.0.2",
-				"conventional-commits-filter": "^2.0.1",
-				"conventional-commits-parser": "^3.0.1",
+				"concat-stream": "^2.0.0",
+				"conventional-changelog-preset-loader": "^2.1.1",
+				"conventional-commits-filter": "^2.0.2",
+				"conventional-commits-parser": "^3.0.2",
 				"git-raw-commits": "2.0.0",
 				"git-semver-tags": "^2.0.2",
 				"meow": "^4.0.0",
 				"q": "^1.5.1"
+			},
+			"dependencies": {
+				"concat-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+					"integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"inherits": "^2.0.3",
+						"readable-stream": "^3.0.2",
+						"typedarray": "^0.0.6"
+					}
+				},
+				"conventional-commits-filter": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.2.tgz",
+					"integrity": "sha512-WpGKsMeXfs21m1zIw4s9H5sys2+9JccTzpN6toXtxhpw2VNF2JUXwIakthKBy+LN4DvJm+TzWhxOMWOs1OFCFQ==",
+					"requires": {
+						"lodash.ismatch": "^4.4.0",
+						"modify-values": "^1.0.0"
+					}
+				},
+				"conventional-commits-parser": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.2.tgz",
+					"integrity": "sha512-y5eqgaKR0F6xsBNVSQ/5cI5qIF3MojddSUi1vKIggRkqUTbkqFKH9P5YX/AT1BVZp9DtSzBTIkvjyVLotLsVog==",
+					"requires": {
+						"JSONStream": "^1.0.4",
+						"is-text-path": "^1.0.0",
+						"lodash": "^4.2.1",
+						"meow": "^4.0.0",
+						"split2": "^2.0.0",
+						"through2": "^3.0.0",
+						"trim-off-newlines": "^1.0.0"
+					}
+				},
+				"readable-stream": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+					"integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"through2": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+					"integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+					"requires": {
+						"readable-stream": "2 || 3"
+					}
+				}
 			}
 		},
 		"convert-source-map": {
@@ -6740,22 +6946,6 @@
 				"lru-cache": "^4.0.1",
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
 			}
 		},
 		"crypto-browserify": {
@@ -7724,6 +7914,11 @@
 				"yeast": "0.1.2"
 			},
 			"dependencies": {
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -8081,9 +8276,9 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-			"integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+			"integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
@@ -8099,53 +8294,10 @@
 						"ms": "2.0.0"
 					}
 				},
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 					"dev": true
 				},
 				"pkg-dir": {
@@ -8196,15 +8348,6 @@
 						"isarray": "^1.0.0"
 					}
 				},
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"dev": true,
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
 				"load-json-file": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -8217,44 +8360,10 @@
 						"strip-bom": "^3.0.0"
 					}
 				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"dev": true,
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"dev": true,
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"dev": true,
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
 					"dev": true
 				},
 				"parse-json": {
@@ -8946,11 +9055,11 @@
 			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
 		},
 		"find-up": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-			"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"requires": {
-				"locate-path": "^3.0.0"
+				"locate-path": "^2.0.0"
 			}
 		},
 		"findup": {
@@ -9348,6 +9457,11 @@
 						"trim-newlines": "^1.0.0"
 					}
 				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
 				"parse-json": {
 					"version": "2.2.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -9725,9 +9839,9 @@
 			}
 		},
 		"handlebars": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.1.tgz",
-			"integrity": "sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+			"integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
 			"requires": {
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
@@ -10215,6 +10329,15 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
 				"get-stdin": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -10238,6 +10361,40 @@
 					"requires": {
 						"ci-info": "^2.0.0"
 					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
 				},
 				"pify": {
 					"version": "3.0.0",
@@ -10397,44 +10554,6 @@
 				"resolve-cwd": "^2.0.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-				},
 				"pkg-dir": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
@@ -10521,9 +10640,9 @@
 			}
 		},
 		"inquirer": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-			"integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+			"version": "6.3.1",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+			"integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
 			"requires": {
 				"ansi-escapes": "^3.2.0",
 				"chalk": "^2.4.2",
@@ -10536,7 +10655,7 @@
 				"run-async": "^2.2.0",
 				"rxjs": "^6.4.0",
 				"string-width": "^2.1.0",
-				"strip-ansi": "^5.0.0",
+				"strip-ansi": "^5.1.0",
 				"through": "^2.3.6"
 			},
 			"dependencies": {
@@ -10589,9 +10708,9 @@
 			"integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
 		},
 		"ipaddr.js": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-			"integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+			"integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
 		},
 		"is-absolute-url": {
 			"version": "2.1.0",
@@ -11027,62 +11146,45 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-api": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
-			"integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.4.tgz",
+			"integrity": "sha512-aAFQL0HA2BLUl18XmTQ7H7CGKI58DtZFvvfmg6e+rA3iNFergvpi16czLV4CpI7HOImMeZ5mqI62dvSNVtUQVA==",
 			"dev": true,
 			"requires": {
 				"async": "^2.6.1",
 				"compare-versions": "^3.2.1",
 				"fileset": "^2.0.3",
-				"istanbul-lib-coverage": "^2.0.3",
-				"istanbul-lib-hook": "^2.0.3",
-				"istanbul-lib-instrument": "^3.1.0",
-				"istanbul-lib-report": "^2.0.4",
-				"istanbul-lib-source-maps": "^3.0.2",
-				"istanbul-reports": "^2.1.1",
-				"js-yaml": "^3.12.0",
-				"make-dir": "^1.3.0",
+				"istanbul-lib-coverage": "^2.0.4",
+				"istanbul-lib-hook": "^2.0.6",
+				"istanbul-lib-instrument": "^3.2.0",
+				"istanbul-lib-report": "^2.0.7",
+				"istanbul-lib-source-maps": "^3.0.5",
+				"istanbul-reports": "^2.2.2",
+				"js-yaml": "^3.13.0",
+				"make-dir": "^2.1.0",
 				"minimatch": "^3.0.4",
 				"once": "^1.4.0"
-			},
-			"dependencies": {
-				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				}
 			}
 		},
 		"istanbul-lib-coverage": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-			"integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+			"integrity": "sha512-LXTBICkMARVgo579kWDm8SqfB6nvSDKNqIOBEjmJRnL04JvoMHCYGWaMddQnseJYtkEuEvO/sIcOxPLk9gERug==",
 			"dev": true
 		},
 		"istanbul-lib-hook": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.3.tgz",
-			"integrity": "sha512-CLmEqwEhuCYtGcpNVJjLV1DQyVnIqavMLFHV/DP+np/g3qvdxu3gsPqYoJMXm15sN84xOlckFB3VNvRbf5yEgA==",
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-2.0.6.tgz",
+			"integrity": "sha512-829DKONApZ7UCiPXcOYWSgkFXa4+vNYoNOt3F+4uDJLKL1OotAoVwvThoEj1i8jmOj7odbYcR3rnaHu+QroaXg==",
 			"dev": true,
 			"requires": {
 				"append-transform": "^1.0.0"
 			}
 		},
 		"istanbul-lib-instrument": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
-			"integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.2.0.tgz",
+			"integrity": "sha512-06IM3xShbNW4NgZv5AP4QH0oHqf1/ivFo8eFys0ZjPXHGldHJQWb3riYOKXqmOqfxXBfxu4B+g/iuhOPZH0RJg==",
 			"dev": true,
 			"requires": {
 				"@babel/generator": "^7.0.0",
@@ -11090,36 +11192,29 @@
 				"@babel/template": "^7.0.0",
 				"@babel/traverse": "^7.0.0",
 				"@babel/types": "^7.0.0",
-				"istanbul-lib-coverage": "^2.0.3",
-				"semver": "^5.5.0"
+				"istanbul-lib-coverage": "^2.0.4",
+				"semver": "^6.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+					"dev": true
+				}
 			}
 		},
 		"istanbul-lib-report": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.4.tgz",
-			"integrity": "sha512-sOiLZLAWpA0+3b5w5/dq0cjm2rrNdAfHWaGhmn7XEFW6X++IV9Ohn+pnELAl9K3rfpaeBfbmH9JU5sejacdLeA==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.7.tgz",
+			"integrity": "sha512-wLH6beJBFbRBLiTlMOBxmb85cnVM1Vyl36N48e4e/aTKSM3WbOx7zbVIH1SQ537fhhsPbX0/C5JB4qsmyRXXyA==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^2.0.3",
-				"make-dir": "^1.3.0",
+				"istanbul-lib-coverage": "^2.0.4",
+				"make-dir": "^2.1.0",
 				"supports-color": "^6.0.0"
 			},
 			"dependencies": {
-				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				},
 				"supports-color": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
@@ -11132,14 +11227,14 @@
 			}
 		},
 		"istanbul-lib-source-maps": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.2.tgz",
-			"integrity": "sha512-JX4v0CiKTGp9fZPmoxpu9YEkPbEqCqBbO3403VabKjH+NRXo72HafD5UgnjTEqHL2SAjaZK1XDuDOkn6I5QVfQ==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.5.tgz",
+			"integrity": "sha512-eDhZ7r6r1d1zQPVZehLc3D0K14vRba/eBYkz3rw16DLOrrTzve9RmnkcwrrkWVgO1FL3EK5knujVe5S8QHE9xw==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
-				"istanbul-lib-coverage": "^2.0.3",
-				"make-dir": "^1.3.0",
+				"istanbul-lib-coverage": "^2.0.4",
+				"make-dir": "^2.1.0",
 				"rimraf": "^2.6.2",
 				"source-map": "^0.6.1"
 			},
@@ -11153,21 +11248,6 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"make-dir": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-					"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-					"dev": true,
-					"requires": {
-						"pify": "^3.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-					"dev": true
-				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11177,9 +11257,9 @@
 			}
 		},
 		"istanbul-reports": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.1.1.tgz",
-			"integrity": "sha512-FzNahnidyEPBCI0HcufJoSEoKykesRlFcSzQqjH9x0+LC8tnnE/p/90PBLu8iZTxr8yYZNyTtiAujUqyN+CIxw==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.2.tgz",
+			"integrity": "sha512-ZFuTdBQ3PSaPnm02aEA4R6mzQ2AF9w03CYiXADzWbbE48v/EFOWF4MaX4FT0NRdqIk48I7o0RPi+S8TMswaCbQ==",
 			"dev": true,
 			"requires": {
 				"handlebars": "^4.1.0"
@@ -11238,6 +11318,15 @@
 						"p-finally": "^1.0.0",
 						"signal-exit": "^3.0.0",
 						"strip-eof": "^1.0.0"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
 					}
 				},
 				"get-stream": {
@@ -11304,6 +11393,16 @@
 						"invert-kv": "^2.0.0"
 					}
 				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
 				"mem": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -11331,6 +11430,30 @@
 						"lcid": "^2.0.0",
 						"mem": "^4.0.0"
 					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -11527,14 +11650,14 @@
 			},
 			"dependencies": {
 				"fsevents": {
-					"version": "1.2.7",
-					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-					"integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
+					"version": "1.2.8",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.8.tgz",
+					"integrity": "sha512-tPvHgPGB7m40CZ68xqFGkKuzN+RnpGmSV+hgeKxhRpbxdqKXUFJGC3yonBOLzQBcJyGpdZFDfCsdOC2KFsXzeA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"nan": "^2.9.2",
-						"node-pre-gyp": "^0.10.0"
+						"nan": "^2.12.1",
+						"node-pre-gyp": "^0.12.0"
 					},
 					"dependencies": {
 						"abbrev": {
@@ -11546,8 +11669,7 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -11568,14 +11690,12 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -11590,20 +11710,17 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -11612,12 +11729,12 @@
 							"optional": true
 						},
 						"debug": {
-							"version": "2.6.9",
+							"version": "4.1.1",
 							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"ms": "2.0.0"
+								"ms": "^2.1.1"
 							}
 						},
 						"deep-extend": {
@@ -11720,8 +11837,7 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -11733,7 +11849,6 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -11748,7 +11863,6 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -11756,14 +11870,12 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -11782,30 +11894,29 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
 						},
 						"ms": {
-							"version": "2.0.0",
+							"version": "2.1.1",
 							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"needle": {
-							"version": "2.2.4",
+							"version": "2.3.0",
 							"bundled": true,
 							"dev": true,
 							"optional": true,
 							"requires": {
-								"debug": "^2.1.2",
+								"debug": "^4.1.0",
 								"iconv-lite": "^0.4.4",
 								"sax": "^1.2.4"
 							}
 						},
 						"node-pre-gyp": {
-							"version": "0.10.3",
+							"version": "0.12.0",
 							"bundled": true,
 							"dev": true,
 							"optional": true,
@@ -11833,13 +11944,13 @@
 							}
 						},
 						"npm-bundled": {
-							"version": "1.0.5",
+							"version": "1.0.6",
 							"bundled": true,
 							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
-							"version": "1.2.0",
+							"version": "1.4.1",
 							"bundled": true,
 							"dev": true,
 							"optional": true,
@@ -11863,8 +11974,7 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -11876,7 +11986,6 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -11962,8 +12071,7 @@
 						"safe-buffer": {
 							"version": "5.1.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -11978,7 +12086,7 @@
 							"optional": true
 						},
 						"semver": {
-							"version": "5.6.0",
+							"version": "5.7.0",
 							"bundled": true,
 							"dev": true,
 							"optional": true
@@ -11999,7 +12107,6 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -12019,7 +12126,6 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -12063,14 +12169,12 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"yallist": {
 							"version": "3.0.3",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						}
 					}
 				}
@@ -12286,6 +12390,15 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
 				"get-stream": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -12308,6 +12421,16 @@
 					"dev": true,
 					"requires": {
 						"invert-kv": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"mem": {
@@ -12337,6 +12460,30 @@
 						"lcid": "^2.0.0",
 						"mem": "^4.0.0"
 					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -12652,11 +12799,18 @@
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+			"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
 			"requires": {
 				"minimist": "^1.2.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
 			}
 		},
 		"jsonfile": {
@@ -12888,6 +13042,21 @@
 				"big.js": "^5.2.2",
 				"emojis-list": "^2.0.0",
 				"json5": "^1.0.1"
+			},
+			"dependencies": {
+				"json5": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+					"requires": {
+						"minimist": "^1.2.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
 			}
 		},
 		"localforage": {
@@ -12899,11 +13068,11 @@
 			}
 		},
 		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"requires": {
-				"p-locate": "^3.0.0",
+				"p-locate": "^2.0.0",
 				"path-exists": "^3.0.0"
 			}
 		},
@@ -12959,6 +13128,11 @@
 			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
 			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
 			"dev": true
+		},
+		"lodash.ismatch": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+			"integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc="
 		},
 		"lodash.memoize": {
 			"version": "4.1.2",
@@ -13074,11 +13248,12 @@
 			}
 		},
 		"lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+			"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
 			"requires": {
-				"yallist": "^3.0.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"lunr": {
@@ -13124,22 +13299,6 @@
 				"promise-retry": "^1.1.1",
 				"socks-proxy-agent": "^4.0.0",
 				"ssri": "^6.0.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
 			}
 		},
 		"makeerror": {
@@ -13288,6 +13447,13 @@
 				"read-pkg-up": "^3.0.0",
 				"redent": "^2.0.0",
 				"trim-newlines": "^2.0.0"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
 			}
 		},
 		"merge-descriptors": {
@@ -13395,9 +13561,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minimist-options": {
 			"version": "3.0.2",
@@ -13415,6 +13581,13 @@
 			"requires": {
 				"safe-buffer": "^5.1.2",
 				"yallist": "^3.0.0"
+			},
+			"dependencies": {
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+				}
 			}
 		},
 		"minizlib": {
@@ -13464,6 +13637,12 @@
 						"pify": "^2.0.0",
 						"pinkie-promise": "^2.0.0"
 					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				},
 				"pify": {
 					"version": "2.3.0",
@@ -13516,13 +13695,6 @@
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 			"requires": {
 				"minimist": "0.0.8"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-				}
 			}
 		},
 		"mockdate": {
@@ -13856,11 +14028,6 @@
 					"version": "0.0.0",
 					"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
 					"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo="
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
 				}
 			}
 		},
@@ -13884,9 +14051,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.14.tgz",
-			"integrity": "sha512-d58EpVZRhQE60kWiWUaaPlK9dyC4zg3ZoMcHcky2d4hDksyQj0rUozwInOl0C66mBsqo01Tuns8AvxnL5S7PKg==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.15.tgz",
+			"integrity": "sha512-cKV097BQaZr8LTSRUa2+oc/aX5L8UkZtPQrMSTgiJEeaW7ymTDCoRaGCoaTqk0lqnalcoSHu4wjSl0Cmj2+bMw==",
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -13991,15 +14158,6 @@
 						"strip-bom": "^2.0.0"
 					}
 				},
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
 				"map-obj": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -14021,6 +14179,11 @@
 						"redent": "^1.0.0",
 						"trim-newlines": "^1.0.0"
 					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				},
 				"parse-json": {
 					"version": "2.2.0",
@@ -14114,11 +14277,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
 					"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 				}
 			}
 		},
@@ -14620,22 +14778,6 @@
 				"lru-cache": "^4.1.3",
 				"make-fetch-happen": "^4.0.1",
 				"npm-package-arg": "^6.1.0"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
 			}
 		},
 		"npm-run-all": {
@@ -14902,13 +15044,6 @@
 			"requires": {
 				"minimist": "~0.0.1",
 				"wordwrap": "~0.0.2"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.10",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-				}
 			}
 		},
 		"optionator": {
@@ -15011,19 +15146,19 @@
 			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
 		},
 		"p-limit": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-			"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"requires": {
-				"p-try": "^2.0.0"
+				"p-try": "^1.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"requires": {
-				"p-limit": "^2.0.0"
+				"p-limit": "^1.1.0"
 			}
 		},
 		"p-map": {
@@ -15050,9 +15185,9 @@
 			"integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo="
 		},
 		"p-try": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-			"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
 		"p-waterfall": {
 			"version": "1.0.0",
@@ -15104,6 +15239,14 @@
 						"pump": "^3.0.0"
 					}
 				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
 				"tar": {
 					"version": "4.4.8",
 					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
@@ -15117,6 +15260,11 @@
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -15292,9 +15440,9 @@
 			}
 		},
 		"parseurl": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
 		},
 		"pascal-case": {
 			"version": "2.0.1",
@@ -15458,6 +15606,46 @@
 			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"requires": {
 				"find-up": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+				}
 			}
 		},
 		"please-upgrade-node": {
@@ -15586,6 +15774,14 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
 				"get-stdin": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -15612,6 +15808,15 @@
 						"invert-kv": "^2.0.0"
 					}
 				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
 				"mem": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -15636,6 +15841,27 @@
 						"lcid": "^2.0.0",
 						"mem": "^4.0.0"
 					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -16349,12 +16575,12 @@
 			}
 		},
 		"proxy-addr": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-			"integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+			"integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
 			"requires": {
 				"forwarded": "~0.1.2",
-				"ipaddr.js": "1.8.0"
+				"ipaddr.js": "1.9.0"
 			}
 		},
 		"prr": {
@@ -16416,9 +16642,9 @@
 			}
 		},
 		"punycode": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+			"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
 		},
 		"q": {
 			"version": "1.5.1",
@@ -16904,46 +17130,6 @@
 			"requires": {
 				"find-up": "^2.0.0",
 				"read-pkg": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-				}
 			}
 		},
 		"readable-stream": {
@@ -17318,6 +17504,15 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
 				"get-stream": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -17340,6 +17535,16 @@
 					"dev": true,
 					"requires": {
 						"invert-kv": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"mem": {
@@ -17369,6 +17574,30 @@
 						"lcid": "^2.0.0",
 						"mem": "^4.0.0"
 					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -17729,6 +17958,12 @@
 					"requires": {
 						"pump": "^3.0.0"
 					}
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
 				}
 			}
 		},
@@ -17880,11 +18115,6 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
 					"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 				},
 				"yargs": {
 					"version": "7.1.0",
@@ -18058,9 +18288,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
-			"integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw=="
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
+			"integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA=="
 		},
 		"serve-static": {
 			"version": "1.13.2",
@@ -18175,49 +18405,6 @@
 				"yargs": "^10.0.3"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-					"requires": {
-						"locate-path": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-					"requires": {
-						"p-locate": "^2.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-					"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-					"requires": {
-						"p-try": "^1.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-					"requires": {
-						"p-limit": "^1.1.0"
-					}
-				},
-				"p-try": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-					"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
-				},
-				"y18n": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-				},
 				"yargs": {
 					"version": "10.1.2",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.2.tgz",
@@ -18499,6 +18686,11 @@
 				"to-array": "0.1.4"
 			},
 			"dependencies": {
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -18524,6 +18716,11 @@
 				"isarray": "2.0.1"
 			},
 			"dependencies": {
+				"component-emitter": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+					"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+				},
 				"debug": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -18942,6 +19139,13 @@
 				"duplexer": "^0.1.1",
 				"minimist": "^1.2.0",
 				"through": "^2.3.4"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				}
 			}
 		},
 		"style-search": {
@@ -19080,9 +19284,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.0.6",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.0.6.tgz",
-					"integrity": "sha512-/+hp3kUf/Csa32ktIaj0OlRqQxrgs30n62M90UBpNd9k+ENEch5S+hmbW3DtcJGz3sYFTh4F3A6fQ0q7KWsp4w==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.0.tgz",
+					"integrity": "sha512-dJEmMwloo0gq40chdtDmE4tMp67ZGwN7MFTgjNqWi2VHEi5Ya6JkuvPWasjcAIm7lg+2if8xxn5R199wspcplg==",
 					"dev": true
 				},
 				"meow": {
@@ -19195,9 +19399,9 @@
 			"dev": true
 		},
 		"svgo": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.1.tgz",
-			"integrity": "sha512-Y1+LyT4/y1ms4/0yxPMSlvx6dIbgklE9w8CIOnfeoFGB74MEkq8inSfEr6NhocTaFbyYp0a1dvNgRKGRmEBlzA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
+			"integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
@@ -19207,7 +19411,7 @@
 				"css-tree": "1.0.0-alpha.28",
 				"css-url-regex": "^1.1.0",
 				"csso": "^3.5.1",
-				"js-yaml": "^3.13.0",
+				"js-yaml": "^3.13.1",
 				"mkdirp": "~0.5.1",
 				"object.values": "^1.1.0",
 				"sax": "~1.2.4",
@@ -19299,9 +19503,9 @@
 			}
 		},
 		"tapable": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
-			"integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+			"integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
 		},
 		"tar": {
 			"version": "2.2.1",
@@ -19386,17 +19590,60 @@
 			}
 		},
 		"test-exclude": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.1.0.tgz",
-			"integrity": "sha512-gwf0S2fFsANC55fSeSqpb8BYk6w3FDvwZxfNjeF6FRgvFa43r+7wRiA/Q0IxoRU37wB/LE8IQ4221BsNucTaCA==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.2.tgz",
+			"integrity": "sha512-N2pvaLpT8guUpb5Fe1GJlmvmzH3x+DAKmmyEQmFP792QcLYoGE1syxztSvPD1V8yPe6VrcCt6YGQVjSRjCASsA==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
+				"glob": "^7.1.3",
 				"minimatch": "^3.0.4",
 				"read-pkg-up": "^4.0.0",
-				"require-main-filename": "^1.0.1"
+				"require-main-filename": "^2.0.0"
 			},
 			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
 				"read-pkg-up": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
@@ -19406,6 +19653,12 @@
 						"find-up": "^3.0.0",
 						"read-pkg": "^3.0.0"
 					}
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
 				}
 			}
 		},
@@ -19633,6 +19886,13 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"requires": {
 				"punycode": "^2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+				}
 			}
 		},
 		"tracekit": {
@@ -20067,6 +20327,13 @@
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
 			"requires": {
 				"punycode": "^2.1.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+				}
 			}
 		},
 		"urix": {
@@ -20081,13 +20348,6 @@
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
-			},
-			"dependencies": {
-				"punycode": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-				}
 			}
 		},
 		"url-template": {
@@ -20107,22 +20367,6 @@
 			"requires": {
 				"lru-cache": "4.1.x",
 				"tmp": "0.0.x"
-			},
-			"dependencies": {
-				"lru-cache": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"requires": {
-						"pseudomap": "^1.0.2",
-						"yallist": "^2.1.2"
-					}
-				},
-				"yallist": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-				}
 			}
 		},
 		"util": {
@@ -20402,6 +20646,14 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
 				"findup-sync": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
@@ -20451,6 +20703,15 @@
 						"invert-kv": "^2.0.0"
 					}
 				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
 				"mem": {
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
@@ -20475,6 +20736,27 @@
 						"lcid": "^2.0.0",
 						"mem": "^4.0.0"
 					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -20930,14 +21212,14 @@
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
 		},
 		"y18n": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-			"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
 		},
 		"yallist": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 		},
 		"yamlparser": {
 			"version": "0.0.2",
@@ -20998,6 +21280,14 @@
 						"strip-eof": "^1.0.0"
 					}
 				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
 				"get-caller-file": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -21022,6 +21312,15 @@
 					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 					"requires": {
 						"invert-kv": "^2.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
 					}
 				},
 				"mem": {
@@ -21049,6 +21348,27 @@
 						"mem": "^4.0.0"
 					}
 				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+				},
 				"require-main-filename": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -21071,6 +21391,11 @@
 					"requires": {
 						"ansi-regex": "^4.1.0"
 					}
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 				},
 				"yargs-parser": {
 					"version": "13.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 		"@automattic/format-currency": "file:./packages/format-currency",
 		"@automattic/muriel-style": "file:./packages/muriel-style",
 		"@automattic/tree-select": "file:./packages/tree-select",
-		"@automattic/wordpress-external-dependencies-plugin": "file:./packages/wordpress-external-dependencies-plugin",
 		"@babel/cli": "7.2.3",
 		"@babel/core": "7.4.0",
 		"@babel/plugin-syntax-dynamic-import": "7.2.0",

--- a/server/bundler/index.js
+++ b/server/bundler/index.js
@@ -7,7 +7,7 @@ const webpackMiddleware = require( 'webpack-dev-middleware' );
 const webpack = require( 'webpack' );
 const chalk = require( 'chalk' );
 const hotMiddleware = require( 'webpack-hot-middleware' );
-const getWebpackConfig = require( 'webpack.config' );
+const webpackConfig = require( 'webpack.config' );
 
 const config = require( 'config' );
 
@@ -17,7 +17,7 @@ const port = process.env.PORT || config( 'port' );
 const shouldProfile = process.env.PROFILE === 'true';
 
 function middleware( app ) {
-	const compiler = webpack( getWebpackConfig() );
+	const compiler = webpack( webpackConfig );
 	const callbacks = [];
 	let built = false;
 	let beforeFirstCompile = true;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,6 @@ const MomentTimezoneDataPlugin = require( 'moment-timezone-data-webpack-plugin' 
 const Minify = require( '@automattic/calypso-build/webpack/minify' );
 const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
-const WordPressExternalDependenciesPlugin = require( '@automattic/wordpress-external-dependencies-plugin' );
 const { cssNameFromFilename } = require( '@automattic/calypso-build/webpack/util' );
 
 /**
@@ -142,15 +141,9 @@ function shouldTranspileDependency( filepath ) {
  *
  * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
  *
- * @param {object}  env                              additional config options
- * @param {boolean} env.externalizeWordPressPackages whether to bundle or extern the `@wordpress/` packages
- *
  * @return {object}                                  webpack config
  */
-function getWebpackConfig( {
-	externalizeWordPressPackages = false,
-	preserveCssCustomProperties = true,
-} = {} ) {
+function getWebpackConfig() {
 	let outputFilename = '[name].[chunkhash].min.js'; // prefer the chunkhash, which depends on the chunk, not the entire build
 	let outputChunkFilename = '[name].[chunkhash].min.js'; // ditto
 
@@ -231,7 +224,7 @@ function getWebpackConfig( {
 					},
 				},
 				SassConfig.loader( {
-					preserveCssCustomProperties,
+					preserveCssCustomProperties: true,
 					includePaths: [ path.join( __dirname, 'client' ) ],
 					prelude: `@import '${ path.join(
 						__dirname,
@@ -326,7 +319,6 @@ function getWebpackConfig( {
 			new MomentTimezoneDataPlugin( {
 				startYear: 2000,
 			} ),
-			externalizeWordPressPackages && new WordPressExternalDependenciesPlugin(),
 		] ),
 		externals: [ 'electron' ],
 	};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -136,205 +136,191 @@ function shouldTranspileDependency( filepath ) {
 	);
 }
 
-/**
- * Return a webpack config object
- *
- * @see {@link https://webpack.js.org/configuration/configuration-types/#exporting-a-function}
- *
- * @return {object}                                  webpack config
- */
-function getWebpackConfig() {
-	let outputFilename = '[name].[chunkhash].min.js'; // prefer the chunkhash, which depends on the chunk, not the entire build
-	let outputChunkFilename = '[name].[chunkhash].min.js'; // ditto
+let outputFilename = '[name].[chunkhash].min.js'; // prefer the chunkhash, which depends on the chunk, not the entire build
+let outputChunkFilename = '[name].[chunkhash].min.js'; // ditto
 
-	// we should not use chunkhash in development: https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405
-	// also we don't minify so dont name them .min.js
-	//
-	// Desktop: no chunks or dll here, just one big file for the desktop app
-	if ( isDevelopment || calypsoEnv === 'desktop' ) {
-		outputFilename = '[name].js';
-		outputChunkFilename = '[name].js';
-	}
-
-	const cssFilename = cssNameFromFilename( outputFilename );
-	const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
-
-	const webpackConfig = {
-		bail: ! isDevelopment,
-		context: __dirname,
-		entry: {
-			build: [ path.join( __dirname, 'client', 'boot', 'app' ) ],
-			domainsLanding: [ path.join( __dirname, 'client', 'landing', 'domains' ) ],
-		},
-		mode: isDevelopment ? 'development' : 'production',
-		devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
-		output: {
-			path: path.join( __dirname, 'public', extraPath ),
-			pathinfo: false,
-			publicPath: `/calypso/${ extraPath }/`,
-			filename: outputFilename,
-			chunkFilename: outputChunkFilename,
-			devtoolModuleFilenameTemplate: 'app:///[resource-path]',
-		},
-		optimization: {
-			splitChunks: {
-				chunks: codeSplit ? 'all' : 'async',
-				name: isDevelopment || shouldEmitStats,
-				maxAsyncRequests: 20,
-				maxInitialRequests: 5,
-			},
-			runtimeChunk: codeSplit ? { name: 'manifest' } : false,
-			moduleIds: 'named',
-			chunkIds: isDevelopment || shouldEmitStats ? 'named' : 'natural',
-			minimize: shouldMinify,
-			minimizer: Minify( {
-				cache: process.env.CIRCLECI
-					? `${ process.env.HOME }/terser-cache/${ extraPath }`
-					: 'docker' !== process.env.CONTAINER,
-				parallel: workerCount,
-				sourceMap: Boolean( process.env.SOURCEMAP ),
-				terserOptions: {
-					mangle: calypsoEnv !== 'desktop',
-				},
-			} ),
-		},
-		module: {
-			noParse: /[/\\]node_modules[/\\]localforage[/\\]dist[/\\]localforage\.js$/,
-			rules: [
-				TranspileConfig.loader( {
-					workerCount,
-					configFile: path.join( __dirname, 'babel.config.js' ),
-					cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache', extraPath ),
-					cacheIdentifier,
-					exclude: /node_modules\//,
-				} ),
-				TranspileConfig.loader( {
-					workerCount,
-					configFile: path.resolve( __dirname, 'babel.dependencies.config.js' ),
-					cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache', extraPath ),
-					cacheIdentifier,
-					include: shouldTranspileDependency,
-				} ),
-				{
-					test: /node_modules[/\\](redux-form|react-redux)[/\\]es/,
-					loader: 'babel-loader',
-					options: {
-						babelrc: false,
-						plugins: [ path.join( __dirname, 'server', 'bundler', 'babel', 'babel-lodash-es' ) ],
-					},
-				},
-				SassConfig.loader( {
-					preserveCssCustomProperties: true,
-					includePaths: [ path.join( __dirname, 'client' ) ],
-					prelude: `@import '${ path.join(
-						__dirname,
-						'assets/stylesheets/shared/_utils.scss'
-					) }';`,
-				} ),
-				{
-					include: path.join( __dirname, 'client/sections.js' ),
-					loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),
-					options: {
-						include: process.env.SECTION_LIMIT ? process.env.SECTION_LIMIT.split( ',' ) : null,
-					},
-				},
-				{
-					test: /\.html$/,
-					loader: 'html-loader',
-				},
-				FileConfig.loader(),
-				{
-					include: require.resolve( 'tinymce/tinymce' ),
-					use: 'exports-loader?window=tinymce',
-				},
-				{
-					test: /node_modules[/\\]tinymce/,
-					use: 'imports-loader?this=>window',
-				},
-			],
-		},
-		resolve: {
-			extensions: [ '.json', '.js', '.jsx' ],
-			modules: [ path.join( __dirname, 'client' ), 'node_modules' ],
-			alias: Object.assign(
-				{
-					'gridicons/example': 'gridicons/dist/example',
-					'react-virtualized': 'react-virtualized/dist/es',
-					'social-logos/example': 'social-logos/build/example',
-					debug: path.resolve( __dirname, 'node_modules/debug' ),
-					store: 'store/dist/store.modern',
-					gridicons$: path.resolve( __dirname, 'client/components/async-gridicons' ),
-				},
-				getAliasesForExtensions( {
-					extensionsDirectory: path.join( __dirname, 'client', 'extensions' ),
-				} )
-			),
-		},
-		node: false,
-		plugins: _.compact( [
-			! codeSplit && new webpack.optimize.LimitChunkCountPlugin( { maxChunks: 1 } ),
-			new webpack.DefinePlugin( {
-				'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
-				PROJECT_NAME: JSON.stringify( config( 'project' ) ),
-				global: 'window',
-			} ),
-			new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
-			isCalypsoClient && new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
-			...SassConfig.plugins( {
-				chunkFilename: cssChunkFilename,
-				filename: cssFilename,
-				minify: ! isDevelopment,
-			} ),
-			isCalypsoClient &&
-				new AssetsWriter( {
-					filename:
-						browserslistEnv === 'defaults'
-							? 'assets-fallback.json'
-							: `assets-${ browserslistEnv }.json`,
-					path: path.join( __dirname, 'server', 'bundler' ),
-					assetExtraPath: extraPath,
-				} ),
-			new DuplicatePackageCheckerPlugin(),
-			shouldCheckForCycles &&
-				new CircularDependencyPlugin( {
-					exclude: /node_modules/,
-					failOnError: false,
-					allowAsyncCycles: false,
-					cwd: process.cwd(),
-				} ),
-			shouldEmitStats &&
-				new BundleAnalyzerPlugin( {
-					analyzerMode: 'disabled', // just write the stats.json file
-					generateStatsFile: true,
-					statsFilename: path.join( __dirname, 'stats.json' ),
-					statsOptions: {
-						source: false,
-						reasons: shouldEmitStatsWithReasons,
-						optimizationBailout: false,
-						chunkOrigins: false,
-						chunkGroups: true,
-					},
-				} ),
-			shouldEmitStats && new webpack.ProgressPlugin( createProgressHandler() ),
-			new MomentTimezoneDataPlugin( {
-				startYear: 2000,
-			} ),
-		] ),
-		externals: [ 'electron' ],
-	};
-
-	if ( isDevelopment ) {
-		webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
-		webpackConfig.entry.build.unshift( 'webpack-hot-middleware/client' );
-	}
-
-	if ( ! config.isEnabled( 'desktop' ) ) {
-		webpackConfig.plugins.push(
-			new webpack.NormalModuleReplacementPlugin( /^lib[/\\]desktop$/, 'lodash/noop' )
-		);
-	}
-
-	return webpackConfig;
+// we should not use chunkhash in development: https://github.com/webpack/webpack-dev-server/issues/377#issuecomment-241258405
+// also we don't minify so dont name them .min.js
+//
+// Desktop: no chunks or dll here, just one big file for the desktop app
+if ( isDevelopment || calypsoEnv === 'desktop' ) {
+	outputFilename = '[name].js';
+	outputChunkFilename = '[name].js';
 }
 
-module.exports = getWebpackConfig;
+const cssFilename = cssNameFromFilename( outputFilename );
+const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
+
+const webpackConfig = {
+	bail: ! isDevelopment,
+	context: __dirname,
+	entry: {
+		build: [ path.join( __dirname, 'client', 'boot', 'app' ) ],
+		domainsLanding: [ path.join( __dirname, 'client', 'landing', 'domains' ) ],
+	},
+	mode: isDevelopment ? 'development' : 'production',
+	devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
+	output: {
+		path: path.join( __dirname, 'public', extraPath ),
+		pathinfo: false,
+		publicPath: `/calypso/${ extraPath }/`,
+		filename: outputFilename,
+		chunkFilename: outputChunkFilename,
+		devtoolModuleFilenameTemplate: 'app:///[resource-path]',
+	},
+	optimization: {
+		splitChunks: {
+			chunks: codeSplit ? 'all' : 'async',
+			name: isDevelopment || shouldEmitStats,
+			maxAsyncRequests: 20,
+			maxInitialRequests: 5,
+		},
+		runtimeChunk: codeSplit ? { name: 'manifest' } : false,
+		moduleIds: 'named',
+		chunkIds: isDevelopment || shouldEmitStats ? 'named' : 'natural',
+		minimize: shouldMinify,
+		minimizer: Minify( {
+			cache: process.env.CIRCLECI
+				? `${ process.env.HOME }/terser-cache/${ extraPath }`
+				: 'docker' !== process.env.CONTAINER,
+			parallel: workerCount,
+			sourceMap: Boolean( process.env.SOURCEMAP ),
+			terserOptions: {
+				mangle: calypsoEnv !== 'desktop',
+			},
+		} ),
+	},
+	module: {
+		noParse: /[/\\]node_modules[/\\]localforage[/\\]dist[/\\]localforage\.js$/,
+		rules: [
+			TranspileConfig.loader( {
+				workerCount,
+				configFile: path.join( __dirname, 'babel.config.js' ),
+				cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache', extraPath ),
+				cacheIdentifier,
+				exclude: /node_modules\//,
+			} ),
+			TranspileConfig.loader( {
+				workerCount,
+				configFile: path.resolve( __dirname, 'babel.dependencies.config.js' ),
+				cacheDirectory: path.join( __dirname, 'build', '.babel-client-cache', extraPath ),
+				cacheIdentifier,
+				include: shouldTranspileDependency,
+			} ),
+			{
+				test: /node_modules[/\\](redux-form|react-redux)[/\\]es/,
+				loader: 'babel-loader',
+				options: {
+					babelrc: false,
+					plugins: [ path.join( __dirname, 'server', 'bundler', 'babel', 'babel-lodash-es' ) ],
+				},
+			},
+			SassConfig.loader( {
+				preserveCssCustomProperties: true,
+				includePaths: [ path.join( __dirname, 'client' ) ],
+				prelude: `@import '${ path.join( __dirname, 'assets/stylesheets/shared/_utils.scss' ) }';`,
+			} ),
+			{
+				include: path.join( __dirname, 'client/sections.js' ),
+				loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),
+				options: {
+					include: process.env.SECTION_LIMIT ? process.env.SECTION_LIMIT.split( ',' ) : null,
+				},
+			},
+			{
+				test: /\.html$/,
+				loader: 'html-loader',
+			},
+			FileConfig.loader(),
+			{
+				include: require.resolve( 'tinymce/tinymce' ),
+				use: 'exports-loader?window=tinymce',
+			},
+			{
+				test: /node_modules[/\\]tinymce/,
+				use: 'imports-loader?this=>window',
+			},
+		],
+	},
+	resolve: {
+		extensions: [ '.json', '.js', '.jsx' ],
+		modules: [ path.join( __dirname, 'client' ), 'node_modules' ],
+		alias: Object.assign(
+			{
+				'gridicons/example': 'gridicons/dist/example',
+				'react-virtualized': 'react-virtualized/dist/es',
+				'social-logos/example': 'social-logos/build/example',
+				debug: path.resolve( __dirname, 'node_modules/debug' ),
+				store: 'store/dist/store.modern',
+				gridicons$: path.resolve( __dirname, 'client/components/async-gridicons' ),
+			},
+			getAliasesForExtensions( {
+				extensionsDirectory: path.join( __dirname, 'client', 'extensions' ),
+			} )
+		),
+	},
+	node: false,
+	plugins: _.compact( [
+		! codeSplit && new webpack.optimize.LimitChunkCountPlugin( { maxChunks: 1 } ),
+		new webpack.DefinePlugin( {
+			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
+			PROJECT_NAME: JSON.stringify( config( 'project' ) ),
+			global: 'window',
+		} ),
+		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),
+		isCalypsoClient && new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),
+		...SassConfig.plugins( {
+			chunkFilename: cssChunkFilename,
+			filename: cssFilename,
+			minify: ! isDevelopment,
+		} ),
+		isCalypsoClient &&
+			new AssetsWriter( {
+				filename:
+					browserslistEnv === 'defaults'
+						? 'assets-fallback.json'
+						: `assets-${ browserslistEnv }.json`,
+				path: path.join( __dirname, 'server', 'bundler' ),
+				assetExtraPath: extraPath,
+			} ),
+		new DuplicatePackageCheckerPlugin(),
+		shouldCheckForCycles &&
+			new CircularDependencyPlugin( {
+				exclude: /node_modules/,
+				failOnError: false,
+				allowAsyncCycles: false,
+				cwd: process.cwd(),
+			} ),
+		shouldEmitStats &&
+			new BundleAnalyzerPlugin( {
+				analyzerMode: 'disabled', // just write the stats.json file
+				generateStatsFile: true,
+				statsFilename: path.join( __dirname, 'stats.json' ),
+				statsOptions: {
+					source: false,
+					reasons: shouldEmitStatsWithReasons,
+					optimizationBailout: false,
+					chunkOrigins: false,
+					chunkGroups: true,
+				},
+			} ),
+		shouldEmitStats && new webpack.ProgressPlugin( createProgressHandler() ),
+		new MomentTimezoneDataPlugin( {
+			startYear: 2000,
+		} ),
+	] ),
+	externals: [ 'electron' ],
+};
+
+if ( isDevelopment ) {
+	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
+	webpackConfig.entry.build.unshift( 'webpack-hot-middleware/client' );
+}
+
+if ( ! config.isEnabled( 'desktop' ) ) {
+	webpackConfig.plugins.push(
+		new webpack.NormalModuleReplacementPlugin( /^lib[/\\]desktop$/, 'lodash/noop' )
+	);
+}
+
+module.exports = webpackConfig;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Now that the app's Wepback config is no longer an entry point for non-Calypso packages and/or apps, let's remove its args, use their default values, and turn it back into an object again. This also allows us to remove the app's `@automattic/wordpress-external-dependencies-plugin` dependency, since the latter is not used by it (only by `calypso-build` built packages).

#### Testing instructions

Verify that Calypso still builds and runs.
