### PR TITLE
Add/auto renewal pop up dialog

### DIFF
--- a/client/me/purchases/manage-purchase/autorenewal-disabling-dialog.jsx
+++ b/client/me/purchases/manage-purchase/autorenewal-disabling-dialog.jsx
@@ -1,0 +1,54 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Dialog from 'components/dialog';
+
+class AutorenewalDisablingDialog extends Component {
+	static propTypes = {
+		translate: PropTypes.func.isRequired,
+		planName: PropTypes.string.isRequired,
+		siteDomain: PropTypes.string.isRequired,
+		expiryDate: PropTypes.string.isRequired,
+	};
+
+	render() {
+		const { planName, siteDomain, expiryDate, translate, onClose } = this.props;
+
+		const description = translate(
+			'By canceling autorenewal, your %(planName)s plan for %(siteDomain)s ' +
+				'will expire on %(expiryDate)s unless you reenable autorenewal or manually renew your plan. ' +
+				'If your plan expires, you will lose access to some awesome features.',
+			{
+				args: {
+					planName,
+					siteDomain,
+					expiryDate,
+				},
+			}
+		);
+
+		return (
+			<Dialog
+				isVisible={ true }
+				additionalClassNames="autorenewal-disabling-dialog"
+				onClose={ onClose }
+			>
+				<p>{ description }</p>
+				<Button onClick={ onClose } primary>
+					{ translate( 'OK' ) }
+				</Button>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( AutorenewalDisablingDialog );

--- a/client/me/purchases/manage-purchase/autorenewal-disabling-dialog.jsx
+++ b/client/me/purchases/manage-purchase/autorenewal-disabling-dialog.jsx
@@ -33,6 +33,10 @@ class AutorenewalDisablingDialog extends Component {
 					siteDomain,
 					expiryDate,
 				},
+				comment:
+					'%(planName)s is the name of a WordPress.com plan, e.g. Personal, Premium, Business. ' +
+					'%(siteDomain)s is a domain name, e.g. example.com, example.wordpress.com. ' +
+					'%(expiryDate)s is a date string, e.g. May 14, 2020',
 			}
 		);
 

--- a/client/me/purchases/manage-purchase/autorenewal-disabling-dialog.jsx
+++ b/client/me/purchases/manage-purchase/autorenewal-disabling-dialog.jsx
@@ -42,6 +42,7 @@ class AutorenewalDisablingDialog extends Component {
 				additionalClassNames="autorenewal-disabling-dialog"
 				onClose={ onClose }
 			>
+				<h2 className="autorenewal-disabling-dialog__header">{ translate( 'Before you go …' ) }</h2>
 				<p>{ description }</p>
 				<Button onClick={ onClose } primary>
 					{ translate( 'OK' ) }

--- a/client/me/purchases/manage-purchase/autorenewal-disabling-dialog.jsx
+++ b/client/me/purchases/manage-purchase/autorenewal-disabling-dialog.jsx
@@ -24,9 +24,9 @@ class AutorenewalDisablingDialog extends Component {
 		const { planName, siteDomain, expiryDate, translate, onClose } = this.props;
 
 		const description = translate(
-			'By canceling autorenewal, your %(planName)s plan for %(siteDomain)s ' +
-				'will expire on %(expiryDate)s unless you reenable autorenewal or manually renew your plan. ' +
-				'If your plan expires, you will lose access to some awesome features.',
+			'By canceling auto-renewal, your %(planName)s plan for %(siteDomain)s will expire on %(expiryDate)s. ' +
+				"When it does, you'll lose access to key features you may be using on your site. " +
+				'To avoid that, turn auto-renewal back on or manually renew your plan before the expiration date.',
 			{
 				args: {
 					planName,
@@ -46,7 +46,7 @@ class AutorenewalDisablingDialog extends Component {
 				additionalClassNames="autorenewal-disabling-dialog"
 				onClose={ onClose }
 			>
-				<h2 className="autorenewal-disabling-dialog__header">{ translate( 'Before you go …' ) }</h2>
+				<h2 className="autorenewal-disabling-dialog__header">{ translate( 'Before you go…' ) }</h2>
 				<p>{ description }</p>
 				<Button onClick={ onClose } primary>
 					{ translate( 'OK' ) }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -40,6 +40,7 @@ import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchas
 import { getSite, isRequestingSites } from 'state/sites/selectors';
 import { getUser } from 'state/users/selectors';
 import { managePurchase } from '../paths';
+import AutorenewalDisablingDialog from './autorenewal-disabling-dialog';
 import FormToggle from 'components/forms/form-toggle';
 import PaymentLogo from 'components/payment-logo';
 import { CALYPSO_CONTACT } from 'lib/url/support';
@@ -300,10 +301,24 @@ class PurchaseMeta extends Component {
 		);
 	}
 
-	onToggleAutorenewal = () => {
-		// TODO: send actual autorenewal enabling / disabling action here and show a pop-up notice
+	onCloseAutorenewalDisablingDialog = () => {
 		this.setState( {
-			isAutorenewalEnabled: ! this.state.isAutorenewalEnabled,
+			showAutorenewalDisablingDialog: false,
+		} );
+	};
+
+	onToggleAutorenewal = () => {
+		// TODO: Use the actual autorenewal enabling / disabling state & actions
+		const { isAutorenewalEnabled } = this.state;
+
+		if ( isAutorenewalEnabled ) {
+			this.setState( {
+				showAutorenewalDisablingDialog: true,
+			} );
+		}
+
+		this.setState( {
+			isAutorenewalEnabled: ! isAutorenewalEnabled,
 		} );
 	};
 
@@ -381,7 +396,7 @@ class PurchaseMeta extends Component {
 	}
 
 	render() {
-		const { translate, purchaseId } = this.props;
+		const { translate, purchaseId, purchase } = this.props;
 
 		if ( isDataLoading( this.props ) || ! purchaseId ) {
 			return this.renderPlaceholder();
@@ -399,6 +414,14 @@ class PurchaseMeta extends Component {
 					{ this.renderPaymentDetails() }
 				</ul>
 				{ this.renderContactSupportToRenewMessage() }
+				{ config.isEnabled( 'autorenewal-toggle' ) && this.state.showAutorenewalDisablingDialog && (
+					<AutorenewalDisablingDialog
+						planName={ 'Premium' }
+						siteDomain={ 'xd.blog' }
+						expiryDate={ purchase.expiryMoment.format( 'LL' ) }
+						onClose={ this.onCloseAutorenewalDisablingDialog }
+					/>
+				) }
 			</Fragment>
 		);
 	}

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -396,7 +396,7 @@ class PurchaseMeta extends Component {
 	}
 
 	render() {
-		const { translate, purchaseId, purchase } = this.props;
+		const { translate, purchaseId, purchase, site } = this.props;
 
 		if ( isDataLoading( this.props ) || ! purchaseId ) {
 			return this.renderPlaceholder();
@@ -416,8 +416,8 @@ class PurchaseMeta extends Component {
 				{ this.renderContactSupportToRenewMessage() }
 				{ config.isEnabled( 'autorenewal-toggle' ) && this.state.showAutorenewalDisablingDialog && (
 					<AutorenewalDisablingDialog
-						planName={ 'Premium' }
-						siteDomain={ 'xd.blog' }
+						planName={ site.plan.product_name_short }
+						siteDomain={ site.domain }
 						expiryDate={ purchase.expiryMoment.format( 'LL' ) }
 						onClose={ this.onCloseAutorenewalDisablingDialog }
 					/>

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -296,3 +296,12 @@
 .manage-purchase__detail-date-span {
 	white-space: nowrap;
 }
+
+.dialog.autorenewal-disabling-dialog {
+	max-width: 440px;
+}
+
+.autorenewal-disabling-dialog__header {
+	font-size: 24px;
+	margin-bottom: 14px;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*This PR is part of the attempt of adding a self-serving plan subscription autorenewal toggle. For more details, please refer to p2-p9jf6J-1GZ*

This PR adds the pop-up dialog showing what it means by turning off the autorenewal:
![image](https://user-images.githubusercontent.com/1842898/57756457-db678280-7725-11e9-8de8-c3fe30e8c6ab.png)

Note that it is still UI-only as its parent branch. Thus the toggle doesn't do anything but demonstrating the UI.

The design itself definitely need some designers' love ❤️

#### Dependency
https://github.com/Automattic/wp-calypso/pull/33014

#### Testing instructions

* Log in as a user with a plan subscription.
* Go to http://calypso.localhost:3000/me/purchases/ and click on the plan card to open the purchase management page.
* Toggle the autorenewal toggle as on, and then toggle it off.
* The dialog should show as expected.
* You should be able to close it by clicking on OK, clicking outside, or pressing the ESC key.
