### PR TITLE
Modernize the RootChild component (try 2)

### DIFF
--- a/client/blocks/edit-gravatar/index.jsx
+++ b/client/blocks/edit-gravatar/index.jsx
@@ -187,9 +187,6 @@ export class EditGravatar extends Component {
 				) }
 			>
 				<div onClick={ this.handleUnverifiedUserClick }>
-					{ this.state.showEmailVerificationNotice && (
-						<VerifyEmailDialog onClose={ this.closeVerifyEmailDialog } />
-					) }
 					<FilePicker accept="image/*" onPick={ this.onReceiveFile }>
 						<div
 							data-tip-target="edit-gravatar"
@@ -214,6 +211,9 @@ export class EditGravatar extends Component {
 						</div>
 					</FilePicker>
 				</div>
+				{ this.state.showEmailVerificationNotice && (
+					<VerifyEmailDialog onClose={ this.closeVerifyEmailDialog } />
+				) }
 				{ this.renderImageEditor() }
 				<div>
 					<p className="edit-gravatar__explanation">

--- a/client/components/accordion/status.jsx
+++ b/client/components/accordion/status.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Gridicon from 'components/gridicon';
@@ -39,48 +39,40 @@ export default class AccordionStatus extends PureComponent {
 		onClick: () => {},
 	};
 
-	state = {};
-
-	constructor() {
-		super( ...arguments );
-
-		this.showTooltip = this.toggleTooltip.bind( this, true );
-		this.hideTooltip = this.toggleTooltip.bind( this, false );
-	}
-
-	setTooltipContext = tooltipContext => {
-		if ( tooltipContext ) {
-			this.setState( { tooltipContext } );
-		}
+	state = {
+		isTooltipVisible: false,
 	};
 
-	toggleTooltip( isTooltipVisible ) {
-		this.setState( { isTooltipVisible } );
-	}
+	showTooltip = () => this.setState( { isTooltipVisible: true } );
+	hideTooltip = () => this.setState( { isTooltipVisible: false } );
+
+	tooltipContextRef = React.createRef();
 
 	render() {
 		const { type, text, url, position } = this.props;
 
 		return (
-			<a
-				href={ url }
-				onClick={ this.props.onClick }
-				ref={ this.setTooltipContext }
-				onMouseEnter={ this.showTooltip }
-				onMouseLeave={ this.hideTooltip }
-				className={ classNames( 'accordion__status', `is-${ type }` ) }
-			>
-				<Gridicon icon={ STATUS_GRIDICON[ type ] } />
+			<Fragment>
+				<a
+					href={ url }
+					onClick={ this.props.onClick }
+					ref={ this.tooltipContextRef }
+					onMouseEnter={ this.showTooltip }
+					onMouseLeave={ this.hideTooltip }
+					className={ classNames( 'accordion__status', `is-${ type }` ) }
+				>
+					<Gridicon icon={ STATUS_GRIDICON[ type ] } />
+				</a>
 				{ text && (
 					<Tooltip
 						position={ position }
 						isVisible={ this.state.isTooltipVisible }
-						context={ this.state.tooltipContext }
+						context={ this.tooltipContextRef.current }
 					>
 						{ text }
 					</Tooltip>
 				) }
-			</a>
+			</Fragment>
 		);
 	}
 }

--- a/client/components/accordion/test/status.jsx
+++ b/client/components/accordion/test/status.jsx
@@ -29,10 +29,10 @@ describe( 'AccordionStatus', () => {
 		};
 		const wrapper = shallow( <AccordionStatus { ...status } /> );
 
-		expect( wrapper )
+		expect( wrapper.find( 'a' ) )
 			.to.have.prop( 'href' )
 			.equal( 'https://wordpress.com' );
-		expect( wrapper ).to.have.className( 'is-error' );
+		expect( wrapper.find( 'a' ) ).to.have.className( 'is-error' );
 		expect( wrapper.find( Gridicon ) )
 			.to.have.prop( 'icon' )
 			.equal( 'notice' );
@@ -47,8 +47,8 @@ describe( 'AccordionStatus', () => {
 	test( 'should render with default props', () => {
 		const wrapper = shallow( <AccordionStatus /> );
 
-		expect( wrapper ).to.not.have.prop( 'href' );
-		expect( wrapper ).to.have.className( 'is-info' );
+		expect( wrapper.find( 'a' ) ).to.not.have.prop( 'href' );
+		expect( wrapper.find( 'a' ) ).to.have.className( 'is-info' );
 		expect( wrapper.find( Gridicon ) )
 			.to.have.prop( 'icon' )
 			.equal( 'info' );
@@ -58,16 +58,16 @@ describe( 'AccordionStatus', () => {
 	test( 'should show tooltip on hover', () => {
 		const wrapper = shallow( <AccordionStatus text="Warning!" /> );
 
-		expect( wrapper.find( Tooltip ) ).to.not.have.prop( 'isVisible' );
+		expect( wrapper.find( Tooltip ) ).to.have.prop( 'isVisible' ).be.false;
 		expect( wrapper.find( Tooltip ) )
 			.to.have.prop( 'position' )
 			.equal( 'top' );
 
-		wrapper.simulate( 'mouseEnter' );
+		wrapper.find( 'a' ).simulate( 'mouseEnter' );
 
 		expect( wrapper.find( Tooltip ) ).to.have.prop( 'isVisible' ).be.true;
 
-		wrapper.simulate( 'mouseLeave' );
+		wrapper.find( 'a' ).simulate( 'mouseLeave' );
 
 		expect( wrapper.find( Tooltip ) ).to.have.prop( 'isVisible' ).be.false;
 	} );
@@ -76,7 +76,7 @@ describe( 'AccordionStatus', () => {
 		const spy = sinon.spy();
 		const wrapper = shallow( <AccordionStatus onClick={ spy } /> );
 
-		wrapper.simulate( 'click' );
+		wrapper.find( 'a' ).simulate( 'click' );
 
 		expect( spy ).to.have.been.calledOnce;
 	} );

--- a/client/components/dialog/index.jsx
+++ b/client/components/dialog/index.jsx
@@ -7,11 +7,6 @@ import Modal from 'react-modal';
 import classnames from 'classnames';
 
 /**
- * Internal dependencies
- */
-import RootChild from 'components/root-child';
-
-/**
  * Style dependencies
  */
 import './style.scss';
@@ -118,24 +113,22 @@ class Dialog extends Component {
 		const contentClassName = classnames( baseClassName + '__content', className );
 
 		return (
-			<RootChild>
-				<Modal
-					isOpen={ this.props.isVisible }
-					onRequestClose={ this.close }
-					closeTimeoutMS={ this.props.leaveTimeout }
-					contentLabel={ this.props.label }
-					overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't
-					className={ dialogClassName }
-					htmlOpenClassName="ReactModal__Html--open"
-					role="dialog"
-					shouldCloseOnEsc={ shouldCloseOnEsc }
-				>
-					<div className={ contentClassName } tabIndex="-1">
-						{ this.props.children }
-					</div>
-					{ this.renderButtonsBar() }
-				</Modal>
-			</RootChild>
+			<Modal
+				isOpen={ this.props.isVisible }
+				onRequestClose={ this.close }
+				closeTimeoutMS={ this.props.leaveTimeout }
+				contentLabel={ this.props.label }
+				overlayClassName={ backdropClassName } // We use flex here which react-modal doesn't
+				className={ dialogClassName }
+				htmlOpenClassName="ReactModal__Html--open"
+				role="dialog"
+				shouldCloseOnEsc={ shouldCloseOnEsc }
+			>
+				<div className={ contentClassName } tabIndex="-1">
+					{ this.props.children }
+				</div>
+				{ this.renderButtonsBar() }
+			</Modal>
 		);
 	}
 }

--- a/client/components/root-child/index.jsx
+++ b/client/components/root-child/index.jsx
@@ -1,67 +1,21 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import ReactDom from 'react-dom';
-import PropTypes from 'prop-types';
 import React from 'react';
-import { Provider as ReduxProvider } from 'react-redux';
-
-/**
- * Internal dependencies
- */
-import { MomentProvider } from 'components/localized-moment/context';
+import ReactDOM from 'react-dom';
 
 export default class RootChild extends React.Component {
-	static contextTypes = {
-		store: PropTypes.object,
-	};
+	container = document.createElement( 'div' );
 
 	componentDidMount() {
-		this.container = document.createElement( 'div' );
 		document.body.appendChild( this.container );
-		this.renderChildren();
-	}
-
-	componentDidUpdate() {
-		this.renderChildren();
 	}
 
 	componentWillUnmount() {
-		if ( ! this.container ) {
-			return;
-		}
-
-		ReactDom.unmountComponentAtNode( this.container );
 		document.body.removeChild( this.container );
-		delete this.container;
 	}
 
-	renderChildren = () => {
-		let content;
-
-		if ( this.props && ( Object.keys( this.props ).length > 1 || ! this.props.children ) ) {
-			content = <div { ...this.props }>{ this.props.children }</div>;
-		} else {
-			content = this.props.children;
-		}
-
-		// Context is lost when creating a new render hierarchy, so ensure that
-		// we preserve the context that we care about
-		if ( this.context.store ) {
-			content = (
-				<ReduxProvider store={ this.context.store }>
-					<MomentProvider>{ content }</MomentProvider>
-				</ReduxProvider>
-			);
-		}
-
-		ReactDom.render( content, this.container );
-	};
-
 	render() {
-		return null;
+		return ReactDOM.createPortal( this.props.children, this.container );
 	}
 }

--- a/client/components/root-child/index.jsx
+++ b/client/components/root-child/index.jsx
@@ -5,17 +5,43 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 export default class RootChild extends React.Component {
-	container = document.createElement( 'div' );
+	// we can render the children only after the container DOM element has been created and added
+	// to the DOM tree. And we can't create and append the element in component constructor because
+	// there is no corresponding destructor that would safely remove it in case the render is not
+	// committed by React.
+	//
+	// A seemingly possible approach is to create the element in constructor, render the portal into
+	// it and then add it to `document.body` in `componentDidMount`. But that creates another subtle
+	// bug: the portal is rendered into a DOM element that's not part of the DOM tree and therefore
+	// is not part of layout and painting, and has no dimensions. Many component's lifecycles and
+	// effect hooks rightfully assume that the element can be measured in `componentDidMount` or
+	// `useEffect`.
+	//
+	// Another thing that fails inside a detached DOM element is accessing `iframe.contentWindow`.
+	// The `contentWindow` is `null` until the `iframe` becomes active, i.e., is added to the DOM
+	// tree. We access the `contentWindow` in `WebPreview`, for example.
+	state = { containerEl: null };
 
 	componentDidMount() {
-		document.body.appendChild( this.container );
+		// create the container element and immediately trigger a rerender
+		const containerEl = document.createElement( 'div' );
+		document.body.appendChild( containerEl );
+		this.setState( { containerEl } ); // eslint-disable-line react/no-did-mount-set-state
 	}
 
 	componentWillUnmount() {
-		document.body.removeChild( this.container );
+		if ( this.state.containerEl ) {
+			document.body.removeChild( this.state.containerEl );
+		}
 	}
 
 	render() {
-		return ReactDOM.createPortal( this.props.children, this.container );
+		// don't render anything until the `containerEl` is created. That's the correct behavior
+		// in SSR (no portals there, `RootChild` renders as empty).
+		if ( ! this.state.containerEl ) {
+			return null;
+		}
+
+		return ReactDOM.createPortal( this.props.children, this.state.containerEl );
 	}
 }

--- a/client/components/root-child/test/index.jsx
+++ b/client/components/root-child/test/index.jsx
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { mount } from 'enzyme';
 import React from 'react';
 import ReactDom from 'react-dom';
@@ -22,12 +21,16 @@ import RootChild from '../';
 class Greeting extends React.Component {
 	static defaultProps = { toWhom: 'World' };
 
+	parentChildRef = React.createRef();
+	rootChildRef = React.createRef();
+
 	render() {
 		return (
+			/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
 			<div className="parent">
-				<h1 ref="parentChild">Greeting</h1>
-				<RootChild { ...this.props.rootChildProps }>
-					<span ref="rootChild">Hello { this.props.toWhom }!</span>
+				<h1 ref={ this.parentChildRef }>Greeting</h1>
+				<RootChild>
+					<span ref={ this.rootChildRef }>Hello { this.props.toWhom }!</span>
 				</RootChild>
 			</div>
 		);
@@ -50,29 +53,15 @@ describe( 'RootChild', () => {
 		test( 'should render any children as descendants of body', () => {
 			const tree = ReactDom.render( React.createElement( Greeting ), container );
 
-			expect( tree.refs.parentChild.parentNode.className ).to.equal( 'parent' );
-
-			expect( tree.refs.rootChild.parentNode.parentNode ).to.eql( document.body );
-		} );
-
-		test( 'accepts props to be added to a wrapper element', () => {
-			const tree = ReactDom.render(
-				React.createElement( Greeting, {
-					rootChildProps: { className: 'wrapper' },
-				} ),
-				container
-			);
-
-			expect( tree.refs.rootChild.parentNode.className ).to.equal( 'wrapper' );
-
-			expect( tree.refs.rootChild.parentNode.parentNode.parentNode ).to.eql( document.body );
+			expect( tree.parentChildRef.current.parentNode.className ).toBe( 'parent' );
+			expect( tree.rootChildRef.current.parentNode.parentNode ).toBe( document.body );
 		} );
 
 		test( 'should update the children if parent is re-rendered', () => {
 			const tree = mount( React.createElement( Greeting ), { attachTo: container } );
 			tree.setProps( { toWhom: 'Universe' } );
 
-			expect( tree.ref( 'rootChild' ).innerHTML ).to.equal( 'Hello Universe!' );
+			expect( tree.instance().rootChildRef.current.innerHTML ).toBe( 'Hello Universe!' );
 			tree.detach();
 		} );
 	} );
@@ -82,7 +71,7 @@ describe( 'RootChild', () => {
 			ReactDom.render( React.createElement( Greeting ), container );
 			ReactDom.unmountComponentAtNode( container );
 
-			expect( [].slice.call( document.body.querySelectorAll( '*' ) ) ).to.eql( [ container ] );
+			expect( Array.from( document.body.querySelectorAll( '*' ) ) ).toEqual( [ container ] );
 		} );
 	} );
 } );

--- a/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
+++ b/client/extensions/woocommerce/app/settings/email/mailchimp/sync_tab.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -32,13 +32,15 @@ class Tooltip extends React.Component {
 
 	render() {
 		return (
-			<div
-				className="mailchimp__sync-notice-list"
-				onMouseEnter={ this.open }
-				onMouseLeave={ this.close }
-				ref={ this.tooltipRef }
-			>
-				{ this.props.children }
+			<Fragment>
+				<div
+					className="mailchimp__sync-notice-list"
+					onMouseEnter={ this.open }
+					onMouseLeave={ this.close }
+					ref={ this.tooltipRef }
+				>
+					{ this.props.children }
+				</div>
 				<TooltipComponent
 					isVisible={ this.state.show }
 					onClose={ this.close }
@@ -47,7 +49,7 @@ class Tooltip extends React.Component {
 				>
 					<div>{ this.props.listName }</div>
 				</TooltipComponent>
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/extensions/woocommerce/components/dashboard-widget/index.js
+++ b/client/extensions/woocommerce/components/dashboard-widget/index.js
@@ -37,9 +37,7 @@ class DashboardWidget extends Component {
 		this.props.onSettingsClose();
 	};
 
-	setSettingsToggle = c => {
-		this.settingsToggle = c;
-	};
+	settingsToggleRef = React.createRef();
 
 	showTooltip = () => {
 		this.setState( { showTooltip: true } );
@@ -86,12 +84,12 @@ class DashboardWidget extends Component {
 					onClick={ this.toggleSettingsPanel }
 					onMouseEnter={ this.showTooltip }
 					onMouseLeave={ this.hideTooltip }
-					ref={ this.setSettingsToggle }
+					ref={ this.settingsToggleRef }
 					size={ 18 }
 				/>
 				<Tooltip
 					baseClassName="dashboard-widget__settings-tooltip"
-					context={ this.settingsToggle }
+					context={ this.settingsToggleRef.current }
 					isVisible={ showTooltip }
 				>
 					{ translate( 'Settings', {
@@ -101,7 +99,7 @@ class DashboardWidget extends Component {
 				{ hasSettingsPanel && (
 					<Popover
 						className="woocommerce dashboard-widget__settings-popover"
-						context={ this.settingsToggle }
+						context={ this.settingsToggleRef.current }
 						isVisible={ showDialog }
 						onClose={ this.onSettingsPanelClose }
 						position="bottom left"

--- a/client/extensions/woocommerce/woocommerce-services/components/info-tooltip/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/info-tooltip/index.js
@@ -31,7 +31,6 @@ export default class InfoTooltip extends Component {
 
 		this.openTooltip = this.openTooltip.bind( this );
 		this.closeTooltip = this.closeTooltip.bind( this );
-		this.anchorRef = null;
 
 		this.state = {
 			showTooltip: false,
@@ -46,7 +45,7 @@ export default class InfoTooltip extends Component {
 		this.setState( { showTooltip: false } );
 	}
 
-	saveAnchorRef = ref => ( this.anchorRef = ref );
+	anchorRef = React.createRef();
 
 	render() {
 		const anchor = this.props.anchor || <Gridicon icon="info-outline" size={ 18 } />;
@@ -54,7 +53,7 @@ export default class InfoTooltip extends Component {
 		return (
 			<span className={ classNames( 'info-tooltip', this.props.className ) }>
 				<span
-					ref={ this.saveAnchorRef }
+					ref={ this.anchorRef }
 					onMouseEnter={ this.openTooltip }
 					onMouseLeave={ this.closeTooltip }
 				>
@@ -66,7 +65,7 @@ export default class InfoTooltip extends Component {
 					showOnMobile
 					onClose={ this.closeTooltip }
 					position={ this.props.position }
-					context={ this.anchorRef }
+					context={ this.anchorRef.current }
 				>
 					<div className="info-tooltip__contents" style={ { maxWidth: this.props.maxWidth } }>
 						{ this.props.children }

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/price-summary.js
@@ -34,18 +34,14 @@ class PriceSummary extends Component {
 		this.setState( { tooltipVisible: false } );
 	};
 
-	setTooltipContext = tooltipContext => {
-		if ( tooltipContext ) {
-			this.setState( { tooltipContext } );
-		}
-	};
+	tooltipContextRef = React.createRef();
 
 	renderDiscountExplanation = () => {
 		const { translate } = this.props;
 		return (
 			<div className="label-purchase-modal__price-item-help">
 				<Gridicon
-					ref={ this.setTooltipContext }
+					ref={ this.tooltipContextRef }
 					icon="help-outline"
 					onMouseEnter={ this.showTooltip }
 					onMouseLeave={ this.hideTooltip }
@@ -54,7 +50,7 @@ class PriceSummary extends Component {
 				<Tooltip
 					className="label-purchase-modal__price-item-tooltip is-dialog-visible"
 					isVisible={ this.state.tooltipVisible }
-					context={ this.state.tooltipContext }
+					context={ this.tooltipContextRef.current }
 				>
 					{ translate(
 						'WooCommerce Services gives you access to USPS ' +

--- a/client/layout/masterbar/publish.jsx
+++ b/client/layout/masterbar/publish.jsx
@@ -106,9 +106,9 @@ class MasterbarItemNew extends React.Component {
 					preloadSection={ this.preloadPostEditor }
 				>
 					{ this.props.children }
-					{ this.renderPopover() }
 				</MasterbarItem>
 				<MasterbarDrafts />
+				{ this.renderPopover() }
 			</div>
 		);
 	}

--- a/client/me/security-2fa-backup-codes-list/index.jsx
+++ b/client/me/security-2fa-backup-codes-list/index.jsx
@@ -302,15 +302,7 @@ class Security2faBackupCodesList extends React.Component {
 							ref={ this.copyCodesButtonRef }
 						>
 							<Gridicon icon="clipboard" />
-							<Tooltip
-								context={ this.copyCodesButtonRef.current }
-								isVisible={ this.state.copyCodesTooltip }
-								position="top"
-							>
-								{ this.props.translate( 'Copy Codes' ) }
-							</Tooltip>
 						</Button>
-
 						<Button
 							className="security-2fa-backup-codes-list__print"
 							disabled={ ! this.props.backupCodes.length }
@@ -320,15 +312,7 @@ class Security2faBackupCodesList extends React.Component {
 							ref={ this.printCodesButtonRef }
 						>
 							<Gridicon icon="print" />
-							<Tooltip
-								context={ this.printCodesButtonRef.current }
-								isVisible={ this.state.printCodesTooltip }
-								position="top"
-							>
-								{ this.props.translate( 'Print Codes' ) }
-							</Tooltip>
 						</Button>
-
 						<Button
 							className="security-2fa-backup-codes-list__download"
 							disabled={ ! this.props.backupCodes.length }
@@ -338,15 +322,29 @@ class Security2faBackupCodesList extends React.Component {
 							ref={ this.downloadCodesButtonRef }
 						>
 							<Gridicon icon="cloud-download" />
-							<Tooltip
-								context={ this.downloadCodesButtonRef.current }
-								isVisible={ this.state.downloadCodesTooltip }
-								position="top"
-							>
-								{ this.props.translate( 'Download Codes' ) }
-							</Tooltip>
 						</Button>
 					</ButtonGroup>
+					<Tooltip
+						context={ this.copyCodesButtonRef.current }
+						isVisible={ this.state.copyCodesTooltip }
+						position="top"
+					>
+						{ this.props.translate( 'Copy Codes' ) }
+					</Tooltip>
+					<Tooltip
+						context={ this.printCodesButtonRef.current }
+						isVisible={ this.state.printCodesTooltip }
+						position="top"
+					>
+						{ this.props.translate( 'Print Codes' ) }
+					</Tooltip>
+					<Tooltip
+						context={ this.downloadCodesButtonRef.current }
+						isVisible={ this.state.downloadCodesTooltip }
+						position="top"
+					>
+						{ this.props.translate( 'Download Codes' ) }
+					</Tooltip>
 				</FormButtonBar>
 			</div>
 		);

--- a/client/my-sites/comments/comment/comment-author.jsx
+++ b/client/my-sites/comments/comment/comment-author.jsx
@@ -2,12 +2,12 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'components/gridicon';
-import { get, isEqual } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -34,10 +34,7 @@ export class CommentAuthor extends Component {
 		isLinkTooltipVisible: false,
 	};
 
-	shouldComponentUpdate = ( nextProps, nextState ) =>
-		! isEqual( this.props, nextProps ) || ! isEqual( this.state, nextState );
-
-	storeLinkIndicatorRef = icon => ( this.hasLinkIndicator = icon );
+	linkIndicatorRef = React.createRef();
 
 	hideLinkTooltip = () => this.setState( { isLinkTooltipVisible: false } );
 
@@ -83,20 +80,22 @@ export class CommentAuthor extends Component {
 				<div className="comment__author-info">
 					<div className="comment__author-info-element">
 						{ hasLink && (
-							<span
-								onMouseEnter={ this.showLinkTooltip }
-								onMouseLeave={ this.hideLinkTooltip }
-								ref={ this.storeLinkIndicatorRef }
-							>
-								<Gridicon icon="link" className="comment__author-has-link" size={ 18 } />
+							<Fragment>
+								<span
+									onMouseEnter={ this.showLinkTooltip }
+									onMouseLeave={ this.hideLinkTooltip }
+									ref={ this.linkIndicatorRef }
+								>
+									<Gridicon icon="link" className="comment__author-has-link" size={ 18 } />
+								</span>
 								<Tooltip
-									context={ this.hasLinkIndicator }
+									context={ this.linkIndicatorRef.current }
 									isVisible={ isLinkTooltipVisible }
 									showOnMobile
 								>
 									{ translate( 'This comment contains links.' ) }
 								</Tooltip>
-							</span>
+							</Fragment>
 						) }
 						<strong className="comment__author-name">
 							<Emojify>{ authorDisplayName || translate( 'Anonymous' ) }</Emojify>

--- a/client/my-sites/marketing/connections/account-dialog-account.jsx
+++ b/client/my-sites/marketing/connections/account-dialog-account.jsx
@@ -18,7 +18,6 @@ import Image from 'components/image';
  */
 import './account-dialog-account.scss';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 const AccountDialogAccount = ( { account, conflicting, onChange, selected, defaultIcon } ) => {
 	const classes = classNames( 'account-dialog-account', {
 		'is-connected': account.isConnected,
@@ -56,7 +55,6 @@ const AccountDialogAccount = ( { account, conflicting, onChange, selected, defau
 		</li>
 	);
 };
-/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 AccountDialogAccount.propTypes = {
 	account: PropTypes.shape( {

--- a/client/my-sites/marketing/connections/account-dialog.jsx
+++ b/client/my-sites/marketing/connections/account-dialog.jsx
@@ -24,7 +24,6 @@ import { warningNotice } from 'state/notices/actions';
  */
 import './account-dialog.scss';
 
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 class AccountDialog extends Component {
 	static propTypes = {
 		accounts: PropTypes.arrayOf( PropTypes.object ),
@@ -213,7 +212,6 @@ class AccountDialog extends Component {
 				{ action: 'connect', label: this.props.translate( 'Connect' ), isPrimary: true },
 			];
 
-		/*eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Dialog
 				isVisible={ this.props.isVisible }
@@ -234,10 +232,8 @@ class AccountDialog extends Component {
 				{ this.getConnectedAccountsContent() }
 			</Dialog>
 		);
-		/*eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
-/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 export default connect(
 	null,

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -57,21 +57,22 @@ class DisconnectJetpackButton extends Component {
 		];
 
 		return (
-			<Button
-				{ ...pick( this.props, buttonPropsList ) }
-				borderless={ linkDisplay }
-				/* eslint-disable wpcalypso/jsx-classname-namespace */
-				className="disconnect-jetpack-button"
-				compact
-				id={ `disconnect-jetpack-${ site.ID }` }
-				onClick={ this.handleClick }
-				scary
-			>
-				{ text ||
-					translate( 'Disconnect', {
-						context: 'Jetpack: Action user takes to disconnect Jetpack site from .com',
-					} ) }
+			<>
 				<QuerySitePlans siteId={ site.ID } />
+				<Button
+					{ ...pick( this.props, buttonPropsList ) }
+					borderless={ linkDisplay }
+					className="disconnect-jetpack-button"
+					compact
+					id={ `disconnect-jetpack-${ site.ID }` }
+					onClick={ this.handleClick }
+					scary
+				>
+					{ text ||
+						translate( 'Disconnect', {
+							context: 'Jetpack: Action user takes to disconnect Jetpack site from .com',
+						} ) }
+				</Button>
 				<DisconnectJetpackDialog
 					isVisible={ this.state.dialogVisible }
 					onClose={ this.hideDialog }
@@ -79,7 +80,7 @@ class DisconnectJetpackButton extends Component {
 					siteId={ site.ID }
 					disconnectHref={ this.props.redirect }
 				/>
-			</Button>
+			</>
 		);
 	}
 }

--- a/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
+++ b/client/my-sites/plugins/disconnect-jetpack/disconnect-jetpack-button.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -57,7 +57,7 @@ class DisconnectJetpackButton extends Component {
 		];
 
 		return (
-			<>
+			<Fragment>
 				<QuerySitePlans siteId={ site.ID } />
 				<Button
 					{ ...pick( this.props, buttonPropsList ) }
@@ -80,7 +80,7 @@ class DisconnectJetpackButton extends Component {
 					siteId={ site.ID }
 					disconnectHref={ this.props.redirect }
 				/>
-			</>
+			</Fragment>
 		);
 	}
 }

--- a/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
@@ -1,15 +1,15 @@
-/** @format */
 /**
  * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
-import i18n from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
+import Button from 'components/button';
 import { purchasesRoot } from 'me/purchases/paths';
 
 /**
@@ -17,30 +17,32 @@ import { purchasesRoot } from 'me/purchases/paths';
  */
 import './style.scss';
 
-const DeleteSiteWarningDialog = ( { isVisible, onClose } ) => (
-	<Dialog
-		isVisible={ isVisible }
-		buttons={ [
-			{ action: 'dismiss', label: i18n.translate( 'Dismiss' ) },
-			<a
-				className="button is-primary" // eslint-disable-line wpcalypso/jsx-classname-namespace
-				href={ purchasesRoot }
-			>
-				{ i18n.translate( 'Manage Purchases', { context: 'button label' } ) }
-			</a>,
-		] }
-		onClose={ onClose }
-		className="delete-site-warning-dialog"
-	>
-		<h1>{ i18n.translate( 'Premium Upgrades' ) }</h1>
-		<p>
-			{ i18n.translate(
-				'You have active premium upgrades on your site. ' +
-					'Please cancel your upgrades prior to deleting your site.'
-			) }
-		</p>
-	</Dialog>
-);
+const DeleteSiteWarningDialog = ( { isVisible, onClose } ) => {
+	const translate = useTranslate();
+	const buttons = [
+		{ action: 'dismiss', label: translate( 'Dismiss' ) },
+		<Button primary href={ purchasesRoot }>
+			{ translate( 'Manage Purchases', { context: 'button label' } ) }
+		</Button>,
+	];
+
+	return (
+		<Dialog
+			isVisible={ isVisible }
+			buttons={ buttons }
+			onClose={ onClose }
+			className="delete-site-warning-dialog"
+		>
+			<h1>{ translate( 'Premium Upgrades' ) }</h1>
+			<p>
+				{ translate(
+					'You have active premium upgrades on your site. ' +
+						'Please cancel your upgrades prior to deleting your site.'
+				) }
+			</p>
+		</Dialog>
+	);
+};
 
 DeleteSiteWarningDialog.propTypes = {
 	isVisible: PropTypes.bool.isRequired,

--- a/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
+++ b/client/my-sites/site-settings/delete-site-warning-dialog/index.jsx
@@ -17,7 +17,7 @@ import { purchasesRoot } from 'me/purchases/paths';
  */
 import './style.scss';
 
-const DeleteSiteWarningDialog = ( { isVisible, onClose } ) => {
+function DeleteSiteWarningDialog( { isVisible, onClose } ) {
 	const translate = useTranslate();
 	const buttons = [
 		{ action: 'dismiss', label: translate( 'Dismiss' ) },
@@ -42,7 +42,7 @@ const DeleteSiteWarningDialog = ( { isVisible, onClose } ) => {
 			</p>
 		</Dialog>
 	);
-};
+}
 
 DeleteSiteWarningDialog.propTypes = {
 	isVisible: PropTypes.bool.isRequired,

--- a/client/my-sites/stats/post-trends/day.jsx
+++ b/client/my-sites/stats/post-trends/day.jsx
@@ -3,7 +3,7 @@
  */
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import React from 'react';
+import React, { Fragment } from 'react';
 import classNames from 'classnames';
 
 /**
@@ -59,12 +59,13 @@ class PostTrendsDay extends React.PureComponent {
 		};
 
 		return (
-			<div
-				className={ classNames( 'post-trends__day', hoveredClass, className ) }
-				onMouseEnter={ postCount > 0 ? this.mouseEnter : null }
-				onMouseLeave={ postCount > 0 ? this.mouseLeave : null }
-				ref={ this.dayRef }
-			>
+			<Fragment>
+				<div
+					className={ classNames( 'post-trends__day', hoveredClass, className ) }
+					onMouseEnter={ postCount > 0 ? this.mouseEnter : null }
+					onMouseLeave={ postCount > 0 ? this.mouseLeave : null }
+					ref={ this.dayRef }
+				/>
 				{ postCount > 0 && (
 					<Tooltip
 						className="chart__tooltip is-streak"
@@ -76,7 +77,7 @@ class PostTrendsDay extends React.PureComponent {
 						{ this.buildTooltipData() }
 					</Tooltip>
 				) }
-			</div>
+			</Fragment>
 		);
 	}
 

--- a/client/my-sites/theme/test/main.jsx
+++ b/client/my-sites/theme/test/main.jsx
@@ -1,4 +1,3 @@
-/** @jest-environment jsdom */
 /**
  * External dependencies
  */
@@ -16,8 +15,8 @@ import { receiveTheme, themeRequestFailure } from 'state/themes/actions';
 
 jest.mock( 'components/data/query-user-purchases', () => require( 'components/empty-component' ) );
 jest.mock( 'components/data/query-site-purchases', () => require( 'components/empty-component' ) );
+jest.mock( 'components/popover', () => require( 'components/empty-component' ) );
 jest.mock( 'lib/analytics', () => ( {} ) );
-jest.mock( 'lib/user', () => () => {} );
 jest.mock( 'lib/wp', () => ( {
 	undocumented: () => ( {
 		getProducts: () => {},

--- a/client/post-editor/editor-action-bar/view-link.jsx
+++ b/client/post-editor/editor-action-bar/view-link.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Fragment } from 'react';
 import Gridicon from 'components/gridicon';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -61,16 +61,18 @@ class EditorViewLink extends React.Component {
 		const isCustomPostType = currentPost && ! includes( [ 'page', 'post' ], currentPost.type );
 
 		return (
-			<Button
-				href={ currentPost.URL }
-				target="_blank"
-				rel="noopener noreferrer"
-				ref={ this.viewLinkTooltipContext }
-				onMouseEnter={ this.showViewLinkTooltip }
-				onMouseLeave={ this.hideViewLinkTooltip }
-				borderless
-			>
-				<Gridicon icon="external" />
+			<Fragment>
+				<Button
+					href={ currentPost.URL }
+					target="_blank"
+					rel="noopener noreferrer"
+					ref={ this.viewLinkTooltipContext }
+					onMouseEnter={ this.showViewLinkTooltip }
+					onMouseLeave={ this.hideViewLinkTooltip }
+					borderless
+				>
+					<Gridicon icon="external" />
+				</Button>
 				<Tooltip
 					className="editor-action-bar__view-post-tooltip"
 					context={ this.viewLinkTooltipContext.current }
@@ -82,7 +84,7 @@ class EditorViewLink extends React.Component {
 						{ this.getTooltipLabel() }
 					</span>
 				</Tooltip>
-			</Button>
+			</Fragment>
 		);
 	}
 }

--- a/client/post-editor/editor-permalink/index.jsx
+++ b/client/post-editor/editor-permalink/index.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { pick } from 'lodash';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -118,17 +118,19 @@ class EditorPermalink extends Component {
 		}
 
 		return (
-			<div
-				className="editor-permalink"
-				onMouseEnter={ this.showTooltip }
-				onMouseLeave={ this.hideTooltip }
-			>
-				<Gridicon
-					className="editor-permalink__toggle"
-					icon="link"
-					onClick={ this.showPopover }
-					ref={ this.permalinkToggleReference }
-				/>
+			<Fragment>
+				<div
+					className="editor-permalink"
+					onMouseEnter={ this.showTooltip }
+					onMouseLeave={ this.hideTooltip }
+				>
+					<Gridicon
+						className="editor-permalink__toggle"
+						icon="link"
+						onClick={ this.showPopover }
+						ref={ this.permalinkToggleReference }
+					/>
+				</div>
 				<Popover
 					isVisible={ this.state.showPopover }
 					onClose={ this.closePopover }
@@ -150,7 +152,7 @@ class EditorPermalink extends Component {
 				>
 					{ tooltipMessage }
 				</Tooltip>
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/post-editor/editor-sticky/index.jsx
+++ b/client/post-editor/editor-sticky/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import React from 'react';
+import React, { Fragment } from 'react';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 import Gridicon from 'components/gridicon';
@@ -86,16 +86,18 @@ class EditorSticky extends React.Component {
 		);
 
 		return (
-			<Button
-				borderless
-				className={ classes }
-				onClick={ this.toggleStickyStatus }
-				onMouseEnter={ this.enableTooltip }
-				onMouseLeave={ this.disableTooltip }
-				aria-label={ translate( 'Stick post to the front page' ) }
-				ref={ this.stickyPostButtonRef }
-			>
-				<Gridicon icon="bookmark" />
+			<Fragment>
+				<Button
+					borderless
+					className={ classes }
+					onClick={ this.toggleStickyStatus }
+					onMouseEnter={ this.enableTooltip }
+					onMouseLeave={ this.disableTooltip }
+					aria-label={ translate( 'Stick post to the front page' ) }
+					ref={ this.stickyPostButtonRef }
+				>
+					<Gridicon icon="bookmark" />
+				</Button>
 				<Tooltip
 					className="editor-sticky__tooltip"
 					context={ this.stickyPostButtonRef.current }
@@ -104,7 +106,7 @@ class EditorSticky extends React.Component {
 				>
 					{ tooltipLabel }
 				</Tooltip>
-			</Button>
+			</Fragment>
 		);
 	}
 }


### PR DESCRIPTION
The first attempt (#32749) had to be reverted because it broke the `LanguagePicker` UI. Any click in the language picker modal would close the modal immediately.

Why? The JSX has the following structure:
```jsx
<button onClick={ this.toggleOpen }>
  <span>Change Language</span>
  { this.state.open && <Dialog /> }
</button>
```

Click events inside the `Dialog` bubble up to the `button` element, even though the button is not the dialog's DOM parent. But it's its React tree parent and React [bubbles the events synthetically](https://reactjs.org/docs/portals.html#event-bubbling-through-portals). Therefore, any click inside the dialog triggers the `toggleOpen` click handler on the button.

This didn't happen when `RootChild` mounted an independent React root and put the `RootChild` children into it.

I fixed the `LanguagePicker` markup, but we'll need to revisit all `RootChild` usages and check for similar event "leaks". Until that's done, this PR is a WIP draft with uncertain future.