### PR TITLE
babel-plugin-transform-wpcalypso-async: remove test dep on plugin-babel-syntax-jsx

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -806,6 +806,7 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
 			"integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 		"@babel/cli": "7.4.4",
 		"@babel/core": "7.4.4",
 		"@babel/plugin-syntax-dynamic-import": "7.2.0",
-		"@babel/plugin-syntax-jsx": "7.2.0",
 		"@babel/plugin-transform-runtime": "7.4.4",
 		"@babel/polyfill": "7.4.4",
 		"@babel/preset-env": "7.4.4",

--- a/packages/babel-plugin-transform-wpcalypso-async/test/index.js
+++ b/packages/babel-plugin-transform-wpcalypso-async/test/index.js
@@ -8,7 +8,8 @@ describe( 'babel-plugin-transform-wpcalypso-async', () => {
 	function transform( code, async = true ) {
 		return babel.transformSync( code, {
 			configFile: false,
-			plugins: [ '@babel/plugin-syntax-jsx', [ require( '..' ), { async } ] ],
+			parserOpts: { plugins: [ 'jsx' ] },
+			plugins: [ [ require( '..' ), { async } ] ],
 		} ).code;
 	}
 


### PR DESCRIPTION
All the Babel syntax plugins are just convenient helpers to add options to the Babylon parser. The `@babel/syntax-jsx` plugin doesn't actually contain the JSX parsing code. It just enables an option on the monolithic parser.

When testing the `transform-wpcalypso-async`, we can eliminate a dependency by passing the option directly in `parserOpts`.

Maybe we should add also peer dependency on `@babel/core` to the package? [Other Babel plugins do it](https://github.com/babel/babel/blob/45ca6751fa7696ea61aa7378aa95a55effd205b6/packages/babel-plugin-syntax-jsx/package.json#L18).
