### PR TITLE
Cover case when user has no pages

### DIFF
--- a/test/e2e/lib/pages/pages-page.js
+++ b/test/e2e/lib/pages/pages-page.js
@@ -39,7 +39,25 @@ export default class PagesPage extends AsyncBaseContainer {
 	}
 
 	async selectAddNewPage() {
-		const selector = By.css( '.pages__add-page' );
-		return await driverHelper.clickWhenClickable( this.driver, selector );
+		const addPageSelector = By.css( '.pages__add-page' ); // Add button when there are pages
+		const startPageSelector = By.css( '.empty-content__action' ); // Add button when there are no pages
+
+		if (
+			await driverHelper.isEventuallyPresentAndDisplayed(
+				this.driver,
+				addPageSelector,
+				this.explicitWaitMS / 5
+			)
+		) {
+			return await driverHelper.clickWhenClickable( this.driver, addPageSelector );
+		} else if (
+			await driverHelper.isEventuallyPresentAndDisplayed(
+				this.driver,
+				startPageSelector,
+				this.explicitWaitMS / 5
+			)
+		) {
+			return await driverHelper.clickWhenClickable( this.driver, startPageSelector );
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When e2e test user's blog is empty (after cronjob deletes everything) [Pages tests are failing](https://circleci.com/gh/Automattic/wp-calypso/261461). This is happening because I didn't cover that case in PR https://github.com/Automattic/wp-calypso/pull/32465 when I changed the way how test user is [adding a new page](https://github.com/Automattic/wp-calypso/pull/32465/files#diff-f80e846ea0cc77334c2c44d5da89ba31R41). That shouldn't happen anymore with this fix. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run any test which adds a new page, for example `Calypso Gutenberg Editor: Pages (mobile) Public Pages: @parallel` with a user who has no page.

#### Fixes
https://circleci.com/gh/Automattic/wp-calypso/261461