### PR TITLE
Theme: Customize Site button to open in a New Tab

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -578,7 +578,7 @@ class ThemeSheet extends React.Component {
 				href={ getUrl ? getUrl( this.props.id ) : null }
 				onClick={ this.onButtonClick }
 				primary={ isActive }
-				target={ this.props.isActive ? '_blank' : null }
+				target={ isActive ? '_blank' : null }
 			>
 				{ this.isLoaded() ? label : placeholder }
 				{ this.props.isWpcomTheme && this.renderPrice() }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -573,6 +573,7 @@ class ThemeSheet extends React.Component {
 				href={ getUrl ? getUrl( this.props.id ) : null }
 				onClick={ this.onButtonClick }
 				primary={ isActive }
+				target={ this.props.isActive ? '_blank' : null }
 			>
 				{ this.isLoaded() ? label : placeholder }
 				{ this.props.isWpcomTheme && this.renderPrice() }
@@ -609,7 +610,7 @@ class ThemeSheet extends React.Component {
 		const analyticsPageTitle = `Themes > Details Sheet${
 			section ? ' > ' + titlecase( section ) : ''
 		}${ siteId ? ' > Site' : '' }`;
-		
+
 		const plansUrl = siteSlug ? `/plans/${ siteSlug }/?plan=value_bundle` : '/plans';
 
 		const { canonicalUrl, currentUserId, description, name: themeName } = this.props;

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -507,8 +507,13 @@ class ThemeSheet extends React.Component {
 	getDefaultOptionLabel = () => {
 		const { defaultOption, isActive, isLoggedIn, isPremium, isPurchased } = this.props;
 		if ( isActive ) {
-			// Customize size
-			return i18n.translate( 'Customize site' );
+			// Customize site
+			return (
+				<span className="theme__sheet-customize-button">
+					<Gridicon icon="external" />
+					{ i18n.translate( 'Customize site' ) }
+				</span>
+			);
 		} else if ( isLoggedIn ) {
 			if ( isPremium && ! isPurchased ) {
 				// purchase

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -75,6 +75,12 @@
 	}
 }
 
+.theme__sheet-customize-button {
+	.gridicon {
+		margin-right: 4px;
+	}
+}
+
 .theme__sheet-button-placeholder {
 	color: transparent;
 }

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -101,7 +101,7 @@ class ThanksModal extends Component {
 	goToCustomizer = () => {
 		this.trackClick( 'thanks modal customize' );
 		this.onCloseModal();
-		page( window.open( this.props.customizeUrl ) );
+		window.open( this.props.customizeUrl, '_blank' );
 	};
 
 	renderThemeInfo = () => {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -100,7 +100,7 @@ class ThanksModal extends Component {
 	goToCustomizer = () => {
 		this.trackClick( 'thanks modal customize' );
 		this.onCloseModal();
-		page( this.props.customizeUrl );
+		page( window.open ( this.props.customizeUrl ) );
 	};
 
 	renderThemeInfo = () => {

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import page from 'page';
 import { translate } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -100,7 +101,7 @@ class ThanksModal extends Component {
 	goToCustomizer = () => {
 		this.trackClick( 'thanks modal customize' );
 		this.onCloseModal();
-		page( window.open ( this.props.customizeUrl ) );
+		page( window.open( this.props.customizeUrl ) );
 	};
 
 	renderThemeInfo = () => {
@@ -173,9 +174,14 @@ class ThanksModal extends Component {
 
 	render() {
 		const { currentTheme, hasActivated, isActivating } = this.props;
-		const customizeSiteText = hasActivated
-			? translate( 'Customize site' )
-			: translate( 'Activating theme…' );
+		const customizeSiteText = hasActivated ? (
+			<span className="thanks-modal__button-customize">
+				<Gridicon icon="external" />
+				{ translate( 'Customize site' ) }
+			</span>
+		) : (
+			translate( 'Activating theme…' )
+		);
 		const buttons = [
 			{
 				action: 'learn',

--- a/client/my-sites/themes/thanks-modal.scss
+++ b/client/my-sites/themes/thanks-modal.scss
@@ -13,6 +13,12 @@
 			margin-left: 0;
 		}
 
+		.thanks-modal__button-customize {
+			.gridicon {
+				margin-right: 4px;
+			}
+		}
+
 		@include breakpoint( '<480px' ) {
 			.button,
 			.button:first-child {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If the theme is active on the user's site, have the button to open in a new tab.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to My Sites > Design > Themes > Info
* Click on the "Customize site" button
* Does it open in a new window? (It should)
* Go back to My Sites > Design > Themes
* Click on an inactive theme
* Click on the "Activate this design" button
* Does it open in a new window? (It shouldn't)
Fixes #33088

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/57916826-8fcee900-788b-11e9-92e7-569b0b7f9825.gif)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/57916845-99f0e780-788b-11e9-83fd-1786c5799f6a.gif)
