### PR TITLE
Sites: Revert to v1.2 for the `/me/sites` and `sites/:site` API calls.

### DIFF
--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -83,7 +83,7 @@ export function requestSites() {
 		return wpcom
 			.me()
 			.sites( {
-				apiVersion: '1.3',
+				apiVersion: '1.2',
 				site_visibility: 'all',
 				include_domain_only: true,
 				site_activity: 'active',
@@ -122,7 +122,7 @@ export function requestSite( siteFragment ) {
 		return wpcom
 			.site( siteFragment )
 			.get( {
-				apiVersion: '1.3',
+				apiVersion: '1.2',
 			} )
 			.then( site => {
 				// If we can't manage the site, don't add it to state.


### PR DESCRIPTION

Revert to v1.2 for the `/me/sites` and `sites/:site` API calls.