### PR TITLE
Add link to the concierge session scheduler in Thank You page

### DIFF
--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -25,7 +25,6 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite, isNewSite } from 'state/sites/selectors';
 import { isEnabled } from 'config';
-import { abtest } from 'lib/abtest';
 
 class ChecklistMain extends PureComponent {
 	state = { complete: false };
@@ -90,18 +89,13 @@ class ChecklistMain extends PureComponent {
 				);
 
 			case 'concierge':
-				const sessionName =
-					'variantQuickstartSession' === abtest( 'conciergeQuickstartSession' )
-						? 'Quick Start Session'
-						: 'Support Session';
 				return translate(
-					'We emailed %(email)s with instructions to schedule your %(sessionName)s call. ' +
+					'We emailed %(email)s with instructions to schedule your Quick Start Session call with us. ' +
 						'In the mean time, let’s get your new site ready for you to share. ' +
 						'We’ve prepared a list of things that will help you get there quickly.',
 					{
 						args: {
 							email: this.props.user.email,
-							sessionName,
 						},
 					}
 				);

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -69,11 +69,10 @@ class ChecklistMain extends PureComponent {
 
 	/**
 	 * Get subheader text to be shown for Checklist
-	 * @param {String} displayMode The query parameter that indicates the display mode, e.g. gsuite or concierge.
-	 * @return {String}            The translated string
+	 * @return {String} The translated string
 	 */
-	getSubHeaderText( displayMode ) {
-		const { translate } = this.props;
+	getSubHeaderText() {
+		const { displayMode, translate } = this.props;
 
 		switch ( displayMode ) {
 			case 'gsuite':
@@ -101,7 +100,7 @@ class ChecklistMain extends PureComponent {
 				);
 
 			default:
-				translate(
+				return translate(
 					"Now that your site has been created, it's time to get it ready for you to share. " +
 						"We've prepared a list of things that will help you get there quickly."
 				);
@@ -109,7 +108,7 @@ class ChecklistMain extends PureComponent {
 	}
 
 	renderHeader() {
-		const { displayMode, isNewlyCreatedSite, translate } = this.props;
+		const { isNewlyCreatedSite, translate } = this.props;
 		const { complete } = this.state;
 
 		if ( complete ) {
@@ -147,7 +146,7 @@ class ChecklistMain extends PureComponent {
 								? translate( 'Thank you for your purchase!' )
 								: translate( 'Your site has been created!' )
 						}
-						subHeaderText={ this.getSubHeaderText( displayMode ) }
+						subHeaderText={ this.getSubHeaderText() }
 					/>
 				</>
 			);

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -25,6 +25,7 @@ import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite, isNewSite } from 'state/sites/selectors';
 import { isEnabled } from 'config';
+import { abtest } from 'lib/abtest';
 
 class ChecklistMain extends PureComponent {
 	state = { complete: false };
@@ -67,6 +68,52 @@ class ChecklistMain extends PureComponent {
 		}
 	}
 
+	/**
+	 * Get subheader text to be shown for Checklist
+	 * @param {String} displayMode The query parameter that indicates the display mode, e.g. gsuite or concierge.
+	 * @return {String}            The translated string
+	 */
+	getSubHeaderText( displayMode ) {
+		const { translate } = this.props;
+
+		switch ( displayMode ) {
+			case 'gsuite':
+				return translate(
+					'We emailed %(email)s with instructions to complete your G Suite setup. ' +
+						'In the mean time, let’s get your new site ready for you to share. ' +
+						'We’ve prepared a list of things that will help you get there quickly.',
+					{
+						args: {
+							email: this.props.user.email,
+						},
+					}
+				);
+
+			case 'concierge':
+				const sessionName =
+					'variantQuickstartSession' === abtest( 'conciergeQuickstartSession' )
+						? 'Quick Start Session'
+						: 'Support Session';
+				return translate(
+					'We emailed %(email)s with instructions to schedule your %(sessionName)s call. ' +
+						'In the mean time, let’s get your new site ready for you to share. ' +
+						'We’ve prepared a list of things that will help you get there quickly.',
+					{
+						args: {
+							email: this.props.user.email,
+							sessionName,
+						},
+					}
+				);
+
+			default:
+				translate(
+					"Now that your site has been created, it's time to get it ready for you to share. " +
+						"We've prepared a list of things that will help you get there quickly."
+				);
+		}
+	}
+
 	renderHeader() {
 		const { displayMode, isNewlyCreatedSite, translate } = this.props;
 		const { complete } = this.state;
@@ -106,23 +153,7 @@ class ChecklistMain extends PureComponent {
 								? translate( 'Thank you for your purchase!' )
 								: translate( 'Your site has been created!' )
 						}
-						subHeaderText={
-							'gsuite' === displayMode
-								? translate(
-										'We emailed %(email)s with instructions to complete your G Suite setup. ' +
-											'In the mean time, let’s get your new site ready for you to share. ' +
-											'We’ve prepared a list of things that will help you get there quickly.',
-										{
-											args: {
-												email: this.props.user.email,
-											},
-										}
-								  )
-								: translate(
-										"Now that your site has been created, it's time to get it ready for you to share. " +
-											"We've prepared a list of things that will help you get there quickly."
-								  )
-						}
+						subHeaderText={ this.getSubHeaderText( displayMode ) }
 					/>
 				</>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -68,13 +68,26 @@ class CheckoutThankYouHeader extends PureComponent {
 	}
 
 	getText() {
-		const { translate, isDataLoaded, hasFailedPurchases, primaryPurchase } = this.props;
+		const {
+			translate,
+			isDataLoaded,
+			hasFailedPurchases,
+			primaryPurchase,
+			displayMode,
+		} = this.props;
 
 		if ( hasFailedPurchases ) {
 			return translate( 'Some of the items in your cart could not be added.' );
 		}
 
 		if ( ! isDataLoaded || ! primaryPurchase ) {
+			if ( 'concierge' === displayMode ) {
+				return translate(
+					'You will receive an email confirmation shortly,' +
+						' along with detailed instructions to schedule your call with us.'
+				);
+			}
+
 			return translate( 'You will receive an email confirmation shortly.' );
 		}
 
@@ -229,6 +242,15 @@ class CheckoutThankYouHeader extends PureComponent {
 		window.location.href = selectedSite.URL;
 	};
 
+	visitScheduler = event => {
+		event.preventDefault();
+		const { selectedSite } = this.props;
+
+		//Maybe record tracks event
+
+		window.location.href = '/me/concierge/' + selectedSite.slug + '/book';
+	};
+
 	startTransfer = event => {
 		event.preventDefault();
 
@@ -240,8 +262,12 @@ class CheckoutThankYouHeader extends PureComponent {
 	};
 
 	getButtonText = () => {
-		const { translate, hasFailedPurchases, primaryPurchase } = this.props;
+		const { translate, hasFailedPurchases, primaryPurchase, displayMode } = this.props;
 		const site = this.props.selectedSite.slug;
+
+		if ( 'concierge' === displayMode ) {
+			return translate( 'Schedule my session' );
+		}
 
 		if ( ! site && hasFailedPurchases ) {
 			return translate( 'Register domain' );
@@ -267,14 +293,24 @@ class CheckoutThankYouHeader extends PureComponent {
 	};
 
 	getButton() {
-		const { hasFailedPurchases, translate, primaryPurchase, selectedSite } = this.props;
+		const {
+			hasFailedPurchases,
+			translate,
+			primaryPurchase,
+			selectedSite,
+			displayMode,
+		} = this.props;
 		const headerButtonClassName = 'button is-primary';
+		const isConciergePurchase = 'concierge' === displayMode;
 
-		if ( hasFailedPurchases || ! primaryPurchase || ! selectedSite || selectedSite.jetpack ) {
+		if (
+			! isConciergePurchase &&
+			( hasFailedPurchases || ! primaryPurchase || ! selectedSite || selectedSite.jetpack )
+		) {
 			return null;
 		}
 
-		if ( isDelayedDomainTransfer( primaryPurchase ) ) {
+		if ( primaryPurchase && isDelayedDomainTransfer( primaryPurchase ) ) {
 			return (
 				<div className="checkout-thank-you__header-button">
 					<button className={ headerButtonClassName } onClick={ this.startTransfer }>
@@ -284,9 +320,11 @@ class CheckoutThankYouHeader extends PureComponent {
 			);
 		}
 
+		const clickHandler = 'concierge' === displayMode ? this.visitScheduler : this.visitSite;
+
 		return (
 			<div className="checkout-thank-you__header-button">
-				<button className={ headerButtonClassName } onClick={ this.visitSite }>
+				<button className={ headerButtonClassName } onClick={ clickHandler }>
 					{ this.getButtonText() }
 				</button>
 			</div>

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -528,7 +528,7 @@ export class CheckoutThankYou extends React.Component {
 	};
 
 	productRelatedMessages = () => {
-		const { selectedSite, sitePlans } = this.props;
+		const { selectedSite, sitePlans, displayMode } = this.props;
 		const purchases = getPurchases( this.props );
 		const failedPurchases = getFailedPurchases( this.props );
 		const hasFailedPurchases = failedPurchases.length > 0;
@@ -546,7 +546,11 @@ export class CheckoutThankYou extends React.Component {
 		if ( ! this.isDataLoaded() ) {
 			return (
 				<div>
-					<CheckoutThankYouHeader isDataLoaded={ false } selectedSite={ selectedSite } />
+					<CheckoutThankYouHeader
+						isDataLoaded={ false }
+						selectedSite={ selectedSite }
+						displayMode={ displayMode }
+					/>
 
 					<CheckoutThankYouFeaturesHeader isDataLoaded={ false } />
 
@@ -570,6 +574,7 @@ export class CheckoutThankYou extends React.Component {
 					selectedSite={ selectedSite }
 					hasFailedPurchases={ hasFailedPurchases }
 					primaryCta={ this.primaryCta }
+					displayMode={ displayMode }
 				/>
 
 				{ primaryPurchase && (

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -462,11 +462,18 @@ export class Checkout extends React.Component {
 			return `/plans/my-plan/${ selectedSiteSlug }?thank-you`;
 		}
 
-		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
-			? `/checkout/thank-you/features/${
-					this.props.selectedFeature
-			  }/${ selectedSiteSlug }/${ receiptId }`
-			: `/checkout/thank-you/${ selectedSiteSlug }/${ receiptId }`;
+		let redirect =
+			this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
+				? `/checkout/thank-you/features/${
+						this.props.selectedFeature
+				  }/${ selectedSiteSlug }/${ receiptId }`
+				: `/checkout/thank-you/${ selectedSiteSlug }/${ receiptId }`;
+
+		if ( cartItems.hasConciergeSession( cart ) ) {
+			redirect += '?d=concierge';
+		}
+
+		return redirect;
 	};
 
 	handleCheckoutExternalRedirect( redirectUrl ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -346,7 +346,7 @@ export class Checkout extends React.Component {
 		// I wouldn't be surprised if it doesn't work as intended in some scenarios.
 		// Especially around the G Suite / Concierge / Checklist logic.
 
-		let renewalItem;
+		let renewalItem, displayModeParam;
 		const {
 			cart,
 			selectedSite,
@@ -449,31 +449,30 @@ export class Checkout extends React.Component {
 			return `/checkout/${ selectedSiteSlug }/add-quickstart-session/${ receiptId }`;
 		}
 
+		if ( cartItems.hasConciergeSession( cart ) ) {
+			displayModeParam = 'd=concierge';
+		}
+
+		const queryParam = displayModeParam ? `?${ displayModeParam }` : '';
+
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {
 			if ( this.props.redirectToPageBuilder ) {
 				return getEditHomeUrl( selectedSiteSlug );
 			}
 			const destination = abtest( 'improvedOnboarding' ) === 'main' ? 'checklist' : 'view';
 
-			return `/${ destination }/${ selectedSiteSlug }`;
+			return `/${ destination }/${ selectedSiteSlug }${ queryParam }`;
 		}
 
 		if ( this.props.isJetpackNotAtomic && config.isEnabled( 'jetpack/checklist' ) ) {
 			return `/plans/my-plan/${ selectedSiteSlug }?thank-you`;
 		}
 
-		let redirect =
-			this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
-				? `/checkout/thank-you/features/${
-						this.props.selectedFeature
-				  }/${ selectedSiteSlug }/${ receiptId }`
-				: `/checkout/thank-you/${ selectedSiteSlug }/${ receiptId }`;
-
-		if ( cartItems.hasConciergeSession( cart ) ) {
-			redirect += '?d=concierge';
-		}
-
-		return redirect;
+		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )
+			? `/checkout/thank-you/features/${
+					this.props.selectedFeature
+			  }/${ selectedSiteSlug }/${ receiptId }`
+			: `/checkout/thank-you/${ selectedSiteSlug }/${ receiptId }${ queryParam }`;
 	};
 
 	handleCheckoutExternalRedirect( redirectUrl ) {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -4,7 +4,7 @@
  */
 import i18n from 'i18n-calypso';
 import React from 'react';
-import { isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 
 /**
  * Internal Dependencies
@@ -92,6 +92,7 @@ export function checkoutThankYou( context, next ) {
 
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
+	const displayMode = get( context, 'query.d' );
 
 	context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
 
@@ -105,6 +106,7 @@ export function checkoutThankYou( context, next ) {
 			domainOnlySiteFlow={ isEmpty( context.params.site ) }
 			selectedFeature={ context.params.feature }
 			selectedSite={ selectedSite }
+			displayMode={ displayMode }
 		/>
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A non-business plan user can purchase a Concierge Session in one of two ways:
1. Post checkout on signup or add new site, the user is redirected to a Concierge Session upsell nudge at `/checkout/{SITE_SLUG}/add-quickstart-session`
2. We may sometimes give the user a direct link to purchase the session (check p7DVsv-65B-p2).

In the first case, after completing the purchase, the user is redirected to the site preview page (/view/{SITE_SLUG}).
In the second case, after completing the purchase, the user is redirected to a "Thank You" page.

In this PR:

* We add a "Schedule my session" button to the Thank You page.

![calypso localhost_3000_checkout_thank-you_vvb421499075 wordpress com_19267823_d=concierge](https://user-images.githubusercontent.com/1269602/56818552-7971d680-6865-11e9-8a28-17aa14b60f82.png)


* We add helpful text to the checklist page that describes the next steps for scheduling a call. 
(why checklist? Even though in the first case, we have site preview as the final destination post signup, in earlier iterations we have had Checklist page as the final destination, and it is not ruled out that this could happen again in future iterations).

<img width="1586" alt="Screenshot_2019-04-29_at_1_27_53_PM" src="https://user-images.githubusercontent.com/1269602/56892094-2fbf0100-6a9c-11e9-885f-0af4384ac704.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**
* On a site that was created at least 30 minutes ago, navigate to http://calypso.localhost:3000/checkout/{SITE_SLUG}/add-quickstart-session
* Complete the purchase of a Quickstart Session (aka concierge session). 
* Verify that you are redirected to the Thank You page(as in the screenshot above).
* Click the `Schedule my session` button and verify that you are redirected to the Scheduler.
* Repeat steps above with http://calypso.localhost:3000/checkout/{SITE_SLUG}/add-support-session

**Scenario 2**
* In your browser, navigate to `/checklist/{SITE_SLUG}?d=concierge`.  Verify that you are redirected to the Checklist page with helpful text on next steps for scheduling a call(check screenshot above). 