### PR TITLE
Updated Calypso Jetpack Mobile Settings to match Jetpack Mobile Settings

### DIFF
--- a/client/my-sites/site-settings/theme-enhancements.jsx
+++ b/client/my-sites/site-settings/theme-enhancements.jsx
@@ -190,12 +190,12 @@ class ThemeEnhancements extends Component {
 					{ this.renderToggle(
 						'wp_mobile_excerpt',
 						! minilevenModuleActive,
-						translate( 'Show excerpts on front page and on archive pages instead of full posts' )
+						translate( 'Use excerpts instead of full posts on front page and archive pages' )
 					) }
 					{ this.renderToggle(
 						'wp_mobile_featured_images',
 						! minilevenModuleActive,
-						translate( 'Hide all featured images' )
+						translate( 'Show featured images' )
 					) }
 					{ this.renderToggle(
 						'wp_mobile_app_promos',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes #32082 

#### Testing instructions


Find an AT site with mobile theme settings enabled:

1) Go to My Site → Settings → Writing.
2) View Mobile Theme settings.

Before 

![before](https://camo.githubusercontent.com/ebcb9bf9e4eb7141856455c69e3e040057f4a1ec/68747470733a2f2f636c642e7774686d732e636f2f6b446c7471392b)

After

![screenshot](https://cld.wthms.co/CXdRJu+)

The settings now match the Jetpack settings: ![match](https://camo.githubusercontent.com/d8ac801aedaf66444bdc1f7cd4607e4aa7852d3f/68747470733a2f2f636c642e7774686d732e636f2f617139716c752b)

The only thing I didn't change was the link to the mobile apps since I'm unsure if we want to remove that. 




