### PR TITLE
Signup: restore 50/50 to the page builder test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -175,10 +175,10 @@ export default {
 		defaultVariation: 'original',
 	},
 	pageBuilderMVP: {
-		datestamp: '20190402',
+		datestamp: '20190418',
 		variations: {
-			control: 0,
-			test: 1,
+			control: 50,
+			test: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,


### PR DESCRIPTION
The Page Builder MVP has some UX drawbacks (lack of menu and logo support, general differences from documented flows) that have turned out to be more problematic than anticipated in testing. We still want to gather some data before decided whether the upsides (single editing UI) make the tradeoffs come out ahead.

#### Changes proposed in this Pull Request

* Make the `pageBuilderMVP` test a 50/50 split

#### Testing instructions
Check this out locally and visit http://calypso.localhost:3000/start/onboarding

Paste the following into your console to enter the test

```
localStorage.setItem( 'ABTests', '{"pageBuilderMVP_20190418":"test"}' );
```

Choose Business. Ensure your interface language is English. After completing signup, you should land in the block editor like this:

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/195089/55500934-003ce600-560f-11e9-8888-22d99c6573db.png">

You should have an editable Site Header block at the top of the editor.

---

To test the non-test variant, visit the same URL as above, but this time paste the following into your console:

```
localStorage.setItem( 'ABTests', '{"pageBuilderMVP_20190418":"control"}' );
```

Verify that you land in the checklist after signup, otherwise following the same instructions.