### PR TITLE
Add Google Adwords card to Marketing Tools

### DIFF
--- a/client/blocks/product-purchase-features-list/google-vouchers.jsx
+++ b/client/blocks/product-purchase-features-list/google-vouchers.jsx
@@ -5,18 +5,30 @@
  */
 
 import React from 'react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import GoogleVoucherDetails from 'my-sites/checkout/checkout-thank-you/google-voucher';
+import PurchaseDetail from 'components/purchase-detail';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
 
 export default ( { selectedSite } ) => {
+	const translate = useTranslate();
 	return (
 		<div className="product-purchase-features-list__item">
 			<QuerySiteVouchers siteId={ selectedSite.ID } />
-			<GoogleVoucherDetails selectedSite={ selectedSite } />
+			<PurchaseDetail
+				alt=""
+				id="google-credits"
+				icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
+				title={ translate( 'Google Ads credit' ) }
+				description={ translate(
+					'Use a $100 credit with Google to bring traffic to your most important Posts and Pages.'
+				) }
+				body={ <GoogleVoucherDetails selectedSite={ selectedSite } /> }
+			/>
 		</div>
 	);
 };

--- a/client/blocks/product-purchase-features-list/google-vouchers.jsx
+++ b/client/blocks/product-purchase-features-list/google-vouchers.jsx
@@ -21,7 +21,7 @@ export default ( { selectedSite } ) => {
 			<QuerySiteVouchers siteId={ selectedSite.ID } />
 			<PurchaseDetail
 				id="google-credits"
-				icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
+				icon={ <img alt="Google AdWords" src="/calypso/images/illustrations/google-adwords.svg" /> }
 				title={ translate( 'Google Ads credit' ) }
 				description={ translate(
 					'Use a %(cost)s credit with Google to bring traffic to your most important Posts and Pages.',

--- a/client/blocks/product-purchase-features-list/google-vouchers.jsx
+++ b/client/blocks/product-purchase-features-list/google-vouchers.jsx
@@ -24,7 +24,12 @@ export default ( { selectedSite } ) => {
 				icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
 				title={ translate( 'Google Ads credit' ) }
 				description={ translate(
-					'Use a $100 credit with Google to bring traffic to your most important Posts and Pages.'
+					'Use a %(cost)s credit with Google to bring traffic to your most important Posts and Pages.',
+					{
+						args: {
+							cost: '$100',
+						},
+					}
 				) }
 				body={ <GoogleVoucherDetails selectedSite={ selectedSite } /> }
 			/>

--- a/client/blocks/product-purchase-features-list/google-vouchers.jsx
+++ b/client/blocks/product-purchase-features-list/google-vouchers.jsx
@@ -23,7 +23,7 @@ export default ( { selectedSite } ) => {
 				id="google-credits"
 				icon={
 					<img
-						alt={ translate( 'Google AdWords' ) }
+						alt={ translate( 'Google AdWords Illustration' ) }
 						src="/calypso/images/illustrations/google-adwords.svg"
 					/>
 				}

--- a/client/blocks/product-purchase-features-list/google-vouchers.jsx
+++ b/client/blocks/product-purchase-features-list/google-vouchers.jsx
@@ -21,7 +21,12 @@ export default ( { selectedSite } ) => {
 			<QuerySiteVouchers siteId={ selectedSite.ID } />
 			<PurchaseDetail
 				id="google-credits"
-				icon={ <img alt="Google AdWords" src="/calypso/images/illustrations/google-adwords.svg" /> }
+				icon={
+					<img
+						alt={ translate( 'Google AdWords' ) }
+						src="/calypso/images/illustrations/google-adwords.svg"
+					/>
+				}
 				title={ translate( 'Google Ads credit' ) }
 				description={ translate(
 					'Use a %(cost)s credit with Google to bring traffic to your most important Posts and Pages.',

--- a/client/blocks/product-purchase-features-list/google-vouchers.jsx
+++ b/client/blocks/product-purchase-features-list/google-vouchers.jsx
@@ -20,7 +20,6 @@ export default ( { selectedSite } ) => {
 		<div className="product-purchase-features-list__item">
 			<QuerySiteVouchers siteId={ selectedSite.ID } />
 			<PurchaseDetail
-				alt=""
 				id="google-credits"
 				icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
 				title={ translate( 'Google Ads credit' ) }

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -25,6 +25,7 @@ import { assignSiteVoucher as assignVoucher } from 'state/sites/vouchers/actions
 import { GOOGLE_CREDITS } from 'state/sites/vouchers/service-types';
 import { getVouchersBySite, getGoogleAdCredits } from 'state/sites/vouchers/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -81,11 +82,13 @@ class GoogleVoucherDetails extends Component {
 			'calypso_plans_google_voucher_generate_click',
 			'Clicked Generate Code Button'
 		);
+		this.props.recordTracksEvent( 'calypso_google_adwords_voucher_generate_click' );
 
 		this.changeStep();
 	}
 
 	onDialogCancel() {
+		this.props.recordTracksEvent( 'calypso_google_adwords_voucher_tos_dialog_cancel_click' );
 		this.setState( { step: INITIAL_STEP } );
 	}
 
@@ -94,6 +97,7 @@ class GoogleVoucherDetails extends Component {
 			'calypso_plans_google_voucher_toc_accept_click',
 			'Clicked Agree Button'
 		);
+		this.props.recordTracksEvent( 'calypso_google_adwords_voucher_tos_accept_click' );
 
 		this.props.assignVoucher( this.props.selectedSite.ID, GOOGLE_CREDITS );
 		this.setState( { step: CODE_REDEEMED } );
@@ -104,6 +108,7 @@ class GoogleVoucherDetails extends Component {
 			'calypso_plans_google_voucher_setup_click',
 			'Clicked Setup Google Ads Button'
 		);
+		this.props.recordTracksEvent( 'calypso_google_adwords_voucher_setup_click' );
 	}
 
 	changeStep() {
@@ -254,6 +259,7 @@ class GoogleVoucherDetails extends Component {
 GoogleVoucherDetails.propTypes = {
 	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 	googleAdCredits: PropTypes.array,
+	recordTracksEvent: PropTypes.func.isRequired,
 };
 
 export default connect(
@@ -266,5 +272,8 @@ export default connect(
 			googleAdCredits: getGoogleAdCredits( state, site ),
 		};
 	},
-	{ assignVoucher }
+	{
+		assignVoucher,
+		recordTracksEvent: recordTracksEventAction,
+	}
 )( localize( GoogleVoucherDetails ) );

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -15,7 +15,6 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import ClipboardButtonInput from 'components/clipboard-button-input';
-
 import PurchaseButton from 'components/purchase-detail/purchase-button';
 import TipInfo from 'components/purchase-detail/tip-info';
 import Dialog from 'components/dialog';
@@ -25,6 +24,7 @@ import QuerySiteVouchers from 'components/data/query-site-vouchers';
 import { assignSiteVoucher as assignVoucher } from 'state/sites/vouchers/actions';
 import { GOOGLE_CREDITS } from 'state/sites/vouchers/service-types';
 import { getVouchersBySite, getGoogleAdCredits } from 'state/sites/vouchers/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 
 /**
  * Style dependencies
@@ -226,6 +226,10 @@ class GoogleVoucherDetails extends Component {
 		const { step } = this.state;
 		let body;
 
+		if ( ! selectedSite.ID ) {
+			return null;
+		}
+
 		switch ( step ) {
 			case INITIAL_STEP:
 				body = this.renderInitialStep();
@@ -248,14 +252,16 @@ class GoogleVoucherDetails extends Component {
 }
 
 GoogleVoucherDetails.propTypes = {
-	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ).isRequired,
+	selectedSite: PropTypes.oneOfType( [ PropTypes.bool, PropTypes.object ] ),
 	googleAdCredits: PropTypes.array,
 };
 
 export default connect(
 	( state, props ) => {
-		const site = props.selectedSite;
+		const site = props.selectedSite || getSelectedSite( state ) || {};
+
 		return {
+			selectedSite: site,
 			vouchers: getVouchersBySite( state, site ),
 			googleAdCredits: getGoogleAdCredits( state, site ),
 		};

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -15,7 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import ClipboardButtonInput from 'components/clipboard-button-input';
-import PurchaseDetails from 'components/purchase-detail';
+
 import PurchaseButton from 'components/purchase-detail/purchase-button';
 import TipInfo from 'components/purchase-detail/tip-info';
 import Dialog from 'components/dialog';
@@ -222,7 +222,7 @@ class GoogleVoucherDetails extends Component {
 	}
 
 	render() {
-		const { selectedSite, translate } = this.props;
+		const { selectedSite } = this.props;
 		const { step } = this.state;
 		let body;
 
@@ -241,16 +241,7 @@ class GoogleVoucherDetails extends Component {
 		return (
 			<div>
 				<QuerySiteVouchers siteId={ selectedSite.ID } />
-				<PurchaseDetails
-					alt=""
-					id="google-credits"
-					icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
-					title={ translate( 'Google Ads credit' ) }
-					description={ translate(
-						'Use a $100 credit with Google to bring traffic to your most important Posts and Pages.'
-					) }
-					body={ body }
-				/>
+				{ body }
 			</div>
 		);
 	}

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -132,7 +132,12 @@ class GoogleVoucherDetails extends Component {
 
 				<TipInfo
 					info={ this.props.translate(
-						'Offer valid in US after spending the first $25 on Google Ads.'
+						'Offer valid in US and CA after spending the first %(cost)s on Google Ads.',
+						{
+							args: {
+								cost: '$25',
+							},
+						}
 					) }
 				/>
 			</div>
@@ -219,7 +224,12 @@ class GoogleVoucherDetails extends Component {
 				<TipInfo
 					className="google-voucher__advice"
 					info={ this.props.translate(
-						'Offer valid in US after spending the first $25 on Google Ads.'
+						'Offer valid in US and CA after spending the first %(cost)s on Google Ads.',
+						{
+							args: {
+								cost: '$25',
+							},
+						}
 					) }
 				/>
 			</div>

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/style.scss
@@ -39,6 +39,10 @@
 	}
 }
 
+.google-voucher__dialog .dialog__content {
+	overflow: hidden;
+}
+
 .google-voucher__dialog-header {
 	display: flex;
 	align-items: center;

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -59,9 +59,16 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			/>
 
 			<QuerySiteVouchers siteId={ selectedSite.ID } />
-			<div>
-				<GoogleVoucherDetails selectedSite={ selectedSite } />
-			</div>
+			<PurchaseDetail
+				alt=""
+				id="google-credits"
+				icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
+				title={ i18n.translate( 'Google Ads credit' ) }
+				description={ i18n.translate(
+					'Use a $100 credit with Google to bring traffic to your most important Posts and Pages.'
+				) }
+				body={ <GoogleVoucherDetails selectedSite={ selectedSite } /> }
+			/>
 
 			{ ! selectedFeature && (
 				<PurchaseDetail

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -46,7 +46,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			<PurchaseDetail
 				icon={
 					<img
-						alt={ i18n.translate( 'Advertising Removed' ) }
+						alt={ i18n.translate( 'Advertising Removed Illustration' ) }
 						src="/calypso/images/upgrades/advertising-removed.svg"
 					/>
 				}
@@ -68,7 +68,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 				id="google-credits"
 				icon={
 					<img
-						alt={ i18n.translate( 'Google AdWords' ) }
+						alt={ i18n.translate( 'Google AdWords Illustration' ) }
 						src="/calypso/images/illustrations/google-adwords.svg"
 					/>
 				}
@@ -88,7 +88,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 				<PurchaseDetail
 					icon={
 						<img
-							alt={ i18n.translate( 'Customize Theme' ) }
+							alt={ i18n.translate( 'Customize Theme Illustration' ) }
 							src="/calypso/images/upgrades/customize-theme.svg"
 						/>
 					}
@@ -106,7 +106,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			<PurchaseDetail
 				icon={
 					<img
-						alt={ i18n.translate( 'Add Media to Your Posts' ) }
+						alt={ i18n.translate( 'Add Media to Your Posts Illustration' ) }
 						src="/calypso/images/upgrades/media-post.svg"
 					/>
 				}
@@ -121,7 +121,10 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			{ isWordadsInstantActivationEligible( selectedSite ) && (
 				<PurchaseDetail
 					icon={
-						<img alt={ i18n.translate( 'WordAds' ) } src="/calypso/images/upgrades/word-ads.svg" />
+						<img
+							alt={ i18n.translate( 'WordAds Illustration' ) }
+							src="/calypso/images/upgrades/word-ads.svg"
+						/>
 					}
 					title={ i18n.translate( 'Easily monetize your site' ) }
 					description={ i18n.translate(

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -60,7 +60,6 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 
 			<QuerySiteVouchers siteId={ selectedSite.ID } />
 			<PurchaseDetail
-				alt=""
 				id="google-credits"
 				icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
 				title={ i18n.translate( 'Google Ads credit' ) }

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -64,7 +64,12 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 				icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
 				title={ i18n.translate( 'Google Ads credit' ) }
 				description={ i18n.translate(
-					'Use a $100 credit with Google to bring traffic to your most important Posts and Pages.'
+					'Use a %(cost)s credit with Google to bring traffic to your most important Posts and Pages.',
+					{
+						args: {
+							cost: '$100',
+						},
+					}
 				) }
 				body={ <GoogleVoucherDetails selectedSite={ selectedSite } /> }
 			/>

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -44,7 +44,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			/>
 
 			<PurchaseDetail
-				icon={ <img alt="" src="/calypso/images/upgrades/advertising-removed.svg" /> }
+				icon={ <img alt="Advertising Removed" src="/calypso/images/upgrades/advertising-removed.svg" /> }
 				title={ i18n.translate( 'Advertising Removed' ) }
 				description={
 					isPremiumPlan
@@ -61,7 +61,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			<QuerySiteVouchers siteId={ selectedSite.ID } />
 			<PurchaseDetail
 				id="google-credits"
-				icon={ <img alt="" src="/calypso/images/illustrations/google-adwords.svg" /> }
+				icon={ <img alt="Google AdWords" src="/calypso/images/illustrations/google-adwords.svg" /> }
 				title={ i18n.translate( 'Google Ads credit' ) }
 				description={ i18n.translate(
 					'Use a %(cost)s credit with Google to bring traffic to your most important Posts and Pages.',
@@ -76,7 +76,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 
 			{ ! selectedFeature && (
 				<PurchaseDetail
-					icon={ <img alt="" src="/calypso/images/upgrades/customize-theme.svg" /> }
+					icon={ <img alt="Customize Theme" src="/calypso/images/upgrades/customize-theme.svg" /> }
 					title={ i18n.translate( 'Customize your theme' ) }
 					description={ i18n.translate(
 						"You now have direct control over your site's fonts and colors in the customizer. " +
@@ -89,7 +89,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			) }
 
 			<PurchaseDetail
-				icon={ <img alt="" src="/calypso/images/upgrades/media-post.svg" /> }
+				icon={ <img alt="Add Media to Your Posts" src="/calypso/images/upgrades/media-post.svg" /> }
 				title={ i18n.translate( 'Video and audio posts' ) }
 				description={ i18n.translate(
 					'Enrich your posts with video and audio, uploaded directly on your site. ' +
@@ -100,7 +100,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			/>
 			{ isWordadsInstantActivationEligible( selectedSite ) && (
 				<PurchaseDetail
-					icon={ <img alt="" src="/calypso/images/upgrades/word-ads.svg" /> }
+					icon={ <img alt="WordAds" src="/calypso/images/upgrades/word-ads.svg" /> }
 					title={ i18n.translate( 'Easily monetize your site' ) }
 					description={ i18n.translate(
 						'Take advantage of WordAds instant activation on your upgraded site. ' +

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -44,7 +44,12 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			/>
 
 			<PurchaseDetail
-				icon={ <img alt="Advertising Removed" src="/calypso/images/upgrades/advertising-removed.svg" /> }
+				icon={
+					<img
+						alt={ i18n.translate( 'Advertising Removed' ) }
+						src="/calypso/images/upgrades/advertising-removed.svg"
+					/>
+				}
 				title={ i18n.translate( 'Advertising Removed' ) }
 				description={
 					isPremiumPlan
@@ -61,7 +66,12 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			<QuerySiteVouchers siteId={ selectedSite.ID } />
 			<PurchaseDetail
 				id="google-credits"
-				icon={ <img alt="Google AdWords" src="/calypso/images/illustrations/google-adwords.svg" /> }
+				icon={
+					<img
+						alt={ i18n.translate( 'Google AdWords' ) }
+						src="/calypso/images/illustrations/google-adwords.svg"
+					/>
+				}
 				title={ i18n.translate( 'Google Ads credit' ) }
 				description={ i18n.translate(
 					'Use a %(cost)s credit with Google to bring traffic to your most important Posts and Pages.',
@@ -76,7 +86,12 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 
 			{ ! selectedFeature && (
 				<PurchaseDetail
-					icon={ <img alt="Customize Theme" src="/calypso/images/upgrades/customize-theme.svg" /> }
+					icon={
+						<img
+							alt={ i18n.translate( 'Customize Theme' ) }
+							src="/calypso/images/upgrades/customize-theme.svg"
+						/>
+					}
 					title={ i18n.translate( 'Customize your theme' ) }
 					description={ i18n.translate(
 						"You now have direct control over your site's fonts and colors in the customizer. " +
@@ -89,7 +104,12 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			) }
 
 			<PurchaseDetail
-				icon={ <img alt="Add Media to Your Posts" src="/calypso/images/upgrades/media-post.svg" /> }
+				icon={
+					<img
+						alt={ i18n.translate( 'Add Media to Your Posts' ) }
+						src="/calypso/images/upgrades/media-post.svg"
+					/>
+				}
 				title={ i18n.translate( 'Video and audio posts' ) }
 				description={ i18n.translate(
 					'Enrich your posts with video and audio, uploaded directly on your site. ' +
@@ -100,7 +120,9 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			/>
 			{ isWordadsInstantActivationEligible( selectedSite ) && (
 				<PurchaseDetail
-					icon={ <img alt="WordAds" src="/calypso/images/upgrades/word-ads.svg" /> }
+					icon={
+						<img alt={ i18n.translate( 'WordAds' ) } src="/calypso/images/upgrades/word-ads.svg" />
+					}
 					title={ i18n.translate( 'Easily monetize your site' ) }
 					description={ i18n.translate(
 						'Take advantage of WordAds instant activation on your upgraded site. ' +

--- a/client/my-sites/feature-upsell/features.jsx
+++ b/client/my-sites/feature-upsell/features.jsx
@@ -105,7 +105,9 @@ class FeaturesComponent extends Component {
 						description={ 'Attract new (and more!) traffic immediately with Google Ads.' }
 						body={
 							<div className="google-voucher__initial-step">
-								<TipInfo info={ 'Offer valid in US after spending the first $25 on Google Ads.' } />
+								<TipInfo
+									info={ 'Offer valid in US and CA after spending the first $25 on Google Ads.' }
+								/>
 							</div>
 						}
 					/>

--- a/client/my-sites/feature-upsell/store-upsell.jsx
+++ b/client/my-sites/feature-upsell/store-upsell.jsx
@@ -123,7 +123,7 @@ class StoreUpsellComponent extends Component {
 							body={
 								<div className="google-voucher__initial-step">
 									<TipInfo
-										info={ 'Offer valid in US after spending the first $25 on Google Ads.' }
+										info={ 'Offer valid in US and CA after spending the first $25 on Google Ads.' }
 									/>
 								</div>
 							}

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -3,7 +3,6 @@
  */
 import { connect } from 'react-redux';
 import page from 'page';
-import PropTypes from 'prop-types';
 import React, { Fragment, FunctionComponent } from 'react';
 import { useTranslate } from 'i18n-calypso';
 
@@ -74,15 +73,6 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 			</MarketingToolsFeature>
 		</Fragment>
 	);
-};
-
-MarketingToolsGoogleAdwordsFeature.propTypes = {
-	isAtomic: PropTypes.bool.isRequired,
-	isJetpack: PropTypes.bool.isRequired,
-	isPremiumOrHigher: PropTypes.bool.isRequired,
-	recordTracksEvent: PropTypes.func.isRequired,
-	siteId: PropTypes.number,
-	siteSlug: PropTypes.string,
 };
 
 export default connect(

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -67,7 +67,7 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 				description={ translate(
 					"Advertise your site where most people are searching: Google. You've got a $100 credit with Google Adwords to drive traffic to your most important pages."
 				) }
-				imagePath="/calypso/images/illustrations/marketing.svg"
+				imagePath="/calypso/images/illustrations/google-adwords-stats.svg"
 			>
 				{ renderButton() }
 			</MarketingToolsFeature>

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -24,7 +24,7 @@ import QuerySiteVouchers from 'components/data/query-site-vouchers';
  */
 import './style.scss';
 
-interface ConnectProps {
+interface ConnectedProps {
 	isAtomic: boolean;
 	isJetpack: boolean;
 	isPremiumOrHigher: boolean;
@@ -32,7 +32,7 @@ interface ConnectProps {
 	siteSlug: string | null;
 }
 
-export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectProps > = ( {
+export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedProps > = ( {
 	isAtomic,
 	isJetpack,
 	isPremiumOrHigher,
@@ -79,7 +79,7 @@ MarketingToolsGoogleAdwordsFeature.propTypes = {
 	siteSlug: PropTypes.string,
 };
 
-export default connect< ConnectProps >( state => {
+export default connect< ConnectedProps >( state => {
 	const site = getSelectedSite( state );
 	const isAtomic = isSiteAtomic( state, site.ID ) || false;
 	const isPremiumOrHigher =

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -38,14 +38,10 @@ export const GoogleAdwordsCard: FunctionComponent< ConnectProps > = ( {
 	}
 
 	const renderButton = () => {
-		const buttonText = isPremiumOrHigher
-			? translate( 'Generate code' )
-			: translate( 'Upgrade to Premium' );
-
 		if ( isPremiumOrHigher ) {
 			return <GoogleVoucherDetails selectedSite={ site } />;
 		}
-		return <Button>{ buttonText }</Button>;
+		return <Button>{ translate( 'Upgrade To Premium' ) }</Button>;
 	};
 
 	return (

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import { addQueryArgs } from 'lib/url';
 import Button from 'components/button';
+import { getCurrentUserCountryCode } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import GoogleVoucherDetails from 'my-sites/checkout/checkout-thank-you/google-voucher';
 import { isPremium, isBusiness, isEcommerce, isEnterprise } from 'lib/products-values';
@@ -30,6 +31,7 @@ interface ConnectedProps {
 	isJetpack: boolean;
 	isPremiumOrHigher: boolean;
 	recordTracksEvent: () => void;
+	showCard: boolean;
 	siteId: number | null;
 	siteSlug: string | null;
 }
@@ -39,11 +41,12 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 	isJetpack,
 	isPremiumOrHigher,
 	recordTracksEvent,
+	showCard,
 	siteId,
 	siteSlug,
 } ) => {
 	const translate = useTranslate();
-	if ( ( isJetpack && ! isAtomic ) || ! siteId || ! siteSlug ) {
+	if ( ! showCard || ( isJetpack && ! isAtomic ) || ! siteId || ! siteSlug ) {
 		return null;
 	}
 
@@ -77,6 +80,8 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 
 export default connect(
 	state => {
+		const userInUsa = getCurrentUserCountryCode( state ) === 'US';
+		const userInCa = getCurrentUserCountryCode( state ) === 'CA';
 		const site = getSelectedSite( state );
 		const isAtomic = isSiteAtomic( state, site.ID ) || false;
 		const isPremiumOrHigher =
@@ -88,6 +93,7 @@ export default connect(
 			isAtomic,
 			isJetpack: site && site.jetpack,
 			isPremiumOrHigher,
+			showCard: userInUsa || userInCa,
 			siteId: site && site.ID,
 			siteSlug: site && site.slug,
 		};

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import React, { Fragment, FunctionComponent } from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import { getSelectedSite } from 'state/ui/selectors';
+import { isPremium, isBusiness, isEcommerce, isEnterprise } from 'lib/products-values';
+import MarketingToolsFeature from './feature';
+import QuerySiteVouchers from 'components/data/query-site-vouchers';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	isJetpack: boolean;
+	isPremiumOrHigher: boolean;
+	selectedSiteId: string;
+}
+
+export const GoogleAdwordsCard: FunctionComponent< Props > = ( {
+	isJetpack,
+	isPremiumOrHigher,
+	selectedSiteId,
+} ) => {
+	const translate = useTranslate();
+	if ( isJetpack || ! isPremiumOrHigher ) {
+		return null;
+	}
+	return (
+		<Fragment>
+			<QuerySiteVouchers siteId={ selectedSiteId } />
+			<MarketingToolsFeature
+				title={ translate( 'Advertise with your $100 Google Adwords credit' ) }
+				description={ translate(
+					'Advertise your site where most people are searching: Google. You’ve got a $100 credit with Google Adwords to drive traffic to your most important pages.'
+				) }
+				imagePath="/calypso/images/illustrations/marketing.svg"
+			>
+				<Button>{ translate( 'Start Sharing' ) }</Button>
+			</MarketingToolsFeature>
+		</Fragment>
+	);
+};
+
+GoogleAdwordsCard.propTypes = {
+	isJetpack: PropTypes.bool,
+	isPremiumOrHigher: PropTypes.bool,
+	selectedSiteId: PropTypes.string,
+};
+
+export default connect( state => {
+	const site = getSelectedSite( state );
+	const isPremiumOrHigher =
+		isPremium( site.plan ) ||
+		isBusiness( site.plan ) ||
+		isEcommerce( site.plan ) ||
+		isEnterprise( site.plan );
+	return {
+		isJetpack: site && site.jetpack,
+		isPremiumOrHigher,
+		selectedSiteId: site.id,
+	};
+} )( GoogleAdwordsCard );

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import { getSelectedSite } from 'state/ui/selectors';
+import GoogleVoucherDetails from 'my-sites/checkout/checkout-thank-you/google-voucher';
 import { isPremium, isBusiness, isEcommerce, isEnterprise } from 'lib/products-values';
 import MarketingToolsFeature from './feature';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
@@ -20,24 +21,36 @@ import QuerySiteVouchers from 'components/data/query-site-vouchers';
  */
 import './style.scss';
 
-interface Props {
+interface ConnectProps {
 	isJetpack: boolean;
 	isPremiumOrHigher: boolean;
-	selectedSiteId: string;
+	site: { id: string };
 }
 
-export const GoogleAdwordsCard: FunctionComponent< Props > = ( {
+export const GoogleAdwordsCard: FunctionComponent< ConnectProps > = ( {
 	isJetpack,
 	isPremiumOrHigher,
-	selectedSiteId,
+	site,
 } ) => {
 	const translate = useTranslate();
-	if ( isJetpack || ! isPremiumOrHigher ) {
+	if ( isJetpack ) {
 		return null;
 	}
+
+	const renderButton = () => {
+		const buttonText = isPremiumOrHigher
+			? translate( 'Generate code' )
+			: translate( 'Upgrade to Premium' );
+
+		if ( isPremiumOrHigher ) {
+			return <GoogleVoucherDetails selectedSite={ site } />;
+		}
+		return <Button>{ buttonText }</Button>;
+	};
+
 	return (
 		<Fragment>
-			<QuerySiteVouchers siteId={ selectedSiteId } />
+			<QuerySiteVouchers siteId={ site.id } />
 			<MarketingToolsFeature
 				title={ translate( 'Advertise with your $100 Google Adwords credit' ) }
 				description={ translate(
@@ -45,7 +58,7 @@ export const GoogleAdwordsCard: FunctionComponent< Props > = ( {
 				) }
 				imagePath="/calypso/images/illustrations/marketing.svg"
 			>
-				<Button>{ translate( 'Start Sharing' ) }</Button>
+				{ renderButton() }
 			</MarketingToolsFeature>
 		</Fragment>
 	);
@@ -54,10 +67,10 @@ export const GoogleAdwordsCard: FunctionComponent< Props > = ( {
 GoogleAdwordsCard.propTypes = {
 	isJetpack: PropTypes.bool.isRequired,
 	isPremiumOrHigher: PropTypes.bool.isRequired,
-	selectedSiteId: PropTypes.string.isRequired,
+	site: PropTypes.shape( { id: PropTypes.string.isRequired } ).isRequired,
 };
 
-export default connect( state => {
+export default connect< ConnectProps >( state => {
 	const site = getSelectedSite( state );
 	const isPremiumOrHigher =
 		isPremium( site.plan ) ||
@@ -67,6 +80,6 @@ export default connect( state => {
 	return {
 		isJetpack: site && site.jetpack,
 		isPremiumOrHigher,
-		selectedSiteId: site.id,
+		site,
 	};
 } )( GoogleAdwordsCard );

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -32,7 +32,7 @@ interface ConnectProps {
 	siteSlug: string | null;
 }
 
-export const GoogleAdwordsCard: FunctionComponent< ConnectProps > = ( {
+export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectProps > = ( {
 	isAtomic,
 	isJetpack,
 	isPremiumOrHigher,
@@ -71,7 +71,7 @@ export const GoogleAdwordsCard: FunctionComponent< ConnectProps > = ( {
 	);
 };
 
-GoogleAdwordsCard.propTypes = {
+MarketingToolsGoogleAdwordsFeature.propTypes = {
 	isAtomic: PropTypes.bool.isRequired,
 	isJetpack: PropTypes.bool.isRequired,
 	isPremiumOrHigher: PropTypes.bool.isRequired,
@@ -82,7 +82,6 @@ GoogleAdwordsCard.propTypes = {
 export default connect< ConnectProps >( state => {
 	const site = getSelectedSite( state );
 	const isAtomic = isSiteAtomic( state, site.ID ) || false;
-	console.log( site.plan );
 	const isPremiumOrHigher =
 		isPremium( site.plan ) ||
 		isBusiness( site.plan ) ||
@@ -95,4 +94,4 @@ export default connect< ConnectProps >( state => {
 		siteId: site && site.ID,
 		siteSlug: site && site.slug,
 	};
-} )( GoogleAdwordsCard );
+} )( MarketingToolsGoogleAdwordsFeature );

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -17,6 +17,7 @@ import GoogleVoucherDetails from 'my-sites/checkout/checkout-thank-you/google-vo
 import { isPremium, isBusiness, isEcommerce, isEnterprise } from 'lib/products-values';
 import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
 import MarketingToolsFeature from './feature';
+import { PLAN_PREMIUM } from 'lib/plans/constants';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
 
 /**
@@ -45,7 +46,7 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 	}
 
 	const handleUpgradeClick = () => {
-		page( addQueryArgs( { plan: 'PLAN_PREMIUM' }, `/plans/${ siteSlug }` ) );
+		page( addQueryArgs( { plan: PLAN_PREMIUM }, `/plans/${ siteSlug }` ) );
 	};
 
 	const renderButton = () => {
@@ -61,7 +62,7 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 			<MarketingToolsFeature
 				title={ translate( 'Advertise with your $100 Google Adwords credit' ) }
 				description={ translate(
-					'Advertise your site where most people are searching: Google. You’ve got a $100 credit with Google Adwords to drive traffic to your most important pages.'
+					"Advertise your site where most people are searching: Google. You've got a $100 credit with Google Adwords to drive traffic to your most important pages."
 				) }
 				imagePath="/calypso/images/illustrations/marketing.svg"
 			>

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -52,9 +52,9 @@ export const GoogleAdwordsCard: FunctionComponent< Props > = ( {
 };
 
 GoogleAdwordsCard.propTypes = {
-	isJetpack: PropTypes.bool,
-	isPremiumOrHigher: PropTypes.bool,
-	selectedSiteId: PropTypes.string,
+	isJetpack: PropTypes.bool.isRequired,
+	isPremiumOrHigher: PropTypes.bool.isRequired,
+	selectedSiteId: PropTypes.string.isRequired,
 };
 
 export default connect( state => {

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -19,6 +19,7 @@ import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
 import MarketingToolsFeature from './feature';
 import { PLAN_PREMIUM } from 'lib/plans/constants';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -29,6 +30,7 @@ interface ConnectedProps {
 	isAtomic: boolean;
 	isJetpack: boolean;
 	isPremiumOrHigher: boolean;
+	recordTracksEvent: () => void;
 	siteId: number | null;
 	siteSlug: string | null;
 }
@@ -37,6 +39,7 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 	isAtomic,
 	isJetpack,
 	isPremiumOrHigher,
+	recordTracksEvent,
 	siteId,
 	siteSlug,
 } ) => {
@@ -46,6 +49,7 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 	}
 
 	const handleUpgradeClick = () => {
+		recordTracksEvent( 'calypso_marketing_tools_adwords_plan_upgrade_button_click' );
 		page( addQueryArgs( { plan: PLAN_PREMIUM }, `/plans/${ siteSlug }` ) );
 	};
 
@@ -76,23 +80,29 @@ MarketingToolsGoogleAdwordsFeature.propTypes = {
 	isAtomic: PropTypes.bool.isRequired,
 	isJetpack: PropTypes.bool.isRequired,
 	isPremiumOrHigher: PropTypes.bool.isRequired,
+	recordTracksEvent: PropTypes.func.isRequired,
 	siteId: PropTypes.number,
 	siteSlug: PropTypes.string,
 };
 
-export default connect< ConnectedProps >( state => {
-	const site = getSelectedSite( state );
-	const isAtomic = isSiteAtomic( state, site.ID ) || false;
-	const isPremiumOrHigher =
-		isPremium( site.plan ) ||
-		isBusiness( site.plan ) ||
-		isEcommerce( site.plan ) ||
-		isEnterprise( site.plan );
-	return {
-		isAtomic,
-		isJetpack: site && site.jetpack,
-		isPremiumOrHigher,
-		siteId: site && site.ID,
-		siteSlug: site && site.slug,
-	};
-} )( MarketingToolsGoogleAdwordsFeature );
+export default connect(
+	state => {
+		const site = getSelectedSite( state );
+		const isAtomic = isSiteAtomic( state, site.ID ) || false;
+		const isPremiumOrHigher =
+			isPremium( site.plan ) ||
+			isBusiness( site.plan ) ||
+			isEcommerce( site.plan ) ||
+			isEnterprise( site.plan );
+		return {
+			isAtomic,
+			isJetpack: site && site.jetpack,
+			isPremiumOrHigher,
+			siteId: site && site.ID,
+			siteSlug: site && site.slug,
+		};
+	},
+	{
+		recordTracksEvent: recordTracksEventAction,
+	}
+)( MarketingToolsGoogleAdwordsFeature );

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -59,7 +59,11 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 		if ( isPremiumOrHigher ) {
 			return <GoogleVoucherDetails />;
 		}
-		return <Button onClick={ handleUpgradeClick }>{ translate( 'Upgrade to Premium' ) }</Button>;
+		return (
+			<Button className="tools__upgrade-button" compact onClick={ handleUpgradeClick }>
+				{ translate( 'Upgrade to Premium' ) }
+			</Button>
+		);
 	};
 
 	return (

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -66,9 +66,18 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 		<Fragment>
 			<QuerySiteVouchers siteId={ siteId } />
 			<MarketingToolsFeature
-				title={ translate( 'Advertise with your $100 Google Adwords credit' ) }
+				title={ translate( 'Advertise with your %(cost)s Google Adwords credit', {
+					args: {
+						cost: '$100',
+					},
+				} ) }
 				description={ translate(
-					"Advertise your site where most people are searching: Google. You've got a $100 credit with Google Adwords to drive traffic to your most important pages."
+					"Advertise your site where most people are searching: Google. You've got a %(cost)s credit with Google Adwords to drive traffic to your most important pages.",
+					{
+						args: {
+							cost: '$100',
+						},
+					}
 				) }
 				imagePath="/calypso/images/illustrations/google-adwords-stats.svg"
 			>

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -59,7 +59,7 @@ export const MarketingToolsGoogleAdwordsFeature: FunctionComponent< ConnectedPro
 		if ( isPremiumOrHigher ) {
 			return <GoogleVoucherDetails />;
 		}
-		return <Button onClick={ handleUpgradeClick }>{ translate( 'Upgrade To Premium' ) }</Button>;
+		return <Button onClick={ handleUpgradeClick }>{ translate( 'Upgrade to Premium' ) }</Button>;
 	};
 
 	return (

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -115,8 +115,6 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 
 				<MarketingToolsGoogleMyBusinessFeature />
 
-				<GoogleAdwordsCard />
-
 				<MarketingToolsGoogleAdwordsFeature />
 			</div>
 		</Fragment>

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
+import GoogleAdwordsCard from './google-adwords';
 import MarketingToolsFeature from './feature';
 import MarketingToolsGoogleMyBusinessFeature from './google-my-business-feature';
 import MarketingToolsHeader from './header';
@@ -67,7 +68,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 
 			<div className="tools__feature-list">
 				<MarketingToolsFeature
-					title={ translate( 'Get social, and share your blog posts where the people are' ) }
+					title={ translate( 'Advertise with your $100 Google Adwords credit' ) }
 					description={ translate(
 						"Use your site's Publicize tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Twitter, Facebook, LinkedIn, and more."
 					) }
@@ -113,6 +114,8 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 				</MarketingToolsFeature>
 
 				<MarketingToolsGoogleMyBusinessFeature />
+
+				<GoogleAdwordsCard />
 			</div>
 		</Fragment>
 	);

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -68,7 +68,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 
 			<div className="tools__feature-list">
 				<MarketingToolsFeature
-					title={ translate( 'Advertise with your $100 Google Adwords credit' ) }
+					title={ translate( 'Get social, and share your blog posts where the people are' ) }
 					description={ translate(
 						"Use your site's Publicize tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Twitter, Facebook, LinkedIn, and more."
 					) }

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -11,7 +11,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
-import GoogleAdwordsCard from './google-adwords';
+import MarketingToolsGoogleAdwordsFeature from './google-adwords';
 import MarketingToolsFeature from './feature';
 import MarketingToolsGoogleMyBusinessFeature from './google-my-business-feature';
 import MarketingToolsHeader from './header';
@@ -116,6 +116,8 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 				<MarketingToolsGoogleMyBusinessFeature />
 
 				<GoogleAdwordsCard />
+
+				<MarketingToolsGoogleAdwordsFeature />
 			</div>
 		</Fragment>
 	);

--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -126,4 +126,30 @@
 		text-align: center;
 		width: auto;
 	}
+
+	@include breakpoint( '>480px' ) {
+		flex-direction: row;
+
+		.button {
+			margin: 0 1em 0 0;
+			width: auto;
+		}
+	}
+
+	@include breakpoint( '>1040px' ) {
+		justify-content: flex-end;
+
+		.button {
+			margin: 0 0 0 1em;
+		}
+
+		.purchase-detail__button {
+			float: right;
+		}
+
+		.google-voucher__setup-google-adwords.purchase-detail__button:not( .is-compact ) {
+			margin-top: 27px;
+		}
+	}
 }
+

--- a/client/my-sites/marketing/tools/style.scss
+++ b/client/my-sites/marketing/tools/style.scss
@@ -116,19 +116,46 @@
 	}
 }
 
+.tools__upgrade-button {
+	text-transform: capitalize;
+}
+
 .tools__feature-list-item-child-row {
 	display: flex;
-	flex-direction: row;
-	justify-content: flex-end;
+	flex-direction: column;
+	justify-content: center;
+	margin-top: 1em;
 
 	.button {
-		margin: 1em 0 0;
+		margin: 0;
 		text-align: center;
 		width: auto;
 	}
 
+	.purchase-detail__info {
+		margin-top: 1em;
+	}
+
+	.google-voucher__initial-step .purchase-detail__button {
+		float: right;
+		font-size: 12px;
+		line-height: 1;
+		padding: 7px;
+	}
+
+	.google-voucher__initial-step {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+	}
+
 	@include breakpoint( '>480px' ) {
 		flex-direction: row;
+		justify-content: flex-end;
+
+		.google-voucher__initial-step {
+			display: block;
+		}
 
 		.button {
 			margin: 0 1em 0 0;
@@ -137,7 +164,7 @@
 	}
 
 	@include breakpoint( '>1040px' ) {
-		justify-content: flex-end;
+		
 
 		.button {
 			margin: 0 0 0 1em;
@@ -145,10 +172,6 @@
 
 		.purchase-detail__button {
 			float: right;
-		}
-
-		.google-voucher__setup-google-adwords.purchase-detail__button:not( .is-compact ) {
-			margin-top: 27px;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Google Adwords card to marketing tools page

#### Testing instructions

* Have site with plan lower than premium
* Goto to Marketing Tools page
* Observe Button on Adwords card says "Upgrade To Premium"
* Have another site with Premium or higher
* Observe button says "Generate Code" and has fine print
* Click generate code observe ToS dialog opens
* Click cancel and observe it closes
* Open again and accept
* Observe that you now code with copy button
* Copy it to ensure that works
* You should also see fine print with a link
* Ensure link works
* Click "Setup Google Ads" button to ensure that works
![Screen Shot 2019-04-30 at 3 30 25 PM](https://user-images.githubusercontent.com/6817400/56989924-a96cf280-6b61-11e9-9334-8ed1434c1789.png)
![Screen Shot 2019-04-30 at 3 30 39 PM](https://user-images.githubusercontent.com/6817400/56989926-a96cf280-6b61-11e9-930d-a0e022154976.png)
![Screen Shot 2019-04-30 at 3 30 49 PM](https://user-images.githubusercontent.com/6817400/56989927-a96cf280-6b61-11e9-88cb-984d3e3cf4f6.png)
![Screen Shot 2019-04-30 at 4 04 18 PM](https://user-images.githubusercontent.com/6817400/56989928-a96cf280-6b61-11e9-9e9c-5ff99d915908.png)
