### PR TITLE
Checklist: Bypass inline help for 3 additional items

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -823,8 +823,10 @@ class WpcomChecklistComponent extends PureComponent {
 					},
 				] }
 				duration={ translate( '%d minute', '%d minutes', { count: 10, args: [ 10 ] } ) }
-				targetUrl={ taskUrls[ task.id ] }
-				onClick={ this.handleInlineHelpStart( task ) }
+				onClick={ this.handleTaskStart( {
+					task,
+					url: taskUrls[ task.id ],
+				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }
@@ -857,8 +859,10 @@ class WpcomChecklistComponent extends PureComponent {
 					},
 				] }
 				duration={ translate( '%d minute', '%d minutes', { count: 8, args: [ 8 ] } ) }
-				targetUrl={ taskUrls[ task.id ] }
-				onClick={ this.handleInlineHelpStart( task ) }
+				onClick={ this.handleTaskStart( {
+					task,
+					url: taskUrls[ task.id ],
+				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }
@@ -889,8 +893,10 @@ class WpcomChecklistComponent extends PureComponent {
 					},
 				] }
 				duration={ translate( '%d minute', '%d minutes', { count: 5, args: [ 5 ] } ) }
-				targetUrl={ taskUrls[ task.id ] }
-				onClick={ this.handleInlineHelpStart( task ) }
+				onClick={ this.handleTaskStart( {
+					task,
+					url: taskUrls[ task.id ],
+				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }


### PR DESCRIPTION
As @ramonjd [mentioned](https://github.com/Automattic/wp-calypso/pull/32782#pullrequestreview-234839559), these items should be updated alongside the the one changed in #32782:

- Change homepage photo
- Add business hours
- Add your services

There was also mention that these might be slated for removal -- let's discuss that here and come to a decision.

#### Changes proposed in this Pull Request

* Use `handleTaskStart` vs `handleInlineHelpStart` for the listed task items

#### Testing instructions

* Create a test site using the onboarding / business flow
* Visit the checklist for the site
* All items should take you to the appropriate location (Should be post editor for all 3 affected by this change)
* `calypso_checklist_task_start` tracks events should be emitted for these items.
