### PR TITLE
Pass the card display name from Apple Pay to the server

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -304,6 +304,7 @@ function getPaygateParameters( cardDetails ) {
 				name: cardDetails.name,
 				zip: cardDetails[ 'postal-code' ],
 				country: cardDetails.country,
+				card_display_name: cardDetails.card_display_name,
 				...cardDetails.tokenized_payment_data,
 			},
 		};

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -350,6 +350,7 @@ export class WebPaymentBox extends React.Component {
 									country: getTaxCountryCode( this.props.cart ),
 									'postal-code': getTaxPostalCode( this.props.cart ),
 									card_brand: token.paymentMethod.network,
+									card_display_name: token.paymentMethod.displayName,
 								};
 
 								setPayment( newCardPayment( cardRawDetails ) );


### PR DESCRIPTION
When a user makes an Apple Pay purchase, Apple Pay provides us a `displayName` property (see for example https://developer.apple.com/documentation/passkit/pkpaymentmethod/1619249-displayname) which is a user-facing description of the card used for payment (typically something like "MasterCard 1234").

This is important, because this is the only place we can get the last 4 digits of the user's actual credit card to be able to show it to the user later on (the payment itself is processed with a token, not the actual card number).

This change simply passes along the `displayName` to the server so it can be saved.

#### Testing instructions

Apple Pay isn't live yet, so there isn't really a good way to test this directly.
