### PR TITLE
Marketing: Update social media logo

### DIFF
--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -71,7 +71,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 					description={ translate(
 						"Use your site's Publicize tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Twitter, Facebook, LinkedIn, and more."
 					) }
-					imagePath="/calypso/images/marketing/mailchimp-logo.svg"
+					imagePath="/calypso/images/marketing/social-media-logos.svg"
 				>
 					<Button compact onClick={ handleStartSharingClick }>
 						{ translate( 'Start Sharing' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes: https://github.com/Automattic/wp-calypso/issues/32767#issuecomment-491750716 as @stephanethomas pointed out.

Sharing card should be using the `/calypso/images/marketing/social-media-logos.svg` instead of `/calypso/images/marketing/mailchimp-logo.svg`

**Before:**
![Screenshot 2019-05-13 09 51 41](https://user-images.githubusercontent.com/4924246/57639427-c7285780-7564-11e9-8aff-6294bff284ce.png)

**After:**
![Screenshot 2019-05-13 09 51 31](https://user-images.githubusercontent.com/4924246/57639446-cdb6cf00-7564-11e9-9b42-705744b1c8cb.png)
