### PR TITLE
Updates the display logic after change to the backend

### DIFF
--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -100,7 +100,8 @@ function getGSuiteSupportedDomains( domains ) {
 			includes( [ domainTypes.REGISTERED ], domain.type ) &&
 			( domain.hasWpcomNameservers || hasGSuite( domain ) );
 		const mapped = includes( [ domainTypes.MAPPED ], domain.type );
-		const notOtherProvidor = domain.googleAppsSubscription.status !== 'other_provider';
+		const notOtherProvidor =
+			domain.googleAppsSubscription && domain.googleAppsSubscription.status !== 'other_provider';
 		return ( wpcomHosted || mapped ) && canDomainAddGSuite( domain.name ) && notOtherProvidor;
 	} );
 }
@@ -156,6 +157,17 @@ function hasGSuite( domain ) {
 }
 
 /**
+ * Given a domain object, does that domain have G Suite with another providor
+ *
+ * @param {Object} domain - domain object
+ * @returns {Boolean} - Does a domain have G Suite with another providor
+ */
+function hasGSuiteOtherProvidor( domain ) {
+	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
+	return 'other_provider' === domainStatus;
+}
+
+/**
  * Given a list of domains does one of them support G Suite
  *
  * @param {Array} domains - list of domain objects
@@ -195,6 +207,7 @@ export {
 	getLoginUrlWithTOSRedirect,
 	getMonthlyPrice,
 	hasGSuite,
+	hasGSuiteOtherProvidor,
 	hasGSuiteSupportedDomain,
 	hasPendingGSuiteUsers,
 	isGSuiteRestricted,

--- a/client/lib/gsuite/index.js
+++ b/client/lib/gsuite/index.js
@@ -100,7 +100,8 @@ function getGSuiteSupportedDomains( domains ) {
 			includes( [ domainTypes.REGISTERED ], domain.type ) &&
 			( domain.hasWpcomNameservers || hasGSuite( domain ) );
 		const mapped = includes( [ domainTypes.MAPPED ], domain.type );
-		return ( wpcomHosted || mapped ) && canDomainAddGSuite( domain.name );
+		const notOtherProvidor = domain.googleAppsSubscription.status !== 'other_provider';
+		return ( wpcomHosted || mapped ) && canDomainAddGSuite( domain.name ) && notOtherProvidor;
 	} );
 }
 
@@ -150,7 +151,8 @@ function getGSuiteSettingsUrl( domainName ) {
  * @returns {Boolean} - Does a domain have G Suite
  */
 function hasGSuite( domain ) {
-	return 'no_subscription' !== get( domain, 'googleAppsSubscription.status', '' );
+	const domainStatus = get( domain, 'googleAppsSubscription.status', '' );
+	return 'no_subscription' !== domainStatus && 'other_provider' !== domainStatus;
 }
 
 /**

--- a/client/lib/gsuite/test/index.js
+++ b/client/lib/gsuite/test/index.js
@@ -61,22 +61,29 @@ describe( 'index', () => {
 
 		test( 'returns empty array if domain is invalid', () => {
 			expect(
-				getGSuiteSupportedDomains( [ { name: 'foogoogle.blog', type: 'REGISTERED' } ] )
+				getGSuiteSupportedDomains( [
+					{ name: 'foogoogle.blog', type: 'REGISTERED', googleAppsSubscription: {} },
+				] )
 			).toEqual( [] );
 		} );
 
 		test( 'returns domain object if domain is valid, type of registered, and wpcom nameservers', () => {
-			const registered = { name: 'foo.blog', type: 'REGISTERED', hasWpcomNameservers: true };
+			const registered = {
+				name: 'foo.blog',
+				type: 'REGISTERED',
+				hasWpcomNameservers: true,
+				googleAppsSubscription: {},
+			};
 			expect( getGSuiteSupportedDomains( [ registered ] ) ).toEqual( [ registered ] );
 		} );
 
 		test( 'returns domain object if domain is valid and type of mapped', () => {
-			const mapped = { name: 'foo.blog', type: 'MAPPED' };
+			const mapped = { name: 'foo.blog', type: 'MAPPED', googleAppsSubscription: {} };
 			expect( getGSuiteSupportedDomains( [ mapped ] ) ).toEqual( [ mapped ] );
 		} );
 
 		test( 'returns domain object if domain is valid and type of site redirected', () => {
-			const siteRedirect = { name: 'foo.blog', type: 'SITE_REDIRECT' };
+			const siteRedirect = { name: 'foo.blog', type: 'SITE_REDIRECT', googleAppsSubscription: {} };
 			expect( getGSuiteSupportedDomains( [ siteRedirect ] ) ).toEqual( [] );
 		} );
 	} );
@@ -100,14 +107,18 @@ describe( 'index', () => {
 
 		test( 'returns false if passed an array with invalid domains', () => {
 			expect(
-				hasGSuiteSupportedDomain( [ { name: 'foogoogle.blog', type: 'REGISTERED' } ] )
+				hasGSuiteSupportedDomain( [
+					{ name: 'foogoogle.blog', type: 'REGISTERED', googleAppsSubscription: {} },
+				] )
 			).toEqual( false );
 		} );
 
 		test( 'returns true if passed an array with valid domains', () => {
-			expect( hasGSuiteSupportedDomain( [ { name: 'foo.blog', type: 'MAPPED' } ] ) ).toEqual(
-				true
-			);
+			expect(
+				hasGSuiteSupportedDomain( [
+					{ name: 'foo.blog', type: 'MAPPED', googleAppsSubscription: {} },
+				] )
+			).toEqual( true );
 		} );
 	} );
 

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -18,6 +18,7 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import {
 	hasGSuite,
 	isGSuiteRestricted,
+	hasGSuiteOtherProvidor,
 	hasGSuiteSupportedDomain,
 	getEligibleGSuiteDomain,
 } from 'lib/gsuite';
@@ -107,6 +108,7 @@ class EmailManagement extends React.Component {
 	emptyContent() {
 		const { selectedDomainName, selectedSiteSlug, translate } = this.props;
 		let emptyContentProps;
+		const selectedDomain = getSelectedDomain( this.props );
 
 		if ( isGSuiteRestricted() && ! selectedDomainName ) {
 			emptyContentProps = {
@@ -115,6 +117,13 @@ class EmailManagement extends React.Component {
 					'To set up email forwarding, and other email ' +
 						'services for your site, upgrade your site’s web address ' +
 						'to a professional custom domain.'
+				),
+			};
+		} else if ( selectedDomain && hasGSuiteOtherProvidor( selectedDomain ) ) {
+			emptyContentProps = {
+				title: translate( 'G Suite is not supported on this domain' ),
+				line: translate(
+					"You're using G Suite with this domain, so you'll use that to create custom email addresses. Visit your G Suite provider to manage your settings."
 				),
 			};
 		} else if ( selectedDomainName ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates logic to account for change to backend that tests to determine if a domain has G Suite somewhere else.

#### Testing instructions

* Apply backend patch
* Have domain that has G Suite with another provider
* You can get this with a canceled G Suite
* Observe that it doesn't try to sell you G Suite when you goto /email

If no domain is selected:
![Screen Shot 2019-04-29 at 1 53 39 PM](https://user-images.githubusercontent.com/6817400/56916274-7efa3700-6a86-11e9-889e-b23dc980af3a.png)

If domain is selected for domain with G Suite other provider:
![Screen Shot 2019-04-29 at 1 54 47 PM](https://user-images.githubusercontent.com/6817400/56916235-70138480-6a86-11e9-83a9-53f9d94c7ca2.png)


