### PR TITLE
Signup: Preload the next step chunk in the flow

### DIFF
--- a/client/signup/README.md
+++ b/client/signup/README.md
@@ -126,15 +126,14 @@ export default class extends React.Component {
 } );
 ```
 
-4 - add the new step to `/client/signup/config/step-components.js`. Include the component:
+4 - add the new step to `/client/signup/config/step-components.js`. Include a reference to the component module:
 ```javascript
-import helloWorldComponent from 'signup/steps/hello-world';
-```
+const stepNameToModuleName = {
+	...
+	'hello-world' : 'hello-world-module-name'; // Referencing signup/steps/hello-world-module-name/index.js
+};
 
-... and then create a new property for it:
-
-```javascript
-'hello-world': helloWorldComponent // This is the component to show for this step
+...
 ```
 
 5 - add the new step to `/client/signup/config/steps-pure.js`. Include the component in the object returned from `generateSteps`:

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, includes, reject } from 'lodash';
+import { assign, get, includes, indexOf, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -150,6 +150,20 @@ const Flows = {
 		Flows.preloadABTestVariationsForStep( flowName, currentStepName );
 
 		return Flows.filterExcludedSteps( Flows.getABTestFilteredFlow( flowName, flow ) );
+	},
+
+	getNextStepNameInFlow( flowName, currentStepName = '' ) {
+		const flow = Flows.getFlows()[ flowName ];
+
+		if ( ! flow ) {
+			return false;
+		}
+		const flowSteps = flow.steps;
+		const currentStepIndex = indexOf( flowSteps, currentStepName );
+		const nextIndex = currentStepIndex + 1;
+		const nextStepName = get( flowSteps, nextIndex );
+
+		return nextStepName;
 	},
 
 	/**

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -72,6 +72,7 @@ import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 // Current directory dependencies
 import steps from './config/steps';
 import flows from './config/flows';
+import { getStepComponent } from './config/step-components';
 import {
 	canResumeFlow,
 	getCompletedSteps,
@@ -203,6 +204,7 @@ class Signup extends React.Component {
 		debug( 'Signup component mounted' );
 		this.startTrackingForBusinessSite();
 		this.recordSignupStart();
+		this.preloadNextStep();
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -211,6 +213,10 @@ class Signup extends React.Component {
 			get( prevProps.signupDependencies, 'siteType' )
 		) {
 			this.startTrackingForBusinessSite();
+		}
+
+		if ( this.props.stepName !== prevProps.stepName ) {
+			this.preloadNextStep();
 		}
 	}
 
@@ -290,6 +296,13 @@ class Signup extends React.Component {
 			this.goToNextStep( flowName );
 		}
 	};
+
+	preloadNextStep() {
+		const currentStepName = this.props.stepName;
+		const nextStepName = flows.getNextStepNameInFlow( this.props.flowName, currentStepName );
+
+		nextStepName && getStepComponent( nextStepName );
+	}
 
 	recordStep = ( stepName = this.props.stepName, flowName = this.props.flowName ) => {
 		analytics.tracks.recordEvent( 'calypso_signup_step_start', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to load the step component that would be next in the current flow ahead of time by calling the async import as soon as the current step changes.

To do so, I've done the following:

- Added a `getNextStepNameInFlow` function, allowing us to give a step name and a flow name, and get the name of the next step in that flow.
- Added and used a `preloadNextStep` function that grabs the next step name and async loads the module in both the `componentDidMount` and `componentDidUpdate` methods.
- Updated the now incorrect docs

#### Testing instructions

- Filter network tab by '`async-load-signup`'
- While signed out, start at: http://calypso.localhost:3000/start/onboarding
	- See that the first step component still loads as expected.
	- You should notice two `async-load-signup` javascript hits in the network tab - one for the first task (`async-load-signup-steps-user`) and one for the next task (`async-load-signup-steps-site-topic`).
- Continue through the steps and watch for those `async-load-signup` javascript hits - each step you progress to should result in the next step being loaded.

- Apply the same test logic to other flows - we should see the `async-load-signup...` chunks load one step before they're actually needed. (http://calypso.localhost:3000/start/import/from-url for example)