### PR TITLE
Rewrite `afterLayoutFlush` as a generic TS function.

### DIFF
--- a/client/lib/after-layout-flush/index.ts
+++ b/client/lib/after-layout-flush/index.ts
@@ -4,6 +4,9 @@ interface Cancelable {
 	cancel: () => void;
 }
 
+// NodeJS and the browser have different return types for `setTimeout`.
+type TimeoutHandle = ReturnType< typeof setTimeout >;
+
 /**
  * Creates a delayed function that invokes `func` as soon as possible after the next layout
  * flush. At that time, it is very unlikely that the DOM has been written to since the last
@@ -19,9 +22,7 @@ interface Cancelable {
  * @returns The new delayed function
  */
 export default function afterLayoutFlush< T extends ( ...args: any[] ) => any >( func: T ) {
-	// NodeJS and the browser have different types for timeouts (NodeJS.Timeout vs number), so
-	// we can't type this variable, or it will cause typing errors with `clearTimeout` later.
-	let timeoutHandle: any = undefined;
+	let timeoutHandle: TimeoutHandle | undefined = undefined;
 	let rafHandle: number | undefined = undefined;
 
 	const hasRAF = typeof requestAnimationFrame === 'function';

--- a/client/lib/after-layout-flush/index.ts
+++ b/client/lib/after-layout-flush/index.ts
@@ -18,9 +18,7 @@ interface Cancelable {
  * @param func - The function to be invoked after the layout flush
  * @returns The new delayed function
  */
-export default function afterLayoutFlush< T extends ( ...args: any[] ) => any >(
-	func: T
-): T & Cancelable {
+export default function afterLayoutFlush< T extends ( ...args: any[] ) => any >( func: T ) {
 	// NodeJS and the browser have different types for timeouts (NodeJS.Timeout vs number), so
 	// we can't type this variable, or it will cause typing errors with `clearTimeout` later.
 	let timeoutHandle: any = undefined;

--- a/client/lib/after-layout-flush/index.ts
+++ b/client/lib/after-layout-flush/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable valid-jsdoc */
+
 interface Cancelable {
 	cancel: () => void;
 }
@@ -13,8 +15,8 @@ interface Cancelable {
  * Inspired by the Firefox performance best practices MDN article at:
  * https://developer.mozilla.org/en-US/Firefox/Performance_best_practices_for_Firefox_fe_engineers
  *
- * @param {Function} func The function to be invoked after the layout flush
- * @returns {Function} The new delayed function
+ * @param func - The function to be invoked after the layout flush
+ * @returns The new delayed function
  */
 export default function afterLayoutFlush< T extends ( ...args: any[] ) => any >(
 	func: T
@@ -100,3 +102,5 @@ export default function afterLayoutFlush< T extends ( ...args: any[] ) => any >(
 
 	return wrappedWithCancel;
 }
+
+/* eslint-enable valid-jsdoc */

--- a/client/lib/after-layout-flush/index.ts
+++ b/client/lib/after-layout-flush/index.ts
@@ -1,11 +1,13 @@
 /* eslint-disable valid-jsdoc */
 
+/**
+ * Internal dependencies
+ */
+import { TimerHandle } from 'types';
+
 interface Cancelable {
 	cancel: () => void;
 }
-
-// NodeJS and the browser have different return types for `setTimeout`.
-type TimeoutHandle = ReturnType< typeof setTimeout >;
 
 /**
  * Creates a delayed function that invokes `func` as soon as possible after the next layout
@@ -22,7 +24,7 @@ type TimeoutHandle = ReturnType< typeof setTimeout >;
  * @returns The new delayed function
  */
 export default function afterLayoutFlush< T extends ( ...args: any[] ) => any >( func: T ) {
-	let timeoutHandle: TimeoutHandle | undefined = undefined;
+	let timeoutHandle: TimerHandle | undefined = undefined;
 	let rafHandle: number | undefined = undefined;
 
 	const hasRAF = typeof requestAnimationFrame === 'function';

--- a/client/lib/after-layout-flush/index.ts
+++ b/client/lib/after-layout-flush/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable valid-jsdoc */
-
 /**
  * Internal dependencies
  */
@@ -103,5 +101,3 @@ export default function afterLayoutFlush< T extends ( ...args: any[] ) => any >(
 
 	return wrappedWithCancel;
 }
-
-/* eslint-enable valid-jsdoc */

--- a/client/types.ts
+++ b/client/types.ts
@@ -18,3 +18,8 @@ export type PostType = 'page' | 'post' | string;
 
 // Comment stuff
 export type CommentId = number;
+
+// Language stuff
+export type Lazy< T > = () => T;
+export type TimestampMS = ReturnType< typeof Date.now >;
+export type TimerHandle = ReturnType< typeof setTimeout >;


### PR DESCRIPTION
`afterLayoutFlush` now takes a function and returns a cancelable function of the same type. This is a stricter contract that helps avoid typing errors in consumers of this library.

This library seemed like a good opportunity to learn and test out more advanced TS concepts like generics, intersection types and union types.

#### Changes proposed in this Pull Request

* Rewrite afterLayoutFlush as a generic TypeScript function.

#### Testing instructions

There are very few actual code changes, with most of this PR being about types. The unit tests should be enough to ensure that the library continues working normally.