### PR TITLE
Fix the data sent in the Apple Pay PaymentRequest

### DIFF
--- a/client/lib/web-payment/index.js
+++ b/client/lib/web-payment/index.js
@@ -31,7 +31,10 @@ export function detectWebPaymentMethod() {
 	if (
 		config.isEnabled( 'my-sites/checkout/web-payment/apple-pay' ) &&
 		window.ApplePaySession &&
-		window.ApplePaySession.canMakePayments()
+		window.ApplePaySession.canMakePayments() &&
+		// Our Apple Pay implementation uses the Payment Request API, so check
+		// that also.
+		window.PaymentRequest
 	) {
 		return WEB_PAYMENT_APPLE_PAY_METHOD;
 	}

--- a/client/my-sites/checkout/checkout/test/web-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/web-payment-box.js
@@ -32,6 +32,7 @@ jest.mock( 'lib/cart-values', () => ( {
 } ) );
 
 window.ApplePaySession = { canMakePayments: () => true };
+window.PaymentRequest = true;
 
 describe( 'WebPaymentBox', () => {
 	const defaultCart = {

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -50,7 +50,7 @@ const debug = debugFactory( 'calypso:checkout:payment:apple-pay' );
 /**
  * Supported card types.
  */
-const SUPPORTED_NETWORKS = [ 'visa', 'mastercard', 'discover', 'amex', 'jcb', 'maestro' ];
+const SUPPORTED_NETWORKS = [ 'visa', 'masterCard', 'discover', 'amex', 'jcb', 'chinaUnionPay' ];
 const APPLE_PAY_MERCHANT_IDENTIFIER = config( 'apple_pay_merchant_id' );
 const PAYMENT_REQUEST_OPTIONS = {
 	requestPayerName: true,
@@ -166,7 +166,7 @@ export class WebPaymentBox extends React.Component {
 			{
 				supportedMethods: WEB_PAYMENT_APPLE_PAY_METHOD,
 				data: {
-					version: 3,
+					version: 2,
 					merchantIdentifier: APPLE_PAY_MERCHANT_IDENTIFIER,
 					merchantCapabilities: [ 'supports3DS', 'supportsCredit', 'supportsDebit' ],
 					supportedNetworks: SUPPORTED_NETWORKS,

--- a/config/development.json
+++ b/config/development.json
@@ -29,7 +29,6 @@
 	"discover_logged_out_redirect_url": "https://discover.wordpress.com",
 	"happychat_url": "https://happychat-io-staging.go-vip.co/customer",
 	"rebrand_cities_prefix": "rebrandcitiesdevelopmentsite",
-	"apple_pay_merchant_id": "merchant.com.wordpress.test",
 	"livechat_support_locales": [ "en", "es", "pt-br" ],
 	"features": {
 		"async-payments": true,


### PR DESCRIPTION
There are a number of minor problems with the data we send when creating a `PaymentRequest` object for Apple Pay payments and which could affect the ability of Apple Pay to work in certain situations:
- Our payment provider doesn't support the `maestro` card network, but does support `chinaUnionPay`, so let's add that.  (Also fixed the capitalization of `masterCard` to match https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951831-supportednetworks, although in practice the difference doesn't seem to matter.)
- With `maestro` gone, the only version requirement we have from the supported card networks is that `jcb` requires version 2 (according to the link above), and I don't see anything at https://developer.apple.com/documentation/apple_pay_on_the_web/apple_pay_on_the_web_version_history/apple_pay_version_3_release_notes that we're using in version 3, so let's drop the version requirement from 3 to 2.
- In practice, our main version requirement comes from the fact that we're using the Payment Request API, but we weren't checking its availability before using it, so let's add a check for that when deciding if Apple Pay should be enabled.
- For development sites, we were sending an outdated merchant ID along with the request, so let's remove that and switch to the main merchant ID.

This patch fixes all the above problems.  It's difficult to test directly, since most of it would require testing on specific older operating systems, but overall it's a relatively straightforward change.