### PR TITLE
Types: Create global types in top-level client module

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -40,16 +40,21 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { protectForm, ProtectedFormProps } from 'lib/protect-form';
 
 /**
+ * Types
+ */
+import * as T from 'types';
+
+/**
  * Style dependencies
  */
 import './style.scss';
 
 interface Props {
-	duplicatePostId: number;
-	postId: number;
-	postType: string;
+	duplicatePostId: T.PostId;
+	postId: T.PostId;
+	postType: T.PostType;
 	pressThis: any;
-	siteAdminUrl: string | null;
+	siteAdminUrl: T.URL | null;
 }
 
 interface State {
@@ -61,8 +66,8 @@ interface State {
 	isMediaModalVisible: boolean;
 	isPreviewVisible: boolean;
 	multiple?: any;
-	postUrl?: string;
-	previewUrl: string;
+	postUrl?: T.URL;
+	previewUrl: T.URL;
 }
 
 enum WindowActions {

--- a/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
+++ b/client/my-sites/marketing/tools/feature-button-with-plan-gate.tsx
@@ -15,10 +15,15 @@ import { getPlan } from 'lib/plans';
 import { hasFeature } from 'state/sites/plans/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
+/**
+ * Types
+ */
+import * as T from 'types';
+
 interface ConnectedProps {
 	hasPlanFeature: boolean;
 	planTitle: string;
-	selectedSiteSlug: string | null;
+	selectedSiteSlug: T.SiteSlug | null;
 }
 
 interface ExternalProps {
@@ -26,10 +31,12 @@ interface ExternalProps {
 	feature: string;
 	onDefaultButtonClick: () => void;
 	onUpgradeButtonClick: () => void;
-	planSlug: string;
+	planSlug: T.PlanSlug;
 }
 
-const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent< ExternalProps & ConnectedProps > = ( {
+const MarketingToolsFeatureButtonWithPlanGate: FunctionComponent<
+	ExternalProps & ConnectedProps
+> = ( {
 	buttonText,
 	hasPlanFeature,
 	onDefaultButtonClick,

--- a/client/my-sites/marketing/tools/google-my-business-feature.tsx
+++ b/client/my-sites/marketing/tools/google-my-business-feature.tsx
@@ -20,11 +20,16 @@ import QueryKeyringServices from 'components/data/query-keyring-services';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
+/**
+ * Types
+ */
+import * as T from 'types';
+
 interface Props {
 	connectedGoogleMyBusinessLocation?: null | any[];
-	recordTracksEvent: () => void;
-	selectedSiteId: number | null;
-	selectedSiteSlug: string | null;
+	recordTracksEvent: typeof recordTracksEventAction;
+	selectedSiteId: T.SiteId | null;
+	selectedSiteSlug: T.SiteSlug | null;
 }
 
 const MarketingToolsGoogleMyBusinessFeature: FunctionComponent< Props > = ( {
@@ -46,10 +51,13 @@ const MarketingToolsGoogleMyBusinessFeature: FunctionComponent< Props > = ( {
 	};
 
 	const handleUpgradeToBusinessPlanClick = () => {
-		recordTracksEvent( 'calypso_marketing_tools_google_my_business_upgrade_to_business_button_click', {
-			plan_slug: PLAN_BUSINESS,
-			feature: FEATURE_GOOGLE_MY_BUSINESS,
-		} );
+		recordTracksEvent(
+			'calypso_marketing_tools_google_my_business_upgrade_to_business_button_click',
+			{
+				plan_slug: PLAN_BUSINESS,
+				feature: FEATURE_GOOGLE_MY_BUSINESS,
+			}
+		);
 	};
 
 	const translate = useTranslate();

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -19,13 +19,18 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
 /**
+ * Types
+ */
+import * as T from 'types';
+
+/**
  * Style dependencies
  */
 import './style.scss';
 
 interface Props {
-	recordTracksEvent: () => void;
-	selectedSiteSlug: string | null;
+	recordTracksEvent: typeof recordTracksEventAction;
+	selectedSiteSlug: T.SiteSlug | null;
 }
 
 export const MarketingTools: FunctionComponent< Props > = ( {
@@ -78,7 +83,11 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 					) }
 					imagePath="/calypso/images/illustrations/expert.svg"
 				>
-					<Button onClick={ handleFindYourExpertClick } href={ '/experts/upwork?source=marketingtools' } target="_blank">
+					<Button
+						onClick={ handleFindYourExpertClick }
+						href={ '/experts/upwork?source=marketingtools' }
+						target="_blank"
+					>
 						{ translate( 'Find Your Expert' ) }
 					</Button>
 				</MarketingToolsFeature>
@@ -90,7 +99,11 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 					) }
 					imagePath="/calypso/images/illustrations/branding.svg"
 				>
-					<Button onClick={ handleCreateALogoClick } href={ 'http://logojoy.grsm.io/looka' } target="_blank">
+					<Button
+						onClick={ handleCreateALogoClick }
+						href={ 'http://logojoy.grsm.io/looka' }
+						target="_blank"
+					>
 						{ translate( 'Create A Logo' ) }
 					</Button>
 				</MarketingToolsFeature>

--- a/client/types.ts
+++ b/client/types.ts
@@ -1,0 +1,20 @@
+// Web stuff
+export type URL = string;
+
+// User stuff
+
+// Site stuff
+export type SiteId = number;
+export type SiteSlug = string;
+
+// Plan stuff
+export type PlanSlug = string;
+
+// Plugin stuff
+
+// Post stuff
+export type PostId = number;
+export type PostType = 'page' | 'post' | string;
+
+// Comment stuff
+export type CommentId = number;


### PR DESCRIPTION
There are certain types which will be useful around various places in
Calypso. These types may even be primitive types like `number` but they
connote a specific kind of value, such as a site id.

In this patch we're creating a top-level module to hold these kind of
shared (common) global types.

The purpose of this is to centralize our definitions for our most common
types and to encourage discoverability. We prefer giving names to our
types in order to foster communication through various dataflows.

Before this change we see that several values are `number` but
afterwards they are `SiteId` and a hover-tip shows `SiteId = number`. To
me it's much clearer to give the name because it specifies what kind of
number it is.

Another oddity is `'page' | 'post' | string` because it widens to
`string`. However, this is another example of using the type system
to provide help on autocomplete and hover-tips. It may be very useful
to know that `PostType` could be "one of these values" _or_ in rarer
cases "any other string value."

**There should be no functional or visual changes in this PR**