### PR TITLE
Imports: Enable manage/import/site-importer-endpoints flag in dev

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -98,6 +98,7 @@
 		"manage/export/guided-transfer": true,
 		"manage/import-in-sidebar": true,
 		"manage/import-to-jetpack": true,
+		"manage/import/site-importer-endpoints": true,
 		"manage/pages": true,
 		"manage/pages/set-front-page": true,
 		"manage/payment-methods": true,


### PR DESCRIPTION
This is to make it easier to develop against live branches

#### Changes proposed in this Pull Request

* Enable the `manage/import/site-importer-endpoints` feature flag in the development environment

#### Testing instructions

See: p1555530052060800-slack-CCT67BWBE