### PR TITLE
Jetpack checklist: add footer with link to WP Admin

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -195,10 +195,12 @@ export class ProductPurchaseFeaturesList extends Component {
 				) }
 				<SiteActivity />
 				<MobileApps />
-				<JetpackReturnToDashboard
-					onClick={ recordReturnToDashboardClick }
-					selectedSite={ selectedSite }
-				/>
+				{ ! isEnabled( 'jetpack/checklist' ) && (
+					<JetpackReturnToDashboard
+						onClick={ recordReturnToDashboardClick }
+						selectedSite={ selectedSite }
+					/>
+				) }
 				<HappinessSupportCard
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isJetpackFreePlan
@@ -238,11 +240,12 @@ export class ProductPurchaseFeaturesList extends Component {
 						link="https://calendly.com/jetpack/concierge"
 					/>
 				) }
-
-				<JetpackReturnToDashboard
-					onClick={ recordReturnToDashboardClick }
-					selectedSite={ selectedSite }
-				/>
+				{ ! isEnabled( 'jetpack/checklist' ) && (
+					<JetpackReturnToDashboard
+						onClick={ recordReturnToDashboardClick }
+						selectedSite={ selectedSite }
+					/>
+				) }
 				<HappinessSupportCard
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }
@@ -272,10 +275,12 @@ export class ProductPurchaseFeaturesList extends Component {
 				) }
 				<SiteActivity />
 				<MobileApps />
-				<JetpackReturnToDashboard
-					onClick={ recordReturnToDashboardClick }
-					selectedSite={ selectedSite }
-				/>
+				{ ! isEnabled( 'jetpack/checklist' ) && (
+					<JetpackReturnToDashboard
+						onClick={ recordReturnToDashboardClick }
+						selectedSite={ selectedSite }
+					/>
+				) }
 				<HappinessSupportCard
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }
@@ -319,10 +324,12 @@ export class ProductPurchaseFeaturesList extends Component {
 						link="https://calendly.com/jetpack/concierge"
 					/>
 				) }
-				<JetpackReturnToDashboard
-					onClick={ recordReturnToDashboardClick }
-					selectedSite={ selectedSite }
-				/>
+				{ ! isEnabled( 'jetpack/checklist' ) && (
+					<JetpackReturnToDashboard
+						onClick={ recordReturnToDashboardClick }
+						selectedSite={ selectedSite }
+					/>
+				) }
 				<HappinessSupportCard
 					isJetpack={ !! selectedSite.jetpack && ! isAutomatedTransfer }
 					isPlaceholder={ isPlaceholder }

--- a/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { get } from 'lodash';
+import { localize } from 'i18n-calypso';
+import React, { PureComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { untrailingslashit } from 'lib/route';
+import Button from 'components/button';
+import Card from 'components/card';
+
+class JetpackChecklistFooter extends PureComponent {
+	handleWPAdminLink = () => {
+		this.props.recordTracksEvent( 'calypso_checklist_wpadmin' );
+	};
+
+	render() {
+		const { translate, wpAdminUrl } = this.props;
+		return (
+			<Card compact className="jetpack-checklist__footer">
+				<p>{ translate( 'Return to your self-hosted WordPress dashboard.' ) }</p>
+				<Button compact href={ wpAdminUrl } onClick={ this.handleWPAdminLink() }>
+					{ translate( 'Return to WP Admin' ) }
+				</Button>
+			</Card>
+		);
+	}
+}
+
+export default connect(
+	state => {
+		const site = getSelectedSite( state );
+
+		return {
+			wpAdminUrl: untrailingslashit( get( site, 'options.admin_url' ) ) + '/admin.php?page=jetpack',
+		};
+	},
+	{
+		recordTracksEvent,
+	}
+)( localize( JetpackChecklistFooter ) );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
@@ -9,9 +9,9 @@ import React, { PureComponent } from 'react';
 /**
  * Internal dependencies
  */
+import { format as formatUrl, parse as parseUrl } from 'url';
 import { getSelectedSite } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { untrailingslashit } from 'lib/route';
 import Button from 'components/button';
 import Card from 'components/card';
 
@@ -44,10 +44,19 @@ class JetpackChecklistFooter extends PureComponent {
 export default connect(
 	state => {
 		const site = getSelectedSite( state );
-		const wpAdminUrl = get( site, 'options.admin_url', '' );
+
+		// Link to "My Plan" page in Jetpack
+		let wpAdminUrl = get( site, 'options.admin_url', '' );
+		wpAdminUrl = wpAdminUrl
+			? formatUrl( {
+					...parseUrl( wpAdminUrl ),
+					query: { page: 'jetpack' },
+					hash: '/my-plan',
+			  } )
+			: '';
 
 		return {
-			wpAdminUrl: wpAdminUrl ? untrailingslashit( wpAdminUrl ) + '/admin.php?page=jetpack' : '',
+			wpAdminUrl,
 		};
 	},
 	{

--- a/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
@@ -17,7 +17,10 @@ import Card from 'components/card';
 
 class JetpackChecklistFooter extends PureComponent {
 	handleWPAdminLink = () => {
-		this.props.recordTracksEvent( 'calypso_checklist_wpadmin' );
+		this.props.recordTracksEvent( 'calypso_checklist_wpadmin_click', {
+			checklist_name: 'jetpack',
+			location: 'JetpackChecklist',
+		} );
 	};
 
 	render() {

--- a/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
@@ -25,6 +25,11 @@ class JetpackChecklistFooter extends PureComponent {
 
 	render() {
 		const { translate, wpAdminUrl } = this.props;
+
+		if ( ! wpAdminUrl ) {
+			return null;
+		}
+
 		return (
 			<Card compact className="jetpack-checklist__footer">
 				<p>{ translate( 'Return to your self-hosted WordPress dashboard.' ) }</p>
@@ -39,9 +44,10 @@ class JetpackChecklistFooter extends PureComponent {
 export default connect(
 	state => {
 		const site = getSelectedSite( state );
+		const wpAdminUrl = get( site, 'options.admin_url', '' );
 
 		return {
-			wpAdminUrl: untrailingslashit( get( site, 'options.admin_url' ) ) + '/admin.php?page=jetpack',
+			wpAdminUrl: wpAdminUrl ? untrailingslashit( wpAdminUrl ) + '/admin.php?page=jetpack' : '',
 		};
 	},
 	{

--- a/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
@@ -25,7 +25,7 @@ class JetpackChecklistFooter extends PureComponent {
 		return (
 			<Card compact className="jetpack-checklist__footer">
 				<p>{ translate( 'Return to your self-hosted WordPress dashboard.' ) }</p>
-				<Button compact href={ wpAdminUrl } onClick={ this.handleWPAdminLink() }>
+				<Button compact href={ wpAdminUrl } onClick={ this.handleWPAdminLink }>
 					{ translate( 'Return to WP Admin' ) }
 				</Button>
 			</Card>

--- a/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
@@ -1,65 +1,22 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
-import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
-import React, { PureComponent } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import { format as formatUrl, parse as parseUrl } from 'url';
-import { getSelectedSite } from 'state/ui/selectors';
-import { recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 import Card from 'components/card';
 
-class JetpackChecklistFooter extends PureComponent {
-	handleWPAdminLink = () => {
-		this.props.recordTracksEvent( 'calypso_checklist_wpadmin_click', {
-			checklist_name: 'jetpack',
-			location: 'JetpackChecklist',
-		} );
-	};
+const JetpackChecklistFooter = ( { translate, handleWpAdminLink, wpAdminUrl } ) => (
+	<Card compact className="jetpack-checklist__footer">
+		<p>{ translate( 'Return to your self-hosted WordPress dashboard.' ) }</p>
+		<Button compact href={ wpAdminUrl } onClick={ handleWpAdminLink }>
+			{ translate( 'Return to WP Admin' ) }
+		</Button>
+	</Card>
+);
 
-	render() {
-		const { translate, wpAdminUrl } = this.props;
-
-		if ( ! wpAdminUrl ) {
-			return null;
-		}
-
-		return (
-			<Card compact className="jetpack-checklist__footer">
-				<p>{ translate( 'Return to your self-hosted WordPress dashboard.' ) }</p>
-				<Button compact href={ wpAdminUrl } onClick={ this.handleWPAdminLink }>
-					{ translate( 'Return to WP Admin' ) }
-				</Button>
-			</Card>
-		);
-	}
-}
-
-export default connect(
-	state => {
-		const site = getSelectedSite( state );
-
-		// Link to "My Plan" page in Jetpack
-		let wpAdminUrl = get( site, 'options.admin_url', '' );
-		wpAdminUrl = wpAdminUrl
-			? formatUrl( {
-					...parseUrl( wpAdminUrl ),
-					query: { page: 'jetpack' },
-					hash: '/my-plan',
-			  } )
-			: '';
-
-		return {
-			wpAdminUrl,
-		};
-	},
-	{
-		recordTracksEvent,
-	}
-)( localize( JetpackChecklistFooter ) );
+export default localize( JetpackChecklistFooter );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -176,14 +176,14 @@ export default connect(
 		const rewindState = get( getRewindState( state, siteId ), 'state', 'uninitialized' );
 
 		// Link to "My Plan" page in Jetpack
-		let wpAdminUrl = get( site, 'options.admin_url', '' );
+		let wpAdminUrl = get( site, 'options.admin_url' );
 		wpAdminUrl = wpAdminUrl
 			? formatUrl( {
 					...parseUrl( wpAdminUrl ),
 					query: { page: 'jetpack' },
 					hash: '/my-plan',
 			  } )
-			: '';
+			: undefined;
 
 		return {
 			akismetFinished: productInstallStatus && productInstallStatus.akismet_status === 'installed',

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -16,6 +14,7 @@ import getJetpackProductInstallStatus from 'state/selectors/get-jetpack-product-
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import getRewindState from 'state/selectors/get-rewind-state';
 import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
+import JetpackChecklistFooter from './footer';
 import JetpackChecklistHeader from './header';
 import QueryJetpackProductInstallStatus from 'components/data/query-jetpack-product-install-status';
 import QueryRewindState from 'components/data/query-rewind-state';
@@ -148,6 +147,8 @@ class JetpackChecklist extends PureComponent {
 						);
 					} ) }
 				</Checklist>
+
+				<JetpackChecklistFooter />
 			</Fragment>
 		);
 	}

--- a/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
@@ -25,3 +25,19 @@
 		margin: 20px auto;
 	}
 }
+
+.jetpack-checklist__footer {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	text-align: center;
+	@include breakpoint( '>660px' ) {
+		flex-direction: row;
+		justify-content: flex-end;
+		text-align: left;
+		p {
+			flex: 1;
+			margin: 0 20px 0 0;
+		}
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds new footer component to Jetpack checklist
* Add link to WP Admin
* Hide `JetpackReturnToDashboard` when the checklist is visibile 

Resolves https://github.com/Automattic/wp-calypso/issues/32558

<img width="710" alt="Screenshot 2019-05-08 at 00 25 16" src="https://user-images.githubusercontent.com/87168/57334250-df911000-7127-11e9-8c4a-93da01f6066f.png">

The button says "WP Admin" to stay consistent with the sidebar: 

<img width="280" alt="Screenshot 2019-05-08 at 00 25 16" src="https://user-images.githubusercontent.com/87168/57334305-03545600-7128-11e9-975c-fddd187badc9.png">


#### Testing instructions

- Go to "My Plan" page in Calypso (`/plans/my-plan/`)

- Check the checklist footer in different resolutions
   <img width="190" alt="Screenshot 2019-05-08 at 00 20 06" src="https://user-images.githubusercontent.com/87168/57334013-3518ed00-7127-11e9-9d3d-9b64e907ae15.png">
  <img width="771" alt="Screenshot 2019-05-08 at 00 19 57" src="https://user-images.githubusercontent.com/87168/57334014-3518ed00-7127-11e9-8d38-b8a3c3d5abc4.png">

- Confirm that link brings you to the right place in wp-admin.

- Confirm that you don't see this:
  <img width="400" alt="Screenshot 2019-05-08 at 00 19 57" src="https://user-images.githubusercontent.com/87168/57334067-60034100-7127-11e9-88c0-ed52b9694bda.png">

