### PR TITLE
Jetpack Checklist: show for free sites as well

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import { isEnabled } from 'config';
 import DocumentHead from 'components/data/document-head';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
@@ -97,7 +97,7 @@ class Plans extends Component {
 	redirectToCalypso() {
 		const { canPurchasePlans, selectedSiteSlug } = this.props;
 
-		if ( selectedSiteSlug && canPurchasePlans && config.isEnabled( 'jetpack/checklist' ) ) {
+		if ( selectedSiteSlug && canPurchasePlans && isEnabled( 'jetpack/checklist' ) ) {
 			return this.redirect( CALYPSO_MY_PLAN_PAGE );
 		}
 
@@ -148,7 +148,7 @@ class Plans extends Component {
 		} );
 		mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_free' );
 
-		if ( this.props.calypsoStartedConnection || config.isEnabled( 'jetpack/checklist' ) ) {
+		if ( this.props.calypsoStartedConnection || isEnabled( 'jetpack/checklist' ) ) {
 			this.redirectToCalypso();
 		} else {
 			this.redirectToWpAdmin();

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -12,6 +12,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import config from 'config';
 import DocumentHead from 'components/data/document-head';
 import HelpButton from './help-button';
 import JetpackConnectHappychatButton from './happychat-button';
@@ -96,6 +97,10 @@ class Plans extends Component {
 	redirectToCalypso() {
 		const { canPurchasePlans, selectedSiteSlug } = this.props;
 
+		if ( selectedSiteSlug && canPurchasePlans && config.isEnabled( 'jetpack/checklist' ) ) {
+			return this.redirect( CALYPSO_MY_PLAN_PAGE );
+		}
+
 		if ( selectedSiteSlug && canPurchasePlans ) {
 			// Redirect to "My Plan" page with the "Jetpack Basic Tour" guided tour enabled.
 			// For more details about guided tours, see layout/guided-tours/README.md
@@ -143,7 +148,7 @@ class Plans extends Component {
 		} );
 		mc.bumpStat( 'calypso_jpc_plan_selection', 'jetpack_free' );
 
-		if ( this.props.calypsoStartedConnection ) {
+		if ( this.props.calypsoStartedConnection || config.isEnabled( 'jetpack/checklist' ) ) {
 			this.redirectToCalypso();
 		} else {
 			this.redirectToWpAdmin();

--- a/client/my-sites/plans/current-plan/jetpack-checklist/header.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/header.js
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import CardHeading from 'components/card-heading';
 
-const JetpackChecklistHeader = ( { translate } ) => (
+const JetpackChecklistHeader = ( { isPaidPlan, translate } ) => (
 	<Card compact className="jetpack-checklist__header">
 		<img
 			className="jetpack-checklist__header-illustration"
@@ -22,9 +22,11 @@ const JetpackChecklistHeader = ( { translate } ) => (
 			<CardHeading>
 				{ translate( "Let's start by securing your site with a few essential security features" ) }
 			</CardHeading>
-			<p>
-				{ translate( 'These security features ensure that your site is secured and backed up.' ) }
-			</p>
+			{ isPaidPlan && (
+				<p>
+					{ translate( 'These security features ensure that your site is secured and backed up.' ) }
+				</p>
+			) }
 		</div>
 	</Card>
 );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -80,7 +80,7 @@ class JetpackChecklist extends PureComponent {
 				{ isPaidPlan && <QueryJetpackProductInstallStatus siteId={ siteId } /> }
 				{ isPaidPlan && <QueryRewindState siteId={ siteId } /> }
 
-				<JetpackChecklistHeader />
+				<JetpackChecklistHeader isPaidPlan={ isPaidPlan } />
 
 				<Checklist
 					isPlaceholder={ ! taskStatuses }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Redirect at the end of free plan selection to Calypso when Jetpack checklists are available. Otherwise, keep redirecting to wp-admin.

Resolves https://github.com/Automattic/wp-calypso/issues/32600

Looks like this:
<img width="1091" alt="Screenshot 2019-05-06 at 13 52 27" src="https://user-images.githubusercontent.com/87168/57221114-8f6e5c80-7006-11e9-9b39-a05135a05183.png">


Differences with paid plans:
- no paid-plan specific copy in the header.
- no "thank you" component
- no "setting up vaultpress/akismet" stuffs

<img width="1075" alt="Screenshot 2019-05-06 at 13 53 49" src="https://user-images.githubusercontent.com/87168/57221146-b331a280-7006-11e9-8a65-361df9b6a261.png">


#### Testing instructions

1.
* Have Jetpack connected, free-plan site
* Go to `http://calypso.localhost:3000/jetpack/connect/plans/:site`
* Press da free button
* Appreciate the checklist
* Confirm that you don't see "thank you" component that paid sites see

2.
* Disconnect your site (press _"Manage site connection"_ link at the bottom of Jetpack dash page in wp-admin)
* Then disable `jetpack/checklist` from `config/development.json` and try again steps in 1. 
* Confirm that you'll end up in WP Admin.

