### PR TITLE
Jetpack checklist: Copy updates in "thank you" splash for free plan

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -97,7 +97,7 @@ class Plans extends Component {
 		const { canPurchasePlans, selectedSiteSlug } = this.props;
 
 		if ( selectedSiteSlug && canPurchasePlans && isEnabled( 'jetpack/checklist' ) ) {
-			return this.redirect( CALYPSO_MY_PLAN_PAGE );
+			return this.redirect( CALYPSO_MY_PLAN_PAGE, { 'thank-you': '' } );
 		}
 
 		if ( selectedSiteSlug && canPurchasePlans ) {

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+
+export class FreePlanThankYouCard extends Component {
+	render() {
+		const { siteSlug, translate } = this.props;
+		return (
+			<Card className="current-plan-thank-you-card__main">
+				<div className="current-plan-thank-you-card__content">
+					<img
+						className="current-plan-thank-you-card__illustration"
+						alt=""
+						aria-hidden="true"
+						src="/calypso/images/illustrations/security.svg"
+					/>
+					<h1 className="current-plan-thank-you-card__title">
+						{ translate( 'Welcome to Jetpack Free!' ) }
+					</h1>
+					<p>
+						{ translate( 'We’ve automatically begun to protect your site from attacks.' ) }
+						<br />
+						{ translate( "You're now ready to finish the rest of the checklist." ) }
+					</p>
+					<Button primary href={ `/plans/my-plan/${ siteSlug }` }>
+						{ translate( 'Continue' ) }
+					</Button>
+				</div>
+			</Card>
+		);
+	}
+}
+
+export default connect( state => {
+	return {
+		siteSlug: getSelectedSiteSlug( state ),
+	};
+} )( localize( FreePlanThankYouCard ) );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
@@ -28,7 +28,7 @@ export class FreePlanThankYouCard extends Component {
 						{ translate( 'Welcome to Jetpack Free!' ) }
 					</h1>
 					<p>
-						{ translate( 'We’ve automatically begun to protect your site from attacks.' ) }
+						{ translate( "We've automatically begun to protect your site from attacks." ) }
 						<br />
 						{ translate( "You're now ready to finish the rest of the checklist." ) }
 					</p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/index.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/index.js
@@ -14,6 +14,7 @@ import getJetpackProductInstallProgress from 'state/selectors/get-jetpack-produc
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
 import ProgressBar from 'components/progress-bar';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 
 export class CurrentPlanThankYouCard extends Component {
 	getMyPlanRoute() {
@@ -23,7 +24,7 @@ export class CurrentPlanThankYouCard extends Component {
 	}
 
 	render() {
-		const { progressComplete, translate } = this.props;
+		const { isFreePlan, progressComplete, translate } = this.props;
 
 		return (
 			<Fragment>
@@ -41,10 +42,16 @@ export class CurrentPlanThankYouCard extends Component {
 										src="/calypso/images/illustrations/security.svg"
 									/>
 									<h1 className="current-plan-thank-you-card__title">
-										{ translate( 'So long spam, hello backups!' ) }
+										{ isFreePlan
+											? translate( 'Welcome to Jetpack Free!' )
+											: translate( 'So long spam, hello backups!' ) }
 									</h1>
 									<p>
-										{ translate( 'We’ve finished setting up spam filtering and backups for you.' ) }
+										{ isFreePlan
+											? translate( 'We’ve automatically begun to protect your site from attacks.' )
+											: translate(
+													'We’ve finished setting up spam filtering and backups for you.'
+											  ) }
 										<br />
 										{ translate( "You're now ready to finish the rest of the checklist." ) }
 									</p>
@@ -61,13 +68,21 @@ export class CurrentPlanThankYouCard extends Component {
 										src="/calypso/images/illustrations/fireworks.svg"
 									/>
 									<h1 className="current-plan-thank-you-card__title">
-										{ translate( 'Thank you for your purchase!' ) }
+										{ isFreePlan
+											? translate( 'Welcome to Jetpack Free!' )
+											: translate( 'Thank you for your purchase!' ) }
 									</h1>
-									<p>{ translate( "Now let's make sure your site is protected." ) }</p>
+									{ ! isFreePlan && (
+										<p>{ translate( "Now let's make sure your site is protected." ) }</p>
+									) }
 									<p>
-										{ translate(
-											"We're setting up spam filters and site backups for you first. Once that's done, our security checklist will guide you through the next steps."
-										) }
+										{ isFreePlan
+											? translate(
+													"We're setting up protecting your site. Once that's done, our security checklist will guide you through the next steps."
+											  )
+											: translate(
+													"We're setting up spam filters and site backups for you first. Once that's done, our security checklist will guide you through the next steps."
+											  ) }
 									</p>
 
 									<ProgressBar isPulsing total={ 100 } value={ progressComplete || 0 } />
@@ -89,6 +104,7 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
+		isFreePlan: isSiteOnFreePlan( state, siteId ),
 		progressComplete: getJetpackProductInstallProgress( state, siteId ),
 		siteId,
 		siteSlug: getSelectedSiteSlug( state ),

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -14,9 +14,8 @@ import getJetpackProductInstallProgress from 'state/selectors/get-jetpack-produc
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
 import ProgressBar from 'components/progress-bar';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 
-export class CurrentPlanThankYouCard extends Component {
+export class PaidPlanThankYouCard extends Component {
 	getMyPlanRoute() {
 		const { siteSlug } = this.props;
 
@@ -24,7 +23,7 @@ export class CurrentPlanThankYouCard extends Component {
 	}
 
 	render() {
-		const { isFreePlan, progressComplete, translate } = this.props;
+		const { progressComplete, translate } = this.props;
 
 		return (
 			<Fragment>
@@ -42,16 +41,12 @@ export class CurrentPlanThankYouCard extends Component {
 										src="/calypso/images/illustrations/security.svg"
 									/>
 									<h1 className="current-plan-thank-you-card__title">
-										{ isFreePlan
-											? translate( 'Welcome to Jetpack Free!' )
-											: translate( 'So long spam, hello backups!' ) }
+										{ translate( 'So long spam, hello backups!' ) }
 									</h1>
 									<p>
-										{ isFreePlan
-											? translate( 'We’ve automatically begun to protect your site from attacks.' )
-											: translate(
-													'We’ve finished setting up spam filtering and backups for you.'
-											  ) }
+										{ translate(
+											'We’ve finished setting up spam filtering and backups for you.'
+										) }
 										<br />
 										{ translate( "You're now ready to finish the rest of the checklist." ) }
 									</p>
@@ -68,21 +63,13 @@ export class CurrentPlanThankYouCard extends Component {
 										src="/calypso/images/illustrations/fireworks.svg"
 									/>
 									<h1 className="current-plan-thank-you-card__title">
-										{ isFreePlan
-											? translate( 'Welcome to Jetpack Free!' )
-											: translate( 'Thank you for your purchase!' ) }
+										{ translate( 'Thank you for your purchase!' ) }
 									</h1>
-									{ ! isFreePlan && (
-										<p>{ translate( "Now let's make sure your site is protected." ) }</p>
-									) }
+									<p>{ translate( "Now let's make sure your site is protected." ) }</p>
 									<p>
-										{ isFreePlan
-											? translate(
-													"We're setting up protecting your site. Once that's done, our security checklist will guide you through the next steps."
-											  )
-											: translate(
-													"We're setting up spam filters and site backups for you first. Once that's done, our security checklist will guide you through the next steps."
-											  ) }
+										{ translate(
+												"We're setting up spam filters and site backups for you first. Once that's done, our security checklist will guide you through the next steps."
+										) }
 									</p>
 
 									<ProgressBar isPulsing total={ 100 } value={ progressComplete || 0 } />
@@ -104,9 +91,7 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
-		isFreePlan: isSiteOnFreePlan( state, siteId ),
 		progressComplete: getJetpackProductInstallProgress( state, siteId ),
-		siteId,
 		siteSlug: getSelectedSiteSlug( state ),
 	};
-} )( localize( CurrentPlanThankYouCard ) );
+} )( localize( PaidPlanThankYouCard ) );

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -37,7 +37,8 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackChecklist from 'my-sites/plans/current-plan/jetpack-checklist';
 import { isEnabled } from 'config';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
-import CurrentPlanThankYouCard from './current-plan-thank-you-card';
+import PaidPlanThankYouCard from './current-plan-thank-you-card/paid-plan-thank-you-card';
+import FreePlanThankYouCard from './current-plan-thank-you-card/free-plan-thank-you-card';
 
 /**
  * Style dependencies
@@ -105,6 +106,9 @@ class CurrentPlan extends Component {
 		const currentPlanSlug = selectedSite.plan.product_slug,
 			isLoading = this.isLoading();
 
+		const currentPlanThankYouCard =
+			currentPlanSlug === 'jetpack_free' ? <FreePlanThankYouCard /> : <PaidPlanThankYouCard />;
+
 		const planConstObj = getPlan( currentPlanSlug ),
 			planFeaturesHeader = translate( '%(planName)s plan features', {
 				args: { planName: planConstObj.getTitle() },
@@ -142,7 +146,7 @@ class CurrentPlan extends Component {
 				) }
 
 				{ showThankYou ? (
-					<CurrentPlanThankYouCard />
+					currentPlanThankYouCard
 				) : (
 					<CurrentPlanHeader
 						isPlaceholder={ isLoading }

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -33,6 +33,7 @@ import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isSiteOnFreePlan from 'state/selectors/is-site-on-free-plan';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackChecklist from 'my-sites/plans/current-plan/jetpack-checklist';
 import { isEnabled } from 'config';
@@ -94,6 +95,7 @@ class CurrentPlan extends Component {
 			domains,
 			hasDomainsLoaded,
 			isExpiring,
+			isFreePlan,
 			path,
 			selectedSite,
 			selectedSiteId,
@@ -106,8 +108,11 @@ class CurrentPlan extends Component {
 		const currentPlanSlug = selectedSite.plan.product_slug,
 			isLoading = this.isLoading();
 
-		const currentPlanThankYouCard =
-			currentPlanSlug === 'jetpack_free' ? <FreePlanThankYouCard /> : <PaidPlanThankYouCard />;
+		const currentPlanThankYouCard = isFreePlan ? (
+			<FreePlanThankYouCard />
+		) : (
+			<PaidPlanThankYouCard />
+		);
 
 		const planConstObj = getPlan( currentPlanSlug ),
 			planFeaturesHeader = translate( '%(planName)s plan features', {
@@ -206,6 +211,7 @@ export default connect( ( state, { requestThankYou } ) => {
 		domains,
 		currentPlan: getCurrentPlan( state, selectedSiteId ),
 		isExpiring: isCurrentPlanExpiring( state, selectedSiteId ),
+		isFreePlan: isSiteOnFreePlan( state, selectedSiteId ),
 		shouldShowDomainWarnings: ! isJetpack || isAutomatedTransfer,
 		hasDomainsLoaded: !! domains,
 		isRequestingSitePlans: isRequestingSitePlans( state, selectedSiteId ),


### PR DESCRIPTION
Since free sites are directed to the checklist, we could show them "thank you" page as a celebratory moment after choosing the free plan.

Copy of that component just needs to be vastly different for free sites.

#### Changes proposed in this Pull Request

* Show "thank you" for  free sites
* Update copy for free sites

Free sites:
<img width="1059" alt="Screenshot 2019-05-17 at 08 30 15" src="https://user-images.githubusercontent.com/87168/57905522-850e5700-787f-11e9-8e57-2c92daa1890c.png">

Paid sites:
<img width="1055" alt="Screenshot 2019-05-17 at 08 40 40" src="https://user-images.githubusercontent.com/87168/57905523-88a1de00-787f-11e9-8ca0-2cbab930030f.png">


#### Testing instructions
* Have Jetpack disconnected
* Go to `http://calypso.localhost:3000/jetpack/connect/plans/:site`
* Press da free button
* Appreciate the checklist
* Confirm that you see "thank you" component that paid sites see and that it has different copy for paid and free plans

