### PR TITLE
Jetpack Features: Feature-flag Concierge Card

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -228,10 +228,12 @@ export class ProductPurchaseFeaturesList extends Component {
 				<JetpackPublicize selectedSite={ selectedSite } />
 				<MobileApps />
 				<SellOnlinePaypal isJetpack />
-				<BusinessOnboarding
-					onClick={ this.props.recordBusinessOnboardingClick }
-					link="https://calendly.com/jetpack/concierge"
-				/>
+				{ isEnabled( 'jetpack/concierge-sessions' ) && (
+					<BusinessOnboarding
+						onClick={ this.props.recordBusinessOnboardingClick }
+						link="https://calendly.com/jetpack/concierge"
+					/>
+				) }
 
 				<JetpackReturnToDashboard
 					onClick={ recordReturnToDashboardClick }
@@ -303,10 +305,12 @@ export class ProductPurchaseFeaturesList extends Component {
 				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<FindNewTheme selectedSite={ selectedSite } />
 
-				<BusinessOnboarding
-					onClick={ this.props.recordBusinessOnboardingClick }
-					link="https://calendly.com/jetpack/concierge"
-				/>
+				{ isEnabled( 'jetpack/concierge-sessions' ) && (
+					<BusinessOnboarding
+						onClick={ this.props.recordBusinessOnboardingClick }
+						link="https://calendly.com/jetpack/concierge"
+					/>
+				) }
 				<JetpackReturnToDashboard
 					onClick={ recordReturnToDashboardClick }
 					selectedSite={ selectedSite }

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -51,6 +51,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/api-cache": true,
+		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connection-rebranding": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -39,6 +39,7 @@
 		"gutenberg/opt-in": true,
 		"help": true,
 		"help/courses": true,
+		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/personalPlan": true,
 		"jitms": false,

--- a/config/development.json
+++ b/config/development.json
@@ -77,6 +77,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/checklist": true,
+		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -43,6 +43,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/api-cache": true,
+		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
 		"jetpack/gutenframe": true,

--- a/config/production.json
+++ b/config/production.json
@@ -42,6 +42,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/api-cache": false,
+		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,6 +45,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
+		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,

--- a/config/test.json
+++ b/config/test.json
@@ -46,6 +46,7 @@
 		"gutenberg/opt-in": true,
 		"help": true,
 		"jetpack/checklist": true,
+		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,
 		"jitms": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -57,6 +57,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/checklist": true,
+		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Spun off #32649. Rather than removing the card, we feature-flag it with `isEnabled( 'jetpack/concierge-sessions' )`, so we can easily turn it back on again when Concierge sessions are back.

#### Testing instructions

- Run this Calypso branch locally
- Create a new [`jurassic.ninja`](https://jurassic.ninja/) site
- Connect it to WP.com: Use the Connect button's link target and append `&calypso_env=development`
- Pick a paid plan (ideally, try each plan once)
- Verify that the Concierge Card has been removed.

The Concierge Card is still displayed for WP.com Business plans! Verify that by buying that plan for a WP.com site, and checking the Thank You page.