### PR TITLE
Signup: Don't round corners of the domain search step on mobile

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -26,4 +26,11 @@
 	.search-filters__dropdown-filters.search-filters__dropdown-filters--is-open {
 		box-shadow: 0 0 0 3px var( --color-accent-light );
 	}
+
+	@include breakpoint( '<660px' ) {
+		.register-domain-step__search-card,
+		.search.is-open.has-focus {
+			border-radius: 0;
+		}
+	}
 }


### PR DESCRIPTION
See https://trello.com/c/d4cnsVT1

#### Changes proposed in this Pull Request

* When the screen is small, remove the border radius. On mobile, other inputs are not rounded, so remove the border-radius setting here as well

#### Testing instructions

* Run this branch on a mobile device (or emulated via dev tools)
* Browse to `/start/onboarding`
* Choose `Business`
* Nearly complete the flow -- progress to the domains step (Give your site an address)
* The input field and surrounding UI should not be rounded.

---

**NOTE:** The search highlighting goes beyond the margin, so it's difficult to see the impact of this change.  This is an issue throughout signup on mobile devices I'm trying to address in #32730.

If you have trouble testing this PR independently because of the above, you can run this in your console:
`document.querySelector('.domains__step-content').style.margin = '0 6px';`

With margin added, it should look like this:
<img width="305" alt="Screen Shot 2019-05-01 at 12 01 06 PM" src="https://user-images.githubusercontent.com/1587282/57026948-ff48a580-6c08-11e9-92fe-327a8e0b5833.png">
