### PR TITLE
Jetpack checklist: remove navigation placeholders

### DIFF
--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -10,6 +10,7 @@ import page from 'page';
 import CurrentPlan from './';
 import { getSelectedSite } from 'state/ui/selectors';
 import { isFreePlan } from 'lib/products-values';
+import { setSection } from 'state/ui/actions';
 
 export function currentPlan( context, next ) {
 	const state = context.store.getState();
@@ -33,6 +34,7 @@ export function currentPlan( context, next ) {
 	context.primary = <CurrentPlan path={ context.path } requestThankYou={ requestThankYou } />;
 
 	if ( requestThankYou ) {
+		context.store.dispatch( setSection( null, { hasSidebar: false } ) );
 		context.secondary = null;
 	}
 

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -33,7 +33,6 @@ import QuerySiteDomains from 'components/data/query-site-domains';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import DomainWarnings from 'my-sites/domains/components/domain-warnings';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import JetpackChecklist from 'my-sites/plans/current-plan/jetpack-checklist';
 import { isEnabled } from 'config';
@@ -123,7 +122,7 @@ class CurrentPlan extends Component {
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
-				{ showThankYou ? <SectionNav /> : <PlansNavigation path={ path } /> }
+				{ ! showThankYou && <PlansNavigation path={ path } /> }
 
 				{ showDomainWarnings && (
 					<DomainWarnings


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove navigation placeholders in Jetpack checklist view when "thank you" banner is visible.

Follow up from https://github.com/Automattic/wp-calypso/pull/32951#issuecomment-493148275

#### Testing instructions

Just to test how it looks like:
- Have a Jetpack site with a paid plan
- Open `http://calypso.localhost:3000/plans/my-plan/:YOUR_SITE?thank-you`

Before:

<img width="1440" alt="Screenshot 2019-05-16 at 22 41 52" src="https://user-images.githubusercontent.com/87168/57882199-d55bc980-782b-11e9-9f36-c30600c3abe1.png">

After:
<img width="1440" alt="Screenshot 2019-05-16 at 22 41 23" src="https://user-images.githubusercontent.com/87168/57882205-d856ba00-782b-11e9-8eef-a7ee857e57a6.png">

