### PR TITLE
PopoverMenu: remove action prop passed to PopoverMenuItem, take 2

### DIFF
--- a/client/components/popover/menu.jsx
+++ b/client/components/popover/menu.jsx
@@ -4,7 +4,6 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { over } from 'lodash';
 
 /**
  * Internal dependencies
@@ -85,15 +84,14 @@ class PopoverMenu extends Component {
 			return child;
 		}
 
-		const boundOnClose = this._onClose.bind( this, child.props.action );
-		let onClick = boundOnClose;
-
-		if ( child.props.onClick ) {
-			onClick = over( [ child.props.onClick, boundOnClose ] );
-		}
+		const { action, onClick } = child.props;
 
 		return React.cloneElement( child, {
-			onClick: onClick,
+			action: null,
+			onClick: () => {
+				onClick && onClick();
+				this._onClose( action );
+			},
 		} );
 	};
 

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -44,15 +44,9 @@ export class MediaLibraryDataSource extends Component {
 		this.setState( { popover: ! this.state.popover } );
 	};
 
-	changeSource = item => {
-		const { target } = item;
-		const action = target.getAttribute( 'action' )
-			? target.getAttribute( 'action' )
-			: target.parentNode.getAttribute( 'action' );
-		const newSource = action ? action : '';
-
-		if ( newSource !== this.props.source ) {
-			this.props.onSourceChange( newSource );
+	changeSource = item => () => {
+		if ( item !== this.props.source ) {
+			this.props.onSourceChange( item );
 		}
 	};
 
@@ -86,7 +80,7 @@ export class MediaLibraryDataSource extends Component {
 
 	renderMenuItems( sources ) {
 		return sources.map( ( { icon, label, value } ) => (
-			<PopoverMenuItem action={ value } key={ value } onClick={ this.changeSource }>
+			<PopoverMenuItem action={ value } key={ value } onClick={ this.changeSource( value ) }>
 				{ icon }
 				{ label }
 			</PopoverMenuItem>

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { find, includes } from 'lodash';
@@ -32,11 +32,7 @@ export class MediaLibraryDataSource extends Component {
 		disabledSources: [],
 	};
 
-	constructor( props ) {
-		super( props );
-
-		this.state = { popover: false };
-	}
+	state = { popover: false };
 
 	storeButtonRef = ref => ( this.buttonRef = ref );
 
@@ -44,9 +40,9 @@ export class MediaLibraryDataSource extends Component {
 		this.setState( { popover: ! this.state.popover } );
 	};
 
-	changeSource = item => () => {
-		if ( item !== this.props.source ) {
-			this.props.onSourceChange( item );
+	changeSource = source => () => {
+		if ( source !== this.props.source ) {
+			this.props.onSourceChange( source );
 		}
 	};
 
@@ -80,7 +76,7 @@ export class MediaLibraryDataSource extends Component {
 
 	renderMenuItems( sources ) {
 		return sources.map( ( { icon, label, value } ) => (
-			<PopoverMenuItem action={ value } key={ value } onClick={ this.changeSource( value ) }>
+			<PopoverMenuItem key={ value } onClick={ this.changeSource( value ) }>
 				{ icon }
 				{ label }
 			</PopoverMenuItem>
@@ -113,22 +109,19 @@ export class MediaLibraryDataSource extends Component {
 				>
 					{ currentSelected && currentSelected.icon }
 					{ this.renderScreenReader( currentSelected ) }
-
-					{ sources.length > 1 && (
-						<Fragment>
-							<Gridicon icon="chevron-down" size={ 18 } />
-							<PopoverMenu
-								context={ this.buttonRef }
-								isVisible={ this.state.popover }
-								position="bottom right"
-								onClose={ this.togglePopover }
-								className="is-dialog-visible media-library__header-popover"
-							>
-								{ this.renderMenuItems( sources ) }
-							</PopoverMenu>
-						</Fragment>
-					) }
+					<Gridicon icon="chevron-down" size={ 18 } />
 				</Button>
+				{ this.state.popover && (
+					<PopoverMenu
+						context={ this.buttonRef }
+						isVisible
+						position="bottom right"
+						onClose={ this.togglePopover }
+						className="is-dialog-visible media-library__header-popover"
+					>
+						{ this.renderMenuItems( sources ) }
+					</PopoverMenu>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -40,9 +40,9 @@ export class MediaLibraryDataSource extends Component {
 		this.setState( { popover: ! this.state.popover } );
 	};
 
-	changeSource = source => () => {
-		if ( source !== this.props.source ) {
-			this.props.onSourceChange( source );
+	changeSource = newSource => () => {
+		if ( newSource !== this.props.source ) {
+			this.props.onSourceChange( newSource );
 		}
 	};
 
@@ -76,7 +76,7 @@ export class MediaLibraryDataSource extends Component {
 
 	renderMenuItems( sources ) {
 		return sources.map( ( { icon, label, value } ) => (
-			<PopoverMenuItem key={ value } onClick={ this.changeSource( value ) }>
+			<PopoverMenuItem key={ value } data-source={ value } onClick={ this.changeSource( value ) }>
 				{ icon }
 				{ label }
 			</PopoverMenuItem>
@@ -111,10 +111,10 @@ export class MediaLibraryDataSource extends Component {
 					{ this.renderScreenReader( currentSelected ) }
 					<Gridicon icon="chevron-down" size={ 18 } />
 				</Button>
-				{ this.state.popover && (
+				{ sources.length > 1 && (
 					<PopoverMenu
 						context={ this.buttonRef }
-						isVisible
+						isVisible={ this.state.popover }
 						position="bottom right"
 						onClose={ this.togglePopover }
 						className="is-dialog-visible media-library__header-popover"

--- a/client/my-sites/media-library/test/data-source.jsx
+++ b/client/my-sites/media-library/test/data-source.jsx
@@ -40,8 +40,8 @@ describe( 'MediaLibraryDataSource', () => {
 					<MediaLibraryDataSource source={ '' } onSourceChange={ noop } />
 				</ReduxProvider>
 			);
-			expect( wrapper.find( 'button[action="google_photos"]' ) ).to.have.length( 1 );
-			expect( wrapper.find( 'button[action="pexels"]' ) ).to.have.length( 1 );
+			expect( wrapper.find( 'button[data-source="google_photos"]' ) ).to.have.length( 1 );
+			expect( wrapper.find( 'button[data-source="pexels"]' ) ).to.have.length( 1 );
 		} );
 
 		test( 'excludes data sources listed in disabledSources', () => {
@@ -55,8 +55,8 @@ describe( 'MediaLibraryDataSource', () => {
 					/>
 				</ReduxProvider>
 			);
-			expect( wrapper.find( 'button[action="google_photos"]' ) ).to.have.length( 1 );
-			expect( wrapper.find( 'button[action="pexels"]' ) ).to.have.length( 0 );
+			expect( wrapper.find( 'button[data-source="google_photos"]' ) ).to.have.length( 1 );
+			expect( wrapper.find( 'button[data-source="pexels"]' ) ).to.have.length( 0 );
 		} );
 	} );
 } );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#32960, which reverted https://github.com/Automattic/wp-calypso/pull/32297. See https://github.com/Automattic/wp-calypso/pull/32297 for details on what this does and why.

The original PR broke the Media Library data source picker, as that component relied on the non-standard `action` attribute being present on the DOM generated by `PopoverMenuItem`. We'd like to remove that attribute, as it's non-standard and it makes React unhappy. Two approaches to fixing it are included in this PR.

The first, smallest, option is in https://github.com/Automattic/wp-calypso/pull/32962/commits/8eb0ee0624a9314cf50fc4c0ce214e1e9f8db701. Instead of inspecting the DOM for an attribute, we bind the current item in the click callback, making it accessible via the closure. 

A second approach is presented in https://github.com/Automattic/wp-calypso/pull/32962/commits/bb9bb680c2dcfb08bcaf43383a65d7c58cbb0f4b. The data source component could access the action via `PopoverMenu`'s `onClose` handler instead. It's unclear from the popover API docs if this is an intended usage or just happenstance. From looking at other usage of popover, this doesn't seem to be a common practice; `onClose` is usually used simply to force the `isVisible` property of the popover to hidden. However, it does allow us to get rid of the binding in each PopoverMenuItem and is arguably even less complicated than the first solution. If adopt this, we should also update the docs to reflect that any action assigned to a PopoverMenuItem is passed to the menu's `onClose` handler.
