### PR TITLE
Load the correct mofule for the domains-only signup step

### DIFF
--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -26,7 +26,7 @@ export default {
 	'creds-permission': loadStep( 'creds-permission' ),
 	domains: loadStep( 'domains' ),
 	'domains-store': loadStep( 'domains' ),
-	'domain-only': loadStep( 'domain' ),
+	'domain-only': loadStep( 'domains' ),
 	'domains-theme-preselected': loadStep( 'domains' ),
 	'domains-launch': loadStep( 'domains' ),
 	'from-url': loadStep( 'import-url' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#32357 set the incorrect name of the module for the domain-only step in signup. This PR corrects this.

#### Testing instructions

Apply the patch and visit a path that loads the domain-only page such as: http://calypso.localhost:3000/start/domain/domain-only?new=testing&search=yes
Make sure that the page loads and that you see the domain search suggestions list.
