### PR TITLE
Gutenberg: Update selected editor when switching to classic (Calypso)

### DIFF
--- a/apps/wpcom-block-editor/src/common/switch-to-classic.js
+++ b/apps/wpcom-block-editor/src/common/switch-to-classic.js
@@ -1,4 +1,4 @@
-/* global _currentSiteId, wpcomGutenberg */
+/* global wpcomGutenberg */
 
 /**
  * External dependencies
@@ -15,28 +15,14 @@ function addSwitchToClassicButton() {
 		setTimeout( () => {
 			$( '.edit-post-more-menu__content .components-menu-group:last-child > div[role=menu]' )
 				.append( `
-				<button type="button" aria-label="${ wpcomGutenberg.switchToClassic.label }" role="menuitem"
-					class="components-button components-menu-item__button components-menu-item__button-switch">
-					${ wpcomGutenberg.switchToClassic.label }
-				</button>
-			` );
-			$( '.components-menu-item__button-switch' ).on( 'click', () => {
-				$.wpcom_proxy_request( {
-					method: 'POST',
-					path: `/sites/${ _currentSiteId }/gutenberg`,
-					apiNamespace: 'wpcom/v2',
-					query: {
-						platform: 'web',
-						editor: 'classic',
-					},
-				} ).done( () => {
-					if ( wpcomGutenberg.isCalypsoify ) {
-						top.window.location.replace( wpcomGutenberg.switchToClassic.url );
-					} else {
-						top.window.location.reload();
-					}
-				} );
-			} );
+					<a 
+						href="${ wpcomGutenberg.switchToClassic.url }" target="_top" role="menuitem" 
+						aria-label="${ wpcomGutenberg.switchToClassic.label }"
+						class="components-button components-menu-item__button" 
+					>
+						${ wpcomGutenberg.switchToClassic.label }
+					</a>
+				` );
 		}, 0 );
 	} );
 }

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -174,11 +174,18 @@ async function redirectIfBlockEditor( context, next ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 
-	// URLs with a set-editor=classic param are used for switching from the block editor to the classic editor, so we
-	// bypass the selected editor check if it is present and update the selected editor for the current user/site pair.
-	const switchToEditor = get( context.query, 'set-editor' );
-	if ( switchToEditor && 'classic' === switchToEditor ) {
-		context.store.dispatch( setSelectedEditor( siteId, 'classic' ) );
+	// URLs with a set-editor=<editorName> param are used for indicating that the user wants to use always the given
+	// editor, so we update the selected editor for the current user/site pair.
+	const newEditorChoice = get( context.query, 'set-editor' );
+	const oldEditorChoice = getSelectedEditor( state, siteId );
+	const allowedEditors = [ 'classic', 'gutenberg' ];
+
+	if ( allowedEditors.indexOf( newEditorChoice ) !== -1 && newEditorChoice !== oldEditorChoice ) {
+		context.store.dispatch( setSelectedEditor( siteId, newEditorChoice ) );
+	}
+
+	// If the new editor is classic, we bypass the selected editor check.
+	if ( 'classic' === newEditorChoice ) {
 		return next();
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, when a user clicked on the "Switch to Classic Editor" button available on the "More tools" menu, we were performing a request to the opt-in API endpoint to set the classic editor as the new desired editor and later redirecting the user to the classic editor URL.

<img width="150" alt="Screen Shot 2019-04-18 at 13 12 47" src="https://user-images.githubusercontent.com/1233880/56404949-9a09c180-62a4-11e9-8c24-a01ed411897e.png">

This approach presents a problem with Jetpack sites since the opt-in API is not available there.

To workaround that, we have two options:

1. Move the Gutenberg opt-in API to Jetpack.
1. Delegate the new desired editor update to the controller of the classic editor URL.

On this PR we're exploring the 2nd option, since the 1st one will involve a huge amount of work.

Now, when the "Switch to Classic Editor" button is clicked, we just redirect to the classic editor URL which will include a `set-editor=classic` param. The Calypso controller of that URL will check that param and update the selected editor to `classic` when found.


#### Testing instructions

- Make sure that your sandbox site has opted in to the block editor.
- Apply D27149-code and sandbox `widgets.wp.com`.
- Go to `/block-editor` and select your sandbox site.
- Open the "More tools" menu and click on the "Switch to Classic Editor" button.
- Make sure the Calypso classic editor is loaded and you see the `set-editor=classic` param on the URL.
- Check your current selected editor is `classic` on the API: `GET https://public-api.wordpress.com/wpcom/v2/sites/:site/gutenberg`.
- Switch again to the block editor using the "Learn more" button on the sidebar.
<img width="259" alt="Screen Shot 2019-04-19 at 13 49 24" src="https://user-images.githubusercontent.com/1233880/56406004-210d6880-62aa-11e9-8e97-3b372d7d6971.png">
<img width="858" alt="Screen Shot 2019-04-19 at 13 49 29" src="https://user-images.githubusercontent.com/1233880/56406009-24a0ef80-62aa-11e9-8d58-c719870df3a4.png">

- Make sure the Calypso iframe block editor is loaded and the `set-editor=classic` param is not present on the URL.
- Check your current selected editor is `gutenberg` on the API: `GET https://public-api.wordpress.com/wpcom/v2/sites/:site/gutenberg`.
