### PR TITLE
Reader: Recommended sites - move the dismiss action to the bottom of the card

### DIFF
--- a/client/blocks/reader-recommended-sites/index.jsx
+++ b/client/blocks/reader-recommended-sites/index.jsx
@@ -73,15 +73,6 @@ export class RecommendedSites extends React.PureComponent {
 								className="reader-recommended-sites__site-list-item"
 								key={ `site-rec-${ index }` }
 							>
-								<div className="reader-recommended-sites__recommended-site-dismiss">
-									<Button
-										borderless
-										title={ this.props.translate( 'Dismiss this recommendation' ) }
-										onClick={ partial( this.handleSiteDismiss, siteId, index ) }
-									>
-										<Gridicon icon="cross" size={ 18 } />
-									</Button>
-								</div>
 								<ConnectedSubscriptionListItem
 									siteId={ siteId }
 									railcar={ site.railcar }
@@ -90,6 +81,16 @@ export class RecommendedSites extends React.PureComponent {
 									followSource={ followSource }
 									onComponentMountWithNewRailcar={ recordRecommendationRender( index ) }
 								/>
+								<div className="reader-recommended-sites__recommended-site-dismiss">
+									<Button
+										compact
+										title={ this.props.translate( 'Dismiss this recommendation' ) }
+										onClick={ partial( this.handleSiteDismiss, siteId, index ) }
+									>
+										<Gridicon icon="cross" size={ 18 } />
+										<span>{ this.props.translate( 'Dismiss' ) }</span>
+									</Button>
+								</div>
 							</li>
 						);
 					} ) }

--- a/client/blocks/reader-recommended-sites/style.scss
+++ b/client/blocks/reader-recommended-sites/style.scss
@@ -9,12 +9,12 @@
 	font-size: 14px;
 	font-weight: 600;
 	letter-spacing: 0.01em;
-	margin: 13px 0 10px;
+	margin: 15px 0 10px;
 	position: relative;
 	text-transform: uppercase;
 
 	@include breakpoint( '>660px' ) {
-		margin: 13px 0 17px;
+		margin: 20px 0 15px;
 	}
 
 	.gridicon {
@@ -26,11 +26,12 @@
 .reader-recommended-sites__list {
 	display: flex;
 	flex-direction: column;
-	margin: 0 0 20px;
+	margin: 0;
 	padding: 0;
 
 	@include breakpoint( '>960px' ) {
 		flex-direction: row;
+		margin: 0 0 20px;
 	}
 }
 
@@ -38,13 +39,13 @@
 	display: flex;
 	flex: 1 1 0%;
 	flex-direction: row;
+	flex-wrap: wrap;
 	list-style-type: none;
+	margin-bottom: 20px;
 	width: 100%;
 
 	@include breakpoint( '>960px' ) {
-		align-items: flex-end;
-		flex-direction: column;
-		margin-top: -40px;
+		margin-bottom: 0;
 	}
 
 	> :last-child {
@@ -52,22 +53,11 @@
 	}
 
 	.reader-recommended-sites__recommended-site-dismiss {
-		width: 30px;
+
+		margin-left: 44px; 
 
 		@include breakpoint( '>960px' ) {
-			display: flex;
-			justify-content: flex-end;
-		}
-
-		.button {
-			padding: 0;
-
-			&.is-borderless .gridicon {
-				fill: var( --color-neutral-200 );
-				width: 14px;
-				height: 14px;
-				top: 0;
-			}
+			align-self: flex-end; 		
 		}
 
 		z-index: z-index( 'root', '.reader-recommended-sites__recommended-site-dismiss' );
@@ -75,9 +65,11 @@
 
 	.reader-subscription-list-item {
 		margin: 0;
+		padding: 0 0 15px;
 
 		@include breakpoint( '<960px' ) {
-			padding: 0 0 20px;
+			padding: 0 0 10px;
+			width: 100%;
 		}
 
 		.follow-button .follow-button__label {


### PR DESCRIPTION
**Changes proposed in this Pull Request:**
1. Move the dismiss action to the bottom of the card.
2. Change the style of the dismiss button - use compact button with a border, add "dismiss" text.

**Testing instructions**
1. Navigate to https://wordpress.com/following/manage
2. Check the "Recommended sites" section under the search bar.
Before:
![image](https://user-images.githubusercontent.com/4550351/57113540-617be480-6d88-11e9-9af7-e8dabd00cd59.png)
Note the dismiss action "x" in the top right corner, floating above the card content.

After:
![image](https://user-images.githubusercontent.com/4550351/57113573-7eb0b300-6d88-11e9-949b-b92900dba6ef.png)
Note the "Dismiss" button at the bottom of the card. I also increased the spacing between the search bar and "Recommended sites" title, as it felt a bit tight.
4. Do the same on mobile.
Before:
![image](https://user-images.githubusercontent.com/4550351/57113620-bd466d80-6d88-11e9-9acf-529f4d6ec7a0.png)

After:
![image](https://user-images.githubusercontent.com/4550351/57113642-d0f1d400-6d88-11e9-8fc7-522f6bf673f9.png)


See #32231
