### PR TITLE
Remove G Suite Monthly AB Tests

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
+++ b/client/components/upgrades/gsuite/gsuite-dialog/product-details.jsx
@@ -10,18 +10,11 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import GSuitePrice from 'components/gsuite/gsuite-price';
 import GSuiteCompactFeatures from 'components/gsuite/gsuite-features/compact';
 
 function GoogleAppsProductDetails( { currencyCode, cost, domain, plan } ) {
 	const translate = useTranslate();
-
-	// currencyCode can safely replace the countryCode, just make sure we have one first
-	const showMonthlyPrice =
-		null !== currencyCode
-			? 'showMonthlyPrice' === abtest( 'gsuiteDomainFlowOptions', currencyCode )
-			: false;
 
 	return (
 		<div className="gsuite-dialog__product-details">
@@ -38,11 +31,7 @@ function GoogleAppsProductDetails( { currencyCode, cost, domain, plan } ) {
 					) }
 				</p>
 
-				<GSuitePrice
-					cost={ cost }
-					currencyCode={ currencyCode }
-					showMonthlyPrice={ showMonthlyPrice }
-				/>
+				<GSuitePrice cost={ cost } currencyCode={ currencyCode } showMonthlyPrice />
 			</div>
 
 			<GSuiteCompactFeatures domainName={ domain } productSlug={ plan } type={ 'list' } />

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -201,18 +201,6 @@ export default {
 		defaultVariation: 'controlSupportSession',
 		allowExistingUsers: true,
 	},
-	gsuitePurchaseCtaOptions: {
-		datestamp: '20190411',
-		variations: {
-			hideBusinessWithAnnualPrices: 25,
-			hideBusinessWithMonthlyPrices: 25,
-			showBusinessWithAnnualPrices: 25,
-			showBusinessWithMonthlyPrices: 25,
-		},
-		defaultVariation: 'hideBusinessWithAnnualPrices',
-		allowExistingUsers: true,
-		countryCodeTargets: [ 'USD' ],
-	},
 	domainSuggestionsEnCheck: {
 		datestamp: '20190415',
 		variations: {
@@ -221,15 +209,5 @@ export default {
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
-	},
-	gsuiteDomainFlowOptions: {
-		datestamp: '20190415',
-		variations: {
-			hideMonthlyPrice: 50,
-			showMonthlyPrice: 50,
-		},
-		defaultVariation: 'hideMonthlyPrice',
-		allowExistingUsers: true,
-		countryCodeTargets: [ 'USD' ],
 	},
 };

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -127,10 +127,10 @@ function getLoginUrlWithTOSRedirect( email, domain ) {
  *
  * @param {Number} cost - cost
  * @param {String} currencyCode - currency code to format with
- * @returns {String} - Formatted Monthly price
+ * @returns {String} - Formatted Monthly price, rounded to the nearest tenth
  */
 function getMonthlyPrice( cost, currencyCode ) {
-	return formatPrice( cost / 12, currencyCode );
+	return formatPrice( cost / 12, currencyCode, { precision: 1 } );
 }
 
 /**

--- a/client/my-sites/email/gsuite-purchase-cta/index.jsx
+++ b/client/my-sites/email/gsuite-purchase-cta/index.jsx
@@ -12,7 +12,6 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import config from 'config';
 import CompactCard from 'components/card/compact';
@@ -24,7 +23,6 @@ import { getSelectedSiteSlug } from 'state/ui/selectors';
 import GSuiteFeatures from 'components/gsuite/gsuite-features';
 import GSuiteLearnMore from 'components/gsuite/gsuite-learn-more';
 import GSuitePrice from 'components/gsuite/gsuite-price';
-import GSuitePurchaseCtaSkuInfo from 'my-sites/email/gsuite-purchase-cta/sku-info';
 import { recordTracksEvent } from 'state/analytics/actions';
 import QueryProductsList from 'components/data/query-products-list';
 
@@ -37,7 +35,6 @@ export const GSuitePurchaseCta = ( {
 	currencyCode,
 	domainName,
 	gsuiteBasicCost,
-	gsuiteBusinessCost,
 	recordTracksEvent: recordEvent,
 	selectedSiteSlug,
 } ) => {
@@ -64,68 +61,6 @@ export const GSuitePurchaseCta = ( {
 
 	const translate = useTranslate();
 	const upgradeAvailable = config.isEnabled( 'upgrades/checkout' );
-	// only allow test for USD users, this is supposed to be a countryCode but nothing prevents
-	// arbitrary codes being used. Also wait until we have the currencyCode to check.
-	const abTestGroup =
-		null !== currencyCode ? abtest( 'gsuitePurchaseCtaOptions', currencyCode ) : 'none';
-	const showBusinessOption =
-		abTestGroup === 'showBusinessWithAnnualPrices' ||
-		abTestGroup === 'showBusinessWithMonthlyPrices';
-	const showMonthlyPrice =
-		abTestGroup === 'hideBusinessWithMonthlyPrices' ||
-		abTestGroup === 'showBusinessWithMonthlyPrices';
-
-	const renderBasicSku = () => (
-		<div>
-			{ showBusinessOption && (
-				<GSuitePurchaseCtaSkuInfo
-					skuName={ translate( 'G Suite Basic' ) }
-					storageText={ translate( '30 GB of Storage' ) }
-				/>
-			) }
-			<GSuitePrice
-				cost={ gsuiteBasicCost }
-				currencyCode={ currencyCode }
-				showMonthlyPrice={ showMonthlyPrice }
-			/>
-			{ upgradeAvailable && (
-				<Button
-					className="gsuite-purchase-cta__get-gsuite-button"
-					onClick={ () => {
-						goToAddGSuiteUsers( 'basic' );
-					} }
-					primary
-				>
-					{ showBusinessOption ? translate( 'Add G Suite Basic' ) : translate( 'Add G Suite' ) }
-				</Button>
-			) }
-		</div>
-	);
-
-	const renderBusinessSku = () => (
-		<div>
-			<GSuitePurchaseCtaSkuInfo
-				skuName={ translate( 'G Suite Business' ) }
-				storageText={ translate( 'Unlimited Storage' ) }
-				storageNoticeText={ translate( 'Accounts with fewer than 5 users have 1 TB per user.' ) }
-			/>
-			<GSuitePrice
-				cost={ gsuiteBusinessCost }
-				currencyCode={ currencyCode }
-				showMonthlyPrice={ showMonthlyPrice }
-			/>
-			{ upgradeAvailable && (
-				<Button
-					className="gsuite-purchase-cta__get-gsuite-button"
-					onClick={ () => {
-						goToAddGSuiteUsers( 'business' );
-					} }
-				>
-					{ translate( 'Add G Suite Business' ) }
-				</Button>
-			) }
-		</div>
-	);
 
 	return (
 		<EmailVerificationGate
@@ -153,13 +88,20 @@ export const GSuitePurchaseCta = ( {
 								'storage, docs, calendars, and more integrated with your site.'
 						) }
 					</p>
-					{ ! showBusinessOption && renderBasicSku() }
-					{ showBusinessOption && (
-						<div className="gsuite-purchase-cta__skus">
-							{ renderBasicSku() }
-							{ renderBusinessSku() }
-						</div>
-					) }
+					<div>
+						<GSuitePrice cost={ gsuiteBasicCost } currencyCode={ currencyCode } showMonthlyPrice />
+						{ upgradeAvailable && (
+							<Button
+								className="gsuite-purchase-cta__get-gsuite-button"
+								onClick={ () => {
+									goToAddGSuiteUsers( 'basic' );
+								} }
+								primary
+							>
+								{ translate( 'Add G Suite' ) }
+							</Button>
+						) }
+					</div>
 				</div>
 
 				<div className="gsuite-purchase-cta__header-image">
@@ -178,7 +120,6 @@ GSuitePurchaseCta.propTypes = {
 	currencyCode: PropTypes.string,
 	domainName: PropTypes.string.isRequired,
 	gsuiteBasicCost: PropTypes.number,
-	gsuiteBusinessCost: PropTypes.number,
 	recordTracksEvent: PropTypes.func.isRequired,
 	selectedSiteSlug: PropTypes.string.isRequired,
 };
@@ -186,7 +127,6 @@ GSuitePurchaseCta.propTypes = {
 export default connect(
 	state => ( {
 		gsuiteBasicCost: getProductCost( state, 'gapps' ),
-		gsuiteBusinessCost: getProductCost( state, 'gapps_unlimited' ),
 		currencyCode: getCurrentUserCurrencyCode( state ),
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	} ),

--- a/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/gsuite-purchase-cta/test/__snapshots__/index.js.snap
@@ -44,11 +44,16 @@ exports[`GSuitePurchaseCta it renders GSuitePurchaseCta 1`] = `
           >
             <span>
               <strong>
-                $72
+                $6
               </strong>
-               per user / year
+               per user / month
             </span>
           </h4>
+          <h5
+            className="gsuite-price__annual-price"
+          >
+            $72 billed yearly
+          </h5>
         </div>
         <button
           className="button gsuite-purchase-cta__get-gsuite-button is-primary"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable both current G Suite AB Tests
* Always show monthly pricing
* Round monthly pricing a little bit

#### Testing instructions

1. Navigate to `/email/:domain/manage/:siteSlug` for a site and domain without G Suite
1. Confirm your screen matches: <img width="700" alt="Screen Shot 2019-04-19 at 3 31 55 PM" src="https://user-images.githubusercontent.com/2810519/56446578-486b3200-62b8-11e9-9e0c-720392452023.png">
1. Navigate through the add domain flow until you hit G Suite Up Sell
1. Confirm you screen matches: <img width="700" alt="Screen Shot 2019-04-19 at 2 30 45 PM" src="https://user-images.githubusercontent.com/2810519/56445546-9e3cdb80-62b2-11e9-9aa6-dda31348b6da.png">
1. Navigate to `/email/:domain/manage/:siteSlug` for a site and domain without G Suite
1. Site your account currency to GBP & EUR, confirm your screen matches:
<img width="300" alt="Screen Shot 2019-04-19 at 2 45 17 PM" src="https://user-images.githubusercontent.com/2810519/56445538-98df9100-62b2-11e9-86b3-5ed021b632fa.png">
<img width="300" alt="Screen Shot 2019-04-19 at 2 44 55 PM" src="https://user-images.githubusercontent.com/2810519/56445540-9aa95480-62b2-11e9-935e-5fce0fd022e8.png">
