### PR TITLE
Async load media upload button in sidebar.

### DIFF
--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -19,10 +19,10 @@ import SidebarButton from 'layout/sidebar/button';
 import config from 'config';
 import { getPostTypes } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
+import AsyncLoad from 'components/async-load';
 import analytics from 'lib/analytics';
 import { decodeEntities } from 'lib/formatting';
 import compareProps from 'lib/compare-props';
-import MediaLibraryUploadButton from 'my-sites/media-library/upload-button';
 import {
 	getSite,
 	getSiteAdminUrl,
@@ -263,14 +263,16 @@ class ManageMenu extends PureComponent {
 				forceInternalLink={ menuItem.forceInternalLink }
 			>
 				{ menuItem.name === 'media' && (
-					<MediaLibraryUploadButton
+					<AsyncLoad
+						require="my-sites/media-library/upload-button"
+						placeholder={ null }
 						className="sidebar__button"
 						site={ site }
 						href={ menuItem.buttonLink }
 						onClick={ this.trackSidebarButtonClick( 'media' ) }
 					>
 						{ this.props.translate( 'Add' ) }
-					</MediaLibraryUploadButton>
+					</AsyncLoad>
 				) }
 				{ menuItem.name !== 'media' && (
 					<SidebarButton

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -19,10 +19,10 @@ import SidebarButton from 'layout/sidebar/button';
 import config from 'config';
 import { getPostTypes } from 'state/post-types/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
+import AsyncLoad from 'components/async-load';
 import analytics from 'lib/analytics';
 import { decodeEntities } from 'lib/formatting';
 import compareProps from 'lib/compare-props';
-import MediaLibraryUploadButton from 'my-sites/media-library/upload-button';
 import {
 	getSite,
 	getSiteAdminUrl,
@@ -224,14 +224,16 @@ class SiteMenu extends PureComponent {
 				forceInternalLink={ menuItem.forceInternalLink }
 			>
 				{ menuItem.name === 'media' && (
-					<MediaLibraryUploadButton
+					<AsyncLoad
+						require="my-sites/media-library/upload-button"
+						placeholder={ null }
 						className="sidebar__button"
 						site={ site }
 						href={ menuItem.buttonLink }
 						onClick={ this.trackSidebarButtonClick( 'media' ) }
 					>
 						{ this.props.translate( 'Add' ) }
-					</MediaLibraryUploadButton>
+					</AsyncLoad>
 				) }
 				{ menuItem.name !== 'media' && (
 					<SidebarButton


### PR DESCRIPTION
This prevents media-related code (`client/lib/media`) from being included in the build chunk, where it's not needed.

Saves ~8KB compressed JS for e.g. `/log-in`.

#### Changes proposed in this Pull Request

* Async load media upload button in sidebar

#### Testing instructions

* Ensure that the upload button is shown and works correctly in the sidebar
