### PR TITLE
People: Update Followers/Email Followers empty states with calls to action

### DIFF
--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -31,6 +31,7 @@ import accept from 'lib/accept';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
 import ListEnd from 'components/list-end';
+import { preventWidows } from 'lib/formatting';
 
 const maxFollowers = 1000;
 
@@ -166,13 +167,29 @@ const Followers = localize(
 
 			let emptyTitle;
 			if ( this.siteHasNoFollowers() ) {
+				const inviteLink = '/people/new/' + this.props.site.id;
+
 				if ( this.props.fetchOptions && 'email' === this.props.fetchOptions.type ) {
-					emptyTitle = this.props.translate(
-						'No one is following you by email yet, but you can invite up to 10 at a time.'
+					emptyTitle = preventWidows(
+						this.props.translate(
+							'No one is following you by email yet, but you can {{a}}invite up to 10 at a time{{/a}}.',
+							{
+								components: {
+									a: <a href={ inviteLink } />,
+								},
+							}
+						)
 					);
 				} else {
-					emptyTitle = this.props.translate(
-						'No WordPress.com followers yet, but you can invite up to 10 at a time.'
+					emptyTitle = preventWidows(
+						this.props.translate(
+							'No WordPress.com followers yet, but you can {{a}}invite up to 10 at a time{{/a}}.',
+							{
+								components: {
+									a: <a href={ inviteLink } />,
+								},
+							}
+						)
 					);
 				}
 				return <EmptyContent title={ emptyTitle } />;

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -167,9 +167,13 @@ const Followers = localize(
 			let emptyTitle;
 			if ( this.siteHasNoFollowers() ) {
 				if ( this.props.fetchOptions && 'email' === this.props.fetchOptions.type ) {
-					emptyTitle = this.props.translate( "You don't have any email followers yet." );
+					emptyTitle = this.props.translate(
+						'No one is following you by email yet, but you can invite up to 10 at a time.'
+					);
 				} else {
-					emptyTitle = this.props.translate( "You don't have any followers yet." );
+					emptyTitle = this.props.translate(
+						'No WordPress.com followers yet, but you can invite up to 10 at a time.'
+					);
 				}
 				return <EmptyContent title={ emptyTitle } />;
 			}

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -33,6 +33,12 @@ import Button from 'components/button';
 import ListEnd from 'components/list-end';
 import { preventWidows } from 'lib/formatting';
 
+/**
+ * Stylesheet dependencies
+ */
+
+import './style.scss';
+
 const maxFollowers = 1000;
 
 const Followers = localize(
@@ -167,7 +173,7 @@ const Followers = localize(
 
 			let emptyTitle;
 			if ( this.siteHasNoFollowers() ) {
-				const inviteLink = '/people/new/' + this.props.site.id;
+				const inviteLink = '/people/new/' + this.props.site.domain;
 
 				if ( this.props.fetchOptions && 'email' === this.props.fetchOptions.type ) {
 					emptyTitle = preventWidows(

--- a/client/my-sites/people/followers-list/style.scss
+++ b/client/my-sites/people/followers-list/style.scss
@@ -1,0 +1,3 @@
+.is-section-people .empty-content__title {
+	font-size: 22px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Initially proposed in #32693, this PR updates the empty state (no followers) copy for the Followers/Email Followers pages to include a CTA to invite people to the site.
* Partially addresses #32234

**Before**

<img width="765" alt="Screen Shot 2019-05-01 at 1 51 44 PM" src="https://user-images.githubusercontent.com/2124984/57032409-47bb8f80-6c18-11e9-870a-784d1857afb1.png">

**After**

<img width="773" alt="Screen Shot 2019-05-01 at 1 48 16 PM" src="https://user-images.githubusercontent.com/2124984/57032210-d976cd00-6c17-11e9-82fd-5094ba758469.png">

#### Testing instructions

* Switch to this PR on a site with no followers and navigate to `/people`
* Click on Followers. Note the changed text and the link, which should point to `/people/new`
* Click on Email Followers. Note the changed text and the link, which should point to `/people/new`
* Also check to make sure any sites with followers and email followers are unaffected.