### PR TITLE
Onboarding: remove "education" site-type entry

### DIFF
--- a/client/components/site-verticals-suggestion-search/popular-topics.jsx
+++ b/client/components/site-verticals-suggestion-search/popular-topics.jsx
@@ -47,15 +47,6 @@ const POPULAR_TOPICS = {
 		translate( 'Fashion' ),
 		translate( 'Portfolio' ),
 	],
-	education: [
-		translate( 'Higher Education & Academy' ),
-		translate( 'Fashion' ),
-		translate( 'School' ),
-		translate( 'Website Designer' ),
-		translate( 'Travel' ),
-		translate( 'Design' ),
-		translate( 'Adult Education School' ),
-	],
 };
 
 class PopularTopics extends PureComponent {

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -31,6 +31,7 @@ export function getSiteTypePropertyValue( key, value, property, siteTypes = getA
  * Returns a current list of site types that are displayed in the signup site-type step
  * Some (or all) of these site types will also have landing pages.
  * A user who comes in via a landing page will not see the Site Topic dropdown.
+ * Do note that id's per site type should not be changed as we add/remove site-types.
  *
  * @return {array} current list of site types
  */
@@ -72,18 +73,6 @@ export function getAllSiteTypes() {
 			siteTitlePlaceholder: i18n.translate( 'E.g., John Appleseed' ),
 			siteTopicHeader: i18n.translate( 'What type of work do you do?' ),
 			siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
-		},
-		{
-			id: 4,
-			slug: 'education',
-			label: i18n.translate( 'Education' ),
-			description: i18n.translate( 'Share school projects and class info.' ),
-			theme: 'pub/twentyfifteen',
-			designType: 'blog',
-			siteTitleLabel: i18n.translate( 'What is the name of your site?' ),
-			siteTitlePlaceholder: i18n.translate( 'E.g., My class' ),
-			siteTopicHeader: i18n.translate( 'What is your website about?' ),
-			siteTopicLabel: i18n.translate( 'What will your site be about?' ),
 		},
 		{
 			id: 5,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the education site-type from the `start/site-type` options:

<img width="676" alt="Screenshot 2019-04-22 at 10 04 29" src="https://user-images.githubusercontent.com/4335450/56513535-ab8edb80-64e7-11e9-97e3-5e2da0cdd385.png">

Notes:
Right now, with these changes, there will still be an option for 'Offer education, training, or mentoring' under the 'What’s the primary goal you have for your site?' question.
There will also still be an entry for education under our verticals.
I'm assuming we still want to keep those but please let me know if that's not the case!

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There's not too much to test here, so just:
- Start at http://calypso.localhost:3000/start
  - You should be taken to http://calypso.localhost:3000/start/site-type
  - You should see the list as in the above screenshot, _without_ the "Education" option