### PR TITLE
Moving the Upcoming Charges table to a new tab

### DIFF
--- a/client/me/billing-history/controller.js
+++ b/client/me/billing-history/controller.js
@@ -6,10 +6,16 @@
 
 import React from 'react';
 import BillingHistoryComponent from './main';
+import UpcomingChargesComponent from './upcoming-charges';
 import Receipt from './receipt';
 
 export function billingHistory( context, next ) {
 	context.primary = React.createElement( BillingHistoryComponent );
+	next();
+}
+
+export function upcomingCharges( context, next ) {
+	context.primary = React.createElement( UpcomingChargesComponent );
 	next();
 }
 

--- a/client/me/billing-history/main.jsx
+++ b/client/me/billing-history/main.jsx
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -15,20 +14,17 @@ import config from 'config';
 import CreditCards from 'me/purchases/credit-cards';
 import PurchasesHeader from '../purchases/purchases-list/header';
 import BillingHistoryTable from './billing-history-table';
-import UpcomingChargesTable from './upcoming-charges-table';
-import SectionHeader from 'components/section-header';
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
-import getPastBillingTransactions from 'state/selectors/get-past-billing-transactions';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const BillingHistory = ( { pastTransactions, translate } ) => (
+const BillingHistory = ( { translate } ) => (
 	<Main className="billing-history">
 		<DocumentHead title={ translate( 'Billing History' ) } />
 		<PageViewTracker path="/me/purchases/billing" title="Me > Billing History" />
@@ -38,18 +34,8 @@ const BillingHistory = ( { pastTransactions, translate } ) => (
 		<Card className="billing-history__receipts">
 			<BillingHistoryTable />
 		</Card>
-		{ pastTransactions && (
-			<div>
-				<SectionHeader label={ translate( 'Upcoming Charges' ) } />
-				<Card className="billing-history__upcoming-charges">
-					<UpcomingChargesTable />
-				</Card>
-			</div>
-		) }
 		{ config.isEnabled( 'upgrades/credit-cards' ) && <CreditCards /> }
 	</Main>
 );
 
-export default connect( state => ( {
-	pastTransactions: getPastBillingTransactions( state ),
-} ) )( localize( BillingHistory ) );
+export default localize( BillingHistory );

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -345,7 +345,8 @@ textarea.billing-history__billing-details-editable {
 	padding: 0;
 }
 
-.billing-history .search-card.card {
+.billing-history .search-card.card,
+.billing-history__upcoming-charges .search-card.card {
 	margin: 0;
 }
 

--- a/client/me/billing-history/upcoming-charges.jsx
+++ b/client/me/billing-history/upcoming-charges.jsx
@@ -24,7 +24,7 @@ import getPastBillingTransactions from 'state/selectors/get-past-billing-transac
  */
 import './style.scss';
 
-const BillingHistory = ( { pastTransactions, translate } ) => (
+const UpcomingCharges = ( { pastTransactions, translate } ) => (
 	<Main>
 		<DocumentHead title={ translate( 'Upcoming Charges' ) } />
 		<PageViewTracker path="/me/purchases/upcoming" title="Me > Upcoming Charges" />
@@ -43,4 +43,4 @@ const BillingHistory = ( { pastTransactions, translate } ) => (
 
 export default connect( state => ( {
 	pastTransactions: getPastBillingTransactions( state ),
-} ) )( localize( BillingHistory ) );
+} ) )( localize( UpcomingCharges ) );

--- a/client/me/billing-history/upcoming-charges.jsx
+++ b/client/me/billing-history/upcoming-charges.jsx
@@ -1,0 +1,46 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+import MeSidebarNavigation from 'me/sidebar-navigation';
+import PurchasesHeader from '../purchases/purchases-list/header';
+import UpcomingChargesTable from './upcoming-charges-table';
+import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+import QueryBillingTransactions from 'components/data/query-billing-transactions';
+import getPastBillingTransactions from 'state/selectors/get-past-billing-transactions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const BillingHistory = ( { pastTransactions, translate } ) => (
+	<Main>
+		<DocumentHead title={ translate( 'Upcoming Charges' ) } />
+		<PageViewTracker path="/me/purchases/upcoming" title="Me > Upcoming Charges" />
+		<MeSidebarNavigation />
+		<QueryBillingTransactions />
+		<PurchasesHeader section={ 'upcoming' } />
+		<Card className="billing-history__upcoming-charges">
+			{ pastTransactions ? (
+				<UpcomingChargesTable />
+			) : (
+				translate( "You don't have any upcoming charges." ) // This is a graceful fallback, in case someone guesses the URL
+			) }
+		</Card>
+	</Main>
+);
+
+export default connect( state => ( {
+	pastTransactions: getPastBillingTransactions( state ),
+} ) )( localize( BillingHistory ) );

--- a/client/me/billing-history/upcoming-charges.jsx
+++ b/client/me/billing-history/upcoming-charges.jsx
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import React from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -17,14 +16,13 @@ import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryBillingTransactions from 'components/data/query-billing-transactions';
-import getPastBillingTransactions from 'state/selectors/get-past-billing-transactions';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-const UpcomingCharges = ( { pastTransactions, translate } ) => (
+const UpcomingCharges = ( { translate } ) => (
 	<Main>
 		<DocumentHead title={ translate( 'Upcoming Charges' ) } />
 		<PageViewTracker path="/me/purchases/upcoming" title="Me > Upcoming Charges" />
@@ -32,15 +30,9 @@ const UpcomingCharges = ( { pastTransactions, translate } ) => (
 		<QueryBillingTransactions />
 		<PurchasesHeader section={ 'upcoming' } />
 		<Card className="billing-history__upcoming-charges">
-			{ pastTransactions ? (
-				<UpcomingChargesTable />
-			) : (
-				translate( "You don't have any upcoming charges." ) // This is a graceful fallback, in case someone guesses the URL
-			) }
+			<UpcomingChargesTable />
 		</Card>
 	</Main>
 );
 
-export default connect( state => ( {
-	pastTransactions: getPastBillingTransactions( state ),
-} ) )( localize( UpcomingCharges ) );
+export default localize( UpcomingCharges );

--- a/client/me/pending-payments/test/index.js
+++ b/client/me/pending-payments/test/index.js
@@ -41,7 +41,7 @@ describe( 'PendingPayments', () => {
 
 		const rules = [
 			'Main.pending-payments Localized(MeSidebarNavigation)',
-			'Main.pending-payments PurchasesHeader[section="pending"]',
+			'Main.pending-payments Connect(Localized(PurchasesHeader))[section="pending"]',
 			'Connect(PurchasesSite)[isPlaceholder=true]',
 		];
 
@@ -59,7 +59,7 @@ describe( 'PendingPayments', () => {
 
 		const rules = [
 			'Main.pending-payments Localized(MeSidebarNavigation)',
-			'Main.pending-payments PurchasesHeader[section="pending"]',
+			'Main.pending-payments Connect(Localized(PurchasesHeader))[section="pending"]',
 			'.pending-payments .pending-payments__no-content EmptyContent',
 		];
 
@@ -84,7 +84,7 @@ describe( 'PendingPayments', () => {
 
 		const rules = [
 			'Main.pending-payments Localized(MeSidebarNavigation)',
-			'Main.pending-payments PurchasesHeader[section="pending"]',
+			'Main.pending-payments Connect(Localized(PurchasesHeader))[section="pending"]',
 			'Main.pending-payments Connect(Localized(PendingListItem))',
 		];
 

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -34,6 +34,14 @@ export default function( router ) {
 		clientRender
 	);
 
+	router(
+		paths.upcomingCharges,
+		sidebar,
+		billingController.upcomingCharges,
+		makeLayout,
+		clientRender
+	);
+
 	if ( config.isEnabled( 'async-payments' ) ) {
 		router(
 			paths.purchasesRoot + '/pending',

--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -6,6 +6,8 @@ export const addCreditCard = purchasesRoot + '/add-credit-card';
 
 export const billingHistory = purchasesRoot + '/billing';
 
+export const upcomingCharges = purchasesRoot + '/upcoming';
+
 export function billingHistoryReceipt( receiptId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof receiptId ) {

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -6,43 +6,51 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
-import { billingHistory, purchasesRoot } from '../../paths.js';
+import { billingHistory, upcomingCharges, purchasesRoot } from '../../paths.js';
 import SectionNav from 'components/section-nav';
 import config from 'config';
+import getPastBillingTransactions from 'state/selectors/get-past-billing-transactions';
 
-const PurchasesHeader = ( { section } ) => {
-	let text = i18n.translate( 'Billing History' );
+const PurchasesHeader = ( { pastTransactions, section, translate } ) => {
+	let text = translate( 'Billing History' );
 
 	if ( section === 'purchases' ) {
-		text = i18n.translate( 'Purchases' );
+		text = translate( 'Purchases' );
 	}
 
 	return (
 		<SectionNav selectedText={ text }>
 			<NavTabs>
 				<NavItem path={ purchasesRoot } selected={ section === 'purchases' }>
-					{ i18n.translate( 'Purchases' ) }
+					{ translate( 'Purchases' ) }
 				</NavItem>
 
 				<NavItem path={ billingHistory } selected={ section === 'billing' }>
-					{ i18n.translate( 'Billing History' ) }
+					{ translate( 'Billing History' ) }
 				</NavItem>
+
+				{ pastTransactions && (
+					<NavItem path={ upcomingCharges } selected={ section === 'upcoming' }>
+						{ translate( 'Upcoming Charges' ) }
+					</NavItem>
+				) }
 
 				{ config.isEnabled( 'async-payments' ) && (
 					<NavItem path={ purchasesRoot + '/pending' } selected={ section === 'pending' }>
-						{ i18n.translate( 'Pending Payments' ) }
+						{ translate( 'Pending Payments' ) }
 					</NavItem>
 				) }
 
 				<NavItem path={ purchasesRoot + '/memberships' } selected={ section === 'memberships' }>
-					{ i18n.translate( 'My Memberships' ) }
+					{ translate( 'My Memberships' ) }
 				</NavItem>
 			</NavTabs>
 		</SectionNav>
@@ -53,4 +61,6 @@ PurchasesHeader.propTypes = {
 	section: PropTypes.string.isRequired,
 };
 
-export default PurchasesHeader;
+export default connect( state => ( {
+	pastTransactions: getPastBillingTransactions( state ),
+} ) )( localize( PurchasesHeader ) );

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -19,7 +19,7 @@ import SectionNav from 'components/section-nav';
 import config from 'config';
 import getPastBillingTransactions from 'state/selectors/get-past-billing-transactions';
 
-const PurchasesHeader = ( { pastTransactions, section, translate } ) => {
+const PurchasesHeader = ( { section, translate } ) => {
 	let text = translate( 'Billing History' );
 
 	if ( section === 'purchases' ) {
@@ -37,11 +37,9 @@ const PurchasesHeader = ( { pastTransactions, section, translate } ) => {
 					{ translate( 'Billing History' ) }
 				</NavItem>
 
-				{ pastTransactions && (
-					<NavItem path={ upcomingCharges } selected={ section === 'upcoming' }>
-						{ translate( 'Upcoming Charges' ) }
-					</NavItem>
-				) }
+				<NavItem path={ upcomingCharges } selected={ section === 'upcoming' }>
+					{ translate( 'Upcoming Charges' ) }
+				</NavItem>
 
 				{ config.isEnabled( 'async-payments' ) && (
 					<NavItem path={ purchasesRoot + '/pending' } selected={ section === 'pending' }>


### PR DESCRIPTION
Moves the Upcoming Charges table from the Billing History screen to a new tab called Upcoming Charges.

Testing:
* Go to /me/purchases/upcoming
* Check if the Upcoming Charges table is in a separate tab
* Check if the Upcoming Charges table only shows up if you have upcoming charges
* Check the fallback in case there are no upcoming charges present

Closes  #32404