### PR TITLE
Marketing/Sharing Buttons: Added tracks event to sharing buttons options

### DIFF
--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -21,7 +21,7 @@ import { getSiteSettings } from 'state/site-settings/selectors';
 import getSharingButtons from 'state/selectors/get-sharing-buttons';
 import { isJetpackSite, isJetpackMinimumVersion, getSiteAdminUrl } from 'state/sites/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
-import { recordGoogleEvent } from 'state/analytics/actions';
+import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
@@ -52,6 +52,7 @@ class SharingButtonsOptions extends Component {
 	}
 
 	trackTwitterViaAnalyticsEvent = () => {
+		this.props.recordTracksEvent( 'calypso_sharing_buttons_twitter_username_field_focused' );
 		this.props.recordGoogleEvent( 'Sharing', 'Focussed Twitter Username Field' );
 	};
 
@@ -287,7 +288,7 @@ const connectComponent = connect(
 			siteId,
 		};
 	},
-	{ recordGoogleEvent }
+	{ recordGoogleEvent, recordTracksEvent }
 );
 
 export default flowRight(

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -18,6 +18,7 @@ import MultiCheckbox from 'components/forms/multi-checkbox';
 import { getPostTypes } from 'state/post-types/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSettings } from 'state/site-settings/selectors';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import getSharingButtons from 'state/selectors/get-sharing-buttons';
 import { isJetpackSite, isJetpackMinimumVersion, getSiteAdminUrl } from 'state/sites/selectors';
 import QueryPostTypes from 'components/data/query-post-types';
@@ -52,11 +53,15 @@ class SharingButtonsOptions extends Component {
 	}
 
 	trackTwitterViaAnalyticsEvent = () => {
-		this.props.recordTracksEvent( 'calypso_sharing_buttons_twitter_username_field_focused' );
+		const { path } = this.props;
+		this.props.recordTracksEvent( 'calypso_sharing_buttons_twitter_username_field_focused', {
+			path,
+		} );
 		this.props.recordGoogleEvent( 'Sharing', 'Focussed Twitter Username Field' );
 	};
 
 	handleMultiCheckboxChange = ( name, event ) => {
+		const { path } = this.props;
 		const delta = xor( this.props.settings.sharing_show, event.value );
 		this.props.onChange( name, event.value );
 		if ( delta.length ) {
@@ -64,6 +69,7 @@ class SharingButtonsOptions extends Component {
 			this.props.recordTracksEvent( 'calypso_sharing_buttons_show_buttons_on_page_click', {
 				page: delta[ 0 ],
 				checked,
+				path,
 			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
@@ -82,6 +88,8 @@ class SharingButtonsOptions extends Component {
 	};
 
 	handleChange = event => {
+		const { path } = this.props;
+
 		let value;
 		if ( 'checkbox' === event.target.type ) {
 			value = event.target.checked;
@@ -93,6 +101,7 @@ class SharingButtonsOptions extends Component {
 			const checked = event.target.checked ? 1 : 0;
 			this.props.recordTracksEvent( 'calypso_sharing_buttons_likes_on_for_all_posts_click', {
 				checked,
+				path,
 			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
@@ -282,6 +291,7 @@ const connectComponent = connect(
 		const isTwitterButtonAllowed =
 			! isJetpack || isJetpackMinimumVersion( state, siteId, '3.4-dev' );
 		const isSharingShowAllowed = ! isJetpack || isJetpackMinimumVersion( state, siteId, '7.3' );
+		const path = getCurrentRouteParameterized( state, siteId );
 
 		const postTypes = filter( values( getPostTypes( state, siteId ) ), 'public' );
 
@@ -294,6 +304,7 @@ const connectComponent = connect(
 			postTypes,
 			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 			siteId,
+			path,
 		};
 	},
 	{ recordGoogleEvent, recordTracksEvent }

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -301,10 +301,10 @@ const connectComponent = connect(
 			isJetpack,
 			isSharingShowAllowed,
 			isTwitterButtonAllowed,
+			path,
 			postTypes,
 			siteAdminUrl: getSiteAdminUrl( state, siteId ),
 			siteId,
-			path,
 		};
 	},
 	{ recordGoogleEvent, recordTracksEvent }

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -90,11 +90,15 @@ class SharingButtonsOptions extends Component {
 		}
 
 		if ( 'jetpack_comment_likes_enabled' === event.target.name ) {
+			const checked = event.target.checked ? 1 : 0;
+			this.props.recordTracksEvent( 'calypso_sharing_buttons_likes_on_for_all_posts_click', {
+				checked,
+			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
 				'Clicked Comment Likes On For All Posts Checkbox',
 				'checked',
-				event.target.checked ? 1 : 0
+				checked
 			);
 		}
 

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -60,12 +60,16 @@ class SharingButtonsOptions extends Component {
 		const delta = xor( this.props.settings.sharing_show, event.value );
 		this.props.onChange( name, event.value );
 		if ( delta.length ) {
-			const checked = -1 !== event.value.indexOf( delta[ 0 ] );
+			const checked = -1 !== event.value.indexOf( delta[ 0 ] ) ? 1 : 0;
+			this.props.recordTracksEvent( 'calypso_sharing_buttons_show_buttons_on_page_click', {
+				page: delta[ 0 ],
+				checked,
+			} );
 			this.props.recordGoogleEvent(
 				'Sharing',
 				'Clicked Show Sharing Buttons On Page Checkbox',
 				delta[ 0 ],
-				checked ? 1 : 0
+				checked
 			);
 		}
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds Tracks events to the Sharing Buttons options.

#### Testing instructions

1. Check out this branch and `npm run build`.
2. Go to `marketing/sharing-buttons/:site`.
3. Ensure that analytics debugging is activated by running this in the browser console and refresh browser: `localStorage.setItem('debug', 'calypso:analytics:*');`
4. Scroll down to the Options section.
5. Toggle the checkboxes under "Show like and sharing buttons on". Verify that a correct tracks event with correct `page` `checked`, and `path` props is fired.
6. On a non-jetpack wordpress.com site, click the "On for all posts" under "Comment Likes". Verify that a correct tracks event with a correct `checked` and `path` props are fired.
7. On a jetpack site, focus the Twitter username field. Verify that a correct tracks event with the correct `path` prop is fired.
