### PR TITLE
Full Site Editing: Conditionally enqueue blocks scripts when editing `wp_template` posts

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blocks/content-slot/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/content-slot/index.js
@@ -2,8 +2,6 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { select } from '@wordpress/data';
-import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -12,22 +10,18 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-domReady( () => {
-	if ( 'wp_template' === select( 'core/editor' ).getCurrentPostType() ) {
-		registerBlockType( 'a8c/content-slot', {
-			title: __( 'Content Slot' ),
-			description: __( 'Placeholder for a post or a page.' ),
-			icon: 'layout',
-			category: 'layout',
-			supports: {
-				align: [ 'wide', 'full' ],
-				anchor: true,
-				html: false,
-				multiple: false,
-				reusable: false,
-			},
-			edit,
-			save: () => null,
-		} );
-	}
+registerBlockType( 'a8c/content-slot', {
+	title: __( 'Content Slot' ),
+	description: __( 'Placeholder for a post or a page.' ),
+	icon: 'layout',
+	category: 'layout',
+	supports: {
+		align: [ 'wide', 'full' ],
+		anchor: true,
+		html: false,
+		multiple: false,
+		reusable: false,
+	},
+	edit,
+	save: () => null,
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template-part/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template-part/index.js
@@ -2,8 +2,6 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { select } from '@wordpress/data';
-import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -12,25 +10,21 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-domReady( () => {
-	if ( 'wp_template' === select( 'core/editor' ).getCurrentPostType() ) {
-		registerBlockType( 'a8c/template-part', {
-			title: __( 'Template Part' ),
-			description: __( 'Display a template part.' ),
-			icon: 'layout',
-			category: 'layout',
-			attributes: {
-				selectedPostId: { type: 'number' },
-				selectedPostType: { type: 'string' },
-			},
-			supports: {
-				align: [ 'wide', 'full' ],
-				anchor: true,
-				html: false,
-				reusable: false,
-			},
-			edit,
-			save: () => null,
-		} );
-	}
+registerBlockType( 'a8c/template-part', {
+	title: __( 'Template Part' ),
+	description: __( 'Display a template part.' ),
+	icon: 'layout',
+	category: 'layout',
+	attributes: {
+		selectedPostId: { type: 'number' },
+		selectedPostType: { type: 'string' },
+	},
+	supports: {
+		align: [ 'wide', 'full' ],
+		anchor: true,
+		html: false,
+		reusable: false,
+	},
+	edit,
+	save: () => null,
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -27,6 +27,10 @@ class A8C_Full_Site_Editing {
 	}
 
 	function register_script_and_style() {
+		if ( ! $this->is_editor_wp_template() ) {
+			return;
+		}
+
 		$script_dependencies = json_decode( file_get_contents(
 			plugin_dir_path( __FILE__ ) . 'dist/full-site-editing-plugin.deps.json'
 		), true );
@@ -75,6 +79,12 @@ class A8C_Full_Site_Editing {
 		}
 		// setting this to `public` will allow it to be found in the search endpoint
 		$post_type->public = true;
+	}
+
+	function is_editor_wp_template() {
+		return
+			( isset( $_GET['post_type'] ) && 'wp_template' === $_GET['post_type'] ) ||
+			( isset( $_GET['post'] ) && 'wp_template' === get_post_type( $_GET['post'] ) );
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -15,10 +15,10 @@ class A8C_Full_Site_Editing {
 		}
 		self::$initialized = true;
 
-		add_action( 'init', array( $this, 'register_script_and_style' ), 100 );
 		add_action( 'init', array( $this, 'register_blocks' ), 100 );
 		add_action( 'init', array( $this, 'register_wp_template' ) );
 		add_action( 'rest_api_init', array( $this, 'allow_searching_for_templates' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script_and_style' ), 100 );
 	}
 
 	function register_wp_template() {
@@ -26,7 +26,7 @@ class A8C_Full_Site_Editing {
 		fse_register_wp_template();
 	}
 
-	function register_script_and_style() {
+	function enqueue_script_and_style() {
 		if ( ! $this->is_editor_wp_template() ) {
 			return;
 		}
@@ -34,17 +34,18 @@ class A8C_Full_Site_Editing {
 		$script_dependencies = json_decode( file_get_contents(
 			plugin_dir_path( __FILE__ ) . 'dist/full-site-editing-plugin.deps.json'
 		), true );
-		wp_register_script(
+		wp_enqueue_script(
 			'a8c-full-site-editing-script',
 			plugins_url( 'dist/full-site-editing-plugin.js', __FILE__ ),
 			is_array( $script_dependencies ) ? $script_dependencies : array(),
-			filemtime( plugin_dir_path( __FILE__ ) . 'dist/full-site-editing-plugin.js' )
+			filemtime( plugin_dir_path( __FILE__ ) . 'dist/full-site-editing-plugin.js' ),
+			true
 		);
 
 		$style_file = is_rtl()
 			? 'full-site-editing-plugin.rtl.css'
 			: 'full-site-editing-plugin.css';
-		wp_register_style(
+		wp_enqueue_style(
 			'a8c-full-site-editing-style',
 			plugins_url( 'dist/' . $style_file, __FILE__ ),
 			array(),
@@ -52,12 +53,8 @@ class A8C_Full_Site_Editing {
 		);
 	}
 
-	// We only need to declare script and style as dependencies once
-	// Because they'll be then enqueued for every block.
 	function register_blocks() {
 		register_block_type( 'a8c/content-slot', array(
-			'editor_script'   => 'a8c-full-site-editing-script',
-			'editor_style'    => 'a8c-full-site-editing-style',
 			'render_callback' => 'render_content_slot_block',
 		 ) );
 
@@ -82,9 +79,8 @@ class A8C_Full_Site_Editing {
 	}
 
 	function is_editor_wp_template() {
-		return
-			( isset( $_GET['post_type'] ) && 'wp_template' === $_GET['post_type'] ) ||
-			( isset( $_GET['post'] ) && 'wp_template' === get_post_type( $_GET['post'] ) );
+		$current_screen = get_current_screen();
+		return 'wp_template' === $current_screen->post_type;
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -27,7 +27,7 @@ class A8C_Full_Site_Editing {
 	}
 
 	function enqueue_script_and_style() {
-		if ( ! $this->is_editor_wp_template() ) {
+		if ( 'wp_template' !== get_current_screen()->post_type ) {
 			return;
 		}
 
@@ -76,11 +76,6 @@ class A8C_Full_Site_Editing {
 		}
 		// setting this to `public` will allow it to be found in the search endpoint
 		$post_type->public = true;
-	}
-
-	function is_editor_wp_template() {
-		$current_screen = get_current_screen();
-		return 'wp_template' === $current_screen->post_type;
 	}
 }
 

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -31,7 +31,6 @@
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",
 		"@wordpress/data": "^4.4.0",
-		"@wordpress/dom-ready": "^2.2.0",
 		"@wordpress/editor": "^9.2.4",
 		"@wordpress/element": "^2.3.0",
 		"@wordpress/i18n": "^3.3.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to limit FSE blocks to be only used in `wp_template` posts. 
In #32657 we merged a JS solution, as implied by the [official docs](https://github.com/WordPress/gutenberg/blob/6f80078228d10985e23c8585c9d88b6c95fff418/docs/designers-developers/developers/filters/block-filters.md#using-a-blacklist).

In this alternative approach, we try to only enqueue the blocks scripts (and styles) when editing a `wp_template` post.

The problem is that the blocks registration must be performed on `init` (or at least, all Core blocks are registered on `init`, and I tried to move FSE's to other hooks to no avail), and consequently, the blocks scripts must also be registered on `init` (before the blocks registration, which automatically enqueues them).
On `init`, though, we don't have any `current_screen` information yet, and so wouldn't work:
```php
$current_screen = get_current_screen();
if ( 'wp_template' === $current_screen->post_type ) {
  // wp_register_script( ... )
}
```
The remaining possibility is to check the query params:
- `$_GET['post_type]` is available when creating new posts.
- `get_post_type( $_GET['post'] )` must be used when modifying an existing one.

#### Testing instructions

* Check that Content and Template blocks are only available when editing a Template post.
* Insert a Template block and pick a post to render. Save and preview (or publish and view) the Template post: make sure the Template block is actually rendering its selected post in the front-end.

Fixes Dennis' concerns in https://github.com/Automattic/wp-calypso/pull/32657#pullrequestreview-232428529 (well, at least _tries to_ 😄)