### PR TITLE
Stats: Restoring stats content link icon

### DIFF
--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -1,0 +1,61 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+
+class StatsActionLink extends PureComponent {
+	static propTypes = {
+		href: PropTypes.string,
+		moduleName: PropTypes.string,
+		translate: PropTypes.func,
+	};
+
+	onClick = event => {
+		event.stopPropagation();
+		analytics.ga.recordEvent(
+			'Stats',
+			'Clicked on External Link in ' + this.props.moduleName + ' List Action Menu'
+		);
+	};
+
+	render() {
+		const { href, translate } = this.props;
+		return (
+			<li className="stats-list__item-action module-content-list-item-action">
+				<a
+					href={ href }
+					onClick={ this.onClick }
+					target="_blank"
+					rel="noopener noreferrer"
+					className="stats-list__item-action-wrapper module-content-list-item-action-wrapper"
+					title={ translate( 'View content in a new window', {
+						textOnly: true,
+						context: 'Stats action tooltip: View content in a new window',
+					} ) }
+					aria-label={ translate( 'View content in a new window', {
+						textOnly: true,
+						context: 'Stats ARIA label: View content in new window action',
+					} ) }
+				>
+					<Gridicon icon="external" size={ 18 } />
+					<span className="stats-list__item-action-label module-content-list-item-action-label module-content-list-item-action-label-view">
+						{ translate( 'View', { context: 'Stats: List item action to view content' } ) }
+					</span>
+				</a>
+			</li>
+		);
+	}
+}
+
+export default localize( StatsActionLink );

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -19,6 +19,7 @@ import analytics from 'lib/analytics';
 import Emojify from 'components/emojify';
 import Follow from './action-follow';
 import Page from './action-page';
+import OpenLink from './action-link';
 import Spam from './action-spam';
 import titlecase from 'to-title-case';
 import { flagUrl } from 'lib/flags';
@@ -164,6 +165,11 @@ class StatsListItem extends React.Component {
 								afterChange={ this.spamHandler }
 								moduleName={ moduleName }
 							/>
+						);
+						break;
+					case 'link':
+						actionItem = (
+							<OpenLink href={ action.data } key={ action.type } moduleName={ moduleName } />
 						);
 						break;
 				}


### PR DESCRIPTION
## Changes proposed in this Pull Request

We had a few complaints about the missing icon link, removed in https://github.com/Automattic/wp-calypso/pull/32748 (see [comments](https://github.com/Automattic/wp-calypso/pull/32748#issuecomment-489609956) in that PR)

The icon linked directly to a user's content.

https://github.com/Automattic/wp-calypso/issues/32252 for context provides context as to why we removed it.

**Should we decide to roll back**, this PR restores the link until we can come up with an alternative.

If @jeffgolenski and @alaczek think it's okay, feel free to close this PR. 👍 

## Testing instructions

Check that the icon is restored and that the link takes you to the content (not the content's stats page)

<img width="473" alt="Screen Shot 2019-05-07 at 8 31 57 am" src="https://user-images.githubusercontent.com/6458278/57259376-afebf480-70a2-11e9-9fae-6cdb0238bdf2.png">


