### PR TITLE
Remove unused processingMessage field from submitted steps

### DIFF
--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -75,7 +75,6 @@ handleSubmit: function( event ) {
 - a `step` object with the property `stepName`, the name of the step you're submitting.
 - (optional) `errors`, an array of errors that will be attached to the step. If provided, the status of the step will be set to `invalid` in the Progress Store.
 - (optional) `providedDependencies`, an object describing the data added by the step to the Dependency Store. Use this only for data that does not come from API requests.
-- (optional) `processingMessage`, a message that is displayed at the end of the flow while the user waits for the apiRequestFunction to process. For example, "Creating your account" or "Setting up your site", depending on what your step does.
 - (optional) `wasSkipped`, a flag indicating that an optional step was skipped when it is set to true.
 
 Some background on `providedDependencies` and the Dependency Store: submitted steps are saved in the Progress Store, where they wait to have their dependencies met. For example, a step that creates a site needs to wait until a user account is created. Once that happens, the step is processed and its result is saved in the Dependency Store, so other steps can use it. You can read more about this [here](https://github.com/Automattic/wp-calypso/tree/master/client/lib/signup).

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -189,7 +189,6 @@ class AboutStep extends Component {
 			shouldHideSiteTitle,
 			shouldHideSiteGoals,
 			previousFlowName,
-			translate,
 			siteType,
 		} = this.props;
 
@@ -310,8 +309,7 @@ class AboutStep extends Component {
 		//Create site
 		SignupActions.submitSignupStep(
 			{
-				processingMessage: translate( 'Collecting your information' ),
-				stepName: stepName,
+				stepName,
 			},
 			[],
 			{

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -60,7 +60,6 @@ class CredsConfirmStep extends Component {
 
 		SignupActions.submitSignupStep(
 			{
-				processingMessage: this.props.translate( 'Setting up your site' ),
 				stepName: this.props.stepName,
 			},
 			undefined,

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -77,7 +77,11 @@ class CredsConfirmStep extends Component {
 		return (
 			<Card className="creds-confirm__card">
 				<h3 className="creds-confirm__title">{ translate( 'Are you sure?' ) }</h3>
-				<img className="creds-confirm__image" src="/calypso/images/illustrations/security.svg" />
+				<img
+					className="creds-confirm__image"
+					src="/calypso/images/illustrations/security.svg"
+					alt=""
+				/>
 				<p className="creds-confirm__description">
 					{ translate(
 						"If you don't share credentials with Jetpack, your site won't be backed up. Our " +

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -44,7 +44,6 @@ class CredsPermissionStep extends Component {
 
 		SignupActions.submitSignupStep(
 			{
-				processingMessage: this.props.translate( 'Setting up your site' ),
 				stepName: this.props.stepName,
 			},
 			undefined,

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -62,7 +62,11 @@ class CredsPermissionStep extends Component {
 			<Card className="creds-permission__card">
 				<QuerySites />
 				<h3 className="creds-permission__title">{ translate( 'Start backing up your site' ) }</h3>
-				<img className="creds-permission__image" src="/calypso/images/illustrations/security.svg" />
+				<img
+					className="creds-permission__image"
+					src="/calypso/images/illustrations/security.svg"
+					alt=""
+				/>
 				<p className="creds-permission__description">
 					{ translate(
 						'Jetpack, a plugin already on your site, can back up and secure your site at no ' +

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -108,14 +108,13 @@ class DomainsStep extends React.Component {
 			const domainItem = cartItems.domainRegistration( { productSlug, domain } );
 
 			SignupActions.submitSignupStep(
-				Object.assign( {
-					processingMessage: props.translate( 'Adding your domain' ),
+				{
 					stepName: props.stepName,
 					domainItem,
 					siteUrl: domain,
 					isPurchasingItem: true,
 					stepSectionName: props.stepSectionName,
-				} ),
+				},
 				[],
 				{ domainItem }
 			);
@@ -208,7 +207,6 @@ class DomainsStep extends React.Component {
 		SignupActions.submitSignupStep(
 			Object.assign(
 				{
-					processingMessage: this.props.translate( 'Adding your domain' ),
 					stepName: this.props.stepName,
 					domainItem,
 					googleAppsCartItem,
@@ -238,7 +236,6 @@ class DomainsStep extends React.Component {
 		SignupActions.submitSignupStep(
 			Object.assign(
 				{
-					processingMessage: this.props.translate( 'Adding your domain mapping' ),
 					stepName: this.props.stepName,
 					[ sectionName ]: state,
 					domainItem,
@@ -270,9 +267,8 @@ class DomainsStep extends React.Component {
 		SignupActions.submitSignupStep(
 			Object.assign(
 				{
-					processingMessage: this.props.translate( 'Adding your domain transfer' ),
 					stepName: this.props.stepName,
-					[ 'transfer' ]: {},
+					transfer: {},
 					domainItem,
 					isPurchasingItem,
 					siteUrl: domain,

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import React, { Component } from 'react';
-import { isEmpty, filter } from 'lodash';
+import { filter } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 
@@ -62,7 +62,6 @@ export class PlansAtomicStoreStep extends Component {
 			stepSectionName,
 			stepName,
 			goToNextStep,
-			translate,
 			designType,
 		} = this.props;
 
@@ -91,9 +90,6 @@ export class PlansAtomicStoreStep extends Component {
 		}
 
 		const step = {
-			processingMessage: isEmpty( cartItem )
-				? translate( 'Free plan selected' )
-				: translate( 'Adding your plan' ),
 			stepName,
 			stepSectionName,
 			cartItem,

--- a/client/signup/steps/plans-atomic-store/test/index.jsx
+++ b/client/signup/steps/plans-atomic-store/test/index.jsx
@@ -107,7 +107,6 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
-		expect( typeof args[ 0 ].processingMessage ).toEqual( 'string' );
 		expect( args[ 0 ].stepName ).toEqual( 'Step name' );
 		expect( args[ 0 ].stepSectionName ).toEqual( 'Step section name' );
 		expect( args[ 0 ].cartItem ).toBe( cartItem );

--- a/client/signup/steps/plans-atomic-store/test/index.jsx
+++ b/client/signup/steps/plans-atomic-store/test/index.jsx
@@ -94,7 +94,7 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 		};
 		const comp = new PlansAtomicStoreStep( myProps );
 		comp.onSelectPlan( { product_slug: PLAN_FREE } );
-		expect( myProps.goToNextStep ).toBeCalled();
+		expect( myProps.goToNextStep ).toHaveBeenCalled();
 	} );
 
 	test( 'Should call submitSignupStep with step details', () => {
@@ -103,7 +103,7 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 		const comp = new PlansAtomicStoreStep( tplProps );
 		const cartItem = { product_slug: PLAN_FREE };
 		comp.onSelectPlan( cartItem );
-		expect( SignupActions.submitSignupStep ).toBeCalled();
+		expect( SignupActions.submitSignupStep ).toHaveBeenCalled();
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
@@ -125,7 +125,7 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 		const comp = new PlansAtomicStoreStep( myProps );
 		const cartItem = { product_slug: PLAN_FREE };
 		comp.onSelectPlan( cartItem );
-		expect( SignupActions.submitSignupStep ).toBeCalled();
+		expect( SignupActions.submitSignupStep ).toHaveBeenCalled();
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
@@ -138,7 +138,7 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 		const comp = new PlansAtomicStoreStep( tplProps );
 		const cartItem = { product_slug: PLAN_FREE };
 		comp.onSelectPlan( cartItem );
-		expect( SignupActions.submitSignupStep ).toBeCalled();
+		expect( SignupActions.submitSignupStep ).toHaveBeenCalled();
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
@@ -152,7 +152,7 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 		const cartItem = { product_slug: PLAN_FREE, free_trial: false };
 		comp.onSelectPlan( cartItem );
 
-		expect( analytics.tracks.recordEvent ).toBeCalled();
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalled();
 
 		const calls = analytics.tracks.recordEvent.mock.calls;
 		const args = calls[ calls.length - 1 ];
@@ -179,7 +179,7 @@ describe( 'PlansAtomicStoreStep.onSelectPlan', () => {
 			const cartItem = { product_slug: plan };
 			const comp = new PlansAtomicStoreStep( myProps );
 			comp.onSelectPlan( cartItem );
-			expect( myProps.goToNextStep ).toBeCalled();
+			expect( myProps.goToNextStep ).toHaveBeenCalled();
 			expect( cartItem.extra ).toEqual( {
 				is_store_signup: true,
 			} );

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -7,7 +7,7 @@
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { isEmpty, intersection } from 'lodash';
+import { intersection } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { parse as parseQs } from 'qs';
@@ -81,7 +81,6 @@ export class PlansStep extends Component {
 			stepName,
 			flowName,
 			goToNextStep,
-			translate,
 		} = this.props;
 
 		if ( cartItem ) {
@@ -109,9 +108,6 @@ export class PlansStep extends Component {
 		}
 
 		const step = {
-			processingMessage: isEmpty( cartItem )
-				? translate( 'Free plan selected' )
-				: translate( 'Adding your plan' ),
 			stepName,
 			stepSectionName,
 			cartItem,

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -111,7 +111,6 @@ describe( 'Plans.onSelectPlan', () => {
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
-		expect( typeof args[ 0 ].processingMessage ).toEqual( 'string' );
 		expect( args[ 0 ].stepName ).toEqual( 'Step name' );
 		expect( args[ 0 ].stepSectionName ).toEqual( 'Step section name' );
 		expect( args[ 0 ].cartItem ).toBe( cartItem );

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -98,7 +98,7 @@ describe( 'Plans.onSelectPlan', () => {
 		};
 		const comp = new PlansStep( myProps );
 		comp.onSelectPlan( { product_slug: PLAN_FREE } );
-		expect( myProps.goToNextStep ).toBeCalled();
+		expect( myProps.goToNextStep ).toHaveBeenCalled();
 	} );
 
 	test( 'Should call submitSignupStep with step details', () => {
@@ -107,7 +107,7 @@ describe( 'Plans.onSelectPlan', () => {
 		const comp = new PlansStep( tplProps );
 		const cartItem = { product_slug: PLAN_FREE };
 		comp.onSelectPlan( cartItem );
-		expect( SignupActions.submitSignupStep ).toBeCalled();
+		expect( SignupActions.submitSignupStep ).toHaveBeenCalled();
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
@@ -129,7 +129,7 @@ describe( 'Plans.onSelectPlan', () => {
 		const comp = new PlansStep( myProps );
 		const cartItem = { product_slug: PLAN_FREE };
 		comp.onSelectPlan( cartItem );
-		expect( SignupActions.submitSignupStep ).toBeCalled();
+		expect( SignupActions.submitSignupStep ).toHaveBeenCalled();
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
@@ -142,7 +142,7 @@ describe( 'Plans.onSelectPlan', () => {
 		const comp = new PlansStep( tplProps );
 		const cartItem = { product_slug: PLAN_FREE };
 		comp.onSelectPlan( cartItem );
-		expect( SignupActions.submitSignupStep ).toBeCalled();
+		expect( SignupActions.submitSignupStep ).toHaveBeenCalled();
 
 		const calls = SignupActions.submitSignupStep.mock.calls;
 		const args = calls[ calls.length - 1 ];
@@ -156,7 +156,7 @@ describe( 'Plans.onSelectPlan', () => {
 		const cartItem = { product_slug: PLAN_FREE, free_trial: false };
 		comp.onSelectPlan( cartItem );
 
-		expect( analytics.tracks.recordEvent ).toBeCalled();
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalled();
 
 		const calls = analytics.tracks.recordEvent.mock.calls;
 		const args = calls[ calls.length - 1 ];
@@ -183,7 +183,7 @@ describe( 'Plans.onSelectPlan', () => {
 			const cartItem = { product_slug: plan };
 			const comp = new PlansStep( myProps );
 			comp.onSelectPlan( cartItem );
-			expect( myProps.goToNextStep ).toBeCalled();
+			expect( myProps.goToNextStep ).toHaveBeenCalled();
 			expect( cartItem.extra ).toEqual( {
 				is_store_signup: true,
 			} );
@@ -206,7 +206,7 @@ describe( 'Plans.onSelectPlan', () => {
 			const cartItem = { product_slug: plan };
 			const comp = new PlansStep( myProps );
 			comp.onSelectPlan( cartItem );
-			expect( myProps.goToNextStep ).toBeCalled();
+			expect( myProps.goToNextStep ).toHaveBeenCalled();
 			expect( cartItem.extra ).toEqual( undefined );
 		} );
 	} );

--- a/client/signup/steps/rebrand-cities-welcome/index.jsx
+++ b/client/signup/steps/rebrand-cities-welcome/index.jsx
@@ -24,13 +24,12 @@ import './style.scss';
 
 class RebrandCitiesWelcomeStep extends Component {
 	handleSubmit = siteTitle => {
-		const { goToNextStep, stepName, stepSectionName, translate } = this.props;
+		const { goToNextStep, stepName, stepSectionName } = this.props;
 
 		this.props.setSiteTitle( siteTitle );
 
 		SignupActions.submitSignupStep( {
 			isPurchasingItem: false,
-			processingMessage: translate( 'Setting up your site' ),
 			siteUrl: generateUniqueRebrandCitiesSiteUrl(),
 			stepName,
 			stepSectionName,

--- a/client/signup/steps/rewind-add-creds/index.jsx
+++ b/client/signup/steps/rewind-add-creds/index.jsx
@@ -35,7 +35,6 @@ class RewindAddCreds extends Component {
 
 	goToCredsForm = () => {
 		SignupActions.submitSignupStep( {
-			processingMessage: this.props.translate( 'Preparing credentials form' ),
 			stepName: this.props.stepName,
 		} );
 

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -46,7 +46,6 @@ class RewindFormCreds extends Component {
 		if ( nextProps.rewindIsNowActive ) {
 			SignupActions.submitSignupStep(
 				{
-					processingMessage: this.props.translate( 'Migrating your credentials' ),
 					stepName: this.props.stepName,
 				},
 				undefined,

--- a/client/signup/steps/rewind-migrate/index.jsx
+++ b/client/signup/steps/rewind-migrate/index.jsx
@@ -45,7 +45,6 @@ class RewindMigrate extends Component {
 		if ( this.props.rewindIsNowActive !== nextProps.rewindIsNowActive ) {
 			SignupActions.submitSignupStep(
 				{
-					processingMessage: this.props.translate( 'Migrating your credentials' ),
 					stepName: this.props.stepName,
 				},
 				undefined,

--- a/client/signup/steps/site-information/index.jsx
+++ b/client/signup/steps/site-information/index.jsx
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { each, includes, reduce, trim, size } from 'lodash';
 
 /**
@@ -257,7 +257,6 @@ export default connect(
 				// Create site
 				SignupActions.submitSignupStep(
 					{
-						processingMessage: i18n.translate( 'Populating your contact information.' ),
 						stepName: ownProps.stepName,
 						flowName: ownProps.flowName,
 					},

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -7,7 +7,7 @@
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import React, { Component } from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { find } from 'lodash';
 
@@ -164,7 +164,6 @@ const mapDispatchToProps = ( dispatch, ownProps ) => ( {
 		);
 		SignupActions.submitSignupStep(
 			{
-				processingMessage: i18n.translate( 'Collecting your information' ),
 				stepName,
 			},
 			[],

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -34,7 +34,6 @@ class SiteTitleStep extends React.Component {
 
 		SignupActions.submitSignupStep(
 			{
-				processingMessage: translate( 'Setting up your site' ),
 				stepName: this.props.stepName,
 				siteTitle,
 			},

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -168,7 +168,6 @@ class Site extends React.Component {
 				this.resetAnalyticsData();
 
 				SignupActions.submitSignupStep( {
-					processingMessage: this.props.translate( 'Setting up your site' ),
 					stepName: this.props.stepName,
 					form: this.state.form,
 					site,

--- a/client/signup/steps/theme-selection/index.jsx
+++ b/client/signup/steps/theme-selection/index.jsx
@@ -50,7 +50,6 @@ class ThemeSelectionStep extends Component {
 		SignupActions.submitSignupStep(
 			{
 				stepName: this.props.stepName,
-				processingMessage: this.props.translate( 'Adding your theme' ),
 				repoSlug,
 			},
 			null,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -152,7 +152,7 @@ export class UserStep extends Component {
 	};
 
 	submit = data => {
-		const { flowName, stepName, oauth2Signup, translate } = this.props;
+		const { flowName, stepName, oauth2Signup } = this.props;
 		const dependencies = {};
 		if ( oauth2Signup ) {
 			dependencies.oauth2_client_id = data.queryArgs.oauth2_client_id;
@@ -161,7 +161,6 @@ export class UserStep extends Component {
 
 		SignupActions.submitSignupStep(
 			{
-				processingMessage: translate( 'Creating your account' ),
 				flowName,
 				stepName,
 				oauth2Signup,

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -102,12 +102,10 @@ function updateStep( state, newStep ) {
 			if ( status === 'pending' || status === 'completed' ) {
 				// This can only happen when submitting a step
 				//
-				// Steps that are resubmitted may decide to omit the
-				// `processingMessage` or `wasSkipped` status of a step if e.g.
-				// the user goes back and chooses to not skip a step. If a step
-				// is submitted without these, we explicitly remove them from
-				// the step data.
-				const { processingMessage, wasSkipped, ...commonStepArgs } = step;
+				// Steps that are resubmitted may decide to omit the `wasSkipped` status of a step if e.g.
+				// the user goes back and chooses to not skip a step. If a step is submitted without it,
+				// we explicitly remove it from the step data.
+				const { wasSkipped, ...commonStepArgs } = step;
 				return { ...commonStepArgs, ...newStep };
 			}
 

--- a/client/state/signup/progress/test/reducer.js
+++ b/client/state/signup/progress/test/reducer.js
@@ -214,11 +214,10 @@ describe( 'reducer', () => {
 		} );
 		describe( 'saving an existing step', () => {
 			test( 'should update the step with a "pending" status if the step has a corresponding API request function', () => {
-				// It should also drop processingMessage and wasSkipped values
+				// It should also drop the wasSkipped value
 				const initialState = [
 					{
 						stepName: 'stepWithAPI',
-						processingMessage: 'something',
 						wasSkipped: true,
 					},
 				];
@@ -235,11 +234,10 @@ describe( 'reducer', () => {
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 			test( 'should update the step with a "completed" status if the step does not have a corresponding API request function', () => {
-				// It should also drop processingMessage and wasSkipped values
+				// It should also drop the wasSkipped value
 				const initialState = [
 					{
 						stepName: 'stepWithoutAPI',
-						processingMessage: 'something',
 						wasSkipped: true,
 					},
 				];


### PR DESCRIPTION
The `processingMessage` field used to be used to show step-by-step progress indicator in the `<ProcessingScreen />` component. But that was removed 3 years ago by @shaunandrews in #5023, in favor of a different design. Time to finish the removal 🙂

**How to test:**
- verify that the `processingMessage` field was only set, never read
- verify that unit tests continue to pass
- verify that the ESLint errors and warnings are unrelated. Too many changed files to fix them.