### PR TITLE
Signup: update segment IDs to reflect backend

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -33,12 +33,14 @@ export function getSiteTypePropertyValue( key, value, property, siteTypes = getA
  * A user who comes in via a landing page will not see the Site Topic dropdown.
  * Do note that id's per site type should not be changed as we add/remove site-types.
  *
+ * Please don't modify the IDs for now until we can integrate the /segments API into Calypso.
+ *
  * @return {array} current list of site types
  */
 export function getAllSiteTypes() {
 	return [
 		{
-			id: 2,
+			id: 2, // This value must correspond with its sibling in the /segments API results
 			slug: 'blog',
 			label: i18n.translate( 'Blog' ),
 			description: i18n.translate( 'Share and discuss ideas, updates, or creations.' ),
@@ -50,7 +52,7 @@ export function getAllSiteTypes() {
 			siteTopicLabel: i18n.translate( 'What will your blog be about?' ),
 		},
 		{
-			id: 1,
+			id: 1, // This value must correspond with its sibling in the /segments API results
 			slug: 'business',
 			label: i18n.translate( 'Business' ),
 			description: i18n.translate( 'Promote products and services.' ),
@@ -63,7 +65,7 @@ export function getAllSiteTypes() {
 			customerType: 'business',
 		},
 		{
-			id: 4,
+			id: 4, // This value must correspond with its sibling in the /segments API results
 			slug: 'professional',
 			label: i18n.translate( 'Professional' ),
 			description: i18n.translate( 'Showcase your portfolio and work.' ),
@@ -75,7 +77,7 @@ export function getAllSiteTypes() {
 			siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
 		},
 		{
-			id: 3,
+			id: 3, // This value must correspond with its sibling in the /segments API results
 			slug: 'online-store',
 			label: i18n.translate( 'Online store' ),
 			description: i18n.translate( 'Sell your collection of products online.' ),

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -63,7 +63,7 @@ export function getAllSiteTypes() {
 			customerType: 'business',
 		},
 		{
-			id: 3,
+			id: 4,
 			slug: 'professional',
 			label: i18n.translate( 'Professional' ),
 			description: i18n.translate( 'Showcase your portfolio and work.' ),
@@ -75,7 +75,7 @@ export function getAllSiteTypes() {
 			siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
 		},
 		{
-			id: 5,
+			id: 3,
 			slug: 'online-store',
 			label: i18n.translate( 'Online store' ),
 			description: i18n.translate( 'Sell your collection of products online.' ),

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -13,7 +13,6 @@ import SignupActions from 'lib/signup/actions';
 import SiteTypeForm from './form';
 import StepWrapper from 'signup/step-wrapper';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 
 class SiteType extends Component {
@@ -68,7 +67,7 @@ export default connect(
 		submitStep: siteTypeValue => {
 			dispatch( submitSiteType( siteTypeValue ) );
 
-			if ( siteTypeValue === getSiteTypePropertyValue( 'id', 5, 'slug' ) ) {
+			if ( 'online-store' === siteTypeValue ) {
 				flowName = 'ecommerce-onboarding';
 			}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request 

Our segment ID are no longer in sync with mobile. This update aligns the IDs until we can integrate the [segments API.](https://public-api.wordpress.com/wpcom/v2/segments)

We're switching the id for `professional` to `4` (currently `3`) and `online-store` to `3` (currently `5`). 

## Data management

The result of the divergence means that we need to update the site segment option for, probably, a ton of blogs. I'll liaise with whomever to help get this done.

## Testing instructions

Check the IDs ins `site-type.js` against the [segments API.](https://public-api.wordpress.com/wpcom/v2/segments)

We also had to update areas where we were relying on the ID as a selector.

Go through the `/start/onboarding` flow and select Online Business as your site type. You should be redirected to the `ecommerce-onboarding` flow.
