### PR TITLE
Google Photos: pass categoryInclude & file type filter

### DIFF
--- a/client/components/data/media-list-data/index.jsx
+++ b/client/components/data/media-list-data/index.jsx
@@ -78,6 +78,11 @@ export default class extends React.Component {
 		if ( props.source ) {
 			query.source = props.source;
 			query.path = 'recent';
+
+			if ( props.source === 'google_photos' ) {
+				// Add any query params specific to Google Photos
+				return utils.getGoogleQuery( query, props );
+			}
 		}
 
 		return query;

--- a/client/components/data/media-list-data/test/index.jsx
+++ b/client/components/data/media-list-data/test/index.jsx
@@ -58,6 +58,34 @@ describe( 'EditorMediaModal', () => {
 		expect( result ).to.eql( { mime_type: 'image/' } );
 	} );
 
+	test( 'should pass and process filter parameter for google photos', () => {
+		const tree = shallow(
+			<MediaListData siteId={ DUMMY_SITE_ID }>
+				<EMPTY_COMPONENT />
+			</MediaListData>
+		).instance();
+		const query = { filter: 'images', source: 'google_photos' };
+		const result = tree.getQuery( query );
+
+		expect( result ).to.eql( {
+			source: 'google_photos',
+			path: 'recent',
+			filter: [ 'mediaType=photo' ],
+		} );
+	} );
+
+	test( 'should not pass and process filter parameter for pexels', () => {
+		const tree = shallow(
+			<MediaListData siteId={ DUMMY_SITE_ID }>
+				<EMPTY_COMPONENT />
+			</MediaListData>
+		).instance();
+		const query = { filter: 'images', source: 'pexels' };
+		const result = tree.getQuery( query );
+
+		expect( result ).to.eql( { source: 'pexels', path: 'recent' } );
+	} );
+
 	test( 'should pass source parameter and set recent path to media query', () => {
 		const tree = shallow(
 			<MediaListData siteId={ DUMMY_SITE_ID }>
@@ -68,5 +96,33 @@ describe( 'EditorMediaModal', () => {
 		const result = tree.getQuery( query );
 
 		expect( result ).to.eql( { path: 'recent', source: 'anything' } );
+	} );
+
+	test( 'should pass categoryFilter parameter to media query for Google Photos', () => {
+		const tree = shallow(
+			<MediaListData siteId={ DUMMY_SITE_ID }>
+				<EMPTY_COMPONENT />
+			</MediaListData>
+		).instance();
+		const query = { categoryFilter: 'cats', source: 'google_photos' };
+		const result = tree.getQuery( query );
+
+		expect( result ).to.eql( {
+			filter: [ 'categoryInclude=cats' ],
+			path: 'recent',
+			source: 'google_photos',
+		} );
+	} );
+
+	test( 'should not pass categoryFilter parameter to media query for other sources', () => {
+		const tree = shallow(
+			<MediaListData siteId={ DUMMY_SITE_ID }>
+				<EMPTY_COMPONENT />
+			</MediaListData>
+		).instance();
+		const query = { categoryFilter: 'cats', source: '' };
+		const result = tree.getQuery( query );
+
+		expect( result ).to.eql( {} );
 	} );
 } );

--- a/client/components/data/media-list-data/test/utils.js
+++ b/client/components/data/media-list-data/test/utils.js
@@ -43,4 +43,57 @@ describe( 'utils', () => {
 			expect( baseType ).to.equal( 'application/' );
 		} );
 	} );
+
+	describe( '#convertMimeFilter()', () => {
+		test( 'show return video for videos type', () => {
+			const filter = utils.convertMimeFilter( 'videos' );
+
+			expect( filter ).to.equal( 'video' );
+		} );
+
+		test( 'show return photo for images type', () => {
+			const filter = utils.convertMimeFilter( 'images' );
+
+			expect( filter ).to.equal( 'photo' );
+		} );
+
+		test( 'show return null for unsupported type', () => {
+			const filter = utils.convertMimeFilter( 'cats' );
+
+			expect( filter ).to.equal( null );
+		} );
+	} );
+
+	describe( '#getGoogleQuery()', () => {
+		test( 'show return original query when no category or filter', () => {
+			const original = { source: 'google_photos' };
+			const google = utils.getGoogleQuery( original, {} );
+
+			expect( google ).to.eql( original );
+		} );
+
+		test( 'show return media type filter when supplied', () => {
+			const original = { filter: 'videos' };
+			const expected = { filter: [ 'mediaType=video' ] };
+			const google = utils.getGoogleQuery( {}, original );
+
+			expect( google ).to.eql( expected );
+		} );
+
+		test( 'show return category filter when supplied', () => {
+			const original = { categoryFilter: 'cats' };
+			const expected = { filter: [ 'categoryInclude=cats' ] };
+			const google = utils.getGoogleQuery( {}, original );
+
+			expect( google ).to.eql( expected );
+		} );
+
+		test( 'show return category and media type filter when supplied', () => {
+			const original = { categoryFilter: 'cats', filter: 'videos' };
+			const expected = { filter: [ 'mediaType=video', 'categoryInclude=cats' ] };
+			const google = utils.getGoogleQuery( {}, original );
+
+			expect( google ).to.eql( expected );
+		} );
+	} );
 } );

--- a/client/components/data/media-list-data/utils.js
+++ b/client/components/data/media-list-data/utils.js
@@ -6,6 +6,7 @@ export default {
 	 * or an unrecognized filter, is provided.
 	 *
 	 * @param {string} filter - The filter to get a mime from
+	 * @returns {string} Mime type
 	 */
 	getMimeBaseTypeFromFilter: function( filter ) {
 		let mime;
@@ -33,5 +34,47 @@ export default {
 		}
 
 		return mime;
+	},
+
+	/**
+	 * Return's a media query suitable for Google Photos.
+	 *
+	 * @param {object} query The existing query object
+	 * @param {object} props Media library request props
+	 * @returns {object} Modified query for Google Photos
+	 */
+	getGoogleQuery: function( query, props ) {
+		const { categoryFilter, filter } = props;
+		const googleFilter = [];
+
+		if ( filter && this.convertMimeFilter( filter ) ) {
+			googleFilter.push( 'mediaType=' + this.convertMimeFilter( filter ) );
+		}
+
+		if ( categoryFilter ) {
+			googleFilter.push( 'categoryInclude=' + categoryFilter );
+		}
+
+		if ( googleFilter.length ) {
+			return { ...query, filter: googleFilter };
+		}
+
+		return query;
+	},
+
+	/**
+	 * Return a file type filter suitable for Google Photos
+	 *
+	 * @param {string} wpMimeFilter Calypso MIME filter
+	 * @returns {string} Converted MIME filter, or null if unsupported type
+	 */
+	convertMimeFilter( wpMimeFilter ) {
+		if ( wpMimeFilter === 'videos' ) {
+			return 'video';
+		} else if ( wpMimeFilter === 'images' ) {
+			return 'photo';
+		}
+
+		return null;
 	},
 };


### PR DESCRIPTION
Adds support to the media library to pass a 'category filter' and 'file type' filter through to the remote API. This will be used by Google Photos to allow additional filtering of media by a pre-defined category or by the type of media.

This only affects Google Photos. There is no visible change from this PR until it is used (as part of #32722 and #32724)

Note you can see this filter in action at #32756

#### Testing instructions

1. Run the included tests
2. Verify that existing media library behaviour is unchanged
