### PR TITLE
Packages: Set material-design-icons to private

### DIFF
--- a/packages/material-design-icons/package.json
+++ b/packages/material-design-icons/package.json
@@ -17,9 +17,7 @@
 		"url": "git+https://github.com/Automattic/wp-calypso.git",
 		"directory": "packages/material-design-icons"
 	},
-	"publishConfig": {
-		"access": "private"
-	},
+	"private": true,
 	"bugs": {
 		"url": "https://github.com/Automattic/wp-calypso/issues"
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Packages: Set material-design-icons to private, and remove 

```
	"publishConfig": {
		"access": "private"
	},
```

The latter was probably meant to achieve the same but didn't quite :grimacing:

#### Testing instructions

Try `npx lerna publish from-package` from `master`, and from this branch:

On `master`, it will say

```
lerna notice cli v3.13.4
lerna info versioning independent
lerna WARN Unable to determine published version, assuming "@automattic/material-design-icons" unpublished.

Found 1 package to publish:
 - @automattic/material-design-icons => 1.0.0

? Are you sure you want to publish these packages?
```

(Say `n[o]` :slightly_smiling_face: )

On this branch:

```
lerna notice cli v3.13.4
lerna info versioning independent
lerna notice from-package No unpublished release found
lerna success No changed packages to publish 
```