### PR TITLE
Shrinkwrap: Revert changes from fac1e7a

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -149,23 +149,6 @@
 						"postcss-value-parser": "^3.3.1"
 					}
 				},
-				"camelcase": {
-					"version": "5.3.1",
-					"bundled": true,
-					"dev": true
-				},
-				"cross-spawn": {
-					"version": "6.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
-					}
-				},
 				"debug": {
 					"version": "4.1.1",
 					"bundled": true,
@@ -174,182 +157,10 @@
 						"ms": "^2.1.1"
 					}
 				},
-				"execa": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cross-spawn": "^6.0.0",
-						"get-stream": "^4.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
-					}
-				},
-				"find-up": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"findup-sync": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"detect-file": "^1.0.0",
-						"is-glob": "^3.1.0",
-						"micromatch": "^3.0.4",
-						"resolve-dir": "^1.0.1"
-					}
-				},
-				"get-stream": {
-					"version": "4.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pump": "^3.0.0"
-					}
-				},
-				"import-local": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"pkg-dir": "^3.0.0",
-						"resolve-cwd": "^2.0.0"
-					}
-				},
-				"invert-kv": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"is-glob": {
-					"version": "3.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.0"
-					}
-				},
-				"lcid": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"invert-kv": "^2.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"mem": {
-					"version": "4.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"map-age-cleaner": "^0.1.1",
-						"mimic-fn": "^2.0.0",
-						"p-is-promise": "^2.0.0"
-					}
-				},
-				"mimic-fn": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true
-				},
-				"os-locale": {
-					"version": "3.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"execa": "^1.0.0",
-						"lcid": "^2.0.0",
-						"mem": "^4.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"bundled": true,
-					"dev": true
-				},
 				"source-map": {
 					"version": "0.5.7",
 					"bundled": true,
 					"dev": true
-				},
-				"webpack-cli": {
-					"version": "3.3.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"chalk": "^2.4.1",
-						"cross-spawn": "^6.0.5",
-						"enhanced-resolve": "^4.1.0",
-						"findup-sync": "^2.0.0",
-						"global-modules": "^1.0.0",
-						"import-local": "^2.0.0",
-						"interpret": "^1.1.0",
-						"loader-utils": "^1.1.0",
-						"supports-color": "^5.5.0",
-						"v8-compile-cache": "^2.0.2",
-						"yargs": "^12.0.5"
-					}
-				},
-				"yargs": {
-					"version": "12.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^3.0.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^3.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1 || ^4.0.0",
-						"yargs-parser": "^11.1.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "11.1.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
-					}
 				}
 			}
 		},
@@ -5729,9 +5540,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000963",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000963.tgz",
-			"integrity": "sha512-n4HUiullc7Lw0LyzpeLa2ffP8KxFBGdxqD/8G3bSL6oB758hZ2UE2CVK+tQN958tJIi0/tfpjAc67aAtoHgnrQ=="
+			"version": "1.0.30000962",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz",
+			"integrity": "sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -6569,9 +6380,9 @@
 			}
 		},
 		"color": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
-			"integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/color/-/color-3.1.0.tgz",
+			"integrity": "sha512-CwyopLkuRYO5ei2EpzpIh6LqJMt6Mt+jZhO5VI5f/wJLZriXQE32/SSqzmrh+QB+AZT81Cj8yv+7zwToW8ahZg==",
 			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.1",
@@ -8244,9 +8055,9 @@
 			"integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.127",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.127.tgz",
-			"integrity": "sha512-1o25iFRf/dbgauTWalEzmD1EmRN3a2CzP/K7UVpYLEBduk96LF0FyUdCcf4Ry2mAWJ1VxyblFjC93q6qlLwA2A=="
+			"version": "1.3.125",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.125.tgz",
+			"integrity": "sha512-XxowpqQxJ4nDwUXHtVtmEhRqBpm2OnjBomZmZtHD0d2Eo0244+Ojezhk3sD/MBSSe2nxCdGQFRXHIsf/LUTL9A=="
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -14563,9 +14374,9 @@
 			}
 		},
 		"node-releases": {
-			"version": "1.1.17",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
-			"integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.15.tgz",
+			"integrity": "sha512-cKV097BQaZr8LTSRUa2+oc/aX5L8UkZtPQrMSTgiJEeaW7ymTDCoRaGCoaTqk0lqnalcoSHu4wjSl0Cmj2+bMw==",
 			"requires": {
 				"semver": "^5.3.0"
 			}
@@ -18246,9 +18057,9 @@
 			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
 		},
 		"resolve": {
-			"version": "1.10.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-			"integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+			"integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Shrinkwrap: Revert changes to `npm-shrinkwrap.json` from fac1e7a (i.e. #32575). Arguably, the package version bump shouldn't even have necessitated an updated shrinkwrap? :thinking: 

As pointed out by @jsnajdr (p1556196416152400-slack-calypso), this might have been the reason for renovate-bot's recent failures (https://github.com/Automattic/wp-calypso/pull/32129#issuecomment-486646112).

#### Testing instructions

Merge and see if it fixes renovate-bot I guess?