### PR TITLE
Signup: Update strings for the user step #improvedOnboarding

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -84,6 +84,7 @@ class SignupForm extends Component {
 		displayNameInput: PropTypes.bool,
 		displayUsernameInput: PropTypes.bool,
 		email: PropTypes.string,
+		flowName: PropTypes.string,
 		footerLink: PropTypes.node,
 		formHeader: PropTypes.node,
 		redirectToAfterLoginUrl: PropTypes.string.isRequired,
@@ -108,6 +109,7 @@ class SignupForm extends Component {
 	static defaultProps = {
 		displayNameInput: false,
 		displayUsernameInput: true,
+		flowName: '',
 		isSocialSignupEnabled: false,
 	};
 
@@ -693,6 +695,8 @@ class SignupForm extends Component {
 	}
 
 	footerLink() {
+		const { flowName, translate } = this.props;
+
 		if ( this.props.positionInFlow !== 0 ) {
 			return;
 		}
@@ -704,7 +708,9 @@ class SignupForm extends Component {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href={ logInUrl }>
-					{ this.props.translate( 'Already have a WordPress.com account?' ) }
+					{ [ 'onboarding', 'onboarding-dev' ].includes( flowName )
+						? translate( 'Log in to create a site for your existing account.' )
+						: translate( 'Already have a WordPress.com account?' ) }
 				</LoggedOutFormLinkItem>
 				{ this.props.oauth2Client && (
 					<LoggedOutFormBackLink

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -75,7 +75,7 @@ class StepWrapper extends Component {
 				return this.props.headerText;
 			}
 
-			return this.props.translate( "Let's get started." );
+			return this.props.translate( "Let's get started" );
 		}
 
 		if ( this.props.fallbackHeaderText !== undefined ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -91,7 +91,7 @@ export class UserStep extends Component {
 	}
 
 	setSubHeaderText( props ) {
-		const { flowName, oauth2Client, translate } = props;
+		const { flowName, oauth2Client, positionInFlow, translate } = props;
 
 		let subHeaderText = props.subHeaderText;
 
@@ -144,6 +144,10 @@ export class UserStep extends Component {
 		} else if ( 'onboarding-dev' === flowName ) {
 			// Displays no sub header for onboarding-dev flow
 			subHeaderText = '';
+		}
+
+		if ( positionInFlow === 0 && [ 'onboarding', 'onboarding-dev' ].includes( flowName ) ) {
+			subHeaderText = translate( 'First, create your WordPress.com account.' );
 		}
 
 		this.setState( { subHeaderText } );


### PR DESCRIPTION
### Changes proposed in this Pull Request

- Remove the period from the title so it's consistent with our other titles: "Let's get started." > `Let's get started`
- Update the subtitle to `First, create your WordPress.com account.` (we use punctuation in subtitles but not titles)
- Change the "Already have a WordPress.com account" to `Log in to create a site for your existing account.`

### Testing instructions

#### Onboarding flow

* In a logged-out browser: https://hash-cdf200d51c5866c2bda94da245a32be7b0518f2f.calypso.live/start
* Changes above should be reflected

#### Other Flows

* In a logged-out browser: https://gravatar.com
* Click `Create Your Own Gravatar`
* Replace `https://wordpress.com/` in the address bar URL with `https://hash-cdf200d51c5866c2bda94da245a32be7b0518f2f.calypso.live/` & open in a new tab
* Compare the two tabs -- they should be identical & pertinent to the Gravatar user creation step

Fixes https://github.com/Automattic/zelda-private/issues/20
