### PR TITLE
Signup: clean up process/save step param names and destination URLs

### DIFF
--- a/client/lib/signup/actions.js
+++ b/client/lib/signup/actions.js
@@ -66,14 +66,12 @@ const SignupActions = {
 		} );
 	},
 
-	processSignupStep( step, errors, providedDependencies ) {
+	processSignupStep( step ) {
 		// deferred because a step can be processed as soon as it is submitted
 		defer( () => {
 			Dispatcher.handleViewAction( {
 				type: 'PROCESS_SIGNUP_STEP',
 				data: step,
-				errors: undefined === errors ? [] : errors,
-				providedDependencies: providedDependencies,
 			} );
 		} );
 	},

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -139,9 +139,7 @@ SignupProgressStore.dispatchToken = Dispatcher.register( function( payload ) {
 			);
 			break;
 		case 'PROCESS_SIGNUP_STEP':
-			SignupProgressStore.reduxStore.dispatch(
-				processStep( addStorableDependencies( step, action ) )
-			);
+			SignupProgressStore.reduxStore.dispatch( processStep( step ) );
 			break;
 		case 'PROCESSED_SIGNUP_STEP':
 			SignupProgressStore.reduxStore.dispatch(

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -114,15 +114,10 @@ SignupProgressStore.dispatchToken = Dispatcher.register( function( payload ) {
 	switch ( action.type ) {
 		case 'SAVE_SIGNUP_STEP':
 			SignupProgressStore.reduxStore.dispatch(
-				saveStep(
-					addStorableDependencies(
-						{
-							...step,
-							lastKnownFlow: currentFlowName,
-						},
-						action
-					)
-				)
+				saveStep( {
+					...step,
+					lastKnownFlow: currentFlowName,
+				} )
 			);
 			break;
 		case 'SUBMIT_SIGNUP_STEP':

--- a/client/lib/signup/progress-store.js
+++ b/client/lib/signup/progress-store.js
@@ -100,7 +100,7 @@ function addStorableDependencies( step, action ) {
  */
 SignupProgressStore.dispatchToken = Dispatcher.register( function( payload ) {
 	const { action } = payload;
-	const currentFlowName = getCurrentFlowName( SignupProgressStore.reduxStore.getState() );
+	const lastKnownFlow = getCurrentFlowName( SignupProgressStore.reduxStore.getState() );
 	const step = { ...action.data, lastUpdated: Date.now() };
 
 	Dispatcher.waitFor( [ SignupDependencyStore.dispatchToken ] );
@@ -113,24 +113,11 @@ SignupProgressStore.dispatchToken = Dispatcher.register( function( payload ) {
 	debug( `Handling ${ action.type }` );
 	switch ( action.type ) {
 		case 'SAVE_SIGNUP_STEP':
-			SignupProgressStore.reduxStore.dispatch(
-				saveStep( {
-					...step,
-					lastKnownFlow: currentFlowName,
-				} )
-			);
+			SignupProgressStore.reduxStore.dispatch( saveStep( { ...step, lastKnownFlow } ) );
 			break;
 		case 'SUBMIT_SIGNUP_STEP':
 			SignupProgressStore.reduxStore.dispatch(
-				submitStep(
-					addStorableDependencies(
-						{
-							...step,
-							lastKnownFlow: currentFlowName,
-						},
-						action
-					)
-				)
+				submitStep( addStorableDependencies( { ...step, lastKnownFlow }, action ) )
 			);
 			break;
 		case 'PROCESS_SIGNUP_STEP':

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -179,9 +179,7 @@ export function generateFlows( {
 
 		'pressable-nux': {
 			steps: [ 'creds-permission', 'creds-confirm', 'creds-complete' ],
-			destination: () => {
-				return '/stats';
-			},
+			destination: '/stats',
 			description: 'Allow new Pressable users to grant permission to server credentials',
 			lastModified: '2017-11-20',
 			disallowResume: true,
@@ -191,9 +189,7 @@ export function generateFlows( {
 
 		'rewind-switch': {
 			steps: [ 'rewind-migrate', 'rewind-were-backing' ],
-			destination: () => {
-				return '/activity-log';
-			},
+			destination: '/activity-log',
 			description:
 				'Allows users with Jetpack plan with VaultPress credentials to migrate credentials',
 			lastModified: '2018-01-27',
@@ -204,9 +200,7 @@ export function generateFlows( {
 
 		'rewind-setup': {
 			steps: [ 'rewind-add-creds', 'rewind-form-creds', 'rewind-were-backing' ],
-			destination: () => {
-				return '/activity-log';
-			},
+			destination: '/activity-log',
 			description: 'Allows users with Jetpack plan to setup credentials',
 			lastModified: '2018-01-27',
 			disallowResume: true,
@@ -216,9 +210,7 @@ export function generateFlows( {
 
 		'rewind-auto-config': {
 			steps: [ 'creds-permission', 'creds-confirm', 'rewind-were-backing' ],
-			destination: () => {
-				return '/activity-log';
-			},
+			destination: '/activity-log',
 			description:
 				'Allow users of sites that can auto-config to grant permission to server credentials',
 			lastModified: '2018-02-13',
@@ -238,9 +230,7 @@ export function generateFlows( {
 				'clone-ready',
 				'clone-cloning',
 			],
-			destination: () => {
-				return '/activity-log';
-			},
+			destination: '/activity-log',
 			description: 'Allow Jetpack users to clone a site via Rewind (alternate restore)',
 			lastModified: '2018-05-28',
 			disallowResume: true,


### PR DESCRIPTION
Three Signup cleanups in one:
**Remove unneeded params from `processSignupStep`**
The only used parameter is `step`. `errors` and `providedDependencies` are not used. The action is used to mark a step as "API function is in progress"

**Remove unneeded params from `saveSignupStep`**
Again, only the `step` param is needed. The action is used to save intermediate state of the step (i.e., filled-in form fields)

The only places where `providedDependencies` are save are
- `submitSignupStep`: user action submits a form with step data
- `processedSignupStep`: API function returned some new dependencies from server

**Cleanup `destination` fields in step specs:**
The `destination can be either a string or a function. We don't always need the function.

A small step towards finally removing Flux from Signup :tada: