### PR TITLE
Post-checkout: Remove back to site button and use primary button in all cases

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -35,7 +35,6 @@ import {
 import GoogleAppsDetails from './google-apps-details';
 import GuidedTransferDetails from './guided-transfer-details';
 import HappinessSupport from 'components/happiness-support';
-import HeaderCake from 'components/header-cake';
 import PlanThankYouCard from 'blocks/plan-thank-you-card';
 import JetpackThankYouCard from './jetpack-thank-you-card';
 import AtomicStoreThankYouCard from './atomic-store-thank-you-card';
@@ -272,7 +271,7 @@ export class CheckoutThankYou extends React.Component {
 		}
 	};
 
-	goBack = () => {
+	primaryCta = () => {
 		if ( this.isDataLoaded() && ! this.isGenericReceipt() ) {
 			const purchases = getPurchases( this.props );
 			const site = this.props.selectedSite.slug;
@@ -448,15 +447,10 @@ export class CheckoutThankYou extends React.Component {
 			return null;
 		}
 
-		const goBackText = this.props.selectedSite
-			? translate( 'Back to my site' )
-			: translate( 'Register Domain' );
-
 		// standard thanks page
 		return (
 			<Main className="checkout-thank-you">
 				<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
-				<HeaderCake onClick={ this.goBack } isCompact backText={ goBackText } />
 
 				<Card className="checkout-thank-you__content">{ this.productRelatedMessages() }</Card>
 
@@ -575,6 +569,7 @@ export class CheckoutThankYou extends React.Component {
 					primaryPurchase={ primaryPurchase }
 					selectedSite={ selectedSite }
 					hasFailedPurchases={ hasFailedPurchases }
+					primaryCta={ this.primaryCta }
 				/>
 
 				{ primaryPurchase && (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `<HeaderCake/>` component in post-purchase thank you page because it's small and easy to miss.
* Add a primary call to action for every purchase case, using the actions present in the removed `<HeaderCake>`.

As mentioned in #31686 I also had trouble getting this post-checkout screen to show up. It works for domain purchases but I couldn't get it for any other purchase (just a concierge interstitial and redirect). However, I left all the logic to account for any type of purchase just in case we still need it.

Before | After
------------ | -------------
<img width="817" alt="Screen Shot 2019-04-18 at 10 52 46" src="https://user-images.githubusercontent.com/448298/56369896-36aa6180-61c8-11e9-97b0-606634932712.png"> | <img width="818" alt="Screen Shot 2019-04-18 at 10 29 46" src="https://user-images.githubusercontent.com/448298/56369753-f2b75c80-61c7-11e9-8672-8468e2ac4d35.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a site without a domain
* Purchase a new domain for the site
* Assert the post-checkout thank you page doesn't have the `Back to my site` header, and there's a primary action button
* Make sure the primary action button works
* Try other purchases (new site with plan, existing site with plan upgrade, Google Apps). If you reach the post-checkout thank you page, confirm the header button is removed and there's a primary action button that works.

Fixes #31686 
