### PR TITLE
Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
 	"packageRules": [
 		{
 			"paths": [ "packages/**" ],
+			"packagePatterns": ["*"],
 			"groupName": "calypso-packages",
 			"rangeStrategy": "replace"
 		},


### PR DESCRIPTION
Add a wildcard packagePatterns match so that lockFileMaintenance is *not* matched by this rule.