### PR TITLE
Media Modal: Improve Readability of Disabled Tabs

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -269,7 +269,7 @@
 
 	&[disabled],
 	.notouch &[disabled]:hover {
-		color: var( --color-neutral-0 );
+		color: var( --color-neutral-200 );
 		cursor: default;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This switches the colour variable from -neutral-0 to -neutral-200 for the section nav disabled component

#### Testing instructions

Open the Gutenberg editor, add an Image Block (so that some tabs will be disabled - you can't add a video or document) and select "Media Library", then compare the two.

**Current:**

<img width="593" alt="Screenshot 2019-04-24 at 20 50 36" src="https://user-images.githubusercontent.com/43215253/56689557-48619c80-66d3-11e9-86d8-3a658489bf98.png">

**Proposed:**

<img width="601" alt="Screenshot 2019-04-24 at 20 50 28" src="https://user-images.githubusercontent.com/43215253/56689574-557e8b80-66d3-11e9-9b16-4b10e4df3574.png">

cc @drw158, @flootr, @blowery 

Fixes #32551
