### PR TITLE
Full Site Editing: change script loading order

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -12,8 +12,7 @@ class A8C_Full_Site_Editing {
 		}
 		self::$initialized = true;
 
-		$this->register_script_and_style();
-
+		add_action( 'init', array( $this, 'register_script_and_style' ), 100 );
 		add_action( 'init', array( $this, 'register_blocks' ), 100 );
 	}
 

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -25,9 +25,6 @@
 		"dev": "npm-run-all --parallel dev:*",
 		"build": "npm-run-all --parallel build:*"
 	},
-	"devDependencies": {
-		"@automattic/calypso-build": "file:../../packages/calypso-build"
-	},
 	"dependencies": {
 		"@wordpress/blocks": "^6.2.3",
 		"@wordpress/components": "^7.3.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Move script registration to `init` hook to avoid showing the following notice:

`Notice: wp_register_script was called incorrectly. Scripts and styles should not be registered or enqueued until the wp_enqueue_scripts, admin_enqueue_scripts, or login_enqueue_scripts hooks...`

Also removed unneeded `devDependencies` according to this review comment https://github.com/Automattic/wp-calypso/pull/32355#discussion_r276417959.

#### Testing instructions

* From the Calypso root, build the plugin with `npx lerna run build --scope='@automattic/full-site-editing'`.
* Move the full-site-editing-plugin folder (or symlink it) into /wp-content/plugins of any WordPress install.
* Open its dashboard, and enable the Full Site Editing plugin.
* Open the block editor, and verify that you can still insert the "Page Content Preview" block.
* Verify that there is no PHP notice from above.