### PR TITLE
README.md: Update Calypso screen shot to reflect latest design

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Calypso is the new WordPress.com front-end – a beautiful redesign of the WordPress dashboard using a single-page web application, powered by the WordPress.com REST API. Calypso is built for reading, writing, and managing all of your WordPress sites in one place.
 
-![beautiful screenshot](https://cldup.com/Q74QJCh0Yl.png)
+![beautiful screenshot](https://cldup.com/cnKYCHeGZM.png)
 
 It’s built with JavaScript – a very light [node](https://nodejs.org/) plus [express](https://expressjs.com/) server, [React.js](https://reactjs.org/), [Redux](https://redux.js.org/), [wpcom.js](https://wpcomjs.com/), and many other wonderful libraries on the front-end.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Calypso is the new WordPress.com front-end – a beautiful redesign of the WordPress dashboard using a single-page web application, powered by the WordPress.com REST API. Calypso is built for reading, writing, and managing all of your WordPress sites in one place.
 
-![beautiful screenshot](https://cldup.com/cnKYCHeGZM.png)
+![beautiful screenshot](https://cldup.com/zBBkP721le.png)
 
 It’s built with JavaScript – a very light [node](https://nodejs.org/) plus [express](https://expressjs.com/) server, [React.js](https://reactjs.org/), [Redux](https://redux.js.org/), [wpcom.js](https://wpcomjs.com/), and many other wonderful libraries on the front-end.
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

A purely cosmetic update for our app's `README.md`, replacing the older screenshot of the Calypso plugins page with an updated version (as of May 1, 2019).

### Before
<img width="400" alt="Screen Shot 2019-05-01 at 1 41 39 pm" src="https://user-images.githubusercontent.com/6458278/57004948-e810b480-6c16-11e9-8e2e-9668b10a2b8b.png">

### After
<img width="400" alt="Screen Shot 2019-05-01 at 1 42 20 pm" src="https://user-images.githubusercontent.com/6458278/57004951-f959c100-6c16-11e9-8840-c692bb34a84d.png">

## Testing instructions

Strap yourself in and behold the [updated README.md](https://github.com/Automattic/wp-calypso/blob/ca32b6eda8148ebfcdc0e3aa8622774a3e1d4a2f/README.md)
