### PR TITLE
Prevent calypso.live test from running for PRs from forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -636,7 +636,6 @@ workflows:
                 - master
                 # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
                 - /pull\/[0-9]+/
-              only: /^(?!pull\/).*$/
       - test-e2e-canary:
           requires:
             - wait-calypso-live

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -631,7 +631,11 @@ workflows:
             - test-server
           filters:
             branches:
-              ignore: master
+              ignore:
+                # Do not spin up calypso.live for `master`
+                - master
+                # Do not spin up calypso.live for fork pull requests. Calypso.live will not build them.
+                - /pull\/[0-9]+/
               only: /^(?!pull\/).*$/
       - test-e2e-canary:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -632,6 +632,7 @@ workflows:
           filters:
             branches:
               ignore: master
+              only: /^(?!pull\/).*$/
       - test-e2e-canary:
           requires:
             - wait-calypso-live


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Do not run `wait-calypso-live` test for PRs with branches from outside of this repository. 

We have a rule [here](https://github.com/Automattic/wp-calypso/blob/master/.circleci/config.yml#L504-L506) to prevent firing of `calypso.live` test branch for such PRs already. But, I thought it would be a nice idea to prevent this job from running at all, for all PRs from outside of this repository.

I am basically taking this idea from [this CircleCI forum answer](https://discuss.circleci.com/t/create-separate-steps-jobs-for-pr-forks-versus-branches/13419/4?u=arunsathiya). I tested this on a personal repository and it seems to work like a charm, but I am not entirely confident about any side effects it might have on Calypso's config though. Happy to investigate further if something's off.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Submit a PR from another branch from this repository, ensure the `wait-calypso-live` test runs.
* Submit a PR from a fork's branch, ensure the `wait-calypso-live` test is not seen.