### PR TITLE
Gutenberg: Use Calypsoify on JP sites ineligible for Gutenframe

### DIFF
--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -198,7 +198,7 @@ async function redirectIfBlockEditor( context, next ) {
 	const postId = getPostID( context );
 	const url = getGutenbergEditorUrl( state, siteId, postId, postType );
 	// pass along parameters, for example press-this
-	return page.redirect( addQueryArgs( context.query, url ) );
+	return window.location.replace( addQueryArgs( context.query, url ) );
 }
 
 export default {

--- a/client/post-editor/controller.js
+++ b/client/post-editor/controller.js
@@ -15,7 +15,6 @@ import { get, has, startsWith } from 'lodash';
 /**
  * Internal dependencies
  */
-import { isEnabled } from 'config';
 import { recordPlaceholdersTiming } from 'lib/perfmon';
 import { startEditingPostCopy, startEditingExistingPost } from 'state/posts/actions';
 import { addQueryArgs, addSiteFragment } from 'lib/route';
@@ -23,15 +22,13 @@ import PostEditor from './post-editor';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { startEditingNewPost, stopEditingPost } from 'state/ui/editor/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSite, getSiteAdminUrl, isJetpackMinimumVersion } from 'state/sites/selectors';
+import { getSite } from 'state/sites/selectors';
 import { getEditorNewPostPath } from 'state/ui/editor/selectors';
 import { getEditURL } from 'state/posts/utils';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
-import isGutenlypsoEnabled from 'state/selectors/is-gutenlypso-enabled';
-import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
-import getEditorUrl from 'state/selectors/get-editor-url';
 import { requestSelectedEditor, setSelectedEditor } from 'state/selected-editor/actions';
+import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
+import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
 
 function getPostID( context ) {
 	if ( ! context.params.post || 'new' === context.params.post ) {
@@ -189,11 +186,7 @@ async function redirectIfBlockEditor( context, next ) {
 		return next();
 	}
 
-	if (
-		! isCalypsoifyGutenbergEnabled( state, siteId ) &&
-		! isGutenlypsoEnabled( state, siteId ) &&
-		! isEnabled( 'jetpack/gutenframe' )
-	) {
+	if ( ! isGutenbergEnabled( state, siteId ) ) {
 		return next();
 	}
 
@@ -203,26 +196,9 @@ async function redirectIfBlockEditor( context, next ) {
 
 	const postType = determinePostType( context );
 	const postId = getPostID( context );
-
-	if ( false === isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) ) {
-		const siteAdminUrl = getSiteAdminUrl( state, siteId );
-		let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;
-
-		if ( postId ) {
-			url = `${ siteAdminUrl }post.php?post=${ postId }&action=edit`;
-		}
-
-		if ( isSiteAtomic( state, siteId ) ) {
-			url = addQueryArgs( { calypsoify: '1' }, url );
-		}
-
-		return window.location.replace( addQueryArgs( context.query, url ) );
-	}
-
-	let url = getEditorUrl( state, siteId, postId, postType );
+	const url = getGutenbergEditorUrl( state, siteId, postId, postType );
 	// pass along parameters, for example press-this
-	url = addQueryArgs( context.query, url );
-	return window.location.replace( url );
+	return page.redirect( addQueryArgs( context.query, url ) );
 }
 
 export default {

--- a/client/state/selectors/is-calypsoify-gutenberg-enabled.js
+++ b/client/state/selectors/is-calypsoify-gutenberg-enabled.js
@@ -1,53 +1,48 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { isEnabled } from 'config';
 import isVipSite from 'state/selectors/is-vip-site';
-import { isJetpackSite } from 'state/sites/selectors';
+import { getSiteAdminUrl, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import getSiteOptions from 'state/selectors/get-site-options';
 import getWordPressVersion from 'state/selectors/get-wordpress-version';
 import versionCompare from 'lib/version-compare';
 import isPluginActive from 'state/selectors/is-plugin-active';
+import { isHttps } from 'lib/url';
 
 export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
 		return false;
 	}
 
-	if ( isEnabled( 'jetpack/gutenframe' ) ) {
-		if (
-			versionCompare(
-				get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ),
-				'7.3-alpha',
-				'>='
-			)
-		) {
+	// We might want Calypsoify flows for Jetpack and Atomic sites.
+	if ( isJetpackSite( state, siteId ) || isSiteAutomatedTransfer( state, siteId ) ) {
+		// But only once they have been updated to WordPress version 5.0 or greater since it will provide Gutenberg
+		// editor by default.
+		const wpVersion = getWordPressVersion( state, siteId );
+		if ( versionCompare( wpVersion, '5.0', '<' ) ) {
 			return false;
 		}
-	}
 
-	// We do want Calypsoify flows for Atomic sites
-	if ( isSiteAutomatedTransfer( state, siteId ) ) {
-		const wpVersion = getWordPressVersion( state, siteId );
-
-		// But not if they activated Classic editor plugin (effectively opting out of Gutenberg)
+		// But not if they activated the Classic Editor plugin (effectively opting out of Gutenberg).
 		if ( isPluginActive( state, siteId, 'classic-editor' ) ) {
 			return false;
 		}
 
-		// But only once they have been updated to WordPress version 5.0 or greater
-		// Since it will provide Gutenberg editor by default
-		if ( versionCompare( wpVersion, '5.0', '>=' ) ) {
-			return true;
+		// We do want Gutenframe flows for JP/AT sites that have been updated to Jetpack 7.3 or greater since it will
+		// provide a way to handle the frame nonces verification. But only if the site has a SSL cert since the browser
+		// cannot embed insecure content in a resource loaded over a secure HTTPS connection.
+		if (
+			isEnabled( 'jetpack/gutenframe' ) &&
+			isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) &&
+			isHttps( getSiteAdminUrl( state, siteId ) )
+		) {
+			return false;
 		}
+
+		return isEnabled( 'calypsoify/gutenberg' );
 	}
 
 	// Prevent Calypsoify redirects if Gutenlypso is enabled.
@@ -59,7 +54,7 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 	}
 
 	// Not ready yet.
-	if ( isJetpackSite( state, siteId ) || isVipSite( state, siteId ) ) {
+	if ( isVipSite( state, siteId ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -1,19 +1,17 @@
 /** @format */
 
 /**
- * External dependencies
- */
-import { get } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { isEnabled } from 'config';
-import getSiteOptions from 'state/selectors/get-site-options';
 import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
 import isVipSite from 'state/selectors/is-vip-site';
-import { isJetpackSite } from 'state/sites/selectors';
 import versionCompare from 'lib/version-compare';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import getWordPressVersion from 'state/selectors/get-wordpress-version';
+import isPluginActive from 'state/selectors/is-plugin-active';
+import { getSiteAdminUrl, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
+import { isHttps } from 'lib/url';
 
 export const isGutenbergEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
@@ -24,16 +22,33 @@ export const isGutenbergEnabled = ( state, siteId ) => {
 		return true;
 	}
 
-	if ( isEnabled( 'jetpack/gutenframe' ) ) {
-		if (
-			versionCompare(
-				get( getSiteOptions( state, siteId ), 'jetpack_version', 0 ),
-				'7.3-alpha',
-				'>='
-			)
-		) {
-			return isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId );
+	// We do want Gutenframe flows for Jetpack and Atomic sites.
+	if ( isJetpackSite( state, siteId ) || isSiteAutomatedTransfer( state, siteId ) ) {
+		// But only once they have been updated to WordPress version 5.0 or greater since it will provide Gutenberg
+		// editor by default.
+		const wpVersion = getWordPressVersion( state, siteId );
+		if ( versionCompare( wpVersion, '5.0', '<' ) ) {
+			return false;
 		}
+
+		// But not if they activated the Classic Editor plugin (effectively opting out of Gutenberg).
+		if ( isPluginActive( state, siteId, 'classic-editor' ) ) {
+			return false;
+		}
+
+		// And also only if they have been updated to Jetpack 7.3 or greater since it will provide a way to handle the
+		// frame nonces verification.
+		if ( ! isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) ) {
+			return false;
+		}
+
+		// But only if the site has a SSL cert since the browser cannot embed insecure content in a resource loaded
+		// over a secure HTTPS connection.
+		if ( ! isHttps( getSiteAdminUrl( state, siteId ) ) ) {
+			return false;
+		}
+
+		return isEnabled( 'jetpack/gutenframe' );
 	}
 
 	return (

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -48,7 +48,9 @@ export const isGutenbergEnabled = ( state, siteId ) => {
 			return false;
 		}
 
-		return isEnabled( 'jetpack/gutenframe' );
+		return (
+			isEnabled( 'jetpack/gutenframe' ) && isEnabled( 'gutenberg' ) && ! isVipSite( state, siteId )
+		);
 	}
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use Calypsoify flows for the block editor on Jetpack sites that are not eligible for Gutenframe:
- Sites without a SSL certificate since browsers don't allow to load an insecure resource (the iframe) over a secure HTTPS connection (Calypso).
- Sites not satisfying the required Jetpack version (7.3+).

#### Testing instructions

Make sure you're testing with a Jetpack site connected to WordPress.com that has opted-in to Gutenberg and does not have SSL certs (a local [Jetpack Docker+Ngrok environment](https://github.com/Automattic/jetpack/tree/master/docker) would be an example).

* Load that Jetpack site in the block editor: `/block-editor/post/:jetpackDomain`.
* Confirm you're redirected to the Calypsoified WP Admin block editor.
* Go to `/posts/:jetpackDomain` and click on the "Add New Post" button.
* Confirm you're redirected to the Calypsoified WP Admin block editor.
* Start creating a post from from `/post/:jetpackDomain`.
* Confirm you're redirected to the Calypsoified WP Admin block editor.

Repeat the above steps with a Jetpack site having a version of Jetpack below 7.3.

Fixes #32626
