### PR TITLE
Jetpack: remove monthly test

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -28,7 +28,6 @@ class JetpackPlansGrid extends Component {
 		isLanding: PropTypes.bool,
 		onSelect: PropTypes.func,
 		selectedSite: PropTypes.object,
-		countryCode: PropTypes.string,
 
 		// Connected
 		translate: PropTypes.func.isRequired,
@@ -67,7 +66,6 @@ class JetpackPlansGrid extends Component {
 							intervalType={ this.props.interval }
 							hideFreePlan={ this.props.hideFreePlan }
 							displayJetpackPlans={ true }
-							countryCode={ this.props.countryCode }
 						/>
 
 						<PlansSkipButton onClick={ this.handleSkipButtonClick } />

--- a/client/jetpack-connect/plans-landing.jsx
+++ b/client/jetpack-connect/plans-landing.jsx
@@ -27,7 +27,6 @@ import { getSite, isRequestingSites } from 'state/sites/selectors';
 import { PLAN_JETPACK_FREE } from 'lib/plans/constants';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { storePlan } from './persistence-utils';
-import { requestGeoLocation } from 'state/data-getters';
 
 const CALYPSO_JETPACK_CONNECT = '/jetpack/connect';
 
@@ -90,16 +89,11 @@ class PlansLanding extends Component {
 	};
 
 	render() {
-		const { interval, requestingSites, site, translate, url, countryCode } = this.props;
+		const { interval, requestingSites, site, translate, url } = this.props;
 
 		// We're redirecting in componentDidMount if the site is already connected
 		// so don't bother rendering any markup if this is the case
 		if ( url && ( site || requestingSites ) ) {
-			return <Placeholder />;
-		}
-
-		// if there's no geolocation info, we wait
-		if ( ! countryCode ) {
 			return <Placeholder />;
 		}
 
@@ -114,7 +108,6 @@ class PlansLanding extends Component {
 					interval={ interval }
 					isLanding={ true }
 					onSelect={ this.storeSelectedPlan }
-					countryCode={ countryCode }
 				>
 					<PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } />
 					<LoggedOutFormLinks>
@@ -132,17 +125,10 @@ const connectComponent = connect(
 	( state, { url } ) => {
 		const rawSite = url ? getJetpackSiteByUrl( state, url ) : null;
 		const site = rawSite ? getSite( state, rawSite.ID ) : null;
-		const geo = requestGeoLocation();
-		let countryCode = geo.data;
-		if ( ! countryCode && geo.state === 'failure' ) {
-			// if our geo requests are being blocked, we default to US
-			countryCode = 'US';
-		}
 
 		return {
 			requestingSites: isRequestingSites( state ),
 			site,
-			countryCode: countryCode,
 		};
 	},
 	{

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -38,7 +38,6 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
-import { requestGeoLocation } from 'state/data-getters';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
 const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
@@ -179,8 +178,7 @@ class Plans extends Component {
 			false !== this.props.notJetpack ||
 			! this.props.canPurchasePlans ||
 			false !== this.props.hasPlan ||
-			false !== this.props.isAutomatedTransfer ||
-			! this.props.countryCode
+			false !== this.props.isAutomatedTransfer
 		);
 	}
 
@@ -191,7 +189,7 @@ class Plans extends Component {
 	};
 
 	render() {
-		const { interval, selectedSite, translate, countryCode } = this.props;
+		const { interval, selectedSite, translate } = this.props;
 
 		if ( this.shouldShowPlaceholder() ) {
 			return (
@@ -216,7 +214,6 @@ class Plans extends Component {
 					isLanding={ false }
 					interval={ interval }
 					selectedSite={ selectedSite }
-					countryCode={ countryCode }
 				>
 					<PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } />
 					<LoggedOutFormLinks>
@@ -236,16 +233,11 @@ class Plans extends Component {
 export { Plans as PlansTestComponent };
 
 const connectComponent = connect(
-	( state, props ) => {
+	state => {
 		const user = getCurrentUser( state );
 		const selectedSite = getSelectedSite( state );
 		const selectedSiteSlug = selectedSite ? selectedSite.slug : '';
-		const geo = requestGeoLocation();
-		let countryCode = geo.data;
-		if ( ! countryCode && geo.state === 'failure' ) {
-			// if our geo requests are being blocked, we default to US
-			countryCode = 'US';
-		}
+
 		const selectedPlanSlug = retrievePlan();
 		const selectedPlan = getPlanBySlug( state, selectedPlanSlug );
 		return {
@@ -262,7 +254,6 @@ const connectComponent = connect(
 			selectedSite,
 			selectedSiteSlug,
 			userId: user ? user.ID : null,
-			countryCode: props.countryCode || countryCode,
 		};
 	},
 	{

--- a/client/jetpack-connect/test/__snapshots__/plans.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/plans.js.snap
@@ -18,7 +18,6 @@ exports[`Plans should render plans 1`] = `
   />
   <Connect(Localized(JetpackPlansGrid))
     basePlansPath="/jetpack/connect/plans"
-    countryCode="US"
     hideFreePlan={true}
     isLanding={false}
     onSelect={[Function]}

--- a/client/jetpack-connect/test/plans.js
+++ b/client/jetpack-connect/test/plans.js
@@ -26,7 +26,7 @@ describe( 'Plans', () => {
 		path.externalRedirect.mockReset();
 	} );
 	test( 'should render plans', () => {
-		const wrapper = shallow( <Plans { ...DEFAULT_PROPS } countryCode={ 'US' } /> );
+		const wrapper = shallow( <Plans { ...DEFAULT_PROPS } /> );
 
 		expect( wrapper ).toMatchSnapshot();
 		expect( wrapper.find( PlansGrid ) ).toHaveLength( 1 );

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -103,17 +103,6 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	jetpackMonthlyPlansOnly: {
-		datestamp: '20190312',
-		variations: {
-			original: 50,
-			monthlyOnly: 50,
-		},
-		defaultVariation: 'original',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-		countryCodeTargets: [ 'ES', 'IT', 'PT', 'FR', 'NL', 'DE', 'BE', 'PL', 'SE' ],
-	},
 	pluginFeaturedTitle: {
 		datestamp: '20190220',
 		variations: {

--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -28,8 +28,6 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { isMobile } from 'lib/viewport';
 import { planLevelsMatch } from 'lib/plans/index';
-import { requestGeoLocation } from 'state/data-getters';
-import { abtest } from 'lib/abtest';
 
 export class PlanFeaturesHeader extends Component {
 	render() {
@@ -106,16 +104,7 @@ export class PlanFeaturesHeader extends Component {
 	}
 
 	renderSignupHeader() {
-		const {
-			planType,
-			popular,
-			newPlan,
-			bestValue,
-			title,
-			audience,
-			translate,
-			countryCode,
-		} = this.props;
+		const { planType, popular, newPlan, bestValue, title, audience, translate } = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
 
@@ -135,9 +124,7 @@ export class PlanFeaturesHeader extends Component {
 				</div>
 				<div className="plan-features__pricing">
 					{ this.getPlanFeaturesPrices() } { this.getBillingTimeframe() }
-					{ countryCode && abtest( 'jetpackMonthlyPlansOnly', countryCode ) !== 'monthlyOnly'
-						? this.getIntervalDiscount()
-						: null }
+					{ this.getIntervalDiscount() }
 				</div>
 			</div>
 		);
@@ -410,6 +397,5 @@ export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) 
 		isYearly,
 		relatedYearlyPlan: isYearly ? null : getPlanBySlug( state, getYearlyPlanByMonthly( planType ) ),
 		siteSlug: getSiteSlug( state, selectedSiteId ),
-		countryCode: requestGeoLocation().data || 'US',
 	};
 } )( localize( PlanFeaturesHeader ) );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -296,7 +296,6 @@ export class PlanFeatures extends Component {
 				primaryUpgrade,
 				isPlaceholder,
 				hideMonthly,
-				countryCode,
 			} = properties;
 			const { rawPrice, discountPrice } = properties;
 			return (
@@ -321,7 +320,6 @@ export class PlanFeatures extends Component {
 						isInSignup={ isInSignup }
 						selectedPlan={ selectedPlan }
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
-						countryCode={ countryCode }
 					/>
 					<p className="plan-features__description">{ planConstantObj.getDescription( abtest ) }</p>
 					<PlanFeaturesActions
@@ -366,7 +364,6 @@ export class PlanFeatures extends Component {
 			selectedPlan,
 			siteType,
 			showPlanCreditsApplied,
-			countryCode,
 			withScroll,
 		} = this.props;
 
@@ -439,7 +436,6 @@ export class PlanFeatures extends Component {
 						selectedPlan={ selectedPlan }
 						showPlanCreditsApplied={ true === showPlanCreditsApplied && ! this.hasDiscountNotice() }
 						title={ planConstantObj.getTitle() }
-						countryCode={ countryCode }
 						plansWithScroll={ withScroll }
 					/>
 				</td>

--- a/client/my-sites/plan-features/test/header.jsx
+++ b/client/my-sites/plan-features/test/header.jsx
@@ -188,7 +188,6 @@ describe( 'PlanIntervalDiscount', () => {
 		rawPrice: 22,
 		relatedMonthlyPlan: { raw_price: 2 },
 		translate: identity,
-		countryCode: 'US',
 	};
 	test( 'should show interval discount for Jetpack during signup', () => {
 		const wrapper = shallow( <PlanFeaturesHeader { ...baseProps } isInSignup isJetpack /> );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -40,7 +40,6 @@ import SegmentedControlItem from 'components/segmented-control/item';
 import PaymentMethods from 'blocks/payment-methods';
 import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import { abtest } from 'lib/abtest';
 import { getDiscountByName } from 'lib/discounts';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import { getSitePlan, getSiteSlug } from 'state/sites/selectors';
@@ -123,13 +122,7 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getPlansForPlanFeatures() {
-		const {
-			displayJetpackPlans,
-			intervalType,
-			selectedPlan,
-			hideFreePlan,
-			countryCode,
-		} = this.props;
+		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan } = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
 
@@ -147,14 +140,6 @@ export class PlansFeaturesMain extends Component {
 		}
 
 		const group = displayJetpackPlans ? GROUP_JETPACK : GROUP_WPCOM;
-
-		if (
-			countryCode &&
-			displayJetpackPlans &&
-			abtest( 'jetpackMonthlyPlansOnly', countryCode ) === 'monthlyOnly'
-		) {
-			term = TERM_MONTHLY;
-		}
 
 		// In WPCOM, only the business plan is available in monthly term
 		// For any other plan, switch to annually.
@@ -321,11 +306,8 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	renderToggle() {
-		const { displayJetpackPlans, withWPPlanTabs, countryCode } = this.props;
+		const { displayJetpackPlans, withWPPlanTabs } = this.props;
 		if ( displayJetpackPlans ) {
-			if ( countryCode && abtest( 'jetpackMonthlyPlansOnly', countryCode ) === 'monthlyOnly' ) {
-				return false;
-			}
 			return this.getIntervalTypeToggle();
 		}
 		if ( withWPPlanTabs ) {


### PR DESCRIPTION
Remove the A/B test introduced by https://github.com/Automattic/wp-calypso/pull/31397

How to test
=========

1. Go to http://calypso.localhost:3000/jetpack/connect/store. You should see the yearly/monthly toggle and should get the yearly plan grid by default, without anything getting broken
2. Bonus points if you are based on any of the countries included in the original test (wink wink  @sirreal  )