### PR TITLE
Signup: remove usage of lib/user from Signup controller

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -22,13 +22,11 @@ import {
 	getStepSectionName,
 	getValidPath,
 } from './utils';
-import userModule from 'lib/user';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import store from 'store';
 import SignupProgressStore from 'lib/signup/progress-store';
 import { setCurrentFlowName } from 'state/signup/flow/actions';
-
-const user = userModule();
+import { isUserLoggedIn } from 'state/current-user/selectors';
 
 /**
  * Constants
@@ -42,10 +40,11 @@ let initialContext;
 
 export default {
 	redirectWithoutLocaleIfLoggedIn( context, next ) {
-		if ( user.get() && getLocale( context.params ) ) {
-			const flowName = getFlowName( context.params ),
-				stepName = getStepName( context.params ),
-				stepSectionName = getStepSectionName( context.params );
+		const userLoggedIn = isUserLoggedIn( context.store.getState() );
+		if ( userLoggedIn && getLocale( context.params ) ) {
+			const flowName = getFlowName( context.params );
+			const stepName = getStepName( context.params );
+			const stepSectionName = getStepSectionName( context.params );
 			let urlWithoutLocale = getStepUrl( flowName, stepName, stepSectionName );
 
 			if ( config.isEnabled( 'wpcom-user-bootstrap' ) ) {
@@ -76,6 +75,7 @@ export default {
 	},
 
 	redirectToFlow( context, next ) {
+		const userLoggedIn = isUserLoggedIn( context.store.getState() );
 		const flowName = getFlowName( context.params );
 		const localeFromParams = getLocale( context.params );
 		const localeFromStore = store.get( 'signup-locale' );
@@ -84,7 +84,7 @@ export default {
 
 		// if flow can be resumed, use saved locale
 		if (
-			! user.get() &&
+			! userLoggedIn &&
 			! localeFromParams &&
 			localeFromStore &&
 			canResumeFlow( flowName, SignupProgressStore.get() )


### PR DESCRIPTION
Replaced with the `isUserLoggedIn` selector.

**How to test:**
The flows at risk seem to be:
- the social signup ones originally from #18557.
- starting a signup with non-en locale (from query param) and the resuming. Is the locale kept?
