### PR TITLE
Remove incorrect paragraph from the discount explanation

### DIFF
--- a/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
+++ b/client/my-sites/checkout/cart/cart-plan-discount-ad.jsx
@@ -72,16 +72,6 @@ export class CartPlanDiscountAd extends Component {
 						}
 					) }
 				</p>
-				<p className="cart__cart-plan-discount-ad-paragraph">
-					{ translate(
-						'The plan and the domain can be renewed together for %(originalPrice)s / year.',
-						{
-							args: {
-								originalPrice: plan.formattedOriginalPrice,
-							},
-						}
-					) }
-				</p>
 			</CartAd>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When upgrading from a single domain to a plan, people would see this ad:

<img width="355" alt="Screenshot 2019-05-01 at 14 18 10" src="https://user-images.githubusercontent.com/82778/57015166-fc0ae500-6c1b-11e9-9426-d494a85a4407.png">

It contradicts with our policy for domain renewals - the domain will not be bundled and will not renew as part of the plan.

#### Testing instructions

1. Use the Store Sandbox
2. Buy a plan (Personal or higher) and a .live domain
3. Cancel the plan and keep the domain
4. Add a plan again

*

Fixes #
