### PR TITLE
Add New Site: celebrate if simple site

### DIFF
--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -103,7 +103,7 @@ export class JetpackConnectNotices extends Component {
 			case IS_DOT_COM:
 				noticeValues.status = 'is-success';
 				noticeValues.icon = 'plugins';
-				noticeValues.text = translate( "That's a WordPress.com site, always connected!" );
+				noticeValues.text = translate( 'Good news! WordPress.com sites already have Jetpack.' );
 				return noticeValues;
 
 			case NOT_WORDPRESS:

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -101,10 +101,9 @@ export class JetpackConnectNotices extends Component {
 				return noticeValues;
 
 			case IS_DOT_COM:
-				noticeValues.icon = 'block';
-				noticeValues.text = translate(
-					"That's a WordPress.com site, so you don't need to connect it."
-				);
+				noticeValues.status = 'is-success';
+				noticeValues.icon = 'plugins';
+				noticeValues.text = translate( "That's a WordPress.com site, so it's always connected!" );
 				return noticeValues;
 
 			case NOT_WORDPRESS:

--- a/client/jetpack-connect/jetpack-connect-notices.jsx
+++ b/client/jetpack-connect/jetpack-connect-notices.jsx
@@ -103,7 +103,7 @@ export class JetpackConnectNotices extends Component {
 			case IS_DOT_COM:
 				noticeValues.status = 'is-success';
 				noticeValues.icon = 'plugins';
-				noticeValues.text = translate( "That's a WordPress.com site, so it's always connected!" );
+				noticeValues.text = translate( "That's a WordPress.com site, always connected!" );
 				return noticeValues;
 
 			case NOT_WORDPRESS:

--- a/client/jetpack-connect/main.jsx
+++ b/client/jetpack-connect/main.jsx
@@ -143,6 +143,8 @@ export class JetpackConnectMain extends Component {
 
 	dismissUrl = () => this.props.dismissUrl( this.state.currentUrl );
 
+	goBack = () => page.back();
+
 	makeSafeRedirectionFunction( func ) {
 		return url => {
 			if ( ! this.state.redirecting ) {
@@ -339,7 +341,7 @@ export class JetpackConnectMain extends Component {
 				status ? (
 					<JetpackConnectNotices
 						noticeType={ status }
-						onDismissClick={ this.dismissUrl }
+						onDismissClick={ IS_DOT_COM === status ? this.goBack : this.dismissUrl }
 						url={ this.state.currentUrl }
 						onTerminalError={ this.props.isMobileAppFlow ? this.redirectToMobileApp : null }
 					/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Implements messaging part of #32400, replacing error message with a positive feedback.

#### Testing instructions

1. If testing with local Calypso build, navigate to Add New Site flow initial step page. With calypso.localhost, it's http://calypso.localhost:3000/jetpack/new?ref=calypso-selector

2. Enter a Simple site URL like https://foobar.wordpress.com and Continue.

3. Close the notice by clicking on the X button at top right corner of the notice.

Expected:

![add-new-site-dead-end](https://user-images.githubusercontent.com/127594/56744853-20535700-672e-11e9-8c6e-9905b3ef6bb1.gif)

Fixes #32400
