### PR TITLE
Signup: Add margin to most steps on mobile

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -549,43 +549,41 @@ class Signup extends React.Component {
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		return (
-			<div className="signup__step" key={ stepKey }>
-				<div className={ `signup__step is-${ kebabCase( this.props.stepName ) }` }>
-					{ shouldRenderLocaleSuggestions && (
-						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
-					) }
-					{ this.state.shouldShowLoadingScreen ? (
-						<SignupProcessingScreen
-							hasCartItems={ this.state.hasCartItems }
-							steps={ this.props.progress }
-							loginHandler={ this.state.loginHandler }
-							signupDependencies={ this.props.signupDependencies }
+			<div className={ `signup__step is-${ kebabCase( this.props.stepName ) }` } key={ stepKey }>
+				{ shouldRenderLocaleSuggestions && (
+					<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
+				) }
+				{ this.state.shouldShowLoadingScreen ? (
+					<SignupProcessingScreen
+						hasCartItems={ this.state.hasCartItems }
+						steps={ this.props.progress }
+						loginHandler={ this.state.loginHandler }
+						signupDependencies={ this.props.signupDependencies }
+						flowName={ this.props.flowName }
+						flowSteps={ flow.steps }
+					/>
+				) : (
+					<Suspense fallback={ null }>
+						<CurrentComponent
+							path={ this.props.path }
+							step={ currentStepProgress }
+							initialContext={ this.props.initialContext }
+							steps={ flow.steps }
+							stepName={ this.props.stepName }
+							meta={ flow.meta || {} }
+							goToNextStep={ this.goToNextStep }
+							goToStep={ this.goToStep }
+							previousFlowName={ this.state.previousFlowName }
 							flowName={ this.props.flowName }
-							flowSteps={ flow.steps }
+							signupProgress={ this.props.progress }
+							signupDependencies={ this.props.signupDependencies }
+							stepSectionName={ this.props.stepSectionName }
+							positionInFlow={ this.getPositionInFlow() }
+							hideFreePlan={ hideFreePlan }
+							{ ...propsFromConfig }
 						/>
-					) : (
-						<Suspense fallback={ null }>
-							<CurrentComponent
-								path={ this.props.path }
-								step={ currentStepProgress }
-								initialContext={ this.props.initialContext }
-								steps={ flow.steps }
-								stepName={ this.props.stepName }
-								meta={ flow.meta || {} }
-								goToNextStep={ this.goToNextStep }
-								goToStep={ this.goToStep }
-								previousFlowName={ this.state.previousFlowName }
-								flowName={ this.props.flowName }
-								signupProgress={ this.props.progress }
-								signupDependencies={ this.props.signupDependencies }
-								stepSectionName={ this.props.stepSectionName }
-								positionInFlow={ this.getPositionInFlow() }
-								hideFreePlan={ hideFreePlan }
-								{ ...propsFromConfig }
-							/>
-						</Suspense>
-					) }
-				</div>
+					</Suspense>
+				) }
 			</div>
 		);
 	}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -3,7 +3,6 @@ body.is-section-signup {
 	// should deal with different color schemes?
 	background: var( --color-primary );
 
-
 	// Adjust the padding as we no longer
 	// show the masterbar.
 	.layout__content {
@@ -36,7 +35,6 @@ body.is-section-signup {
 // avoid stepping on the toes of our oauth users, like Crowdsignal.
 body.is-section-signup .layout:not( .dops ),
 body.is-section-signup .layout.gravatar {
-
 	// Update the logo that appears when loading Calypso
 	// to match the homepage, using primary-dark with opacity.
 	.wpcom-site__logo {
@@ -52,7 +50,7 @@ body.is-section-signup .layout.gravatar {
 			padding-bottom: 16px;
 			margin-bottom: 24px;
 			border-radius: 6px;
-			@include elevation ( 3dp );
+			@include elevation( 3dp );
 		}
 
 		.empty-content__title {
@@ -81,7 +79,7 @@ body.is-section-signup .layout.gravatar {
 		right: 0;
 		max-height: 300px;
 		overflow: auto;
-		@include elevation ( 2dp );
+		@include elevation( 2dp );
 	}
 
 	@include breakpoint( '<660px' ) {

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -163,3 +163,12 @@ body.is-section-signup .layout.gravatar .formatted-header {
 .is-section-signup .layout__primary {
 	overflow: visible;
 }
+
+// Room to breathe on mobile
+.signup .signup__step:not( .is-plans ):not( .is-site-type ) {
+	margin: auto;
+
+	@include breakpoint( '<660px' ) {
+		margin: auto 6px;
+	}
+}


### PR DESCRIPTION
When testing the solution for #32729, it was difficult to see how the controls were rendered because the input focus highlights exceeded the margins on mobile breakpoints.

This change proposes we add a small amount of margin on the left and right of most signup steps at that size, so inputs can fully render without spilling out -- I've excluded the `site-type` & `plans` steps. They will continue render completely and properly without the extra margin.

| Before | After |
|---|---|
| ![before-signup-steps-breathe](https://user-images.githubusercontent.com/1587282/57030226-0f18b780-6c12-11e9-8da0-14bd571591ab.gif) | ![after-signup-steps-breathe](https://user-images.githubusercontent.com/1587282/57030244-18a21f80-6c12-11e9-9673-60bc408de2c6.gif)
 |

#### Changes proposed in this Pull Request

* At a small breakpoint, add a small amount of margin on the left and right of the signup step (except for specific steps)
* Remove a superfluous nested `.signup__step` div
* Prettier tweaks

#### Testing instructions

* Complete as many flows as possible on various mobile device breakpoints
* All components should be fully & properly rendered (with and without focus for inputs like text fields and search boxes)
* Make sure the removal of the extra `.signup__step` div has no side effects. ([current usage](https://github.com/Automattic/wp-calypso/search?q=signup__step&unscoped_q=signup__step))