### PR TITLE
Revert "PopoverMenu: remove action prop passed to PopoverMenuItem"

### DIFF
--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -4,6 +4,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { over } from 'lodash';
 
 /**
  * Internal dependencies
@@ -84,14 +85,15 @@ class PopoverMenu extends Component {
 			return child;
 		}
 
-		const { action, onClick } = child.props;
+		const boundOnClose = this._onClose.bind( this, child.props.action );
+		let onClick = boundOnClose;
+
+		if ( child.props.onClick ) {
+			onClick = over( [ child.props.onClick, boundOnClose ] );
+		}
 
 		return React.cloneElement( child, {
-			action: null,
-			onClick: () => {
-				onClick && onClick();
-				this._onClose( action );
-			},
+			onClick: onClick,
 		} );
 	};
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#32297

Currently on the Calypso media modal, the `PopoverMenu` items are broken with this error on the console when clicking on `WordPress library`, `Google Photos library` or `Free photo library`:

```
Uncaught TypeError: Cannot read property 'target' of undefined
    at eval (data-source.jsx:58)
    at onClick (menu.jsx:48)
    at HTMLUnknownElement.callCallback (react-dom.development.js:149)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:199)
    at invokeGuardedCallback (react-dom.development.js:256)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js:270)
    at executeDispatch (react-dom.development.js:561)
    at executeDispatchesInOrder (react-dom.development.js:583)
    at executeDispatchesAndRelease (react-dom.development.js:680)
    at executeDispatchesAndReleaseTopLevel (react-dom.development.js:688)
```

This PR reverts the changes made earlier.