### PR TITLE
Build: Fix how splitChunk names are set and generated in production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -171,7 +171,7 @@ const webpackConfig = {
 	optimization: {
 		splitChunks: {
 			chunks: codeSplit ? 'all' : 'async',
-			name: isDevelopment || shouldEmitStats,
+			name: !! ( isDevelopment || shouldEmitStats ),
 			maxAsyncRequests: 20,
 			maxInitialRequests: 5,
 		},
@@ -243,7 +243,7 @@ const webpackConfig = {
 		],
 	},
 	resolve: {
-			extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
+		extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 		modules: [ path.join( __dirname, 'client' ), 'node_modules' ],
 		alias: Object.assign(
 			{


### PR DESCRIPTION
`optimization.splitChunks.name` must be a boolean `false` for chunk names to be suppressed, but is set to `undefined` for production builds that do not emit stats. This results in auto-generated names for automatically split chunks, like `vendors~build~landing`, which take up more room in the resulting JS and increase the size of our bundles.

#### Changes proposed in this Pull Request

* Force `splitChunks.name` to a boolean to fix how chunk names are generated in production builds.

#### Testing instructions

* `CALYPSO_ENV=production npm run build`
* Inspect the results in `public/evergreen` and `public/fallback`. There should be no files with `~` in the filename, like `vendors~*`


