### PR TITLE
Sidebar Redesign: Fix Invisible Selected Icon

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -621,6 +621,10 @@ form.sidebar__button input {
 		.gridicons-external {
 			display: inline-block;
 		}
+		
+		.selected svg {
+			fill: var( --sidebar-menu-selected-a-color );
+		}
 	
 		&.is-togglable {
 			.sidebar__menu-list {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the intended variable for icons when a tab in the sidebar is selected

#### Testing instructions

Follow the instructions in the original issue.

**Current:**

<img width="267" alt="Screenshot 2019-04-21 at 08 18 57" src="https://user-images.githubusercontent.com/43215253/56466880-a199a980-640f-11e9-8ab4-44aef2daef5c.png">

**Proposed:**

<img width="252" alt="Screenshot 2019-04-21 at 08 31 35" src="https://user-images.githubusercontent.com/43215253/56466904-e45b8180-640f-11e9-815a-ce6f920271f9.png">


cc @arunsathiya, @flootr, @blowery, @griffbrad

Fixes #32444
