### PR TITLE
Remove extensions loader from server config

### DIFF
--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -83,11 +83,6 @@ const webpackConfig = {
 	module: {
 		rules: [
 			{
-				test: /extensions[/\\]index/,
-				exclude: path.join( __dirname, 'node_modules' ),
-				loader: path.join( __dirname, 'server', 'bundler', 'extensions-loader' ),
-			},
-			{
 				include: path.join( __dirname, 'client/sections.js' ),
 				use: {
 					loader: path.join( __dirname, 'server', 'bundler', 'sections-loader' ),


### PR DESCRIPTION
In #27415 we removed the extensions loader from Calypso.  We didn't
remove the configuration for it from the `webpack.config.node.js` file.

It probably didn't break becuase `extensions/index` wasn't being loaded
on the server and so the rule didn't match and the loader wasn't
requested.

This patch removes the reference that should have disappeared in that PR.

## Testing

Try and build and run Calypso. Verify that the SSR routes work, for example, `/themes`