### PR TITLE
Add Marketing Tool Google My Business Card

### DIFF
--- a/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
+++ b/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
@@ -16,27 +16,27 @@ import { hasFeature } from 'state/sites/plans/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-interface ConnectProps {
+interface ConnectedProps {
 	hasPlanFeature: boolean;
 	planTitle: string;
 	selectedSiteSlug: string | null;
 }
 
-interface OwnProps {
+interface ExternalProps {
 	buttonText: string;
 	feature: string;
 	handleButtonClick: () => void;
-	minPlanSlug: string;
+	planSlug: string;
 	upgradeClickEvent?: string;
 }
 
-const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent< OwnProps & ConnectProps > = ( {
+const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent< ExternalProps & ConnectedProps > = ( {
 	buttonText,
 	feature,
 	handleButtonClick,
 	hasPlanFeature,
+	planSlug,
 	planTitle,
-	minPlanSlug,
 	selectedSiteSlug,
 	upgradeClickEvent,
 } ) => {
@@ -45,11 +45,11 @@ const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent< OwnProps & Con
 	const handleUpgradeClick = () => {
 		if ( upgradeClickEvent ) {
 			recordTracksEvent( upgradeClickEvent, {
-				plan_slug: minPlanSlug,
+				plan_slug: planSlug,
 				feature,
 			} );
 		}
-		page( addQueryArgs( { plan: minPlanSlug }, `/plans/${ selectedSiteSlug }` ) );
+		page( addQueryArgs( { plan: planSlug }, `/plans/${ selectedSiteSlug }` ) );
 	};
 
 	if ( hasPlanFeature ) {
@@ -67,11 +67,11 @@ const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent< OwnProps & Con
 	);
 };
 
-export default connect< ConnectProps, {}, OwnProps >( ( state, { feature, minPlanSlug } ) => {
+export default connect< ConnectedProps, {}, ExternalProps >( ( state, { feature, planSlug } ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
 		hasPlanFeature: selectedSiteId ? hasFeature( state, selectedSiteId, feature ) : false,
-		planTitle: getPlan( minPlanSlug ).getTitle(),
+		planTitle: getPlan( planSlug ).getTitle(),
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	};
 } )( MarketingToolsFeatureButtonWithPlanGate );

--- a/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
+++ b/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
@@ -14,7 +14,6 @@ import Button from 'components/button';
 import { getPlan } from 'lib/plans';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
 
 interface ConnectedProps {
 	hasPlanFeature: boolean;

--- a/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
+++ b/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
@@ -25,35 +25,32 @@ interface ConnectedProps {
 interface ExternalProps {
 	buttonText: string;
 	feature: string;
-	handleButtonClick: () => void;
+	onDefaultButtonClick: () => void;
+	onUpgradeButtonClick: () => void;
 	planSlug: string;
-	upgradeClickEvent?: string;
 }
 
 const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent< ExternalProps & ConnectedProps > = ( {
 	buttonText,
-	feature,
-	handleButtonClick,
 	hasPlanFeature,
+	onDefaultButtonClick,
+	onUpgradeButtonClick,
 	planSlug,
 	planTitle,
 	selectedSiteSlug,
-	upgradeClickEvent,
 } ) => {
 	const translate = useTranslate();
 
 	const handleUpgradeClick = () => {
-		if ( upgradeClickEvent ) {
-			recordTracksEvent( upgradeClickEvent, {
-				plan_slug: planSlug,
-				feature,
-			} );
+		if ( onUpgradeButtonClick ) {
+			onUpgradeButtonClick();
 		}
+
 		page( addQueryArgs( { plan: planSlug }, `/plans/${ selectedSiteSlug }` ) );
 	};
 
 	if ( hasPlanFeature ) {
-		return <Button onClick={ handleButtonClick }>{ buttonText }</Button>;
+		return <Button onClick={ onDefaultButtonClick }>{ buttonText }</Button>;
 	}
 
 	return (
@@ -69,6 +66,7 @@ const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent< ExternalProps 
 
 export default connect< ConnectedProps, {}, ExternalProps >( ( state, { feature, planSlug } ) => {
 	const selectedSiteId = getSelectedSiteId( state );
+
 	return {
 		hasPlanFeature: selectedSiteId ? hasFeature( state, selectedSiteId, feature ) : false,
 		planTitle: getPlan( planSlug ).getTitle(),

--- a/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
+++ b/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
@@ -58,7 +58,7 @@ const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent< OwnProps & Con
 
 	return (
 		<Button onClick={ handleUpgradeClick }>
-			{ translate( 'Upgrade to %(plan)s', {
+			{ translate( 'Upgrade To %(plan)s', {
 				args: {
 					plan: planTitle,
 				},

--- a/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
+++ b/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React, { FunctionComponent } from 'react';
+import page from 'page';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { addQueryArgs } from 'lib/url';
+import Button from 'components/button';
+import { getPlan } from 'lib/plans';
+import { hasFeature } from 'state/sites/plans/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
+
+interface ConnectProps {
+	hasPlanFeature: boolean;
+	planTitle: string;
+	selectedSiteSlug: string | null;
+}
+
+interface OwnProps {
+	buttonText: string;
+	feature: string;
+	handleButtonClick: () => void;
+	minPlanSlug: string;
+	upgradeClickEvent?: string;
+}
+
+const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent< OwnProps & ConnectProps > = ( {
+	buttonText,
+	feature,
+	handleButtonClick,
+	hasPlanFeature,
+	planTitle,
+	minPlanSlug,
+	selectedSiteSlug,
+	upgradeClickEvent,
+} ) => {
+	const translate = useTranslate();
+
+	const handleUpgradeClick = () => {
+		if ( upgradeClickEvent ) {
+			recordTracksEvent( upgradeClickEvent, {
+				plan_slug: minPlanSlug,
+				feature,
+			} );
+		}
+		page( addQueryArgs( { plan: minPlanSlug }, `/plans/${ selectedSiteSlug }` ) );
+	};
+
+	if ( hasPlanFeature ) {
+		return <Button onClick={ handleButtonClick }>{ buttonText }</Button>;
+	}
+
+	return (
+		<Button onClick={ handleUpgradeClick }>
+			{ translate( 'Upgrade to %(plan)s', {
+				args: {
+					plan: planTitle,
+				},
+			} ) }
+		</Button>
+	);
+};
+
+export default connect< ConnectProps, {}, OwnProps >( ( state, { feature, minPlanSlug } ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+	return {
+		hasPlanFeature: selectedSiteId ? hasFeature( state, selectedSiteId, feature ) : false,
+		planTitle: getPlan( minPlanSlug ).getTitle(),
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+	};
+} )( MarketingToolsFeatureButtonWithPlanGate );

--- a/client/my-sites/marketing/tools/google-my-business-feature.tsx
+++ b/client/my-sites/marketing/tools/google-my-business-feature.tsx
@@ -10,9 +10,9 @@ import { useTranslate } from 'i18n-calypso';
  * Internal dependencies
  */
 import Button from 'components/button';
+import { FEATURE_GOOGLE_MY_BUSINESS, PLAN_BUSINESS } from 'lib/plans/constants';
 import getGoogleMyBusinessConnectedLocation from 'state/selectors/get-google-my-business-connected-location';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
-import { FEATURE_GOOGLE_MY_BUSINESS, PLAN_BUSINESS } from 'lib/plans/constants';
 import MarketingToolsFeature from './feature';
 import MarketingToolsFeatureButtonWithPlanGate from './feature-button-with-plan-gate';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';

--- a/client/my-sites/marketing/tools/google-my-business-feature.tsx
+++ b/client/my-sites/marketing/tools/google-my-business-feature.tsx
@@ -62,7 +62,7 @@ const MarketingToolsGoogleMyBusinessFeature: FunctionComponent< Props > = ( {
 					/>
 				) : (
 					<Button onClick={ handleGoToGoogleMyBusinessClick }>
-						{ translate( 'Go to Google My Business' ) }
+						{ translate( 'Go To Google My Business' ) }
 					</Button>
 				) }
 			</MarketingToolsFeature>

--- a/client/my-sites/marketing/tools/google-my-business-feature.tsx
+++ b/client/my-sites/marketing/tools/google-my-business-feature.tsx
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import page from 'page';
+import React, { Fragment, FunctionComponent } from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import getGoogleMyBusinessConnectedLocation from 'state/selectors/get-google-my-business-connected-location';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import { FEATURE_GOOGLE_MY_BUSINESS, PLAN_BUSINESS } from 'lib/plans/constants';
+import MarketingToolsFeature from './feature';
+import MarketingToolsFeatureButtonWithPlanGate from './feature-button-with-plan-gate';
+import QueryKeyringConnections from 'components/data/query-keyring-connections';
+import QueryKeyringServices from 'components/data/query-keyring-services';
+import QuerySiteKeyrings from 'components/data/query-site-keyrings';
+
+interface Props {
+	connectedGoogleMyBusinessLocation?: null | any[];
+	selectedSiteId: number | null;
+	selectedSiteSlug: string | null;
+}
+
+const MarketingToolsGoogleMyBusinessFeature: FunctionComponent< Props > = ( {
+	connectedGoogleMyBusinessLocation,
+	selectedSiteId,
+	selectedSiteSlug,
+} ) => {
+	const handleConnectToGoogleMyBusinessClick = () => {
+		page( `/google-my-business/${ selectedSiteSlug || '' }` );
+	};
+
+	const handleGoToGoogleMyBusinessClick = () => {
+		page( `/google-my-business/${ selectedSiteSlug || '' }` );
+	};
+
+	const translate = useTranslate();
+
+	return (
+		<Fragment>
+			{ selectedSiteId && <QuerySiteKeyrings siteId={ selectedSiteId } /> }
+			<QueryKeyringConnections forceRefresh />
+			<QueryKeyringServices />
+
+			<MarketingToolsFeature
+				description={ translate(
+					'Get ahead of your competition. Be there when customers search businesses like yours on Google Search and Maps by connecting to Google My Business.'
+				) }
+				imagePath="/calypso/images/illustrations/business.svg"
+				title={ translate( 'Let your customers find you on Google' ) }
+			>
+				{ ! connectedGoogleMyBusinessLocation ? (
+					<MarketingToolsFeatureButtonWithPlanGate
+						buttonText={ translate( 'Connect to Google My Business' ) }
+						feature={ FEATURE_GOOGLE_MY_BUSINESS }
+						minPlanSlug={ PLAN_BUSINESS }
+						handleButtonClick={ handleConnectToGoogleMyBusinessClick }
+					/>
+				) : (
+					<Button onClick={ handleGoToGoogleMyBusinessClick }>
+						{ translate( 'Go to Google My Business' ) }
+					</Button>
+				) }
+			</MarketingToolsFeature>
+		</Fragment>
+	);
+};
+
+export default connect( state => {
+	const selectedSiteId = getSelectedSiteId( state );
+	return {
+		connectedGoogleMyBusinessLocation: getGoogleMyBusinessConnectedLocation(
+			state,
+			selectedSiteId
+		),
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+		selectedSiteId,
+	};
+} )( MarketingToolsGoogleMyBusinessFeature );

--- a/client/my-sites/marketing/tools/google-my-business-feature.tsx
+++ b/client/my-sites/marketing/tools/google-my-business-feature.tsx
@@ -57,7 +57,7 @@ const MarketingToolsGoogleMyBusinessFeature: FunctionComponent< Props > = ( {
 					<MarketingToolsFeatureButtonWithPlanGate
 						buttonText={ translate( 'Connect to Google My Business' ) }
 						feature={ FEATURE_GOOGLE_MY_BUSINESS }
-						minPlanSlug={ PLAN_BUSINESS }
+						planSlug={ PLAN_BUSINESS }
 						handleButtonClick={ handleConnectToGoogleMyBusinessClick }
 					/>
 				) : (

--- a/client/my-sites/marketing/tools/google-my-business-feature.tsx
+++ b/client/my-sites/marketing/tools/google-my-business-feature.tsx
@@ -18,24 +18,38 @@ import MarketingToolsFeatureButtonWithPlanGate from './feature-button-with-plan-
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
 import QueryKeyringServices from 'components/data/query-keyring-services';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 interface Props {
 	connectedGoogleMyBusinessLocation?: null | any[];
+	recordTracksEvent: () => void;
 	selectedSiteId: number | null;
 	selectedSiteSlug: string | null;
 }
 
 const MarketingToolsGoogleMyBusinessFeature: FunctionComponent< Props > = ( {
 	connectedGoogleMyBusinessLocation,
+	recordTracksEvent,
 	selectedSiteId,
 	selectedSiteSlug,
 } ) => {
 	const handleConnectToGoogleMyBusinessClick = () => {
-		page( `/google-my-business/${ selectedSiteSlug || '' }` );
+		recordTracksEvent( 'calypso_marketing_tools_connect_to_google_my_business_button_click' );
+
+		page( `/google-my-business/new/${ selectedSiteSlug || '' }` );
 	};
 
 	const handleGoToGoogleMyBusinessClick = () => {
-		page( `/google-my-business/${ selectedSiteSlug || '' }` );
+		recordTracksEvent( 'calypso_marketing_tools_go_to_google_my_business_button_click' );
+
+		page( `/google-my-business/stats/${ selectedSiteSlug || '' }` );
+	};
+
+	const handleUpgradeToBusinessPlanClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_google_my_business_upgrade_to_business_button_click', {
+			plan_slug: PLAN_BUSINESS,
+			feature: FEATURE_GOOGLE_MY_BUSINESS,
+		} );
 	};
 
 	const translate = useTranslate();
@@ -57,8 +71,9 @@ const MarketingToolsGoogleMyBusinessFeature: FunctionComponent< Props > = ( {
 					<MarketingToolsFeatureButtonWithPlanGate
 						buttonText={ translate( 'Connect to Google My Business' ) }
 						feature={ FEATURE_GOOGLE_MY_BUSINESS }
+						onDefaultButtonClick={ handleConnectToGoogleMyBusinessClick }
+						onUpgradeButtonClick={ handleUpgradeToBusinessPlanClick }
 						planSlug={ PLAN_BUSINESS }
-						handleButtonClick={ handleConnectToGoogleMyBusinessClick }
 					/>
 				) : (
 					<Button onClick={ handleGoToGoogleMyBusinessClick }>
@@ -70,14 +85,20 @@ const MarketingToolsGoogleMyBusinessFeature: FunctionComponent< Props > = ( {
 	);
 };
 
-export default connect( state => {
-	const selectedSiteId = getSelectedSiteId( state );
-	return {
-		connectedGoogleMyBusinessLocation: getGoogleMyBusinessConnectedLocation(
-			state,
-			selectedSiteId
-		),
-		selectedSiteSlug: getSelectedSiteSlug( state ),
-		selectedSiteId,
-	};
-} )( MarketingToolsGoogleMyBusinessFeature );
+export default connect(
+	state => {
+		const selectedSiteId = getSelectedSiteId( state );
+
+		return {
+			connectedGoogleMyBusinessLocation: getGoogleMyBusinessConnectedLocation(
+				state,
+				selectedSiteId
+			),
+			selectedSiteSlug: getSelectedSiteSlug( state ),
+			selectedSiteId,
+		};
+	},
+	{
+		recordTracksEvent: recordTracksEventAction,
+	}
+)( MarketingToolsGoogleMyBusinessFeature );

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -12,6 +12,7 @@ import { useTranslate } from 'i18n-calypso';
 import Button from 'components/button';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import MarketingToolsFeature from './feature';
+import MarketingToolsGoogleMyBusinessFeature from './google-my-business-feature';
 import MarketingToolsHeader from './header';
 import { marketingSharingButtons, marketingTraffic } from 'my-sites/marketing/paths';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
@@ -93,6 +94,8 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 						{ translate( 'Create A Logo' ) }
 					</Button>
 				</MarketingToolsFeature>
+
+				<MarketingToolsGoogleMyBusinessFeature />
 			</div>
 		</Fragment>
 	);

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -71,7 +71,7 @@ import PlanFeaturesScroller from './scroller';
 
 export class PlanFeatures extends Component {
 	render() {
-		const { isInSignup, planProperties, withScroll } = this.props;
+		const { isInSignup, planProperties, plans, selectedPlan, withScroll } = this.props;
 		const tableClasses = classNames(
 			'plan-features__table',
 			`has-${ planProperties.length }-cols`
@@ -92,6 +92,10 @@ export class PlanFeatures extends Component {
 			bottomButtons = <tr>{ this.renderBottomButtons() }</tr>;
 		}
 
+		const initialSelectedIndex = selectedPlan
+			? plans.indexOf( selectedPlan )
+			: findIndex( planProperties, { popular: true } );
+
 		return (
 			<div className={ planWrapperClasses }>
 				<QueryActivePromotions />
@@ -104,7 +108,7 @@ export class PlanFeatures extends Component {
 								withScroll={ withScroll }
 								planCount={ planProperties.length }
 								cellSelector=".plan-features__table-item"
-								initialSelectedIndex={ findIndex( planProperties, { popular: true } ) }
+								initialSelectedIndex={ initialSelectedIndex }
 							>
 								<table className={ tableClasses }>
 									<tbody>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Google My Business Card to marketing Tools

**Without Business**
<img width="400" alt="Screen Shot 2019-04-30 at 9 24 30 AM" src="https://user-images.githubusercontent.com/2810519/56977429-05b42000-6b2a-11e9-8740-5927c4b5b3a2.png">
**With Business - Not Connected to GMB Location**
<img width="400" alt="Screen Shot 2019-04-30 at 9 24 39 AM" src="https://user-images.githubusercontent.com/2810519/56977436-08167a00-6b2a-11e9-84cb-cf08f4036ca2.png">
**Connected to GMB**
<img width="400" alt="Screen Shot 2019-04-30 at 1 22 19 PM" src="https://user-images.githubusercontent.com/2810519/56990850-07421000-6b4b-11e9-9103-6878dc18ee3d.png">


#### Testing instructions

1. Navigate to `/marketing/tools/:siteSlug`
1. For each case above verify the new card matches
1. Confirm the "Upgrade to Business" button  goes to the plans page with the business plan "suggested"
1. Confirm the "Connect to Google My Business Button" goes to `/google-my-business/select-business-type/:siteSlug`