### PR TITLE
Modernize the RootChild component

### DIFF
--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -34,7 +34,7 @@ const BlogStickers = ( { blogId, teams, stickers } ) => {
 		<div className="blog-stickers">
 			<QueryBlogStickers blogId={ blogId } />
 			{ isTeamMember && stickers && stickers.length > 0 && (
-				<InfoPopover rootClassName="blog-stickers__popover">
+				<InfoPopover>
 					<BlogStickersList stickers={ stickers } />
 				</InfoPopover>
 			) }

--- a/client/blocks/calendar-button/README.md
+++ b/client/blocks/calendar-button/README.md
@@ -63,7 +63,6 @@ This property defines to this component as a `button`. You shouldn't change this
 * `events`
 * `ignoreContext`
 * `isVisible`
-* `rootClassName`
 * `selectedDay`
 * `showDelay`
 * `siteId`

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -28,7 +28,6 @@ class CalendarButton extends Component {
 		events: PropTypes.array,
 		ignoreContext: PropTypes.shape( { getDOMNode: PropTypes.function } ),
 		isVisible: PropTypes.bool,
-		rootClassName: PropTypes.string,
 		selectedDay: PropTypes.object,
 		showDelay: PropTypes.number,
 		siteId: PropTypes.number,
@@ -80,29 +79,25 @@ class CalendarButton extends Component {
 			return null;
 		}
 
-		const calendarProperties = Object.assign(
-			{},
-			pick( this.props, [
-				'autoPosition',
-				'closeOnEsc',
-				'disabledDays',
-				'events',
-				'showOutsideDays',
-				'ignoreContext',
-				'isVisible',
-				'modifiers',
-				'rootClassName',
-				'selectedDay',
-				'showDelay',
-				'siteId',
-				'onDateChange',
-				'onMonthChange',
-				'onDayMouseEnter',
-				'onDayMouseLeave',
-				'onShow',
-				'onClose',
-			] )
-		);
+		const calendarProperties = pick( this.props, [
+			'autoPosition',
+			'closeOnEsc',
+			'disabledDays',
+			'events',
+			'showOutsideDays',
+			'ignoreContext',
+			'isVisible',
+			'modifiers',
+			'selectedDay',
+			'showDelay',
+			'siteId',
+			'onDateChange',
+			'onMonthChange',
+			'onDayMouseEnter',
+			'onDayMouseLeave',
+			'onShow',
+			'onClose',
+		] );
 
 		return (
 			<AsyncLoad

--- a/client/blocks/calendar-popover/README.md
+++ b/client/blocks/calendar-popover/README.md
@@ -70,7 +70,6 @@ The site's timezone value, in the format of 'America/Araguaina (see https://en.w
 * `ignoreContext`
 * `isVisible`
 * `position`
-* `rootClassName`
 * `showDelay`
 * `onClose`
 * `onShow`
@@ -82,4 +81,3 @@ The site's timezone value, in the format of 'America/Araguaina (see https://en.w
  * `siteId`
  * `onDateChange`
  * `onMonthChange`
-

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -35,7 +35,6 @@ class CalendarPopover extends Component {
 		ignoreContext: PropTypes.shape( { getDOMNode: PropTypes.function } ),
 		isVisible: PropTypes.bool,
 		position: PropTypes.string,
-		rootClassName: PropTypes.string,
 		showDelay: PropTypes.number,
 		onClose: PropTypes.func,
 		onShow: PropTypes.func,
@@ -100,21 +99,17 @@ class CalendarPopover extends Component {
 	}
 
 	render() {
-		const popoverProps = Object.assign(
-			{},
-			pick( this.props, [
-				'autoPosition',
-				'closeOnEsc',
-				'context',
-				'ignoreContext',
-				'isVisible',
-				'position',
-				'rootClassName',
-				'showDelay',
-				'onClose',
-				'onShow',
-			] )
-		);
+		const popoverProps = pick( this.props, [
+			'autoPosition',
+			'closeOnEsc',
+			'context',
+			'ignoreContext',
+			'isVisible',
+			'position',
+			'showDelay',
+			'onClose',
+			'onShow',
+		] );
 
 		return (
 			<div className="calendar-popover">

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -11,6 +11,7 @@ import url from 'url';
 import { startsWith } from 'lodash';
 import React from 'react';
 import ReactDom from 'react-dom';
+import Modal from 'react-modal';
 import store from 'store';
 
 /**
@@ -188,6 +189,9 @@ export const utils = () => {
 
 	// Add accessible-focus listener
 	accessibleFocus();
+
+	// Configure app element that React Modal will aria-hide when modal is open
+	Modal.setAppElement( document.getElementById( 'wpcom' ) );
 };
 
 export const configureReduxStore = ( currentUser, reduxStore ) => {

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -53,7 +53,6 @@ class DialogBase extends Component {
 				onRequestClose={ this._close }
 				closeTimeoutMS={ this.props.leaveTimeout }
 				contentLabel={ this.props.label }
-				appElement={ document.getElementById( 'wpcom' ) }
 				overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't
 				className={ dialogClassName }
 				htmlOpenClassName="ReactModal__Html--open"

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -8,7 +8,6 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
-import RootChild from 'components/root-child';
 import DialogBase from './dialog-base';
 
 class Dialog extends Component {
@@ -26,11 +25,7 @@ class Dialog extends Component {
 	};
 
 	render() {
-		return (
-			<RootChild>
-				<DialogBase { ...this.props } onDialogClose={ this.onDialogClose } />
-			</RootChild>
-		);
+		return <DialogBase { ...this.props } onDialogClose={ this.onDialogClose } />;
 	}
 
 	onDialogClose = action => {

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -4,7 +4,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { defer, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -18,31 +17,18 @@ class Dialog extends Component {
 		baseClassName: PropTypes.string,
 		leaveTimeout: PropTypes.number,
 		onClose: PropTypes.func,
-		onClosed: PropTypes.func,
 		shouldCloseOnEsc: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isVisible: false,
 		leaveTimeout: 200,
-		onClosed: noop,
-	};
-
-	checkOnClosed = ref => {
-		if ( null === ref ) {
-			defer( this.props.onClosed );
-		}
 	};
 
 	render() {
 		return (
 			<RootChild>
-				<DialogBase
-					{ ...this.props }
-					ref={ this.checkOnClosed }
-					key="dialog"
-					onDialogClose={ this.onDialogClose }
-				/>
+				<DialogBase { ...this.props } onDialogClose={ this.onDialogClose } />
 			</RootChild>
 		);
 	}

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -36,7 +36,6 @@ export default class InfoPopover extends Component {
 			'left',
 			'top left',
 		] ),
-		rootClassName: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -87,7 +86,6 @@ export default class InfoPopover extends Component {
 					position={ this.props.position }
 					onClose={ this.handleClose }
 					className={ classNames( 'popover', 'info-popover__tooltip', this.props.className ) }
-					rootClassName={ this.props.rootClassName }
 				>
 					{ this.props.children }
 				</Popover>

--- a/client/components/language-picker/test/__snapshots__/modal.js.snap
+++ b/client/components/language-picker/test/__snapshots__/modal.js.snap
@@ -20,7 +20,6 @@ exports[`LanguagePickerModal should render 1`] = `
   isVisible={true}
   leaveTimeout={200}
   onClose={[Function]}
-  onClosed={[Function]}
 >
   <SectionNav
     allowDropdown={true}

--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -79,12 +79,6 @@ This describes the position of the popover relative to the thing it is pointing
 at. If the arrow is supposed to point at something to the top and left of the
 Popover, the correct value for `position` is `bottom right`.
 
-#### `rootClassName { string } - optional`
-
-The `<Popover />` component is mounted into a `<ReactChild />` component at the
-root of the `<body>`. Use this property if you want to add a cuestom css class
-to this root element.
-
 #### `showDelay { number } - default: 0 (false)`
 
 Adds a delay before to show the popover. Its value is defined in `milliseconds`.

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -52,7 +52,6 @@ class Popover extends Component {
 			'left',
 			'top left',
 		] ),
-		rootClassName: PropTypes.string,
 		showDelay: PropTypes.number,
 		onClose: PropTypes.func,
 		onShow: PropTypes.func,
@@ -478,7 +477,7 @@ class Popover extends Component {
 		this.debug( 'rendering ...' );
 
 		return (
-			<RootChild className={ this.props.rootClassName }>
+			<RootChild>
 				<div style={ this.getStylePosition() } className={ classes }>
 					<div className="popover__arrow" />
 

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -22,7 +22,6 @@ class PopoverMenu extends Component {
 		onClose: PropTypes.func.isRequired,
 		position: PropTypes.string,
 		className: PropTypes.string,
-		rootClassName: PropTypes.string,
 		popoverComponent: PropTypes.func,
 		popoverTitle: PropTypes.string, // used by ReaderPopover
 		customPosition: PropTypes.object,
@@ -51,7 +50,6 @@ class PopoverMenu extends Component {
 			isVisible,
 			popoverTitle,
 			position,
-			rootClassName,
 		} = this.props;
 
 		return (
@@ -65,7 +63,6 @@ class PopoverMenu extends Component {
 				isVisible={ isVisible }
 				popoverTitle={ popoverTitle }
 				position={ position }
-				rootClassName={ rootClassName }
 			>
 				<div
 					ref={ this.menu }

--- a/client/components/root-child/index.jsx
+++ b/client/components/root-child/index.jsx
@@ -1,67 +1,21 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import ReactDom from 'react-dom';
-import PropTypes from 'prop-types';
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { MomentProvider } from 'components/localized-moment/context';
+import ReactDOM from 'react-dom';
 
 export default class RootChild extends React.Component {
-	static contextTypes = {
-		store: PropTypes.object,
-	};
+	container = document.createElement( 'div' );
 
 	componentDidMount() {
-		this.container = document.createElement( 'div' );
 		document.body.appendChild( this.container );
-		this.renderChildren();
-	}
-
-	componentDidUpdate() {
-		this.renderChildren();
 	}
 
 	componentWillUnmount() {
-		if ( ! this.container ) {
-			return;
-		}
-
-		ReactDom.unmountComponentAtNode( this.container );
 		document.body.removeChild( this.container );
-		delete this.container;
 	}
 
-	renderChildren = () => {
-		let content;
-
-		if ( this.props && ( Object.keys( this.props ).length > 1 || ! this.props.children ) ) {
-			content = <div { ...this.props }>{ this.props.children }</div>;
-		} else {
-			content = this.props.children;
-		}
-
-		// Context is lost when creating a new render hierarchy, so ensure that
-		// we preserve the context that we care about
-		if ( this.context.store ) {
-			content = (
-				<ReduxProvider store={ this.context.store }>
-					<MomentProvider>{ content }</MomentProvider>
-				</ReduxProvider>
-			);
-		}
-
-		ReactDom.render( content, this.container );
-	};
-
 	render() {
-		return null;
+		return ReactDOM.createPortal( this.props.children, this.container );
 	}
 }

--- a/client/components/root-child/test/index.jsx
+++ b/client/components/root-child/test/index.jsx
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { mount } from 'enzyme';
 import React from 'react';
 import ReactDom from 'react-dom';
@@ -22,12 +21,16 @@ import RootChild from '../';
 class Greeting extends React.Component {
 	static defaultProps = { toWhom: 'World' };
 
+	parentChildRef = React.createRef();
+	rootChildRef = React.createRef();
+
 	render() {
 		return (
+			/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
 			<div className="parent">
-				<h1 ref="parentChild">Greeting</h1>
-				<RootChild { ...this.props.rootChildProps }>
-					<span ref="rootChild">Hello { this.props.toWhom }!</span>
+				<h1 ref={ this.parentChildRef }>Greeting</h1>
+				<RootChild>
+					<span ref={ this.rootChildRef }>Hello { this.props.toWhom }!</span>
 				</RootChild>
 			</div>
 		);
@@ -50,29 +53,15 @@ describe( 'RootChild', () => {
 		test( 'should render any children as descendants of body', () => {
 			const tree = ReactDom.render( React.createElement( Greeting ), container );
 
-			expect( tree.refs.parentChild.parentNode.className ).to.equal( 'parent' );
-
-			expect( tree.refs.rootChild.parentNode.parentNode ).to.eql( document.body );
-		} );
-
-		test( 'accepts props to be added to a wrapper element', () => {
-			const tree = ReactDom.render(
-				React.createElement( Greeting, {
-					rootChildProps: { className: 'wrapper' },
-				} ),
-				container
-			);
-
-			expect( tree.refs.rootChild.parentNode.className ).to.equal( 'wrapper' );
-
-			expect( tree.refs.rootChild.parentNode.parentNode.parentNode ).to.eql( document.body );
+			expect( tree.parentChildRef.current.parentNode.className ).toBe( 'parent' );
+			expect( tree.rootChildRef.current.parentNode.parentNode ).toBe( document.body );
 		} );
 
 		test( 'should update the children if parent is re-rendered', () => {
 			const tree = mount( React.createElement( Greeting ), { attachTo: container } );
 			tree.setProps( { toWhom: 'Universe' } );
 
-			expect( tree.ref( 'rootChild' ).innerHTML ).to.equal( 'Hello Universe!' );
+			expect( tree.instance().rootChildRef.current.innerHTML ).toBe( 'Hello Universe!' );
 			tree.detach();
 		} );
 	} );
@@ -82,7 +71,7 @@ describe( 'RootChild', () => {
 			ReactDom.render( React.createElement( Greeting ), container );
 			ReactDom.unmountComponentAtNode( container );
 
-			expect( [].slice.call( document.body.querySelectorAll( '*' ) ) ).to.eql( [ container ] );
+			expect( Array.from( document.body.querySelectorAll( '*' ) ) ).toEqual( [ container ] );
 		} );
 	} );
 } );

--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -33,7 +33,6 @@ function Tooltip( props ) {
 		<Popover
 			autoPosition={ props.autoPosition }
 			className={ classes }
-			rootClassName={ props.rootClassName }
 			context={ props.context }
 			id={ props.id }
 			isVisible={ props.isVisible }
@@ -51,7 +50,6 @@ Tooltip.propTypes = {
 	id: PropTypes.string,
 	isVisible: PropTypes.bool,
 	position: PropTypes.string,
-	rootClassName: PropTypes.string,
 	status: PropTypes.string,
 	showDelay: PropTypes.number,
 	showOnMobile: PropTypes.bool,


### PR DESCRIPTION
The `RootChild` component was created before `React.createPortal` existed and can be substantially modernized. The main benefit is seeing the whole app as one rendered tree in React Devtools. Instead of multiple confusing roots.

There are several steps:

**Remove `rootClassName` prop from `Popover` and related components**
The prop is not meaningfully used anywhere and it's difficult to implement with Portal. It styles the container `div` that's not managed by React. Updating the classname on prop change would require some manual DOM manipulation.

**Remove `onClosed` property on `Dialog`**
Not strictly related to `RootChild`, but it's a nice removal of prop that's ever been used in a Reader Full Post modal (abandoned in #8969, Oct 2016) and previously added in #7408.

**Move initialization of `appElement` prop to app boot**
`react-modal` has an `appElement` prop that's a DOM node of the main app. Keeping it there leads to errors in tests and server-side code (because `RootChild` gets removed from `Dialog`). There is no DOM in these environment. We move the initialization to the Calypso boot code.

**How to test:** After opening a modal dialog in Calypso, check that the `#wpcom` DOM element has an `aria-hidden="true"` attribute. It should be unset after closing the modal.

**Remove usage of `RootChild` in `Dialog`**
The `react-modal` package already uses `React.createPortal` internally. There's no need for an extra `RootChild` wrapper.

**Finally, implement `RootChild` using `React.createPortal`**
It's now a simple wrapper around a portal that created a `div` in DOM and puts a portal into it. Note that we don't need to render the Redux and Moment providers here: we no longer implement multiple independent React roots, but rather create portals in a single tree.