### PR TITLE
Signup: WPCC: Use the oauth2_redirect from the server not from the client

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -520,7 +520,7 @@ export function createAccount(
 				if ( oauth2Signup ) {
 					assign( providedDependencies, {
 						oauth2_client_id: queryArgs.oauth2_client_id,
-						oauth2_redirect: queryArgs.oauth2_redirect,
+						oauth2_redirect: response && response.oauth2_redirect.split( '@' )[ 1 ],
 					} );
 				}
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -520,7 +520,7 @@ export function createAccount(
 				if ( oauth2Signup ) {
 					assign( providedDependencies, {
 						oauth2_client_id: queryArgs.oauth2_client_id,
-						oauth2_redirect: response && response.oauth2_redirect.split( '@' )[ 1 ],
+						oauth2_redirect: get( response, 'oauth2_redirect', '' ).split( '@' )[ 1 ],
 					} );
 				}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The current behaviour redirects the user in the WPCC flow using the value passed in the query string. This changes that behaviour to use the value returned from the server, so that users can't interfere with it.

#### To see the existing issue

* Go to gravatar.com in an incognito window
* Click on "Create your own Gravatar"
* Change the oauth2_redirect parameter from public-api.wordpress.com to bing.com
* Create an account
* You will be redirected to the wordpress.com homepage

### To test

* Checkout this branch
* Go to gravatar.com in an incognito window
* Click on "Create your own Gravatar"
* Change the oauth2_redirect parameter from public-api.wordpress.com to bing.com
* Change https://wordpress.com to http://calypso.localhost:3000
* Create an account
* You will be redirected to the Gravatar conneciton flow