### PR TITLE
Theme Showcase: Add aria-label to CTA banner Close button. Fixes #32287

### DIFF
--- a/client/my-sites/themes/themes-banner/index.jsx
+++ b/client/my-sites/themes/themes-banner/index.jsx
@@ -91,7 +91,13 @@ class ThemesBanner extends PureComponent {
 				<Button className="themes-banner__cta" compact primary>
 					{ translate( 'See the theme' ) }
 				</Button>
-				<Button className="themes-banner__close" onClick={ this.handleBannerClose }>
+				<Button
+					className="themes-banner__close"
+					onClick={ this.handleBannerClose }
+					aria-label={ translate( 'Close', {
+						comment: 'Aria label to close the Theme banner',
+					} ) }
+				>
 					<Gridicon icon="cross-small" size={ 18 } />
 				</Button>
 				{ image && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an `aria-label` of "Close" to the CTA banner Close button

Before:

![before](https://user-images.githubusercontent.com/177929/56293911-eb3d7800-6121-11e9-85cf-c3b239c9a7d4.png)

After:

![after](https://user-images.githubusercontent.com/177929/56293928-f0022c00-6121-11e9-80ac-238730a604cc.png)

#### Testing instructions

1. Go to https://wordpress.com/themes
2. See the theme showcase banner
3. Inspect the source
4. The close button has a "Close" label

Fixes #32287
