### PR TITLE
GSuite: Move Skip button next to primary action button for better Muriel comp…

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-dialog/style.scss
+++ b/client/components/upgrades/gsuite/gsuite-dialog/style.scss
@@ -166,26 +166,26 @@
 }
 
 .gsuite-dialog__footer {
+
+	@include breakpoint( '>480px' ) {
+		display: flex;
+		justify-content: flex-end;
+	}
+
 	.gsuite-dialog__continue-button {
 		@include breakpoint( '<480px' ) {
 			width: 100%;
 			margin-top: 10px;
 		}
-
-		@include breakpoint( '>480px' ) {
-			float: right;
-		}
 	}
 
 	.gsuite-dialog__checkout-button {
 		color: var( --color-text-subtle );
+		margin-right: 10px;
 
 		@include breakpoint( '<480px' ) {
 			width: 100%;
-		}
-
-		@include breakpoint( '>480px' ) {
-			float: left;
+			margin-right: 0;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Move the Skip button next to the "Yes, Add Email" button for better alignment with Muriel guidelines.

**Before**

<img width="737" alt="Screen Shot 2019-05-13 at 2 27 13 PM" src="https://user-images.githubusercontent.com/2124984/57644953-387b0100-758b-11e9-907c-5feb0d93bc36.png">

**After**

<img width="748" alt="Screen Shot 2019-05-13 at 2 27 04 PM" src="https://user-images.githubusercontent.com/2124984/57644962-3ca71e80-758b-11e9-95e9-c91a50d484cf.png">

#### Testing instructions

* Switch to this PR and select a domain to add to your site under `/domains/add/`
* You'll be brought to the GSuite purchase flow. Note the placement of the buttons at the bottom of the screen.

Fixes #32519
