### PR TITLE
Earn: Fix Missing WordAds Styles & CSS Migration

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -124,8 +124,6 @@
 @import 'me/purchases/remove-purchase/style';
 @import 'me/sidebar-navigation/style';
 @import 'me/sidebar/style';
-@import 'my-sites/earn/style';
-@import 'my-sites/earn/ads/style';
 @import 'my-sites/checklist/style';
 @import 'my-sites/checklist/wpcom-checklist/checklist-navigation/style';
 @import 'my-sites/customize/style';

--- a/client/blocks/upgrade-nudge-expanded/style.scss
+++ b/client/blocks/upgrade-nudge-expanded/style.scss
@@ -18,6 +18,10 @@
 	.upgrade-nudge-expanded__plan-card {
 		.plan-compare-card {
 			width: 100%;
+			
+			strong {
+				margin-right: 5px;
+			}
 		}
 
 		@include breakpoint( '>960px' ) {

--- a/client/blocks/upgrade-nudge-expanded/style.scss
+++ b/client/blocks/upgrade-nudge-expanded/style.scss
@@ -18,10 +18,6 @@
 	.upgrade-nudge-expanded__plan-card {
 		.plan-compare-card {
 			width: 100%;
-			
-			strong {
-				margin-right: 5px;
-			}
 		}
 
 		@include breakpoint( '>960px' ) {

--- a/client/my-sites/earn/ads/style.scss
+++ b/client/my-sites/earn/ads/style.scss
@@ -1,5 +1,3 @@
-@import 'my-sites/stats/stats-module/style.scss';
-
 .earnings_breakdown, .earnings_history {
 	.module-content {
 		display: block;

--- a/client/my-sites/earn/ads/style.scss
+++ b/client/my-sites/earn/ads/style.scss
@@ -1,3 +1,5 @@
+@import 'my-sites/stats/stats-module/style.scss';
+
 .earnings_breakdown, .earnings_history {
 	.module-content {
 		display: block;
@@ -86,7 +88,7 @@
 	}
 
 	tbody tr:hover {
-		background-color: #f3f6f8;
+		background-color: var( --color-neutral-50 );
 	}
 }
 
@@ -157,6 +159,6 @@
 }
 
 .ads__activate-description {
-	border-top: 1px solid #e9eff3;
+	border-top: 1px solid var( --color-border-subtle );
 	padding: 24px;
 }

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -33,8 +33,8 @@ import { isSiteWordadsUnsafe } from 'state/wordads/status/selectors';
 import { wordadsUnsafeValues } from 'state/wordads/status/schema';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { isPremium } from '../../../lib/products-values';
-import { canAccessEarnSection } from '../../../lib/ads/utils';
+import { isPremium } from 'lib/products-values';
+import { canAccessEarnSection } from 'lib/ads/utils';
 
 /**
  * Style dependencies

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -11,8 +11,11 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isWordadsInstantActivationEligible, canUpgradeToUseWordAds } from 'lib/ads/utils';
-import { isBusiness } from 'lib/products-values';
+import { isWordadsInstantActivationEligible, 
+		canUpgradeToUseWordAds, 
+		canAccessEarnSection 
+} from 'lib/ads/utils';
+import { isPremium, isBusiness } from 'lib/products-values';
 import FeatureExample from 'components/feature-example';
 import FormButton from 'components/forms/form-button';
 import Card from 'components/card';
@@ -33,13 +36,12 @@ import { isSiteWordadsUnsafe } from 'state/wordads/status/selectors';
 import { wordadsUnsafeValues } from 'state/wordads/status/schema';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
-import { isPremium } from 'lib/products-values';
-import { canAccessEarnSection } from 'lib/ads/utils';
 
 /**
  * Style dependencies
  */
 import './style.scss';
+import 'my-sites/stats/stats-module/style.scss';
 
 class AdsWrapper extends Component {
 	static propTypes = {

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -37,6 +35,11 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 import { isJetpackSite } from 'state/sites/selectors';
 import { isPremium } from '../../../lib/products-values';
 import { canAccessEarnSection } from '../../../lib/ads/utils';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class AdsWrapper extends Component {
 	static propTypes = {

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -17,12 +17,16 @@ import { saveAs } from 'browser-filesaver';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import Card from 'components/card';
 import InfiniteScroll from 'components/infinite-scroll';
-import './style.scss';
 import QueryMembershipsEarnings from 'components/data/query-memberships-earnings';
 import { requestSubscribers } from 'state/memberships/subscribers/actions';
 import { decodeEntities } from 'lib/formatting';
 import Gravatar from 'components/gravatar';
 import Button from 'components/button';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class MembershipsSection extends Component {
 	constructor( props ) {

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -1,3 +1,0 @@
-main.earn .plan-compare-card-item strong {
-	margin-right: 5px;
-}

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -62,6 +62,10 @@
 .plan-compare-card-item {
 	display: flex;
 	list-style-type: none;
+	
+	strong:first-of-type {
+		margin-right: 5px;
+	}
 }
 
 .plan-compare-card-item.is-highlight {

--- a/client/my-sites/stats/wordads/index.jsx
+++ b/client/my-sites/stats/wordads/index.jsx
@@ -35,6 +35,7 @@ import StickyPanel from 'components/sticky-panel';
  * Style dependencies
  */
 import './style.scss';
+import 'my-sites/earn/ads/style.scss';
 
 function updateQueryString( query = {} ) {
 	return {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Imports the stats module. This was causing the earn page to break upon refreshing, as the styles are necessary for the page to display 
* Migrates the CSS
* Removes the CSS specific which adds a space between the bold characters and the normal characters to the ads page to the component itself. I believe this is currently the only place where it's used? If used in the future though, this prevents that CSS from being repeated 
* Switches colours to colour variables

#### Testing instructions

When testing, please note that the Earn page is already broken for Jetpack sites and the lack of anything-ness isn't exclusive to this PR. 

Check that everything looks the same, specifically this on a site without WordAds: 
<img width="838" alt="Screenshot 2019-05-06 at 14 20 07" src="https://user-images.githubusercontent.com/43215253/57227794-27ba1080-700a-11e9-8c77-5fe9ce7e8b7b.png">

Then follow the instructions in the issue below and verify that you can't reproduce.

cc @jsnajdr, @blowery, @artpi 

Fixes #32422
