### PR TITLE
Allow toggling of feature flags with cookie

### DIFF
--- a/client/config/README.md
+++ b/client/config/README.md
@@ -32,12 +32,19 @@ we can process the compiled scripts and remove code for disabled features in
 production.
 
 When Calypso is running in development mode or in the `stage` environment, you
-can specify a `?flags=` query argument to modify feature flags for each full
-page load.  Examples:
+can specify a `?flags=` query argument or a `flags` cookie to modify feature 
+flags for each full page load.  
+
+Query argument examples:
 
 - `?flags=flag1`: Enable feature `flag1`.
 - `?flags=-flag2`: Disable feature `flag2`.
 - `?flags=+flag1,-flag2`: Enable feature `flag1` and disable feature `flag2`.
+
+You can use the same syntax in a cookie:
+
+- `document.cookie = 'flags=+flag1,-flag2;max-age=1209600;path=/';`: Enable feature `flag1` and disable feature `flag2`.
+- `document.cookie = 'flags=';`: Reset flags cookie to return to config values.
 
 Note: the `?flags` argument won't work for feature flags used by the Node.js
 server.  For this case, you can use the

--- a/client/config/README.md
+++ b/client/config/README.md
@@ -46,7 +46,7 @@ You can use the same syntax in a cookie:
 - `document.cookie = 'flags=+flag1,-flag2;max-age=1209600;path=/';`: Enable feature `flag1` and disable feature `flag2`.
 - `document.cookie = 'flags= ; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;';`: Reset flags cookie to config values.
 
-Note: the `?flags` argument won't work for feature flags used by the Node.js
+Note: the `flags` query argument and cookie won't work for feature flags used by the Node.js
 server.  For this case, you can use the
 [`ENABLE_FEATURES` and/or `DISABLE_FEATURES`](../../config/README.md#feature-flags)
 environment variables instead.

--- a/client/config/README.md
+++ b/client/config/README.md
@@ -44,7 +44,7 @@ Query argument examples:
 You can use the same syntax in a cookie:
 
 - `document.cookie = 'flags=+flag1,-flag2;max-age=1209600;path=/';`: Enable feature `flag1` and disable feature `flag2`.
-- `document.cookie = 'flags=';`: Reset flags cookie to return to config values.
+- `document.cookie = 'flags= ; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;';`: Reset flags cookie to config values.
 
 Note: the `?flags` argument won't work for feature flags used by the Node.js
 server.  For this case, you can use the

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -33,33 +33,34 @@ export function isCalypsoLive() {
 	return typeof window !== 'undefined' && CALYPSO_LIVE_REGEX.test( window.location.host );
 }
 
-if ( process.env.NODE_ENV === 'development' || configData.env_id === 'stage' || isCalypsoLive() ) {
-	function applyFlags( flagsString ) {
-		const flags = flagsString.split( ',' );
-		flags.forEach( flagRaw => {
-			const flag = flagRaw.replace( /^[-+]/, '' );
-			const enabled = ! /^-/.test( flagRaw );
-			configData.features[ flag ] = enabled;
-			// eslint-disable-next-line no-console
-			console.log(
-				'%cConfig flag %s via URL: %s',
-				'font-weight: bold;',
-				enabled ? 'enabled' : 'disabled',
-				flag
-			);
-		} );
-	}
+function applyFlags( flagsString, modificationMethod ) {
+	const flags = flagsString.split( ',' );
+	flags.forEach( flagRaw => {
+		const flag = flagRaw.replace( /^[-+]/, '' );
+		const enabled = ! /^-/.test( flagRaw );
+		configData.features[ flag ] = enabled;
+		// eslint-disable-next-line no-console
+		console.log(
+			'%cConfig flag %s via %s: %s',
+			'font-weight: bold;',
+			enabled ? 'enabled' : 'disabled',
+			modificationMethod,
+			flag
+		);
+	} );
+}
 
+if ( process.env.NODE_ENV === 'development' || configData.env_id === 'stage' || isCalypsoLive() ) {
 	const cookies = cookie.parse( document.cookie );
 
 	if ( cookies.flags ) {
-		applyFlags( cookies.flags );
+		applyFlags( cookies.flags, 'cookie' );
 	}
 
 	const match =
 		document.location.search && document.location.search.match( /[?&]flags=([^&]+)(&|$)/ );
 	if ( match ) {
-		applyFlags( match[ 1 ] );
+		applyFlags( match[ 1 ], 'URL' );
 	}
 }
 

--- a/client/config/index.js
+++ b/client/config/index.js
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import cookie from 'cookie';
+
+/**
  * Internal dependencies
  */
 
@@ -29,10 +34,8 @@ export function isCalypsoLive() {
 }
 
 if ( process.env.NODE_ENV === 'development' || configData.env_id === 'stage' || isCalypsoLive() ) {
-	const match =
-		document.location.search && document.location.search.match( /[?&]flags=([^&]+)(&|$)/ );
-	if ( match ) {
-		const flags = match[ 1 ].split( ',' );
+	function applyFlags( flagsString ) {
+		const flags = flagsString.split( ',' );
 		flags.forEach( flagRaw => {
 			const flag = flagRaw.replace( /^[-+]/, '' );
 			const enabled = ! /^-/.test( flagRaw );
@@ -45,6 +48,18 @@ if ( process.env.NODE_ENV === 'development' || configData.env_id === 'stage' || 
 				flag
 			);
 		} );
+	}
+
+	const cookies = cookie.parse( document.cookie );
+
+	if ( cookies.flags ) {
+		applyFlags( cookies.flags );
+	}
+
+	const match =
+		document.location.search && document.location.search.match( /[?&]flags=([^&]+)(&|$)/ );
+	if ( match ) {
+		applyFlags( match[ 1 ] );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, on non-production environments, we allow folks to toggle
feature flags via the query string argument `flags`.  This can be
helpful for testing the flag itself.

This commit adds the ability for toggling feature flags using the same
syntax via a cookie.  The use case targeted by this addition is
different than the query argument.  For HEs trying to provide support
for customers (either by taking screenshots or just reproducing an issue
by navigating Calypso), it can be disruptive when we deploy a major
feature to staging.  The HE sees one experience and the customer sees
something else.  Replicating the customer's experience (by going
directly to production) is disruptive for the HE.

So, with this addition, we can include instructions for setting a cookie
with a little one-liner snippet when pre-announcing a big UX change to
HEs.

Similarly to the query argument flag modifications, we call
`console.log` so there is at least some visibility regarding the altered
config.  Beyond that, the example given in the docs includes a cookie
that expires after a couple weeks.  This is intended to clear out these
custom flag tweaks to return folks to the stock experience and hopefully
reduce confusion caused by someone forgetting that they've set a flag.

If this ends up being used frequently, we may explore adding some
UI and/or a browser extension for managing these flags.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set a cookie in your JS console to enable the nav drawer feature flag on this PR's calypso.live instance: `document.cookie = 'flags=+ui/streamlined-nav-drawer;max-age=1209600;path=/';`
* Following a page refresh, you should now the "My Sites" nav drawer redesign with the expandable sub-menus. 
* Clear out the cookie to return to the current production sidebar design: `document.cookie = 'flags= ; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;';`

