### PR TITLE
Signup: Alias anonUserId to WPCOM user id when user is created

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -741,16 +741,19 @@ const analytics = {
 		},
 	},
 
-	identifyUser: function() {
+	identifyUser: function( newUserId = '', newUserName = '' ) {
 		const anonymousUserId = this.tracks.anonymousUserId();
 
 		// Don't identify the user if we don't have one
-		if ( _user && _user.initialized ) {
+		if ( ( _user && _user.initialized ) || ( newUserId && newUserName ) ) {
 			if ( anonymousUserId ) {
 				recordAliasInFloodlight();
 			}
 
-			window._tkq.push( [ 'identifyUser', _user.get().ID, _user.get().username ] );
+			const userId = newUserId || _user.get().ID;
+			const userName = newUserName || _user.get().username;
+
+			window._tkq.push( [ 'identifyUser', userId, userName ] );
 		}
 	},
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -512,6 +512,29 @@ export function createAccount(
 
 				// Fire after a new user registers.
 				analytics.recordRegistration();
+				/**
+				 * Auto login the user when it has been created.
+				 */
+				user.clear();
+				user.fetching = false;
+
+				user.on( 'change', () => {
+					const newLoggedUser = user.get();
+
+					if ( newLoggedUser && newLoggedUser.ID ) {
+						analytics.identifyUser( newLoggedUser.ID, newLoggedUser.username );
+					} else {
+						/**
+						 * The user fetching is a bit fragile and sometimes it requires to do a double-fetch.
+						 */
+						user.clear();
+						user.fetching = false;
+						user.fetch();
+					}
+				} );
+
+				// Force fetch the user details
+				user.fetch();
 
 				const username =
 					( response && response.signup_sandbox_username ) ||

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -22,6 +22,7 @@ import {
 	supportsPrivacyProtectionPurchase,
 	planItem as getCartItemForPlan,
 } from 'lib/cart-values/cart-items';
+import log from 'lib/catch-js-errors/log';
 
 // State actions and selectors
 import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
@@ -527,6 +528,13 @@ export function createAccount(
 						/**
 						 * The user fetching is a bit fragile and sometimes it requires to do a double-fetch.
 						 */
+						log(
+							'Signup new user account creation: performing a new fetch of user if previous fetch fails',
+							{
+								newLoggedUser: newLoggedUser && newLoggedUser.ID ? newLoggedUser.ID : undefined,
+								userFetching: user.fetching,
+							}
+						);
 						user.clear();
 						user.fetching = false;
 						user.fetch();


### PR DESCRIPTION
## Changes proposed in this Pull Request

Reverting changes in #13563, which reverted changes in #11715

See p3Ex-3uT-p2 and p3Ex-3vP-p2


## Testing instructions

Open dev tools and in the Network tab, search for “alias”

 Go through the onboarding flow. 

`t.gif` (the pixel we load to alias the user) should load immediately after the user is created and we have a user id available to alias.

<img width="832" alt="Screen Shot 2019-06-22 at 10 41 27 am" src="https://user-images.githubusercontent.com/6458278/59961610-6a607b00-94da-11e9-9fc7-f6e382c0c077.png">

E.g.,

![Jun-22-2019 10-40-42](https://user-images.githubusercontent.com/6458278/59961620-751b1000-94da-11e9-837d-e6aff86f1247.gif)


