### PR TITLE
Gutenberg: Avoid Gutenframe flows on JP sites without SSL certs

### DIFF
--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -17,19 +17,19 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 		return false;
 	}
 
-	if ( isJetpackSite( state, siteId ) || isSiteAutomatedTransfer( state, siteId ) ) {
-		// We do want Gutenframe flows for JP/AT sites that have been updated to Jetpack 7.3 or greater since it will
-		// handle the required token verification. But only if the site has a SSL cert since the browser cannot embed
-		// insecure content in a resource loaded over a secure HTTPS connection.
-		if (
-			isEnabled( 'jetpack/gutenframe' ) &&
-			isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) &&
-			isHttps( getSiteAdminUrl( state, siteId ) )
-		) {
-			return false;
-		}
+	// We do want Gutenframe flows for JP/AT sites that have been updated to Jetpack 7.3 or greater since it will
+	// handle the required token verification. But only if the site has a SSL cert since the browser cannot embed
+	// insecure content in a resource loaded over a secure HTTPS connection.
+	if (
+		isEnabled( 'jetpack/gutenframe' ) &&
+		isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) &&
+		isHttps( getSiteAdminUrl( state, siteId ) )
+	) {
+		return false;
+	}
 
-		// Otherwise, we use Calypsoify flows
+	// We do want Calypsoify flows for Atomic sites
+	if ( isSiteAutomatedTransfer( state, siteId ) ) {
 		const wpVersion = getWordPressVersion( state, siteId );
 
 		// But not if they activated Classic editor plugin (effectively opting out of Gutenberg)
@@ -53,7 +53,7 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 	}
 
 	// Not ready yet.
-	if ( isVipSite( state, siteId ) ) {
+	if ( isJetpackSite( state, siteId ) || isVipSite( state, siteId ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -1,19 +1,13 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { isEnabled } from 'config';
-import getSiteOptions from 'state/selectors/get-site-options';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import isVipSite from 'state/selectors/is-vip-site';
-import { isJetpackSite } from 'state/sites/selectors';
-import versionCompare from 'lib/version-compare';
+import { isJetpackSite, getSiteAdminUrl, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { isHttps } from 'lib/url';
 
 export const isGutenbergEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
@@ -24,16 +18,15 @@ export const isGutenbergEnabled = ( state, siteId ) => {
 		return true;
 	}
 
-	if ( isEnabled( 'jetpack/gutenframe' ) ) {
-		if (
-			versionCompare(
-				get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ),
-				'7.3-alpha',
-				'>='
-			)
-		) {
-			return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
-		}
+	// We do want Gutenframe flows for JP/AT sites that have been updated to Jetpack 7.3 or greater since it will
+	// handle the required token verification. But only if the site has a SSL cert since the browser cannot embed
+	// insecure content in a resource loaded over a secure HTTPS connection.
+	if (
+		isEnabled( 'jetpack/gutenframe' ) &&
+		isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) &&
+		isHttps( getSiteAdminUrl( state, siteId ) )
+	) {
+		return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
 	}
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to avoid a [Mixed Content](https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content) failure when iframing in Calypso the block editor of a JP site without a SSL cert, we now check the protocol of the WP Admin URL before determining we want to use Gutenframe flows for the site.

If the WP Admin URL protocol is not `https`, then we redirect the user to Calypso classic editor as we currently do on production.

#### Testing instructions

* Make sure you have a Jetpack site connected to WordPress.com that does not have SSL certs. A local [Jetpack Docker+Ngrok environment](https://github.com/Automattic/jetpack/tree/master/docker) would be an example.
* Load that Jetpack site in the block editor: `/block-editor/post/:jetpackDomain`.
* Confirm you're redirected to the Calypso classic editor.

Fixes #32626
