### PR TITLE
Adjust material icon fill on hover and selected states

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -379,7 +379,8 @@ form.sidebar__button input {
 	}
 
 	.gridicon,
-	.jetpack-logo {
+	.jetpack-logo,
+	.material-icon	{
 		fill: var( --sidebar-menu-selected-a-color );
 	}
 
@@ -482,7 +483,8 @@ form.sidebar__button input {
 		}
 
 		.gridicon,
-		.jetpack-logo {
+		.jetpack-logo,
+		.material-icon	{
 			fill: var( --sidebar-menu-hover-color );
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the sidenav icon fill on hover and selected states in the Me section.

<img width="251" alt="Screen Shot 2019-05-06 at 7 10 58 PM" src="https://user-images.githubusercontent.com/5375500/57260679-b6db1e80-7032-11e9-9db7-64ffa32115f7.png">

@drw158 Doing this made me think of another question however --  does it make sense to change the font weight here when a nav item is selected? 

#### Testing instructions

* Visit wordpress.com/me section
* Hover and select a menu item

Referencing #32842 