### PR TITLE
Checkout - Jetpack: after finishing, send user to the new Checklist

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -480,8 +480,7 @@ export class JetpackThankYouCard extends Component {
 	}
 
 	renderAction( progress = 0 ) {
-		const { goBackToSiteLink, selectedSite: site, translate } = this.props;
-		const buttonUrl = site && goBackToSiteLink;
+		const { siteId, selectedSite: site, translate } = this.props;
 		// We return instructions for setting up manually
 		// when we finish if something errored
 		if ( this.isErrored() && ! this.props.isInstalling ) {
@@ -499,6 +498,10 @@ export class JetpackThankYouCard extends Component {
 			);
 		}
 
+		// TODO: Before this branch is merged
+		// * checklist must be in stable Calypso
+		// * we need to update this URL to the final path /plans/my-plan/${ siteId }?thank-you
+		const buttonUrl = site && `https://wpcalypso.wordpress.com/plans/my-plan/${ siteId }?thank-you`;
 		if ( 100 === progress ) {
 			return (
 				<div className="checkout-thank-you__jetpack-action-buttons">
@@ -509,7 +512,7 @@ export class JetpackThankYouCard extends Component {
 						onClick={ this.onBackToYourSiteClick }
 						href={ buttonUrl }
 					>
-						{ translate( 'Back to your site' ) }
+						{ translate( 'Start checklist' ) }
 					</a>
 					{ this.renderLiveChatButton() }
 				</div>


### PR DESCRIPTION
This PR will update the button at the end of the Checkout process, so instead of sending the user back to their site, it will send it to to Plan > My Plan, with Checklist initiated.

For now, this PR goes to `https://wpcalypso.wordpress.com/plans/my-plan/${ siteId }?thank-you` and we need to update this URL to the final relative path `/plans/my-plan/${ siteId }?thank-you` once the checklist is merged into stable Calypso.

#### Changes proposed in this Pull Request

* replace URL pointing to site and instead point it to Checklist
* update button label

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* start with a Jetpack site
* purchase a plan
* follow the checkout process
* the last screen should have this button asking user to go to checklist
* it must go to Plan > My Plan with checklist initiated

Fixes #32582
