### PR TITLE
CircleCI: Build o2-blocks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,6 +276,17 @@ jobs:
             NODE_ENV=production npm run build-notifications -- --output-path=$CIRCLE_ARTIFACTS/notifications-panel
       - store-artifacts-and-test-results
 
+  build-o2-blocks:
+    <<: *defaults
+    parallelism: 1
+    steps:
+      - prepare
+      - run:
+          name: Build Gutenberg Blocks for internal p2s
+          command: |
+            npx lerna run build --scope='@automattic/o2-blocks' -- -- --output-path=$CIRCLE_ARTIFACTS/o2-blocks
+      - store-artifacts-and-test-results
+
   build-wpcom-block-editor:
     <<: *defaults
     parallelism: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
       - run:
           name: Build Gutenberg Blocks for internal p2s
           command: |
-            npx lerna run build --scope='@automattic/o2-blocks' -- -- --output-path=$CIRCLE_ARTIFACTS/o2-blocks
+            NODE_ENV=production npx lerna run build --scope='@automattic/o2-blocks' -- -- --output-path=$CIRCLE_ARTIFACTS/o2-blocks
       - store-artifacts-and-test-results
 
   build-wpcom-block-editor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -604,6 +604,9 @@ workflows:
       - build-notifications:
           requires:
             - setup
+      - build-o2-blocks:
+          requires:
+            - setup
       - build-wpcom-block-editor:
           requires:
             - setup


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* CircleCI: Build o2-blocks

This should allow us to guard against issues such as wrong monorepo `devDependencies` (see e.g. #32383).

We're already building the other subdir in `apps/`, `wpcom-block-editor`. Their built files should go to different artifacts directories, which is why I'm adding a new task, rather than just unifying them into one task.

#### Testing instructions

Verify that CircleCI is all green for this PR, especially the new `ci/circleci: o2-blocks` task.

On this PR, click on the `ci/circleci: o2-blocks` task. Select the artifacts tab. Verify that the `o2-blocks/` subdirectory contains built JS and CSS files.