### PR TITLE
Fix gridicon errors when icon is undefined.

### DIFF
--- a/client/components/async-gridicons/index.jsx
+++ b/client/components/async-gridicons/index.jsx
@@ -33,7 +33,7 @@ class AsyncGridicon extends Component {
 		super( props );
 	}
 	checkAndLoad() {
-		if ( ! loadedIcons.has( this.props.icon ) ) {
+		if ( this.props.icon && ! loadedIcons.has( this.props.icon ) ) {
 			loadIcon( this.props.icon ).then( () => this.update() );
 		}
 	}


### PR DESCRIPTION
While we're waiting for the complete overhaul of gridicons, this fixes an existing bug when the `icon` prop is empty.

Fixes https://github.com/Automattic/wp-calypso/issues/32425

#### Changes proposed in this Pull Request

* Ensure we don't try to load anything when the `icon` prop is `undefined`.

#### Testing instructions

* Open "My Sites".
* Ensure the warning `Error loading icon 'undefined': Cannot find module './undefined'` no longer appears.
