### PR TITLE
WP.com block editor: Add missing styles from Core 5.2

### DIFF
--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -1,4 +1,15 @@
 @media ( min-width: 782px ) {
+	.edit-post-layout__content {
+		position: fixed;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		top: 88px;
+		min-height: calc( 100% - 88px );
+		height: auto;
+		margin-left: 160px;
+	}
+
 	body.is-fullscreen-mode .edit-post-layout__content {
 		top: 56px;
 		position: fixed;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds to the WP.com block editor package the styles from Core 5.2 that are currently missing in WordPress.com and breaking the layout of the iframed blocked editor (see D27813-code). 

These styles can be removed as soon as D27605-code is merged. They are need now to allow D27813-code to be deployed first without requiring D27605-code.


#### Testing instructions

See D27813-code
