### PR TITLE
Google Photos: add category filters

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -59,6 +59,7 @@ export class MediaLibraryContent extends React.Component {
 		scrollable: PropTypes.bool,
 		onAddMedia: PropTypes.func,
 		onMediaScaleChange: PropTypes.func,
+		onCategoryFilterChange: PropTypes.func,
 		onEditItem: PropTypes.func,
 		postId: PropTypes.number,
 		isConnected: PropTypes.bool,
@@ -68,6 +69,7 @@ export class MediaLibraryContent extends React.Component {
 		mediaValidationErrors: Object.freeze( {} ),
 		onAddMedia: noop,
 		source: '',
+		onCategoryFilterChange: noop,
 	};
 
 	componentDidUpdate( prevProps ) {
@@ -346,6 +348,7 @@ export class MediaLibraryContent extends React.Component {
 				filter={ this.props.filter }
 				search={ this.props.search }
 				source={ this.props.source }
+				categoryFilter={ this.props.categoryFilter }
 			>
 				<MediaLibrarySelectedData siteId={ this.props.site.ID }>
 					<MediaLibraryList
@@ -378,7 +381,9 @@ export class MediaLibraryContent extends React.Component {
 					visible={ ! this.props.isRequesting }
 					canCopy={ this.props.postId === undefined }
 					source={ this.props.source }
+					categoryFilter={ this.props.categoryFilter }
 					onSourceChange={ this.props.onSourceChange }
+					onCategoryFilterChange={ this.props.onCategoryFilterChange }
 					selectedItems={ this.props.selectedItems }
 					sticky={ ! this.props.scrollable }
 					hasAttribution={ 'pexels' === this.props.source }

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -19,6 +19,7 @@ import Button from 'components/button';
 import MediaActions from 'lib/media/actions';
 import MediaListStore from 'lib/media/list-store';
 import StickyPanel from 'components/sticky-panel';
+import SelectDropdown from 'components/select-dropdown';
 
 const DEBOUNCE_TIME = 250;
 
@@ -103,6 +104,10 @@ class MediaLibraryExternalHeader extends React.Component {
 		} );
 	};
 
+	onSelectCategory = option => {
+		this.props.onCategoryFilterChange( option.value );
+	};
+
 	renderCopyButton() {
 		const { selectedItems, translate } = this.props;
 
@@ -123,11 +128,92 @@ class MediaLibraryExternalHeader extends React.Component {
 		return <span className="media-library__pexels-attribution">{ attribution }</span>;
 	}
 
+	renderCategoryFilter() {
+		const { translate } = this.props;
+		const categories = [
+			{
+				value: '',
+				label: translate( 'All categories' ),
+			},
+			{
+				value: 'animals',
+				label: translate( 'Animals' ),
+			},
+			{
+				value: 'birthdays',
+				label: translate( 'Birthdays' ),
+			},
+			{
+				value: 'cityscapes',
+				label: translate( 'Cityscapes' ),
+			},
+			{
+				value: 'food',
+				label: translate( 'Food' ),
+			},
+			{
+				value: 'landmarks',
+				label: translate( 'Landmarks' ),
+			},
+			{
+				value: 'landscapes',
+				label: translate( 'Landscapes' ),
+			},
+			{
+				value: 'night',
+				label: translate( 'Night' ),
+			},
+			{
+				value: 'people',
+				label: translate( 'People' ),
+			},
+			{
+				value: 'pets',
+				label: translate( 'Pets' ),
+			},
+			{
+				value: 'selfies',
+				label: translate( 'Selfies' ),
+			},
+			{
+				value: 'sport',
+				label: translate( 'Sport' ),
+			},
+			{
+				value: 'travel',
+				label: translate( 'Travel' ),
+			},
+			{
+				value: 'weddings',
+				label: translate( 'Weddings' ),
+			},
+		];
+
+		return (
+			<SelectDropdown
+				compact
+				options={ categories }
+				onSelect={ this.onSelectCategory }
+				disabled={ this.state.fetching }
+				initialSelected={ this.props.categoryFilter }
+			/>
+		);
+	}
+
 	renderCard() {
-		const { onMediaScaleChange, translate, canCopy, hasRefreshButton, hasAttribution } = this.props;
+		const {
+			onMediaScaleChange,
+			translate,
+			canCopy,
+			hasRefreshButton,
+			hasAttribution,
+			source,
+		} = this.props;
 
 		return (
 			<Card className="media-library__header">
+				{ source === 'google_photos' && this.renderCategoryFilter() }
+
 				{ hasAttribution && this.renderPexelsAttribution() }
 
 				{ hasRefreshButton && (

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -140,6 +140,10 @@ class MediaLibraryExternalHeader extends React.Component {
 				label: translate( 'Animals' ),
 			},
 			{
+				value: 'arts',
+				label: translate( 'Arts' ),
+			},
+			{
 				value: 'birthdays',
 				label: translate( 'Birthdays' ),
 			},
@@ -148,8 +152,36 @@ class MediaLibraryExternalHeader extends React.Component {
 				label: translate( 'Cityscapes' ),
 			},
 			{
+				value: 'crafts',
+				label: translate( 'Crafts' ),
+			},
+			{
 				value: 'food',
 				label: translate( 'Food' ),
+			},
+			{
+				value: 'fashion',
+				label: translate( 'Fashion' ),
+			},
+			{
+				value: 'food',
+				label: translate( 'Food' ),
+			},
+			{
+				value: 'flowers',
+				label: translate( 'Flowers' ),
+			},
+			{
+				value: 'gardens',
+				label: translate( 'Gardens' ),
+			},
+			{
+				value: 'holidays',
+				label: translate( 'Holidays' ),
+			},
+			{
+				value: 'houses',
+				label: translate( 'Houses' ),
 			},
 			{
 				value: 'landmarks',

--- a/client/my-sites/media-library/external-media-header.jsx
+++ b/client/my-sites/media-library/external-media-header.jsx
@@ -19,7 +19,6 @@ import Button from 'components/button';
 import MediaActions from 'lib/media/actions';
 import MediaListStore from 'lib/media/list-store';
 import StickyPanel from 'components/sticky-panel';
-import SelectDropdown from 'components/select-dropdown';
 
 const DEBOUNCE_TIME = 250;
 
@@ -104,8 +103,8 @@ class MediaLibraryExternalHeader extends React.Component {
 		} );
 	};
 
-	onSelectCategory = option => {
-		this.props.onCategoryFilterChange( option.value );
+	onSelectCategory = ev => {
+		this.props.onCategoryFilterChange( ev.target.value );
 	};
 
 	renderCopyButton() {
@@ -221,15 +220,25 @@ class MediaLibraryExternalHeader extends React.Component {
 			},
 		];
 
+		// We use a standard 'select' element here as it solves height/overlap issues with the SelectDropdown that occur when there are no items in the media library.
+		// These would be complicated to fix without further changes to the media library. The standard select element is already used elsewhere in Calypso and requires the
+		// 'is-compact' class to get the correct styling.
+		/* eslint-disable wpcalypso/jsx-classname-namespace, jsx-a11y/no-onchange */
 		return (
-			<SelectDropdown
-				compact
-				options={ categories }
-				onSelect={ this.onSelectCategory }
+			<select
+				onChange={ this.onSelectCategory }
 				disabled={ this.state.fetching }
-				initialSelected={ this.props.categoryFilter }
-			/>
+				value={ this.props.categoryFilter || '' }
+				className="is-compact"
+			>
+				{ categories.map( ( item, pos ) => (
+					<option key={ pos } value={ item.value }>
+						{ item.label }
+					</option>
+				) ) }
+			</select>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	renderCard() {

--- a/client/my-sites/media-library/index.jsx
+++ b/client/my-sites/media-library/index.jsx
@@ -56,9 +56,11 @@ class MediaLibrary extends Component {
 		enabledFilters: PropTypes.arrayOf( PropTypes.string ),
 		search: PropTypes.string,
 		source: PropTypes.string,
+		categoryFilter: PropTypes.string,
 		onAddMedia: PropTypes.func,
 		onFilterChange: PropTypes.func,
 		onSourceChange: PropTypes.func,
+		onCategoryFilterChange: PropTypes.func,
 		onSearch: PropTypes.func,
 		onScaleChange: PropTypes.func,
 		onEditItem: PropTypes.func,
@@ -171,6 +173,7 @@ class MediaLibrary extends Component {
 				filterRequiresUpgrade={ this.filterRequiresUpgrade() }
 				search={ this.props.search }
 				source={ this.props.source }
+				categoryFilter={ this.props.categoryFilter }
 				isConnected={ this.props.isConnected }
 				containerWidth={ this.props.containerWidth }
 				single={ this.props.single }
@@ -179,6 +182,7 @@ class MediaLibrary extends Component {
 				onAddAndEditImage={ this.props.onAddAndEditImage }
 				onMediaScaleChange={ this.props.onScaleChange }
 				onSourceChange={ this.props.onSourceChange }
+				onCategoryFilterChange={ this.props.onCategoryFilterChange }
 				selectedItems={ this.props.mediaLibrarySelectedItems }
 				onDeleteItem={ this.props.onDeleteItem }
 				onEditItem={ this.props.onEditItem }

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -19,7 +19,8 @@
 	}
 }
 
-.media-library__header .button {
+.media-library__header .button,
+.media-library__header .select-dropdown {
 	margin-right: 8px;
 }
 
@@ -213,6 +214,10 @@
 
 .media-library__content .notice {
 	margin-bottom: 0;
+}
+
+.media-library__content {
+	min-height: 600px;
 }
 
 .media-library__list {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -19,8 +19,19 @@
 	}
 }
 
+.media-library__header select {
+	font-size: 12px;
+	padding-top: 2px;
+	font-weight: 500;
+	color: var( --color-text-subtle );
+
+	&:disabled {
+		color: var( --color-neutral-50 );
+	}
+}
+
 .media-library__header .button,
-.media-library__header .select-dropdown {
+.media-library__header select {
 	margin-right: 8px;
 }
 
@@ -214,10 +225,6 @@
 
 .media-library__content .notice {
 	margin-bottom: 0;
-}
-
-.media-library__content {
-	min-height: 600px;
 }
 
 .media-library__list {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -20,6 +20,7 @@
 }
 
 .media-library__header select {
+	margin: 0;
 	font-size: 12px;
 	padding-top: 2px;
 	font-weight: 500;
@@ -33,6 +34,10 @@
 .media-library__header .button,
 .media-library__header select {
 	margin-right: 8px;
+
+	@include breakpoint( '<660px' ) {
+		margin-bottom: 8px;
+	}
 }
 
 .media-library__header .button.media-library__upload-button {

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -51,6 +51,7 @@ class Media extends Component {
 		editedVideoItem: null,
 		selectedItems: [],
 		source: '',
+		categoryFilter: null,
 	};
 
 	containerRef = React.createRef();
@@ -65,6 +66,11 @@ class Media extends Component {
 	}
 
 	onFilterChange = filter => {
+		this.changeFilterPage( filter );
+		this.setState( { categoryFilter: null } );
+	};
+
+	changeFilterPage = filter => {
 		let redirect = '/media';
 
 		if ( filter ) {
@@ -285,6 +291,12 @@ class Media extends Component {
 
 		MediaActions.sourceChanged( this.props.selectedSite.ID );
 		this.setState( { source }, cb );
+		this.changeFilterPage( '' );
+	};
+
+	handleCategoryFilterChange = categoryFilter => {
+		this.setState( { categoryFilter } );
+		this.changeFilterPage( '' );
 	};
 
 	deleteMediaByItemDetail = () => {
@@ -418,10 +430,12 @@ class Media extends Component {
 							single={ false }
 							filter={ this.props.filter }
 							source={ this.state.source }
+							categoryFilter={ this.state.categoryFilter }
 							onEditItem={ this.openDetailsModalForASingleImage }
 							onViewDetails={ this.openDetailsModalForAllSelected }
 							onDeleteItem={ this.handleDeleteMediaEvent }
 							onSourceChange={ this.handleSourceChange }
+							onCategoryFilterChange={ this.handleCategoryFilterChange }
 							modal={ false }
 							containerWidth={ this.state.containerWidth }
 						/>

--- a/client/post-editor/media-modal/index.jsx
+++ b/client/post-editor/media-modal/index.jsx
@@ -161,6 +161,7 @@ export class EditorMediaModal extends Component {
 			detailSelectedIndex: 0,
 			source: props.source ? props.source : '',
 			gallerySettings: props.initialGallerySettings,
+			categoryFilter: null,
 		};
 	}
 
@@ -412,7 +413,7 @@ export class EditorMediaModal extends Component {
 			analytics.mc.bumpStat( 'editor_media_actions', 'filter_' + ( filter || 'all' ) );
 		}
 
-		this.setState( { filter } );
+		this.setState( { filter, categoryFilter: null } );
 	};
 
 	onScaleChange = () => {
@@ -440,6 +441,10 @@ export class EditorMediaModal extends Component {
 			search: undefined,
 			filter: '',
 		} );
+	};
+
+	onCategoryFilterChange = categoryFilter => {
+		this.setState( { categoryFilter, filter: '' } );
 	};
 
 	onClose = () => {
@@ -619,11 +624,13 @@ export class EditorMediaModal extends Component {
 						enabledFilters={ this.props.enabledFilters }
 						search={ this.state.search }
 						source={ this.state.source }
+						categoryFilter={ this.state.categoryFilter }
 						onAddMedia={ this.onAddMedia }
 						onAddAndEditImage={ this.onAddAndEditImage }
 						onFilterChange={ this.onFilterChange }
 						onScaleChange={ this.onScaleChange }
 						onSourceChange={ this.onSourceChange }
+						onCategoryFilterChange={ this.onCategoryFilterChange }
 						onSearch={ this.onSearch }
 						onEditItem={ this.editItem }
 						fullScreenDropZone={ false }


### PR DESCRIPTION
Adds a 'category filter' to Google Photos in the media library.

<img width="386" alt="Media_‹_Testy_Blog_—_WordPress_com" src="https://user-images.githubusercontent.com/1277682/57067660-878d8000-6cc7-11e9-9b12-a1de82238d0e.png">

This is supplied with a pre-defined set of categories, as supported by Google Photos. Selecting a category will filter the results to show only photos in that category.

<img width="442" alt="Media_‹_Testy_Blog_—_WordPress_com" src="https://user-images.githubusercontent.com/1277682/57067637-76dd0a00-6cc7-11e9-9d3c-2f897ecb02ed.png">

Note that this filter relies on the accuracy of Google's image categorisation. It is entirely possible that Google may mis-categorise an image.

Category filtering combined with a video file type is disabled, and changing the file type will reset the category.

A modification is also made to the media library minimum height. This prevents a problem where an empty media library has insufficient height to display the category filter dropdown.

#### Testing instructions

1. From the media page, change to Google Photos
2. Verify that all your media items are shown when no category is selected
3. Select a category that will return results. Verify the results are relevant to the category
4. Select a category that won't return results (if possible). Verify that no results are shown
5. Click the category filter and verify that the dropdown is fully visible
6. Select 'all categories' and verify that all your media items are shown
7. Verify category filtering also works from the post media modal
8. Verify that changing the category while a video file type is chosen resets the file type to `all`
9. Verify that changing the file type filter to `video` while a category is chosen resets the category to `all`