### PR TITLE
Turn off nav drawer feature flag on wpcalypso.

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -148,7 +148,7 @@
 		"try/single-cdn": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
-		"ui/streamlined-nav-drawer": true,
+		"ui/streamlined-nav-drawer": false,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,


### PR DESCRIPTION
We need to update some e2e tests to take the updated nav structure (see
PR #32370) into account.  In the meantime, this PR disables the
associated feature flag on wpcalypso so that folks can run e2e tests
against calypso.live.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Navigate to this PR's calypso.live URL.  You should see the nav drawer as it is in production currently.

You can toggle the nav drawer redesign on manually by adding "?flags=+ui/streamlined-nav-drawer" to your URL.