### PR TITLE
People: Update email followers heading for clarity

### DIFF
--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -187,8 +187,8 @@ const Followers = localize(
 
 				if ( this.props.type === 'email' ) {
 					headerText = this.props.translate(
-						'You have %(number)d email follower',
-						'You have %(number)d email followers',
+						'You have %(number)d follower receiving updates by email',
+						'You have %(number)d followers receiving updates by email',
 						{
 							args: { number: this.props.totalFollowers },
 							count: this.props.totalFollowers,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes heading from "You have X email follower(s)" to "You have X follower(s) receiving updates by email" to better clarify the difference between "Followers" and "Email Followers"

**Before**

<img width="749" alt="Screen Shot 2019-05-01 at 2 05 18 PM" src="https://user-images.githubusercontent.com/2124984/57033169-31aece80-6c1a-11e9-93f0-f7fde82d3470.png">
<img width="742" alt="Screen Shot 2019-05-01 at 2 05 27 PM" src="https://user-images.githubusercontent.com/2124984/57033170-31aece80-6c1a-11e9-978b-fb6d553cfca2.png">

**After**

<img width="754" alt="Screen Shot 2019-05-01 at 1 59 23 PM" src="https://user-images.githubusercontent.com/2124984/57033070-ea284280-6c19-11e9-8912-0319aa83aeb1.png">

<img width="748" alt="Screen Shot 2019-05-01 at 2 01 13 PM" src="https://user-images.githubusercontent.com/2124984/57033071-ea284280-6c19-11e9-9fd8-30081e09f69e.png">

#### Testing instructions

* Switch to this PR, navigate to `/people/email-followers/`, note the change in the header text.
* Check all states; site with 1 email follower, site with multiple email followers, and a site with no email followers.

Fixes #32234
