### PR TITLE
Skip the transfer page if the user has already selected a domain

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -218,7 +218,6 @@ class RegisterDomainStep extends React.Component {
 			bloggerFilterAdded: false,
 			clickedExampleSuggestion: false,
 			filters: this.getInitialFiltersState(),
-			lastDomainIsMappable: false,
 			lastDomainIsTransferrable: false,
 			lastDomainSearched: null,
 			lastDomainStatus: null,
@@ -337,7 +336,6 @@ class RegisterDomainStep extends React.Component {
 	clearLastDomainState() {
 		this.setState( {
 			lastDomainStatus: null,
-			lastDomainIsMappable: false,
 			lastDomainIsTransferrable: false,
 		} );
 	}
@@ -739,19 +737,16 @@ class RegisterDomainStep extends React.Component {
 
 					const {
 						AVAILABLE,
-						MAPPABLE,
 						MAPPED_SAME_SITE_TRANSFERRABLE,
 						TRANSFERRABLE,
 						UNKNOWN,
 					} = domainAvailability;
 					const isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
-					const isDomainMappable = get( result, 'mappable', false ) === MAPPABLE;
 					const isDomainTransferrable = TRANSFERRABLE === status;
 
 					this.setState( {
 						exactMatchDomain: domainChecked,
 						lastDomainStatus: status,
-						lastDomainIsMappable: isDomainMappable,
 						lastDomainIsTransferrable: isDomainTransferrable,
 					} );
 					if ( isDomainAvailable ) {
@@ -1251,7 +1246,6 @@ class RegisterDomainStep extends React.Component {
 		} else {
 			const query = stringify( {
 				initialQuery: this.state.lastQuery.trim(),
-				isDomainMappable: this.state.lastDomainIsMappable,
 				isDomainTransferrable: this.state.lastDomainIsTransferrable,
 			} );
 			useYourDomainUrl = `${ this.props.basePath }/use-your-domain`;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1236,7 +1236,10 @@ class RegisterDomainStep extends React.Component {
 		if ( this.props.useYourDomainUrl ) {
 			useYourDomainUrl = this.props.useYourDomainUrl;
 		} else {
-			const query = stringify( { initialQuery: this.state.lastQuery.trim() } );
+			const query = stringify( {
+				initialQuery: this.state.lastQuery.trim(),
+				lastDomainStatus: this.state.lastDomainStatus,
+			} );
 			useYourDomainUrl = `${ this.props.basePath }/use-your-domain`;
 			if ( this.props.selectedSite ) {
 				useYourDomainUrl += `/${ this.props.selectedSite.slug }?${ query }`;

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -218,6 +218,7 @@ class RegisterDomainStep extends React.Component {
 			bloggerFilterAdded: false,
 			clickedExampleSuggestion: false,
 			filters: this.getInitialFiltersState(),
+			lastDomainIsMappable: false,
 			lastDomainIsTransferrable: false,
 			lastDomainSearched: null,
 			lastDomainStatus: null,
@@ -331,6 +332,14 @@ class RegisterDomainStep extends React.Component {
 		) {
 			this.focusSearchCard();
 		}
+	}
+
+	clearLastDomainState() {
+		this.setState( {
+			lastDomainStatus: null,
+			lastDomainIsMappable: false,
+			lastDomainIsTransferrable: false,
+		} );
 	}
 
 	getNewRailcarId() {
@@ -711,11 +720,12 @@ class RegisterDomainStep extends React.Component {
 				/^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/i
 			)
 		) {
-			this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
+			this.clearLastDomainState();
 			return;
 		}
+
 		if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
-			this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
+			this.clearLastDomainState();
 			return;
 		}
 
@@ -729,16 +739,19 @@ class RegisterDomainStep extends React.Component {
 
 					const {
 						AVAILABLE,
+						MAPPABLE,
 						MAPPED_SAME_SITE_TRANSFERRABLE,
 						TRANSFERRABLE,
 						UNKNOWN,
 					} = domainAvailability;
 					const isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
+					const isDomainMappable = get( result, 'mappable', false ) === MAPPABLE;
 					const isDomainTransferrable = TRANSFERRABLE === status;
 
 					this.setState( {
 						exactMatchDomain: domainChecked,
 						lastDomainStatus: status,
+						lastDomainIsMappable: isDomainMappable,
 						lastDomainIsTransferrable: isDomainTransferrable,
 					} );
 					if ( isDomainAvailable ) {
@@ -1238,7 +1251,8 @@ class RegisterDomainStep extends React.Component {
 		} else {
 			const query = stringify( {
 				initialQuery: this.state.lastQuery.trim(),
-				lastDomainStatus: this.state.lastDomainStatus,
+				isDomainMappable: this.state.lastDomainIsMappable,
+				isDomainTransferrable: this.state.lastDomainIsTransferrable,
 			} );
 			useYourDomainUrl = `${ this.props.basePath }/use-your-domain`;
 			if ( this.props.selectedSite ) {

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -52,7 +52,8 @@ class UseYourDomainStep extends React.Component {
 		domainsWithPlansOnly: PropTypes.bool,
 		goBack: PropTypes.func,
 		initialQuery: PropTypes.string,
-		lastDomainStatus: PropTypes.string,
+		isDomainMappable: PropTypes.bool,
+		isDomainTransferrable: PropTypes.bool,
 		isSignupStep: PropTypes.bool,
 		mapDomainUrl: PropTypes.string,
 		transferDomainUrl: PropTypes.string,
@@ -100,7 +101,7 @@ class UseYourDomainStep extends React.Component {
 		if ( selectedSite ) {
 			const query = stringify( {
 				initialQuery: this.state.searchQuery.trim(),
-				lastDomainStatus: this.props.lastDomainStatus,
+				isDomainMappable: this.props.isDomainMappable,
 			} );
 			buildMapDomainUrl += `/${ selectedSite.slug }?${ query }`;
 		}
@@ -133,7 +134,7 @@ class UseYourDomainStep extends React.Component {
 		if ( selectedSite ) {
 			const query = stringify( {
 				initialQuery: this.state.searchQuery.trim(),
-				lastDomainStatus: this.props.lastDomainStatus,
+				isDomainTransferrable: this.props.isDomainTransferrable,
 			} );
 			buildTransferDomainUrl += `/${ selectedSite.slug }?${ query }`;
 		}

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -52,6 +52,7 @@ class UseYourDomainStep extends React.Component {
 		domainsWithPlansOnly: PropTypes.bool,
 		goBack: PropTypes.func,
 		initialQuery: PropTypes.string,
+		lastDomainStatus: PropTypes.string,
 		isSignupStep: PropTypes.bool,
 		mapDomainUrl: PropTypes.string,
 		transferDomainUrl: PropTypes.string,
@@ -97,7 +98,10 @@ class UseYourDomainStep extends React.Component {
 
 		buildMapDomainUrl = `${ basePathForMapping }/mapping`;
 		if ( selectedSite ) {
-			const query = stringify( { initialQuery: this.state.searchQuery.trim() } );
+			const query = stringify( {
+				initialQuery: this.state.searchQuery.trim(),
+				lastDomainStatus: this.props.lastDomainStatus,
+			} );
 			buildMapDomainUrl += `/${ selectedSite.slug }?${ query }`;
 		}
 
@@ -127,7 +131,10 @@ class UseYourDomainStep extends React.Component {
 		buildTransferDomainUrl = `${ basePathForTransfer }/transfer`;
 
 		if ( selectedSite ) {
-			const query = stringify( { initialQuery: this.state.searchQuery.trim() } );
+			const query = stringify( {
+				initialQuery: this.state.searchQuery.trim(),
+				lastDomainStatus: this.props.lastDomainStatus,
+			} );
 			buildTransferDomainUrl += `/${ selectedSite.slug }?${ query }`;
 		}
 

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -52,7 +52,6 @@ class UseYourDomainStep extends React.Component {
 		domainsWithPlansOnly: PropTypes.bool,
 		goBack: PropTypes.func,
 		initialQuery: PropTypes.string,
-		isDomainMappable: PropTypes.bool,
 		isDomainTransferrable: PropTypes.bool,
 		isSignupStep: PropTypes.bool,
 		mapDomainUrl: PropTypes.string,
@@ -99,10 +98,7 @@ class UseYourDomainStep extends React.Component {
 
 		buildMapDomainUrl = `${ basePathForMapping }/mapping`;
 		if ( selectedSite ) {
-			const query = stringify( {
-				initialQuery: this.state.searchQuery.trim(),
-				isDomainMappable: this.props.isDomainMappable,
-			} );
+			const query = stringify( { initialQuery: this.state.searchQuery.trim() } );
 			buildMapDomainUrl += `/${ selectedSite.slug }?${ query }`;
 		}
 

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -106,7 +106,10 @@ const mapDomain = ( context, next ) => {
 			<PageViewTracker path={ domainMapping( ':site' ) } title="Domain Search > Domain Mapping" />
 			<DocumentHead title={ translate( 'Map a Domain' ) } />
 			<CartData>
-				<MapDomain initialQuery={ context.query.initialQuery } />
+				<MapDomain
+					initialQuery={ context.query.initialQuery }
+					lastDomainStatus={ context.query.lastDomainStatus }
+				/>
 			</CartData>
 		</Main>
 	);

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -125,6 +125,7 @@ const transferDomain = ( context, next ) => {
 				<TransferDomain
 					basePath={ sectionify( context.path ) }
 					initialQuery={ context.query.initialQuery }
+					lastDomainStatus={ context.query.lastDomainStatus }
 				/>
 			</CartData>
 		</Main>
@@ -152,6 +153,7 @@ const useYourDomain = ( context, next ) => {
 				<UseYourDomainStep
 					basePath={ sectionify( context.path ) }
 					initialQuery={ context.query.initialQuery }
+					lastDomainStatus={ context.query.lastDomainStatus }
 					goBack={ handleGoBack }
 				/>
 			</CartData>
@@ -168,6 +170,7 @@ const transferDomainPrecheck = ( context, next ) => {
 	const handleGoBack = () => {
 		page( domainManagementTransferIn( siteSlug, domain ) );
 	};
+
 	context.primary = (
 		<Main>
 			<PageViewTracker

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -14,7 +14,6 @@ import DocumentHead from 'components/data/document-head';
 import { sectionify } from 'lib/route';
 import Main from 'components/main';
 import { addItem } from 'lib/upgrades/actions';
-import { cartItems } from 'lib/cart-values';
 import productsFactory from 'lib/products-list';
 import getSites from 'state/selectors/get-sites';
 import { getSelectedSiteId, getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -28,7 +27,6 @@ import TransferDomainStep from 'components/domains/transfer-domain-step';
 import UseYourDomainStep from 'components/domains/use-your-domain-step';
 import GoogleApps from 'components/upgrades/gsuite';
 import {
-	domainManagementList,
 	domainManagementTransferIn,
 	domainManagementTransferInPrecheck,
 	domainMapping,
@@ -40,13 +38,11 @@ import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { makeLayout, render as clientRender } from 'controller';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { isGSuiteRestricted } from 'lib/gsuite';
-import wp from 'lib/wp';
 
 /**
  * Module variables
  */
 const productsList = productsFactory();
-const wpcom = wp.undocumented();
 
 const domainsAddHeader = ( context, next ) => {
 	context.getSiteSelectionHeaderText = () => {
@@ -110,10 +106,7 @@ const mapDomain = ( context, next ) => {
 			<PageViewTracker path={ domainMapping( ':site' ) } title="Domain Search > Domain Mapping" />
 			<DocumentHead title={ translate( 'Map a Domain' ) } />
 			<CartData>
-				<MapDomain
-					initialQuery={ context.query.initialQuery }
-					isDomainMappable={ context.query.isDomainMappable === 'true' }
-				/>
+				<MapDomain initialQuery={ context.query.initialQuery } />
 			</CartData>
 		</Main>
 	);
@@ -160,7 +153,6 @@ const useYourDomain = ( context, next ) => {
 				<UseYourDomainStep
 					basePath={ sectionify( context.path ) }
 					initialQuery={ context.query.initialQuery }
-					isDomainMappable={ context.query.isDomainMappable === 'true' }
 					isDomainTransferrable={ context.query.isDomainTransferrable === 'true' }
 					goBack={ handleGoBack }
 				/>
@@ -263,33 +255,6 @@ const redirectIfNoSite = redirectTo => {
 	};
 };
 
-const redirectIfDomainIsMappable = ( context, next ) => {
-	if ( get( context, 'query.isDomainMappable', false ) !== 'true' ) {
-		next();
-	}
-
-	const state = context.store.getState();
-	const selectedSite = getSelectedSite( state );
-	const domain = get( context, 'query.initialQuery', '' );
-
-	// For VIP sites we handle domain mappings differently
-	// We don't go through the usual checkout process
-	// Instead, we add the mapping directly
-	if ( selectedSite.is_vip ) {
-		wpcom
-			.addVipDomainMapping( selectedSite.ID, domain )
-			.then(
-				() => page( domainManagementList( selectedSite.slug ) ),
-				error => this.setState( { errorMessage: error.message } )
-			);
-		return;
-	}
-
-	addItem( cartItems.domainMapping( { domain } ) );
-
-	page.redirect( '/checkout/' + selectedSite.slug );
-};
-
 const redirectToUseYourDomainIfVipSite = ( context, next ) => {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
@@ -334,7 +299,6 @@ export default {
 	mapDomain,
 	googleAppsWithRegistration,
 	redirectToDomainSearchSuggestion,
-	redirectIfDomainIsMappable,
 	redirectIfNoSite,
 	redirectToUseYourDomainIfVipSite,
 	transferDomain,

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -190,7 +190,7 @@ export default function() {
 			'/domains/add',
 			siteSelection,
 			domainsController.domainsAddHeader,
-			domainsController.redirectToUseYourDomainIfVipSite(),
+			domainsController.redirectToUseYourDomainIfVipSite,
 			domainsController.jetpackNoDomainsWarning,
 			sites,
 			makeLayout,
@@ -232,7 +232,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.redirectToUseYourDomainIfVipSite(),
+			domainsController.redirectToUseYourDomainIfVipSite,
 			domainsController.jetpackNoDomainsWarning,
 			domainsController.domainSearch,
 			makeLayout,
@@ -244,7 +244,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.redirectToUseYourDomainIfVipSite(),
+			domainsController.redirectToUseYourDomainIfVipSite,
 			domainsController.jetpackNoDomainsWarning,
 			domainsController.redirectToDomainSearchSuggestion
 		);
@@ -266,6 +266,7 @@ export default function() {
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/mapping' ),
 			domainsController.jetpackNoDomainsWarning,
+			domainsController.redirectIfDomainIsMappable,
 			domainsController.mapDomain,
 			makeLayout,
 			clientRender

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -266,7 +266,6 @@ export default function() {
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add/mapping' ),
 			domainsController.jetpackNoDomainsWarning,
-			domainsController.redirectIfDomainIsMappable,
 			domainsController.mapDomain,
 			makeLayout,
 			clientRender

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -26,6 +26,7 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 import QueryProductsList from 'components/data/query-products-list';
 import { getProductsList } from 'state/products-list/selectors';
 import TrademarkClaimsNotice from 'components/domains/trademark-claims-notice';
+import { parseTwoDigitYear } from 'moment';
 
 const wpcom = wp.undocumented();
 
@@ -116,19 +117,13 @@ export class MapDomain extends Component {
 
 	componentWillMount() {
 		this.checkSiteIsUpgradeable( this.props );
-		//this.checkIfDomainIsMappable(  );
 	}
 
 	componentWillReceiveProps( nextProps ) {
 		this.checkSiteIsUpgradeable( nextProps );
+		this.checkIfDomainIsTransferrable( nextProps );
 	}
-	/*
-	checkIfDomainIsMappable( props ) {
-		if  ( this.handleMapDomain === true ){
 
-		}
-	}
-*/
 	checkSiteIsUpgradeable( props ) {
 		if ( props.selectedSite && ! props.isSiteUpgradeable ) {
 			page.redirect( '/domains/add/mapping' );
@@ -160,6 +155,12 @@ export class MapDomain extends Component {
 			/>
 		);
 	};
+
+	checkIfDomainIsTransferrable( props ) {
+		if ( props.lastDomainStatus === 'transferrable' ) {
+			//page.redirect( '/checkout' );
+		}
+	}
 
 	render() {
 		if ( this.state.showTrademarkClaimsNotice ) {

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -26,8 +26,6 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 import QueryProductsList from 'components/data/query-products-list';
 import { getProductsList } from 'state/products-list/selectors';
 import TrademarkClaimsNotice from 'components/domains/trademark-claims-notice';
-import { parseTwoDigitYear } from 'moment';
-import { domainAvailability } from 'lib/domains/constants';
 
 const wpcom = wp.undocumented();
 
@@ -122,7 +120,6 @@ export class MapDomain extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		this.checkSiteIsUpgradeable( nextProps );
-		this.checkIfDomainIsMappable( nextProps );
 	}
 
 	checkSiteIsUpgradeable( props ) {
@@ -156,12 +153,6 @@ export class MapDomain extends Component {
 			/>
 		);
 	};
-
-	checkIfDomainIsMappable( props ) {
-		if ( props.lastDomainStatus === domainAvailability.TRANSFERRABLE ) {
-			this.handleMapDomain( this.props.initialQuery );
-		}
-	}
 
 	render() {
 		if ( this.state.showTrademarkClaimsNotice ) {

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -121,7 +121,7 @@ export class MapDomain extends Component {
 
 	componentWillReceiveProps( nextProps ) {
 		this.checkSiteIsUpgradeable( nextProps );
-		this.checkIfDomainIsTransferrable( nextProps );
+		this.checkIfDomainIsMappable( nextProps );
 	}
 
 	checkSiteIsUpgradeable( props ) {
@@ -156,9 +156,9 @@ export class MapDomain extends Component {
 		);
 	};
 
-	checkIfDomainIsTransferrable( props ) {
+	checkIfDomainIsMappable( props ) {
 		if ( props.lastDomainStatus === 'transferrable' ) {
-			//page.redirect( '/checkout' );
+			this.handleMapDomain( this.props.initialQuery );
 		}
 	}
 

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -27,6 +27,7 @@ import QueryProductsList from 'components/data/query-products-list';
 import { getProductsList } from 'state/products-list/selectors';
 import TrademarkClaimsNotice from 'components/domains/trademark-claims-notice';
 import { parseTwoDigitYear } from 'moment';
+import { domainAvailability } from 'lib/domains/constants';
 
 const wpcom = wp.undocumented();
 
@@ -157,7 +158,7 @@ export class MapDomain extends Component {
 	};
 
 	checkIfDomainIsMappable( props ) {
-		if ( props.lastDomainStatus === 'transferrable' ) {
+		if ( props.lastDomainStatus === domainAvailability.TRANSFERRABLE ) {
 			this.handleMapDomain( this.props.initialQuery );
 		}
 	}

--- a/client/my-sites/domains/map-domain/index.jsx
+++ b/client/my-sites/domains/map-domain/index.jsx
@@ -116,12 +116,19 @@ export class MapDomain extends Component {
 
 	componentWillMount() {
 		this.checkSiteIsUpgradeable( this.props );
+		//this.checkIfDomainIsMappable(  );
 	}
 
 	componentWillReceiveProps( nextProps ) {
 		this.checkSiteIsUpgradeable( nextProps );
 	}
+	/*
+	checkIfDomainIsMappable( props ) {
+		if  ( this.handleMapDomain === true ){
 
+		}
+	}
+*/
 	checkSiteIsUpgradeable( props ) {
 		if ( props.selectedSite && ! props.isSiteUpgradeable ) {
 			page.redirect( '/domains/add/mapping' );

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -154,6 +154,8 @@ export class TransferDomain extends Component {
 
 		const { errorMessage } = this.state;
 
+		const forcePrecheck = this.props.lastDomainStatus === 'transferrable';
+
 		return (
 			<span>
 				<QueryProductsList />
@@ -169,6 +171,7 @@ export class TransferDomain extends Component {
 					onRegisterDomain={ this.handleRegisterDomain }
 					onTransferDomain={ this.handleTransferDomain }
 					analyticsSection="domains"
+					forcePrecheck={ forcePrecheck }
 				/>
 			</span>
 		);

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -26,7 +26,6 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 import QueryProductsList from 'components/data/query-products-list';
 import { getProductsList } from 'state/products-list/selectors';
 import TrademarkClaimsNotice from 'components/domains/trademark-claims-notice';
-import { domainAvailability } from 'lib/domains/constants';
 
 export class TransferDomain extends Component {
 	static propTypes = {
@@ -34,6 +33,7 @@ export class TransferDomain extends Component {
 		query: PropTypes.string,
 		cart: PropTypes.object.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
+		isDomainTransferrable: PropTypes.bool,
 		isSiteUpgradeable: PropTypes.bool,
 		productsList: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object,
@@ -155,8 +155,6 @@ export class TransferDomain extends Component {
 
 		const { errorMessage } = this.state;
 
-		const forcePrecheck = this.props.lastDomainStatus === domainAvailability.TRANSFERRABLE;
-
 		return (
 			<span>
 				<QueryProductsList />
@@ -172,7 +170,7 @@ export class TransferDomain extends Component {
 					onRegisterDomain={ this.handleRegisterDomain }
 					onTransferDomain={ this.handleTransferDomain }
 					analyticsSection="domains"
-					forcePrecheck={ forcePrecheck }
+					forcePrecheck={ this.props.isDomainTransferrable }
 				/>
 			</span>
 		);

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -26,6 +26,7 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 import QueryProductsList from 'components/data/query-products-list';
 import { getProductsList } from 'state/products-list/selectors';
 import TrademarkClaimsNotice from 'components/domains/trademark-claims-notice';
+import { domainAvailability } from 'lib/domains/constants';
 
 export class TransferDomain extends Component {
 	static propTypes = {
@@ -154,7 +155,7 @@ export class TransferDomain extends Component {
 
 		const { errorMessage } = this.state;
 
-		const forcePrecheck = this.props.lastDomainStatus === 'transferrable';
+		const forcePrecheck = this.props.lastDomainStatus === domainAvailability.TRANSFERRABLE;
 
 		return (
 			<span>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enhancement. Ref: Trello-Cobalt

- [x] If a user indicated that they want to transfer a domain name on the domain search page we don't need to show the add/transfer page because this repeats the same information the user already entered.

![screenshot](https://cld.wthms.co/fQA63k+)

#### Testing instructions


1. Go to My Site > Manage > Domains -> Add a Domain
2. Type domain that's already registered elsewhere, select "Yes, I own this domain"
![screenshot](https://cld.wthms.co/b8z2WD+)
3. Clicking "Transfer to WordPress.com" is already fixed (forces precheck if the domain is transferrable) 



