### PR TITLE
Signup: Update strings for site type step

### DIFF
--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -35,9 +35,9 @@ class SiteType extends Component {
 			hasInitializedSitesBackUrl,
 		} = this.props;
 
-		const headerText = translate( 'What are we building today?' );
+		const headerText = translate( 'What kind of site are you building?' );
 		const subHeaderText = translate(
-			'Choose the best starting point for your site. You can add or change features later on.'
+			'This is just a starting point. You can add or change features later.'
 		);
 
 		return (


### PR DESCRIPTION
|Before|After|
|---|---|
|<img width="491" alt="site-type-strings-before" src="https://user-images.githubusercontent.com/1587282/57937129-54381d00-7893-11e9-9c64-2027b7f4101b.png">|<img width="491" alt="Screen Shot 2019-05-17 at 11 00 46 AM" src="https://user-images.githubusercontent.com/1587282/57937047-310d6d80-7893-11e9-9241-f6b2b3dc09c6.png">|

#### Changes proposed in this Pull Request

* Change values of two strings in the site type step component

#### Testing instructions

* Run branch
* Visit `/start`
* Progress forward or back through the flow to the site type step (if not there already)

Fixes https://github.com/Automattic/zelda-private/issues/21
