### PR TITLE
Marketing/Traffic: added Tracks events to site stats toggle groups

### DIFF
--- a/client/my-sites/site-settings/jetpack-site-stats.jsx
+++ b/client/my-sites/site-settings/jetpack-site-stats.jsx
@@ -26,11 +26,10 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteRoles } from 'state/site-roles/selectors';
 import { getStatsPathForTab } from 'lib/route';
 import { recordTracksEvent } from 'state/analytics/actions';
-import getCurrentRoute from 'state/selectors/get-current-route';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isJetpackModuleUnavailableInDevelopmentMode from 'state/selectors/is-jetpack-module-unavailable-in-development-mode';
 import isJetpackSiteInDevelopmentMode from 'state/selectors/is-jetpack-site-in-development-mode';
-import { getSiteSlug } from 'state/sites/selectors';
 
 class JetpackSiteStats extends Component {
 	static defaultProps = {
@@ -199,9 +198,7 @@ export default connect(
 			siteId,
 			'stats'
 		);
-		const path = getCurrentRoute( state )
-			.replace( getSiteSlug( state, siteId ), ':site' )
-			.replace( siteId, ':siteid' );
+		const path = getCurrentRouteParameterized( state, siteId );
 
 		return {
 			siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On the site stats settings components there are some toggle button groups that were not logging Tracks events because their `onChange` callback was overridden, and only the default callback was logging Tracks events.

This updates the `onChange` callback to fire tracks events for these group toggles.

#### Testing instructions

1. Make sure you are on a jetpack site with the highest plan.
2. Ensure that analytics debugging is activated by running this in the browser console: `localStorage.setItem('debug', 'calypso:analytics:*');`
2. Go to `/marketing/traffic/:site`.
3. On the "Site stats" section, expand the box by clicking the arrow on the right side.
4. Toggle some of the toggles under "Count logged in page views from
" and "Allow stats reports to be viewed by".
5. In the console, verify that a Tracks event is fired each time you toggle with the correct `path`, `blog_id`, `group`, and `field` properties.
