### PR TITLE
Select Site: Fix Hidden Site Message

### DIFF
--- a/client/components/site-selector/style.scss
+++ b/client/components/site-selector/style.scss
@@ -201,13 +201,12 @@
 }
 
 .site-selector__hidden-sites-message {
-	color: var( --sidebar-text-color );
+	color: var( --color-text-subtle );
 	display: block;
 	font-size: 12px;
 	padding: 16px 16px 24px;
 
 	.site-selector__manage-hidden-sites {
-		color: var( --sidebar-text-color );
 		text-decoration: underline;
 	}
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -214,13 +214,18 @@
 			border-color: var( --sidebar-border-color );
 		}
 		
+		&__no-results {
+			color: var( --sidebar-heading-color );
+		}
+		
+		&__hidden-sites-message,
+		&__manage-hidden-sites {
+			color: var( --sidebar-text-color );
+		}
+		
 		.all-sites {
 			border-color: var( --sidebar-border-color );
 		}
-	}
-
-	.site-selector__no-results {
-		color: var( --sidebar-heading-color );
 	}
 	
 	.all-sites .count {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#30710 introduced a bug where when asked to select a site, in Nightfall, nothing would appear as it was using sidebar variables.

<img width="410" alt="Screenshot 2019-05-19 at 18 09 04" src="https://user-images.githubusercontent.com/43215253/57985618-64522700-7a62-11e9-96c3-ba3ff7cd18fa.png">

This is a pretty much identical fix to the hidden site lock, where it now only uses sidebar variables if actually in the sidebar. 

<img width="379" alt="Screenshot 2019-05-19 at 18 09 13" src="https://user-images.githubusercontent.com/43215253/57985627-8481e600-7a62-11e9-8dd1-73f94523553b.png">

#### Testing instructions

Switch to the Nightfall scheme and visit `/plans` and verify you can see the message now, but nothing has changed in the sidebar itself.

<img width="247" alt="Screenshot 2019-05-19 at 18 16 02" src="https://user-images.githubusercontent.com/43215253/57985635-a54a3b80-7a62-11e9-93e3-5bb90454e371.png">

cc @sixhours, @flootr, @blowery 