### PR TITLE
Sidebar Banner: Remove Right Margin

### DIFF
--- a/client/my-sites/current-site/sidebar-banner/style.scss
+++ b/client/my-sites/current-site/sidebar-banner/style.scss
@@ -7,11 +7,7 @@
 		display: flex;
 
 		@include breakpoint( '<660px' ) {
-			padding: 0 24px;
-		}
-
-		@include breakpoint( '<960px' ) {
-			margin-right: 5px;
+			padding: 0 19px;
 		}
 
 		.sidebar-banner__icon-wrapper {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The right margin was added a year ago when "Upgrade" was a button (#23044), but it feels a bit odd and random now since it's no longer a button. This proposes removing the margin and slightly adjusting the padding to compensate. 

#### Testing instructions

**Before:**

<img width="359" alt="Screenshot_2019-05-11_at_20 08 01" src="https://user-images.githubusercontent.com/43215253/57574028-65af9e00-7429-11e9-86a8-1e0641bbb725.png">

**After:**

<img width="355" alt="Screenshot_2019-05-11_at_20 08 35" src="https://user-images.githubusercontent.com/43215253/57574033-6f390600-7429-11e9-8d17-6d956b038433.png">

Just something I noticed whilst looking at #32912 

(cc @drw158, @davemart-in, @shaunandrews) 