### PR TITLE
Plans: Force the wide plan selection on signup, tabbed /plans

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -54,7 +54,6 @@ import {
 	isJetpackSite,
 } from 'state/sites/selectors';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { isRequestingActivePromotions } from 'state/active-promotions/selectors';
 import {
 	isBestValue,
 	isMonthly,
@@ -103,25 +102,23 @@ export class PlanFeatures extends Component {
 					{ this.renderNotice() }
 					<div ref={ this.contentRef } className="plan-features__content">
 						{ mobileView }
-						{ ! this.props.isRequestingActivePromotions && (
-							<PlanFeaturesScroller
-								withScroll={ withScroll }
-								planCount={ planProperties.length }
-								cellSelector=".plan-features__table-item"
-								initialSelectedIndex={ initialSelectedIndex }
-							>
-								<table className={ tableClasses }>
-									<tbody>
-										<tr>{ this.renderPlanHeaders() }</tr>
-										{ ! withScroll && planDescriptions }
-										<tr>{ this.renderTopButtons() }</tr>
-										{ withScroll && planDescriptions }
-										{ this.renderPlanFeatureRows() }
-										{ ! withScroll && ! isInSignup && bottomButtons }
-									</tbody>
-								</table>
-							</PlanFeaturesScroller>
-						) }
+						<PlanFeaturesScroller
+							withScroll={ withScroll }
+							planCount={ planProperties.length }
+							cellSelector=".plan-features__table-item"
+							initialSelectedIndex={ initialSelectedIndex }
+						>
+							<table className={ tableClasses }>
+								<tbody>
+									<tr>{ this.renderPlanHeaders() }</tr>
+									{ ! withScroll && planDescriptions }
+									<tr>{ this.renderTopButtons() }</tr>
+									{ withScroll && planDescriptions }
+									{ this.renderPlanFeatureRows() }
+									{ ! withScroll && ! isInSignup && bottomButtons }
+								</tbody>
+							</table>
+						</PlanFeaturesScroller>
 					</div>
 				</div>
 			</div>
@@ -897,7 +894,6 @@ export default connect(
 			sitePlan,
 			siteType,
 			planCredits,
-			isRequestingActivePromotions: isRequestingActivePromotions( state ),
 			hasPlaceholders: hasPlaceholders( planProperties ),
 			showPlanCreditsApplied:
 				sitePlan &&

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -439,9 +439,7 @@ export default connect(
 			// pretty versatile, we could rename it from discounts to flags/features/anything else and make it more
 			// universal.
 			withWPPlanTabs: isDiscountActive( getDiscountByName( 'new_plans' ), state ),
-			plansWithScroll:
-				! props.displayJetpackPlans &&
-				isDiscountActive( getDiscountByName( 'plans_no_tabs' ), state ),
+			plansWithScroll: ! props.displayJetpackPlans && props.plansWithScroll,
 			customerType: guessCustomerType( state, props ),
 			domains: getDecoratedSiteDomains( state, siteId ),
 			isChatAvailable: isHappychatAvailable( state ),

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -107,6 +107,7 @@ class Plans extends React.Component {
 							selectedPlan={ this.props.selectedPlan }
 							withDiscount={ this.props.withDiscount }
 							site={ selectedSite }
+							plansWithScroll={ false }
 						/>
 					</div>
 				</Main>

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -75,13 +75,7 @@ export class PlansStep extends Component {
 	}
 
 	onSelectPlan = cartItem => {
-		const {
-			additionalStepData,
-			stepSectionName,
-			stepName,
-			flowName,
-			goToNextStep,
-		} = this.props;
+		const { additionalStepData, stepSectionName, stepName, flowName, goToNextStep } = this.props;
 
 		if ( cartItem ) {
 			analytics.tracks.recordEvent( 'calypso_signup_plan_select', {
@@ -173,6 +167,7 @@ export class PlansStep extends Component {
 					domainName={ this.getDomainName() }
 					customerType={ this.getCustomerType() }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
+					plansWithScroll={ true }
 				/>
 				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
 				 * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* https://trello.com/c/IjWqQIYa
* We are going to use the wide version of the plans selector during signup, but on `/plans` we are going to stick to the tabbed version.

#### Testing instructions

* Check out `/plans` on one of your sites, you should see the tabbed version
* From `/start` when you get to the plans selection step you should see the wide version.
