### PR TITLE
Make it possible to redirect users to the checklist after signup

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -15,6 +15,7 @@ export function generateFlows( {
 	getSiteDestination = noop,
 	getPostsDestination = noop,
 	getRedirectDestination = noop,
+	getChecklistDestination = noop,
 } = {} ) {
 	const flows = {
 		account: {
@@ -313,7 +314,7 @@ export function generateFlows( {
 
 	flows.private = {
 		steps: [ 'user', 'site' ],
-		destination: getSiteDestination,
+		destination: getChecklistDestination,
 		description: 'Test private site signup',
 		lastModified: '2018-10-22',
 	};

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -63,7 +63,16 @@ function getRedirectDestination( dependencies ) {
 	return '/';
 }
 
-const flows = generateFlows( { getPostsDestination, getSiteDestination, getRedirectDestination } );
+function getChecklistDestination( dependencies ) {
+	return '/checklist/' + dependencies.siteSlug;
+}
+
+const flows = generateFlows( {
+	getPostsDestination,
+	getSiteDestination,
+	getRedirectDestination,
+	getChecklistDestination,
+} );
 
 function removeUserStepFromFlow( flow ) {
 	if ( ! flow ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Right now the way we redirect people in signup is very messy. I am trying to address this in #29136, but I'm splitting that into smaller PRs to make it easier to reason about and merge. 

This PR just creates a new function which redirects users to the checklist after signup, and implements it in the /start/private flow.

#### Testing instructions

* Go to /start/private
* Create a site
* Check that you are redirected to the checklist

