### PR TITLE
Use SVG external content for social-logos.

### DIFF
--- a/client/blocks/login/social-connect-prompt.jsx
+++ b/client/blocks/login/social-connect-prompt.jsx
@@ -9,7 +9,6 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { capitalize } from 'lodash';
-import SocialLogo from 'social-logos';
 
 /**
  * Internal dependencies
@@ -23,6 +22,7 @@ import {
 } from 'state/login/selectors';
 import { connectSocialUser } from 'state/login/actions';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
+import SocialLogo from 'components/social-logo';
 
 class SocialConnectPrompt extends Component {
 	static propTypes = {

--- a/client/blocks/post-share/connection.jsx
+++ b/client/blocks/post-share/connection.jsx
@@ -12,7 +12,7 @@ import cssSafeUrl from 'lib/css-safe-url';
  */
 import FormToggle from 'components/forms/form-toggle/compact';
 import classNames from 'classnames';
-import SocialLogo from 'social-logos';
+import SocialLogo from 'components/social-logo';
 
 const PostShareConnection = ( { connection, isActive, onToggle } ) => {
 	const {
@@ -41,7 +41,7 @@ const PostShareConnection = ( { connection, isActive, onToggle } ) => {
 	}
 
 	return (
-		<div onClick={ toggle } className={ classes }>
+		<div onClick={ toggle } className={ classes } role="presentation">
 			<div className="post-share__service-account-image" style={ accountImageStyle }>
 				&nbsp;
 			</div>

--- a/client/blocks/post-share/publicize-actions-list.jsx
+++ b/client/blocks/post-share/publicize-actions-list.jsx
@@ -17,7 +17,7 @@ import getPostSharePublishedActions from 'state/selectors/get-post-share-publish
 
 import getPostShareScheduledActions from 'state/selectors/get-post-share-scheduled-actions';
 import QuerySharePostActions from 'components/data/query-share-post-actions/index.jsx';
-import SocialLogo from 'social-logos';
+import SocialLogo from 'components/social-logo';
 import EllipsisMenu from 'components/ellipsis-menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import { SCHEDULED, PUBLISHED } from './constants';

--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -11,7 +11,6 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { stringify } from 'qs';
 import page from 'page';
-import SocialLogo from 'social-logos';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -20,6 +19,7 @@ import { localize } from 'i18n-calypso';
 import ReaderPopoverMenu from 'reader/components/reader-popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import Gridicon from 'gridicons';
+import SocialLogo from 'components/social-logo';
 import * as stats from 'reader/stats';
 import { preload } from 'sections-helper';
 import SiteSelector from 'components/site-selector';

--- a/client/components/date-picker/event.jsx
+++ b/client/components/date-picker/event.jsx
@@ -6,8 +6,12 @@
 
 import React from 'react';
 import Gridicon from 'gridicons';
-import SocialLogo from 'social-logos';
 import classNames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import SocialLogo from 'components/social-logo';
 
 const renderIcon = icon =>
 	icon && (

--- a/client/components/share-button/index.jsx
+++ b/client/components/share-button/index.jsx
@@ -4,13 +4,13 @@
  */
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import SocialLogo from 'social-logos';
 import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
+import SocialLogo from 'components/social-logo';
 import services from './services';
 
 /**

--- a/client/components/social-logo/docs/example.jsx
+++ b/client/components/social-logo/docs/example.jsx
@@ -1,0 +1,86 @@
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import SocialLogo from '../index';
+
+const logos = [
+	'amazon',
+	'behance',
+	'blogger',
+	'blogger-alt',
+	'codepen',
+	'dribbble',
+	'dropbox',
+	'eventbrite',
+	'facebook',
+	'feed',
+	'flickr',
+	'foursquare',
+	'ghost',
+	'github',
+	'google',
+	'google-alt',
+	'google-plus',
+	'google-plus-alt',
+	'instagram',
+	'linkedin',
+	'mail',
+	'medium',
+	'pinterest',
+	'pinterest-alt',
+	'pocket',
+	'polldaddy',
+	'print',
+	'reddit',
+	'share',
+	'skype',
+	'spotify',
+	'squarespace',
+	'stumbleupon',
+	'telegram',
+	'tumblr',
+	'tumblr-alt',
+	'twitch',
+	'twitter',
+	'twitter-alt',
+	'vimeo',
+	'whatsapp',
+	'woocommerce',
+	'wordpress',
+	'xanga',
+	'youtube',
+];
+
+export default function SocialLogoExample() {
+	function handleClick( icon ) {
+		const toCopy = '<SocialLogo icon="' + icon + '" />';
+		window.prompt( 'Copy component code:', toCopy );
+	}
+
+	return (
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+		<div className="design-assets__group">
+			<h2>
+				<a href="/devdocs/design/social-logo">Social Logo</a>
+			</h2>
+			<div>
+				{ logos.map( logo => (
+					<SocialLogo
+						key={ logo }
+						icon={ logo }
+						size={ 48 }
+						onClick={ () => handleClick( logo ) }
+					/>
+				) ) }
+			</div>
+		</div>
+	);
+}
+
+SocialLogoExample.displayName = 'SocialLogo';

--- a/client/components/social-logo/index.jsx
+++ b/client/components/social-logo/index.jsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import spritePath from 'social-logos/svg-sprite/social-logos.svg';
+
+function SocialLogo( props ) {
+	const { size = 24, icon, onClick, className, ...otherProps } = props;
+
+	// Using a missing icon doesn't produce any errors, just a blank icon, which is the exact intended behaviour.
+	// This means we don't need to perform any checks on the icon name.
+	const iconName = `social-logo-${ icon }`;
+	// The current CSS expects individual icon classes in the form of e.g. `.twitter`, but the social-logos build
+	// appears to generate them in the form of `.social-logo-twitter` instead.
+	// We add both here, to ensure compatibility.
+	const iconClass = classnames( 'social-logo', iconName, icon, className );
+
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			className={ iconClass }
+			height={ size }
+			width={ size }
+			onClick={ onClick }
+			{ ...otherProps }
+		>
+			<use xlinkHref={ `${ spritePath }#${ icon }` } />
+		</svg>
+	);
+}
+
+SocialLogo.propTypes = {
+	icon: PropTypes.string.isRequired,
+	size: PropTypes.number,
+	onClick: PropTypes.func,
+	className: PropTypes.string,
+};
+
+export default React.memo( SocialLogo );

--- a/client/components/vertical-menu/items/social-item.jsx
+++ b/client/components/vertical-menu/items/social-item.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,7 +7,11 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get, identity } from 'lodash';
-import SocialLogo from 'social-logos';
+
+/**
+ * Internal dependencies
+ */
+import SocialLogo from 'components/social-logo';
 
 /**
  * Style dependencies
@@ -34,14 +36,16 @@ export const SocialItem = props => {
 		'is-selected': isSelected,
 	} );
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<div className={ classes } onClick={ () => onClick( service ) }>
+		<div className={ classes } onClick={ () => onClick( service ) } role="presentation">
 			<div className="vertical-menu__items__social-icon">
 				<SocialLogo icon={ icon } size={ 24 } />
 			</div>
 			<span className="vertical-menu__items__social-label">{ label }</span>
 		</div>
 	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 SocialItem.propTypes = {

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * Internal dependencies
  */
@@ -71,7 +70,7 @@ export SegmentedControl from 'components/segmented-control/docs/example';
 export SelectDropdown from 'components/select-dropdown/docs/example';
 export ShareButton from 'components/share-button/docs/example';
 export SiteTitleControl from 'components/site-title/docs/example';
-export SocialLogos from 'social-logos/example';
+export SocialLogos from 'components/social-logo/docs/example';
 export Spinner from 'components/spinner/docs/example';
 export SpinnerButton from 'components/spinner-button/docs/example';
 export SpinnerLine from 'components/spinner-line/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -287,6 +287,8 @@ class DesignAssets extends React.Component {
 	}
 }
 
+let DesignAssetsExport = DesignAssets;
+
 if ( config.isEnabled( 'devdocs/components-usage-stats' ) ) {
 	const mapStateToProps = state => {
 		const { componentsUsageStats } = state;
@@ -309,10 +311,10 @@ if ( config.isEnabled( 'devdocs/components-usage-stats' ) ) {
 		dispatchFetchComponentsUsageStats: PropTypes.func,
 	};
 
-	DesignAssets = connect(
+	DesignAssetsExport = connect(
 		mapStateToProps,
 		mapDispatchToProps
 	)( DesignAssets );
 }
 
-export default DesignAssets;
+export default DesignAssetsExport;

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -101,7 +101,7 @@ import SegmentedControl from 'components/segmented-control/docs/example';
 import SelectDropdown from 'components/select-dropdown/docs/example';
 import ShareButton from 'components/share-button/docs/example';
 import SiteTitleControl from 'components/site-title/docs/example';
-import SocialLogos from 'social-logos/example';
+import SocialLogos from 'components/social-logo/docs/example';
 import Spinner from 'components/spinner/docs/example';
 import SpinnerButton from 'components/spinner-button/docs/example';
 import SpinnerLine from 'components/spinner-line/docs/example';

--- a/client/devdocs/design/playground-scope.js
+++ b/client/devdocs/design/playground-scope.js
@@ -4,7 +4,6 @@
  * External dependencies
  */
 export Gridicon from 'gridicons';
-export SocialLogo from 'social-logos';
 
 /**
  * Docs examples
@@ -104,6 +103,7 @@ export SegmentedControl from 'components/segmented-control';
 export SelectDropdown from 'components/select-dropdown';
 export ShareButton from 'components/share-button';
 export SiteTitleControl from 'components/site-title';
+export SocialLogo from 'components/social-logo';
 export Spinner from 'components/spinner';
 export SpinnerButton from 'components/spinner-button';
 export SpinnerLine from 'components/spinner-line';

--- a/client/extensions/woocommerce/components/share-widget/index.js
+++ b/client/extensions/woocommerce/components/share-widget/index.js
@@ -6,13 +6,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import config from 'config';
 import { localize } from 'i18n-calypso';
-import SocialLogo from 'social-logos';
 import url from 'url';
 
 /**
  * Internal dependencies
  */
 import DashboardWidget from 'woocommerce/components/dashboard-widget';
+import SocialLogo from 'components/social-logo';
 
 class ShareWidget extends Component {
 	static propTypes = {

--- a/client/my-sites/activity/activity-log-item/activity-actor.jsx
+++ b/client/my-sites/activity/activity-log-item/activity-actor.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
  */
 import Gravatar from 'components/gravatar';
 import JetpackLogo from 'components/jetpack-logo';
-import SocialLogo from 'social-logos';
+import SocialLogo from 'components/social-logo';
 import { translate } from 'i18n-calypso';
 import ActivityActorIcon from './activity-actor-icon';
 

--- a/client/my-sites/importer/importer-logo.jsx
+++ b/client/my-sites/importer/importer-logo.jsx
@@ -5,7 +5,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { includes } from 'lodash';
-import SocialLogo from 'social-logos';
 
 /**
  * Internal dependencies
@@ -13,6 +12,7 @@ import SocialLogo from 'social-logos';
 import GoDaddyGoCentralLogo from './logos/godaddy-gocentral';
 import WixLogo from './logos/wix';
 import MediumLogo from './logos/medium';
+import SocialLogo from 'components/social-logo';
 
 const ImporterLogo = ( { icon } ) => {
 	if ( includes( [ 'wordpress', 'blogger-alt', 'squarespace' ], icon ) ) {

--- a/client/my-sites/marketing/buttons/preview-button.jsx
+++ b/client/my-sites/marketing/buttons/preview-button.jsx
@@ -57,10 +57,10 @@ export default class SharingButtonsPreviewButton extends React.Component {
 	}
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 
-	onClick() {
+	onClick = () => {
 		analytics.ga.recordEvent( 'Sharing', 'Clicked Share Button', this.props.button.ID );
 		this.props.onClick();
-	}
+	};
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	render() {

--- a/client/my-sites/marketing/buttons/preview-button.jsx
+++ b/client/my-sites/marketing/buttons/preview-button.jsx
@@ -1,41 +1,35 @@
-/** @format */
-
 /**
  * External dependencies
  */
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import createReactClass from 'create-react-class';
 import classNames from 'classnames';
 import photon from 'photon';
-import SocialLogo from 'social-logos';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import SocialLogo from 'components/social-logo';
 
-export default createReactClass( {
-	displayName: 'SharingButtonsPreviewButton',
-
-	propsTypes: {
+export default class SharingButtonsPreviewButton extends React.Component {
+	static propTypes = {
 		button: PropTypes.object.isRequired,
 		style: PropTypes.oneOf( [ 'icon-text', 'icon', 'text', 'official' ] ),
 		enabled: PropTypes.bool,
 		onMouseOver: PropTypes.func,
 		onClick: PropTypes.func,
-	},
+	};
 
-	getDefaultProps: function() {
-		return {
-			style: 'icon',
-			enabled: true,
-			onClick: function() {},
-		};
-	},
+	static defaultProps = {
+		style: 'icon',
+		enabled: true,
+		onClick: function() {},
+	};
 
-	getIcon: function() {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	getIcon() {
 		const shortnameToSocialLogo = {
 			email: 'mail',
 			'google-plus-1': 'google-plus-alt',
@@ -60,14 +54,16 @@ export default createReactClass( {
 				/>
 			);
 		}
-	},
+	}
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 
-	onClick: function() {
+	onClick() {
 		analytics.ga.recordEvent( 'Sharing', 'Clicked Share Button', this.props.button.ID );
 		this.props.onClick();
-	},
+	}
 
-	render: function() {
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	render() {
 		const classes = classNames(
 			'sharing-buttons-preview-button',
 			'style-' + this.props.style,
@@ -79,10 +75,17 @@ export default createReactClass( {
 		);
 
 		return (
-			<div className={ classes } onClick={ this.onClick } onMouseOver={ this.props.onMouseOver }>
+			// eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
+			<div
+				className={ classes }
+				onClick={ this.onClick }
+				onMouseOver={ this.props.onMouseOver }
+				role="presentation"
+			>
 				{ this.getIcon() }
 				<span className="sharing-buttons-preview-button__service">{ this.props.button.name }</span>
 			</div>
 		);
-	},
-} );
+	}
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+}

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -10,7 +10,6 @@ import classnames from 'classnames';
 import { connect } from 'react-redux';
 import { identity, isEqual, find, replace, some, isFunction, get } from 'lodash';
 import { localize } from 'i18n-calypso';
-import SocialLogo from 'social-logos';
 
 /**
  * Internal dependencies
@@ -48,6 +47,7 @@ import requestExternalAccess from 'lib/sharing';
 import MailchimpSettings, { renderMailchimpLogo } from './mailchimp-settings';
 import config from 'config';
 import PicasaMigration from './picasa-migration';
+import SocialLogo from 'components/social-logo';
 
 /**
  * Check if the connection is broken or requires reauth.

--- a/docs/icons.md
+++ b/docs/icons.md
@@ -73,6 +73,9 @@ The icon grid is based on Gridicons and adheres to the same rules (see above). [
 
 ### Usage
 
+There is a Calypso component for Social Logos, which is implemented differently from the legacy version in the `social-logos` package.
+Please be sure to use the Calypso component, as it provides better loading performance.
+
 Import the iconset and decide at run-time which icon to use:
 
 ```

--- a/docs/icons.md
+++ b/docs/icons.md
@@ -67,7 +67,7 @@ The tricky part is that not all icons need this `offset-adjust` hack, only some 
 
 ## Social Logos
 
-We have a `SocialLogos` component available for use in Calypso. Each logo was pulled from the official branding resource of each service. Branding guidelines were adhered to as much as possible.
+We have a `SocialLogo` component available for use in Calypso. Each logo was pulled from the official branding resource of each service. Branding guidelines were adhered to as much as possible.
 
 The icon grid is based on Gridicons and adheres to the same rules (see above). [View the repository on GitHub](https://github.com/Automattic/social-logos) for more information.
 
@@ -76,7 +76,7 @@ The icon grid is based on Gridicons and adheres to the same rules (see above). [
 Import the iconset and decide at run-time which icon to use:
 
 ```
-import SocialLogo from 'social-logos';
+import SocialLogo from 'components/social-logo';
 //...
 render() {
     return <SocialLogo icon="twitter" size={ 48 } />;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -41,7 +41,7 @@
 				"css-loader": "2.1.1",
 				"duplicate-package-checker-webpack-plugin": "3.0.0",
 				"file-loader": "3.0.1",
-				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
+				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
 				"node-sass": "4.11.0",
 				"postcss-custom-properties": "8.0.9",
 				"postcss-loader": "3.0.0",
@@ -57,8 +57,7 @@
 			"dependencies": {
 				"@babel/core": {
 					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
-					"integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
@@ -79,8 +78,7 @@
 				},
 				"@babel/plugin-transform-runtime": {
 					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.0.tgz",
-					"integrity": "sha512-1uv2h9wnRj98XX3g0l4q+O3jFM6HfayKup7aIu4pnnlzGz0H+cYckGBC74FZIWJXJSXAmeJ9Yu5Gg2RQpS4hWg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.0.0",
@@ -91,8 +89,7 @@
 				},
 				"@babel/preset-env": {
 					"version": "7.4.2",
-					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.2.tgz",
-					"integrity": "sha512-OEz6VOZaI9LW08CWVS3d9g/0jZA6YCn1gsKIy/fut7yZCJti5Lm1/Hi+uo/U+ODm7g4I6gULrCP+/+laT8xAsA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.0.0",
@@ -144,8 +141,7 @@
 				},
 				"autoprefixer": {
 					"version": "9.4.4",
-					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.4.tgz",
-					"integrity": "sha512-7tpjBadJyHKf+gOJEmKhZIksWxdZCSrnKbbTJNsw+/zX9+f//DLELRQPWjjjVoDbbWlCuNRkN7RfmZwDVgWMLw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"browserslist": "^4.3.7",
@@ -158,14 +154,12 @@
 				},
 				"camelcase": {
 					"version": "5.3.1",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"bundled": true,
 					"dev": true
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
@@ -177,8 +171,7 @@
 				},
 				"debug": {
 					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -186,8 +179,7 @@
 				},
 				"execa": {
 					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
@@ -201,8 +193,7 @@
 				},
 				"find-up": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
@@ -210,8 +201,7 @@
 				},
 				"findup-sync": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-					"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"detect-file": "^1.0.0",
@@ -222,8 +212,7 @@
 				},
 				"get-stream": {
 					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -231,8 +220,7 @@
 				},
 				"import-local": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"pkg-dir": "^3.0.0",
@@ -241,14 +229,12 @@
 				},
 				"invert-kv": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+					"bundled": true,
 					"dev": true
 				},
 				"is-glob": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
@@ -256,8 +242,7 @@
 				},
 				"lcid": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"invert-kv": "^2.0.0"
@@ -265,8 +250,7 @@
 				},
 				"locate-path": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
@@ -275,8 +259,7 @@
 				},
 				"mem": {
 					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
-					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
@@ -286,14 +269,12 @@
 				},
 				"mimic-fn": {
 					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+					"bundled": true,
 					"dev": true
 				},
 				"os-locale": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
-					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"execa": "^1.0.0",
@@ -303,8 +284,7 @@
 				},
 				"p-limit": {
 					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -312,8 +292,7 @@
 				},
 				"p-locate": {
 					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
@@ -321,20 +300,17 @@
 				},
 				"p-try": {
 					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"bundled": true,
 					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"bundled": true,
 					"dev": true
 				},
 				"webpack-cli": {
 					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.0.tgz",
-					"integrity": "sha512-t1M7G4z5FhHKJ92WRKwZ1rtvi7rHc0NZoZRbSkol0YKl4HvcC8+DsmGDmK7MmZxHSAetHagiOsjOB6MmzC2TUw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
@@ -352,8 +328,7 @@
 				},
 				"yargs": {
 					"version": "12.0.5",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
@@ -372,8 +347,7 @@
 				},
 				"yargs-parser": {
 					"version": "11.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+					"bundled": true,
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -19268,9 +19242,12 @@
 			}
 		},
 		"social-logos": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/social-logos/-/social-logos-2.0.0.tgz",
-			"integrity": "sha1-5x71006P0BSpRaI+VdBu+k4Ctr0="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/social-logos/-/social-logos-2.1.0.tgz",
+			"integrity": "sha512-MhDx8Rz9fZAegVd5t6836K8u5R4U5loqAo9Dc52ckjnA0FQhl7cJeNYV/EHC/wGIU5oqTOo75eBl6VC7yjKBNA==",
+			"requires": {
+				"prop-types": "^15.5.7"
+			}
 		},
 		"socket.io": {
 			"version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
 	},
 	"dependencies": {
 		"@automattic/format-currency": "file:./packages/format-currency",
-		"@automattic/muriel-style": "file:./packages/muriel-style",
 		"@automattic/material-design-icons": "file:./packages/material-design-icons",
+		"@automattic/muriel-style": "file:./packages/muriel-style",
 		"@automattic/tree-select": "file:./packages/tree-select",
 		"@babel/cli": "7.4.4",
 		"@babel/core": "7.4.4",
@@ -172,7 +172,7 @@
 		"rememo": "3.0.0",
 		"resize-observer-polyfill": "1.5.1",
 		"rtlcss": "2.4.0",
-		"social-logos": "2.0.0",
+		"social-logos": "2.1.0",
 		"socket.io-client": "2.2.0",
 		"source-map": "0.7.3",
 		"source-map-support": "0.5.12",

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
 	roots: [ '<rootDir>/client/' ],
 	testEnvironment: 'node',
 	transformIgnorePatterns: [
-		'node_modules[\\/\\\\](?!flag-icon-css|redux-form|simple-html-tokenizer|draft-js)',
+		'node_modules[\\/\\\\](?!flag-icon-css|redux-form|simple-html-tokenizer|draft-js|social-logos)',
 	],
 	testMatch: [ '<rootDir>/client/**/test/*.js?(x)', '!**/.eslintrc.*' ],
 	testURL: 'https://example.com',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -249,7 +249,6 @@ const webpackConfig = {
 			{
 				'gridicons/example': 'gridicons/dist/example',
 				'react-virtualized': 'react-virtualized/dist/es',
-				'social-logos/example': 'social-logos/build/example',
 				debug: path.resolve( __dirname, 'node_modules/debug' ),
 				store: 'store/dist/store.modern',
 				gridicons$: path.resolve( __dirname, 'client/components/async-gridicons' ),


### PR DESCRIPTION
Reimplement social-logos using an SVG external content approach, instead of SVG transpiled into React components. This helps keep images as images (which is good for performance), while maintaining styleability. Old browsers are supported through the already-included `svg4everyone` polyfill.

See #32364 for a similar change, which added Material Icons with the same approach.

This PR moves ~15KB from JS to SVG in several sections and async chunks.

#### Changes proposed in this Pull Request

* Bump `social-logos` package version to `2.1.0`, which includes the SVG spritemap.
* Implement `components/social-logo` using SVG external content approach.
* Rewrite all uses of `SocialLogo` to use `components/social-logo` instead of the `social-logos` package.
* Replace usage of example in `social-logos` package with a new example in `components/social-logo/docs`.

#### Testing instructions

* Test as many places where social logos are used as possible. Ensure that logos look identical to before this change.
