### PR TITLE
Don't validate the signup form on change

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -154,6 +154,7 @@ class SignupForm extends Component {
 			debounceWait: VALIDATION_DELAY_AFTER_FIELD_CHANGES,
 			hideFieldErrorsOnChange: true,
 			initialState: this.props.step ? this.props.step.form : undefined,
+			skipSanitizeAndValidateOnFieldChange: true,
 		} );
 
 		const initialState = this.formStateController.getInitialState();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I spent some more time looking at this: https://github.com/Automattic/wp-calypso/issues/31694. I found a way to totally disable the validation when the field values change. This might be an improvement, but it does mean that you won't know if your changes are valid until you move on to the next field. This would be particularly annoying for the username field.

* Only validate the signup form on blur, not on change.

#### Testing instructions

* Open http://calypso.localhost:3000/start and enter an invalid email address
* Check that it doesn't turn red until you come out of the field

Fixes #31694 
