### PR TITLE
o2 blocks: add "Automattic" category to block picker

### DIFF
--- a/apps/o2-blocks/.eslintrc.js
+++ b/apps/o2-blocks/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
 	rules: {
+		'import/no-extraneous-dependencies': 0,
 		'react/react-in-jsx-scope': 0,
 		'wpcalypso/jsx-classname-namespace': 0,
 	},

--- a/apps/o2-blocks/src/category.js
+++ b/apps/o2-blocks/src/category.js
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { getCategories, setCategories } from '@wordpress/blocks';
+
+setCategories( [
+	...getCategories().filter( ( { slug } ) => slug !== 'a8c' ),
+	// Add Automattic block category to block picker
+	{
+		slug: 'a8c',
+		title: 'Automattic',
+		icon: (
+			<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+				<path
+					fill="#3399cc"
+					d="M12 21.5c-6.1 0-10-4.4-10-9V12c0-4.6 4-9 10-9 6.1 0 10.1 4.3 10.1 9v.6c0 4.5-3.9 8.9-10.1 8.9zm6.9-9.5c0-3.3-2.4-6.3-6.8-6.3s-6.8 3-6.8 6.3v.4c0 3.3 2.4 6.4 6.8 6.4s6.8-3 6.8-6.4V12z"
+				/>
+				<path
+					fill="#000000"
+					d="M14.1 8.5c.6.4.7 1.2.4 1.7l-2.9 4.6c-.4.6-1.2.8-1.7.4-.7-.4-.9-1.2-.5-1.8l2.9-4.6c.4-.5 1.2-.7 1.8-.3z"
+				/>
+			</svg>
+		),
+	},
+] );

--- a/apps/o2-blocks/src/editor-notes/editor.js
+++ b/apps/o2-blocks/src/editor-notes/editor.js
@@ -36,7 +36,7 @@ const save = () => null;
 registerBlockType( 'a8c/editor-notes', {
 	title: "Editor's Notes",
 	icon: 'welcome-write-blog',
-	category: 'common',
+	category: 'a8c',
 	attributes,
 	edit,
 	save,

--- a/apps/o2-blocks/src/editor.js
+++ b/apps/o2-blocks/src/editor.js
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import './category';
 import './editor-notes/editor';
 import './prev-next/editor';
 import './todo/editor';

--- a/apps/o2-blocks/src/prev-next/editor.js
+++ b/apps/o2-blocks/src/prev-next/editor.js
@@ -68,7 +68,7 @@ const edit = ( { attributes, className, isSelected, setAttributes } ) => {
 registerBlockType( 'a8c/prev-next', {
 	title: __( 'Prev/Next Links' ),
 	icon: 'leftright',
-	category: 'common',
+	category: 'a8c',
 	description: __( 'Link this post to sequential posts in a series of related posts.' ),
 	keywords: [ __( 'links' ) ],
 	attributes: blockAttributes,

--- a/apps/o2-blocks/src/todo/editor.js
+++ b/apps/o2-blocks/src/todo/editor.js
@@ -271,7 +271,7 @@ const save = class extends Component {
 registerBlockType( 'a8c/todo', {
 	title: __( 'Task List' ),
 	icon: 'editor-ul',
-	category: 'common',
+	category: 'a8c',
 	keywords: [ __( 'todo' ) ],
 	attributes: blockAttributes,
 	edit,


### PR DESCRIPTION
Add Automattic category to block picker

<img width="465" alt="Screenshot 2019-05-16 at 22 21 59" src="https://user-images.githubusercontent.com/87168/57881301-99276980-7829-11e9-9dca-d1787b9590e8.png">

More discoverable these blocks are in P2s, more we'll use them and the more people will be encouraged to experiment on building new blocks.

### Testing
Follow instructions in `apps/o2-blocks/README.md` and in D28325-code