### PR TITLE
Signup: Bump the cache buster for wpcom-salesteam

### DIFF
--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -63,7 +63,7 @@ export class PlansStep extends Component {
 			const salesTeamScript = document.createElement( 'script' );
 			salesTeamScript.setAttribute(
 				'src',
-				'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/js/wpcom-salesteam.js?ver=20190221'
+				'//s0.wp.com/wp-content/a8c-plugins/wpcom-salesteam/js/wpcom-salesteam.js?ver=20190418'
 			);
 			salesTeamScript.setAttribute( 'defer', true );
 			document.head.appendChild( salesTeamScript );


### PR DESCRIPTION
The current version has some cache pollution that makes IE11 hiccup. Bump the version to get ahead of the cache pollution.

#### Testing instructions

* Verify signup works with no script error hiccups on IE11

