### PR TITLE
Packages: Add file-loader dep to calypso-build

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -40,7 +40,8 @@
 				"caniuse-api": "3.0.0",
 				"css-loader": "2.1.1",
 				"duplicate-package-checker-webpack-plugin": "3.0.0",
-				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
+				"file-loader": "3.0.1",
+				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
 				"node-sass": "4.11.0",
 				"postcss-custom-properties": "8.0.9",
 				"postcss-loader": "3.0.0",
@@ -56,7 +57,8 @@
 			"dependencies": {
 				"@babel/core": {
 					"version": "7.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.0.tgz",
+					"integrity": "sha512-Dzl7U0/T69DFOTwqz/FJdnOSWS57NpjNfCwMKHABr589Lg8uX1RrlBIJ7L5Dubt/xkLsx0xH5EBFzlBVes1ayA==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
@@ -77,7 +79,8 @@
 				},
 				"@babel/plugin-transform-runtime": {
 					"version": "7.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.0.tgz",
+					"integrity": "sha512-1uv2h9wnRj98XX3g0l4q+O3jFM6HfayKup7aIu4pnnlzGz0H+cYckGBC74FZIWJXJSXAmeJ9Yu5Gg2RQpS4hWg==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.0.0",
@@ -88,7 +91,8 @@
 				},
 				"@babel/preset-env": {
 					"version": "7.4.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.4.2.tgz",
+					"integrity": "sha512-OEz6VOZaI9LW08CWVS3d9g/0jZA6YCn1gsKIy/fut7yZCJti5Lm1/Hi+uo/U+ODm7g4I6gULrCP+/+laT8xAsA==",
 					"dev": true,
 					"requires": {
 						"@babel/helper-module-imports": "^7.0.0",
@@ -140,7 +144,8 @@
 				},
 				"autoprefixer": {
 					"version": "9.4.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.4.tgz",
+					"integrity": "sha512-7tpjBadJyHKf+gOJEmKhZIksWxdZCSrnKbbTJNsw+/zX9+f//DLELRQPWjjjVoDbbWlCuNRkN7RfmZwDVgWMLw==",
 					"dev": true,
 					"requires": {
 						"browserslist": "^4.3.7",
@@ -153,12 +158,14 @@
 				},
 				"camelcase": {
 					"version": "5.3.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
@@ -170,7 +177,8 @@
 				},
 				"debug": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
@@ -178,7 +186,8 @@
 				},
 				"execa": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
@@ -192,7 +201,8 @@
 				},
 				"find-up": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
@@ -200,7 +210,8 @@
 				},
 				"findup-sync": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+					"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
 					"dev": true,
 					"requires": {
 						"detect-file": "^1.0.0",
@@ -211,7 +222,8 @@
 				},
 				"get-stream": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -219,7 +231,8 @@
 				},
 				"import-local": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
 					"dev": true,
 					"requires": {
 						"pkg-dir": "^3.0.0",
@@ -228,12 +241,14 @@
 				},
 				"invert-kv": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
 					"dev": true
 				},
 				"is-glob": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 					"dev": true,
 					"requires": {
 						"is-extglob": "^2.1.0"
@@ -241,7 +256,8 @@
 				},
 				"lcid": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 					"dev": true,
 					"requires": {
 						"invert-kv": "^2.0.0"
@@ -249,7 +265,8 @@
 				},
 				"locate-path": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
@@ -258,7 +275,8 @@
 				},
 				"mem": {
 					"version": "4.3.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 					"dev": true,
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
@@ -268,12 +286,14 @@
 				},
 				"mimic-fn": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 					"dev": true
 				},
 				"os-locale": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 					"dev": true,
 					"requires": {
 						"execa": "^1.0.0",
@@ -283,7 +303,8 @@
 				},
 				"p-limit": {
 					"version": "2.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -291,7 +312,8 @@
 				},
 				"p-locate": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
@@ -299,17 +321,20 @@
 				},
 				"p-try": {
 					"version": "2.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
 				"source-map": {
 					"version": "0.5.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
 					"dev": true
 				},
 				"webpack-cli": {
 					"version": "3.3.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.0.tgz",
+					"integrity": "sha512-t1M7G4z5FhHKJ92WRKwZ1rtvi7rHc0NZoZRbSkol0YKl4HvcC8+DsmGDmK7MmZxHSAetHagiOsjOB6MmzC2TUw==",
 					"dev": true,
 					"requires": {
 						"chalk": "^2.4.1",
@@ -327,7 +352,8 @@
 				},
 				"yargs": {
 					"version": "12.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+					"integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
 					"dev": true,
 					"requires": {
 						"cliui": "^4.0.0",
@@ -346,7 +372,8 @@
 				},
 				"yargs-parser": {
 					"version": "11.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+					"integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -5977,7 +6004,8 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -5995,11 +6023,13 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -6012,15 +6042,18 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -6123,7 +6156,8 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -6133,6 +6167,7 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -6145,17 +6180,20 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -6172,6 +6210,7 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -6244,7 +6283,8 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -6254,6 +6294,7 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -6329,7 +6370,8 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -6359,6 +6401,7 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -6376,6 +6419,7 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -6414,11 +6458,13 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true
+							"bundled": true,
+							"optional": true
 						}
 					}
 				}
@@ -12164,7 +12210,8 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -12185,12 +12232,14 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -12205,17 +12254,20 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -12332,7 +12384,8 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -12344,6 +12397,7 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -12358,6 +12412,7 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -12365,12 +12420,14 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -12389,6 +12446,7 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -12469,7 +12527,8 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -12481,6 +12540,7 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -12566,7 +12626,8 @@
 						"safe-buffer": {
 							"version": "5.1.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -12602,6 +12663,7 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -12621,6 +12683,7 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -12664,12 +12727,14 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						}
 					}
 				}
@@ -21659,9 +21724,9 @@
 			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 		},
 		"worker-farm": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-			"integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+			"integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
 			"requires": {
 				"errno": "~0.1.7"
 			}

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "1.0.0-rc.2",
+	"version": "1.0.0-rc.3",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"config",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -49,6 +49,7 @@
 		"caniuse-api": "3.0.0",
 		"css-loader": "2.1.1",
 		"duplicate-package-checker-webpack-plugin": "3.0.0",
+		"file-loader": "3.0.1",
 		"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
 		"node-sass": "4.11.0",
 		"postcss-custom-properties": "8.0.9",

--- a/packages/calypso-build/webpack/file-loader.js
+++ b/packages/calypso-build/webpack/file-loader.js
@@ -7,7 +7,7 @@ module.exports.loader = () => ( {
 	test: /\.(?:gif|jpg|jpeg|png|svg)$/i,
 	use: [
 		{
-			loader: 'file-loader',
+			loader: require.resolve( 'file-loader' ),
 			options: {
 				name: '[name]-[hash].[ext]',
 				outputPath: 'images/',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `file-loader` dep to `calypso-build`, and use `require.resolve()` as a safeguard to ensure the dep is there.
* Bump `calypso-build` version to `1.0.0-rc.3`.

The missing `file-loader` was discovered by @jeffersonrabb at https://github.com/Automattic/newspack-blocks/pull/7#issuecomment-489134511.

#### Testing instructions

Will test with `newspack-blocks` once published :slightly_smiling_face: 