### PR TITLE
Inline Help: Increase elevation on floating button

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -57,7 +57,7 @@
 	padding: 1px;
 	border-radius: 100%;
 	background-color: var( --color-primary );
-	box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.15 );
+	@include elevation( 4dp );
 	border: 1px solid var( --color-primary-dark );
 	transition: all 0.2s ease-in-out;
 	overflow: visible;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increase box shadows on floating inline help button to `4dp` using the elevation mixin to help set it apart from the content below.
* I initially started with `3dp` but didn't see enough of a difference. I don't know if `4dp` is too high, though. Thoughts on how I'm using elevation here are welcome!

**Before**

<img width="293" alt="Screen Shot 2019-04-30 at 9 32 16 AM" src="https://user-images.githubusercontent.com/2124984/56966303-d226c500-6b2c-11e9-9881-128c0e199d81.png">

**After**

<img width="301" alt="Screen Shot 2019-04-30 at 9 43 18 AM" src="https://user-images.githubusercontent.com/2124984/56966319-dc48c380-6b2c-11e9-9418-1914db36b45e.png">

#### Testing instructions

* Switch to this PR
* Check out the box shadows on the inline help button in the lower right corner.

Fixes #32525
