### PR TITLE
Full Site Editing: Use JS to conditionally register FSE blocks

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/post-content/index.js
@@ -1,3 +1,4 @@
+/* global fullSiteEditing */
 /**
  * WordPress dependencies
  */
@@ -10,18 +11,20 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( 'a8c/post-content', {
-	title: __( 'Content Slot' ),
-	description: __( 'Placeholder for a post or a page.' ),
-	icon: 'layout',
-	category: 'layout',
-	supports: {
-		align: [ 'wide', 'full' ],
-		anchor: true,
-		html: false,
-		multiple: false,
-		reusable: false,
-	},
-	edit,
-	save: () => null,
-} );
+if ( 'wp_template' === fullSiteEditing.editorPostType ) {
+	registerBlockType( 'a8c/post-content', {
+		title: __( 'Content Slot' ),
+		description: __( 'Placeholder for a post or a page.' ),
+		icon: 'layout',
+		category: 'layout',
+		supports: {
+			align: [ 'wide', 'full' ],
+			anchor: true,
+			html: false,
+			multiple: false,
+			reusable: false,
+		},
+		edit,
+		save: () => null,
+	} );
+}

--- a/apps/full-site-editing/full-site-editing-plugin/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/blocks/template/index.js
@@ -1,3 +1,4 @@
+/* global fullSiteEditing */
 /**
  * WordPress dependencies
  */
@@ -10,21 +11,23 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( 'a8c/template', {
-	title: __( 'Template Part' ),
-	description: __( 'Display a template part.' ),
-	icon: 'layout',
-	category: 'layout',
-	attributes: {
-		selectedPostId: { type: 'number' },
-		selectedPostType: { type: 'string' },
-	},
-	supports: {
-		align: [ 'wide', 'full' ],
-		anchor: true,
-		html: false,
-		reusable: false,
-	},
-	edit,
-	save: () => null,
-} );
+if ( 'wp_template' === fullSiteEditing.editorPostType ) {
+	registerBlockType( 'a8c/template', {
+		title: __( 'Template Part' ),
+		description: __( 'Display a template part.' ),
+		icon: 'layout',
+		category: 'layout',
+		attributes: {
+			selectedPostId: { type: 'number' },
+			selectedPostType: { type: 'string' },
+		},
+		supports: {
+			align: [ 'wide', 'full' ],
+			anchor: true,
+			html: false,
+			reusable: false,
+		},
+		edit,
+		save: () => null,
+	} );
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -27,10 +27,6 @@ class A8C_Full_Site_Editing {
 	}
 
 	function enqueue_script_and_style() {
-		if ( 'wp_template' !== get_current_screen()->post_type ) {
-			return;
-		}
-
 		$script_dependencies = json_decode( file_get_contents(
 			plugin_dir_path( __FILE__ ) . 'dist/full-site-editing-plugin.deps.json'
 		), true );
@@ -41,6 +37,10 @@ class A8C_Full_Site_Editing {
 			filemtime( plugin_dir_path( __FILE__ ) . 'dist/full-site-editing-plugin.js' ),
 			true
 		);
+
+		wp_localize_script( 'a8c-full-site-editing-script', 'fullSiteEditing', array(
+			'editorPostType' => get_current_screen()->post_type,
+		) );
 
 		$style_file = is_rtl()
 			? 'full-site-editing-plugin.rtl.css'
@@ -55,7 +55,7 @@ class A8C_Full_Site_Editing {
 
 	function register_blocks() {
 		register_block_type( 'a8c/post-content', array(
-			'render_callback' => 'render_content_slot_block',
+			'render_callback' => 'render_post_content_block',
 		 ) );
 
 		register_block_type( 'a8c/template', array(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change how FSE blocks are conditionally registered.

Previously, the whole script was only enqueued when the editor post type was `wp_template`.
This is bad once we start adding to the script parts that are supposed to work in other screens too, like, for example, the Template Selector sidebar (see #32865).

This PR instead of killing the enqueue function when not editing `wp_template`, it uses `wp_localize_script` to add the post type slug as a JS global variable, that will be then checked on blocks registration.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the [FSE readme](https://github.com/Automattic/wp-calypso/blob/e759e056360b72576e124989c4174afef78bc1db/apps/full-site-editing/README.md#local-development); setup and enable the plugin.
* Create a Template and make sure you are able to insert a Template Part and a Content Slot block.
* Save and reload, and make sure they are rendered as expected.
* Create a Page or a Post, and make sure you cannot insert Template Part or Content Slot blocks.