### PR TITLE
Some improvements to addReducerToStore types.

### DIFF
--- a/client/state/add-reducer.ts
+++ b/client/state/add-reducer.ts
@@ -16,7 +16,19 @@ function normalizeKey( key: string[] ): string {
 	return key.join( '.' );
 }
 
-async function initializeState( store: Store, storageKey: string, reducer: Reducer ) {
+interface OptionalStorageKey {
+	storageKey?: string;
+}
+
+interface WithAddReducer {
+	addReducer: ( keys: string[], subReducer: Reducer & OptionalStorageKey ) => void;
+}
+
+async function initializeState(
+	store: Store & WithAddReducer,
+	storageKey: string,
+	reducer: Reducer & OptionalStorageKey
+) {
 	const storedState = await getStateFromLocalStorage( reducer, storageKey );
 
 	if ( storedState ) {
@@ -26,11 +38,10 @@ async function initializeState( store: Store, storageKey: string, reducer: Reduc
 
 // For a given store, creates a function that adds a new reducer to the store,
 // and loads (asynchronously) and applies the persisted state for it.
-export const addReducerToStore = < T extends Reducer >( store: Store ) => (
-	key: string[],
-	reducer: T
-): Promise< void > => {
-	const storageKey: string = reducer.storageKey;
+export const addReducerToStore = < T extends Reducer & OptionalStorageKey >(
+	store: Store & WithAddReducer
+) => ( key: string[], reducer: T ): Promise< void > => {
+	const storageKey: string | undefined = reducer.storageKey;
 	const normalizedKey = normalizeKey( key );
 
 	const previousReducer = reducers.get( normalizedKey );

--- a/client/state/add-reducer.ts
+++ b/client/state/add-reducer.ts
@@ -4,7 +4,7 @@
 import { APPLY_STORED_STATE } from 'state/action-types';
 import { getStateFromLocalStorage } from 'state/initial-state';
 
-const initializations = new Map< string, Promise >();
+const initializations = new Map< string, Promise< void > >();
 const reducers = new Map< string, ( state: object, action: object ) => object >();
 
 function normalizeKey( key: string[] ): string {
@@ -26,9 +26,9 @@ async function initializeState(
 // For a given store, creates a function that adds a new reducer to the store,
 // and loads (asynchronously) and applies the persisted state for it.
 export const addReducerToStore = ( store: object ) => (
-	key: string,
+	key: string[],
 	reducer: ( state: object, action: object ) => object
-): Promise => {
+): Promise< void > => {
 	const storageKey: string = reducer.storageKey;
 	const normalizedKey = normalizeKey( key );
 

--- a/client/state/add-reducer.ts
+++ b/client/state/add-reducer.ts
@@ -1,21 +1,22 @@
 /**
+ * External Dependencies
+ */
+import { Reducer } from 'redux';
+
+/**
  * Internal Dependencies
  */
 import { APPLY_STORED_STATE } from 'state/action-types';
 import { getStateFromLocalStorage } from 'state/initial-state';
 
 const initializations = new Map< string, Promise< void > >();
-const reducers = new Map< string, ( state: object, action: object ) => object >();
+const reducers = new Map< string, Reducer >();
 
 function normalizeKey( key: string[] ): string {
 	return key.join( '.' );
 }
 
-async function initializeState(
-	store: object,
-	storageKey: string,
-	reducer: ( state: object, action: object ) => object
-) {
+async function initializeState( store: object, storageKey: string, reducer: Reducer ) {
 	const storedState = await getStateFromLocalStorage( reducer, storageKey );
 
 	if ( storedState ) {
@@ -25,9 +26,9 @@ async function initializeState(
 
 // For a given store, creates a function that adds a new reducer to the store,
 // and loads (asynchronously) and applies the persisted state for it.
-export const addReducerToStore = ( store: object ) => (
+export const addReducerToStore = < T extends Reducer >( store: object ) => (
 	key: string[],
-	reducer: ( state: object, action: object ) => object
+	reducer: T
 ): Promise< void > => {
 	const storageKey: string = reducer.storageKey;
 	const normalizedKey = normalizeKey( key );

--- a/client/state/add-reducer.ts
+++ b/client/state/add-reducer.ts
@@ -1,7 +1,7 @@
 /**
  * External Dependencies
  */
-import { Reducer } from 'redux';
+import { Reducer, Store } from 'redux';
 
 /**
  * Internal Dependencies
@@ -16,7 +16,7 @@ function normalizeKey( key: string[] ): string {
 	return key.join( '.' );
 }
 
-async function initializeState( store: object, storageKey: string, reducer: Reducer ) {
+async function initializeState( store: Store, storageKey: string, reducer: Reducer ) {
 	const storedState = await getStateFromLocalStorage( reducer, storageKey );
 
 	if ( storedState ) {
@@ -26,7 +26,7 @@ async function initializeState( store: object, storageKey: string, reducer: Redu
 
 // For a given store, creates a function that adds a new reducer to the store,
 // and loads (asynchronously) and applies the persisted state for it.
-export const addReducerToStore = < T extends Reducer >( store: object ) => (
+export const addReducerToStore = < T extends Reducer >( store: Store ) => (
 	key: string[],
 	reducer: T
 ): Promise< void > => {


### PR DESCRIPTION
These are some small typing improvements to `addReducerToStore`, after VSCode finally started showing Typescript warnings for me.

#### Changes proposed in this Pull Request

* Fix wrong type on `key` argument.
* Add return type to promises.
* Use `Reducer` type from Redux, instead of a custom function type.

#### Testing instructions

These are just typing fixes, so there shouldn't be the need to test anything.