### PR TITLE
Full Site Editing: Fix PHP files missing in development workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -309,7 +309,7 @@ jobs:
           command: |
             npx lerna run build --scope='@automattic/full-site-editing'
             cp -R apps/full-site-editing/blank-theme $CIRCLE_ARTIFACTS/full-site-editing/
-            cp -R apps/full-site-editing/full-site-editing $CIRCLE_ARTIFACTS/full-site-editing/
+            cp -R apps/full-site-editing/full-site-editing-plugin $CIRCLE_ARTIFACTS/full-site-editing/
       - store-artifacts-and-test-results
 
   test-client:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -308,7 +308,8 @@ jobs:
           name: Build the Full Site Editing plugin and theme
           command: |
             npx lerna run build --scope='@automattic/full-site-editing'
-            cp -R apps/full-site-editing/dist $CIRCLE_ARTIFACTS/full-site-editing/
+            cp -R apps/full-site-editing/blank-theme $CIRCLE_ARTIFACTS/full-site-editing/
+            cp -R apps/full-site-editing/full-site-editing $CIRCLE_ARTIFACTS/full-site-editing/
       - store-artifacts-and-test-results
 
   test-client:

--- a/apps/full-site-editing/README.md
+++ b/apps/full-site-editing/README.md
@@ -6,30 +6,25 @@ This app contains both the `full-site-editing-plugin` and the required `blank-th
 
 ```
 /blank-theme
+  /dist
+    blank-theme.css
+    blank-theme.deps.json
+    blank-theme.js
+    blank-theme.rtl.css
   functions.php
   index.js
   index.php
   index.scss
 
 /full-site-editing-plugin
+  /dist
+    full-site-editing-plugin.css
+    full-site-editing-plugin.deps.json
+    full-site-editing-plugin.js
+    full-site-editing-plugin.rtl.css
   full-site-editing-plugin.php
   index.js
   index.scss
-
-/dist
-  /blank-theme
-    blank-theme.css
-    blank-theme.js
-    functions.php
-    index.js
-    index.php
-    index.scss
-  /full-site-editing-plugin
-    full-site-editing-plugin.css
-    full-site-editing-plugin.js
-    full-site-editing-plugin.php
-    index.js
-    index.scss
 ```
 
 ## Build System
@@ -42,7 +37,7 @@ Compiles both the theme and the plugin, and watches for changes.
 - `npx lerna run build --scope='@automattic/full-site-editing'`<br>
 Compiles and minifies for production both the theme and the plugin.
 
-Both these scripts will also move all source and PHP files into their respective folder inside `/dist`.
+Both these scripts will also move all source and PHP files into `/dist` in their respective folder.
 
 The entry points are:
 
@@ -51,11 +46,8 @@ The entry points are:
 
 The outputs are:
 
-- `/dist/blank-theme`
-- `/dist/full-site-editing-plugin`
-
-Note that compiled JS and CSS will have the folder name (e.g. `blank-theme.js`), and will be positioned in the folder root (e.g. `/dist/blank-theme/blank-theme.js`), which is the same level of the main PHP file.<br>
-Enqueue your scripts accordingly!
+- `/blank-theme/dist`
+- `/full-site-editing-plugin/dist`
 
 ## Local Development
 
@@ -66,7 +58,7 @@ E.g.
 ```
 npx lerna run build --scope='@automattic/full-site-editing'
 
-ln -s ~/Dev/wp-calypso/apps/full-site-editing/dist/full-site-editing-plugin/ ~/Dev/wordpress/wp-content/plugins/full-site-editing-plugin
+ln -s ~/Dev/wp-calypso/apps/full-site-editing/full-site-editing-plugin/ ~/Dev/wordpress/wp-content/plugins/full-site-editing-plugin
 
-ln -s ~/Dev/wp-calypso/apps/full-site-editing/dist/blank-theme/ ~/Dev/wordpress/wp-content/themes/blank-theme
+ln -s ~/Dev/wp-calypso/apps/full-site-editing/blank-theme/ ~/Dev/wordpress/wp-content/themes/blank-theme
 ```

--- a/apps/full-site-editing/blank-theme/index.js
+++ b/apps/full-site-editing/blank-theme/index.js
@@ -1,0 +1,1 @@
+// Silence is golden

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -18,13 +18,13 @@ class A8C_Full_Site_Editing {
 
 	function register_script_and_style() {
 		$script_dependencies = json_decode( file_get_contents(
-			plugin_dir_path( __FILE__ ) . 'full-site-editing-plugin.deps.json'
+			plugin_dir_path( __FILE__ ) . 'dist/full-site-editing-plugin.deps.json'
 		), true );
 		wp_register_script(
 			'a8c-full-site-editing-script',
-			plugins_url( 'full-site-editing-plugin.js', __FILE__ ),
+			plugins_url( 'dist/full-site-editing-plugin.js', __FILE__ ),
 			is_array( $script_dependencies ) ? $script_dependencies : array(),
-			filemtime( plugin_dir_path( __FILE__ ) . 'full-site-editing-plugin.js' )
+			filemtime( plugin_dir_path( __FILE__ ) . 'dist/full-site-editing-plugin.js' )
 		);
 
 		$style_file = is_rtl()
@@ -32,9 +32,9 @@ class A8C_Full_Site_Editing {
 			: 'full-site-editing-plugin.css';
 		wp_register_style(
 			'a8c-full-site-editing-style',
-			plugins_url( $style_file, __FILE__ ),
+			plugins_url( 'dist/' . $style_file, __FILE__ ),
 			array(),
-			filemtime( plugin_dir_path( __FILE__ ) . $style_file )
+			filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
 		);
 	}
 

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -16,15 +16,14 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"scripts": {
-		"copy-to-dist": "cp -R *plugin *theme dist",
 		"plugin": "calypso-build --source='plugin'",
 		"dev:plugin": "npm run plugin",
 		"build:plugin": "NODE_ENV=production npm run plugin",
 		"theme": "calypso-build --source='theme'",
 		"dev:theme": "npm run theme",
 		"build:theme": "NODE_ENV=production npm run theme",
-		"dev": "rimraf dist && mkdir dist && npm run copy-to-dist && npm-run-all --parallel dev:*",
-		"build": "rimraf dist && npm-run-all --parallel build:* && npm run copy-to-dist"
+		"dev": "rimraf dist && npm-run-all --parallel dev:*",
+		"build": "rimraf dist && npm-run-all --parallel build:*"
 	},
 	"dependencies": {
 		"@wordpress/blocks": "^6.2.3",

--- a/apps/full-site-editing/webpack.config.js
+++ b/apps/full-site-editing/webpack.config.js
@@ -6,6 +6,7 @@
 /**
  * External dependencies
  */
+// eslint-disable-next-line import/no-extraneous-dependencies
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
 
@@ -33,11 +34,11 @@ function getWebpackConfig( env = {}, argv = {} ) {
 
 	if ( 'theme' === argv.source ) {
 		argv.entry = path.join( __dirname, 'blank-theme' );
-		argv[ 'output-path' ] = path.join( __dirname, 'dist', 'blank-theme' );
+		argv[ 'output-path' ] = path.join( __dirname, 'blank-theme', 'dist' );
 		argv[ 'output-filename' ] = 'blank-theme.js';
 	} else {
 		argv.entry = path.join( __dirname, 'full-site-editing-plugin' );
-		argv[ 'output-path' ] = path.join( __dirname, 'dist', 'full-site-editing-plugin' );
+		argv[ 'output-path' ] = path.join( __dirname, 'full-site-editing-plugin', 'dist' );
 		argv[ 'output-filename' ] = 'full-site-editing-plugin.js';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

@mattwiebe noticed that the dev workflow merged in #32431 didn't take into account PHP files.
The workflow consisted in moving everything from the source folder to `/dist`, but only JS and SCSS files were watched and kept updated, while any update to PHP files would have required to manually move the files.

* Revert the dev/build approach to #32355 (one `/dist` folder _inside_ plugin and theme, instead of a `/dist` folder _containing_ plugin and theme).
* Update the CircleCI to copy both plugin and theme folders, instead of just the content of the `/dist`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that the CircleCI artifacts for the `build-full-site-editing` job contains the `blank-theme` and `full-site-editing-plugin` folders, and that they contain all source files plus a `/dist` folder with the compiled files.
* On a sandbox, try running the script proposed in D27401-code (make sure to use a Circle ID job created after this PR!), and check that its testing instructions are still cleared.