### PR TITLE
Fix code limiting features to include Ecommerce

### DIFF
--- a/client/components/seo-preview-pane/index.jsx
+++ b/client/components/seo-preview-pane/index.jsx
@@ -20,7 +20,7 @@ import SearchPreview from 'components/seo/search-preview';
 import VerticalMenu from 'components/vertical-menu';
 import PostMetadata from 'lib/post-metadata';
 import { formatExcerpt } from 'lib/post-normalizer/rule-create-better-excerpt';
-import { isBusiness, isEnterprise, isJetpackPremium } from 'lib/products-values';
+import { isBusiness, isEnterprise, isJetpackPremium, isEcommerce } from 'lib/products-values';
 import { parseHtml } from 'lib/formatting';
 import { SocialItem } from 'components/vertical-menu/items';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -35,7 +35,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import './style.scss';
 
 const PREVIEW_IMAGE_WIDTH = 512;
-const hasSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackPremium );
+const hasSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackPremium, isEcommerce );
 
 const largeBlavatar = site => {
 	const siteIcon = get( site, 'icon.img' );

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -35,7 +35,13 @@ import isPrivateSite from 'state/selectors/is-private-site';
 import { toApi as seoTitleToApi } from 'components/seo/meta-title-editor/mappings';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestSite } from 'state/sites/actions';
-import { isBusiness, isEnterprise, isJetpackBusiness, isJetpackPremium } from 'lib/products-values';
+import {
+	isBusiness,
+	isEnterprise,
+	isJetpackBusiness,
+	isJetpackPremium,
+	isEcommerce,
+} from 'lib/products-values';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { getPlugins } from 'state/plugins/installed/selectors';
 import {
@@ -62,7 +68,13 @@ import './style.scss';
 // Not perfect but meets the needs of this component well
 const anyHtmlTag = /<\/?[a-z][a-z0-9]*\b[^>]*>/i;
 
-const hasSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackBusiness, isJetpackPremium );
+const hasSupportingPlan = overSome(
+	isBusiness,
+	isEnterprise,
+	isJetpackBusiness,
+	isJetpackPremium,
+	isEcommerce
+);
 
 function getGeneralTabUrl( slug ) {
 	return `/settings/general/${ slug }`;
@@ -291,7 +303,6 @@ export class SeoForm extends React.Component {
 		const nudgeTitle = siteIsJetpack
 			? translate( 'Enable SEO Tools by upgrading to Jetpack Premium' )
 			: translate( 'Enable SEO Tools by upgrading to the Business plan' );
-
 		return (
 			<div>
 				<QuerySiteSettings siteId={ siteId } />
@@ -456,7 +467,6 @@ const mapStateToProps = state => {
 	const conflictedSeoPlugin = siteIsJetpack
 		? getFirstConflictingPlugin( activePlugins ) // Pick first one to keep the notice short.
 		: null;
-
 	return {
 		conflictedSeoPlugin,
 		isFetchingSite: isRequestingSite( state, siteId ),

--- a/client/post-editor/editor-drawer/index.jsx
+++ b/client/post-editor/editor-drawer/index.jsx
@@ -17,7 +17,7 @@ import AccordionSection from 'components/accordion/section';
 import CategoriesTagsAccordion from 'post-editor/editor-categories-tags/accordion';
 import AsyncLoad from 'components/async-load';
 import EditorMoreOptionsSlug from 'post-editor/editor-more-options/slug';
-import { isBusiness, isEnterprise, isJetpackPremium } from 'lib/products-values';
+import { isBusiness, isEnterprise, isJetpackPremium, isEcommerce } from 'lib/products-values';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import QueryPostTypes from 'components/data/query-post-types';
 import QuerySiteSettings from 'components/data/query-site-settings';
@@ -49,7 +49,7 @@ import './style.scss';
 /**
  * Constants
  */
-const hasSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackPremium );
+const hasSupportingPlan = overSome( isBusiness, isEnterprise, isJetpackPremium, isEcommerce );
 
 /**
  * A mapping of post type to hard-coded post types support. These values are


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes feature gates to include ecommerce plan

#### Testing instructions

* Goto Marketing -> Traffic -> Toggle on SEO
* Observe Page Title Structure card

I have no idea where the other two show up but figured ecom is the highest plan so it should have everything.
