### PR TITLE
Calypso Build: Allow Zero (Babel) Config

### DIFF
--- a/apps/wpcom-block-editor/babel.config.js
+++ b/apps/wpcom-block-editor/babel.config.js
@@ -1,3 +1,0 @@
-module.exports = {
-	extends: require.resolve( '@automattic/calypso-build/babel.config.js' ),
-};

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -87,9 +87,9 @@ function getWebpackConfig(
 		module: {
 			rules: [
 				TranspileConfig.loader( {
-					workerCount,
 					cacheDirectory: true,
 					exclude: /node_modules\//,
+					workerCount,
 				} ),
 				SassConfig.loader( {
 					preserveCssCustomProperties: false,

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -6,6 +6,7 @@
 /**
  * External dependencies
  */
+const fs = require( 'fs' );
 const path = require( 'path' );
 const webpack = require( 'webpack' );
 const DuplicatePackageCheckerPlugin = require( 'duplicate-package-checker-webpack-plugin' );
@@ -58,6 +59,11 @@ function getWebpackConfig(
 	const cssFilename = cssNameFromFilename( outputFilename );
 	const cssChunkFilename = cssNameFromFilename( outputChunkFilename );
 
+	let babelConfig = path.join( process.cwd(), 'babel.config.js' );
+	if ( ! fs.existsSync( babelConfig ) ) {
+		babelConfig = path.join( __dirname, 'babel.config.js' ); // Default to this package's Babel config
+	}
+
 	const webpackConfig = {
 		bail: ! isDevelopment,
 		entry,
@@ -88,6 +94,7 @@ function getWebpackConfig(
 			rules: [
 				TranspileConfig.loader( {
 					cacheDirectory: true,
+					configFile: babelConfig,
 					exclude: /node_modules\//,
 					workerCount,
 				} ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Calypso Build: Allow Zero (Babel) Config

Prior to this PR, packages and apps using `@automattic/calypso-build` had to provide a `babel.config.js` of their own, even if it was just `extends`ing `@automattic/calypso-build/babel.config.js`. This is changed per this PR, which will simply fall back to using that file if no `babel.config.js` is found in the current working directory (from which it is assumed the build tool will be run in order to build a package).

#### Testing instructions

Verify that `@automattic/wpcom-block-editor` (whose Babel config is removed) still builds:

```
npx lerna run build --scope='@automattic/wpcom-block-editor'
```
