### PR TITLE
Jetpack checklist: put more focus on checklist

### DIFF
--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -31,11 +31,13 @@ export function currentPlan( context, next ) {
 		return null;
 	}
 
-	context.primary = (
-		<CurrentPlan
-			path={ context.path }
-			requestThankYou={ context.query.hasOwnProperty( 'thank-you' ) }
-		/>
-	);
+	const requestThankYou = context.query.hasOwnProperty( 'thank-you' );
+
+	context.primary = <CurrentPlan path={ context.path } requestThankYou={ requestThankYou } />;
+
+	if ( requestThankYou ) {
+		context.secondary = null;
+	}
+
 	next();
 }

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import page from 'page';
 
@@ -11,8 +8,9 @@ import page from 'page';
  * Internal Dependencies
  */
 import CurrentPlan from './';
-import { isFreePlan } from 'lib/products-values';
 import { getSelectedSite } from 'state/ui/selectors';
+import { isFreePlan } from 'lib/products-values';
+import { setSection } from 'state/ui/actions';
 
 export function currentPlan( context, next ) {
 	const state = context.store.getState();
@@ -36,6 +34,7 @@ export function currentPlan( context, next ) {
 	context.primary = <CurrentPlan path={ context.path } requestThankYou={ requestThankYou } />;
 
 	if ( requestThankYou ) {
+		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 		context.secondary = null;
 	}
 

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -10,7 +10,6 @@ import page from 'page';
 import CurrentPlan from './';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isFreePlan } from 'lib/products-values';
-import { setSection } from 'state/ui/actions';
 
 export function currentPlan( context, next ) {
 	const state = context.store.getState();
@@ -34,7 +33,6 @@ export function currentPlan( context, next ) {
 	context.primary = <CurrentPlan path={ context.path } requestThankYou={ requestThankYou } />;
 
 	if ( requestThankYou ) {
-		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 		context.secondary = null;
 	}
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -21,6 +21,7 @@ import {
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import DocumentHead from 'components/data/document-head';
+import FeatureExample from 'components/feature-example';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import PlansNavigation from 'my-sites/plans/navigation';
 import ProductPurchaseFeaturesList from 'blocks/product-purchase-features-list';
@@ -156,7 +157,13 @@ class CurrentPlan extends Component {
 				{ showJetpackChecklist && (
 					<Fragment>
 						<QueryJetpackPlugins siteIds={ [ selectedSiteId ] } />
-						<JetpackChecklist />
+						{ showThankYou ? (
+							<FeatureExample role="presentation">
+								<JetpackChecklist />
+							</FeatureExample>
+						) : (
+							<JetpackChecklist />
+						) }
 					</Fragment>
 				) }
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -97,6 +97,7 @@ class CurrentPlan extends Component {
 			selectedSiteId,
 			shouldShowDomainWarnings,
 			showJetpackChecklist,
+			showThankYou,
 			translate,
 		} = this.props;
 
@@ -139,7 +140,7 @@ class CurrentPlan extends Component {
 					/>
 				) }
 
-				{ this.props.showThankYou ? (
+				{ showThankYou ? (
 					<CurrentPlanThankYouCard />
 				) : (
 					<CurrentPlanHeader
@@ -159,14 +160,18 @@ class CurrentPlan extends Component {
 					</Fragment>
 				) }
 
-				<div
-					className={ classNames( 'current-plan__header-text current-plan__text', {
-						'is-placeholder': { isLoading },
-					} ) }
-				>
-					<h1 className="current-plan__header-heading">{ planFeaturesHeader }</h1>
-				</div>
-				<ProductPurchaseFeaturesList plan={ currentPlanSlug } isPlaceholder={ isLoading } />
+				{ ! showThankYou && (
+					<Fragment>
+						<div
+							className={ classNames( 'current-plan__header-text current-plan__text', {
+								'is-placeholder': { isLoading },
+							} ) }
+						>
+							<h1 className="current-plan__header-heading">{ planFeaturesHeader }</h1>
+						</div>
+						<ProductPurchaseFeaturesList plan={ currentPlanSlug } isPlaceholder={ isLoading } />
+					</Fragment>
+				) }
 
 				<TrackComponentView eventName={ 'calypso_plans_my_plan_view' } />
 			</Main>

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -88,13 +88,13 @@ class CurrentPlan extends Component {
 
 	render() {
 		const {
-			selectedSite,
-			selectedSiteId,
-			domains,
 			currentPlan,
+			domains,
 			hasDomainsLoaded,
 			isExpiring,
 			path,
+			selectedSite,
+			selectedSiteId,
 			shouldShowDomainWarnings,
 			showJetpackChecklist,
 			translate,

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -33,6 +33,7 @@ import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackChecklist from 'my-sites/plans/current-plan/jetpack-checklist';
 import { isEnabled } from 'config';
@@ -122,7 +123,7 @@ class CurrentPlan extends Component {
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
-				<PlansNavigation path={ path } />
+				{ showThankYou ? <SectionNav /> : <PlansNavigation path={ path } /> }
 
 				{ showDomainWarnings && (
 					<DomainWarnings


### PR DESCRIPTION
Put more focus on "thank you" and the checklist when landing on Calypso-proper first time during Jetpack onboarding.

#### Changes proposed in this Pull Request
While "thank you" -component is visible:
* Hide "feature list"
* Make checklist less visible
* Hide sidebar & section navigation

![image](https://user-images.githubusercontent.com/87168/57622027-6bc28d80-7595-11e9-8b57-71cbf530012f.png)

Resolves https://github.com/Automattic/wp-calypso/issues/32171

#### TODO / can be done in follow up PRs
- Possibly add a `noGradient` to `FeatureExample` component or add a new component to hide content like in designs instead of using gradient fadeout (pending https://github.com/Automattic/wp-calypso/issues/32171#issuecomment-491333788)
- Improve mobile size

#### Testing instructions

Just to test how it looks like:
- Have a Jetpack site with a paid plan
- Open `http://calypso.localhost:3000/plans/my-plan/:YOUR_SITE?thank-you`

Test the flow
- Click through the flow, do you see thank you without all the surrounding UI but when clicking "hide message" or "continue", all that UI comes back?
- Test also free plan since it shouldn't direct you via "thank you" flow
- Test that non-Jetpack flows are unaffected
- Check that things look like expected on mobile, too.