### PR TITLE
Inline help: change button hover animation from wiggle to elevation

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -82,6 +82,7 @@
 	&:hover:not( .is-active ) {
 		@include elevation( 6dp );
 		background: var( --color-primary );
+		transform: scale( 1.15 );
 	}
 
 	&.is-active {

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -80,8 +80,7 @@
 	}
 
 	&:hover:not( .is-active ) {
-		animation: wiggle 0.8s 0.5s ease-in-out infinite;
-		box-shadow: 0 2px 6px rgba( 0, 0, 0, 0.3 );
+		@include elevation( 6dp );
 		background: var( --color-primary );
 	}
 
@@ -101,21 +100,6 @@
 		position: absolute;
 		top: -2px;
 		left: -3px;
-	}
-}
-
-@keyframes wiggle {
-	0% {
-		transform: rotate( 0 );
-	}
-	40% {
-		transform: rotate( 15deg );
-	}
-	50% {
-		transform: rotate( -15deg );
-	}
-	100% {
-		transform: rotate( 0 );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove wiggle animation on inline help button hover. Use an increased elevation as the hover state instead. This is similar to how Google does their hover state on the Compose button in Gmail.

**Before**
![inline help before](https://user-images.githubusercontent.com/448298/57165212-71b1b500-6dc4-11e9-885e-4fa9f1d411d9.gif)

**After**
![inline help after](https://user-images.githubusercontent.com/448298/57165220-74aca580-6dc4-11e9-9089-77229d1b0415.gif)

#### Testing instructions

* Check out this branch or use https://calypso.live/?branch=update/inline-help-button-animation
* Hover over the inline help button in the bottom right corner
* Make sure the animation is the increased elevation (shadow) instead of the wiggle

Fixes #32639
