### PR TITLE
Earn Page: Fix Blank Screen for Jetpack Sites

### DIFF
--- a/client/blocks/upgrade-nudge-expanded/index.jsx
+++ b/client/blocks/upgrade-nudge-expanded/index.jsx
@@ -54,18 +54,13 @@ class UpgradeNudgeExpanded extends Component {
 	}
 
 	render() {
-		//Display only if upgrade path available
-		if (
-			! this.props.currentPlan ||
-			( this.props.planConstants.availableFor &&
-				! this.props.planConstants.availableFor( this.props.currentPlan.product_slug ) )
-		) {
+		if ( ! this.props.currentPlan ) {
 			return null;
 		}
 
 		const price = formatCurrency( this.props.plan.raw_price / 12, this.props.plan.currency_code );
 		const features = this.props.planConstants
-			.getPromotedFeatures()
+			.getPlanCompareFeatures()
 			.filter( feature => feature !== this.props.highlightedFeature )
 			.slice( 0, 6 );
 

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -28,7 +28,7 @@ import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import QueryWordadsStatus from 'components/data/query-wordads-status';
 import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
-import { PLAN_PREMIUM, FEATURE_WORDADS_INSTANT } from 'lib/plans/constants';
+import { PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, FEATURE_WORDADS_INSTANT } from 'lib/plans/constants';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getSiteFragment } from 'lib/route';
 import { isSiteWordadsUnsafe } from 'state/wordads/status/selectors';
@@ -193,6 +193,25 @@ class AdsWrapper extends Component {
 		);
 	}
 
+
+	renderjetpackUpsell() {
+		const { translate } = this.props;
+		return (
+			<UpgradeNudgeExpanded
+				plan={ PLAN_JETPACK_PREMIUM }
+				title={ translate( 'Upgrade to the Premium plan and start earning' ) }
+				subtitle={ translate(
+					"By upgrading to the Premium plan, you'll be able to monetize your site through the Jetpack Ads program."
+				) }
+				highlightedFeature={ FEATURE_WORDADS_INSTANT }
+				benefits={ [
+					translate( 'Instantly enroll into the Jetpack Ads network.' ),
+					translate( 'Earn money from your content and traffic.' ),
+				] }
+			/>
+		);
+	}
+
 	render() {
 		const { site, translate } = this.props;
 		const jetpackPremium = site.jetpack && ( isPremium( site.plan ) || isBusiness( site.plan ) );
@@ -212,6 +231,8 @@ class AdsWrapper extends Component {
 			);
 		} else if ( ! site.options.wordads && isWordadsInstantActivationEligible( site ) ) {
 			component = this.renderInstantActivationToggle( component );
+		} else if ( canUpgradeToUseWordAds( site ) && site.jetpack  && ! jetpackPremium ) {
+			component = this.renderjetpackUpsell();
 		} else if ( canUpgradeToUseWordAds( site ) ) {
 			component = this.renderUpsell();
 		} else if ( ! ( site.options.wordads || jetpackPremium ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds an upsell for Jetpack sites with the Free/Personal Plan, preventing the blank screen that currently appears when someone visits it, leaving them with nothing to do. It also removes some of the unnecessary logic in the expanded upgrade nudge that was being problematic, as it's only used on the Earn page which displays something else if the user has the plan needed. 

#### Testing instructions

Currently, when you visit the Earn page (/earn) on a Jetpack site, you'll see this. 

<img width="862" alt="Screenshot_2019-05-11_at_14 32 22" src="https://user-images.githubusercontent.com/43215253/57570525-eacf8e80-73fa-11e9-8ee3-93215f1ae2bf.png">

Verify with this PR that you'll see this, but you'll still see the WordPress.com Premium Plan upgrade nudge if you visit that page with a WordPress.com site. 

<img width="836" alt="Screenshot_2019-05-11_at_14 30 08" src="https://user-images.githubusercontent.com/43215253/57570533-02a71280-73fb-11e9-8f87-977524ff9151.png">

Also confirm that with a Jetpack Premium Plan, this nudge doesn't appear. It shouldn't, but I don't have a plan to test, and this should definitely be confirmed first. 

cc @cphilleo, @artpi, @rclations
