### PR TITLE
FAQ: Use the breakpoint mixin

### DIFF
--- a/client/components/faq/style.scss
+++ b/client/components/faq/style.scss
@@ -35,10 +35,12 @@ $faq-gutter-width: 24px;
 	padding-left: ($faq-gutter-width / 2);
 	padding-right: ($faq-gutter-width / 2);
 
-	@media
-		( min-width: 480px ) and ( max-width: 660px ),
-		( min-width: 800px ) and ( max-width: 1040px ) {
-			width: 50%;
+	@include breakpoint( '480px-660px' ) {
+		width: 50%;
+	}
+
+	@include breakpoint( '800px-1040px' ) {
+		width: 50%;
 	}
 
 	@include breakpoint( '>1040px' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use the breakpoint mixin instead of media queries directly.

#### Testing instructions

* Go to: http://calypso.localhost:3000/devdocs/design/f-a-q
* Check that between 480 and 660 the FAQs are in two columns
* Check that between 800 and 1040 the FAQs are in two columns

