### PR TITLE
Activity Log: Enable Jetpack security alerts in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -106,6 +106,7 @@
 		"reader/user-mention-suggestions": false,
 		"resume-editing": true,
 		"republicize": true,
+		"rewind-alerts": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables the "rewind-alerts" (which should probably be renamed to jetpack-security-alerts) in the production environment.

#### Testing instructions

* Just load the PR and make sure there are no errors.