### PR TITLE
Google Analytics: make available on all paid plans

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -43,7 +43,7 @@ import {
 	TYPE_BUSINESS,
 	TERM_ANNUALLY,
 } from 'lib/plans/constants';
-import { findFirstSimilarPlanKey } from 'lib/plans';
+import { findFirstSimilarPlanKey, isJetpackPersonalPlan } from 'lib/plans';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 
@@ -286,7 +286,8 @@ export class GoogleAnalyticsForm extends Component {
 const mapStateToProps = state => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
-	const isGoogleAnalyticsEligible = site && site.plan && isCurrentPlanPaid( state, siteId );
+	const isGoogleAnalyticsEligible =
+		site && site.plan && isCurrentPlanPaid( state, siteId ) && ! isJetpackPersonalPlan( site.plan );
 	const jetpackModuleActive = isJetpackModuleActive( state, siteId, 'google-analytics' );
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const googleAnalyticsEnabled = site && ( ! siteIsJetpack || jetpackModuleActive );

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -23,15 +23,6 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormTextValidation from 'components/forms/form-input-validation';
 import FormAnalyticsStores from './form-analytics-stores';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
-import {
-	isBusiness,
-	isEnterprise,
-	isFreeJetpackPlan,
-	isJetpackBusiness,
-	isJetpackPremium,
-	isVipPlan,
-	isEcommerce,
-} from 'lib/products-values';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { isJetpackSite, isCurrentPlanPaid } from 'state/sites/selectors';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -23,7 +23,6 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormTextValidation from 'components/forms/form-input-validation';
 import FormAnalyticsStores from './form-analytics-stores';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
-
 import {
 	isBusiness,
 	isEnterprise,
@@ -287,8 +286,7 @@ export class GoogleAnalyticsForm extends Component {
 const mapStateToProps = state => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
-	const isGoogleAnalyticsEligible =
-		site && site.plan && ( isCurrentPlanPaid( state, siteId ) || isFreeJetpackPlan( site.plan ) );
+	const isGoogleAnalyticsEligible = site && site.plan && isCurrentPlanPaid( state, siteId );
 	const jetpackModuleActive = isJetpackModuleActive( state, siteId, 'google-analytics' );
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const googleAnalyticsEnabled = site && ( ! siteIsJetpack || jetpackModuleActive );

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { find, flowRight, partialRight, pick, overSome } from 'lodash';
+import { find, flowRight, partialRight, pick } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,16 +23,18 @@ import FormTextInput from 'components/forms/form-text-input';
 import FormTextValidation from 'components/forms/form-input-validation';
 import FormAnalyticsStores from './form-analytics-stores';
 import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
+
 import {
 	isBusiness,
 	isEnterprise,
+	isFreeJetpackPlan,
 	isJetpackBusiness,
 	isJetpackPremium,
 	isVipPlan,
 	isEcommerce,
 } from 'lib/products-values';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite, isCurrentPlanPaid } from 'state/sites/selectors';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
@@ -47,13 +49,6 @@ import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
 
 const validateGoogleAnalyticsCode = code => ! code || code.match( /^UA-\d+-\d+$/i );
-const hasBusinessPlan = overSome(
-	isBusiness,
-	isEcommerce,
-	isEnterprise,
-	isJetpackBusiness,
-	isVipPlan
-);
 
 export class GoogleAnalyticsForm extends Component {
 	state = {
@@ -293,7 +288,7 @@ const mapStateToProps = state => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const isGoogleAnalyticsEligible =
-		site && site.plan && ( hasBusinessPlan( site.plan ) || isJetpackPremium( site.plan ) );
+		site && site.plan && ( isCurrentPlanPaid( state, siteId ) || isFreeJetpackPlan( site.plan ) );
 	const jetpackModuleActive = isJetpackModuleActive( state, siteId, 'google-analytics' );
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const googleAnalyticsEnabled = site && ( ! siteIsJetpack || jetpackModuleActive );

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -40,7 +40,7 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import {
 	FEATURE_GOOGLE_ANALYTICS,
 	TYPE_PREMIUM,
-	TYPE_BUSINESS,
+	TYPE_BLOGGER,
 	TERM_ANNUALLY,
 } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey, isJetpackPersonalPlan } from 'lib/plans';
@@ -120,10 +120,8 @@ export class GoogleAnalyticsForm extends Component {
 		const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.active : false;
 
 		const nudgeTitle = siteIsJetpack
-			? translate(
-					'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional'
-			  )
-			: translate( 'Connect your site to Google Analytics in seconds with the Business plan' );
+			? translate( 'Enable Google Analytics by upgrading to Jetpack Premium' )
+			: translate( 'Enable Google Analytics by upgrading to any paid plan' );
 
 		return (
 			<form id="analytics" onSubmit={ handleSubmitForm }>
@@ -145,7 +143,7 @@ export class GoogleAnalyticsForm extends Component {
 						event={ 'google_analytics_settings' }
 						feature={ FEATURE_GOOGLE_ANALYTICS }
 						plan={ findFirstSimilarPlanKey( site.plan.product_slug, {
-							type: siteIsJetpack ? TYPE_PREMIUM : TYPE_BUSINESS,
+							type: siteIsJetpack ? TYPE_PREMIUM : TYPE_BLOGGER,
 							...( siteIsJetpack ? { term: TERM_ANNUALLY } : {} ),
 						} ) }
 						title={ nudgeTitle }
@@ -278,7 +276,7 @@ export class GoogleAnalyticsForm extends Component {
 		if ( ! this.props.site ) {
 			return null;
 		}
-		// Only show Google Analytics for business users.
+		// Only show Google Analytics for users with a paid plan.
 		return this.form();
 	}
 }

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -31,14 +31,7 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import {
 	PLAN_FREE,
-	PLAN_BUSINESS,
-	PLAN_BUSINESS_2_YEARS,
-	PLAN_PREMIUM,
-	PLAN_PREMIUM_2_YEARS,
-	PLAN_PERSONAL,
-	PLAN_PERSONAL_2_YEARS,
 	PLAN_BLOGGER,
-	PLAN_BLOGGER_2_YEARS,
 	PLAN_JETPACK_FREE,
 	PLAN_JETPACK_PERSONAL,
 	PLAN_JETPACK_PERSONAL_MONTHLY,
@@ -79,36 +72,18 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 		showUpgradeNudge: true,
 	};
 
-	[ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ].forEach( product_slug => {
-		test( `Business 1 year for (${ product_slug })`, () => {
-			const comp = shallow(
-				<GoogleAnalyticsForm
-					{ ...myProps }
-					siteIsJetpack={ false }
-					site={ { plan: { product_slug } } }
-				/>
-			);
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
-				PLAN_BUSINESS
-			);
-		} );
-	} );
-
-	[ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ].forEach( product_slug => {
-		test( `Business 2 year for (${ product_slug })`, () => {
-			const comp = shallow(
-				<GoogleAnalyticsForm
-					{ ...myProps }
-					siteIsJetpack={ false }
-					site={ { plan: { product_slug } } }
-				/>
-			);
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
-			expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
-				PLAN_BUSINESS_2_YEARS
-			);
-		} );
+	test( `Business 1 year for (${ PLAN_FREE })`, () => {
+		const comp = shallow(
+			<GoogleAnalyticsForm
+				{ ...myProps }
+				siteIsJetpack={ false }
+				site={ { plan: { PLAN_FREE } } }
+			/>
+		);
+		expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 1 );
+		expect( comp.find( 'Banner[event="google_analytics_settings"]' ).props().plan ).toBe(
+			PLAN_BLOGGER
+		);
 	} );
 
 	[ PLAN_JETPACK_FREE, PLAN_JETPACK_PERSONAL, PLAN_JETPACK_PERSONAL_MONTHLY ].forEach(

--- a/client/my-sites/site-settings/test/form-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-analytics.jsx
@@ -72,12 +72,12 @@ describe( 'Upsell Banner should get appropriate plan constant', () => {
 		showUpgradeNudge: true,
 	};
 
-	test( `Business 1 year for (${ PLAN_FREE })`, () => {
+	test( `Blogger 1 year for (${ PLAN_FREE })`, () => {
 		const comp = shallow(
 			<GoogleAnalyticsForm
 				{ ...myProps }
 				siteIsJetpack={ false }
-				site={ { plan: { PLAN_FREE } } }
+				site={ { plan: { product_slug: PLAN_FREE } } }
 			/>
 		);
 		expect( comp.find( 'Banner[event="google_analytics_settings"]' ) ).toHaveLength( 1 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This makes Google Analytics available on all paid plans except for Jetpack personal. Jetpack personal and free will be added in a later PR.

#### Testing instructions

Google Analytics tracking IDs are added at Settings > Traffic > Google Analytics Tracking ID.

1. Attempt to add a Google Analytics tracking ID for each paid plan, and verify that you can do so.
2. Attempt to add a Google Analytics tracking ID for the free plan, and verify that you are prompted to upgrade.
