### PR TITLE
Fix: Allow atomic sites running on the latest infrastructure to be upgraded to the eCommerce plan.

### DIFF
--- a/client/state/selectors/can-upgrade-to-plan.js
+++ b/client/state/selectors/can-upgrade-to-plan.js
@@ -13,6 +13,7 @@ import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlan, isWpComBusinessPlan, isWpComEcommercePlan, isFreePlan } from 'lib/plans';
 import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
 
 /**
  * Whether a given site can be upgraded to a specific plan.
@@ -36,8 +37,10 @@ export default function( state, siteId, planKey ) {
 		? freePlan
 		: get( plan, [ 'productSlug' ], freePlan );
 
-	// Exception for upgrading Atomic sites to eCommerce
-	if ( isWpComEcommercePlan( planKey ) && isSiteAutomatedTransfer( state, siteId ) ) {
+	// Exception for upgrading Atomic v1 sites to eCommerce
+	const isAtomicV1 =
+		isSiteAutomatedTransfer( state, siteId ) && ! isSiteWpcomAtomic( state, siteId );
+	if ( isWpComEcommercePlan( planKey ) && isAtomicV1 ) {
 		return false;
 	}
 

--- a/client/state/selectors/is-site-wpcom-atomic.js
+++ b/client/state/selectors/is-site-wpcom-atomic.js
@@ -1,0 +1,16 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Retruns true if the questioned site is a WPCOM Atomic site.
+ *
+ * @param {Object} state the global state tree
+ * @param {Number} siteId the questioned site ID.
+ * @return {Boolean} Whether the site is a WPCOM Atomic site.
+ */
+export default ( state, siteId ) =>
+	get( state, [ 'sites', 'items', siteId, 'options', 'is_wpcom_atomic' ], false );

--- a/client/state/selectors/test/can-upgrade-to-plan.js
+++ b/client/state/selectors/test/can-upgrade-to-plan.js
@@ -332,9 +332,20 @@ describe( 'canUpgradeToPlan', () => {
 			} );
 		} );
 
-		test( 'should return false for atomic site when upgrading to eCommerce', () => {
+		test( 'should return false for atomic v1 site when upgrading to eCommerce', () => {
 			[ PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS ].forEach( planToPurchase => {
 				expect( canUpgradeToPlan( atomicFreeState, siteId, planToPurchase ) ).toBe( false );
+			} );
+		} );
+
+		test( 'should return true for atomic v2 site when upgrading to eCommerce', () => {
+			const atomicV2State = {
+				...atomicFreeState,
+			};
+			atomicV2State.sites.items[ siteId ].options.is_wpcom_atomic = true;
+
+			[ PLAN_ECOMMERCE, PLAN_ECOMMERCE_2_YEARS ].forEach( planToPurchase => {
+				expect( canUpgradeToPlan( atomicV2State, siteId, planToPurchase ) ).toBe( true );
 			} );
 		} );
 

--- a/client/state/selectors/test/is-site-wpcom-atomic.js
+++ b/client/state/selectors/test/is-site-wpcom-atomic.js
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
+
+describe( 'isSiteWpcomAtomic()', () => {
+	test( 'should default to false', () => {
+		expect( isSiteWpcomAtomic( {}, 123 ) ).toBe( false );
+	} );
+
+	test( 'should return the correct wpcom atomic field', () => {
+		const state = {
+			sites: {
+				items: {
+					[ 123 ]: {
+						options: {
+							is_wpcom_atomic: true,
+						},
+					},
+				},
+			},
+		};
+
+		expect( isSiteWpcomAtomic( state, 123 ) ).toBe( true );
+	} );
+} );

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -39,6 +39,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'is_domain_only',
 	'is_mapped_domain',
 	'is_redirect',
+	'is_wpcom_atomic',
 	'is_wpcom_store',
 	'woocommerce_is_active',
 	'jetpack_version',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to resolve the issue that an atomic v2 site can't be upgraded to the eCommerce plan. The reason is that `isAutomatedTransfer()` returns the same for both the v1 sites and the v2 sites, hence making `canUpgradeToPlan()` return `false` for the both.

With code-D27313 exposes `is_wpcom_atomic` data for indicating the v2 sites, this PR implements a new selector, `isSiteWpcomAtomic()` and update `canUpgradeToPlan()` accordingly to fix the issue.

#### Dependency
code-D27313

#### Testing instructions

##### Unit test
1. `npm run test-client is-site-wpcom-atomic can-upgrade-to-plan` should pass.

##### e2e test
1. Apply D27313
1. Choose an atomic v2 site and go to http://calypso.localhost:3000/plans/. You should be able to upgrade to the eCommerce plan from there.
1. Choose an atomic v1 site and go to http://calypso.localhost:3000/plans/. You should not be able to upgrade to the eCommerce plan as always.

