### PR TITLE
People: Update remove follower flow

### DIFF
--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -78,10 +78,9 @@ const Followers = localize(
 				<div>
 					<p>
 						{ this.props.translate(
-							'If removed, this follower will stop receiving notifications about this site, unless they re-follow.'
+							'Removing this follower will make them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again.'
 						) }
 					</p>
-					<p>{ this.props.translate( 'Would you still like to remove this follower?' ) }</p>
 				</div>,
 				accepted => {
 					if ( accepted ) {

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -78,7 +78,7 @@ const Followers = localize(
 				<div>
 					<p>
 						{ this.props.translate(
-							'Removing this follower will make them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again.'
+							'Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again.'
 						) }
 					</p>
 				</div>,

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -167,16 +167,16 @@ class PeopleListItem extends React.PureComponent {
 					<div className="people-list-item__actions">
 						<Button
 							compact
-							scary
-							borderless
 							className="people-list-item__remove-button"
 							onClick={ onRemove }
 							data-e2e-remove-login={ get( user, 'login', '' ) }
 						>
-							<Gridicon icon="trash" />
-							{ translate( 'Remove', {
-								context: 'Verb: Remove a user or follower from the blog.',
-							} ) }
+							<Gridicon icon="cross" />
+							<span>
+								{ translate( 'Remove', {
+									context: 'Verb: Remove a user or follower from the blog.',
+								} ) }
+							</span>
 						</Button>
 					</div>
 				) }


### PR DESCRIPTION
Fixes #32215 by making a few small improvements to the "Remove Follower" flow, to address potential confusion.

---

**Before**

![before](https://user-images.githubusercontent.com/426518/58260421-10f01980-7d7f-11e9-9ccc-bda37a807f8c.png)

<img width="577" alt="ranimac3 screenshot 2019-05-23 at 17 03 34" src="https://user-images.githubusercontent.com/426518/58259192-bc4b9f00-7d7c-11e9-97a1-c6733a864507.png">

The remove button is inconsistent with Muriel patterns and looks too dramatic/scary for what it actually does. 

The confirmation message could more clearly communicate what is going to happen.

---

**After**

![after](https://user-images.githubusercontent.com/426518/58260412-0cc3fc00-7d7f-11e9-9e1e-80441aceecad.png)

<img width="573" alt="ranimac3 screenshot 2019-05-23 at 17 11 03" src="https://user-images.githubusercontent.com/426518/58259721-c6ba6880-7d7d-11e9-8ecb-8edc1a9ede0e.png">

> Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again.

Change the "remove" button to make it less _scary_ and more consistent with [Muriel patterns](https://murieldesignsystem.blog/components/buttons/).

Change the confirmation notice to make the process easier to understand fully.

---

## Testing instructions

- Switch to this branch.
- Go to Manage and then People and then Followers or Email Followers.
- Confirm that the button is using the new style.
- Press the button to see the confirmation message (no need to go further and actually remove the subscriber.)
- Confirm that the message is using the new copy.