### PR TITLE
Checkout abtest: Move cart to right

### DIFF
--- a/client/components/data/store-connection/index.jsx
+++ b/client/components/data/store-connection/index.jsx
@@ -70,9 +70,12 @@ class StoreConnection extends React.Component {
 			return React.createElement( this.props.component, this.state );
 		}
 
-		const child = React.Children.only( this.props.children );
+		// const child = React.Children.only( this.props.children );
 
-		return React.cloneElement( child, this.state );
+		// return React.cloneElement( child, this.state );
+		return React.Children.map( this.props.children, child => {
+			return React.cloneElement( child, this.state );
+		} );
 	}
 }
 

--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import SidebarRegion from './region';
+import { abtest } from 'lib/abtest';
 
 export default class extends React.Component {
 	static displayName = 'Sidebar';
@@ -22,9 +23,13 @@ export default class extends React.Component {
 			el => el.type === SidebarRegion
 		);
 
+		const sidebarClass = 'right' === abtest( 'showCheckoutCartRight' ) ? '' : 'sidebar';
+
 		return (
 			<ul
-				className={ classNames( 'sidebar', this.props.className, { 'has-regions': hasRegions } ) }
+				className={ classNames( sidebarClass, this.props.className, {
+					'has-regions': hasRegions,
+				} ) }
 				onClick={ this.props.onClick }
 				data-tip-target="sidebar"
 			>

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -336,3 +336,17 @@
 		}
 	}
 }
+
+.is-section-show-cart-right .layout__primary {
+	display: flex;
+}
+
+.is-section-show-cart-right .layout__primary .main {
+	margin: 0 auto;
+	margin-right: 0;
+}
+
+.is-section-show-cart-right .layout__primary .secondary-cart {
+	margin: 0 auto;
+	margin-left: 20px;
+}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -192,4 +192,13 @@ export default {
 		defaultVariation: 'noOffer',
 		allowExistingUsers: true,
 	},
+	showCheckoutCartRight: {
+		datestamp: '20190502',
+		variations: {
+			right: 50,
+			original: 50,
+		},
+		defaultVariation: 'right',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -23,6 +23,7 @@ import CheckoutThankYouComponent from './checkout-thank-you';
 import ConciergeSessionNudge from './concierge-session-nudge';
 import ConciergeQuickstartSession from './concierge-quickstart-session';
 import { isGSuiteRestricted } from 'lib/gsuite';
+import { abtest } from 'lib/abtest';
 
 export function checkout( context, next ) {
 	const { feature, plan, product } = context.params;
@@ -36,6 +37,7 @@ export function checkout( context, next ) {
 
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
+	context.store.dispatch( setSection( { name: 'show-cart-right' }, { hasSidebar: false } ) );
 
 	context.primary = (
 		<CheckoutData>
@@ -46,14 +48,23 @@ export function checkout( context, next ) {
 				couponCode={ context.query.code }
 				plan={ plan }
 			/>
+
+			{ 'right' === abtest( 'showCheckoutCartRight' ) && (
+				<CartData>
+					<SecondaryCart selectedSite={ selectedSite } />
+				</CartData>
+			) }
 		</CheckoutData>
 	);
 
-	context.secondary = (
-		<CartData>
-			<SecondaryCart selectedSite={ selectedSite } />
-		</CartData>
-	);
+	if ( 'original' === abtest( 'showCheckoutCartRight' ) ) {
+		context.secondary = (
+			<CartData>
+				<SecondaryCart selectedSite={ selectedSite } />
+			</CartData>
+		);
+	}
+
 	next();
 }
 

--- a/public/images/upgrades/netbanking.svg
+++ b/public/images/upgrades/netbanking.svg
@@ -1,9 +1,0 @@
-<?xml version="1.0"?>
-<svg viewBox="0 0 224 48" width="224" height="48" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet">
- <g class="layer">
-  <g class="layer" id="svg_1">
-   <rect fill="#ffffff" height="43" id="svg_4" stroke="#016087" stroke-width="2" width="218" x="3" y="2.5"/>
-   <text fill="#016087" font-family="Helvetica, Arial, sans-serif" font-size="32" font-weight="bold" id="svg_3" stroke="#23354b" stroke-width="0" text-anchor="middle" x="112.00781" xml:space="preserve" y="34.25">Net Banking</text>
-  </g>
- </g>
-</svg>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new abtest that shows cart contents on the right.

![calypso localhost_3000_checkout_dnjadjah7362786728 wpcomstaging com](https://user-images.githubusercontent.com/1269602/57235796-4ee00480-7041-11e9-998f-6c016d74e5fd.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

WIP
 