### PR TITLE
Remove usages of moz-document url-prefix() hack

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -256,17 +256,10 @@
 
 		&:first-child::first-letter {
 			float: left;
-			margin: 18px 12px 0 0;
+			margin: 10px 12px 0 0;
 			font-size: 66px;
 			font-weight: 400;
-			line-height: 0.5;
-		}
-
-		// Firefox-only position fix
-		@-moz-document url-prefix('') {
-			&:first-child::first-letter {
-				margin-top: 9px;
-			}
+			line-height: 0.7;
 		}
 	}
 

--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/packages-step/style.scss
@@ -131,13 +131,9 @@
 	margin-bottom: 10px;
 	float: left;
 	margin-right: 15px;
-}
 
-@-moz-document url-prefix('') {
-	/* fix the width in Firefox */
-	.packages-step__package-weight {
-		width: 135px;
-		margin-right: 65px;
+	input {
+		min-width: 0;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove Firefox CSS hacks that are about to stop working.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* WooCommerce fix:
    * On an order fulfillment page.
    * Click "Print label & fulfill.
    * Open the "Packages" section of the modal.
    * See the correctly spaced fields for "Total Weight" and "Require Signature."
* "Discover" section of Reader fix:
    * Visit [this URL](http://calypso.localhost:3000/read/blogs/53424024/posts/37036) in Firefox.
        * Compare to [the public version](https://wordpress.com/read/blogs/53424024/posts/37036).
    * Notice the correct alignment of the `first-letter` in the opening paragraph.

---

##### WooCommerce fix:

**Before**

![image](https://user-images.githubusercontent.com/435/58040304-cfe7d300-7afa-11e9-800d-4f54ad232ac5.png)

**After**

![image](https://user-images.githubusercontent.com/435/58040334-e68e2a00-7afa-11e9-97d6-24ab1b06a414.png)

##### `first-letter`fix

**Before**

<img width="135" alt="image" src="https://user-images.githubusercontent.com/435/58326989-5c94d880-7dfc-11e9-9ade-6f992f6a2124.png">

**After**

<img width="124" alt="image" src="https://user-images.githubusercontent.com/435/58327004-68809a80-7dfc-11e9-9a41-908d349a6084.png">

Fixes #32388