### PR TITLE
Marketing: Add tracking to Marketing Tools page

### DIFF
--- a/client/my-sites/marketing/tools/feature.tsx
+++ b/client/my-sites/marketing/tools/feature.tsx
@@ -9,7 +9,7 @@ import React, { ReactNode, FunctionComponent } from 'react';
 import Card from 'components/card';
 import CardHeading from 'components/card-heading';
 
-interface MarketingToolsFeatureProps {
+interface Props {
 	children: ReactNode;
 	description: string;
 	disclaimer?: string;
@@ -18,7 +18,7 @@ interface MarketingToolsFeatureProps {
 	title: string;
 }
 
-const MarketingToolsFeature: FunctionComponent< MarketingToolsFeatureProps > = ( {
+const MarketingToolsFeature: FunctionComponent< Props > = ( {
 	children,
 	description,
 	disclaimer,

--- a/client/my-sites/marketing/tools/header.tsx
+++ b/client/my-sites/marketing/tools/header.tsx
@@ -36,7 +36,7 @@ const MarketingToolsHeader: FunctionComponent< Props > = ( {
 
 				<h2 className="tools__header-description">
 					{ translate(
-						'Optimize your site for search engines and get more exposure for your business. Let’s make the most of your site’s built-in SEO tools!'
+						"Optimize your site for search engines and get more exposure for your business. Let's make the most of your site's built-in SEO tools!"
 					) }
 				</h2>
 

--- a/client/my-sites/marketing/tools/header.tsx
+++ b/client/my-sites/marketing/tools/header.tsx
@@ -10,11 +10,11 @@ import { useTranslate } from 'i18n-calypso';
 import Button from 'components/button';
 import Card from 'components/card';
 
-interface MarketingToolsHeaderProps {
+interface Props {
 	handleButtonClick: () => void;
 }
 
-const MarketingToolsHeader: FunctionComponent< MarketingToolsHeaderProps > = ( {
+const MarketingToolsHeader: FunctionComponent< Props > = ( {
 	handleButtonClick,
 } ) => {
 	const translate = useTranslate();

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -24,6 +24,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import './style.scss';
 
 interface MarketingToolsProps {
+	recordTracksEvent: () => void;
 	selectedSiteSlug: string | null;
 }
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -63,7 +63,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 				<MarketingToolsFeature
 					title={ translate( 'Get social, and share your blog posts where the people are' ) }
 					description={ translate(
-						'Use your site’s Publicize tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Twitter, Facebook, LinkedIn, and more.'
+						"Use your site's Publicize tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Twitter, Facebook, LinkedIn, and more."
 					) }
 					imagePath="/calypso/images/illustrations/marketing.svg"
 				>
@@ -73,7 +73,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 				<MarketingToolsFeature
 					title={ translate( 'Need an expert to help realize your vision? Hire one!' ) }
 					description={ translate(
-						'We’ve partnered with Upwork, a network of freelancers with a huge pool of WordPress experts. Hire a pro to help build your dream site.'
+						"We've partnered with Upwork, a network of freelancers with a huge pool of WordPress experts. Hire a pro to help build your dream site."
 					) }
 					imagePath="/calypso/images/illustrations/expert.svg"
 				>
@@ -85,7 +85,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 				<MarketingToolsFeature
 					title={ translate( 'Want to build a great brand? Start with a great logo' ) }
 					description={ translate(
-						'A custom logo helps your brand pop and makes your site memorable. Our partner Looka is standing by if you’d like some professional help.'
+						"A custom logo helps your brand pop and makes your site memorable. Our partner Looka is standing by if you'd like some professional help."
 					) }
 					imagePath="/calypso/images/illustrations/branding.svg"
 				>

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -3,7 +3,6 @@
  */
 import { connect } from 'react-redux';
 import page from 'page';
-import PropTypes from 'prop-types';
 import React, { Fragment, FunctionComponent } from 'react';
 import { useTranslate } from 'i18n-calypso';
 
@@ -23,12 +22,12 @@ import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/ac
  */
 import './style.scss';
 
-interface MarketingToolsProps {
+interface Props {
 	recordTracksEvent: () => void;
 	selectedSiteSlug: string | null;
 }
 
-export const MarketingTools: FunctionComponent< MarketingToolsProps > = ( {
+export const MarketingTools: FunctionComponent< Props > = ( {
 	recordTracksEvent,
 	selectedSiteSlug,
 } ) => {
@@ -97,11 +96,6 @@ export const MarketingTools: FunctionComponent< MarketingToolsProps > = ( {
 			</div>
 		</Fragment>
 	);
-};
-
-MarketingTools.propTypes = {
-	recordTracksEvent: PropTypes.func.isRequired,
-	selectedSiteSlug: PropTypes.string,
 };
 
 export default connect(

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -16,7 +16,7 @@ import MarketingToolsFeature from './feature';
 import MarketingToolsHeader from './header';
 import { marketingSharingButtons, marketingTraffic } from 'my-sites/marketing/paths';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { recordTracksEvent } from 'state/analytics/actions';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -109,6 +109,6 @@ export default connect(
 		selectedSiteSlug: getSelectedSiteSlug( state ),
 	} ),
 	{
-		recordTracksEvent,
+		recordTracksEvent: recordTracksEventAction,
 	}
 )( MarketingTools );

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -15,6 +15,8 @@ import { getSelectedSiteSlug } from 'state/ui/selectors';
 import MarketingToolsFeature from './feature';
 import MarketingToolsHeader from './header';
 import { marketingSharingButtons, marketingTraffic } from 'my-sites/marketing/paths';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -26,21 +28,37 @@ interface MarketingToolsProps {
 }
 
 export const MarketingTools: FunctionComponent< MarketingToolsProps > = ( {
+	recordTracksEvent,
 	selectedSiteSlug,
 } ) => {
 	const translate = useTranslate();
 
 	const handleBoostMyTrafficClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_boost_my_traffic_button_click' );
+
 		page( marketingTraffic( selectedSiteSlug ) );
 	};
 
+	const handleCreateALogoClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_create_a_logo_button_click' );
+	};
+
+	const handleFindYourExpertClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_find_your_expert_button_click' );
+	};
+
 	const handleStartSharingClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_start_sharing_button_click' );
+
 		page( marketingSharingButtons( selectedSiteSlug ) );
 	};
 
 	return (
 		<Fragment>
+			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
+
 			<MarketingToolsHeader handleButtonClick={ handleBoostMyTrafficClick } />
+
 			<div className="tools__feature-list">
 				<MarketingToolsFeature
 					title={ translate( 'Get social, and share your blog posts where the people are' ) }
@@ -59,10 +77,11 @@ export const MarketingTools: FunctionComponent< MarketingToolsProps > = ( {
 					) }
 					imagePath="/calypso/images/illustrations/expert.svg"
 				>
-					<Button href={ '/experts/upwork?source=marketingtools' } target="_blank">
+					<Button onClick={ handleFindYourExpertClick } href={ '/experts/upwork?source=marketingtools' } target="_blank">
 						{ translate( 'Find Your Expert' ) }
 					</Button>
 				</MarketingToolsFeature>
+
 				<MarketingToolsFeature
 					title={ translate( 'Want to build a great brand? Start with a great logo' ) }
 					description={ translate(
@@ -70,7 +89,7 @@ export const MarketingTools: FunctionComponent< MarketingToolsProps > = ( {
 					) }
 					imagePath="/calypso/images/illustrations/branding.svg"
 				>
-					<Button href={ 'http://logojoy.grsm.io/looka' } target="_blank">
+					<Button onClick={ handleCreateALogoClick } href={ 'http://logojoy.grsm.io/looka' } target="_blank">
 						{ translate( 'Create A Logo' ) }
 					</Button>
 				</MarketingToolsFeature>
@@ -80,9 +99,15 @@ export const MarketingTools: FunctionComponent< MarketingToolsProps > = ( {
 };
 
 MarketingTools.propTypes = {
+	recordTracksEvent: PropTypes.func.isRequired,
 	selectedSiteSlug: PropTypes.string,
 };
 
-export default connect( state => ( {
-	selectedSiteSlug: getSelectedSiteSlug( state ),
-} ) )( MarketingTools );
+export default connect(
+	state => ( {
+		selectedSiteSlug: getSelectedSiteSlug( state ),
+	} ),
+	{
+		recordTracksEvent,
+	}
+)( MarketingTools );

--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -17,7 +17,8 @@
 .tools__header-title {
 	font-size: 21px;
 	font-weight: 400;
-	margin: 10px 5px;
+	margin-bottom: 10px;
+	margin-top: 10px;
 }
 
 .tools__header-description {
@@ -30,6 +31,7 @@
 	display: flex;
 	flex-direction: row;
 	margin: 20px 0;
+
 	.button {
 		@include breakpoint( '<480px' ) {
 			width: 100%;
@@ -40,6 +42,7 @@
 
 .tools__header-image-wrapper {
 	display: none;
+
 	@include breakpoint( '>1040px' ) {
 		display: flex;
 		min-width: 300px;
@@ -60,6 +63,7 @@
 	flex-direction: column;
 	margin: 0.5em;
 	width: calc( 100% - 1em );
+
 	@include breakpoint( '>1040px' ) {
 		width: calc( 50% - 1em );
 	}
@@ -78,6 +82,7 @@
 
 .tools__feature-list-item-body-text {
 	width: 100%;
+
 	@include breakpoint( '>1040px' ) {
 		width: 75%;
 	}
@@ -98,6 +103,7 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-start;
+
 	.button {
 		margin: 1em 0 0;
 		text-align: center;
@@ -106,6 +112,7 @@
 
 	@include breakpoint( '>480px' ) {
 		flex-direction: row;
+
 		.button {
 			margin: 0 1em 0 0;
 			width: auto;
@@ -114,6 +121,7 @@
 
 	@include breakpoint( '>1040px' ) {
 		justify-content: flex-end;
+
 		.button {
 			margin: 0 0 0 1em;
 		}


### PR DESCRIPTION
This pull request makes sure we are tracking pageviews as well as clicks on the new `Marketing Tools` page:
 
![screenshot](https://user-images.githubusercontent.com/594356/56975758-c7425380-6b71-11e9-868f-10132c8e5942.png)

#### Testing instructions
 
1. Run `git checkout add/tracking-to-marketing-tools` and start your server, or open a [live branch](https://calypso.live/?branch=add/tracking-to-marketing-tools)
2. Open the [`Marketing Tools` page](http://calypso.localhost:3000/marketing/tools)
3. Execute `localStorage.setItem( 'debug', 'calypso:analytics:*' )` in your browser's console
4. Reload the page, and assert that an event is triggered for the pageview
5. Click any button from this page, and assert that an event is triggered in each case