### PR TITLE
Signup: ensure CSS consistency across the steps

### DIFF
--- a/client/signup/steps/site-information/style.scss
+++ b/client/signup/steps/site-information/style.scss
@@ -30,14 +30,24 @@
 
 	.button {
 		position: absolute;
-		bottom: 3px;
+		top: 3px;
 		right: 3px;
 		width: auto;
 		padding: 5px 8px;
+		transition: none;
 
 		.gridicon {
 			height: 24px;
 			width: 24px;
+		}
+	}
+}
+
+/* We need specificity here to overwrite client/signup/style.scss */
+body.is-section-signup {
+	.site-information__wrapper .site-information__field-control button.button {
+		@include breakpoint( '<660px' ) {
+			padding: 9px 12px;
 		}
 	}
 }

--- a/client/signup/steps/site-style/style.scss
+++ b/client/signup/steps/site-style/style.scss
@@ -142,15 +142,27 @@
 		border-color: var( --color-accent-light );
 		background-color: var( --color-neutral-0 );
 	}
+
 }
 
 .site-style__submit-wrapper {
 	align-self: center;
 
+	.button {
+		width: auto;
+		padding: 5px 8px;
+
+		.gridicon {
+			height: 24px;
+			width: 24px;
+		}
+	}
+
 	@include breakpoint( '<660px' ) {
 		padding: 8px;
 
 		.button {
+			position: static;
 			width: 100%;
 		}
 	}

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -69,8 +69,6 @@ body.is-section-jetpack-connect .site-topic__content {
 		right: 3px;
 		padding: 5px 8px;
 		@include elevation ( 1dp );
-		transition: all 150ms ease-in-out;
-		transition-delay: 150ms;
 
 		&[disabled] {
 			opacity: 0;
@@ -79,6 +77,10 @@ body.is-section-jetpack-connect .site-topic__content {
 		.gridicon {
 			height: 24px;
 			width: 24px;
+		}
+
+		@include breakpoint( '<660px' ) {
+			padding: 9px 12px;
 		}
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Experts agree that three out of five arrow signup buttons featured in the onboarding journey have fluctuating body mass indexes. 

With a little _C_o_SS_metic surgery we were able to trim some lateral margins here and inject a dose of padding there to enable them to reenter production with confidence.

<img width="247" alt="Screen Shot 2019-04-18 at 3 45 51 pm" src="https://user-images.githubusercontent.com/6458278/56339317-10e58280-61f1-11e9-833b-294f6a7359fa.png">

There are some rather [specific style declarations](https://github.com/Automattic/wp-calypso/blob/11d8030/client/signup/style.scss#L98) so we had to get more specificer [sic]

This is a quick fix only. It might be worth creating a reusuable component if the arrow button is to feature prominently.

## Testing instructions

Test the site topic, site title and site style^ steps in various screen widths.

The arrow buttons should be of a consistent size in both dimensions and font.

<img width="551" alt="Screen Shot 2019-04-18 at 3 39 47 pm" src="https://user-images.githubusercontent.com/6458278/56339218-a6344700-61f0-11e9-9deb-a4b51e7607c7.png">

<img width="392" alt="Screen Shot 2019-04-18 at 3 39 53 pm" src="https://user-images.githubusercontent.com/6458278/56339219-a6344700-61f0-11e9-8e39-209d852e1261.png">

^ http://calypso.localhost:3000/start/onboarding-dev/site-style-with-preview