### PR TITLE
CircleCI: Build full-site-editing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ references:
         "$CIRCLE_ARTIFACTS/notifications-panel" \
         "$CIRCLE_ARTIFACTS/translate"           \
         "$CIRCLE_ARTIFACTS/screenshots"         \
+        "$CIRCLE_ARTIFACTS/full-site-editing"   \
         "$CIRCLE_ARTIFACTS/wpcom-block-editor"  \
         "$CIRCLE_TEST_REPORTS/client"           \
         "$CIRCLE_TEST_REPORTS/eslint"           \
@@ -296,6 +297,18 @@ jobs:
           name: Build the block editor in WordPress.com integration utils package
           command: |
             npx lerna run build --scope='@automattic/wpcom-block-editor' -- -- --output-path=$CIRCLE_ARTIFACTS/wpcom-block-editor
+      - store-artifacts-and-test-results
+
+  build-full-site-editing:
+    <<: *defaults
+    parallelism: 1
+    steps:
+      - prepare
+      - run:
+          name: Build the Full Site Editing plugin and theme
+          command: |
+            npx lerna run build --scope='@automattic/full-site-editing'
+            cp -R apps/full-site-editing/dist $CIRCLE_ARTIFACTS/full-site-editing/
       - store-artifacts-and-test-results
 
   test-client:
@@ -601,6 +614,9 @@ workflows:
           filters:
             branches:
               ignore: master
+      - build-full-site-editing:
+          requires:
+            - setup
       - build-notifications:
           requires:
             - setup

--- a/apps/full-site-editing/README.md
+++ b/apps/full-site-editing/README.md
@@ -4,37 +4,32 @@ This app contains both the `full-site-editing-plugin` and the required `blank-th
 
 ## File Architecture
 
-These is an example of what we should find inside the theme and plugin folders:
-
 ```
 /blank-theme
-  /dist
-    blank-theme.css
-    blank-theme.js
   functions.php
   index.js
   index.php
   index.scss
 
 /full-site-editing-plugin
-  /dist
-    full-site-editing-plugin.css
-    full-site-editing-plugin.js
   full-site-editing-plugin.php
   index.js
   index.scss
-```
 
-## Local Development
-
-Symlink both the theme and the plugin into a local WordPress install.
-
-E.g.
-
-```
-ln -s ~/Dev/wp-calypso/apps/full-site-editing/full-site-editing-plugin/ ~/Dev/wordpress/wp-content/plugins/full-site-editing-plugin
-
-ln -s ~/Dev/wp-calypso/apps/full-site-editing/blank-theme/ ~/Dev/wordpress/wp-content/themes/blank-theme
+/dist
+  /blank-theme
+    blank-theme.css
+    blank-theme.js
+    functions.php
+    index.js
+    index.php
+    index.scss
+  /full-site-editing-plugin
+    full-site-editing-plugin.css
+    full-site-editing-plugin.js
+    full-site-editing-plugin.php
+    index.js
+    index.scss
 ```
 
 ## Build System
@@ -47,6 +42,8 @@ Compiles both the theme and the plugin, and watches for changes.
 - `npx lerna run build --scope='@automattic/full-site-editing'`<br>
 Compiles and minifies for production both the theme and the plugin.
 
+Both these scripts will also move all source and PHP files into their respective folder inside `/dist`.
+
 The entry points are:
 
 - `/blank-theme/index.js`
@@ -54,5 +51,22 @@ The entry points are:
 
 The outputs are:
 
-- `/blank-theme/dist/blank-theme.(js|css)`
-- `/full-site-editing-plugin/dist/full-site-editing-plugin.(js|css)`
+- `/dist/blank-theme`
+- `/dist/full-site-editing-plugin`
+
+Note that compiled JS and CSS will have the folder name (e.g. `blank-theme.js`), and will be positioned in the folder root (e.g. `/dist/blank-theme/blank-theme.js`), which is the same level of the main PHP file.<br>
+Enqueue your scripts accordingly!
+
+## Local Development
+
+Build (or `run dev`) and symlink both the theme and the plugin into a local WordPress install.
+
+E.g.
+
+```
+npx lerna run build --scope='@automattic/full-site-editing'
+
+ln -s ~/Dev/wp-calypso/apps/full-site-editing/dist/full-site-editing-plugin/ ~/Dev/wordpress/wp-content/plugins/full-site-editing-plugin
+
+ln -s ~/Dev/wp-calypso/apps/full-site-editing/dist/blank-theme/ ~/Dev/wordpress/wp-content/themes/blank-theme
+```

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -18,18 +18,18 @@ class A8C_Full_Site_Editing {
 
 	function register_script_and_style() {
 		$script_dependencies = json_decode( file_get_contents(
-			plugin_dir_path( __FILE__ ) . 'dist/full-site-editing-plugin.deps.json'
+			plugin_dir_path( __FILE__ ) . 'full-site-editing-plugin.deps.json'
 		), true );
 		wp_register_script(
 			'a8c-full-site-editing-script',
-			plugins_url( 'dist/full-site-editing-plugin.js', __FILE__ ),
+			plugins_url( 'full-site-editing-plugin.js', __FILE__ ),
 			is_array( $script_dependencies ) ? $script_dependencies : array(),
-			filemtime( plugin_dir_path( __FILE__ ) . 'dist/full-site-editing-plugin.js' )
+			filemtime( plugin_dir_path( __FILE__ ) . 'full-site-editing-plugin.js' )
 		);
 
 		$style_file = is_rtl()
-			? 'dist/full-site-editing-plugin.rtl.css'
-			: 'dist/full-site-editing-plugin.css';
+			? 'full-site-editing-plugin.rtl.css'
+			: 'full-site-editing-plugin.css';
 		wp_register_style(
 			'a8c-full-site-editing-style',
 			plugins_url( $style_file, __FILE__ ),

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -16,15 +16,15 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
-		"php": "cp -R *plugin *theme dist",
+		"copy-to-dist": "cp -R *plugin *theme dist",
 		"plugin": "calypso-build --source='plugin'",
 		"dev:plugin": "npm run plugin",
 		"build:plugin": "NODE_ENV=production npm run plugin",
 		"theme": "calypso-build --source='theme'",
 		"dev:theme": "npm run theme",
 		"build:theme": "NODE_ENV=production npm run theme",
-		"dev": "rimraf dist && mkdir dist && npm run php && npm-run-all --parallel dev:*",
-		"build": "rimraf dist && npm-run-all --parallel build:* && npm run php"
+		"dev": "rimraf dist && mkdir dist && npm run copy-to-dist && npm-run-all --parallel dev:*",
+		"build": "rimraf dist && npm-run-all --parallel build:* && npm run copy-to-dist"
 	},
 	"dependencies": {
 		"@wordpress/blocks": "^6.2.3",

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -16,14 +16,15 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
+		"php": "cp -R *plugin *theme dist",
 		"plugin": "calypso-build --source='plugin'",
 		"dev:plugin": "npm run plugin",
 		"build:plugin": "NODE_ENV=production npm run plugin",
 		"theme": "calypso-build --source='theme'",
 		"dev:theme": "npm run theme",
 		"build:theme": "NODE_ENV=production npm run theme",
-		"dev": "npm-run-all --parallel dev:*",
-		"build": "npm-run-all --parallel build:*"
+		"dev": "rimraf dist && mkdir dist && npm run php && npm-run-all --parallel dev:*",
+		"build": "rimraf dist && npm-run-all --parallel build:* && npm run php"
 	},
 	"dependencies": {
 		"@wordpress/blocks": "^6.2.3",

--- a/apps/full-site-editing/webpack.config.js
+++ b/apps/full-site-editing/webpack.config.js
@@ -33,11 +33,11 @@ function getWebpackConfig( env = {}, argv = {} ) {
 
 	if ( 'theme' === argv.source ) {
 		argv.entry = path.join( __dirname, 'blank-theme' );
-		argv[ 'output-path' ] = path.join( __dirname, 'blank-theme', 'dist' );
+		argv[ 'output-path' ] = path.join( __dirname, 'dist', 'blank-theme' );
 		argv[ 'output-filename' ] = 'blank-theme.js';
 	} else {
 		argv.entry = path.join( __dirname, 'full-site-editing-plugin' );
-		argv[ 'output-path' ] = path.join( __dirname, 'full-site-editing-plugin', 'dist' );
+		argv[ 'output-path' ] = path.join( __dirname, 'dist', 'full-site-editing-plugin' );
 		argv[ 'output-filename' ] = 'full-site-editing-plugin.js';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a CircleCI job that creates artifacts from the `dist` folder containing plugin and theme.
* Update the whole build system of the app (check the updated readme).

#### Testing instructions

* On CircleCI, check the artifacts contained in the `build-full-site-editing` job.
* Make sure they contain all the built files and the source and PHP files as well.
* Locally, run the following scripts, and make sure they work as expected.
  * `npx lerna run dev --scope='@automattic/full-site-editing'`
  * `npx lerna run build --scope='@automattic/full-site-editing'`
* Don't forget to update the symlinks to the dist (check the updated readme) if needed!

Fix #32488 (see also D27231-code)