### PR TITLE
Remove unintentionally added test functions

### DIFF
--- a/client/components/async-loader/test/index.js
+++ b/client/components/async-loader/test/index.js
@@ -66,10 +66,3 @@ test( 'creates wrapped components only on state change', async () => {
 		expect( renderCount ).toBe( 2 );
 	} );
 } );
-
-export const invalid = async () => {
-	1;
-};
-export const valid = async () => {
-	await Promise.resolve();
-};


### PR DESCRIPTION
Remove some functions that were never intended to be added.

These were added when investigating the `require-await` rule added in https://github.com/Automattic/wp-calypso/pull/30697.

Via https://github.com/Automattic/wp-calypso/pull/30700/files#r277897927

#### Changes proposed in this Pull Request

* Remove unused redundant functions

#### Testing instructions

* No changes