### PR TITLE
Stylelint: lint all the scss files, not just ones under `/client/**`

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,7 +244,7 @@
 		"postinstall": "npm run build-packages",
 		"lint": "run-s -s lint:*",
 		"lint:config-defaults": "node server/config/validate-config-keys.js",
-		"lint:css": "stylelint \"client/**/*.scss\" --syntax scss",
+		"lint:css": "stylelint \"**/*.scss\" --syntax scss",
 		"lint:js": "npm run -s install-if-deps-outdated && eslint --ext .js --ext .jsx --ext .ts --ext .tsx --cache .",
 		"lint:mixedindent": "mixedindentlint --ignore-comments \"client/**/*.scss\" \"assets/**/*.scss\" \"**/*.js\" \"**/*.jsx\" \"**/*.tsx\" \"**/*.tsx\" \"!build/**\" \"!node_modules/**\" \"!public/**\" \"!client/config/index.js\"",
 		"prestart": "npx check-node-version --package && npm run -s install-if-deps-outdated && node bin/welcome.js",


### PR DESCRIPTION
Since we have scss files under `/packages`, `/apps`, `/assets/stylesheets`... it makes sense to lint 'em all. For example: [`packages/muriel-style/typography.scss`](https://github.com/Automattic/wp-calypso/blob/073abff711bceecb9d39be709b78d8ed60a2e72c/packages/muriel-style/typography.scss)

Stylelint itself [ignores `node_modules` already](https://stylelint.io/user-guide/configuration/#ignorefiles) by default.

#### Changes proposed in this Pull Request

* Apply stylelint to all scss files, not just to ones under `client/**`

#### Testing instructions

Run `npm run lint:css` — you should see only one extra file throwing warnings