### PR TITLE
View Page menu item: remove the unneeded preventDefault call

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -92,8 +92,7 @@ class Page extends Component {
 		return ( this.props.site && this.props.site.domain ) || '...';
 	}
 
-	viewPage = event => {
-		event.preventDefault();
+	viewPage = () => {
 		const { isPreviewable, page, previewURL } = this.props;
 
 		if ( page.status && page.status === 'publish' ) {


### PR DESCRIPTION
No need to prevent the default for a button element, as there is no default action.
It would be useful to override navigation in `<a href onClick>`, but that's not the case here.

Regressed by #32297 that stopped passing the DOM event to the `onClick` handler.