### PR TITLE
Add new blacklisted plugin slugs - March 2019

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -270,6 +270,7 @@ export class PluginMeta extends Component {
 			'wpmu-database-reset',
 			'wps-hide-login',
 			'z-inventory-manager',
+			'wp-uninstaller-by-azed',
 
 			// backup
 			'backup-wd',
@@ -289,6 +290,7 @@ export class PluginMeta extends Component {
 			'wp-rocket',
 			'wp-speed-of-light',
 			'wp-super-cache',
+			'sg-cachepress',
 
 			// sql heavy
 			'another-wordpress-classifieds-plugin',
@@ -345,6 +347,10 @@ export class PluginMeta extends Component {
 			'wp-monero-miner-using-coin-hive',
 			'wpematico',
 			'zapp-proxy-server',
+			'propellerads-official',
+			'p3',
+			'yellow-pencil-visual-theme-customizer',
+			'yuzo-related-post',
 		];
 
 		return includes( unsupportedPlugins, plugin.slug );

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -349,7 +349,6 @@ export class PluginMeta extends Component {
 			'zapp-proxy-server',
 			'propellerads-official',
 			'p3',
-			'yellow-pencil-visual-theme-customizer',
 			'yuzo-related-post',
 		];
 

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -267,10 +267,10 @@ export class PluginMeta extends Component {
 			'wp-file-manager',
 			'wp-prefix-changer',
 			'wp-reset',
+			'wp-uninstaller-by-azed',
 			'wpmu-database-reset',
 			'wps-hide-login',
 			'z-inventory-manager',
-			'wp-uninstaller-by-azed',
 
 			// backup
 			'backup-wd',
@@ -284,13 +284,13 @@ export class PluginMeta extends Component {
 			'comet-cache',
 			'hyper-cache',
 			'quick-cache',
+			'sg-cachepress',
 			'w3-total-cache',
 			'wp-cache',
 			'wp-fastest-cache',
 			'wp-rocket',
 			'wp-speed-of-light',
 			'wp-super-cache',
-			'sg-cachepress',
 
 			// sql heavy
 			'another-wordpress-classifieds-plugin',
@@ -336,7 +336,9 @@ export class PluginMeta extends Component {
 			'event-espresso-decaf',
 			'fast-velocity-minify',
 			'nginx-helper',
+			'p3',
 			'porn-embed',
+			'propellerads-official',
 			'speed-contact-bar',
 			'robo-gallery',
 			'video-importer',
@@ -346,10 +348,8 @@ export class PluginMeta extends Component {
 			'wp-monero-miner-pro',
 			'wp-monero-miner-using-coin-hive',
 			'wpematico',
-			'zapp-proxy-server',
-			'propellerads-official',
-			'p3',
 			'yuzo-related-post',
+			'zapp-proxy-server',
 		];
 
 		return includes( unsupportedPlugins, plugin.slug );


### PR DESCRIPTION
Adding the following plugins to be blacklisted.

* wp-uninstaller-by-azed
* sg-cachepress
* propellerads-official
* p3
* yellow-pencil-visual-theme-customizer (Removed from blacklist. New security release from devs and the plugin restored on repo)
* yuzo-related-post
