### PR TITLE
Themes: Fix theme showcase banners

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -183,6 +183,7 @@ $z-layers: (
 		'.upwork-stats-nudge__close-icon': 1,
 		'.gsuite-stats-nudge__close-icon': 1,
 		'.people-list-item.card.is-compact:focus': 1,
+		'.themes-banner__close': 1,
 	),
 	'.is-section-signup': (
 		'.is-section-signup::before': -1,

--- a/client/my-sites/themes/themes-banner/index.jsx
+++ b/client/my-sites/themes/themes-banner/index.jsx
@@ -79,18 +79,7 @@ class ThemesBanner extends PureComponent {
 		}
 		const backgroundStyle = backgroundColor ? { backgroundColor } : {};
 		return (
-			<a
-				className="themes-banner"
-				role="button"
-				style={ backgroundStyle }
-				onClick={ this.recordEvent }
-				href={ themeUrl }
-			>
-				<h1 className="themes-banner__title">{ title }</h1>
-				<p className="themes-banner__description">{ description }</p>
-				<Button className="themes-banner__cta" compact primary>
-					{ translate( 'See the theme' ) }
-				</Button>
+			<div className="themes-banner" style={ backgroundStyle }>
 				<Button
 					className="themes-banner__close"
 					onClick={ this.handleBannerClose }
@@ -100,18 +89,25 @@ class ThemesBanner extends PureComponent {
 				>
 					<Gridicon icon="cross-small" size={ 18 } />
 				</Button>
-				{ image && (
-					<img
-						alt={ translate( '%(themeName)s Theme', {
-							args: { themeName },
-						} ) }
-						width={ imageWidth }
-						className="themes-banner__image"
-						src={ safeImageUrl( image ) }
-						style={ { transform: imageTransform } }
-					/>
-				) }
-			</a>
+				<a role="button" onClick={ this.recordEvent } href={ themeUrl }>
+					<h1 className="themes-banner__title">{ title }</h1>
+					<p className="themes-banner__description">{ description }</p>
+					<Button className="themes-banner__cta" compact primary>
+						{ translate( 'See the theme' ) }
+					</Button>
+					{ image && (
+						<img
+							alt={ translate( '%(themeName)s Theme', {
+								args: { themeName },
+							} ) }
+							width={ imageWidth }
+							className="themes-banner__image"
+							src={ safeImageUrl( image ) }
+							style={ { transform: imageTransform } }
+						/>
+					) }
+				</a>
+			</div>
 		);
 	}
 }

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -2,7 +2,7 @@
 	background: no-repeat var( --color-accent );
 	display: none;
 	overflow: hidden;
-	padding: 0.8em 325px 0.8em 0.8em;
+	padding: 0.8em 30vw 0.8em 0.8em;
 	position: relative;
 	user-select: none;
 	$image_max_width: 410px;
@@ -33,6 +33,7 @@
 	.button.themes-banner__cta {
 		color: inherit;
 		position: relative;
+		z-index: 1;
 	}
 
 	h1 {
@@ -51,7 +52,6 @@
 	p {
 		margin: 0;
 		text-shadow: 0 1px 1px rgba( black, 0.4 );
-		z-index: 1;
 	}
 
 	img {
@@ -62,11 +62,8 @@
 		top: 0;
 		right: 0;
 		user-select: none;
+		width: 35vw;
 		z-index: 0;
-
-		@include breakpoint( '<1400px' ) {
-			opacity: 0.5;
-		}
 	}
 
 	.button.themes-banner__cta {

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -2,28 +2,29 @@
 	background: no-repeat var( --color-accent );
 	display: none;
 	overflow: hidden;
-	padding: 0.8em 30vw 0.8em 0.8em;
 	position: relative;
 	user-select: none;
 
-	&::before {
-		background: rgba( black, 0.13 );
-		content: '\020';
-		display: block;
-		height: 100%;
-		position: absolute;
-			top: 0;
-			left: 0;
-		width: 100%;
-	}
-
 	a {
-		color: white !important;
+		color: #fff;
+		display: block;
+		padding: 0.8em 30vw 0.8em 0.8em;
+
+		&::before {
+			background: rgba( 0, 0, 0, 0.13 );
+			content: '\020';
+			display: block;
+			height: 100%;
+			position: absolute;
+				top: 0;
+				left: 0;
+			width: 100%;
+		}
 
 		&:hover,
 		&:focus,
 		&:visited {
-			color: white !important;
+			color: #fff;
 		}
 	}
 
@@ -41,7 +42,7 @@
 		letter-spacing: 0.01em;
 		margin: -0.1em 0;
 		line-height: 1.3;
-		text-shadow: 0 1px 1px rgba( black, 0.5 );
+		text-shadow: 0 1px 1px rgba( 0, 0, 0, 0.5 );
 
 		+ p {
 			margin-top: 0.6em;
@@ -50,7 +51,7 @@
 
 	p {
 		margin: 0;
-		text-shadow: 0 1px 1px rgba( black, 0.4 );
+		text-shadow: 0 1px 1px rgba( 0, 0, 0, 0.4 );
 	}
 
 	img {
@@ -71,7 +72,7 @@
 
 	.button.themes-banner__close {
 		display: block;
-		background: rgba( white, 0.66 );
+		background: rgba( 255, 255, 255, 0.66 );
 		border: none;
 		border-radius: 0;
 		line-height: 0.9;
@@ -83,7 +84,7 @@
 		z-index: 1;
 
 		&:hover {
-			background: rgba( white, 0.8 );
+			background: rgba( 255, 255, 255, 0.8 );
 			cursor: pointer;
 		}
 

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -5,7 +5,6 @@
 	padding: 0.8em 30vw 0.8em 0.8em;
 	position: relative;
 	user-select: none;
-	$image_max_width: 540px;
 
 	&::before {
 		background: rgba( black, 0.13 );
@@ -56,7 +55,7 @@
 
 	img {
 		transform-origin: top right;
-		max-width: $image_max_width;
+		max-width: 540px;
 		transition: opacity 400ms ease-in-out;
 		position: absolute;
 		top: 0;

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -1,18 +1,11 @@
 .themes-banner {
 	background: no-repeat var( --color-accent );
-	color: white !important;
 	display: none;
 	overflow: hidden;
 	padding: 0.8em;
 	position: relative;
 	user-select: none;
 	$image_max_width: 410px;
-
-	&:hover,
-	&:focus,
-	&:visited {
-		color: white !important;
-	}
 
 	&::before {
 		background: rgba( black, 0.13 );
@@ -23,6 +16,16 @@
 			top: 0;
 			left: 0;
 		width: 100%;
+	}
+
+	a {
+		color: white !important;
+
+		&:hover,
+		&:focus,
+		&:visited {
+			color: white !important;
+		}
 	}
 
 	h1,
@@ -79,8 +82,10 @@
 		right: 0;
 		top: 0;
 		width: 1.7em;
+		z-index: 1;
 
 		&:hover {
+			background: rgba( white, 0.8 );
 			cursor: pointer;
 		}
 

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -5,7 +5,7 @@
 	padding: 0.8em 30vw 0.8em 0.8em;
 	position: relative;
 	user-select: none;
-	$image_max_width: 410px;
+	$image_max_width: 540px;
 
 	&::before {
 		background: rgba( black, 0.13 );

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -2,7 +2,7 @@
 	background: no-repeat var( --color-accent );
 	display: none;
 	overflow: hidden;
-	padding: 0.8em;
+	padding: 0.8em 325px 0.8em 0.8em;
 	position: relative;
 	user-select: none;
 	$image_max_width: 410px;
@@ -51,6 +51,7 @@
 	p {
 		margin: 0;
 		text-shadow: 0 1px 1px rgba( black, 0.4 );
+		z-index: 1;
 	}
 
 	img {
@@ -61,6 +62,7 @@
 		top: 0;
 		right: 0;
 		user-select: none;
+		z-index: 0;
 
 		@include breakpoint( '<1400px' ) {
 			opacity: 0.5;

--- a/client/my-sites/themes/themes-banner/style.scss
+++ b/client/my-sites/themes/themes-banner/style.scss
@@ -81,7 +81,7 @@
 		right: 0;
 		top: 0;
 		width: 1.7em;
-		z-index: 1;
+		z-index: z-index( 'root', '.themes-banner__close' );
 
 		&:hover {
 			background: rgba( 255, 255, 255, 0.8 );


### PR DESCRIPTION
This PR fixes a few things related to the theme showcase banner code. Mostly fixes an issue where the close button wasn't accessible. There's also a visual problem, shown here:

![Screenshot_2019-05-02 WordPress Themes — WordPress com](https://user-images.githubusercontent.com/4297811/57110244-8bbf9a80-6cd3-11e9-92d3-93d2cd51f7b0.png)

The changes in this PR look like this:

![Screenshot_2019-05-02 WordPress Themes ‹ Chris' Awesomesauce Sandbox (Site Title) — WordPress com FIXED green](https://user-images.githubusercontent.com/4297811/57110324-e953e700-6cd3-11e9-99e3-7dce62ba46f1.png)

#### Changes proposed in this Pull Request

* Re-arrange the theme banner elements so the close button isn't being overridden by the link element. Fixes #32739
* CSS changes to accommodate the markup changes
* Fixed a `z-index` issue where the image sat above the banner copy
* Also made the banner work responsively, so the text never sits on top of the image, improving readability.

#### Testing instructions

* Browse to Design > Themes
* Note that the banner text doesn't sit on top of the theme screenshot
* Check that the X button closes the banner