### PR TITLE
Gridicons: Forward refs on gridicons to the wrapped svg

### DIFF
--- a/client/blocks/reader-site-notification-settings/index.jsx
+++ b/client/blocks/reader-site-notification-settings/index.jsx
@@ -46,6 +46,9 @@ class ReaderSiteNotificationSettings extends Component {
 		selected: this.props.emailDeliveryFrequency,
 	};
 
+	iconRef = React.createRef();
+	spanRef = React.createRef();
+
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( nextProps.emailDeliveryFrequency !== this.props.emailDeliveryFrequency ) {
 			this.setState( { selected: nextProps.emailDeliveryFrequency } );
@@ -59,9 +62,6 @@ class ReaderSiteNotificationSettings extends Component {
 	closePopover = () => {
 		this.setState( { showPopover: false } );
 	};
-
-	saveIconRef = ref => ( this.iconRef = ref );
-	saveSpanRef = ref => ( this.spanRef = ref );
 
 	setSelected = text => () => {
 		const { siteId } = this.props;
@@ -136,9 +136,9 @@ class ReaderSiteNotificationSettings extends Component {
 				<button
 					className="reader-site-notification-settings__button"
 					onClick={ this.togglePopoverVisibility }
-					ref={ this.saveSpanRef }
+					ref={ this.spanRef }
 				>
-					<Gridicon icon="cog" size={ 24 } ref={ this.saveIconRef } />
+					<Gridicon icon="cog" size={ 24 } ref={ this.iconRef } />
 					<span
 						className="reader-site-notification-settings__button-label"
 						title={ translate( 'Notification settings' ) }
@@ -150,8 +150,8 @@ class ReaderSiteNotificationSettings extends Component {
 				<ReaderPopover
 					onClose={ this.closePopover }
 					isVisible={ this.state.showPopover }
-					context={ this.iconRef }
-					ignoreContext={ this.spanRef }
+					context={ this.iconRef.current }
+					ignoreContext={ this.spanRef.current }
 					position={ 'bottom left' }
 					className="reader-site-notification-settings__popout"
 				>

--- a/client/components/gridicon/index.jsx
+++ b/client/components/gridicon/index.jsx
@@ -15,7 +15,7 @@ function needsOffset( name, icons ) {
 	return icons.indexOf( name ) >= 0;
 }
 
-function Gridicon( props ) {
+const Gridicon = React.forwardRef( ( props, ref ) => {
 	const { size = 24, icon, onClick, className, ...otherProps } = props;
 	const isModulo18 = size % 18 === 0;
 
@@ -30,7 +30,6 @@ function Gridicon( props ) {
 		  ]
 		: [];
 	const iconClass = classnames( 'gridicon', iconName, className, ...offsetClasses );
-
 	return (
 		<svg
 			xmlns="http://www.w3.org/2000/svg"
@@ -39,12 +38,13 @@ function Gridicon( props ) {
 			height={ size }
 			width={ size }
 			onClick={ onClick }
+			ref={ ref }
 			{ ...otherProps }
 		>
 			<use xlinkHref={ `${ spritePath }#${ iconName }` } />
 		</svg>
 	);
-}
+} );
 
 Gridicon.propTypes = {
 	icon: PropTypes.string.isRequired,


### PR DESCRIPTION
When Gridicons were redone in #32763, they switched from being Class components to Functional components. Functional components cannot be the target of a React ref unless the ref is forwarded using React.createRef. We use Gridicons by ref a number of places in Calypso as popover contexts.

Add ref forwarding to fix various places.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on the settings cog on any subscriptions on /following/manage or the top of any site stream in the Reader. The popover should appear.
