### PR TITLE
People: Update the Invites page with better copy

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -322,9 +322,7 @@ class InvitePeople extends React.Component {
 							/>
 							<FormSettingExplanation>
 								{ translate(
-									'Want to invite new users to your site? The more the merrier! ' +
-										'Invite as many as you want, up to 10 at a time, by adding ' +
-										'their email addresses or WordPress.com usernames.'
+									'Enter up to 10 WordPress.com usernames or email addresses at a time.'
 								) }
 							</FormSettingExplanation>
 						</div>
@@ -356,8 +354,7 @@ class InvitePeople extends React.Component {
 							/>
 							<FormSettingExplanation>
 								{ translate(
-									'(Optional) You can enter a custom message of up to 500 characters ' +
-										'that will be included in the invitation to the user(s).'
+									'(Optional) Enter a custom message to be sent with your invitation.'
 								) }
 							</FormSettingExplanation>
 						</FormFieldset>

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -129,15 +129,35 @@ class PeopleInvites extends React.PureComponent {
 			return requesting ? this.renderPlaceholder() : this.renderEmptyContent();
 		}
 
+		const pendingLabel = translate(
+			'You have a pending invite for %(numberPeople)d user',
+			'You have pending invites for %(numberPeople)d users',
+			{
+				args: {
+					numberPeople: pendingInviteCount,
+				},
+				count: pendingInviteCount,
+				context: 'A navigation label.',
+			}
+		);
+
+		const acceptedLabel = translate(
+			'%(numberPeople)d user has accepted your invite',
+			'%(numberPeople)d users have accepted your invites',
+			{
+				args: {
+					numberPeople: acceptedInviteCount,
+				},
+				count: acceptedInviteCount,
+				context: 'A navigation label.',
+			}
+		);
+
 		return (
 			<React.Fragment>
 				{ hasPendingInvites ? (
 					<div className="people-invites__pending">
-						<PeopleListSectionHeader
-							label={ translate( 'Pending' ) }
-							count={ pendingInviteCount }
-							site={ site }
-						/>
+						<PeopleListSectionHeader label={ pendingLabel } site={ site } />
 						<Card className="people-invites__invites-list">
 							{ pendingInvites.map( this.renderInvite ) }
 						</Card>
@@ -149,8 +169,7 @@ class PeopleInvites extends React.PureComponent {
 				{ hasAcceptedInvites && (
 					<div className="people-invites__accepted">
 						<PeopleListSectionHeader
-							label={ translate( 'Accepted' ) }
-							count={ acceptedInviteCount }
+							label={ acceptedLabel }
 							// Excluding `site=` hides the "Invite user" link.
 						>
 							{ this.renderClearAll() }

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -120,10 +120,10 @@ class PeopleInvites extends React.PureComponent {
 		}
 
 		const hasAcceptedInvites = acceptedInvites && acceptedInvites.length > 0;
-		const acceptedInviteCount = hasAcceptedInvites ? acceptedInvites.length : null;
+		const acceptedInviteCount = hasAcceptedInvites ? acceptedInvites.length : 0;
 
 		const hasPendingInvites = pendingInvites && pendingInvites.length > 0;
-		const pendingInviteCount = hasPendingInvites ? pendingInvites.length : null;
+		const pendingInviteCount = hasPendingInvites ? pendingInvites.length : 0;
 
 		if ( ! hasPendingInvites && ! hasAcceptedInvites ) {
 			return requesting ? this.renderPlaceholder() : this.renderEmptyContent();

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -137,7 +137,6 @@ class PeopleInvites extends React.PureComponent {
 					numberPeople: pendingInviteCount,
 				},
 				count: pendingInviteCount,
-				context: 'A navigation label.',
 			}
 		);
 
@@ -149,7 +148,6 @@ class PeopleInvites extends React.PureComponent {
 					numberPeople: acceptedInviteCount,
 				},
 				count: acceptedInviteCount,
-				context: 'A navigation label.',
 			}
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Uses the same format as we introduced in #32247 for the Invites section of the People area.
* Update helper copy on the Invites form for brevity and clarity.
* /cc'ing @obi2020 for help with copy on this one

**Before**

<img width="744" alt="Screen Shot 2019-04-30 at 12 31 29 PM" src="https://user-images.githubusercontent.com/2124984/56978192-fb534f80-6b44-11e9-83ea-4dcb2daadbd1.png">

**After**

<img width="740" alt="Screen Shot 2019-04-30 at 12 35 28 PM" src="https://user-images.githubusercontent.com/2124984/56989065-91946f00-6b5f-11e9-832f-a0d007771fcd.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/people/invites`
* Invite 1 person to your site - Note the changes to the text in the red circled area
* Invite multiple people to your site - Note the changes to the text in the red circled area
* Have one person accept the invite - Note the changes to the text in the red circled area
* Have multiple people accept the invite - Note the changes to the text in the red circled area

Fixes #32487