### PR TITLE
Signup: remove the limit from the default vertical search

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -172,7 +172,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		return (
 			<>
 				<QueryVerticals searchTerm={ inputValue.trim() } debounceTime={ 300 } />
-				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } limit={ 1 } />
+				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } />
 				<SuggestionSearch
 					id="siteTopic"
 					placeholder={ placeholder || translate( 'Enter a keyword or select one from below.' ) }
@@ -193,7 +193,7 @@ export default localize(
 	connect(
 		( state, ownProps ) => ( {
 			verticals: getVerticals( state, ownProps.searchValue ) || [],
-			defaultVertical: get( getVerticals( state, 'business' ), '0', {} ),
+			defaultVertical: get( getVerticals( state, DEFAULT_VERTICAL_KEY ), '0', {} ),
 		} ),
 		null
 	)( SiteVerticalsSuggestionSearch )

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -7,7 +7,6 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
     searchTerm=""
   />
   <Connect(QueryVerticals)
-    limit={1}
     searchTerm="business"
   />
   <SuggestionSearch

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -10,7 +10,6 @@ import { get, find } from 'lodash';
  * Internal dependencies
  */
 import { getVerticals } from 'state/signup/verticals/selectors';
-import { DEFAULT_VERTICAL_KEY } from 'state/signup/verticals/constants';
 
 export function getSiteVerticalName( state ) {
 	return get( state, 'signup.steps.siteVertical.name', '' );
@@ -29,12 +28,10 @@ export function getSiteVerticalData( state ) {
 		return match;
 	}
 
-	const defaultVerticalData = get( verticals, [ DEFAULT_VERTICAL_KEY, 0 ], {} );
-
 	return {
 		isUserInputVertical: true,
 		parent: '',
-		preview: defaultVerticalData.preview || '',
+		preview: '',
 		verticalId: '',
 		verticalName,
 		verticalSlug: verticalName,

--- a/client/state/signup/steps/site-vertical/test/selectors.js
+++ b/client/state/signup/steps/site-vertical/test/selectors.js
@@ -10,12 +10,24 @@ import {
 	getSiteVerticalIsUserInput,
 	getSiteVerticalPreview,
 	getSiteVerticalParentId,
+	getSiteVerticalData,
 } from '../selectors';
 
 describe( 'selectors', () => {
 	const verticals = {
 		felice: [
-			{ verticalName: 'felice', preview: '<!--gutenberg-besties-forever <p>Fist bump!</p>-->' },
+			{
+				verticalName: 'felice',
+				verticalSlug: 'felice',
+				preview: '<!--gutenberg-besties-forever <p>Fist bump!</p>-->',
+			},
+		],
+		contento: [
+			{
+				verticalName: 'contento',
+				verticalSlug: 'contento',
+				preview: '<!--gutenberg-loves-you <p>High five!</p>-->',
+			},
 		],
 	};
 
@@ -90,6 +102,24 @@ describe( 'selectors', () => {
 			expect( getSiteVerticalParentId( state ) ).toEqual(
 				state.signup.steps.siteVertical.parentId
 			);
+		} );
+	} );
+	describe( 'getSiteVerticalData', () => {
+		const defaultPreviewData = {
+			isUserInputVertical: true,
+			parent: '',
+			preview: '',
+			verticalId: '',
+			verticalName: '',
+			verticalSlug: '',
+		};
+
+		test( 'should return default vertical object with empty string values', () => {
+			expect( getSiteVerticalData( {} ) ).toEqual( defaultPreviewData );
+		} );
+
+		test( 'should return direct match', () => {
+			expect( getSiteVerticalData( state ) ).toEqual( verticals.felice[ 0 ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Changes proposed in this Pull Request

When searching for `'business'` at the site topic step, the first several character yield results, however once you type the full term, the list disappears! 👻

<img width="419" alt="Screenshot 2019-04-25 at 11 50 44" src="https://user-images.githubusercontent.com/6458278/56781670-46105700-6827-11e9-996f-ab52faa5008c.png">

<img width="417" alt="Screenshot 2019-04-25 at 11 50 51" src="https://user-images.githubusercontent.com/6458278/56781667-4577c080-6827-11e9-9aeb-f9dd1b22c8fb.png">

The reason this happens is that `'business'` just so happens to be the default vertical we cache, and, when requesting it, we limit the results to `1`. 

The consequence is that subsequent searches for `'business'` will fetch the cached result (all one of them), rather than conducting a new search.

So we're removing the limit constraint on the default vertical so that it returns full results. That way, when a user searches for `business`, they'll get several results and not just one. 🎉 

We're also removing a default vertical search in the `getSiteVerticalData()` selector, which wasn't returning anything (if there is no match in the verticals collection for a given term, there are no verticals in which to search for a default key!) and also adding tests for it.

Props to @AnnaMag for reporting this 'feature'

## Testing instructions

Cruise on over to `/start/onboarding` and, at the site topic steps, search for `Busi`, then `Business`.

You should see vertical results. 🕺 

<img width="545" alt="Screen Shot 2019-04-26 at 1 46 59 pm" src="https://user-images.githubusercontent.com/6458278/56782282-d059ba80-6829-11e9-9b07-9f92368e860b.png">

<img width="541" alt="Screen Shot 2019-04-26 at 1 47 05 pm" src="https://user-images.githubusercontent.com/6458278/56782283-d0f25100-6829-11e9-9dfa-a9858f6d1295.png">

