### PR TITLE
GSuite: Replace incorrect HEX value with --color-text-subtle

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-dialog/style.scss
+++ b/client/components/upgrades/gsuite/gsuite-dialog/style.scss
@@ -105,7 +105,7 @@
 	padding: 0 30px;
 
 	h4 {
-		color: #7799ae;
+		color: var( --color-text-subtle );
 		margin-top: 30px;
 		margin-bottom: 4px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates a hard-coded HEX value to `--color-text-subtle` on the G Suite upgrade form.

**Before**

<img width="665" alt="Screen Shot 2019-04-24 at 11 15 50 AM" src="https://user-images.githubusercontent.com/2124984/56671462-afa33080-6682-11e9-9796-15d879d8dd18.png">

**After**

<img width="649" alt="Screen Shot 2019-04-24 at 11 16 11 AM" src="https://user-images.githubusercontent.com/2124984/56671468-b2058a80-6682-11e9-8e1b-17b5940cc160.png">

#### Testing instructions

* Switch to this PR and go to `/domains/add/`
* Select a domain to purchase
* On the G Suite upgrade screen, note the text color change.

Fixes #32518
