### PR TITLE
Add z-index to themes banner close button

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -183,6 +183,7 @@ $z-layers: (
 		'.upwork-stats-nudge__close-icon': 1,
 		'.gsuite-stats-nudge__close-icon': 1,
 		'.people-list-item.card.is-compact:focus': 1,
+		'.themes-banner__close': 1,
 	),
 	'.is-section-signup': (
 		'.is-section-signup::before': -1,

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -79,6 +79,7 @@
 		right: 0;
 		top: 0;
 		width: 1.7em;
+		z-index: z-index( 'root', '.themes-banner__close' );
 
 		&:hover {
 			cursor: pointer;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #32739 issue it's reported that it's not possible to close the theme. Adding z-index to theme banner close button solves the problem.


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Link to test: http://calypso.localhost:3000/themes/

Fixes #32739 