### PR TITLE
Marketing: added page tracker to traffic page

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -13,6 +13,7 @@ import { flowRight, partialRight, pick } from 'lodash';
  * Internal dependencies
  */
 import Main from 'components/main';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
 import SeoSettingsHelpCard from 'my-sites/site-settings/seo-settings/help';
@@ -45,6 +46,7 @@ const SiteSettingsTraffic = ( {
 	translate,
 } ) => (
 	<Main className="settings-traffic site-settings">
+		<PageViewTracker path="/marketing/traffic/:site" title="Marketing > Traffic" />
 		<DocumentHead title={ translate( 'Site Settings' ) } />
 		<JetpackDevModeNotice />
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -23,7 +23,6 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import Banner from 'components/banner';
-import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getSeoTitleFormatsForSite, isJetpackSite, isRequestingSite } from 'state/sites/selectors';
 import {
 	isSiteSettingsSaveSuccessful,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a page view tracker to the Traffic page.

This page view tracker used to be found in `my-sites/site-settings/seo-settings/form.jsx`, but it now makes more sense to move it to `my-sites/marketing/traffic/index.js`.

#### Testing instructions

1. Open `config/development.json` and set `features.google-analytics` to `true`. Re-run `npm run start` to make the changes take effect.
2. Go to analytics.google.com on your a8c account and open the wordpress.com > Calypso Local Test > All Web Site Data view. Go to the real-time view.
3. Visit `marketing/traffic/:site`.
4. Verify that your page view shows in the real-time dashboard.