### PR TITLE
Re-adding the "View post" link to Posts & Pages stats.

### DIFF
--- a/client/my-sites/stats/stats-list/action-link.jsx
+++ b/client/my-sites/stats/stats-list/action-link.jsx
@@ -1,0 +1,61 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import analytics from 'lib/analytics';
+
+class StatsActionLink extends PureComponent {
+	static propTypes = {
+		href: PropTypes.string,
+		moduleName: PropTypes.string,
+		translate: PropTypes.func,
+	};
+
+	onClick = event => {
+		event.stopPropagation();
+		analytics.ga.recordEvent(
+			'Stats',
+			'Clicked on External Link in ' + this.props.moduleName + ' List Action Menu'
+		);
+	};
+
+	render() {
+		const { href, translate } = this.props;
+		return (
+			<li className="stats-list__item-action module-content-list-item-action">
+				<a
+					href={ href }
+					onClick={ this.onClick }
+					target="_blank"
+					rel="noopener noreferrer"
+					className="stats-list__item-action-wrapper module-content-list-item-action-wrapper"
+					title={ translate( 'View content in a new window', {
+						textOnly: true,
+						context: 'Stats action tooltip: View content in a new window',
+					} ) }
+					aria-label={ translate( 'View content in a new window', {
+						textOnly: true,
+						context: 'Stats ARIA label: View content in new window action',
+					} ) }
+				>
+					<Gridicon icon="external" size={ 18 } />
+					<span className="stats-list__item-action-label module-content-list-item-action-label module-content-list-item-action-label-view">
+						{ translate( 'View', { context: 'Stats: List item action to view content' } ) }
+					</span>
+				</a>
+			</li>
+		);
+	}
+}
+
+export default localize( StatsActionLink );

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -20,6 +20,7 @@ import Emojify from 'components/emojify';
 import Follow from './action-follow';
 import Page from './action-page';
 import Spam from './action-spam';
+import OpenLink from './action-link';
 import titlecase from 'to-title-case';
 import { flagUrl } from 'lib/flags';
 import { recordTrack } from 'reader/stats';
@@ -164,6 +165,11 @@ class StatsListItem extends React.Component {
 								afterChange={ this.spamHandler }
 								moduleName={ moduleName }
 							/>
+						);
+						break;
+					case 'link':
+						actionItem = (
+							<OpenLink href={ action.data } key={ action.type } moduleName={ moduleName } />
 						);
 						break;
 				}

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -86,6 +86,10 @@ class StatsListItem extends React.Component {
 		let gaEvent;
 		const moduleName = titlecase( this.props.moduleName );
 
+		if ( event.keyCode && event.keyCode !== 13 ) {
+			return;
+		}
+
 		debug( 'props', this.props );
 		if ( ! this.state.disabled ) {
 			if ( this.props.children ) {
@@ -347,6 +351,7 @@ class StatsListItem extends React.Component {
 				<span
 					className="stats-list__module-content-list-item-wrapper"
 					onClick={ this.onClick }
+					onKeyUp={ this.onClick }
 					tabIndex="0"
 					role="button"
 				>

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -118,6 +118,10 @@
 			background-color: var( --color-neutral-0 );
 		}
 
+		.module-content-list-item-action .module-content-list-item-action-wrapper {
+			display: inline-block;
+		}
+
 		.module-content-list-item-right::before {
 			background-image: linear-gradient( to right, $transparent 0%, var( --color-neutral-0 ) 90% );
 		}
@@ -495,7 +499,7 @@ ul.module-content-list-item-action-submenu {
 	// Action wrapper, what's actually selected
 	.module-content-list-item-action-wrapper {
 		@extend %mobile-interface-element;
-		display: inline-block;
+		display: none;
 		text-align: center;
 		margin: 0;
 		line-height: inherit;

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -119,7 +119,7 @@
 		}
 
 		.module-content-list-item-action .module-content-list-item-action-wrapper {
-			display: inline-block;
+			opacity: 1;
 		}
 
 		.module-content-list-item-right::before {
@@ -130,6 +130,9 @@
 		.module-content-list-item-action-hidden {
 			display: inline-block;
 		}
+	}
+	.module-content-list-item-link .module-content-list-item-action-wrapper:focus {
+		opacity: 1;
 	}
 
 	// Don't show hover on legend row
@@ -499,7 +502,7 @@ ul.module-content-list-item-action-submenu {
 	// Action wrapper, what's actually selected
 	.module-content-list-item-action-wrapper {
 		@extend %mobile-interface-element;
-		display: none;
+		opacity: 0;
 		text-align: center;
 		margin: 0;
 		line-height: inherit;


### PR DESCRIPTION
We had a few complaints about the missing icon link, removed in #32748 (see comments  and customer reports in that PR). In this PR I'm re-introducing the icon link, when customer hovers over an item in the "Posts & Pages" stats module (this will also affect the "Videos", and "Authors" module in the same way). We're doing it this way to reduce visual clutter, while keeping the functionality for customers who relied on it.

**Testing instructions**
1. Navigate to https://wordpress.com/stats/day/{site}
2. Verify that the external link icon is not there in the "Posts & Pages" module. 
![image](https://user-images.githubusercontent.com/4550351/57819268-0952d280-77cb-11e9-986a-ea4e56241492.png)

3. Hover over any of the rows in the "Posts & Pages" module. You should see the "View post" icon, linking directly to the post/page (outside Calypso).

![image](https://user-images.githubusercontent.com/4550351/57819285-1a034880-77cb-11e9-92c0-d27542661d9b.png)




Initially removed to fix #32252.

