### PR TITLE
Infinite List: Migrate Styling

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -71,7 +71,6 @@
 @import 'components/forms/range/style';
 @import 'components/forms/sortable-list/style';
 @import 'components/image/style';
-@import 'components/infinite-list/style';
 @import 'components/info-popover/style';
 @import 'components/keyed-suggestions/style';
 @import 'components/legend-item/style';

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -19,6 +17,11 @@ import ScrollStore from './scroll-store';
 import ScrollHelper from './scroll-helper';
 import scrollTo from 'lib/scroll-to';
 import smartSetState from 'lib/react-smart-set-state';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const debug = debugFactory( 'calypso:infinite-list' );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrates the styling of the infinite list component as part of #27515.

#### Testing instructions

Visit a place where this component is used (such as `people/followers/site`) and check that the `infinite-list__spacer` class has a width of 100%.

<img width="420" alt="Screenshot 2019-04-22 at 09 43 28" src="https://user-images.githubusercontent.com/43215253/56492403-a3cd3800-64e3-11e9-8f35-0a9bb573ec50.png">

cc @jsnajdr, @blowery, @flootr 
