### PR TITLE
People: Only show the author selector if reassigning posts to a new author

### DIFF
--- a/client/my-sites/people/delete-user/index.jsx
+++ b/client/my-sites/people/delete-user/index.jsx
@@ -87,7 +87,11 @@ class DeleteUser extends React.Component {
 
 		updateObj[ name ] = value;
 
-		this.setState( { authorSelectorToggled: true } );
+		if ( event.currentTarget.value === 'reassign' ) {
+			this.setState( { authorSelectorToggled: true } );
+		} else {
+			this.setState( { authorSelectorToggled: false } );
+		}
 
 		this.setState( updateObj );
 		this.props.recordGoogleEvent( 'People', 'Selected Delete User Assignment', 'Assign', value );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Noticed while looking into another issue, the author selector dropdown appears even if you select "Delete all content created by X". We should only show the Author Selector drop-down menu if we're reassigning posts to the deleted author; otherwise it should stay hidden.

**Before**

<img width="738" alt="Screen Shot 2019-05-13 at 1 44 46 PM" src="https://user-images.githubusercontent.com/2124984/57642441-534a7700-7585-11e9-832f-5895ccf97cd4.png">

**After**

<img width="735" alt="Screen Shot 2019-05-13 at 1 45 02 PM" src="https://user-images.githubusercontent.com/2124984/57642450-59405800-7585-11e9-81bf-39177cf5917c.png">

#### Testing instructions

* Switch to this PR and navigate to `/people/team/[site]`
* Click on a user and look at the "Delete [User]" section at the bottom
* Check the "Delete all content created by X" checkbox. The Author Selector should not appear.
* Check "Attribute all content to a different user" and the Author Selector should appear.