### PR TITLE
Web Preview: iOS iframe not resizing

### DIFF
--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -35,6 +35,7 @@ export class WebPreviewContent extends Component {
 		device: this.props.defaultViewportDevice || 'computer',
 		loaded: false,
 		isLoadingSubpage: false,
+		isIOS: /iPad|iPod|iPhone/.test( navigator.userAgent ),
 	};
 
 	setIframeInstance = ref => {
@@ -242,6 +243,7 @@ export class WebPreviewContent extends Component {
 			'is-phone': this.state.device === 'phone',
 			'is-seo': this.state.device === 'seo',
 			'is-loaded': this.state.loaded,
+			'is-ios': this.state.isIOS,
 		} );
 
 		const showLoadingMessage =
@@ -281,6 +283,7 @@ export class WebPreviewContent extends Component {
 							src="about:blank"
 							onLoad={ this.setLoaded }
 							title={ this.props.iframeTitle || translate( 'Preview' ) }
+							scrolling={ this.state.isIOS ? 'no' : 'auto' }
 						/>
 					</div>
 					{ 'seo' === this.state.device && (

--- a/client/components/web-preview/content.jsx
+++ b/client/components/web-preview/content.jsx
@@ -25,6 +25,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { isInlineHelpPopoverVisible } from 'state/inline-help/selectors';
 
 const debug = debugModule( 'calypso:web-preview' );
+const isIOS = /iPad|iPod|iPhone/.test( navigator ? navigator.userAgent : '' );
 
 export class WebPreviewContent extends Component {
 	previewId = uuid();
@@ -35,7 +36,6 @@ export class WebPreviewContent extends Component {
 		device: this.props.defaultViewportDevice || 'computer',
 		loaded: false,
 		isLoadingSubpage: false,
-		isIOS: /iPad|iPod|iPhone/.test( navigator.userAgent ),
 	};
 
 	setIframeInstance = ref => {
@@ -243,7 +243,7 @@ export class WebPreviewContent extends Component {
 			'is-phone': this.state.device === 'phone',
 			'is-seo': this.state.device === 'seo',
 			'is-loaded': this.state.loaded,
-			'is-ios': this.state.isIOS,
+			'is-ios': isIOS,
 		} );
 
 		const showLoadingMessage =
@@ -283,7 +283,7 @@ export class WebPreviewContent extends Component {
 							src="about:blank"
 							onLoad={ this.setLoaded }
 							title={ this.props.iframeTitle || translate( 'Preview' ) }
-							scrolling={ this.state.isIOS ? 'no' : 'auto' }
+							scrolling={ isIOS ? 'no' : 'auto' }
 						/>
 					</div>
 					{ 'seo' === this.state.device && (

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -223,6 +223,14 @@ a.web-preview__external.button {
 	.is-seo & {
 		max-width: 865px;
 	}
+
+	// This is a fix to ensure iframes are responsive in iOs
+	// In order for it to work, the iframe must have the `scrolling="no"` attribute
+	// which is deprecated in HTML5, but there you go...
+	.is-ios & {
+		min-width: 100%;
+		width: 1px;
+	}
 }
 
 .web-preview__frame-wrapper {

--- a/client/components/web-preview/style.scss
+++ b/client/components/web-preview/style.scss
@@ -233,6 +233,24 @@ a.web-preview__external.button {
 	}
 }
 
+.web-preview__placeholder {
+	.is-ios & {
+		margin: 0 auto;
+	}
+
+	.is-tablet.is-ios & {
+		max-width: 783px;
+	}
+
+	.is-phone.is-ios & {
+		max-width: 460px;
+	}
+
+	.is-seo.is-ios & {
+		max-width: 865px;
+	}
+}
+
 .web-preview__frame-wrapper {
 	position: absolute;
 		top: 0;


### PR DESCRIPTION
## Changes proposed in this Pull Request

iOS handles iframe resizing and scrolling inconsistently. 

Though I can't yet pinpoint the exact cause, this is a common fix for the issue, though in the future it will be better to troubleshoot at the theme level as well in the hope it can be isolated there, thus removing the need for this change.

<img width="300" alt="Screen Shot 2019-05-09 at 12 40 16 pm" src="https://user-images.githubusercontent.com/6458278/57425175-ac509d00-725d-11e9-84c1-45bc47aea284.png">

See: `paObgF-9t-p2`

## Testing instructions

In an iOS device, or on a Simulator, create a new site using the `/start/about` flow and ensure to select the `Promote your business...` checkbox.

After having created the site, check the preview. It shouldn't overflow and should still be scrollable.

<img width="300" alt="Screen Shot 2019-05-09 at 12 13 06 pm" src="https://user-images.githubusercontent.com/6458278/57425162-a0fd7180-725d-11e9-9038-4ea10e1f69bf.png">


