### PR TITLE
Domain Transfer/Mapping Step: Remove "http://" Prefix

### DIFF
--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -22,7 +22,7 @@ import DomainProductPrice from 'components/domains/domain-product-price';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import { MAP_EXISTING_DOMAIN, INCOMING_DOMAIN_TRANSFER } from 'lib/url/support';
-import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import FormTextInput from 'components/forms/form-text-input';
 import {
 	recordAddDomainButtonClickInMapDomain,
 	recordFormSubmitInMapDomain,
@@ -113,9 +113,7 @@ class MapDomainStep extends React.Component {
 					/>
 
 					<div className="map-domain-step__add-domain" role="group">
-						<FormTextInputWithAffixes
-							noWrap
-							prefix="http://"
+						<FormTextInput
 							className="map-domain-step__external-domain"
 							type="text"
 							value={ this.state.searchQuery }

--- a/client/components/domains/map-domain-step/index.jsx
+++ b/client/components/domains/map-domain-step/index.jsx
@@ -114,6 +114,7 @@ class MapDomainStep extends React.Component {
 
 					<div className="map-domain-step__add-domain" role="group">
 						<FormTextInputWithAffixes
+							noWrap
 							prefix="http://"
 							className="map-domain-step__external-domain"
 							type="text"

--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -63,15 +63,8 @@
 	margin-top: 20px;
 }
 
-.map-domain-step__add-domain .form-text-input-with-affixes {
-	
-	@include breakpoint( '<480px' ) {
-		flex-flow: row;
-	}
-
-	&__prefix {
-		flex: inherit;
-	}
+.map-domain-step__add-domain .form-text-input-with-affixes__prefix {
+	flex: inherit;
 }
 
 input.map-domain-step__external-domain {

--- a/client/components/domains/map-domain-step/style.scss
+++ b/client/components/domains/map-domain-step/style.scss
@@ -63,8 +63,15 @@
 	margin-top: 20px;
 }
 
-.map-domain-step__add-domain .form-text-input-with-affixes__prefix {
-	flex: inherit;
+.map-domain-step__add-domain .form-text-input-with-affixes {
+	
+	@include breakpoint( '<480px' ) {
+		flex-flow: row;
+	}
+
+	&__prefix {
+		flex: inherit;
+	}
 }
 
 input.map-domain-step__external-domain {

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -36,7 +36,7 @@ import Banner from 'components/banner';
 import Notice from 'components/notice';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite } from 'state/ui/selectors';
-import FormTextInputWithAffixes from 'components/forms/form-text-input-with-affixes';
+import FormTextInput from 'components/forms/form-text-input';
 import TransferDomainPrecheck from './transfer-domain-precheck';
 import { INCOMING_DOMAIN_TRANSFER } from 'lib/url/support';
 import HeaderCake from 'components/header-cake';
@@ -244,10 +244,9 @@ class TransferDomainStep extends React.Component {
 					</div>
 
 					<div className="transfer-domain-step__add-domain" role="group">
-						<FormTextInputWithAffixes
+						<FormTextInput
 							// eslint-disable-next-line jsx-a11y/no-autofocus
 							autoFocus={ true }
-							prefix="http://"
 							type="text"
 							value={ searchQuery }
 							placeholder={ translate( 'example.com' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* ~~This prevents a full width field for adding a domain on mobile. I think that this issue only really is present with adding a domain, so I've focused this PR on that, as I have a feeling that this decision was intentional for the component itself (due to the inclusion of noWrap)~~

**Update:** This now completely removes the prefix (see discussion below)

#### Testing instructions

Visit `start/domains/mapping` (or the route to add a domain) and compare.

**Current on Larger Screens:**

<img width="917" alt="Screenshot 2019-04-27 at 18 20 23" src="https://user-images.githubusercontent.com/43215253/56852988-e646a880-6919-11e9-95ea-80492fc67e1e.png">

**Current on Mobile:**

<img width="289" alt="Screenshot 2019-04-27 at 18 20 55" src="https://user-images.githubusercontent.com/43215253/56852997-fcecff80-6919-11e9-89a9-f736e5078035.png">

**Proposed on desktop:**

<img width="1535" alt="Screenshot 2019-05-04 at 08 59 29" src="https://user-images.githubusercontent.com/43215253/57176073-47570a80-6e4b-11e9-907a-4b231375fc8c.png">
<img width="1137" alt="Screenshot 2019-05-04 at 08 59 52" src="https://user-images.githubusercontent.com/43215253/57176074-47570a80-6e4b-11e9-9368-5b9c77897b58.png">

**Proposed on Mobile:**

<img width="276" alt="Screenshot 2019-05-04 at 08 59 17" src="https://user-images.githubusercontent.com/43215253/57176068-3e663900-6e4b-11e9-9c3c-2ea856f8f3d0.png">

Fixes #26278

cc @sixhours, @drw158, @shaunandrews, @aidvu 
