### PR TITLE
notifications: add polyfills to standalone build

### DIFF
--- a/apps/notifications/src/standalone/index.js
+++ b/apps/notifications/src/standalone/index.js
@@ -1,3 +1,4 @@
+import '@babel/polyfill';
 import ReactDOM from 'react-dom';
 import React from 'react';
 


### PR DESCRIPTION
I'm not sure this is the best or correct way to actually import the polyfills into the standalone notifications build so I'm happy to take any feedback on this.

#### Changes proposed in this Pull Request

* Add `@babel/polyfill` import to standalone notifications build

#### Testing instructions

Follow testing instructions found at PCYsg-elI-p2

Compare the builds for this branch (280767) and master (280569) in **IE11** - you should see that the latter doesn't seem to work and fail with a console error about `Object.assign` not being defined.

