### PR TITLE
Checklist task: don't link completed task from the title

### DIFF
--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -178,7 +178,9 @@ class Task extends PureComponent {
 			>
 				<div className="checklist__task-primary">
 					<h3 className="checklist__task-title">
-						{ ( completed && completedTitle ) || (
+						{ completed ? (
+							completedTitle || title
+						) : (
 							<Button
 								borderless
 								className="checklist__task-title-link"

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -178,15 +178,17 @@ class Task extends PureComponent {
 			>
 				<div className="checklist__task-primary">
 					<h3 className="checklist__task-title">
-						<Button
-							borderless
-							className="checklist__task-title-link"
-							href={ href }
-							onClick={ this.onTaskClick }
-							target={ target }
-						>
-							{ ( completed && completedTitle ) || title }
-						</Button>
+						{ ( completed && completedTitle ) || (
+							<Button
+								borderless
+								className="checklist__task-title-link"
+								href={ href }
+								onClick={ this.onTaskClick }
+								target={ target }
+							>
+								{ title }
+							</Button>
+						) }
 					</h3>
 					<p className="checklist__task-description">{ description }</p>
 					{ completedDescription && (


### PR DESCRIPTION
Jetpack Checklist task: don't link completed tasks from the title since it's not obvious and thus confusing.

Resolves https://github.com/Automattic/wp-calypso/issues/33093

### Testing instructions

#### Checklist for Jetpack sites
- Have a Jetpack connected site and open `http://calypso.localhost:3000/plans/my-plan/:site`
- Titles are links for uncompleted tasks
- Titles are NOT links for completed tasks
- You can still click "configure" meta links

<img width="955" alt="Screenshot 2019-05-17 at 08 53 24" src="https://user-images.githubusercontent.com/87168/57906068-58f3d580-7881-11e9-9445-9f2730b44ead.png">

#### Checklist for wpcom sites
- Have a wpcom site with a plan and open `http://calypso.localhost:3000/checklist/:site`
- Confirm that you can toggle open greyed and collapsed, unfinished tasks
- Titles are links for uncompleted tasks
- Titles are NOT links for completed tasks
- You can still click "configure" meta links

<img width="742" alt="image" src="https://user-images.githubusercontent.com/87168/57906274-1b437c80-7882-11e9-8603-4340dd03db55.png">
