### PR TITLE
Respect `plan` Query Arg in `/plans/`

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -392,18 +392,23 @@ const guessCustomerType = ( state, props ) => {
 
 	const site = props.site;
 	const currentPlan = getSitePlan( state, get( site, [ 'ID' ] ) );
-	if ( currentPlan ) {
-		const group = GROUP_WPCOM;
-		const businessPlanSlugs = [
-			findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_PREMIUM } )[ 0 ],
-			findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_PREMIUM } )[ 0 ],
-			findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_BUSINESS } )[ 0 ],
-			findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_BUSINESS } )[ 0 ],
-			findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_ECOMMERCE } )[ 0 ],
-			findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_ECOMMERCE } )[ 0 ],
-		]
-			.map( planKey => getPlan( planKey ) )
-			.map( plan => plan.getStoreSlug() );
+	const selectedPlan = props.selectedPlan;
+
+	const group = GROUP_WPCOM;
+	const businessPlanSlugs = [
+		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_PREMIUM } )[ 0 ],
+		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_PREMIUM } )[ 0 ],
+		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_BUSINESS } )[ 0 ],
+		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_BUSINESS } )[ 0 ],
+		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_ECOMMERCE } )[ 0 ],
+		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_ECOMMERCE } )[ 0 ],
+	]
+		.map( planKey => getPlan( planKey ) )
+		.map( plan => plan.getStoreSlug() );
+
+	if ( selectedPlan ) {
+		return businessPlanSlugs.includes( selectedPlan ) ? 'business' : 'personal';
+	} else if ( currentPlan ) {
 		const isPlanInBusinessGroup = businessPlanSlugs.indexOf( currentPlan.product_slug ) !== -1;
 		return isPlanInBusinessGroup ? 'business' : 'personal';
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* if `plan` is give as a query arg to `/plans/` respect that in the initial segment selection

#### Testing instructions

1. Navigate to `/plans/:siteSlug?plan=business-bundle` on a free or personal plan
2. Verify the plans and the "suggested" badge in the following screenshot match
<img width="1026" alt="Screen Shot 2019-05-20 at 9 15 29 PM" src="https://user-images.githubusercontent.com/2810519/58068100-d864fb80-7b44-11e9-9dbd-96771719060a.png">
