### PR TITLE
Gutenframe: Use Calypso Revisions for autosave comparison.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -56,18 +56,14 @@ function handlePostTrash( calypsoPort ) {
 }
 
 function overrideRevisions( calypsoPort ) {
-	$( '#editor' ).on(
-		'click',
-		'.components-panel .edit-post-last-revision__panel .editor-post-last-revision__title, .components-notice.is-warning .components-notice__action.is-link',
-		e => {
-			e.preventDefault();
+	$( '#editor' ).on( 'click', '[href*="revision.php"]', e => {
+		e.preventDefault();
 
-			calypsoPort.postMessage( { action: 'openRevisions' } );
+		calypsoPort.postMessage( { action: 'openRevisions' } );
 
-			calypsoPort.addEventListener( 'message', onLoadRevision, false );
-			calypsoPort.start();
-		}
-	);
+		calypsoPort.addEventListener( 'message', onLoadRevision, false );
+		calypsoPort.start();
+	} );
 
 	function onLoadRevision( message ) {
 		const action = get( message, 'data.action', '' );
@@ -492,6 +488,32 @@ function handleGoToAllPosts( calypsoPort ) {
 	} );
 }
 
+/**
+ * Modify links in order to open them in parent window and not in a child iframe.
+ */
+function openLinksInParentFrame() {
+	const viewPostLinkSelectors = [
+		'.components-notice-list .is-success .components-notice__action.is-link', // View Post link in success notice
+		'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
+		'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
+	].join( ',' );
+	$( '#editor' ).on( 'click', viewPostLinkSelectors, e => {
+		e.preventDefault();
+		window.open( e.target.href, '_top' );
+	} );
+
+	if ( calypsoifyGutenberg.manageReusableBlocksUrl ) {
+		const manageReusableBlocksLinkSelectors = [
+			'.editor-inserter__manage-reusable-blocks', // Link in the Blocks Inserter
+			'a.components-menu-item__button[href*="post_type=wp_block"]', // Link in the More Menu
+		].join( ',' );
+		$( '#editor' ).on( 'click', manageReusableBlocksLinkSelectors, e => {
+			e.preventDefault();
+			window.open( calypsoifyGutenberg.manageReusableBlocksUrl, '_top' );
+		} );
+	}
+}
+
 function initPort( message ) {
 	if ( 'initPort' !== message.data.action ) {
 		return;
@@ -563,6 +585,8 @@ function initPort( message ) {
 		handlePreview( calypsoPort );
 
 		handleGoToAllPosts( calypsoPort );
+
+		openLinksInParentFrame();
 	}
 
 	window.removeEventListener( 'message', initPort, false );

--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -58,7 +58,7 @@ function handlePostTrash( calypsoPort ) {
 function overrideRevisions( calypsoPort ) {
 	$( '#editor' ).on(
 		'click',
-		'.components-panel .edit-post-last-revision__panel .editor-post-last-revision__title',
+		'.components-panel .edit-post-last-revision__panel .editor-post-last-revision__title, .components-notice.is-warning .components-notice__action.is-link',
 		e => {
 			e.preventDefault();
 


### PR DESCRIPTION
If a post is loaded with an autosave more recent than the version in the db, the block editor will present an admin notice, giving the user the opportunity to compare the two versions on the revisions page (eg. `/wp-admin/revision.php?revision=xxxxx`). This applies to both WordPress.com and Jetpack iframed sites.

<img width="1130" alt="Screen Shot 2019-04-29 at 12 53 20 PM" src="https://user-images.githubusercontent.com/349751/56922937-363e8000-6a7e-11e9-80bc-638fe379e3b5.png">

With Gutenframe, we don't want to serve the core page at `revision.php`, but rather the Calypso Revisions modal:

<img width="1462" alt="Screen Shot 2019-04-29 at 12 58 16 PM" src="https://user-images.githubusercontent.com/349751/56923064-7ef63900-6a7e-11e9-9376-28eca2960d11.png">

This PR updates the `overrideRevisions` selector to include the notice link, so that the link is also handled by Gutenframe.

#### Testing instructions

Note that the Gutenframe code is served by `widgets.wp.com`, based on CircleCI builds of the `apps/wpcom-block-editor` directory (so testing is a little more involved).

* Apply D27601-code and sandbox `widgets.wp.com`.
* Load a new post on a WP.com test site in Gutenframe (eg. `https://wordpress.com/block-editor/post/:site`).
* Save the post, make edits, and allow an autosave to happen.
* Close the window without saving.
* From Calypso again, open the new post, and be sure you get the admin notice shown above.
* Click the "View the autosave" link.
* Verify the Calypso Revisions modal opens and functions as expected.
