### PR TITLE
Match JS and TS exclude configs.

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,5 +8,18 @@
 			"*": [ "test/*", "server/*", "client/*" ]
 		}
 	},
-	"exclude": [ "node_modules", "**/node_modules/*", "public", "build" ]
+	"exclude": [
+		"public",
+		"node_modules",
+		"**/node_modules/*",
+		"build",
+		"**/build/*",
+		"**/build-module/*",
+		"**/build-style/*",
+		"**/dist/*",
+		"cached-results.json",
+		"stats.json",
+		"server/bundlers/assets-*.json",
+		"server/devdocs/search-index.js"
+	]
 }


### PR DESCRIPTION
I'm not sure if this will have much impact, but it seems reasonable to ensure that the excludes in `jsconfig.json` match the ones in `tsconfig.json`.

#### Changes proposed in this Pull Request

* Update excludes in `jsconfig.json` to match the ones in `tsconfig.json`.

#### Testing instructions

There should be no need to test anything, as this only affects IDE configuration.
