### PR TITLE
Guided Tour: Fix User Avatar Steps

### DIFF
--- a/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
@@ -60,7 +60,15 @@ export const ChecklistUserAvatarTour = makeTour(
 			) }
 		</Step>
 
-		<Step name="crop-image" placement="right">
+		<Step
+			name="crop-image"
+			target="image-editor-button-done"
+			placement="below"
+			arrow="top-right"
+			style={ {
+				border: '2px solid white',
+			} }
+		>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>
@@ -73,7 +81,7 @@ export const ChecklistUserAvatarTour = makeTour(
 			) }
 		</Step>
 
-		<Step name="finish" placement="right">
+		<Step name="finish" target="edit-gravatar" placement="beside">
 			{ ( { translate } ) => (
 				<Fragment>
 					<h1 className="tours__title">

--- a/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
@@ -51,7 +51,7 @@ export const ChecklistUserAvatarTour = makeTour(
 			) }
 		</Step>
 
-		<Step name="image-notice" placement="right">
+		<Step name="image-notice" placement="right" dark={ true }>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>{ translate( "Let's make sure it looks right before we proceed." ) }</p>
@@ -65,9 +65,7 @@ export const ChecklistUserAvatarTour = makeTour(
 			target="image-editor-button-done"
 			placement="below"
 			arrow="top-right"
-			style={ {
-				border: '2px solid white',
-			} }
+			dark={ true }
 		>
 			{ ( { translate } ) => (
 				<Fragment>

--- a/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
@@ -21,6 +21,14 @@ import {
 	Tour,
 } from 'layout/guided-tours/config-elements';
 
+function handleTargetDisappear( { quit, next } ) {
+	if ( document.querySelector( '.image-editor' ) ) {
+		next();
+	} else {
+		quit();
+	}
+}
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const ChecklistUserAvatarTour = makeTour(
 	<Tour { ...meta }>
@@ -51,7 +59,15 @@ export const ChecklistUserAvatarTour = makeTour(
 			) }
 		</Step>
 
-		<Step name="image-notice" placement="right" dark={ true }>
+		<Step
+			name="image-notice"
+			target=".image-editor__crop"
+			placement="right"
+			// HACK: this line hide the step then moves on the next step to workaround a bug.
+			onTargetDisappear={ handleTargetDisappear }
+			style={ { visibility: 'hidden' } }
+			dark={ true }
+		>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>{ translate( "Let's make sure it looks right before we proceed." ) }</p>
@@ -63,16 +79,20 @@ export const ChecklistUserAvatarTour = makeTour(
 		<Step
 			name="crop-image"
 			target="image-editor-button-done"
-			placement="below"
-			arrow="top-right"
+			placement="above"
+			arrow="bottom-right"
+			onTargetDisappear={ handleTargetDisappear }
 			dark={ true }
 		>
 			{ ( { translate } ) => (
 				<Fragment>
 					<p>
-						{ translate( 'Alright! Press {{b}}Change My Photo{{/b}} to save your changes.', {
-							components: { b: <strong /> },
-						} ) }
+						{ translate(
+							'Crop image as needed then press {{b}}Change My Photo{{/b}} button to save your changes.',
+							{
+								components: { b: <strong /> },
+							}
+						) }
 					</p>
 					<Continue target="image-editor-button-done" step="finish" click hidden />
 				</Fragment>

--- a/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-user-avatar-tour/index.js
@@ -88,7 +88,7 @@ export const ChecklistUserAvatarTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							'Crop image as needed then press {{b}}Change My Photo{{/b}} button to save your changes.',
+							'Crop your image, then press {{b}}Change My Photo{{/b}} to save your changes.',
 							{
 								components: { b: <strong /> },
 							}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update `ChecklistUserAvatarTour` class to address issue #32254.

Specifically,

- "Let's make sure it looks right before we proceed." step is now hidden. It could not be removed because Guided Tour currently does not support stepping through Image Editor dialog interaction. `onTargetDisappear` is used for both step progression on Upload and dismissal on Cancel.

- "Alright! Press "Change my photo" step message now incorporates blurb about cropping image as well as prompt to press the primary button." `onTargetDisappear` is used for both step dismissal on Cancel.

<img width="643" alt="screenshot_670" src="https://user-images.githubusercontent.com/127594/58063575-ab5c1d00-7b33-11e9-96c2-a0ac99b5dc89.png">

- Finishing step is moved beside the Avatar image to avoid overlapping update feedback message.

<img width="820" alt="screenshot_658" src="https://user-images.githubusercontent.com/127594/57802855-c120ab00-770b-11e9-8451-dfb6d167c555.png">

#### Testing instructions

Navigate to http://calypso.localhost:3000/me?tour=checklistUserAvatar and go through the tour.

Fixes #32254