### PR TITLE
Fixes link on sharing card on marketing tools page

### DIFF
--- a/client/my-sites/marketing/paths.ts
+++ b/client/my-sites/marketing/paths.ts
@@ -1,7 +1,11 @@
-export const marketingTraffic = (siteSlug?: string | null ): string => {
+export const marketingConnections = ( siteSlug?: string | null ): string => {
+	return `/marketing/connections/${ siteSlug || '' }`;
+};
+
+export const marketingTraffic = ( siteSlug?: string | null ): string => {
 	return `/marketing/traffic/${ siteSlug || '' }`;
 };
 
-export const marketingSharingButtons = (siteSlug?: string | null ): string => {
+export const marketingSharingButtons = ( siteSlug?: string | null ): string => {
 	return `/marketing/sharing-buttons/${ siteSlug || '' }`;
 };

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -14,7 +14,7 @@ import { getSelectedSiteSlug } from 'state/ui/selectors';
 import MarketingToolsFeature from './feature';
 import MarketingToolsGoogleMyBusinessFeature from './google-my-business-feature';
 import MarketingToolsHeader from './header';
-import { marketingSharingButtons, marketingTraffic } from 'my-sites/marketing/paths';
+import { marketingConnections, marketingTraffic } from 'my-sites/marketing/paths';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
@@ -56,7 +56,7 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 	const handleStartSharingClick = () => {
 		recordTracksEvent( 'calypso_marketing_tools_start_sharing_button_click' );
 
-		page( marketingSharingButtons( selectedSiteSlug ) );
+		page( marketingConnections( selectedSiteSlug ) );
 	};
 
 	return (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates link for Sharing Card to go to social connections

#### Testing instructions

* Checkout branch
* Have a site
* Goto My Sites
* Tools->Marketing
* Look for the card titled: "Get social, and share your blog posts where the people are"
* Click the link
* Observe URL is: `http://calypso.localhost:3000/marketing/connections/{site}`

<img width="530" alt="Screen Shot 2019-05-13 at 2 31 59 PM" src="https://user-images.githubusercontent.com/6817400/57645268-e5ee1480-758b-11e9-807d-e6cb40a8e783.png">

