### PR TITLE
Jetpack Sync Panel: Add Whitespace in Notice

### DIFF
--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -172,11 +172,11 @@ class JetpackSyncPanel extends React.Component {
 					{ translate(
 						'Jetpack Sync keeps your WordPress.com dashboard up to date. ' +
 							'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience.'
-					) }
+					) + ' ' }
 
 					{ ! this.shouldDisableSync() &&
 						translate(
-							' If you suspect some data is missing, you can {{link}}initiate a sync manually{{/link}}.',
+							'If you suspect some data is missing, you can {{link}}initiate a sync manually{{/link}}.',
 							{
 								components: {
 									link: <a href="" onClick={ this.onSyncRequestButtonClick } />,

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -171,12 +171,12 @@ class JetpackSyncPanel extends React.Component {
 				<div className="jetpack-sync-panel__action">
 					{ translate(
 						'Jetpack Sync keeps your WordPress.com dashboard up to date. ' +
-							'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience. '
+							'Data is sent from your site to the WordPress.com dashboard regularly to provide a faster experience.'
 					) }
 
 					{ ! this.shouldDisableSync() &&
 						translate(
-							'If you suspect some data is missing, you can {{link}}initiate a sync manually{{/link}}.',
+							' If you suspect some data is missing, you can {{link}}initiate a sync manually{{/link}}.',
 							{
 								components: {
 									link: <a href="" onClick={ this.onSyncRequestButtonClick } />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Very minor PR, just fixes a missing space I noticed whilst doing something else.

#### Testing instructions

Visit `settings/manage-connection/site`.

**Before:**

<img width="715" alt="Screenshot 2019-05-06 at 20 20 23" src="https://user-images.githubusercontent.com/43215253/57249373-ac258700-703c-11e9-8634-12395f3f58b8.png">

**After:**

<img width="699" alt="Screenshot 2019-05-06 at 20 20 17" src="https://user-images.githubusercontent.com/43215253/57249392-b5165880-703c-11e9-8e49-8de87d7c012b.png">

cc @simison, @tyxla 