### PR TITLE
Social Sharing Buttons: Invert active/inactive states opacity

### DIFF
--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -1027,9 +1027,17 @@
 .sharing-buttons-preview__panel-content .sharing-buttons-preview-button {
 	margin-top: 8px;
 	cursor: pointer;
-	opacity: 0.4;
+	opacity: 0.6;
 	@include breakpoint( '<480px' ) {
 		margin: 18px 18px 0 0;
+	}
+
+	&:hover {
+		opacity: 0.8;
+	}
+
+	&.style-icon {
+		opacity: 0.4;
 	}
 
 	&.style-icon:hover {
@@ -1041,6 +1049,7 @@
 		opacity: 1;
 	}
 
+	/* These icons have a light background and need special treatment to stay readable. */
 	&.style-icon.share-email,
 	&.style-icon.share-print {
 		opacity: 0.6;

--- a/client/my-sites/sharing/style.scss
+++ b/client/my-sites/sharing/style.scss
@@ -1027,21 +1027,31 @@
 .sharing-buttons-preview__panel-content .sharing-buttons-preview-button {
 	margin-top: 8px;
 	cursor: pointer;
+	opacity: 0.4;
 	@include breakpoint( '<480px' ) {
 		margin: 18px 18px 0 0;
 	}
 
 	&.style-icon:hover {
 		border: none;
-		opacity: 0.6;
+		opacity: 0.7;
 	}
 
 	&.is-enabled {
-		opacity: 0.3;
+		opacity: 1;
 	}
 
-	&.is-enabled.style-icon {
-		opacity: 0.2;
+	&.style-icon.share-email,
+	&.style-icon.share-print {
+		opacity: 0.6;
+
+		&:hover {
+			opacity: 0.9;
+		}
+
+		&.is-enabled {
+			opacity: 1;
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Active buttons should be more opaque, inactive buttons should be less opaque. 
* Also increase opacity of inactive buttons slightly for better readability (although I wonder if the contrast between active and inactive states is reduced too much now...)
* Using opacity and color in this way is not accessible; colorblindness, for example, makes it harder to tell the difference between active and inactive states when using different colored icons with varying levels of opacity. We should consider adding a visual indicator of some other kind (a border? Checkmark next to each box?) to make this more accessible, but the current change is a small improvement in the meantime.

**Before**

<img width="697" alt="Screen Shot 2019-04-17 at 1 35 12 PM" src="https://user-images.githubusercontent.com/2124984/56308933-71ec5800-6116-11e9-9ca1-d9bb61e6b3de.png">
<img width="687" alt="Screen Shot 2019-04-17 at 1 35 19 PM" src="https://user-images.githubusercontent.com/2124984/56308934-71ec5800-6116-11e9-97ab-8e14d37206ec.png">
<img width="687" alt="Screen Shot 2019-04-17 at 1 35 26 PM" src="https://user-images.githubusercontent.com/2124984/56308935-71ec5800-6116-11e9-849f-bcfd8ef8315b.png">

**After**

<img width="689" alt="Screen Shot 2019-04-17 at 1 46 32 PM" src="https://user-images.githubusercontent.com/2124984/56309308-533a9100-6117-11e9-8920-5b00bb4bf62b.png">
<img width="680" alt="Screen Shot 2019-04-17 at 1 46 39 PM" src="https://user-images.githubusercontent.com/2124984/56309309-533a9100-6117-11e9-8b42-98c9bec6756c.png">
<img width="684" alt="Screen Shot 2019-04-17 at 1 46 49 PM" src="https://user-images.githubusercontent.com/2124984/56309310-533a9100-6117-11e9-8116-2435e67552c8.png">


#### Testing instructions

* Switch to this PR, navigate to Sharing -> Sharing Buttons or `/sharing/buttons`
* Click "Edit sharing buttons" button.
* Note the opacity changes for all button types when active and inactive; icon, icon & text, text only.

Fixes #32224
