### PR TITLE
 Packages: Bump calypso-build version to 1.0.0

### DIFF
--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-build",
-	"version": "1.0.0-rc.3",
+	"version": "1.0.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"config",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -3,6 +3,7 @@
 	"version": "1.0.0",
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
+		"babel",
 		"config",
 		"webpack",
 		"wordpress"

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -4,6 +4,9 @@
 	"description": "Shared Calypso build configuration files",
 	"keywords": [
 		"babel",
+		"build",
+		"bundle",
+		"compile",
 		"config",
 		"webpack",
 		"wordpress"


### PR DESCRIPTION
I think we're ready for primetime. Evidence to corroborate that claim: https://github.com/Automattic/newspack-blocks/pull/7

#### Changes proposed in this Pull Request

Bump calypso-build version to 1.0.0, and add a `babel` keyword.

(Any more keywords we should add?)

#### Testing instructions

:man_shrugging: 