### PR TITLE
Signup Site Mockup: Enable render tracking (simpler)

### DIFF
--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -73,7 +73,14 @@ class SiteMockups extends Component {
 		return true;
 	}
 
-	updateDebounced = debounce( this.forceUpdate, 777 );
+	updateDebounced = debounce( () => {
+		this.forceUpdate();
+		this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_rendered', {
+			site_type: this.props.siteType,
+			vertical_slug: this.props.verticalSlug,
+			site_style: this.props.siteStyle || 'default',
+		} );
+	}, 777 );
 
 	/**
 	 * Returns an interpolated site preview content block with template markers
@@ -97,8 +104,12 @@ class SiteMockups extends Component {
 		return content;
 	}
 
-	handleClick = size =>
-		this.props.handleClick( this.props.verticalSlug, this.props.siteStyle, size );
+	handlePreviewClick = size =>
+		this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_clicked', {
+			size,
+			vertical_slug: this.props.verticalSlug,
+			site_style: this.props.siteStyle || 'default',
+		} );
 
 	render() {
 		const {
@@ -126,7 +137,7 @@ class SiteMockups extends Component {
 			},
 			langSlug,
 			isRtl,
-			onPreviewClick: this.handleClick,
+			onPreviewClick: this.handlePreviewClick,
 			className: siteStyle,
 		};
 
@@ -166,14 +177,7 @@ export default connect(
 			fontUrl: style.fontUrl,
 		};
 	},
-	dispatch => ( {
-		handleClick: ( verticalSlug, siteStyle, size ) =>
-			dispatch(
-				recordTracksEvent( 'calypso_signup_site_preview_mockup_clicked', {
-					size,
-					vertical_slug: verticalSlug,
-					site_style: siteStyle || 'default',
-				} )
-			),
-	} )
+	{
+		recordTracksEvent,
+	}
 )( SiteMockups );

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -75,11 +75,13 @@ class SiteMockups extends Component {
 
 	updateDebounced = debounce( () => {
 		this.forceUpdate();
-		this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_rendered', {
-			site_type: this.props.siteType,
-			vertical_slug: this.props.verticalSlug,
-			site_style: this.props.siteStyle || 'default',
-		} );
+		if ( this.props.verticalPreviewContent ) {
+			this.props.recordTracksEvent( 'calypso_signup_site_preview_mockup_rendered', {
+				site_type: this.props.siteType,
+				vertical_slug: this.props.verticalSlug,
+				site_style: this.props.siteStyle || 'default',
+			} );
+		}
 	}, 777 );
 
 	/**


### PR DESCRIPTION
This is a simpler version of #32486 that leaves the debounced `forceUpdate` call in place & just kicks off the tracks event if content is present in the connected prop, `verticalPreviewContent`.

#### Changes proposed in this Pull Request

* Rename `handleClick` to `handlePreviewClick` since it's specific to the preview -- not the whole component.
* Simplify the `mapDispatchToProps` to just tack on `recordTracksEvent`
* Call `recordTracksEvent` as appropriate in `handlePreviewClick`
* Call `recordTracksEvent` with appropriate args in the debounced function which calls `React.Component#forceUpdate`

#### Testing instructions

* Run this branch
* enable debugging for tracks events: In your browser console: `localStorage.setItem( 'debug', 'calypso:analytics:tracks' )`
* Search for some things, choose from the default set, etc. etc -- you should see the `calypso_signup_site_preview_mockup_rendered` event being fired at the appropriate time
* Click on a mockup
  * Make sure the `calypso_signup_site_preview_mockup_clicked` event still fires