### PR TITLE
Site Launch: Update site title 

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { noop } from 'lodash';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -22,6 +23,7 @@ export function generateFlows( {
 			destination: '/',
 			description: 'Create an account without a blog.',
 			lastModified: '2015-07-07',
+			pageTitle: translate( 'Create an account' ),
 		},
 
 		business: {
@@ -308,6 +310,7 @@ export function generateFlows( {
 		description: 'A flow to launch a private site.',
 		providesDependenciesInQuery: [ 'siteSlug' ],
 		lastModified: '2019-01-16',
+		pageTitle: translate( 'Launch your site' ),
 	};
 
 	flows.import = {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -22,6 +22,7 @@ import {
 	getStepName,
 	getStepSectionName,
 	getValidPath,
+	getFlowPageTitle,
 } from './utils';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import store from 'store';
@@ -142,6 +143,7 @@ export default {
 			stepName,
 			stepSectionName,
 			stepComponent,
+			pageTitle: getFlowPageTitle( flowName ),
 		} );
 
 		next();

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -531,6 +531,20 @@ class Signup extends React.Component {
 		return flows.getFlow( this.props.flowName ).steps.length;
 	}
 
+	getPageTitle() {
+		const { flowName } = this.props;
+
+		if ( flowName === 'account' ) {
+			return translate( 'Create an account' );
+		}
+
+		if ( flowName === 'launch-site' ) {
+			return translate( 'Launch your site' );
+		}
+
+		return translate( 'Create a site' );
+	}
+
 	renderCurrentStep() {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
@@ -622,15 +636,11 @@ class Signup extends React.Component {
 			return this.props.siteId && waitToRenderReturnValue;
 		}
 
-		const pageTitle =
-			this.props.flowName === 'account'
-				? translate( 'Create an account' )
-				: translate( 'Create a site' );
 		const showProgressIndicator = 'pressable-nux' === this.props.flowName ? false : true;
 
 		return (
 			<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
-				<DocumentHead title={ pageTitle } />
+				<DocumentHead title={ this.getPageTitle() } />
 				<SignupHeader
 					positionInFlow={ this.getPositionInFlow() }
 					flowLength={ this.getFlowLength() }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -21,7 +21,6 @@ import {
 	pick,
 	startsWith,
 } from 'lodash';
-import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
 /**
@@ -105,6 +104,10 @@ class Signup extends React.Component {
 		siteDomains: PropTypes.array,
 		isPaidPlan: PropTypes.bool,
 		trackAffiliateReferral: PropTypes.func.isRequired,
+		flowName: PropTypes.string,
+		stepName: PropTypes.string,
+		pageTitle: PropTypes.string,
+		stepSectionName: PropTypes.string,
 	};
 
 	constructor( props, context ) {
@@ -531,20 +534,6 @@ class Signup extends React.Component {
 		return flows.getFlow( this.props.flowName ).steps.length;
 	}
 
-	getPageTitle() {
-		const { flowName } = this.props;
-
-		if ( flowName === 'account' ) {
-			return translate( 'Create an account' );
-		}
-
-		if ( flowName === 'launch-site' ) {
-			return translate( 'Launch your site' );
-		}
-
-		return translate( 'Create a site' );
-	}
-
 	renderCurrentStep() {
 		const domainItem = get( this.props, 'signupDependencies.domainItem', false );
 		const currentStepProgress = find( this.props.progress, { stepName: this.props.stepName } );
@@ -640,7 +629,7 @@ class Signup extends React.Component {
 
 		return (
 			<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
-				<DocumentHead title={ this.getPageTitle() } />
+				<DocumentHead title={ this.props.pageTitle } />
 				<SignupHeader
 					positionInFlow={ this.getPositionInFlow() }
 					flowLength={ this.getFlowLength() }

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -3,6 +3,7 @@
  * Exernal dependencies
  */
 import { filter, find, includes, indexOf, isEmpty, merge, pick } from 'lodash';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -110,6 +111,11 @@ export function getNextStepName( flowName, currentStepName ) {
 export function getFlowSteps( flowName ) {
 	const flow = flows.getFlow( flowName );
 	return flow.steps;
+}
+
+export function getFlowPageTitle( flowName ) {
+	const flow = flows.getFlow( flowName );
+	return flow.pageTitle || translate( 'Create a site' );
 }
 
 export function getValueFromProgressStore( { signupProgress, stepName, fieldName } ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request

The page title on the launch flow reads "Create a site". Let's update it to "Launch your site"

<img width="607" alt="Screen Shot 2019-05-07 at 2 44 58 pm" src="https://user-images.githubusercontent.com/6458278/57272412-f4918300-70d6-11e9-9b54-69799f42ae5d.png">

## Testing instructions

Create a site (ensure that the site title during onboarding is `'Create a site'`

Once created, view the site and enter the launch flow. The site title should be `'Launch your site'`


