### PR TITLE
CI: Bump caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,13 @@ references:
   restore-jest-cache: &restore-jest-cache
     name: Restore Jest cache
     keys:
-      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
-      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}
-      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-master
-      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}
+      - v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
+      - v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}
+      - v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-master
+      - v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}
   save-jest-cache: &save-jest-cache
     name: Save Jest cache
-    key: v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
+    key: v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/jest-cache
 
@@ -65,13 +65,13 @@ references:
   restore-terser-cache: &restore-terser-cache
     name: Restore Terser cache
     keys:
-      - v0-terser-{{ .Branch }}-{{ .Revision }}
-      - v0-terser-{{ .Branch }}
-      - v0-terser-master
-      - v0-terser
+      - v1-terser-{{ .Branch }}-{{ .Revision }}
+      - v1-terser-{{ .Branch }}
+      - v1-terser-master
+      - v1-terser
   save-terser-cache: &save-terser-cache
     name: Save Terser cache
-    key: v0-terser-{{ .Branch }}-{{ .Revision }}
+    key: v1-terser-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/terser-cache
 
@@ -87,16 +87,16 @@ references:
   restore-git-cache: &restore-git-cache
     name: Restore git cache
     keys:
-      - v2-git-{{ .Branch }}-{{ .Revision }}
-      - v2-git-{{ .Branch }}
-      - v2-git-master
-      - v2-git
+      - v3-git-{{ .Branch }}-{{ .Revision }}
+      - v3-git-{{ .Branch }}
+      - v3-git-master
+      - v3-git
   update-git-master: &update-git-master
     name: Update master branch
     command: git fetch --force origin master
   save-git-cache: &save-git-cache
     name: Save git cache
-    key: v2-git-{{ .Branch }}-{{ .Revision }}
+    key: v3-git-{{ .Branch }}-{{ .Revision }}
     paths:
       - '.git'
 
@@ -115,8 +115,8 @@ references:
   restore-npm-cache: &restore-npm-cache
     name: 'Restore npm cache'
     keys:
-      - v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
-      - v3-npm-modules-{{ checksum ".nvmrc" }}
+      - v4-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+      - v4-npm-modules-{{ checksum ".nvmrc" }}
 
   npm-install: &npm-install
     name: Install npm dependencies
@@ -124,7 +124,7 @@ references:
 
   save-npm-cache: &save-npm-cache
     name: 'Save node_modules cache'
-    key: v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+    key: v4-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
     paths:
       - ~/.npm
   npm-e2e-install: &npm-e2e-install
@@ -136,13 +136,13 @@ references:
   restore-babel-client-cache: &restore-babel-client-cache
     name: Restore Babel Client Cache
     keys:
-      - v1-babel-client-{{ .Branch }}-{{ .Revision }}
-      - v1-babel-client-{{ .Branch }}
-      - v1-babel-client-master
-      - v1-babel-client
+      - v2-babel-client-{{ .Branch }}-{{ .Revision }}
+      - v2-babel-client-{{ .Branch }}
+      - v2-babel-client-master
+      - v2-babel-client
   save-babel-client-cache: &save-babel-client-cache
     name: Save Babel Client Cache
-    key: v1-babel-client-{{ .Branch }}-{{ .Revision }}
+    key: v2-babel-client-{{ .Branch }}-{{ .Revision }}
     paths:
       - 'build/.babel-client-cache'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,13 @@ references:
   restore-jest-cache: &restore-jest-cache
     name: Restore Jest cache
     keys:
-      - v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
-      - v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}
-      - v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-master
-      - v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}
+      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
+      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}
+      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-master
+      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}
   save-jest-cache: &save-jest-cache
     name: Save Jest cache
-    key: v8-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
+    key: v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/jest-cache
 
@@ -65,13 +65,13 @@ references:
   restore-terser-cache: &restore-terser-cache
     name: Restore Terser cache
     keys:
-      - v1-terser-{{ .Branch }}-{{ .Revision }}
-      - v1-terser-{{ .Branch }}
-      - v1-terser-master
-      - v1-terser
+      - v0-terser-{{ .Branch }}-{{ .Revision }}
+      - v0-terser-{{ .Branch }}
+      - v0-terser-master
+      - v0-terser
   save-terser-cache: &save-terser-cache
     name: Save Terser cache
-    key: v1-terser-{{ .Branch }}-{{ .Revision }}
+    key: v0-terser-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/terser-cache
 
@@ -87,16 +87,16 @@ references:
   restore-git-cache: &restore-git-cache
     name: Restore git cache
     keys:
-      - v3-git-{{ .Branch }}-{{ .Revision }}
-      - v3-git-{{ .Branch }}
-      - v3-git-master
-      - v3-git
+      - v2-git-{{ .Branch }}-{{ .Revision }}
+      - v2-git-{{ .Branch }}
+      - v2-git-master
+      - v2-git
   update-git-master: &update-git-master
     name: Update master branch
     command: git fetch --force origin master
   save-git-cache: &save-git-cache
     name: Save git cache
-    key: v3-git-{{ .Branch }}-{{ .Revision }}
+    key: v2-git-{{ .Branch }}-{{ .Revision }}
     paths:
       - '.git'
 
@@ -115,8 +115,8 @@ references:
   restore-npm-cache: &restore-npm-cache
     name: 'Restore npm cache'
     keys:
-      - v4-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
-      - v4-npm-modules-{{ checksum ".nvmrc" }}
+      - v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+      - v3-npm-modules-{{ checksum ".nvmrc" }}
 
   npm-install: &npm-install
     name: Install npm dependencies
@@ -124,7 +124,7 @@ references:
 
   save-npm-cache: &save-npm-cache
     name: 'Save node_modules cache'
-    key: v4-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+    key: v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
     paths:
       - ~/.npm
   npm-e2e-install: &npm-e2e-install
@@ -136,13 +136,13 @@ references:
   restore-babel-client-cache: &restore-babel-client-cache
     name: Restore Babel Client Cache
     keys:
-      - v2-babel-client-{{ .Branch }}-{{ .Revision }}
-      - v2-babel-client-{{ .Branch }}
-      - v2-babel-client-master
-      - v2-babel-client
+      - v1-babel-client-{{ .Branch }}-{{ .Revision }}
+      - v1-babel-client-{{ .Branch }}
+      - v1-babel-client-master
+      - v1-babel-client
   save-babel-client-cache: &save-babel-client-cache
     name: Save Babel Client Cache
-    key: v2-babel-client-{{ .Branch }}-{{ .Revision }}
+    key: v1-babel-client-{{ .Branch }}-{{ .Revision }}
     paths:
       - 'build/.babel-client-cache'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,13 @@ references:
   restore-jest-cache: &restore-jest-cache
     name: Restore Jest cache
     keys:
-      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
-      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}
-      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-master
-      - v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-master
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}
   save-jest-cache: &save-jest-cache
     name: Save Jest cache
-    key: v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
+    key: {{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/jest-cache
 
@@ -65,13 +65,13 @@ references:
   restore-terser-cache: &restore-terser-cache
     name: Restore Terser cache
     keys:
-      - v0-terser-{{ .Branch }}-{{ .Revision }}
-      - v0-terser-{{ .Branch }}
-      - v0-terser-master
-      - v0-terser
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}-{{ .Revision }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-master
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser
   save-terser-cache: &save-terser-cache
     name: Save Terser cache
-    key: v0-terser-{{ .Branch }}-{{ .Revision }}
+    key: {{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/terser-cache
 
@@ -87,16 +87,16 @@ references:
   restore-git-cache: &restore-git-cache
     name: Restore git cache
     keys:
-      - v2-git-{{ .Branch }}-{{ .Revision }}
-      - v2-git-{{ .Branch }}
-      - v2-git-master
-      - v2-git
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-{{ .Branch }}-{{ .Revision }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-{{ .Branch }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-master
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git
   update-git-master: &update-git-master
     name: Update master branch
     command: git fetch --force origin master
   save-git-cache: &save-git-cache
     name: Save git cache
-    key: v2-git-{{ .Branch }}-{{ .Revision }}
+    key: {{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-{{ .Branch }}-{{ .Revision }}
     paths:
       - '.git'
 
@@ -115,8 +115,8 @@ references:
   restore-npm-cache: &restore-npm-cache
     name: 'Restore npm cache'
     keys:
-      - v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
-      - v3-npm-modules-{{ checksum ".nvmrc" }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}
 
   npm-install: &npm-install
     name: Install npm dependencies
@@ -124,7 +124,7 @@ references:
 
   save-npm-cache: &save-npm-cache
     name: 'Save node_modules cache'
-    key: v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+    key: {{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
     paths:
       - ~/.npm
   npm-e2e-install: &npm-e2e-install
@@ -136,13 +136,13 @@ references:
   restore-babel-client-cache: &restore-babel-client-cache
     name: Restore Babel Client Cache
     keys:
-      - v1-babel-client-{{ .Branch }}-{{ .Revision }}
-      - v1-babel-client-{{ .Branch }}
-      - v1-babel-client-master
-      - v1-babel-client
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}-{{ .Revision }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-master
+      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client
   save-babel-client-cache: &save-babel-client-cache
     name: Save Babel Client Cache
-    key: v1-babel-client-{{ .Branch }}-{{ .Revision }}
+    key: {{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}-{{ .Revision }}
     paths:
       - 'build/.babel-client-cache'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,13 +49,13 @@ references:
   restore-jest-cache: &restore-jest-cache
     name: Restore Jest cache
     keys:
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-master
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-master
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}
   save-jest-cache: &save-jest-cache
     name: Save Jest cache
-    key: {{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v7-jest-{{ .Environment.CIRCLE_JOB }}-{{ .Environment.CIRCLE_NODE_INDEX }}/{{ .Environment.CIRCLE_NODE_TOTAL }}-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/jest-cache
 
@@ -65,13 +65,13 @@ references:
   restore-terser-cache: &restore-terser-cache
     name: Restore Terser cache
     keys:
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}-{{ .Revision }}
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-master
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}-{{ .Revision }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-master
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser
   save-terser-cache: &save-terser-cache
     name: Save Terser cache
-    key: {{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}-{{ .Revision }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v0-terser-{{ .Branch }}-{{ .Revision }}
     paths:
       - ~/terser-cache
 
@@ -87,16 +87,16 @@ references:
   restore-git-cache: &restore-git-cache
     name: Restore git cache
     keys:
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-{{ .Branch }}-{{ .Revision }}
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-{{ .Branch }}
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-master
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-{{ .Branch }}-{{ .Revision }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-{{ .Branch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-master
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git
   update-git-master: &update-git-master
     name: Update master branch
     command: git fetch --force origin master
   save-git-cache: &save-git-cache
     name: Save git cache
-    key: {{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-{{ .Branch }}-{{ .Revision }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v2-git-{{ .Branch }}-{{ .Revision }}
     paths:
       - '.git'
 
@@ -115,8 +115,8 @@ references:
   restore-npm-cache: &restore-npm-cache
     name: 'Restore npm cache'
     keys:
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}
 
   npm-install: &npm-install
     name: Install npm dependencies
@@ -124,7 +124,7 @@ references:
 
   save-npm-cache: &save-npm-cache
     name: 'Save node_modules cache'
-    key: {{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v3-npm-modules-{{ checksum ".nvmrc" }}-{{ checksum "npm-shrinkwrap.json" }}
     paths:
       - ~/.npm
   npm-e2e-install: &npm-e2e-install
@@ -136,13 +136,13 @@ references:
   restore-babel-client-cache: &restore-babel-client-cache
     name: Restore Babel Client Cache
     keys:
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}-{{ .Revision }}
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-master
-      - {{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}-{{ .Revision }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-master
+      - v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client
   save-babel-client-cache: &save-babel-client-cache
     name: Save Babel Client Cache
-    key: {{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}-{{ .Revision }}
+    key: v{{ .Environment.GLOBAL_CACHE_PREFIX }}-v1-babel-client-{{ .Branch }}-{{ .Revision }}
     paths:
       - 'build/.babel-client-cache'
 


### PR DESCRIPTION
This increments all of the CircleCI cache prefixes to discard all of the existing caches.

Some of the caches seem to have unbounded growth, like terser. At some point the weight of saving and restoring the cache becomes more costly that a clean build.

By invalidating the caches periodically, we can reduce the save/load cost 

I'm not sure of a good way to automate this or how often it should be done, but see this build of an example of a 1GB terser cache that takes 51s to restore and 2:11m to save!

https://circleci.com/gh/Automattic/wp-calypso/293510

#### Testing instructions

* The first CI run will likely be slower because no cache will be used. Cache save should be quicker:
  https://circleci.com/gh/Automattic/wp-calypso/293572
  0s restore, 3:42m to build, 1s to save cache
* Subsequent CI runs will be faster than current master because caches will be quick to restore and save.
  https://circleci.com/gh/Automattic/wp-calypso/293612
  0s restore (4.3MB), 2:19m build, 0s save
