### PR TITLE
Packages: Increase line height on text style

### DIFF
--- a/packages/muriel-style/typography.scss
+++ b/packages/muriel-style/typography.scss
@@ -26,7 +26,7 @@
 .text-body {
   font-weight: 400;
   font-size: 16px;
-  line-height: 22px;
+  line-height: 24px;
 }
 
 .text-body-small {


### PR DESCRIPTION
We should increase the line height to adhere to Material so that it lines up with the 8dp grid.

#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
