### PR TITLE
Disable removeDomainsStepFromOnboarding AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -109,8 +109,8 @@ export default {
 	removeDomainsStepFromOnboarding: {
 		datestamp: '20190412',
 		variations: {
-			keep: 50,
-			remove: 50,
+			keep: 100,
+			remove: 0,
 		},
 		defaultVariation: 'keep',
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This Pull Requests disables removeDomainsStepFromOnboarding and restores the domains signup step for all users. 

#### Testing instructions

1. Open signup in incognito mode a few times
2. Confirm that you are always assigned to the "keep" variation of removeDomainsStepFromOnboarding test
3. Choose a business segment and confirm the domains step is present