### PR TITLE
Remove unneeded popup check

### DIFF
--- a/test/e2e/lib/components/nav-bar-component.js
+++ b/test/e2e/lib/components/nav-bar-component.js
@@ -82,17 +82,4 @@ export default class NavBarComponent extends AsyncBaseContainer {
 			return await driverHelper.clickWhenClickable( self.driver, guidedToursDismissButtonSelector );
 		}
 	}
-
-	async dismissStatsPopup() {
-		const statsPopupSelector = by.css( '.first-view.is-visible' );
-
-		const isPresent = await driverHelper.isEventuallyPresentAndDisplayed(
-			this.driver,
-			statsPopupSelector,
-			2000
-		);
-		if ( isPresent === true ) {
-			return await driverHelper.clickWhenClickable( self.driver, statsPopupSelector );
-		}
-	}
 }

--- a/test/e2e/specs/wp-invite-users-spec.js
+++ b/test/e2e/specs/wp-invite-users-spec.js
@@ -145,7 +145,6 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 
 			const navBarComponent = await NavBarComponent.Expect( driver );
 			await navBarComponent.clickMySites();
-			await navBarComponent.dismissStatsPopup();
 			return await NoSitesComponent.Expect( driver );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The stats popup has been removed, so we no longer need to check for it.

#### Testing instructions

* Make sure the `Inviting new user as an Editor` test passes on desktop and mobile
