### PR TITLE
People: Make delete user attribution option clearer

### DIFF
--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -20,6 +20,7 @@ import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormButton from 'components/forms/form-button';
 import FormButtonsBar from 'components/forms/form-buttons-bar';
+import User from 'components/user';
 import AuthorSelector from 'blocks/author-selector';
 import { deleteUser } from 'lib/users/actions';
 import accept from 'lib/accept';
@@ -80,6 +81,29 @@ class DeleteUser extends React.Component {
 
 		this.setState( updateObj );
 		this.props.recordGoogleEvent( 'People', 'Selected Delete User Assignment', 'Assign', value );
+	};
+
+	getAuthorSelector = () => {
+		return (
+			<AuthorSelector
+				allowSingleUser
+				siteId={ this.props.siteId }
+				onSelect={ this.onSelectAuthor }
+				exclude={ [ this.props.user.ID ] }
+				ignoreContext={ this.reassignLabel }
+			>
+				{ this.state.reassignUser ? (
+					<span>
+						<Gravatar size={ 26 } user={ this.state.reassignUser } />
+						<span className="delete-user__reassign-user-name">
+							{ this.state.reassignUser.name }
+						</span>
+					</span>
+				) : (
+					this.getAuthorSelectPlaceholder()
+				) }
+			</AuthorSelector>
+		);
 	};
 
 	setReassignLabel = label => ( this.reassignLabel = label );
@@ -143,38 +167,16 @@ class DeleteUser extends React.Component {
 	};
 
 	getAuthorSelectPlaceholder = () => {
-		const { translate } = this.props;
 		return (
-			<span className="delete-user__select-placeholder">{ translate( 'select a user' ) }</span>
+			<span className="delete-user__select-placeholder">
+				<User size={ 26 } user={ { name: /* Don't translate yet */ 'Choose an author…' } } />
+			</span>
 		);
 	};
 
 	getTranslatedAssignLabel = () => {
 		const { translate } = this.props;
-		return translate( 'Attribute all content to {{AuthorSelector/}}', {
-			components: {
-				AuthorSelector: (
-					<AuthorSelector
-						allowSingleUser
-						siteId={ this.props.siteId }
-						onSelect={ this.onSelectAuthor }
-						exclude={ [ this.props.user.ID ] }
-						ignoreContext={ this.reassignLabel }
-					>
-						{ this.state.reassignUser ? (
-							<span>
-								<Gravatar size={ 26 } user={ this.state.reassignUser } />
-								<span className="delete-user__reassign-user-name">
-									{ this.state.reassignUser.name }
-								</span>
-							</span>
-						) : (
-							this.getAuthorSelectPlaceholder()
-						) }
-					</AuthorSelector>
-				),
-			},
-		} );
+		return translate( 'Attribute all content to another user' );
 	};
 
 	isDeleteButtonDisabled = () => {
@@ -219,6 +221,8 @@ class DeleteUser extends React.Component {
 							/>
 
 							<span>{ this.getTranslatedAssignLabel() }</span>
+
+							<div className="delete-user__author-selector">{ this.getAuthorSelector() }</div>
 						</FormLabel>
 
 						<FormLabel>

--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -44,6 +44,7 @@ class DeleteUser extends React.Component {
 		showDialog: false,
 		radioOption: false,
 		reassignUser: false,
+		authorSelectorToggled: false,
 	};
 
 	getRemoveText = () => {
@@ -79,6 +80,8 @@ class DeleteUser extends React.Component {
 
 		updateObj[ name ] = value;
 
+		this.setState( { authorSelectorToggled: true } );
+
 		this.setState( updateObj );
 		this.props.recordGoogleEvent( 'People', 'Selected Delete User Assignment', 'Assign', value );
 	};
@@ -103,6 +106,14 @@ class DeleteUser extends React.Component {
 					this.getAuthorSelectPlaceholder()
 				) }
 			</AuthorSelector>
+		);
+	};
+
+	getAuthorSelectPlaceholder = () => {
+		return (
+			<span className="delete-user__select-placeholder">
+				<User size={ 26 } user={ { name: /* Don't translate yet */ 'Choose an author…' } } />
+			</span>
 		);
 	};
 
@@ -166,14 +177,6 @@ class DeleteUser extends React.Component {
 		this.props.recordGoogleEvent( 'People', 'Clicked Remove User on Edit User Single Site' );
 	};
 
-	getAuthorSelectPlaceholder = () => {
-		return (
-			<span className="delete-user__select-placeholder">
-				<User size={ 26 } user={ { name: /* Don't translate yet */ 'Choose an author…' } } />
-			</span>
-		);
-	};
-
 	getTranslatedAssignLabel = () => {
 		const { translate } = this.props;
 		return translate( 'Attribute all content to another user' );
@@ -222,7 +225,9 @@ class DeleteUser extends React.Component {
 
 							<span>{ this.getTranslatedAssignLabel() }</span>
 
-							<div className="delete-user__author-selector">{ this.getAuthorSelector() }</div>
+							{ this.state.authorSelectorToggled ? (
+								<div className="delete-user__author-selector">{ this.getAuthorSelector() }</div>
+							) : null }
 						</FormLabel>
 
 						<FormLabel>

--- a/client/my-sites/people/delete-user/style.scss
+++ b/client/my-sites/people/delete-user/style.scss
@@ -1,5 +1,14 @@
+.delete-user__author-selector {
+	display: inline-block;
+	margin: 0.5em 0 0.5em 16px;
+}
+
 .delete-user__select-placeholder {
-	border-bottom: 1px solid var( --color-neutral-light );
+	font-weight: 400;
+
+	& .user {
+		display: inline-block;
+	}
 }
 
 .delete-user__explanation {
@@ -12,7 +21,9 @@
 }
 
 .delete-user__reassign-user-name {
+	font-weight: 400;
 	margin: 0 3px 0 8px;
+	vertical-align: middle;
 }
 
 .delete-user__remove-user .gridicon {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR simplifies the option to attribute all content by a deleted user to a new author, by only showing the author selector when this option is checked.

**Before**

<img width="738" alt="Screen Shot 2019-04-29 at 3 16 36 PM" src="https://user-images.githubusercontent.com/2124984/56920672-da7df200-6a91-11e9-92ff-3dd2f5d69a43.png">

**After**

<img width="740" alt="Screen Shot 2019-04-29 at 3 18 31 PM" src="https://user-images.githubusercontent.com/2124984/56920769-1618bc00-6a92-11e9-8b6c-c8bcf68ba34d.png">

<img width="734" alt="Screen Shot 2019-04-29 at 3 18 41 PM" src="https://user-images.githubusercontent.com/2124984/56920772-187b1600-6a92-11e9-9ed5-fcbc491534ab.png">

#### Testing instructions

* Switch to this PR and go to `/people/` on a site with multiple users
* Click on a user
* Scroll down to the Delete section and ensure the Author selector is not visible
* Check the "Attribute all content to another user" option and the Author Selector should appear
* Ensure deleting the user correctly assigns their posts to the selected author
* Is this pattern accessible?

Fixes #32399