### PR TITLE
Earn: Redirect remaining /ads/* paths to /earn after section rename

### DIFF
--- a/client/my-sites/earn/controller.js
+++ b/client/my-sites/earn/controller.js
@@ -13,13 +13,11 @@ import page from 'page';
 import Main from './main';
 
 export default {
-	redirect: function( context ) {
+	redirectToAdsEarnings: function( context ) {
 		page.redirect( '/earn/ads-earnings/' + context.params.site_id );
-		return;
 	},
 	redirectToAdsSettings: function( context ) {
 		page.redirect( '/earn/ads-settings/' + context.params.site_id );
-		return;
 	},
 	layout: function( context, next ) {
 		// Scroll to the top

--- a/client/my-sites/earn/index.js
+++ b/client/my-sites/earn/index.js
@@ -16,10 +16,13 @@ export default function() {
 	page( '/earn/memberships', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/ads-settings', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/ads-earnings', siteSelection, sites, makeLayout, clientRender );
-	page( '/earn/:site_id', earnController.redirect, makeLayout, clientRender );
-	// These 2 are legacy URLs to redirect if they are present anywhere on the web.
-	page( '/ads/earnings/:site_id', earnController.redirect, makeLayout, clientRender );
+	page( '/earn/:site_id', earnController.redirectToAdsEarnings, makeLayout, clientRender );
+	// These are legacy URLs to redirect if they are present anywhere on the web.
+	page( '/ads/earnings/:site_id', earnController.redirectToAdsEarnings, makeLayout, clientRender );
 	page( '/ads/settings/:site_id', earnController.redirectToAdsSettings, makeLayout, clientRender );
+	page( '/ads/:site_id', earnController.redirectToAdsEarnings, makeLayout, clientRender );
+	page( '/ads', '/earn' );
+	page( '/ads/*', '/earn' );
 
 	page(
 		'/earn/:section/:site_id',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`/ads/*` paths that were not previously redirected are leading to a blank screen when visited.  This update will redirect all `/ads/*` path not already redirected back to the Earn section.

#### Testing instructions

* Run Calypso locally
* Test using a WordAds enabled site
* Visit `http://calypso.localhost:3000/ads/earnings/:site_id` verify redirect to `http://calypso.localhost:3000/earn/ads-earnings/:site_id`
* Visit `http://calypso.localhost:3000/ads/settings/:site_id` verify redirect to `http://calypso.localhost:3000/earn/ads-settings/:site_id`
* Visit `http://calypso.localhost:3000/ads` verify redirect to `http://calypso.localhost:3000/earn`
* Visit `http://calypso.localhost:3000/ads/foo` verify redirect to `http://calypso.localhost:3000/earn`

cc @artpi Please review to make sure this doesn't affect Memberships
