### PR TITLE
A/B Test: Adding Concierge dial options

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -182,4 +182,14 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	conciergeUpsellDial: {
+		//this test is used to dial down
+		datestamp: '20190429',
+		variations: {
+			offer: 50,
+			noOffer: 50,
+		},
+		defaultVariation: 'noOffer',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -437,6 +437,7 @@ export class Checkout extends React.Component {
 		// This tests the flow that was not eligible for G Suite
 		// There's an additional test above that tests directly aginst the G Suite upsell
 		if (
+			'offer' === abtest( 'conciergeUpsellDial' ) &&
 			config.isEnabled( 'upsell/concierge-session' ) &&
 			! cartItems.hasConciergeSession( cart ) &&
 			! cartItems.hasJetpackPlan( cart ) &&

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -437,7 +437,6 @@ export class Checkout extends React.Component {
 		// This tests the flow that was not eligible for G Suite
 		// There's an additional test above that tests directly aginst the G Suite upsell
 		if (
-			'offer' === abtest( 'conciergeUpsellDial' ) &&
 			config.isEnabled( 'upsell/concierge-session' ) &&
 			! cartItems.hasConciergeSession( cart ) &&
 			! cartItems.hasJetpackPlan( cart ) &&
@@ -447,7 +446,9 @@ export class Checkout extends React.Component {
 		) {
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
-			return `/checkout/${ selectedSiteSlug }/add-quickstart-session/${ receiptId }`;
+			if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
+				return `/checkout/${ selectedSiteSlug }/add-quickstart-session/${ receiptId }`;
+			}
 		}
 
 		if ( this.props.isEligibleForCheckoutToChecklist && receipt ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Simple PR to add a way to dial down the people who see the upsell offer.

#### Testing instructions

Use the link below to test:

* Place yourself in the two different groups `offer` and `noOffer` for the `conciergeUpsellDial` AB test.
* Create a new site or use an existing test site.
* Purchase or upgrade to a plan (no domain) other than Business or eCommerce.
* After purchase, confirm you're shown the Concierge upsell page in the `offer` variant or not in the `noOffer` variant.