### PR TITLE
Full Site Editing: Add the Template Selector sidebar

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -17,6 +17,7 @@ class A8C_Full_Site_Editing {
 
 		add_action( 'init', array( $this, 'register_blocks' ), 100 );
 		add_action( 'init', array( $this, 'register_template_post_types' ) );
+		add_action( 'init', array( $this, 'register_meta_template_id' ) );
 		add_action( 'rest_api_init', array( $this, 'allow_searching_for_templates' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script_and_style' ), 100 );
 	}
@@ -24,6 +25,19 @@ class A8C_Full_Site_Editing {
 	function register_template_post_types() {
 		require_once plugin_dir_path( __FILE__ ) . 'wp-template.php';
 		fse_register_template_post_types();
+	}
+
+	function register_meta_template_id() {
+		register_post_meta( '', '_wp_template_id', array(
+			'auth_callback' => array( $this, 'meta_template_id_auth_callback' ),
+			'show_in_rest'  => true,
+			'single'        => true,
+			'type'          => 'integer',
+		) );
+	}
+
+	function meta_template_id_auth_callback() {
+		return current_user_can( 'edit_theme_options' );
 	}
 
 	function enqueue_script_and_style() {

--- a/apps/full-site-editing/full-site-editing-plugin/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/index.js
@@ -3,3 +3,4 @@
  */
 import './blocks/post-content';
 import './blocks/template';
+import './plugins/template-selector-sidebar';

--- a/apps/full-site-editing/full-site-editing-plugin/plugins/template-selector-sidebar/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/plugins/template-selector-sidebar/index.js
@@ -1,3 +1,4 @@
+/* global fullSiteEditing */
 /**
  * External dependencies
  */
@@ -25,16 +26,21 @@ const TemplateSelectorSidebar = compose(
 			dispatch( 'core/editor' ).editPost( { meta: { _wp_template_id: templateId } } ),
 	} ) ),
 	withSelect( select => {
-		const { getEntityRecord } = select( 'core' );
+		const { canUser, getEntityRecord } = select( 'core' );
 		const templateId = get(
 			select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
 			'_wp_template_id'
 		);
 		return {
+			canUserUpdateSettings: canUser( 'update', 'settings' ),
 			selectedTemplate: templateId && getEntityRecord( 'postType', 'wp_template', templateId ),
 		};
 	} )
-)( ( { setTemplateId, selectedTemplate } ) => {
+)( ( { canUserUpdateSettings, setTemplateId, selectedTemplate } ) => {
+	if ( ! canUserUpdateSettings ) {
+		return null;
+	}
+
 	const onSelectTemplate = ( { id } ) => {
 		setTemplateId( parseInt( id, 10 ) );
 	};
@@ -58,14 +64,8 @@ const TemplateSelectorSidebar = compose(
 	);
 } );
 
-/*
- * @todo Conditional loading
- * @see #33025
- *
- * Only load this if the editor post type is `wp_template` and the user can `edit_theme_options`.
- *
- * E.g. `if ( 'wp_template' !== fullSiteEditing.editorPostType )`
- */
-registerPlugin( 'fse-template-selector-sidebar', {
-	render: TemplateSelectorSidebar,
-} );
+if ( 'wp_template' !== fullSiteEditing.editorPostType ) {
+	registerPlugin( 'fse-template-selector-sidebar', {
+		render: TemplateSelectorSidebar,
+	} );
+}

--- a/apps/full-site-editing/full-site-editing-plugin/plugins/template-selector-sidebar/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/plugins/template-selector-sidebar/index.js
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { PanelBody } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/edit-post';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import PostAutocomplete from '../../components/post-autocomplete';
+
+const TemplateSelectorSidebar = compose(
+	withDispatch( dispatch => ( {
+		setTemplateId: templateId =>
+			dispatch( 'core/editor' ).editPost( { meta: { _wp_template_id: templateId } } ),
+	} ) ),
+	withSelect( select => {
+		const { getEntityRecord } = select( 'core' );
+		const templateId = get(
+			select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+			'_wp_template_id'
+		);
+		return {
+			selectedTemplate: templateId && getEntityRecord( 'postType', 'wp_template', templateId ),
+		};
+	} )
+)( ( { setTemplateId, selectedTemplate } ) => {
+	const onSelectTemplate = ( { id } ) => {
+		setTemplateId( parseInt( id, 10 ) );
+	};
+
+	return (
+		<Fragment>
+			<PluginSidebarMoreMenuItem target="fse-template-sidebar" icon="layout">
+				{ __( 'Template' ) }
+			</PluginSidebarMoreMenuItem>
+			<PluginSidebar icon="layout" name="fse-template-sidebar" title={ __( 'Template' ) }>
+				<PanelBody>
+					{ __( 'Select a template' ) }
+					<PostAutocomplete
+						initialValue={ get( selectedTemplate, [ 'title', 'rendered' ] ) }
+						onSelectPost={ onSelectTemplate }
+						postType="wp_template"
+					/>
+				</PanelBody>
+			</PluginSidebar>
+		</Fragment>
+	);
+} );
+
+/*
+ * @todo Conditional loading
+ * @see #33025
+ *
+ * Only load this if the editor post type is `wp_template` and the user can `edit_theme_options`.
+ *
+ * E.g. `if ( 'wp_template' !== fullSiteEditing.editorPostType )`
+ */
+registerPlugin( 'fse-template-selector-sidebar', {
+	render: TemplateSelectorSidebar,
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/plugins/template-selector-sidebar/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/plugins/template-selector-sidebar/index.js
@@ -64,7 +64,10 @@ const TemplateSelectorSidebar = compose(
 	);
 } );
 
-if ( 'wp_template' !== fullSiteEditing.editorPostType ) {
+if (
+	'wp_template' !== fullSiteEditing.editorPostType &&
+	'wp_template_part' !== fullSiteEditing.editorPostType
+) {
 	registerPlugin( 'fse-template-selector-sidebar', {
 		render: TemplateSelectorSidebar,
 	} );

--- a/apps/full-site-editing/full-site-editing-plugin/plugins/template-selector-sidebar/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/plugins/template-selector-sidebar/index.js
@@ -64,10 +64,7 @@ const TemplateSelectorSidebar = compose(
 	);
 } );
 
-if (
-	'wp_template' !== fullSiteEditing.editorPostType &&
-	'wp_template_part' !== fullSiteEditing.editorPostType
-) {
+if ( 'page' === fullSiteEditing.editorPostType ) {
 	registerPlugin( 'fse-template-selector-sidebar', {
 		render: TemplateSelectorSidebar,
 	} );

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -31,9 +31,11 @@
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",
 		"@wordpress/data": "^4.4.0",
+		"@wordpress/edit-post": "^3.3.4",
 		"@wordpress/editor": "^9.2.4",
 		"@wordpress/element": "^2.3.0",
 		"@wordpress/i18n": "^3.3.0",
+		"@wordpress/plugins": "^2.2.0",
 		"@wordpress/url": "^2.5.0",
 		"classnames": "^2.2.6",
 		"lodash": "^4.17.11"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new `_wp_template_id` post meta to store the post's selected template ID.

* Add a new `fse-template-selector-sidebar` block editor sidebar to non-template post types, with an autocomplete selector for templates.

![Screenshot 2019-05-17 at 12 22 02](https://user-images.githubusercontent.com/2070010/57925364-e8a87c80-789f-11e9-872f-94c63e22991a.png)

Note: this PR will make full sense after #33097, as the selector will only search for "proper" templates (`wp_template` CPT), and not also for template parts (`wp_template_part` CPT).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the [FSE readme](https://github.com/Automattic/wp-calypso/blob/e759e056360b72576e124989c4174afef78bc1db/apps/full-site-editing/README.md#local-development); setup and enable the plugin.
* Create a Template if needed.
* Create or edit a post or a page.
* Open the Template sidebar, select a template, and save the post.
* Reload and make sure the template selector is pre-filled with the correct template.