### PR TITLE
Signup: Localize the string in the Site Topic step

### DIFF
--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -6,6 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -28,6 +29,7 @@ class SiteTopicStep extends Component {
 		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		siteType: PropTypes.string,
+		translate: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -44,7 +46,9 @@ class SiteTopicStep extends Component {
 		// once we have more granular copies per segments, these should only be used for the default case.
 		const headerText =
 			getSiteTypePropertyValue( 'slug', this.props.siteType, 'siteTopicHeader' ) || '';
-		const commonSubHeaderText = 'This information helps us build the best site for your needs.';
+		const commonSubHeaderText = this.props.translate(
+			'This information helps us build the best site for your needs.'
+		);
 
 		return {
 			headerText,
@@ -99,4 +103,4 @@ export default connect(
 		isUserInput: getSiteVerticalIsUserInput( state ),
 	} ),
 	mapDispatchToProps
-)( SiteTopicStep );
+)( localize( SiteTopicStep ) );


### PR DESCRIPTION
Currently, the site topic step has an untranslatable string:

![Screen Shot 2019-05-15 at 2 54 03 PM](https://user-images.githubusercontent.com/1587282/57801329-77db5600-7721-11e9-813b-dbf0cc919cc5.png)

This wraps it so we can add translations.

#### Changes proposed in this Pull Request

* wrap `SiteTopicStep` w/ `localize`
* wrap string in `this.props.translate`
* add to PropTypes

#### Testing instructions

* Complete an onboarding flows on this branch for an english and in a non-english locale account
* Notice the untranslated string
* There should be no errors in the console