### PR TITLE
Revert "Gutenberg: Avoid Gutenframe flows on JP sites without SSL certs"

### DIFF
--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -1,31 +1,37 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { isEnabled } from 'config';
 import isVipSite from 'state/selectors/is-vip-site';
-import { getSiteAdminUrl, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import getSiteOptions from 'state/selectors/get-site-options';
 import getWordPressVersion from 'state/selectors/get-wordpress-version';
 import versionCompare from 'lib/version-compare';
 import isPluginActive from 'state/selectors/is-plugin-active';
-import { isHttps } from 'lib/url';
 
 export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
 		return false;
 	}
 
-	// We do want Gutenframe flows for JP/AT sites that have been updated to Jetpack 7.3 or greater since it will
-	// handle the required token verification. But only if the site has a SSL cert since the browser cannot embed
-	// insecure content in a resource loaded over a secure HTTPS connection.
-	if (
-		isEnabled( 'jetpack/gutenframe' ) &&
-		isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) &&
-		isHttps( getSiteAdminUrl( state, siteId ) )
-	) {
-		return false;
+	if ( isEnabled( 'jetpack/gutenframe' ) ) {
+		if (
+			versionCompare(
+				get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ),
+				'7.3-alpha',
+				'>='
+			)
+		) {
+			return false;
+		}
 	}
 
 	// We do want Calypsoify flows for Atomic sites

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -1,13 +1,19 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { isEnabled } from 'config';
+import getSiteOptions from 'state/selectors/get-site-options';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import isVipSite from 'state/selectors/is-vip-site';
-import { isJetpackSite, getSiteAdminUrl, isJetpackMinimumVersion } from 'state/sites/selectors';
-import { isHttps } from 'lib/url';
+import { isJetpackSite } from 'state/sites/selectors';
+import versionCompare from 'lib/version-compare';
 
 export const isGutenbergEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
@@ -18,15 +24,16 @@ export const isGutenbergEnabled = ( state, siteId ) => {
 		return true;
 	}
 
-	// We do want Gutenframe flows for JP/AT sites that have been updated to Jetpack 7.3 or greater since it will
-	// handle the required token verification. But only if the site has a SSL cert since the browser cannot embed
-	// insecure content in a resource loaded over a secure HTTPS connection.
-	if (
-		isEnabled( 'jetpack/gutenframe' ) &&
-		isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) &&
-		isHttps( getSiteAdminUrl( state, siteId ) )
-	) {
-		return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
+	if ( isEnabled( 'jetpack/gutenframe' ) ) {
+		if (
+			versionCompare(
+				get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ),
+				'7.3-alpha',
+				'>='
+			)
+		) {
+			return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
+		}
 	}
 
 	return (


### PR DESCRIPTION
Reverts Automattic/wp-calypso#32628

While testing the changes in `wpcalypso` I was getting an infinite redirection loop from `block-editor/post` to `/post` and from `/post` to `/block-editor/post`. Not sure why, by I'm reverting this change.