### PR TITLE
Full Site Editing: Restrict FSE blocks post selectors to appropriate post types

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/edit.js
@@ -78,7 +78,7 @@ const PostContentEdit = compose(
 					>
 						<div className="post-content-block__selector">
 							<div>{ __( 'Select something to preview:' ) }</div>
-							<PostAutocomplete onSelectPost={ onSelectPost } />
+							<PostAutocomplete postType={ [ 'page', 'post' ] } onSelectPost={ onSelectPost } />
 							{ !! selectedPost && (
 								<a href={ `?post=${ selectedPost.id }&action=edit` }>
 									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.rendered', '' ) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
@@ -78,7 +78,7 @@ const TemplateEdit = compose(
 							<PostAutocomplete postType="wp_template" onSelectPost={ onSelectPost } />
 							{ !! selectedPost && (
 								<a href={ `?post=${ selectedPost.id }&action=edit` }>
-									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.rendered', '' ) ) }
+									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.raw', '' ) ) }
 								</a>
 							) }
 						</div>
@@ -86,7 +86,7 @@ const TemplateEdit = compose(
 				) }
 				{ showContent && (
 					<RawHTML className="template-block__content">
-						{ get( selectedPost, 'content.rendered' ) }
+						{ get( selectedPost, 'content.raw' ) }
 					</RawHTML>
 				) }
 			</div>

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
@@ -75,7 +75,7 @@ const TemplateEdit = compose(
 						instructions={ __( 'Select a template part to display' ) }
 					>
 						<div className="template-block__selector">
-							<PostAutocomplete onSelectPost={ onSelectPost } />
+							<PostAutocomplete postType="wp_template" onSelectPost={ onSelectPost } />
 							{ !! selectedPost && (
 								<a href={ `?post=${ selectedPost.id }&action=edit` }>
 									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.rendered', '' ) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
@@ -78,7 +78,7 @@ const TemplateEdit = compose(
 							<PostAutocomplete postType="wp_template" onSelectPost={ onSelectPost } />
 							{ !! selectedPost && (
 								<a href={ `?post=${ selectedPost.id }&action=edit` }>
-									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.raw', '' ) ) }
+									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.rendered', '' ) ) }
 								</a>
 							) }
 						</div>
@@ -86,7 +86,7 @@ const TemplateEdit = compose(
 				) }
 				{ showContent && (
 					<RawHTML className="template-block__content">
-						{ get( selectedPost, 'content.raw' ) }
+						{ get( selectedPost, 'content.rendered' ) }
 					</RawHTML>
 				) }
 			</div>

--- a/apps/full-site-editing/full-site-editing-plugin/components/post-autocomplete/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/components/post-autocomplete/index.js
@@ -18,7 +18,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import './style.scss';
 
-const updateSuggestions = debounce( async ( search, setState ) => {
+const updateSuggestions = debounce( async ( search, postType, setState ) => {
 	setState( {
 		loading: true,
 		showSuggestions: true,
@@ -30,6 +30,7 @@ const updateSuggestions = debounce( async ( search, setState ) => {
 			context: 'embed',
 			per_page: 20,
 			search,
+			...( !! postType && { subtype: postType } ),
 		} ),
 	} );
 
@@ -53,12 +54,18 @@ const selectSuggestion = ( suggestion, setState ) => {
 		type: suggestion.subtype,
 	};
 };
+
+/**
+ * External props:
+ * @param {Function} onSelectPost Callback invoked when a post is selected, returning its object.
+ * @param {?string|Array} postType If set, limits the search to the given post type, or array of post types.
+ */
 const PostAutocomplete = withState( {
 	loading: false,
 	search: '',
 	showSuggestions: false,
 	suggestions: [],
-} )( ( { loading, onSelectPost, search, setState, showSuggestions, suggestions } ) => {
+} )( ( { loading, onSelectPost, postType, search, setState, showSuggestions, suggestions } ) => {
 	const onChange = inputValue => {
 		setState( { search: inputValue } );
 		if ( inputValue.length < 2 ) {
@@ -68,7 +75,7 @@ const PostAutocomplete = withState( {
 			} );
 			return;
 		}
-		updateSuggestions( inputValue, setState );
+		updateSuggestions( inputValue, postType, setState );
 	};
 
 	const onClick = suggestion => () => {

--- a/apps/full-site-editing/full-site-editing-plugin/wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/wp-template.php
@@ -84,27 +84,6 @@ class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
-	 * Filters a response based on the context defined in the schema.
-	 *
-	 * @param array  $data    Response data to fiter.
-	 * @param string $context Context defined in the schema.
-	 * @return array Filtered response.
-	 */
-	public function filter_response_by_context( $data, $context ) {
-		$data = parent::filter_response_by_context( $data, $context );
-
-		/*
-		 * Remove `title.rendered` and `content.rendered` from the response. It
-		 * doesn't make sense for a reusable template to have rendered content on its
-		 * own, since rendering a template requires it to be inside a post or a page.
-		 */
-		unset( $data['title']['rendered'] );
-		unset( $data['content']['rendered'] );
-
-		return $data;
-	}
-
-	/**
 	 * Retrieves the template's schema, conforming to JSON Schema.
 	 *
 	 * @return array Item schema data.
@@ -119,14 +98,6 @@ class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
 		 */
 		$schema['properties']['title']['properties']['raw']['context']   = array( 'view', 'edit' );
 		$schema['properties']['content']['properties']['raw']['context'] = array( 'view', 'edit' );
-
-		/*
-		 * Remove `title.rendered` and `content.rendered` from the schema. It doesn’t
-		 * make sense for a reusable template to have rendered content on its own, since
-		 * rendering a template requires it to be inside a post or a page.
-		 */
-		unset( $schema['properties']['title']['properties']['rendered'] );
-		unset( $schema['properties']['content']['properties']['rendered'] );
 
 		return $schema;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updated the `PostAutocomplete` selector with a new `postType` prop that, if set, restricts the search to the given post type, or array of post types.

* Content block will only be able to search, select, and preview `post` and `page` posts.

* Template block will only be able to search, select, and render `wp_template` posts.

#### Testing instructions

* Make sure to have a bunch of well recognizable Posts, Pages, and Templates posts published.
* In a Template, insert the Template block, and make sure the selector only returns Templates.
* Insert the Content block, and make sure the selector doesn't return any Templates, but only Posts and Pages.

Fixes #32618
Fixes #32619
