### PR TITLE
TypeScript: Exclude large files and folders

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,19 @@
 			"*": [ "*", "client/*", "server/*" ]
 		}
 	},
-	"include": [ "client", "server" ]
+	"include": [ "client", "server" ],
+	"exclude": [
+		"public",
+		"node_modules",
+		"**/node_modules/*",
+		"build",
+		"**/build/*",
+		"**/build-module/*",
+		"**/build-style/*",
+		"**/dist/*",
+		"cached-results.json",
+		"stats.json",
+		"server/bundlers/assets-*.json",
+		"server/devdocs/search-index.js"
+	]
 }


### PR DESCRIPTION
@copons noted that Visual Studio Code repeatedly asks to setup exclude
patterns to omit processing of large files and folders. It does this for
performance reasons.

In this patch I've excluded our node modules and a couple of our largest
files: the search index, the assets files in the bundler, and built
scripts.  These files don't add anything to our dev flow by keeping them
in the compiler: they only take up memory.

## Testing

As this shouldn't affect the build of Calypso there's no runtime testing
to perform: this is a development-time performance optimization.

Open the `master` branch in VSCode and see the alert open to ask you
to setup exclude paths. In this branch it shouldn't ask.

Initializing the TypeScript system does seem to take a long time in VSCode.
I've been using PhpStorm and haven't had the same delay but maybe there
are further refinements we can make to speed it up.
