### PR TITLE
Checkout: fix untranslated string

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-terms.jsx
+++ b/client/my-sites/checkout/checkout/checkout-terms.jsx
@@ -19,7 +19,11 @@ class CheckoutTerms extends React.Component {
 		return (
 			<Fragment>
 				<div className="checkout__terms">
-					<strong>By checking out:</strong>
+					<strong>
+						{ this.props.translate( 'By checking out:', {
+							comment: 'Headline before a list of terms the customer is agreeing to on checkout.',
+						} ) }
+					</strong>
 				</div>
 				<TermsOfService hasRenewableSubscription={ cartItems.hasRenewableSubscription( cart ) } />
 				<DomainRegistrationAgreement cart={ cart } />

--- a/client/my-sites/checkout/checkout/checkout-terms.jsx
+++ b/client/my-sites/checkout/checkout/checkout-terms.jsx
@@ -21,7 +21,8 @@ class CheckoutTerms extends React.Component {
 				<div className="checkout__terms">
 					<strong>
 						{ this.props.translate( 'By checking out:', {
-							comment: 'Headline before a list of terms the customer is agreeing to on checkout.',
+							comment:
+								'Headline before a list of terms the customer is agreeing to on checkout. Screenshot: https://user-images.githubusercontent.com/1379730/55166390-66c09080-5145-11e9-9c13-6c1b3b693786.png',
 						} ) }
 					</strong>
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap string in translation function

#### Testing instructions

* Verify that "By checking out:" is  displayed properly in checkout
* Check that string exists in calypso-strings.php after running `npm run translate`:
`cat calypso-strings.pot | grep "By checking out:" -B 3 -A 2` 
