### PR TITLE
Google Photos: enable mime type filtering

### DIFF
--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -108,15 +108,27 @@ export class MediaLibraryFilterBar extends Component {
 		this.props.onFilterChange( filter );
 	};
 
-	renderTabItems() {
-		if ( this.props.source !== '' ) {
-			return null;
+	getFiltersForSource( source ) {
+		if ( source === 'pexels' ) {
+			return [];
 		}
 
-		const tabs = [ '', 'this-post', 'images', 'documents', 'videos', 'audio' ];
+		if ( source === 'google_photos' ) {
+			return [ '', 'images', 'videos' ];
+		}
+
+		return [ '', 'this-post', 'images', 'documents', 'videos', 'audio' ];
+	}
+
+	renderTabItems() {
+		const tabs = this.getFiltersForSource( this.props.source );
 
 		if ( ! this.props.post ) {
 			pull( tabs, 'this-post' );
+		}
+
+		if ( tabs.length === 0 ) {
+			return null;
 		}
 
 		return (

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -278,6 +278,11 @@ class Media extends Component {
 			searchUrl( '', this.props.search );
 		}
 
+		if ( this.props.filter ) {
+			// Reset the filter so we don't switch to a source that doesn't support the filter
+			this.onFilterChange( '' );
+		}
+
 		MediaActions.sourceChanged( this.props.selectedSite.ID );
 		this.setState( { source }, cb );
 	};

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -435,7 +435,11 @@ export class EditorMediaModal extends Component {
 
 	onSourceChange = source => {
 		MediaActions.sourceChanged( this.props.site.ID );
-		this.setState( { source, search: undefined } );
+		this.setState( {
+			source,
+			search: undefined,
+			filter: '',
+		} );
 	};
 
 	onClose = () => {


### PR DESCRIPTION
The old Picasa API didn't support filtering media by type, and so the feature was disabled in the Calypso UI.

<img width="404" alt="Media_‹_Testy_Blog_—_WordPress_com" src="https://user-images.githubusercontent.com/1277682/57064330-dc2bfd80-6cbd-11e9-8865-7674c2758968.png">

The new Google Photos API does support media type filtering, and so this PR restores the UI in the media library and allows the type to be passed through to the remote API request.

<img width="454" alt="Media_‹_Testy_Blog_—_WordPress_com" src="https://user-images.githubusercontent.com/1277682/57064375-fbc32600-6cbd-11e9-9bf2-1bf23dd11ff6.png">

Only video and image types are supported.

Note that the media library in the Gutenberg post editor currently does not support filtering, and this option is disabled there for Google Photos and for WordPress media.

#### Testing instructions

1. Open the media page on a site (note this is the top level menu option, not the media modal when editing a post)
2. Verify that WordPress media can be filtered by clicking between the media types (see above screenshot)
3. Switch to Google Photos and verify that the media type filter is visible, shows image and video filtering
4. Verify that image and video filtering works
5. Switch to Pexels and verify that the media type filter is removed
6. Switch to WordPress media and pick the `documents` filter
7. Switch to Google Photos and verify that the filter is reset to 'all'
