### PR TITLE
Gutenframe: Add a stylesheet to the block editor build.

### DIFF
--- a/apps/wpcom-block-editor/src/common/index.js
+++ b/apps/wpcom-block-editor/src/common/index.js
@@ -3,3 +3,4 @@
  */
 import './rich-text';
 import './switch-to-classic';
+import './style.scss';

--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -1,0 +1,5 @@
+@media ( min-width: 782px ) {
+	body.is-fullscreen-mode .edit-post-layout__content {
+		overflow-y: inherit;
+	}
+}

--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -1,5 +1,13 @@
 @media ( min-width: 782px ) {
 	body.is-fullscreen-mode .edit-post-layout__content {
-		overflow-y: inherit;
+		top: 56px;
+		position: fixed;
+	}
+}
+
+@media screen and ( max-width: 600px ) {
+	// stylelint-disable-next-line selector-max-id
+	#wpbody {
+		padding-top: 0;
 	}
 }

--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -11,3 +11,7 @@
 		padding-top: 0;
 	}
 }
+
+.components-notice-list {
+	z-index: 29; // Ensure notices are placed behind the editor header (z-index: 30).
+}

--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -5,9 +5,9 @@
 	}
 }
 
-@media screen and ( max-width: 600px ) {
+@media ( max-width: 600px ) {
 	// stylelint-disable-next-line selector-max-id
-	#wpbody {
+	.is-iframed #wpbody {
 		padding-top: 0;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* To allow styles pertaining to the iframed block editor to be enqueued by Jetpack and Atomic sites, this PR adds a stylesheet to the build process for the app. This app is served from `widgets.wp.com`.

#### Testing instructions

See https://github.com/Automattic/jetpack/pull/12279

Fixes #32637 
