### PR TITLE
Update Chromedriver so that it will work with 74

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ references:
   # between CI and local
   update-chromedriver-for-e2e: &update-chromedriver-for-e2e
     name: Update Chromedriver to compatible version
-    command: npm install chromedriver@73.0.0
+    command: npm install chromedriver@$CHROMEDRIVER_VERSION
 
   # Babel cache
   # More about the CircleCI cache: https://circleci.com/docs/2.0/caching

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,13 @@ references:
     name: Install e2e npm dependencies
     command: cd test/e2e && npm ci
 
+  # Update Chrome since chromedriver now only supports a single version and we can get mismatches
+  # between CI and local
+  update-chrome-for-e2e: &update-chrome-for-e2e
+    name: Update Chrome to latest stable
+    command: sudo wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb &&
+      dpkg -i google-chrome-stable_current_amd64.deb
+
   # Babel cache
   # More about the CircleCI cache: https://circleci.com/docs/2.0/caching
   restore-babel-client-cache: &restore-babel-client-cache
@@ -531,6 +538,7 @@ jobs:
     steps:
       - prepare
       - run: *set-e2e-variables
+      - run: *update-chrome-for-e2e
       - run: npm run decryptconfig
       - run: ./scripts/randomize.sh specs
       - run: ./scripts/run-wrapper.sh
@@ -558,6 +566,7 @@ jobs:
     steps:
       - prepare
       - run: *set-e2e-variables
+      - run: *update-chrome-for-e2e
       - run: sudo apt-get install -y fonts-ipafont-gothic xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic fonts-wqy-zenhei
       - run:
           name: Skip Jetpack Tests if needed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,12 +131,6 @@ references:
     name: Install e2e npm dependencies
     command: cd test/e2e && npm ci
 
-  # Update Chromedriver since it now only supports a single version and we can get mismatches
-  # between CI and local
-  update-chromedriver-for-e2e: &update-chromedriver-for-e2e
-    name: Update Chromedriver to compatible version
-    command: npm install chromedriver@$CHROMEDRIVER_VERSION
-
   # Babel cache
   # More about the CircleCI cache: https://circleci.com/docs/2.0/caching
   restore-babel-client-cache: &restore-babel-client-cache
@@ -537,7 +531,6 @@ jobs:
     steps:
       - prepare
       - run: *set-e2e-variables
-      - run: *update-chromedriver-for-e2e
       - run: npm run decryptconfig
       - run: ./scripts/randomize.sh specs
       - run: ./scripts/run-wrapper.sh
@@ -565,7 +558,6 @@ jobs:
     steps:
       - prepare
       - run: *set-e2e-variables
-      - run: *update-chromedriver-for-e2e
       - run: sudo apt-get install -y fonts-ipafont-gothic xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic fonts-wqy-zenhei
       - run:
           name: Skip Jetpack Tests if needed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,8 +135,8 @@ references:
   # between CI and local
   update-chrome-for-e2e: &update-chrome-for-e2e
     name: Update Chrome to latest stable
-    command: sudo wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb &&
-      dpkg -i google-chrome-stable_current_amd64.deb
+    command: wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb &&
+      sudo dpkg -i google-chrome-stable_current_amd64.deb
 
   # Babel cache
   # More about the CircleCI cache: https://circleci.com/docs/2.0/caching

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,12 +131,11 @@ references:
     name: Install e2e npm dependencies
     command: cd test/e2e && npm ci
 
-  # Update Chrome since chromedriver now only supports a single version and we can get mismatches
+  # Update Chromedriver since it now only supports a single version and we can get mismatches
   # between CI and local
-  update-chrome-for-e2e: &update-chrome-for-e2e
-    name: Update Chrome to latest stable
-    command: wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb &&
-      sudo dpkg -i google-chrome-stable_current_amd64.deb
+  update-chromedriver-for-e2e: &update-chromedriver-for-e2e
+    name: Update Chromedriver to compatible version
+    command: npm install chromedriver@73.0.0
 
   # Babel cache
   # More about the CircleCI cache: https://circleci.com/docs/2.0/caching
@@ -538,7 +537,7 @@ jobs:
     steps:
       - prepare
       - run: *set-e2e-variables
-      - run: *update-chrome-for-e2e
+      - run: *update-chromedriver-for-e2e
       - run: npm run decryptconfig
       - run: ./scripts/randomize.sh specs
       - run: ./scripts/run-wrapper.sh
@@ -566,7 +565,7 @@ jobs:
     steps:
       - prepare
       - run: *set-e2e-variables
-      - run: *update-chrome-for-e2e
+      - run: *update-chromedriver-for-e2e
       - run: sudo apt-get install -y fonts-ipafont-gothic xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic fonts-wqy-zenhei
       - run:
           name: Skip Jetpack Tests if needed

--- a/test/e2e/docs/config.md
+++ b/test/e2e/docs/config.md
@@ -92,3 +92,4 @@ These environment variables are intended for use inside CircleCI, to control whi
 | SKIP_TEST_REGEX | The value of this variable will be used in the `-i -g *****` parameter, to skip any tests that match the given RegEx.  List multiple keywords separated by a `|` (i.e. `Invite|Domain|Theme`) | `Empty String` | No |
 | SKIP_DOMAIN_TESTS | If this value is set to `true`, the tests that attempt domain registration with be skipped.  | false | No |
 | SKIP_JETPACK | If this value is set to `true`, the Jetpack tests with be skipped. Useful to disable scheduled tests without modifying circleCI config  | false | No |
+| CHROMEDRIVER_VERSION | This specifies the actual version of the Chromedriver binary that is used. It needs to be set to a version compatible with the version of Chrome installed | null | No

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -3014,9 +3014,9 @@
 			}
 		},
 		"chromedriver": {
-			"version": "73.0.0",
-			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-73.0.0.tgz",
-			"integrity": "sha512-RnZOTgAa3prPmA1QDHtrsEhppDGiosND5O/0ukWwGuU+EglCBHvYl1x3Mh/YypMIkmydRyq50XPrNYZadsM6rQ==",
+			"version": "74.0.0",
+			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-74.0.0.tgz",
+			"integrity": "sha512-xXgsq0l4gVTY9X5vuccOSVj/iEBm3Bf5MIwzSAASIRJagt4BlWw77SxQq1f4JAJ35/9Ys4NLMA/kWFbd7A/gfQ==",
 			"requires": {
 				"del": "^3.0.0",
 				"extract-zip": "^1.6.7",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -25,7 +25,7 @@
 		"@babel/runtime": "7.3.1",
 		"asana-phrase": "0.0.8",
 		"cached-path-relative": ">=1.0.2",
-		"chromedriver": "74.0.0",
+		"chromedriver": "*",
 		"concurrently": "^3.6.1",
 		"config": "1.28.0",
 		"esformatter-braces": "^1.2.1",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -25,7 +25,7 @@
 		"@babel/runtime": "7.3.1",
 		"asana-phrase": "0.0.8",
 		"cached-path-relative": ">=1.0.2",
-		"chromedriver": "*",
+		"chromedriver": "74.0.0",
 		"concurrently": "^3.6.1",
 		"config": "1.28.0",
 		"esformatter-braces": "^1.2.1",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -25,7 +25,7 @@
 		"@babel/runtime": "7.3.1",
 		"asana-phrase": "0.0.8",
 		"cached-path-relative": ">=1.0.2",
-		"chromedriver": "^73.0.0",
+		"chromedriver": "74.0.0",
 		"concurrently": "^3.6.1",
 		"config": "1.28.0",
 		"esformatter-braces": "^1.2.1",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -25,9 +25,10 @@
 		"@babel/runtime": "7.3.1",
 		"asana-phrase": "0.0.8",
 		"cached-path-relative": ">=1.0.2",
-		"chromedriver": "74.0.0",
+		"chromedriver": "^74.0.0",
 		"concurrently": "^3.6.1",
 		"config": "1.28.0",
+		"cryptiles": ">=4.1.2",
 		"esformatter-braces": "^1.2.1",
 		"esformatter-collapse-objects-a8c": "^0.1.0",
 		"esformatter-dot-notation": "^1.3.1",
@@ -62,8 +63,7 @@
 		"testarmada-magellan-mocha-plugin": "github:Automattic/magellan-mocha-plugin#660cf2c",
 		"xml2json-command": "^0.0.3",
 		"xmpp.js": "^0.3.0",
-		"xunit-viewer": "^5.1.8",
-		"cryptiles": ">=4.1.2"
+		"xunit-viewer": "^5.1.8"
 	},
 	"devDependencies": {
 		"babel-eslint": "10.0.1",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*Updates chromedriver package in e2e tests so that it will run on Chrome 74 locally. Additionally, I set the `CHROMEDRIVER_VERSION` variable in the build which will specify which version of the binary to install. Since we need a different version of Chromedriver to run against Chrome 72 in CI than we do locally, this will work around it. I also added it to the docs just so we know what to change next time

#### Testing instructions

* Ensure tests pass in CI and that at least one test runs locally
