### PR TITLE
Google My Business Nudge: Migrate Styling

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -15,7 +15,6 @@
 @import 'blocks/domain-to-plan-nudge/style';
 @import 'blocks/follow-button/style';
 @import 'blocks/gdpr-banner/style';
-@import 'blocks/google-my-business-stats-nudge/style';
 @import 'blocks/inline-help/style';
 @import 'blocks/support-article-dialog/style';
 @import 'blocks/like-button/style';

--- a/client/blocks/google-my-business-stats-nudge/index.js
+++ b/client/blocks/google-my-business-stats-nudge/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -21,6 +19,11 @@ import { dismissNudge } from './actions';
 import { enhanceWithDismissCount } from 'my-sites/google-my-business/utils';
 import { enhanceWithSiteType, recordTracksEvent } from 'state/analytics/actions';
 import { withEnhancers } from 'state/utils';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class GoogleMyBusinessStatsNudge extends Component {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrates the styling of the Google My Business Nudge as part of #27515 and #27534

#### Testing instructions

Visit the stats page and verify that everything looks identical.

<img width="1073" alt="Screenshot 2019-04-21 at 21 35 41" src="https://user-images.githubusercontent.com/43215253/56475260-b44ac780-647d-11e9-9ac5-bd1cc9a812f9.png">

cc @jsnajdr, @blowery, @flootr 
