### PR TITLE
A/B Test: Upsell - Concierge Quickstart pricing

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -183,4 +183,13 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
+	conciergePricing: {
+		datestamp: '20190522',
+		variations: {
+			controlOldPrice: 50,
+			variantNewPrice: 50,
+		},
+		defaultVariation: 'controlOldPrice',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/cart-values/cart-items.js
+++ b/client/lib/cart-values/cart-items.js
@@ -732,6 +732,12 @@ export function conciergeSessionItem() {
 	};
 }
 
+export function conciergeSessionAltItem() {
+	return {
+		product_slug: 'concierge-quickstart',
+	};
+}
+
 /**
  * Creates a new shopping cart item for the specified plan.
  *
@@ -1244,4 +1250,5 @@ export default {
 	hasStaleItem,
 	hasTransferProduct,
 	conciergeSessionItem,
+	conciergeSessionAltItem,
 };

--- a/client/lib/products-values/index.js
+++ b/client/lib/products-values/index.js
@@ -456,7 +456,9 @@ export function isConciergeSession( product ) {
 	product = formatProduct( product );
 	assertValidProduct( product );
 
-	return 'concierge-session' === product.product_slug;
+	return (
+		'concierge-session' === product.product_slug || 'concierge-quickstart' === product.product_slug
+	);
 }
 
 export default {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a WIP for the Concierge Pricing testing. 

p8Eqe3-zL

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D28240-code to your sandboxed `public-api.wordpress.com`.
* Make sure you're assigned to the `variantNewPrice` group of `conciergePricing` test.
* Create a new website on any paid plan except for Business or eCommerce.
* Once you purchase the plan, you will see upsell for concierge quick start session as follows. Note that the price should be _$67.00_.
  <img width="500" alt="Checkout_‹_Quick_Start_Session_—_WordPress_com" src="https://user-images.githubusercontent.com/212034/57862688-bb25e980-7833-11e9-8a41-517a3d5c34ee.png">
* Buy the concierge quickstart session and you get an email for booking the session.
* Check if you're able to book the support session.