### PR TITLE
Signup: Tweaks to Crowdsignal signup page

### DIFF
--- a/client/blocks/signup-form/crowdsignal.jsx
+++ b/client/blocks/signup-form/crowdsignal.jsx
@@ -50,27 +50,6 @@ class CrowdsignalSignupForm extends Component {
 
 	hideSignupForm = () => this.setState( { showSignupForm: false } );
 
-	renderLearnMoreLink() {
-		const { translate } = this.props;
-		const link = (
-			<a
-				href="https://en.support.wordpress.com/wpcc-faq/"
-				target="_blank"
-				rel="noopener noreferrer"
-			/>
-		);
-
-		return (
-			<p className="signup-form__crowdsignal-learn-more">
-				{ translate( 'Why WordPress.com? {{a}}Learn more{{/a}}.', {
-					components: {
-						a: link,
-					},
-				} ) }
-			</p>
-		);
-	}
-
 	render() {
 		const { translate } = this.props;
 
@@ -99,7 +78,7 @@ class CrowdsignalSignupForm extends Component {
 						<div className="signup-form__crowdsignal-card-content">
 							<p className="signup-form__crowdsignal-card-subheader">
 								{ translate(
-									'The fastest way.{{br/}}Use one of your existing accounts{{br/}}to sign up with Crowdsignal:',
+									'The fastest way.{{br/}}Use one of your existing accounts{{br/}}to sign up for Crowdsignal:',
 									{
 										components: {
 											br: <br />,
@@ -114,7 +93,7 @@ class CrowdsignalSignupForm extends Component {
 								className="signup-form__crowdsignal-wpcom"
 							>
 								<WordPressLogo size={ 20 } />
-								<span>{ translate( 'Sign up with WordPress.com' ) }</span>
+								<span>{ translate( 'Sign in with WordPress.com' ) }</span>
 							</Button>
 							{ this.props.isSocialSignupEnabled && (
 								<SocialSignupForm
@@ -130,7 +109,6 @@ class CrowdsignalSignupForm extends Component {
 							>
 								{ translate( 'Create a WordPress.com Account' ) }
 							</Button>
-							{ this.renderLearnMoreLink() }
 						</div>
 					</div>
 
@@ -154,12 +132,26 @@ class CrowdsignalSignupForm extends Component {
 									>
 										{ translate( 'Create a WordPress.com Account' ) }
 									</FormButton>
-
-									{ this.renderLearnMoreLink() }
 								</LoggedOutFormFooter>
 							</LoggedOutForm>
 						</div>
 					</div>
+				</div>
+
+				<div className="signup-form__crowdsignal-tos">
+					<span>
+						{ translate(
+							'By creating an account via any of the options above,{{br/}}you agree to our {{a}}Terms of Service{{/a}}.',
+							{
+								components: {
+									a: (
+										<a href="https://wordpress.com/tos" target="_blank" rel="noopener noreferrer" />
+									),
+									br: <br />,
+								},
+							}
+						) }
+					</span>
 				</div>
 
 				<div className={ backButtonWrapperClass }>

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -40,6 +40,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		a {
 			font-weight: 600;
 		}
+
+		@include breakpoint( '<660px' ) {
+			margin: 40px 0;
+		}
 	}
 }
 
@@ -132,6 +136,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 			margin: 0 15px 0 0;
 			height: 22px;
 			width: 22px;
+		}
+
+		@include breakpoint( '<660px' ) {
+			margin-bottom: 20px;
 		}
 	}
 
@@ -277,6 +285,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	color: var( --color-neutral-500 );
 	margin-top: 20px;
 	padding: 0 20px;
+
+	@include breakpoint( '<660px' ) {
+		margin-top: 40px;
+	}
 }
 
 .signup-form__crowdsignal-footer {

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -25,7 +25,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 		color: var( --color-text );
 
 		font-family: 'Muli', $sans;
-		margin-bottom: 40px;
+		margin-bottom: 20px;
 	}
 
 	.formatted-header__title {
@@ -35,6 +35,8 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	}
 
 	.formatted-header__subtitle {
+		font-size: 15px;
+
 		a {
 			font-weight: 600;
 		}
@@ -115,6 +117,10 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	.logged-out-form__footer {
 		margin-top: 40px;
 	}
+
+	.signup-form__social {
+		padding: 0;
+	}
 }
 
 .signup-form__crowdsignal-social {
@@ -175,6 +181,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	background-color: var( --color-crowdsignal );
 	color: var( --color-white );
 	text-align: center;
+	margin-bottom: 0;
 
 	@include breakpoint( '>660px' ) {
 		display: none;
@@ -263,6 +270,12 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	@include breakpoint( '>660px' ) {
 		display: none;
 	}
+}
+
+.signup-form__crowdsignal-tos {
+	text-align: center;
+	color: var( --color-neutral-500 );
+	margin-top: 20px;
 }
 
 .signup-form__crowdsignal-footer {

--- a/client/blocks/signup-form/crowdsignal.scss
+++ b/client/blocks/signup-form/crowdsignal.scss
@@ -276,6 +276,7 @@ body.is-section-signup .layout .signup.is-crowdsignal .step-wrapper {
 	text-align: center;
 	color: var( --color-neutral-500 );
 	margin-top: 20px;
+	padding: 0 20px;
 }
 
 .signup-form__crowdsignal-footer {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -113,10 +113,16 @@ export class UserStep extends Component {
 				} );
 			} else if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 				subHeaderText = translate(
-					'By creating an account via any of the options below,{{br/}}you agree to our {{a}}Terms of Service{{/a}}.',
+					'Crowdsignal now uses WordPress.com Accounts.{{br/}}{{a}}Learn more about the benefits{{/a}}',
 					{
 						components: {
-							a: <a href="https://wordpress.com/tos" target="_blank" rel="noopener noreferrer" />,
+							a: (
+								<a
+									href="https://crowdsignal.com/2012/12/03/crowdsignal-wordpress-account/"
+									target="_blank"
+									rel="noopener noreferrer"
+								/>
+							),
 							br: <br />,
 						},
 					}


### PR DESCRIPTION
Adding some copy tweaks to the Crowdsignal signup page, to make it clearer why a WordPress.com account is required.

#### Changes proposed in this Pull Request

* Adds some new text in the header to help explain that a WordPress.com account is required, with a link to an informative blog post on Crowdsignal.com.
* Moves the terms and conditions blurb to below the signup forms.
* Fixes some CSS issues related to button widths and spacing margins.
* Removes the `Why WordPress.com?` text.

Before:
<img width="1219" alt="Screen Shot 2019-04-23 at 4 11 43 PM" src="https://user-images.githubusercontent.com/789137/56621793-c003ce80-65e2-11e9-99e5-7eb29072e333.png">

After:
<img width="1200" alt="Screen Shot 2019-04-23 at 4 10 42 PM" src="https://user-images.githubusercontent.com/789137/56621796-c85c0980-65e2-11e9-9c95-afd20a3dadc7.png">

After (Mobile):
<img width="431" alt="Screen Shot 2019-04-24 at 3 09 03 PM" src="https://user-images.githubusercontent.com/789137/56697237-f0ab3d00-66a2-11e9-8533-2debf9d4a000.png">

#### Testing instructions
Visit [this link](https://hash-16b07a60d47c115a371addbe66d558578fa38f18.calypso.live/start/crowdsignal/oauth2-name?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D6e61852a5381f6b5236c3814aaf7992d452eecca755c3696d60713abaf088463%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dsignup%2526action%253Drequest_access_token%26wpcom_connect%3D1%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login&oauth2_client_id=978) on calypso.live. The signup page should look like the screenshots. Verify that the copy is correct and margins/spacing looks correct at all screen sizes.

Note: I don't think it is possible to actually test creating account locally, due to the WPCC redirect url being different 🤔 


