### PR TITLE
redirect after checkout to the passed URL param

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -349,6 +349,7 @@ export class Checkout extends React.Component {
 		let renewalItem;
 		const {
 			cart,
+			redirectTo,
 			selectedSite,
 			selectedSiteSlug,
 			transaction: {
@@ -360,6 +361,10 @@ export class Checkout extends React.Component {
 			'[0].extra.receipt_for_domain',
 			0
 		);
+
+		if ( redirectTo ) {
+			return redirectTo;
+		}
 
 		// Note: this function is called early on for redirect-type payment methods, when the receipt isn't set yet.
 		// The `:receiptId` string is filled in by our callback page after the PayPal checkout

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -40,6 +40,7 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import QueryPlans from 'components/data/query-plans';
 import SecurePaymentForm from './secure-payment-form';
 import SecurePaymentFormPlaceholder from './secure-payment-form-placeholder';
+import { isExternal } from 'lib/url';
 import { AUTO_RENEWAL } from 'lib/url/support';
 import {
 	RECEIVED_WPCOM_RESPONSE,
@@ -362,7 +363,7 @@ export class Checkout extends React.Component {
 			0
 		);
 
-		if ( redirectTo ) {
+		if ( redirectTo && ! isExternal( redirectTo ) ) {
 			return redirectTo;
 		}
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -45,6 +45,7 @@ export function checkout( context, next ) {
 				selectedFeature={ feature }
 				couponCode={ context.query.code }
 				plan={ plan }
+				redirectTo={ context.query.redirect_to }
 			/>
 		</CheckoutData>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change is part of #29136, but I'm splitting it out to make that PR smaller and easier to reason about. The idea is that we can provide a `redirect_to` parameter to `/checkout` which sends users to a different destination after checkout.

#### Testing instructions

* Add something to your cart and go to checkout
* Add ?redirect_to=me to the URL and reload the page
* Go through checkout and check that you are redirected to /me

