### PR TITLE
Add the UI-only autorenewal toggle

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -308,7 +308,7 @@ class PurchaseMeta extends Component {
 	};
 
 	renderExpiration() {
-		const { purchase, translate, moment } = this.props;
+		const { purchase, translate } = this.props;
 
 		if ( isDomainTransfer( purchase ) ) {
 			return null;
@@ -324,12 +324,12 @@ class PurchaseMeta extends Component {
 			const subsBillingText = isAutorenewalEnabled
 				? translate( 'You will be billed on %(renewDate)s', {
 						args: {
-							renewDate: moment( purchase.renewDate ).format( 'LL' ),
+							renewDate: purchase.renewMoment.format( 'LL' ),
 						},
 				  } )
 				: translate( 'Expires on %(expireDate)s', {
 						args: {
-							expireDate: moment( purchase.expiryDate ).format( 'LL' ),
+							expireDate: purchase.expiryMoment.format( 'LL' ),
 						},
 				  } );
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -35,6 +35,7 @@ import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchas
 import { getSite, isRequestingSites } from 'state/sites/selectors';
 import { getUser } from 'state/users/selectors';
 import { managePurchase } from '../paths';
+import FormToggle from 'components/forms/form-toggle';
 import PaymentLogo from 'components/payment-logo';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import UserItem from 'components/user';
@@ -299,6 +300,13 @@ class PurchaseMeta extends Component {
 		);
 	}
 
+	onToggleAutorenewal = () => {
+		// TODO: send actual autorenewal enabling / disabling action here and show a pop-up notice
+		this.setState( {
+			isAutorenewalEnabled: ! this.state.isAutorenewalEnabled,
+		} );
+	};
+
 	renderExpiration() {
 		const { purchase, translate, moment } = this.props;
 
@@ -314,12 +322,12 @@ class PurchaseMeta extends Component {
 				? translate( 'Auto-renew is ON' )
 				: translate( 'Auto-renew is OFF' );
 			const subsBillingText = isAutorenewalEnabled
-				? translate( 'You will be billed on %{renewDate}s', {
+				? translate( 'You will be billed on %(renewDate)s', {
 						args: {
 							renewDate: moment( purchase.renewDate ).format( 'LL' ),
 						},
 				  } )
-				: translate( 'Expires on %{expireDate}s', {
+				: translate( 'Expires on %(expireDate)s', {
 						args: {
 							expireDate: moment( purchase.expiryDate ).format( 'LL' ),
 						},
@@ -328,8 +336,15 @@ class PurchaseMeta extends Component {
 			return (
 				<li>
 					<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
-					<p className="manage-purchase__detail">{ subsRenewText }</p>
-					<p className="manage-purchase__detail">{ subsBillingText }</p>
+					<span className="manage-purchase__detail">
+						{ subsRenewText }
+						<FormToggle
+							className="manage-purchase__detail-auto-renewal-toggle"
+							checked={ isAutorenewalEnabled }
+							onChange={ this.onToggleAutorenewal }
+						/>
+					</span>
+					<span className="manage-purchase__detail">{ subsBillingText }</span>
 				</li>
 			);
 		}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -28,7 +28,12 @@ import {
 	isSubscription,
 	paymentLogoType,
 } from 'lib/purchases';
-import { isDomainRegistration, isDomainTransfer, isConciergeSession } from 'lib/products-values';
+import {
+	isPlan,
+	isDomainRegistration,
+	isDomainTransfer,
+	isConciergeSession,
+} from 'lib/products-values';
 import { getPlan } from 'lib/plans';
 
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
@@ -314,7 +319,9 @@ class PurchaseMeta extends Component {
 			return null;
 		}
 
-		if ( config.isEnabled( 'autorenewal-toggle' ) && isSubscription( purchase ) ) {
+		// The toggle is only available for the plan subscription for now, and will be gradully rolled out to
+		// domains and G suite.
+		if ( config.isEnabled( 'autorenewal-toggle' ) && isPlan( purchase ) ) {
 			// TODO: remove this once the proper state has been introduced.
 			const { isAutorenewalEnabled } = this.state;
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -69,7 +69,9 @@ class PurchaseMeta extends Component {
 		if ( config.isEnabled( 'autorenewal-toggle' ) ) {
 			// TODO: remove this once the proper state has been introduced.
 			this.state = {
-				isAutorenewalEnabled: false,
+				...( config.isEnabled( 'autorenewal-toggle' ) && {
+					isAutorenewalEnabled: false,
+				} ),
 			};
 		}
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -332,18 +332,25 @@ class PurchaseMeta extends Component {
 			// TODO: remove this once the proper state has been introduced.
 			const { isAutorenewalEnabled } = this.state;
 
+			const dateSpan = <span className="manage-purchase__detail-date-span" />;
 			const subsRenewText = isAutorenewalEnabled
 				? translate( 'Auto-renew is ON' )
 				: translate( 'Auto-renew is OFF' );
 			const subsBillingText = isAutorenewalEnabled
-				? translate( 'You will be billed on %(renewDate)s', {
+				? translate( 'You will be billed on {{dateSpan}}%(renewDate)s{{/dateSpan}}', {
 						args: {
 							renewDate: purchase.renewMoment.format( 'LL' ),
 						},
+						components: {
+							dateSpan,
+						},
 				  } )
-				: translate( 'Expires on %(expireDate)s', {
+				: translate( 'Expires on {{dateSpan}}%(expireDate)s{{/dateSpan}}', {
 						args: {
 							expireDate: purchase.expiryMoment.format( 'LL' ),
+						},
+						components: {
+							dateSpan,
 						},
 				  } );
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -325,6 +325,7 @@ class PurchaseMeta extends Component {
 		// domains and G suite.
 		if (
 			config.isEnabled( 'autorenewal-toggle' ) &&
+			purchase.renewMoment &&
 			isPlan( purchase ) &&
 			! isExpired( purchase )
 		) {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -336,15 +336,11 @@ class PurchaseMeta extends Component {
 			return (
 				<li>
 					<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
-					<span className="manage-purchase__detail">
-						{ subsRenewText }
-						<FormToggle
-							className="manage-purchase__detail-auto-renewal-toggle"
-							checked={ isAutorenewalEnabled }
-							onChange={ this.onToggleAutorenewal }
-						/>
-					</span>
+					<span className="manage-purchase__detail">{ subsRenewText }</span>
 					<span className="manage-purchase__detail">{ subsBillingText }</span>
+					<span className="manage-purchase__detail">
+						<FormToggle checked={ isAutorenewalEnabled } onChange={ this.onToggleAutorenewal } />
+					</span>
 				</li>
 			);
 		}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -321,7 +321,11 @@ class PurchaseMeta extends Component {
 
 		// The toggle is only available for the plan subscription for now, and will be gradully rolled out to
 		// domains and G suite.
-		if ( config.isEnabled( 'autorenewal-toggle' ) && isPlan( purchase ) ) {
+		if (
+			config.isEnabled( 'autorenewal-toggle' ) &&
+			isPlan( purchase ) &&
+			! isExpired( purchase )
+		) {
 			// TODO: remove this once the proper state has been introduced.
 			const { isAutorenewalEnabled } = this.state;
 

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -63,18 +63,11 @@ class PurchaseMeta extends Component {
 		purchaseId: false,
 	};
 
-	constructor( props ) {
-		super( props );
-
-		if ( config.isEnabled( 'autorenewal-toggle' ) ) {
-			// TODO: remove this once the proper state has been introduced.
-			this.state = {
-				...( config.isEnabled( 'autorenewal-toggle' ) && {
-					isAutorenewalEnabled: false,
-				} ),
-			};
-		}
-	}
+	state = {
+		...( config.isEnabled( 'autorenewal-toggle' ) && {
+			isAutorenewalEnabled: false,
+		} ),
+	};
 
 	renderPrice() {
 		const { purchase, translate } = this.props;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -199,6 +199,10 @@
 			&:last-child {
 				padding-right: 0;
 			}
+			&:first-child:nth-last-child(4),
+			&:first-child:nth-last-child(4) ~ li {
+				  max-width: 25%;
+			}
 		}
 
 		+ li {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -292,3 +292,7 @@
 		padding: 16px 24px;
 	}
 }
+
+.manage-purchase__detail-date-span {
+	white-space: nowrap;
+}

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -236,10 +236,10 @@
 
 .manage-purchase__detail {
 	@include breakpoint( '<660px' ) {
-		display: block;
-		float: right;
 		text-align: right;
 	}
+
+	display: block;
 
 	.payment-logo {
 		margin-right: 5px;

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -199,8 +199,8 @@
 			&:last-child {
 				padding-right: 0;
 			}
-			&:first-child:nth-last-child(4),
-			&:first-child:nth-last-child(4) ~ li {
+			&:first-child:nth-last-child( 4 ),
+			&:first-child:nth-last-child( 4 ) ~ li {
 				  max-width: 25%;
 			}
 		}

--- a/config/development.json
+++ b/config/development.json
@@ -34,6 +34,7 @@
 	"features": {
 		"async-payments": true,
 		"account-recovery": true,
+		"autorenewal-toggle": true,
 		"ad-tracking": false,
 		"automated-transfer": true,
 		"apple-pay": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*This PR is part of the attempt of adding a self-serving plan subscription autorenewal toggle. For more details, please refer to p2-p9jf6J-1GZ*

This PR adds a UI-only autorenewal toggle under the purchase management page, according to @nodeone 's design:
![demo-renew-toggle](https://user-images.githubusercontent.com/1842898/57691287-64bf7c00-7676-11e9-9c4e-f1a0a6bf75ce.gif)

It is only enabled in the development environment through `autorenewal-toggle` feature flag. UI-only means that it does nothing for now. The actual functionalities will be wired in through the future PRs.

#### Testing instructions

Note that this is UI-only and is only enabled in the development environment.

* Log in as a user who has plan subscriptions and non-plan purchases
* Go to http://calypso.localhost:3000/me/purchases/
* Click on any plan subscriptions, see the toggle, and you should be able to toggle it as expected.
* Click on any non-plan purchases and there shouldn't be this toggle.