### PR TITLE
Change onboarding-dev to zelda in CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,14 +19,14 @@
 /client/boot @Automattic/team-calypso
 
 # Client blocks
-/client/blocks/inline-help @Automattic/onboarding-dev
+/client/blocks/inline-help @Automattic/zelda
 
 # Client state
 /client/state/jetpack-connect @Automattic/luna
-/client/state/signup @Automattic/onboarding-dev
+/client/state/signup @Automattic/zelda
 
 # Client components
-/client/components/site-verticals-suggestion-search @Automattic/onboarding-dev
+/client/components/site-verticals-suggestion-search @Automattic/zelda
 
 # Client framework parts
 /client/config @Automattic/team-calypso
@@ -35,7 +35,7 @@
 /client/layout @Automattic/team-calypso
 
 # Client sites
-/client/my-sites/checklist @Automattic/onboarding-dev
+/client/my-sites/checklist @Automattic/zelda
 
 # Comments management
 /client/my-sites/comment* @Automattic/lannister
@@ -60,7 +60,7 @@
 /server @Automattic/team-calypso
 
 # Signup
-/client/signup @Automattic/onboarding-dev
+/client/signup @Automattic/zelda
 
 # Test infrastructure
 /test @Automattic/team-calypso


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The WordPress.com onboarding group name changed to Zelda and this PR reflect this change in CODEOWNERS file.

#### Testing instructions

Just eyeballing should be enough