### PR TITLE
[e2e] Change the way how we click on Password Protected option

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -200,9 +200,10 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 			this.driver,
 			By.css( '.edit-post-post-visibility__toggle' )
 		);
-		await driverHelper.clickWhenClickable(
+		await driverHelper.selectElementByText(
 			this.driver,
-			By.css( '.editor-post-visibility__dialog-radio[value="password"]' )
+			By.css( '.editor-post-visibility__dialog-label' ),
+			'Password Protected'
 		);
 		return await driverHelper.setWhenSettable(
 			this.driver,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change the way how we click on Password Protected option to avoid failures like [this](https://circleci.com/gh/Automattic/wp-calypso/284730). I reproduced it locally, but it doesn't happen every time. This fix is similar to https://github.com/Automattic/wp-calypso/pull/32900

#### Testing instructions

Make sure that `Password Protected Posts: @parallel` for Gutenberg editor is passing, both desktop and mobile. 