### PR TITLE
Gutenframe: Don't hide admin notices on small sceeens

### DIFF
--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -6,7 +6,7 @@
 }
 
 @media ( min-width: 600px ) {
-	body.is-fullscreen-mode .edit-post-header {
+	body.is-iframed.is-fullscreen-mode .edit-post-header {
 		top: 0;
 	}
 }
@@ -30,7 +30,7 @@
 }
 
 @media ( min-width: 782px ) and ( max-width: 1079px ) {
-	.edit-post-layout.has-fixed-toolbar .components-notice {
+	.is-fullscreen-mode .edit-post-layout.has-fixed-toolbar .components-notice {
 		top: 37px;
 	}
 }

--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -29,6 +29,12 @@
 	}
 }
 
+@media ( min-width: 782px ) and ( max-width: 1079px ) {
+	.edit-post-layout.has-fixed-toolbar .components-notice {
+		top: 37px;
+	}
+}
+
 .components-notice-list {
 	z-index: 29; // Ensure notices are placed behind the editor header (z-index: 30).
 }

--- a/apps/wpcom-block-editor/src/common/style.scss
+++ b/apps/wpcom-block-editor/src/common/style.scss
@@ -1,3 +1,16 @@
+@media ( max-width: 600px ) {
+	// stylelint-disable-next-line selector-max-id
+	.is-iframed #wpbody {
+		padding-top: 0;
+	}
+}
+
+@media ( min-width: 600px ) {
+	body.is-fullscreen-mode .edit-post-header {
+		top: 0;
+	}
+}
+
 @media ( min-width: 782px ) {
 	.edit-post-layout__content {
 		position: fixed;
@@ -13,13 +26,6 @@
 	body.is-fullscreen-mode .edit-post-layout__content {
 		top: 56px;
 		position: fixed;
-	}
-}
-
-@media ( max-width: 600px ) {
-	// stylelint-disable-next-line selector-max-id
-	.is-iframed #wpbody {
-		padding-top: 0;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replicates Gutenberg Core's style for screen sizes 782px and up, since we continue to hide the toolbar in fullscreen mode, even on small screens.
* Adjusts positioning of notice on screen sizes between 782px and 1079px when Top Toolbar is enabled.
#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox widgets.wp.com and apply D28151-code.
* Publish or update a post to create an admin notice.
* Resize your browser window to between 600px and 782px wide.
* Verify admin notice is displayed fully.
* Activate Top Toolbar.
* Resize your browser window to between 782px and 1079px wide.
* Verify admin notice is displayed fully.

Fixes #32958
