### PR TITLE
Marketing: added tracks events to autosaving toggles

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -22,6 +22,7 @@ import {
 	getSiteSettingsSaveError,
 	getSiteSettings,
 } from 'state/site-settings/selectors';
+import getCurrentRoute from 'state/selectors/get-current-route';
 import getJetpackSettings from 'state/selectors/get-jetpack-settings';
 import isJetpackSettingsSaveFailure from 'state/selectors/is-jetpack-settings-save-failure';
 import isRequestingJetpackSettings from 'state/selectors/is-requesting-jetpack-settings';
@@ -31,7 +32,7 @@ import { saveSiteSettings } from 'state/site-settings/actions';
 import { saveJetpackSettings } from 'state/jetpack/settings/actions';
 import { removeNotice, successNotice, errorNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
+import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 
@@ -189,6 +190,10 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 
 		handleAutosavingToggle = name => () => {
 			this.props.trackEvent( `Toggled ${ name }` );
+			this.props.trackTracksEvent( 'calypso_settings_autosaving_toggle_updated', {
+				name,
+				path: this.props.path,
+			} );
 			this.props.updateFields( { [ name ]: ! this.props.fields[ name ] }, () => {
 				this.submitForm();
 			} );
@@ -264,6 +269,9 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const settingsFields = {
 				site: keys( settings ),
 			};
+			const path = getCurrentRoute( state )
+				.replace( getSiteSlug( state, siteId ), ':site' )
+				.replace( siteId, ':siteid' );
 
 			const isJetpack = isJetpackSite( state, siteId );
 
@@ -293,6 +301,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 				isSavingSettings,
 				isSaveRequestSuccessful,
 				jetpackFieldsToUpdate,
+				path,
 				siteIsJetpack: isJetpack,
 				siteSettingsSaveError,
 				settings,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds Tracks events to the autosaving toggles in the settings section.

#### Testing instructions

1. Make sure you are on a jetpack site with the highest plan.
2. Go to `/marketing/traffic/:site`.
3. Ensure that analytics debugging is activated by running this in the browser console: `localStorage.setItem('debug', 'calypso:analytics:*');`
4. For each of the following toggles, toggle them and observe in the console that a `calypso_settings_autosaving_toggle_updated` event is logged with the correct name, path, and blog ID:

- "Display an additional ad at the top of each page"
- "Show related content after posts"
- "Show a "Related" header to more clearly separate the related section from posts"
- "Show a thumbnail image where available"