### PR TITLE
Marketing/Sharing Buttons: Added tracks event to sharing buttons preview

### DIFF
--- a/client/my-sites/marketing/buttons/appearance.jsx
+++ b/client/my-sites/marketing/buttons/appearance.jsx
@@ -19,7 +19,7 @@ import ButtonsStyle from './style';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import isPrivateSite from 'state/selectors/is-private-site';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
 class SharingButtonsAppearance extends Component {
 	static propTypes = {
@@ -56,19 +56,26 @@ class SharingButtonsAppearance extends Component {
 
 	onReblogsLikesCheckboxClicked = event => {
 		this.props.onChange( event.target.name, ! event.target.checked );
+		const checked = event.target.checked ? 1 : 0;
 		if ( 'disabled_reblogs' === event.target.name ) {
+			this.props.recordTracksEvent( 'calypso_sharing_buttons_show_reblog_checkbox_click', {
+				checked,
+			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
 				'Clicked Show Reblog Button Checkbox',
 				'checked',
-				event.target.checked ? 1 : 0
+				checked
 			);
 		} else if ( 'disabled_likes' === event.target.name ) {
+			this.props.recordTracksEvent( 'calypso_sharing_buttons_show_like_checkbox_click', {
+				checked,
+			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
 				'Clicked Show Like Button Checkbox',
 				'checked',
-				event.target.checked ? 1 : 0
+				checked
 			);
 		}
 	};
@@ -188,7 +195,7 @@ const connectComponent = connect(
 			isPrivate,
 		};
 	},
-	{ recordGoogleEvent }
+	{ recordGoogleEvent, recordTracksEvent }
 );
 
 export default flowRight(

--- a/client/my-sites/marketing/buttons/appearance.jsx
+++ b/client/my-sites/marketing/buttons/appearance.jsx
@@ -18,6 +18,7 @@ import ButtonsPreviewPlaceholder from './preview-placeholder';
 import ButtonsStyle from './style';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import isPrivateSite from 'state/selectors/is-private-site';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
@@ -56,10 +57,14 @@ class SharingButtonsAppearance extends Component {
 
 	onReblogsLikesCheckboxClicked = event => {
 		this.props.onChange( event.target.name, ! event.target.checked );
+
+		const { path } = this.props;
 		const checked = event.target.checked ? 1 : 0;
+
 		if ( 'disabled_reblogs' === event.target.name ) {
 			this.props.recordTracksEvent( 'calypso_sharing_buttons_show_reblog_checkbox_click', {
 				checked,
+				path,
 			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
@@ -70,6 +75,7 @@ class SharingButtonsAppearance extends Component {
 		} else if ( 'disabled_likes' === event.target.name ) {
 			this.props.recordTracksEvent( 'calypso_sharing_buttons_show_like_checkbox_click', {
 				checked,
+				path,
 			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
@@ -193,6 +199,7 @@ const connectComponent = connect(
 		return {
 			isJetpack,
 			isPrivate,
+			path: getCurrentRouteParameterized( state, siteId ),
 		};
 	},
 	{ recordGoogleEvent, recordTracksEvent }

--- a/client/my-sites/marketing/buttons/buttons.jsx
+++ b/client/my-sites/marketing/buttons/buttons.jsx
@@ -32,7 +32,7 @@ import isSavingSharingButtons from 'state/selectors/is-saving-sharing-buttons';
 import isSharingButtonsSaveSuccessful from 'state/selectors/is-sharing-buttons-save-successful';
 import { isJetpackSite } from 'state/sites/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import { successNotice, errorNotice } from 'state/notices/actions';
 import { activateModule } from 'state/jetpack/modules/actions';
 import { protectForm } from 'lib/protect-form';
@@ -64,6 +64,7 @@ class SharingButtons extends Component {
 		if ( this.state.buttonsPendingSave ) {
 			this.props.saveSharingButtons( this.props.siteId, this.state.buttonsPendingSave );
 		}
+		this.props.recordTracksEvent( 'calypso_sharing_buttons_save_changes_click' );
 		this.props.recordGoogleEvent( 'Sharing', 'Clicked Save Changes Button' );
 
 		if ( ! isJetpack || isLikesModuleActive !== false ) {
@@ -188,6 +189,7 @@ const connectComponent = connect(
 		activateModule,
 		errorNotice,
 		recordGoogleEvent,
+		recordTracksEvent,
 		saveSharingButtons,
 		saveSiteSettings,
 		successNotice,

--- a/client/my-sites/marketing/buttons/buttons.jsx
+++ b/client/my-sites/marketing/buttons/buttons.jsx
@@ -27,6 +27,7 @@ import {
 	isSavingSiteSettings,
 	isSiteSettingsSaveSuccessful,
 } from 'state/site-settings/selectors';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import getSharingButtons from 'state/selectors/get-sharing-buttons';
 import isSavingSharingButtons from 'state/selectors/is-saving-sharing-buttons';
 import isSharingButtonsSaveSuccessful from 'state/selectors/is-sharing-buttons-save-successful';
@@ -56,7 +57,7 @@ class SharingButtons extends Component {
 	};
 
 	saveChanges = event => {
-		const { isJetpack, isLikesModuleActive, siteId } = this.props;
+		const { isJetpack, isLikesModuleActive, siteId, path } = this.props;
 
 		event.preventDefault();
 
@@ -64,7 +65,7 @@ class SharingButtons extends Component {
 		if ( this.state.buttonsPendingSave ) {
 			this.props.saveSharingButtons( this.props.siteId, this.state.buttonsPendingSave );
 		}
-		this.props.recordTracksEvent( 'calypso_sharing_buttons_save_changes_click' );
+		this.props.recordTracksEvent( 'calypso_sharing_buttons_save_changes_click', { path } );
 		this.props.recordGoogleEvent( 'Sharing', 'Clicked Save Changes Button' );
 
 		if ( ! isJetpack || isLikesModuleActive !== false ) {
@@ -173,6 +174,7 @@ const connectComponent = connect(
 		const isSavingButtons = isSavingSharingButtons( state, siteId );
 		const isSaveSettingsSuccessful = isSiteSettingsSaveSuccessful( state, siteId );
 		const isSaveButtonsSuccessful = isSharingButtonsSaveSuccessful( state, siteId );
+		const path = getCurrentRouteParameterized( state, siteId );
 
 		return {
 			isJetpack,
@@ -183,6 +185,7 @@ const connectComponent = connect(
 			settings,
 			buttons,
 			siteId,
+			path,
 		};
 	},
 	{

--- a/client/my-sites/marketing/buttons/preview-button.jsx
+++ b/client/my-sites/marketing/buttons/preview-button.jsx
@@ -58,6 +58,10 @@ export default class SharingButtonsPreviewButton extends React.Component {
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 	onClick = () => {
+		analytics.tracks.recordEvent( 'calypso_sharing_buttons_share_button_click', {
+			service: this.props.button.ID,
+			enabled: ! this.props.enabled, // during onClick enabled is the old state, so negating gives the new state
+		} );
 		analytics.ga.recordEvent( 'Sharing', 'Clicked Share Button', this.props.button.ID );
 		this.props.onClick();
 	};

--- a/client/my-sites/marketing/buttons/preview-button.jsx
+++ b/client/my-sites/marketing/buttons/preview-button.jsx
@@ -4,6 +4,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 import photon from 'photon';
 
@@ -11,15 +12,18 @@ import photon from 'photon';
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import SocialLogo from 'components/social-logo';
 
-export default class SharingButtonsPreviewButton extends React.Component {
+class SharingButtonsPreviewButton extends React.Component {
 	static propTypes = {
 		button: PropTypes.object.isRequired,
 		style: PropTypes.oneOf( [ 'icon-text', 'icon', 'text', 'official' ] ),
 		enabled: PropTypes.bool,
 		onMouseOver: PropTypes.func,
 		onClick: PropTypes.func,
+		path: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -61,6 +65,7 @@ export default class SharingButtonsPreviewButton extends React.Component {
 		analytics.tracks.recordEvent( 'calypso_sharing_buttons_share_button_click', {
 			service: this.props.button.ID,
 			enabled: ! this.props.enabled, // during onClick enabled is the old state, so negating gives the new state
+			path: this.props.path,
 		} );
 		analytics.ga.recordEvent( 'Sharing', 'Clicked Share Button', this.props.button.ID );
 		this.props.onClick();
@@ -93,3 +98,9 @@ export default class SharingButtonsPreviewButton extends React.Component {
 	}
 	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
+
+export default connect( state => {
+	return {
+		path: getCurrentRouteParameterized( state, getSelectedSiteId( state ) ),
+	};
+} )( SharingButtonsPreviewButton );

--- a/client/my-sites/marketing/buttons/preview.jsx
+++ b/client/my-sites/marketing/buttons/preview.jsx
@@ -8,6 +8,7 @@ import { filter, some } from 'lodash';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 
 /**
@@ -19,6 +20,8 @@ import ButtonsPreviewAction from './preview-action';
 import ButtonsTray from './tray';
 import { decodeEntities } from 'lib/formatting';
 import analytics from 'lib/analytics';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 class SharingButtonsPreview extends React.Component {
 	static displayName = 'SharingButtonsPreview';
@@ -49,30 +52,36 @@ class SharingButtonsPreview extends React.Component {
 	};
 
 	toggleEditLabel = () => {
+		const { path } = this.props;
+
 		const isEditingLabel = ! this.state.isEditingLabel;
 		this.setState( { isEditingLabel: isEditingLabel } );
 
 		if ( isEditingLabel ) {
 			this.hideButtonsTray();
-			analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_text_click' );
+			analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_text_click', { path } );
 			analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Text Link' );
 		} else {
-			analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_text_close_click' );
+			analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_text_close_click', { path } );
 			analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Text Done Button' );
 		}
 	};
 
 	showButtonsTray = visibility => {
+		const { path } = this.props;
+
 		this.setState( {
 			isEditingLabel: false,
 			buttonsTrayVisibility: visibility,
 		} );
 
-		analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_buttons_click' );
+		analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_buttons_click', { path } );
 		analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Buttons Links', visibility );
 	};
 
 	hideButtonsTray = () => {
+		const { path } = this.props;
+
 		if ( ! this.state.buttonsTrayVisibility ) {
 			return;
 		}
@@ -80,7 +89,7 @@ class SharingButtonsPreview extends React.Component {
 		// Hide button tray by resetting state to default
 		this.setState( { buttonsTrayVisibility: null } );
 
-		analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_buttons_close_click' );
+		analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_buttons_close_click', { path } );
 		analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Buttons Done Button' );
 	};
 
@@ -234,4 +243,6 @@ class SharingButtonsPreview extends React.Component {
 	}
 }
 
-export default localize( SharingButtonsPreview );
+export default connect( state => {
+	return { path: getCurrentRouteParameterized( state, getSelectedSiteId( state ) ) };
+} )( localize( SharingButtonsPreview ) );

--- a/client/my-sites/marketing/buttons/preview.jsx
+++ b/client/my-sites/marketing/buttons/preview.jsx
@@ -54,8 +54,10 @@ class SharingButtonsPreview extends React.Component {
 
 		if ( isEditingLabel ) {
 			this.hideButtonsTray();
+			analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_text_click' );
 			analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Text Link' );
 		} else {
+			analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_text_close_click' );
 			analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Text Done Button' );
 		}
 	};
@@ -66,6 +68,7 @@ class SharingButtonsPreview extends React.Component {
 			buttonsTrayVisibility: visibility,
 		} );
 
+		analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_buttons_click' );
 		analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Buttons Links', visibility );
 	};
 
@@ -77,6 +80,7 @@ class SharingButtonsPreview extends React.Component {
 		// Hide button tray by resetting state to default
 		this.setState( { buttonsTrayVisibility: null } );
 
+		analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_buttons_close_click' );
 		analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Buttons Done Button' );
 	};
 

--- a/client/my-sites/marketing/buttons/style.jsx
+++ b/client/my-sites/marketing/buttons/style.jsx
@@ -29,6 +29,7 @@ class SharingButtonsStyle extends React.Component {
 
 	onChange = value => {
 		this.props.onChange( value );
+		analytics.tracks.recordEvent( 'calypso_sharing_buttons_style_radio_button_click', { value } );
 		analytics.ga.recordEvent( 'Sharing', 'Clicked Button Style Radio Button', value );
 	};
 

--- a/client/my-sites/marketing/buttons/style.jsx
+++ b/client/my-sites/marketing/buttons/style.jsx
@@ -7,11 +7,14 @@
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
 import analytics from 'lib/analytics';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 class SharingButtonsStyle extends React.Component {
 	static displayName = 'SharingButtonsStyle';
@@ -28,8 +31,13 @@ class SharingButtonsStyle extends React.Component {
 	};
 
 	onChange = value => {
+		const { path } = this.props;
+
 		this.props.onChange( value );
-		analytics.tracks.recordEvent( 'calypso_sharing_buttons_style_radio_button_click', { value } );
+		analytics.tracks.recordEvent( 'calypso_sharing_buttons_style_radio_button_click', {
+			value,
+			path,
+		} );
 		analytics.ga.recordEvent( 'Sharing', 'Clicked Button Style Radio Button', value );
 	};
 
@@ -89,4 +97,6 @@ class SharingButtonsStyle extends React.Component {
 	}
 }
 
-export default localize( SharingButtonsStyle );
+export default connect( state => {
+	return { path: getCurrentRouteParameterized( state, getSelectedSiteId( state ) ) };
+} )( localize( SharingButtonsStyle ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds Tracks events to the sharing buttons preview in the Marketing section.

#### Testing instructions

1. Check out this branch and `npm run build`.
2. On a non-jetpack wordpress.com site, go to `marketing/sharing-buttons/:site`.
3. Ensure that analytics debugging is activated by running this in the browser console and refreshing browser: `localStorage.setItem('debug', 'calypso:analytics:*');`
4. Click "Edit label text". Verify that the correct tracks event is fired.
5. Click "Close". Verify that the correct tracks event is fired.
6. Click either "Add sharing buttons" or "Add More button". Verify that the correct tracks event is fired.
7. Click one of the sharing services. Verify that the correct tracks event is fired with the correct `service` and `enabled` props.
8. Click "Close". Verify that the correct tracks event is fired.
9. Change the button style. Verify that the correct tracks event is fired with the correct `value` prop.
10. Toggle both the "show reblog" and "show like" checkboxes. Verify that correct tracks events are fired with the correct `checked` prop.
11. Click "Save Changes" under the sharing buttons preview. Verify that the correct tracks event is fired.
