### PR TITLE
Importer Signup Flow: Auto start import once in Calypso-proper

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -6,6 +6,7 @@
  */
 import debugFactory from 'debug';
 import { camelCase, isPlainObject, omit, pick, reject, snakeCase } from 'lodash';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies.
@@ -1838,6 +1839,21 @@ Undocumented.prototype.updateImporter = function( siteId, importerStatus ) {
 	return this.wpcom.req.post( {
 		path: `/sites/${ siteId }/imports/${ importerStatus.importerId }`,
 		formData: [ [ 'importStatus', JSON.stringify( importerStatus ) ] ],
+	} );
+};
+
+Undocumented.prototype.importWithSiteImporter = function(
+	siteId,
+	importerStatus,
+	params,
+	targetUrl
+) {
+	debug( `/sites/${ siteId }/site-importer/import-site?${ stringify( params ) }` );
+
+	return this.wpcom.req.post( {
+		path: `/sites/${ siteId }/site-importer/import-site?${ stringify( params ) }`,
+		apiNamespace: 'wpcom/v2',
+		formData: [ [ 'import_status', JSON.stringify( importerStatus ) ], [ 'site_url', targetUrl ] ],
 	} );
 };
 

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
+import { defer } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,7 +45,7 @@ class ImporterAuthorMapping extends React.Component {
 		const { hasSingleAuthor, onSelect: selectAuthor } = this.props;
 
 		if ( hasSingleAuthor ) {
-			selectAuthor( this.props.currentUser );
+			defer( () => selectAuthor( this.props.currentUser ) );
 		}
 	}
 

--- a/client/my-sites/importer/from-signup-landing-pane.jsx
+++ b/client/my-sites/importer/from-signup-landing-pane.jsx
@@ -1,0 +1,28 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import ImporterActionButtonContainer from 'my-sites/importer/importer-action-buttons/container';
+import BusyImportingButton from 'my-sites/importer/importer-action-buttons/busy-importing-button';
+
+export const FromSignupLandingPane = ( { translate } ) => (
+	<div>
+		<p>
+			{ translate(
+				'Thanks for choosing WordPress.com, ' +
+					'give us a moment while we get started importing your content!'
+			) }
+		</p>
+		<ImporterActionButtonContainer>
+			<BusyImportingButton />
+		</ImporterActionButtonContainer>
+	</div>
+);
+
+export default localize( FromSignupLandingPane );

--- a/client/my-sites/importer/site-importer/index.jsx
+++ b/client/my-sites/importer/site-importer/index.jsx
@@ -18,6 +18,7 @@ import Card from 'components/card';
 import ImporterHeader from '../importer-header';
 import ImportingPane from '../importing-pane';
 import SiteImporterInputPane from './site-importer-input-pane';
+import FromSignupLandingPane from '../from-signup-landing-pane';
 
 /**
  * Module variables
@@ -75,6 +76,9 @@ export default class extends React.PureComponent {
 					importerStatus={ state }
 					{ ...{ icon, title, description, isEnabled, site } }
 				/>
+				{ state.importerState === appStates.FROM_SIGNUP && (
+					<FromSignupLandingPane engine={ state.engine } />
+				) }
 				{ includes( importingStates, state.importerState ) && (
 					<ImportingPane
 						{ ...this.props }

--- a/client/state/imports/constants.js
+++ b/client/state/imports/constants.js
@@ -4,6 +4,7 @@ export const appStates = Object.freeze( {
 	DEFUNCT: 'importer-defunct',
 	DISABLED: 'importer-disabled',
 	EXPIRE_PENDING: 'importer-expire-pending',
+	FROM_SIGNUP: 'from-signup',
 	IMPORT_FAILURE: 'importer-import-failure',
 	IMPORT_SUCCESS: 'importer-import-success',
 	IMPORTING: 'importer-importing',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to kick-off a site-importer import automatically after a new customer finishes up their signup flow and lands in Calypso-proper - giving them a smoother landing experience and a nicer welcome to their new account (as opposed to immediately having to go through extra steps and do extra work right away!)

Some of the additions/extras that you'll find:

- The `/site-importer/import-site/` endpoint call is now extracted out in to `wpcom.undocumented` - this was just to help lessen the cognitive burden of working within the actions file.
- The automatic `selectAuthor` calls in `author-mapping-item.jsx` are now `defer`red. This was previously causing some less than helpful 'Cannot dispatch while already dispatching' type errors.
- Renamed `renderImportersList ` to `renderImportersMain` - it just made a bit more sense to be more general about what we're rendering here.
- A little bit of guarding against type errors in `sortAndStringify`
- An additional from-signup importing 'pane' and logic to render it. This new pane is very basic right now but I hope designers see this as a blank canvas to welcome new customers. We have the opportunity to add some better messaging, some illustration - anything really. This pane will be shown instead of showing the various import stages being run automatically and will eventually be replaced once the import has actually started progressing (screen shots below).

Landing from the signup flow, while we set up the import we override with this pane:
<img width="647" alt="Screenshot 2019-04-20 at 10 39 30" src="https://user-images.githubusercontent.com/4335450/56460506-a5b6c000-6358-11e9-87b6-832a90ea409d.png">

Once the import is actually in progress, we move on to the regular panes:
<img width="631" alt="Screenshot 2019-04-20 at 10 39 42" src="https://user-images.githubusercontent.com/4335450/56460507-a5b6c000-6358-11e9-9cf6-6fc1541f8d2d.png">

Note: I've tagged this as needing a design review. I'd love to hear thoughts from @shaunandrews, @dezzie and anyone else about the new pane shown above.

#### Testing instructions

First, test the regular import flows. Try a Wix import, try a WordPress import, try the Wix import on a site that has two authors (on the WP side), try the same with a site with only a single author (WP side).
They should all work as expected (ask for further details if needed).

Then, test from the signup flow:
- Start at http://calypso.localhost:3000/start/import/from-url
- Enter a Wix URL and confirm the site (as per directions in #31721) (Here's an example URL: https://smt593.wixsite.com/wowz/static-page)
- You should see the signup flow progress and follow in to Calypso-proper where you'll land at  `http://calypso.localhost:3000/settings/import/{ a newly generated x.wordpress.com url }?signup=1`
- You should see the importer and it'll display the pane shown in the first screenshot shown in the description above
- After a few moments, you'll see the screen from the second screenshot where your import will start processing and showing a progress bar.
- You should eventually see that the import was successful and be given the option to view site.
