### PR TITLE
Checkout: add space around Jetpack logo

### DIFF
--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -428,8 +428,7 @@ div.popover-cart__popover {
 	}
 
 	.jetpack-logo {
-		margin-bottom: 32px;
-		margin-top: 32px;
+		margin: 32px 0;
 	}
 }
 

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -247,7 +247,7 @@
 		position: absolute;
 		top: 12px;
 		right: 12px;
-		
+
 		&:hover {
 			color: var( --color-primary );
 		}
@@ -428,6 +428,7 @@ div.popover-cart__popover {
 	}
 
 	.jetpack-logo {
+		margin-bottom: 32px;
 		margin-top: 32px;
 	}
 }


### PR DESCRIPTION
Just some small polish on the checkout page.

Before

<img width="497" alt="Screenshot 2019-05-20 at 12 39 06" src="https://user-images.githubusercontent.com/87168/58012618-88af1180-7afd-11e9-8c6a-e8c55057bd0f.png">

After, the logo has more space under it

<img width="456" alt="Screenshot 2019-05-20 at 12 44 12" src="https://user-images.githubusercontent.com/87168/58012617-88167b00-7afd-11e9-9a19-941aa6e329c9.png">

The component is in https://github.com/Automattic/wp-calypso/blob/ec951fb42d9924746667f08db03af97b211cde23/client/my-sites/checkout/cart/secondary-cart.jsx#L103


#### Changes proposed in this Pull Request

* Add some space under Jetpack logo on the checkout page

#### Testing instructions

- Buy a plan while connecting Jetpack
- Observe `http://calypso.localhost:3000/checkout/:site` step
