### PR TITLE
Layout: Replace media queries with the breakpoint mixin

### DIFF
--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -309,7 +309,7 @@
 
 // Display sidebar as a panel under a main payment component in mobile checkout
 .layout.is-section-checkout {
-	@media ( max-width: 660px ) {
+	@include breakpoint( '<660px' ) {
 		.layout__content {
 			display: flex;
 			flex-flow: column;
@@ -379,7 +379,7 @@ div.checkout__container .section-header.card {
 	}
 }
 
-@media ( max-width: 660px ) {
+@include breakpoint( '<660px' ) {
    	.layout__primary .secondary-cart {
 		margin-left: 0;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This replaces a couple of direct media queries with our breakpoint mixin

#### Testing instructions

- Put something in your cart and go to checkout
- Resize your browser window to <600px
- Check that you can still show/hide the order summary on mobile:

<img width="500" alt="Screenshot 2019-05-21 at 15 26 40" src="https://user-images.githubusercontent.com/275961/58104696-19105380-7bdd-11e9-905d-cb52e5f9b31d.png">
