### PR TITLE
Improve async loading of signup steps

### DIFF
--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -1,181 +1,76 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
+import { memoize } from 'lodash';
 
-/**
- * Internal dependencies
- */
-import AsyncLoad from 'components/async-load';
-
-const AboutStepComponent = props => (
-	<AsyncLoad require="signup/steps/about" placeholder={ null } { ...props } />
-);
-const CloneStartComponent = props => (
-	<AsyncLoad require="signup/steps/clone-start" placeholder={ null } { ...props } />
-);
-const CloneDestinationComponent = props => (
-	<AsyncLoad require="signup/steps/clone-destination" placeholder={ null } { ...props } />
-);
-const CloneCredentialsComponent = props => (
-	<AsyncLoad require="signup/steps/clone-credentials" placeholder={ null } { ...props } />
-);
-const ClonePointComponent = props => (
-	<AsyncLoad require="signup/steps/clone-point" placeholder={ null } { ...props } />
-);
-const CloneJetpackComponent = props => (
-	<AsyncLoad require="signup/steps/clone-jetpack" placeholder={ null } { ...props } />
-);
-const CloneReadyComponent = props => (
-	<AsyncLoad require="signup/steps/clone-ready" placeholder={ null } { ...props } />
-);
-const CloneCloningComponent = props => (
-	<AsyncLoad require="signup/steps/clone-cloning" placeholder={ null } { ...props } />
-);
-const CredsConfirmComponent = props => (
-	<AsyncLoad require="signup/steps/creds-confirm" placeholder={ null } { ...props } />
-);
-const CredsCompleteComponent = props => (
-	<AsyncLoad require="signup/steps/creds-complete" placeholder={ null } { ...props } />
-);
-const CredsPermissionComponent = props => (
-	<AsyncLoad require="signup/steps/creds-permission" placeholder={ null } { ...props } />
-);
-const DomainsStepComponent = props => (
-	<AsyncLoad require="signup/steps/domains" placeholder={ null } { ...props } />
-);
-const ImportURLStepComponent = props => (
-	<AsyncLoad require="signup/steps/import-url" placeholder={ null } { ...props } />
-);
-const PlansStepComponent = props => (
-	<AsyncLoad require="signup/steps/plans" placeholder={ null } { ...props } />
-);
-const SiteComponent = props => (
-	<AsyncLoad require="signup/steps/site" placeholder={ null } { ...props } />
-);
-const RebrandCitiesWelcomeComponent = props => (
-	<AsyncLoad require="signup/steps/rebrand-cities-welcome" placeholder={ null } { ...props } />
-);
-const RewindMigrate = props => (
-	<AsyncLoad require="signup/steps/rewind-migrate" placeholder={ null } { ...props } />
-);
-const RewindWereBacking = props => (
-	<AsyncLoad require="signup/steps/rewind-were-backing" placeholder={ null } { ...props } />
-);
-const RewindAddCreds = props => (
-	<AsyncLoad require="signup/steps/rewind-add-creds" placeholder={ null } { ...props } />
-);
-const RewindFormCreds = props => (
-	<AsyncLoad require="signup/steps/rewind-form-creds" placeholder={ null } { ...props } />
-);
-const SiteOrDomainComponent = props => (
-	<AsyncLoad require="signup/steps/site-or-domain" placeholder={ null } { ...props } />
-);
-const SitePicker = props => (
-	<AsyncLoad require="signup/steps/site-picker" placeholder={ null } { ...props } />
-);
-const SiteTitleComponent = props => (
-	<AsyncLoad require="signup/steps/site-title" placeholder={ null } { ...props } />
-);
-const SiteStyleComponent = props => (
-	<AsyncLoad require="signup/steps/site-style" placeholder={ null } { ...props } />
-);
-const SiteTopicComponent = props => (
-	<AsyncLoad require="signup/steps/site-topic" placeholder={ null } { ...props } />
-);
-const SiteTypeComponent = props => (
-	<AsyncLoad require="signup/steps/site-type" placeholder={ null } { ...props } />
-);
-const SiteInformationComponent = props => (
-	<AsyncLoad require="signup/steps/site-information" placeholder={ null } { ...props } />
-);
-const SurveyStepComponent = props => (
-	<AsyncLoad require="signup/steps/survey" placeholder={ null } { ...props } />
-);
-const ThemeSelectionComponent = props => (
-	<AsyncLoad require="signup/steps/theme-selection" placeholder={ null } { ...props } />
-);
-const UserSignupComponent = props => (
-	<AsyncLoad require="signup/steps/user" placeholder={ null } { ...props } />
-);
-const PlansStepWithoutFreePlan = props => (
-	<AsyncLoad require="signup/steps/plans-without-free" placeholder={ null } { ...props } />
-);
-const PlansAtomicStoreComponent = props => (
-	<AsyncLoad require="signup/steps/plans-atomic-store" placeholder={ null } { ...props } />
-);
-const ReaderLandingStepComponent = props => (
-	<AsyncLoad require="signup/steps/reader-landing" placeholder={ null } { ...props } />
-);
-const LaunchSiteComponent = props => (
-	<AsyncLoad require="signup/steps/launch-site" placeholder={ null } { ...props } />
+const loadStep = memoize( stepName =>
+	React.lazy( () =>
+		import( /* webpackChunkName: "async-load-signup-steps-[request]", webpackInclude: /signup\/steps\/[a-z-]+\/index.jsx$/ */ `signup/steps/${ stepName }` )
+	)
 );
 
 export default {
-	about: AboutStepComponent,
-	'clone-start': CloneStartComponent,
-	'clone-destination': CloneDestinationComponent,
-	'clone-credentials': CloneCredentialsComponent,
-	'clone-point': ClonePointComponent,
-	'clone-jetpack': CloneJetpackComponent,
-	'clone-ready': CloneReadyComponent,
-	'clone-cloning': CloneCloningComponent,
-	'creds-confirm': CredsConfirmComponent,
-	'creds-complete': CredsCompleteComponent,
-	'creds-permission': CredsPermissionComponent,
-	domains: DomainsStepComponent,
-	'domains-store': DomainsStepComponent,
-	'domain-only': DomainsStepComponent,
-	'domains-theme-preselected': DomainsStepComponent,
-	'domains-launch': DomainsStepComponent,
-	'from-url': ImportURLStepComponent,
-	launch: LaunchSiteComponent,
-	plans: PlansStepComponent,
-	'plans-launch': PlansStepComponent,
-	'plans-personal': PlansStepComponent,
-	'plans-premium': PlansStepComponent,
-	'plans-business': PlansStepComponent,
-	'plans-store-nux': PlansAtomicStoreComponent,
-	'plans-site-selected': PlansStepWithoutFreePlan,
-	site: SiteComponent,
-	'rebrand-cities-welcome': RebrandCitiesWelcomeComponent,
-	'rewind-migrate': RewindMigrate,
-	'rewind-were-backing': RewindWereBacking,
-	'rewind-add-creds': RewindAddCreds,
-	'rewind-form-creds': RewindFormCreds,
-	'site-information': SiteInformationComponent,
-	'site-information-without-domains': SiteInformationComponent,
-	'site-information-title': SiteInformationComponent,
-	'site-information-address': SiteInformationComponent,
-	'site-information-phone': SiteInformationComponent,
-	'site-or-domain': SiteOrDomainComponent,
-	'site-picker': SitePicker,
-	'site-style': SiteStyleComponent,
-	'site-title': SiteTitleComponent,
-	'site-topic': SiteTopicComponent,
-	'site-type': SiteTypeComponent,
-	survey: SurveyStepComponent,
-	'survey-user': UserSignupComponent,
-	test:
-		process.env.NODE_ENV === 'development'
-			? require( 'signup/steps/test-step' ).default
-			: undefined,
-	themes: ThemeSelectionComponent,
-	'website-themes': ThemeSelectionComponent,
-	'blog-themes': ThemeSelectionComponent,
-	'themes-site-selected': ThemeSelectionComponent,
-	user: UserSignupComponent,
-	'oauth2-user': UserSignupComponent,
-	'oauth2-name': UserSignupComponent,
-	displayname: UserSignupComponent,
-	'reader-landing': ReaderLandingStepComponent,
+	about: loadStep( 'about' ),
+	'clone-start': loadStep( 'clone-start' ),
+	'clone-destination': loadStep( 'clone-destination' ),
+	'clone-credentials': loadStep( 'clone-credentials' ),
+	'clone-point': loadStep( 'clone-point' ),
+	'clone-jetpack': loadStep( 'clone-jetpack' ),
+	'clone-ready': loadStep( 'clone-ready' ),
+	'clone-cloning': loadStep( 'clone-cloning' ),
+	'creds-confirm': loadStep( 'creds-confirm' ),
+	'creds-complete': loadStep( 'creds-complete' ),
+	'creds-permission': loadStep( 'creds-permission' ),
+	domains: loadStep( 'domains' ),
+	'domains-store': loadStep( 'domains' ),
+	'domain-only': loadStep( 'domain' ),
+	'domains-theme-preselected': loadStep( 'domains' ),
+	'domains-launch': loadStep( 'domains' ),
+	'from-url': loadStep( 'import-url' ),
+	launch: loadStep( 'launch-site' ),
+	plans: loadStep( 'plans' ),
+	'plans-launch': loadStep( 'plans' ),
+	'plans-personal': loadStep( 'plans' ),
+	'plans-premium': loadStep( 'plans' ),
+	'plans-business': loadStep( 'plans' ),
+	'plans-store-nux': loadStep( 'plans-atomic-store' ),
+	'plans-site-selected': loadStep( 'plans-without-free' ),
+	site: loadStep( 'site' ),
+	'rebrand-cities-welcome': loadStep( 'rebrand-cities-welcome' ),
+	'rewind-migrate': loadStep( 'rewind-migrate' ),
+	'rewind-were-backing': loadStep( 'rewind-were-backing' ),
+	'rewind-add-creds': loadStep( 'rewind-add-creds' ),
+	'rewind-form-creds': loadStep( 'rewind-form-creds' ),
+	'site-information': loadStep( 'site-information' ),
+	'site-information-without-domains': loadStep( 'site-information' ),
+	'site-information-title': loadStep( 'site-information' ),
+	'site-information-address': loadStep( 'site-information' ),
+	'site-information-phone': loadStep( 'site-information' ),
+	'site-or-domain': loadStep( 'site-or-domain' ),
+	'site-picker': loadStep( 'site-picker' ),
+	'site-style': loadStep( 'site-style' ),
+	'site-title': loadStep( 'site-title' ),
+	'site-topic': loadStep( 'site-topic' ),
+	'site-type': loadStep( 'site-type' ),
+	survey: loadStep( 'survey' ),
+	'survey-user': loadStep( 'survey-user' ),
+	test: loadStep( 'test-step' ),
+	themes: 'theme-selection',
+	'website-themes': loadStep( 'theme-selection' ),
+	'blog-themes': loadStep( 'theme-selection' ),
+	'themes-site-selected': loadStep( 'theme-selection' ),
+	user: loadStep( 'user' ),
+	'oauth2-user': loadStep( 'user' ),
+	'oauth2-name': loadStep( 'user' ),
+	displayname: loadStep( 'user' ),
+	'reader-landing': loadStep( 'reader-landing' ),
 	// Steps with preview
-	'site-style-with-preview': SiteStyleComponent,
-	'site-topic-with-preview': SiteTopicComponent,
-	'site-information-with-preview': SiteInformationComponent,
-	'site-information-title-with-preview': SiteInformationComponent,
-	'site-information-address-with-preview': SiteInformationComponent,
-	'site-information-phone-with-preview': SiteInformationComponent,
-	'domains-with-preview': DomainsStepComponent,
+	'site-style-with-preview': loadStep( 'site-style' ),
+	'site-topic-with-preview': loadStep( 'site-topic' ),
+	'site-information-with-preview': loadStep( 'site-information' ),
+	'site-information-title-with-preview': loadStep( 'site-information' ),
+	'site-information-address-with-preview': loadStep( 'site-information' ),
+	'site-information-phone-with-preview': loadStep( 'site-information' ),
+	'domains-with-preview': loadStep( 'domains' ),
 };

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -6,7 +6,9 @@ import { memoize } from 'lodash';
 
 const loadStep = memoize( stepName =>
 	React.lazy( () =>
-		import( /* webpackChunkName: "async-load-signup-steps-[request]", webpackInclude: /signup\/steps\/[a-z-]+\/index.jsx$/ */ `signup/steps/${ stepName }` )
+		import(
+			/* webpackChunkName: "async-load-signup-steps-[request]", webpackInclude: /signup\/steps\/[a-z-]+\/index.jsx$/ */ `signup/steps/${ stepName }`
+		)
 	)
 );
 
@@ -56,7 +58,7 @@ export default {
 	survey: loadStep( 'survey' ),
 	'survey-user': loadStep( 'survey-user' ),
 	test: loadStep( 'test-step' ),
-	themes: 'theme-selection',
+	themes: loadStep( 'theme-selection' ),
 	'website-themes': loadStep( 'theme-selection' ),
 	'blog-themes': loadStep( 'theme-selection' ),
 	'themes-site-selected': loadStep( 'theme-selection' ),

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -6,7 +6,7 @@ import cookie from 'cookie';
 import debugModule from 'debug';
 import page from 'page';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Suspense } from 'react';
 import {
 	assign,
 	defer,
@@ -564,24 +564,26 @@ class Signup extends React.Component {
 							flowSteps={ flow.steps }
 						/>
 					) : (
-						<CurrentComponent
-							path={ this.props.path }
-							step={ currentStepProgress }
-							initialContext={ this.props.initialContext }
-							steps={ flow.steps }
-							stepName={ this.props.stepName }
-							meta={ flow.meta || {} }
-							goToNextStep={ this.goToNextStep }
-							goToStep={ this.goToStep }
-							previousFlowName={ this.state.previousFlowName }
-							flowName={ this.props.flowName }
-							signupProgress={ this.props.progress }
-							signupDependencies={ this.props.signupDependencies }
-							stepSectionName={ this.props.stepSectionName }
-							positionInFlow={ this.getPositionInFlow() }
-							hideFreePlan={ hideFreePlan }
-							{ ...propsFromConfig }
-						/>
+						<Suspense fallback={ null }>
+							<CurrentComponent
+								path={ this.props.path }
+								step={ currentStepProgress }
+								initialContext={ this.props.initialContext }
+								steps={ flow.steps }
+								stepName={ this.props.stepName }
+								meta={ flow.meta || {} }
+								goToNextStep={ this.goToNextStep }
+								goToStep={ this.goToStep }
+								previousFlowName={ this.state.previousFlowName }
+								flowName={ this.props.flowName }
+								signupProgress={ this.props.progress }
+								signupDependencies={ this.props.signupDependencies }
+								stepSectionName={ this.props.stepSectionName }
+								positionInFlow={ this.getPositionInFlow() }
+								hideFreePlan={ hideFreePlan }
+								{ ...propsFromConfig }
+							/>
+						</Suspense>
 					) }
 				</div>
 			</div>


### PR DESCRIPTION
I tried to improve the work done in #32282 by introducing `React.lazy` and full dynamic webpack import of the signup steps. The code is less verbose now.

It's strange that the `signup` chunk got much bigger. I expected exactly the opposite 😕 