### PR TITLE
Full Site Editing: Fix blocks console errors

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blocks/content-slot/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/content-slot/edit.js
@@ -12,7 +12,7 @@ import { IconButton, Placeholder, Toolbar } from '@wordpress/components';
 import { withState } from '@wordpress/compose';
 import { BlockControls } from '@wordpress/editor';
 import { Fragment, RawHTML } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -64,12 +64,11 @@ const ContentSlotEdit = withState( {
 					>
 						<div className="a8c-content-slot-block__selector">
 							<div>{ __( 'Select something to preview:' ) }</div>
-							<PostAutocomplete
-								selectedPostTitle={ get( selectedPost, 'title.rendered' ) }
-								onSelectPost={ onSelectPost }
-							/>
+							<PostAutocomplete onSelectPost={ onSelectPost } />
 							{ !! selectedPost && (
-								<a href={ `?post=${ selectedPost.id }&action=edit` }>{ __( 'Edit' ) }</a>
+								<a href={ `?post=${ selectedPost.id }&action=edit` }>
+									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.rendered', '' ) ) }
+								</a>
 							) }
 						</div>
 					</Placeholder>

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template-part/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template-part/edit.js
@@ -12,7 +12,7 @@ import { IconButton, Placeholder, Toolbar } from '@wordpress/components';
 import { withState } from '@wordpress/compose';
 import { BlockControls } from '@wordpress/editor';
 import { Fragment, RawHTML } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -81,12 +81,11 @@ const TemplatePartEdit = withState( {
 						instructions={ __( 'Select a template part to display' ) }
 					>
 						<div className="a8c-template-part-block__selector">
-							<PostAutocomplete
-								selectedPostTitle={ get( selectedPost, 'title.rendered' ) }
-								onSelectPost={ onSelectPost }
-							/>
-							{ !! selectedPostId && (
-								<a href={ `?post=${ selectedPostId }&action=edit` }>{ __( 'Edit' ) }</a>
+							<PostAutocomplete onSelectPost={ onSelectPost } />
+							{ !! selectedPost && (
+								<a href={ `?post=${ selectedPost.id }&action=edit` }>
+									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.rendered', '' ) ) }
+								</a>
 							) }
 						</div>
 					</Placeholder>

--- a/apps/full-site-editing/full-site-editing-plugin/components/post-autocomplete/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/components/post-autocomplete/index.js
@@ -59,60 +59,50 @@ const selectSuggestion = async ( suggestion, setState ) => {
 };
 const PostAutocomplete = withState( {
 	loading: false,
-	search: null,
+	search: '',
 	showSuggestions: false,
 	suggestions: [],
-} )(
-	( {
-		loading,
-		onSelectPost,
-		search,
-		selectedPostTitle,
-		setState,
-		showSuggestions,
-		suggestions,
-	} ) => {
-		const onChange = inputValue => {
-			setState( { search: inputValue } );
-			if ( inputValue.length < 2 ) {
-				setState( {
-					loading: false,
-					showSuggestions: false,
-				} );
-				return;
-			}
-			updateSuggestions( inputValue, setState );
-		};
+} )( ( { loading, onSelectPost, search, setState, showSuggestions, suggestions } ) => {
+	const onChange = inputValue => {
+		setState( { search: inputValue } );
+		if ( inputValue.length < 2 ) {
+			setState( {
+				loading: false,
+				showSuggestions: false,
+			} );
+			return;
+		}
+		updateSuggestions( inputValue, setState );
+	};
 
-		const onClick = suggestion => async () => {
-			const selectedPost = await selectSuggestion( suggestion, setState );
-			onSelectPost( selectedPost );
-		};
+	const onClick = suggestion => async () => {
+		const selectedPost = await selectSuggestion( suggestion, setState );
+		onSelectPost( selectedPost );
+	};
 
-		return (
-			<div className="a8c-post-autocomplete">
-				<TextControl
-					autoComplete="off"
-					onChange={ onChange }
-					placeholder={ __( 'Type to search' ) }
-					type="search"
-					value={ search !== null ? search : selectedPostTitle }
-				/>
-				{ loading && <Spinner /> }
-				{ showSuggestions && !! suggestions.length && (
-					<Popover focusOnMount={ false } noArrow position="bottom">
-						<div className="a8c-post-autocomplete__suggestions">
-							{ map( suggestions, suggestion => (
-								<Button isLarge isLink key={ suggestion.id } onClick={ onClick( suggestion ) }>
-									{ suggestion.title }
-								</Button>
-							) ) }
-						</div>
-					</Popover>
-				) }
-			</div>
-		);
-	}
-);
+	return (
+		<div className="a8c-post-autocomplete">
+			<TextControl
+				autoComplete="off"
+				onChange={ onChange }
+				placeholder={ __( 'Type to search' ) }
+				type="search"
+				value={ search }
+			/>
+			{ loading && <Spinner /> }
+			{ showSuggestions && !! suggestions.length && (
+				<Popover focusOnMount={ false } noArrow position="bottom">
+					<div className="a8c-post-autocomplete__suggestions">
+						{ map( suggestions, suggestion => (
+							<Button isLarge isLink key={ suggestion.id } onClick={ onClick( suggestion ) }>
+								{ suggestion.title }
+							</Button>
+						) ) }
+					</div>
+				</Popover>
+			) }
+		</div>
+	);
+} );
 
 export default PostAutocomplete;

--- a/apps/full-site-editing/full-site-editing-plugin/components/post-autocomplete/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/components/post-autocomplete/index.js
@@ -103,7 +103,7 @@ const PostAutocomplete = withState( {
 					<Popover focusOnMount={ false } noArrow position="bottom">
 						<div className="a8c-post-autocomplete__suggestions">
 							{ map( suggestions, suggestion => (
-								<Button isLarge isLink onClick={ onClick( suggestion ) }>
+								<Button isLarge isLink key={ suggestion.id } onClick={ onClick( suggestion ) }>
 									{ suggestion.title }
 								</Button>
 							) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/components/post-autocomplete/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/components/post-autocomplete/index.js
@@ -92,7 +92,7 @@ const PostAutocomplete = withState( {
 		return (
 			<div className="a8c-post-autocomplete">
 				<TextControl
-					autocomplete="off"
+					autoComplete="off"
 					onChange={ onChange }
 					placeholder={ __( 'Type to search' ) }
 					type="search"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In my previous PR I was accidentally running React in production, suppressing console warnings.
This PR takes care of them.

* Replace `autocomplete` attribute with the React-compliant `autoComplete`.
* Give a unique `key` to the post selector's suggestions popover items.
* Fix the autocomplete input field being uncontrolled (on change it updates its own state) and controlled (its value falls back to the `props.selectedPostTitle` provided by the parent component) at the same time. For this reason, I've moved the selected post title away from the input field, and into the "Edit" link below.

(Sorry for the high LOC diff, but by removing one prop the entire PostAutocomplete component changed its indentation.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the `wp-config.php` contains:
```php
define( 'WP_DEBUG', true );
define( 'SCRIPT_DEBUG', true );
```
* Poke around the Content and Template blocks and make sure they don't throw the errors listed above in console.

Note that there are other unrelated console errors, but as far as I can see they are caused by Gutenberg itself.