### PR TITLE
Sidebar: WP Admin Jetpack link to My Plan

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -70,6 +70,7 @@ import {
 } from 'state/my-sites/sidebar/actions';
 import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
 import { canAccessEarnSection } from 'lib/ads/utils';
+import isVipSite from 'state/selectors/is-vip-site';
 
 /**
  * Module variables
@@ -661,7 +662,7 @@ export class MySitesSidebar extends Component {
 		}
 
 		const adminUrl =
-			this.props.isJetpack && ! this.props.isAtomicSite
+			this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip
 				? formatUrl(
 						Object.assign( parseUrl( site.options.admin_url ), {
 							query: { page: 'jetpack' },
@@ -690,13 +691,13 @@ export class MySitesSidebar extends Component {
 
 	// Check for cases where WP Admin links should appear, where we need support for legacy reasons (VIP, older users, testing).
 	useWPAdminFlows() {
-		const { site } = this.props;
+		const { isVip } = this.props;
 		const currentUser = this.props.currentUser;
 		const userRegisteredDate = new Date( currentUser.date );
 		const cutOffDate = new Date( '2015-09-07' );
 
 		// VIP sites should always show a WP Admin link regardless of the current user.
-		if ( site && site.is_vip ) {
+		if ( isVip ) {
 			return true;
 		}
 
@@ -956,6 +957,7 @@ function mapStateToProps( state ) {
 		isPreviewable: isSitePreviewable( state, selectedSiteId ),
 		isSharingEnabledOnJetpackSite,
 		isAtomicSite: !! isSiteAutomatedTransfer( state, selectedSiteId ),
+		isVip: isVipSite( state, selectedSiteId ),
 		siteId,
 		site,
 		siteSuffix: site ? '/' + site.slug : '',

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -691,13 +691,18 @@ export class MySitesSidebar extends Component {
 
 	// Check for cases where WP Admin links should appear, where we need support for legacy reasons (VIP, older users, testing).
 	useWPAdminFlows() {
-		const { isVip } = this.props;
+		const { isAtomicSite, isJetpack, isVip } = this.props;
 		const currentUser = this.props.currentUser;
 		const userRegisteredDate = new Date( currentUser.date );
 		const cutOffDate = new Date( '2015-09-07' );
 
 		// VIP sites should always show a WP Admin link regardless of the current user.
 		if ( isVip ) {
+			return true;
+		}
+
+		// Jetpack (not Atomic) sites should always show a WP Admin
+		if ( isJetpack && ! isAtomicSite ) {
 			return true;
 		}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -663,12 +663,11 @@ export class MySitesSidebar extends Component {
 
 		const adminUrl =
 			this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip
-				? formatUrl(
-						Object.assign( parseUrl( site.options.admin_url ), {
-							query: { page: 'jetpack' },
-							hash: '/my-plan',
-						} )
-				  )
+				? formatUrl( {
+						...parseUrl( site.options.admin_url ),
+						query: { page: 'jetpack' },
+						hash: '/my-plan',
+				  } )
 				: site.options.admin_url;
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace*/

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import page from 'page';
+import { format as formatUrl, parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -659,12 +660,21 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		const adminUrl = this.props.isAtomicSite
+			? site.options.admin_url
+			: formatUrl(
+					Object.assign( parseUrl( site.options.admin_url ), {
+						query: { page: 'jetpack' },
+						hash: '/my-plan',
+					} )
+			  );
+
 		/* eslint-disable wpcalypso/jsx-classname-namespace*/
 		return (
 			<li className="wp-admin">
 				<a
 					onClick={ this.trackWpadminClick }
-					href={ site.options.admin_url }
+					href={ adminUrl }
 					target="_blank"
 					rel="noopener noreferrer"
 				>

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -660,14 +660,15 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
-		const adminUrl = this.props.isAtomicSite
-			? site.options.admin_url
-			: formatUrl(
-					Object.assign( parseUrl( site.options.admin_url ), {
-						query: { page: 'jetpack' },
-						hash: '/my-plan',
-					} )
-			  );
+		const adminUrl =
+			this.props.isJetpack && ! this.props.isAtomicSite
+				? formatUrl(
+						Object.assign( parseUrl( site.options.admin_url ), {
+							query: { page: 'jetpack' },
+							hash: '/my-plan',
+						} )
+				  )
+				: site.options.admin_url;
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace*/
 		return (


### PR DESCRIPTION
Part of #32565

Change the WP Admin sidebar link to point to the Jetpack My Plan page for Jetpack sites.

## Questions

@jeffgolenski 

- Was the intention to change the WP Admin link _only_ from the My Plan page in Calypso? The change is currently for all Calypso routes.
- Users created after `2015-09-07` don't see the WP Admin link. Should we override that for Jetpack sites? I did that in 6bfc3f0 — _all users see WP Admin link for Jetpack (not atomic) sites_
- Should this be scoped to a certain permission? 🤷‍♂ I tried with a `contributor` and they just see a generic Jetpack dashboard. 
- ~Do we need a VIP site check?~ ✅ We did, I added it.

## Testing instructions

* Open the sidebar for a Jetpack site. The WP Admin link should point to the WP Admin Jetpack My Plan for the site.
* Verify that Atomic and Simple sites point to WP Admin (not a Jetpack route)
* Create a new user and verify that you see the WP Admin link for Jetpack sites (not Atomic sites) (and you wouldn't without this change).