### PR TITLE
Comment Author More Info Element: Fix Word Breaking

### DIFF
--- a/client/my-sites/comments/comment/comment-author-more-info.jsx
+++ b/client/my-sites/comments/comment/comment-author-more-info.jsx
@@ -174,24 +174,22 @@ export class CommentAuthorMoreInfo extends Component {
 					) }
 
 					{ ! authorEmail && (
-						<div className="comment__author-more-info-element">
-							<div>
-								{ translate(
-									"Anonymous messages can't be blocked individually, " +
-										'but you can update your {{a}}settings{{/a}} to ' +
-										'only allow comments from registered users.',
-									{
-										components: {
-											a: (
-												<a
-													href={ `/settings/discussion/${ siteSlug }` }
-													onClick={ trackAnonymousModeration }
-												/>
-											),
-										},
-									}
-								) }
-							</div>
+						<div>
+							{ translate(
+								"Anonymous messages can't be blocked individually, " +
+									'but you can update your {{a}}settings{{/a}} to ' +
+									'only allow comments from registered users.',
+								{
+									components: {
+										a: (
+											<a
+												href={ `/settings/discussion/${ siteSlug }` }
+												onClick={ trackAnonymousModeration }
+											/>
+										),
+									},
+								}
+							) }
 						</div>
 					) }
 				</Popover>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the class name for the text without an icon so the styles aren't applied. The styles make sense when an icon is next to it, but they're unnecessary when there's no icon. Instead, it's causing an issue because it's using `word-break: break-all;`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Submit an anonymous comment (no email)
* Visit the Comments page
* Click User Info in the top right
* Resize your screen a bit

**Before:**

Notice the information at the bottom.
"Anonymous messages can't be block
ed"
...
"to allow comment
s"

<img width="262" alt="Screenshot 2019-05-01 at 19 52 01" src="https://user-images.githubusercontent.com/43215253/57036049-2627cb80-6c4b-11e9-9dbc-7b75c0e7c574.png">

**After:**

Now defaulting to breaking words instead of all. 

<img width="218" alt="Screenshot 2019-05-01 at 19 52 49" src="https://user-images.githubusercontent.com/43215253/57036060-2922bc00-6c4b-11e9-8836-632f8cdf80a7.png">

Hiding white spaces might make this easier to review.

Fixes an issue I accidentally stumbled upon. :)

cc @jsnajdr, @Copons, @dmsnell 
