### PR TITLE
Migrate WebPreview component CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -86,7 +86,6 @@
 @import 'components/text-diff/style';
 @import 'components/pagination/style';
 @import 'components/tooltip/style';
-@import 'components/web-preview/style';
 @import 'components/wizard/style';
 @import 'components/environment-badge/style';
 @import 'blocks/credit-card-form/style';

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -20,6 +20,11 @@ import RootChild from 'components/root-child';
 import { setPreviewShowing } from 'state/ui/actions';
 import WebPreviewContent from './content';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class WebPreviewModal extends Component {
 	static propTypes = {
 		// Display the preview

--- a/client/components/web-preview/component.jsx
+++ b/client/components/web-preview/component.jsx
@@ -163,7 +163,9 @@ export class WebPreviewModal extends Component {
 		return (
 			<RootChild>
 				<div className={ className }>
+					{ /* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */ }
 					<div className="web-preview__backdrop" onClick={ this.props.onClose } />
+					{ /* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */ }
 					<div className="web-preview__content">
 						<WebPreviewContent
 							{ ...this.props }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Let's import web preview styles directly in the `components/web-preview` component!

Let's remove the import from the components file!

Let's 🕺 !

### Affected pages

**Site preview `/view/{hereisacoolsiteslug}`**

<img width="300" alt="Screen Shot 2019-05-09 at 2 41 47 pm" src="https://user-images.githubusercontent.com/6458278/57427737-a57b5780-7268-11e9-8260-41472ac4285e.png">

**Stats page site preview, e.g., `/stats/post/{id}/{hereisacoolsiteslug}`**

<img width="300" alt="Screen Shot 2019-05-09 at 2 46 42 pm" src="https://user-images.githubusercontent.com/6458278/57427937-774a4780-7269-11e9-881b-16352cd06c6b.png">

**Theme preview, e.g., `/theme/twentynineteen/{hereisacoolsiteslug}`**

**New post/page preview e.g., `/post/{hereisacoolsiteslug}/{id}`**

**New Gutenberg post/page preview e.g.,  `/block-editor/post/{hereisacoolsiteslug}/{id}`**

## Testing instructions

Check that there no regressions in the web preview


