### PR TITLE
Fix accessiblity for the social log in button

### DIFF
--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -196,7 +196,9 @@ class GoogleLoginButton extends Component {
 				className: classNames( { disabled: isDisabled } ),
 				onClick: this.handleClick,
 				onMouseOver: this.showError,
+				onFocus: this.showError,
 				onMouseOut: this.hideError,
+				onBlur: this.hideError,
 			};
 
 			customButton = React.cloneElement( children, childProps );
@@ -210,7 +212,9 @@ class GoogleLoginButton extends Component {
 					<button
 						className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
 						onMouseOver={ this.showError }
+						onFocus={ this.showError }
 						onMouseOut={ this.hideError }
+						onBlur={ this.hideError }
 						onClick={ this.handleClick }
 					>
 						<GoogleIcon isDisabled={ isDisabled } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds an onFocus and onBlur event to the social login button for accessibility reasons.

#### Testing instructions

* The easiest way to test this is to break social login by changing the client ID on line 102 (to anything)
* Then when you hover over, or focus on, the button, the error message should show
* When you take your mouse off the button, or tab away from it, the error message should hide.

This came up in https://github.com/Automattic/wp-calypso/pull/33155 but I wanted to fix it in a different PR, to keep it easier to review
