### PR TITLE
Domains: add A/B test for select button

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -31,6 +31,7 @@ import ProgressBar from 'components/progress-bar';
 import { getDomainPrice, getDomainSalePrice, getTld, isHstsRequired } from 'lib/domains';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
 import { getProductsList } from 'state/products-list/selectors';
+import { hasDomainCredit } from 'state/sites/plans/selectors';
 import Badge from 'components/badge';
 import InfoPopover from 'components/info-popover';
 import { HTTPS_SSL } from 'lib/url/support';
@@ -126,6 +127,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			suggestion,
 			translate,
 			pendingCheckSuggestion,
+			siteHasDomainCredit,
 		} = this.props;
 		const { domain_name: domain } = suggestion;
 		const isAdded = hasDomainInCart( cart, domain );
@@ -144,7 +146,7 @@ class DomainRegistrationSuggestion extends React.Component {
 			} );
 
 			buttonStyles = { ...buttonStyles, primary: false };
-		} else if ( isSignupStep ) {
+		} else if ( isSignupStep || siteHasDomainCredit ) {
 			buttonContent = translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		} else {
 			buttonContent = shouldBundleDomainWithPlan(
@@ -337,11 +339,13 @@ const mapStateToProps = ( state, props ) => {
 	const productSlug = get( props, 'suggestion.product_slug' );
 	const productsList = getProductsList( state );
 	const currentUserCurrencyCode = getCurrentUserCurrencyCode( state );
+	const siteId = get( props, 'selectedSite.ID' );
 
 	return {
 		showHstsNotice: isHstsRequired( productSlug, productsList ),
 		productCost: getDomainPrice( productSlug, productsList, currentUserCurrencyCode ),
 		productSaleCost: getDomainSalePrice( productSlug, productsList, currentUserCurrencyCode ),
+		siteHasDomainCredit: hasDomainCredit( state, siteId ),
 	};
 };
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -14,6 +14,7 @@ import page from 'page';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
 import DomainSuggestion from 'components/domains/domain-suggestion';
 import {
 	shouldBundleDomainWithPlan,
@@ -131,6 +132,10 @@ class DomainRegistrationSuggestion extends React.Component {
 
 		let buttonContent;
 		let buttonStyles = this.props.buttonStyles;
+		const buttonCopyTest =
+			abtest( 'domainSelectButtonCopy' ) === 'purchase'
+				? translate( 'Purchase', { context: 'Domain mapping suggestion button' } )
+				: translate( 'Select', { context: 'Domain mapping suggestion button' } );
 
 		if ( isAdded ) {
 			buttonContent = translate( '{{checkmark/}} In Cart', {
@@ -139,14 +144,19 @@ class DomainRegistrationSuggestion extends React.Component {
 			} );
 
 			buttonStyles = { ...buttonStyles, primary: false };
+		} else if ( isSignupStep ) {
+			buttonContent = translate( 'Select', { context: 'Domain mapping suggestion button' } );
 		} else {
-			buttonContent =
-				! isSignupStep &&
-				shouldBundleDomainWithPlan( domainsWithPlansOnly, selectedSite, cart, suggestion )
-					? translate( 'Upgrade', {
-							context: 'Domain mapping suggestion button with plan upgrade',
-					  } )
-					: translate( 'Select', { context: 'Domain mapping suggestion button' } );
+			buttonContent = shouldBundleDomainWithPlan(
+				domainsWithPlansOnly,
+				selectedSite,
+				cart,
+				suggestion
+			)
+				? translate( 'Upgrade', {
+						context: 'Domain mapping suggestion button with plan upgrade',
+				  } )
+				: buttonCopyTest;
 		}
 
 		if ( this.isUnavailableDomain( suggestion.domain_name ) ) {

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -136,8 +136,8 @@ class DomainRegistrationSuggestion extends React.Component {
 		let buttonStyles = this.props.buttonStyles;
 		const buttonCopyTest =
 			abtest( 'domainSelectButtonCopy' ) === 'purchase'
-				? translate( 'Purchase', { context: 'Domain mapping suggestion button' } )
-				: translate( 'Select', { context: 'Domain mapping suggestion button' } );
+				? translate( 'Purchase', { context: 'verb' } )
+				: translate( 'Select', { context: 'Domain suggestion button' } );
 
 		if ( isAdded ) {
 			buttonContent = translate( '{{checkmark/}} In Cart', {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -135,4 +135,13 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	domainSelectButtonCopy: {
+		datestamp: '20190426',
+		variations: {
+			select: 50,
+			purchase: 50,
+		},
+		defaultVariation: 'select',
+		allowExistingUsers: true,
+	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an A/B test for the button to choose a domain. Two variations are `Select` and `Purchase`

The test will only affect the button copy on an existing site that can purchase a domain without upgrading — it already has a domain using the plan credit, or the account is older than "domains with plan only".

<img width="803" alt="Screen Shot 2019-04-26 at 11 05 10" src="https://user-images.githubusercontent.com/448298/56820863-fc217400-681a-11e9-87a5-1dfe7869f065.png">

If going through signup, the button should always say "Select" since you're selecting it and moving on to plan selection.

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/448298/56820922-1eb38d00-681b-11e9-95f8-74d4b47e6d8e.png">

If searching for a domain on an existing site that needs to be upgraded to purchase, the button should say "Upgrade".

<img width="753" alt="Screen Shot 2019-04-26 at 11 17 55" src="https://user-images.githubusercontent.com/448298/56820853-f3c93900-681a-11e9-9d21-9b36d61f30a7.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch or open the calypso.live link
* Put yourself in the `select` variation of `domainSelectButtonCopy` A/B test using the environment badge at the bottom of the screen
* Select an account/site that already has a domain or is not "domains with plan only" (i.e. you can purchase a domain for the site without needing to upgrade).
* Go to Domains > Add to search for a domain
* Confirm the button for each domain says "Select"
* Change to the `purchase` variation of the test, the page will reload
* Confirm the button for each domain says "Purchase"
* Create a new site
* Confirm the buttons at the domain step say "Select"
* Go to a site that doesn't have a plan and needs to be upgraded to purchase a domain
* Confirm the button says "Upgrade" when searching for a domain

Fixes #32526
