### PR TITLE
Adjust header button so icon and text sit side by side

### DIFF
--- a/client/components/header-button/style.scss
+++ b/client/components/header-button/style.scss
@@ -3,7 +3,7 @@
 	border: none;
 	border-radius: 0;
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
 	font-weight: normal;
 	justify-content: center;
 	min-width: 140px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Changes header button from this:

https://www.dropbox.com/s/x48q1wlb9iwyrm2/Screenshot%202019-05-14%2012.17.10.png?dl=0

to this:

https://www.dropbox.com/s/twsz9iz3x9vie1i/Screenshot%202019-05-14%2012.17.55.png?dl=0

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit /plugins from your WP site.

View the "Upload Plugin" button on the top right of the main content.

Fixes: https://github.com/Automattic/wp-calypso/issues/32949
