### PR TITLE
Domains: clean up search results styles

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -1,7 +1,7 @@
 .domain-product-price {
 	color: var( --color-text );
 	font-weight: 400;
-	font-size: 0.875em;
+	font-size: 14px;
 	line-height: 1;
 	display: flex;
 	flex-direction: column;
@@ -9,7 +9,7 @@
 
 	@include breakpoint( '>660px' ) {
 		align-items: flex-end;
-		font-size: 17px;
+		font-size: 16px;
 		padding-right: 2em;
 
 		.featured-domain-suggestions & {
@@ -47,11 +47,6 @@
 	.domain-product-price__price,
 	.domain-product-price__renewal-price {
 		margin: auto 0;
-		font-size: 0.9em;
-
-		@include breakpoint( '>480px' ) {
-			font-size: 1em;
-		}
 	}
 
 	&.is-free-domain,

--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -10,10 +10,21 @@
 	@include breakpoint( '>660px' ) {
 		align-items: flex-end;
 		font-size: 16px;
-		padding-right: 2em;
 
 		.featured-domain-suggestions & {
 			align-items: flex-start;
+		}
+	}
+
+	.is-section-signup & {
+		@include breakpoint( '>660px' ) {
+			padding-right: 2em;
+		}
+	}
+
+	.is-section-domains & {
+		@include breakpoint( '>800px' ) {
+			padding-right: 2em;
 		}
 	}
 

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -257,7 +257,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		if ( title ) {
 			return (
 				<div className="domain-registration-suggestion__progress-bar">
-					<ProgressBar { ...progressBarProps } />
+					<ProgressBar compact { ...progressBarProps } />
 					<span className="domain-registration-suggestion__progress-bar-text">{ title }</span>
 				</div>
 			);

--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -257,7 +257,7 @@ class DomainRegistrationSuggestion extends React.Component {
 		if ( title ) {
 			return (
 				<div className="domain-registration-suggestion__progress-bar">
-					<ProgressBar compact { ...progressBarProps } />
+					<ProgressBar { ...progressBarProps } />
 					<span className="domain-registration-suggestion__progress-bar-text">{ title }</span>
 				</div>
 			);

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -1,14 +1,13 @@
 .domain-suggestion {
-	box-sizing: border-box;
-
-	@include clear-fix;
+	display: flex;
+	flex-direction: column;
 
 	@include breakpoint( '>660px' ) {
 		padding: 15px 20px;
 	}
 
 	@include breakpoint( '>480px' ) {
-		display: flex;
+		flex-direction: row;
 		align-items: center;
 	}
 
@@ -140,13 +139,11 @@
 }
 
 .domain-registration-suggestion__title {
-	font-size: 1.3em;
+	font-size: 16px;
 
 	@include breakpoint( '>480px' ) {
 		align-self: center;
 		padding-right: 2em;
-		font-size: 1em;
-		line-height: 1.25;
 	}
 }
 
@@ -155,7 +152,6 @@
 	text-align: center;
 	margin-top: 0.5em;
 	padding: 0.25em 3em;
-	float: right;
 	transition: all 0.1s linear;
 
 	&.is-primary {
@@ -182,7 +178,6 @@
 
 	@include breakpoint( '>480px' ) {
 		flex: 1 0 auto;
-		float: none;
 		margin-left: 1em;
 		margin-top: 0;
 	}

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -173,6 +173,7 @@
 
 	&.is-borderless {
 		color: var( --color-primary );
+		margin-top: 0;
 		padding: 0;
 	}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -1,4 +1,4 @@
-.domain-suggestion {
+.domain-suggestion:not( .featured-domain-suggestion ) {
 	display: flex;
 	flex-direction: column;
 
@@ -6,9 +6,18 @@
 		padding: 15px 20px;
 	}
 
-	@include breakpoint( '>480px' ) {
-		flex-direction: row;
-		align-items: center;
+	.is-section-signup & {
+		@include breakpoint( '>480px' ) {
+			flex-direction: row;
+			align-items: center;
+		}
+	}
+
+	.is-section-domains & {
+		@include breakpoint( '>800px' ) {
+			flex-direction: row;
+			align-items: center;
+		}
 	}
 
 	&.is-clickable {
@@ -177,10 +186,20 @@
 		padding: 0;
 	}
 
-	@include breakpoint( '>480px' ) {
-		flex: 1 0 auto;
-		margin-left: 1em;
-		margin-top: 0;
+	.is-section-signup & {
+		@include breakpoint( '>480px' ) {
+			flex: 1 0 auto;
+			margin-left: 1em;
+			margin-top: 0;
+		}
+	}
+
+	.is-section-domains & {
+		@include breakpoint( '>800px' ) {
+			flex: 1 0 auto;
+			margin-left: 1em;
+			margin-top: 0;
+		}
 	}
 }
 
@@ -195,7 +214,15 @@
 		color: var( --color-neutral-0 );
 	}
 
-	@include breakpoint( '>480px' ) {
-		display: block;
+	.is-section-signup & {
+		@include breakpoint( '>480px' ) {
+			display: block;
+		}
+	}
+
+	.is-section-domains & {
+		@include breakpoint( '>800px' ) {
+			display: block;
+		}
 	}
 }

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -150,7 +150,7 @@
 .button.domain-suggestion__action {
 	min-width: 66px;
 	text-align: center;
-	margin-top: 0.5em;
+	margin-top: 16px;
 	padding: 0.25em 3em;
 	transition: all 0.1s linear;
 
@@ -173,7 +173,7 @@
 
 	&.is-borderless {
 		color: var( --color-primary );
-		padding: 0.25em;
+		padding: 0;
 	}
 
 	@include breakpoint( '>480px' ) {
@@ -184,6 +184,7 @@
 }
 
 .domain-suggestion__chevron {
+	display: none;
 	margin-left: 10px;
 	flex: 1 0 auto;
 	color: var( --color-neutral-light );
@@ -191,5 +192,9 @@
 	.is-placeholder & {
 		animation: loading-fade 1.6s ease-in-out infinite;
 		color: var( --color-neutral-0 );
+	}
+
+	@include breakpoint( '>480px' ) {
+		display: block;
 	}
 }

--- a/client/components/domains/domain-transfer-suggestion/style.scss
+++ b/client/components/domains/domain-transfer-suggestion/style.scss
@@ -8,9 +8,17 @@
 	  text-align: left;
 	  width: 100%;
 
-	  @include breakpoint( '>480px' ) {
-	  	width: auto;
-	  }
+	  .is-section-signup & {
+		  @include breakpoint( '>480px' ) {
+		  	width: auto;
+		  }
+		}
+
+		.is-section-domains & {
+			@include breakpoint( '>800px' ) {
+		  	width: auto;
+		  }
+		}
 	}
 }
 

--- a/client/components/domains/domain-transfer-suggestion/style.scss
+++ b/client/components/domains/domain-transfer-suggestion/style.scss
@@ -3,7 +3,14 @@
 	align-items: center;
 
 	& .button.domain-suggestion__action.is-borderless {
-	    flex: 1 0 auto;
+	  flex: 1 0 auto;
+	  font-size: 14px;
+	  text-align: left;
+	  width: 100%;
+
+	  @include breakpoint( '>480px' ) {
+	  	width: auto;
+	  }
 	}
 }
 
@@ -14,12 +21,14 @@
 		width: 75%;
 	}
 
+	h3 {
+		font-size: 16px;
+	}
+
 	> p {
 		color: var( --color-neutral-700 );
 		font-size: 12px;
-		font-weight: 600;
 		margin-bottom: 0;
-		opacity: 0.7;
 
 		@include breakpoint( '>960px' ) {
 			margin-bottom: 8px;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -23,7 +23,7 @@
 		min-width: 66px;
 		margin-top: 0.5em;
 		text-align: center;
-		padding: 0.25em 3em;
+		padding: 0.5em 3em;
 		float: right;
 		transition: all 0.1s linear;
 		width: 100%;
@@ -67,13 +67,13 @@
     }
 
     .domain-registration-suggestion__title {
-		font-size: 1.6em;
-		font-weight: 600;
+		font-size: 20px;
+		font-weight: 400;
 		line-height: 1.2;
 		margin-bottom: 0.25em;
 
 		@include breakpoint( '>480px' ) {
-			font-size: 2em;
+			font-size: 24px;
 			margin-bottom: 0.125em;
 		}
 	}
@@ -94,12 +94,13 @@
 	.domain-registration-suggestion__progress-bar {
 		align-items: center;
 		display: flex;
+		font-size: 12px;
+		margin-top: 16px;
 		order: 2;
 
 		.progress-bar {
 			width: 25%;
 			margin-right: 1em;
-			height: 10px;
 		}
 	}
 
@@ -109,6 +110,7 @@
 
 	.domain-registration-suggestion__match-reason {
 		color: var( --color-text-subtle );
+		font-size: 12px;
 		padding: 0.125em 0;
 		display: flex;
 		align-items: center;
@@ -129,7 +131,6 @@
 			align-self: flex-start;
 			margin-left: 0;
 			flex-grow: 0;
-			padding: 0.5em 3em;
 		}
 	}
 	&.is-unavailable {

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -1,5 +1,6 @@
 .featured-domain-suggestions {
 	display: flex;
+	flex-direction: column;
 
 	&.featured-domain-suggestions--has-match-reasons .featured-domain-suggestion {
 		.domain-registration-suggestion__match-reasons {
@@ -12,19 +13,32 @@
 			font-size: 16px;
 		}
 	}
+
+	.is-section-signup & {
+		@include breakpoint( '>480px' ) {
+			flex-direction: row;
+		}
+	}
+
+	.is-section-domains & {
+		@include breakpoint( '>800px' ) {
+			flex-direction: row;
+		}
+	}
 }
 
 .featured-domain-suggestion {
+	display: flex;
 	flex-direction: column;
+	justify-content: space-between;
 	margin-top: 0;
 	width: 100%;
 
 	.button.domain-suggestion__action {
-		min-width: 66px;
-		margin-top: 0.5em;
+		margin-left: 0;
+		margin-top: 1em;
 		text-align: center;
 		padding: 0.5em 3em;
-		float: right;
 		transition: all 0.1s linear;
 		width: 100%;
 
@@ -37,16 +51,11 @@
 			margin-left: 40px;
 			min-height: 26px;
 		}
-
-		@include breakpoint( '>480px' ) {
-			flex: 1 0 auto;
-			float: none;
-			margin-left: 1em;
-		}
 	}
 
 	.domain-suggestion__content {
 		display: flex;
+		flex-basis: 100%;
 		flex-direction: column;
 		justify-content: flex-start;
 		flex-grow: 2;
@@ -121,18 +130,6 @@
 		}
 	}
 
-	// .card increases specificity
-	&.card .domain-suggestion__action {
-		margin-top: 1em;
-
-		// Increase specificity
-		&.button {
-			width: 100%;
-			align-self: flex-start;
-			margin-left: 0;
-			flex-grow: 0;
-		}
-	}
 	&.is-unavailable {
 		.domain-registration-suggestion__progress-bar,
 		.domain-registration-suggestion__match-reasons {

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -100,6 +100,12 @@
 		}
 	}
 
+	.search-filters__tld-button {
+		font-size: 14px;
+		padding-top: 0.5em;
+		padding-bottom: 0.5em;
+	}
+
 	&.search-filters__tld-filter-bar--is-domain-management
 		.search-filters__tld-button:nth-child( n + 6 ) {
 		display: none;

--- a/client/components/domains/search-filters/style.scss
+++ b/client/components/domains/search-filters/style.scss
@@ -100,10 +100,14 @@
 		}
 	}
 
-	.search-filters__tld-button {
-		font-size: 14px;
-		padding-top: 0.5em;
-		padding-bottom: 0.5em;
+	// Increase specificity to override button styles in signup
+	body.is-section-signup .layout & {
+		button.search-filters__tld-button,
+		button.search-filters__popover-button {
+			font-size: 14px;
+			padding-top: 0.5em;
+			padding-bottom: 0.5em;
+		}
 	}
 
 	&.search-filters__tld-filter-bar--is-domain-management


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Tweaking some domain search results styles on mobile breakpoints
* Cleaning up some broken layouts on medium breakpoints in the domains section

**Mobile**

Before | After
------------ | -------------
![signup-mobile-before](https://user-images.githubusercontent.com/448298/57713428-75ed9600-7640-11e9-86f0-a7abf43f4bfc.png) | ![signup-mobile-after](https://user-images.githubusercontent.com/448298/57713434-78e88680-7640-11e9-8489-61bcdf75bb00.png)

**/domains/add**

Before | After
------------ | -------------
![domains-med-before](https://user-images.githubusercontent.com/448298/57713496-94ec2800-7640-11e9-9bd3-b49c4a85f6d0.png) | ![domains-med-after](https://user-images.githubusercontent.com/448298/57713501-99184580-7640-11e9-80c8-b6e23ab59665.png)



#### Testing instructions

* Checkout this branch locally or visit https://calypso.live/?branch=update/domain-search-mobile

Signup:
* Change your viewport to `<480px`
* Add a new site
* On the domain step, confirm it looks like the **After** screenshot above
* Make the viewport bigger to make sure nothing looks broken

/domains/add:
* Change your viewport to somewhere between `660px` and `800px`
* Visit `Manage > Domains` in the sidebar and click the `Add domain` button
* Search for a domain and confirm it looks like the **After** screenshot above
* Make the viewport bigger to make sure everything scales properly

Fixes #32523