### PR TITLE
Signup: Use inset box shadows to highlight selected input

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -16,7 +16,7 @@
 	.search.is-open.has-focus {
 		border: none;
 		border-radius: 3px;
-		box-shadow: 0 0 0 3px var( --color-accent-light );
+		box-shadow: inset 0 0 0 4px var( --color-accent-light );
 	}
 
 	.search-filters__dropdown-filters {

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -26,4 +26,8 @@
 	.search-filters__dropdown-filters.search-filters__dropdown-filters--is-open {
 		box-shadow: 0 0 0 3px var( --color-accent-light );
 	}
+
+	.search__input-fade {
+		height: 42px;
+	}
 }

--- a/client/signup/steps/site-title/style.scss
+++ b/client/signup/steps/site-title/style.scss
@@ -41,7 +41,9 @@
 			border-radius: 0;
 		}
 
-		&:focus {
+		&:focus,
+		&:focus:hover, // This is weird...without it, the highlight goes away on mouseover
+		&:active {
 			box-shadow: inset 0 0 0 4px var( --color-accent-light );
 		}
 	}

--- a/client/signup/steps/site-title/style.scss
+++ b/client/signup/steps/site-title/style.scss
@@ -42,7 +42,7 @@
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 3px var( --color-accent-light );
+			box-shadow: inset 0 0 0 4px var( --color-accent-light );
 		}
 	}
 

--- a/client/signup/steps/site-title/style.scss
+++ b/client/signup/steps/site-title/style.scss
@@ -24,11 +24,18 @@
 		// Extra padding to account for the button
 		padding: 10px 100px 12px 16px;
 
-		// Match the radious of the fieldset
-		border-radius: 4px;
+		// Slightly smaller than the radius of the
+		// fieldset to avoid any white bleeding through
+		// around the corners.
+		border-radius: 3px;
 
-		// No need for a border here
-		border: none;
+		// Removing the standard box-shadow affect in
+		// favor of a simple border.
+		box-shadow: none;
+
+		// Lets use a bigger border. It gets a color
+		// when the input is active.
+		border: 3px solid transparent;
 
 		// On smaller screens the buttons get bigger,
 		// so this input needs to get bigger, too.
@@ -44,12 +51,9 @@
 		&:focus,
 		&:focus:hover, // This is weird...without it, the highlight goes away on mouseover
 		&:active {
-			box-shadow: inset 0 0 0 4px var( --color-accent-light );
+			border-color: var( --color-accent-light );
+			box-shadow: none;
 		}
-	}
-
-	button {
-		@include elevation( 1dp );
 	}
 
 	.card {
@@ -86,8 +90,8 @@
 
 	.button {
 		position: absolute;
-		top: 3px;
-		right: 3px;
+		top: 6px;
+		right: 6px;
 		width: auto;
 		padding: 5px 8px;
 		transition: none;

--- a/client/signup/steps/site-title/style.scss
+++ b/client/signup/steps/site-title/style.scss
@@ -11,7 +11,7 @@
 	.form-fieldset {
 		border-radius: 4px;
 		background: var( --color-white );
-		@include elevation ( 2dp );
+		@include elevation( 2dp );
 	}
 
 	label {
@@ -49,7 +49,7 @@
 	}
 
 	button {
-		@include elevation ( 1dp );
+		@include elevation( 1dp );
 	}
 
 	.card {

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -25,11 +25,18 @@ body.is-section-jetpack-connect .site-topic__content {
 		// the search icon.
 		padding: 10px 64px 12px 42px;
 
-		// Trying out a rounded input
-		border-radius: 4px;
+		// Slightly smaller than the radius of the
+		// container to avoid any white bleeding
+		// through around the corners.
+		border-radius: 3px;
 
-		// No need for a border here
-		border: none;
+		// Removing the standard box-shadow affect in
+		// favor of a simple border.
+		box-shadow: none;
+
+		// Lets use a bigger border. It gets a color
+		// when the input is active.
+		border: 3px solid transparent;
 
 		@include breakpoint( '<660px' ) {
 			// On smaller screens the buttons get bigger,
@@ -41,8 +48,11 @@ body.is-section-jetpack-connect .site-topic__content {
 			border-radius: 0;
 		}
 
-		&:focus {
-			box-shadow: inset 0 0 0 4px var( --color-accent-light );
+		&:focus,
+		&:focus:hover,
+		&:active {
+			border-color: var( --color-accent-light );
+			box-shadow: none;
 		}
 	}
 
@@ -68,8 +78,8 @@ body.is-section-jetpack-connect .site-topic__content {
 
 	.button {
 		position: absolute;
-		top: 3px;
-		right: 3px;
+		top: 6px;
+		right: 6px;
 		padding: 5px 8px;
 		@include elevation( 1dp );
 

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -13,7 +13,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		z-index: 1000; // I know, I know...
 		border-radius: 4px;
 		background: var( --color-white );
-		@include elevation ( 2dp );
+		@include elevation( 2dp );
 	}
 
 	.suggestion-search .gridicon {
@@ -53,7 +53,7 @@ body.is-section-jetpack-connect .site-topic__content {
 	.suggestions__wrapper {
 		position: relative;
 		top: 0;
-		@include elevation ( 0 );
+		@include elevation( 0 );
 		margin-top: 3px;
 		margin-bottom: 0;
 		border-radius: 0 0 4px 4px;
@@ -71,7 +71,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		top: 3px;
 		right: 3px;
 		padding: 5px 8px;
-		@include elevation ( 1dp );
+		@include elevation( 1dp );
 
 		&[disabled] {
 			opacity: 0;

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -42,7 +42,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		}
 
 		&:focus {
-			box-shadow: 0 0 0 3px var( --color-accent-light );
+			box-shadow: inset 0 0 0 4px var( --color-accent-light );
 		}
 	}
 


### PR DESCRIPTION
As pointed out in #32730, the box shadows indicating an input is selected / focused are being rendered outside the visible margins on mobile viewports.  This improves the situation by making the highlighting `inset`.

#### Changes proposed in this Pull Request

* Declare specific box shadows are `inset`
* Increase the blur-radius from 3px to 4px so there isn't a small gap next to the button
* Site Title: override box-shadow on :focus:hover as well -- [borrowed](https://github.com/Automattic/wp-calypso/blob/bc9e8cd93a08a4edac85d42233dbd909990091ff/client/signup/steps/site-type/style.scss#L116) from the site-type step
* Domains Step: Reduce the height of the search__input-fade overlay. Otherwise, the overlay occluded the box-shadow on the input

#### Testing instructions

* Complete  as many flows as possible on various mobile device & desktop breakpoints
* All components should be fully & properly rendered (with and without focus for inputs like text fields and search boxes)