### PR TITLE
Add Blogger Plan Test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -175,4 +175,12 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	hideBloggerPlan: {
+		datestamp: '20190521',
+		variations: {
+			hide: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+	},
 };

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -70,10 +70,6 @@ $plan-features-sidebar-width: 272px;
 	margin-right: auto;
 }
 
-.plan-features__table.has-2-cols {
-	max-width: 720px;
-}
-
 .plan-features__table.has-1-cols {
 	max-width: 337px;
 }

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -125,6 +126,7 @@ export class PlansFeaturesMain extends Component {
 		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan } = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
+		const hideBloggerPlan = abtest( 'hideBloggerPlan' ) === 'hide';
 
 		let term;
 		if ( intervalType === 'monthly' ) {
@@ -159,12 +161,12 @@ export class PlansFeaturesMain extends Component {
 		} else {
 			plans = [
 				findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
-				findPlansKeys( { group, term, type: TYPE_BLOGGER } )[ 0 ],
+				hideBloggerPlan ? null : findPlansKeys( { group, term, type: TYPE_BLOGGER } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PREMIUM } )[ 0 ],
 				findPlansKeys( { group, term: businessPlanTerm, type: TYPE_BUSINESS } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_ECOMMERCE } )[ 0 ],
-			];
+			].filter( el => el !== null );
 		}
 
 		if ( hideFreePlan ) {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -34,7 +34,7 @@ import CartData from 'components/data/cart';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isEnabled } from 'config';
-import { plansLink, planMatches, findPlansKeys, getPlan } from 'lib/plans';
+import { plansLink, planMatches, findPlansKeys, getPlan, isBloggerPlan } from 'lib/plans';
 import Button from 'components/button';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
@@ -123,10 +123,19 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getPlansForPlanFeatures() {
-		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan } = this.props;
+		const {
+			displayJetpackPlans,
+			intervalType,
+			selectedPlan,
+			hideFreePlan,
+			sitePlanSlug,
+		} = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
-		const hideBloggerPlan = abtest( 'hideBloggerPlan' ) === 'hide';
+		const hideBloggerPlan =
+			! isBloggerPlan( selectedPlan ) &&
+			! isBloggerPlan( sitePlanSlug ) &&
+			abtest( 'hideBloggerPlan' ) === 'hide';
 
 		let term;
 		if ( intervalType === 'monthly' ) {
@@ -416,6 +425,7 @@ const guessCustomerType = ( state, props ) => {
 export default connect(
 	( state, props ) => {
 		const siteId = get( props.site, [ 'ID' ] );
+		const sitePlan = getSitePlan( state, siteId );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and
@@ -429,6 +439,7 @@ export default connect(
 			isChatAvailable: isHappychatAvailable( state ),
 			siteId: siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
+			sitePlanSlug: sitePlan && sitePlan.product_slug,
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We would like to test a variation in which the plan lineup has 4 plans instead of 5 without changing the design.

#### Testing instructions

1. Sign up with a new user and site
2. When reaching the plan section, check if you're assigned to 'hide' or 'control' in the new test. 'hide' should see 4 plans, 'control' should see 5.
3. With a logged in new user, go to /plans
4. Check if you're assigned to 'hide' or 'control' in the new test. 'hide' should see 4 plans, 'control' should see 5.
5. Repeat for both 'hide' and 'control'
