### PR TITLE
Full Site Editing: Docker environment

### DIFF
--- a/apps/full-site-editing/.gitignore
+++ b/apps/full-site-editing/.gitignore
@@ -1,0 +1,11 @@
+## Things for docker-composer
+/docker/data/mysql/*
+!/docker/data/mysql/.gitkeep
+/docker/logs/*
+!/docker/logs/.gitkeep
+# Custom environment for docker containers
+/docker/.env
+/docker/wordpress-develop/*
+!/docker/wordpress-develop/.gitkeep
+/docker/wordpress/*
+!/docker/wordpress/.gitkeep

--- a/apps/full-site-editing/docker/Dockerfile
+++ b/apps/full-site-editing/docker/Dockerfile
@@ -1,0 +1,87 @@
+FROM ubuntu:xenial
+
+VOLUME ["/var/www/html"]
+
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+# Install required Ubuntu packages for having Apache PHP as a module
+# as well a bunch of other packages
+RUN \
+	apt-get update \
+	&& apt-get install -y language-pack-en-base software-properties-common \
+	&& add-apt-repository ppa:ondrej/php \
+	&& apt-get update \
+	&& apt-get install -y \
+		apache2 \
+		composer \
+		curl \
+		less \
+		libapache2-mod-php7.3 \
+		libsodium23 \
+		mysql-client \
+		nano \
+		php-apcu \
+		php-xdebug \
+		php7.3 \
+		php7.3-bcmath \
+		php7.3-cli \
+		php7.3-curl \
+		php7.3-gd \
+		php7.3-imagick \
+		php7.3-json \
+		php7.3-ldap \
+		php7.3-mbstring \
+		php7.3-mysql \
+		php7.3-opcache \
+		php7.3-pgsql \
+		php7.3-soap \
+		php7.3-sqlite3 \
+		php7.3-xml \
+		php7.3-xsl \
+		php7.3-zip \
+		ssmtp \
+		subversion \
+		sudo \
+		vim \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Enable mod_rewrite in Apache
+RUN a2enmod rewrite
+
+# Install wp-cli
+RUN curl -o /usr/local/bin/wp -SL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli-nightly.phar \
+	&& chmod +x /usr/local/bin/wp
+
+# Install PHPUnit
+RUN curl https://phar.phpunit.de/phpunit-7.phar -L -o phpunit.phar \
+	&& chmod +x phpunit.phar \
+	&& mv phpunit.phar /usr/local/bin/phpunit
+
+# Copy a default config file for an apache host
+COPY ./config/apache_default /etc/apache2/sites-available/000-default.conf
+
+# Copy a default set of settings for PHP (php.ini)
+COPY ./config/php.ini /etc/php/7.3/apache2/conf.d/20-jetpack-wordpress.ini
+COPY ./config/php.ini /etc/php/7.3/cli/conf.d/20-jetpack-wordpress.ini
+
+# Copy single site htaccess to tmp. run.sh will move it to the site's base dir if there's none present.
+COPY ./config/htaccess /tmp/htaccess
+COPY ./config/htaccess-multi /tmp/htaccess-multi
+
+# Copy wp-tests-config to tmp. run.sh will move it to the WordPress source code base dir if there's none present.
+COPY ./config/wp-tests-config.php /tmp/wp-tests-config.php
+
+# Copy a default set of settings for SMTP.
+COPY ./config/ssmtp.conf /etc/ssmtp/ssmtp.conf
+
+# Copy our cmd bash script
+COPY ./bin/run.sh /usr/local/bin/run
+
+# Make our cmd script be executable
+RUN chmod +x /usr/local/bin/run
+
+# Set the working directory for the next commands
+WORKDIR /var/www/html
+
+CMD ["/usr/local/bin/run"]

--- a/apps/full-site-editing/docker/bin/install.sh
+++ b/apps/full-site-editing/docker/bin/install.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if $(wp --allow-root core is-installed); then
+	echo
+	echo "WordPress has already been installed. Uninstall it first by running:"
+	echo
+	echo "  npm run docker:uninstall"
+	echo
+	exit 1;
+fi
+
+# Install WP core
+wp --allow-root core install \
+	--url=${WP_DOMAIN} \
+	--title="${WP_TITLE}" \
+	--admin_user=${WP_ADMIN_USER} \
+	--admin_password=${WP_ADMIN_PASSWORD} \
+	--admin_email=${WP_ADMIN_EMAIL} \
+	--skip-email
+
+# Discourage search engines from indexing. Can be changed via UI in Settings->Reading.
+wp --allow-root option update blog_public 0
+
+# Install Query Monitor plugin
+# https://wordpress.org/plugins/query-monitor/
+wp --allow-root plugin install query-monitor --activate
+
+# Install and activate Gutenberg debugger
+# https://wordpress.org/plugins/g-debugger/
+wp --allow-root plugin install g-debugger
+wp --allow-root plugin activate g-debugger
+
+# Install and activate Jetpack
+wp --allow-root plugin install jetpack
+wp --allow-root plugin activate jetpack
+
+# Activate Full Site Editing plugin
+wp --allow-root plugin activate full-site-editing-plugin
+
+echo
+echo "WordPress installed. Open ${WP_DOMAIN}"
+echo

--- a/apps/full-site-editing/docker/bin/run.sh
+++ b/apps/full-site-editing/docker/bin/run.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -e
+
+# This file is run for the Docker image defined in Dockerfile.
+# These commands will be run each time the container is run.
+#
+# If you modify anything here, remember to build the image again by running:
+# yarn docker:build-image
+
+user="${APACHE_RUN_USER:-www-data}"
+group="${APACHE_RUN_GROUP:-www-data}"
+
+# Download WordPress
+[ -f /var/www/html/xmlrpc.php ] || wp --allow-root core download
+
+# Configure WordPress
+if [ ! -f /var/www/html/wp-config.php ]; then
+	echo "Creating wp-config.php ..."
+	# Loop until wp cli exits with 0
+	# because if running the containers for the first time,
+	# the mysql container will reject connections until it has set the database data
+	# See "No connections until MySQL init completes" in https://hub.docker.com/_/mysql/
+	times=15
+	i=1
+	while [ "$i" -le "$times" ]; do
+		sleep 3
+		wp --allow-root config create \
+			--dbhost=${MYSQL_HOST} \
+			--dbname=${MYSQL_DATABASE} \
+			--dbuser=${MYSQL_USER} \
+			--dbpass=${MYSQL_PASSWORD} \
+			&& break
+		[ ! $? -eq 0 ] || break;
+		echo "Waiting for creating wp-config.php until mysql is ready to receive connections"
+		(( i++ ))
+	done
+
+	echo "Setting other wp-config.php constants..."
+	wp --allow-root config set WP_DEBUG true --raw --type=constant
+	wp --allow-root config set WP_DEBUG_LOG true --raw --type=constant
+	wp --allow-root config set WP_DEBUG_DISPLAY false --raw --type=constant
+
+	# Respecting Dockerfile-forwarded environment variables
+	# Allow to be reverse-proxied from https
+	wp --allow-root config set "_SERVER['HTTPS']" "isset( \$_SERVER['HTTP_X_FORWARDED_PROTO'] ) && \$_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https' ? 'on' : NULL" \
+		--raw \
+		--type=variable
+
+	# Allow this installation to run on http or https.
+	wp --allow-root config set DOCKER_REQUEST_URL \
+		"( ! empty( \$_SERVER['HTTPS'] ) ? 'https://' : 'http://' ) . ( ! empty( \$_SERVER['HTTP_HOST'] ) ? \$_SERVER['HTTP_HOST'] : 'localhost' )" \
+		--raw \
+		--type=constant
+	wp --allow-root config set WP_SITEURL "DOCKER_REQUEST_URL" --raw --type=constant
+	wp --allow-root config set WP_HOME "DOCKER_REQUEST_URL" --raw --type=constant
+fi
+
+# Copy single site htaccess if none is present
+if [ ! -f /var/www/html/.htaccess ]; then
+	cp /tmp/htaccess /var/www/html/.htaccess
+fi
+
+# If we don't have the wordpress test helpers, download them
+if [ ! -d /tmp/wordpress-develop/tests ]; then
+	# Get latest WordPress unit-test helper files
+	svn co \
+		https://develop.svn.wordpress.org/trunk/tests/phpunit/data \
+		/tmp/wordpress-develop/tests/phpunit/data \
+		--trust-server-cert \
+		--non-interactive
+	svn co \
+		https://develop.svn.wordpress.org/trunk/tests/phpunit/includes \
+		/tmp/wordpress-develop/tests/phpunit/includes \
+		--trust-server-cert \
+		--non-interactive
+fi
+
+# Create a wp-tests-config.php if there's none currently
+if [ ! -f /tmp/wordpress-develop/wp-tests-config.php ]; then
+	cp /tmp/wp-tests-config.php /tmp/wordpress-develop/wp-tests-config.php
+fi
+
+WP_HOST_PORT=":$HOST_PORT"
+
+if [ 80 -eq "$HOST_PORT" ]; then
+	WP_HOST_PORT=""
+fi
+
+echo
+echo "Open http://${WP_DOMAIN}${WP_HOST_PORT}/ to see your site!"
+echo
+
+# Run apache in the foreground so the container keeps running
+echo "Running Apache in the foreground"
+apachectl -D FOREGROUND

--- a/apps/full-site-editing/docker/bin/tail.sh
+++ b/apps/full-site-editing/docker/bin/tail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+WP_DEBUG_LOG=/var/www/html/wp-content/debug.log
+
+if [ ! -e "$WP_DEBUG_LOG" ] ; then
+	touch "$WP_DEBUG_LOG"
+fi
+
+tail -F --lines 100 "$WP_DEBUG_LOG"

--- a/apps/full-site-editing/docker/bin/uninstall.sh
+++ b/apps/full-site-editing/docker/bin/uninstall.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Empty DB
+wp --allow-root db reset --yes
+
+# Ensure we have single-site htaccess instead of multisite,
+# just like we would have in fresh container.
+cp -f /tmp/htaccess /var/www/html/.htaccess
+
+# Remove "uploads" and "upgrade" folders
+rm -fr /var/www/html/wp-content/uploads /var/www/html/wp-content/upgrade
+
+# Empty WP debug log
+truncate -s 0 /var/www/html/wp-content/debug.log
+
+# Ensure wp-config.php doesn't have multi-site settings
+echo
+echo "Clearing out possible multi-site related settings from wp-config.php"
+echo "It's okay to see errors if these did't exist..."
+wp --allow-root config delete WP_ALLOW_MULTISITE
+wp --allow-root config delete MULTISITE
+wp --allow-root config delete SUBDOMAIN_INSTALL
+wp --allow-root config delete base
+wp --allow-root config delete DOMAIN_CURRENT_SITE
+wp --allow-root config delete PATH_CURRENT_SITE
+wp --allow-root config delete SITE_ID_CURRENT_SITE
+wp --allow-root config delete BLOG_ID_CURRENT_SITE
+
+echo
+echo "WordPress uninstalled. To install it again, run:"
+echo
+echo "  yarn docker:install"
+echo

--- a/apps/full-site-editing/docker/config/apache_default
+++ b/apps/full-site-editing/docker/config/apache_default
@@ -1,0 +1,39 @@
+ServerName localhost
+
+<VirtualHost *:80>
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	ServerName localhost
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+
+		<Directory /var/www/html>
+				AllowOverride All
+				Require all granted
+		</Directory>
+
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+		# ErrorLog /var/log/apache-errors.log
+		# CustomLog /var/log/apache-access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/apps/full-site-editing/docker/config/htaccess
+++ b/apps/full-site-editing/docker/config/htaccess
@@ -1,0 +1,10 @@
+# BEGIN WordPress
+<IfModule mod_rewrite.c>
+	RewriteEngine On
+	RewriteBase /
+	RewriteRule ^index\.php$ - [L]
+	RewriteCond %{REQUEST_FILENAME} !-f
+	RewriteCond %{REQUEST_FILENAME} !-d
+	RewriteRule . /index.php [L]
+</IfModule>
+# END WordPress

--- a/apps/full-site-editing/docker/config/php.ini
+++ b/apps/full-site-editing/docker/config/php.ini
@@ -1,0 +1,16 @@
+short_open_tag = Off
+session.auto_start = Off
+file_uploads = On
+memory_limit = 64M
+upload_max_filesize = 64M
+post_max_size = 64M
+display_errors = On
+error_reporting = E_ALL
+error_log = /var/log/php/errors.log
+sendmail_path = /usr/sbin/ssmtp -t
+xdebug.remote_enable = On
+xdebug.remote_host = docker.for.mac.localhost
+xdebug.remote_handler = dbgp
+xdebug.profiler_enable = Off;
+xdebug.profiler_enable_trigger = On;
+xdebug.profiler_output_dir = "/var/www/html"

--- a/apps/full-site-editing/docker/config/ssmtp.conf
+++ b/apps/full-site-editing/docker/config/ssmtp.conf
@@ -1,0 +1,23 @@
+#
+# Config file for sSMTP sendmail
+#
+# The person who gets all mail for userids < 1000
+# Make this empty to disable rewriting.
+root=postmaster
+
+# The place where the mail goes.
+mailhub=maildev:25
+#UseSTARTTLS=NO
+#AuthUser=
+#AuthPass=
+
+# Where will the mail seem to come from?
+#rewriteDomain=
+
+# The full hostname
+hostname=localhost
+
+# Are users allowed to set their own From: address?
+# YES - Allow the user to specify their own From: address
+# NO - Use the system generated From: address
+#FromLineOverride=YES

--- a/apps/full-site-editing/docker/config/wp-tests-config.php
+++ b/apps/full-site-editing/docker/config/wp-tests-config.php
@@ -1,0 +1,77 @@
+<?php
+
+/* Path to the WordPress codebase you'd like to test. Add a forward slash in the end. */
+define( 'ABSPATH', '/var/www/html/' );
+
+/*
+ * Path to the theme to test with.
+ *
+ * The 'default' theme is symlinked from test/phpunit/data/themedir1/default into
+ * the themes directory of the WordPress installation defined above.
+ */
+define( 'WP_DEFAULT_THEME', 'default' );
+
+// Test with multisite enabled.
+// Alternatively, use the tests/phpunit/multisite.xml configuration file.
+// define( 'WP_TESTS_MULTISITE', true );
+
+// Force known bugs to be run.
+// Tests with an associated Trac ticket that is still open are normally skipped.
+// define( 'WP_TESTS_FORCE_KNOWN_BUGS', true );
+
+// Test with WordPress debug mode (default).
+define( 'WP_DEBUG', true );
+
+// Enable error logging for tests
+define( 'WP_DEBUG_LOG', true );
+
+// Additional constants for better error log
+@error_reporting( E_ALL );
+@ini_set( 'log_errors', true );
+@ini_set( 'log_errors_max_len', '0' );
+
+define( 'WP_DEBUG_DISPLAY', false );
+define( 'CONCATENATE_SCRIPTS', false );
+define( 'SCRIPT_DEBUG', true );
+define( 'SAVEQUERIES', true );
+
+// ** MySQL settings ** //
+
+// This configuration file will be used by the copy of WordPress being tested.
+// wordpress/wp-config.php will be ignored.
+
+// WARNING WARNING WARNING!
+// These tests will DROP ALL TABLES in the database with the prefix named below.
+// DO NOT use a production database or one that is shared with something else.
+
+define( 'DB_NAME', getenv( 'MYSQL_DATABASE' ) );
+define( 'DB_USER', getenv( 'MYSQL_USER' ) );
+define( 'DB_PASSWORD', getenv( 'MYSQL_PASSWORD' ) );
+define( 'DB_HOST', getenv( 'MYSQL_HOST' ) );
+define( 'DB_CHARSET', 'utf8' );
+define( 'DB_COLLATE', '' );
+
+/**#@+
+ * Authentication Unique Keys and Salts.
+ *
+ * Change these to different unique phrases!
+ * You can generate these using the {@link https://api.wordpress.org/secret-key/1.1/salt/ WordPress.org secret-key service}
+ */
+define( 'AUTH_KEY',         'put your unique phrase here' );
+define( 'SECURE_AUTH_KEY',  'put your unique phrase here' );
+define( 'LOGGED_IN_KEY',    'put your unique phrase here' );
+define( 'NONCE_KEY',        'put your unique phrase here' );
+define( 'AUTH_SALT',        'put your unique phrase here' );
+define( 'SECURE_AUTH_SALT', 'put your unique phrase here' );
+define( 'LOGGED_IN_SALT',   'put your unique phrase here' );
+define( 'NONCE_SALT',       'put your unique phrase here' );
+
+$table_prefix = 'wptests_';   // Only numbers, letters, and underscores please!
+
+define( 'WP_TESTS_DOMAIN', 'example.org' );
+define( 'WP_TESTS_EMAIL', 'admin@example.org' );
+define( 'WP_TESTS_TITLE', 'Test Blog' );
+
+define( 'WP_PHP_BINARY', 'php' );
+
+define( 'WPLANG', '' );

--- a/apps/full-site-editing/docker/default.env
+++ b/apps/full-site-editing/docker/default.env
@@ -1,0 +1,32 @@
+# Default configuration for Docker containers.
+#
+# To modify, copy values over to ".env" file.
+# Values in ".env" file will override values
+# in "default.env".
+#
+# Values passed via command-line arguments take precedence over .env files:
+# $ WP_DOMAIN=example.com yarn docker:up
+#
+# Note that there is no special handling of quotation marks.
+# This means that they are part of the value.
+#
+# Note that these variables are not available in docker-compose.yml
+# Variables show up defined inside containers only.
+
+# WordPress - Only WP_ADMIN_PASSWORD needs to be changed
+WP_DOMAIN=localhost
+WP_ADMIN_USER=wordpress
+WP_ADMIN_EMAIL=wordpress@example.com
+# If this site is or will be publicly accessible, change WP_ADMIN_PASSWORD to something unique and secure
+WP_ADMIN_PASSWORD=wordpress
+WP_TITLE=HelloWord
+
+# Database - No changes necessary
+MYSQL_HOST=db:3306
+MYSQL_DATABASE=wordpress
+MYSQL_USER=wordpress
+MYSQL_PASSWORD=wordpress
+MYSQL_ROOT_PASSWORD=wordpress
+
+# Xdebug
+PHP_IDE_CONFIG=serverName=Test

--- a/apps/full-site-editing/docker/docker-compose.yml
+++ b/apps/full-site-editing/docker/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '3.3'
+
+services:
+  ## A default mysql image
+  ## We map a local directory (data/mysql) so we can have the mysql data locally
+  ## and reuse it if we need to remove containers and images for rebuilding from scratch.
+  db:
+    container_name: full_site_editing_mysql
+    image: mysql:5.7
+    volumes:
+      - ./data/mysql:/var/lib/mysql
+    restart: always
+    ports:
+      - "${PORT_MYSQL:-3306}:3306"
+    env_file:
+      - default.env
+      - .env
+
+  ## - The container wordpress is a very basic but custom container with WordPress and all of the tools we need
+  ##   for development.
+  ## - The container will be named full_site_editing_wordpress for easy reference when running docker/docker-compose commands
+  ##
+  ## Here we map the following:
+  ##  - The local root directory (with Jetpack source code) into the container's directory for WordPress plugins
+  ##  - The docker/mu-plugins directory you can put custom code that gets loaded with WordPress
+  ##  - The docker/wordpress-develop directory where we'll get WordPress source code with unit tests
+  ##  - The docker/wordpress directory so we can have Wordpress source code modifiable from the host file system
+  ##  - The docker/logs/apache2 directory so we can access Apache log files directly from the host file system
+  ##  - The docker/logs/php directory so we can access PHP log files directly from the host file system
+  ##  - The docker/bin directory for provisioning scripts
+  wordpress:
+    container_name: full_site_editing_wordpress
+    depends_on:
+      - db
+    build: .
+    image: full_site_editing_wordpress:localbuild
+    volumes:
+      - ../blank-theme:/var/www/html/wp-content/themes/blank-theme
+      - ../full-site-editing-plugin:/var/www/html/wp-content/plugins/full-site-editing-plugin
+      ## Kludge for not having docker contain recursive stuff
+      ## You will see on your filesystem that this dir gets created
+      - ./wordpress-develop:/tmp/wordpress-develop
+      - ./wordpress:/var/www/html
+      - ./logs/apache2/:/var/log/apache2
+      - ./logs/php:/var/log/php
+      - ./bin:/var/scripts
+    ports:
+      - "${PORT_WORDPRESS:-80}:80"
+    restart: always
+    env_file:
+      - default.env
+      - .env
+    environment:
+      - HOST_PORT=${PORT_WORDPRESS:-80}

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -23,7 +23,18 @@
 		"dev:theme": "npm run theme",
 		"build:theme": "NODE_ENV=production npm run theme",
 		"dev": "rimraf dist && npm-run-all --parallel dev:*",
-		"build": "rimraf dist && npm-run-all --parallel build:*"
+		"build": "rimraf dist && npm-run-all --parallel build:*",
+		"docker:install": "npm run docker:compose exec wordpress bash -c \"/var/scripts/install.sh\"",
+		"docker:uninstall": "npm run docker:compose exec wordpress bash -c \"/var/scripts/uninstall.sh\"",
+		"docker:env": "node -e \"require('fs').createWriteStream( 'docker/.env', { flags: 'a' } );\"",
+		"docker:compose": "npm run docker:env && docker-compose -f docker/docker-compose.yml",
+		"docker:up": "npm run docker:compose up",
+		"docker:down": "npm run docker:compose down",
+		"docker:stop": "npm run docker:compose stop",
+		"docker:clean": "npm run docker:compose down --rmi all -v && rm -rf docker/wordpress/* docker/wordpress/.htaccess docker/wordpress-develop/* docker/logs/* docker/data/mysql/*",
+		"docker:sh": "npm run docker:compose exec wordpress bash",
+		"docker:wp": "npm run docker:compose exec wordpress wp --allow-root --path=/var/www/html/",
+		"docker:tail": "npm run docker:compose exec wordpress bash -c \"/var/scripts/tail.sh\""
 	},
 	"dependencies": {
 		"@wordpress/blocks": "^6.2.3",


### PR DESCRIPTION
This PR adds configuration and commands to run a docker environment with WordPress for the Full Site Editing plugin development. This was inspired by Jetpack's docker setup.

#### Changes proposed in this Pull Request

* Adds docker configuration for a WordPress container that maps the `/dist` folders of _Full Site Editing_ and _Blank Theme_.
* Adds `npm` commands to start, stop and run commands on the WordPress container.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Compile the _Full Site Editing_ and _Blank Theme_ Apps by running:
`npx lerna run dev --scope='@automattic/full-site-editing'`
* Start the docker container by running `npm run docker:up` on the `/apps/full-site-editing` folder.
* Optionally, configure WordPress and install some support plugins by running `npm run docker:install`. Otherwise, you'll have to configure it manually.

Pending tasks:

- [ ] Add Documentation (`README.md`)
