### PR TITLE
Account: Add a new language: Saraiki

### DIFF
--- a/client/languages.js
+++ b/client/languages.js
@@ -659,12 +659,12 @@ export const languages = [
 		territories: [ '151' ],
 	},
 	{
-		value: 486,
-		langSlug: 'skr',
-		name: 'Saraiki',
-		rtl: true,
-		wpLocale: 'skr',
-		territories: [ '034' ],
+		"value": 486,
+		"langSlug": "skr",
+		"name": "سرائیکی",
+		"rtl": true,
+		"wpLocale": "skr",
+		"territories": [ "034" ]
 	},
 	{
 		value: 65,

--- a/client/languages.js
+++ b/client/languages.js
@@ -659,6 +659,14 @@ export const languages = [
 		territories: [ '151' ],
 	},
 	{
+		value: 486,
+		langSlug: 'skr',
+		name: 'Saraiki',
+		rtl: true,
+		wpLocale: 'skr',
+		territories: [ '034' ],
+	},
+	{
 		value: 65,
 		langSlug: 'sl',
 		name: 'Slovenščina',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a new language Option: Sariki

<img width="1019" alt="calyspo-language-selector-saraiki" src="https://user-images.githubusercontent.com/203408/57916817-ea6c4300-7893-11e9-8541-ec46c344cb51.png">
<img width="1359" alt="calypso-saraiki-stats-page" src="https://user-images.githubusercontent.com/203408/57916819-ec360680-7893-11e9-999e-2bded67f30cc.png">

#### Testing instructions

* Go to /me/account and find Saraiki under Asia-Pacific
* Activate the language by saving settings
* Ensure that Saraiki has been loaded (loading widgets.wp.com/languages/calypso/skr.json and displaying an RTL language)

See also pxLjZ-5i3-p2