### PR TITLE
fix test for happiness support button

### DIFF
--- a/client/components/happiness-support/test/index.jsx
+++ b/client/components/happiness-support/test/index.jsx
@@ -44,9 +44,9 @@ describe( 'HappinessSupport', () => {
 	} );
 
 	test( 'should render a translated support button', () => {
-		expect( wrapper.find( 'Button.happiness-support__support-button' ).props().children ).to.equal(
-			'Translated: Support documentation'
-		);
+		expect(
+			wrapper.find( 'Button.happiness-support__support-button>span' ).props().children
+		).to.equal( 'Translated: Support documentation' );
 	} );
 
 	test( 'should render a support button with link to SUPPORT_ROOT if it is not for JetPack', () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

It seems like https://github.com/Automattic/wp-calypso/pull/32612 left a failing test. As the structure of the tree changed, the selector used in that test to match a translated string didn't match anymore.

* tests: fix selector to match expected string

#### Testing instructions

* Make sure `npm run test-client` runs without any failures


