### PR TITLE
Stats: Fix for errant "0" character when viewing a site with no annual stats

### DIFF
--- a/client/my-sites/stats/annual-site-stats/index.js
+++ b/client/my-sites/stats/annual-site-stats/index.js
@@ -188,7 +188,7 @@ class AnnualSiteStats extends Component {
 					{ isWidget && currentYearData && this.renderWidgetContent( currentYearData, strings ) }
 					{ isWidget && previousYearData && this.renderWidgetContent( previousYearData, strings ) }
 					{ ! isWidget && years && this.renderTable( years, strings ) }
-					{ isWidget && years && years.length && (
+					{ isWidget && years && years.length !== 0 && (
 						<div className="module-expand">
 							<a href={ viewAllLink }>
 								{ translate( 'View All', { context: 'Stats: Button label to expand a panel' } ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use a comparison where `years.length !== 0` rather than checking the value of `years.length` alone, since the latter outputs the value. 

**Before**

<img width="486" alt="Screen Shot 2019-04-22 at 12 57 08 PM" src="https://user-images.githubusercontent.com/2124984/56512717-311d8600-64fe-11e9-84f6-7ec77731a5c1.png">

**After**

<img width="484" alt="Screen Shot 2019-04-22 at 12 57 20 PM" src="https://user-images.githubusercontent.com/2124984/56512724-34b10d00-64fe-11e9-86f0-7819debdfa4d.png">

#### Testing instructions

* Switch to this PR and create a brand new site.
* Navigate to Stats, go to Insights tab at the top
* Look at the Annual Site Stats widget; there should be no "0" character at the bottom of the box.
* Check with a site that does have stats; it should still display a "View all" link at the bottom.

Fixes #32470
