### PR TITLE
Domains: Add type=submit for Site Redirect Go button

### DIFF
--- a/client/my-sites/domains/domain-search/site-redirect-step.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect-step.jsx
@@ -64,7 +64,12 @@ class SiteRedirectStep extends React.Component {
 							onChange={ this.setSearchQuery }
 							onClick={ this.recordInputFocus }
 						/>
-						<Button primary className="site-redirect-step__go" onClick={ this.recordGoButtonClick }>
+						<Button
+							primary
+							className="site-redirect-step__go"
+							type="submit"
+							onClick={ this.recordGoButtonClick }
+						>
 							{ translate( 'Go', {
 								context: 'Upgrades: Label for adding Site Redirect',
 							} ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds `type="submit"` to the `<Button>` component within the `<form>` element. Prior to this change, could only submit the redirect domain via hitting Enter in the text input field.

#### Testing instructions

1. Starting at URL: https://wordpress.com/domains/add/site-redirect/SITE_URL
2. Type a registered domain, not mapped to the same site, in the domain field.
3. Click Go button to observe the site redirect added to cart (or rejected if a redirect is already in cart).

---
#user-report 10981396-hc
Fixes #32346

cc @jsnajdr Having my hand at my first PR 😉Your feedback & help would be much appreciated!
