### PR TITLE
SIFTSCIENCE_URL should be a const as it is never reassigned

### DIFF
--- a/client/lib/siftscience/index.js
+++ b/client/lib/siftscience/index.js
@@ -15,8 +15,8 @@ import { loadScript } from 'lib/load-script';
 import user from 'lib/user';
 import config from 'config';
 
-let SIFTSCIENCE_URL = 'https://cdn.siftscience.com/s.js',
-	hasLoaded = false;
+const SIFTSCIENCE_URL = 'https://cdn.siftscience.com/s.js';
+let hasLoaded = false;
 
 if ( ! window._sift ) {
 	window._sift = [];


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is causing an error in https://github.com/Automattic/wp-calypso/pull/33155, but I didn't want to put the fix in that PR, to make it easier to review.