### PR TITLE
Cache the results of ApplePaySession.canMakePayments() for better performance on certain Safari versions

### DIFF
--- a/client/lib/web-payment/index.js
+++ b/client/lib/web-payment/index.js
@@ -12,6 +12,36 @@ export const WEB_PAYMENT_BASIC_CARD_METHOD = 'basic-card';
 export const WEB_PAYMENT_APPLE_PAY_METHOD = 'https://apple.com/apple-pay';
 
 /**
+ * Determines if Apple Pay is an available payment method.
+ *
+ * @returns {boolean} True if Apple Pay is an enabled payment method and if the
+ *                    user's device supports Apple Pay, false otherwise.
+ */
+export function isApplePayAvailable() {
+	if ( ! config.isEnabled( 'my-sites/checkout/web-payment/apple-pay' ) ) {
+		return false;
+	}
+
+	// Our Apple Pay implementation uses the Payment Request API, so check that
+	// first.
+	if ( ! window.PaymentRequest ) {
+		return false;
+	}
+
+	// Check if Apple Pay is available. This can be very expensive on certain
+	// Safari versions due to a bug (https://trac.webkit.org/changeset/243447/webkit),
+	// and there is no way it can change during a page request, so cache the
+	// result.
+	if ( typeof isApplePayAvailable.canMakePayments === 'undefined' ) {
+		isApplePayAvailable.canMakePayments = Boolean(
+			window.ApplePaySession && window.ApplePaySession.canMakePayments()
+		);
+	}
+
+	return isApplePayAvailable.canMakePayments;
+}
+
+/**
  * Returns an available Web Payment method.
  *
  * Web Payments (`PaymentRequest` API) are available only if the
@@ -24,18 +54,7 @@ export const WEB_PAYMENT_APPLE_PAY_METHOD = 'https://apple.com/apple-pay';
  *                         if none can be detected.
  */
 export function detectWebPaymentMethod() {
-	if ( ! config.isEnabled( 'my-sites/checkout/web-payment' ) ) {
-		return null;
-	}
-
-	if (
-		config.isEnabled( 'my-sites/checkout/web-payment/apple-pay' ) &&
-		window.ApplePaySession &&
-		window.ApplePaySession.canMakePayments() &&
-		// Our Apple Pay implementation uses the Payment Request API, so check
-		// that also.
-		window.PaymentRequest
-	) {
+	if ( isApplePayAvailable() ) {
 		return WEB_PAYMENT_APPLE_PAY_METHOD;
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -122,7 +122,6 @@
 		"me/my-profile": true,
 		"me/notifications": true,
 		"me/trophies": false,
-		"my-sites/checkout/web-payment": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": true,

--- a/config/production.json
+++ b/config/production.json
@@ -80,7 +80,6 @@
 		"me/my-profile": true,
 		"me/notifications": true,
 		"me/trophies": false,
-		"my-sites/checkout/web-payment": false,
 		"my-sites/checkout/web-payment/apple-pay": false,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -82,7 +82,6 @@
 		"me/my-profile": true,
 		"me/notifications": true,
 		"me/trophies": false,
-		"my-sites/checkout/web-payment": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -98,7 +98,6 @@
 		"me/my-profile": true,
 		"me/notifications": true,
 		"me/trophies": false,
-		"my-sites/checkout/web-payment": true,
 		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"network-connection": true,


### PR DESCRIPTION
During testing, Apple Pay is leading to very bad performance on the checkout page for certain versions of Safari on Mac.

It's likely due to [this bug](https://trac.webkit.org/changeset/243447/webkit), fixed in the latest versions of WebKit but not yet included in the latest official Safari release.

This pull request implements a workaround of only calling `ApplePaySession.canMakePayments()` once per page request, and caching the result.  Hopefully that will improve performance a lot.

The new code is contained within a new function called `isApplePayAvailable()`.  We can later use that function when collecting stats on Apple Pay usage, so to make sure it always tells the truth without having to run duplicate checks, I've also simplified things by removing the `my-sites/checkout/web-payment` configuration setting in this patch; this was effectively a global kill-switch for all wallet-based payment methods (both Apple Pay and `basic-card`, the latter of which we don't expose to users anyway).  This setting isn't necessary since we already have settings for the individual payment methods, and they are already set correctly in all environments.

p7DVsv-6xD-p2
