### PR TITLE
File Importer: Check for previous status UPLOAD_PROCESSING to enable zip imports

### DIFF
--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -48,7 +48,8 @@ class UploadingPane extends React.PureComponent {
 		const { importerStatus: prevImporterStatus } = prevProps;
 
 		if (
-			prevImporterStatus.importerState === appStates.UPLOADING &&
+			( prevImporterStatus.importerState === appStates.UPLOADING ||
+				prevImporterStatus.importerState === appStates.UPLOAD_PROCESSING ) &&
 			importerState === appStates.UPLOAD_SUCCESS
 		) {
 			defer( () => startMappingAuthors( importerId ) );


### PR DESCRIPTION
The change introduced in https://github.com/Automattic/wp-calypso/pull/32324 meant that imports of zip files weren't proceeding beyond the initial upload, because in that situation the previous state is UPLOAD_PROCESSING and not UPLOADING.

#### Changes proposed in this Pull Request

* This PR adds UPLOAD_PROCESSING to the possible previous states in the condition for the statement which triggers author mapping.

#### Testing instructions

* Run this branch
* Test all engines which support file uploads (WordPress, Blogger, Medium, and Squarespace) - especially zip imports to WordPress and Medium.
* Upon uploading a proper export file, the import should continue to the next step
* You should be able to complete an import as before

Fixes issue reported in p2EDhh-Lg-p2
