### PR TITLE
Gutenframe: Dismiss the autosave notice after loading a revision

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -73,6 +73,7 @@ function overrideRevisions( calypsoPort ) {
 			const blocks = parse( payload.content );
 			dispatch( 'core/editor' ).editPost( payload );
 			dispatch( 'core/editor' ).resetBlocks( blocks );
+			dispatch( 'core/notices' ).removeNotice( 'autosave-exists' );
 
 			calypsoPort.removeEventListener( 'message', onLoadRevision, false );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes the autosave notice when a user takes the decision to load a revision. We intentionally keep the notice if the user closes the revision modal without loading any revision since clicking on "View the autosave" technically doesn't convey the intention of closing the notice.

<img width="1130" alt="Screen Shot 2019-04-29 at 12 53 20 PM" src="https://user-images.githubusercontent.com/349751/57001037-6e6fbc80-6b6b-11e9-93aa-f29da57a957f.png">

#### Testing instructions

- Apply D27719-code and sandbox `widgets.wp.com`.
- Go to `/block-editor/post/` and select a sandbox site.
- Publish the post, make edits, and allow an autosave to happen.
- Reload the window without saving.
- Note how the autosave notice is shown.
- Click the "View the autosave" link.
- Close the modal without loading any revision.
- Make sure the autosave notice is still visible.
- Click the "View the autosave" link again.
- Load the autosave revision.
- Make sure the autosave notice is no longer visible.

Fixes #32710
