### PR TITLE
Build: Fix up desktop detection and paths for dev

### DIFF
--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -58,7 +58,7 @@ class Desktop extends React.Component {
 						rel="stylesheet"
 						type="text/css"
 						data-webpack={ true }
-						href={ `/calypso/build.${ isRTL ? 'rtl.css' : 'css' }` }
+						href={ `/calypso/evergreen/build.${ isRTL ? 'rtl.css' : 'css' }` }
 					/>
 					<link rel="stylesheet" id="desktop-css" href="/desktop/wordpress-desktop.css" />
 				</Head>
@@ -122,7 +122,7 @@ class Desktop extends React.Component {
 						/>
 					) }
 
-					<script src="/calypso/build.js" />
+					<script src="/calypso/evergreen/build.js" />
 					<script src="/desktop/desktop-app.js" />
 					{ i18nLocaleScript && <script src={ i18nLocaleScript } /> }
 					<script type="text/javascript">startApp();</script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,7 @@ const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.BROWSERSLIST_ENV !== 'server';
-const isDesktop = calypsoEnv === 'desktop';
+const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
 
 const defaultBrowserslistEnv = isCalypsoClient && ! isDesktop ? 'evergreen' : 'defaults';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;
@@ -143,7 +143,7 @@ let outputChunkFilename = '[name].[chunkhash].min.js'; // ditto
 // also we don't minify so dont name them .min.js
 //
 // Desktop: no chunks or dll here, just one big file for the desktop app
-if ( isDevelopment || calypsoEnv === 'desktop' ) {
+if ( isDevelopment || isDesktop ) {
 	outputFilename = '[name].js';
 	outputChunkFilename = '[name].js';
 }
@@ -186,7 +186,7 @@ const webpackConfig = {
 			parallel: workerCount,
 			sourceMap: Boolean( process.env.SOURCEMAP ),
 			terserOptions: {
-				mangle: calypsoEnv !== 'desktop',
+				mangle: ! isDesktop,
 			},
 		} ),
 	},


### PR DESCRIPTION
 This allows the desktop server to boot up and to be found.

#### Changes proposed in this Pull Request

* Fix how we detect the desktop envionment, also checking for desktop-development, and fix the page we serve to use the evergreen path.

#### Testing instructions

* Check out wp-desktop's develop branch
* Check out this branch in the wp-desktop repo's calypso submodule `cd calypso; git fetch; git checkout fix/desktop-development`
* Run the dev server `make dev-server` (this takes ... forever. Looking into it. Seems to be `LimitChunkCountPlugin`)
* In a separate terminal run `make dev`
* Verify that Calypso comes up inside the desktop shell

See https://github.com/Automattic/wp-calypso/pull/32673
