### PR TITLE
Gutenberg: Avoid Calypsoify flows on Jetpack sites

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -10,7 +10,7 @@ import { get, isInteger } from 'lodash';
  * Internal dependencies
  */
 import isGutenbergEnabled from 'state/selectors/is-gutenberg-enabled';
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import isWpAdminGutenbergEnabled from 'state/selectors/is-wp-admin-gutenberg-enabled';
 import { EDITOR_START } from 'state/action-types';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import CalypsoifyIframe from './calypsoify-iframe';
@@ -45,7 +45,7 @@ export const redirect = ( context, next ) => {
 	const state = getState();
 	const siteId = getSelectedSiteId( state );
 
-	if ( isCalypsoifyGutenbergEnabled( state, siteId ) ) {
+	if ( isWpAdminGutenbergEnabled( state, siteId ) ) {
 		const postType = determinePostType( context );
 		const postId = getPostID( context );
 		const url = getGutenbergEditorUrl( state, siteId, postId, postType );

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -38,7 +38,7 @@ import { savePost, deletePost, trashPost, restorePost } from 'state/posts/action
 import { withoutNotice } from 'state/notices/actions';
 import { isEnabled } from 'config';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import isWpAdminGutenbergEnabled from 'state/selectors/is-wp-admin-gutenberg-enabled';
 import getEditorUrl from 'state/selectors/get-editor-url';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 
@@ -201,7 +201,7 @@ class Page extends Component {
 			return null;
 		}
 
-		if ( this.props.calypsoifyGutenberg ) {
+		if ( this.props.wpAdminGutenberg ) {
 			return (
 				<PopoverMenuItem onClick={ this.props.recordEditPage } href={ this.props.editorUrl }>
 					<Gridicon icon="pencil" size={ 18 } />
@@ -277,11 +277,11 @@ class Page extends Component {
 	}
 
 	getCopyItem() {
-		const { calypsoifyGutenberg, page: post, duplicateUrl } = this.props;
+		const { wpAdminGutenberg, page: post, duplicateUrl } = this.props;
 		if (
 			! includes( [ 'draft', 'future', 'pending', 'private', 'publish' ], post.status ) ||
 			! utils.userCan( 'edit_post', post ) ||
-			calypsoifyGutenberg
+			wpAdminGutenberg
 		) {
 			return null;
 		}
@@ -647,8 +647,8 @@ const mapState = ( state, props ) => {
 		siteSlugOrId,
 		editorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.ID' ), 'page' ),
 		parentEditorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.parent.ID' ), 'page' ),
-		calypsoifyGutenberg:
-			isCalypsoifyGutenbergEnabled( state, pageSiteId ) &&
+		wpAdminGutenberg:
+			isWpAdminGutenbergEnabled( state, pageSiteId ) &&
 			'gutenberg' === getSelectedEditor( state, pageSiteId ),
 		duplicateUrl: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' ),
 	};

--- a/client/my-sites/sidebar/manage-menu.jsx
+++ b/client/my-sites/sidebar/manage-menu.jsx
@@ -35,7 +35,7 @@ import { canCurrentUser as canCurrentUserStateSelector } from 'state/selectors/c
 import { itemLinkMatches } from './utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import isWpAdminGutenbergEnabled from 'state/selectors/is-wp-admin-gutenberg-enabled';
 import { getEditorUrl as getEditorUrlStateSelector } from 'state/selectors/get-editor-url';
 import isVipSite from 'state/selectors/is-vip-site';
 
@@ -54,7 +54,7 @@ class ManageMenu extends PureComponent {
 		siteAdminUrl: PropTypes.string,
 		site: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		siteSlug: PropTypes.string,
-		calypsoifyGutenberg: PropTypes.bool,
+		wpAdminGutenberg: PropTypes.bool,
 	};
 
 	// We default to `/my` posts when appropriate
@@ -76,7 +76,7 @@ class ManageMenu extends PureComponent {
 	}
 
 	getDefaultMenuItems() {
-		const { calypsoifyGutenberg, getEditorUrl, siteSlug, translate } = this.props;
+		const { wpAdminGutenberg, getEditorUrl, siteSlug, translate } = this.props;
 
 		return [
 			{
@@ -87,7 +87,7 @@ class ManageMenu extends PureComponent {
 				config: 'manage/pages',
 				link: '/pages',
 				buttonLink: getEditorUrl( 'page' ),
-				forceButtonTargetInternal: calypsoifyGutenberg,
+				forceButtonTargetInternal: wpAdminGutenberg,
 				wpAdminLink: 'edit.php?post_type=page',
 				showOnAllMySites: true,
 			},
@@ -100,7 +100,7 @@ class ManageMenu extends PureComponent {
 				link: '/posts' + this.getMyParameter(),
 				paths: [ '/posts', '/posts/my' ],
 				buttonLink: getEditorUrl( 'post' ),
-				forceButtonTargetInternal: calypsoifyGutenberg,
+				forceButtonTargetInternal: wpAdminGutenberg,
 				wpAdminLink: 'edit.php',
 				showOnAllMySites: true,
 			},
@@ -355,7 +355,7 @@ class ManageMenu extends PureComponent {
 					wpAdminLink: 'edit.php?post_type=' + postType.name,
 					showOnAllMySites: false,
 					buttonLink,
-					forceButtonTargetInternal: this.props.calypsoifyGutenberg,
+					forceButtonTargetInternal: this.props.wpAdminGutenberg,
 				} );
 			},
 			[]
@@ -396,8 +396,8 @@ export default connect(
 		site: getSite( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 		isVip: isVipSite( state, siteId ),
-		calypsoifyGutenberg:
-			isCalypsoifyGutenbergEnabled( state, siteId ) &&
+		wpAdminGutenberg:
+			isWpAdminGutenbergEnabled( state, siteId ) &&
 			'gutenberg' === getSelectedEditor( state, siteId ),
 	} ),
 	{ recordTracksEvent },

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -35,7 +35,7 @@ import { canCurrentUser as canCurrentUserStateSelector } from 'state/selectors/c
 import { itemLinkMatches } from './utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import isWpAdminGutenbergEnabled from 'state/selectors/is-wp-admin-gutenberg-enabled';
 import { getEditorUrl as getEditorUrlStateSelector } from 'state/selectors/get-editor-url';
 import isVipSite from 'state/selectors/is-vip-site';
 
@@ -54,7 +54,7 @@ class SiteMenu extends PureComponent {
 		siteAdminUrl: PropTypes.string,
 		site: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		siteSlug: PropTypes.string,
-		calypsoifyGutenberg: PropTypes.bool,
+		wpAdminGutenberg: PropTypes.bool,
 	};
 
 	// We default to `/my` posts when appropriate
@@ -76,7 +76,7 @@ class SiteMenu extends PureComponent {
 	}
 
 	getDefaultMenuItems() {
-		const { calypsoifyGutenberg, getEditorUrl, siteSlug, translate } = this.props;
+		const { wpAdminGutenberg, getEditorUrl, siteSlug, translate } = this.props;
 
 		return [
 			{
@@ -87,7 +87,7 @@ class SiteMenu extends PureComponent {
 				config: 'manage/pages',
 				link: '/pages',
 				buttonLink: getEditorUrl( 'page' ),
-				forceButtonTargetInternal: calypsoifyGutenberg,
+				forceButtonTargetInternal: wpAdminGutenberg,
 				wpAdminLink: 'edit.php?post_type=page',
 				showOnAllMySites: true,
 			},
@@ -100,7 +100,7 @@ class SiteMenu extends PureComponent {
 				link: '/posts' + this.getMyParameter(),
 				paths: [ '/posts', '/posts/my' ],
 				buttonLink: getEditorUrl( 'post' ),
-				forceButtonTargetInternal: calypsoifyGutenberg,
+				forceButtonTargetInternal: wpAdminGutenberg,
 				wpAdminLink: 'edit.php',
 				showOnAllMySites: true,
 			},
@@ -316,7 +316,7 @@ class SiteMenu extends PureComponent {
 					wpAdminLink: 'edit.php?post_type=' + postType.name,
 					showOnAllMySites: false,
 					buttonLink,
-					forceButtonTargetInternal: this.props.calypsoifyGutenberg,
+					forceButtonTargetInternal: this.props.wpAdminGutenberg,
 				} );
 			},
 			[]
@@ -349,8 +349,8 @@ export default connect(
 		site: getSite( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 		isVip: isVipSite( state, siteId ),
-		calypsoifyGutenberg:
-			isCalypsoifyGutenbergEnabled( state, siteId ) &&
+		wpAdminGutenberg:
+			isWpAdminGutenbergEnabled( state, siteId ) &&
 			'gutenberg' === getSelectedEditor( state, siteId ),
 	} ),
 	{ recordTracksEvent },

--- a/client/state/selectors/get-gutenberg-editor-url.js
+++ b/client/state/selectors/get-gutenberg-editor-url.js
@@ -2,21 +2,28 @@
 /**
  * Internal dependencies
  */
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import isWpAdminGutenbergEnabled from 'state/selectors/is-wp-admin-gutenberg-enabled';
 import { getSiteAdminUrl, getSiteSlug } from 'state/sites/selectors';
 import { getEditorPath } from 'state/ui/editor/selectors';
+import { isEnabled } from 'config';
+import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
+import { addQueryArgs } from 'lib/route';
 
 export const getGutenbergEditorUrl = ( state, siteId, postId = null, postType = 'post' ) => {
-	if ( isCalypsoifyGutenbergEnabled( state, siteId ) ) {
+	if ( isWpAdminGutenbergEnabled( state, siteId ) ) {
 		const siteAdminUrl = getSiteAdminUrl( state, siteId );
+		let url = `${ siteAdminUrl }post-new.php?post_type=${ postType }`;
 
 		if ( postId ) {
-			return `${ siteAdminUrl }post.php?post=${ postId }&action=edit&calypsoify=1`;
+			url = `${ siteAdminUrl }post.php?post=${ postId }&action=edit`;
 		}
-		if ( 'post' === postType ) {
-			return `${ siteAdminUrl }post-new.php?calypsoify=1`;
+
+		// We want Calypsoify flows on Atomic sites
+		if ( isSiteAtomic( state, siteId ) && isEnabled( 'calypsoify/gutenberg' ) ) {
+			url = addQueryArgs( { calypsoify: '1' }, url );
 		}
-		return `${ siteAdminUrl }post-new.php?post_type=${ postType }&calypsoify=1`;
+
+		return url;
 	}
 
 	if ( postId ) {

--- a/client/state/selectors/is-gutenberg-enabled.js
+++ b/client/state/selectors/is-gutenberg-enabled.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import isCalypsoifyGutenbergEnabled from 'state/selectors/is-calypsoify-gutenberg-enabled';
+import isWpAdminGutenbergEnabled from 'state/selectors/is-wp-admin-gutenberg-enabled';
 import isGutenframeEnabled from 'state/selectors/is-gutenframe-enabled';
 import isVipSite from 'state/selectors/is-vip-site';
 
@@ -16,10 +16,7 @@ export const isGutenbergEnabled = ( state, siteId ) => {
 		return false;
 	}
 
-	return (
-		isCalypsoifyGutenbergEnabled( state, siteId ) ||
-		isGutenframeEnabled( state, siteId )
-	);
+	return isWpAdminGutenbergEnabled( state, siteId ) || isGutenframeEnabled( state, siteId );
 };
 
 export default isGutenbergEnabled;

--- a/client/state/selectors/is-wp-admin-gutenberg-enabled.js
+++ b/client/state/selectors/is-wp-admin-gutenberg-enabled.js
@@ -11,12 +11,12 @@ import versionCompare from 'lib/version-compare';
 import isPluginActive from 'state/selectors/is-plugin-active';
 import { isHttps } from 'lib/url';
 
-export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
+export const isWpAdminGutenbergEnabled = ( state, siteId ) => {
 	if ( ! siteId ) {
 		return false;
 	}
 
-	// We might want Calypsoify flows for Jetpack and Atomic sites.
+	// We might want WP Admin flows for Jetpack and Atomic sites.
 	if ( isJetpackSite( state, siteId ) || isSiteAutomatedTransfer( state, siteId ) ) {
 		// But only once they have been updated to WordPress version 5.0 or greater since it will provide Gutenberg
 		// editor by default.
@@ -42,10 +42,10 @@ export const isCalypsoifyGutenbergEnabled = ( state, siteId ) => {
 			return false;
 		}
 
-		return isEnabled( 'calypsoify/gutenberg' );
+		return true;
 	}
 
 	return false;
 };
 
-export default isCalypsoifyGutenbergEnabled;
+export default isWpAdminGutenbergEnabled;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

On https://github.com/Automattic/wp-calypso/pull/32674 we started to use Calypsoify flows on JP sites not elegible for Gutenframe. We took that decision under the premise that having the same flows for both Jetpack and Atomic sites is better than maintaining one more exception for JP sites.

Unfortunately, that is causing some confusion to Jetpack users, since they are used to working with wp-admin.

This PR reverts some of the changes introduced in #32674 and ensures JP users are redirected to WP Admin if the site is inelegible for Gutenframe.

I also included a small refactor that renames the `isCalypsoifyGutenbergEnabled` selector to `isWpAdminGutenbergEnabled` in order to make more clear Calypso supports two editor modes: Gutenframe and WP Admin Gutenberg. 

Calypsoify should be considered a variation of the WP Admin Gutenberg mode we use only on Atomic sites.

#### Testing instructions

Make sure you get the expected editor when you go to `/block-editor` and select a test site:

| Site | Expected editor |
| --- | --- |
| Jetpack (<v7.3) | WP Admin |
| Jetpack (>=v7.3) | Gutenframe |
| Atomic (<v7.3) | WP Admin (Calypsoified) |
| Atomic (>=v7.3) | Gutenframe |

Fixes #32812
