### PR TITLE
Use the unencoded URL

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -55,7 +55,7 @@ function getPostsDestination( dependencies ) {
 function getRedirectDestination( dependencies ) {
 	if (
 		dependencies.oauth2_redirect &&
-		dependencies.oauth2_redirect.match( /^https%3A%2F%2Fpublic-api.wordpress.com/i )
+		dependencies.oauth2_redirect.startsWith( 'https://public-api.wordpress.com' )
 	) {
 		return dependencies.oauth2_redirect;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This broke the WPCC flows

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open an incognito window
- Go to gravatar.com
- Click create your own Gravatar
- Be taken to wordpress.com/start
- Change https://wordpress.com ot http://calypso.localhost:3000
- Create an account
- Check you are redirected back to Gravatar.
