### PR TITLE
Payment Logo Component: Migrate Styling

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -82,7 +82,6 @@
 @import 'components/mini-site-preview/style';
 @import 'components/mobile-back-to-sidebar/style';
 @import 'components/notice/style';
-@import 'components/payment-logo/style';
 @import 'components/plans/plan-pill/style';
 @import 'components/plans/plan-icon/style';
 @import 'blocks/product-purchase-features-list/style';

--- a/client/components/payment-logo/index.jsx
+++ b/client/components/payment-logo/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,6 +7,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { keys } from 'lodash';
 import i18n from 'i18n-calypso';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const ALT_TEXT = {
 	alipay: 'Alipay',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrates the styling of the payment logo component as part of #27515.

#### Testing instructions

Visit `/plans/site` and verify that the payment logos appear beneath the plan table.

cc @jsnajdr, @blowery, @flootr 
