### PR TITLE
Signup Utils: inline mergeFormWithValue into the only usage place

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -16,6 +16,7 @@ import {
 	keys,
 	map,
 	mapKeys,
+	merge,
 	pick,
 	snakeCase,
 } from 'lodash';
@@ -49,7 +50,6 @@ import LoggedOutFormLinks from 'components/logged-out-form/links';
 import LoggedOutFormLinkItem from 'components/logged-out-form/link-item';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
 import LoggedOutFormFooter from 'components/logged-out-form/footer';
-import { mergeFormWithValue } from 'signup/utils';
 import CrowdsignalSignupForm from './crowdsignal';
 import SocialSignupForm from './social';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
@@ -132,11 +132,12 @@ class SignupForm extends Component {
 	}
 
 	autoFillUsername( form ) {
-		return mergeFormWithValue( {
-			form,
-			fieldName: 'username',
-			fieldValue: this.props.suggestedUsername || '',
-		} );
+		if ( formState.getFieldValue( form, 'username' ) ) {
+			return form;
+		}
+
+		const value = this.props.suggestedUsername || '';
+		return merge( form, { username: { value } } );
 	}
 
 	recordBackLinkClick = () => {

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -18,7 +18,6 @@ import {
 	getStepName,
 	getLocale,
 	getFlowName,
-	mergeFormWithValue,
 } from '../utils';
 import mockedFlows from './fixtures/flows';
 import flows from 'signup/config/flows';
@@ -219,27 +218,6 @@ describe( 'utils', () => {
 		test( 'should return null if the field is not present', () => {
 			delete signupProgress[ 1 ].site;
 			assert.equal( getValueFromProgressStore( config ), null );
-		} );
-	} );
-
-	describe( 'mergeFormWithValue', () => {
-		const config = {
-			fieldName: 'username',
-			fieldValue: 'calypso',
-		};
-
-		test( "should return the form with the field added if the field doesn't have a value", () => {
-			const form = { username: {} };
-			config.form = form;
-			assert.deepEqual( mergeFormWithValue( config ), {
-				username: { value: 'calypso' },
-			} );
-		} );
-
-		test( 'should return the form unchanged if there is already a value in the form', () => {
-			const form = { username: { value: 'wordpress' } };
-			config.form = form;
-			assert.equal( mergeFormWithValue( config ), form );
 		} );
 	} );
 } );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -2,7 +2,7 @@
 /**
  * Exernal dependencies
  */
-import { filter, find, includes, indexOf, isEmpty, merge, pick } from 'lodash';
+import { filter, find, includes, indexOf, isEmpty, pick } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -11,7 +11,6 @@ import { translate } from 'i18n-calypso';
 import { getLanguage } from 'lib/i18n-utils';
 import steps from 'signup/config/steps-pure';
 import flows from 'signup/config/flows';
-import formState from 'lib/form-state';
 import userFactory from 'lib/user';
 
 const user = userFactory();
@@ -121,15 +120,6 @@ export function getFlowPageTitle( flowName ) {
 export function getValueFromProgressStore( { signupProgress, stepName, fieldName } ) {
 	const siteStepProgress = find( signupProgress, step => step.stepName === stepName );
 	return siteStepProgress ? siteStepProgress[ fieldName ] : null;
-}
-
-export function mergeFormWithValue( { form, fieldName, fieldValue } ) {
-	if ( ! formState.getFieldValue( form, fieldName ) ) {
-		return merge( form, {
-			[ fieldName ]: { value: fieldValue },
-		} );
-	}
-	return form;
 }
 
 export function getDestination( destination, dependencies, flowName ) {


### PR DESCRIPTION
**The problem:**
The `blocks/signup-form` component imports the `signup/utils` module only to get the `mergeFormWithValue` utility function. The `signup/utils` module depends on many other signup stuff like the complete steps and flows definitions. Because the `signup-form` block is used at several other sections outside Signup (Accept Invite, Jetpack Connect), unnecessary code is dragged into these sections.

**The solution:**
The `mergeFormWithValue` function is ever used only once and can be easily inlined there. See the [ICFY report comment](https://github.com/Automattic/wp-calypso/pull/33019#issuecomment-492260703) to see the very nice impact on the affected sections.

**How to test:**
To trigger the execution of the affected code, do the following:
1. Go to `/start/delta-blog`, one of the few remaining flows that first select a `domain` and only then create an `user`.
2. When at the `user` step, verify that the username was pre-filled with a suggestion based on the domain name.
3. Change the suggested username to something else, and move focus away from the username field. The `blur` event will trigger a `saveSignupStep` action.
4. Reload the page. The flow is resumed at the `user` step. Verify that the `username` field contains the value you entered, not the domain-based suggestion.