### PR TITLE
InfoPopover: improve a11y, fix ESLint warnings, prepare for RootChild modernization

### DIFF
--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
@@ -46,9 +46,28 @@ export default class InfoPopover extends Component {
 		position: 'bottom',
 	};
 
+	iconRef = React.createRef();
+
 	state = { showPopover: false };
 
-	handleClick = event => {
+	handleClickOrKeyDown = event => {
+		if ( event.type === 'keydown' ) {
+			// ArrowDown only opens the popup
+			if ( event.key === 'ArrowDown' && this.state.showPopover ) {
+				return;
+			}
+
+			// Esc only closes the popup
+			if ( event.key === 'Esc' && ! this.state.showPopover ) {
+				return;
+			}
+
+			// Enter and Space toggle the popup
+			if ( event.key !== 'Enter' && event.key !== ' ' ) {
+				return;
+			}
+		}
+
 		event.preventDefault();
 		event.stopPropagation();
 
@@ -68,30 +87,39 @@ export default class InfoPopover extends Component {
 
 	render() {
 		return (
-			<span
-				onClick={ this.handleClick }
-				ref="infoPopover"
-				className={ classNames(
-					'info-popover',
-					{ is_active: this.state.showPopover },
-					this.props.className
-				) }
-			>
-				<Gridicon icon={ this.props.icon } size={ this.props.iconSize } />
-				<Popover
-					autoRtl={ this.props.autoRtl }
-					id={ this.props.id }
-					isVisible={ this.state.showPopover }
-					context={ this.refs && this.refs.infoPopover }
-					ignoreContext={ this.props.ignoreContext }
-					position={ this.props.position }
-					onClose={ this.handleClose }
-					className={ classNames( 'popover', 'info-popover__tooltip', this.props.className ) }
-					rootClassName={ this.props.rootClassName }
+			<Fragment>
+				<span
+					role="button"
+					tabIndex="0"
+					aria-haspopup
+					aria-expanded={ this.state.showPopover }
+					onClick={ this.handleClickOrKeyDown }
+					onKeyDown={ this.handleClickOrKeyDown }
+					ref={ this.iconRef }
+					className={ classNames(
+						'info-popover',
+						{ 'is-active': this.state.showPopover },
+						this.props.className
+					) }
 				>
-					{ this.props.children }
-				</Popover>
-			</span>
+					<Gridicon icon={ this.props.icon } size={ this.props.iconSize } />
+				</span>
+				{ this.state.showPopover && (
+					<Popover
+						autoRtl={ this.props.autoRtl }
+						id={ this.props.id }
+						isVisible
+						context={ this.iconRef.current }
+						ignoreContext={ this.props.ignoreContext }
+						position={ this.props.position }
+						onClose={ this.handleClose }
+						className={ classNames( 'popover', 'info-popover__tooltip', this.props.className ) }
+						rootClassName={ this.props.rootClassName }
+					>
+						{ this.props.children }
+					</Popover>
+				) }
+			</Fragment>
 		);
 	}
 }

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -67,6 +67,7 @@ export default class InfoPopover extends Component {
 		return (
 			<Fragment>
 				<button
+					type="button"
 					aria-haspopup
 					aria-expanded={ this.state.showPopover }
 					onClick={ this.handleClick }

--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -50,29 +50,7 @@ export default class InfoPopover extends Component {
 
 	state = { showPopover: false };
 
-	handleClickOrKeyDown = event => {
-		if ( event.type === 'keydown' ) {
-			// ArrowDown only opens the popup
-			if ( event.key === 'ArrowDown' && this.state.showPopover ) {
-				return;
-			}
-
-			// Esc only closes the popup
-			if ( event.key === 'Esc' && ! this.state.showPopover ) {
-				return;
-			}
-
-			// Enter and Space toggle the popup
-			if ( event.key !== 'Enter' && event.key !== ' ' ) {
-				return;
-			}
-		}
-
-		event.preventDefault();
-		event.stopPropagation();
-
-		this.setState( { showPopover: ! this.state.showPopover }, this.recordStats );
-	};
+	handleClick = () => this.setState( { showPopover: ! this.state.showPopover }, this.recordStats );
 
 	handleClose = () => this.setState( { showPopover: false }, this.recordStats );
 
@@ -88,13 +66,10 @@ export default class InfoPopover extends Component {
 	render() {
 		return (
 			<Fragment>
-				<span
-					role="button"
-					tabIndex="0"
+				<button
 					aria-haspopup
 					aria-expanded={ this.state.showPopover }
-					onClick={ this.handleClickOrKeyDown }
-					onKeyDown={ this.handleClickOrKeyDown }
+					onClick={ this.handleClick }
 					ref={ this.iconRef }
 					className={ classNames(
 						'info-popover',
@@ -103,7 +78,7 @@ export default class InfoPopover extends Component {
 					) }
 				>
 					<Gridicon icon={ this.props.icon } size={ this.props.iconSize } />
-				</span>
+				</button>
 				{ this.state.showPopover && (
 					<Popover
 						autoRtl={ this.props.autoRtl }
@@ -113,7 +88,7 @@ export default class InfoPopover extends Component {
 						ignoreContext={ this.props.ignoreContext }
 						position={ this.props.position }
 						onClose={ this.handleClose }
-						className={ classNames( 'popover', 'info-popover__tooltip', this.props.className ) }
+						className={ classNames( 'info-popover__tooltip', this.props.className ) }
 						rootClassName={ this.props.rootClassName }
 					>
 						{ this.props.children }

--- a/client/components/info-popover/style.scss
+++ b/client/components/info-popover/style.scss
@@ -1,14 +1,16 @@
-.info-popover .gridicon {
-	cursor: pointer;
-	color: var( --color-neutral-200 );
-
-	&:hover {
-		color: var( --color-neutral-700 );
+.info-popover {
+	.gridicon {
+		cursor: pointer;
+		color: var( --color-neutral-200 );
 	}
-}
 
-.info-popover.is_active .gridicon {
-	color: var( --color-neutral-700 );
+	.accessible-focus &:focus,
+	&:hover,
+	&.is-active {
+		.gridicon {
+			color: var( --color-neutral-700 );
+		}
+	}
 }
 
 .popover.info-popover__tooltip {


### PR DESCRIPTION
Several improvements for the `InfoPopover` component:

<img width="345" alt="Screenshot 2019-05-09 at 11 14 29" src="https://user-images.githubusercontent.com/664258/57442152-a5b92a00-724b-11e9-9f7f-25ff22eaad73.png">

**Prepare for `RootChild` modernization**
Move the popover modal markup outside the clickable "info" element. Otherwise, clicks inside the popover would bubble up to the "info" element and would toggle it (because React Portal behaves that way). One small step towards making #32899 shippable.

**Improve accessibility**
The "info" element has a "button" role, is tabbable and focusable, focus is visible during keyboard navigation, and the popover can be toggled with keyboard. Enter and Space toggles it, ArrowDown opens it and Escape closes it.

There are plenty of other possible a11y improvements we could make: put `aria-label` on the info icon, link the icon and the popover with the `aria-controls` attribute... A11y is such a vast topic 😮 But that's for other PRs. My main goal here was the `RootChild` compatibility.

**Fix ESlint warnings**
Convert React string refs to modern `React.createRef`.
