### PR TITLE
Reader: center content that's been centered in Gutenberg

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -125,6 +125,7 @@
 		display: block;
 		margin-top: 24px;
 		margin-bottom: 24px;
+		text-align: center;
 	}
 
 	.wp-caption.alignnone {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed that when centering an image block in Gutenberg, the image isn't centered in Reader but the caption is:

<img width="1004" alt="Screen Shot 2019-04-22 at 17 41 54" src="https://user-images.githubusercontent.com/17325/56484920-f7607580-6525-11e9-97a7-1c086331aba6.png">

This PR centres content with the `aligncenter` class applied.

After:

<img width="1029" alt="Screen Shot 2019-04-22 at 17 42 34" src="https://user-images.githubusercontent.com/17325/56484953-152dda80-6526-11e9-9ec7-63d527350e8c.png">

#### Testing instructions

Take a look at:

http://calypso.localhost:3000/read/blogs/82798297/posts/127

Ensure that the image is centred.

Compare with https://wpcalypso.wordpress.com/read/blogs/82798297/posts/127, where it is not.
