### PR TITLE
Don't init the /sites section at boot

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -159,4 +159,3 @@
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
 @import 'blocks/image-selector/style';
-@import 'my-sites/sites/style';

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -19,7 +19,6 @@ import store from 'store';
 import config from 'config';
 import { ReduxWrappedLayout } from 'controller';
 import notices from 'notices';
-import setupMySitesRoute from 'my-sites';
 import authController from 'auth/controller';
 import emailVerification from 'components/email-verification';
 import { getSavedVariations } from 'lib/abtest'; // used by error logger
@@ -353,8 +352,6 @@ export const setupMiddlewares = ( currentUser, reduxStore ) => {
 			next();
 		} );
 	}
-
-	setupMySitesRoute();
 
 	const state = reduxStore.getState();
 	if ( config.isEnabled( 'happychat' ) ) {

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import i18n from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -15,7 +15,12 @@ import Card from 'components/card';
 import Main from 'components/main';
 import SiteSelector from 'components/site-selector';
 
-export class Sites extends Component {
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class Sites extends Component {
 	static propTypes = {
 		siteBasePath: PropTypes.string.isRequired,
 	};
@@ -41,7 +46,7 @@ export class Sites extends Component {
 		return site;
 	};
 
-	getHeaderText = () => {
+	getHeaderText() {
 		if ( this.props.getSiteSelectionHeaderText ) {
 			return this.props.getSiteSelectionHeaderText();
 		}
@@ -51,58 +56,58 @@ export class Sites extends Component {
 			path = path.toLowerCase();
 		}
 
-		switch ( path ) {
-			case 'activity-log':
-				path = i18n.translate( 'Activity' );
-				break;
-			case 'stats':
-				path = i18n.translate( 'Insights' );
-				break;
-			case 'plans':
-				path = i18n.translate( 'Plans' );
-				break;
-			case 'media':
-				path = i18n.translate( 'Media' );
-				break;
-			case 'sharing':
-				path = i18n.translate( 'Sharing' );
-				break;
-			case 'people':
-				path = i18n.translate( 'People' );
-				break;
-			case 'domains':
-				path = i18n.translate( 'Domains' );
-				break;
-			case 'settings':
-				path = i18n.translate( 'Settings' );
-				break;
-		}
+		const { translate } = this.props;
 
 		// nicer wording for editor routes
 		const editorRouters = [ 'page', 'post', 'edit', 'block-editor' ];
 		if ( editorRouters.includes( path ) ) {
-			return i18n.translate( 'Select a site to start writing' );
+			return translate( 'Select a site to start writing' );
 		}
 
-		return i18n.translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
-			args: {
-				path: path,
-			},
+		switch ( path ) {
+			case 'activity-log':
+				path = translate( 'Activity' );
+				break;
+			case 'stats':
+				path = translate( 'Insights' );
+				break;
+			case 'plans':
+				path = translate( 'Plans' );
+				break;
+			case 'media':
+				path = translate( 'Media' );
+				break;
+			case 'sharing':
+				path = translate( 'Sharing' );
+				break;
+			case 'people':
+				path = translate( 'People' );
+				break;
+			case 'domains':
+				path = translate( 'Domains' );
+				break;
+			case 'settings':
+				path = translate( 'Settings' );
+				break;
+		}
+
+		return translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
+			args: { path },
 			components: {
 				strong: <strong />,
 			},
 		} );
-	};
+	}
 
 	render() {
 		return (
 			<Main className="sites">
 				<h2 className="sites__select-heading">{ this.getHeaderText() }</h2>
-				<Card className="sites__selector-wrapper">
+				<Card className="sites__select-wrapper">
 					<SiteSelector
 						filter={ this.filterSites }
 						siteBasePath={ this.props.siteBasePath }
-						groups={ true }
+						groups
 					/>
 				</Card>
 			</Main>
@@ -110,4 +115,4 @@ export class Sites extends Component {
 	}
 }
 
-export default Sites;
+export default localize( Sites );

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -10,7 +10,7 @@
 	}
 }
 
-.sites__selector-wrapper.card {
+.sites__select-wrapper.card {
 	padding: 0;
 
 	.site-selector {


### PR DESCRIPTION
There is a perfectly fine dynamically loaded `/sites` section, so why init it at boot? Removing this code eliminates `my-sites/controller`-related code from the `build` chunk.

The `build` chunk loses almost 10% of weight. The code gets duplicated into many sections though. Detailed ICFY report that includes both chunk groups and individual chunks: http://iscalypsofastyet.com/branch?branch=add/sites-section

In a simple drive-by change, the `Sites` component gets migrated to CSS and decorated with the `localize` HOC.

**How to test:**
1. go to `/sites`: do you see site selector UI?
2. go to `/sites/site.blog` (or select a site in step 1): are you redirected to `/stats/insights`?
