### PR TITLE
[e2e] Update tests for new Nav drawer

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -148,7 +148,7 @@
 		"try/single-cdn": true,
 		"ui/first-view": true,
 		"ui/first-view/reset-route": true,
-		"ui/streamlined-nav-drawer": false,
+		"ui/streamlined-nav-drawer": true,
 		"upgrades/checkout": true,
 		"upgrades/credit-cards": true,
 		"upgrades/domain-search": true,

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -56,7 +56,10 @@ export default class SidebarComponent extends AsyncBaseContainer {
 
 	async selectThemes() {
 		await this.expandDrawerItem( 'Design' );
-		return await driverHelper.clickWhenClickable( this.driver, By.css( '.menu-link-text[data-e2e-sidebar="Themes"]' ) ) // TODO: data-tip-target target is missing
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.menu-link-text[data-e2e-sidebar="Themes"]' )
+		); // TODO: data-tip-target target is missing
 	}
 
 	async customizeTheme() {
@@ -99,6 +102,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectImport() {
+		await this.expandDrawerItem( 'Tools' );
 		return await this._scrollToAndClickMenuItem( 'side-menu-import' );
 	}
 

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -18,11 +18,30 @@ export default class SidebarComponent extends AsyncBaseContainer {
 		this.storeSelector = By.css( '.menu-link-text[data-e2e-sidebar="Store"]' );
 	}
 
+	async expandDrawerItem( itemName ) {
+		const selector = await driverHelper.getElementByText(
+			this.driver,
+			By.css( '.sidebar__heading' ),
+			itemName
+		);
+		const itemSelector = await this.driver.findElement( selector );
+		const isExpanded = await itemSelector.getAttribute( 'aria-expanded' );
+		if ( isExpanded === 'false' ) {
+			await driverHelper.selectElementByText(
+				this.driver,
+				By.css( '.sidebar__heading' ),
+				itemName
+			);
+		}
+	}
+
 	async selectDomains() {
+		await this.expandDrawerItem( 'Manage' );
 		return await this._scrollToAndClickMenuItem( 'domains' );
 	}
 
 	async selectPeople() {
+		await this.expandDrawerItem( 'Manage' );
 		return await this._scrollToAndClickMenuItem( 'people' );
 	}
 
@@ -31,10 +50,12 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectManagePlugins() {
+		await this.expandDrawerItem( 'Tools' );
 		return await this._scrollToAndClickMenuItem( 'side-menu-plugins', { clickButton: true } );
 	}
 
 	async selectThemes() {
+		await this.expandDrawerItem( 'Themes' );
 		return await this._scrollToAndClickMenuItem( 'themes', { clickButton: true } );
 	}
 
@@ -55,6 +76,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectActivity() {
+		await this.expandDrawerItem( 'Tools' );
 		return await this._scrollToAndClickMenuItem( 'activity' );
 	}
 
@@ -67,10 +89,12 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectSettings() {
+		await this.expandDrawerItem( 'Manage' );
 		return await this._scrollToAndClickMenuItem( 'settings' );
 	}
 
 	async selectMedia() {
+		await this.expandDrawerItem( 'Site' );
 		return await this._scrollToAndClickMenuItem( 'side-menu-media' );
 	}
 
@@ -79,14 +103,17 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectPages() {
+		await this.expandDrawerItem( 'Site' );
 		return await this._scrollToAndClickMenuItem( 'side-menu-page' );
 	}
 
 	async selectPosts() {
+		await this.expandDrawerItem( 'Site' );
 		return await this._scrollToAndClickMenuItem( 'side-menu-post' );
 	}
 
 	async selectComments() {
+		await this.expandDrawerItem( 'Site' );
 		return await this._scrollToAndClickMenuItem( 'side-menu-comments' );
 	}
 

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -55,8 +55,8 @@ export default class SidebarComponent extends AsyncBaseContainer {
 	}
 
 	async selectThemes() {
-		await this.expandDrawerItem( 'Themes' );
-		return await this._scrollToAndClickMenuItem( 'themes', { clickButton: true } );
+		await this.expandDrawerItem( 'Design' );
+		return await driverHelper.clickWhenClickable( this.driver, By.css( '.menu-link-text[data-e2e-sidebar="Themes"]' ) ) // TODO: data-tip-target target is missing
 	}
 
 	async customizeTheme() {

--- a/test/e2e/lib/components/sidebar-component.js
+++ b/test/e2e/lib/components/sidebar-component.js
@@ -24,6 +24,7 @@ export default class SidebarComponent extends AsyncBaseContainer {
 			By.css( '.sidebar__heading' ),
 			itemName
 		);
+		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
 		const itemSelector = await this.driver.findElement( selector );
 		const isExpanded = await itemSelector.getAttribute( 'aria-expanded' );
 		if ( isExpanded === 'false' ) {

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -16,6 +16,7 @@ import NavBarComponent from '../components/nav-bar-component.js';
 import * as dataHelper from '../data-helper';
 import * as driverManager from '../driver-manager';
 import * as loginCookieHelper from '../login-cookie-helper';
+import PagesPage from '../pages/pages-page';
 
 const host = dataHelper.getJetpackHost();
 
@@ -129,7 +130,10 @@ export default class LoginFlow {
 		await this.loginAndSelectMySite( site, { useFreshLogin: useFreshLogin } );
 
 		const sidebarComponent = await SidebarComponent.Expect( this.driver );
-		await sidebarComponent.selectAddNewPage();
+		await sidebarComponent.selectPages();
+
+		const pagesPage = await PagesPage.Expect( this.driver );
+		await pagesPage.selectAddNewPage();
 
 		if ( ! usingGutenberg ) {
 			this.editorPage = await EditorPage.Expect( this.driver );

--- a/test/e2e/lib/pages/pages-page.js
+++ b/test/e2e/lib/pages/pages-page.js
@@ -37,4 +37,9 @@ export default class PagesPage extends AsyncBaseContainer {
 		const pageTitleSelector = By.linkText( `${ title }` );
 		return await driverHelper.clickWhenClickable( this.driver, pageTitleSelector );
 	}
+
+	async selectAddNewPage() {
+		const selector = By.css( '.pages__add-page' );
+		return await driverHelper.clickWhenClickable( this.driver, selector );
+	}
 }

--- a/test/e2e/specs/wp-import-site-spec.js
+++ b/test/e2e/specs/wp-import-site-spec.js
@@ -42,14 +42,6 @@ describe( 'Verify Import Option: (' + screenSize + ') @parallel', function() {
 		await navBarComponent.clickMySites();
 	} );
 
-	step( "Can see an 'Import' option", async function() {
-		const sideBarComponent = await SideBarComponent.Expect( driver );
-		return assert(
-			await sideBarComponent.settingsOptionExists(),
-			'The settings menu option does not exist'
-		);
-	} );
-
 	step( "Following 'Import' menu option opens the Import page", async function() {
 		const sideBarComponent = await SideBarComponent.Expect( driver );
 		await sideBarComponent.selectImport();

--- a/test/e2e/specs/wp-view-site-spec.js
+++ b/test/e2e/specs/wp-view-site-spec.js
@@ -30,7 +30,7 @@ before( async function() {
 
 describe( `[${ host }] View site from sidebar: (${ screenSize }) @parallel @jetpack`, function() {
 	this.timeout( mochaTimeOut );
-	describe( 'View site and close:', function() {
+	describe.skip( 'View site and close:', function() {
 		step( 'Can Log In and go to My Sites', async function() {
 			const loginFlow = new LoginFlow( driver );
 			return await loginFlow.loginAndSelectMySite();
@@ -38,7 +38,7 @@ describe( `[${ host }] View site from sidebar: (${ screenSize }) @parallel @jetp
 
 		step( 'Can view the default site from sidebar', async function() {
 			this.sidebarComponent = await SidebarComponent.Expect( driver );
-			return await this.sidebarComponent.selectViewThisSite();
+			return await this.sidebarComponent.selectViewThisSite(); // TODO: Where to select Preview site?
 		} );
 
 		step( 'Can see the web preview button', async function() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Tests are updated to match changes in the sidebar. New sidebar is enabled on this branch and all tests should pass. 

#### Testing instructions

Make sure that all tests are passing in CircleCI. 

**Notes:**

[One test](https://github.com/Automattic/wp-calypso/pull/32465/files#diff-8d3bc73947fb0715fe419a34164c4820R33) is excluded from the suite since there is no preview button in the sidebar. 

@griffbrad This PR should be merged right after nav drawer goes public. 


