### PR TITLE
Marketing/Connections: add tracks events to connections page

### DIFF
--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -19,7 +19,7 @@ import ScreenReaderText from 'components/screen-reader-text';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import UsersStore from 'lib/users/store';
 
 class SharingConnection extends Component {
@@ -70,15 +70,18 @@ class SharingConnection extends Component {
 
 	toggleSitewideConnection = event => {
 		if ( ! this.state.isSavingSitewide ) {
-			const isNowSitewide = event.target.checked;
+			const isNowSitewide = event.target.checked ? 1 : 0;
 
 			this.setState( { isSavingSitewide: true } );
 			this.props.onToggleSitewideConnection( this.props.connection, isNowSitewide );
+			this.props.recordTracksEvent( 'calypso_connections_connection_sitewide_checkbox_clicked', {
+				is_now_sitewide: isNowSitewide,
+			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
 				'Clicked Connection Available to All Users Checkbox',
 				this.props.service.ID,
-				isNowSitewide ? 1 : 0
+				isNowSitewide
 			);
 		}
 	};
@@ -254,5 +257,5 @@ export default connect(
 			userId: getCurrentUserId( state ),
 		};
 	},
-	{ recordGoogleEvent }
+	{ recordGoogleEvent, recordTracksEvent }
 )( localize( SharingConnection ) );

--- a/client/my-sites/marketing/connections/connection.jsx
+++ b/client/my-sites/marketing/connections/connection.jsx
@@ -18,6 +18,7 @@ import Gridicon from 'gridicons';
 import ScreenReaderText from 'components/screen-reader-text';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import UsersStore from 'lib/users/store';
@@ -69,6 +70,8 @@ class SharingConnection extends Component {
 	};
 
 	toggleSitewideConnection = event => {
+		const { path } = this.props;
+
 		if ( ! this.state.isSavingSitewide ) {
 			const isNowSitewide = event.target.checked ? 1 : 0;
 
@@ -76,6 +79,7 @@ class SharingConnection extends Component {
 			this.props.onToggleSitewideConnection( this.props.connection, isNowSitewide );
 			this.props.recordTracksEvent( 'calypso_connections_connection_sitewide_checkbox_clicked', {
 				is_now_sitewide: isNowSitewide,
+				path,
 			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
@@ -255,6 +259,7 @@ export default connect(
 			keyringUser,
 			userHasCaps: canCurrentUser( state, siteId, 'edit_others_posts' ),
 			userId: getCurrentUserId( state ),
+			path: getCurrentRouteParameterized( state, siteId ),
 		};
 	},
 	{ recordGoogleEvent, recordTracksEvent }

--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -146,5 +146,5 @@ export default connect(
 			path: getCurrentRouteParameterized( state, siteId ),
 		};
 	},
-	{ recordTracksEventAction }
+	{ recordTracksEvent: recordTracksEventAction }
 )( localize( SharingServiceAction ) );

--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -94,7 +94,10 @@ const SharingServiceAction = ( {
 					compact
 					href="https://public-api.wordpress.com/rest/v1.1/sharing/mailchimp/signup"
 					onClick={ () => {
-						recordTracksEvent( 'calypso_connections_signup_click', { service: 'mailchimp', path } );
+						recordTracksEvent( 'calypso_connections_signup_button_click', {
+							service: 'mailchimp',
+							path,
+						} );
 						return true;
 					} }
 					target="_blank"

--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -13,8 +13,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { getSelectedSiteId } from 'state/ui/selectors';
 import Button from 'components/button';
+import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 import { getRemovableConnections } from 'state/sharing/publicize/selectors';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 
 const SharingServiceAction = ( {
 	isConnecting,
@@ -25,6 +28,7 @@ const SharingServiceAction = ( {
 	service,
 	status,
 	translate,
+	recordTracksEvent,
 } ) => {
 	let warning = false,
 		label;
@@ -88,6 +92,10 @@ const SharingServiceAction = ( {
 					className="connections__signup"
 					compact
 					href="https://public-api.wordpress.com/rest/v1.1/sharing/mailchimp/signup"
+					onClick={ () => {
+						recordTracksEvent( 'calypso_connections_signup_click', { service: 'mailchimp' } );
+						return true;
+					} }
 					target="_blank"
 					disabled={ isPending }
 				>
@@ -116,6 +124,7 @@ SharingServiceAction.propTypes = {
 	service: PropTypes.object.isRequired,
 	status: PropTypes.string,
 	translate: PropTypes.func,
+	recordTracksEvent: PropTypes.func,
 };
 
 SharingServiceAction.defaultProps = {
@@ -128,6 +137,14 @@ SharingServiceAction.defaultProps = {
 	translate: identity,
 };
 
-export default connect( ( state, { service } ) => ( {
-	removableConnections: getRemovableConnections( state, service.ID ),
-} ) )( localize( SharingServiceAction ) );
+export default connect(
+	( state, { service } ) => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			removableConnections: getRemovableConnections( state, service.ID ),
+			path: getCurrentRouteParameterized( state, siteId ),
+		};
+	},
+	{ recordTracksEventAction }
+)( localize( SharingServiceAction ) );

--- a/client/my-sites/marketing/connections/service-action.jsx
+++ b/client/my-sites/marketing/connections/service-action.jsx
@@ -29,6 +29,7 @@ const SharingServiceAction = ( {
 	status,
 	translate,
 	recordTracksEvent,
+	path,
 } ) => {
 	let warning = false,
 		label;
@@ -93,7 +94,7 @@ const SharingServiceAction = ( {
 					compact
 					href="https://public-api.wordpress.com/rest/v1.1/sharing/mailchimp/signup"
 					onClick={ () => {
-						recordTracksEvent( 'calypso_connections_signup_click', { service: 'mailchimp' } );
+						recordTracksEvent( 'calypso_connections_signup_click', { service: 'mailchimp', path } );
 						return true;
 					} }
 					target="_blank"

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -106,6 +106,7 @@ export class SharingService extends Component {
 	 */
 	performAction = () => {
 		const connectionStatus = this.getConnectionStatus( this.props.service.ID );
+		const { path } = this.props;
 
 		// Depending on current status, perform an action when user clicks the
 		// service action button
@@ -116,18 +117,21 @@ export class SharingService extends Component {
 			this.removeConnection();
 			this.props.recordTracksEvent( 'calypso_connections_disconnect_button_click', {
 				service: this.props.service.ID,
+				path,
 			} );
 			this.props.recordGoogleEvent( 'Sharing', 'Clicked Disconnect Button', this.props.service.ID );
 		} else if ( 'reconnect' === connectionStatus ) {
 			this.refresh();
 			this.props.recordTracksEvent( 'calypso_connections_reconnect_button_click', {
 				service: this.props.service.ID,
+				path,
 			} );
 			this.props.recordGoogleEvent( 'Sharing', 'Clicked Reconnect Button', this.props.service.ID );
 		} else {
 			this.addConnection( this.props.service, this.state.newKeyringId );
 			this.props.recordTracksEvent( 'calypso_connections_connect_button_click', {
 				service: this.props.service.ID,
+				path,
 			} );
 			this.props.recordGoogleEvent( 'Sharing', 'Clicked Connect Button', this.props.service.ID );
 		}
@@ -150,6 +154,8 @@ export class SharingService extends Component {
 	addConnection = ( service, keyringConnectionId, externalUserId = 0 ) => {
 		this.setState( { isConnecting: true } );
 
+		const { path } = this.props;
+
 		if ( service ) {
 			if ( keyringConnectionId ) {
 				// Since we have a Keyring connection to work with, we can immediately
@@ -157,6 +163,7 @@ export class SharingService extends Component {
 				this.createOrUpdateConnection( keyringConnectionId, externalUserId );
 				this.props.recordTracksEvent( 'calypso_connections_connect_button_in_modal_click', {
 					service: this.props.service.ID,
+					path,
 				} );
 				this.props.recordGoogleEvent(
 					'Sharing',
@@ -190,6 +197,7 @@ export class SharingService extends Component {
 			this.setState( { isConnecting: false } );
 			this.props.recordTracksEvent( 'calypso_connections_cancel_button_in_modal_click', {
 				service: this.props.service.ID,
+				path,
 			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
@@ -224,8 +232,11 @@ export class SharingService extends Component {
 	};
 
 	connectAnother = () => {
+		const { path } = this.props;
+
 		this.props.recordTracksEvent( 'calypso_connections_connect_another_button_click', {
 			service: this.props.service.ID,
+			path,
 		} );
 		this.props.recordGoogleEvent(
 			'Sharing',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the Connections page to use Tracks events.

#### Testing instructions

1. Check out this branch and `npm run build`.
2. On a site with at least a Business plan, go to `marketing/connections/:site`.
3. Ensure that analytics debugging is activated by running this in the browser console: `localStorage.setItem('debug', 'calypso:analytics:*');`
4. Click "Sign up" on the Mailchimp box and verify that a tracks event with the correct service prop is sent.
5. Click "connect" on any site and verify that a tracks event with the correct service prop is sent. Continue to connect to the site.
6. Click "disconnect" on any site that is connected and verify that a tracks event with the correct service prop is sent.
7. To test reconnecting, edit `getConnectionStatus` in `marketing/connections/service.jsx` to always return `reconnect`. Then click "reconnect" for any service and verify that a tracks event with the correct service prop is sent.
8. Visually verify that the code related to the modal popup is correct. (I was unable to determine how to get Calypso into that state.)
9. Set up any of the connections under the "Publicize Your Posts" section. Expand the connection with the arrow on the right side, then click "Connection available to all administrators, editors, and authors". Verify that a tracks event with the correct `is_now_sitewide` prop is sent.
