### PR TITLE
Checklist: Move email verification item towards the bottom of the list

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -31,7 +31,6 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 		tasks.push( task );
 	};
 
-	addTask( 'email_verified' );
 	addTask( 'site_created', true );
 
 	if ( 'business' === segmentSlug ) {
@@ -66,6 +65,7 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 
 	addTask( 'custom_domain_registered' );
 	addTask( 'mobile_app_installed' );
+	addTask( 'email_verified' );
 
 	if ( get( taskStatuses, 'email_verified.completed' ) && isSiteUnlaunched ) {
 		addTask( 'site_launched' );

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -63,9 +63,9 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 		}
 	}
 
+	addTask( 'email_verified' );
 	addTask( 'custom_domain_registered' );
 	addTask( 'mobile_app_installed' );
-	addTask( 'email_verified' );
 
 	if ( get( taskStatuses, 'email_verified.completed' ) && isSiteUnlaunched ) {
 		addTask( 'site_launched' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR moves the email verification checklist item towards the bottom of the checklist, rather than near the top:

<img width="764" alt="Screenshot 2019-04-22 at 10 43 39" src="https://user-images.githubusercontent.com/4335450/56516388-2b6c7400-64ef-11e9-80ea-ab504756701d.png">

It's not a particularly welcoming thing for folks to see as soon as they land in Calypso from signup and feels much more like a chore than some of the other, more fun, items!

In the screenshot shown above its the last item. However, if the site is 'unlaunched' there will be a task following the verification task to launch the site, and if `onboarding-checklist/email-setup` is enabled 3 more tasks will also show at the bottom of the checklist: 'email_setup', 'email_forwarding_upgraded_to_gsuite' and 'gsuite_tos_accepted'.

I've tagged the Onboarding design squad to get your opinions on having this step collapsed. Is it fine that it's collapsed right up until all the prior steps have been completed? New users might not yet know how to change their email, or resend the verification email otherwise.

#### Testing instructions

- Start at http://calypso.localhost:3000/start and follow the flow to create a new site (You'll need to use a non a8c email address for this)
  - You should land in the checklist UI
  - You should now see the email verification step appear right down at the bottom of this list.
- Confirm your email address, you should now see this item move up to the 'completed' section, though it should appear at the bottom of that section.