### PR TITLE
Cart Icon: Add Hover Colour

### DIFF
--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -242,6 +242,10 @@
 		position: absolute;
 		top: 12px;
 		right: 12px;
+		
+		&:hover {
+			color: var( --color-accent );
+		}
 	}
 
 	&:focus {

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -244,7 +244,7 @@
 		right: 12px;
 		
 		&:hover {
-			color: var( --color-accent );
+			color: var( --color-primary );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a hover colour to the cart icon. I'm not exactly sure if it should be accent or primary (cc @drw158), but I'm assuming accent since it's a hover state.

#### Testing instructions

Hover over the cart icon on the plans page. 

**Normal:**

<img width="110" alt="Screenshot 2019-04-21 at 07 58 21" src="https://user-images.githubusercontent.com/43215253/56466542-86c53600-640b-11e9-9f41-4e5c1ee9182e.png">

**Hover:**

<img width="185" alt="Screenshot 2019-04-21 at 07 58 04" src="https://user-images.githubusercontent.com/43215253/56466544-917fcb00-640b-11e9-8d67-685ddf27fc69.png">

cc @sixhours, @blowery, @flootr 

Fixes #32405
