### PR TITLE
Marketing/Sharing: Clarify that visibility setting applies to both sharing buttons and likes

### DIFF
--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -207,7 +207,7 @@ class SharingButtonsOptions extends Component {
 		return (
 			<fieldset className="sharing-buttons__fieldset">
 				<legend className="sharing-buttons__fieldset-heading">
-					{ translate( 'Show sharing buttons on', {
+					{ translate( 'Show like and sharing buttons on', {
 						context: 'Sharing options: Header',
 						comment:
 							'Possible values are: "Front page, Archive Pages, and Search Results", "Posts", "Pages", "Media"',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The option currently called "Show sharing buttons on" actually applies to the sharing *section*, which is to say, both sharing buttons and likes. Currently, if you enable Like buttons but do not check the box to show sharing buttons on posts, you will not see Likes on posts, which is confusing.

#### Testing instructions

* Go to Marketing -> Sharing Buttons and scroll down to the Options section.

Before:
<img width="445" alt="Screen Shot 2019-05-08 at 11 44 36 PM" src="https://user-images.githubusercontent.com/52152/57432675-55aa7b00-71eb-11e9-9322-690bb4761ca1.png">

After:
<img width="434" alt="Screen Shot 2019-05-08 at 11 44 30 PM" src="https://user-images.githubusercontent.com/52152/57432688-5d6a1f80-71eb-11e9-87be-7a31de9011e8.png">


Fixes: p8oabR-lP-p2
