### PR TITLE
Remove Jetpack sharing enabled gate

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -559,7 +559,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	marketing() {
-		const { isJetpack, isSharingEnabledOnJetpackSite, path, site } = this.props;
+		const { path, site } = this.props;
 		const marketingLink = '/marketing' + this.props.siteSuffix;
 
 		if ( site && ! this.props.canUserPublishPosts ) {
@@ -567,10 +567,6 @@ export class MySitesSidebar extends Component {
 		}
 
 		if ( ! this.props.siteId ) {
-			return null;
-		}
-
-		if ( isJetpack && ! isSharingEnabledOnJetpackSite ) {
 			return null;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes logic that hides Marketing if Jetpack publicize is turned off.

#### Testing instructions

* Have Jetpack site, turn off publicize, observe Marketing tab is still there.
