### PR TITLE
Site Topic Step: fix width of the absolute-positioned selector

### DIFF
--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -8,8 +8,7 @@ body.is-section-jetpack-connect .site-topic__content {
 	.form-fieldset {
 		margin-bottom: 0;
 		position: absolute;
-		left: 0;
-		right: 0;
+		width: 100%;
 		z-index: 1000; // I know, I know...
 		border-radius: 4px;
 		background: var( --color-white );


### PR DESCRIPTION
Fixes wrong width of the selector element I see on Chrome 75 on Mac:

<img width="553" alt="Screenshot 2019-05-17 at 09 41 17" src="https://user-images.githubusercontent.com/664258/57911660-9f98fe00-7888-11e9-82d3-ebf96e57ee51.png">

Apparently Chrome doesn't respect the `right: 0` property. Replaced the `left` and `right` properties with `width: 100%`. I thought I knew CSS, but have no idea what's going on here. The parent element with `position: relative` has the correct dimensions, and yet the absolute-positioned child element doesn't fill the whole width. Safari and Firefox are ok both before and after.

A little question for @shaunandrews: why does the `.form-fieldset` need `z-index: 1000`? It doesn't seem to overlap another element. Maybe on a different page (other than signup) it does?