### PR TITLE
Add tracks event to the nudges on the cart sidebar

### DIFF
--- a/client/my-sites/checkout/cart/cart-plan-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad.jsx
@@ -14,19 +14,29 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { isPlan } from 'lib/products-values';
 import { addItem } from 'lib/upgrades/actions';
 import { PLAN_PREMIUM } from 'lib/plans/constants';
 
-class CartPlanAd extends Component {
+export class CartPlanAd extends Component {
 	addToCartAndRedirect = event => {
-		event.preventDefault();
+		if ( event ) {
+			event.preventDefault();
+		}
+
 		const domainRegistrations = cartItems.getDomainRegistrations( this.props.cart );
 		const domainToBundle = get( domainRegistrations, '[0].meta', '' );
+
+		this.props.recordTracksEvent( 'calypso_banner_cta_click', {
+			cta_name: 'cart_domain_to_plan_upsell',
+		} );
+
 		addItem( cartItems.premiumPlan( PLAN_PREMIUM, { domainToBundle } ) );
 		page( '/checkout/' + this.props.selectedSite.slug );
 	};
@@ -63,9 +73,9 @@ class CartPlanAd extends Component {
 						components: { strong: <strong /> },
 					}
 				) }{' '}
-				<a href="" onClick={ this.addToCartAndRedirect }>
+				<Button onClick={ this.addToCartAndRedirect } borderless compact>
 					{ this.props.translate( 'Upgrade Now' ) }
-				</a>
+				</Button>
 			</CartAd>
 		);
 	}
@@ -77,10 +87,15 @@ CartPlanAd.propTypes = {
 	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 };
 
-export default connect( state => {
+const mapStateToProps = state => {
 	const selectedSiteId = getSelectedSiteId( state );
 
 	return {
 		isDomainOnly: isDomainOnlySite( state, selectedSiteId ),
 	};
-} )( localize( CartPlanAd ) );
+};
+
+export default connect(
+	mapStateToProps,
+	{ recordTracksEvent }
+)( localize( CartPlanAd ) );

--- a/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { once } from 'lodash';
 
 /**
  * Internal dependencies
@@ -16,15 +17,21 @@ import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
 import { fetchSitePlans } from 'state/sites/plans/actions';
 import { getPlansBySite } from 'state/sites/plans/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { isPlan } from 'lib/products-values';
 import { shouldFetchSitePlans } from 'lib/plans';
 
-class CartPlanDiscountAd extends Component {
+export class CartPlanDiscountAd extends Component {
 	static propTypes = {
 		cart: PropTypes.object,
 		translate: PropTypes.func.isRequired,
 		sitePlans: PropTypes.object,
 	};
+
+	constructor( props ) {
+		super( props );
+		this.trackPlanDiscountAd = once( this.props.trackPlanDiscountAd );
+	}
 
 	componentDidMount() {
 		this.props.fetchSitePlans( this.props.sitePlans, this.props.selectedSite );
@@ -48,6 +55,8 @@ class CartPlanDiscountAd extends Component {
 		if ( plan.rawDiscount === 0 || ! plan.isDomainUpgrade ) {
 			return null;
 		}
+
+		this.trackPlanDiscountAd();
 
 		return (
 			<CartAd>
@@ -90,6 +99,9 @@ export default connect(
 				if ( shouldFetchSitePlans( sitePlans, site ) ) {
 					dispatch( fetchSitePlans( site.ID ) );
 				}
+			},
+			trackPlanDiscountAd: () => {
+				dispatch( recordTracksEvent( 'cart_plan_discount_ad' ) );
 			},
 		};
 	}

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -210,6 +210,11 @@
 	@include breakpoint( '<660px' ) {
 		display: none;
 	}
+
+	.button.is-borderless {
+		color: var( --color-link );
+		font-weight: initial;
+	}
 }
 
 .cart__cart-plan-discount-ad-paragraph:last-child {

--- a/client/my-sites/checkout/cart/test/cart-plan-ad.js
+++ b/client/my-sites/checkout/cart/test/cart-plan-ad.js
@@ -1,0 +1,113 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+
+jest.mock( 'page' );
+jest.mock( 'lib/upgrades/actions' );
+
+import { CartPlanAd } from '../cart-plan-ad';
+import CartAd from '../cart-ad';
+
+describe( 'cart-plan-ad', () => {
+	const BLOGGER_PLAN = {
+		expired: false,
+		is_free: false,
+		product_id: 1010,
+		product_name_short: 'Blogger',
+		product_slug: 'blogger-bundle',
+		user_is_owner: true,
+	};
+
+	const FREE_PLAN = {
+		expired: false,
+		is_free: true,
+		product_id: 1,
+		product_name_short: 'Free',
+		product_slug: 'free_plan',
+		user_is_owner: false,
+	};
+
+	const PERSONAL_PLAN_CART_ITEM = {
+		is_domain_registration: false,
+		product_id: 1009,
+		product_name: 'WordPress.com Personal',
+		product_slug: 'personal-bundle',
+	};
+
+	const DOMAIN_REGISTRATION_CART_ITEM = {
+		is_domain_registration: true,
+		product_id: 76,
+		product_name: '.blog Domain Registration',
+		product_slug: 'dotblog_domain',
+	};
+
+	const CART = {
+		hasLoadedFromServer: true,
+		hasPendingServerUpdates: false,
+		products: [ DOMAIN_REGISTRATION_CART_ITEM ],
+	};
+
+	const props = {
+		cart: CART,
+		isDomainOnly: false,
+		translate: str => str,
+		selectedSite: {
+			slug: 'example.com',
+			plan: FREE_PLAN,
+		},
+	};
+
+	test( 'Should be rendered when the cart has one domain registration only', () => {
+		const wrapper = shallow( <CartPlanAd { ...props } /> );
+		expect( wrapper.exists( CartAd ) ).toBe( true );
+	} );
+
+	test( 'Should not be rendered when no site is selected', () => {
+		const wrapper = shallow( <CartPlanAd { ...props } selectedSite={ undefined } /> );
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	test( 'Should not be rendered when the cart has any paid plan', () => {
+		const wrapper = shallow(
+			<CartPlanAd
+				{ ...props }
+				cart={ {
+					...CART,
+					products: [ PERSONAL_PLAN_CART_ITEM, DOMAIN_REGISTRATION_CART_ITEM ],
+				} }
+			/>
+		);
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	test( 'Should not be rendered when the selected site is on any paid plan', () => {
+		const wrapper = shallow(
+			<CartPlanAd
+				{ ...props }
+				selectedSite={ {
+					...props.selectedSite,
+					plan: BLOGGER_PLAN,
+				} }
+			/>
+		);
+		expect( wrapper.type() ).toBe( null );
+	} );
+
+	test( 'Should call recordTracksEvent() when the cta clicked', () => {
+		const recordTracksEvent = jest.fn();
+		const ad = shallow( <CartPlanAd { ...props } recordTracksEvent={ recordTracksEvent } /> );
+
+		ad.find( 'a' ).simulate( 'click' );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_banner_cta_click', {
+			cta_name: 'cart_domain_to_plan_upsell',
+		} );
+	} );
+} );

--- a/client/my-sites/checkout/cart/test/cart-plan-ad.js
+++ b/client/my-sites/checkout/cart/test/cart-plan-ad.js
@@ -102,9 +102,9 @@ describe( 'cart-plan-ad', () => {
 
 	test( 'Should call recordTracksEvent() when the cta clicked', () => {
 		const recordTracksEvent = jest.fn();
-		const ad = shallow( <CartPlanAd { ...props } recordTracksEvent={ recordTracksEvent } /> );
+		const wrapper = shallow( <CartPlanAd { ...props } recordTracksEvent={ recordTracksEvent } /> );
 
-		ad.find( 'a' ).simulate( 'click' );
+		wrapper.find( 'Button' ).simulate( 'click' );
 
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_banner_cta_click', {
 			cta_name: 'cart_domain_to_plan_upsell',

--- a/client/my-sites/checkout/cart/test/cart-plan-discount-ad.js
+++ b/client/my-sites/checkout/cart/test/cart-plan-discount-ad.js
@@ -1,0 +1,77 @@
+/**
+ * @format
+ * @jest-environment jsdom
+ */
+
+/**
+ * External dependencies
+ */
+import { shallow } from 'enzyme';
+import React from 'react';
+
+jest.mock( 'page' );
+jest.mock( 'state/sites/plans/actions' );
+jest.mock( 'state/analytics/actions' );
+
+import { CartPlanDiscountAd } from '../cart-plan-discount-ad';
+import CartAd from '../cart-ad';
+
+describe( 'cart-plan-discount-ad', () => {
+	const BLOGGER_PLAN = {
+		expired: false,
+		is_free: false,
+		product_id: 1010,
+		product_name_short: 'Blogger',
+		product_slug: 'blogger-bundle',
+		user_is_owner: true,
+	};
+
+	const CART = {
+		hasLoadedFromServer: true,
+		hasPendingServerUpdates: false,
+		products: [ BLOGGER_PLAN ],
+	};
+
+	const props = {
+		cart: CART,
+		translate: str => str,
+		sitePlans: {
+			hasLoadedFromServer: true,
+			data: [
+				{
+					rawDiscount: 10,
+					isDomainUpgrade: true,
+					formattedDiscount: '$10',
+					formattedOriginalPrice: '$20',
+					productSlug: BLOGGER_PLAN.product_slug,
+				},
+			],
+		},
+		fetchSitePlans: () => {},
+		trackPlanDiscountAd: () => {},
+	};
+
+	test( 'Should call trackPlanDiscountAd() when the nudge appears', () => {
+		const trackPlanDiscountAd = jest.fn();
+		const wrapper = shallow(
+			<CartPlanDiscountAd { ...props } trackPlanDiscountAd={ trackPlanDiscountAd } />
+		);
+
+		expect( wrapper.type() ).toBe( CartAd );
+		expect( trackPlanDiscountAd ).toHaveBeenCalled();
+	} );
+
+	test( 'Should not call trackPlanDiscountAd() when the nudge is not rendered', () => {
+		const trackPlanDiscountAd = jest.fn();
+		const wrapper = shallow(
+			<CartPlanDiscountAd
+				{ ...props }
+				cart={ { hasLoadedFromServer: false } }
+				trackPlanDiscountAd={ trackPlanDiscountAd }
+			/>
+		);
+
+		expect( wrapper.type() ).toBe( null );
+		expect( trackPlanDiscountAd ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add tracks event to the nudges on the cart sidebar.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run the following code in the project root. All tests against the nudge components should be passed.
```
npm run test-client client/my-sites/checkout/cart/test/
```
