### PR TITLE
Full Site Editing: add the `wp_template` post_type

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -14,6 +14,12 @@ class A8C_Full_Site_Editing {
 
 		add_action( 'init', array( $this, 'register_script_and_style' ), 100 );
 		add_action( 'init', array( $this, 'register_blocks' ), 100 );
+		add_action( 'init', array( $this, 'register_wp_template' ) );
+	}
+
+	function register_wp_template() {
+		require_once plugin_dir_path( __FILE__ ) . 'wp-template.php';
+		fse_register_wp_template();
 	}
 
 	function register_script_and_style() {

--- a/apps/full-site-editing/full-site-editing-plugin/wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wp-template.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * Mostly a copy of how the `wp_block` is registered in core
+ *
+ * @return void
+ */
+function fse_register_wp_template() {
+	register_post_type(
+		'wp_template',
+		array(
+			'labels'                => array(
+				'name'                     => _x( 'Templates', 'post type general name' ),
+				'singular_name'            => _x( 'Template', 'post type singular name' ),
+				'menu_name'                => _x( 'Templates', 'admin menu' ),
+				'name_admin_bar'           => _x( 'Template', 'add new on admin bar' ),
+				'add_new'                  => _x( 'Add New', 'Template' ),
+				'add_new_item'             => __( 'Add New Template' ),
+				'new_item'                 => __( 'New Template' ),
+				'edit_item'                => __( 'Edit Template' ),
+				'view_item'                => __( 'View Template' ),
+				'all_items'                => __( 'All Templates' ),
+				'search_items'             => __( 'Search Templates' ),
+				'not_found'                => __( 'No Templates found.' ),
+				'not_found_in_trash'       => __( 'No Templates found in Trash.' ),
+				'filter_items_list'        => __( 'Filter Templates list' ),
+				'items_list_navigation'    => __( 'Templates list navigation' ),
+				'items_list'               => __( 'Templates list' ),
+				'item_published'           => __( 'Template published.' ),
+				'item_published_privately' => __( 'Template published privately.' ),
+				'item_reverted_to_draft'   => __( 'Template reverted to draft.' ),
+				'item_scheduled'           => __( 'Template scheduled.' ),
+				'item_updated'             => __( 'Template updated.' ),
+			),
+			'public'                => false,
+			'show_ui'               => true,
+			'show_in_menu'          => true,
+			'rewrite'               => false,
+			'show_in_rest'          => true,
+			'rest_base'             => 'Templates',
+			'rest_controller_class' => 'A8C_REST_Templates_Controller',
+			'capability_type'       => 'Template',
+			'capabilities'          => array(
+				// You need to be able to edit posts, in order to read Templates in their raw form.
+				'read'                   => 'edit_posts',
+				// You need to be able to publish posts, in order to create Templates.
+				'create_posts'           => 'customize',
+				'edit_posts'             => 'customize',
+				'edit_published_posts'   => 'customize',
+				'delete_published_posts' => 'customize',
+				'edit_others_posts'      => 'customize',
+				'delete_others_posts'    => 'customize',
+			),
+			'map_meta_cap'          => true,
+			'supports'              => array(
+				'title',
+				'editor',
+			),
+		)
+	);
+}
+
+/**
+ * Based on `WP_REST_Blocks_Controller` from core
+ */
+class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
+
+	/**
+	 * Checks if a block can be read.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param object $post Post object that backs the block.
+	 * @return bool Whether the block can be read.
+	 */
+	public function check_read_permission( $post ) {
+		// Ensure that the user is logged in and has the read_blocks capability.
+		$post_type = get_post_type_object( $post->post_type );
+		if ( ! current_user_can( $post_type->cap->read_post, $post->ID ) ) {
+			return false;
+		}
+
+		return parent::check_read_permission( $post );
+	}
+
+	/**
+	 * Filters a response based on the context defined in the schema.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param array  $data    Response data to fiter.
+	 * @param string $context Context defined in the schema.
+	 * @return array Filtered response.
+	 */
+	public function filter_response_by_context( $data, $context ) {
+		$data = parent::filter_response_by_context( $data, $context );
+
+		/*
+		 * Remove `title.rendered` and `content.rendered` from the response. It
+		 * doesn't make sense for a reusable block to have rendered content on its
+		 * own, since rendering a block requires it to be inside a post or a page.
+		 */
+		unset( $data['title']['rendered'] );
+		unset( $data['content']['rendered'] );
+
+		return $data;
+	}
+
+	/**
+	 * Retrieves the block's schema, conforming to JSON Schema.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		/*
+		 * Allow all contexts to access `title.raw` and `content.raw`. Clients always
+		 * need the raw markup of a reusable block to do anything useful, e.g. parse
+		 * it or display it in an editor.
+		 */
+		$schema['properties']['title']['properties']['raw']['context']   = array( 'view', 'edit' );
+		$schema['properties']['content']['properties']['raw']['context'] = array( 'view', 'edit' );
+
+		/*
+		 * Remove `title.rendered` and `content.rendered` from the schema. It doesn’t
+		 * make sense for a reusable block to have rendered content on its own, since
+		 * rendering a block requires it to be inside a post or a page.
+		 */
+		unset( $schema['properties']['title']['properties']['rendered'] );
+		unset( $schema['properties']['content']['properties']['rendered'] );
+
+		return $schema;
+	}
+
+}

--- a/apps/full-site-editing/full-site-editing-plugin/wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wp-template.php
@@ -66,13 +66,13 @@ function fse_register_wp_template() {
 class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
 
 	/**
-	 * Checks if a block can be read.
+	 * Checks if a template can be read.
 	 *
-	 * @param object $post Post object that backs the block.
-	 * @return bool Whether the block can be read.
+	 * @param object $post Post object that backs the template.
+	 * @return bool Whether the template can be read.
 	 */
 	public function check_read_permission( $post ) {
-		// Ensure that the user is logged in and has the read_blocks capability.
+		// Ensure that the user is logged in and has the edit_posts capability.
 		$post_type = get_post_type_object( $post->post_type );
 		if ( ! current_user_can( $post_type->cap->read_post, $post->ID ) ) {
 			return false;
@@ -93,8 +93,8 @@ class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
 
 		/*
 		 * Remove `title.rendered` and `content.rendered` from the response. It
-		 * doesn't make sense for a reusable block to have rendered content on its
-		 * own, since rendering a block requires it to be inside a post or a page.
+		 * doesn't make sense for a reusable template to have rendered content on its
+		 * own, since rendering a template requires it to be inside a post or a page.
 		 */
 		unset( $data['title']['rendered'] );
 		unset( $data['content']['rendered'] );
@@ -103,7 +103,7 @@ class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Retrieves the block's schema, conforming to JSON Schema.
+	 * Retrieves the template's schema, conforming to JSON Schema.
 	 *
 	 * @return array Item schema data.
 	 */
@@ -112,7 +112,7 @@ class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
 
 		/*
 		 * Allow all contexts to access `title.raw` and `content.raw`. Clients always
-		 * need the raw markup of a reusable block to do anything useful, e.g. parse
+		 * need the raw markup of a reusable template to do anything useful, e.g. parse
 		 * it or display it in an editor.
 		 */
 		$schema['properties']['title']['properties']['raw']['context']   = array( 'view', 'edit' );
@@ -120,8 +120,8 @@ class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
 
 		/*
 		 * Remove `title.rendered` and `content.rendered` from the schema. It doesn’t
-		 * make sense for a reusable block to have rendered content on its own, since
-		 * rendering a block requires it to be inside a post or a page.
+		 * make sense for a reusable template to have rendered content on its own, since
+		 * rendering a template requires it to be inside a post or a page.
 		 */
 		unset( $schema['properties']['title']['properties']['rendered'] );
 		unset( $schema['properties']['content']['properties']['rendered'] );

--- a/apps/full-site-editing/full-site-editing-plugin/wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wp-template.php
@@ -41,15 +41,15 @@ function fse_register_wp_template() {
 			'rest_controller_class' => 'A8C_REST_Templates_Controller',
 			'capability_type'       => 'Template',
 			'capabilities'          => array(
-				// You need to be able to edit posts, in order to read Templates in their raw form.
+				// You need to be able to edit posts, in order to read templates in their raw form.
 				'read'                   => 'edit_posts',
-				// You need to be able to publish posts, in order to create Templates.
-				'create_posts'           => 'customize',
-				'edit_posts'             => 'customize',
-				'edit_published_posts'   => 'customize',
-				'delete_published_posts' => 'customize',
-				'edit_others_posts'      => 'customize',
-				'delete_others_posts'    => 'customize',
+				// You need to be able to customize, in order to create templates.
+				'create_posts'           => 'edit_theme_options',
+				'edit_posts'             => 'edit_theme_options',
+				'edit_published_posts'   => 'edit_theme_options',
+				'delete_published_posts' => 'edit_theme_options',
+				'edit_others_posts'      => 'edit_theme_options',
+				'delete_others_posts'    => 'edit_theme_options',
 			),
 			'map_meta_cap'          => true,
 			'supports'              => array(

--- a/apps/full-site-editing/full-site-editing-plugin/wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wp-template.php
@@ -32,7 +32,7 @@ function fse_register_wp_template() {
 				'item_scheduled'           => __( 'Template scheduled.' ),
 				'item_updated'             => __( 'Template updated.' ),
 			),
-			'public'                => false,
+			'public'                => true, // temp to support the search endpoint
 			'show_ui'               => true,
 			'show_in_menu'          => true,
 			'rewrite'               => false,

--- a/apps/full-site-editing/full-site-editing-plugin/wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wp-template.php
@@ -68,8 +68,6 @@ class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
 	/**
 	 * Checks if a block can be read.
 	 *
-	 * @since 5.0.0
-	 *
 	 * @param object $post Post object that backs the block.
 	 * @return bool Whether the block can be read.
 	 */
@@ -85,8 +83,6 @@ class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
 
 	/**
 	 * Filters a response based on the context defined in the schema.
-	 *
-	 * @since 5.0.0
 	 *
 	 * @param array  $data    Response data to fiter.
 	 * @param string $context Context defined in the schema.
@@ -108,8 +104,6 @@ class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
 
 	/**
 	 * Retrieves the block's schema, conforming to JSON Schema.
-	 *
-	 * @since 5.0.0
 	 *
 	 * @return array Item schema data.
 	 */

--- a/apps/full-site-editing/full-site-editing-plugin/wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wp-template.php
@@ -37,7 +37,7 @@ function fse_register_wp_template() {
 			'show_in_menu'          => true,
 			'rewrite'               => false,
 			'show_in_rest'          => true,
-			'rest_base'             => 'Templates',
+			'rest_base'             => 'templates',
 			'rest_controller_class' => 'A8C_REST_Templates_Controller',
 			'capability_type'       => 'Template',
 			'capabilities'          => array(

--- a/apps/full-site-editing/full-site-editing-plugin/wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wp-template.php
@@ -21,9 +21,9 @@ function fse_register_wp_template() {
 				'view_item'                => __( 'View Template' ),
 				'all_items'                => __( 'All Templates' ),
 				'search_items'             => __( 'Search Templates' ),
-				'not_found'                => __( 'No Templates found.' ),
-				'not_found_in_trash'       => __( 'No Templates found in Trash.' ),
-				'filter_items_list'        => __( 'Filter Templates list' ),
+				'not_found'                => __( 'No templates found.' ),
+				'not_found_in_trash'       => __( 'No templates found in Trash.' ),
+				'filter_items_list'        => __( 'Filter templates list' ),
 				'items_list_navigation'    => __( 'Templates list navigation' ),
 				'items_list'               => __( 'Templates list' ),
 				'item_published'           => __( 'Template published.' ),
@@ -39,7 +39,7 @@ function fse_register_wp_template() {
 			'show_in_rest'          => true,
 			'rest_base'             => 'templates',
 			'rest_controller_class' => 'A8C_REST_Templates_Controller',
-			'capability_type'       => 'Template',
+			'capability_type'       => 'template',
 			'capabilities'          => array(
 				// You need to be able to edit posts, in order to read templates in their raw form.
 				'read'                   => 'edit_posts',


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* registers the `wp_template` post_type and associated REST controller on the `/templates` route

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the [README](https://github.com/Automattic/wp-calypso/blob/master/apps/full-site-editing/README.md) to build the plugin. (If the script fails, please run `npm distclean` and `npm ci` first (required because of a recent [`calypso-build`](https://github.com/Automattic/wp-calypso/pull/32295) change).
* Note the presence of a `Templates` menu item
* try to publish and edit a Template

Fixes #32244
