### PR TITLE
Fixes "Site Plan" string literal in client/me/purchases/remove-purchase/index.jsx

### DIFF
--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -34,7 +34,6 @@ import {
 	isRemovable,
 	isRefundable,
 	maybeWithinRefundPeriod,
-	purchaseType,
 } from 'lib/purchases';
 import { isDataLoading } from '../utils';
 import { isDomainRegistration, isGoogleApps, isJetpackPlan, isPlan } from 'lib/products-values';
@@ -410,9 +409,12 @@ class RemovePurchase extends Component {
 		return (
 			<div>
 				<p>
-					{ translate( 'Are you sure you want to remove %(productName)s from {{siteName/}}?', {
+					{ translate( 'Are you sure you want to remove %(productName)s from {{domain/}}?', {
 						args: { productName },
-						components: { siteName: <em>{ purchaseType( purchase ) }</em> },
+						components: { domain: <em>{ purchase.domain }</em> },
+						// ^ is the internal WPcom domain i.e. example.wordpress.com
+						// if we want to use the purchased domain we can swap with the below line
+						//{ components: { domain: <em>{ getIncludedDomain( purchase ) }</em> } }
 					} ) }{' '}
 					{ isGoogleApps( purchase )
 						? translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes #32014 
 

#### Testing instructions


- Start at https://wordpress.com/me/purchases
- Click on a paid WordPress.com plan
- Follow the removal instructions
- On the final removal step, note a copy that reads Are you sure you want to remove {plan} from {domain}


**Before**:

![screenshot](https://cld.wthms.co/Bo5Oh6+)

After:

![screenshot](https://cld.wthms.co/Edzv1z+)

![screenshot](https://cld.wthms.co/9TJPip+)

I used the internal WPcom domain as that what was already in place for the removal confirmation, and it makes way more sense for plans without domains and to avoid screwy situations there. Site names are also a bad choice because they can be duplicates. 

* Fixes #32014
