### PR TITLE
Gutenframe: Use the new `jetpack_frame_nonce` site option for Jetpack sites.

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -21,6 +21,7 @@ import {
 	getSiteAdminUrl,
 	isRequestingSites,
 	isRequestingSite,
+	isJetpackSite,
 } from 'state/sites/selectors';
 import { addQueryArgs } from 'lib/route';
 import { getEnabledFilters, getDisabledDataSources, mediaCalypsoToGutenberg } from './media-utils';
@@ -407,7 +408,8 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) 
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
 	const postTypeTrashUrl = getPostTypeTrashUrl( state, postType );
-	const frameNonce = getSiteOption( state, siteId, 'jetpack_frame_nonce' ) || '';
+	const siteOption = isJetpackSite( state, siteId ) ? 'jetpack_frame_nonce' : 'frame_nonce';
+	const frameNonce = getSiteOption( state, siteId, siteOption ) || '';
 
 	let queryArgs = pickBy( {
 		post: postId,

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -407,7 +407,7 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) 
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
 	const postTypeTrashUrl = getPostTypeTrashUrl( state, postType );
-	const frameNonce = getSiteOption( state, siteId, 'frame_nonce' ) || '';
+	const frameNonce = getSiteOption( state, siteId, 'jetpack_frame_nonce' ) || '';
 
 	let queryArgs = pickBy( {
 		post: postId,

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -160,29 +160,3 @@ export const requestSiteAlerts = siteId => {
 		}
 	);
 };
-
-/**
- * Request a site's frame nonce from the v1.3 sites endpoint.
- *
- * @param {number} siteId  Site Id.
- * @return {*} Stored data container for request.
- */
-export const requestFrameNonce = siteId => {
-	const id = `frame-nonce-${ siteId }`;
-
-	return requestHttpData(
-		id,
-		http(
-			{
-				apiVersion: '1.3',
-				method: 'GET',
-				path: `/sites/${ siteId }`,
-			},
-			{}
-		),
-		{
-			freshness: 5 * 60 * 1000, // TODO this should match iframe nonce expiry
-			fromApi: () => ( { options: { frame_nonce } } ) => [ [ id, frame_nonce ] ],
-		}
-	);
-};

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -41,6 +41,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'is_wpcom_atomic',
 	'is_wpcom_store',
 	'woocommerce_is_active',
+	'jetpack_frame_nonce',
 	'jetpack_version',
 	'main_network_site',
 	'permalink_structure',

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -136,18 +136,18 @@ describe( 'actions', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( '/rest/v1.3/sites/2916284' )
+				.get( '/rest/v1.2/sites/2916284' )
 				.reply( 200, {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
 					capabilities: {},
 				} )
-				.get( '/rest/v1.3/sites/77203074' )
+				.get( '/rest/v1.2/sites/77203074' )
 				.reply( 403, {
 					error: 'authorization_required',
 					message: 'User cannot access this private blog.',
 				} )
-				.get( '/rest/v1.3/sites/8894098' )
+				.get( '/rest/v1.2/sites/8894098' )
 				.reply( 200, {
 					ID: 8894098,
 					name: 'Some random site I dont have access to',

--- a/client/state/sites/test/actions.js
+++ b/client/state/sites/test/actions.js
@@ -136,18 +136,18 @@ describe( 'actions', () => {
 		useNock( nock => {
 			nock( 'https://public-api.wordpress.com:443' )
 				.persist()
-				.get( '/rest/v1.2/sites/2916284' )
+				.get( '/rest/v1.3/sites/2916284' )
 				.reply( 200, {
 					ID: 2916284,
 					name: 'WordPress.com Example Blog',
 					capabilities: {},
 				} )
-				.get( '/rest/v1.2/sites/77203074' )
+				.get( '/rest/v1.3/sites/77203074' )
 				.reply( 403, {
 					error: 'authorization_required',
 					message: 'User cannot access this private blog.',
 				} )
-				.get( '/rest/v1.2/sites/8894098' )
+				.get( '/rest/v1.3/sites/8894098' )
 				.reply( 200, {
 					ID: 8894098,
 					name: 'Some random site I dont have access to',


### PR DESCRIPTION
After problems with the Marketing section pointed out that we need to keep the rest of Calypso on v1.2 sites endpoints, we [reverted](https://github.com/Automattic/wp-calypso/pull/32778) the calls in `requestSites` and `requestSite` to v1.2.

Rather than Gutenframe rely on the the v1.3 sites endpoints itself, we decided to move to a simpler implementation of just adding a new site option to the existing endpoints, `jetpack_frame_nonce` (https://github.com/Automattic/jetpack/pull/12261 and https://github.com/Automattic/jetpack/pull/12262). This PR moves Gutenframe off of the v1.3 usage to the new v1.2 `jetpack_frame_nonce` field instead.

**Testing Instructions**
* Apply D27770-code to your sandbox and sandbox the API.
* Make sure your Jetpack testing site is up-to-date on `master`.
* Load your testing site in Gutenframe, eg. `http://calypso.localhost:3000/block-editor/post/:JPsite`.
* Ensure the block editor loads properly.

Let's also verify the Marketing section is unaffected.
* Select a Jetpack or Atomic site.
* Go to Marketing > Traffic, and verify "Enable SEO Tools to optimize your site for search engines" is active.
* Make changes under the "Page Title Structure" section, and click "Save Settings".
* Verify the API calls are successful, with no 404 errors.