### PR TITLE
Colour Scheming: Use Primary Button for Browser Notifications

### DIFF
--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -670,6 +670,7 @@ class PushNotificationSettings extends React.Component {
 		let blockedInstruction,
 			buttonClass,
 			buttonDisabled,
+			buttonPrimary,
 			buttonText,
 			deniedText,
 			stateClass,
@@ -683,6 +684,7 @@ class PushNotificationSettings extends React.Component {
 			case 'disabling':
 				buttonClass = { 'is-enable': true };
 				buttonDisabled = true;
+				buttonPrimary = true;
 				buttonText = this.props.translate( 'Enable' );
 				stateClass = { 'is-disabled': true };
 				stateText = this.props.translate( 'Disabled' );
@@ -690,6 +692,7 @@ class PushNotificationSettings extends React.Component {
 			case 'enabling':
 				buttonClass = { 'is-disable': true };
 				buttonDisabled = true;
+				buttonPrimary = false;
 				buttonText = this.props.translate( 'Disable' );
 				stateClass = { 'is-enabled': true };
 				stateText = this.props.translate( 'Enabled' );
@@ -697,6 +700,7 @@ class PushNotificationSettings extends React.Component {
 			case 'unsubscribed':
 				buttonClass = { 'is-enable': true };
 				buttonDisabled = false;
+				buttonPrimary = true;
 				buttonText = this.props.translate( 'Enable' );
 				stateClass = { 'is-disabled': true };
 				stateText = this.props.translate( 'Disabled' );
@@ -704,6 +708,7 @@ class PushNotificationSettings extends React.Component {
 			case 'subscribed':
 				buttonClass = { 'is-disable': true };
 				buttonDisabled = false;
+				buttonPrimary = false;
 				buttonText = this.props.translate( 'Disable' );
 				stateClass = { 'is-enabled': true };
 				stateText = this.props.translate( 'Enabled' );
@@ -712,6 +717,7 @@ class PushNotificationSettings extends React.Component {
 				blockedInstruction = this.getBlockedInstruction();
 				buttonClass = { 'is-enable': true };
 				buttonDisabled = true;
+				buttonPrimary = true;
 				buttonText = this.props.translate( 'Enable' );
 				stateClass = { 'is-disabled': true };
 				stateText = this.props.translate( 'Disabled' );
@@ -784,6 +790,7 @@ class PushNotificationSettings extends React.Component {
 						buttonClass
 					) }
 					disabled={ buttonDisabled }
+					primary={ buttonPrimary }
 					onClick={ this.clickHandler }
 				>
 					{ buttonText }

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -126,22 +126,4 @@
 	 	bottom: 24px;
 		right: 24px;
 	}
-
-	&.is-enable {
-		background: var( --color-accent );
-		border-color: var( --color-accent-dark );
-		color: var( --color-white );
-
-		&:hover,
-		&:focus {
-			border-color: var( --color-accent-dark );
-			color: var( --color-white );
-		}
-		&[disabled],
-		&:disabled {
-			background: var( --color-primary-50 );
-			border-color: var( --color-primary-200 );
-			color: var( --color-white );
-		}
-	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed that there's one case in Calypso where the primary button is recreated using accent colours, when I don't think it needs to be. This actually makes it a primary button. 

#### Testing instructions

Head to `me/notifications` and check that the "Enable" button is still primary, then disabled whilst activating, and then primary again if disabled. Basically, there should be no visual changes, so this is basically a janitorial PR.

<img width="786" alt="Screenshot 2019-04-21 at 08 54 56" src="https://user-images.githubusercontent.com/43215253/56467179-82048000-6413-11e9-94a0-568eeec0fab7.png">
 
cc @flootr, @blowery 