### PR TITLE
Reader: Add megaphone.fm to the list of trusted iframe sources

### DIFF
--- a/client/lib/post-normalizer/utils.js
+++ b/client/lib/post-normalizer/utils.js
@@ -179,6 +179,7 @@ export function iframeIsWhitelisted( iframe ) {
 		'embed.radiopublic.com',
 		'gfycat.com',
 		'scribd.com',
+		'megaphone.fm',
 	];
 	const hostName = iframe.src && url.parse( iframe.src ).hostname;
 	const iframeSrc = hostName && hostName.toLowerCase();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Allow megaphone.fm as an embeddable iframe

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load http://calypso.localhost:3000/read/feeds/40406696/posts/2270993281 and verify that the player's play button works

