### PR TITLE
JP Features: Remove Site Security, Spam Filtering, Automatic Updates Cards

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -220,7 +220,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
-				<JetpackAntiSpam selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackAntiSpam selectedSite={ selectedSite } /> }
 				<JetpackVideo selectedSite={ selectedSite } />
 				<JetpackWordPressCom selectedSite={ selectedSite } />
 				<MonetizeSite selectedSite={ selectedSite } />
@@ -260,7 +260,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
-				<JetpackAntiSpam selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackAntiSpam selectedSite={ selectedSite } /> }
 				<JetpackWordPressCom selectedSite={ selectedSite } />
 				<SiteActivity />
 				<MobileApps />
@@ -290,7 +290,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
-				<JetpackAntiSpam selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackAntiSpam selectedSite={ selectedSite } /> }
 				<JetpackSearch selectedSite={ selectedSite } />
 				<SiteActivity />
 				<JetpackVideo selectedSite={ selectedSite } />

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -216,7 +216,7 @@ export class ProductPurchaseFeaturesList extends Component {
 		} = this.props;
 		return (
 			<Fragment>
-				<JetpackBackupSecurity />
+				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackBackupSecurity /> }
 				{ supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
@@ -256,7 +256,7 @@ export class ProductPurchaseFeaturesList extends Component {
 
 		return (
 			<Fragment>
-				<JetpackBackupSecurity />
+				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackBackupSecurity /> }
 				{ supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
@@ -286,7 +286,7 @@ export class ProductPurchaseFeaturesList extends Component {
 		} = this.props;
 		return (
 			<Fragment>
-				<JetpackBackupSecurity />
+				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackBackupSecurity /> }
 				{ supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -187,7 +187,9 @@ export class ProductPurchaseFeaturesList extends Component {
 		} = this.props;
 		return (
 			<Fragment>
-				<JetpackWordPressCom selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist' ) && (
+					<JetpackWordPressCom selectedSite={ selectedSite } />
+				) }
 				{ supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
@@ -222,7 +224,9 @@ export class ProductPurchaseFeaturesList extends Component {
 				) }
 				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackAntiSpam selectedSite={ selectedSite } /> }
 				<JetpackVideo selectedSite={ selectedSite } />
-				<JetpackWordPressCom selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist' ) && (
+					<JetpackWordPressCom selectedSite={ selectedSite } />
+				) }
 				<MonetizeSite selectedSite={ selectedSite } />
 				<SiteActivity />
 				<JetpackPublicize selectedSite={ selectedSite } />
@@ -261,7 +265,9 @@ export class ProductPurchaseFeaturesList extends Component {
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
 				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackAntiSpam selectedSite={ selectedSite } /> }
-				<JetpackWordPressCom selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist' ) && (
+					<JetpackWordPressCom selectedSite={ selectedSite } />
+				) }
 				<SiteActivity />
 				<MobileApps />
 				<JetpackReturnToDashboard
@@ -294,7 +300,9 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackSearch selectedSite={ selectedSite } />
 				<SiteActivity />
 				<JetpackVideo selectedSite={ selectedSite } />
-				<JetpackWordPressCom selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist' ) && (
+					<JetpackWordPressCom selectedSite={ selectedSite } />
+				) }
 				<MonetizeSite selectedSite={ selectedSite } />
 				<MobileApps />
 				<JetpackPublicize selectedSite={ selectedSite } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Spun off #32649. Rather than removing these cards, we need to feature-flag them with `! isEnabled( 'jetpack/checklist' )`, since the Jetpack checklist isn't in production yet -- so we shouldn't remove the cards for everyone, but only for those users that get the checklist.

#### Testing instructions

- Run this Calypso branch locally
- Create a new [`jurassic.ninja`](https://jurassic.ninja/) site
- Connect it to WP.com: Use the Connect button's link target and append `&calypso_env=development`
- Pick a paid plan (ideally, try each plan once)
- Verify that the cards listed in this PR's title have been removed.

Now apply the following patch, restart Calypso, and run through the instructions above again. Verify that the cards are still present in this case:

```diff
diff --git a/config/development.json b/config/development.json
index dd783038c9..b79024d208 100644
--- a/config/development.json
+++ b/config/development.json
@@ -76,7 +76,7 @@
                "i18n/community-translator": false,
                "jetpack/api-cache": true,
                "jetpack/blocks/beta": true,
-               "jetpack/checklist": true,
+               "jetpack/checklist": false,
                "jetpack/connect-redirect-pressable-credential-approval": true,
                "jetpack/connect/remote-install": true,
                "jetpack/connect/mobile-app-flow": true,
```