### PR TITLE
Gutenframe: Add page view tracking.

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -354,8 +354,18 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 	closePreviewModal = () => this.setState( { isPreviewVisible: false } );
 
+	getStatsPath = () => {
+		const { postId } = this.props;
+		return postId ? '/block-editor/:post_type/:site/:post_id' : '/block-editor/:post_type/:site';
+	};
+
+	getStatsProps = () => {
+		const { postId, postType } = this.props;
+		return postId ? { post_type: postType, post_id: postId } : { post_type: postType };
+	};
+
 	render() {
-		const { iframeUrl, siteId, shouldLoadIframe, statsPath, statsProps } = this.props;
+		const { iframeUrl, siteId, shouldLoadIframe } = this.props;
 		const {
 			classicBlockEditorId,
 			isMediaModalVisible,
@@ -370,7 +380,11 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 		return (
 			<Fragment>
-				<PageViewTracker path={ statsPath } title="Block Editor" properties={ statsProps } />
+				<PageViewTracker
+					path={ this.getStatsPath() }
+					title="Block Editor"
+					properties={ this.getStatsProps() }
+				/>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<div className="main main-column calypsoify is-iframe" role="main">
 					{ ! isIframeLoaded && <Placeholder /> }
@@ -412,10 +426,6 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 }
 
 const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) => {
-	const statsPath = postId
-		? '/block-editor/:post_type/:site/:post_id'
-		: '/block-editor/:post_type/:site';
-	const statsProps = postId ? { post_type: postType, post_id: postId } : { post_type: postType };
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
 	const postTypeTrashUrl = getPostTypeTrashUrl( state, postType );
@@ -455,8 +465,6 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) 
 		shouldLoadIframe,
 		siteAdminUrl,
 		siteId,
-		statsPath,
-		statsProps,
 	};
 };
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -38,6 +38,7 @@ import WebPreview from 'components/web-preview';
 import { trashPost } from 'state/posts/actions';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { protectForm, ProtectedFormProps } from 'lib/protect-form';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
 
 /**
  * Types
@@ -354,7 +355,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	closePreviewModal = () => this.setState( { isPreviewVisible: false } );
 
 	render() {
-		const { iframeUrl, siteId, shouldLoadIframe } = this.props;
+		const { iframeUrl, siteId, shouldLoadIframe, statsPath, statsProps } = this.props;
 		const {
 			classicBlockEditorId,
 			isMediaModalVisible,
@@ -369,6 +370,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 		return (
 			<Fragment>
+				<PageViewTracker path={ statsPath } title="Block Editor" properties={ statsProps } />
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<div className="main main-column calypsoify is-iframe" role="main">
 					{ ! isIframeLoaded && <Placeholder /> }
@@ -410,6 +412,10 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 }
 
 const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) => {
+	const statsPath = postId
+		? '/block-editor/:post_type/:site/:post_id'
+		: '/block-editor/:post_type/:site';
+	const statsProps = postId ? { post_type: postType, post_id: postId } : { post_type: postType };
 	const siteId = getSelectedSiteId( state );
 	const currentRoute = getCurrentRoute( state );
 	const postTypeTrashUrl = getPostTypeTrashUrl( state, postType );
@@ -449,6 +455,8 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) 
 		shouldLoadIframe,
 		siteAdminUrl,
 		siteId,
+		statsPath,
+		statsProps,
 	};
 };
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -364,6 +364,27 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		return postId ? { post_type: postType, post_id: postId } : { post_type: postType };
 	};
 
+	getStatsTitle = () => {
+		const { postId, postType } = this.props;
+		let postTypeText: string;
+
+		switch ( postType ) {
+			case 'post':
+				postTypeText = 'Post';
+				break;
+			case 'page':
+				postTypeText = 'Page';
+				break;
+			default:
+				postTypeText = 'Custom Post Type';
+				break;
+		}
+
+		return postId
+			? `Block Editor > ${ postTypeText } > Edit`
+			: `Block Editor > ${ postTypeText } > New`;
+	};
+
 	render() {
 		const { iframeUrl, siteId, shouldLoadIframe } = this.props;
 		const {
@@ -382,7 +403,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			<Fragment>
 				<PageViewTracker
 					path={ this.getStatsPath() }
-					title="Block Editor"
+					title={ this.getStatsTitle() }
 					properties={ this.getStatsProps() }
 				/>
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }


### PR DESCRIPTION
Add page view tracking to the `/block-editor` paths.

There are only two path formats: one with an ID (if editing an existing post) and one without (starting a new post). The post type is also passed along, as is the post ID (if applicable). Note that the `site_type` (Jetpack, dotcom, etc) is automatically handled by the component.

<img width="1317" alt="Screen Shot 2019-05-07 at 5 57 38 PM" src="https://user-images.githubusercontent.com/349751/57342030-ab026180-70f1-11e9-9061-9d2296a1786f.png">

It is expected behaviour to see two calls per instance, one "called with props" and one "with actual props".

Guidlines: https://wpcalypso.wordpress.com/devdocs/client/lib/analytics/page-view-tracker/README.md

#### Testing instructions
Note: The true browser path for custom post types includes an `edit` segment (eg. `block-editor/edit/jetpack-testimonial/:site` (for both new and existing posts). `<PageViewTracker>` will still properly identify the post type, so I'm not distinguishing between paths with `edit`, since they're conceptually the same as the post/page paths, and will allow better analysis between post types.

1. Set `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )` in the browser console to enable the debug.
2. Navigate to any/all of `/block-editor/:postType/:site/:postId` on sites that have Gutenframe active.
3. Verify that the appropriate page view instance is recorded: `/block-editor/:postType/:site/:postId` for editing an existing post, or `/block-editor/:postType/:site` in the case of a new post.
4. Verify the correct properties are passed into the component.
5. Using the React devtools, inspect the `title` prop of the `<PageViewTracker>` component, and verify it's correct.