### PR TITLE
Gutenframe: Prevents the iframe from loading using a cached frame nonce

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -16,7 +16,12 @@ import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
 import EditorMediaModal from 'post-editor/editor-media-modal';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteOption, getSiteAdminUrl, isRequestingSites } from 'state/sites/selectors';
+import {
+	getSiteOption,
+	getSiteAdminUrl,
+	isRequestingSites,
+	isRequestingSite,
+} from 'state/sites/selectors';
 import { addQueryArgs } from 'lib/route';
 import { getEnabledFilters, getDisabledDataSources, mediaCalypsoToGutenberg } from './media-utils';
 import { replaceHistory, setRoute, navigate } from 'state/ui/actions';
@@ -424,6 +429,9 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) 
 
 	const iframeUrl = addQueryArgs( queryArgs, siteAdminUrl );
 
+	// Prevents the iframe from loading using a cached frame nonce.
+	const shouldLoadIframe = ! isRequestingSites( state ) && ! isRequestingSite( state, siteId );
+
 	return {
 		allPostsUrl: getPostTypeAllPostsUrl( state, postType ),
 		currentRoute,
@@ -431,7 +439,7 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) 
 		frameNonce,
 		iframeUrl,
 		postTypeTrashUrl,
-		shouldLoadIframe: ! isRequestingSites( state ), // Prevents the iframe from loading using a cached frame nonce.
+		shouldLoadIframe,
 		siteAdminUrl,
 		siteId,
 	};

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -16,7 +16,7 @@ import MediaActions from 'lib/media/actions';
 import MediaStore from 'lib/media/store';
 import EditorMediaModal from 'post-editor/editor-media-modal';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteOption, getSiteAdminUrl } from 'state/sites/selectors';
+import { getSiteOption, getSiteAdminUrl, isRequestingSites } from 'state/sites/selectors';
 import { addQueryArgs } from 'lib/route';
 import { getEnabledFilters, getDisabledDataSources, mediaCalypsoToGutenberg } from './media-utils';
 import { replaceHistory, setRoute, navigate } from 'state/ui/actions';
@@ -343,7 +343,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	closePreviewModal = () => this.setState( { isPreviewVisible: false } );
 
 	render() {
-		const { iframeUrl, siteId } = this.props;
+		const { iframeUrl, siteId, shouldLoadIframe } = this.props;
 		const {
 			classicBlockEditorId,
 			isMediaModalVisible,
@@ -361,14 +361,16 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<div className="main main-column calypsoify is-iframe" role="main">
 					{ ! isIframeLoaded && <Placeholder /> }
-					{ /* eslint-disable-next-line jsx-a11y/iframe-has-title */ }
-					<iframe
-						ref={ this.iframeRef }
-						/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
-						className={ isIframeLoaded ? 'is-iframe-loaded' : undefined }
-						src={ iframeUrl }
-						onLoad={ () => this.setState( { isIframeLoaded: true } ) }
-					/>
+					{ shouldLoadIframe && (
+						/* eslint-disable-next-line jsx-a11y/iframe-has-title */
+						<iframe
+							ref={ this.iframeRef }
+							/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
+							className={ isIframeLoaded ? 'is-iframe-loaded' : undefined }
+							src={ iframeUrl }
+							onLoad={ () => this.setState( { isIframeLoaded: true } ) }
+						/>
+					) }
 				</div>
 				<MediaLibrarySelectedData siteId={ siteId }>
 					<EditorMediaModal
@@ -424,13 +426,14 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) 
 
 	return {
 		allPostsUrl: getPostTypeAllPostsUrl( state, postType ),
-		siteId,
 		currentRoute,
+		editedPostId: getEditorPostId( state ),
+		frameNonce,
 		iframeUrl,
 		postTypeTrashUrl,
+		shouldLoadIframe: ! isRequestingSites( state ), // Prevents the iframe from loading using a cached frame nonce.
 		siteAdminUrl,
-		frameNonce,
-		editedPostId: getEditorPostId( state ),
+		siteId,
 	};
 };
 

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -121,7 +121,9 @@ export function requestSite( siteFragment ) {
 
 		return wpcom
 			.site( siteFragment )
-			.get()
+			.get( {
+				apiVersion: '1.3',
+			} )
 			.then( site => {
 				// If we can't manage the site, don't add it to state.
 				if ( ! ( site && site.capabilities ) ) {

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -136,18 +136,18 @@ describe( 'actions', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( '/rest/v1.1/sites/2916284' )
+				.get( '/rest/v1.3/sites/2916284' )
 				.reply( 200, {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
 					capabilities: {},
 				} )
-				.get( '/rest/v1.1/sites/77203074' )
+				.get( '/rest/v1.3/sites/77203074' )
 				.reply( 403, {
 					error: 'authorization_required',
 					message: 'User cannot access this private blog.',
 				} )
-				.get( '/rest/v1.1/sites/8894098' )
+				.get( '/rest/v1.3/sites/8894098' )
 				.reply( 200, {
 					ID: 8894098,
 					name: 'Some random site I dont have access to',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevents the iframed block editor from loading if we're fetching the site info and waits until the request has finished. This avoids to render the iframe using an invalid cached frame nonce. Also, this also prevents the iframe from being rendered twice when the frame nonce value changes.
* Bumps `/sites/:site` API version to 1.3. Previously we were using the v1.1 version which was returning invalid frame nonces for Jetpack sites. These invalid nonces were overwriting (and being used instead of) the valid nonces from `/me/sites` if a `requestSite` action finished after a `requestSites` action.

#### Testing instructions

* Load a Jetpack site in the block editor: `/block-editor/post/:jetpackDomain`.
* Open the browser devtools and clean the site data:
<img width="770" alt="Screen Shot 2019-04-26 at 12 58 34" src="https://user-images.githubusercontent.com/1233880/56782685-237c3f00-6823-11e9-8cb2-42041d5bf917.png">

* Reload the page.
* Check the iframed block editor loads successfully. 
* Confirm the iframe is rendered only once by checking there is only one single request to `/wp-admin/post-new.php` on the Network tab on the browser devtools (actually, you'll find two but the 2nd one is just a redirection):
<img width="691" alt="Screen Shot 2019-04-26 at 13 03 47" src="https://user-images.githubusercontent.com/1233880/56782817-bfa64600-6823-11e9-962f-49053039a4b5.png">

* Under the the same Network tab, search for "v1.3/sites" to verify the API calls were made to v1.3: 
<img width="1097" alt="Screen Shot 2019-04-26 at 13 14 58" src="https://user-images.githubusercontent.com/1233880/56783206-76ef8c80-6825-11e9-9660-142eed64f76c.png">


Fixes #31877 .
