### PR TITLE
Migrate CSS of Manage Purchases

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -107,7 +107,6 @@
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
-@import 'me/purchases/manage-purchase/plan-details/style';
 @import 'me/purchases/remove-purchase/style';
 @import 'me/sidebar-navigation/style';
 @import 'me/sidebar/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -67,7 +67,6 @@
 @import 'components/logged-out-form/style';
 @import 'components/locale-suggestions/style';
 @import 'components/main/style';
-@import 'components/marketing-survey/cancel-purchase-form/style';
 @import 'components/mini-site-preview/style';
 @import 'components/mobile-back-to-sidebar/style';
 @import 'components/notice/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -107,7 +107,6 @@
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
-@import 'me/purchases/components/loading-placeholder/style';
 @import 'me/purchases/purchase-item/style';
 @import 'me/purchases/purchases-site/style';
 @import 'me/purchases/manage-purchase/plan-details/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -107,7 +107,6 @@
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
-@import 'me/pending-payments/style';
 @import 'me/purchases/cancel-purchase/style';
 @import 'me/purchases/components/loading-placeholder/style';
 @import 'me/purchases/purchase-item/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -71,10 +71,8 @@
 @import 'components/mini-site-preview/style';
 @import 'components/mobile-back-to-sidebar/style';
 @import 'components/notice/style';
-@import 'blocks/product-purchase-features-list/style';
 @import 'components/popover/style';
 @import 'components/post-excerpt/style';
-@import 'components/purchase-detail/style';
 @import 'components/rewind-credentials-form/style';
 @import 'components/section-nav/style';
 @import 'components/segmented-control/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -107,7 +107,6 @@
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
-@import 'me/purchases/purchases-site/style';
 @import 'me/purchases/manage-purchase/plan-details/style';
 @import 'me/purchases/remove-purchase/style';
 @import 'me/sidebar-navigation/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -107,7 +107,6 @@
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
-@import 'me/purchases/cancel-purchase/style';
 @import 'me/purchases/components/loading-placeholder/style';
 @import 'me/purchases/purchase-item/style';
 @import 'me/purchases/purchases-site/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -107,7 +107,6 @@
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
-@import 'me/purchases/purchase-item/style';
 @import 'me/purchases/purchases-site/style';
 @import 'me/purchases/manage-purchase/plan-details/style';
 @import 'me/purchases/remove-purchase/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -107,7 +107,6 @@
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/notification-settings/wpcom-settings/style';
-@import 'me/purchases/remove-purchase/style';
 @import 'me/sidebar-navigation/style';
 @import 'me/sidebar/style';
 @import 'my-sites/earn/style';

--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -54,6 +54,11 @@ import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class ProductPurchaseFeaturesList extends Component {
 	static propTypes = {
 		plan: PropTypes.oneOf( Object.keys( PLANS_LIST ) ).isRequired,

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -31,6 +31,11 @@ import {
 	nextAdventureOptionsForPurchase,
 } from './options-for-product';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class CancelPurchaseForm extends React.Component {
 	static propTypes = {
 		chatInitiated: PropTypes.func.isRequired,

--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -17,6 +17,11 @@ import { abtest } from 'lib/abtest';
 import PurchaseButton from './purchase-button';
 import TipInfo from './tip-info';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class PurchaseDetail extends PureComponent {
 	static propTypes = {
 		buttonText: PropTypes.string,

--- a/client/components/purchase-detail/purchase-button.jsx
+++ b/client/components/purchase-detail/purchase-button.jsx
@@ -6,6 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -13,10 +14,10 @@ import React from 'react';
 import Button from 'components/button';
 
 const PurchaseButton = ( {
-	className = false,
+	className,
 	href,
 	disabled,
-	onClick = () => {},
+	onClick,
 	target,
 	rel,
 	text,
@@ -24,7 +25,7 @@ const PurchaseButton = ( {
 } ) => {
 	return (
 		<Button
-			className={ `${ className ? className + ' ' : '' }purchase-detail__button` }
+			className={ classNames( 'purchase-detail__button', className ) }
 			disabled={ disabled }
 			href={ href }
 			onClick={ onClick }

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -69,8 +69,6 @@
 }
 
 .purchase-detail__button {
-	text-align: center;
-
 	&:not( .clipboard-button ) {
 		width: 80%;
 	}

--- a/client/me/pending-payments/index.jsx
+++ b/client/me/pending-payments/index.jsx
@@ -30,6 +30,11 @@ import getPrimarySiteId from 'state/selectors/get-primary-site-id';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export const requestId = userId => `pending-payments:${ userId }`;
 
 const requestPendingPayments = userId => {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -42,6 +42,11 @@ import titles from 'me/purchases/titles';
 import TrackPurchasePageView from 'me/purchases/track-purchase-page-view';
 import { getCurrentUserId } from 'state/current-user/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class CancelPurchase extends React.Component {
 	static propTypes = {
 		hasLoadedSites: PropTypes.bool.isRequired,

--- a/client/me/purchases/components/loading-placeholder/index.jsx
+++ b/client/me/purchases/components/loading-placeholder/index.jsx
@@ -14,6 +14,11 @@ import React from 'react';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class LoadingPlaceholder extends React.Component {
 	static propTypes = {
 		path: PropTypes.string,

--- a/client/me/purchases/manage-purchase/plan-details/index.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/index.jsx
@@ -25,6 +25,11 @@ import { getName, isExpired } from 'lib/purchases';
 import { isJetpackPlan, isFreeJetpackPlan } from 'lib/products-values';
 import { getPluginsForSite } from 'state/plugins/premium/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PurchasePlanDetails extends Component {
 	static propTypes = {
 		purchaseId: PropTypes.number,

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -37,6 +37,11 @@ import { managePurchase } from '../paths';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { getPlanTermLabel } from 'lib/plans';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const eventProperties = warning => ( { warning, position: 'purchase-list' } );
 
 class PurchaseItem extends Component {

--- a/client/me/purchases/purchases-site/header.jsx
+++ b/client/me/purchases/purchases-site/header.jsx
@@ -18,6 +18,11 @@ import QuerySites from 'components/data/query-sites';
 import Site from 'blocks/site';
 import SitePlaceholder from 'blocks/site/placeholder';
 
+/**
+ * Style dependencies
+ */
+import './header.scss';
+
 class PurchaseSiteHeader extends Component {
 	static propTypes = {
 		isPlaceholder: PropTypes.bool,

--- a/client/me/purchases/purchases-site/header.scss
+++ b/client/me/purchases/purchases-site/header.scss
@@ -1,0 +1,24 @@
+.purchases-site__header {
+	&.card.is-compact {
+		padding: 0;
+	}
+
+	.site.is-loading {
+		.site-icon,
+		.site__title,
+		.site__domain {
+			@include placeholder( 23% );
+		}
+	}
+
+	.site.is-disconnected .site-icon {
+		height: 32px;
+		width: 32px;
+		line-height: 32px;
+		font-size: 32px;
+	}
+
+	.site .site__content {
+		padding: 11px 24px;
+	}
+}

--- a/client/me/purchases/purchases-site/index.jsx
+++ b/client/me/purchases/purchases-site/index.jsx
@@ -20,6 +20,11 @@ import PurchaseItem from '../purchase-item';
 import PurchaseSiteHeader from './header';
 import PurchaseReconnectNotice from './reconnect-notice';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const PurchasesSite = ( {
 	hasLoadedSite,
 	isPlaceholder,

--- a/client/me/purchases/purchases-site/style.scss
+++ b/client/me/purchases/purchases-site/style.scss
@@ -21,31 +21,6 @@
 	}
 }
 
-.purchases-site__header {
-	&.card.is-compact {
-		padding: 0;
-	}
-
-	.site.is-loading {
-		.site-icon,
-		.site__title,
-		.site__domain {
-			@include placeholder( 23% );
-		}
-	}
-
-	.site.is-disconnected .site-icon {
-		height: 32px;
-		width: 32px;
-		line-height: 32px;
-		font-size: 32px;
-	}
-
-	.site .site__content {
-		padding: 11px 24px;
-	}
-}
-
 .purchases-list .action-card__illustration {
 	@include breakpoint( '>960px' ) {
 		margin: -40px 20px 0 -20px;

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -55,6 +55,11 @@ import isPrecancellationChatAvailable from 'state/happychat/selectors/is-precanc
 import { getCurrentUserId } from 'state/current-user/selectors';
 
 /**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
  * Module dependencies
  */
 import debugFactory from 'debug';

--- a/client/my-sites/feature-upsell/feature.jsx
+++ b/client/my-sites/feature-upsell/feature.jsx
@@ -12,7 +12,7 @@ import { noop } from 'lodash';
 /**
  * Internal dependencies
  */
-import PurchaseButton from 'components/purchase-detail/purchase-button';
+import Button from 'components/button';
 import TipInfo from 'components/purchase-detail/tip-info';
 
 export default class Feature extends PureComponent {
@@ -53,15 +53,16 @@ export default class Feature extends PureComponent {
 		}
 
 		return (
-			<PurchaseButton
+			<Button
 				disabled={ isSubmitting }
 				href={ href }
 				onClick={ onClick }
 				primary={ primaryButton }
 				target={ target }
 				rel={ rel }
-				text={ buttonText }
-			/>
+			>
+				{ buttonText }
+			</Button>
 		);
 	}
 


### PR DESCRIPTION
Migrates CSS of the:
- `/me/purchases` section
- purchase details on `/plans/my-plan` (click "Plan" in site sidebar to get there)
- UI for removing/canceling purchases including the "reasons for cancel" survey modal

Everything was very very straightforward to migrate, no problems expected.