### PR TITLE
Crowdsignal Sign In: Fix unclickable 'Lost your password?' link

### DIFF
--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -403,6 +403,7 @@
 
 		.wp-login__main.main {
 			max-width: 550px;
+			margin-bottom: 80px;
 		}
 	}
 }
@@ -462,7 +463,7 @@
 		text-decoration: none;
 		text-transform: capitalize;
 		width: auto;
-		
+
 		@include breakpoint( '>480px' ) {
 			width: 100%;
 		}
@@ -643,7 +644,7 @@
 		font-family: $sans;
 		margin: 0 0 8px;
 		padding: 0;
-		
+
 		@include breakpoint( '>480px' ) {
 			font-size: 2em;
 			margin: 2em 0 0;


### PR DESCRIPTION
The footer uses absolute positioning and was covering up the forgot password link. I added some margin to the bottom of the main class to get it clickable again:

<img width="1212" alt="Screen Shot 2019-05-08 at 11 08 35 AM" src="https://user-images.githubusercontent.com/789137/57397487-a7b6b680-7181-11e9-8d60-349be62f9ad0.png">

**To Test**
* Visit: `/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3Db17e5de1a68ffa4182b4e105b2eca7906a848db548fdd46dec4c46abf9dfe5d9%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1` from an incognito window.
* The 'Lost your password' and other links should all be clickable!