### PR TITLE
G Suite: remove padding on form and fix input width bug

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-dialog/style.scss
+++ b/client/components/upgrades/gsuite/gsuite-dialog/style.scss
@@ -102,7 +102,6 @@
 .gsuite-dialog__users {
 	border-bottom: 1px solid var( --color-neutral-50 );
 	display: block;
-	padding: 0 30px;
 
 	h4 {
 		color: var( --color-text-subtle );
@@ -113,6 +112,11 @@
 	.gsuite-dialog__user-fields {
 		animation: gsuite-user-show 0.3s ease-in-out;
 		margin-bottom: 20px;
+	}
+
+	.gsuite-dialog__user-email {
+		// override browser defaults so input can shrink
+		min-width: 0;
 	}
 
 	.gsuite-dialog__user-first-name {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove left and right padding from the "add user" form on the G Suite upsell.
* Fix a bug in Firefox where the email input didn't shrink as expected.

**Before**
<img src="https://user-images.githubusercontent.com/448298/57020624-d8ce3e80-6bf7-11e9-8b4b-b136fdd8df0f.png" alt="image" width="771">

**After**
<img width="771" alt="image" src="https://user-images.githubusercontent.com/448298/57079437-53fa2800-6cbe-11e9-948a-92e1f05f9403.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Starting at URL: https://wordpress.com/domains/add
* Select a site
* Search for or select a suggested domain
* On the G Suite upsell, confirm the add user form doesn't have any left/right padding
* If not already using Firefox, repeat the steps in Firefox
* Resize the browser window to make sure the email input shrinks as expected


Fixes #32721
