### PR TITLE
Add `aria-label` to site topic and site title input fields in signup.

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -201,6 +201,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 					autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 					isSearching={ this.isVerticalSearchPending() }
 					railcar={ railcar }
+					aria-label={ this.props[ 'aria-label' ] }
 				/>
 				{ shouldShowPopularTopics && <PopularTopics onSelect={ this.onSiteTopicChange } /> }
 			</>

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -36,6 +36,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		showPopular: PropTypes.bool,
 		siteType: PropTypes.string,
 		verticals: PropTypes.array,
+		labelText: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -201,7 +202,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 					autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 					isSearching={ this.isVerticalSearchPending() }
 					railcar={ railcar }
-					aria-label={ this.props[ 'aria-label' ] }
+					aria-label={ this.props.labelText }
 				/>
 				{ shouldShowPopularTopics && <PopularTopics onSelect={ this.onSiteTopicChange } /> }
 			</>

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -30,6 +30,7 @@ class SuggestionSearch extends Component {
 		value: PropTypes.string,
 		autoFocus: PropTypes.bool,
 		railcar: PropTypes.object,
+		'aria-label': PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -145,6 +146,7 @@ class SuggestionSearch extends Component {
 					onKeyDown={ this.handleSuggestionKeyDown }
 					autoComplete="off"
 					autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
+					aria-label={ this.props[ 'aria-label' ] }
 				/>
 				<Suggestions
 					ref={ this.setSuggestionsRef }

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -15,9 +15,7 @@ import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
 import Button from 'components/button';
 import FormTextInput from 'components/forms/form-text-input';
-import FormLabel from 'components/forms/form-label';
 import FormFieldset from 'components/forms/form-fieldset';
-import InfoPopover from 'components/info-popover';
 import QueryVerticals from 'components/data/query-verticals';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -80,31 +78,16 @@ class SiteTitleStep extends Component {
 	};
 
 	renderSiteTitleStep = () => {
-		const {
-			shouldFetchVerticalData,
-			siteTitle,
-			siteType,
-			siteVerticalName,
-			translate,
-		} = this.props;
+		const { shouldFetchVerticalData, siteTitle, siteType, siteVerticalName } = this.props;
 		const fieldLabel = getSiteTypePropertyValue( 'slug', siteType, 'siteTitleLabel' ) || '';
 		const fieldPlaceholder =
 			getSiteTypePropertyValue( 'slug', siteType, 'siteTitlePlaceholder' ) || '';
-		const fieldDescription = translate(
-			"We'll use this as your site title. Don't worry, you can change this later."
-		);
 		return (
 			<div className="site-title__wrapper">
 				{ shouldFetchVerticalData && <QueryVerticals searchTerm={ siteVerticalName } /> }
 				<form>
 					<div className="site-title__field-control site-title__title">
 						<FormFieldset>
-							<FormLabel htmlFor="title">
-								{ fieldLabel }
-								<InfoPopover className="site-title__info-popover" position="top">
-									{ fieldDescription }
-								</InfoPopover>
-							</FormLabel>
 							<FormTextInput
 								id="title"
 								name="title"

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -113,6 +113,7 @@ class SiteTitleStep extends Component {
 								value={ siteTitle }
 								maxLength={ 100 }
 								autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+								aria-label={ fieldLabel }
 							/>
 							<Button
 								title={ this.props.translate( 'Continue' ) }

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -83,6 +83,7 @@ class SiteTopicForm extends Component {
 					<FormFieldset>
 						<SiteVerticalsSuggestionSearch
 							placeholder={ suggestionSearchInputPlaceholder }
+							aria-label={ this.props.translate( 'What does your business do?' ) }
 							onChange={ this.onSiteTopicChange }
 							showPopular={ true }
 							searchValue={ siteTopic }

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -76,6 +76,7 @@ class SiteTopicForm extends Component {
 		const { isButtonDisabled, siteTopic, siteType } = this.props;
 		const suggestionSearchInputPlaceholder =
 			getSiteTypePropertyValue( 'slug', siteType, 'siteTopicInputPlaceholder' ) || '';
+		const headerText = getSiteTypePropertyValue( 'slug', siteType, 'siteTopicLabel' ) || '';
 
 		return (
 			<div className={ classNames( 'site-topic__content', { 'is-empty': ! siteTopic } ) }>
@@ -83,7 +84,7 @@ class SiteTopicForm extends Component {
 					<FormFieldset>
 						<SiteVerticalsSuggestionSearch
 							placeholder={ suggestionSearchInputPlaceholder }
-							aria-label={ this.props.translate( 'What does your business do?' ) }
+							labelText={ headerText }
 							onChange={ this.onSiteTopicChange }
 							showPopular={ true }
 							searchValue={ siteTopic }

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -59,7 +59,12 @@ class SiteTopicStep extends Component {
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ subHeaderText }
 					signupProgress={ this.props.signupProgress }
-					stepContent={ <SiteTopicForm submitForm={ this.props.submitSiteTopic } /> }
+					stepContent={
+						<SiteTopicForm
+							submitForm={ this.props.submitSiteTopic }
+							siteType={ this.props.siteType }
+						/>
+					}
 					showSiteMockups={ this.props.showSiteMockups }
 				/>
 			</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add `aria-label` to site topic and site title input fields in signup.

#### Testing instructions
1. Starting at URL: https://wordpress.com/start/
2. Select Business and proceed to next step.
3. The input field in the "What does your business do?" step should have `aria-label` attribute. Proceed to next step.
4. The input field in the "Tell us your site's name" step should have `aria-label` attribute as well.

This is my attempt at fixing #32704, I'm not 100% sure this is the right way to go about it though. There's an inconsistency between the two steps - the site title step has a hidden `<label>` element (using `display: none` ) linked to the input, while the site topic step does not. I'm wondering if maybe I should remove the `<label>` from site title step, to make the markup consistent between the two (since hidden label is ignored by screen readers)?

See #32704
