### PR TITLE
Improve checklist component for narrow screens

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -58,6 +58,7 @@
 	}
 
 	&-summary {
+		align-self: center;
 		font-size: 12px;
 		line-height: 24px;
 		color: var( --color-text-subtle );

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -2,20 +2,38 @@
 	display: flex;
 	flex-direction: row;
 
+	@include breakpoint( '<480px' ) {
+		flex-direction: column;
+		justify-content: flex-end;
+	}
+
+	&.card {
+		padding: 0;
+	}
+
 	&-main {
 		display: flex;
 		flex: 1 1;
 		flex-direction: column;
 		align-items: stretch;
+		padding: 16px 24px;
+		@include breakpoint( '<480px' ) {
+			padding: 16px;
+		}
 	}
 
 	&-secondary {
+		align-items: stretch;
 		display: flex;
-		flex: 2 1;
 		flex-direction: row;
-		align-items: center;
+		flex: 2 1;
 		justify-content: flex-end;
-		padding-right: 36px;
+		padding: 0;
+
+		@include breakpoint( '<480px' ) {
+			justify-content: flex-end;
+			border-top: 1px solid var( --color-border-subtle );
+		}
 	}
 
 	&-progress {
@@ -44,14 +62,14 @@
 		line-height: 24px;
 		color: var( --color-text-subtle );
 		cursor: pointer;
+		padding: 16px;
+		@include breakpoint( '<480px' ) {
+			flex: 1;
+		}
 	}
 
 	&-action {
-		position: absolute;
-		top: 0;
-		right: 0;
 		width: 48px;
-		height: 100%;
 		border-left: 1px solid var( --color-neutral-0 );
 		cursor: pointer;
 

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -109,10 +109,6 @@
 		@include breakpoint( '<480px' ) {
 			flex-direction: column;
 		}
-
-		&.is-completed {
-			flex-direction: row;
-		}
 	}
 
 	&::before {
@@ -315,6 +311,9 @@
 			font-weight: 400;
 			width: 100%;
 			text-align: right;
+			@include breakpoint( '<480px' ) {
+				text-align: left;
+			}
 		}
 
 		@include breakpoint( '<480px' ) {

--- a/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
@@ -23,7 +23,7 @@
 		max-width: 80%;
 		display: block;
 		margin: 20px auto;
-		@include breakpoint( '<480px' ) {
+		@include breakpoint( '<660px' ) {
 			display: none;
 		}
 	}

--- a/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
@@ -23,6 +23,9 @@
 		max-width: 80%;
 		display: block;
 		margin: 20px auto;
+		@include breakpoint( '<480px' ) {
+			display: none;
+		}
 	}
 }
 


### PR DESCRIPTION
Improves checklist component and Jetpack checklist on mobile/narrow screens. 

Partially helps with https://github.com/Automattic/wp-calypso/issues/32835

#### Changes proposed in this Pull Request

##### Hide image on small screens:

Before
<img src="https://user-images.githubusercontent.com/87168/57921389-ee08c580-78a5-11e9-98f6-c767fff6d049.png" alt="" width="300">

After
<img src="https://user-images.githubusercontent.com/87168/57921397-f3fea680-78a5-11e9-8244-a8c36a891b3a.png" alt="" width="300">

##### Action under titles on small screens:

Before
<img src="https://user-images.githubusercontent.com/87168/57921580-548de380-78a6-11e9-9d57-73eeaa4a75ec.png" alt="" width="300">

After
<img src="https://user-images.githubusercontent.com/87168/57921569-4dff6c00-78a6-11e9-9f83-a6b124272b87.png" alt="" width="300">

##### Improve toggle

Before
<img src="https://user-images.githubusercontent.com/87168/57921547-43dd6d80-78a6-11e9-9d57-4db8a65d868a.png" alt="" width="300">

After
<img src="https://user-images.githubusercontent.com/87168/57921529-39bb6f00-78a6-11e9-9b67-9233f71b35a7.png" alt="" width="300">



#### Testing instructions

- With Jetpack site, open `http://calypso.localhost:3000/plans/my-plan/:site`
- With a paid wpcom site, open `http://calypso.localhost:3000/checklist/:site`

Confirm that everything looks good on different screen sizes. Screens over 480px wide or so shouldn't have any changes, apart from the image being gone in Jetpack checklist already under 660pxp.

Pay especially attention to margins/paddings so that everything is aligned and not changed in different screen sizes.