### PR TITLE
Prevent Widows for copy items in Onboarding ProcessingScreen

### DIFF
--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -106,33 +106,40 @@ export class SignupProcessingScreen extends Component {
 
 			return loginHandler
 				? this.props.translate(
-						"{{strong}}Done!{{/strong}} Thanks for waiting, %(domain)s is all set up and we're ready " +
-							'for you to get started.',
+						"{{strong}}Done!{{/strong}} Thanks for waiting, %(domain)s is all set up and we're ready {{br/}}for you to get started.",
 						{
-							components: { strong: <strong /> },
+							components: { strong: <strong />, br: <br /> },
 							args: { domain },
+							comment:
+								'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
 						}
 				  )
 				: this.props.translate(
-						'{{strong}}Awesome!{{/strong}} Give us one minute and we’ll move right along.',
+						'{{strong}}Awesome!{{/strong}} Give us one minute and {{br/}}we’ll move right along.',
 						{
-							components: { strong: <strong /> },
+							components: { strong: <strong />, br: <br /> },
 							args: { domain },
+							comment:
+								'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
 						}
 				  );
 		}
 
 		return loginHandler
 			? this.props.translate(
-					'{{strong}}Done!{{/strong}} Thanks for waiting, we’re ready for you to get started.',
+					'{{strong}}Done!{{/strong}} Thanks for waiting, we’re ready for you {{br/}}to get started.',
 					{
-						components: { strong: <strong /> },
+						components: { strong: <strong />, br: <br /> },
+						comment:
+							'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
 					}
 			  )
 			: this.props.translate(
-					'{{strong}}Awesome!{{/strong}} Give us one minute and we’ll move right along.',
+					'{{strong}}Awesome!{{/strong}} Give us one minute and {{br/}}we’ll move right along.',
 					{
-						components: { strong: <strong /> },
+						components: { strong: <strong />, br: <br /> },
+						comment:
+							'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
 					}
 			  );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to prevent the text widows we see in the final screen of signup, right before we're taken to Calypso proper, by adding `<br>` tags to each copy item:

<img width="342" alt="Screenshot 2019-04-22 at 14 37 35" src="https://user-images.githubusercontent.com/4335450/56533267-3550a000-650c-11e9-98ab-0f8722a224df.png">

<img width="377" alt="Screenshot 2019-04-29 at 14 11 07" src="https://user-images.githubusercontent.com/4335450/56898306-a81bc700-6a88-11e9-999c-fd5788a8fdec.png">

Note that I'm looking to address this in a more robust way by fixing the `preventWidows` util function - I'm tracking that in #32652
For anybody hitting this PR and finding themselves confused by the conversation below, also note that I had originally planned to do that here but then changed the approach to follow @ramonjd's suggestion.

#### Testing instructions

First reproduce to confirm the issue:
- Set your browser viewport to be ~384 pixels wide
- On master & while logged out, go to http://calypso.localhost:3000/start
- Go through the signup steps and watch for the final steps where a large WP logo shows with copy underneath. You should see something like the 'Before' screenshot shown above.

Next, Apply this branch and go through the same process of creating a new account
- This time around, when you hit the last screen, you should see 2 floating words as opposed to one. Just like in the 'After' screenshot above.