### PR TITLE
Earn Page: Fix Plan Icon not Fitting into Circle

### DIFF
--- a/client/blocks/upgrade-nudge-expanded/style.scss
+++ b/client/blocks/upgrade-nudge-expanded/style.scss
@@ -45,10 +45,8 @@
 	}
 
 	.upgrade-nudge-expanded__title-plan-icon {
-		width: 55px;
-		height: 55px;
-		margin: 1px;
-		background-repeat: no-repeat;
+		width: 56px;
+		height: 56px;
 	}
 
 	.upgrade-nudge-expanded__title-message {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes the plan icon fitting into the circle at `/earn`

#### Testing instructions

Visit the `/earn` page on a site without WordAds (it's the only place where this component is currently used), and zoom in a bit (you don't need to, it's still visible without zooming, it just makes it a bit easier to test).

**Current:**

<img width="1100" alt="Screenshot 2019-05-12 at 18 58 19" src="https://user-images.githubusercontent.com/43215253/57586103-c9e56700-74e8-11e9-8473-b04998462b62.png">

**Proposed:**

<img width="1092" alt="Screenshot 2019-05-12 at 18 58 48" src="https://user-images.githubusercontent.com/43215253/57586107-d49ffc00-74e8-11e9-83fc-593a50e947b3.png">

Also test it with #32970.

**Current:**

<img width="1099" alt="Screenshot 2019-05-12 at 18 56 11" src="https://user-images.githubusercontent.com/43215253/57586112-e8e3f900-74e8-11e9-8f04-162aceb4b392.png">
<img width="1087" alt="Screenshot 2019-05-12 at 18 58 09" src="https://user-images.githubusercontent.com/43215253/57586113-ed101680-74e8-11e9-903b-ed0a2e66b4bb.png">
<img width="709" alt="Screenshot 2019-05-12 at 19 00 25" src="https://user-images.githubusercontent.com/43215253/57586123-0618c780-74e9-11e9-840c-7e9416fa3cb4.png">


**Proposed:**

<img width="1086" alt="Screenshot 2019-05-12 at 18 56 42" src="https://user-images.githubusercontent.com/43215253/57586119-ff8a5000-74e8-11e9-849a-f0f3a9bf8c76.png">
<img width="1102" alt="Screenshot 2019-05-12 at 18 57 38" src="https://user-images.githubusercontent.com/43215253/57586120-ff8a5000-74e8-11e9-8d1e-85f47262f104.png">
<img width="710" alt="Screenshot 2019-05-12 at 18 59 48" src="https://user-images.githubusercontent.com/43215253/57586116-f7321500-74e8-11e9-9585-9e14e90d4ced.png">

cc @artpi, @rodrigoi, @blowery 
