### PR TITLE
Woo 404: Replace the media query with a call to our breakpoint mixin

### DIFF
--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -107,7 +107,7 @@
 		margin: 35px 200px 0 0;
 		max-width: initial;
 
-		@media( max-width: 660px ) {
+		@include breakpoint( '<660px' ) {
 			margin: 0;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This replaces a media query with a call to our breakpoint mixin

#### Testing instructions

Check that the woo 404 page looks the same