### PR TITLE
Tax: set location for redirect payment methods.

### DIFF
--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -32,6 +32,7 @@ import { validatePaymentDetails, maskField, unmaskField } from 'lib/checkout';
 import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from 'lib/checkout/constants';
 import DomainRegistrationRefundPolicy from './domain-registration-refund-policy';
 import DomainRegistrationAgreement from './domain-registration-agreement';
+import { setPayment } from 'lib/upgrades/actions';
 
 export class RedirectPaymentBox extends PureComponent {
 	static displayName = 'RedirectPaymentBox';
@@ -52,6 +53,12 @@ export class RedirectPaymentBox extends PureComponent {
 			errorMessages: [],
 			paymentDetails: this.setPaymentDetailsState( props.paymentType ),
 		};
+
+		// Call setPayment to reset the tax location
+		const newPayment = {
+			paymentMethod: paymentMethodClassName( props.paymentType ),
+		};
+		setPayment( newPayment );
 	}
 
 	setPaymentDetailsState( paymentType ) {

--- a/client/my-sites/checkout/checkout/test/redirect-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/redirect-payment-box.js
@@ -39,9 +39,13 @@ import {
 jest.mock( 'lib/cart-values', () => ( {
 	isPaymentMethodEnabled: jest.fn( false ),
 	paymentMethodName: jest.fn( false ),
+	paymentMethodClassName: jest.fn( false ),
+	setTaxLocation: jest.fn( () => () => ( {} ) ),
+	fillInAllCartItemAttributes: jest.fn( () => ( {} ) ),
 	cartItems: {
 		hasRenewableSubscription: jest.fn( false ),
 		hasRenewalItem: jest.fn( false ),
+		getAll: jest.fn( false ),
 	},
 } ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If there's an existing US credit card selected in the saved card, switching to a redirect type payment method (all of which are currently non-US), doesn't reset the tax.

* This adds a `setPayment()` call to the redirect paymentBox constructor. It works, but it probably doesn't make much sense to do it this way.


#### Testing instructions
* Use IP that enables a local payment method (DE/NL/BE/CN/BR/PL)
* Have a saved CC with a US country code
* When loading the checkout form, tax will be added
* Switch to the redirect payment method tab, tax should be reset

