### PR TITLE
Signup: add site segment query component

### DIFF
--- a/client/components/data/query-segments/README.md
+++ b/client/components/data/query-segments/README.md
@@ -1,9 +1,9 @@
 Query Site Segments
 ===========================
 
-`<QuerySegments />` is a React component used to fire a network requests for `/segments`, which returns site segment information for signup.
+`<QuerySegments />` is a React component used to fire a network request for the `/segments` endpoint, which returns site segment information for signup.
 
-Because it's static data from the server, it will only fire if segments data isn't found in the state tree.
+Because it's static data from the server, it will only fire if there are no segments data in the state tree.
 
 ## Usage
 

--- a/client/components/data/query-segments/README.md
+++ b/client/components/data/query-segments/README.md
@@ -7,9 +7,9 @@ Because it's static data from the server, it will only fire if there are no segm
 
 ## Usage
 
-Render the component It does not accept any props or children, nor does it render any elements to the page.
+Render the component. It accepts neither props or children, nor does it render any elements to the page.
 
-```es6
+```js
 import QuerySegments from 'components/data/query-segments';
 import { getSegments } from 'state/signup/segments/selectors';
 
@@ -22,7 +22,7 @@ class MyComponent extends React.Component {
 				<QuerySegments />
 				<ul>
 				{
-					segments && segments.map( segments => {
+					segments.length && segments.map( segments => {
 						return ( <li>{ segments.id }</li> );
 					} )
 				}

--- a/client/components/data/query-segments/README.md
+++ b/client/components/data/query-segments/README.md
@@ -1,0 +1,42 @@
+Query Site Segments
+===========================
+
+`<QuerySegments />` is a React component used to fire a network requests for `/segments`, which returns site segment information for signup.
+
+Because it's static data from the server, it will only fire if segments data isn't found in the state tree.
+
+## Usage
+
+Render the component It does not accept any props or children, nor does it render any elements to the page.
+
+```es6
+import QuerySegments from 'components/data/query-segments';
+import { getSegments } from 'state/signup/segments/selectors';
+
+class MyComponent extends React.Component {
+	render() {
+		const { segments } = this.props;
+
+		return (
+			<div>
+				<QuerySegments />
+				<ul>
+				{
+					segments && segments.map( segments => {
+						return ( <li>{ segments.id }</li> );
+					} )
+				}
+				</ul>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	state => ( {
+		segments: getSegments( state ),
+	} ),
+)( MyComponent );
+
+```
+

--- a/client/components/data/query-segments/index.jsx
+++ b/client/components/data/query-segments/index.jsx
@@ -1,0 +1,39 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import { requestSegments } from 'state/signup/segments/actions';
+import { getSegments } from 'state/signup/segments/selectors';
+
+export class QuerySegments extends Component {
+	static propTypes = {
+		requestSegments: PropTypes.func,
+		segments: PropTypes.array,
+	};
+
+	componentWillMount() {
+		if ( ! this.props.segments ) {
+			this.props.requestSegments();
+		}
+	}
+
+	render() {
+		return null;
+	}
+}
+
+export default connect(
+	state => ( {
+		segments: getSegments( state ),
+	} ),
+	{ requestSegments }
+)( QuerySegments );

--- a/client/components/data/query-segments/test/index.js
+++ b/client/components/data/query-segments/test/index.js
@@ -1,0 +1,39 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import { QuerySegments } from '../';
+
+describe( 'QuerySegments', () => {
+	test( 'should mount as an empty object', () => {
+		const requestSegments = jest.fn();
+		const wrapped = shallow( <QuerySegments requestSegments={ requestSegments } /> );
+
+		expect( wrapped ).toEqual( {} );
+	} );
+
+	test( 'should call request on mount.', () => {
+		const requestSegments = jest.fn();
+
+		shallow( <QuerySegments requestSegments={ requestSegments } /> );
+
+		expect( requestSegments ).toHaveBeenCalled();
+	} );
+
+	test( 'should not call request on mount if segments have been already populated.', () => {
+		const requestSegments = jest.fn();
+
+		shallow(
+			<QuerySegments requestSegments={ requestSegments } segments={ [ { a: 1 }, { b: 2 } ] } />
+		);
+
+		expect( requestSegments ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
## Changes proposed in this Pull Request

Creating a query component so we can request the `/segments` API data. We'll probably render this in `client/signup/main.jsx`

Requires #33084

## Testing instructions

`npm run test-client client/components/data/query-segments`
