### PR TITLE
Domains: Update invalid auth code copy

### DIFF
--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -21,6 +21,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import FormattedHeader from 'components/formatted-header';
 import {
 	CALYPSO_CONTACT,
+	INCOMING_DOMAIN_TRANSFER_AUTH_CODE_INVALID,
 	INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE,
 	INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK,
 } from 'lib/url/support';
@@ -293,7 +294,24 @@ class TransferDomainPrecheck extends React.Component {
 						isError={ authCodeInvalid }
 					/>
 					{ authCodeInvalid && (
-						<FormInputValidation text={ translate( 'Auth Code invalid' ) } isError />
+						<FormInputValidation
+							text={ translate(
+								'The auth code you entered is invalid. ' +
+									'Please try again, or see {{a}}this support document{{/a}} for more troubleshooting steps.',
+								{
+									components: {
+										a: (
+											<a
+												href={ INCOMING_DOMAIN_TRANSFER_AUTH_CODE_INVALID }
+												rel="noopener noreferrer"
+												target="_blank"
+											/>
+										),
+									},
+								}
+							) }
+							isError
+						/>
 					) }
 				</div>
 			</div>

--- a/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
+++ b/client/components/domains/transfer-domain-step/transfer-domain-precheck.jsx
@@ -296,8 +296,8 @@ class TransferDomainPrecheck extends React.Component {
 					{ authCodeInvalid && (
 						<FormInputValidation
 							text={ translate(
-								'The auth code you entered is invalid. ' +
-									'Please try again, or see {{a}}this support document{{/a}} for more troubleshooting steps.',
+								'The auth code you entered is invalid. Please verify you’re entering the correct code, ' +
+									'or see {{a}}this support document{{/a}} for more troubleshooting steps.',
 								{
 									components: {
 										a: (

--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -40,6 +40,7 @@ export const INCOMING_DOMAIN_TRANSFER_STATUSES_CANCEL = `${ root }/incoming-doma
 export const INCOMING_DOMAIN_TRANSFER = `${ root }/incoming-domain-transfer/`;
 export const INCOMING_DOMAIN_TRANSFER_PREPARE_UNLOCK = `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#unlock`;
 export const INCOMING_DOMAIN_TRANSFER_PREPARE_AUTH_CODE = `${ root }/incoming-domain-transfer/prepare-domain-for-transfer/#auth-code`;
+export const INCOMING_DOMAIN_TRANSFER_AUTH_CODE_INVALID = `${ root }/incoming-domain-transfer/#auth-code-invalid`;
 export const EMAIL_FORWARDING = `${ root }/email-forwarding`;
 export const EMAIL_VALIDATION_AND_VERIFICATION = `${ root }/domains/register-domain/#email-validation-and-verification`;
 export const EMPTY_SITE = `${ root }/empty-site/`;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Link to the support docs and make the copy clearer.

#### Testing instructions

- Try to transfer a domain. (you can try with mine: http://calypso.localhost:3000/domains/add/transfer/testable.wales?initialQuery=codeden.net)
- Confirm you see the new message in the precheck screen.