### PR TITLE
Full Site Editing: Only allow FSE blocks in wp_template CPT

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blocks/content-slot/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/content-slot/index.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -10,18 +12,22 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( 'a8c/content-slot', {
-	title: __( 'Content Slot' ),
-	description: __( 'Placeholder for a post or a page.' ),
-	icon: 'layout',
-	category: 'layout',
-	supports: {
-		align: [ 'wide', 'full' ],
-		anchor: true,
-		html: false,
-		multiple: false,
-		reusable: false,
-	},
-	edit,
-	save: () => null,
+domReady( () => {
+	if ( 'wp_template' === select( 'core/editor' ).getCurrentPostType() ) {
+		registerBlockType( 'a8c/content-slot', {
+			title: __( 'Content Slot' ),
+			description: __( 'Placeholder for a post or a page.' ),
+			icon: 'layout',
+			category: 'layout',
+			supports: {
+				align: [ 'wide', 'full' ],
+				anchor: true,
+				html: false,
+				multiple: false,
+				reusable: false,
+			},
+			edit,
+			save: () => null,
+		} );
+	}
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template-part/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template-part/index.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
+import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -10,21 +12,25 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( 'a8c/template-part', {
-	title: __( 'Template Part' ),
-	description: __( 'Display a template part.' ),
-	icon: 'layout',
-	category: 'layout',
-	attributes: {
-		selectedPostId: { type: 'number' },
-		selectedPostType: { type: 'string' },
-	},
-	supports: {
-		align: [ 'wide', 'full' ],
-		anchor: true,
-		html: false,
-		reusable: false,
-	},
-	edit,
-	save: () => null,
+domReady( () => {
+	if ( 'wp_template' === select( 'core/editor' ).getCurrentPostType() ) {
+		registerBlockType( 'a8c/template-part', {
+			title: __( 'Template Part' ),
+			description: __( 'Display a template part.' ),
+			icon: 'layout',
+			category: 'layout',
+			attributes: {
+				selectedPostId: { type: 'number' },
+				selectedPostType: { type: 'string' },
+			},
+			supports: {
+				align: [ 'wide', 'full' ],
+				anchor: true,
+				html: false,
+				reusable: false,
+			},
+			edit,
+			save: () => null,
+		} );
+	}
 } );

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -31,6 +31,7 @@
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",
 		"@wordpress/data": "^4.4.0",
+		"@wordpress/dom-ready": "^2.2.0",
 		"@wordpress/editor": "^9.2.4",
 		"@wordpress/element": "^2.3.0",
 		"@wordpress/i18n": "^3.3.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Restrict the usage of Content and Template blocks in the `wp_template` CPT.

Note: my first thinking was to use the [`allowed_block_types` filter](https://github.com/WordPress/gutenberg/blob/6f80078228d10985e23c8585c9d88b6c95fff418/docs/designers-developers/developers/filters/block-filters.md#hiding-blocks-from-the-inserter), which _seems_ designed exactly for this purpose, but in fact falls short of our needs.
The first parameter (and return value) can be `true` if all blocks are allowed, `false` if none, or a **whitelist** of allowed blocks.
This means that, if we want to disallow FSE blocks from all post types except `wp_template`, we would need to return an array including **all** blocks except the FSE ones.
The filter doesn't make such list available, and as far as I know there is no way to get it in PHP.

JS-side, it's slightly easier but less elegant: once the DOM is ready, only register the blocks if the current post's type is `wp_template`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create or edit a Template post, and make sure it's possible to insert both the Content and Template blocks. Also check on the front-end, and make sure Content output a temporary placeholder message, and Template the selected post.
* Create or edit a post of any other type, and make sure the Content and Template blocks aren't available.

Part of #32618 and #32619 