### PR TITLE
Full Site Editing: make `wp_template` not `public` by default

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -18,6 +18,7 @@ class A8C_Full_Site_Editing {
 		add_action( 'init', array( $this, 'register_script_and_style' ), 100 );
 		add_action( 'init', array( $this, 'register_blocks' ), 100 );
 		add_action( 'init', array( $this, 'register_wp_template' ) );
+		add_action( 'rest_api_init', array( $this, 'allow_searching_for_templates' ) );
 	}
 
 	function register_wp_template() {
@@ -59,6 +60,21 @@ class A8C_Full_Site_Editing {
 		register_block_type( 'a8c/template-part', array(
 			'render_callback' => 'render_template_part_block',
 		) );
+	}
+
+	/**
+	 * This will set the `wp_template` post type to `public` to support
+	 * the core search endpoint, which looks for it.
+	 *
+	 * @return void
+	 */
+	function allow_searching_for_templates() {
+		$post_type = get_post_type_object( 'wp_template' );
+		if ( ! is_a( $post_type, 'WP_Post_Type' ) ) {
+			return;
+		}
+		// setting this to `public` will allow it to be found in the search endpoint
+		$post_type->public = true;
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -70,7 +70,7 @@ class A8C_Full_Site_Editing {
 	 */
 	function allow_searching_for_templates() {
 		$post_type = get_post_type_object( 'wp_template' );
-		if ( ! is_a( $post_type, 'WP_Post_Type' ) ) {
+		if ( ! ( $post_type instanceof WP_Post_Type ) ) {
 			return;
 		}
 		// setting this to `public` will allow it to be found in the search endpoint

--- a/apps/full-site-editing/full-site-editing-plugin/wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wp-template.php
@@ -46,10 +46,12 @@ function fse_register_wp_template() {
 				// You need to be able to customize, in order to create templates.
 				'create_posts'           => 'edit_theme_options',
 				'edit_posts'             => 'edit_theme_options',
+				'delete_posts'           => 'edit_theme_options',
 				'edit_published_posts'   => 'edit_theme_options',
 				'delete_published_posts' => 'edit_theme_options',
 				'edit_others_posts'      => 'edit_theme_options',
 				'delete_others_posts'    => 'edit_theme_options',
+				'publish_posts'          => 'edit_theme_options'
 			),
 			'map_meta_cap'          => true,
 			'supports'              => array(

--- a/apps/full-site-editing/full-site-editing-plugin/wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wp-template.php
@@ -32,7 +32,7 @@ function fse_register_wp_template() {
 				'item_scheduled'           => __( 'Template scheduled.' ),
 				'item_updated'             => __( 'Template updated.' ),
 			),
-			'public'                => true, // temp to support the search endpoint
+			'public'                => false,
 			'show_ui'               => true,
 			'show_in_menu'          => true,
 			'rewrite'               => false,


### PR DESCRIPTION
The `public` flag when registering a post type opens it up to all kinds of exposure. Since we only have this in place to support searching through the core endpoint, this simply makes the CPT `public` when in an API endpoint.

We could probably do more robust detection than this to more strictly limit exposure (eg hooking into `WP_Query`) but since it's unlikely that we will continue to use the core search endpoint, this will do fine for now.



#### Changes proposed in this Pull Request

* set the `public` property on the `wp_template` CPT during a REST request

#### Testing instructions

* ensure that searching in the Content Slot and Template Part blocks still works
* look in feeds and frontend search results (and whatever you can think of) for `wp_template` posts (they shouldn't appear)

Fixes #32491
