### PR TITLE
Signup: update and use site title in the onboarding flows

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -107,7 +107,7 @@ export function generateFlows( {
 		},
 
 		onboarding: {
-			steps: [ 'user', 'site-type', 'site-topic', 'site-information-title', 'domains', 'plans' ],
+			steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains', 'plans' ],
 			destination: getSiteDestination,
 			description: 'The improved onboarding flow.',
 			lastModified: '2019-01-24',
@@ -118,7 +118,7 @@ export function generateFlows( {
 				'user',
 				'site-type',
 				'site-topic-with-preview',
-				'site-information-title-with-preview',
+				'site-title-with-preview',
 				'site-style-with-preview',
 				'domains-with-preview',
 				'plans',
@@ -133,7 +133,7 @@ export function generateFlows( {
 				'user',
 				'site-type',
 				'site-topic-with-preview',
-				'site-information-title-with-preview',
+				'site-title-with-preview',
 				'site-style-with-preview',
 				'domains-with-preview',
 				'plans',

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -269,11 +269,7 @@ const Flows = {
 			'remove' === abtest( 'removeDomainsStepFromOnboarding' )
 		) {
 			flow = Flows.removeStepFromFlow( 'domains-with-preview', flow );
-			flow = replaceStepInFlow(
-				flow,
-				'site-information-title-with-preview',
-				'site-information-without-domains'
-			);
+			flow = replaceStepInFlow( flow, 'site-title-with-preview', 'site-title-without-domains' );
 
 			return flow;
 		}

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -165,6 +165,7 @@ export default {
 	'site-picker': SitePicker,
 	'site-style': SiteStyleComponent,
 	'site-title': SiteTitleComponent,
+	'site-title-without-domains': SiteTitleComponent,
 	'site-topic': SiteTopicComponent,
 	'site-type': SiteTypeComponent,
 	survey: SurveyStepComponent,
@@ -190,4 +191,5 @@ export default {
 	'site-information-address-with-preview': SiteInformationComponent,
 	'site-information-phone-with-preview': SiteInformationComponent,
 	'domains-with-preview': DomainsStepComponent,
+	'site-title-with-preview': SiteTitleComponent,
 };

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -502,6 +502,17 @@ export function generateSteps( {
 			},
 		},
 
+		'site-title-without-domains': {
+			stepName: 'site-title-without-domains',
+			apiRequestFunction: createSiteWithCart,
+			delayApiRequestUntilComplete: true,
+			dependencies: [ 'themeSlugWithRepo' ],
+			providesDependencies: [ 'siteTitle', 'siteId', 'siteSlug', 'domainItem', 'themeItem' ],
+			props: {
+				showSiteMockups: true,
+			},
+		},
+
 		'site-style': {
 			stepName: 'site-style',
 			providesDependencies: [ 'siteStyle', 'themeSlugWithRepo' ],
@@ -579,6 +590,14 @@ export function generateSteps( {
 			},
 			dependencies: [ 'themeSlugWithRepo' ],
 			delayApiRequestUntilComplete: true,
+		},
+
+		'site-title-with-preview': {
+			stepName: 'site-title-with-preview',
+			providesDependencies: [ 'siteTitle' ],
+			props: {
+				showSiteMockups: true,
+			},
 		},
 
 		launch: {

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -19,11 +19,11 @@ import {
 	getSiteVerticalPreview,
 	getSiteVerticalSlug,
 } from 'state/signup/steps/site-vertical/selectors';
-import { getSiteInformation } from 'state/signup/steps/site-information/selectors';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getSiteStyleOptions, getThemeCssUri } from 'lib/signup/site-styles';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getLocaleSlug, getLanguage } from 'lib/i18n-utils';
+import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 
 /**
  * Style dependencies
@@ -45,8 +45,6 @@ function SiteMockupHelpTip() {
 
 class SiteMockups extends Component {
 	static propTypes = {
-		address: PropTypes.string,
-		phone: PropTypes.string,
 		siteStyle: PropTypes.string,
 		siteType: PropTypes.string,
 		stepName: PropTypes.string,
@@ -56,8 +54,6 @@ class SiteMockups extends Component {
 	};
 
 	static defaultProps = {
-		address: '',
-		phone: '',
 		siteStyle: '',
 		siteType: '',
 		stepName: '',
@@ -86,45 +82,19 @@ class SiteMockups extends Component {
 	 * @return {string} Formatted content
 	 */
 	getContent( content = '' ) {
-		const { title: CompanyName, address, phone } = this.props;
+		const { title: CompanyName } = this.props;
 		if ( 'string' === typeof content ) {
 			each(
 				{
 					CompanyName,
-					Address: this.formatAddress( address ) || translate( 'Your Address' ),
-					Phone: phone || translate( 'Your Phone Number' ),
+					Address: translate( 'Your Address' ),
+					Phone: translate( 'Your Phone Number' ),
 				},
 				( value, key ) =>
 					( content = content.replace( new RegExp( '{{' + key + '}}', 'gi' ), value ) )
 			);
 		}
 		return content;
-	}
-
-	getTagline() {
-		const { address, phone } = this.props;
-		const hasAddress = ! isEmpty( address );
-		const hasPhone = ! isEmpty( phone );
-
-		if ( ! hasAddress && ! hasPhone ) {
-			return translate( 'You’ll be able to customize this to your needs.' );
-		}
-
-		return [
-			hasAddress ? this.formatAddress( address ) : '',
-			hasAddress && hasPhone ? ' &middot; ' : '',
-			hasPhone ? phone : '',
-		].join( '' );
-	}
-
-	/**
-	 *
-	 * @param {string} address An address formatted onto separate lines
-	 * @return {string} Get rid of the last line of the address.
-	 */
-	formatAddress( address ) {
-		const parts = address.split( '\n' );
-		return parts.slice( 0, 2 ).join( ', ' );
 	}
 
 	handleClick = size =>
@@ -151,7 +121,7 @@ class SiteMockups extends Component {
 			cssUrl: getThemeCssUri( themeSlug, isRtl ),
 			content: {
 				title,
-				tagline: this.getTagline(),
+				tagline: translate( 'You’ll be able to customize this to your needs.' ),
 				body: this.getContent( verticalPreviewContent ),
 			},
 			langSlug,
@@ -179,22 +149,19 @@ class SiteMockups extends Component {
 
 export default connect(
 	( state, ownProps ) => {
-		const siteInformation = getSiteInformation( state );
 		const siteStyle = getSiteStyle( state );
 		const siteType = getSiteType( state );
 		const styleOptions = getSiteStyleOptions( siteType );
 		const style = find( styleOptions, { id: siteStyle || 'modern' } );
 		return {
-			title: siteInformation.title || translate( 'Your New Website' ),
-			address: siteInformation.address,
-			phone: siteInformation.phone,
+			title: getSiteTitle( state ) || translate( 'Your New Website' ),
 			siteStyle,
 			siteType,
 			verticalPreviewContent: getSiteVerticalPreview( state ),
 			verticalSlug: getSiteVerticalSlug( state ),
 			shouldShowHelpTip:
 				'site-topic-with-preview' === ownProps.stepName ||
-				'site-information-title-with-preview' === ownProps.stepName,
+				'site-title-with-preview' === ownProps.stepName,
 			themeSlug: style.theme,
 			fontUrl: style.fontUrl,
 		};

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -607,11 +607,11 @@ export default connect(
 		shouldHideSiteGoals:
 			'onboarding' === ownProps.flowName && includes( ownProps.steps, 'site-type' ),
 		shouldHideSiteTitle:
-			'onboarding' === ownProps.flowName && includes( ownProps.steps, 'site-information' ),
+			'onboarding' === ownProps.flowName && includes( ownProps.steps, 'site-title' ),
 		shouldSkipAboutStep:
 			includes( ownProps.steps, 'site-type' ) &&
 			includes( ownProps.steps, 'site-topic' ) &&
-			includes( ownProps.steps, 'site-information' ),
+			includes( ownProps.steps, 'site-title' ),
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 	} ),
 	{

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -3,23 +3,39 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
+import Gridicon from 'gridicons';
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
-import SignupSiteTitle from 'components/signup-site-title';
-import SiteTitleExample from 'components/site-title-example';
+import Button from 'components/button';
+import FormTextInput from 'components/forms/form-text-input';
+import FormLabel from 'components/forms/form-label';
+import FormFieldset from 'components/forms/form-fieldset';
+import InfoPopover from 'components/info-popover';
+import QueryVerticals from 'components/data/query-verticals';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { setSiteTitle } from 'state/signup/steps/site-title/actions';
+import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import {
+	getSiteVerticalName,
+	getSiteVerticalPreview,
+} from 'state/signup/steps/site-vertical/selectors';
 
-import { translate } from 'i18n-calypso';
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
-class SiteTitleStep extends React.Component {
+class SiteTitleStep extends Component {
 	static propTypes = {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
@@ -27,54 +43,120 @@ class SiteTitleStep extends React.Component {
 		setSiteTitle: PropTypes.func.isRequired,
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
+		translate: PropTypes.func.isRequired,
+		siteTitle: PropTypes.string,
+		siteVerticalName: PropTypes.string,
+		shouldFetchVerticalData: PropTypes.bool,
+		siteType: PropTypes.string,
 	};
 
-	submitSiteTitleStep = siteTitle => {
+	componentDidMount() {
+		SignupActions.saveSignupStep( {
+			stepName: this.props.stepName,
+		} );
+	}
+
+	handleInputChange = ( { currentTarget: { value = '' } } ) => this.props.setSiteTitle( value );
+
+	handleSubmit = event => {
+		event.preventDefault();
+
+		const { goToNextStep, flowName, siteTitle, stepName } = this.props;
+
 		this.props.setSiteTitle( siteTitle );
 
 		SignupActions.submitSignupStep(
 			{
-				stepName: this.props.stepName,
-				siteTitle,
+				stepName,
+				flowName,
 			},
 			{ siteTitle }
 		);
 
-		this.props.goToNextStep();
-	};
+		this.props.recordTracksEvent( 'calypso_signup_actions_submit_site_title', {
+			value: siteTitle,
+		} );
 
-	skipStep = () => {
-		this.submitSiteTitleStep( '' );
+		goToNextStep();
 	};
 
 	renderSiteTitleStep = () => {
+		const {
+			shouldFetchVerticalData,
+			siteTitle,
+			siteType,
+			siteVerticalName,
+			translate,
+		} = this.props;
+		const fieldLabel = getSiteTypePropertyValue( 'slug', siteType, 'siteTitleLabel' ) || '';
+		const fieldPlaceholder =
+			getSiteTypePropertyValue( 'slug', siteType, 'siteTitlePlaceholder' ) || '';
+		const fieldDescription = translate(
+			"We'll use this as your site title. Don't worry, you can change this later."
+		);
 		return (
-			<div>
-				<SignupSiteTitle onSubmit={ this.submitSiteTitleStep } />
-				<SiteTitleExample />
+			<div className="site-title__wrapper">
+				{ shouldFetchVerticalData && <QueryVerticals searchTerm={ siteVerticalName } /> }
+				<form>
+					<div className="site-title__field-control site-title__title">
+						<FormFieldset>
+							<FormLabel htmlFor="title">
+								{ fieldLabel }
+								<InfoPopover className="site-title__info-popover" position="top">
+									{ fieldDescription }
+								</InfoPopover>
+							</FormLabel>
+							<FormTextInput
+								id="title"
+								name="title"
+								placeholder={ fieldPlaceholder }
+								onChange={ this.handleInputChange }
+								value={ siteTitle }
+								maxLength={ 100 }
+								autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+							/>
+							<Button
+								title={ this.props.translate( 'Continue' ) }
+								aria-label={ this.props.translate( 'Continue' ) }
+								primary
+								type="submit"
+								onClick={ this.handleSubmit }
+							>
+								<Gridicon icon="arrow-right" />
+							</Button>{' '}
+						</FormFieldset>
+					</div>
+				</form>
 			</div>
 		);
 	};
 
 	render() {
-		const headerText = translate( 'Give your new site a name.' );
+		const {
+			flowName,
+			positionInFlow,
+			showSiteMockups,
+			signupProgress,
+			stepName,
+			translate,
+		} = this.props;
+		const headerText = translate( "Tell us your site's name" );
 		const subHeaderText = translate(
-			'Enter a Site Title that will be displayed for visitors. You can always change this later.'
+			'This will appear at the top of your site and can be changed at anytime.'
 		);
-
 		return (
 			<div>
 				<StepWrapper
-					flowName={ this.props.flowName }
-					stepName={ this.props.stepName }
-					positionInFlow={ this.props.positionInFlow }
+					flowName={ flowName }
+					stepName={ stepName }
+					positionInFlow={ positionInFlow }
 					headerText={ headerText }
 					fallbackHeaderText={ headerText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ subHeaderText }
-					signupProgress={ this.props.signupProgress }
+					signupProgress={ signupProgress }
 					stepContent={ this.renderSiteTitleStep() }
-					goToNextStep={ this.skipStep }
+					showSiteMockups={ showSiteMockups }
 				/>
 			</div>
 		);
@@ -82,6 +164,16 @@ class SiteTitleStep extends React.Component {
 }
 
 export default connect(
-	null,
-	{ setSiteTitle }
-)( SiteTitleStep );
+	( state, ownProps ) => {
+		const siteType = getSiteType( state );
+		const shouldFetchVerticalData =
+			ownProps.showSiteMockups && siteType === 'business' && getSiteVerticalPreview( state ) === '';
+		return {
+			siteTitle: getSiteTitle( state ),
+			siteVerticalName: getSiteVerticalName( state ),
+			shouldFetchVerticalData,
+			siteType,
+		};
+	},
+	{ recordTracksEvent, setSiteTitle }
+)( localize( SiteTitleStep ) );

--- a/client/signup/steps/site-title/style.scss
+++ b/client/signup/steps/site-title/style.scss
@@ -1,0 +1,107 @@
+.site-title__wrapper {
+	max-width: 480px;
+	min-height: 46px;
+	margin: 0 auto;
+	position: relative;
+	.site-title__field-control {
+		margin: 0 auto;
+	}
+
+	// Mimic a card
+	.form-fieldset {
+		border-radius: 4px;
+		background: var( --color-white );
+		@include elevation ( 2dp );
+	}
+
+	label {
+		// The label isn't needed when
+		// there's only one input.
+		display: none;
+	}
+
+	input {
+		// Extra padding to account for the button
+		padding: 10px 100px 12px 16px;
+
+		// Match the radious of the fieldset
+		border-radius: 4px;
+
+		// No need for a border here
+		border: none;
+
+		// On smaller screens the buttons get bigger,
+		// so this input needs to get bigger, too.
+		@include breakpoint( '<660px' ) {
+			padding-top: 15px;
+			padding-bottom: 15px;
+
+			// The rounded borders look strange on
+			// smaller screens.
+			border-radius: 0;
+		}
+
+		&:focus {
+			box-shadow: 0 0 0 3px var( --color-accent-light );
+		}
+	}
+
+	button {
+		@include elevation ( 1dp );
+	}
+
+	.card {
+		margin: 0 auto;
+		background: transparent;
+		border: 0;
+		box-shadow: none;
+		padding: 0;
+	}
+}
+
+.site-title__info-popover {
+	margin-left: 5px;
+
+	.gridicon {
+		margin-bottom: -3px;
+		color: var( --color-white );
+	}
+}
+
+.site-title__field-control {
+	margin: 0 auto 20px;
+	filter: blur( 0 );
+	transform: translateZ( 0 ) translateX( 0 );
+	transition: 500ms ease-in-out opacity, 500ms ease-in-out filter, 500ms ease-in-out transform;
+
+	&:last-child {
+		margin: 0 auto;
+	}
+
+	.form-fieldset {
+		margin-bottom: 0;
+	}
+
+	.button {
+		position: absolute;
+		top: 3px;
+		right: 3px;
+		width: auto;
+		padding: 5px 8px;
+		transition: none;
+
+		.gridicon {
+			height: 24px;
+			width: 24px;
+		}
+	}
+}
+
+/* We need specificity here to overwrite client/signup/style.scss */
+body.is-section-signup {
+	.site-title__wrapper .site-title__field-control button.button {
+		@include breakpoint( '<660px' ) {
+			padding: 9px 12px;
+		}
+	}
+}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -60,16 +60,6 @@ body.is-section-signup .layout.gravatar {
 		}
 	}
 
-	// With the dark background, the border on cards looks a
-	// a little strange. Lets try a shadow instead. -shaun
-	.is-site-information .site-information__wrapper:not( .is-single-fieldset ) .card {
-		@include elevation ( 2dp );
-
-		.dops & {
-			@include elevation ( 0 );
-		}
-	}
-
 	//Masterbar is hidden but still has height
 	//which is how sticky panel offset is calculated.
 	//Setting height to zero removes the offset

--- a/test/e2e/lib/pages/signup/site-title-page.js
+++ b/test/e2e/lib/pages/signup/site-title-page.js
@@ -12,9 +12,9 @@ import * as driverHelper from '../../driver-helper.js';
 
 import AsyncBaseContainer from '../../async-base-container';
 
-export default class SiteInfoPage extends AsyncBaseContainer {
+export default class SiteTitlePage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.site-information__wrapper' ) );
+		super( driver, By.css( '.site-title__wrapper' ) );
 	}
 
 	async enterSiteTitle( siteTitle ) {
@@ -24,7 +24,7 @@ export default class SiteInfoPage extends AsyncBaseContainer {
 	async submitForm() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.site-information__wrapper button.is-primary' )
+			By.css( '.site-title__wrapper button.is-primary' )
 		);
 	}
 }

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -30,7 +30,7 @@ import CheckOutThankyouPage from '../lib/pages/signup/checkout-thankyou-page.js'
 import ImportFromURLPage from '../lib/pages/signup/import-from-url-page';
 import SiteTypePage from '../lib/pages/signup/site-type-page';
 import SiteTopicPage from '../lib/pages/signup/site-topic-page';
-import SiteInfoPage from '../lib/pages/signup/site-info-page';
+import SiteTitlePage from '../lib/pages/signup/site-title-page';
 import LoginPage from '../lib/pages/login-page';
 import MagicLoginPage from '../lib/pages/magic-login-page';
 import ReaderPage from '../lib/pages/reader-page';
@@ -1682,9 +1682,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "Site Information" page, and enter the site title', async function() {
-			const siteInfoPage = await SiteInfoPage.Expect( driver );
-			await siteInfoPage.enterSiteTitle( blogName );
-			return await siteInfoPage.submitForm();
+			const siteTitlePage = await SiteTitlePage.Expect( driver );
+			await siteTitlePage.enterSiteTitle( blogName );
+			return await siteTitlePage.submitForm();
 		} );
 
 		step(
@@ -1793,9 +1793,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can see the "Site Information" page, and enter the site title', async function() {
-			const siteInfoPage = await SiteInfoPage.Expect( driver );
-			await siteInfoPage.enterSiteTitle( blogName );
-			return await siteInfoPage.submitForm();
+			const siteTitlePage = await SiteTitlePage.Expect( driver );
+			await siteTitlePage.enterSiteTitle( blogName );
+			return await siteTitlePage.submitForm();
 		} );
 
 		step(


### PR DESCRIPTION
## Changes proposed in this Pull Request

### Using site title component in the flow

Since we're no longer capturing `phone` and `address` values, we don't need to use the site information component.

Instead, let's update the site title component with the latest styles, and plug its value into the state.

### Retiring the site information Tracks event

We'll use `calypso_signup_actions_submit_site_title` in the place of `calypso_signup_actions_submit_site_information`.

👉 _TODO: cc those who are using `calypso_signup_actions_submit_site_information` in their funnels_

## Testing instructions

Create a site and fill out the site title step. Check the following:

1. That we're saving `siteTitle` to the `state.signup.steps.siteTitle`
2. When you submit the site title step, we're firing `calypso_signup_actions_submit_site_title` tracking event with `{ value: 'your site title' }`
3. After creating a site, the site title you entered appears on your site.

Since #32432 we're not using the `site-information-without-domains` step, but just to make sure, test the flow using the `remove` variation of the `removeDomainsStepFromOnboarding` AB test –

<img width="600" alt="Screen Shot 2019-04-25 at 2 36 39 pm" src="https://user-images.githubusercontent.com/6458278/56710210-57465e80-6768-11e9-9ba3-5543c250cf90.png">

– and repeat the steps above. 👍 We've created `site-title-without-domain` to replace it.