### PR TITLE
Convert reader/lib/author-name-blacklist to TypeScript

### DIFF
--- a/client/reader/lib/author-name-blacklist/index.ts
+++ b/client/reader/lib/author-name-blacklist/index.ts
@@ -1,20 +1,8 @@
 /**
- * External dependencies
- */
-import { includes } from 'lodash';
-
-const authorNameBlacklist = [ 'admin' ];
-
-/**
  * Is the provided author name blacklisted?
  *
  * @param {string} authorName Author name
  * @returns {boolean} True if blacklisted
  */
-export const isAuthorNameBlacklisted = ( authorName: string ): boolean => {
-	if ( ! authorName ) {
-		return false;
-	}
-
-	return includes( authorNameBlacklist, authorName.toLowerCase() );
-};
+export const isAuthorNameBlacklisted = ( authorName: string ) =>
+	!! authorName && 'admin' === authorName.toLowerCase();

--- a/client/reader/lib/author-name-blacklist/index.ts
+++ b/client/reader/lib/author-name-blacklist/index.ts
@@ -1,6 +1,5 @@
-/** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
 import { includes } from 'lodash';
 
@@ -12,7 +11,7 @@ const authorNameBlacklist = [ 'admin' ];
  * @param {string} authorName Author name
  * @returns {boolean} True if blacklisted
  */
-export const isAuthorNameBlacklisted = authorName => {
+export const isAuthorNameBlacklisted = ( authorName: string ): boolean => {
 	if ( ! authorName ) {
 		return false;
 	}

--- a/client/reader/lib/author-name-blacklist/index.ts
+++ b/client/reader/lib/author-name-blacklist/index.ts
@@ -1,8 +1,8 @@
 /**
  * Is the provided author name blacklisted?
  *
- * @param {string} authorName Author name
- * @returns {boolean} True if blacklisted
+ * @param authorName - Author name
+ * @returns True if blacklisted
  */
 export const isAuthorNameBlacklisted = ( authorName: string ) =>
 	!! authorName && 'admin' === authorName.toLowerCase();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Dipping a toe into the world of TypeScript.

Converts the existing `reader/lib/author-name-blacklist/index.js` to `reader/lib/author-name-blacklist/index.ts`.

#### Testing instructions

No functional changes. Ensure that your Reader stream loads as expected:

http://calypso.localhost:3000/
