### PR TITLE
Sidebar: Hide Manage Tab when Empty

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -873,7 +873,7 @@ export class MySitesSidebar extends Component {
 					{ this.activity() }
 				</ExpandableSidebarMenu>
 
-				{ configuration ? (
+				{ configuration && this.props.canUserManageOptions ? (
 					<ExpandableSidebarMenu
 						onClick={ this.props.toggleMySitesSidebarManageMenu }
 						expanded={ this.props.isManageOpen }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -873,7 +873,7 @@ export class MySitesSidebar extends Component {
 					{ this.activity() }
 				</ExpandableSidebarMenu>
 
-				{ configuration && this.upgrades() && this.users() && this.siteSettings() ? (
+				{ configuration && ( this.upgrades() || this.users() || this.siteSettings() ) ? (
 					<ExpandableSidebarMenu
 						onClick={ this.props.toggleMySitesSidebarManageMenu }
 						expanded={ this.props.isManageOpen }

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -873,7 +873,7 @@ export class MySitesSidebar extends Component {
 					{ this.activity() }
 				</ExpandableSidebarMenu>
 
-				{ configuration && this.props.canUserManageOptions ? (
+				{ configuration && this.upgrades() && this.users() && this.siteSettings() ? (
 					<ExpandableSidebarMenu
 						onClick={ this.props.toggleMySitesSidebarManageMenu }
 						expanded={ this.props.isManageOpen }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the Manage Tab doesn't have anything to display when opened, just don't display the tab. 

#### Testing instructions

Sign in to a site as an administrator and verify that the Manage option is still there. Now sign into one as an Editor (or any other role), where it's currently empty and verify it's not there. 

**Before, as a contributor:**

<img width="265" alt="Screenshot_2019-05-14_at_17 30 07" src="https://user-images.githubusercontent.com/43215253/57715662-28d4e880-766f-11e9-9b5d-e76b52d05fa5.png">

**After, as an non-admin:**

<img width="269" alt="Screenshot_2019-05-14_at_17 34 04" src="https://user-images.githubusercontent.com/43215253/57715687-37230480-766f-11e9-8aab-6708a8080ef9.png">

Fixes #33020 

cc @arunsathiya, @davemart-in, @griffbrad
