### PR TITLE
Domains: Close A/B test for different EN vendors

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -165,15 +165,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	domainSuggestionsEnCheck: {
-		datestamp: '20190415',
-		variations: {
-			control: 50,
-			test: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	conciergeUpsellDial: {
 		//this test is used to dial down the upsell offer
 		datestamp: '20190429',

--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -2,14 +2,10 @@
 /**
  * Internal dependencies
  */
-import { abtest, isUsingGivenLocales } from 'lib/abtest';
+import { isUsingGivenLocales } from 'lib/abtest';
 
 export const getSuggestionsVendor = () => {
 	if ( isUsingGivenLocales( [ 'en' ] ) ) {
-		if ( abtest( 'domainSuggestionsEnCheck' ) === 'test' ) {
-			return 'variation2_front';
-		}
-
 		return 'variation_front';
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Test concluded. Deploy a default variation.

#### Testing instructions

- Go to Domains -> Add
- Search for a domain
- Make sure the vendor is `variation_front`
- Try the same in signup