### PR TITLE
Marketing/Traffic: Added path property to the SEO Settings Tracks events

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -25,9 +25,9 @@ import CountedTextarea from 'components/forms/counted-textarea';
 import Banner from 'components/banner';
 import {
 	getSeoTitleFormatsForSite,
+	getSiteSlug,
 	isJetpackSite,
 	isRequestingSite,
-	getSiteSlug,
 } from 'state/sites/selectors';
 import {
 	isSiteSettingsSaveSuccessful,
@@ -229,16 +229,21 @@ export class SeoForm extends React.Component {
 
 	trackSubmission = () => {
 		const { dirtyFields } = this.state;
-		const { trackFormSubmitted, trackTitleFormatsUpdated, trackFrontPageMetaUpdated } = this.props;
+		const {
+			path,
+			trackFormSubmitted,
+			trackTitleFormatsUpdated,
+			trackFrontPageMetaUpdated,
+		} = this.props;
 
-		trackFormSubmitted( { path: this.props.path } );
+		trackFormSubmitted( { path } );
 
 		if ( dirtyFields.has( 'seoTitleFormats' ) ) {
-			trackTitleFormatsUpdated( { path: this.props.path } );
+			trackTitleFormatsUpdated( { path } );
 		}
 
 		if ( dirtyFields.has( 'frontPageMetaDescription' ) ) {
-			trackFrontPageMetaUpdated( { path: this.props.path } );
+			trackFrontPageMetaUpdated( { path } );
 		}
 	};
 

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -23,12 +23,18 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import Banner from 'components/banner';
-import { getSeoTitleFormatsForSite, isJetpackSite, isRequestingSite } from 'state/sites/selectors';
+import {
+	getSeoTitleFormatsForSite,
+	isJetpackSite,
+	isRequestingSite,
+	getSiteSlug,
+} from 'state/sites/selectors';
 import {
 	isSiteSettingsSaveSuccessful,
 	getSiteSettingsSaveError,
 } from 'state/site-settings/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import getCurrentRoute from 'state/selectors/get-current-route';
 import isHiddenSite from 'state/selectors/is-hidden-site';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'state/selectors/is-private-site';
@@ -225,14 +231,14 @@ export class SeoForm extends React.Component {
 		const { dirtyFields } = this.state;
 		const { trackFormSubmitted, trackTitleFormatsUpdated, trackFrontPageMetaUpdated } = this.props;
 
-		trackFormSubmitted();
+		trackFormSubmitted( { path: this.props.path } );
 
 		if ( dirtyFields.has( 'seoTitleFormats' ) ) {
-			trackTitleFormatsUpdated();
+			trackTitleFormatsUpdated( { path: this.props.path } );
 		}
 
 		if ( dirtyFields.has( 'frontPageMetaDescription' ) ) {
-			trackFrontPageMetaUpdated();
+			trackFrontPageMetaUpdated( { path: this.props.path } );
 		}
 	};
 
@@ -473,6 +479,9 @@ const mapStateToProps = state => {
 		hasSeoPreviewFeature: hasFeature( state, siteId, FEATURE_SEO_PREVIEW_TOOLS ),
 		isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),
 		saveError: getSiteSettingsSaveError( state, siteId ),
+		path: getCurrentRoute( state )
+			.replace( getSiteSlug( state, siteId ), ':site' )
+			.replace( siteId, ':siteid' ),
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The SEO Settings on the Traffic page already log events `calypso_seo_settings_form_submit`, `calypso_seo_tools_title_formats_updated`, and `calypso_seo_tools_front_page_meta_updated`. However, the `path` property was not being passed and so `blog_id` and related properties were not set on the Tracks event.

This fixes that by passing a `path` property.

#### Testing instructions

1. Check out the branch and `npm run start`.
2. Execute `localStorage.setItem('debug', 'calypso:analytics:*');` in the browser console to see tracks debugging events.
3. Pick a site with a business plan or higher.
4. Go to `http://calypso.localhost:3000/marketing/traffic/:site`.
5. Edit items under "Page Title structure" and "Website Meta", then click "Save Settings".
6. Assert in the console that these events are fired with `path` and `blog_id` set: `calypso_seo_settings_form_submit`, `calypso_seo_tools_title_formats_updated`, and `calypso_seo_tools_front_page_meta_updated`.
