### PR TITLE
Marketing: factored out getCurrentRouteParameterized

### DIFF
--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -15,12 +15,12 @@ import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { activateModule, deactivateModule } from 'state/jetpack/modules/actions';
-import getCurrentRoute from 'state/selectors/get-current-route';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import getJetpackModule from 'state/selectors/get-jetpack-module';
 import isActivatingJetpackModule from 'state/selectors/is-activating-jetpack-module';
 import isDeactivatingJetpackModule from 'state/selectors/is-deactivating-jetpack-module';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
-import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 class JetpackModuleToggle extends Component {
 	static defaultProps = {
@@ -100,9 +100,7 @@ export default connect(
 			toggling,
 			toggleDisabled: moduleDetailsNotLoaded || toggling,
 			isJetpackSite: isJetpackSite( state, siteId ),
-			path: getCurrentRoute( state )
-				.replace( getSiteSlug( state, siteId ), ':site' )
-				.replace( siteId, ':siteid' ),
+			path: getCurrentRouteParameterized( state, siteId ),
 		};
 	},
 	{

--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -68,6 +68,7 @@ class JetpackModuleToggle extends Component {
 		}
 
 		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<span className="jetpack-module-toggle">
 				<CompactFormToggle
 					id={ `${ this.props.siteId }-${ this.props.moduleSlug }-toggle` }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -23,18 +23,13 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import CountedTextarea from 'components/forms/counted-textarea';
 import Banner from 'components/banner';
-import {
-	getSeoTitleFormatsForSite,
-	getSiteSlug,
-	isJetpackSite,
-	isRequestingSite,
-} from 'state/sites/selectors';
+import { getSeoTitleFormatsForSite, isJetpackSite, isRequestingSite } from 'state/sites/selectors';
 import {
 	isSiteSettingsSaveSuccessful,
 	getSiteSettingsSaveError,
 } from 'state/site-settings/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import getCurrentRoute from 'state/selectors/get-current-route';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import isHiddenSite from 'state/selectors/is-hidden-site';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'state/selectors/is-private-site';
@@ -494,9 +489,7 @@ const mapStateToProps = state => {
 		hasSeoPreviewFeature: hasFeature( state, siteId, FEATURE_SEO_PREVIEW_TOOLS ),
 		isSaveSuccess: isSiteSettingsSaveSuccessful( state, siteId ),
 		saveError: getSiteSettingsSaveError( state, siteId ),
-		path: getCurrentRoute( state )
-			.replace( getSiteSlug( state, siteId ), ':site' )
-			.replace( siteId, ':siteid' ),
+		path: getCurrentRouteParameterized( state, siteId ),
 	};
 };
 

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -22,7 +22,7 @@ import {
 	getSiteSettingsSaveError,
 	getSiteSettings,
 } from 'state/site-settings/selectors';
-import getCurrentRoute from 'state/selectors/get-current-route';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import getJetpackSettings from 'state/selectors/get-jetpack-settings';
 import isJetpackSettingsSaveFailure from 'state/selectors/is-jetpack-settings-save-failure';
 import isRequestingJetpackSettings from 'state/selectors/is-requesting-jetpack-settings';
@@ -32,7 +32,7 @@ import { saveSiteSettings } from 'state/site-settings/actions';
 import { saveJetpackSettings } from 'state/jetpack/settings/actions';
 import { removeNotice, successNotice, errorNotice } from 'state/notices/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite, getSiteSlug } from 'state/sites/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import QueryJetpackSettings from 'components/data/query-jetpack-settings';
 
@@ -269,9 +269,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			const settingsFields = {
 				site: keys( settings ),
 			};
-			const path = getCurrentRoute( state )
-				.replace( getSiteSlug( state, siteId ), ':site' )
-				.replace( siteId, ':siteid' );
+			const path = getCurrentRouteParameterized( state, siteId );
 
 			const isJetpack = isJetpackSite( state, siteId );
 

--- a/client/state/selectors/get-current-route-parameterized.js
+++ b/client/state/selectors/get-current-route-parameterized.js
@@ -1,0 +1,27 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import getCurrentRoute from 'state/selectors/get-current-route';
+import { getSiteSlug } from 'state/sites/selectors';
+
+/**
+ * Returns the current route with site slug replaced by :site and site Id
+ * replaced by :siteid. Note that other parameters such as :domain are not currently
+ * supported.
+ *
+ * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
+ * @return {?String}        path of site if known
+ */
+export default function getCurrentRouteParameterized( state, siteId ) {
+	const route = getCurrentRoute( state );
+	const slug = getSiteSlug( state, siteId );
+
+	if ( null === route || null === slug ) {
+		return null;
+	}
+
+	return route.replace( slug, ':site' ).replace( siteId, ':siteid' );
+}

--- a/client/state/selectors/get-current-route-parameterized.js
+++ b/client/state/selectors/get-current-route-parameterized.js
@@ -13,7 +13,7 @@ import { getSiteSlug } from 'state/sites/selectors';
  *
  * @param  {Object}  state  Global state tree
  * @param  {Number}  siteId Site ID
- * @return {?String}        path of site if known
+ * @return {?String}        The current route with site parameters
  */
 export default function getCurrentRouteParameterized( state, siteId ) {
 	const route = getCurrentRoute( state );

--- a/client/state/selectors/test/get-current-route-parameterized.js
+++ b/client/state/selectors/test/get-current-route-parameterized.js
@@ -1,0 +1,67 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
+
+describe( 'getCurrentRouteParameterized()', () => {
+	const ui = {
+		route: {
+			path: {
+				current: '/test/url/testsite.blog',
+			},
+		},
+	};
+
+	const sites = {
+		items: { '12345': { URL: 'http://testsite.blog' } },
+	};
+
+	test( 'it returns null when state is missing the path', () => {
+		const state = {
+			ui: {},
+			sites: sites,
+		};
+
+		expect( getCurrentRouteParameterized( state, 12345 ) ).to.be.null;
+	} );
+
+	test( 'it returns null when state is missing the site', () => {
+		const state = {
+			ui: ui,
+			sites: { items: {} },
+		};
+
+		expect( getCurrentRouteParameterized( state, 12345 ) ).to.be.null;
+	} );
+
+	test( 'it replaces the site slug with :site', () => {
+		const state = {
+			ui: ui,
+			sites: sites,
+		};
+
+		expect( getCurrentRouteParameterized( state, 12345 ) ).to.equal( '/test/url/:site' );
+	} );
+
+	test( 'it replaces the site ID with :siteid', () => {
+		const state = {
+			ui: {
+				route: {
+					path: {
+						current: '/test/url/12345',
+					},
+				},
+			},
+			sites: sites,
+		};
+
+		expect( getCurrentRouteParameterized( state, 12345 ) ).to.equal( '/test/url/:siteid' );
+	} );
+} );

--- a/client/state/selectors/test/get-current-route-parameterized.js
+++ b/client/state/selectors/test/get-current-route-parameterized.js
@@ -43,8 +43,8 @@ describe( 'getCurrentRouteParameterized()', () => {
 
 	test( 'it replaces the site slug with :site', () => {
 		const state = {
-			ui: ui,
-			sites: sites,
+			ui,
+			sites,
 		};
 
 		expect( getCurrentRouteParameterized( state, 12345 ) ).to.equal( '/test/url/:site' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The logic of turning a route like `/marketing/traffic/somesite.blog` into `/marketing/traffic/:site` was repeated in several places.

This consolidates the logic into the `getCurrentRouteParameterized` selector.

#### Testing instructions

1. Checkout the branch and `npm run start`.
2. Get a Jetpack site with the highest plan.
3. Ensure that analytics debugging is activated by running this in the browser console: localStorage.setItem('debug', 'calypso:analytics:*');
4. Go to `/marketing/traffic/:site`.
5. Do each of the following and verify that events with the correct parameterized path are displayed in the console:

- Edit items under "Page Title structure" and "Website Meta", then click "Save Settings".
- Toggle any of the Jetpack modules ( Ads, SEO, Site stats, Google analytics, wp.me shortlinks, Generate XML sitemaps, Site verification services )
- Toggle any of the following toggles: "Display an additional ad at the top of each page", "Show related content after posts", "Show a "Related" header to more clearly separate the related section from posts", "Show a thumbnail image where available"


