### PR TITLE
Domain transfer: Make sure header title and description for the domai…

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -193,11 +193,11 @@ class TransferDomainStep extends React.Component {
 		let domainProductPriceText;
 		if ( isFreewithPlan ) {
 			domainProductPriceText = translate(
-				'Adds one year of domain registration for free with your plan'
+				'Adds one year of domain registration for free with your plan.'
 			);
 		} else if ( domainsWithPlansOnlyButNoPlan ) {
 			domainProductPriceText = translate(
-				'One additional year of domain registration included in paid plans'
+				'One additional year of domain registration included in paid plans.'
 			);
 		} else if ( domainProductSalePrice ) {
 			domainProductPriceText = translate( 'Sale price is %(cost)s', {

--- a/client/components/domains/transfer-domain-step/style.scss
+++ b/client/components/domains/transfer-domain-step/style.scss
@@ -10,17 +10,25 @@
 	.transfer-domain-step__domain-description {
 		display: flex;
 		justify-content: space-between;
+		flex-direction: column;
 		margin-bottom: 20px;
+
+		@include breakpoint( '>960px' ) {
+			flex-direction: row;
+		}
 	}
 
 	.transfer-domain-step__price {
 		font-weight: 600;
-		text-align: right;
 
 		&.is-free-with-plan,
 		&.is-sale-price {
 			font-weight: 400;
 			font-size: 90%;
+		}
+
+		@include breakpoint( '>960px' ) {
+			text-align: right;
 		}
 	}
 


### PR DESCRIPTION
…n transfer are stacked on mobile

**Testing instructions**
1. Test on a site with Personal or higher plan, that has unused domain credits (does not use custom domain yet).
2. On mobile navigate to My Sites > Manage > Domains > Add Domain (https://wordpress.com/domains/add/{site})
3. Select "Already Own a Domain", and on the next screen "Transfer to WordPress.com" option.
4. Note how the header and description are displayed side-by-side.
5. The same can be observed in the site creation flow, when signing up as a new user.

Before:

![image](https://user-images.githubusercontent.com/4550351/57351564-b4e59c80-71a5-11e9-9b09-84dd80e4994b.png)

After:
![image](https://user-images.githubusercontent.com/4550351/57351582-c8910300-71a5-11e9-8b94-c87fc15f42f5.png)


Fixes #32825
