### PR TITLE
Update checkout details form button to "Continue"

### DIFF
--- a/client/components/domains/contact-details-form-fields/README.md
+++ b/client/components/domains/contact-details-form-fields/README.md
@@ -93,9 +93,7 @@ Example:
 
 ```js
 {
-    submitButton: this.hasAnotherStep()
-        ? translate( 'Continue' )
-        : translate( 'Continue' ),
+    submitButton: translate( 'Continue' ),
     organization: translate(
         'Registering this domain for a company? + Add Organization Name',
         'Registering these domains for a company? + Add Organization Name',

--- a/client/components/domains/contact-details-form-fields/README.md
+++ b/client/components/domains/contact-details-form-fields/README.md
@@ -95,7 +95,7 @@ Example:
 {
     submitButton: this.hasAnotherStep()
         ? translate( 'Continue' )
-        : translate( 'Continue to Checkout' ),
+        : translate( 'Continue' ),
     organization: translate(
         'Registering this domain for a company? + Add Organization Name',
         'Registering these domains for a company? + Add Organization Name',

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -144,9 +144,7 @@ export class DomainDetailsForm extends PureComponent {
 	}
 
 	getSubmitButtonText() {
-		return this.hasAnotherStep()
-			? this.props.translate( 'Continue' )
-			: this.props.translate( 'Continue' );
+		return this.props.translate( 'Continue' );
 	}
 
 	renderSubmitButton() {

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -146,7 +146,7 @@ export class DomainDetailsForm extends PureComponent {
 	getSubmitButtonText() {
 		return this.hasAnotherStep()
 			? this.props.translate( 'Continue' )
-			: this.props.translate( 'Continue to Checkout' );
+			: this.props.translate( 'Continue' );
 	}
 
 	renderSubmitButton() {

--- a/client/my-sites/checkout/checkout/domain-details-form.jsx
+++ b/client/my-sites/checkout/checkout/domain-details-form.jsx
@@ -143,17 +143,13 @@ export class DomainDetailsForm extends PureComponent {
 		);
 	}
 
-	getSubmitButtonText() {
-		return this.props.translate( 'Continue' );
-	}
-
 	renderSubmitButton() {
 		return (
 			<FormButton
 				className="checkout__domain-details-form-submit-button"
 				onClick={ this.handleSubmitButtonClick }
 			>
-				{ this.getSubmitButtonText() }
+				{ this.props.translate( 'Continue' ) }
 			</FormButton>
 		);
 	}
@@ -176,7 +172,7 @@ export class DomainDetailsForm extends PureComponent {
 	renderDomainContactDetailsFields() {
 		const { contactDetails, translate, userCountryCode } = this.props;
 		const labelTexts = {
-			submitButton: this.getSubmitButtonText(),
+			submitButton: translate( 'Continue' ),
 			organization: translate(
 				'Registering this domain for a company? + Add Organization Name',
 				'Registering these domains for a company? + Add Organization Name',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update checkout details form button text to `Continue`. Details in https://github.com/Automattic/wp-calypso/issues/32528

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Launch the live branch available below.
- Visit a WordPress.com site.
- Add a domain to cart.
- Continue on the checkout process.
- While entering your contact details for registration, ensure the button reads `Continue`.

#### Before

<img width="771" alt="Screenshot 2019-04-25 at 07 24 29" src="https://user-images.githubusercontent.com/18581859/56704589-4fb49480-672b-11e9-9d3c-377e79e3d971.png">

#### After

<img width="765" alt="Screenshot 2019-04-25 at 07 24 56" src="https://user-images.githubusercontent.com/18581859/56704591-504d2b00-672b-11e9-9386-984817d4f779.png">

Fixes https://github.com/Automattic/wp-calypso/issues/32528
