### PR TITLE
Jetpack connect: show "back to your site" if setting up takes long

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -537,7 +537,7 @@ export class JetpackThankYouCard extends Component {
 					<Fragment>
 						<p>
 							{ translate(
-								'We’re loading your security features now. In the meantime, head back to your site'
+								'We’re loading your security features now. In the meantime, head back to your site.'
 							) }
 						</p>
 						<p>{ backToYourSiteButton }</p>


### PR DESCRIPTION
Old Jetpack connect flow: show "back to your site" if setting up takes long

#### Changes proposed in this Pull Request

* Show "back to your site" if setup progress is still ongoing after 30 seconds.

First:

<img width="547" alt="Screenshot 2019-05-15 at 18 13 46" src="https://user-images.githubusercontent.com/87168/57787255-b3841900-773d-11e9-9962-c4988db4bc3d.png">

Then after a wait:

<img width="525" alt="Screenshot 2019-05-15 at 18 13 53" src="https://user-images.githubusercontent.com/87168/57787270-b8e16380-773d-11e9-94e3-88a7c8bf7eed.png">

Finally this should be the final screen:

<img width="522" alt="Screenshot 2019-05-15 at 18 17 12" src="https://user-images.githubusercontent.com/87168/57787281-bc74ea80-773d-11e9-9a7b-730d79375675.png">

Convo p1557928997038900-slack-luna

#### Testing instructions
- Create a new site https://jurassic.ninja/?create
- Connect (append `&calypso_env=development` to connection URL in order to land in localhost instead of wpcom) and buy a plan
- When testing on localhost, you'll have `jetpack/checklist` feature flag on so you should turn that off in `config/development.json`