### PR TITLE
Unbreak ctrl+click on context menu buttons

### DIFF
--- a/client/blocks/inline-help/inline-help-rich-result.jsx
+++ b/client/blocks/inline-help/inline-help-rich-result.jsx
@@ -34,9 +34,15 @@ const amendYouTubeLink = ( link = '' ) =>
 
 class InlineHelpRichResult extends Component {
 	static propTypes = {
-		result: PropTypes.object,
 		setDialogState: PropTypes.func.isRequired,
 		closePopover: PropTypes.func.isRequired,
+		searchQuery: PropTypes.string,
+		result: PropTypes.object,
+		type: PropTypes.string,
+		postId: PropTypes.number,
+		title: PropTypes.string,
+		description: PropTypes.string,
+		tour: PropTypes.string,
 	};
 
 	buttonLabels = {
@@ -56,17 +62,14 @@ class InlineHelpRichResult extends Component {
 	};
 
 	handleClick = event => {
-		event.preventDefault();
-		const { href } = event.target;
-		const { type, result } = this.props;
-		const tour = get( result, RESULT_TOUR );
-		const postId = get( result, 'post_id' );
 		const isLocaleEnglish = 'en' === getLocaleSlug();
+		const { type, tour, link, searchQuery, postId } = this.props;
+
 		const tracksData = omitBy(
 			{
-				search_query: this.props.searchQuery,
+				search_query: searchQuery,
 				tour,
-				result_url: href,
+				result_url: link,
 			},
 			isUndefined
 		);
@@ -75,38 +78,25 @@ class InlineHelpRichResult extends Component {
 		this.props.closePopover();
 
 		if ( type === RESULT_TOUR ) {
+			event.preventDefault();
 			this.props.requestGuidedTour( tour );
 		} else if ( type === RESULT_VIDEO ) {
-			if ( event.metaKey ) {
-				window.open( href, '_blank' );
-			} else {
-				this.props.setDialogState( {
-					showDialog: true,
-					dialogType: 'video',
-					videoLink: get( result, RESULT_LINK ),
-				} );
-			}
+			event.preventDefault();
+			this.props.setDialogState( {
+				showDialog: true,
+				dialogType: 'video',
+				videoLink: link,
+			} );
 		} else if ( type === RESULT_ARTICLE && postId && isLocaleEnglish ) {
 			// Until we can deliver localized inline support article content, we send the
 			// the user to the localized support blog, if one exists.
-			this.props.openSupportArticleDialog( { postId, postUrl: href } );
-		} else {
-			if ( ! href ) {
-				return;
-			}
-			if ( event.metaKey ) {
-				window.open( href, '_blank' );
-			} else {
-				window.location = href;
-			}
-		}
+			event.preventDefault();
+			this.props.openSupportArticleDialog( { postId, postUrl: link } );
+		} // else falls back on href
 	};
 
 	render() {
-		const { result, type } = this.props;
-		const title = get( result, RESULT_TITLE );
-		const description = get( result, RESULT_DESCRIPTION );
-		const link = amendYouTubeLink( get( result, RESULT_LINK ) );
+		const { type, title, description, link } = this.props;
 		const buttonLabel = get( this.buttonLabels, type, '' );
 		const buttonIcon = get( this.buttonIcons, type );
 		const classes = classNames( 'inline-help__richresult__title' );
@@ -125,10 +115,16 @@ class InlineHelpRichResult extends Component {
 	}
 }
 
-const mapStateToProps = ( state, ownProps ) => ( {
+const mapStateToProps = ( state, { result } ) => ( {
 	searchQuery: getSearchQuery( state ),
-	type: get( ownProps.result, RESULT_TYPE, RESULT_ARTICLE ),
+	type: get( result, RESULT_TYPE, RESULT_ARTICLE ),
+	title: get( result, RESULT_TITLE ),
+	link: amendYouTubeLink( get( result, RESULT_LINK ) ),
+	description: get( result, RESULT_DESCRIPTION ),
+	tour: get( result, RESULT_TOUR ),
+	postId: get( result, 'post_id' ),
 } );
+
 const mapDispatchToProps = {
 	recordTracksEvent,
 	requestGuidedTour,


### PR DESCRIPTION
Metakey + click is a mac only and browser specific convention to open a
link in a new tab or window. Removing detection and falling back on
generic browser behavior achieves the same result.

event.target only contains the href if it is the button being clicked,
when clicking on the buttons icon instead of the buttons text the
resulting article popup will be missing the external article link.

#### Changes proposed in this Pull Request

* This change removes the check for metakey and replaces the event.target href with
the link from props.


#### Testing instructions

- [x] Video embed - /me/account context has a video for changing
password
- [x] Media - has a tour for Learn Media Library Basics
- [x] Article not/localized

