### PR TITLE
Nav Drawer: Fix Mobile Colour Contrast Issues

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -374,7 +374,7 @@ form.sidebar__button input {
 	}
 	
 	.sidebar__button {
-			color: var( --sidebar-menu-selected-a-color );
+		color: var( --sidebar-menu-selected-a-color );
 		border-color: var( --sidebar-menu-selected-a-color );
 
 		&:hover {

--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -355,44 +355,42 @@ form.sidebar__button input {
 }
 
 // Selected Menu
-@include breakpoint( '>660px' ) {
-	.sidebar__menu .selected:not( .sidebar__plugins-item ) {
-		background-color: var( --sidebar-menu-selected-background-color );
+.sidebar__menu .selected:not( .sidebar__plugins-item ) {
+	background-color: var( --sidebar-menu-selected-background-color );
 
-		a {
-			color: var( --sidebar-menu-selected-a-color );
+	a {
+		color: var( --sidebar-menu-selected-a-color );
 
-			.sidebar__menu-link-secondary-text {
-				color: inherit;
-			}
-
-			&:first-child::after {
-				background: overflow-gradient(
-					var( --sidebar-menu-selected-a-first-child-after-background ),
-					50%
-				);
-			}
+		.sidebar__menu-link-secondary-text {
+			color: inherit;
 		}
 
-		.sidebar__button {
+		&:first-child::after {
+			background: overflow-gradient(
+				var( --sidebar-menu-selected-a-first-child-after-background ),
+				50%
+			);
+		}
+	}
+	
+	.sidebar__button {
+			color: var( --sidebar-menu-selected-a-color );
+		border-color: var( --sidebar-menu-selected-a-color );
+
+		&:hover {
 			color: var( --sidebar-menu-selected-a-color );
 			border-color: var( --sidebar-menu-selected-a-color );
-
-			&:hover {
-				color: var( --sidebar-menu-selected-a-color );
-				border-color: var( --sidebar-menu-selected-a-color );
-			}
 		}
+	}
 
-		.gridicon,
-		.jetpack-logo {
-			fill: var( --sidebar-menu-selected-a-color );
-		}
+	.gridicon,
+	.jetpack-logo {
+		fill: var( --sidebar-menu-selected-a-color );
+	}
 
-		&.is-action-button-selected a {
-			&:first-child::after {
-				background: linear-gradient( to right, rgba( var( --sidebar-menu-selected-a-first-child-after-background ), 0 ), rgba( var( --sidebar-menu-selected-a-first-child-after-background ), 1 ) 50% );
-			}
+	&.is-action-button-selected a {
+		&:first-child::after {
+			background: linear-gradient( to right, rgba( var( --sidebar-menu-selected-a-first-child-after-background ), 0 ), rgba( var( --sidebar-menu-selected-a-first-child-after-background ), 1 ) 50% );
 		}
 	}
 }

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -19,6 +19,18 @@
 	}
 }
 
+/* Because the sparkline is an image, there's an exception here
+ * where specific color schemes are targeted instead of using 
+ * CSS variables. This ensures that the sparkline can still be 
+ * seen (as white) on some of the darker color schemes.
+ */
+.is-classic-blue .sidebar__menu li.stats.selected .sidebar__sparkline, 
+.is-powder-snow .sidebar__menu li.stats.selected .sidebar__sparkline,
+.is-nightfall .sidebar__menu li.stats.selected .sidebar__sparkline {
+	filter: brightness( 100 );
+	-webkit-filter: brightness( 100 );
+}
+
 .sidebar__menu li.stats a::after,
 .notouch .sidebar__menu li.stats:hover:not( .selected ) a:first-child::after {
 	background: none;
@@ -42,4 +54,3 @@
 		fill: var( --color-primary );
 	}
 }
-

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -1,4 +1,6 @@
 // Reader Sidebar
+@import 'layout/sidebar/style';
+
 .is-group-reader .sidebar {
 	overflow-x: hidden;
 
@@ -8,33 +10,7 @@
 
 	.sidebar__menu {
 		margin-bottom: 8px;
-
-		.selected {
-			.menu-link-icon,
-			.sidebar__menu-action .gridicon,
-			.sidebar-dynamic-menu-action-icon {
-				fill: var( --sidebar-gridicon-fill );
-			}
-
-			.sidebar-streams__edit-icon {
-				fill: var( --sidebar-gridicon-fill );
-			}
-
-			.gridicon {
-				@include breakpoint( '<660px' ) {
-					fill: var( --sidebar-gridicon-fill );
-				}
-			}
-
-			li > a,
-			li > a:visited,
-			:not( .sidebar__button ) {
-				@include breakpoint( '<660px' ) {
-					color: var( --sidebar-text-color );
-				}
-			}
-		}
-
+		
 		.sidebar-streams__team {
 			border-top: 0;
 		}

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -1,6 +1,4 @@
 // Reader Sidebar
-@import 'layout/sidebar/style';
-
 .is-group-reader .sidebar {
 	overflow-x: hidden;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the mobile colour contrast issues, mainly by removing breakpoints. 

**Proposed:**

The Reader now relies on the sidebar styles where possible instead of overriding them with the wrong variables)

<img width="555" alt="Screenshot_2019-05-04_at_12 49 57" src="https://user-images.githubusercontent.com/43215253/57178670-13d8a800-6e6c-11e9-9368-b08ea74fdd98.png">

The sparkline when selected is now white on Nightfall, Classic Blue and Powder Snow (I found it really tricky to see on Powder Snow). 

cc @drw158 @sixhours, I remember this being discussed a while ago. I don't know how I feel about this because this is the only exception where a scheme is being targeted instead of using variables, but it's only the case where an image needs to be themed. 

<img width="558" alt="Screenshot_2019-05-04_at_12 49 49" src="https://user-images.githubusercontent.com/43215253/57178671-14713e80-6e6c-11e9-91e5-a1c7a68637ca.png">

Me sidebar also fixed. 
<img width="555" alt="Screenshot_2019-05-04_at_12 50 05" src="https://user-images.githubusercontent.com/43215253/57178696-80ec3d80-6e6c-11e9-9a0c-5f3da35bed1a.png">

For comparison, here's current. 

**Current:**

<img width="546" alt="Screenshot_2019-05-04_at_12 50 32" src="https://user-images.githubusercontent.com/43215253/57178711-9e210c00-6e6c-11e9-882d-82005dcb693e.png">
<img width="553" alt="Screenshot_2019-05-04_at_12 50 19" src="https://user-images.githubusercontent.com/43215253/57178712-9e210c00-6e6c-11e9-9a7c-424770b5be20.png">
<img width="553" alt="Screenshot_2019-05-04_at_12 50 40" src="https://user-images.githubusercontent.com/43215253/57178713-9e210c00-6e6c-11e9-8a13-bc7d044f95b3.png">


#### Testing instructions

When reviewing this code, I'd recommend hiding whitespaces. For visual checks, I'd recommend testing with the Powder Snow scheme since it's pretty much the darkest. Ensure that there aren't any adverse colour effects. This should only touch mobile devices, so you'll need to resize your screen to below 660px, but also ensure there's no changes on desktop devices. 

Fixes #32814
