### PR TITLE
Only add url part if invite for certain roles

### DIFF
--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -231,7 +231,14 @@ class InvitePeople extends React.Component {
 			has_custom_message: 'string' === typeof message && !! message.length,
 		} );
 
-		page( `/people/new/${ this.props.site.slug }/sent` );
+		if (
+			role === 'administrator' ||
+			role === 'editor' ||
+			role === 'author' ||
+			role === 'contributor'
+		) {
+			page( `/people/new/${ this.props.site.slug }/sent` );
+		}
 	};
 
 	isSubmitDisabled = () => {

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -231,12 +231,7 @@ class InvitePeople extends React.Component {
 			has_custom_message: 'string' === typeof message && !! message.length,
 		} );
 
-		if (
-			role === 'administrator' ||
-			role === 'editor' ||
-			role === 'author' ||
-			role === 'contributor'
-		) {
+		if ( includes( [ 'administrator', 'editor', 'author', 'contributor' ], role ) ) {
 			page( `/people/new/${ this.props.site.slug }/sent` );
 		}
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Follow up for: https://github.com/Automattic/wp-calypso/pull/32054
* Only add url part when invite is for an Admin, Editor, Author, or Contributor.


#### Testing instructions

* Add follower to your site
* /sent should not be appended to url
* Add admin to your site
* /sent should be appended to url

