### PR TITLE
Signup Processing Screen: remove unused code

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -73,7 +73,6 @@ $z-layers: (
 		'.stats-popular__empty': 1,
 		'.is-actionable .theme__thumbnail-label': 1,
 		'.accessible-focus .current-theme__button:focus': 1,
-		'.signup-processing-screen__processing-step.is-processing:before': 1,
 		'.accessible-focus .theme__more-button button:focus': 1,
 		'.domain-suggestion.is-clickable:hover': 1,
 		'.editor-html-toolbar': 1,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -115,14 +115,8 @@ class Signup extends React.Component {
 
 		this.state = {
 			controllerHasReset: false,
-			login: false,
-			dependencies: props.signupDependencies,
-			siteDomains: props.siteDomains,
-			isPaidPlan: props.isPaidPlan,
 			shouldShowLoadingScreen: false,
 			resumingStep: undefined,
-			loginHandler: null,
-			hasCartItems: false,
 			plans: false,
 			previousFlowName: null,
 		};
@@ -300,19 +294,6 @@ class Signup extends React.Component {
 		}
 	};
 
-	checkForCartItems = signupDependencies => {
-		const dependenciesContainCartItem = dependencies => {
-			return (
-				dependencies &&
-				( dependencies.cartItem || dependencies.domainItem || dependencies.themeItem )
-			);
-		};
-
-		if ( dependenciesContainCartItem( signupDependencies ) ) {
-			this.setState( { hasCartItems: true } );
-		}
-	};
-
 	recordStep = ( stepName = this.props.stepName, flowName = this.props.flowName ) => {
 		analytics.tracks.recordEvent( 'calypso_signup_step_start', {
 			flow: flowName,
@@ -352,21 +333,11 @@ class Signup extends React.Component {
 			flow: this.props.flowName,
 		} );
 
-		if ( dependencies && ( dependencies.cartItem || dependencies.domainItem ) ) {
-			this.handleLogin( dependencies, destination );
-		} else {
-			this.setState( {
-				loginHandler: this.handleLogin.bind( this, dependencies, destination ),
-			} );
-		}
+		this.handleLogin( dependencies, destination );
 	};
 
-	handleLogin = ( dependencies, destination, event ) => {
+	handleLogin( dependencies, destination ) {
 		const userIsLoggedIn = this.props.isLoggedIn;
-
-		if ( event && event.redirectTo ) {
-			destination = event.redirectTo;
-		}
 
 		debug( `Logging you in to "${ destination }"` );
 
@@ -409,7 +380,7 @@ class Signup extends React.Component {
 				} );
 			}
 		}
-	};
+	}
 
 	loginRedirectTo = path => {
 		let redirectTo;
@@ -557,14 +528,7 @@ class Signup extends React.Component {
 						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 					) }
 					{ this.state.shouldShowLoadingScreen ? (
-						<SignupProcessingScreen
-							hasCartItems={ this.state.hasCartItems }
-							steps={ this.props.progress }
-							loginHandler={ this.state.loginHandler }
-							signupDependencies={ this.props.signupDependencies }
-							flowName={ this.props.flowName }
-							flowSteps={ flow.steps }
-						/>
+						<SignupProcessingScreen steps={ this.props.progress } />
 					) : (
 						<CurrentComponent
 							path={ this.props.path }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -166,12 +166,11 @@ class Signup extends React.Component {
 			);
 		}
 
-		this.checkForCartItems( this.props.signupDependencies );
 		this.recordStep();
 	}
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const { signupDependencies, stepName, flowName, progress } = nextProps;
+		const { stepName, flowName, progress } = nextProps;
 
 		this.removeFulfilledSteps( nextProps );
 
@@ -194,8 +193,6 @@ class Signup extends React.Component {
 		if ( ! this.state.controllerHasReset && ! isEqual( this.props.progress, progress ) ) {
 			this.updateShouldShowLoadingScreen( progress );
 		}
-
-		this.checkForCartItems( signupDependencies );
 	}
 
 	componentWillUnmount() {

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -525,7 +525,7 @@ class Signup extends React.Component {
 						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 					) }
 					{ this.state.shouldShowLoadingScreen ? (
-						<SignupProcessingScreen steps={ this.props.progress } />
+						<SignupProcessingScreen />
 					) : (
 						<CurrentComponent
 							path={ this.props.path }

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -157,8 +157,8 @@ export class SignupProcessingScreen extends Component {
 			<div>
 				{ this.renderFloaties() }
 
-				<div className="signup-processing__content">
-					<p className="signup-process-screen__title">{ this.getTitle() }</p>
+				<div className="signup-processing-screen__content">
+					<p className="signup-processing-screen__title">{ this.getTitle() }</p>
 				</div>
 				<div className="signup-processing-screen__loader">
 					{ this.props.translate( 'Loading…' ) }

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -6,16 +6,9 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { find, isEmpty } from 'lodash';
+import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
-import { connect } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { showOAuth2Layout } from 'state/ui/oauth2-clients/selectors';
-import { getCurrentUser } from 'state/current-user/selectors';
 
 /**
  * Style dependencies
@@ -24,37 +17,8 @@ import './style.scss';
 
 export class SignupProcessingScreen extends Component {
 	static propTypes = {
-		hasCartItems: PropTypes.bool.isRequired,
-		loginHandler: PropTypes.func,
 		steps: PropTypes.array.isRequired,
-		user: PropTypes.object,
-		signupProgress: PropTypes.array,
-		flowSteps: PropTypes.array,
-		useOAuth2Layout: PropTypes.bool.isRequired,
 	};
-
-	state = {
-		siteSlug: '',
-		hasPaidSubscription: false,
-	};
-
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		const dependencies = nextProps.signupDependencies;
-
-		if ( isEmpty( dependencies ) ) {
-			return;
-		}
-
-		const siteSlug = dependencies.siteSlug;
-		if ( siteSlug && this.state.siteSlug !== siteSlug ) {
-			this.setState( { siteSlug } );
-		}
-
-		const hasPaidSubscription = !! ( dependencies.cartItem || dependencies.domainItem );
-		if ( hasPaidSubscription && this.state.hasPaidSubscription !== hasPaidSubscription ) {
-			this.setState( { hasPaidSubscription } );
-		}
-	}
 
 	renderFloaties() {
 		// Non standard gridicon sizes are used here because we display giant, floating icons on the page with an animation
@@ -95,61 +59,31 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	getTitle() {
-		const { loginHandler } = this.props;
-
 		const stepWithDomainItem = find( this.props.steps, step => step.domainItem );
 
 		if ( stepWithDomainItem ) {
 			const domain = stepWithDomainItem.domainItem.meta;
 
-			return loginHandler
-				? this.props.translate(
-						"{{strong}}Done!{{/strong}} Thanks for waiting, %(domain)s is all set up and we're ready {{br/}}for you to get started.",
-						{
-							components: { strong: <strong />, br: <br /> },
-							args: { domain },
-							comment:
-								'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
-						}
-				  )
-				: this.props.translate(
-						'{{strong}}Awesome!{{/strong}} Give us one minute and {{br/}}we’ll move right along.',
-						{
-							components: { strong: <strong />, br: <br /> },
-							args: { domain },
-							comment:
-								'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
-						}
-				  );
+			return this.props.translate(
+				'{{strong}}Awesome!{{/strong}} Give us one minute and {{br/}}we’ll move right along.',
+				{
+					components: { strong: <strong />, br: <br /> },
+					args: { domain },
+					comment:
+						'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
+				}
+			);
 		}
 
-		return loginHandler
-			? this.props.translate(
-					'{{strong}}Done!{{/strong}} Thanks for waiting, we’re ready for you {{br/}}to get started.',
-					{
-						components: { strong: <strong />, br: <br /> },
-						comment:
-							'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
-					}
-			  )
-			: this.props.translate(
-					'{{strong}}Awesome!{{/strong}} Give us one minute and {{br/}}we’ll move right along.',
-					{
-						components: { strong: <strong />, br: <br /> },
-						comment:
-							'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
-					}
-			  );
+		return this.props.translate(
+			'{{strong}}Awesome!{{/strong}} Give us one minute and {{br/}}we’ll move right along.',
+			{
+				components: { strong: <strong />, br: <br /> },
+				comment:
+					'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
+			}
+		);
 	}
-
-	componentDidUpdate = () => {
-		const { loginHandler } = this.props;
-
-		if ( loginHandler ) {
-			loginHandler();
-			return null;
-		}
-	};
 
 	render() {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -169,7 +103,4 @@ export class SignupProcessingScreen extends Component {
 	}
 }
 
-export default connect( state => ( {
-	useOAuth2Layout: showOAuth2Layout( state ),
-	user: getCurrentUser( state ),
-} ) )( localize( SignupProcessingScreen ) );
+export default localize( SignupProcessingScreen );

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -5,8 +5,6 @@
  */
 
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { find } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
@@ -16,10 +14,6 @@ import Gridicon from 'gridicons';
 import './style.scss';
 
 export class SignupProcessingScreen extends Component {
-	static propTypes = {
-		steps: PropTypes.array.isRequired,
-	};
-
 	renderFloaties() {
 		// Non standard gridicon sizes are used here because we display giant, floating icons on the page with an animation
 		/* eslint-disable wpcalypso/jsx-gridicon-size, wpcalypso/jsx-classname-namespace */
@@ -59,22 +53,6 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	getTitle() {
-		const stepWithDomainItem = find( this.props.steps, step => step.domainItem );
-
-		if ( stepWithDomainItem ) {
-			const domain = stepWithDomainItem.domainItem.meta;
-
-			return this.props.translate(
-				'{{strong}}Awesome!{{/strong}} Give us one minute and {{br/}}we’ll move right along.',
-				{
-					components: { strong: <strong />, br: <br /> },
-					args: { domain },
-					comment:
-						'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
-				}
-			);
-		}
-
 		return this.props.translate(
 			'{{strong}}Awesome!{{/strong}} Give us one minute and {{br/}}we’ll move right along.',
 			{
@@ -90,7 +68,6 @@ export class SignupProcessingScreen extends Component {
 		return (
 			<div>
 				{ this.renderFloaties() }
-
 				<div className="signup-processing-screen__content">
 					<p className="signup-processing-screen__title">{ this.getTitle() }</p>
 				</div>

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -71,9 +71,6 @@ export class SignupProcessingScreen extends Component {
 				<div className="signup-processing-screen__content">
 					<p className="signup-processing-screen__title">{ this.getTitle() }</p>
 				</div>
-				<div className="signup-processing-screen__loader">
-					{ this.props.translate( 'Loading…' ) }
-				</div>
 			</div>
 		);
 		/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -256,7 +256,7 @@
 	}
 }
 
-.signup-processing__content {
+.signup-processing-screen__content {
 	position: relative;
 	z-index: 1;
 	max-width: 500px;
@@ -277,36 +277,13 @@
 	}
 }
 
-.signup-process-screen__title {
+.signup-processing-screen__title {
 	margin: 360px 0 0;
 	padding: 0 16px;
 	text-align: center;
 	animation: fade-in 0.8s 1 cubic-bezier( 0.075, 0.82, 0.165, 1 );
 	animation-fill-mode: forwards;
 }
-
-/* Continue Button */
-@keyframes pulse {
-	0%,
-	100% {
-		opacity: 1;
-	}
-	60% {
-		opacity: 0.4;
-	}
-}
-
-.processing-screen__continue-button {
-	display: block;
-	padding: 10px 24px;
-	margin: 24px auto 48px;
-}
-
-.processing-screen__continue-button:disabled {
-	animation: pulse 1s infinite linear;
-}
-
-// Not entirely sure what this stuff is all about... -shaun
 
 .signup-processing-screen__loader {
 	animation: load8 1.1s infinite linear;
@@ -334,106 +311,4 @@
 	100% {
 		transform: rotate( 360deg );
 	}
-}
-
-.signup-process-screen__confetti {
-	display: block;
-	width: 284px;
-	height: 99px;
-	margin: 2em auto;
-}
-.signup-process-screen__title-test {
-	font-size: 1.35em;
-	font-weight: 300;
-}
-.signup-processing__upgrade-nudge {
-	background: var( --color-white );
-	text-align: center;
-	outline: 30px solid var( --color-white );
-	margin-bottom: 30px;
-}
-.signup-processing__title-subdomain {
-	text-transform: uppercase;
-	color: var( --color-neutral-500 );
-	font-size: 0.7em;
-	margin: 3px;
-	text-align: left;
-
-	@include breakpoint( '<480px' ) {
-		text-align: inherit;
-	}
-}
-.signup-processing__address-bar {
-	display: flex;
-	background: var( --color-neutral-400 );
-	border-radius: 8px;
-	flex-direction: row;
-	padding: 10px;
-	text-align: left;
-
-	@include breakpoint( '<480px' ) {
-		border-radius: 0;
-	}
-}
-.signup-processing__address-bar .gridicon {
-	fill: var( --color-neutral-700 );
-	margin-right: 10px;
-	align-self: center;
-	flex: 0 0 24px;
-}
-.signup-processing__address-field {
-	flex: 1;
-	background: var( --color-white );
-	margin: 0 0 0 5px;
-	padding: 8px;
-	box-sizing: border-box;
-	width: 100%;
-	overflow: auto;
-}
-.signup-processing__address-field.is-placeholder::after {
-	content: 'placeholder.wordpress.com';
-	color: transparent;
-	background-color: var( --color-neutral-0 );
-	animation: loading-fade 1.6s ease-in-out infinite;
-}
-.signup-processing__bubble {
-	position: relative;
-	background: #c2f4ff url( '/calypso/images/signup/seo-guy.svg' ) no-repeat 28px 50%;
-	background-size: 121px auto;
-	border-radius: 28px;
-	color: var( --color-neutral-700 );
-	width: 400px;
-	max-width: 96%;
-	padding: 28px;
-	margin: 50px auto 20px;
-	box-sizing: border-box;
-
-	p {
-		text-align: left;
-		padding-left: 140px;
-		margin: 0;
-	}
-
-	@include breakpoint( '<480px' ) {
-		background-size: 90px auto;
-
-		p {
-			padding-left: 115px;
-		}
-	}
-}
-.signup-processing__bubble-tail {
-	position: absolute;
-	fill: #c2f4ff;
-	width: 47px;
-	height: 31px;
-	top: -30px;
-	left: 30%;
-}
-.signup-processing__nudge-message {
-	width: 400px;
-	max-width: 96%;
-	color: var( --color-neutral-400 );
-	margin: 1.5em auto;
-	box-sizing: border-box;
 }

--- a/client/signup/processing-screen/style.scss
+++ b/client/signup/processing-screen/style.scss
@@ -284,31 +284,3 @@
 	animation: fade-in 0.8s 1 cubic-bezier( 0.075, 0.82, 0.165, 1 );
 	animation-fill-mode: forwards;
 }
-
-.signup-processing-screen__loader {
-	animation: load8 1.1s infinite linear;
-	border-top: 1.1em solid rgba( 255, 255, 255, 0.2 );
-	border-right: 1.1em solid rgba( 255, 255, 255, 0.2 );
-	border-bottom: 1.1em solid rgba( 255, 255, 255, 0.2 );
-	border-left: 1.1em solid #ffffff;
-	font-size: 5px;
-	margin: 20px auto;
-	position: relative;
-	transform: translateZ( 0 );
-	@include hide-content-accessibly;
-}
-
-.signup-processing-screen__loader,
-.signup-processing-screen__loader::after {
-	border-radius: 50%;
-	height: 10em;
-	width: 10em;
-}
-@keyframes load8 {
-	0% {
-		transform: rotate( 0deg );
-	}
-	100% {
-		transform: rotate( 360deg );
-	}
-}

--- a/test/e2e/lib/pages/signup/signup-processing-page.js
+++ b/test/e2e/lib/pages/signup/signup-processing-page.js
@@ -16,10 +16,7 @@ import LoginPage from '../../pages/login-page';
 
 export default class SignupProcessingPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.signup-processing__content' ) );
-		this.continueButtonSelector = By.css(
-			'button.email-confirmation__button:not([disabled]),button.processing-screen__continue-button:not([disabled])'
-		);
+		super( driver, By.css( '.signup-processing-screen__content' ) );
 	}
 
 	async waitForPage() {


### PR DESCRIPTION
During its lifetime, the `SignupProcessingScreen` component did a lot of things it doesn't do anymore today:
- show a "Continue" button to finish the signup flow and navigate to final destination (with an optional stop at the login page). This button is long gone (#28242) and today all flows continue automatically.
- render something conditionally based on flow name, cart items etc. Today, the only conditional left is determining whether we register a domain (then the screen shows the domain name) or do something else.
- show upgrade nudges (e.g., for SEO). These were all removed eventually after negative results in A/B testing.

A lot of the unused code was still left, unfortunately. This PR removes a lot of it:
- remove unused CSS and cleanup the CSS class names a bit (consistent `.signup-processing-screen` prefix)
- call `this.handleLogin` at the end of `handleFlowComplete`, never pass it to the processing screen component. The "Continue" button used to call the login handler, today everything is automatic.
- remove unused state and props.