### PR TITLE
Masterbar: migrate CSS styles to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -102,9 +102,6 @@
 @import 'components/happychat/style';
 @import 'components/happychat/agent-w/style';
 @import 'layout/community-translator/style';
-@import 'layout/masterbar/style';
-@import 'layout/masterbar/oauth-client';
-@import 'layout/masterbar/crowdsignal';
 @import 'layout/nps-survey-notice/style';
 @import 'layout/sidebar/style';
 @import 'lib/accept/style';

--- a/client/layout/masterbar/crowdsignal.jsx
+++ b/client/layout/masterbar/crowdsignal.jsx
@@ -10,6 +10,11 @@ import { filter, tap } from 'lodash';
  */
 import WordPressLogo from 'components/wordpress-logo';
 
+/**
+ * Style dependencies
+ */
+import './crowdsignal.scss';
+
 class CrowdsignalOauthMasterbar extends Component {
 	componentDidMount() {
 		// Crowdsignal's OAuth2 pages should load and use the 'Muli' font to match the marketing page

--- a/client/layout/masterbar/logged-out.jsx
+++ b/client/layout/masterbar/logged-out.jsx
@@ -6,7 +6,6 @@
 
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import Masterbar from './masterbar';
 import { connect } from 'react-redux';
 import { getLocaleSlug, localize } from 'i18n-calypso';
 import { get, includes, startsWith } from 'lodash';
@@ -15,6 +14,7 @@ import { get, includes, startsWith } from 'lodash';
  * Internal dependencies
  */
 import config from 'config';
+import Masterbar from './masterbar';
 import Item from './item';
 import WordPressLogo from 'components/wordpress-logo';
 import WordPressWordmark from 'components/wordpress-wordmark';

--- a/client/layout/masterbar/masterbar.jsx
+++ b/client/layout/masterbar/masterbar.jsx
@@ -3,17 +3,21 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 const Masterbar = ( { children } ) => (
 	<header id="header" className="masterbar">
 		{ children }
 	</header>
 );
-
-Masterbar.displayName = 'Masterbar';
+/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 Masterbar.propTypes = {
 	children: PropTypes.node.isRequired,

--- a/client/layout/masterbar/oauth-client.jsx
+++ b/client/layout/masterbar/oauth-client.jsx
@@ -15,6 +15,11 @@ import { localizeUrl } from 'lib/i18n-utils';
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import CrowdsignalOauthMasterbar from './crowdsignal';
 
+/**
+ * Style dependencies
+ */
+import './oauth-client.scss';
+
 const DefaultOauthClientMasterbar = ( { oauth2Client } ) => (
 	<header className="masterbar masterbar__oauth-client">
 		<nav>

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -586,16 +586,16 @@
 		border-top: 1px solid #e6e6e6;
 		margin: 10px -16px 0;
 		padding-top: 30px;
-		width: calc( 100% + ( $woo-form-whitespace * 2 ) );
+		width: calc( 100% + ( #{ $woo-form-whitespace } * 2 ) );
 
 		@include breakpoint( '>480px' ) {
 			margin: 10px -24px 0;
-			width: calc( 100% + ( $woo-form-whitespace-480 * 2 ) );
+			width: calc( 100% + ( #{ $woo-form-whitespace-480 } * 2 ) );
 		}
 
 		@include breakpoint( '>660px' ) {
 			margin: 20px -100px 0;
-			width: calc( 100% + ( $woo-form-whitespace-660 * 2 ) );
+			width: calc( 100% + ( #{ $woo-form-whitespace-660 } * 2 ) );
 		}
 	}
 


### PR DESCRIPTION
**How to test:**
Check out the masterbar both in logged-in and logged-out versions.

OAuth login pages have a lot of custom styling. Go to the following sites:
- crowdsignal.com
- woocommerce.com
- akismet.com

and try to login there. You're redirected to a custom-styled Calypso login page.

To test locally or on calypso.live, copy the URL path (the `client_id` and `redirect_to` query params are important) and change the host.