### PR TITLE
Revert "Modernize the RootChild component"

### DIFF
--- a/client/blocks/blog-stickers/index.jsx
+++ b/client/blocks/blog-stickers/index.jsx
@@ -34,7 +34,7 @@ const BlogStickers = ( { blogId, teams, stickers } ) => {
 		<div className="blog-stickers">
 			<QueryBlogStickers blogId={ blogId } />
 			{ isTeamMember && stickers && stickers.length > 0 && (
-				<InfoPopover>
+				<InfoPopover rootClassName="blog-stickers__popover">
 					<BlogStickersList stickers={ stickers } />
 				</InfoPopover>
 			) }

--- a/client/blocks/calendar-button/README.md
+++ b/client/blocks/calendar-button/README.md
@@ -63,6 +63,7 @@ This property defines to this component as a `button`. You shouldn't change this
 * `events`
 * `ignoreContext`
 * `isVisible`
+* `rootClassName`
 * `selectedDay`
 * `showDelay`
 * `siteId`

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -28,6 +28,7 @@ class CalendarButton extends Component {
 		events: PropTypes.array,
 		ignoreContext: PropTypes.shape( { getDOMNode: PropTypes.function } ),
 		isVisible: PropTypes.bool,
+		rootClassName: PropTypes.string,
 		selectedDay: PropTypes.object,
 		showDelay: PropTypes.number,
 		siteId: PropTypes.number,
@@ -79,25 +80,29 @@ class CalendarButton extends Component {
 			return null;
 		}
 
-		const calendarProperties = pick( this.props, [
-			'autoPosition',
-			'closeOnEsc',
-			'disabledDays',
-			'events',
-			'showOutsideDays',
-			'ignoreContext',
-			'isVisible',
-			'modifiers',
-			'selectedDay',
-			'showDelay',
-			'siteId',
-			'onDateChange',
-			'onMonthChange',
-			'onDayMouseEnter',
-			'onDayMouseLeave',
-			'onShow',
-			'onClose',
-		] );
+		const calendarProperties = Object.assign(
+			{},
+			pick( this.props, [
+				'autoPosition',
+				'closeOnEsc',
+				'disabledDays',
+				'events',
+				'showOutsideDays',
+				'ignoreContext',
+				'isVisible',
+				'modifiers',
+				'rootClassName',
+				'selectedDay',
+				'showDelay',
+				'siteId',
+				'onDateChange',
+				'onMonthChange',
+				'onDayMouseEnter',
+				'onDayMouseLeave',
+				'onShow',
+				'onClose',
+			] )
+		);
 
 		return (
 			<AsyncLoad

--- a/client/blocks/calendar-popover/README.md
+++ b/client/blocks/calendar-popover/README.md
@@ -70,6 +70,7 @@ The site's timezone value, in the format of 'America/Araguaina (see https://en.w
 * `ignoreContext`
 * `isVisible`
 * `position`
+* `rootClassName`
 * `showDelay`
 * `onClose`
 * `onShow`
@@ -81,3 +82,4 @@ The site's timezone value, in the format of 'America/Araguaina (see https://en.w
  * `siteId`
  * `onDateChange`
  * `onMonthChange`
+

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -35,6 +35,7 @@ class CalendarPopover extends Component {
 		ignoreContext: PropTypes.shape( { getDOMNode: PropTypes.function } ),
 		isVisible: PropTypes.bool,
 		position: PropTypes.string,
+		rootClassName: PropTypes.string,
 		showDelay: PropTypes.number,
 		onClose: PropTypes.func,
 		onShow: PropTypes.func,
@@ -99,17 +100,21 @@ class CalendarPopover extends Component {
 	}
 
 	render() {
-		const popoverProps = pick( this.props, [
-			'autoPosition',
-			'closeOnEsc',
-			'context',
-			'ignoreContext',
-			'isVisible',
-			'position',
-			'showDelay',
-			'onClose',
-			'onShow',
-		] );
+		const popoverProps = Object.assign(
+			{},
+			pick( this.props, [
+				'autoPosition',
+				'closeOnEsc',
+				'context',
+				'ignoreContext',
+				'isVisible',
+				'position',
+				'rootClassName',
+				'showDelay',
+				'onClose',
+				'onShow',
+			] )
+		);
 
 		return (
 			<div className="calendar-popover">

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -11,7 +11,6 @@ import url from 'url';
 import { startsWith } from 'lodash';
 import React from 'react';
 import ReactDom from 'react-dom';
-import Modal from 'react-modal';
 import store from 'store';
 
 /**
@@ -189,9 +188,6 @@ export const utils = () => {
 
 	// Add accessible-focus listener
 	accessibleFocus();
-
-	// Configure app element that React Modal will aria-hide when modal is open
-	Modal.setAppElement( document.getElementById( 'wpcom' ) );
 };
 
 export const configureReduxStore = ( currentUser, reduxStore ) => {

--- a/client/components/dialog/dialog-base.jsx
+++ b/client/components/dialog/dialog-base.jsx
@@ -53,6 +53,7 @@ class DialogBase extends Component {
 				onRequestClose={ this._close }
 				closeTimeoutMS={ this.props.leaveTimeout }
 				contentLabel={ this.props.label }
+				appElement={ document.getElementById( 'wpcom' ) }
 				overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't
 				className={ dialogClassName }
 				htmlOpenClassName="ReactModal__Html--open"

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -4,10 +4,12 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { defer, noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import RootChild from 'components/root-child';
 import DialogBase from './dialog-base';
 
 class Dialog extends Component {
@@ -16,16 +18,33 @@ class Dialog extends Component {
 		baseClassName: PropTypes.string,
 		leaveTimeout: PropTypes.number,
 		onClose: PropTypes.func,
+		onClosed: PropTypes.func,
 		shouldCloseOnEsc: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isVisible: false,
 		leaveTimeout: 200,
+		onClosed: noop,
+	};
+
+	checkOnClosed = ref => {
+		if ( null === ref ) {
+			defer( this.props.onClosed );
+		}
 	};
 
 	render() {
-		return <DialogBase { ...this.props } onDialogClose={ this.onDialogClose } />;
+		return (
+			<RootChild>
+				<DialogBase
+					{ ...this.props }
+					ref={ this.checkOnClosed }
+					key="dialog"
+					onDialogClose={ this.onDialogClose }
+				/>
+			</RootChild>
+		);
 	}
 
 	onDialogClose = action => {

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -36,6 +36,7 @@ export default class InfoPopover extends Component {
 			'left',
 			'top left',
 		] ),
+		rootClassName: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -86,6 +87,7 @@ export default class InfoPopover extends Component {
 					position={ this.props.position }
 					onClose={ this.handleClose }
 					className={ classNames( 'popover', 'info-popover__tooltip', this.props.className ) }
+					rootClassName={ this.props.rootClassName }
 				>
 					{ this.props.children }
 				</Popover>

--- a/client/components/language-picker/test/__snapshots__/modal.js.snap
+++ b/client/components/language-picker/test/__snapshots__/modal.js.snap
@@ -20,6 +20,7 @@ exports[`LanguagePickerModal should render 1`] = `
   isVisible={true}
   leaveTimeout={200}
   onClose={[Function]}
+  onClosed={[Function]}
 >
   <SectionNav
     allowDropdown={true}

--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -79,6 +79,12 @@ This describes the position of the popover relative to the thing it is pointing
 at. If the arrow is supposed to point at something to the top and left of the
 Popover, the correct value for `position` is `bottom right`.
 
+#### `rootClassName { string } - optional`
+
+The `<Popover />` component is mounted into a `<ReactChild />` component at the
+root of the `<body>`. Use this property if you want to add a cuestom css class
+to this root element.
+
 #### `showDelay { number } - default: 0 (false)`
 
 Adds a delay before to show the popover. Its value is defined in `milliseconds`.

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -52,6 +52,7 @@ class Popover extends Component {
 			'left',
 			'top left',
 		] ),
+		rootClassName: PropTypes.string,
 		showDelay: PropTypes.number,
 		onClose: PropTypes.func,
 		onShow: PropTypes.func,
@@ -477,7 +478,7 @@ class Popover extends Component {
 		this.debug( 'rendering ...' );
 
 		return (
-			<RootChild>
+			<RootChild className={ this.props.rootClassName }>
 				<div style={ this.getStylePosition() } className={ classes }>
 					<div className="popover__arrow" />
 

--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -22,6 +22,7 @@ class PopoverMenu extends Component {
 		onClose: PropTypes.func.isRequired,
 		position: PropTypes.string,
 		className: PropTypes.string,
+		rootClassName: PropTypes.string,
 		popoverComponent: PropTypes.func,
 		popoverTitle: PropTypes.string, // used by ReaderPopover
 		customPosition: PropTypes.object,
@@ -50,6 +51,7 @@ class PopoverMenu extends Component {
 			isVisible,
 			popoverTitle,
 			position,
+			rootClassName,
 		} = this.props;
 
 		return (
@@ -63,6 +65,7 @@ class PopoverMenu extends Component {
 				isVisible={ isVisible }
 				popoverTitle={ popoverTitle }
 				position={ position }
+				rootClassName={ rootClassName }
 			>
 				<div
 					ref={ this.menu }

--- a/client/components/root-child/index.jsx
+++ b/client/components/root-child/index.jsx
@@ -1,21 +1,67 @@
+/** @format */
+
 /**
  * External dependencies
  */
+
+import ReactDom from 'react-dom';
+import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { Provider as ReduxProvider } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { MomentProvider } from 'components/localized-moment/context';
 
 export default class RootChild extends React.Component {
-	container = document.createElement( 'div' );
+	static contextTypes = {
+		store: PropTypes.object,
+	};
 
 	componentDidMount() {
+		this.container = document.createElement( 'div' );
 		document.body.appendChild( this.container );
+		this.renderChildren();
+	}
+
+	componentDidUpdate() {
+		this.renderChildren();
 	}
 
 	componentWillUnmount() {
+		if ( ! this.container ) {
+			return;
+		}
+
+		ReactDom.unmountComponentAtNode( this.container );
 		document.body.removeChild( this.container );
+		delete this.container;
 	}
 
+	renderChildren = () => {
+		let content;
+
+		if ( this.props && ( Object.keys( this.props ).length > 1 || ! this.props.children ) ) {
+			content = <div { ...this.props }>{ this.props.children }</div>;
+		} else {
+			content = this.props.children;
+		}
+
+		// Context is lost when creating a new render hierarchy, so ensure that
+		// we preserve the context that we care about
+		if ( this.context.store ) {
+			content = (
+				<ReduxProvider store={ this.context.store }>
+					<MomentProvider>{ content }</MomentProvider>
+				</ReduxProvider>
+			);
+		}
+
+		ReactDom.render( content, this.container );
+	};
+
 	render() {
-		return ReactDOM.createPortal( this.props.children, this.container );
+		return null;
 	}
 }

--- a/client/components/root-child/test/index.jsx
+++ b/client/components/root-child/test/index.jsx
@@ -6,6 +6,7 @@
 /**
  * External dependencies
  */
+import { expect } from 'chai';
 import { mount } from 'enzyme';
 import React from 'react';
 import ReactDom from 'react-dom';
@@ -21,16 +22,12 @@ import RootChild from '../';
 class Greeting extends React.Component {
 	static defaultProps = { toWhom: 'World' };
 
-	parentChildRef = React.createRef();
-	rootChildRef = React.createRef();
-
 	render() {
 		return (
-			/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
 			<div className="parent">
-				<h1 ref={ this.parentChildRef }>Greeting</h1>
-				<RootChild>
-					<span ref={ this.rootChildRef }>Hello { this.props.toWhom }!</span>
+				<h1 ref="parentChild">Greeting</h1>
+				<RootChild { ...this.props.rootChildProps }>
+					<span ref="rootChild">Hello { this.props.toWhom }!</span>
 				</RootChild>
 			</div>
 		);
@@ -53,15 +50,29 @@ describe( 'RootChild', () => {
 		test( 'should render any children as descendants of body', () => {
 			const tree = ReactDom.render( React.createElement( Greeting ), container );
 
-			expect( tree.parentChildRef.current.parentNode.className ).toBe( 'parent' );
-			expect( tree.rootChildRef.current.parentNode.parentNode ).toBe( document.body );
+			expect( tree.refs.parentChild.parentNode.className ).to.equal( 'parent' );
+
+			expect( tree.refs.rootChild.parentNode.parentNode ).to.eql( document.body );
+		} );
+
+		test( 'accepts props to be added to a wrapper element', () => {
+			const tree = ReactDom.render(
+				React.createElement( Greeting, {
+					rootChildProps: { className: 'wrapper' },
+				} ),
+				container
+			);
+
+			expect( tree.refs.rootChild.parentNode.className ).to.equal( 'wrapper' );
+
+			expect( tree.refs.rootChild.parentNode.parentNode.parentNode ).to.eql( document.body );
 		} );
 
 		test( 'should update the children if parent is re-rendered', () => {
 			const tree = mount( React.createElement( Greeting ), { attachTo: container } );
 			tree.setProps( { toWhom: 'Universe' } );
 
-			expect( tree.instance().rootChildRef.current.innerHTML ).toBe( 'Hello Universe!' );
+			expect( tree.ref( 'rootChild' ).innerHTML ).to.equal( 'Hello Universe!' );
 			tree.detach();
 		} );
 	} );
@@ -71,7 +82,7 @@ describe( 'RootChild', () => {
 			ReactDom.render( React.createElement( Greeting ), container );
 			ReactDom.unmountComponentAtNode( container );
 
-			expect( Array.from( document.body.querySelectorAll( '*' ) ) ).toEqual( [ container ] );
+			expect( [].slice.call( document.body.querySelectorAll( '*' ) ) ).to.eql( [ container ] );
 		} );
 	} );
 } );

--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -33,6 +33,7 @@ function Tooltip( props ) {
 		<Popover
 			autoPosition={ props.autoPosition }
 			className={ classes }
+			rootClassName={ props.rootClassName }
 			context={ props.context }
 			id={ props.id }
 			isVisible={ props.isVisible }
@@ -50,6 +51,7 @@ Tooltip.propTypes = {
 	id: PropTypes.string,
 	isVisible: PropTypes.bool,
 	position: PropTypes.string,
+	rootClassName: PropTypes.string,
 	status: PropTypes.string,
 	showDelay: PropTypes.number,
 	showOnMobile: PropTypes.bool,


### PR DESCRIPTION
This PR reverts https://github.com/Automattic/wp-calypso/pull/32749 since it seems to be related to an issue which is preventing users from changing the interface language.

**Testing instructions**
- Go to `/me/account`.
- Select a new interface language.
- Save your account settings.
- Make sure the UI is translated with the new selected language.

Fixes https://github.com/Automattic/wp-calypso/issues/32877