### PR TITLE
Passwordless signup: Showing what can be done with the API

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -691,3 +691,33 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 		flows.excludeStep( stepName );
 	}
 }
+
+export function createPasswordlessUser( callback, dependencies, data ) {
+	const { email } = data;
+
+	wpcom.undocumented().usersEmailNew( { email }, function( error, response ) {
+		if ( error ) {
+			callback( error );
+
+			return;
+		}
+		callback( error, response );
+	} );
+}
+
+export function verifyPasswordlessUser( callback, dependencies, data ) {
+	const { email, code } = data;
+
+	wpcom.undocumented().usersEmailVerification( { email, code }, function( error, response ) {
+		if ( error ) {
+			callback( error );
+
+			return;
+		}
+		const providedDependencies = assign(
+			{},
+			{ email, username: email, bearer_token: response.token.access_token }
+		);
+		callback( error, providedDependencies );
+	} );
+}

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1391,6 +1391,48 @@ Undocumented.prototype.validateNewUser = function( data, fn ) {
 };
 
 /**
+ * Sign up for a new passwordless user account
+ *
+ * @param {object} query - an object with the following values: email
+ * @param {Function} fn - Function to invoke when request is complete
+ */
+Undocumented.prototype.usersEmailNew = function( query, fn ) {
+	debug( '/users/email/new' );
+
+	// This API call is restricted to these OAuth keys
+	restrictByOauthKeys( query );
+
+	// Set the language for the user
+	query.locale = getLocaleSlug();
+	const args = {
+		path: '/users/email/new',
+		body: query,
+	};
+	return this.wpcom.req.post( args, fn );
+};
+
+/**
+ * Verify a new passwordless user account
+ *
+ * @param {object} query - an object with the following values: email, code
+ * @param {Function} fn - Function to invoke when request is complete
+ */
+Undocumented.prototype.usersEmailVerification = function( query, fn ) {
+	debug( '/users/email/verification' );
+
+	// This API call is restricted to these OAuth keys
+	restrictByOauthKeys( query );
+
+	// Set the language for the user
+	query.locale = getLocaleSlug();
+	const args = {
+		path: '/users/email/verification',
+		body: query,
+	};
+	return this.wpcom.req.post( args, fn );
+};
+
+/**
  * Request a "Magic Login" email be sent to a user so they can use it to log in
  * @param  {object} data - object containing an email address
  * @param  {Function} fn - Function to invoke when request is complete

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1402,8 +1402,6 @@ Undocumented.prototype.usersEmailNew = function( query, fn ) {
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
 
-	// Set the language for the user
-	query.locale = getLocaleSlug();
 	const args = {
 		path: '/users/email/new',
 		body: query,
@@ -1423,8 +1421,6 @@ Undocumented.prototype.usersEmailVerification = function( query, fn ) {
 	// This API call is restricted to these OAuth keys
 	restrictByOauthKeys( query );
 
-	// Set the language for the user
-	query.locale = getLocaleSlug();
 	const args = {
 		path: '/users/email/verification',
 		body: query,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -219,6 +219,13 @@ export function generateFlows( {
 			allowContinue: false,
 			hideFlowProgress: true,
 		},
+
+		simple: {
+			steps: [ 'passwordless' ],
+			destination: '/',
+			description: 'A very simple signup flow',
+			lastModified: '2019-05-09',
+		},
 	};
 
 	if ( config.isEnabled( 'rewind/clone-site' ) ) {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -54,6 +54,7 @@ const stepNameToModuleName = {
 	'site-topic-with-preview': 'site-topic',
 	'domains-with-preview': 'domains',
 	'site-title-with-preview': 'site-title',
+	passwordless: 'passwordless',
 };
 
 export async function getStepComponent( stepName ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -489,6 +489,13 @@ export function generateSteps( {
 			apiRequestFunction: launchSiteApi,
 			dependencies: [ 'siteSlug' ],
 		},
+
+		passwordless: {
+			stepName: 'passwordless',
+			providesToken: true,
+			providesDependencies: [ 'bearer_token', 'email', 'username' ],
+			unstorableDependencies: [ 'bearer_token' ],
+		},
 	};
 }
 

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -140,7 +140,7 @@ export class PasswordlessStep extends Component {
 		const { translate } = this.props;
 
 		if ( this.state.submitting ) {
-			return translate( 'Creating Your account…' );
+			return translate( 'Creating your account…' );
 		}
 
 		return translate( 'Create your account' );

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -4,7 +4,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { identity } from 'lodash';
 
@@ -13,7 +12,6 @@ import { identity } from 'lodash';
  */
 import StepWrapper from 'signup/step-wrapper';
 import SignupActions from 'lib/signup/actions';
-import { recordTracksEvent } from 'state/analytics/actions';
 import ValidationFieldset from 'signup/validation-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
@@ -161,7 +159,9 @@ export class PasswordlessStep extends Component {
 	renderNotice() {
 		return (
 			this.state.noticeMessage && (
-				<Notice status={ this.state.noticeStatus }>{ this.state.noticeMessage }</Notice>
+				<Notice showDismiss={ false } status={ this.state.noticeStatus }>
+					{ this.state.noticeMessage }
+				</Notice>
 			)
 		);
 	}
@@ -253,9 +253,4 @@ export class PasswordlessStep extends Component {
 	}
 }
 
-export default connect(
-	null,
-	{
-		recordTracksEvent,
-	}
-)( localize( PasswordlessStep ) );
+export default localize( PasswordlessStep );

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -1,0 +1,261 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { identity } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import SignupActions from 'lib/signup/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
+import ValidationFieldset from 'signup/validation-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import LoggedOutForm from 'components/logged-out-form';
+import LoggedOutFormFooter from 'components/logged-out-form/footer';
+import Button from 'components/button';
+import { createPasswordlessUser, verifyPasswordlessUser } from 'lib/signup/step-actions';
+import Notice from 'components/notice';
+
+import FormStateStore from 'lib/form-state';
+import createFormStore from 'lib/form-state/store';
+const { getFieldValue } = FormStateStore;
+
+export class PasswordlessStep extends Component {
+	static propTypes = {
+		flowName: PropTypes.string,
+		translate: PropTypes.func,
+	};
+
+	static defaultProps = {
+		translate: identity,
+	};
+
+	state = {
+		errorMessages: null,
+		noticeMessage: '',
+		noticeStatus: '',
+		submitting: false,
+		showVerificationCode: false,
+	};
+
+	UNSAFE_componentWillMount() {
+		this.formStore = createFormStore( {
+			syncInitialize: {
+				fieldNames: [ 'email', 'code' ],
+			},
+		} );
+	}
+
+	handleFieldChange = event => {
+		event.preventDefault();
+
+		this.setState( {
+			errorMessages: null,
+		} );
+
+		this.formStore.handleFieldChange( {
+			name: event.target.name,
+			value: event.target.value,
+		} );
+	};
+
+	createUser = event => {
+		event.preventDefault();
+		const data = { email: getFieldValue( this.formStore.get(), 'email' ) };
+
+		this.setState( {
+			submitting: true,
+		} );
+
+		createPasswordlessUser( this.handleUserCreationRequest, null, data );
+	};
+
+	handleUserCreationRequest = ( error, response ) => {
+		if ( error ) {
+			this.setState( {
+				errorMessages: [ error.message ],
+				submitting: false,
+			} );
+
+			return;
+		}
+
+		this.setState( {
+			errorMessages: null,
+			noticeMessage: response && response.message,
+			noticeStatus: response && response.warning ? 'is-warning' : 'is-info',
+			showVerificationCode: true,
+			submitting: false,
+		} );
+	};
+
+	verifyUser = event => {
+		event.preventDefault();
+		const data = {
+			email: getFieldValue( this.formStore.get(), 'email' ),
+			code: getFieldValue( this.formStore.get(), 'code' ),
+		};
+
+		this.setState( {
+			errorMessages: null,
+			submitting: true,
+		} );
+
+		verifyPasswordlessUser( this.handleUserVerificationRequest, null, data );
+	};
+
+	handleUserVerificationRequest = ( error, providedDependencies ) => {
+		if ( error ) {
+			this.setState( {
+				errorMessages: [ error && error.message ],
+				submitting: false,
+			} );
+
+			return;
+		}
+
+		this.submitStep( providedDependencies );
+	};
+
+	submitStep = providedDependencies => {
+		const { flowName, stepName } = this.props;
+
+		SignupActions.submitSignupStep(
+			{
+				flowName,
+				stepName,
+			},
+			providedDependencies
+		);
+
+		this.props.goToNextStep();
+	};
+
+	createUserButtonText() {
+		const { translate } = this.props;
+
+		if ( this.state.submitting ) {
+			return translate( 'Creating Your account…' );
+		}
+
+		return translate( 'Create your account' );
+	}
+
+	validateButtonText() {
+		const { translate } = this.props;
+
+		if ( this.state.submitting ) {
+			return translate( 'Verifying your code…' );
+		}
+
+		return translate( 'Verify your code' );
+	}
+
+	renderNotice() {
+		return (
+			this.state.noticeMessage && (
+				<Notice status={ this.state.noticeStatus }>{ this.state.noticeMessage }</Notice>
+			)
+		);
+	}
+
+	renderVerificationForm() {
+		return (
+			<LoggedOutForm onSubmit={ this.verifyUser } noValidate>
+				{ this.renderNotice() }
+				<ValidationFieldset errorMessages={ this.state.errorMessages }>
+					<FormLabel htmlFor="code">{ this.props.translate( 'Verifcation code' ) }</FormLabel>
+					<FormTextInput
+						autoCapitalize={ 'off' }
+						className="passwordless__code"
+						type="text"
+						name="code"
+						onChange={ this.handleFieldChange }
+						disabled={ this.state.submitting }
+					/>
+				</ValidationFieldset>
+				<LoggedOutFormFooter>
+					<Button
+						type="submit"
+						primary
+						busy={ this.state.submitting }
+						disabled={ this.state.submitting }
+					>
+						{ this.validateButtonText() }
+					</Button>
+				</LoggedOutFormFooter>
+			</LoggedOutForm>
+		);
+	}
+
+	renderSignupForm() {
+		return (
+			<LoggedOutForm onSubmit={ this.createUser } noValidate>
+				{ this.renderNotice() }
+				<ValidationFieldset errorMessages={ this.state.errorMessages }>
+					<FormLabel htmlFor="email">{ this.props.translate( 'Email address' ) }</FormLabel>
+					<FormTextInput
+						autoCapitalize={ 'off' }
+						className="passwordless__code"
+						type="hidden"
+						name="code"
+						onChange={ this.handleFieldChange }
+						disabled={ this.state.submitting }
+					/>
+					<FormTextInput
+						autoCapitalize={ 'off' }
+						className="passwordless__email"
+						type="email"
+						name="email"
+						onChange={ this.handleFieldChange }
+						disabled={ this.state.submitting }
+					/>
+				</ValidationFieldset>
+				<LoggedOutFormFooter>
+					<Button
+						type="submit"
+						primary
+						busy={ this.state.submitting }
+						disabled={ this.state.submitting }
+					>
+						{ this.createUserButtonText() }
+					</Button>
+				</LoggedOutFormFooter>
+			</LoggedOutForm>
+		);
+	}
+
+	renderStepContent() {
+		return this.state.showVerificationCode
+			? this.renderVerificationForm()
+			: this.renderSignupForm();
+	}
+
+	render() {
+		return (
+			<StepWrapper
+				flowName={ this.props.flowName }
+				stepName={ this.props.stepName }
+				headerText={ this.props.headerText }
+				subHeaderText={ this.props.translate( 'Create a WordPress.com account' ) }
+				positionInFlow={ this.props.positionInFlow }
+				signupProgress={ this.props.signupProgress }
+				stepContent={ this.renderStepContent() }
+			/>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+	}
+)( localize( PasswordlessStep ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The PR adds a new step to signup to enable passwordless signup. This has been supported in the API for several years but it's never been implemented on wp.com.

There are some open questions on the expected behaviour:
1. If a user enters a known email address, do we allow them to use this flow to log in, or should we send them to /log-in?
2. If a user enters a unknown email address, do we expect them to verify it with a code before creating the account? Currently we don't do this, so this feels like an extra unnecessary step, but the advantage of doing it is that the email address is verified.

This currently doesn't work for 2FA accounts. How we handle 2FA will depend on the decisions we make on the above questions...

#### Testing instructions

For a new account
* Go to http://calypso.localhost:3000/start/simple
* Enter an email address that isn't associated with a WordPress.com account
* Enter the verification code that is emailed to you
* Check you are logged in

For an existing account
* Go to http://calypso.localhost:3000/start/simple
* Enter an email address that is already associated with a WordPress.com account (but one without 2FA)
* Enter the verification code that is emailed to you
* Check you are logged in

