### PR TITLE
Monorepo: Ignore `dist` in apps subdirectories too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,6 @@ cover.html
 cached-requests.json
 
 # Monorepo output
-/apps/*/dist/
+/apps/**/dist/
 /client/notifications/dist/
 /packages/*/dist/


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The change in #32433 assumed that all `/dist` folders are in the root of their app folders.
This is not the case for `full-site-editing` that consists of two parts (a theme and a plugin), each with their own `/dist` folder inside.

This change also ignores `dist` folders when located in subdirectories.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build some apps and check that their `/dist` folders aren't tracked by git.
  - `npx lerna run build --scope='@automattic/full-site-editing'`
  - `npx lerna run build --scope="@automattic/o2-blocks"`