### PR TITLE
Gutenframe: Allow Jetpack sites back in to the site selector.

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -35,7 +35,7 @@ export class Sites extends Component {
 
 		// No support for Gutenberg on VIP or Jetpack sites yet.
 		if ( /^\/block-editor/.test( path ) ) {
-			return ! site.is_vip && ! site.jetpack;
+			return ! site.is_vip;
 		}
 
 		return site;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allow Jetpack (and Atomic) sites in the site selector for the `/block-editor` path.

<img width="1033" alt="Screen Shot 2019-05-01 at 11 16 43 AM" src="https://user-images.githubusercontent.com/349751/57033772-a970ff00-6c02-11e9-841e-3ed902de7a0b.png">

#### Testing instructions

* On `master`, go to `/block-editor/post` directly.
* Verify the site selector returns no results for Jetpack or Atomic sites.
* Switch to this branch.
* Go to the same path, and perform the same search.
* Verify your site now appears, and selecting it opens a Gutenframed editor.
