### PR TITLE
Signup: Updating padding to cater for the new, narrower arrow button and mobile widths

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -169,13 +169,23 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	render() {
 		const { autoFocus, placeholder, translate } = this.props;
 		const { inputValue, railcar } = this.state;
+		const shouldShowPopularTopics = this.shouldShowPopularTopics();
+		const placeholderText = shouldShowPopularTopics
+			? translate( 'Enter a topic or select from below.', {
+					comment:
+						'Text input field placeholder. Should be fewer than 35 chars to fit mobile width.',
+			  } )
+			: translate( 'Enter a topic.', {
+					comment:
+						'Text input field placeholder. Should be fewer than 35 chars to fit mobile width.',
+			  } );
 		return (
 			<>
 				<QueryVerticals searchTerm={ inputValue.trim() } debounceTime={ 300 } />
 				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } />
 				<SuggestionSearch
 					id="siteTopic"
-					placeholder={ placeholder || translate( 'Enter a keyword or select one from below.' ) }
+					placeholder={ placeholder || placeholderText }
 					onChange={ this.onSiteTopicChange }
 					suggestions={ this.getSuggestions() }
 					value={ inputValue }
@@ -183,7 +193,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 					isSearching={ this.isVerticalSearchPending() }
 					railcar={ railcar }
 				/>
-				{ this.shouldShowPopularTopics() && <PopularTopics onSelect={ this.onSiteTopicChange } /> }
+				{ shouldShowPopularTopics && <PopularTopics onSelect={ this.onSiteTopicChange } /> }
 			</>
 		);
 	}

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -15,7 +15,7 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
     isSearching=""
     onChange={[Function]}
     onSelect={[Function]}
-    placeholder="Enter a keyword or select one from below."
+    placeholder="Enter a topic."
     railcar={
       Object {
         "action": "site_vertical_selected",

--- a/client/signup/steps/site-information/style.scss
+++ b/client/signup/steps/site-information/style.scss
@@ -72,7 +72,7 @@ body.is-section-signup {
 
 	input {
 		// Extra padding to account for the button
-		padding: 10px 100px 12px 16px;
+		padding: 10px 64px 12px 16px;
 
 		// Match the radious of the fieldset
 		border-radius: 4px;
@@ -83,8 +83,7 @@ body.is-section-signup {
 		// On smaller screens the buttons get bigger,
 		// so this input needs to get bigger, too.
 		@include breakpoint( '<660px' ) {
-			padding-top: 15px;
-			padding-bottom: 15px;
+			padding: 15px 64px 15px 16px;
 
 			// The rounded borders look strange on
 			// smaller screens.

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -3,6 +3,8 @@
 /**
  * External dependencies
  */
+import Gridicon from 'gridicons';
+import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -12,7 +14,6 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Gridicon from 'gridicons';
 import FormFieldset from 'components/forms/form-fieldset';
 import SiteVerticalsSuggestionSearch from 'components/site-verticals-suggestion-search';
 import { setSiteVertical } from 'state/signup/steps/site-vertical/actions';
@@ -73,7 +74,7 @@ class SiteTopicForm extends Component {
 	render() {
 		const { isButtonDisabled, siteTopic } = this.props;
 		return (
-			<div className="site-topic__content">
+			<div className={ classNames( 'site-topic__content', { 'is-empty': ! siteTopic } ) }>
 				<form onSubmit={ this.onSubmit }>
 					<FormFieldset>
 						<SiteVerticalsSuggestionSearch

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -46,6 +46,10 @@ body.is-section-jetpack-connect .site-topic__content {
 		}
 	}
 
+	&.is-empty input {
+		padding-right: 15px;
+	}
+
 	.suggestions__wrapper {
 		position: relative;
 		top: 0;

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -23,7 +23,7 @@ body.is-section-jetpack-connect .site-topic__content {
 	input {
 		// Extra padding to account for the button and
 		// the search icon.
-		padding: 10px 100px 12px 42px;
+		padding: 10px 64px 12px 42px;
 
 		// Trying out a rounded input
 		border-radius: 4px;
@@ -34,8 +34,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		@include breakpoint( '<660px' ) {
 			// On smaller screens the buttons get bigger,
 			// so this input needs to get bigger, too.
-			padding-top: 15px;
-			padding-bottom: 15px;
+			padding: 15px 64px 15px 42px;
 
 			// The rounded borders look strange on
 			// smaller screens.


### PR DESCRIPTION
## Changes proposed in this Pull Request

Copy and padding changes to accommodate narrow widths.

**Before:** 
<img width="394" alt="Screen Shot 2019-04-26 at 3 20 05 pm" src="https://user-images.githubusercontent.com/6458278/56785796-07d06300-683a-11e9-88b2-68cf315da2ab.png">

😱 

**After:**
<img width="397" alt="Screen Shot 2019-04-26 at 3 38 07 pm" src="https://user-images.githubusercontent.com/6458278/56785802-0c951700-683a-11e9-856c-9c00910c9fd5.png">

🍸 

Also creating a condition to deliver varying copy in the site vertical input for the case where we display no popular topics.

## Testing
Check the site topic and site title steps in narrow widths. Enter text, remove text.

Does everything look as it should?
