### PR TITLE
Signup: remove unused errors param from submitSignupStep

### DIFF
--- a/client/lib/signup/README.md
+++ b/client/lib/signup/README.md
@@ -36,7 +36,7 @@ Each action takes a `step` object with the following properties:
 
 #### Actions
 
--   `submitSignupStep( step, errors, providedDependencies )` — the user submits a step
+-   `submitSignupStep( step, providedDependencies )` — the user submits a step
 -   `processedSignupStep( step, errors, providedDependencies )` — a step processed by the API
 
 If `errors` has a non-zero length, it will be attached to the step and the step's status will be set to `invalid` as it is added to the store. If a `providedDependencies` object is included, its information will be added to the dependency store.

--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -24,7 +24,7 @@ const SignupActions = {
 		} );
 	},
 
-	submitSignupStep( step, errors, providedDependencies ) {
+	submitSignupStep( step, providedDependencies ) {
 		const { stepName } = step;
 
 		// Transform the keys since tracks events only accept snaked prop names.
@@ -62,7 +62,6 @@ const SignupActions = {
 		Dispatcher.handleViewAction( {
 			type: 'SUBMIT_SIGNUP_STEP',
 			data: step,
-			errors: undefined === errors ? [] : errors,
 			providedDependencies: providedDependencies,
 		} );
 	},

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -580,9 +580,7 @@ export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
 
 	if ( siteDomains && siteDomains.length > 1 ) {
 		const domainItem = undefined;
-		SignupActions.submitSignupStep( { stepName: stepName, domainItem }, [], {
-			domainItem,
-		} );
+		SignupActions.submitSignupStep( { stepName, domainItem }, { domainItem } );
 		recordExcludeStepEvent( stepName, siteDomains );
 
 		fulfilledDependencies = fulfilledDependencies.concat( [ 'domainItem' ] );
@@ -599,12 +597,12 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 
 	if ( isPaidPlan ) {
 		const cartItem = undefined;
-		SignupActions.submitSignupStep( { stepName: stepName, cartItem }, [], { cartItem } );
+		SignupActions.submitSignupStep( { stepName, cartItem }, { cartItem } );
 		recordExcludeStepEvent( stepName, sitePlanSlug );
 		fulfilledDependencies = fulfilledDependencies.concat( [ 'cartItem' ] );
 	} else if ( defaultDependencies && defaultDependencies.cartItem ) {
 		const cartItem = getCartItemForPlan( defaultDependencies.cartItem );
-		SignupActions.submitSignupStep( { stepName, cartItem }, [], { cartItem } );
+		SignupActions.submitSignupStep( { stepName, cartItem }, { cartItem } );
 		recordExcludeStepEvent( stepName, defaultDependencies.cartItem );
 		fulfilledDependencies = fulfilledDependencies.concat( [ 'cartItem' ] );
 	}
@@ -667,10 +665,10 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 			otherText: '',
 		} );
 
-		SignupActions.submitSignupStep( { stepName: 'survey' }, [], {
-			surveySiteType: 'blog',
-			surveyQuestion: vertical,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: 'survey' },
+			{ surveySiteType: 'blog', surveyQuestion: vertical }
+		);
 
 		nextProps.submitSiteVertical( { name: vertical }, stepName );
 

--- a/client/lib/signup/test/dependency-store.js
+++ b/client/lib/signup/test/dependency-store.js
@@ -45,7 +45,7 @@ describe( 'dependency-store', () => {
 	} );
 
 	test( 'should store dependencies if they are provided in either signup action', () => {
-		SignupActions.submitSignupStep( { stepName: 'userCreation' }, [], { bearer_token: 'TOKEN' } );
+		SignupActions.submitSignupStep( { stepName: 'userCreation' }, { bearer_token: 'TOKEN' } );
 
 		expect( SignupDependencyStore.get() ).toEqual( { bearer_token: 'TOKEN' } );
 

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -116,24 +116,17 @@ describe( 'flow-controller', () => {
 		} );
 
 		test( 'should call apiRequestFunction on steps with that property', done => {
-			SignupActions.submitSignupStep( { stepName: 'userCreation' }, [], { bearer_token: 'TOKEN' } );
-
-			SignupActions.submitSignupStep( {
-				stepName: 'asyncStep',
-				done,
-			} );
+			SignupActions.submitSignupStep( { stepName: 'userCreation' }, { bearer_token: 'TOKEN' } );
+			SignupActions.submitSignupStep( { stepName: 'asyncStep', done } );
 		} );
 
 		test( 'should not call apiRequestFunction multiple times', done => {
-			SignupActions.submitSignupStep( { stepName: 'userCreation' }, [], { bearer_token: 'TOKEN' } );
-			SignupActions.submitSignupStep( {
-				stepName: 'asyncStep',
-				done,
-			} );
+			SignupActions.submitSignupStep( { stepName: 'userCreation' }, { bearer_token: 'TOKEN' } );
+			SignupActions.submitSignupStep( { stepName: 'asyncStep', done } );
 
 			// resubmit the first step to initiate another call to SignupFlowController#_process
 			// implicitly asserting that apiRequestFunction/done is only called once
-			SignupActions.submitSignupStep( { stepName: 'userCreation' }, [], { bearer_token: 'TOKEN' } );
+			SignupActions.submitSignupStep( { stepName: 'userCreation' }, { bearer_token: 'TOKEN' } );
 		} );
 	} );
 

--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -73,7 +73,6 @@ handleSubmit: function( event ) {
 `submitSignupStep` takes the following parameters:
 
 - a `step` object with the property `stepName`, the name of the step you're submitting.
-- (optional) `errors`, an array of errors that will be attached to the step. If provided, the status of the step will be set to `invalid` in the Progress Store.
 - (optional) `providedDependencies`, an object describing the data added by the step to the Dependency Store. Use this only for data that does not come from API requests.
 - (optional) `wasSkipped`, a flag indicating that an optional step was skipped when it is set to true.
 

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -22,8 +22,6 @@ import { getStepUrl } from 'signup/utils';
  */
 import './style.scss';
 
-const { submitSignupStep } = SignupActions;
-
 export class NavigationLink extends Component {
 	static propTypes = {
 		goToNextStep: PropTypes.func,
@@ -89,7 +87,10 @@ export class NavigationLink extends Component {
 
 	handleClick = () => {
 		if ( this.props.direction === 'forward' ) {
-			submitSignupStep( { stepName: this.props.stepName }, [], this.props.defaultDependencies );
+			SignupActions.submitSignupStep(
+				{ stepName: this.props.stepName },
+				this.props.defaultDependencies
+			);
 
 			this.props.goToNextStep();
 		}

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -308,14 +308,11 @@ class AboutStep extends Component {
 
 		//Create site
 		SignupActions.submitSignupStep(
-			{
-				stepName,
-			},
-			[],
+			{ stepName },
 			{
 				themeSlugWithRepo: themeRepo,
 				siteTitle: siteTitleValue,
-				designType: designType,
+				designType,
 				surveyQuestion: siteTopicInput,
 			}
 		);

--- a/client/signup/steps/clone-credentials/index.jsx
+++ b/client/signup/steps/clone-credentials/index.jsx
@@ -39,10 +39,7 @@ class CloneCredentialsStep extends Component {
 	};
 
 	goToNextStep = () => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			roleName: 'alternate',
-		} );
-
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, { roleName: 'alternate' } );
 		this.props.goToNextStep();
 	};
 

--- a/client/signup/steps/clone-destination/index.jsx
+++ b/client/signup/steps/clone-destination/index.jsx
@@ -68,10 +68,10 @@ class CloneDestinationStep extends Component {
 		);
 
 		if ( isEmpty( errors ) ) {
-			SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-				destinationSiteName,
-				destinationSiteUrl,
-			} );
+			SignupActions.submitSignupStep(
+				{ stepName: this.props.stepName },
+				{ destinationSiteName, destinationSiteUrl }
+			);
 
 			this.props.goToNextStep();
 		} else {

--- a/client/signup/steps/clone-jetpack/index.jsx
+++ b/client/signup/steps/clone-jetpack/index.jsx
@@ -32,17 +32,16 @@ class CloneJetpackStep extends Component {
 	};
 
 	selectNew = () => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			cloneJetpack: 'new',
-		} );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, { cloneJetpack: 'new' } );
 
 		this.props.goToNextStep();
 	};
 
 	selectMigrate = () => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			cloneJetpack: 'migrate',
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{ cloneJetpack: 'migrate' }
+		);
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/clone-point/index.jsx
+++ b/client/signup/steps/clone-point/index.jsx
@@ -47,17 +47,13 @@ class ClonePointStep extends Component {
 	};
 
 	selectCurrent = () => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			clonePoint: 0,
-		} );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, { clonePoint: 0 } );
 
 		this.props.goToNextStep();
 	};
 
 	selectedPoint = activityTs => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			clonePoint: activityTs,
-		} );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, { clonePoint: activityTs } );
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/clone-ready/index.jsx
+++ b/client/signup/steps/clone-ready/index.jsx
@@ -36,7 +36,7 @@ class CloneReadyStep extends Component {
 	goToNextStep = () => {
 		const { originBlogId, clonePoint } = this.props.payload;
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {} );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName } );
 
 		this.props.initRewind( originBlogId, clonePoint, this.props.payload );
 		this.props.goToNextStep();

--- a/client/signup/steps/clone-start/index.jsx
+++ b/client/signup/steps/clone-start/index.jsx
@@ -35,11 +35,10 @@ class CloneStartStep extends Component {
 	goToNextStep = () => {
 		const { originBlogId, originSiteSlug, originSiteName } = this.props;
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			originBlogId,
-			originSiteSlug,
-			originSiteName,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{ originBlogId, originSiteSlug, originSiteName }
+		);
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -58,13 +58,7 @@ class CredsConfirmStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_share', {} );
 
-		SignupActions.submitSignupStep(
-			{
-				stepName: this.props.stepName,
-			},
-			undefined,
-			{ rewindconfig: true }
-		);
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, { rewindconfig: true } );
 
 		this.props.goToStep(
 			'pressable-nux' === this.props.flowName ? 'creds-complete' : 'rewind-were-backing'

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -42,13 +42,7 @@ class CredsPermissionStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_pressable_nux_credentials_share', {} );
 
-		SignupActions.submitSignupStep(
-			{
-				stepName: this.props.stepName,
-			},
-			undefined,
-			{ rewindconfig: true }
-		);
+		SignupActions.submitSignupStep( { stepName: this.props.stepName }, { rewindconfig: true } );
 
 		this.props.goToStep(
 			'pressable-nux' === this.props.flowName ? 'creds-complete' : 'rewind-were-backing'

--- a/client/signup/steps/design-type-with-atomic-store/index.jsx
+++ b/client/signup/steps/design-type-with-atomic-store/index.jsx
@@ -106,10 +106,10 @@ class DesignTypeWithAtomicStoreStep extends Component {
 			return;
 		}
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			designType,
-			themeSlugWithRepo,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{ designType, themeSlugWithRepo }
+		);
 
 		// If the user chooses `store` as design type, redirect to the `ecommerce` flow.
 		// For other choices, continue with the current flow.

--- a/client/signup/steps/design-type-with-store/index.jsx
+++ b/client/signup/steps/design-type-with-store/index.jsx
@@ -112,10 +112,10 @@ class DesignTypeWithStoreStep extends Component {
 
 		const themeSlugWithRepo = getThemeForDesignType( designType );
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			designType,
-			themeSlugWithRepo,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{ designType, themeSlugWithRepo }
+		);
 
 		this.props.goToNextStep();
 	};

--- a/client/signup/steps/design-type/index.jsx
+++ b/client/signup/steps/design-type/index.jsx
@@ -140,10 +140,10 @@ export class DesignTypeStep extends Component {
 
 		this.props.recordTracksEvent( 'calypso_triforce_select_design', { category: designType } );
 
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {
-			designType,
-			themeSlugWithRepo,
-		} );
+		SignupActions.submitSignupStep(
+			{ stepName: this.props.stepName },
+			{ designType, themeSlugWithRepo }
+		);
 		this.props.goToNextStep();
 	}
 }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -115,7 +115,6 @@ class DomainsStep extends React.Component {
 					isPurchasingItem: true,
 					stepSectionName: props.stepSectionName,
 				},
-				[],
 				{ domainItem }
 			);
 
@@ -183,9 +182,7 @@ class DomainsStep extends React.Component {
 
 	handleSkip = () => {
 		const domainItem = undefined;
-		SignupActions.submitSignupStep( { stepName: this.props.stepName, domainItem }, [], {
-			domainItem,
-		} );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName, domainItem }, { domainItem } );
 		this.props.goToNextStep();
 	};
 
@@ -216,7 +213,6 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			[],
 			{ domainItem }
 		);
 
@@ -245,7 +241,6 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			[],
 			{ domainItem }
 		);
 
@@ -276,7 +271,6 @@ class DomainsStep extends React.Component {
 				},
 				this.getThemeArgs()
 			),
-			[],
 			{ domainItem }
 		);
 

--- a/client/signup/steps/launch-site/index.jsx
+++ b/client/signup/steps/launch-site/index.jsx
@@ -12,15 +12,7 @@ import SignupActions from 'lib/signup/actions';
 class LaunchSiteComponent extends Component {
 	componentDidMount() {
 		const { flowName, stepName, goToNextStep } = this.props;
-
-		SignupActions.submitSignupStep(
-			{
-				stepName,
-			},
-			[],
-			{}
-		);
-
+		SignupActions.submitSignupStep( { stepName } );
 		goToNextStep( flowName );
 	}
 

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -98,7 +98,7 @@ export class PlansAtomicStoreStep extends Component {
 
 		const providedDependencies = { cartItem };
 
-		SignupActions.submitSignupStep( step, [], providedDependencies );
+		SignupActions.submitSignupStep( step, providedDependencies );
 
 		goToNextStep();
 	}

--- a/client/signup/steps/plans-atomic-store/test/index.jsx
+++ b/client/signup/steps/plans-atomic-store/test/index.jsx
@@ -142,7 +142,7 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
-		expect( args[ 2 ].cartItem ).toBe( cartItem );
+		expect( args[ 1 ].cartItem ).toBe( cartItem );
 	} );
 
 	test( 'Should call recordEvent when cartItem is specified', () => {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -116,7 +116,7 @@ export class PlansStep extends Component {
 
 		const providedDependencies = { cartItem };
 
-		SignupActions.submitSignupStep( step, [], providedDependencies );
+		SignupActions.submitSignupStep( step, providedDependencies );
 
 		goToNextStep();
 	};

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -146,7 +146,7 @@ describe( 'Plans.onSelectPlan', () => {
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
-		expect( args[ 2 ].cartItem ).toBe( cartItem );
+		expect( args[ 1 ].cartItem ).toBe( cartItem );
 	} );
 
 	test( 'Should call recordEvent when cartItem is specified', () => {

--- a/client/signup/steps/reader-landing/index.jsx
+++ b/client/signup/steps/reader-landing/index.jsx
@@ -20,7 +20,7 @@ import './style.scss';
 
 class ReaderLandingStep extends Component {
 	handleButtonClick = () => {
-		SignupActions.submitSignupStep( { stepName: this.props.stepName }, [], {} );
+		SignupActions.submitSignupStep( { stepName: this.props.stepName } );
 		this.props.goToNextStep();
 	};
 

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -44,13 +44,7 @@ class RewindFormCreds extends Component {
 	 */
 	componentWillUpdate( nextProps ) {
 		if ( nextProps.rewindIsNowActive ) {
-			SignupActions.submitSignupStep(
-				{
-					stepName: this.props.stepName,
-				},
-				undefined,
-				{ rewindconfig: true }
-			);
+			SignupActions.submitSignupStep( { stepName: this.props.stepName }, { rewindconfig: true } );
 			this.props.goToNextStep();
 		}
 	}

--- a/client/signup/steps/rewind-migrate/index.jsx
+++ b/client/signup/steps/rewind-migrate/index.jsx
@@ -43,13 +43,7 @@ class RewindMigrate extends Component {
 	 */
 	componentWillUpdate( nextProps ) {
 		if ( this.props.rewindIsNowActive !== nextProps.rewindIsNowActive ) {
-			SignupActions.submitSignupStep(
-				{
-					stepName: this.props.stepName,
-				},
-				undefined,
-				{ rewindconfig: true }
-			);
+			SignupActions.submitSignupStep( { stepName: this.props.stepName }, { rewindconfig: true } );
 			this.props.goToNextStep();
 		}
 	}

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -260,7 +260,6 @@ export default connect(
 						stepName: ownProps.stepName,
 						flowName: ownProps.flowName,
 					},
-					[],
 					submitData
 				);
 				ownProps.goToNextStep( ownProps.flowName );

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -121,7 +121,6 @@ class SiteOrDomain extends Component {
 				siteUrl,
 				isPurchasingItem: true,
 			},
-			[],
 			{ designType, domainItem, siteUrl }
 		);
 	}
@@ -131,13 +130,15 @@ class SiteOrDomain extends Component {
 
 		// we can skip the next two steps in the `domain-first` flow if the
 		// user is only purchasing a domain
-		SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true }, [], {} );
-		SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], {
-			themeSlugWithRepo: 'pub/twentysixteen',
-		} );
-		SignupActions.submitSignupStep( { stepName: 'plans-site-selected', wasSkipped: true }, [], {
-			cartItem: null,
-		} );
+		SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true } );
+		SignupActions.submitSignupStep(
+			{ stepName: 'themes', wasSkipped: true },
+			{ themeSlugWithRepo: 'pub/twentysixteen' }
+		);
+		SignupActions.submitSignupStep(
+			{ stepName: 'plans-site-selected', wasSkipped: true },
+			{ cartItem: null }
+		);
 		goToStep( 'user' );
 	}
 
@@ -151,7 +152,7 @@ class SiteOrDomain extends Component {
 		} else if ( designType === 'existing-site' ) {
 			goToNextStep();
 		} else {
-			SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true }, [], {} );
+			SignupActions.submitSignupStep( { stepName: 'site-picker', wasSkipped: true } );
 			goToStep( 'themes' );
 		}
 	};

--- a/client/signup/steps/site-picker/site-picker-submit.jsx
+++ b/client/signup/steps/site-picker/site-picker-submit.jsx
@@ -23,25 +23,23 @@ export class SitePickerSubmit extends React.Component {
 			hasPaidPlan = siteHasPaidPlan( selectedSite ),
 			{ ID: siteId, slug: siteSlug } = selectedSite;
 
-		SignupActions.submitSignupStep(
-			{
-				stepName,
-				stepSectionName,
-				siteId,
-				siteSlug,
-			},
-			[],
-			{}
-		);
-
-		SignupActions.submitSignupStep( { stepName: 'themes', wasSkipped: true }, [], {
-			themeSlugWithRepo: 'pub/twentysixteen',
+		SignupActions.submitSignupStep( {
+			stepName,
+			stepSectionName,
+			siteId,
+			siteSlug,
 		} );
 
+		SignupActions.submitSignupStep(
+			{ stepName: 'themes', wasSkipped: true },
+			{ themeSlugWithRepo: 'pub/twentysixteen' }
+		);
+
 		if ( hasPaidPlan ) {
-			SignupActions.submitSignupStep( { stepName: 'plans-site-selected', wasSkipped: true }, [], {
-				cartItem: null,
-			} );
+			SignupActions.submitSignupStep(
+				{ stepName: 'plans-site-selected', wasSkipped: true },
+				{ cartItem: null }
+			);
 
 			goToStep( 'user' );
 		} else {

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -162,16 +162,7 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 				site_style: styleLabel,
 			} )
 		);
-		SignupActions.submitSignupStep(
-			{
-				stepName,
-			},
-			[],
-			{
-				siteStyle,
-				themeSlugWithRepo,
-			}
-		);
+		SignupActions.submitSignupStep( { stepName }, { siteStyle, themeSlugWithRepo } );
 
 		goToNextStep( flowName );
 	},

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -37,7 +37,6 @@ class SiteTitleStep extends React.Component {
 				stepName: this.props.stepName,
 				siteTitle,
 			},
-			[],
 			{ siteTitle }
 		);
 

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -180,7 +180,6 @@ class SurveyStep extends React.Component {
 				stepSectionName: this.props.stepSectionName,
 				otherWriteIn: otherWriteIn,
 			},
-			[],
 			{ surveySiteType: this.props.surveySiteType, surveyQuestion: value }
 		);
 

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -52,7 +52,6 @@ class ThemeSelectionStep extends Component {
 				stepName: this.props.stepName,
 				repoSlug,
 			},
-			null,
 			{
 				themeSlugWithRepo: repoSlug,
 			}

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -166,7 +166,6 @@ export class UserStep extends Component {
 				oauth2Signup,
 				...data,
 			},
-			null,
 			dependencies
 		);
 

--- a/client/state/importer-nux/actions.js
+++ b/client/state/importer-nux/actions.js
@@ -88,14 +88,17 @@ export const submitImportUrlStep = ( { stepName, siteUrl: siteUrlFromInput } ) =
 				retryTimeout: 1000,
 			} );
 
-			return SignupActions.submitSignupStep( { stepName }, [], {
-				sitePreviewImageBlob: imageBlob,
-				importEngine: engine,
-				importFavicon: favicon,
-				importSiteUrl,
-				siteTitle,
-				themeSlugWithRepo: 'pub/modern-business',
-			} );
+			return SignupActions.submitSignupStep(
+				{ stepName },
+				{
+					sitePreviewImageBlob: imageBlob,
+					importEngine: engine,
+					importFavicon: favicon,
+					importSiteUrl,
+					siteTitle,
+					themeSlugWithRepo: 'pub/modern-business',
+				}
+			);
 		} )
 		.catch( error => {
 			throw new Error( error );

--- a/client/state/signup/steps/site-type/actions.js
+++ b/client/state/signup/steps/site-type/actions.js
@@ -25,15 +25,6 @@ export function submitSiteType( siteType ) {
 		const themeSlugWithRepo =
 			getSiteTypePropertyValue( 'slug', siteType, 'theme' ) || 'pub/independent-publisher-2';
 
-		SignupActions.submitSignupStep(
-			{
-				stepName: 'site-type',
-			},
-			[],
-			{
-				siteType,
-				themeSlugWithRepo,
-			}
-		);
+		SignupActions.submitSignupStep( { stepName: 'site-type' }, { siteType, themeSlugWithRepo } );
 	};
 }

--- a/client/state/signup/steps/site-vertical/actions.js
+++ b/client/state/signup/steps/site-vertical/actions.js
@@ -31,5 +31,5 @@ export function setSiteVertical( siteVerticalData ) {
  */
 export const submitSiteVertical = ( siteVerticalData, stepName = 'site-topic' ) => dispatch => {
 	dispatch( setSiteVertical( siteVerticalData ) );
-	SignupActions.submitSignupStep( { stepName }, [], { siteTopic: siteVerticalData.name } );
+	SignupActions.submitSignupStep( { stepName }, { siteTopic: siteVerticalData.name } );
 };


### PR DESCRIPTION
Removes unused `errors` param from `SignupActions.submitSignupStep`. It's never used.

The only action where `errors` make sense is `processedSignupStep`, dispatched after a step's "API function" is called. That part of the step can fail.

One small step towards finally removing Flux from Signup.