### PR TITLE
Signup: Steps (Domain): Improve Keyboard UX + Accessibility

### DIFF
--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -238,10 +238,10 @@ export class DropdownFilters extends Component {
 					errorMessages={ this.getOverallValidationErrors() }
 				>
 					<div className="search-filters__buttons">
-						<Button onClick={ this.handleFiltersReset }>{ translate( 'Reset' ) }</Button>
 						<Button primary onClick={ this.handleFiltersSubmit }>
 							{ translate( 'Apply' ) }
 						</Button>
+						<Button onClick={ this.handleFiltersReset }>{ translate( 'Reset' ) }</Button>
 					</div>
 				</ValidationFieldset>
 			</Popover>

--- a/client/components/domains/search-filters/dropdown-filters.jsx
+++ b/client/components/domains/search-filters/dropdown-filters.jsx
@@ -36,10 +36,14 @@ export class DropdownFilters extends Component {
 			maxCharacters: PropTypes.string,
 			exactSldMatchesOnly: PropTypes.bool,
 		} ).isRequired,
-
+		popoverId: PropTypes.string,
 		onChange: PropTypes.func.isRequired,
 		onReset: PropTypes.func.isRequired,
 		onSubmit: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		popoverId: 'search-filters-dropdown-filters',
 	};
 
 	state = {
@@ -144,7 +148,14 @@ export class DropdownFilters extends Component {
 					'search-filters__dropdown-filters--is-open': this.state.showPopover,
 				} ) }
 			>
-				<Button borderless ref={ this.button } onClick={ this.togglePopover }>
+				<Button
+					aria-describedby={ this.props.popoverId }
+					aria-expanded={ this.state.showPopover }
+					aria-haspopup="true"
+					borderless
+					ref={ this.button }
+					onClick={ this.togglePopover }
+				>
 					<Gridicon icon="cog" size={ 12 } />
 					<span className="search-filters__dropdown-filters-button-text">
 						{ this.props.translate( 'Filters' ) }
@@ -159,6 +170,7 @@ export class DropdownFilters extends Component {
 	renderPopover() {
 		const {
 			filters: { includeDashes, maxCharacters, exactSldMatchesOnly },
+			popoverId,
 			translate,
 		} = this.props;
 
@@ -168,9 +180,12 @@ export class DropdownFilters extends Component {
 
 		return (
 			<Popover
+				aria-label="Domain Search Filters"
 				autoPosition={ false }
 				className="search-filters__popover"
 				context={ this.button.current }
+				id={ popoverId }
+				isFocusOnShow
 				isVisible={ this.state.showPopover }
 				onClose={ this.handleFiltersSubmit }
 				position="bottom left"

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -83,14 +83,14 @@
 
 .search-filters__buttons {
 	display: flex;
-	flex-flow: row wrap;
+	flex-flow: row-reverse;
 	justify-content: space-between;
 
 	.button {
 		flex: 1 0 auto;
-		margin-right: 1em;
+		margin-left: 1em;
 		&:last-child {
-			margin-right: 0;
+			margin-left: 0;
 		}
 
 		&.search-filters__button--is-placeholder {

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -1,8 +1,7 @@
-
 .search-filters__dropdown-filters {
 	align-items: center;
 	border-left: 1px solid var( --color-neutral-100 );
-	height: 51px;// same as .search
+	height: 51px; // same as .search
 	z-index: z-index( 'root', '.search' );
 
 	// Move the filter so its "inside" the
@@ -15,6 +14,9 @@
 
 	.button {
 		align-items: center;
+		border-radius: 3px;
+		border-bottom-left-radius: 0;
+		border-top-left-radius: 0;
 		display: flex;
 		flex-direction: column;
 		font-weight: normal;
@@ -23,6 +25,14 @@
 		padding: 0 1em;
 		transition: 0.1s all linear;
 		width: 100%;
+
+		&.is-borderless {
+			&:hover,
+			&:focus {
+				border-color: transparent;
+				box-shadow: 0 0 0 3px var( --color-accent-light ), -1px 0 0 3px var( --color-accent-light );
+			}
+		}
 
 		.gridicon {
 			top: 0;

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -14,9 +14,7 @@
 
 	.button {
 		align-items: center;
-		border-radius: 3px;
-		border-bottom-left-radius: 0;
-		border-top-left-radius: 0;
+		border-radius: 0 3px 3px 0;
 		display: flex;
 		flex-direction: column;
 		font-weight: normal;

--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -133,6 +133,10 @@ rendered as a button.
 
 Sets a custom className on the button or link.
 
+#### `isFocusOnShow { bool } - default: false`
+
+Focuses the Popover when it shows. Useful for controlling/improving keyboard navigation.
+
 #### `isSelected { bool } - default: false`
 
 Defines whether or not the `PopoverMenuItem` is the currently selected one.

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -209,6 +209,11 @@ class Popover extends Component {
 			return null;
 		}
 
+		if ( this.domContext ) {
+			this.debug( 'Refocusing the previous active DOM node' );
+			this.domContext.focus();
+		}
+
 		this.close( true );
 	}
 
@@ -471,11 +476,6 @@ class Popover extends Component {
 		if ( ! this.props.isVisible ) {
 			this.debug( 'popover should be already closed' );
 			return null;
-		}
-
-		if ( this.domContext ) {
-			this.debug( 'Refocusing the previous active DOM node' );
-			this.domContext.focus();
 		}
 
 		this.props.onClose( wasCanceled );

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -40,6 +40,7 @@ class Popover extends Component {
 		closeOnEsc: PropTypes.bool,
 		id: PropTypes.string,
 		ignoreContext: PropTypes.shape( { getDOMNode: PropTypes.function } ),
+		isFocusOnShow: PropTypes.bool,
 		isRtl: PropTypes.bool,
 		isVisible: PropTypes.bool,
 		position: PropTypes.oneOf( [
@@ -70,6 +71,7 @@ class Popover extends Component {
 		autoRtl: true,
 		className: '',
 		closeOnEsc: true,
+		isFocusOnShow: false,
 		isRtl: false,
 		isVisible: false,
 		position: 'top',
@@ -271,6 +273,15 @@ class Popover extends Component {
 		this.willReposition = window.requestAnimationFrame( this.setPosition );
 	}
 
+	focusPopover() {
+		if ( ! this.props.isFocusOnShow || ! this.popoverNode ) {
+			return null;
+		}
+
+		this.debug( 'focusing the Popover' );
+		this.popoverNode.focus();
+	}
+
 	setDOMBehavior( domContainer ) {
 		if ( ! domContainer ) {
 			this.unbindClickoutHandler();
@@ -283,11 +294,14 @@ class Popover extends Component {
 
 		// store DOM element referencies
 		this.domContainer = domContainer;
+		this.popoverNode = document.getElementById( this.id );
 
 		// store context (target) reference into a property
 		this.domContext = ReactDom.findDOMNode( this.props.context );
 
 		this.setPosition();
+
+		this.focusPopover();
 	}
 
 	getPositionClass( position = this.props.position ) {
@@ -459,6 +473,11 @@ class Popover extends Component {
 			return null;
 		}
 
+		if ( this.domContext ) {
+			this.debug( 'Refocusing the previous active DOM node' );
+			this.domContext.focus();
+		}
+
 		this.props.onClose( wasCanceled );
 	}
 
@@ -478,10 +497,15 @@ class Popover extends Component {
 		this.debug( 'rendering ...' );
 
 		return (
-			<RootChild className={ this.props.rootClassName }>
+			<RootChild
+				aria-label={ this.props[ 'aria-label' ] }
+				className={ this.props.rootClassName }
+				id={ this.id }
+				role="tooltip"
+				tabIndex={ this.props.isFocusOnShow ? 0 : null }
+			>
 				<div style={ this.getStylePosition() } className={ classes }>
 					<div className="popover__arrow" />
-
 					<div ref={ this.setDOMBehavior } className="popover__inner">
 						{ this.props.children }
 					</div>


### PR DESCRIPTION
#### Changes + Fixes

This PR improves the overall keyboard UX and adds accessibility support for the `Popover` component that appears within the Domain Search Filter component within the sign up flow.

## Improve keyboard tab interaction for Domain Search Filter dropdown

![Screen Recording 2019-05-06 at 10 24 PM](https://user-images.githubusercontent.com/2322354/57267591-a042c080-704e-11e9-905d-3adc19468ef1.gif)

This update improves the keyboard tab interaction by prioritizing the focus
of the primary action (Apply) first, before the secondary action (Reset).

With this update, the tab order now flows like:

1. Text Field
2. Checkbox
3. Checkbox
4. Apply
5. Reset

Previously, it flowed like:

1. Text Field
2. Checkbox
3. Checkbox
4. Reset
5. Apply

Visually, the UI looks exactly the same.

The idea for this is to better align the user intention for keyboard navigation. If this interaction is desirable and something we'd want to use throughout the app, then we can create a new Component that wraps action elements (typically Buttons) to automatically handle the order. At the moment, the styles are added directly to the wrapping element.

## Popover + Search Filters Dropdown: Improving focus interaction + accessibility

![Screen Recording 2019-05-06 at 10 23 PM](https://user-images.githubusercontent.com/2322354/57267605-adf84600-704e-11e9-8c66-441fe56eed11.gif)

(GIF: Shows complete keyboard navigation with Mac OS Voiceover turned on! What you see in the darker box is what voiceover is reading to the user. It now recognizes that the Popover is a proper popover.. er.. [Tooltip](https://www.w3.org/TR/wai-aria-practices-1.1/#tooltip))

This update enhances the base `Popover` component with improved keyboard
interactions + accessibility support.

A new Popover prop has been added - `isFocusOnShow` (`bool`). By default,
it is `false`, which ensures that the experience for current Popover use
remains the same.

However, once that prop is set to true, on show, the focus will be shifted
to the `Popover`.

Aria roles, labels, and descriptions have been added to ensure proper
screen-reader/voiceover support.

The first place that the Popover will become focused on open would be within
the Domain Search Filters Dropdown.

Aria labels and ids have been added to the trigger (context) button to
associate it with the Popover.

Since this update is on the base `Popover` component, that means it keyboard + accessibility can be improved site/app wide, if desired. Again, since I didn't want to make wide sweeping changes, the focus feature is currently opt-in.

## Button Focus style fixes

Lastly, the Button styles within the Search Filter has been adjusted to better match the hover/focus styles of the surrounding Input component.

**Before**
![Screen Recording 2019-05-06 at 10 18 PM](https://user-images.githubusercontent.com/2322354/57267640-d08a5f00-704e-11e9-8b0e-1ec4679bb07b.gif)


**After**
![Screen Recording 2019-05-06 at 10 21 PM](https://user-images.githubusercontent.com/2322354/57267643-d41de600-704e-11e9-8e2a-20e0f1c15999.gif)

## Docs, PropTypes, and Debugs

For the `Popover` component I've added debugs (where useful), as well as `propTypes`, `defaultProps`, and some documentation to the README.md.

#### Testing instructions

1. Create a new Wordpress.com account
2. Go through the sign up flow until `/start/domains`
3. Click on the filters button, the Popover should open as normal
4. Popover should focus on open
5. Press tab to tab around
6. Turn on voiceover if you're curious, and try using the Input/Popover component

#### Review

cc'ing @lamosty and @jsnmoon for review! 🙏 (Thanks!)

#### Additional notes

I wanted to write some basic tests for the `Popover`. When I tried, I got these errors from Jest:

```
 FAIL  client/components/popover/test/popover.jsx
  ● Test suite failed to run

    ReferenceError: window is not defined

      at Object.<anonymous> (node_modules/component-event/index.js:1:39)
      at Object.<anonymous> (node_modules/click-outside/index.js:6:1)
```

After some poking around, it looks like Jest is set up with `node`, not `JSDOM`, so things like `window`, and `document` aren't available by default.

I checked some of the other components, and they didn't look like they had tests.
Hopefully this is okay for now. If not, let me know, and I'll do my best to add some. I just thought I'd get some thoughts before I go.. mocking a bunch of things from `window` 😊 