### PR TITLE
Update post titles in combined Reader cards so they wrap

### DIFF
--- a/client/blocks/reader-combined-card/style.scss
+++ b/client/blocks/reader-combined-card/style.scss
@@ -53,12 +53,9 @@
 	display: block;
 	font-size: 17px;
 	font-weight: 700;
-	line-height: 1.2;
-	max-height: 16px * 1.6;
+	line-height: 1.4;
 	padding-left: 1px;
 	position: relative;
-	white-space: nowrap;
-	word-wrap: break-word;
 }
 
 .reader-combined-card__post-title-link,
@@ -69,11 +66,6 @@
 	&:hover,
 	&:focus {
 		color: var( --color-neutral-700 );
-	}
-
-	&::after {
-		@include long-content-fade( $size: 35px );
-		height: 16px * 1.4;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This pull requests removes the non-wrapping/fade out styles from the combined cards in the Reader. When displayed next to the 'standard' card's design, the cut off titles can look "broken". 

#### Testing instructions

* In the Reader, follow a prolific blog that frequently has long post titles. One example is [Newslines](https://newslanes.wordpress.com/), from the original issue report.
* View the Reader. Note the appearance of the 'combined cards' -- sets of posts the reader displays together to make sure blogs that post more frequently don't overwhelm your reader screen. Both the title and post excerpt don't wrap, and fade out to the right.
* Apply the patch.
* Confirm that the longer titles in the combined cards are no longer wrapping and fading out, so they appear more similar to single article cards. 
* Confirm that no new visual weirdness is introduced. 

**Before the patch:**
![Screen Shot 2019-04-29 at 3 14 01 PM](https://user-images.githubusercontent.com/177561/56930743-a9ea8800-6a92-11e9-9776-883453e81b78.png)
![Screen Shot 2019-04-29 at 3 15 01 PM](https://user-images.githubusercontent.com/177561/56930750-ace57880-6a92-11e9-83bb-fe6a332b58b3.png)

**After the patch:**
![Screen Shot 2019-04-29 at 3 12 58 PM](https://user-images.githubusercontent.com/177561/56931094-b1f6f780-6a93-11e9-8da0-4e928885edde.png)
![Screen Shot 2019-04-29 at 3 17 33 PM](https://user-images.githubusercontent.com/177561/56931100-b6231500-6a93-11e9-8cb3-8aa13d56a286.png)

Fixes #32393.
