### PR TITLE
CI: Remove branch from gp-localci-client checkout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ jobs:
           name: Build New Strings .pot
           when: always
           command: |
-            git clone --single-branch --depth=1 --branch 'update/include-typescript' https://github.com/Automattic/gp-localci-client.git
+            git clone --single-branch --depth=1 https://github.com/Automattic/gp-localci-client.git
             bash gp-localci-client/generate-new-strings-pot.sh "$CIRCLE_BRANCH" "$CIRCLE_SHA1" "$CIRCLE_ARTIFACTS/translate"
             rm -rf gp-localci-client
       - store-artifacts-and-test-results


### PR DESCRIPTION
With #31902, it was necessary to use a branch from https://github.com/Automattic/gp-localci-client/pull/16. 

Now that https://github.com/Automattic/gp-localci-client/pull/16 and #31902 have been merged, we
can use the default `master` branch again.

Frees the branch from https://github.com/Automattic/gp-localci-client/pull/16 to be deleted.

#### Testing instructions

* `Build New Strings .pot` job on CircleCI continues to work as expected.