### PR TITLE
Signup Site Mockup: Enable render tracking

### DIFF
--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -69,7 +69,7 @@ class SiteMockups extends Component {
 			return;
 		}
 
-		recordTracksEvent( 'calypso_signup_site_preview_rendered', {
+		this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_rendered', {
 			site_type: siteType,
 			vertical_slug: verticalSlug,
 			site_style: siteStyle || 'default',
@@ -98,8 +98,13 @@ class SiteMockups extends Component {
 		return content;
 	}
 
-	handleClick = size =>
-		this.props.handleClick( this.props.verticalSlug, this.props.siteStyle, size );
+	handleClick = size => {
+		this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_clicked', {
+			size,
+			vertical_slug: this.props.verticalSlug,
+			site_style: this.props.siteStyle || 'default',
+		} );
+	};
 
 	render() {
 		const {
@@ -167,14 +172,7 @@ export default connect(
 			fontUrl: style.fontUrl,
 		};
 	},
-	dispatch => ( {
-		handleClick: ( verticalSlug, siteStyle, size ) =>
-			dispatch(
-				recordTracksEvent( 'calypso_signup_site_preview_mockup_clicked', {
-					size,
-					vertical_slug: verticalSlug,
-					site_style: siteStyle || 'default',
-				} )
-			),
-	} )
+	{
+		recordTracksEvent,
+	}
 )( SiteMockups );

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { each, find, isEmpty } from 'lodash';
+import { debounce, each, find, isEmpty } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -62,18 +62,22 @@ class SiteMockups extends Component {
 		verticalPreviewContent: '',
 	};
 
-	componentDidUpdate( prevProps ) {
-		const { siteStyle, siteType, verticalPreviewContent, verticalSlug } = this.props;
-
-		if ( ! verticalPreviewContent || prevProps.verticalPreviewContent === verticalPreviewContent ) {
-			return;
-		}
+	debouncedRenderedEvent = debounce( () => {
+		const { siteStyle, siteType, verticalSlug } = this.props;
 
 		this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_rendered', {
 			site_type: siteType,
 			vertical_slug: verticalSlug,
 			site_style: siteStyle || 'default',
 		} );
+	}, 777 );
+
+	componentDidUpdate( prevProps ) {
+		const { verticalPreviewContent } = this.props;
+
+		if ( verticalPreviewContent && prevProps.verticalPreviewContent !== verticalPreviewContent ) {
+			this.debouncedRenderedEvent();
+		}
 	}
 
 	/**

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { debounce, each, find, isEmpty } from 'lodash';
+import { each, find, isEmpty } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -62,18 +62,19 @@ class SiteMockups extends Component {
 		verticalPreviewContent: '',
 	};
 
-	shouldComponentUpdate( nextProps ) {
-		// Debouncing updates to the preview content
-		// prevents the flashing effect.
-		if ( nextProps.verticalPreviewContent !== this.props.verticalPreviewContent ) {
-			this.updateDebounced();
-			return false;
+	componentDidUpdate( prevProps ) {
+		const { siteStyle, siteType, verticalPreviewContent, verticalSlug } = this.props;
+
+		if ( ! verticalPreviewContent || prevProps.verticalPreviewContent === verticalPreviewContent ) {
+			return;
 		}
 
-		return true;
+		recordTracksEvent( 'calypso_signup_site_preview_rendered', {
+			site_type: siteType,
+			vertical_slug: verticalSlug,
+			site_style: siteStyle || 'default',
+		} );
 	}
-
-	updateDebounced = debounce( this.forceUpdate, 777 );
 
 	/**
 	 * Returns an interpolated site preview content block with template markers

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { debounce, each, find, isEmpty } from 'lodash';
 import { translate } from 'i18n-calypso';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -24,6 +25,8 @@ import { getSiteStyleOptions, getThemeCssUri } from 'lib/signup/site-styles';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getLocaleSlug, getLanguage } from 'lib/i18n-utils';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
+
+const debug = debugFactory( 'calypso:signup:site-mockup' );
 
 /**
  * Style dependencies
@@ -139,6 +142,8 @@ class SiteMockups extends Component {
 			onPreviewClick: this.handleClick,
 			className: siteStyle,
 		};
+
+		debug( 'Rendering SiteMockups component' );
 
 		return (
 			<div className={ siteMockupClasses }>

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { debounce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -40,7 +41,7 @@ class SiteTopicForm extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	onSiteTopicChange = verticalData => {
+	onSiteTopicChange = debounce( verticalData => {
 		this.props.setSiteVertical( {
 			isUserInput: verticalData.isUserInputVertical,
 			name: verticalData.verticalName,
@@ -49,7 +50,7 @@ class SiteTopicForm extends Component {
 			id: verticalData.verticalId,
 			parentId: verticalData.parent,
 		} );
-	};
+	}, 777 );
 
 	onSubmit = event => {
 		const { isUserInput, siteSlug, siteTopic, verticalId, verticalParentId } = this.props;

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { debounce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -41,7 +40,7 @@ class SiteTopicForm extends Component {
 		translate: PropTypes.func.isRequired,
 	};
 
-	onSiteTopicChange = debounce( verticalData => {
+	onSiteTopicChange = verticalData => {
 		this.props.setSiteVertical( {
 			isUserInput: verticalData.isUserInputVertical,
 			name: verticalData.verticalName,
@@ -50,7 +49,7 @@ class SiteTopicForm extends Component {
 			id: verticalData.verticalId,
 			parentId: verticalData.parent,
 		} );
-	}, 777 );
+	};
 
 	onSubmit = event => {
 		const { isUserInput, siteSlug, siteTopic, verticalId, verticalParentId } = this.props;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* `debounce` the `setSiteVertical` call in the `site-topic/form` (instead of preventing updates via a `debounce` call in `shouldComponentUpdate`)
* Watch for updates to `verticalPreviewContent` in `componentDidUpdate` & record the event when it changes
* Simplify the `mapDispatchToProps` to just tack on `recordTracksEvent`
* Call the above as appropriate in `handleClick`

#### Testing instructions

* Familiarize yourself with the look and feel of the `onboarding-for-business/site-topic-with-preview` step on `master` (`/start/onboarding`, choose `Business`, search for a vertical, select a few, etc.)
* Run this branch
* enable debugging for tracks events: In your browser console: `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )`
* Search for some things, choose from the default set, etc. etc -- you should see the `calypso_signup_site_preview_mockup_rendered` event being fired at the appropriate time
* Click on a mockup
  * Make sure the `calypso_signup_site_preview_mockup_clicked` event still fires
* The UI should behave as at least as well as before (changing the placement of the `debounce` call should not adversely affect the selection, animation, progress through the flow, etc.)