### PR TITLE
Gutenframe: Bump required JP version to v7.3.1.

### DIFF
--- a/client/state/selectors/is-gutenframe-enabled.js
+++ b/client/state/selectors/is-gutenframe-enabled.js
@@ -32,9 +32,9 @@ export const isGutenframeEnabled = ( state, siteId ) => {
 			return false;
 		}
 
-		// And also only if they have been updated to Jetpack 7.3 or greater since it will provide a way to handle the
+		// And also only if they have been updated to Jetpack 7.3.1 or greater since it will provide a way to handle the
 		// frame nonces verification.
-		if ( ! isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) ) {
+		if ( ! isJetpackMinimumVersion( state, siteId, '7.3.1-alpha' ) ) {
 			return false;
 		}
 

--- a/client/state/selectors/is-wp-admin-gutenberg-enabled.js
+++ b/client/state/selectors/is-wp-admin-gutenberg-enabled.js
@@ -33,13 +33,13 @@ export const isWpAdminGutenbergEnabled = ( state, siteId ) => {
 		}
 
 		// And not if the site is eligible for Gutenframe:
-		// - Updated to Jetpack 7.3 or greater in order to handle the frame nonces verification.
+		// - Updated to Jetpack 7.3.1 or greater in order to handle the frame nonces verification.
 		// - We are over a insecure HTTPS connection or the site has a SSL cert since the browser cannot embed insecure
 		//   content in a resource loaded over a secure HTTPS connection.
 		// - Not using any plugin that changes the block editor flows.
 		if (
 			isEnabled( 'jetpack/gutenframe' ) &&
-			isJetpackMinimumVersion( state, siteId, '7.3-alpha' ) &&
+			isJetpackMinimumVersion( state, siteId, '7.3.1-alpha' ) &&
 			( 'http:' === window.location.protocol || isHttps( getSiteAdminUrl( state, siteId ) ) ) &&
 			! isAnyPluginActive( state, siteId, deniedPluginsListForGutenberg )
 		) {


### PR DESCRIPTION
Bump required JP version to v7.3.1, allowing alphas for testing. This is so that needed fixes from the first launch with 7.3 are included in the user experience.

#### Testing instructions

* Load this branch in local dev.
* Verify a redirect happens instead of Gutenframe on your JP test site with v7.3.
* Apply the latest 7.3.1 version from the beta plugin to your JP test site.
* Verify Gutenframe works.

Fixes #32956 .
