### PR TITLE
Upgrade Prettier to 1.17.0

### DIFF
--- a/client/components/async-gridicons/index.jsx
+++ b/client/components/async-gridicons/index.jsx
@@ -13,8 +13,10 @@ import FallbackIcon from './fallback';
 const loadedIcons = new Map();
 
 function loadIcon( icon ) {
-	return import( /* webpackChunkName: "gridicons", webpackInclude: /\.js$/, webpackExclude: /dist\/(index\.js|example\.js)$/, webpackMode: "lazy-once" */
-	`gridicons/dist/${ icon }` ).then(
+	return import(
+		/* webpackChunkName: "gridicons", webpackInclude: /\.js$/, webpackExclude: /dist\/(index\.js|example\.js)$/, webpackMode: "lazy-once" */
+		`gridicons/dist/${ icon }`
+	).then(
 		g => {
 			loadedIcons.set( icon, g.default );
 			return g.default;

--- a/client/components/clipboard-button-input/index.jsx
+++ b/client/components/clipboard-button-input/index.jsx
@@ -29,12 +29,12 @@ function ClipboardButtonInput( { value = '', className, disabled, hideHttp, disp
 	const [ isCopied, setCopied ] = React.useState( false );
 
 	// toggle the `isCopied` flag back to `false` after 4 seconds
-	React.useEffect(() => {
+	React.useEffect( () => {
 		if ( isCopied ) {
 			const confirmationTimeout = setTimeout( () => setCopied( false ), 4000 );
 			return () => clearTimeout( confirmationTimeout );
 		}
-	}, [ isCopied ]);
+	}, [ isCopied ] );
 
 	const showConfirmation = () => {
 		setCopied( true );

--- a/client/components/data/query-gsuite-users/index.jsx
+++ b/client/components/data/query-gsuite-users/index.jsx
@@ -14,11 +14,11 @@ import isRequestingGSuiteUsers from 'state/selectors/is-requesting-gsuite-users'
 import { getGSuiteUsers } from 'state/gsuite-users/actions';
 
 const QueryGSuiteUsers = ( { siteId, request, isRequesting } ) => {
-	useEffect(() => {
+	useEffect( () => {
 		if ( ! isRequesting ) {
 			request( siteId );
 		}
-	}, [ siteId, request, isRequesting ]);
+	}, [ siteId, request, isRequesting ] );
 	return null;
 };
 

--- a/client/components/data/query-reader-tag/index.jsx
+++ b/client/components/data/query-reader-tag/index.jsx
@@ -13,9 +13,9 @@ import { connect } from 'react-redux';
 import { requestTags } from 'state/reader/tags/items/actions';
 
 const QueryReaderTag = ( { tag, requestTags: request } ) => {
-	useEffect(() => {
+	useEffect( () => {
 		request( tag );
-	}, [ request, tag ]);
+	}, [ request, tag ] );
 	return null;
 };
 

--- a/client/components/forms/clipboard-button/index.jsx
+++ b/client/components/forms/clipboard-button/index.jsx
@@ -23,19 +23,19 @@ function ClipboardButton( { className, text, onCopy = noop, ...rest } ) {
 	const successCallback = React.useRef();
 
 	// update the callbacks on rerenders that change `text` or `onCopy`
-	React.useEffect(() => {
+	React.useEffect( () => {
 		textCallback.current = () => text;
 		successCallback.current = onCopy;
-	}, [ text, onCopy ]);
+	}, [ text, onCopy ] );
 
 	// create the `Clipboard` object on mount and destroy on unmount
-	React.useEffect(() => {
+	React.useEffect( () => {
 		const buttonEl = ReactDom.findDOMNode( buttonRef.current );
 		const clipboard = new Clipboard( buttonEl, { text: () => textCallback.current() } );
 		clipboard.on( 'success', () => successCallback.current() );
 
 		return () => clipboard.destroy();
-	}, []);
+	}, [] );
 
 	return (
 		<Button

--- a/client/components/localized-moment/context.js
+++ b/client/components/localized-moment/context.js
@@ -36,7 +36,9 @@ class MomentProvider extends React.Component {
 			debug( 'Loading moment locale for %s', currentLocale );
 			try {
 				// expose the import load promise as instance property. Useful for tests that wait for it
-				this.loadingLocalePromise = import( /* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ currentLocale }` );
+				this.loadingLocalePromise = import(
+					/* webpackChunkName: "moment-locale-[request]", webpackInclude: /\.js$/ */ `moment/locale/${ currentLocale }`
+				);
 				await this.loadingLocalePromise;
 			} catch ( error ) {
 				debug( 'Failed to load moment locale for %s', currentLocale, error );

--- a/client/components/share-button/services.js
+++ b/client/components/share-button/services.js
@@ -44,5 +44,5 @@ export default {
 	linkedin,
 	tumblr,
 	pinterest,
-	telegram,	
+	telegram,
 };

--- a/client/layout/guided-tours/tours/site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/site-title-tour/index.js
@@ -23,9 +23,7 @@ import {
 import { SettingsButton } from '../button-labels';
 
 export const SiteTitleTour = makeTour(
-	<Tour
-		{...meta}
-	>
+	<Tour { ...meta }>
 		<Step name="init" placement="right" next="click-settings" style={ { animationDelay: '2s' } }>
 			{ ( { translate } ) => (
 				<Fragment>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -213,7 +213,7 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-  gsuiteDomainFlowOptions: {
+	gsuiteDomainFlowOptions: {
 		datestamp: '20190415',
 		variations: {
 			hideMonthlyPrice: 50,

--- a/client/lib/checkout/processor-specific.js
+++ b/client/lib/checkout/processor-specific.js
@@ -86,7 +86,7 @@ export function fullAddressFieldsRules() {
 			description: i18n.translate( 'Postal Code' ),
 			rules: [ 'required' ],
 		},
-	}
+	};
 }
 
 /**
@@ -99,22 +99,25 @@ export function ebanxFieldRules( country ) {
 	const ebanxFields = PAYMENT_PROCESSOR_COUNTRIES_FIELDS[ country ].fields || [];
 
 	return pick(
-		Object.assign( {
-			document: {
-				description: i18n.translate( 'Taxpayer Identification Number' ),
-				rules: [ 'validBrazilTaxId' ],
-			},
+		Object.assign(
+			{
+				document: {
+					description: i18n.translate( 'Taxpayer Identification Number' ),
+					rules: [ 'validBrazilTaxId' ],
+				},
 
-			'phone-number': {
-				description: i18n.translate( 'Phone Number' ),
-				rules: [ 'required' ],
-			},
+				'phone-number': {
+					description: i18n.translate( 'Phone Number' ),
+					rules: [ 'required' ],
+				},
 
-			'postal-code': {
-				description: i18n.translate( 'Postal Code' ),
-				rules: [ 'required' ],
+				'postal-code': {
+					description: i18n.translate( 'Postal Code' ),
+					rules: [ 'required' ],
+				},
 			},
-		}, fullAddressFieldsRules() ),
+			fullAddressFieldsRules()
+		),
 		ebanxFields
 	);
 }

--- a/client/lib/query-manager/paginated/test/index.js
+++ b/client/lib/query-manager/paginated/test/index.js
@@ -306,9 +306,9 @@ describe( 'PaginatedQueryManager', () => {
 		} );
 
 		test( 'should use the constructors DefaultQuery.number if query object does not specify it', () => {
-			const customizedManager = new class extends TestCustomQueryManager {
+			const customizedManager = new ( class extends TestCustomQueryManager {
 				static DefaultQuery = { number: 25 };
-			}().receive(
+			} )().receive(
 				[
 					{ ID: 144 },
 					{ ID: 152 },

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -437,11 +437,11 @@ describe( 'QueryManager', () => {
 		} );
 
 		test( 'should sort when extended using subclassed static compare', () => {
-			let sortingManager = new class extends QueryManager {
+			let sortingManager = new ( class extends QueryManager {
 				static compare( query, a, b ) {
 					return a.ID - b.ID;
 				}
-			}();
+			} )();
 			[ { ID: 4 }, { ID: 2 }, { ID: 3 } ].forEach(
 				item =>
 					( sortingManager = sortingManager.receive( item, {

--- a/client/lib/viewport/react.js
+++ b/client/lib/viewport/react.js
@@ -28,7 +28,7 @@ export function useBreakpoint( breakpoint ) {
 		breakpoint,
 	} ) );
 
-	useEffect(() => {
+	useEffect( () => {
 		function handleBreakpointChange( isActive ) {
 			setState( prevState => {
 				// Ensure we bail out without rendering if nothing changes, by preserving state.
@@ -42,7 +42,7 @@ export function useBreakpoint( breakpoint ) {
 		const unsubscribe = subscribeIsWithinBreakpoint( breakpoint, handleBreakpointChange );
 		// The unsubscribe function is the entire cleanup for the effect.
 		return unsubscribe;
-	}, [ breakpoint ]);
+	}, [ breakpoint ] );
 
 	return breakpoint === state.breakpoint ? state.isActive : isWithinBreakpoint( breakpoint );
 }

--- a/client/me/profile-links/index.jsx
+++ b/client/me/profile-links/index.jsx
@@ -174,17 +174,17 @@ class ProfileLinks extends React.Component {
 		return (
 			<Fragment>
 				<QueryProfileLinks />
-					<SectionHeader label={ this.props.translate( 'Profile Links' ) }>
-						<AddProfileLinksButtons
-							showingForm={ this.state.showingForm }
-							onShowAddOther={ this.showAddOther }
-							showPopoverMenu={ this.state.showPopoverMenu }
-							onShowAddWordPress={ this.showAddWordPress }
-							onShowPopoverMenu={ this.showPopoverMenu }
-							onClosePopoverMenu={ this.closePopoverMenu }
-						/>
-					</SectionHeader>
-					<Card>{ this.state.showingForm ? this.renderForm() : this.renderProfileLinks() }</Card>
+				<SectionHeader label={ this.props.translate( 'Profile Links' ) }>
+					<AddProfileLinksButtons
+						showingForm={ this.state.showingForm }
+						onShowAddOther={ this.showAddOther }
+						showPopoverMenu={ this.state.showPopoverMenu }
+						onShowAddWordPress={ this.showAddWordPress }
+						onShowPopoverMenu={ this.showPopoverMenu }
+						onClosePopoverMenu={ this.closePopoverMenu }
+					/>
+				</SectionHeader>
+				<Card>{ this.state.showingForm ? this.renderForm() : this.renderProfileLinks() }</Card>
 				<ListEnd />
 			</Fragment>
 		);

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -38,11 +38,11 @@ export const GSuitePurchaseCta = ( {
 	recordTracksEvent: recordEvent,
 	selectedSiteSlug,
 } ) => {
-	useEffect(() => {
+	useEffect( () => {
 		recordEvent( 'calypso_email_gsuite_purchase_cta_view', {
 			domain_name: domainName,
 		} );
-	}, [ domainName ]);
+	}, [ domainName ] );
 
 	const goToAddGSuiteUsers = planType => {
 		recordEvent( 'calypso_email_gsuite_purchase_cta_get_gsuite_click', {

--- a/client/my-sites/importer/importer-godaddy-gocentral.jsx
+++ b/client/my-sites/importer/importer-godaddy-gocentral.jsx
@@ -19,7 +19,9 @@ class ImporterGoDaddyGoCentral extends React.PureComponent {
 	importerData = {
 		title: 'GoDaddy',
 		icon: 'godaddy-gocentral',
-		description: this.props.translate( 'Import posts, pages, and media from sites made with the GoDaddy GoCentral website builder.' ),
+		description: this.props.translate(
+			'Import posts, pages, and media from sites made with the GoDaddy GoCentral website builder.'
+		),
 		uploadDescription: this.props.translate( 'Type your existing site URL to start the import.' ),
 		engine: 'godaddy-gocentral',
 	};

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -16192,8 +16192,8 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.16.4/wp-prettier-1.16.4.tgz",
-			"integrity": "sha512-6zPssCHOXpHkyI4ZnTAoVTZPV/ivDWDaiyrWqQZm71OnwsL7vcMdEzn3ckDLJgibmxPFQs3nxDdRmI7yX6iW+w==",
+			"version": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.17.0/wp-prettier-1.17.0.tgz",
+			"integrity": "sha512-T6Ya21PFyCgcrTDvMe8pNx9kMpg6nm5KG6ohAx7UzDdcTClsH0X83pNjdQ3AuVJwStz6fhIBW8Wo9P3BEHqFLQ==",
 			"dev": true
 		},
 		"pretty-error": {

--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
 		"ncp": "2.0.0",
 		"nock": "10.0.6",
 		"npm-merge-driver": "2.3.5",
-		"prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.16.4/wp-prettier-1.16.4.tgz",
+		"prettier": "https://github.com/Automattic/wp-prettier/releases/download/wp-1.17.0/wp-prettier-1.17.0.tgz",
 		"react-test-renderer": "16.8.6",
 		"readline-sync": "1.4.9",
 		"replace": "1.1.0",

--- a/packages/i18n-calypso/src/use-translate.js
+++ b/packages/i18n-calypso/src/use-translate.js
@@ -13,11 +13,11 @@ export default function( i18n ) {
 	return function useTranslate() {
 		const [ translate, setTranslate ] = React.useState( bindTranslate );
 
-		React.useEffect(() => {
+		React.useEffect( () => {
 			const onChange = () => setTranslate( bindTranslate );
 			i18n.on( 'change', onChange );
 			return () => i18n.off( 'change', onChange );
-		}, []);
+		}, [] );
 
 		return translate;
 	};


### PR DESCRIPTION
Upgrade to the updated version of the WordPress fork.

- the first commit updates formatting with the old Prettier 1.16.4, so that we see clean diffs after upgrade.
- the second commit upgrades the package.
- the third commit reformats with the new Prettier 1.17.0.

Notable changes:
- `useEffect` formatting inserts correct WP paren spaces. This was a fork bugfix rather than an upstream change
- dynamic `import()` statements with long Webpack configs are formatted differently. Not sure if better 🙂 
- parens are added around obscure IIFE-like expressions like `new ( class extends Component {} )().method()`. We have a few of these in tests.