### PR TITLE
Replace media queries with the breakpoint mixin

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -327,14 +327,14 @@
 		width: 175px;
 		position: relative;
 
-		@media ( min-width: 1400px ) {
+		@include breakpoint( '>1400px' ) {
 			position: absolute;
 			left: inherit;
 			right: -( 175px + 32px );
 			margin-left: 0;
 		}
 
-		@media ( max-width: 1400px ) {
+		@include breakpoint( '<1400px' ) {
 			background: var( --color-neutral-0 );
 			margin: 0 0 24px;
 			padding: 16px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This replaces the media query on full screen reader posts with the breakpoint mixin

#### Testing instructions

* Check that the blockquotes on this page: http://calypso.localhost:3000/read/blogs/489937/posts/257310

Look the same as on wordpress.com...

E.g:
<img width="435" alt="Screenshot 2019-05-21 at 15 02 35" src="https://user-images.githubusercontent.com/275961/58102649-88844400-7bd9-11e9-8c65-df8643351889.png">

