### PR TITLE
Gutenframe: Add Gutenframe to production and the desktop development environments.

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -55,6 +55,7 @@
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connection-rebranding": true,
+		"jetpack/gutenframe": true,
 		"jetpack/happychat": true,
 		"jetpack/onboarding": true,
 		"jetpack_core_inline_update": true,

--- a/config/production.json
+++ b/config/production.json
@@ -46,6 +46,7 @@
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
+		"jetpack/gutenframe": true,
 		"jetpack/happychat": true,
 		"jitms": true,
 		"login/magic-login": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -49,6 +49,7 @@
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
+		"jetpack/gutenframe": true,
 		"jetpack/happychat": true,
 		"jitms": true,
 		"login/magic-login": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Activate `jetpack/gutenframe` on `staging` and `production`, as well as `desktop-development` for later testing.
* This is the launch of phase 2 here: p3fqKv-6Hh-p2

#### Testing instructions

* Once in staging, Jetpack iframing flows should be available (for Atomic sites too).
