### PR TITLE
Gutenberg: Use Calypso Classic on AT sites if the Classic Editor plugin is active

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -51,6 +51,7 @@ import { isCommunityTranslatorEnabled } from 'components/community-translator/ut
 import { isE2ETest } from 'lib/e2e';
 import BodySectionCssClass from './body-section-css-class';
 import { retrieveMobileRedirect } from 'jetpack-connect/persistence-utils';
+import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 
 class Layout extends Component {
 	static displayName = 'Layout';
@@ -125,6 +126,7 @@ class Layout extends Component {
 				{ this.props.shouldQueryAllSites && <QuerySites allSites /> }
 				<QueryPreferences />
 				<QuerySiteSelectedEditor siteId={ this.props.siteId } />
+				{ this.props.siteId && <QueryJetpackPlugins siteIds={ [ this.props.siteId ] } /> }
 				<AsyncLoad require="layout/guided-tours" placeholder={ null } />
 				{ config.isEnabled( 'nps-survey/notice' ) && ! isE2ETest() && (
 					<AsyncLoad require="layout/nps-survey-notice" placeholder={ null } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed that multiple selectors were not able to detect if the Classic Editor plugin was installed because we didn't have any plugin stored on the state. 

I realized this was due to the lack of any dispatched action fetching the plugin and probably the cause of the issue described on p3fqKv-6Hh-p2 (#comment-10150). 

Since we need the plugins in different parts of the application (on page controllers, on individual components) I decided to include the `QueryJetpackPlugins` query component in the `Layout` component, so the state will always reflect the installed plugins.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install the Classic Editor plugin on an Atomic site.
* In Calypso, go to `/posts/:atomicSiteSlug`.
* Click on the "Add New Post" button.
* Make sure you see the Calypso Classic editor.

Fixes #32676
