### PR TITLE
Revert "Checklist: Move email verification item towards the bottom of the list"

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -31,6 +31,7 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 		tasks.push( task );
 	};
 
+	addTask( 'email_verified' );
 	addTask( 'site_created', true );
 
 	if ( 'business' === segmentSlug ) {
@@ -65,7 +66,6 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 
 	addTask( 'custom_domain_registered' );
 	addTask( 'mobile_app_installed' );
-	addTask( 'email_verified' );
 
 	if ( get( taskStatuses, 'email_verified.completed' ) && isSiteUnlaunched ) {
 		addTask( 'site_launched' );

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -63,9 +63,9 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 		}
 	}
 
-	addTask( 'email_verified' );
 	addTask( 'custom_domain_registered' );
 	addTask( 'mobile_app_installed' );
+	addTask( 'email_verified' );
 
 	if ( get( taskStatuses, 'email_verified.completed' ) && isSiteUnlaunched ) {
 		addTask( 'site_launched' );


### PR DESCRIPTION
There's an issue with private-by-default and as a result it makes sense to temporarily bump the email-confirmation step back up the list.

Reverts Automattic/wp-calypso#32480