### PR TITLE
Packages: Bump calypso-build version to 1.0.0-rc.2

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "1.0.0-rc.1",
+	"version": "1.0.0-rc.2",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"config",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Mostly to include #32601.

#### Testing instructions

Nothing to test really. Once I've released the new npm version, I'll test it with `newspack-blocks`.