### PR TITLE
Full Site Editing: add security checks for WordPress.com

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -15,10 +15,28 @@ class A8C_Full_Site_Editing {
 		}
 		self::$initialized = true;
 
+		if( ! $this->is_full_site_editing_allowed() ) {
+			return;
+		}
+
 		add_action( 'init', array( $this, 'register_blocks' ), 100 );
 		add_action( 'init', array( $this, 'register_wp_template' ) );
 		add_action( 'rest_api_init', array( $this, 'allow_searching_for_templates' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script_and_style' ), 100 );
+	}
+
+	/**
+	 * Returns true if the current site is not VIP
+	 * and we are running on a WordPress.com sandbox and proxied.
+	 * Or, if WordPress is in debug mode, for a local development environment.
+	 */
+	function is_full_site_editing_allowed() {
+		return (
+				function_exists( 'wpcom_is_proxied_request' ) && wpcom_is_proxied_request()
+				&& function_exists( 'wpcom_is_vip' ) && ! wpcom_is_vip()
+				&& defined( 'WPCOM_SANDBOXED' ) && WPCOM_SANDBOXED
+				&& function_exists( 'has_blog_sticker' ) && has_blog_sticker( 'full-site-editing' )
+			) || ( defined( 'WP_DEBUG' ) && WP_DEBUG );
 	}
 
 	function register_wp_template() {


### PR DESCRIPTION
This PR adds rules to the Full Site Editing plugin's initialization so it can be safely deployed to WordPress.com without disrupting the service.
These are the checks:

- The WP-Admin interface and the Site's frontend has to be accessed using A8C proxy.
- The site loaded can't be a VIP on WordPress.com site.
- The code has to be executed on the WordPress.com sandbox.
- The `full-site-editing` sticker has to be present.

For a local development environment, the `WP_DEBUG` constant has to be defined as `true`.

| ![Invalid Post Type](https://user-images.githubusercontent.com/233601/57504797-4c450f80-72cc-11e9-8aa9-496b79363fe6.png) |
| - |
| CPT blocked page |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test this you'll have to:

- Load this branch on your development environment, with the `WP_DEBUG` constant defined as `true`.
- Sandbox `public-api.wordpress.com` and a WordPress.com site and a VIP test site.
- Build the code following [build instructions](https://github.com/Automattic/wp-calypso/tree/master/apps/full-site-editing).
- Upload the code to your WordPress.com sandbox `mu-plugins` folder.
- Create a `PHP` file on the `mu-plugins` folder to load the plugin. For example:
```php
<?php

require_once __DIR__ . '/full-site-editing/full-site-editing-plugin.php';
```

If you are not feeling adventurous, you just can use D28037-code that should take care of your sandbox for you.

Verify that:

* The local development environment is not blocking the `wp_template`.
* If you access a sandboxed site outside of A8C's proxy, using a VIP site, or with a sandboxed site without the `full-site-editing` sticker, the `CPT` is blocked.
* If the `CPT` is accessible, everything should work fine.
* The site's frontend should never be disrupted (we'll, not until we have a theme).

Part of #32796 
