### PR TITLE
Checklist: Bypass inline help for "Edit About text" item

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -784,8 +784,10 @@ class WpcomChecklistComponent extends PureComponent {
 					},
 				] }
 				duration={ translate( '%d minute', '%d minutes', { count: 5, args: [ 5 ] } ) }
-				targetUrl={ taskUrls[ task.id ] }
-				onClick={ this.handleInlineHelpStart( task ) }
+				onClick={ this.handleTaskStart( {
+					task,
+					url: taskUrls[ task.id ],
+				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }


### PR DESCRIPTION
I wasn't able to reproduce the loop in #32726, however, the inline help dialog being shown before the redirect is (IMO) undesirable.

It also looks like we haven't been collecting the `calypso_checklist_task_start` event on this item (verifying now).  This will rectify that if so.

#### Changes proposed in this Pull Request

* Call `handleTaskStart` instead of `handleInlineHelpStart`
* Remove `targetUrl` prop as the redirect is done by `handleTaskStart`

#### Testing instructions

* Create a new site at wordpress.com/start/onboarding
* After Signup, you should be redirected to the Checklist (wordpress.com/checklist/{site})
* Click "Edit About Text" to go to the block editor
  * You should **NOT** see an inline help dialog pop up
* Click back button to leave the editor without completing the task
* Navigate back to the Checklist (wordpress.com/checklist/{site})
* Click "Edit About Text" to go to the block editor
  * The window should **NOT** redirect a number of times while loading the block editor
* A `calypso_checklist_task_start` event should be recorded for the interaction


Fixes #32726
