### PR TITLE
Previews: Revert back to using the v1.2 frame nonce.

### DIFF
--- a/client/blocks/site-preview/index.jsx
+++ b/client/blocks/site-preview/index.jsx
@@ -103,7 +103,7 @@ function mapStateToProps( state ) {
 		selectedSite: getPreviewSite( state ),
 		selectedSiteId,
 		selectedSiteUrl: siteUrl.replace( /::/g, '/' ),
-		selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce_site_only' ) || '',
+		selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ) || '',
 		previewUrl: getPreviewUrl( state ),
 		isDomainOnlySite: isDomainOnlySite( state, selectedSiteId ),
 	};

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -100,7 +100,7 @@ class PreviewMain extends React.Component {
 			{
 				theme_preview: true,
 				iframe: true,
-				'frame-nonce': this.props.site.options.frame_nonce_site_only,
+				'frame-nonce': this.props.site.options.frame_nonce,
 			},
 			baseUrl
 		);

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -12,7 +12,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { isSitePreviewable } from 'state/sites/selectors';
+import { getSiteOption, isSitePreviewable } from 'state/sites/selectors';
 import { addQueryArgs } from 'lib/route';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import { isWithinBreakpoint, isMobile, isDesktop } from 'lib/viewport';
@@ -95,12 +95,13 @@ class PreviewMain extends React.Component {
 			return;
 		}
 
+		const { selectedSiteNonce } = this.props;
 		const baseUrl = this.getBasePreviewUrl();
 		const newUrl = addQueryArgs(
 			{
 				theme_preview: true,
 				iframe: true,
-				'frame-nonce': this.props.site.options.frame_nonce,
+				'frame-nonce': selectedSiteNonce,
 			},
 			baseUrl
 		);
@@ -191,6 +192,7 @@ const mapState = state => {
 	const selectedSiteId = getSelectedSiteId( state );
 	return {
 		isPreviewable: isSitePreviewable( state, selectedSiteId ),
+		selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ) || '',
 		site: getSelectedSite( state ),
 		siteId: selectedSiteId,
 	};

--- a/client/state/posts/utils.js
+++ b/client/state/posts/utils.js
@@ -565,7 +565,7 @@ export const getPreviewURL = function( site, post, autosavePreviewUrl ) {
 		}
 		if ( site.options.frame_nonce ) {
 			parsed = url.parse( previewUrl, true );
-			parsed.query[ 'frame-nonce' ] = site.options.frame_nonce_site_only;
+			parsed.query[ 'frame-nonce' ] = site.options.frame_nonce;
 			delete parsed.search;
 			previewUrl = url.format( parsed );
 		}

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -32,7 +32,6 @@ export const SITE_REQUEST_OPTIONS = [
 	'default_sharing_status',
 	'design_type',
 	'frame_nonce',
-	'frame_nonce_site_only',
 	'gmt_offset',
 	'has_pending_automated_transfer',
 	'is_automated_transfer',


### PR DESCRIPTION
We will no longer be adding a v1.3 to the sites endpoints, but rather will add a `jetpack_frame_nonce` field to existing endpoints, specifically for the purpose of WP.com block editor iframing.

By having all of Calypso using v1.3 of the sites endpoints through `requestSites`, features associated to Jetpack were getting 404 errors for those endpoints (since Jetpack v7.3 hadn't been released yet). This prompted the decision to just stay on v1.2.

Now that Calypso is back to using v1.2 of the sites endpoints, let's move previews back to the compatible v1.2 `frame_nonce`, allowing us to clear away `frame_nonce_site_only`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a post for a simple site in the Calypso editor (not the block editor).
* Click the Preview button.
* Verify the preview modal works as expected.
* Check the `/me/sites` API call that was made, verify it no longer has a `frame_nonce_site_only` options field.

Let's also verify the Marketing section is unaffected.
* Select a Jetpack or Atomic site.
* Go to Marketing > Traffic, and verify "Enable SEO Tools to optimize your site for search engines" is active.
* Make changes under the "Page Title Structure" section, and click "Save Settings".
* Verify the API calls are successful, with no 404 errors.