### PR TITLE
Revert "Classic Editor: removes After the Deadline from the toolbar"

### DIFF
--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -203,6 +203,7 @@ export default class extends React.Component {
 		onUndo: PropTypes.func,
 		onTextEditorChange: PropTypes.func,
 		isGutenbergClassicBlock: PropTypes.bool,
+		isVipSite: PropTypes.bool,
 	};
 
 	static contextTypes = {
@@ -239,7 +240,7 @@ export default class extends React.Component {
 	}
 
 	componentDidMount() {
-		const { isGutenbergClassicBlock } = this.props;
+		const { isGutenbergClassicBlock, isVipSite } = this.props;
 		this.mounted = true;
 
 		const setup = function( editor ) {
@@ -275,6 +276,7 @@ export default class extends React.Component {
 
 		const ltrButton = isRtl ? 'ltr,' : '';
 		const gutenbergClassName = isGutenbergClassicBlock ? ' is-gutenberg' : '';
+		const spellchecker = isVipSite ? ',spellchecker' : '';
 
 		tinymce.init( {
 			selector: '#' + this._id,
@@ -351,7 +353,7 @@ export default class extends React.Component {
 				: Math.max( document.documentElement.clientHeight - 300, 300 ),
 			autoresize_bottom_margin: isGutenbergClassicBlock || isMobile() ? 10 : 50,
 
-			toolbar1: `wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,${ ltrButton }wpcom_advanced`,
+			toolbar1: `wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright${ spellchecker },wp_more,${ ltrButton }wpcom_advanced`,
 			toolbar2:
 				'strikethrough,underline,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
 			toolbar3: '',

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -40,6 +40,7 @@ import editorButtonAnalyticsPlugin from './plugins/editor-button-analytics/plugi
 import calypsoAlertPlugin from './plugins/calypso-alert/plugin';
 import contactFormPlugin from './plugins/contact-form/plugin';
 import simplePaymentsPlugin from './plugins/simple-payments/plugin';
+import afterTheDeadlinePlugin from './plugins/after-the-deadline/plugin';
 import wptextpatternPlugin from './plugins/wptextpattern/plugin';
 import toolbarPinPlugin from './plugins/toolbar-pin/plugin';
 import insertMenuPlugin from './plugins/insert-menu/plugin';
@@ -69,6 +70,7 @@ import wpEmojiPlugin from './plugins/wpemoji/plugin';
 	editorButtonAnalyticsPlugin,
 	calypsoAlertPlugin,
 	contactFormPlugin,
+	afterTheDeadlinePlugin,
 	wptextpatternPlugin,
 	toolbarPinPlugin,
 	embedPlugin,
@@ -135,6 +137,7 @@ const PLUGINS = [
 	'wpcom',
 	'wpeditimage',
 	'wplink',
+	'AtD',
 	'directionality',
 	'wpemoji',
 	'wpcom/autoresize',
@@ -336,6 +339,10 @@ export default class extends React.Component {
 			menubar: false,
 			indent: false,
 
+			// AfterTheDeadline Configuration
+			atd_rpc_id: 'https://wordpress.com',
+			atd_ignore_enable: true,
+
 			// Try to find a suitable minimum size based on the viewport height
 			// minus the surrounding editor chrome to avoid scrollbars. In the
 			// future, we should calculate from the rendered editor bounds.
@@ -344,7 +351,7 @@ export default class extends React.Component {
 				: Math.max( document.documentElement.clientHeight - 300, 300 ),
 			autoresize_bottom_margin: isGutenbergClassicBlock || isMobile() ? 10 : 50,
 
-			toolbar1: `wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,wp_more,${ ltrButton }wpcom_advanced`,
+			toolbar1: `wpcom_insert_menu,formatselect,bold,italic,bullist,numlist,link,blockquote,alignleft,aligncenter,alignright,spellchecker,wp_more,${ ltrButton }wpcom_advanced`,
 			toolbar2:
 				'strikethrough,underline,hr,alignjustify,forecolor,pastetext,removeformat,wp_charmap,outdent,indent,undo,redo,wp_help',
 			toolbar3: '',

--- a/client/components/tinymce/plugins/after-the-deadline/core.js
+++ b/client/components/tinymce/plugins/after-the-deadline/core.js
@@ -1,0 +1,708 @@
+/**
+ * /*
+ * atd.core.js - A building block to create a front-end for AtD
+ * Author      : Raphael Mudge & Andrew Duthie, Automattic
+ * License     : LGPL
+ * Project     : http:
+ * Contact     : raffi@automattic.com, andrew.duthie@automattic.com
+ *
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import { translate } from 'i18n-calypso';
+
+function AtDCore() {
+	/* these are the categories of errors AtD should ignore */
+	this.ignore_types = [
+		'Bias Language',
+		'Cliches',
+		'Complex Expression',
+		'Diacritical Marks',
+		'Double Negatives',
+		'Hidden Verbs',
+		'Jargon Language',
+		'Passive voice',
+		'Phrases to Avoid',
+		'Redundant Expression',
+	];
+
+	/* these are the phrases AtD should ignore */
+	this.ignore_strings = {};
+
+	/* Localized strings */
+	// Back-compat, not used
+	this.i18n = {};
+}
+
+/*
+ * Setters
+ */
+
+AtDCore.prototype.setIgnoreStrings = function( strings ) {
+	const parent = this;
+
+	if ( 'string' === typeof strings ) {
+		strings = strings.split( /,\s*/g );
+	}
+
+	this.map( strings, function( string ) {
+		parent.ignore_strings[ string ] = 1;
+	} );
+};
+
+AtDCore.prototype.showTypes = function( strings ) {
+	let show_types = strings.split( /,\s*/g ),
+		types = {},
+		ignore_types = [];
+
+	/* set some default types that we want to make optional */
+
+	/* grammar checker options */
+	types[ 'Double Negatives' ] = 1;
+	types[ 'Hidden Verbs' ] = 1;
+	types[ 'Passive voice' ] = 1;
+	types[ 'Bias Language' ] = 1;
+
+	/* style checker options */
+	types[ 'Cliches' ] = 1; // eslint-disable-line dot-notation
+	types[ 'Complex Expression' ] = 1;
+	types[ 'Diacritical Marks' ] = 1;
+	types[ 'Jargon Language' ] = 1;
+	types[ 'Phrases to Avoid' ] = 1;
+	types[ 'Redundant Expression' ] = 1;
+
+	this.map( show_types, function( type ) {
+		types[ type ] = undefined;
+	} );
+
+	this.map( this.ignore_types, function( type ) {
+		if ( types[ type ] !== undefined ) {
+			ignore_types.push( type );
+		}
+	} );
+
+	this.ignore_types = ignore_types;
+};
+
+/*
+ * Error Parsing Code
+ */
+
+AtDCore.prototype.makeError = function( error_s, tokens, type, seps ) {
+	const struct = {};
+	struct.type = type;
+	struct.string = error_s;
+	struct.tokens = tokens;
+
+	if ( new RegExp( '\\b' + error_s + '\\b' ).test( error_s ) ) {
+		struct.regexp = new RegExp(
+			'(?!' + error_s + '<)\\b' + error_s.replace( /\s+/g, seps ) + '\\b'
+		);
+	} else if ( new RegExp( error_s + '\\b' ).test( error_s ) ) {
+		struct.regexp = new RegExp( '(?!' + error_s + '<)' + error_s.replace( /\s+/g, seps ) + '\\b' );
+	} else if ( new RegExp( '\\b' + error_s ).test( error_s ) ) {
+		struct.regexp = new RegExp( '(?!' + error_s + '<)\\b' + error_s.replace( /\s+/g, seps ) );
+	} else {
+		struct.regexp = new RegExp( '(?!' + error_s + '<)' + error_s.replace( /\s+/g, seps ) );
+	}
+
+	struct.used = false; /* flag whether we've used this rule or not */
+
+	return struct;
+};
+
+AtDCore.prototype.addToErrorStructure = function( errors, list, type, seps ) {
+	const parent = this;
+
+	this.map( list, function( error ) {
+		const tokens = error.word.split( /\s+/ );
+		const pre = error.pre;
+		const first = tokens[ 0 ];
+
+		if ( errors[ '__' + first ] === undefined ) {
+			errors[ '__' + first ] = {};
+			errors[ '__' + first ].pretoks = {};
+			errors[ '__' + first ].defaults = [];
+		}
+
+		if ( pre === '' ) {
+			errors[ '__' + first ].defaults.push(
+				parent.makeError( error.word, tokens, type, seps, pre )
+			);
+		} else {
+			if ( errors[ '__' + first ].pretoks[ '__' + pre ] === undefined ) {
+				errors[ '__' + first ].pretoks[ '__' + pre ] = [];
+			}
+
+			errors[ '__' + first ].pretoks[ '__' + pre ].push(
+				parent.makeError( error.word, tokens, type, seps, pre )
+			);
+		}
+	} );
+};
+
+AtDCore.prototype.buildErrorStructure = function( spellingList, enrichmentList, grammarList ) {
+	const seps = this._getSeparators();
+	const errors = {};
+
+	this.addToErrorStructure( errors, spellingList, 'hiddenSpellError', seps );
+	this.addToErrorStructure( errors, grammarList, 'hiddenGrammarError', seps );
+	this.addToErrorStructure( errors, enrichmentList, 'hiddenSuggestion', seps );
+	return errors;
+};
+
+AtDCore.prototype._getSeparators = function() {
+	let re = '',
+		i;
+	const str = '"s!#$%&()*+,./:;<=>?@[\\]^_{|}';
+
+	// Build word separator regexp
+	for ( i = 0; i < str.length; i++ ) {
+		re += '\\' + str.charAt( i );
+	}
+
+	return '(?:(?:[\xa0' + re + '])|(?:\\-\\-))+';
+};
+
+AtDCore.prototype.processXML = function( responseXML ) {
+	let types,
+		errors,
+		grammarErrors,
+		spellingErrors,
+		enrichment,
+		i,
+		errorString,
+		errorType,
+		errorDescription,
+		errorContext,
+		suggestion,
+		suggestions,
+		j,
+		errorUrl,
+		errorStruct,
+		ecount;
+
+	/* types of errors to ignore */
+	types = {};
+
+	this.map( this.ignore_types, function( type ) {
+		types[ type ] = 1;
+	} );
+
+	/* save suggestions in the editor object */
+	this.suggestions = [];
+
+	/* process through the errors */
+	errors = responseXML.getElementsByTagName( 'error' );
+
+	/* words to mark */
+	grammarErrors = [];
+	spellingErrors = [];
+	enrichment = [];
+
+	for ( i = 0; i < errors.length; i++ ) {
+		if ( errors[ i ].getElementsByTagName( 'string' ).item( 0 ).firstChild !== null ) {
+			errorString = errors[ i ].getElementsByTagName( 'string' ).item( 0 ).firstChild.data;
+			errorType = errors[ i ].getElementsByTagName( 'type' ).item( 0 ).firstChild.data;
+			errorDescription = errors[ i ].getElementsByTagName( 'description' ).item( 0 ).firstChild
+				.data;
+
+			if ( errors[ i ].getElementsByTagName( 'precontext' ).item( 0 ).firstChild !== null ) {
+				errorContext = errors[ i ].getElementsByTagName( 'precontext' ).item( 0 ).firstChild.data;
+			} else {
+				errorContext = '';
+			}
+
+			/* create a hashtable with information about the error in the editor object, we will use this later
+			   to populate a popup menu with information and suggestions about the error */
+
+			if ( this.ignore_strings[ errorString ] === undefined ) {
+				suggestion = {};
+				suggestion.description = errorDescription;
+				suggestion.suggestions = [];
+
+				/* used to find suggestions when a highlighted error is clicked on */
+				suggestion.matcher = new RegExp(
+					'^' + errorString.replace( /\s+/, this._getSeparators() ) + '$'
+				);
+
+				suggestion.context = errorContext;
+				suggestion.string = errorString;
+				suggestion.type = errorType;
+
+				this.suggestions.push( suggestion );
+
+				if ( errors[ i ].getElementsByTagName( 'suggestions' ).item( 0 ) !== null ) {
+					suggestions = errors[ i ]
+						.getElementsByTagName( 'suggestions' )
+						.item( 0 )
+						.getElementsByTagName( 'option' );
+					for ( j = 0; j < suggestions.length; j++ ) {
+						suggestion.suggestions.push( suggestions[ j ].firstChild.data );
+					}
+				}
+
+				/* setup the more info url */
+				if ( errors[ i ].getElementsByTagName( 'url' ).item( 0 ) !== null ) {
+					errorUrl = errors[ i ].getElementsByTagName( 'url' ).item( 0 ).firstChild.data;
+					suggestion.moreinfo = errorUrl + '&theme=tinymce';
+				}
+
+				if ( types[ errorDescription ] === undefined ) {
+					if ( errorType === 'suggestion' ) {
+						enrichment.push( { word: errorString, pre: errorContext } );
+					}
+
+					if ( errorType === 'grammar' ) {
+						grammarErrors.push( { word: errorString, pre: errorContext } );
+					}
+				}
+
+				if ( errorType === 'spelling' || errorDescription === 'Homophone' ) {
+					spellingErrors.push( { word: errorString, pre: errorContext } );
+				}
+
+				if ( errorDescription === 'Cliches' ) {
+					suggestion.description =
+						'Clichés'; /* done here for backwards compatability with current user settings */
+				}
+
+				if ( errorDescription === 'Spelling' ) {
+					suggestion.description = translate( 'Spelling', {
+						comment: 'Proofreading error description',
+					} );
+				}
+
+				if ( errorDescription === 'Repeated Word' ) {
+					suggestion.description = translate( 'Repeated Word', {
+						comment: 'Proofreading error description',
+					} );
+				}
+
+				if ( errorDescription === 'Did you mean...' ) {
+					suggestion.description = translate( 'Did you mean…', {
+						comment: 'Proofreading error description',
+					} );
+				}
+			} // end if ignore[errorString] == undefined
+		} // end if
+	} // end for loop
+
+	ecount = spellingErrors.length + grammarErrors.length + enrichment.length;
+
+	if ( ecount > 0 ) {
+		errorStruct = this.buildErrorStructure( spellingErrors, enrichment, grammarErrors );
+	} else {
+		errorStruct = undefined;
+	}
+
+	/* save some state in this object, for retrieving suggestions later */
+	return { errors: errorStruct, count: ecount, suggestions: this.suggestions };
+};
+
+AtDCore.prototype.findSuggestion = function( element ) {
+	let text = element.innerHTML,
+		context = ( this.getAttrib( element, 'pre' ) + '' ).replace( /[\\,!\\?\\."\s]/g, '' ),
+		len = this.suggestions.length,
+		errorDescription,
+		i;
+
+	for ( i = 0; i < len; i++ ) {
+		if (
+			( context === '' || context === this.suggestions[ i ].context ) &&
+			this.suggestions[ i ].matcher.test( text )
+		) {
+			errorDescription = this.suggestions[ i ];
+			break;
+		}
+	}
+	return errorDescription;
+};
+
+/*
+ * TokenIterator class
+ */
+
+function TokenIterator( tokens ) {
+	this.tokens = tokens;
+	this.index = 0;
+	this.count = 0;
+	this.last = 0;
+}
+
+TokenIterator.prototype.next = function() {
+	let current = this.tokens[ this.index ];
+	this.count = this.last;
+	this.last += current.length + 1;
+	this.index++;
+
+	/* strip single quotes from token, AtD does this when presenting errors */
+	if ( current !== '' ) {
+		if ( current[ 0 ] === "'" ) {
+			current = current.substring( 1, current.length );
+		}
+
+		if ( current[ current.length - 1 ] === "'" ) {
+			current = current.substring( 0, current.length - 1 );
+		}
+	}
+
+	return current;
+};
+
+TokenIterator.prototype.hasNext = function() {
+	return this.index < this.tokens.length;
+};
+
+TokenIterator.prototype.hasNextN = function( n ) {
+	return this.index + n < this.tokens.length;
+};
+
+TokenIterator.prototype.skip = function( m, n ) {
+	this.index += m;
+	this.last += n;
+
+	if ( this.index < this.tokens.length ) {
+		this.count = this.last - this.tokens[ this.index ].length;
+	}
+};
+
+TokenIterator.prototype.getCount = function() {
+	return this.count;
+};
+
+TokenIterator.prototype.peek = function( n ) {
+	let peepers = [],
+		end = this.index + n,
+		x;
+
+	for ( x = this.index; x < end; x++ ) {
+		peepers.push( this.tokens[ x ] );
+	}
+	return peepers;
+};
+
+/*
+ *  code to manage highlighting of errors
+ */
+AtDCore.prototype.markMyWords = function( container_nodes, errors ) {
+	let seps = new RegExp( this._getSeparators() ),
+		nl = [],
+		ecount = 0 /* track number of highlighted errors */,
+		parent = this,
+		bogus = this._isTinyMCE ? ' data-mce-bogus="1"' : '',
+		emptySpan = '<span class="mceItemHidden"' + bogus + '>&nbsp;</span>',
+		textOnlyMode,
+		iterator;
+
+	/**
+	 * Split a text node into an ordered list of siblings:
+	 * - text node to the left of the match
+	 * - the element replacing the match
+	 * - text node to the right of the match
+	 *
+	 * We have to leave the text to the left and right of the match alone
+	 * in order to prevent XSS
+	 *
+	 * @return array
+	 */
+
+	function splitTextNode( textnode, regexp, replacement ) {
+		let text = textnode.nodeValue,
+			index = text.search( regexp ),
+			match = text.match( regexp ),
+			captured = [],
+			cursor;
+
+		if ( index < 0 || ! match.length ) {
+			return [ textnode ];
+		}
+
+		if ( index > 0 ) {
+			// capture left text node
+			captured.push( document.createTextNode( text.substr( 0, index ) ) );
+		}
+
+		// capture the replacement of the matched string
+		captured.push( parent.create( match[ 0 ].replace( regexp, replacement ) ) );
+
+		cursor = index + match[ 0 ].length;
+
+		if ( cursor < text.length ) {
+			// capture right text node
+			captured.push( document.createTextNode( text.substr( cursor ) ) );
+		}
+
+		return captured;
+	}
+
+	/* Collect all text nodes */
+	/* Our goal--ignore nodes that are already wrapped */
+
+	this._walk( container_nodes, function( n ) {
+		if ( n.nodeType === 3 && ! parent.isMarkedNode( n ) ) {
+			nl.push( n );
+		}
+	} );
+
+	/* walk through the relevant nodes */
+
+	this.map( nl, function( n ) {
+		let foundStrings = {},
+			v,
+			tokens,
+			previous,
+			doReplaces,
+			token,
+			current,
+			defaults,
+			done,
+			prev,
+			curr,
+			newNode,
+			x,
+			regexp,
+			result,
+			i,
+			contents,
+			y,
+			nnode;
+
+		if ( n.nodeType === 3 ) {
+			v = n.nodeValue; /* we don't want to mangle the HTML so use the actual encoded string */
+			tokens = n.nodeValue.split(
+				seps
+			); /* split on the unencoded string so we get access to quotes as " */
+			previous = '';
+
+			doReplaces = [];
+
+			iterator = new TokenIterator( tokens );
+
+			while ( iterator.hasNext() ) {
+				token = iterator.next();
+				current = errors[ '__' + token ];
+
+				if ( current !== undefined && current.pretoks !== undefined ) {
+					defaults = current.defaults;
+					current = current.pretoks[ '__' + previous ];
+
+					done = false;
+					prev = v.substr( 0, iterator.getCount() );
+					curr = v.substr( prev.length, v.length );
+
+					function checkErrors( error ) {
+						if (
+							error !== undefined &&
+							! error.used &&
+							foundStrings[ '__' + error.string ] === undefined &&
+							error.regexp.test( curr )
+						) {
+							foundStrings[ '__' + error.string ] = 1;
+							doReplaces.push( [
+								error.regexp,
+								'<span class="' + error.type + '" pre="' + previous + '"' + bogus + '>$&</span>',
+							] );
+
+							error.used = true;
+							done = true;
+						}
+					}
+
+					if ( current !== undefined ) {
+						previous = previous + ' ';
+						parent.map( current, checkErrors );
+					}
+
+					if ( ! done ) {
+						previous = '';
+						parent.map( defaults, checkErrors );
+					}
+				}
+
+				previous = token;
+			} // end while
+
+			/* do the actual replacements on this span */
+			if ( doReplaces.length > 0 ) {
+				newNode = n;
+
+				for ( x = 0; x < doReplaces.length; x++ ) {
+					regexp = doReplaces[ x ][ 0 ];
+					result = doReplaces[ x ][ 1 ];
+
+					/* it's assumed that this function is only being called on text nodes (nodeType == 3), the iterating is necessary
+					   because eventually the whole thing gets wrapped in an mceItemHidden span and from there it's necessary to
+					   handle each node individually. */
+					function bringTheHurt( node ) {
+						let span, splitNodes;
+
+						if ( node.nodeType === 3 ) {
+							ecount++;
+
+							/* sometimes IE likes to ignore the space between two spans, solution is to insert a placeholder span with
+							   a non-breaking space.  The markup removal code substitutes this span for a space later */
+							if (
+								parent.isIE() &&
+								node.nodeValue.length > 0 &&
+								node.nodeValue.substr( 0, 1 ) === ' '
+							) {
+								return parent.create(
+									emptySpan +
+										node.nodeValue.substr( 1, node.nodeValue.length - 1 ).replace( regexp, result ),
+									false
+								);
+							}
+
+							if ( textOnlyMode ) {
+								return parent.create( node.nodeValue.replace( regexp, result ), false );
+							}
+
+							span = parent.create( '<span />' );
+							if ( typeof textOnlyMode === 'undefined' ) {
+								// cache this to avoid adding / removing nodes unnecessarily
+								textOnlyMode = typeof span.appendChild !== 'function';
+								if ( textOnlyMode ) {
+									parent.remove( span );
+									return parent.create( node.nodeValue.replace( regexp, result ), false );
+								}
+							}
+
+							// "Visual" mode
+							splitNodes = splitTextNode( node, regexp, result );
+							for ( i = 0; i < splitNodes.length; i++ ) {
+								span.appendChild( splitNodes[ i ] );
+							}
+
+							node = span;
+							return node;
+						}
+
+						contents = parent.contents( node );
+
+						for ( y = 0; y < contents.length; y++ ) {
+							if ( contents[ y ].nodeType === 3 && regexp.test( contents[ y ].nodeValue ) ) {
+								if (
+									parent.isIE() &&
+									contents[ y ].nodeValue.length > 0 &&
+									contents[ y ].nodeValue.substr( 0, 1 ) === ' '
+								) {
+									nnode = parent.create(
+										emptySpan +
+											contents[ y ].nodeValue
+												.substr( 1, contents[ y ].nodeValue.length - 1 )
+												.replace( regexp, result ),
+										true
+									);
+								} else {
+									nnode = parent.create( contents[ y ].nodeValue.replace( regexp, result ), true );
+								}
+
+								parent.replaceWith( contents[ y ], nnode );
+								parent.removeParent( nnode );
+
+								ecount++;
+
+								return node; /* we did a replacement so we can call it quits, errors only get used once */
+							}
+						}
+
+						return node;
+					} // jshint ignore:line
+
+					newNode = bringTheHurt( newNode );
+				}
+
+				parent.replaceWith( n, newNode );
+			}
+		}
+	} );
+
+	return ecount;
+};
+
+AtDCore.prototype._walk = function( elements, f ) {
+	let i;
+	for ( i = 0; i < elements.length; i++ ) {
+		f.call( f, elements[ i ] );
+		this._walk( this.contents( elements[ i ] ), f );
+	}
+};
+
+AtDCore.prototype.removeWords = function( node, w ) {
+	let count = 0;
+	const parent = this;
+
+	this.map( this.findSpans( node ).reverse(), function( n ) {
+		let nnode;
+		if (
+			n &&
+			( parent.isMarkedNode( n ) ||
+				parent.hasClass( n, 'mceItemHidden' ) ||
+				parent.isEmptySpan( n ) )
+		) {
+			if ( n.innerHTML === '&nbsp;' ) {
+				nnode = document.createTextNode( ' ' ); /* hax0r */
+				parent.replaceWith( n, nnode );
+			} else if ( ! w || n.innerHTML === w ) {
+				parent.removeParent( n );
+				count++;
+			}
+		}
+	} );
+
+	return count;
+};
+
+AtDCore.prototype.isEmptySpan = function( node ) {
+	return (
+		this.getAttrib( node, 'class' ) === '' &&
+		this.getAttrib( node, 'style' ) === '' &&
+		this.getAttrib( node, 'id' ) === '' &&
+		! this.hasClass( node, 'Apple-style-span' ) &&
+		this.getAttrib( node, 'mce_name' ) === ''
+	);
+};
+
+AtDCore.prototype.isMarkedNode = function( node ) {
+	return (
+		this.hasClass( node, 'hiddenGrammarError' ) ||
+		this.hasClass( node, 'hiddenSpellError' ) ||
+		this.hasClass( node, 'hiddenSuggestion' )
+	);
+};
+
+/*
+ * Context Menu Helpers
+ */
+AtDCore.prototype.applySuggestion = function( element, suggestion ) {
+	let node;
+	if ( suggestion === '(omit)' ) {
+		this.remove( element );
+	} else {
+		node = this.create( suggestion );
+		this.replaceWith( element, node );
+		this.removeParent( node );
+	}
+};
+
+/*
+ * Check for an error
+ */
+AtDCore.prototype.hasErrorMessage = function( xmlr ) {
+	return xmlr !== undefined && xmlr.getElementsByTagName( 'message' ).item( 0 ) !== null;
+};
+
+AtDCore.prototype.getErrorMessage = function( xmlr ) {
+	return xmlr.getElementsByTagName( 'message' ).item( 0 );
+};
+
+/* this should always be an error, alas... not practical */
+AtDCore.prototype.isIE = function() {
+	return navigator.appName === 'Microsoft Internet Explorer';
+};
+
+export default AtDCore;

--- a/client/components/tinymce/plugins/after-the-deadline/plugin.js
+++ b/client/components/tinymce/plugins/after-the-deadline/plugin.js
@@ -1,0 +1,527 @@
+/**
+ * /*
+ * TinyMCE Writing Improvement Tool Plugin
+ * Author: Raphael Mudge (raffi@automattic.com), Andrew Duthie (andrew.duthie@automattic.com)
+ *
+ * http:
+ *
+ * Distributed under the LGPL
+ *
+ * Derived from:
+ * 	$Id: editor_plugin_src.js 425 2007-11-21 15:17:39Z spocke $
+ *
+ * 	@author Moxiecode
+ * 	@copyright Copyright (C) 2004-2008, Moxiecode Systems AB, All rights reserved.
+ *
+ * 	Moxiecode Spell Checker plugin released under the LGPL with TinyMCE
+ *
+ * @format
+ */
+
+/**
+ * External dependencies
+ */
+import tinymce from 'tinymce/tinymce';
+import { stringify } from 'qs';
+import { find, throttle } from 'lodash';
+import { getLocaleSlug, translate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import AtDCore from './core';
+import PreferencesActions from 'lib/preferences/actions';
+import PreferencesStore from 'lib/preferences/store';
+
+/**
+ * Module variables
+ */
+const SERVICE_HOSTNAME = 'service.afterthedeadline.com';
+const SERVICE_LOCALIZED_SUBDOMAINS = [ 'en', 'pt', 'de', 'es', 'fr' ];
+const IGNORE_PREFERENCE_NAME = 'editorProofreadIgnore';
+
+function plugin( editor ) {
+	let suggestionsMenu,
+		started,
+		atdCore,
+		dom,
+		each = tinymce.each;
+
+	const SuggestionsMenu = tinymce.ui.Menu.extend( {
+		init( settings ) {
+			settings.context = 'contextmenu';
+			settings.autofix = false;
+
+			this.throttledReposition = throttle( this.reposition.bind( this ), 200 );
+			this.on( 'autohide', event => event.preventDefault() );
+			this.boundHideIfNotMarked = this.hideIfNotMarked.bind( this );
+
+			this._super( settings );
+		},
+
+		hideIfNotMarked( event ) {
+			if ( ! isMarkedNode( event.target ) ) {
+				this.hide();
+			}
+		},
+
+		hide() {
+			this._super();
+			this.remove();
+			window.removeEventListener( 'scroll', this.throttledReposition );
+			editor.off( 'SpellcheckEnd click touchstart focusout', this.boundHideIfNotMarked );
+		},
+
+		postRender() {
+			this._super();
+			this.reposition();
+			window.addEventListener( 'scroll', this.throttledReposition );
+			editor.on( 'SpellcheckEnd click touchstart focusout', this.boundHideIfNotMarked );
+		},
+
+		reposition() {
+			const rootNode = editor.dom.getRoot();
+			const pos = tinymce.DOM.getPos( editor.getContentAreaContainer() );
+			const targetPos = editor.dom.getPos( this.settings.target );
+
+			// Adjust targetPos for scrolling in the editor
+			if ( rootNode.nodeName === 'BODY' ) {
+				targetPos.x -= rootNode.ownerDocument.documentElement.scrollLeft || rootNode.scrollLeft;
+				targetPos.y -= rootNode.ownerDocument.documentElement.scrollTop || rootNode.scrollTop;
+			} else {
+				targetPos.x -= rootNode.scrollLeft;
+				targetPos.y -= rootNode.scrollTop;
+			}
+
+			pos.x += targetPos.x;
+			pos.y += targetPos.y;
+
+			this.moveTo( pos.x, pos.y + this.settings.target.offsetHeight );
+		},
+	} );
+
+	/* initializes the functions used by the AtD Core UI Module */
+	function initAtDCore() {
+		atdCore = new AtDCore();
+		atdCore.map = each;
+		atdCore._isTinyMCE = true;
+
+		atdCore.getAttrib = function( node, key ) {
+			return dom.getAttrib( node, key );
+		};
+
+		atdCore.findSpans = function( parent ) {
+			if ( parent === undefined ) {
+				return dom.select( 'span' );
+			}
+
+			return dom.select( 'span', parent );
+		};
+
+		atdCore.hasClass = function( node, className ) {
+			return dom.hasClass( node, className );
+		};
+
+		atdCore.contents = function( node ) {
+			return node.childNodes;
+		};
+
+		atdCore.replaceWith = function( old_node, new_node ) {
+			return dom.replace( new_node, old_node );
+		};
+
+		atdCore.create = function( node_html ) {
+			return dom.create( 'span', { class: 'mceItemHidden', 'data-mce-bogus': 1 }, node_html );
+		};
+
+		atdCore.removeParent = function( node ) {
+			dom.remove( node, true );
+			return node;
+		};
+
+		atdCore.remove = function( node ) {
+			dom.remove( node );
+		};
+
+		atdCore.setIgnoreStrings( editor.getParam( 'atd_ignore_strings', [] ).join( ',' ) );
+		atdCore.showTypes( editor.getParam( 'atd_show_types', '' ) );
+	}
+
+	function isMarkedNode( node ) {
+		return (
+			node.className && /\bhidden(GrammarError|SpellError|Suggestion)\b/.test( node.className )
+		);
+	}
+
+	function markMyWords( errors ) {
+		return atdCore.markMyWords( atdCore.contents( editor.getBody() ), errors );
+	}
+
+	// If no more suggestions, finish.
+	function checkIfFinished() {
+		if (
+			! editor.dom.select( 'span.hiddenSpellError, span.hiddenGrammarError, span.hiddenSuggestion' )
+				.length
+		) {
+			if ( suggestionsMenu ) {
+				suggestionsMenu.hide();
+			}
+
+			finish();
+		}
+	}
+
+	function ignoreWord( target, word, all ) {
+		if ( all ) {
+			each(
+				editor.dom.select(
+					'span.hiddenSpellError, span.hiddenGrammarError, span.hiddenSuggestion'
+				),
+				function( node ) {
+					const text = node.innerText || node.textContent;
+
+					if ( text === word ) {
+						dom.remove( node, true );
+					}
+				}
+			);
+		} else {
+			editor.dom.remove( target, true );
+		}
+
+		checkIfFinished();
+	}
+
+	// Called when the user clicks "Finish" or when no more suggestions left.
+	// Removes all remaining spans and fires custom event.
+	function finish() {
+		let node,
+			regex = new RegExp( 'mceItemHidden|hidden(((Grammar|Spell)Error)|Suggestion)' ),
+			nodes = editor.dom.select( 'span' ),
+			i = nodes.length;
+
+		while ( i-- ) {
+			// reversed
+			node = nodes[ i ];
+
+			if ( node.className && regex.test( node.className ) ) {
+				editor.dom.remove( node, true );
+			}
+		}
+
+		// Rebuild the DOM so AtD core can find the text nodes
+		editor.setContent( editor.getContent( { format: 'raw' } ), { format: 'raw' } );
+
+		started = false;
+		editor.nodeChanged();
+		editor.fire( 'SpellcheckEnd' );
+	}
+
+	function getServiceHostName() {
+		// Attempt to find a supported localized subdomain which matches the
+		// currently configured locale slug
+		const localeSlug = getLocaleSlug();
+		const subdomain = find( SERVICE_LOCALIZED_SUBDOMAINS, locale => {
+			// Match on full localeSlug ("en") or with variant ("pt-BR")
+			return localeSlug === locale || 0 === localeSlug.indexOf( locale + '-' );
+		} );
+
+		if ( subdomain ) {
+			return `${ subdomain }.${ SERVICE_HOSTNAME }`;
+		}
+
+		// Use base hostname if localization not supported
+		return SERVICE_HOSTNAME;
+	}
+
+	function sendRequest( path, data, success ) {
+		// Display spinner
+		editor.setProgressState( true );
+
+		// Request from localized service hostname
+		const xhr = new XMLHttpRequest();
+		xhr.open( 'POST', `https://${ getServiceHostName() }/${ path }` );
+		xhr.addEventListener( 'readystatechange', () => {
+			if ( 4 === xhr.readyState ) {
+				editor.setProgressState();
+
+				if ( 200 === xhr.status ) {
+					success( '' + xhr.responseText, xhr );
+				}
+			}
+		} );
+
+		const key = editor.getParam( 'atd_rpc_id' );
+		xhr.send( stringify( { data, key } ) );
+	}
+
+	function setAlwaysIgnore( text ) {
+		// Save ignore preference
+		const ignores = PreferencesStore.get( IGNORE_PREFERENCE_NAME ) || [];
+		if ( -1 === ignores.indexOf( text ) ) {
+			ignores.push( text );
+		}
+
+		PreferencesActions.set( IGNORE_PREFERENCE_NAME, ignores );
+	}
+
+	// Create the suggestions menu
+	function showSuggestions( target ) {
+		let items = [],
+			text = target.innerText || target.textContent,
+			errorDescription = atdCore.findSuggestion( target );
+
+		if ( ! errorDescription ) {
+			items.push( {
+				text: translate( 'No suggestions', { comment: 'Editor proofreading no suggestions' } ),
+				classes: 'atd-menu-title',
+				disabled: true,
+			} );
+		} else {
+			items.push( {
+				text: errorDescription.description,
+				classes: 'atd-menu-title',
+				disabled: true,
+			} );
+
+			if ( errorDescription.suggestions.length ) {
+				items.push( { text: '-' } ); // separator
+
+				each( errorDescription.suggestions, function( suggestion ) {
+					items.push( {
+						text: suggestion,
+						onclick: function() {
+							atdCore.applySuggestion( target, suggestion );
+							checkIfFinished();
+						},
+					} );
+				} );
+			}
+		}
+
+		if ( errorDescription && errorDescription.moreinfo ) {
+			items.push( { text: '-' } ); // separator
+
+			items.push( {
+				text: translate( 'Explain…', { comment: 'Editor proofreading menu item' } ),
+				onclick: function() {
+					editor.windowManager.open( {
+						title: translate( 'Explain…', { comment: 'Editor proofreading menu item' } ),
+						url: errorDescription.moreinfo,
+						width: 480,
+						height: 380,
+						inline: true,
+					} );
+				},
+			} );
+		}
+
+		items.push.apply( items, [
+			{ text: '-' }, // separator
+			{
+				text: translate( 'Ignore suggestion', { comment: 'Editor proofreading menu item' } ),
+				onclick: function() {
+					ignoreWord( target, text );
+				},
+			},
+		] );
+
+		if ( editor.getParam( 'atd_ignore_enable' ) ) {
+			items.push( {
+				text: translate( 'Ignore always', { comment: 'Editor proofreading menu item' } ),
+				onclick: function() {
+					setAlwaysIgnore( text );
+					ignoreWord( target, text, true );
+				},
+			} );
+		} else {
+			items.push( {
+				text: translate( 'Ignore all', { comment: 'Editor proofreading menu item' } ),
+				onclick: function() {
+					ignoreWord( target, text, true );
+				},
+			} );
+		}
+
+		// Render menu
+		suggestionsMenu = new SuggestionsMenu( { items, target } );
+		suggestionsMenu.renderTo( document.body );
+		suggestionsMenu.on( 'hide', () => {
+			suggestionsMenu = null;
+		} );
+	}
+
+	// Init everything
+	editor.on( 'init', function() {
+		// Set dom and atdCore
+		dom = editor.dom;
+		initAtDCore();
+
+		// add a command to request a document check and process the results.
+		editor.addCommand( 'mceWritingImprovementTool', function( callback ) {
+			let results,
+				errorCount = 0;
+
+			if ( typeof callback !== 'function' ) {
+				callback = function() {};
+			}
+
+			// checks if a global var for click stats exists and increments it if it does...
+			if ( typeof window.AtD_proofread_click_count !== 'undefined' ) {
+				window.AtD_proofread_click_count++;
+			}
+
+			// remove the previous errors
+			if ( started ) {
+				finish();
+				return;
+			}
+
+			// send request to our service
+			sendRequest( 'checkDocument', editor.getContent( { format: 'raw' } ), function(
+				data,
+				request
+			) {
+				// turn off the spinning thingie
+				editor.setProgressState();
+
+				// if the server is not accepting requests, let the user know
+				if (
+					request.status !== 200 ||
+					request.responseText.substr( 1, 4 ) === 'html' ||
+					! request.responseXML
+				) {
+					editor.windowManager.alert(
+						translate(
+							'There was a problem communicating with the Proofreading service. Try again in one minute.',
+							{ comment: 'Editor proofreading error' }
+						),
+						callback( 0 )
+					);
+
+					return;
+				}
+
+				// check to see if things are broken first and foremost
+				if ( request.responseXML.getElementsByTagName( 'message' ).item( 0 ) !== null ) {
+					editor.windowManager.alert(
+						request.responseXML.getElementsByTagName( 'message' ).item( 0 ).firstChild.data,
+						callback( 0 )
+					);
+
+					return;
+				}
+
+				results = atdCore.processXML( request.responseXML );
+
+				if ( results.count > 0 ) {
+					errorCount = markMyWords( results.errors );
+				}
+
+				if ( ! errorCount ) {
+					editor.windowManager.alert(
+						translate( 'No writing errors were found.', {
+							comment: 'Editor proofreading success prompt',
+						} )
+					);
+				} else {
+					started = true;
+					editor.fire( 'SpellcheckStart' );
+				}
+
+				callback( errorCount );
+			} );
+		} );
+
+		if ( editor.settings.content_css !== false ) {
+			// CSS for underlining suggestions
+			dom.addStyle(
+				'.hiddenSpellError{border-bottom:2px solid red;cursor:default;}' +
+					'.hiddenGrammarError{border-bottom:2px solid green;cursor:default;}' +
+					'.hiddenSuggestion{border-bottom:2px solid blue;cursor:default;}'
+			);
+		}
+
+		// Click on misspelled word
+		editor.on( 'click', function( event ) {
+			if ( isMarkedNode( event.target ) ) {
+				event.preventDefault();
+				editor.selection.select( event.target );
+				// Create the suggestions menu
+				showSuggestions( event.target );
+			}
+		} );
+	} );
+
+	( () => {
+		// Don't bother with ignore preferences if option disabled
+		if ( ! editor.getParam( 'atd_ignore_enable' ) ) {
+			return;
+		}
+
+		// Fetch preferences if unknown
+		if ( undefined === PreferencesStore.getAll() ) {
+			PreferencesActions.fetch();
+		}
+
+		// Sync ignored strings to core
+		function syncToCore() {
+			const ignores = PreferencesStore.get( IGNORE_PREFERENCE_NAME );
+			if ( ignores ) {
+				atdCore.setIgnoreStrings( ignores );
+			}
+		}
+
+		editor.on( 'init', () => {
+			PreferencesStore.on( 'change', syncToCore );
+		} );
+
+		editor.on( 'remove', () => {
+			PreferencesStore.off( 'change', syncToCore );
+		} );
+	} )();
+
+	editor.on( 'SpellcheckStart SpellcheckEnd', event => {
+		editor.contentDocument.body.spellcheck = 'spellcheckend' === event.type;
+		if ( ! editor.contentDocument.body.spellcheck ) {
+			editor.contentDocument.body.focus();
+			editor.contentDocument.body.blur();
+		}
+	} );
+
+	editor.addMenuItem( 'spellchecker', {
+		text: translate( 'Proofread Writing', { comment: 'Editor proofreading toolbar tooltip' } ),
+		context: 'tools',
+		cmd: 'mceWritingImprovementTool',
+		onPostRender: function() {
+			const self = this;
+
+			editor.on( 'SpellcheckStart SpellcheckEnd', function() {
+				self.active( started );
+			} );
+		},
+	} );
+
+	editor.addButton( 'spellchecker', {
+		tooltip: translate( 'Proofread Writing', { comment: 'Editor proofreading button tooltip' } ),
+		cmd: 'mceWritingImprovementTool',
+		onPostRender: function() {
+			const self = this;
+
+			editor.on( 'SpellcheckStart SpellcheckEnd', function() {
+				self.active( started );
+			} );
+		},
+	} );
+
+	editor.on( 'remove', function() {
+		if ( suggestionsMenu ) {
+			suggestionsMenu.remove();
+			suggestionsMenu = null;
+		}
+	} );
+}
+
+export default function() {
+	tinymce.PluginManager.add( 'AtD', plugin );
+}

--- a/client/post-editor/post-editor.jsx
+++ b/client/post-editor/post-editor.jsx
@@ -59,6 +59,7 @@ import {
 import { getCurrentUserId } from 'state/current-user/selectors';
 import editedPostHasContent from 'state/selectors/edited-post-has-content';
 import hasBrokenSiteUserConnection from 'state/selectors/has-broken-site-user-connection';
+import isVipSite from 'state/selectors/is-vip-site';
 import EditorConfirmationSidebar from 'post-editor/editor-confirmation-sidebar';
 import EditorDocumentHead from 'post-editor/editor-document-head';
 import EditorPostTypeUnsupported from 'post-editor/editor-post-type-unsupported';
@@ -356,6 +357,7 @@ export class PostEditor extends React.Component {
 									ref={ this.storeEditor }
 									mode={ mode }
 									isNew={ this.props.isNew }
+									isVipSite={ this.props.isVipSite }
 									onSetContent={ this.debouncedSaveRawContent }
 									onInit={ this.onEditorInitialized }
 									onChange={ this.onEditorContentChange }
@@ -1150,6 +1152,7 @@ const enhance = flow(
 				layoutFocus: getCurrentLayoutFocus( state ),
 				hasBrokenPublicizeConnection: hasBrokenSiteUserConnection( state, siteId, userId ),
 				isSitePreviewable: isSitePreviewable( state, siteId ),
+				isVipSite: isVipSite( state, siteId ),
 				isConfirmationSidebarEnabled: isConfirmationSidebarEnabled( state, siteId ),
 				isSaveBlocked: isEditorSaveBlocked( state ),
 				previewUrl: getEditorPostPreviewUrl( state ),


### PR DESCRIPTION
This PR Reverts Automattic/wp-calypso#31865 and adds a check to enable _After the Deadline_ just for VIP on WordPress.com.

| Simple Site | VIP Site |
| - | - |
| ![FireShot Capture 005 - New Post ‹ Development Site with a Free Plan — WordPress com_ - calypso localhost](https://user-images.githubusercontent.com/233601/57346313-6d6afc00-7124-11e9-958e-e62148699499.png) | ![FireShot Capture 003 - New Post ‹ VIP test   {test} — WordPress com - calypso localhost](https://user-images.githubusercontent.com/233601/57346267-444a6b80-7124-11e9-84d4-b9b46a7f4d1b.png) |

**How To Test**

To verify this PR you'll need two sites. A regular simple site, and get a user on one of our VIP sites on WordPress.com following these instructions: PCYsg-2Rv-p2

***Simple Sites***
- Switch a Simple Site to the Classic Editor.
- Create or open an existing Post/Page with the Classic Editor.
- Verify that the _Proofread Writing_ button does not appear on the toolbar.

***VIP on WordPress.com***
- Create or open an existing Post/Page with the Classic Editor.
- Verify that the _Proofread Writing_ button appears next to last on the toolbar. 

Part of #32859 

🤯
