### PR TITLE
Add missing await

### DIFF
--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -464,7 +464,7 @@ export async function ensurePopupsClosed( driver ) {
 		await switchToWindowByIndex( driver, windowIndex );
 		await closeCurrentWindow( driver );
 	}
-	return switchToWindowByIndex( driver, 0 );
+	return await switchToWindowByIndex( driver, 0 );
 }
 
 export async function refreshIfJNError( driver, timeout = 2000 ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add missing `await` before `switchToWindowByIndex`. Probably this was causing ['invalid session id'](https://circleci.com/gh/Automattic/wp-e2e-tests-for-branches/16868) error. 

#### Testing instructions

Make sure that tests are passing in CircleCI. 