### PR TITLE
Sites: Bump `/me/sites` API version to 1.3.

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -83,7 +83,7 @@ export function requestSites() {
 		return wpcom
 			.me()
 			.sites( {
-				apiVersion: '1.2',
+				apiVersion: '1.3',
 				site_visibility: 'all',
 				include_domain_only: true,
 				site_activity: 'active',


### PR DESCRIPTION
_DO NOT MERGE – requires https://github.com/Automattic/jetpack/pull/12095._

Bump `/me/sites` API version to 1.3. This is in preparation for iframing the block editor of Jetpack sites.

See: p3fqKv-6Hh-p2

#### Testing instructions

* Load http://calypso.localhost:3000 on this branch with devtools open.
* Under the Network tab, search for "sites", and verify the API call was made to v1.3: `https://public-api.wordpress.com/rest/v1.3/me/sites`.
