### PR TITLE
Improve the wpcalypso/jsx-classname-namespace ESLint rule

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -99,7 +99,6 @@ export default {
 
 		// Extract this into a component...
 		context.primary = (
-			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			<Main className="auth">
 				<p className="auth__welcome">Loading user...</p>
 				<PulsingDot active />

--- a/client/blocks/author-compact-profile/placeholder.jsx
+++ b/client/blocks/author-compact-profile/placeholder.jsx
@@ -12,7 +12,6 @@ import React from 'react';
 import ReaderAvatar from 'blocks/reader-avatar';
 
 const AuthorCompactProfilePlaceholder = () => {
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<div className="author-compact-profile is-placeholder">
 			<div className="author-compact-profile__avatar-link">
@@ -26,7 +25,6 @@ const AuthorCompactProfilePlaceholder = () => {
 			</div>
 		</div>
 	);
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 };
 
 export default AuthorCompactProfilePlaceholder;

--- a/client/blocks/comment-button/index.jsx
+++ b/client/blocks/comment-button/index.jsx
@@ -23,7 +23,6 @@ function CommentButton( props ) {
 	const { commentCount, href, onClick, showLabel, tagName, target } = props;
 	const translate = useTranslate();
 
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return React.createElement(
 		tagName,
 		omitBy(
@@ -48,7 +47,6 @@ function CommentButton( props ) {
 			) }
 		</span>
 	);
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
 CommentButton.propTypes = {

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -97,7 +97,7 @@ class DomainProductPrice extends React.Component {
 		const { price, salePrice, translate } = this.props;
 
 		return (
-			<div className={ classnames( 'domain-product-price', 'is-free-domain' ) }>
+			<div className="domain-product-price is-free-domain">
 				<div className="domain-product-price__sale-price">{ salePrice }</div>
 				<div className="domain-product-price__renewal-price">
 					{ translate( 'Renews at: %(cost)s {{small}}/year{{/small}}', {
@@ -115,7 +115,7 @@ class DomainProductPrice extends React.Component {
 		}
 
 		return (
-			<div className={ classnames( 'domain-product-price' ) }>
+			<div className="domain-product-price">
 				<span className="domain-product-price__price">
 					{ this.props.translate( '%(cost)s {{small}}/year{{/small}}', {
 						args: { cost: this.props.price },

--- a/client/my-sites/themes/logged-out.jsx
+++ b/client/my-sites/themes/logged-out.jsx
@@ -16,7 +16,6 @@ import { connectOptions } from './theme-options';
 const ConnectedThemeShowcase = connectOptions( ThemeShowcase );
 
 export default props => (
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	<Main className="themes">
 		<ConnectedThemeShowcase
 			{ ...props }
@@ -29,5 +28,4 @@ export default props => (
 			showUploadButton={ false }
 		/>
 	</Main>
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 );

--- a/client/my-sites/themes/multi-site.jsx
+++ b/client/my-sites/themes/multi-site.jsx
@@ -16,14 +16,12 @@ import { connectOptions } from './theme-options';
 import ThemeShowcase from './theme-showcase';
 
 const MultiSiteThemeShowcase = connectOptions( props => (
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	<Main className="themes">
 		<SidebarNavigation />
 		<ThemesSiteSelectorModal { ...props }>
 			<ThemeShowcase source="showcase" showUploadButton={ false } />
 		</ThemesSiteSelectorModal>
 	</Main>
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 ) );
 
 export default props => (

--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -87,7 +87,6 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 	}
 
 	return (
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<Main className="themes">
 			<SidebarNavigation />
 			<CurrentTheme siteId={ siteId } />
@@ -145,7 +144,6 @@ const ConnectedSingleSiteJetpack = connectOptions( props => {
 				) }
 			</ThemeShowcase>
 		</Main>
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);
 } );
 

--- a/client/my-sites/themes/single-site-wpcom.jsx
+++ b/client/my-sites/themes/single-site-wpcom.jsx
@@ -66,7 +66,6 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 		}
 	}
 	return (
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<Main className="themes">
 			<SidebarNavigation />
 			<CurrentTheme siteId={ siteId } />
@@ -83,7 +82,6 @@ const ConnectedSingleSiteWpcom = connectOptions( props => {
 				<ThanksModal source={ 'list' } />
 			</ThemeShowcase>
 		</Main>
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);
 } );
 

--- a/packages/eslint-plugin-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-plugin-wpcalypso/CHANGELOG.md
@@ -1,6 +1,8 @@
-#### next (…)
+#### v4.1.0 (2019-05-07)
 
-- Enhancement: Update `i18n-ellipsis` rule to catch usage in @wordpress/i18n functions
+- Enhancement: `jsx-classname-namespace` doesn't limit classnames without suffix to root elements
+- Enhancement: `jsx-classname-namespace` accepts both file and directory name when validating class name
+- Enhancement: `i18n-ellipsis` rule updated to catch usage in @wordpress/i18n functions
 
 #### v4.0.2 (2018-08-10)
 

--- a/packages/eslint-plugin-wpcalypso/lib/rules/jsx-classname-namespace.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/jsx-classname-namespace.js
@@ -19,36 +19,12 @@ const path = require( 'path' );
 const rule = ( module.exports = function( context ) {
 	const rootFiles = ( context.options[ 0 ] || {} ).rootFiles || rule.DEFAULT_ROOT_FILES;
 
-	function isModuleExportNode( node ) {
-		return (
-			'ExpressionStatement' === node.type &&
-			'AssignmentExpression' === node.expression.type &&
-			'MemberExpression' === node.expression.left.type &&
-			'module' === node.expression.left.object.name &&
-			'exports' === node.expression.left.property.name
-		);
-	}
-
-	function isIdentifierInDescendents( node, name ) {
-		switch ( node.type ) {
-			case 'Identifier':
-				return node.name === name;
-
-			case 'CallExpression':
-				return node.arguments.some( function( argNode ) {
-					return isIdentifierInDescendents( argNode, name );
-				} );
-		}
-
-		return false;
-	}
-
 	function isRenderCallExpression( node ) {
-		let calleeName;
 		if ( 'CallExpression' !== node.type ) {
 			return false;
 		}
 
+		let calleeName;
 		if ( 'MemberExpression' === node.callee.type ) {
 			calleeName = node.callee.property.name;
 		} else if ( 'Identifier' === node.callee.type ) {
@@ -58,199 +34,27 @@ const rule = ( module.exports = function( context ) {
 		return calleeName && 'render' === calleeName;
 	}
 
-	function isRenderFunction( node ) {
-		if ( 'FunctionExpression' !== node.type ) {
-			return false;
-		}
-
-		if ( 'Property' === node.parent.type ) {
-			return 'init' === node.parent.kind && 'render' === node.parent.key.name;
-		}
-
-		if ( 'MethodDefinition' === node.parent.type ) {
-			return 'render' === node.parent.key.name;
+	function isInRenderCallExpession( node ) {
+		for ( let parent = node; parent; parent = parent.parent ) {
+			if ( isRenderCallExpression( parent ) ) {
+				return true;
+			}
 		}
 
 		return false;
-	}
-
-	function isFunctionType( node ) {
-		return (
-			-1 !==
-			[ 'FunctionExpression', 'FunctionDeclaration', 'ArrowFunctionExpression' ].indexOf(
-				node.type
-			)
-		);
-	}
-
-	function getFunctionReturnValue( node ) {
-		let i, bodyNode;
-
-		// An arrow function expression is one whose return statement is
-		// implicit. It does not have a body block.
-		//
-		// See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
-		if ( 'ArrowFunctionExpression' === node.type && node.expression ) {
-			return node.body;
-		}
-
-		for ( i = 0; i < node.body.body.length; i++ ) {
-			bodyNode = node.body.body[ i ];
-			if ( 'ReturnStatement' === bodyNode.type ) {
-				return bodyNode.argument;
-			}
-		}
-	}
-
-	function isSameIdentifier( nodeA, nodeB ) {
-		if ( ! nodeA || ! nodeB ) {
-			return false;
-		}
-
-		if ( 'Identifier' !== nodeA.type || 'Identifier' !== nodeB.type ) {
-			return false;
-		}
-
-		return nodeA.name === nodeB.name;
 	}
 
 	function isFolderRootFile( filename ) {
 		return rootFiles.indexOf( path.basename( filename ) ) !== -1;
 	}
 
-	function isRootElementInFile( node ) {
-		let isElementReturnArg,
-			elementAssignedIdentifier,
-			parent,
-			functionExpression,
-			functionName,
-			isRoot;
-
-		const element = node.parent.parent;
-
-		switch ( element.parent.type ) {
-			case 'ArrowFunctionExpression':
-				isElementReturnArg = element.parent.expression;
-				break;
-
-			case 'ReturnStatement':
-				isElementReturnArg = true;
-				break;
-
-			case 'VariableDeclarator':
-				elementAssignedIdentifier = element.parent.id;
-				break;
-		}
-
-		parent = element;
-
-		do {
-			parent = parent.parent;
-
-			// Abort if render call expression (i.e. ReactDOM.render)
-			if ( isRenderCallExpression( parent ) ) {
-				return null;
-			}
-
-			// Continue through ancestors if we've already determined whether
-			// this is root, to ensure we're not in a render call expression
-			if ( undefined !== isRoot ) {
-				continue;
-			}
-
-			// If wrapped in a JSX element, the node is a child
-			if ( 'JSXElement' === parent.type ) {
-				isRoot = false;
-			}
-
-			if ( isFunctionType( parent ) ) {
-				functionExpression = parent;
-
-				// If inside function expression, check that the name of the
-				// property is "render" (React.createClass or Component class)
-				if ( isRenderFunction( parent ) ) {
-					isRoot = true;
-				}
-
-				// If wrapped in function declaration, check the declaration
-				// is part of a default export (stateless function component)
-				switch ( parent.type ) {
-					case 'ArrowFunctionExpression':
-					case 'FunctionDeclaration':
-						if (
-							'ExportDefaultDeclaration' === parent.parent.type ||
-							isModuleExportNode( parent.parent )
-						) {
-							isRoot = true;
-						}
-						break;
-
-					case 'FunctionExpression':
-						if (
-							'AssignmentExpression' === parent.parent.type &&
-							isModuleExportNode( parent.parent.parent )
-						) {
-							isRoot = true;
-						}
-				}
-
-				// If we suspect the element is the root, confirm that it's the
-				// return value of the function
-				if (
-					isRoot &&
-					! isElementReturnArg &&
-					! isSameIdentifier( elementAssignedIdentifier, getFunctionReturnValue( parent ) )
-				) {
-					isRoot = false;
-				}
-			}
-
-			// If we've exhausted parent options, check to see whether exports
-			// refer to last visited function expression
-			if ( 'Program' === parent.type && functionExpression ) {
-				switch ( functionExpression.type ) {
-					case 'FunctionDeclaration':
-						if ( functionExpression.id ) {
-							functionName = functionExpression.id.name;
-						}
-						break;
-
-					case 'ArrowFunctionExpression':
-						if ( 'VariableDeclarator' === functionExpression.parent.type ) {
-							functionName = functionExpression.parent.id.name;
-						}
-						break;
-				}
-
-				isRoot =
-					!! functionName &&
-					parent.body.some( function( programNode ) {
-						if ( 'ExportDefaultDeclaration' === programNode.type ) {
-							return isIdentifierInDescendents( programNode.declaration, functionName );
-						}
-
-						// `module.exports` assignment, check that right-side
-						// assignment value matches function name
-						if ( isModuleExportNode( programNode ) ) {
-							return isIdentifierInDescendents( programNode.expression.right, functionName );
-						}
-
-						return false;
-					} );
-			}
-		} while ( parent.parent );
-
-		return !! isRoot;
-	}
-
 	return {
 		JSXAttribute: function( node ) {
-			let rawClassName, expected;
-
 			if ( 'className' !== node.name.name ) {
 				return;
 			}
 
+			let rawClassName;
 			if ( 'JSXExpressionContainer' === node.value.type ) {
 				rawClassName = node.value.expression;
 			} else {
@@ -261,46 +65,35 @@ const rule = ( module.exports = function( context ) {
 				return;
 			}
 
-			const filename = context.getFilename();
-			const isRootFile = isFolderRootFile( filename );
-			const isRootElement = isRootElementInFile( node );
-
-			// `null` return value indicates intent to abort validation
-			if ( null === isRootElement ) {
+			// we don't validate elements inside `ReactDOM.render` expressions
+			if ( isInRenderCallExpession( node ) ) {
 				return;
 			}
 
+			const filename = context.getFilename();
+
+			const namespaces = [ path.basename( path.dirname( filename ) ) ];
+			if ( ! isFolderRootFile( filename ) ) {
+				namespaces.push( path.basename( filename, path.extname( filename ) ) );
+			}
+
+			const prefixPatterns = namespaces.map(
+				namespace => new RegExp( `^${ namespace }(__[a-z0-9-]+)?$` )
+			);
+
 			const classNames = rawClassName.value.split( ' ' );
-			const namespace = path.basename( path.dirname( filename ) );
-			const prefixPattern = new RegExp( `^${ namespace }__[a-z0-9-]+$` );
-
-			const isError = ! classNames.some( function( className ) {
-				if ( isRootElement && isRootFile ) {
-					return className === namespace;
-				}
-
-				// Non-root node should have class name starting with but not
-				// equal to namespace prefix
-				return prefixPattern.test( className );
-			} );
+			const isError = ! classNames.some( className =>
+				prefixPatterns.some( prefixPattern => prefixPattern.test( className ) )
+			);
 
 			if ( ! isError ) {
 				return;
 			}
 
-			expected = namespace;
-			if ( ! ( isRootElement && isRootFile ) ) {
-				expected += '__ prefix';
-			}
-
-			if ( isRootElement && ! isRootFile ) {
-				expected += ` or to be in ${ rootFiles.length > 1 ? 'one of ' : '' }${ rootFiles.join(
-					', '
-				) }`;
-			}
+			const expected = namespaces.map( namespace => namespace + '__' ).join( ' or ' ) + ' prefix';
 
 			context.report( {
-				node: node,
+				node,
 				message: rule.ERROR_MESSAGE,
 				data: { expected },
 			} );
@@ -309,7 +102,7 @@ const rule = ( module.exports = function( context ) {
 } );
 
 rule.ERROR_MESSAGE = 'className should follow CSS namespace guidelines (expected {{expected}})';
-rule.DEFAULT_ROOT_FILES = [ 'index.js', 'index.jsx' ];
+rule.DEFAULT_ROOT_FILES = [ 'index.js', 'index.jsx', 'index.ts', 'index.tsx' ];
 
 rule.schema = [
 	{

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/jsx-classname-namespace.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/jsx-classname-namespace.js
@@ -10,16 +10,15 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require( '../jsx-classname-namespace' ),
-	formatMessage = require( '../../../test-utils/format-message' ),
-	RuleTester = require( 'eslint' ).RuleTester;
+const rule = require( '../jsx-classname-namespace' );
+const formatMessage = require( '../../../test-utils/format-message' );
+const { RuleTester } = require( 'eslint' );
 
 //------------------------------------------------------------------------------
 // Constants
 //------------------------------------------------------------------------------
 
-const EXPECTED_FOO_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo' } );
-const EXPECTED_FOO_PREFIX_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo__ prefix' } );
+const EXPECTED_FOO_ERROR = formatMessage( rule.ERROR_MESSAGE, { expected: 'foo__ prefix' } );
 
 //------------------------------------------------------------------------------
 // Tests
@@ -38,103 +37,11 @@ new RuleTester( {
 			filename: '/tmp/foo/index.js',
 		},
 		{
-			code: 'export default function() { const foo = <Foo className="foo" />; return foo; }',
-			filename: '/tmp/foo/index.js',
-		},
-		{
 			code: 'export default function() { return <Foo className="quux foo" />; }',
 			filename: '/tmp/foo/index.js',
 		},
 		{
-			code:
-				'export default function() { const child = <div className="foo__child" />; return <Foo className="foo">{ child }</Foo>; }',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code: 'export default () => <Foo className="foo" />;',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code: 'export default () => { return <Foo className="foo" />; }',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code: 'const Foo = () => <Foo className="foo" />; export default Foo;',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'import localize from "./localize"; const Foo = () => <Foo className="foo" />; export default localize( localize( Foo ) );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'import connect from "./connect"; const Foo = () => <Foo className="foo" />; export default connect()( Foo );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code: 'const Foo = () => <Foo className="foo" />; module.exports = Foo;',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'const localize = require( "./localize" ); const Foo = () => <Foo className="foo" />; module.exports = localize( localize( Foo ) );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'const connect = require( "./connect" ); const Foo = () => <Foo className="foo" />; module.exports = connect()( Foo );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code: 'function Foo() { return <Foo className="foo" />; } export default Foo;',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code: 'module.exports = function() { return <Foo className="foo" />; }',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'export default React.createClass( { render: function() { return <Foo className="foo" />; } } );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'export default React.createClass( { render: function() { const foo = <Foo className="foo" />; return foo; } } );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'export default React.createClass( { render: function() { return ( <Foo className="foo" /> ); } } );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'export default React.createClass( { render() { return <Foo className="foo"><div className="foo__child" /></Foo>; } } );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'export default React.createClass( { render() { const child = <div className="foo__child" />; return <Foo className="foo">{ child }</Foo>; } } );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'const isOk = true; export default React.createClass( { render() { return <Foo className="foo">{ isOk && <div className="foo__child" /> }</Foo>; } } );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code:
-				'export default React.createClass( { child() { return <div className="foo__child" />; }, render() { return <Foo className="foo" />; } } );',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code: 'function child() { return <Foo className="foo__child" />; }',
-			filename: '/tmp/foo/index.js',
-		},
-		{
-			code: 'function child() { return <Foo className="quux foo__child" />; }',
+			code: 'export default function() { return <div className="foo__child" />; }',
 			filename: '/tmp/foo/index.js',
 		},
 		{
@@ -142,13 +49,11 @@ new RuleTester( {
 			filename: '/tmp/foo/index.js',
 		},
 		{
-			code:
-				'import localize from "./localize"; class Foo { render() { return <Foo className="foo" />; } } export default localize( Foo );',
+			code: 'export default function() { return <div><div className="foo" /></div>; }',
 			filename: '/tmp/foo/index.js',
 		},
 		{
-			code:
-				'import connect from "./connect"; class Foo { render() { return <Foo className="foo" />; } } export default connect()( Foo );',
+			code: 'export default function() { return <div className="foo__child-example2" />; }',
 			filename: '/tmp/foo/index.js',
 		},
 		{
@@ -172,17 +77,30 @@ new RuleTester( {
 			filename: '/tmp/foo/index.js',
 		},
 		{
+			code: 'export default function() { return <div className="foo" />; }',
+			filename: '/tmp/foo/foo-child.js',
+		},
+		{
+			code: 'export default function() { return <div className="foo-child" />; }',
+			filename: '/tmp/foo/foo-child.js',
+		},
+		{
 			code: 'export default function() { return <div className="foo__child" />; }',
 			filename: '/tmp/foo/foo-child.js',
 		},
 		{
-			code: 'export default function() { return <div className="foo__child-example2" />; }',
+			code: 'export default function() { return <div className="foo-child__child" />; }',
 			filename: '/tmp/foo/foo-child.js',
 		},
 		{
 			code: 'export default function() { return <div className="foo"></div>; }',
-			filename: '/tmp/foo/foo.js',
-			options: [ { rootFiles: [ 'foo.js' ] } ],
+			filename: '/tmp/foo/bar.js',
+			options: [ { rootFiles: [ 'bar.js' ] } ],
+		},
+		{
+			code:
+				'export default class Foo { child() { return <div className="foo" />; } render() { return this.child(); } };',
+			filename: '/tmp/foo/index.js',
 		},
 	],
 
@@ -190,302 +108,43 @@ new RuleTester( {
 		{
 			code: 'export default function() { return <Foo className="foobar" />; }',
 			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code: 'export default function() { const foo = <Foo className="foobar" />; return foo; }',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'export default function() { const child = <div className="foo" />; return <Foo className="foo">{ child }</Foo>; }',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_PREFIX_ERROR,
-				},
-			],
-		},
-		{
-			code: 'export default function() { return <Foo className="quux foobar" />; }',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
+			errors: [ { message: EXPECTED_FOO_ERROR } ],
 		},
 		{
 			code: 'export default () => <Foo className="foobar" />;',
 			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
+			errors: [ { message: EXPECTED_FOO_ERROR } ],
 		},
 		{
-			code: 'export default () => { return <Foo className="foobar" />; }',
+			code: 'export default function() { return <Foo className="quux foobar" />; }',
 			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code: 'const Foo = () => <Foo className="foobar" />; export default Foo;',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'import localize from "./localize"; const Foo = () => <Foo className="foobar" />; export default localize( localize( Foo ) );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'import connect from "./connect"; const Foo = () => <Foo className="foobar" />; export default connect()( Foo );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code: 'const Foo = () => <Foo className="foobar" />; module.exports = Foo;',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'const localize = require( "./localize" ); const Foo = () => <Foo className="foobar" />; module.exports = localize( localize( Foo ) );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'const connect = require( "./connect" ); const Foo = () => <Foo className="foobar" />; module.exports = connect()( Foo );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code: 'function Foo() { return <Foo className="foobar" />; } export default Foo;',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code: 'module.exports = function() { return <Foo className="foobar" />; }',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'export default React.createClass( { render: function() { return <Foo className="foobar" />; } } );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'export default React.createClass( { render: function() { const foo = <Foo className="foobar" />; return foo; } } );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'export default React.createClass( { render: function() { return ( <Foo className="foobar" /> ); } } );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'export default React.createClass( { render() { return <Foo className="foo"><div className="foobar__child" /></Foo>; } } );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_PREFIX_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'export default React.createClass( { render() { const child = <div className="foo" />; return <Foo className="foo">{ child }</Foo>; } } );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_PREFIX_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'const isOk = true; export default React.createClass( { render() { return <Foo className="foo">{ isOk && <div className="foobar__child" /> }</Foo>; } } );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_PREFIX_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'export default React.createClass( { child() { return <div className="foobar__child" />; }, render() { return <Foo className="foo" />; } } );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_PREFIX_ERROR,
-				},
-			],
+			errors: [ { message: EXPECTED_FOO_ERROR } ],
 		},
 		{
 			code: 'function child() { return <Foo className="foobar__child" />; }',
 			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_PREFIX_ERROR,
-				},
-			],
+			errors: [ { message: EXPECTED_FOO_ERROR } ],
 		},
 		{
 			code: 'function child() { return <Foo className="quux foobar__child" />; }',
 			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_PREFIX_ERROR,
-				},
-			],
+			errors: [ { message: EXPECTED_FOO_ERROR } ],
 		},
 		{
-			code: 'export default class Foo { render() { return <Foo className="foobar" />; } }',
+			code: 'export default function() { return <div className="foo__" />; }',
 			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
+			errors: [ { message: EXPECTED_FOO_ERROR } ],
 		},
 		{
-			code:
-				'import localize from "./localize"; class Foo { render() { return <Foo className="foobar" />; } } export default localize( Foo );',
+			code: 'export default function() { return <Foo className="foo__child_example" />; }',
 			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
+			errors: [ { message: EXPECTED_FOO_ERROR } ],
 		},
 		{
-			code:
-				'import connect from "./connect"; class Foo { render() { return <Foo className="foobar" />; } } export default connect()( Foo );',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_ERROR,
-				},
-			],
-		},
-		{
-			code: 'export default function() { return <div className="foo" />; }',
-			filename: '/tmp/foo/foo-child.js',
-			errors: [
-				{
-					message: formatMessage( rule.ERROR_MESSAGE, {
-						expected: `foo__ prefix or to be in one of ${ rule.DEFAULT_ROOT_FILES.join( ', ' ) }`,
-					} ),
-				},
-			],
-		},
-		{
-			code: 'export default function() { return <div className="foo" />; }',
-			filename: '/tmp/foo/foo-child.js',
-			options: [ { rootFiles: [ 'one.js' ] } ],
-			errors: [
-				{
-					message: formatMessage( rule.ERROR_MESSAGE, {
-						expected: 'foo__ prefix or to be in one.js',
-					} ),
-				},
-			],
-		},
-		{
-			code:
-				'export default function() { return <Foo className="foo"><div className="foo__" /></Foo>; }',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_PREFIX_ERROR,
-				},
-			],
-		},
-		{
-			code:
-				'export default function() { return <Foo className="foo"><div className="foo__child__example" /></Foo>; }',
-			filename: '/tmp/foo/index.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_PREFIX_ERROR,
-				},
-			],
-		},
-		{
-			code: 'export default function() { return <div><div className="foo" /></div>; }',
-			filename: '/tmp/foo/foo-child.js',
-			errors: [
-				{
-					message: EXPECTED_FOO_PREFIX_ERROR,
-				},
-			],
+			code: 'export default function() { return <div className="bar"></div>; }',
+			filename: '/tmp/foo/bar.js',
+			options: [ { rootFiles: [ 'bar.js' ] } ],
+			errors: [ { message: EXPECTED_FOO_ERROR } ],
 		},
 	],
 } );

--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-plugin-wpcalypso",
-	"version": "4.0.2",
+	"version": "4.1.0",
 	"description": "Custom ESLint rules for the WordPress.com Calypso project",
 	"repository": {
 		"type": "git",

--- a/packages/eslint-plugin-wpcalypso/package.json
+++ b/packages/eslint-plugin-wpcalypso/package.json
@@ -7,6 +7,7 @@
 		"url": "https://github.com/Automattic/wp-calypso.git",
 		"directory": "packages/eslint-plugin-wpcalypso"
 	},
+	"license": "GPL-2.0-or-later",
 	"keywords": [
 		"eslint",
 		"eslintplugin",
@@ -20,5 +21,7 @@
 	"engines": {
 		"node": ">=10"
 	},
-	"license": "GPL-2.0-or-later"
+	"peerDependencies": {
+		"eslint": ">=5"
+	}
 }


### PR DESCRIPTION
The `wpcalypso/jsx-classname-namespace` is one of the most often disabled ones. Over 150 instances in our codebase. That doesn't speak favorably about its usefulness. This PR attempts to remove some of the annoying behavior and make the rule more flexible.

**CSS class name suffixes**
The root element of a component should have a class name without a suffix:
```jsx
<div className="domain-product-price" />
```
and the child elements should have `__` suffixes:
```jsx
<div className="domain-product-price__sale-price" />
```

**Root or child element?**
The current rule tries to guess whether the element is root or not:
1. Is it in index file? The file `domain-product-price/index.jsx` is allowed to have elements with `className="domain-product-price"`, but `domain-product-price/placeholder.jsx` is not. Suffix is required.
2. Is it in the root render method? The class name without suffix can be used in the `render` method, but it can't be, e.g., in `renderPlaceholder`.
3. Is it in the top-level element? The element without suffix must be the top-level JSX element returned from the `render` method or from a functional component. Most of the code of the rule is checking the code for connection between returned element and the default export of the component. Going through function references, HOC wrappers...

This PR removes these limitations. The suffixed and not-suffixed classnames can be anywhere. They are only checked against the file and directory name.

- `domain-product-price/index.jsx`: `domain-product-price` and `domain-product-price__xxx` class names are allowed.
- `domain-product-price/featured-domain.jsx`: both `domain-product-price` and `featured-domain` prefixes are allowed. The `featured-domain` was not allowed before, but it's a very frequent use case. And if it was in `domain-product-price/featured-domain/index.jsx` file, then `featured-domain` would have been allowed, too. That's a clear loophole.

The rule also checks that the suffix uses only letters, numbers and `-` characters. Namely, multiple underscores are not allowed:
- `theme__detail-header` :+1:
- `theme__detail__header` :-1:
- `theme__detail___header` :-1:

The test suite also gets a lot simpler, because we don't need to test the "is it the root element returned by module's default export?" question.

Applying this PR decreases the number of violations from 660 to 600.