### PR TITLE
Customizer: Refresh site data when navigating "back"

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -282,7 +282,7 @@ class Customize extends React.Component {
 
 	renderErrorPage = error => {
 		return (
-			<div className="main main-column customize" role="main">
+			<div className="main main-column customize customize__main-error" role="main">
 				<PageViewTracker path="/customize/:site" title="Customizer" />
 				<SidebarNavigation />
 				<EmptyContent
@@ -317,7 +317,7 @@ class Customize extends React.Component {
 
 		if ( ! this.props.site ) {
 			return (
-				<div className="main main-column customize is-iframe" role="main">
+				<div className="main main-column customize customize__main is-iframe" role="main">
 					<PageViewTracker path="/customize/:site" title="Customizer" />
 					<CustomizerLoadingPanel />
 				</div>
@@ -343,10 +343,10 @@ class Customize extends React.Component {
 			// component. If the loading takes longer than 25 seconds (see
 			// waitForLoading above) then an error will be shown.
 			return (
-				<div className="main main-column customize is-iframe" role="main">
+				<div className="main main-column customize customize__main is-iframe" role="main">
 					<PageViewTracker path="/customize/:site" title="Customizer" />
 					<CustomizerLoadingPanel isLoaded={ this.state.iframeLoaded } />
-					<iframe className={ iframeClassName } src={ iframeUrl } />
+					<iframe className={ iframeClassName } src={ iframeUrl } title="Customizer" />
 				</div>
 			);
 		}

--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -23,6 +23,7 @@ import EmptyContent from 'components/empty-content';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import Actions from 'my-sites/customize/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { requestSite } from 'state/sites/actions';
 import { themeActivated } from 'state/themes/actions';
 import { getCustomizerFocus } from './panels';
 import getMenusUrl from 'state/selectors/get-menus-url';
@@ -127,6 +128,7 @@ class Customize extends React.Component {
 
 		debug( 'returning to previous page', path );
 		page.back( path );
+		this.props.requestSite( this.props.siteId );
 	};
 
 	navigateTo = destination => {
@@ -368,11 +370,12 @@ export default connect(
 		const siteId = get( site, 'ID' );
 		return {
 			site,
+			siteId,
 			menusUrl: getMenusUrl( state, siteId ),
 			isJetpack: isJetpackSite( state, siteId ),
 			// TODO: include panel from props?
 			customizerUrl: getCustomizerUrl( state, siteId ),
 		};
 	},
-	{ themeActivated }
+	{ requestSite, themeActivated }
 )( localize( Customize ) );


### PR DESCRIPTION
Currently, when I change the site title via the Customizer, then click the "back" button, I'm returned to Calypso, but the [data component](https://github.com/Automattic/wp-calypso/blob/47e778be86708c16aeb78a8a23c8aaeea8bcac0b/client/components/data/query-sites/README.md) responsible for keeping site data fresh doesn't kick in.

The result is, the "old" site title continues to be displayed in the `Site` component even after clicking around to at least some other sections within my-sites.

This explicitly refreshes the site when the customizer iframe tells Calypso it is "done."

| Before  | After |
| ------------- | ------------- |
| ![before-update-site-customize-back](https://user-images.githubusercontent.com/1587282/56677404-796bae00-668e-11e9-935e-4d709095a2da.gif) | ![after-update-site-customize-back](https://user-images.githubusercontent.com/1587282/56677414-7ffa2580-668e-11e9-9001-35c32084efcf.gif)  |


#### Changes proposed in this Pull Request

* Kick off a call via `requestSite` when a "back" message is received from the iframe

#### Testing instructions

##### Confirm the issue
* Browse to `My Sites` in production
* Navigate to `Customize`
* Drill into `Site Identity`
* Alter the `Site Title`
* Click `Publish`
* Click the back button (the arrow icon in the top left)
* Notice the site title does not update in the sidebar

##### Confirm the fix

* Repeat the above on this branch
* Notice the site title does update in the sidebar 