### PR TITLE
Signup: Use `preventWidows` on mockup title and tagline.

### DIFF
--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -24,6 +24,7 @@ import { getSiteStyleOptions, getThemeCssUri } from 'lib/signup/site-styles';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getLocaleSlug, getLanguage } from 'lib/i18n-utils';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
+import { preventWidows } from 'lib/formatting';
 
 /**
  * Style dependencies
@@ -120,8 +121,8 @@ class SiteMockups extends Component {
 			fontUrl,
 			cssUrl: getThemeCssUri( themeSlug, isRtl ),
 			content: {
-				title,
-				tagline: translate( 'You’ll be able to customize this to your needs.' ),
+				title: preventWidows( title ),
+				tagline: preventWidows( translate( 'You’ll be able to customize this to your needs.' ) ),
 				body: this.getContent( verticalPreviewContent ),
 			},
 			langSlug,


### PR DESCRIPTION
Some of the larger-font site styles (Calm and Sophisticated) have title and tagline wrapping issues. On the end site, these values will be filtered through `widont`, so we can use `preventWidows` for the mockups.

Before: | After:
------------ | -------------
![before](https://user-images.githubusercontent.com/942359/56926615-2c2d7900-6aa0-11e9-8876-0091a04023b9.png) | <img width="298" alt="after" src="https://user-images.githubusercontent.com/942359/56926583-1029d780-6aa0-11e9-827b-8f3bdaa4e204.png">

**To Test:**
- visit wordpress.com/start/onboarding/
- select "business" segment
- leave the site title alone
- on the site style step, try the different styles
- select "Calm" and navigate back to the site title step
- try different title with the "Calm" style applied


