### PR TITLE
Full Site Editing: Template Parts can only be inserted into Templates

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -11,10 +11,7 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-if (
-	'wp_template' === fullSiteEditing.editorPostType ||
-	'wp_template_part' === fullSiteEditing.editorPostType
-) {
+if ( 'wp_template' === fullSiteEditing.editorPostType ) {
 	registerBlockType( 'a8c/template', {
 		title: __( 'Template Part' ),
 		description: __( 'Display a template part.' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* To reduce the FSE scope and also to avoid infinite loops: limit the Template Part block to just the Template post type.

Practically speaking, this prevents adding a Template Part inside another Template Part, whose usefulness is debatable.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow the [FSE readme](https://github.com/Automattic/wp-calypso/blob/e759e056360b72576e124989c4174afef78bc1db/apps/full-site-editing/README.md#local-development), and setup the plugin.
* Create a Template, and make sure you can add Template Part blocks.
* Create any other post type (including Template Part), and make sure you cannot add Template Part blocks.

Fixes #32622
