### PR TITLE
Site Settings: fixed split Composing card after AtD removal.

### DIFF
--- a/client/my-sites/site-settings/composing/index.jsx
+++ b/client/my-sites/site-settings/composing/index.jsx
@@ -14,6 +14,7 @@ import { connect } from 'react-redux';
 import Latex from './latex';
 import Shortcodes from './shortcodes';
 import Card from 'components/card';
+import CompactCard from 'components/card/compact';
 import DateTimeFormat from '../date-time-format';
 import DefaultPostFormat from './default-post-format';
 import PublishConfirmation from './publish-confirmation';
@@ -32,9 +33,11 @@ const Composing = ( {
 	siteIsJetpack,
 	updateFields,
 } ) => {
+	const CardComponent = siteIsJetpack ? CompactCard : Card;
+
 	return (
 		<Fragment>
-			<Card className="composing__card site-settings">
+			<CardComponent className="composing__card site-settings">
 				<PublishConfirmation />
 				<DefaultPostFormat
 					eventTracker={ eventTracker }
@@ -43,7 +46,7 @@ const Composing = ( {
 					isSavingSettings={ isSavingSettings }
 					onChangeField={ onChangeField }
 				/>
-			</Card>
+			</CardComponent>
 
 			{ siteIsJetpack && (
 				<Fragment>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a regression caused by https://github.com/Automattic/wp-calypso/pull/31880 on the Site's Settings Writing tab, on the Composing Section.

For Jetpack sites, the Composing card is split in two, when it should be one card. This does not affect Simple Sites.

| Before | After |
| - | - |
| ![Screen Shot 2019-04-24 at 14 17 21](https://user-images.githubusercontent.com/233601/56679613-dcb00d00-669b-11e9-9562-49d8baf51327.png) | ![Screen Shot 2019-04-24 at 14 17 32](https://user-images.githubusercontent.com/233601/56679632-ea659280-669b-11e9-9bcc-5f188ac28fe3.png) |

This was caused by a merge conflict resolution during rebase.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the Writing tab on a Jetpack site settings.
* Verify that the compose card is displayed correctly.