### PR TITLE
Marketing/Traffic: add tracks events to google analytics fields

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -31,6 +31,7 @@ import {
 	isVipPlan,
 	isEcommerce,
 } from 'lib/products-values';
+import { recordTracksEvent } from 'state/analytics/actions';
 import { isJetpackSite } from 'state/sites/selectors';
 import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
@@ -76,8 +77,11 @@ export class GoogleAnalyticsForm extends Component {
 	};
 
 	handleToggleChange = key => {
-		const { fields } = this.props;
+		const { fields, path } = this.props;
 		const value = fields.wga ? ! fields.wga[ key ] : false;
+
+		this.props.recordTracksEvent( 'calypso_google_analytics_setting_changed', { key, path } );
+
 		this.handleFieldChange( key, value );
 	};
 
@@ -305,9 +309,13 @@ const mapStateToProps = state => {
 	};
 };
 
+const mapDispatchToProps = {
+	recordTracksEvent,
+};
+
 const connectComponent = connect(
 	mapStateToProps,
-	null,
+	mapDispatchToProps,
 	null,
 	{ pure: false }
 );

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -57,6 +57,7 @@ const hasBusinessPlan = overSome(
 export class GoogleAnalyticsForm extends Component {
 	state = {
 		isCodeValid: true,
+		loggedGoogleAnalyticsModified: false,
 	};
 
 	handleFieldChange = ( key, value ) => {
@@ -188,7 +189,10 @@ export class GoogleAnalyticsForm extends Component {
 									eventTracker( 'Focused Analytics Key Field' )();
 								} }
 								onKeyPress={ () => {
-									trackTracksEvent( 'calypso_google_analytics_key_field_modified', { path } );
+									if ( ! this.state.loggedGoogleAnalyticsModified ) {
+										trackTracksEvent( 'calypso_google_analytics_key_field_modified', { path } );
+										this.setState( { loggedGoogleAnalyticsModified: true } );
+									}
 									uniqueEventTracker( 'Typed In Analytics Key Field' )();
 								} }
 								isError={ ! this.state.isCodeValid }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds some Tracks events to the Google Analytics settings fields.

#### Testing instructions

1. Checkout this branch and `npm run start`.
2. Ensure that analytics debugging is activated by running this in the browser console: `localStorage.setItem('debug', 'calypso:analytics:*');`
3. Pick an Atomic site with ecommerce enabled.
4. Go to `/marketing/traffic/:site`.
5. Make sure Google Analytics is enabled.
6. Focus the Google Analytics key field. Check the console to verify that the correct Tracks event was logged with a correct path.
7. Edit the Google Analytics key field. Check the console to verify that the correct Tracks event was logged with a correct path.
8. Toggle some of the other Google Analytics settings. Check the console to verify that the correct Tracks event was logged with a correct path and key.