### PR TITLE
Types: Add types to protect-form

### DIFF
--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -13,9 +13,9 @@ import { Subtract } from 'utility-types';
  */
 const debug = debugModule( 'calypso:protect-form' );
 
-type ProtectableForm = ReturnType< typeof protectForm > | ProtectFormGuard;
+type ComponentMarkedWithFormChanges = Component;
 
-let formsChanged: ProtectableForm[] = [];
+let formsChanged: ComponentMarkedWithFormChanges[] = [];
 let listenerCount = 0;
 
 function warnIfChanged( event: BeforeUnloadEvent ) {
@@ -42,13 +42,13 @@ function removeBeforeUnloadListener() {
 	}
 }
 
-function markChanged( form: ProtectableForm ) {
+function markChanged( form: ComponentMarkedWithFormChanges ) {
 	if ( ! includes( formsChanged, form ) ) {
 		formsChanged.push( form );
 	}
 }
 
-function markSaved( form: ProtectableForm ) {
+function markSaved( form: ComponentMarkedWithFormChanges ) {
 	formsChanged = without( formsChanged, form );
 }
 

--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -1,10 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import PropTypes from 'prop-types';
 import React, { Component, ComponentType } from 'react';
 import debugModule from 'debug';
 import page from 'page';
@@ -16,10 +12,10 @@ import { Subtract } from 'utility-types';
  * Module variables
  */
 const debug = debugModule( 'calypso:protect-form' );
-let formsChanged = [];
+let formsChanged: any[] = [];
 let listenerCount = 0;
 
-function warnIfChanged( event ) {
+function warnIfChanged( event: BeforeUnloadEvent ) {
 	if ( ! formsChanged.length ) {
 		return;
 	}
@@ -43,13 +39,13 @@ function removeBeforeUnloadListener() {
 	}
 }
 
-function markChanged( form ) {
+function markChanged( form: any ) {
 	if ( ! includes( formsChanged, form ) ) {
 		formsChanged.push( form );
 	}
 }
 
-function markSaved( form ) {
+function markSaved( form: any ) {
 	formsChanged = without( formsChanged, form );
 }
 
@@ -88,14 +84,13 @@ export const protectForm = < P extends ProtectedFormProps >(
 		}
 	};
 
+interface ProtectFormGuardProps {
+	isChanged: boolean;
+}
 /*
  * Declarative variant that takes a 'isChanged' prop.
  */
-export class ProtectFormGuard extends Component {
-	static propTypes = {
-		isChanged: PropTypes.bool.isRequired,
-	};
-
+export class ProtectFormGuard extends Component< ProtectFormGuardProps > {
 	componentDidMount() {
 		addBeforeUnloadListener();
 		if ( this.props.isChanged ) {
@@ -108,7 +103,7 @@ export class ProtectFormGuard extends Component {
 		markSaved( this );
 	}
 
-	componentWillReceiveProps( nextProps ) {
+	componentWillReceiveProps( nextProps: ProtectFormGuardProps ) {
 		if ( nextProps.isChanged !== this.props.isChanged ) {
 			nextProps.isChanged ? markChanged( this ) : markSaved( this );
 		}
@@ -129,7 +124,7 @@ function windowConfirm() {
 	return window.confirm( confirmText );
 }
 
-export const checkFormHandler = ( context, next ) => {
+export const checkFormHandler: PageJS.Callback = ( context, next ) => {
 	if ( ! formsChanged.length ) {
 		return next();
 	}

--- a/client/lib/protect-form/index.tsx
+++ b/client/lib/protect-form/index.tsx
@@ -12,7 +12,10 @@ import { Subtract } from 'utility-types';
  * Module variables
  */
 const debug = debugModule( 'calypso:protect-form' );
-let formsChanged: any[] = [];
+
+type ProtectableForm = ReturnType< typeof protectForm > | ProtectFormGuard;
+
+let formsChanged: ProtectableForm[] = [];
 let listenerCount = 0;
 
 function warnIfChanged( event: BeforeUnloadEvent ) {
@@ -39,13 +42,13 @@ function removeBeforeUnloadListener() {
 	}
 }
 
-function markChanged( form: any ) {
+function markChanged( form: ProtectableForm ) {
 	if ( ! includes( formsChanged, form ) ) {
 		formsChanged.push( form );
 	}
 }
 
-function markSaved( form: any ) {
+function markSaved( form: ProtectableForm ) {
 	formsChanged = without( formsChanged, form );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Type `protect-form`, eliminates several TypeScript errors leaving only an error that `i18n-calypso` is untyped.

#### Testing instructions

* Check the job for reduced errors in `protect-form`: https://circleci.com/gh/Automattic/wp-calypso/282167