### PR TITLE
Happiness Support: Make the Support documentation button borderless with external icon

### DIFF
--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import GridiconExternal from 'gridicons/dist/external';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import {
 	CALYPSO_CONTACT,
@@ -142,12 +143,14 @@ export class HappinessSupport extends Component {
 
 		return (
 			<Button
+				borderless
 				href={ url }
 				target="_blank"
 				rel="noopener noreferrer"
 				className="happiness-support__support-button"
 			>
-				{ this.props.translate( 'Support documentation' ) }
+				<GridiconExternal />
+				<span>{ this.props.translate( 'Support documentation' ) }</span>
 			</Button>
 		);
 	}

--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -68,4 +68,9 @@
 			}
 		}
 	}
+
+	.happiness-support__support-button {
+		padding-bottom: 11px;
+		padding-top: 2px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `GridiconExternal` to notify it's an external link
* Switch to a `borderless` button
* Adjust padding to align vertically align it with HappyChat button

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to [Plans > My Plan](https://wordpress.com/plans/my-plan/) (Make sure you have a paid plan to see the Happiness Support panel)

Before:
![Screenshot 2019-04-26 at 16 06 06](https://user-images.githubusercontent.com/177929/56817414-7367ff80-683d-11e9-838f-3f75db80bb25.png)

After:
![Screenshot 2019-04-26 at 16 06 50](https://user-images.githubusercontent.com/177929/56817423-795de080-683d-11e9-87ae-3bf1409a86fe.png)

Fixes #32530 
