### PR TITLE
Calypso build: Add ts(x) extensions to calypso-build

### DIFF
--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -114,7 +114,7 @@ function getWebpackConfig(
 			],
 		},
 		resolve: {
-			extensions: [ '.json', '.js', '.jsx' ],
+			extensions: [ '.json', '.js', '.jsx', '.ts', '.tsx' ],
 			modules: [ 'node_modules' ],
 		},
 		node: false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Calypso build includes the typescript babel preset, but the default build can't even find `ts`/`tsx` files!

Add the `ts`/`tsx` extensions to the webpack config so these files can be used.

#### Testing instructions

* Packages/apps/Calypso build doesn't break?
* #32872 (extracted from there)
