### PR TITLE
Kill the manage button in the reader sidebar.

### DIFF
--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -97,12 +97,6 @@ export class ReaderSidebar extends React.Component {
 		recordTrack( 'calypso_reader_sidebar_followed_sites_clicked' );
 	}
 
-	handleReaderSidebarFollowManageClicked() {
-		recordAction( 'clicked_reader_sidebar_follow_manage' );
-		recordGaEvent( 'Clicked Reader Sidebar Follow Manage' );
-		recordTrack( 'calypso_reader_sidebar_follow_manage_clicked' );
-	}
-
 	handleReaderSidebarConversationsClicked() {
 		recordAction( 'clicked_reader_sidebar_conversations' );
 		recordGaEvent( 'Clicked Reader Sidebar Conversations' );
@@ -151,13 +145,6 @@ export class ReaderSidebar extends React.Component {
 									<span className="menu-link-text">
 										{ this.props.translate( 'Followed Sites' ) }
 									</span>
-								</a>
-								<a
-									href="/following/manage"
-									onClick={ this.handleReaderSidebarFollowManageClicked }
-									className="sidebar__button"
-								>
-									{ this.props.translate( 'Manage' ) }
 								</a>
 							</li>
 							<li


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Get rid of the manage button.  Part of the overall nav drawer clean-up.  (Related PR: https://github.com/Automattic/wp-calypso/pull/32251)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The embedded "Manage" button next to "Followed Sites" should be gone.

