### PR TITLE
Full Site Editing: Rename the Post Content and Template blocks

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/edit.js
@@ -20,7 +20,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import PostAutocomplete from '../../components/post-autocomplete';
 
-const ContentSlotEdit = compose(
+const PostContentEdit = compose(
 	withState( {
 		isEditing: false,
 		selectedPostId: undefined,
@@ -66,7 +66,7 @@ const ContentSlotEdit = compose(
 				</BlockControls>
 			) }
 			<div
-				className={ classNames( 'a8c-content-slot-block', {
+				className={ classNames( 'post-content-block', {
 					[ `align${ align }` ]: align,
 				} ) }
 			>
@@ -76,7 +76,7 @@ const ContentSlotEdit = compose(
 						label={ __( 'Content Slot' ) }
 						instructions={ __( 'Placeholder for a post or a page.' ) }
 					>
-						<div className="a8c-content-slot-block__selector">
+						<div className="post-content-block__selector">
 							<div>{ __( 'Select something to preview:' ) }</div>
 							<PostAutocomplete onSelectPost={ onSelectPost } />
 							{ !! selectedPost && (
@@ -88,7 +88,7 @@ const ContentSlotEdit = compose(
 					</Placeholder>
 				) }
 				{ showPreview && (
-					<RawHTML className="a8c-content-slot-block__preview">
+					<RawHTML className="post-content-block__preview">
 						{ get( selectedPost, 'content.rendered' ) }
 					</RawHTML>
 				) }
@@ -97,4 +97,4 @@ const ContentSlotEdit = compose(
 	);
 } );
 
-export default ContentSlotEdit;
+export default PostContentEdit;

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( 'core/post-content', {
+registerBlockType( 'a8c/post-content', {
 	title: __( 'Content Slot' ),
 	description: __( 'Placeholder for a post or a page.' ),
 	icon: 'layout',

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( 'a8c/content-slot', {
+registerBlockType( 'core/post-content', {
 	title: __( 'Content Slot' ),
 	description: __( 'Placeholder for a post or a page.' ),
 	icon: 'layout',

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/index.php
@@ -1,9 +1,9 @@
 <?php
 
-function render_content_slot_block( $attributes, $content ) {
+function render_post_content_block( $attributes, $content ) {
 	$align = isset( $attributes['align'] ) ? ' align' . $attributes['align'] : '';
 
-	$content = '<div class="a8c-content'. $align . '">'
+	$content = '<div class="post-content'. $align . '">'
 		. __( '[Renders some content]' )
 		. '</div>';
 

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/style.scss
@@ -1,8 +1,8 @@
-.a8c-content-slot-block.alignfull {
+.post-content-block.alignfull {
 	padding: 0 12px;
 }
 
-.a8c-content-slot-block__selector {
+.post-content-block__selector {
 	width: 300px;
 	a {
 		font-family: sans-serif;
@@ -11,7 +11,7 @@
 	}
 }
 
-.a8c-content-slot-block__preview {
+.post-content-block__preview {
 	pointer-events: none;
 	&::after {
 		content: '';

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
@@ -21,7 +21,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import PostAutocomplete from '../../components/post-autocomplete';
 import './style.scss';
 
-const TemplatePartEdit = compose(
+const TemplateEdit = compose(
 	withSelect( ( select, { attributes } ) => {
 		const { getEntityRecord } = select( 'core' );
 		const { selectedPostId, selectedPostType } = attributes;
@@ -64,7 +64,7 @@ const TemplatePartEdit = compose(
 				</BlockControls>
 			) }
 			<div
-				className={ classNames( 'a8c-template-part-block', {
+				className={ classNames( 'template-block', {
 					[ `align${ align }` ]: align,
 				} ) }
 			>
@@ -74,7 +74,7 @@ const TemplatePartEdit = compose(
 						label={ __( 'Template Part' ) }
 						instructions={ __( 'Select a template part to display' ) }
 					>
-						<div className="a8c-template-part-block__selector">
+						<div className="template-block__selector">
 							<PostAutocomplete onSelectPost={ onSelectPost } />
 							{ !! selectedPost && (
 								<a href={ `?post=${ selectedPost.id }&action=edit` }>
@@ -85,7 +85,7 @@ const TemplatePartEdit = compose(
 					</Placeholder>
 				) }
 				{ showContent && (
-					<RawHTML className="a8c-template-part-block__content">
+					<RawHTML className="template-block__content">
 						{ get( selectedPost, 'content.rendered' ) }
 					</RawHTML>
 				) }
@@ -94,4 +94,4 @@ const TemplatePartEdit = compose(
 	);
 } );
 
-export default TemplatePartEdit;
+export default TemplateEdit;

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( 'core/template', {
+registerBlockType( 'a8c/template', {
 	title: __( 'Template Part' ),
 	description: __( 'Display a template part.' ),
 	icon: 'layout',

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/index.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( 'a8c/template-part', {
+registerBlockType( 'core/template', {
 	title: __( 'Template Part' ),
 	description: __( 'Display a template part.' ),
 	icon: 'layout',

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/index.php
@@ -1,6 +1,6 @@
 <?php
 
-function render_template_part_block( $attributes ) {
+function render_template_block( $attributes ) {
 	if ( ! isset( $attributes['selectedPostId'] ) || ! is_int( $attributes['selectedPostId'] ) ) {
 		return;
 	}
@@ -8,7 +8,7 @@ function render_template_part_block( $attributes ) {
 	$post = get_post( $attributes['selectedPostId'] );
 	setup_postdata( $post );
 
-	$content = '<div class="a8c-template-part'. $align . '">'
+	$content = '<div class="template'. $align . '">'
 		. apply_filters( 'the_content', get_the_content() )
 		. '</div>';
 

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/style.scss
@@ -1,8 +1,8 @@
-.a8c-template-part-block.alignfull {
+.template-block.alignfull {
 	padding: 0 12px;
 }
 
-.a8c-template-part-block__selector {
+.template-block__selector {
 	width: 300px;
 	a {
 		font-family: sans-serif;
@@ -11,7 +11,7 @@
 	}
 }
 
-.a8c-template-part-block__content {
+.template-block__content {
 	pointer-events: none;
 	&::after {
 		content: '';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Full Site Editing
  */
 
-require_once( 'blocks/content-slot/index.php' );
+require_once( 'blocks/post-content/index.php' );
 require_once( 'blocks/template-part/index.php' );
 
 class A8C_Full_Site_Editing {
@@ -54,7 +54,7 @@ class A8C_Full_Site_Editing {
 	}
 
 	function register_blocks() {
-		register_block_type( 'a8c/content-slot', array(
+		register_block_type( 'core/post-content', array(
 			'render_callback' => 'render_content_slot_block',
 		 ) );
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -54,11 +54,11 @@ class A8C_Full_Site_Editing {
 	}
 
 	function register_blocks() {
-		register_block_type( 'core/post-content', array(
+		register_block_type( 'a8c/post-content', array(
 			'render_callback' => 'render_content_slot_block',
 		 ) );
 
-		register_block_type( 'core/template', array(
+		register_block_type( 'a8c/template', array(
 			'render_callback' => 'render_template_block',
 		) );
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -4,7 +4,7 @@
  */
 
 require_once( 'blocks/post-content/index.php' );
-require_once( 'blocks/template-part/index.php' );
+require_once( 'blocks/template/index.php' );
 
 class A8C_Full_Site_Editing {
 	static $initialized = false;
@@ -58,8 +58,8 @@ class A8C_Full_Site_Editing {
 			'render_callback' => 'render_content_slot_block',
 		 ) );
 
-		register_block_type( 'a8c/template-part', array(
-			'render_callback' => 'render_template_part_block',
+		register_block_type( 'core/template', array(
+			'render_callback' => 'render_template_block',
 		) );
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/index.js
@@ -2,4 +2,4 @@
  * Internal dependencies
  */
 import './blocks/post-content';
-import './blocks/template-part';
+import './blocks/template';

--- a/apps/full-site-editing/full-site-editing-plugin/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/index.js
@@ -1,5 +1,5 @@
 /**
  * Internal dependencies
  */
-import './blocks/content-slot';
+import './blocks/post-content';
 import './blocks/template-part';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Rename `a8c/content-slot` into `a8c/post-content`
* Rename `a8c/template-part` into `a8c/template`

Note: this PR doesn't change the functionality, nor the copy.
Let's give us more time to think how we want to present these blocks to the users, and involve editorial when necessary.

See paAmJe-fT-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* [Build the Full Site Editing plugin](https://github.com/Automattic/wp-calypso/blob/ec422edf146a4d0e2c46a9515a65058d8f1d4950/apps/full-site-editing/README.md#local-development).
* Smoke test the Content Slot and Template Part blocks and make sure they work as expected:
  - Content Slot should not render anything on the front end (just a temporary placeholder message), and shouldn't persist the selected content preview.
  - Template Part should render the selected content and persist it in the editor.
* Switch to code editor and make sure they appear as `a8c/post-content` and `a8c/template`.