### PR TITLE
Full Site Editing: Remove block editor opt-out for new sites

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -420,10 +420,13 @@ function mapStateToProps( state, { moment } ) {
 
 	const isUsingGutenbergPageTemplates =
 		[
+			'twentynineteen',
+			'calm-business',
+			'elegant-business',
+			'friendly-business',
 			'modern-business',
 			'professional-business',
 			'sophisticated-business',
-			'calm-business',
 		].includes( getActiveTheme( state, siteId ) ) &&
 		moment( getSiteOption( state, siteId, 'created_at' ) ).isAfter( '20190314' );
 

--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -4,7 +4,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
-import { noop } from 'lodash';
+import { flowRight as compose, noop } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -59,6 +59,10 @@ import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { getEditedPostValue } from 'state/posts/selectors';
 import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
+import QueryActiveTheme from 'components/data/query-active-theme';
+import { getActiveTheme } from 'state/themes/selectors';
+import { getSiteOption } from 'state/sites/selectors';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class InlineHelpPopover extends Component {
 	static propTypes = {
@@ -262,6 +266,7 @@ class InlineHelpPopover extends Component {
 		const {
 			translate,
 			showNotification,
+			siteId,
 			setNotification,
 			setStoredTask,
 			showOptIn,
@@ -271,6 +276,7 @@ class InlineHelpPopover extends Component {
 
 		return (
 			<>
+				<QueryActiveTheme siteId={ siteId } />
 				{ showOptOut && (
 					<Button
 						onClick={ this.switchToClassicEditor }
@@ -398,7 +404,7 @@ const upworkNudgeClicked = () => {
 	);
 };
 
-function mapStateToProps( state ) {
+function mapStateToProps( state, { moment } ) {
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
 	const classicRoute = currentRoute.replace( '/block-editor/', '' );
@@ -412,6 +418,15 @@ function mapStateToProps( state ) {
 	const gutenbergUrl = getGutenbergEditorUrl( state, siteId, postId, postType );
 	const isEligibleForChecklist = isEligibleForDotcomChecklist( state, siteId );
 
+	const isUsingGutenbergPageTemplates =
+		[
+			'modern-business',
+			'professional-business',
+			'sophisticated-business',
+			'calm-business',
+		].includes( getActiveTheme( state, siteId ) ) &&
+		moment( getSiteOption( state, siteId, 'created_at' ) ).isAfter( '20190314' );
+
 	return {
 		isOnboardingWelcomeVisible: isEligibleForChecklist && isOnboardingWelcomePromptVisible( state ),
 		isChecklistPromptVisible: isInlineHelpChecklistPromptVisible( state ),
@@ -422,7 +437,7 @@ function mapStateToProps( state ) {
 		selectedEditor: getSelectedEditor( state, siteId ),
 		classicUrl: `/${ classicRoute }`,
 		siteId,
-		showOptOut: optInEnabled && isGutenbergEditor,
+		showOptOut: optInEnabled && isGutenbergEditor && ! isUsingGutenbergPageTemplates,
 		showOptIn: optInEnabled && isCalypsoClassic,
 		gutenbergUrl,
 	};
@@ -440,7 +455,11 @@ const mapDispatchToProps = {
 	upworkNudgeClicked,
 };
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( localize( InlineHelpPopover ) );
+export default compose(
+	localize,
+	withLocalizedMoment,
+	connect(
+		mapStateToProps,
+		mapDispatchToProps
+	)
+)( InlineHelpPopover );


### PR DESCRIPTION
Removes the opt-out button from the help popover for sites that have the page templates theme and were created after the AB test went live.

#### Changes proposed in this Pull Request

Adds a check on the help popover dialog for the site's creation date and the site's theme. If the site has been created after the AB test date and the active theme is one of the four _Twenty Nineteen_ forks for business, the opt-out button is hidden.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/233601/57034310-8dcb2000-6c25-11e9-915d-eacbffc6c936.png) | ![FireShot Capture 001 - Site Pages ‹ Another Onboarding Site — WordPress com - calypso localhost](https://user-images.githubusercontent.com/233601/57034340-a3d8e080-6c25-11e9-9c23-e2eb6a34f8ea.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test this you'll need two sites. A regular site, preferably created before March 14th, 2019, and a _new_ site created using the _Improved Onboarding_. If you don't have one, you'll have to set the `improvedOnboarding` A/B test to the `onboarding` variation and create a site using the _Business_ segment.

Then edit a page or post with both sites and open the help popover. The _Switch to Classic Editor_ editor should not be visible for the new site.

Fixes #32439 
