### PR TITLE
Update desktop to use fallback builds

### DIFF
--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -58,7 +58,7 @@ class Desktop extends React.Component {
 						rel="stylesheet"
 						type="text/css"
 						data-webpack={ true }
-						href={ `/calypso/build.${ isRTL ? 'rtl.css' : 'css' }` }
+						href={ `/calypso/fallback/build.${ isRTL ? 'rtl.css' : 'css' }` }
 					/>
 					<link rel="stylesheet" id="desktop-css" href="/desktop/wordpress-desktop.css" />
 				</Head>
@@ -122,7 +122,7 @@ class Desktop extends React.Component {
 						/>
 					) }
 
-					<script src="/calypso/build.js" />
+					<script src="/calypso/fallback/build.js" />
 					<script src="/desktop/desktop-app.js" />
 					{ i18nLocaleScript && <script src={ i18nLocaleScript } /> }
 					<script type="text/javascript">startApp();</script>

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -101,7 +101,7 @@ function isUAInBrowserslist( userAgentString, environment = 'defaults' ) {
 }
 
 function getBuildTargetFromRequest( request ) {
-	const isDesktop = calypsoEnv === 'desktop';
+	const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
 	const isEvergreen = ! isDesktop && isUAInBrowserslist( request.useragent.source, 'evergreen' );
 	const isForcedFallback = request.query.forceFallback;
 	// Development is always evergreen.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,7 +42,7 @@ const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
 const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.BROWSERSLIST_ENV !== 'server';
-const isDesktop = calypsoEnv === 'desktop';
+const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
 
 const defaultBrowserslistEnv = isCalypsoClient && ! isDesktop ? 'evergreen' : 'defaults';
 const browserslistEnv = process.env.BROWSERSLIST_ENV || defaultBrowserslistEnv;


### PR DESCRIPTION
This PR updates the desktop client to make it work with the new targets introduced in https://github.com/Automattic/wp-calypso/pull/30768.

# Changes proposed in this Pull Request
- Update references in `desktop.jsx` to point to the fallback build.
- Use the fallback build for desktop development.

# Testing instructions
These changes can be tested using the current `release/4.2.0` branch of WPDesktop. 
- Build the app for development and verify that Calypso starts.
- Build the app for release and verify that Calypso starts.
