### PR TITLE
Fail gracefully when accountToConnect is null

### DIFF
--- a/client/my-sites/marketing/connections/account-dialog.jsx
+++ b/client/my-sites/marketing/connections/account-dialog.jsx
@@ -62,7 +62,9 @@ class AccountDialog extends Component {
 	onClose = action => {
 		const accountToConnect = this.getAccountToConnect();
 		const externalUserId =
-			this.props.service.multiple_external_user_ID_support && accountToConnect.isExternal
+			this.props.service.multiple_external_user_ID_support &&
+			accountToConnect &&
+			accountToConnect.isExternal
 				? accountToConnect.ID
 				: 0;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds check to ensure `accountToConnect` exists

#### Testing instructions

* Starting at URL: https://wordpress.com/marketing/connections/eric.blog
* Click "Connect" button for Google My Business
* Connect to account
* View modal
* Try to click "Connect" or "Cancel" buttons in modal and notice modal does not close

Fixes #33060
