### PR TITLE
Jetpack Checklist: Open 'View spam stats' Link in New Tab

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -119,6 +119,7 @@ class JetpackChecklist extends PureComponent {
 							href={ JETPACK_CHECKLIST_TASK_AKISMET.getUrl( siteSlug ) }
 							inProgress={ ! akismetFinished }
 							onClick={ this.handleTaskStart( { taskId: 'jetpack_spam_filtering' } ) }
+							target="_blank"
 						/>
 					) }
 					{ map( taskStatuses, ( status, taskId ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Jetpack Checklist: Open 'View spam stats' Link in New Tab

I probably should've just done this as part of #32700 :sweat_smile: Oh well.

#### Testing instructions

- Run this Calypso branch locally
- Create a new [`jurassic.ninja`](https://jurassic.ninja/) site
- Connect it to WP.com: Use the Connect button's link target and append `&calypso_env=development`
- Pick a paid plan
- Verify that the 'View spam stats' link (part of the 'We've automatically turned on spam filtering' task) opens a new tab. (Everything else should be unchanged.)

Fixes #32697
