### PR TITLE
Woo: Change CSS rules to be mobile first

### DIFF
--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -64,18 +64,18 @@
 	@import 'woocommerce-services/style';
 
 	.main {
-		padding-top: 35px;
+		padding-top: 72px;
 
-		@include breakpoint( '<660px' ) {
-			padding-top: 72px;
+		@include breakpoint( '>660px' ) {
+			padding-top: 35px;
 		}
 	}
 
 	.woocommerce__placeholder {
-		padding-top: 32px;
+		padding-top: 16px;
 
-		@include breakpoint( '<660px' ) {
-			padding-top: 16px;
+		@include breakpoint( '>660px' ) {
+			padding-top: 32px;
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This changes these breakpoints to be mobile first. The behaviour will be the same but devices with smaller will only have to process one rule, not two.
