### PR TITLE
Google Photos: add to large image sources

### DIFF
--- a/client/my-sites/media-library/filter-bar.jsx
+++ b/client/my-sites/media-library/filter-bar.jsx
@@ -23,7 +23,7 @@ import DataSource from './data-source';
 // These source supply very large images, and there are instances such as
 // the site icon editor, where we want to disable them because the editor
 // can't handle the large images.
-const largeImageSources = [ 'pexels' ];
+const largeImageSources = [ 'pexels', 'google_photos' ];
 
 export class MediaLibraryFilterBar extends Component {
 	static propTypes = {


### PR DESCRIPTION
The media library has the ability to disable media sources when editing the site icon due to problems with Calypso copying large files from an external source.

Currently Pexels is disabled, and Google Photos should now also be added to the list as it doesn't work (probably since the Gutenberg/Calypso changes occurred)/

### Testing

1. Go to `Manage > Settings` on a site and click the `change` button the site icon.
2. Note that Google Photos and Pexels are not in the list of sources, which is now not clickable.

<img width="321" alt="Site_Settings_‹_Testy_Blog_—_WordPress_com" src="https://user-images.githubusercontent.com/1277682/57372626-24e82880-718e-11e9-958e-758d226bf9a6.png">

3. Go to the `Site > Media` page and verify that Google Photos is still available