### PR TITLE
Themes: Fix Broken "View Plan" Button

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -609,6 +609,8 @@ class ThemeSheet extends React.Component {
 		const analyticsPageTitle = `Themes > Details Sheet${
 			section ? ' > ' + titlecase( section ) : ''
 		}${ siteId ? ' > Site' : '' }`;
+		
+		const plansUrl = siteSlug ? `/plans/${ siteSlug }/?plan=value_bundle` : '/plans';
 
 		const { canonicalUrl, currentUserId, description, name: themeName } = this.props;
 		const title =
@@ -654,7 +656,7 @@ class ThemeSheet extends React.Component {
 					event="themes_plan_particular_free_with_plan"
 					callToAction={ translate( 'View Plans' ) }
 					forceHref={ true }
-					href={ `/plans/${ siteSlug }/?plan=value_bundle` }
+					href={ plansUrl }
 				/>
 			);
 			previewUpsellBanner = React.cloneElement( pageUpsellBanner, {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -594,13 +594,13 @@ class ThemeSheet extends React.Component {
 		const {
 			id,
 			siteId,
+			siteSlug,
 			retired,
 			isPremium,
 			isJetpack,
 			translate,
 			hasUnlimitedPremiumThemes,
 			previousRoute,
-			siteSlug
 		} = this.props;
 
 		const analyticsPath = `/theme/${ id }${ section ? '/' + section : '' }${

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -600,6 +600,7 @@ class ThemeSheet extends React.Component {
 			translate,
 			hasUnlimitedPremiumThemes,
 			previousRoute,
+			siteSlug
 		} = this.props;
 
 		const analyticsPath = `/theme/${ id }${ section ? '/' + section : '' }${
@@ -653,6 +654,7 @@ class ThemeSheet extends React.Component {
 					event="themes_plan_particular_free_with_plan"
 					callToAction={ translate( 'View Plans' ) }
 					forceHref={ true }
+					href={ `/plans/${ siteSlug }/?plan=value_bundle` }
 				/>
 			);
 			previewUpsellBanner = React.cloneElement( pageUpsellBanner, {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If the user is in a state without a selected site, which is entirely possible for this bit of the Themes page, the "View Plans" button is broken. This fixes the issue by requesting the user to select a site to open Plans if they're not in a selected site.

#### Testing instructions

Firstly, check a premium theme directly (eg. visit `/theme/veni`). Verify upon clicking the prompt, you need to select a site. 

<img width="471" alt="Screenshot 2019-05-07 at 21 05 10" src="https://user-images.githubusercontent.com/43215253/57330017-d47cb680-710c-11e9-94e7-204a6cea51af.png">

Then try again, ensuring you click "Themes" in the sidebar, then pick a premium theme and click the nudge. Verify that you don't need to select a site, you're automatically redirected to the Plans page of the site you've already selected.

cc @davidakennedy, @adamziel, @donpark 

Fixes #32867
