### PR TITLE
Progress bar component: improve accessibility

### DIFF
--- a/client/components/checklist/header.js
+++ b/client/components/checklist/header.js
@@ -33,11 +33,18 @@ export class ChecklistHeader extends PureComponent {
 		return (
 			<Card compact className="checklist__header">
 				<div className="checklist__header-main">
-					<div className="checklist__header-progress">
+					{ /* This is hidden from screen-readers because `ProgressBar` already announces same info. */ }
+					<div aria-hidden="true" className="checklist__header-progress">
 						<h2 className="checklist__header-progress-text">{ progressText }</h2>
 						<span className="checklist__header-progress-number">{ `${ completed }/${ total }` }</span>
 					</div>
-					<ProgressBar compact canGoBackwards total={ total } value={ completed } />
+					<ProgressBar
+						canGoBackwards
+						compact
+						title={ progressText }
+						total={ total }
+						value={ completed }
+					/>
 				</div>
 				<div className="checklist__header-secondary">
 					{ /* eslint-disable-next-line jsx-a11y/label-has-for */ }

--- a/client/components/progress-bar/index.jsx
+++ b/client/components/progress-bar/index.jsx
@@ -9,6 +9,11 @@ import React, { PureComponent } from 'react';
 import classnames from 'classnames';
 
 /**
+ * Internal dependencies
+ */
+import ScreenReaderText from 'components/screen-reader-text';
+
+/**
  * Style dependencies
  */
 import './style.scss';
@@ -66,11 +71,12 @@ export default class ProgressBar extends PureComponent {
 				aria-valuemax={ total }
 				aria-valuemin={ 0 }
 				aria-valuenow={ value }
-				aria-valuetext={ title || '' }
 				className="progress-bar__progress"
 				role="progressbar"
 				style={ styles }
-			/>
+			>
+				{ title && <ScreenReaderText>{ title }</ScreenReaderText> }
+			</div>
 		);
 	}
 

--- a/client/components/progress-bar/index.jsx
+++ b/client/components/progress-bar/index.jsx
@@ -9,11 +9,6 @@ import React, { PureComponent } from 'react';
 import classnames from 'classnames';
 
 /**
- * Internal dependencies
- */
-import ScreenReaderText from 'components/screen-reader-text';
-
-/**
  * Style dependencies
  */
 import './style.scss';
@@ -59,19 +54,23 @@ export default class ProgressBar extends PureComponent {
 	}
 
 	renderBar() {
-		const title = this.props.title ? (
-			<ScreenReaderText>{ this.props.title }</ScreenReaderText>
-		) : null;
+		const { color, title, total, value } = this.props;
 
 		const styles = { width: this.getCompletionPercentage() + '%' };
-		if ( this.props.color ) {
-			styles.backgroundColor = this.props.color;
+		if ( color ) {
+			styles.backgroundColor = color;
 		}
 
 		return (
-			<div className="progress-bar__progress" style={ styles }>
-				{ title }
-			</div>
+			<div
+				aria-valuemax={ total }
+				aria-valuemin="0"
+				aria-valuenow={ value }
+				aria-valuetext={ title }
+				className="progress-bar__progress"
+				role="progressbar"
+				style={ styles }
+			/>
 		);
 	}
 

--- a/client/components/progress-bar/index.jsx
+++ b/client/components/progress-bar/index.jsx
@@ -64,9 +64,9 @@ export default class ProgressBar extends PureComponent {
 		return (
 			<div
 				aria-valuemax={ total }
-				aria-valuemin="0"
+				aria-valuemin={ 0 }
 				aria-valuenow={ value }
-				aria-valuetext={ title }
+				aria-valuetext={ title || '' }
 				className="progress-bar__progress"
 				role="progressbar"
 				style={ styles }

--- a/client/components/progress-bar/style.scss
+++ b/client/components/progress-bar/style.scss
@@ -20,11 +20,13 @@
 	background-color: var( --color-primary );
 	border-radius: 4.5px;
 	transition: width 200ms;
+	@media ( prefers-reduced-motion: reduce ) {
+		transition: none;
+	}
 }
 
 .progress-bar.is-pulsing .progress-bar__progress {
 	animation: progress-bar-animation 3300ms infinite linear;
-
 	background-size: 50px 100%;
 	background-image: linear-gradient(
 		-45deg,
@@ -33,6 +35,10 @@
 		var( --color-primary-light ) 72%,
 		var( --color-primary ) 72%
 	);
+
+	@media ( prefers-reduced-motion: reduce ) {
+		animation: none;
+	}
 }
 
 @keyframes progress-bar-animation {

--- a/client/components/progress-bar/test/index.jsx
+++ b/client/components/progress-bar/test/index.jsx
@@ -19,9 +19,7 @@ describe( 'ProgressBar', () => {
 	test( 'should show the title', () => {
 		const progressBar = shallow( <ProgressBar value={ 20 } title="foo" /> );
 
-		expect( progressBar.find( '.progress-bar__progress' ).props()[ 'aria-valuetext' ] ).to.be.equal(
-			'foo'
-		);
+		expect( progressBar.find( '.progress-bar__progress' ).contains( 'foo' ) ).to.be.true;
 	} );
 
 	test( 'should add is-pulsing class when isPulsing property is true', () => {

--- a/client/components/progress-bar/test/index.jsx
+++ b/client/components/progress-bar/test/index.jsx
@@ -19,7 +19,9 @@ describe( 'ProgressBar', () => {
 	test( 'should show the title', () => {
 		const progressBar = shallow( <ProgressBar value={ 20 } title="foo" /> );
 
-		expect( progressBar.find( '.progress-bar__progress' ).contains( 'foo' ) ).to.be.true;
+		expect( progressBar.find( '.progress-bar__progress' ).props()[ 'aria-valuetext' ] ).to.be.equal(
+			'foo'
+		);
 	} );
 
 	test( 'should add is-pulsing class when isPulsing property is true', () => {
@@ -52,6 +54,14 @@ describe( 'ProgressBar', () => {
 		expect( progressBar.find( '.progress-bar__progress' ).props().style.width ).to.be.equal(
 			'50%'
 		);
+	} );
+
+	test( 'should have correct aria values', () => {
+		const progressBar = shallow( <ProgressBar value={ 20 } total={ 40 } /> );
+		const props = progressBar.find( '.progress-bar__progress' ).props();
+
+		expect( props[ 'aria-valuenow' ] ).to.be.equal( 20 );
+		expect( props[ 'aria-valuemax' ] ).to.be.equal( 40 );
 	} );
 
 	test( 'should have the color provided by the color property', () => {


### PR DESCRIPTION
Improve accessibility of the progress bar component.

#### Changes proposed in this Pull Request

- Add `aria-valuemax/valuemin/valuenow` attributes
- Add `role="progressbar"`
- Remove CSS animations and transition if user has changed browser setting to `prefers-reduced-motion: reduce`

Further reading:

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_progressbar_role
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion

#### Testing instructions

Either:
- Have a Jetpack site and open `http://calypso.localhost:3000/plans/my-plan/:site`
- Have a wpcom site and open `http://calypso.localhost:3000/checklist/:site` 

This bar:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/87168/57698071-56189b00-765d-11e9-8468-b17f098e967b.png">

Should produce this HTML:
```html
<div
  aria-valuemax="6"
  aria-valuemin="0"
  aria-valuenow="3"
  class="progress-bar__progress"
  role="progressbar"
  style="width: 50%;"
>
  <span class="screen-reader-text">Your Jetpack setup progress</span>
</div>
```

Here's how to test reduced motion setting: https://css-tricks.com/introduction-reduced-motion-media-query/#article-header-id-4 — supported by current Firefox, Safari and Chrome
