### PR TITLE
Reader: Offer Option to Return to Followed Sites

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -16,7 +16,7 @@ import { stringify } from 'qs';
 import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
 import SearchInput from 'components/search';
-import HeaderBack from 'reader/header-back';
+import HeaderCake from 'components/header-cake';
 import ReaderMain from 'reader/components/reader-main';
 import getBlockedSites from 'state/selectors/get-blocked-sites';
 import getDismissedSites from 'state/selectors/get-dismissed-sites';
@@ -212,8 +212,10 @@ class FollowingManage extends Component {
 				<MobileBackToSidebar>
 					<h1>{ translate( 'Streams' ) }</h1>
 				</MobileBackToSidebar>
-				<div class="following-manage__back">
-					<HeaderBack/>
+				<div className="following-manage__back">
+					<HeaderCake backHref={ '/' }>
+						<h1>{ translate( 'Follow Something New' ) }</h1>
+					</HeaderCake>
 				</div>
 				{ ! searchResults && sitesQuery && (
 					<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } />
@@ -224,7 +226,6 @@ class FollowingManage extends Component {
 						offset={ recommendedSitesPagingOffset + PAGE_SIZE || 0 }
 					/>
 				) }
-				<h2 className="following-manage__header">{ translate( 'Follow Something New' ) }</h2>
 				<div ref={ this.handleStreamMounted } />
 				<div className="following-manage__fixed-area" ref={ this.handleSearchBoxMounted }>
 					<CompactCard className="following-manage__input-card">

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -215,9 +215,6 @@ class FollowingManage extends Component {
 				</div>
 				<ReaderMain className="following-manage">
 					<DocumentHead title={ 'Manage Following' } />
-					<MobileBackToSidebar>
-						<h1>{ translate( 'Streams' ) }</h1>
-					</MobileBackToSidebar>
 					{ ! searchResults && sitesQuery && (
 						<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } />
 					) }

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -212,7 +212,7 @@ class FollowingManage extends Component {
 				<MobileBackToSidebar>
 					<h1>{ translate( 'Streams' ) }</h1>
 				</MobileBackToSidebar>
-				<div className="following-manage__back">
+				<div className="following-manage__header">
 					<HeaderCake backHref={ '/' }>
 						<h1>{ translate( 'Follow Something New' ) }</h1>
 					</HeaderCake>

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -16,6 +16,7 @@ import { stringify } from 'qs';
 import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
 import SearchInput from 'components/search';
+import HeaderBack from 'reader/header-back';
 import ReaderMain from 'reader/components/reader-main';
 import getBlockedSites from 'state/selectors/get-blocked-sites';
 import getDismissedSites from 'state/selectors/get-dismissed-sites';
@@ -211,6 +212,9 @@ class FollowingManage extends Component {
 				<MobileBackToSidebar>
 					<h1>{ translate( 'Streams' ) }</h1>
 				</MobileBackToSidebar>
+				<div class="following-manage__back">
+					<HeaderBack/>
+				</div>
 				{ ! searchResults && sitesQuery && (
 					<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } />
 				) }

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External Dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { trim, debounce, random, take, reject, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
@@ -207,84 +207,86 @@ class FollowingManage extends Component {
 
 		/* eslint-disable jsx-a11y/no-autofocus */
 		return (
-			<ReaderMain className="following-manage">
-				<DocumentHead title={ 'Manage Following' } />
-				<MobileBackToSidebar>
-					<h1>{ translate( 'Streams' ) }</h1>
-				</MobileBackToSidebar>
+			<Fragment>
 				<div className="following-manage__header">
 					<HeaderCake backHref={ '/' }>
 						<h1>{ translate( 'Follow Something New' ) }</h1>
 					</HeaderCake>
 				</div>
-				{ ! searchResults && sitesQuery && (
-					<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } />
-				) }
-				{ this.shouldRequestMoreRecs() && (
-					<QueryReaderRecommendedSites
-						seed={ recommendationsSeed }
-						offset={ recommendedSitesPagingOffset + PAGE_SIZE || 0 }
-					/>
-				) }
-				<div ref={ this.handleStreamMounted } />
-				<div className="following-manage__fixed-area" ref={ this.handleSearchBoxMounted }>
-					<CompactCard className="following-manage__input-card">
-						<SearchInput
-							onSearch={ this.updateQuery }
-							onSearchClose={ this.handleSearchClosed }
-							autoFocus={ this.props.autoFocusInput }
-							delaySearch={ true }
-							delayTimeout={ 500 }
-							placeholder={ searchPlaceholderText }
-							additionalClasses="following-manage__search-new"
-							initialValue={ sitesQuery }
-							value={ sitesQuery }
-							maxLength={ 500 }
-							disableAutocorrect={ true }
-						/>
-					</CompactCard>
-
-					{ showFollowByUrl && (
-						<div className="following-manage__url-follow">
-							<FollowButton
-								followLabel={ translate( 'Follow %s', {
-									args: sitesQueryWithoutProtocol,
-								} ) }
-								followingLabel={ translate( 'Following %s', {
-									args: sitesQueryWithoutProtocol,
-								} ) }
-								siteUrl={ addSchemeIfMissing( readerAliasedFollowFeedUrl, 'http' ) }
-								followSource={ READER_FOLLOWING_MANAGE_URL_INPUT }
-							/>
-						</div>
+				<ReaderMain className="following-manage">
+					<DocumentHead title={ 'Manage Following' } />
+					<MobileBackToSidebar>
+						<h1>{ translate( 'Streams' ) }</h1>
+					</MobileBackToSidebar>
+					{ ! searchResults && sitesQuery && (
+						<QueryReaderFeedsSearch query={ sitesQuery } excludeFollowed={ true } />
 					) }
-				</div>
-				{ ! sitesQuery && (
-					<RecommendedSites
-						sites={ take( filteredRecommendedSites, 2 ) }
-						followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
-					/>
-				) }
-				{ !! sitesQuery && ! isFollowByUrlWithNoSearchResults && (
-					<FollowingManageSearchFeedsResults
-						searchResults={ searchResults }
-						showMoreResults={ showMoreResults }
-						onShowMoreResultsClicked={ this.handleShowMoreClicked }
-						width={ this.state.width }
-						searchResultsCount={ searchResultsCount }
-						query={ sitesQuery }
-					/>
-				) }
-				{ showExistingSubscriptions && (
-					<FollowingManageSubscriptions
-						width={ this.state.width }
-						query={ subsQuery }
-						sortOrder={ subsSortOrder }
-						windowScrollerRef={ this.handleWindowScrollerMounted }
-					/>
-				) }
-				{ ! hasFollows && <FollowingManageEmptyContent /> }
-			</ReaderMain>
+					{ this.shouldRequestMoreRecs() && (
+						<QueryReaderRecommendedSites
+							seed={ recommendationsSeed }
+							offset={ recommendedSitesPagingOffset + PAGE_SIZE || 0 }
+						/>
+					) }
+					<div ref={ this.handleStreamMounted } />
+					<div className="following-manage__fixed-area" ref={ this.handleSearchBoxMounted }>
+						<CompactCard className="following-manage__input-card">
+							<SearchInput
+								onSearch={ this.updateQuery }
+								onSearchClose={ this.handleSearchClosed }
+								autoFocus={ this.props.autoFocusInput }
+								delaySearch={ true }
+								delayTimeout={ 500 }
+								placeholder={ searchPlaceholderText }
+								additionalClasses="following-manage__search-new"
+								initialValue={ sitesQuery }
+								value={ sitesQuery }
+								maxLength={ 500 }
+								disableAutocorrect={ true }
+							/>
+						</CompactCard>
+
+						{ showFollowByUrl && (
+							<div className="following-manage__url-follow">
+								<FollowButton
+									followLabel={ translate( 'Follow %s', {
+										args: sitesQueryWithoutProtocol,
+									} ) }
+									followingLabel={ translate( 'Following %s', {
+										args: sitesQueryWithoutProtocol,
+									} ) }
+									siteUrl={ addSchemeIfMissing( readerAliasedFollowFeedUrl, 'http' ) }
+									followSource={ READER_FOLLOWING_MANAGE_URL_INPUT }
+								/>
+							</div>
+						) }
+					</div>
+					{ ! sitesQuery && (
+						<RecommendedSites
+							sites={ take( filteredRecommendedSites, 2 ) }
+							followSource={ READER_FOLLOWING_MANAGE_RECOMMENDATION }
+						/>
+					) }
+					{ !! sitesQuery && ! isFollowByUrlWithNoSearchResults && (
+						<FollowingManageSearchFeedsResults
+							searchResults={ searchResults }
+							showMoreResults={ showMoreResults }
+							onShowMoreResultsClicked={ this.handleShowMoreClicked }
+							width={ this.state.width }
+							searchResultsCount={ searchResultsCount }
+							query={ sitesQuery }
+						/>
+					) }
+					{ showExistingSubscriptions && (
+						<FollowingManageSubscriptions
+							width={ this.state.width }
+							query={ subsQuery }
+							sortOrder={ subsSortOrder }
+							windowScrollerRef={ this.handleWindowScrollerMounted }
+						/>
+					) }
+					{ ! hasFollows && <FollowingManageEmptyContent /> }
+				</ReaderMain>
+			</Fragment>
 		);
 		/* eslint-enable jsx-a11y/no-autofocus */
 	}

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -32,7 +32,6 @@ import RecommendedSites from 'blocks/reader-recommended-sites';
 import FollowingManageSubscriptions from './subscriptions';
 import FollowingManageSearchFeedsResults from './feed-search-results';
 import FollowingManageEmptyContent from './empty';
-import MobileBackToSidebar from 'components/mobile-back-to-sidebar';
 import FollowButton from 'reader/follow-button';
 import {
 	READER_FOLLOWING_MANAGE_URL_INPUT,

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -1,5 +1,4 @@
 .following-manage__header .card {
-		border: none;
 		box-shadow: none;
 		margin: 0;
 }

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -1,16 +1,6 @@
-.following-manage__header {
-	font-weight: 600;
-	margin: 0 0 14px 14px;
-
-	@include breakpoint( '>660px' ) {
-		margin: 0 0 26px;
-	}
-}
-
-.following-manage__back .card {
+.following-manage__header .card {
 		border: none;
 		box-shadow: none;
-		padding-left: 2px;
 		margin: 0;
 }
 

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -1,10 +1,17 @@
 .following-manage__header {
 	font-weight: 600;
-	margin: 14px 0 14px 14px;
+	margin: 0 0 14px 14px;
 
 	@include breakpoint( '>660px' ) {
-		margin: 36px 0 20px;
+		margin: 0 0 26px;
 	}
+}
+
+.following-manage__back .card {
+		border: none;
+		box-shadow: none;
+		padding-left: 2px;
+		margin: 0;
 }
 
 .following-manage .search {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds an option to return to the Reader from the Manage Following page.

**Desktop:**
<img width="1514" alt="Screenshot 2019-05-03 at 16 57 14" src="https://user-images.githubusercontent.com/43215253/57149911-bb9a9b00-6dc4-11e9-99c3-d3ceef67e8f9.png">

**Mobile:**
<img width="291" alt="Screenshot 2019-05-03 at 16 57 28" src="https://user-images.githubusercontent.com/43215253/57149912-bc333180-6dc4-11e9-9821-58706aab7382.png">

#### Testing instructions

Visit the reader and click the "Manage Following" button. Now try and click the "Back" button. 

Fixes #32640
