### PR TITLE
Plans: make Jetpack Video feature card button update automatically in Calypso.

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -46,6 +46,7 @@ import JetpackWordPressCom from './jetpack-wordpress-com';
 import MobileApps from './mobile-apps';
 import SellOnlinePaypal from './sell-online-paypal';
 import SiteActivity from './site-activity';
+import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { isEnabled } from 'config';
 import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
@@ -57,6 +58,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 export class ProductPurchaseFeaturesList extends Component {
 	static propTypes = {
 		plan: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,
+		isVideoPressActive: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 	};
 
@@ -211,11 +213,13 @@ export class ProductPurchaseFeaturesList extends Component {
 	getJetpackPremiumFeatures() {
 		const {
 			isAutomatedTransfer,
+			isVideoPressActive,
 			isPlaceholder,
 			recordReturnToDashboardClick,
 			selectedSite,
 			supportsJetpackSiteAccelerator,
 		} = this.props;
+
 		return (
 			<Fragment>
 				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackBackupSecurity /> }
@@ -223,7 +227,7 @@ export class ProductPurchaseFeaturesList extends Component {
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
 				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackAntiSpam selectedSite={ selectedSite } /> }
-				<JetpackVideo selectedSite={ selectedSite } />
+				<JetpackVideo selectedSite={ selectedSite } isVideoPressActive={ isVideoPressActive } />
 				{ ! isEnabled( 'jetpack/checklist' ) && (
 					<JetpackWordPressCom selectedSite={ selectedSite } />
 				) }
@@ -287,11 +291,13 @@ export class ProductPurchaseFeaturesList extends Component {
 	getJetpackBusinessFeatures() {
 		const {
 			isAutomatedTransfer,
+			isVideoPressActive,
 			isPlaceholder,
 			selectedSite,
 			recordReturnToDashboardClick,
 			supportsJetpackSiteAccelerator,
 		} = this.props;
+
 		return (
 			<Fragment>
 				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackBackupSecurity /> }
@@ -301,7 +307,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ ! isEnabled( 'jetpack/checklist' ) && <JetpackAntiSpam selectedSite={ selectedSite } /> }
 				<JetpackSearch selectedSite={ selectedSite } />
 				<SiteActivity />
-				<JetpackVideo selectedSite={ selectedSite } />
+				<JetpackVideo selectedSite={ selectedSite } isVideoPressActive={ isVideoPressActive } />
 				{ ! isEnabled( 'jetpack/checklist' ) && (
 					<JetpackWordPressCom selectedSite={ selectedSite } />
 				) }
@@ -375,6 +381,7 @@ export default connect(
 
 		return {
 			isAutomatedTransfer,
+			isVideoPressActive: isJetpackModuleActive( state, selectedSiteId, 'videopress' ),
 			selectedSite,
 			planHasDomainCredit: hasDomainCredit( state, selectedSiteId ),
 			supportsJetpackSiteAccelerator:

--- a/client/blocks/product-purchase-features-list/jetpack-video.jsx
+++ b/client/blocks/product-purchase-features-list/jetpack-video.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import PurchaseDetail from 'components/purchase-detail';
 
-export default localize( ( { selectedSite, translate } ) => {
+export default localize( ( { isVideoPressActive, selectedSite, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
@@ -21,7 +21,7 @@ export default localize( ( { selectedSite, translate } ) => {
 				description={ translate(
 					'High-speed, high-definition video hosting with no third-party ads.'
 				) }
-				buttonText={ translate( 'Activate' ) }
+				buttonText={ isVideoPressActive ? translate( 'Active' ) : translate( 'Activate' ) }
 				href={ `/media/videos/${ selectedSite.slug }` }
 			/>
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

VideoPress module activation in wp-admin does not translate to the feature card in Calypso. Here, we make the CTA button "Responsive".



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* on a site with a Jetpack Premium plan or higher:
1. Go to `:site/wp-admin/admin.php?page=jetpack#/my-plan`
2. Activate 'video hosting'
3. Go to Settings-> Performance and validate whether the Video Toggle has been turned ON
4. Same as 3, but in Calypso
5. Also in Calypso go to `https://wordpress.com/plans/my-plan/:site` and verify that 
it CTA is active and hints to "Upload videos".

Fixes https://github.com/Automattic/jetpack/issues/12192
