### PR TITLE
Full Site Editing: Add default value support for PostAutocomplete

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/edit.js
@@ -78,7 +78,11 @@ const PostContentEdit = compose(
 					>
 						<div className="post-content-block__selector">
 							<div>{ __( 'Select something to preview:' ) }</div>
-							<PostAutocomplete postType={ [ 'page', 'post' ] } onSelectPost={ onSelectPost } />
+							<PostAutocomplete
+								defaultValue={ get( selectedPost, 'title.rendered' ) }
+								onSelectPost={ onSelectPost }
+								postType={ [ 'page', 'post' ] }
+							/>
 							{ !! selectedPost && (
 								<a href={ `?post=${ selectedPost.id }&action=edit` }>
 									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.rendered', '' ) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/edit.js
@@ -79,13 +79,13 @@ const PostContentEdit = compose(
 						<div className="post-content-block__selector">
 							<div>{ __( 'Select something to preview:' ) }</div>
 							<PostAutocomplete
-								initialValue={ get( selectedPost, 'title.rendered' ) }
+								initialValue={ get( selectedPost, [ 'title', 'rendered' ] ) }
 								onSelectPost={ onSelectPost }
 								postType={ [ 'page', 'post' ] }
 							/>
 							{ !! selectedPost && (
 								<a href={ `?post=${ selectedPost.id }&action=edit` }>
-									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.rendered', '' ) ) }
+									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, [ 'title', 'rendered' ], '' ) ) }
 								</a>
 							) }
 						</div>
@@ -93,7 +93,7 @@ const PostContentEdit = compose(
 				) }
 				{ showPreview && (
 					<RawHTML className="post-content-block__preview">
-						{ get( selectedPost, 'content.rendered' ) }
+						{ get( selectedPost, [ 'content', 'rendered' ] ) }
 					</RawHTML>
 				) }
 			</div>

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/edit.js
@@ -79,7 +79,7 @@ const PostContentEdit = compose(
 						<div className="post-content-block__selector">
 							<div>{ __( 'Select something to preview:' ) }</div>
 							<PostAutocomplete
-								defaultValue={ get( selectedPost, 'title.rendered' ) }
+								initialValue={ get( selectedPost, 'title.rendered' ) }
 								onSelectPost={ onSelectPost }
 								postType={ [ 'page', 'post' ] }
 							/>

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
@@ -75,7 +75,11 @@ const TemplateEdit = compose(
 						instructions={ __( 'Select a template part to display' ) }
 					>
 						<div className="template-block__selector">
-							<PostAutocomplete postType="wp_template" onSelectPost={ onSelectPost } />
+							<PostAutocomplete
+								defaultValue={ get( selectedPost, 'title.rendered' ) }
+								onSelectPost={ onSelectPost }
+								postType="wp_template"
+							/>
 							{ !! selectedPost && (
 								<a href={ `?post=${ selectedPost.id }&action=edit` }>
 									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.rendered', '' ) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
@@ -76,13 +76,13 @@ const TemplateEdit = compose(
 					>
 						<div className="template-block__selector">
 							<PostAutocomplete
-								initialValue={ get( selectedPost, 'title.rendered' ) }
+								initialValue={ get( selectedPost, [ 'title', 'rendered' ] ) }
 								onSelectPost={ onSelectPost }
 								postType="wp_template"
 							/>
 							{ !! selectedPost && (
 								<a href={ `?post=${ selectedPost.id }&action=edit` }>
-									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, 'title.rendered', '' ) ) }
+									{ sprintf( __( 'Edit "%s"' ), get( selectedPost, [ 'title', 'rendered' ], '' ) ) }
 								</a>
 							) }
 						</div>
@@ -90,7 +90,7 @@ const TemplateEdit = compose(
 				) }
 				{ showContent && (
 					<RawHTML className="template-block__content">
-						{ get( selectedPost, 'content.rendered' ) }
+						{ get( selectedPost, [ 'content', 'rendered' ] ) }
 					</RawHTML>
 				) }
 			</div>

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/edit.js
@@ -76,7 +76,7 @@ const TemplateEdit = compose(
 					>
 						<div className="template-block__selector">
 							<PostAutocomplete
-								defaultValue={ get( selectedPost, 'title.rendered' ) }
+								initialValue={ get( selectedPost, 'title.rendered' ) }
 								onSelectPost={ onSelectPost }
 								postType="wp_template"
 							/>

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/i18n": "^3.3.0",
 		"@wordpress/url": "^2.5.0",
 		"classnames": "^2.2.6",
-		"lodash": "^4.17.11"
+		"lodash": "^4.17.11",
+		"prop-types": "^15.7.2"
 	}
 }

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -36,7 +36,6 @@
 		"@wordpress/i18n": "^3.3.0",
 		"@wordpress/url": "^2.5.0",
 		"classnames": "^2.2.6",
-		"lodash": "^4.17.11",
-		"prop-types": "^15.7.2"
+		"lodash": "^4.17.11"
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Convert `PostAutocomplete` to a class component to be able to set the internal state on mount if needed.

This is needed to persist the input value across mounts.
`PostAutocomplete` is used in both FSE blocks: they have two states (placeholder and preview) and toggling between them unmounts each other.
So, every time we pick a post in `PostAutocomplete`, we toggle to the preview, and the input field is cleared.

Apparently this is frowned upon by the linter (reason why I had to add a disable comment), but I can't think of a better way to do it.
The problem is that I can't just do `<input value={ this.state.search || this.props.defaultValue } />` (stripped down example code), because React would complain about the input field being both controlled and uncontrolled.
I guess the other option would be to `ref` the input field, but to me it seems worse than triggering a second render on mount for such a simple component.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Edit a Template and add a Template Part and a Content Slot.
* Select a post in each block, and toggle back and forth between placeholder and preview.
* Make sure the selected post title persist across the toggles.
* Make sure `PostAutocomplete` does not have any unexpected behaviours.