### PR TITLE
Plan Icon: CSS Migration 

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -78,7 +78,6 @@
 @import 'components/mini-site-preview/style';
 @import 'components/mobile-back-to-sidebar/style';
 @import 'components/notice/style';
-@import 'components/plans/plan-icon/style';
 @import 'blocks/product-purchase-features-list/style';
 @import 'components/popover/style';
 @import 'components/post-excerpt/style';

--- a/client/components/plans/plan-icon/index.jsx
+++ b/client/components/plans/plan-icon/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -22,6 +20,11 @@ import {
 	isEcommercePlan,
 	getPlanClass,
 } from 'lib/plans';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export default class PlanIcon extends Component {
 	getIcon( planName ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrates the styling of the plan icon component as part of #27515.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit `/plans/my-plan/site` on a Jetpack/Atomic site and check the styles for the plan icon that appears. There should be no visual difference. 

<img width="1046" alt="Screenshot 2019-05-03 at 20 54 07" src="https://user-images.githubusercontent.com/43215253/57162261-9c603580-6de5-11e9-891c-4a36bb155a9e.png">
