### PR TITLE
Add labels for the 2-year plan subscription

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -453,3 +453,19 @@ export function applyTestFiltersToPlansList( planName, abtest ) {
 
 	return filteredPlanConstantObj;
 }
+
+export function getPlanTermLabel( planName, translate ) {
+	const plan = getPlan( planName );
+	if ( ! plan || ! plan.term ) {
+		return;
+	}
+
+	switch ( plan.term ) {
+		case TERM_MONTHLY:
+			return translate( 'Monthly subscription' );
+		case TERM_ANNUALLY:
+			return translate( 'Annual subscription' );
+		case TERM_BIENNIALLY:
+			return translate( 'Two year subscription' );
+	}
+}

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -27,6 +27,8 @@ import {
 	requestBillingTransaction,
 } from 'state/billing-transactions/individual-transactions/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
+import { planMatches } from 'lib/plans';
+import { TERM_BIENNIALLY } from 'lib/plans/constants';
 
 class BillingReceipt extends React.Component {
 	componentDidMount() {
@@ -177,11 +179,13 @@ class BillingReceipt extends React.Component {
 		const groupedTransactionItems = groupDomainProducts( transaction.items, translate );
 
 		const items = groupedTransactionItems.map( item => {
+			const isTwoYearPlan = planMatches( item.wpcom_product_slug, { term: TERM_BIENNIALLY } );
 			return (
 				<tr key={ item.id }>
 					<td className="billing-history__receipt-item-name">
 						<span>{ item.variation }</span>
 						<small>({ item.type_localized })</small>
+						{ isTwoYearPlan ? <em>{ translate( 'Two year subscription' ) }</em> : null }
 						<br />
 						<em>{ item.domain }</em>
 					</td>

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -27,8 +27,7 @@ import {
 	requestBillingTransaction,
 } from 'state/billing-transactions/individual-transactions/actions';
 import { recordGoogleEvent } from 'state/analytics/actions';
-import { planMatches } from 'lib/plans';
-import { TERM_BIENNIALLY } from 'lib/plans/constants';
+import { getPlanTermLabel } from 'lib/plans';
 
 class BillingReceipt extends React.Component {
 	componentDidMount() {
@@ -179,13 +178,13 @@ class BillingReceipt extends React.Component {
 		const groupedTransactionItems = groupDomainProducts( transaction.items, translate );
 
 		const items = groupedTransactionItems.map( item => {
-			const isTwoYearPlan = planMatches( item.wpcom_product_slug, { term: TERM_BIENNIALLY } );
+			const termLabel = getPlanTermLabel( item.wpcom_product_slug, translate );
 			return (
 				<tr key={ item.id }>
 					<td className="billing-history__receipt-item-name">
 						<span>{ item.variation }</span>
 						<small>({ item.type_localized })</small>
-						{ isTwoYearPlan ? <em>{ translate( 'Two year subscription' ) }</em> : null }
+						<em>{ termLabel }</em>
 						<br />
 						<em>{ item.domain }</em>
 					</td>

--- a/client/me/billing-history/receipt.jsx
+++ b/client/me/billing-history/receipt.jsx
@@ -184,7 +184,7 @@ class BillingReceipt extends React.Component {
 					<td className="billing-history__receipt-item-name">
 						<span>{ item.variation }</span>
 						<small>({ item.type_localized })</small>
-						<em>{ termLabel }</em>
+						{ termLabel ? <em>{ termLabel }</em> : null }
 						<br />
 						<em>{ item.domain }</em>
 					</td>

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -23,6 +23,8 @@ import SearchCard from 'components/search-card';
 import { setPage, setQuery } from 'state/ui/billing-transactions/actions';
 import getBillingTransactionFilters from 'state/selectors/get-billing-transaction-filters';
 import getFilteredBillingTransactions from 'state/selectors/get-filtered-billing-transactions';
+import { planMatches } from 'lib/plans';
+import { TERM_BIENNIALLY } from 'lib/plans/constants';
 
 class TransactionsTable extends React.Component {
 	static displayName = 'TransactionsTable';
@@ -87,11 +89,17 @@ class TransactionsTable extends React.Component {
 
 	serviceNameDescription = transaction => {
 		let description;
+		const isTwoYearPlan = planMatches( transaction.wpcom_product_slug, { term: TERM_BIENNIALLY } );
 		if ( transaction.domain ) {
 			description = (
 				<div>
 					<strong>{ transaction.plan }</strong>
 					<small>{ transaction.domain }</small>
+					{ isTwoYearPlan ? (
+						<div>
+							<small>{ this.props.translate( 'Two year subscription' ) }</small>
+						</div>
+					) : null }
 				</div>
 			);
 		} else {

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -88,17 +88,13 @@ class TransactionsTable extends React.Component {
 
 	serviceNameDescription = transaction => {
 		let description;
-		const termLabel = getPlanTermLabel( transaction.wpcom_product_slug, this.props.translate );
 		if ( transaction.domain ) {
+			const termLabel = getPlanTermLabel( transaction.wpcom_product_slug, this.props.translate );
 			description = (
 				<div>
 					<strong>{ transaction.plan }</strong>
 					<small>{ transaction.domain }</small>
-					{ termLabel ? (
-						<div>
-							<small>{ termLabel }</small>
-						</div>
-					) : null }
+					{ termLabel ? <small>{ termLabel }</small> : null }
 				</div>
 			);
 		} else {

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -23,8 +23,7 @@ import SearchCard from 'components/search-card';
 import { setPage, setQuery } from 'state/ui/billing-transactions/actions';
 import getBillingTransactionFilters from 'state/selectors/get-billing-transaction-filters';
 import getFilteredBillingTransactions from 'state/selectors/get-filtered-billing-transactions';
-import { planMatches } from 'lib/plans';
-import { TERM_BIENNIALLY } from 'lib/plans/constants';
+import { getPlanTermLabel } from 'lib/plans';
 
 class TransactionsTable extends React.Component {
 	static displayName = 'TransactionsTable';
@@ -89,15 +88,15 @@ class TransactionsTable extends React.Component {
 
 	serviceNameDescription = transaction => {
 		let description;
-		const isTwoYearPlan = planMatches( transaction.wpcom_product_slug, { term: TERM_BIENNIALLY } );
+		const termLabel = getPlanTermLabel( transaction.wpcom_product_slug, this.props.translate );
 		if ( transaction.domain ) {
 			description = (
 				<div>
 					<strong>{ transaction.plan }</strong>
 					<small>{ transaction.domain }</small>
-					{ isTwoYearPlan ? (
+					{ termLabel ? (
 						<div>
-							<small>{ this.props.translate( 'Two year subscription' ) }</small>
+							<small>{ termLabel }</small>
 						</div>
 					) : null }
 				</div>

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -180,11 +180,12 @@ class PurchaseItem extends Component {
 
 	render() {
 		const { isPlaceholder, isDisconnectedSite, purchase, isJetpack, translate } = this.props;
-		const classes = classNames;
-		'purchase-item',
+		const classes = classNames(
+			'purchase-item',
 			{ 'is-expired': purchase && 'expired' === purchase.expiryStatus },
 			{ 'is-placeholder': isPlaceholder },
-			{ 'is-included-with-plan': purchase && isIncludedWithPlan( purchase ) };
+			{ 'is-included-with-plan': purchase && isIncludedWithPlan( purchase ) }
+		);
 		const termLabel =
 			purchase && purchase.productSlug ? getPlanTermLabel( purchase.productSlug, translate ) : null;
 

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -35,6 +35,7 @@ import PlanIcon from 'components/plans/plan-icon';
 import Gridicon from 'gridicons';
 import { managePurchase } from '../paths';
 import TrackComponentView from 'lib/analytics/track-component-view';
+import { getPlanTermLabel } from 'lib/plans';
 
 const eventProperties = warning => ( { warning, position: 'purchase-list' } );
 
@@ -178,13 +179,14 @@ class PurchaseItem extends Component {
 	}
 
 	render() {
-		const { isPlaceholder, isDisconnectedSite, purchase, isJetpack } = this.props;
-		const classes = classNames(
-			'purchase-item',
+		const { isPlaceholder, isDisconnectedSite, purchase, isJetpack, translate } = this.props;
+		const classes = classNames;
+		'purchase-item',
 			{ 'is-expired': purchase && 'expired' === purchase.expiryStatus },
 			{ 'is-placeholder': isPlaceholder },
-			{ 'is-included-with-plan': purchase && isIncludedWithPlan( purchase ) }
-		);
+			{ 'is-included-with-plan': purchase && isIncludedWithPlan( purchase ) };
+		const termLabel =
+			purchase && purchase.productSlug ? getPlanTermLabel( purchase.productSlug, translate ) : null;
 
 		let content;
 		if ( isPlaceholder ) {
@@ -196,6 +198,7 @@ class PurchaseItem extends Component {
 					<div className="purchase-item__details">
 						<div className="purchase-item__title">{ getName( purchase ) }</div>
 						<div className="purchase-item__purchase-type">{ purchaseType( purchase ) }</div>
+						{ termLabel ? <div className="purchase-item__term-label">{ termLabel }</div> : null }
 						<div className="purchase-item__purchase-date">{ this.renewsOrExpiresOn() }</div>
 					</div>
 				</span>

--- a/client/me/purchases/purchase-item/style.scss
+++ b/client/me/purchases/purchase-item/style.scss
@@ -69,6 +69,7 @@
 	}
 }
 
+.purchase-item__term-label,
 .purchase-item__purchase-date,
 .purchase-item__purchase-type {
 	line-height: 14px;
@@ -95,7 +96,8 @@
 	}
 }
 
-.purchase-item__purchase-type {
+.purchase-item__term-label,
+.purchase-item__purchase-type, {
 	color: var( --color-text-subtle );
 	font-size: 12px;
 	margin: 0 0 4px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We don't indicate in the Billing Receipt if the plan is 1 or 2 year leading to confusion, especially if a discount was applied and the price of a 2-year plan becomes close to the price of a 1-year plan

#### Testing instructions

Apply D27156-code
Buy a 2-year plan
Check the receipt in http://calypso.localhost:3000/me/purchases/billing (click on it)

<img width="766" alt="Screenshot 2019-04-19 at 11 16 56" src="https://user-images.githubusercontent.com/82778/56416050-61fc8180-6298-11e9-8f9d-49c1ad6aeffb.png">

Check /me/purchases with various plans