### PR TITLE
Install fonts for i18n tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -677,12 +677,6 @@ workflows:
           test-flags: '-W -S $CIRCLE_SHA1'
           test-target: 'WOO'
           slack-webhook: '$SLACK_WOO'
-      - test-e2e-canary:
-          name: test-e2e-i18n-monthly
-          requires:
-            - wait-calypso-live
-          test-target: 'I18N'
-          test-flags: '-i'
 
   calypso-nightly:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -558,6 +558,7 @@ jobs:
     steps:
       - prepare
       - run: *set-e2e-variables
+      - run: sudo apt-get install -y fonts-ipafont-gothic xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic fonts-wqy-zenhei
       - run:
           name: Skip Jetpack Tests if needed
           command: |
@@ -676,6 +677,12 @@ workflows:
           test-flags: '-W -S $CIRCLE_SHA1'
           test-target: 'WOO'
           slack-webhook: '$SLACK_WOO'
+      - test-e2e-canary:
+          name: test-e2e-i18n-monthly
+          requires:
+            - wait-calypso-live
+          test-target: 'I18N'
+          test-flags: '-i'
 
   calypso-nightly:
     jobs:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Install missing fonts for i18n canary tests. For missing fonts the screenshots were showing squares instead of characters

#### Testing instructions
* Nothing really to test. I triggered a test build where the fonts were installed and all the tests passed- https://circleci.com/gh/Automattic/wp-calypso/269363
