### PR TITLE
Signup: avoid flicker by loading the step component in route handler

### DIFF
--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -1,71 +1,65 @@
-/**
- * External dependencies
- */
-import React from 'react';
-import { memoize } from 'lodash';
-
-const loadStep = memoize( stepName =>
-	React.lazy( () =>
-		import(
-			/* webpackChunkName: "async-load-signup-steps-[request]", webpackInclude: /signup\/steps\/[a-z-]+\/index.jsx$/ */ `signup/steps/${ stepName }`
-		)
-	)
-);
-
-export default {
-	about: loadStep( 'about' ),
-	'clone-start': loadStep( 'clone-start' ),
-	'clone-destination': loadStep( 'clone-destination' ),
-	'clone-credentials': loadStep( 'clone-credentials' ),
-	'clone-point': loadStep( 'clone-point' ),
-	'clone-jetpack': loadStep( 'clone-jetpack' ),
-	'clone-ready': loadStep( 'clone-ready' ),
-	'clone-cloning': loadStep( 'clone-cloning' ),
-	'creds-confirm': loadStep( 'creds-confirm' ),
-	'creds-complete': loadStep( 'creds-complete' ),
-	'creds-permission': loadStep( 'creds-permission' ),
-	domains: loadStep( 'domains' ),
-	'domains-store': loadStep( 'domains' ),
-	'domain-only': loadStep( 'domains' ),
-	'domains-theme-preselected': loadStep( 'domains' ),
-	'domains-launch': loadStep( 'domains' ),
-	'from-url': loadStep( 'import-url' ),
-	launch: loadStep( 'launch-site' ),
-	plans: loadStep( 'plans' ),
-	'plans-launch': loadStep( 'plans' ),
-	'plans-personal': loadStep( 'plans' ),
-	'plans-premium': loadStep( 'plans' ),
-	'plans-business': loadStep( 'plans' ),
-	'plans-store-nux': loadStep( 'plans-atomic-store' ),
-	'plans-site-selected': loadStep( 'plans-without-free' ),
-	site: loadStep( 'site' ),
-	'rebrand-cities-welcome': loadStep( 'rebrand-cities-welcome' ),
-	'rewind-migrate': loadStep( 'rewind-migrate' ),
-	'rewind-were-backing': loadStep( 'rewind-were-backing' ),
-	'rewind-add-creds': loadStep( 'rewind-add-creds' ),
-	'rewind-form-creds': loadStep( 'rewind-form-creds' ),
-	'site-or-domain': loadStep( 'site-or-domain' ),
-	'site-picker': loadStep( 'site-picker' ),
-	'site-style': loadStep( 'site-style' ),
-	'site-title': loadStep( 'site-title' ),
-	'site-title-without-domains': loadStep( 'site-title' ),
-	'site-topic': loadStep( 'site-topic' ),
-	'site-type': loadStep( 'site-type' ),
-	survey: loadStep( 'survey' ),
-	'survey-user': loadStep( 'survey-user' ),
-	test: loadStep( 'test-step' ),
-	themes: loadStep( 'theme-selection' ),
-	'website-themes': loadStep( 'theme-selection' ),
-	'blog-themes': loadStep( 'theme-selection' ),
-	'themes-site-selected': loadStep( 'theme-selection' ),
-	user: loadStep( 'user' ),
-	'oauth2-user': loadStep( 'user' ),
-	'oauth2-name': loadStep( 'user' ),
-	displayname: loadStep( 'user' ),
-	'reader-landing': loadStep( 'reader-landing' ),
+const stepNameToModuleName = {
+	about: 'about',
+	'clone-start': 'clone-start',
+	'clone-destination': 'clone-destination',
+	'clone-credentials': 'clone-credentials',
+	'clone-point': 'clone-point',
+	'clone-jetpack': 'clone-jetpack',
+	'clone-ready': 'clone-ready',
+	'clone-cloning': 'clone-cloning',
+	'creds-confirm': 'creds-confirm',
+	'creds-complete': 'creds-complete',
+	'creds-permission': 'creds-permission',
+	domains: 'domains',
+	'domains-store': 'domains',
+	'domain-only': 'domains',
+	'domains-theme-preselected': 'domains',
+	'domains-launch': 'domains',
+	'from-url': 'import-url',
+	launch: 'launch-site',
+	plans: 'plans',
+	'plans-launch': 'plans',
+	'plans-personal': 'plans',
+	'plans-premium': 'plans',
+	'plans-business': 'plans',
+	'plans-store-nux': 'plans-atomic-store',
+	'plans-site-selected': 'plans-without-free',
+	site: 'site',
+	'rebrand-cities-welcome': 'rebrand-cities-welcome',
+	'rewind-migrate': 'rewind-migrate',
+	'rewind-were-backing': 'rewind-were-backing',
+	'rewind-add-creds': 'rewind-add-creds',
+	'rewind-form-creds': 'rewind-form-creds',
+	'site-or-domain': 'site-or-domain',
+	'site-picker': 'site-picker',
+	'site-style': 'site-style',
+	'site-title': 'site-title',
+	'site-title-without-domains': 'site-title',
+	'site-topic': 'site-topic',
+	'site-type': 'site-type',
+	survey: 'survey',
+	'survey-user': 'survey-user',
+	test: 'test-step',
+	themes: 'theme-selection',
+	'website-themes': 'theme-selection',
+	'blog-themes': 'theme-selection',
+	'themes-site-selected': 'theme-selection',
+	user: 'user',
+	'oauth2-user': 'user',
+	'oauth2-name': 'user',
+	displayname: 'user',
+	'reader-landing': 'reader-landing',
 	// Steps with preview
-	'site-style-with-preview': loadStep( 'site-style' ),
-	'site-topic-with-preview': loadStep( 'site-topic' ),
-	'domains-with-preview': loadStep( 'domains' ),
-	'site-title-with-preview': loadStep( 'site-title' ),
+	'site-style-with-preview': 'site-style',
+	'site-topic-with-preview': 'site-topic',
+	'domains-with-preview': 'domains',
+	'site-title-with-preview': 'site-title',
 };
+
+export async function getStepComponent( stepName ) {
+	const moduleName = stepNameToModuleName[ stepName ];
+	const module = await import(
+		/* webpackChunkName: "async-load-signup-steps-[request]", webpackInclude: /signup\/steps\/[a-z-]+\/index.jsx$/ */ `signup/steps/${ moduleName }`
+	);
+	return module.default;
+}

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -13,6 +13,7 @@ import config from 'config';
 import { sectionify } from 'lib/route';
 import analytics from 'lib/analytics';
 import SignupComponent from './main';
+import { getStepComponent } from './config/step-components';
 import {
 	getStepUrl,
 	canResumeFlow,
@@ -112,13 +113,16 @@ export default {
 		next();
 	},
 
-	start( context, next ) {
-		const basePath = sectionify( context.path ),
-			flowName = getFlowName( context.params ),
-			stepName = getStepName( context.params ),
-			stepSectionName = getStepSectionName( context.params );
+	async start( context, next ) {
+		const basePath = sectionify( context.path );
+		const flowName = getFlowName( context.params );
+		const stepName = getStepName( context.params );
+		const stepSectionName = getStepSectionName( context.params );
 
 		const { query } = initialContext;
+
+		// wait for the step component module to load
+		const stepComponent = await getStepComponent( stepName );
 
 		analytics.pageView.record(
 			basePath,
@@ -135,9 +139,11 @@ export default {
 			flowName: flowName,
 			queryObject: query,
 			refParameter: query && query.ref,
-			stepName: stepName,
-			stepSectionName: stepSectionName,
+			stepName,
+			stepSectionName,
+			stepComponent,
 		} );
+
 		next();
 	},
 };

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -6,7 +6,7 @@ import cookie from 'cookie';
 import debugModule from 'debug';
 import page from 'page';
 import PropTypes from 'prop-types';
-import React, { Suspense } from 'react';
+import React from 'react';
 import {
 	assign,
 	defer,
@@ -73,7 +73,6 @@ import { getDomainsBySiteId } from 'state/sites/domains/selectors';
 // Current directory dependencies
 import steps from './config/steps';
 import flows from './config/flows';
-import stepComponents from './config/step-components';
 import {
 	canResumeFlow,
 	getCompletedSteps,
@@ -534,18 +533,18 @@ class Signup extends React.Component {
 
 	renderCurrentStep() {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
-		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } ),
-			CurrentComponent = stepComponents[ this.props.stepName ],
-			propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props ),
-			stepKey = this.state.shouldShowLoadingScreen ? 'processing' : this.props.stepName,
-			flow = flows.getFlow( this.props.flowName ),
-			hideFreePlan = !! (
-				this.state.plans ||
-				( ( isDomainRegistration( domainItem ) ||
-					isDomainTransfer( domainItem ) ||
-					isDomainMapping( domainItem ) ) &&
-					this.props.domainsWithPlansOnly )
-			);
+		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
+		const CurrentComponent = this.props.stepComponent;
+		const propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props );
+		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : this.props.stepName;
+		const flow = flows.getFlow( this.props.flowName );
+		const hideFreePlan = !! (
+			this.state.plans ||
+			( ( isDomainRegistration( domainItem ) ||
+				isDomainTransfer( domainItem ) ||
+				isDomainMapping( domainItem ) ) &&
+				this.props.domainsWithPlansOnly )
+		);
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		return (
@@ -564,26 +563,24 @@ class Signup extends React.Component {
 							flowSteps={ flow.steps }
 						/>
 					) : (
-						<Suspense fallback={ null }>
-							<CurrentComponent
-								path={ this.props.path }
-								step={ currentStepProgress }
-								initialContext={ this.props.initialContext }
-								steps={ flow.steps }
-								stepName={ this.props.stepName }
-								meta={ flow.meta || {} }
-								goToNextStep={ this.goToNextStep }
-								goToStep={ this.goToStep }
-								previousFlowName={ this.state.previousFlowName }
-								flowName={ this.props.flowName }
-								signupProgress={ this.props.progress }
-								signupDependencies={ this.props.signupDependencies }
-								stepSectionName={ this.props.stepSectionName }
-								positionInFlow={ this.getPositionInFlow() }
-								hideFreePlan={ hideFreePlan }
-								{ ...propsFromConfig }
-							/>
-						</Suspense>
+						<CurrentComponent
+							path={ this.props.path }
+							step={ currentStepProgress }
+							initialContext={ this.props.initialContext }
+							steps={ flow.steps }
+							stepName={ this.props.stepName }
+							meta={ flow.meta || {} }
+							goToNextStep={ this.goToNextStep }
+							goToStep={ this.goToStep }
+							previousFlowName={ this.state.previousFlowName }
+							flowName={ this.props.flowName }
+							signupProgress={ this.props.progress }
+							signupDependencies={ this.props.signupDependencies }
+							stepSectionName={ this.props.stepSectionName }
+							positionInFlow={ this.getPositionInFlow() }
+							hideFreePlan={ hideFreePlan }
+							{ ...propsFromConfig }
+						/>
 					) }
 				</div>
 			</div>
@@ -683,7 +680,5 @@ export default connect(
 		submitSiteVertical,
 		loadTrackingTool,
 		trackAffiliateReferral: affiliateReferral,
-	},
-	undefined,
-	{ pure: false }
+	}
 )( Signup );


### PR DESCRIPTION
Inspired by @spen's work in #32718, I'm implementing a way to avoid flicker when advancing from one signup step to another.

Conceptually, the original code works like this:
```js
page( '/signup/:stepName', ( context, next ) => {
  const { stepName } = context.params;
  ReactDOM.render(
    <AsyncLoad require=`signup/steps/${ stepName }` placeholder={ <Placeholder /> } />,
    reactRootEl
  );
} );
```
When a new route is navigated to, it immediately rerenders the UI, but because it doesn't have a step component to render, it renders a placeholder. That causes flicker.

My PR changes that to this:
```js
page( '/signup/:stepName', async ( context, next ) => {
  const { stepName } = context.params;
  const stepModule = await import( `signup/steps/${ stepName }` );
  const StepComponent = stepModule.default;

  ReactDOM.render(
    <StepComponent />,
    reactRootEl
  );
} );
```
Here, the route handler first waits for the module to load. In the meantime, the old UI is rendered: no React update happened yet.

Only after the step component is loaded, we rerender. The old step is replaced with the new step, with no intermediate React state.

Nice case study for route-based code splitting and async-loading, as opposed to the component-based approach.

What do you think? Does it test well?