### PR TITLE
Checklist: sorting checklist tasks

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -91,14 +91,9 @@
 
 .checklist__task {
 	width: 100%;
-	order: 100;
 
 	.hide-completed &.is-completed {
 		display: none;
-	}
-
-	&.is-completed {
-		order: 0;
 	}
 
 	&.card {

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, memoize, omit, pick, isBoolean } from 'lodash';
+import { get, memoize, omit, orderBy, pick, isBoolean } from 'lodash';
 import debugModule from 'debug';
 import config from 'config';
 
@@ -97,7 +97,7 @@ class WpcomTaskList {
 	}
 
 	getAll() {
-		return this.tasks;
+		return orderBy( this.tasks, [ 'isCompleted' ], [ 'desc' ] );
 	}
 
 	get( taskId ) {

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.js
@@ -47,8 +47,37 @@ export const JETPACK_CHECKLIST_TASKS = {
 		duration: getJetpackChecklistTaskDuration( 3 ),
 		tourId: 'jetpackSignIn',
 	},
+	jetpack_spam_filtering: {
+		title: translate( "We're automatically turning on spam filtering." ),
+		completedButtonText: translate( 'View spam stats' ),
+		completedTitle: translate( "We've automatically turned on spam filtering." ),
+		getUrl: siteSlug =>
+			`//${ siteSlug.replace( '::', '/' ) }/wp-admin/admin.php?page=akismet-key-config`,
+	},
+	jetpack_protect: {
+		title: translate( "We've automatically protected you from brute force login attacks." ),
+		completedButtonText: translate( 'Configure' ),
+		getUrl: siteSlug => `/settings/security/${ siteSlug }`,
+	},
+	jetpack_backups_rewind: {
+		title: translate( 'Backup and Scan' ),
+		description: translate(
+			"Connect your site's server to Jetpack to perform backups, restores, and security scans."
+		),
+		completedButtonText: translate( 'Change', { context: 'verb' } ),
+		completedTitle: translate( 'You turned on Backup and Scan.' ),
+		getUrl: siteSlug => `/settings/security/${ siteSlug }`,
+		duration: getJetpackChecklistTaskDuration( 3 ),
+	},
+	jetpack_backups_vaultpress: {
+		title: translate( "We're automatically turning on Backup and Scan." ),
+		completedTitle: translate( "We've automatically turned on Backup and Scan." ),
+		completedButtonText: translate( 'View security dashboard' ),
+		getUrl: () => 'https://dashboard.vaultpress.com',
+	},
 };
 
+/*
 export const JETPACK_CHECKLIST_TASK_AKISMET = {
 	title: translate( "We're automatically turning on spam filtering." ),
 	completedButtonText: translate( 'View spam stats' ),
@@ -80,3 +109,4 @@ export const JETPACK_CHECKLIST_TASK_BACKUPS_VAULTPRESS = {
 	completedButtonText: translate( 'View security dashboard' ),
 	getUrl: () => 'https://dashboard.vaultpress.com',
 };
+*/


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR resolves #32823 and intends to goes someway to resolve #30386 by creating a sortable task status collection for Jetpack tasks.

The intention is to ensure that the tasks are rendered in a meaningful order for accessibility and also for sanity.

WooCommerce tasks to come...

## Testing instructions

To come...

