### PR TITLE
Update to Business and eCommerce plans. Word it as "Jetpack Advanced …

### DIFF
--- a/client/lib/plans/constants.js
+++ b/client/lib/plans/constants.js
@@ -50,6 +50,7 @@ export const FEATURE_WP_SUBDOMAIN = 'wordpress-subdomain';
 export const FEATURE_BLOG_DOMAIN = 'blog-domain';
 export const FEATURE_CUSTOM_DOMAIN = 'custom-domain';
 export const FEATURE_JETPACK_ESSENTIAL = 'jetpack-essential';
+export const FEATURE_JETPACK_ADVANCED = 'jetpack-advanced';
 export const FEATURE_FREE_THEMES = 'free-themes';
 export const FEATURE_UNLIMITED_PREMIUM_THEMES = 'premium-themes';
 export const FEATURE_3GB_STORAGE = '3gb-storage';

--- a/client/lib/plans/features-list.js
+++ b/client/lib/plans/features-list.js
@@ -351,6 +351,18 @@ export const FEATURES_LIST = {
 			),
 	},
 
+	[ constants.FEATURE_JETPACK_ADVANCED ]: {
+		getSlug: () => constants.FEATURE_JETPACK_ADVANCED,
+		getTitle: () => i18n.translate( 'Jetpack Advanced Features' ),
+		getDescription: () =>
+			i18n.translate(
+				'Speed up your site’s performance and protect it from spammers. ' +
+					'Access detailed records of all activity on your site and restore your site ' +
+					'to a previous point in time with just a click! While you’re at it, ' +
+					'improve your SEO with our Advanced SEO tools and automate social media sharing.'
+			),
+	},
+
 	[ constants.FEATURE_UNLIMITED_PREMIUM_THEMES ]: {
 		getSlug: () => constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 		getTitle: () =>

--- a/client/lib/plans/plans-list.js
+++ b/client/lib/plans/plans-list.js
@@ -161,7 +161,7 @@ const getPlanEcommerceDetails = () => ( {
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_CUSTOM_DOMAIN,
-			constants.FEATURE_JETPACK_ESSENTIAL,
+			constants.FEATURE_JETPACK_ADVANCED,
 			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			constants.FEATURE_ADVANCED_DESIGN,
@@ -332,7 +332,7 @@ const getPlanBusinessDetails = () => ( {
 		compact( [
 			// pay attention to ordering, shared features should align on /plan page
 			constants.FEATURE_CUSTOM_DOMAIN,
-			constants.FEATURE_JETPACK_ESSENTIAL,
+			constants.FEATURE_JETPACK_ADVANCED,
 			constants.FEATURE_EMAIL_LIVE_CHAT_SUPPORT,
 			constants.FEATURE_UNLIMITED_PREMIUM_THEMES,
 			constants.FEATURE_ADVANCED_DESIGN,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- For the Business and eCommerce plans,  
  change “Jetpack Essential Features” to “Jetpack **Advanced** Features”.
  - Update tooltip text for “Jetpack Advanced Features” to say:
    _Speed up your site’s performance and protect it from spammers. Access detailed records of all activity on your site and restore your site to a previous point in time with just a click! While you’re at it, improve your SEO with our Advanced SEO tools and automate social media sharing._

#### Testing instructions

- Use calypso.live branch to test the `/plans` page.
- Confirm the above changes for the Business and eCommerce plans.

It should match-up with D27162-code.

