### PR TITLE
Auto-renewal Toggle: make the toggle functional

### DIFF
--- a/client/lib/upgrades/actions/index.js
+++ b/client/lib/upgrades/actions/index.js
@@ -59,4 +59,10 @@ export { goToDomainCheckout } from './domain-search';
 
 export { startFreeTrial } from './free-trials';
 
-export { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from './purchases';
+export {
+	cancelAndRefundPurchase,
+	cancelPurchase,
+	submitSurvey,
+	disableAutoRenew,
+	enableAutoRenew,
+} from './purchases';

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -42,3 +42,23 @@ export function submitSurvey( surveyName, siteID, surveyData ) {
 		} )
 		.catch( err => debug( err ) ); // shouldn't get here
 }
+
+export function disableAutoRenew( purchaseId, onComplete ) {
+	wpcom.disableAutoRenew( purchaseId, ( error, data ) => {
+		debug( error, data );
+
+		const success = ! error && data.success;
+
+		onComplete( success );
+	} );
+}
+
+export function enableAutoRenew( purchaseId, onComplete ) {
+	wpcom.enableAutoRenew( purchaseId, ( error, data ) => {
+		debug( error, data );
+
+		const success = ! error && data.success;
+
+		onComplete( success );
+	} );
+}

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1926,12 +1926,35 @@ Undocumented.prototype.getQandA = function( query, site, fn ) {
 	);
 };
 
+// TODO: remove this once the auto-renewal toggle has been fully rolled out.
 Undocumented.prototype.cancelPurchase = function( purchaseId, fn ) {
 	debug( 'upgrades/{purchaseId}/disable-auto-renew' );
 
 	return this.wpcom.req.post(
 		{
 			path: `/upgrades/${ purchaseId }/disable-auto-renew`,
+		},
+		fn
+	);
+};
+
+Undocumented.prototype.disableAutoRenew = function( purchaseId, fn ) {
+	debug( 'upgrades/{purchaseId}/disable-auto-renew' );
+
+	return this.wpcom.req.post(
+		{
+			path: `/upgrades/${ purchaseId }/disable-auto-renew`,
+		},
+		fn
+	);
+};
+
+Undocumented.prototype.enableAutoRenew = function( purchaseId, fn ) {
+	debug( 'upgrades/{purchaseId}/enable-auto-renew' );
+
+	return this.wpcom.req.post(
+		{
+			path: `/upgrades/${ purchaseId }/enable-auto-renew`,
 		},
 		fn
 	);

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -28,6 +28,7 @@ import {
 	isSubscription,
 	paymentLogoType,
 } from 'lib/purchases';
+import { disableAutoRenew, enableAutoRenew } from 'lib/upgrades/actions';
 import {
 	isPlan,
 	isDomainRegistration,
@@ -37,6 +38,7 @@ import {
 import { getPlan } from 'lib/plans';
 
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
+import { fetchSitePurchases } from 'state/purchases/actions';
 import { getSite, isRequestingSites } from 'state/sites/selectors';
 import { getUser } from 'state/users/selectors';
 import { managePurchase } from '../paths';
@@ -308,22 +310,28 @@ class PurchaseMeta extends Component {
 	};
 
 	onToggleAutorenewal = () => {
-		// TODO: Use the actual autorenewal enabling / disabling state & actions
-		const { isAutorenewalEnabled } = this.state;
+		const {
+			purchase: { id: purchaseId, siteId },
+			isAutorenewalEnabled,
+		} = this.props;
 
 		if ( isAutorenewalEnabled ) {
-			this.setState( {
-				showAutorenewalDisablingDialog: true,
+			disableAutoRenew( purchaseId, success => {
+				if ( success ) {
+					this.props.fetchSitePurchases( siteId );
+				}
+			} );
+		} else {
+			enableAutoRenew( purchaseId, success => {
+				if ( success ) {
+					this.props.fetchSitePurchases( siteId );
+				}
 			} );
 		}
-
-		this.setState( {
-			isAutorenewalEnabled: ! isAutorenewalEnabled,
-		} );
 	};
 
 	renderExpiration() {
-		const { purchase, translate } = this.props;
+		const { purchase, translate, isAutorenewalEnabled } = this.props;
 
 		if ( isDomainTransfer( purchase ) ) {
 			return null;
@@ -337,9 +345,6 @@ class PurchaseMeta extends Component {
 			isPlan( purchase ) &&
 			! isExpired( purchase )
 		) {
-			// TODO: remove this once the proper state has been introduced.
-			const { isAutorenewalEnabled } = this.state;
-
 			const dateSpan = <span className="manage-purchase__detail-date-span" />;
 			const subsRenewText = isAutorenewalEnabled
 				? translate( 'Auto-renew is ON' )
@@ -427,14 +432,20 @@ class PurchaseMeta extends Component {
 	}
 }
 
-export default connect( ( state, { purchaseId } ) => {
-	const purchase = getByPurchaseId( state, purchaseId );
+export default connect(
+	( state, { purchaseId } ) => {
+		const purchase = getByPurchaseId( state, purchaseId );
 
-	return {
-		hasLoadedSites: ! isRequestingSites( state ),
-		hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
-		purchase,
-		site: purchase ? getSite( state, purchase.siteId ) : null,
-		owner: purchase ? getUser( state, purchase.userId ) : null,
-	};
-} )( localize( PurchaseMeta ) );
+		return {
+			hasLoadedSites: ! isRequestingSites( state ),
+			hasLoadedUserPurchasesFromServer: hasLoadedUserPurchasesFromServer( state ),
+			purchase,
+			site: purchase ? getSite( state, purchase.siteId ) : null,
+			owner: purchase ? getUser( state, purchase.userId ) : null,
+			isAutorenewalEnabled: purchase ? ! isExpiring( purchase ) : null,
+		};
+	},
+	{
+		fetchSitePurchases,
+	}
+)( localize( PurchaseMeta ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*This PR is part of the attempt of adding a self-serving plan subscription autorenewal toggle. For more details, please refer to p2-p9jf6J-1GZ*

This PR makes the auto-renewal toggle functional, instead of just UI demonstration:
![demo-auto-renew-toggle](https://user-images.githubusercontent.com/1842898/58410246-5d4f9800-80a4-11e9-99f3-7cebec6f264a.gif)

Note that it is a known issue that the payment method will disappear after the first toggling. As it would need some fixes from the backend, I'm going to fix it in an individual PR.

#### Testing instructions

1. Go to http://calypso.localhost:3000/me/purchases/ and click on any plan subscription that is not expired.
1. Disable the auto-renewal via the toggle and make sure it is indeed disabled from the SA.
1. Enable the auto-renewal via the toggle and make sure it is indeed enabled from the SA.