### PR TITLE
Fix: domain-to-plan upsell nudge appears when renew domain

### DIFF
--- a/client/my-sites/checkout/cart/cart-plan-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-ad.jsx
@@ -14,6 +14,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import Button from 'components/button';
 import CartAd from './cart-ad';
 import { cartItems } from 'lib/cart-values';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -36,9 +37,11 @@ class CartPlanAd extends Component {
 		const domainRegistrations = cartItems.getDomainRegistrations( cart );
 		const isDomainPremium =
 			domainRegistrations.length === 1 && get( domainRegistrations[ 0 ], 'extra.premium', false );
+		const hasRenewalItem = cartItems.hasRenewalItem( cart );
 
 		return (
 			! isDomainOnly &&
+			! hasRenewalItem &&
 			cart.hasLoadedFromServer &&
 			! cart.hasPendingServerUpdates &&
 			! cartItems.hasDomainCredit( cart ) &&
@@ -63,9 +66,9 @@ class CartPlanAd extends Component {
 						components: { strong: <strong /> },
 					}
 				) }{' '}
-				<a href="" onClick={ this.addToCartAndRedirect }>
+				<Button onClick={ this.addToCartAndRedirect } borderless compact>
 					{ this.props.translate( 'Upgrade Now' ) }
-				</a>
+				</Button>
 			</CartAd>
 		);
 	}

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -210,6 +210,11 @@
 	@include breakpoint( '<660px' ) {
 		display: none;
 	}
+
+	.button.is-borderless {
+		color: var( --color-link );
+		font-weight: initial;
+	}
 }
 
 .cart__cart-plan-discount-ad-paragraph:last-child {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hide the nudge when a user attempts to renew domains since we provide free domain only for the first year.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new website on a paid plan with a custom domain.
* Remove the plan subscription, so the site subscribes only domain mapping and the domain registration.
* Try to renew the domain in Calypso.

The domain to plan upsell nudge should not show up in the cart sidebar.

<img width="300" alt="Checkout_‹_Taggon_on_wordpress_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/56599842-67f4b880-6632-11e9-9624-f9215d0c5e9d.png">
