### PR TITLE
Signup: remove cached results from site vertical

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -50,7 +50,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		this.state = {
 			railcar: this.getNewRailcar(),
 			candidateVerticals: [],
-			isSuggestionSelected: false,
 			inputValue: props.searchValue,
 		};
 	}
@@ -92,19 +91,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	 */
 	setSearchResults = results => {
 		if ( results && results.length ) {
-			const { candidateVerticals, inputValue, isSuggestionSelected } = this.state;
-			// If the user is typing
-			// and the only result is a user input (non-vertical),
-			// and we have some previous results
-			// then concat that with the previous results and remove the last user input
-			if (
-				! isSuggestionSelected &&
-				! find( results, item => ! item.isUserInputVertical ) &&
-				1 < candidateVerticals.length
-			) {
-				results = candidateVerticals.filter( item => ! item.isUserInputVertical ).concat( results );
-			}
-
+			const { inputValue } = this.state;
 			this.setState( { candidateVerticals: results }, () =>
 				this.updateVerticalData( this.searchForVerticalMatches( inputValue ), inputValue )
 			);
@@ -154,11 +141,9 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	 * Callback to be passed to consuming component when the search field is updated.
 	 *
 	 * @param {String}  value                The new search value
-	 * @param {Boolean} isSuggestionSelected Whether the user has selected a suggestion
 	 */
-	onSiteTopicChange = ( value, isSuggestionSelected = false ) => {
+	onSiteTopicChange = value => {
 		const newState = {
-			isSuggestionSelected,
 			inputValue: value,
 		};
 
@@ -172,12 +157,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		// to prevent unnecessary site preview updates
 		this.updateVerticalData( this.searchForVerticalMatches( value ), value );
 	};
-
-	/*
-	 * Because this is a 'click' selection, we call `this.onSiteTopicChange`
-	 * setting `isSuggestionSelected` to true.
-	 */
-	onSelectPopularTopic = value => this.onSiteTopicChange( value, true );
 
 	/**
 	 * Returns an array of vertical values - suggestions - that is consumable by `<SuggestionSearch />`
@@ -203,9 +182,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 					isSearching={ this.isVerticalSearchPending() }
 					railcar={ railcar }
 				/>
-				{ this.shouldShowPopularTopics() && (
-					<PopularTopics onSelect={ this.onSelectPopularTopic } />
-				) }
+				{ this.shouldShowPopularTopics() && <PopularTopics onSelect={ this.onSiteTopicChange } /> }
 			</>
 		);
 	}

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -82,18 +82,17 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	isVerticalSearchPending = () => this.state.inputValue && 0 === this.props.verticals.length;
 
 	/**
-	 * Sets `state.results` with incoming vertical results, retaining previous non-user vertical search results
-	 * if the incoming vertical results contain only user-defined results.
-	 *
-	 * This function could better be performed in the backend eventually.
+	 * Sets `state.candidateVerticals` with incoming vertical results.
 	 *
 	 * @param {Array} results Incoming vertical results
 	 */
 	setSearchResults = results => {
 		if ( results && results.length ) {
-			const { inputValue } = this.state;
 			this.setState( { candidateVerticals: results }, () =>
-				this.updateVerticalData( this.searchForVerticalMatches( inputValue ), inputValue )
+				this.updateVerticalData(
+					this.searchForVerticalMatches( this.state.inputValue ),
+					this.state.inputValue
+				)
 			);
 		}
 	};
@@ -160,6 +159,8 @@ export class SiteVerticalsSuggestionSearch extends Component {
 
 	/**
 	 * Returns an array of vertical values - suggestions - that is consumable by `<SuggestionSearch />`
+	 * We use the `this.state.candidateVerticals` array instead of `this.props.verticals`
+	 * so `<SuggestionSearch />` has a list to filter in between requests.
 	 *
 	 * @returns {Array} The array of vertical values.
 	 */


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR removes the caching of the previous search results. We currently show the last known results list if a user searches for a vertical that doesn't exist. ([Reference](https://github.com/Automattic/wp-calypso/pull/31378#issuecomment-473898731))

This can lead to some confusing results.

<img width="602" alt="Screen Shot 2019-04-18 at 11 49 29 am" src="https://user-images.githubusercontent.com/6458278/56337792-5ce0f900-61ea-11e9-99eb-5008e75651d6.png">

## Testing

The site vertical search should work as it does presently with the exception of the cached results.

For example, searching for `Professional` immediately after search for `Da` and receiving results should ultimately yield one result (Professional) and not any previous, cached results.


