### PR TITLE
Try/stats grid

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -49,7 +49,7 @@
 	@include clear-fix;
 	position: relative;
 	margin: 0;
-	padding: 79px 32px 32px ( $sidebar-width-max + 32px + 1px );
+	padding: 79px 24px 24px ( $sidebar-width-max + 24px );
 	box-sizing: border-box;
 	overflow: hidden;
 

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -49,7 +49,7 @@
 	@include clear-fix;
 	position: relative;
 	margin: 0;
-	padding: 79px 24px 24px ( $sidebar-width-max + 24px );
+	padding: 79px 32px 32px ( $sidebar-width-max + 32px + 1px );
 	box-sizing: border-box;
 	overflow: hidden;
 

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -227,22 +227,6 @@ class StatsSite extends Component {
 							/>
 							{ videoList }
 						</div>
-						<div className="stats__module-column">
-							<Countries
-								path="countries"
-								period={ this.props.period }
-								query={ query }
-								summary={ false }
-							/>
-							<StatsModule
-								path="clicks"
-								moduleStrings={ moduleStrings.clicks }
-								period={ this.props.period }
-								query={ query }
-								statType="statsClicks"
-								showSummaryLink
-							/>
-						</div>
 						<div className="stats__module-column grid-align-right">
 							<StatsModule
 								path="referrers"
@@ -262,6 +246,22 @@ class StatsSite extends Component {
 								showSummaryLink
 							/>
 							{ podcastList }
+						</div>
+						<div className="stats__module-column">
+							<Countries
+								path="countries"
+								period={ this.props.period }
+								query={ query }
+								summary={ false }
+							/>
+							<StatsModule
+								path="clicks"
+								moduleStrings={ moduleStrings.clicks }
+								period={ this.props.period }
+								query={ query }
+								statType="statsClicks"
+								showSummaryLink
+							/>
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -243,7 +243,7 @@ class StatsSite extends Component {
 								showSummaryLink
 							/>
 						</div>
-						<div className="stats__module-column">
+						<div className="stats__module-column grid-align-right">
 							<StatsModule
 								path="referrers"
 								moduleStrings={ moduleStrings.referrers }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -163,7 +163,7 @@ class StatsModule extends Component {
 		} );
 
 		return (
-			<div>
+			<div class="stats__module-card-container">
 				{ siteId && statType && (
 					<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 				) }

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -41,12 +41,12 @@
 	grid-template-columns: repeat( 4, [col-start] minmax(16px, 1fr) );
 	grid-gap: 16px;
 
-	@include breakpoint( '>660px' ){
+	@include breakpoint( '>660px' ) {
 		grid-template-columns: repeat( 8, [col-start] minmax(16px, 1fr) );
 		grid-gap: 24px;
 	}
 
-	@include breakpoint( '>1040px' ){
+	@include breakpoint( '>1040px' ) {
 		grid-template-columns: repeat( 12, [col-start] minmax(16px, 1fr) );
 		grid-gap: 24px;
 	}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -21,7 +21,17 @@
 
 .card.stats-module {
 	padding: 0;
-	margin-bottom: 10px;
+	margin-bottom: 0;
+}
+
+.stats__module-card-container {
+	margin-bottom: 16px;
+	@include breakpoint ( '>660px' ) {
+		margin-bottom: 24px;
+	}
+	&:last-child {
+		margin-bottom: 0;
+	}
 }
 
 // Site sections

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -23,9 +23,23 @@
 	padding: 0;
 	margin-bottom: 10px;
 }
+
 // Site sections
 .stats__module-list {
-	@include clear-fix;
+	// @include clear-fix;
+	display: grid;
+	grid-template-columns: repeat( 4, [col-start] minmax(16px, 1fr) );
+	grid-gap: 16px;
+
+	@include breakpoint( '>660px' ){
+		grid-template-columns: repeat( 8, [col-start] minmax(16px, 1fr) );
+		grid-gap: 24px;
+	}
+
+	@include breakpoint( '>1040px' ){
+		grid-template-columns: repeat( 12, [col-start] minmax(16px, 1fr) );
+		grid-gap: 24px;
+	}
 }
 
 .stats-insights__nonperiodic {

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -1,31 +1,19 @@
+.stats__module-column {
+	grid-column: span 4;
+}
 
 // Module container
-@include breakpoint( '>960px' ) {
-	.stats__module-column {
-		float: right;
-		width: calc( 50% - 4px );
+// @include breakpoint( '>660px' ) {
+// 	.stats__module-column {
+// 		// grid-column: span 4;
+// 	}
+// }
 
-		&:first-child {
-			float: left;
-		}
-
-		&:last-child {
-			clear: right;
-		}
-	}
-}
-
-@include breakpoint( '>1280px' ) {
-	.stats__module-column {
-		width: calc( 33% - 3px );
-
-		&:last-child {
-			clear: none;
-			left: -10px;
-			position: relative;
-		}
-	}
-}
+// @include breakpoint( '>1040px' ) {
+// 	.stats__module-column {
+// 		grid-column: span 4;
+// 	}
+// }
 
 .old-stats-link .button .gridicon {
 	margin-bottom: -2px;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -1,26 +1,33 @@
 .stats__module-column {
 	grid-column: span 4;
 	@include breakpoint( '>660px' ) {
-		@include breakpoint( '<960px' ){
+		@include breakpoint( '<960px' ) {
 			grid-column: span 8;
 		}
 	}
 
-	@include breakpoint( '>1040px' ){
-		@include breakpoint( '<1280px' ){
+	@include breakpoint( '>1040px' ) {
+		@include breakpoint( '<1280px' ) {
 			grid-column: span 6;
 		}
 	}
 
+	// This class is necessary to keep the reflow position 
+	// of the masonry layout as designed 
 	&.grid-align-right {
+		@include breakpoint( '<960px' ) {
+			grid-row-start: 3;
+		}
 		@include breakpoint( '>960px' ) {
 			@include breakpoint( '<1040px' ) {
 				grid-column: 5 / span 4;
+				grid-row-start: 2;
 			}
 		}
 		@include breakpoint( '>1040px' ) {
 			@include breakpoint( '<1280px' ) {
 				grid-column: 7 / span 6;
+				grid-row-start: 2;
 			}
 		}
 	}

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -1,26 +1,30 @@
 .stats__module-column {
 	grid-column: span 4;
+	@include breakpoint( '>660px' ) {
+		@include breakpoint( '<960px' ){
+			grid-column: span 8;
+		}
+	}
+
+	@include breakpoint( '>1040px' ){
+		@include breakpoint( '<1280px' ){
+			grid-column: span 6;
+		}
+	}
+
 	&.grid-align-right {
-		@include breakpoint ( '<1040px' ){
-			@include breakpoint ( '>660px' ){
+		@include breakpoint( '>960px' ) {
+			@include breakpoint( '<1040px' ) {
 				grid-column: 5 / span 4;
+			}
+		}
+		@include breakpoint( '>1040px' ) {
+			@include breakpoint( '<1280px' ) {
+				grid-column: 7 / span 6;
 			}
 		}
 	}
 }
-
-// Module container
-// @include breakpoint( '>660px' ) {
-// 	.stats__module-column {
-// 		// grid-column: span 4;
-// 	}
-// }
-
-// @include breakpoint( '>1040px' ) {
-// 	.stats__module-column {
-// 		grid-column: span 4;
-// 	}
-// }
 
 .old-stats-link .button .gridicon {
 	margin-bottom: -2px;

--- a/client/my-sites/stats/style.scss
+++ b/client/my-sites/stats/style.scss
@@ -1,5 +1,12 @@
 .stats__module-column {
 	grid-column: span 4;
+	&.grid-align-right {
+		@include breakpoint ( '<1040px' ){
+			@include breakpoint ( '>660px' ){
+				grid-column: 5 / span 4;
+			}
+		}
+	}
 }
 
 // Module container


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use CSS grid to apply a layout grid (based on [Muriel](https://murieldesignsystem.blog/foundation/layout/)) to the stats page.

<img width="600" alt="Screen Shot 2019-04-30 at 12 02 00 PM" src="https://cdn-std.dprcdn.net/files/acc_705626/Qk9KKG">

#### Testing instructions

* Go to the stats page for a specific site e.g. http://calypso.localhost:3000/stats/day/[yoursite]
* Confirm that modules behave similarly to the current experience at all breakpoints, but aligned to a grid. 
* Optionally, use this [chrome extension](https://chrome.google.com/webstore/detail/muriel-grid/heabkjiofmaphebjodoflpglpkdojpmg) to test the grid at various breakpoints.

cc @timmyc as the author of the percentage and float-based current approach.