### PR TITLE
Allow multiple sections to add a reducer.

### DIFF
--- a/client/state/add-reducer.js
+++ b/client/state/add-reducer.js
@@ -22,7 +22,7 @@ async function initializeState( store, reducer, storageKey ) {
 
 // For a given store, creates a function that adds a new reducer to the store,
 // and loads (asynchronously) and applies the persisted state for it.
-export const addReducerToStore = store => async ( key, reducer ) => {
+export const addReducerToStore = store => ( key, reducer ) => {
 	const { storageKey } = reducer;
 	const normalizedKey = normalizeKey( key );
 	let init = initializations[ normalizedKey ];
@@ -39,5 +39,5 @@ export const addReducerToStore = store => async ( key, reducer ) => {
 		initializations[ normalizedKey ] = init;
 	}
 
-	await init;
+	return init;
 };

--- a/client/state/add-reducer.js
+++ b/client/state/add-reducer.js
@@ -3,24 +3,41 @@
 /**
  * Internal Dependencies
  */
-
 import { APPLY_STORED_STATE } from 'state/action-types';
 import { getStateFromLocalStorage } from 'state/initial-state';
+
+const initializations = {};
+
+function normalizeKey( key ) {
+	return Array.isArray( key ) ? key.join( '.' ) : key;
+}
+
+async function initializeState( store, reducer, storageKey ) {
+	const storedState = await getStateFromLocalStorage( reducer, storageKey );
+
+	if ( storedState ) {
+		store.dispatch( { type: APPLY_STORED_STATE, storageKey, storedState } );
+	}
+}
 
 // For a given store, creates a function that adds a new reducer to the store,
 // and loads (asynchronously) and applies the persisted state for it.
 export const addReducerToStore = store => async ( key, reducer ) => {
-	store.addReducer( key, reducer );
-
 	const { storageKey } = reducer;
-	if ( ! storageKey ) {
-		return;
+	const normalizedKey = normalizeKey( key );
+	let init = initializations[ normalizedKey ];
+
+	if ( ! init ) {
+		store.addReducer( key, reducer );
+
+		if ( storageKey ) {
+			init = initializeState( store, reducer, storageKey );
+		} else {
+			init = Promise.resolve();
+		}
+
+		initializations[ normalizedKey ] = init;
 	}
 
-	const storedState = await getStateFromLocalStorage( reducer, storageKey );
-	if ( ! storedState ) {
-		return;
-	}
-
-	store.dispatch( { type: APPLY_STORED_STATE, storageKey, storedState } );
+	await init;
 };

--- a/client/state/add-reducer.js
+++ b/client/state/add-reducer.js
@@ -10,7 +10,7 @@ const initializations = {};
 const reducers = {};
 
 function normalizeKey( key ) {
-	return Array.isArray( key ) ? key.join( '.' ) : key;
+	return key.join( '.' );
 }
 
 async function initializeState( store, reducer, storageKey ) {

--- a/client/state/add-reducer.js
+++ b/client/state/add-reducer.js
@@ -7,6 +7,7 @@ import { APPLY_STORED_STATE } from 'state/action-types';
 import { getStateFromLocalStorage } from 'state/initial-state';
 
 const initializations = {};
+const reducers = {};
 
 function normalizeKey( key ) {
 	return Array.isArray( key ) ? key.join( '.' ) : key;
@@ -27,6 +28,12 @@ export const addReducerToStore = store => ( key, reducer ) => {
 	const normalizedKey = normalizeKey( key );
 	let init = initializations[ normalizedKey ];
 
+	if ( init && reducer !== reducers[ normalizedKey ] ) {
+		throw new Error(
+			`Different reducers on multiple calls to \`addReducerToStore\` for key: ${ normalizedKey }`
+		);
+	}
+
 	if ( ! init ) {
 		store.addReducer( key, reducer );
 
@@ -37,6 +44,7 @@ export const addReducerToStore = store => ( key, reducer ) => {
 		}
 
 		initializations[ normalizedKey ] = init;
+		reducers[ normalizedKey ] = reducer;
 	}
 
 	return init;

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -556,6 +556,16 @@ describe( 'loading stored state with dynamic reducers', () => {
 				'B:country': 'France',
 				_timestamp,
 			},
+			'redux-state-123456789:CD': {
+				'CD:city': 'Lisbon',
+				'CD:country': 'Portugal',
+				_timestamp,
+			},
+			'redux-state-123456789:E': {
+				'E:city': 'Madrid',
+				'E:country': 'Spain',
+				_timestamp,
+			},
 		};
 
 		// localforage mock to return mock IndexedDB state
@@ -626,6 +636,77 @@ describe( 'loading stored state with dynamic reducers', () => {
 			a: {
 				city: 'London',
 				country: 'UK',
+			},
+		} );
+	} );
+
+	test( 'loads state after adding a nested reducer', async () => {
+		// initial reducer. includes only the `currentUser` subreducer.
+		const reducer = combineReducers( {
+			currentUser: currentUserReducer,
+		} );
+
+		// load initial state and create Redux store with it
+		const state = await getInitialState( reducer );
+		const store = createReduxStore( state, reducer );
+
+		// verify that the initial Redux store loaded state only for `currentUser`
+		expect( store.getState() ).toEqual( {
+			currentUser: {
+				id: 123456789,
+			},
+		} );
+
+		// load a reducer dynamically
+		const cdReducer = withStorageKey( 'CD', withKeyPrefix( 'CD' ) );
+		await addReducerToStore( store )( [ 'c', 'd' ], cdReducer );
+
+		// verify that the Redux store contains the stored state for `A` now
+		expect( store.getState() ).toEqual( {
+			currentUser: {
+				id: 123456789,
+			},
+			c: {
+				d: {
+					city: 'Lisbon',
+					country: 'Portugal',
+				},
+			},
+		} );
+	} );
+
+	test( 'loads state a single time after adding a reducer twice', async () => {
+		// initial reducer. includes only the `currentUser` subreducer.
+		const reducer = combineReducers( {
+			currentUser: currentUserReducer,
+		} );
+
+		// load initial state and create Redux store with it
+		const state = await getInitialState( reducer );
+		const store = createReduxStore( state, reducer );
+
+		// verify that the initial Redux store loaded state only for `currentUser`
+		expect( store.getState() ).toEqual( {
+			currentUser: {
+				id: 123456789,
+			},
+		} );
+
+		// load a reducer dynamically
+		const eReducer = withStorageKey( 'E', withKeyPrefix( 'E' ) );
+		await Promise.all( [
+			addReducerToStore( store )( 'e', eReducer ),
+			addReducerToStore( store )( 'e', eReducer ),
+		] );
+
+		// verify that the Redux store contains the stored state for `E` now
+		expect( store.getState() ).toEqual( {
+			currentUser: {
+				id: 123456789,
+			},
+			e: {
+				city: 'Madrid',
+				country: 'Spain',
 			},
 		} );
 	} );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -710,4 +710,33 @@ describe( 'loading stored state with dynamic reducers', () => {
 			},
 		} );
 	} );
+
+	test( 'throws an error when adding two different reducers to the same key', async () => {
+		// initial reducer. includes only the `currentUser` subreducer.
+		const reducer = combineReducers( {
+			currentUser: currentUserReducer,
+		} );
+
+		// load initial state and create Redux store with it
+		const state = await getInitialState( reducer );
+		const store = createReduxStore( state, reducer );
+
+		// verify that the initial Redux store loaded state only for `currentUser`
+		expect( store.getState() ).toEqual( {
+			currentUser: {
+				id: 123456789,
+			},
+		} );
+
+		// load a reducer dynamically
+		const bReducer = withStorageKey( 'B', withKeyPrefix( 'B' ) );
+		const cReducer = withStorageKey( 'C', withKeyPrefix( 'C' ) );
+
+		expect( () => {
+			Promise.all( [
+				addReducerToStore( store )( 'b', bReducer ),
+				addReducerToStore( store )( 'b', cReducer ),
+			] );
+		} ).toThrow();
+	} );
 } );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -626,7 +626,7 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		// load a reducer dynamically
 		const aReducer = withStorageKey( 'A', withKeyPrefix( 'A' ) );
-		await addReducerToStore( store )( 'a', aReducer );
+		await addReducerToStore( store )( [ 'a' ], aReducer );
 
 		// verify that the Redux store contains the stored state for `A` now
 		expect( store.getState() ).toEqual( {
@@ -695,8 +695,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 		// load a reducer dynamically
 		const eReducer = withStorageKey( 'E', withKeyPrefix( 'E' ) );
 		await Promise.all( [
-			addReducerToStore( store )( 'e', eReducer ),
-			addReducerToStore( store )( 'e', eReducer ),
+			addReducerToStore( store )( [ 'e' ], eReducer ),
+			addReducerToStore( store )( [ 'e' ], eReducer ),
 		] );
 
 		// verify that the Redux store contains the stored state for `E` now
@@ -734,8 +734,8 @@ describe( 'loading stored state with dynamic reducers', () => {
 
 		expect( () => {
 			Promise.all( [
-				addReducerToStore( store )( 'b', bReducer ),
-				addReducerToStore( store )( 'b', cReducer ),
+				addReducerToStore( store )( [ 'b' ], bReducer ),
+				addReducerToStore( store )( [ 'b' ], cReducer ),
 			] );
 		} ).toThrow();
 	} );


### PR DESCRIPTION
`addReducerToStore` now runs a single initialisation per key, allowing for multiple sections to register the same async reducer without causing race conditions.

#### Changes proposed in this Pull Request

* Run a single initialization per key passed to `addReducerToStore`
* Add some extra tests

#### Testing instructions

* Ensure unit tests work correctly
* Ensure there are no errors in sections with async-loaded reducers
