### PR TITLE
Domains: Make "show more results" a button on domain search

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -35,7 +35,6 @@ import { localize } from 'i18n-calypso';
  */
 import config from 'config';
 import wpcom from 'lib/wp';
-import Card from 'components/card';
 import CompactCard from 'components/card/compact';
 import Notice from 'components/notice';
 import StickyPanel from 'components/sticky-panel';
@@ -89,6 +88,7 @@ import {
 	enqueueSearchStatReport,
 } from 'components/domains/register-domain-step/analytics';
 import Spinner from 'components/spinner';
+import Button from 'components/button';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 import { isBlogger } from 'lib/products-values';
 
@@ -490,23 +490,25 @@ class RegisterDomainStep extends React.Component {
 			return null;
 		}
 
-		const className = classNames( 'button', 'register-domain-step__next-page', {
+		const className = classNames( 'register-domain-step__next-page', {
 			'register-domain-step__next-page--is-loading': isLoading,
 		} );
 		return (
-			<Card
-				className={ className }
-				disabled={ isLoading }
-				onClick={ this.showNextPage }
-				tagName="button"
-			>
+			<CompactCard className={ className }>
 				<div className="register-domain-step__next-page-content">
-					{ this.props.translate( 'Show more results' ) }
+					<Button
+						borderless
+						className="register-domain-step__next-page-button"
+						disabled={ isLoading }
+						onClick={ this.showNextPage }
+					>
+						{ this.props.translate( 'Show more results' ) }
+					</Button>
 				</div>
 				<div className="register-domain-step__next-page-loader">
 					<Spinner size={ 20 } />
 				</div>
-			</Card>
+			</CompactCard>
 		);
 	}
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -87,7 +87,6 @@ import {
 	resetSearchCount,
 	enqueueSearchStatReport,
 } from 'components/domains/register-domain-step/analytics';
-import Spinner from 'components/spinner';
 import Button from 'components/button';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 import { isBlogger } from 'lib/products-values';
@@ -495,19 +494,14 @@ class RegisterDomainStep extends React.Component {
 		} );
 		return (
 			<CompactCard className={ className }>
-				<div className="register-domain-step__next-page-content">
-					<Button
-						borderless
-						className="register-domain-step__next-page-button"
-						disabled={ isLoading }
-						onClick={ this.showNextPage }
-					>
-						{ this.props.translate( 'Show more results' ) }
-					</Button>
-				</div>
-				<div className="register-domain-step__next-page-loader">
-					<Spinner size={ 20 } />
-				</div>
+				<Button
+					className="register-domain-step__next-page-button"
+					disabled={ isLoading }
+					busy={ isLoading }
+					onClick={ this.showNextPage }
+				>
+					{ this.props.translate( 'Show more results' ) }
+				</Button>
 			</CompactCard>
 		);
 	}

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -79,53 +79,8 @@
 }
 
 .register-domain-step__next-page {
-	.register-domain-step__next-page-button {
-		color: var( --color-primary );
-
-		&:hover {
-			color: var( --color-primary-dark );
-		}
-	}
-
-	.spinner {
-		margin-left: 0.5em;
-
-		.spinner__outer {
-			border-width: 0.15em;
-			animation-duration: 2s;
-		}
-
-		.spinner__inner {
-			border-color: transparent;
-		}
-	}
-
-	.register-domain-step__next-page-loader,
-	.register-domain-step__next-page-content {
-		transition: 0.1s linear opacity;
-
-		display: flex;
-		align-items: center;
-		justify-content: center;
-	}
-
-	.register-domain-step__next-page-loader {
-		position: absolute;
-		left: 50%;
-		top: 50%;
-		transform: translate( -50%, -50% );
-		opacity: 0;
-	}
-
-	&.register-domain-step__next-page--is-loading {
-		.register-domain-step__next-page-loader {
-			opacity: 1;
-		}
-
-		.register-domain-step__next-page-content {
-			opacity: 0.3;
-		}
-	}
+	display: flex;
+	justify-content: center;
 }
 
 .register-domain-step {

--- a/client/components/domains/register-domain-step/style.scss
+++ b/client/components/domains/register-domain-step/style.scss
@@ -53,8 +53,7 @@
 	}
 }
 
-.register-domain-step__filter-reset-notice,
-.register-domain-step__next-page {
+.register-domain-step__filter-reset-notice {
 	color: var( --color-primary );
 	font-weight: 500;
 	width: 100%;
@@ -80,6 +79,14 @@
 }
 
 .register-domain-step__next-page {
+	.register-domain-step__next-page-button {
+		color: var( --color-primary );
+
+		&:hover {
+			color: var( --color-primary-dark );
+		}
+	}
+
 	.spinner {
 		margin-left: 0.5em;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change "Show more results" on domain search to use a proper button component

<img width="671" alt="image" src="https://user-images.githubusercontent.com/448298/56691279-906dc880-66ad-11e9-92f6-416c7c70b950.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start from http://calypso.localhost:3000/domains/add/
* Select a site
* Search for a domain
* Confirm the "Show more results button looks ok
* Confirm the button works as expected and shows more results when clicked

Fixes #32516
