### PR TITLE
Checklist: expand checklist tasks onclick

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -159,6 +159,15 @@
 			background: var( --color-accent );
 			border-color: var( --color-accent );
 		}
+
+		&.is-disabled,
+		&.is-disabled:focus,
+		&.is-disabled:hover,
+		&.is-disabled:active {
+			border: 2px solid var( --color-neutral-100 );
+			background: var( --color-white );
+			cursor: default;
+		}
 	}
 
 	.spinner {

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -68,7 +68,7 @@ class Task extends PureComponent {
 			);
 		}
 
-		if ( disableIcon && ! completed ) {
+		if ( disableIcon ) {
 			return (
 				<div className="checklist__task-icon is-disabled">
 					<ScreenReaderText>{ translate( 'Waiting to complete' ) }</ScreenReaderText>

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -7,6 +7,7 @@ import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import CompactCard from 'components/card/compact';
 import Focusable from 'components/focusable';
 import ScreenReaderText from 'components/screen-reader-text';
 import Spinner from 'components/spinner';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 class Task extends PureComponent {
 	static propTypes = {
@@ -42,12 +44,19 @@ class Task extends PureComponent {
 		trackTaskDisplay: () => {},
 	};
 
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isCollapsed: props.firstIncomplete.id !== props.id,
+		};
+	}
+
 	componentDidMount() {
 		this.props.trackTaskDisplay( this.props.id, this.props.completed, 'checklist' );
 	}
 
 	renderCheckmarkIcon() {
-		const { completed, inProgress, isWarning, translate } = this.props;
+		const { completed, disableIcon, inProgress, isWarning, translate } = this.props;
 		const onDismiss = ! completed ? this.props.onDismiss : undefined;
 
 		if ( inProgress ) {
@@ -56,6 +65,14 @@ class Task extends PureComponent {
 					<ScreenReaderText>{ translate( 'In progress' ) }</ScreenReaderText>
 					{ this.renderGridicon() }
 				</Fragment>
+			);
+		}
+
+		if ( disableIcon && ! completed ) {
+			return (
+				<div className="checklist__task-icon is-disabled">
+					<ScreenReaderText>{ translate( 'Waiting to complete' ) }</ScreenReaderText>
+				</div>
 			);
 		}
 
@@ -95,6 +112,21 @@ class Task extends PureComponent {
 		return null;
 	}
 
+	onTaskClick = event => {
+		event.preventDefault();
+
+		if ( this.props.isExpandable && this.state.isCollapsed ) {
+			this.props.recordTracksEvent( 'calypso_checklist_task_expand', {
+				step_name: this.props.id,
+			} );
+			this.setState( {
+				isCollapsed: false,
+			} );
+		} else {
+			this.props.onClick();
+		}
+	};
+
 	renderGridicon() {
 		if ( this.props.inProgress ) {
 			return <Spinner size={ 20 } />;
@@ -128,11 +160,9 @@ class Task extends PureComponent {
 			target,
 			title,
 			translate,
-			firstIncomplete,
 		} = this.props;
 		const { buttonText = translate( 'Do it!' ) } = this.props;
 		const hasActionlink = completed && completedButtonText;
-		const isCollapsed = firstIncomplete && firstIncomplete.id !== this.props.id;
 
 		return (
 			<CompactCard
@@ -141,18 +171,12 @@ class Task extends PureComponent {
 					'is-completed': completed,
 					'is-in-progress': inProgress,
 					'has-actionlink': hasActionlink,
-					'is-collapsed': isCollapsed,
+					'is-collapsed': this.state.isCollapsed,
 				} ) }
 			>
 				<div className="checklist__task-primary">
 					<h3 className="checklist__task-title">
-						<Button
-							borderless
-							className="checklist__task-title-link"
-							href={ href }
-							onClick={ onClick }
-							target={ target }
-						>
+						<Button borderless className="checklist__task-title-link" href={ href }  onClick={ this.onTaskClick } target={ target }>
 							{ ( completed && completedTitle ) || title }
 						</Button>
 					</h3>
@@ -167,13 +191,7 @@ class Task extends PureComponent {
 					) }
 				</div>
 				<div className="checklist__task-secondary">
-					<Button
-						className="checklist__task-action"
-						href={ href }
-						onClick={ onClick }
-						primary={ buttonPrimary }
-						target={ target }
-					>
+					<Button className="checklist__task-action" href={ href } onClick={ onClick } primary={ buttonPrimary } target={ target }>
 						{ hasActionlink ? completedButtonText : buttonText }
 					</Button>
 					{ duration && (
@@ -189,4 +207,7 @@ class Task extends PureComponent {
 	}
 }
 
-export default localize( Task );
+export default connect(
+	null,
+	{ recordTracksEvent }
+)( localize( Task ) );

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -7,7 +7,6 @@ import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -17,7 +16,6 @@ import CompactCard from 'components/card/compact';
 import Focusable from 'components/focusable';
 import ScreenReaderText from 'components/screen-reader-text';
 import Spinner from 'components/spinner';
-import { recordTracksEvent } from 'state/analytics/actions';
 
 class Task extends PureComponent {
 	static propTypes = {
@@ -28,6 +26,7 @@ class Task extends PureComponent {
 		completedDescription: PropTypes.node,
 		completedTitle: PropTypes.node,
 		description: PropTypes.node,
+		disableIcon: PropTypes.bool,
 		duration: PropTypes.string,
 		href: PropTypes.string,
 		isCollapsed: PropTypes.bool,
@@ -115,9 +114,6 @@ class Task extends PureComponent {
 		if ( ! completed && this.isTaskCollapsed() && onCollapsedClick ) {
 			event.preventDefault();
 			onCollapsedClick( id );
-			this.props.recordTracksEvent( 'calypso_checklist_task_expand', {
-				step_name: id,
-			} );
 		} else {
 			// The task-related action
 			onClick();
@@ -212,7 +208,4 @@ class Task extends PureComponent {
 	}
 }
 
-export default connect(
-	null,
-	{ recordTracksEvent }
-)( localize( Task ) );
+export default localize( Task );

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -29,7 +29,6 @@ class Task extends PureComponent {
 		disableIcon: PropTypes.bool,
 		duration: PropTypes.string,
 		href: PropTypes.string,
-		isCollapsed: PropTypes.bool,
 		inProgress: PropTypes.bool,
 		isWarning: PropTypes.bool,
 		onClick: PropTypes.func,

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -35,6 +35,7 @@ class Task extends PureComponent {
 		onClick: PropTypes.func,
 		onCollapsedClick: PropTypes.func,
 		onDismiss: PropTypes.func,
+		selectedTaskId: PropTypes.string,
 		target: PropTypes.string,
 		title: PropTypes.node.isRequired,
 		translate: PropTypes.func.isRequired,
@@ -107,7 +108,6 @@ class Task extends PureComponent {
 	}
 
 	onTaskClick = event => {
-
 		const { completed, id, onClick, onCollapsedClick } = this.props;
 
 		// We presuppose expandability based on the presence of `onCollapsedClick`
@@ -121,9 +121,11 @@ class Task extends PureComponent {
 	};
 
 	isTaskCollapsed = () =>
-		typeof this.props.isCollapsed === 'boolean'
-			? this.props.isCollapsed
-			: this.props.firstIncomplete && this.props.firstIncomplete.id !== this.props.id;
+		this.props.selectedTaskId
+			? // If any task is selected, we only check if this task matches the selected ID...
+			  this.props.selectedTaskId !== this.props.id
+			: // If no task is selected, fall back to checking if this task is the first in line
+			  this.props.firstIncomplete && this.props.firstIncomplete.id !== this.props.id;
 
 	renderGridicon() {
 		if ( this.props.inProgress ) {
@@ -177,7 +179,13 @@ class Task extends PureComponent {
 			>
 				<div className="checklist__task-primary">
 					<h3 className="checklist__task-title">
-						<Button borderless className="checklist__task-title-link" href={ href }  onClick={ this.onTaskClick } target={ target }>
+						<Button
+							borderless
+							className="checklist__task-title-link"
+							href={ href }
+							onClick={ this.onTaskClick }
+							target={ target }
+						>
 							{ ( completed && completedTitle ) || title }
 						</Button>
 					</h3>
@@ -192,7 +200,13 @@ class Task extends PureComponent {
 					) }
 				</div>
 				<div className="checklist__task-secondary">
-					<Button className="checklist__task-action" href={ href } onClick={ onClick } primary={ buttonPrimary } target={ target }>
+					<Button
+						className="checklist__task-action"
+						href={ href }
+						onClick={ onClick }
+						primary={ buttonPrimary }
+						target={ target }
+					>
 						{ taskActionButtonText }
 					</Button>
 					{ duration && (

--- a/client/my-sites/checklist/style.scss
+++ b/client/my-sites/checklist/style.scss
@@ -17,3 +17,8 @@
 		margin: 0 3px;
 	}
 }
+
+.checklist__task-title-link {
+	width: 100%;
+	text-align: left;
+}

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -332,7 +332,7 @@ class WpcomChecklistComponent extends PureComponent {
 			closePopover: closePopover,
 			trackTaskDisplay: this.trackTaskDisplay,
 			isExpandable: true,
-			disableIcon: 'email_verified' === task.id,
+			disableIcon: ! task.isCompleted && 'email_verified' === task.id,
 		};
 
 		if ( this.shouldRenderTask( task.id ) ) {

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -60,6 +60,7 @@ class WpcomChecklistComponent extends PureComponent {
 		emailSent: false,
 		error: null,
 		gSuiteDialogVisible: false,
+		selectedTaskId: null,
 	};
 
 	constructor() {
@@ -160,6 +161,8 @@ class WpcomChecklistComponent extends PureComponent {
 			location,
 		} );
 	};
+
+	onCollapsedClick = selectedTaskId => this.setState( { selectedTaskId } );
 
 	handleTaskStartThenDismiss = args => () => {
 		const { task } = args;
@@ -321,6 +324,9 @@ class WpcomChecklistComponent extends PureComponent {
 
 		const taskList = getTaskList( this.props );
 		const firstIncomplete = taskList.getFirstIncompleteTask();
+		const isCollapsed = this.state.selectedTaskId
+			? this.state.selectedTaskId !== task.id
+			: undefined;
 
 		const baseProps = {
 			id: task.id,
@@ -328,10 +334,13 @@ class WpcomChecklistComponent extends PureComponent {
 			completed: task.isCompleted,
 			siteSlug,
 			firstIncomplete,
-			buttonPrimary: firstIncomplete && firstIncomplete.id === task.id,
+			buttonPrimary: ! isCollapsed,
 			closePopover: closePopover,
 			trackTaskDisplay: this.trackTaskDisplay,
-			isExpandable: true,
+			onCollapsedClick: this.onCollapsedClick,
+			// Overrides the default collapsed state for the task
+			isCollapsed,
+			// only render an unclickable grey circle
 			disableIcon: ! task.isCompleted && 'email_verified' === task.id,
 		};
 

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -162,7 +162,12 @@ class WpcomChecklistComponent extends PureComponent {
 		} );
 	};
 
-	onCollapsedClick = selectedTaskId => this.setState( { selectedTaskId } );
+	onCollapsedClick = selectedTaskId => {
+		this.setState( { selectedTaskId } );
+		this.props.recordTracksEvent( 'calypso_checklist_task_expand', {
+			step_name: selectedTaskId,
+		} );
+	};
 
 	handleTaskStartThenDismiss = args => () => {
 		const { task } = args;

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -331,6 +331,8 @@ class WpcomChecklistComponent extends PureComponent {
 			buttonPrimary: firstIncomplete && firstIncomplete.id === task.id,
 			closePopover: closePopover,
 			trackTaskDisplay: this.trackTaskDisplay,
+			isExpandable: true,
+			disableIcon: 'email_verified' === task.id,
 		};
 
 		if ( this.shouldRenderTask( task.id ) ) {

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -329,9 +329,7 @@ class WpcomChecklistComponent extends PureComponent {
 
 		const taskList = getTaskList( this.props );
 		const firstIncomplete = taskList.getFirstIncompleteTask();
-		const isCollapsed = this.state.selectedTaskId
-			? this.state.selectedTaskId !== task.id
-			: undefined;
+		const buttonPrimary = this.state.selectedTaskId ? this.state.selectedTaskId === task.id : true;
 
 		const baseProps = {
 			id: task.id,
@@ -339,7 +337,7 @@ class WpcomChecklistComponent extends PureComponent {
 			completed: task.isCompleted,
 			siteSlug,
 			firstIncomplete,
-			buttonPrimary: ! isCollapsed,
+			buttonPrimary,
 			closePopover: closePopover,
 			trackTaskDisplay: this.trackTaskDisplay,
 			onCollapsedClick: this.onCollapsedClick,

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -343,10 +343,9 @@ class WpcomChecklistComponent extends PureComponent {
 			closePopover: closePopover,
 			trackTaskDisplay: this.trackTaskDisplay,
 			onCollapsedClick: this.onCollapsedClick,
-			// Overrides the default collapsed state for the task
-			isCollapsed,
 			// only render an unclickable grey circle
 			disableIcon: ! task.isCompleted && 'email_verified' === task.id,
+			selectedTaskId: this.state.selectedTaskId,
 		};
 
 		if ( this.shouldRenderTask( task.id ) ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request

When a user visits the checklist, all but the first unfinished task is collapsed and clicking on collapsed tasks sends the user to do the event instead of expanding the task. 

The better experience would be to expand the clicked task so that the user can read the description and decide to start the event via the "**Do it**" button.

![May-01-2019 12-14-08](https://user-images.githubusercontent.com/6458278/57003773-5e5be980-6c0c-11e9-9d49-ee28b96943d5.gif)

ℹ️ These changes should only affect the WordPress.com checklist. cc @Automattic/luna to ensure that the Jetpack checklist isn't affected. I checked, but it'd be good to get more practised 👀over it

![May-01-2019 12-33-15](https://user-images.githubusercontent.com/6458278/57003928-88fa7200-6c0d-11e9-8f62-19ba65e9f725.gif)

## Testing instructions

### Collapsibility
Clicking on an **uncompleted**, collapsed task should expand it and display the description and "**Do it**" button. The currently-expanded **uncompleted** task should collapse.

Furthermore, a `calypso_checklist_task_expand` event should fire with a step_name property, the value of which is the task id.

<img width="614" alt="Screen Shot 2019-05-01 at 12 15 51 pm" src="https://user-images.githubusercontent.com/6458278/57003654-9f9fc980-6c0b-11e9-9255-c5c3d838090d.png">

### _"Confirm your email address"_ task

1. Create a site with a new user account.
2. Check that the _"Confirm your email address"_ task is present and is collapsible according to the above tests. 
<img width="786" alt="Screen Shot 2019-05-01 at 12 13 08 pm" src="https://user-images.githubusercontent.com/6458278/57003737-058c5100-6c0c-11e9-94f2-b326d5a608bd.png">
3. Check that you cannot interact with the icon
4. Expand the task and verify your email address
5. When you're redirected to the checklist page again, the task should be complete.
<img width="601" alt="Screen Shot 2019-05-01 at 12 17 19 pm" src="https://user-images.githubusercontent.com/6458278/57003740-0de48c00-6c0c-11e9-9833-b5c7090606e6.png">



