### PR TITLE
Package i18n: Add typescript parsing

### DIFF
--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -1,3 +1,10 @@
+4.0.0
+------
+
+* Add TypeScript handling.
+* Add useTranslate hook.
+* Remove moment-timezone dependency.
+
 3.0.0
 ------
 

--- a/packages/i18n-calypso/cli/i18n.js
+++ b/packages/i18n-calypso/cli/i18n.js
@@ -43,6 +43,7 @@ module.exports = function i18nCalypso( config ) {
 				'jsx',
 				'objectRestSpread',
 				'trailingFunctionCommas',
+				'typescript',
 			],
 			allowImportExportEverywhere: true,
 		},

--- a/packages/i18n-calypso/cli/test/examples/i18n-test-examples.ts
+++ b/packages/i18n-calypso/cli/test/examples/i18n-test-examples.ts
@@ -1,0 +1,105 @@
+// This file is just an example of different translation requests that will be parsed as part of the test. This file itself doesn't need to actually work. :-)
+/*eslint-disable */
+function test( unused: any ): any {
+	// simplest case... just a translation, no special options
+	var content = i18n.translate( 'My hat has three corners.' );
+
+	// or it could also be called like this
+	content = i18n.translate( { original: 'My hat has three corners too.' } );
+
+	// pluralization
+	var numHats = howManyHats(); // returns integer
+	content = i18n.translate( {
+		original: {
+			single: 'My hat has four corners.',
+			plural: 'My hats have five corners.',
+			count: numHats,
+		},
+	} );
+
+	// Should be merged in POT with the pluralized form
+	content = i18n.translate( { original: 'My hat has four corners.' } );
+
+	// Should catch template literals
+	content = i18n.translate( `My hat has six corners.` );
+	content = i18n.translate( `My hat
+has seventeen
+corners.` );
+
+	// providing context
+	content = i18n.translate( {
+		original: 'post',
+		context: 'verb',
+	} );
+
+	// passing string as initial argument
+	content = i18n.translate( 'post2', { context: 'verb2' } );
+
+	// add a comment to the translator
+	content = i18n.translate( {
+		original: 'g:i:s a',
+		comment: 'draft saved date format, see http://php.net/date',
+	} );
+
+	// sprintf-style string substitution
+	// NOTE: You can also pass args as an array,
+	// although named arguments are more explicit and encouraged
+	// See http://www.diveintojavascript.com/projects/javascript-sprintf
+	var city = getCity(), // returns string
+		zip = getZip(); // returns string
+
+	content = i18n.translate( {
+		original: 'Your city is %(city)s and your zip is %(zip)s.',
+		args: {
+			city,
+			zip,
+		},
+	} );
+
+	// test the new syntax for translating plurals
+	content = i18n.translate( 'single test', 'plural test', { count: 1 } );
+
+	// count should accept a variable placeholder
+	var varCount = 1;
+	content = i18n.translate( 'single test2', 'plural test2', { count: varCount } );
+
+	// test the ability to break strings to multiple lines
+	// prettier-ignore
+	content = React.createElement( 'div', {}, i18n.translate(
+		"This is a multi-line translation with \"mixed quotes\" " +
+		'and mixed \'single quotes\''
+	) );
+
+	content = this.translate( 'The string key text', {
+		context: 'context with a literal string key',
+	} );
+
+	i18n.translate( 'My hat has three corners.', {
+		comment: 'Second ocurrence',
+	} );
+
+	i18n.translate( 'My hat has one corner.', 'My hat has many corners.', {
+		context: 'context after new plural syntax',
+		count: 5,
+	} );
+	i18n.translate( 'This is how the test performed\u2026' );
+
+	i18n.translate(
+		"It's been %(timeLapsed)s since {{href}}{{postTitle/}}{{/href}} was published. Here's how the post has performed so far\u2026",
+		{
+			args: {
+				timeLapsed: postTime.fromNow( true ),
+			},
+			components: {
+				href: React.createElement( 'a', {
+					href: post.URL,
+					target: '_blank',
+					rel: 'noopener noreferrer',
+				} ),
+				postTitle: React.createElement( Emojify, {}, postTitle ),
+			},
+			context:
+				'Stats: Sentence showing how much time has passed since the last post, and how the stats are',
+		}
+	);
+}

--- a/packages/i18n-calypso/cli/test/examples/i18n-test-examples.tsx
+++ b/packages/i18n-calypso/cli/test/examples/i18n-test-examples.tsx
@@ -1,6 +1,6 @@
 // This file is just an example of different translation requests that will be parsed as part of the test. This file itself doesn't need to actually work. :-)
 /*eslint-disable */
-function test() {
+function test( unused: any ): any {
 	// simplest case... just a translation, no special options
 	var content = i18n.translate( 'My hat has three corners.' );
 

--- a/packages/i18n-calypso/cli/test/examples/i18n-test-examples.tsx
+++ b/packages/i18n-calypso/cli/test/examples/i18n-test-examples.tsx
@@ -1,0 +1,101 @@
+// This file is just an example of different translation requests that will be parsed as part of the test. This file itself doesn't need to actually work. :-)
+/*eslint-disable */
+function test() {
+	// simplest case... just a translation, no special options
+	var content = i18n.translate( 'My hat has three corners.' );
+
+	// or it could also be called like this
+	content = i18n.translate( { original: 'My hat has three corners too.' } );
+
+	// pluralization
+	var numHats = howManyHats(); // returns integer
+	content = i18n.translate( {
+		original: {
+			single: 'My hat has four corners.',
+			plural: 'My hats have five corners.',
+			count: numHats,
+		},
+	} );
+
+	// Should be merged in POT with the pluralized form
+	content = i18n.translate( { original: 'My hat has four corners.' } );
+
+	// Should catch template literals
+	content = i18n.translate( `My hat has six corners.` );
+	content = i18n.translate( `My hat
+has seventeen
+corners.` );
+
+	// providing context
+	content = i18n.translate( {
+		original: 'post',
+		context: 'verb',
+	} );
+
+	// passing string as initial argument
+	content = i18n.translate( 'post2', { context: 'verb2' } );
+
+	// add a comment to the translator
+	content = i18n.translate( {
+		original: 'g:i:s a',
+		comment: 'draft saved date format, see http://php.net/date',
+	} );
+
+	// sprintf-style string substitution
+	// NOTE: You can also pass args as an array,
+	// although named arguments are more explicit and encouraged
+	// See http://www.diveintojavascript.com/projects/javascript-sprintf
+	var city = getCity(), // returns string
+		zip = getZip(); // returns string
+
+	content = i18n.translate( {
+		original: 'Your city is %(city)s and your zip is %(zip)s.',
+		args: {
+			city,
+			zip,
+		},
+	} );
+
+	// test the new syntax for translating plurals
+	content = i18n.translate( 'single test', 'plural test', { count: 1 } );
+
+	// count should accept a variable placeholder
+	var varCount = 1;
+	content = i18n.translate( 'single test2', 'plural test2', { count: varCount } );
+
+	// test the ability to break strings to multiple lines
+	// prettier-ignore
+	content = <div>{ i18n.translate(
+		"This is a multi-line translation with \"mixed quotes\" " +
+		'and mixed \'single quotes\''
+	) }</div>;
+
+	content = this.translate( 'The string key text', {
+		context: 'context with a literal string key',
+	} );
+
+	i18n.translate( 'My hat has three corners.', {
+		comment: 'Second ocurrence',
+	} );
+
+	i18n.translate( 'My hat has one corner.', 'My hat has many corners.', {
+		context: 'context after new plural syntax',
+		count: 5,
+	} );
+	i18n.translate( 'This is how the test performed\u2026' );
+
+	i18n.translate(
+		"It's been %(timeLapsed)s since {{href}}{{postTitle/}}{{/href}} was published. Here's how the post has performed so far\u2026",
+		{
+			args: {
+				timeLapsed: postTime.fromNow( true ),
+			},
+			components: {
+				href: <a href={ post.URL } target="_blank" rel="noopener noreferrer" />,
+				postTitle: <Emojify>{ postTitle }</Emojify>,
+			},
+			context:
+				'Stats: Sentence showing how much time has passed since the last post, and how the stats are',
+		}
+	);
+}

--- a/packages/i18n-calypso/cli/test/i18n.js
+++ b/packages/i18n-calypso/cli/test/i18n.js
@@ -11,8 +11,10 @@ const i18nCalypsoCLI = require( '../i18n' );
 
 // generate whitelist file
 const sourceFiles = [
-	'examples/i18n-test-examples.jsx',
 	'examples/i18n-test-example-second-file.jsx',
+	'examples/i18n-test-examples.ts',
+	'examples/i18n-test-examples.tsx',
+	'examples/i18n-test-examples.jsx',
 ].map( file => path.join( __dirname, file ) );
 
 /**
@@ -99,7 +101,7 @@ describe( 'POT', () => {
 	test( 'should combine strings', () => {
 		expect( output ).toEqual(
 			expect.stringMatching(
-				/#: test\/examples\/i18n-test-examples.jsx:\d+\n#: test\/examples\/i18n-test-examples.jsx:\d+\n#. Second ocurrence\nmsgid "My hat has three corners."/
+				/(?:#: test\/examples\/i18n-test-examples.[jt]sx?:\d+\n)+#. Second ocurrence\nmsgid "My hat has three corners."/
 			)
 		);
 	} );

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "4.0.0-alpha.1",
+	"version": "4.0.0-alpha.2",
 	"description": "i18n JavaScript library on top of Jed originally used in Calypso",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
Add TypeScript parsing and tests to i18n-calypso
Bump alpha version
Add changelog

The new tests are mostly copy/paste of existing tests. They did allow me to verify that the simple change in c49a174 allows TypeScript to be handled correctly.

c49a174 cherry-picked from #31902 

This should unblock https://github.com/Automattic/gp-localci-client/pull/16

#### Testing instructions

* Tests pass?
* i18n continues to work as expected in circleci?