### PR TITLE
Jetpack Checklist: Update Monitoring Step after completion

### DIFF
--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -3,6 +3,7 @@
  */
 import { combineReducers, createReducer } from 'state/utils';
 import {
+	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	SITE_CHECKLIST_RECEIVE,
 	SITE_CHECKLIST_TASK_UPDATE,
 	SITE_CHECKLIST_REQUEST,
@@ -28,6 +29,17 @@ export const items = createReducer(
 				...state,
 				[ siteId ]: { ...siteState, tasks },
 			};
+		},
+		[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: ( state, { moduleSlug, siteId } ) => {
+			if ( moduleSlug === 'monitor' ) {
+				const siteState = state[ siteId ];
+				const tasks = { ...siteState.tasks, jetpack_monitor: true };
+				return {
+					...state,
+					[ siteId ]: { ...siteState, tasks },
+				};
+			}
+			return state;
 		},
 	},
 	itemSchemas

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,12 +1,4 @@
 /**
- * External dependencies
- *
- * @format
- */
-
-import { assign } from 'lodash';
-
-/**
  * Internal dependencies
  */
 import { combineReducers, createReducer } from 'state/utils';
@@ -31,10 +23,10 @@ export const items = createReducer(
 		} ),
 		[ SITE_CHECKLIST_TASK_UPDATE ]: ( state, { siteId, taskId } ) => {
 			const siteState = state[ siteId ];
-			const tasks = assign( {}, siteState.tasks, { [ taskId ]: true } );
+			const tasks = { ...siteState.tasks, [ taskId ]: true };
 			return {
 				...state,
-				[ siteId ]: assign( {}, siteState, { tasks } ),
+				[ siteId ]: { ...siteState, tasks },
 			};
 		},
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Mark the 'Downtime Monitoring' step as complete right when enabling the corresponding Jetpack Module (using the toggle on the security settings screen).

Previously, a user returning to the checklist after enabling that toggle would see the corresponding checklist item as still to-be-completed, see https://github.com/Automattic/wp-calypso/issues/32248#issuecomment-494345941 for background. Kudos @sirreal for the idea for this fix, which is to have the checklist reducer listen to the Jetpack Module activating action.

#### Testing instructions

- Start Calypso locally, using this branch
- Create a new jurassic.ninja site
- Locate the 'Connect to WP.com' button in wp-admin, copy its link target, and append `&calypso_env=development` to it. Navigate to that URL.
- Select a paid plan
- On the 'Thank You' page, locate the 'Downtime Monitoring' task, and click the 'Do it!' button next to it
- Enable the Downtime Monitoring Toggle, as advised by the Guided Tour
- Go back to the checklist, as advised by the Guided Tour
- Verify that the 'Downtime Monitoring' task is now marked as completed (possibly after a _very_ brief delay)

#### Follow-up

We might want to do something like this for the other tasks as well.