### PR TITLE
Change CartSummaryBar GridIcon size to numeric

### DIFF
--- a/client/my-sites/checkout/cart/cart-summary-bar.jsx
+++ b/client/my-sites/checkout/cart/cart-summary-bar.jsx
@@ -28,7 +28,7 @@ class CartSummaryBar extends React.Component {
 		return (
 			<div>
 				<SectionHeader className="cart__header" label={ text }>
-					<Gridicon icon="cart" size="18" />
+					<Gridicon icon="cart" size={ 18 } />
 				</SectionHeader>
 			</div>
 		);


### PR DESCRIPTION
per [prop change](https://github.com/Automattic/wp-calypso/pull/32763/files#diff-365efd9efc5707cc265e14d483068b86R51) in #32763

#### Changes proposed in this Pull Request

* Change CartSummaryBar GridIcon size to numeric

#### Testing instructions
* View cart
