### PR TITLE
Reader: Avoid fatal type errors when a cross-post author is not available.

### DIFF
--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -205,7 +205,7 @@ class CrossPost extends PureComponent {
 							</a>
 						</h1>
 					) }
-					<Emojify>{ post.author && this.getDescription( post.author.first_name ) }</Emojify>
+					{ post.author && <Emojify>{ this.getDescription( post.author.first_name ) }</Emojify> }
 				</div>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
 				{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -205,7 +205,7 @@ class CrossPost extends PureComponent {
 							</a>
 						</h1>
 					) }
-					<Emojify>{ this.getDescription( post.author.first_name ) }</Emojify>
+					<Emojify>{ post.author && this.getDescription( post.author.first_name ) }</Emojify>
 				</div>
 				{ feedId && <QueryReaderFeed feedId={ +feedId } includeMeta={ false } /> }
 				{ siteId && <QueryReaderSite siteId={ +siteId } includeMeta={ false } /> }


### PR DESCRIPTION
It's possible for the Reader to receive post objects that don't include a valid author object, as demonstrated by this post: https://make.wordpress.org/community/2019/04/18/the-get-involved-table-at-wceu-2019/

<img width="2169" alt="Screen Shot 2019-04-18 at 10 00 06 AM" src="https://user-images.githubusercontent.com/349751/56378851-1fb54080-61c3-11e9-8c9a-479192c2ec03.png">

This PR just verifies a valid author object exists before attempting to use it in a cross-post description.

#### Testing instructions

* Subscribe to make.wordpress.org, or set the `post.author` object to `null` in the `<CrossPost />` `render` method.
* Load the Reader.
* Verify the reader loads, with no `Uncaught TypeError: Cannot read property 'first_name' of null` console errors (and a white screen).
