### PR TITLE
TypeScript: Add TS docs to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,7 +66,7 @@
 /test @Automattic/team-calypso
 
 # Types, TypeScript, and type annotations
-*.ts *.tsx @Automattic/type-review
+*.ts *.tsx docs/coding-guidelines/typescript* @Automattic/type-review
 
 # G Suite
 /client/blocks/gsuite-stats-nudge @Automattic/amber


### PR DESCRIPTION
Should have added this in the original PR (#31902)
This patch should flag the @Automattic/type-review for review
when someone changes the project documentation for TypeScript.

## Testing

No formal testing - just audit the change