### PR TITLE
Store verticals list per segment instead of one global list

### DIFF
--- a/client/components/data/query-verticals/index.jsx
+++ b/client/components/data/query-verticals/index.jsx
@@ -18,6 +18,7 @@ export class QueryVerticals extends Component {
 	static propTypes = {
 		isFetched: PropTypes.bool,
 		searchTerm: PropTypes.string,
+		siteType: PropTypes.string,
 		limit: PropTypes.number,
 		debounceTime: PropTypes.number,
 		debounceFunc: PropTypes.func,
@@ -27,6 +28,7 @@ export class QueryVerticals extends Component {
 		isFetched: false,
 		limit: 7,
 		searchTerm: '',
+		siteType: '',
 		debounceTime: 0,
 		debounceFunc: debounce,
 	};
@@ -42,18 +44,18 @@ export class QueryVerticals extends Component {
 	};
 
 	componentDidMount() {
-		const { searchTerm = '', limit } = this.props;
+		const { searchTerm = '', siteType, limit } = this.props;
 		const trimmedSearchTerm = searchTerm.trim();
 
 		this.debouncedRequest = this.bindDebouncedRequest();
 
 		if ( trimmedSearchTerm ) {
-			this.debouncedRequest( trimmedSearchTerm, limit );
+			this.debouncedRequest( trimmedSearchTerm, siteType, limit );
 		}
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { isFetched, searchTerm, limit, debounceTime } = this.props;
+		const { isFetched, searchTerm, siteType, limit, debounceTime } = this.props;
 		const trimmedSearchTerm = searchTerm.trim();
 
 		if ( prevProps.debounceTime !== debounceTime ) {
@@ -61,7 +63,7 @@ export class QueryVerticals extends Component {
 		}
 
 		if ( ! isFetched && trimmedSearchTerm ) {
-			this.debouncedRequest( trimmedSearchTerm, limit );
+			this.debouncedRequest( trimmedSearchTerm, siteType, limit );
 		}
 	}
 
@@ -72,7 +74,7 @@ export class QueryVerticals extends Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		isFetched: null !== getVerticals( state, ownProps.searchTerm ),
+		isFetched: null !== getVerticals( state, ownProps.searchTerm, ownProps.siteType ),
 	} ),
 	{
 		requestVerticals,

--- a/client/components/data/query-verticals/index.jsx
+++ b/client/components/data/query-verticals/index.jsx
@@ -18,7 +18,7 @@ export class QueryVerticals extends Component {
 	static propTypes = {
 		isFetched: PropTypes.bool,
 		searchTerm: PropTypes.string,
-		siteType: PropTypes.string,
+		siteTypeId: PropTypes.number,
 		limit: PropTypes.number,
 		debounceTime: PropTypes.number,
 		debounceFunc: PropTypes.func,
@@ -28,7 +28,6 @@ export class QueryVerticals extends Component {
 		isFetched: false,
 		limit: 7,
 		searchTerm: '',
-		siteType: '',
 		debounceTime: 0,
 		debounceFunc: debounce,
 	};
@@ -44,18 +43,18 @@ export class QueryVerticals extends Component {
 	};
 
 	componentDidMount() {
-		const { searchTerm = '', siteType, limit } = this.props;
+		const { searchTerm = '', siteTypeId, limit } = this.props;
 		const trimmedSearchTerm = searchTerm.trim();
 
 		this.debouncedRequest = this.bindDebouncedRequest();
 
 		if ( trimmedSearchTerm ) {
-			this.debouncedRequest( trimmedSearchTerm, siteType, limit );
+			this.debouncedRequest( trimmedSearchTerm, siteTypeId, limit );
 		}
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { isFetched, searchTerm, siteType, limit, debounceTime } = this.props;
+		const { isFetched, searchTerm, siteTypeId, limit, debounceTime } = this.props;
 		const trimmedSearchTerm = searchTerm.trim();
 
 		if ( prevProps.debounceTime !== debounceTime ) {
@@ -63,7 +62,7 @@ export class QueryVerticals extends Component {
 		}
 
 		if ( ! isFetched && trimmedSearchTerm ) {
-			this.debouncedRequest( trimmedSearchTerm, siteType, limit );
+			this.debouncedRequest( trimmedSearchTerm, siteTypeId, limit );
 		}
 	}
 
@@ -74,7 +73,7 @@ export class QueryVerticals extends Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		isFetched: null !== getVerticals( state, ownProps.searchTerm, ownProps.siteType ),
+		isFetched: null !== getVerticals( state, ownProps.searchTerm, ownProps.siteTypeId ),
 	} ),
 	{
 		requestVerticals,

--- a/client/components/data/query-verticals/index.jsx
+++ b/client/components/data/query-verticals/index.jsx
@@ -18,7 +18,7 @@ export class QueryVerticals extends Component {
 	static propTypes = {
 		isFetched: PropTypes.bool,
 		searchTerm: PropTypes.string,
-		siteTypeId: PropTypes.number,
+		siteType: PropTypes.string,
 		limit: PropTypes.number,
 		debounceTime: PropTypes.number,
 		debounceFunc: PropTypes.func,
@@ -28,6 +28,7 @@ export class QueryVerticals extends Component {
 		isFetched: false,
 		limit: 7,
 		searchTerm: '',
+		siteType: '',
 		debounceTime: 0,
 		debounceFunc: debounce,
 	};
@@ -43,18 +44,18 @@ export class QueryVerticals extends Component {
 	};
 
 	componentDidMount() {
-		const { searchTerm = '', siteTypeId, limit } = this.props;
+		const { searchTerm = '', siteType, limit } = this.props;
 		const trimmedSearchTerm = searchTerm.trim();
 
 		this.debouncedRequest = this.bindDebouncedRequest();
 
 		if ( trimmedSearchTerm ) {
-			this.debouncedRequest( trimmedSearchTerm, siteTypeId, limit );
+			this.debouncedRequest( trimmedSearchTerm, siteType, limit );
 		}
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { isFetched, searchTerm, siteTypeId, limit, debounceTime } = this.props;
+		const { isFetched, searchTerm, siteType, limit, debounceTime } = this.props;
 		const trimmedSearchTerm = searchTerm.trim();
 
 		if ( prevProps.debounceTime !== debounceTime ) {
@@ -62,7 +63,7 @@ export class QueryVerticals extends Component {
 		}
 
 		if ( ! isFetched && trimmedSearchTerm ) {
-			this.debouncedRequest( trimmedSearchTerm, siteTypeId, limit );
+			this.debouncedRequest( trimmedSearchTerm, siteType, limit );
 		}
 	}
 
@@ -73,7 +74,7 @@ export class QueryVerticals extends Component {
 
 export default connect(
 	( state, ownProps ) => ( {
-		isFetched: null !== getVerticals( state, ownProps.searchTerm, ownProps.siteTypeId ),
+		isFetched: null !== getVerticals( state, ownProps.searchTerm, ownProps.siteType ),
 	} ),
 	{
 		requestVerticals,

--- a/client/components/data/query-verticals/test/index.js
+++ b/client/components/data/query-verticals/test/index.js
@@ -40,7 +40,7 @@ describe( 'QueryVerticals', () => {
 		const wrapped = shallow( <QueryVerticals requestVerticals={ requestVerticals } /> );
 
 		const updatedProps = {
-			siteType: '',
+			siteTypeId: 1,
 			searchTerm: 'Foo',
 			limit: 7,
 			isFetched: false,
@@ -50,7 +50,7 @@ describe( 'QueryVerticals', () => {
 
 		expect( requestVerticals ).toHaveBeenCalledWith(
 			updatedProps.searchTerm,
-			updatedProps.siteType,
+			updatedProps.siteTypeId,
 			updatedProps.limit
 		);
 	} );

--- a/client/components/data/query-verticals/test/index.js
+++ b/client/components/data/query-verticals/test/index.js
@@ -40,6 +40,7 @@ describe( 'QueryVerticals', () => {
 		const wrapped = shallow( <QueryVerticals requestVerticals={ requestVerticals } /> );
 
 		const updatedProps = {
+			siteType: '',
 			searchTerm: 'Foo',
 			limit: 7,
 			isFetched: false,
@@ -47,7 +48,11 @@ describe( 'QueryVerticals', () => {
 
 		wrapped.setProps( updatedProps );
 
-		expect( requestVerticals ).toHaveBeenCalledWith( updatedProps.searchTerm, updatedProps.limit );
+		expect( requestVerticals ).toHaveBeenCalledWith(
+			updatedProps.searchTerm,
+			updatedProps.siteType,
+			updatedProps.limit
+		);
 	} );
 
 	test( 'should not call request on update if isFetched is true.', () => {

--- a/client/components/data/query-verticals/test/index.js
+++ b/client/components/data/query-verticals/test/index.js
@@ -40,7 +40,7 @@ describe( 'QueryVerticals', () => {
 		const wrapped = shallow( <QueryVerticals requestVerticals={ requestVerticals } /> );
 
 		const updatedProps = {
-			siteTypeId: 1,
+			siteType: '',
 			searchTerm: 'Foo',
 			limit: 7,
 			isFetched: false,
@@ -50,7 +50,7 @@ describe( 'QueryVerticals', () => {
 
 		expect( requestVerticals ).toHaveBeenCalledWith(
 			updatedProps.searchTerm,
-			updatedProps.siteTypeId,
+			updatedProps.siteType,
 			updatedProps.limit
 		);
 	} );

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -16,7 +16,7 @@ import { v4 as uuid } from 'uuid';
 import SuggestionSearch from 'components/suggestion-search';
 import PopularTopics from 'components/site-verticals-suggestion-search/popular-topics';
 import QueryVerticals from 'components/data/query-verticals';
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { getSiteTypeId } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
 import { DEFAULT_VERTICAL_KEY } from 'state/signup/verticals/constants';
 
@@ -33,7 +33,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		placeholder: PropTypes.string,
 		searchValue: PropTypes.string,
 		showPopular: PropTypes.bool,
-		siteType: PropTypes.string,
+		siteTypeId: PropTypes.number,
 		verticals: PropTypes.array,
 	};
 
@@ -43,7 +43,6 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		onChange: () => {},
 		placeholder: '',
 		searchValue: '',
-		siteType: '',
 		showPopular: false,
 		verticals: [],
 	};
@@ -170,7 +169,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	getSuggestions = () => this.state.candidateVerticals.map( vertical => vertical.verticalName );
 
 	render() {
-		const { autoFocus, placeholder, siteType, translate } = this.props;
+		const { autoFocus, placeholder, siteTypeId, translate } = this.props;
 		const { inputValue, railcar } = this.state;
 		const shouldShowPopularTopics = this.shouldShowPopularTopics();
 		const placeholderText = shouldShowPopularTopics
@@ -186,10 +185,10 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			<>
 				<QueryVerticals
 					searchTerm={ inputValue.trim() }
-					siteType={ siteType }
+					siteTypeId={ siteTypeId }
 					debounceTime={ 300 }
 				/>
-				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } siteType={ siteType } />
+				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } siteTypeId={ siteTypeId } />
 				<SuggestionSearch
 					id="siteTopic"
 					placeholder={ placeholder || placeholderText }
@@ -208,14 +207,14 @@ export class SiteVerticalsSuggestionSearch extends Component {
 
 export default localize(
 	connect(
-		( state, ownProps ) => ( {
-			verticals: getVerticals( state, ownProps.searchValue, getSiteType( state ) ) || [],
-			defaultVertical: get(
-				getVerticals( state, DEFAULT_VERTICAL_KEY, getSiteType( state ) ),
-				'0',
-				{}
-			),
-		} ),
+		( state, ownProps ) => {
+			const siteTypeId = ownProps.siteTypeId || getSiteTypeId( state );
+			return {
+				siteTypeId,
+				verticals: getVerticals( state, ownProps.searchValue, siteTypeId ) || [],
+				defaultVertical: get( getVerticals( state, DEFAULT_VERTICAL_KEY, siteTypeId ), '0', {} ),
+			};
+		},
 		null
 	)( SiteVerticalsSuggestionSearch )
 );

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -16,6 +16,7 @@ import { v4 as uuid } from 'uuid';
 import SuggestionSearch from 'components/suggestion-search';
 import PopularTopics from 'components/site-verticals-suggestion-search/popular-topics';
 import QueryVerticals from 'components/data/query-verticals';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
 import { DEFAULT_VERTICAL_KEY } from 'state/signup/verticals/constants';
 
@@ -32,6 +33,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		placeholder: PropTypes.string,
 		searchValue: PropTypes.string,
 		showPopular: PropTypes.bool,
+		siteType: PropTypes.string,
 		verticals: PropTypes.array,
 	};
 
@@ -41,6 +43,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		onChange: () => {},
 		placeholder: '',
 		searchValue: '',
+		siteType: '',
 		showPopular: false,
 		verticals: [],
 	};
@@ -167,7 +170,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	getSuggestions = () => this.state.candidateVerticals.map( vertical => vertical.verticalName );
 
 	render() {
-		const { autoFocus, placeholder, translate } = this.props;
+		const { autoFocus, placeholder, siteType, translate } = this.props;
 		const { inputValue, railcar } = this.state;
 		const shouldShowPopularTopics = this.shouldShowPopularTopics();
 		const placeholderText = shouldShowPopularTopics
@@ -181,8 +184,12 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			  } );
 		return (
 			<>
-				<QueryVerticals searchTerm={ inputValue.trim() } debounceTime={ 300 } />
-				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } />
+				<QueryVerticals
+					searchTerm={ inputValue.trim() }
+					siteType={ siteType }
+					debounceTime={ 300 }
+				/>
+				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } siteType={ siteType } />
 				<SuggestionSearch
 					id="siteTopic"
 					placeholder={ placeholder || placeholderText }
@@ -202,8 +209,12 @@ export class SiteVerticalsSuggestionSearch extends Component {
 export default localize(
 	connect(
 		( state, ownProps ) => ( {
-			verticals: getVerticals( state, ownProps.searchValue ) || [],
-			defaultVertical: get( getVerticals( state, DEFAULT_VERTICAL_KEY ), '0', {} ),
+			verticals: getVerticals( state, ownProps.searchValue, getSiteType( state ) ) || [],
+			defaultVertical: get(
+				getVerticals( state, DEFAULT_VERTICAL_KEY, getSiteType( state ) ),
+				'0',
+				{}
+			),
 		} ),
 		null
 	)( SiteVerticalsSuggestionSearch )

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -16,7 +16,7 @@ import { v4 as uuid } from 'uuid';
 import SuggestionSearch from 'components/suggestion-search';
 import PopularTopics from 'components/site-verticals-suggestion-search/popular-topics';
 import QueryVerticals from 'components/data/query-verticals';
-import { getSiteTypeId } from 'state/signup/steps/site-type/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
 import { DEFAULT_VERTICAL_KEY } from 'state/signup/verticals/constants';
 
@@ -33,7 +33,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		placeholder: PropTypes.string,
 		searchValue: PropTypes.string,
 		showPopular: PropTypes.bool,
-		siteTypeId: PropTypes.number,
+		siteType: PropTypes.string,
 		verticals: PropTypes.array,
 	};
 
@@ -43,6 +43,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		onChange: () => {},
 		placeholder: '',
 		searchValue: '',
+		siteType: '',
 		showPopular: false,
 		verticals: [],
 	};
@@ -169,7 +170,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	getSuggestions = () => this.state.candidateVerticals.map( vertical => vertical.verticalName );
 
 	render() {
-		const { autoFocus, placeholder, siteTypeId, translate } = this.props;
+		const { autoFocus, placeholder, siteType, translate } = this.props;
 		const { inputValue, railcar } = this.state;
 		const shouldShowPopularTopics = this.shouldShowPopularTopics();
 		const placeholderText = shouldShowPopularTopics
@@ -185,10 +186,10 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			<>
 				<QueryVerticals
 					searchTerm={ inputValue.trim() }
-					siteTypeId={ siteTypeId }
+					siteType={ siteType }
 					debounceTime={ 300 }
 				/>
-				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } siteTypeId={ siteTypeId } />
+				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } siteType={ siteType } />
 				<SuggestionSearch
 					id="siteTopic"
 					placeholder={ placeholder || placeholderText }
@@ -207,14 +208,14 @@ export class SiteVerticalsSuggestionSearch extends Component {
 
 export default localize(
 	connect(
-		( state, ownProps ) => {
-			const siteTypeId = ownProps.siteTypeId || getSiteTypeId( state );
-			return {
-				siteTypeId,
-				verticals: getVerticals( state, ownProps.searchValue, siteTypeId ) || [],
-				defaultVertical: get( getVerticals( state, DEFAULT_VERTICAL_KEY, siteTypeId ), '0', {} ),
-			};
-		},
+		( state, ownProps ) => ( {
+			verticals: getVerticals( state, ownProps.searchValue, getSiteType( state ) ) || [],
+			defaultVertical: get(
+				getVerticals( state, DEFAULT_VERTICAL_KEY, getSiteType( state ) ),
+				'0',
+				{}
+			),
+		} ),
 		null
 	)( SiteVerticalsSuggestionSearch )
 );

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -5,9 +5,11 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
   <Connect(QueryVerticals)
     debounceTime={300}
     searchTerm=""
+    siteType=""
   />
   <Connect(QueryVerticals)
     searchTerm="business"
+    siteType=""
   />
   <SuggestionSearch
     autoFocus={false}

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -5,11 +5,11 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
   <Connect(QueryVerticals)
     debounceTime={300}
     searchTerm=""
-    siteTypeId={1}
+    siteType=""
   />
   <Connect(QueryVerticals)
     searchTerm="business"
-    siteTypeId={1}
+    siteType=""
   />
   <SuggestionSearch
     autoFocus={false}

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -5,11 +5,11 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
   <Connect(QueryVerticals)
     debounceTime={300}
     searchTerm=""
-    siteType=""
+    siteTypeId={1}
   />
   <Connect(QueryVerticals)
     searchTerm="business"
-    siteType=""
+    siteTypeId={1}
   />
   <SuggestionSearch
     autoFocus={false}

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -42,6 +42,7 @@ const defaultProps = {
 	},
 	translate: str => str,
 	searchValue: '',
+	siteTypeId: 1,
 };
 
 describe( '<SiteVerticalsSuggestionSearch />', () => {

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -42,7 +42,6 @@ const defaultProps = {
 	},
 	translate: str => str,
 	searchValue: '',
-	siteTypeId: 1,
 };
 
 describe( '<SiteVerticalsSuggestionSearch />', () => {

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -25,7 +25,7 @@ import {
 	getSiteVerticalParentId,
 } from 'state/signup/steps/site-vertical/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { getSiteTypeId } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
 
 /**
@@ -73,7 +73,7 @@ class SiteTopicForm extends Component {
 	};
 
 	render() {
-		const { isButtonDisabled, siteTopic, siteType } = this.props;
+		const { isButtonDisabled, siteTopic, siteTypeId } = this.props;
 		return (
 			<div className={ classNames( 'site-topic__content', { 'is-empty': ! siteTopic } ) }>
 				<form onSubmit={ this.onSubmit }>
@@ -83,7 +83,7 @@ class SiteTopicForm extends Component {
 							showPopular={ true }
 							searchValue={ siteTopic }
 							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
-							siteType={ siteType }
+							siteTypeId={ siteTypeId }
 						/>
 						<Button
 							title={ this.props.translate( 'Continue' ) }
@@ -103,13 +103,13 @@ class SiteTopicForm extends Component {
 
 export default connect(
 	state => {
-		const siteType = getSiteType( state );
+		const siteTypeId = getSiteTypeId( state );
 		const siteTopic = getSiteVerticalName( state );
-		const isButtonDisabled = ! siteTopic || null == getVerticals( state, siteTopic, siteType );
+		const isButtonDisabled = ! siteTopic || null == getVerticals( state, siteTopic, siteTypeId );
 
 		return {
 			siteTopic,
-			siteType,
+			siteTypeId,
 			siteSlug: getSiteVerticalSlug( state ),
 			isUserInput: getSiteVerticalIsUserInput( state ),
 			isButtonDisabled,

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -25,6 +25,7 @@ import {
 	getSiteVerticalParentId,
 } from 'state/signup/steps/site-vertical/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
 
 /**
@@ -72,7 +73,7 @@ class SiteTopicForm extends Component {
 	};
 
 	render() {
-		const { isButtonDisabled, siteTopic } = this.props;
+		const { isButtonDisabled, siteTopic, siteType } = this.props;
 		return (
 			<div className={ classNames( 'site-topic__content', { 'is-empty': ! siteTopic } ) }>
 				<form onSubmit={ this.onSubmit }>
@@ -82,6 +83,7 @@ class SiteTopicForm extends Component {
 							showPopular={ true }
 							searchValue={ siteTopic }
 							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
+							siteType={ siteType }
 						/>
 						<Button
 							title={ this.props.translate( 'Continue' ) }
@@ -101,11 +103,13 @@ class SiteTopicForm extends Component {
 
 export default connect(
 	state => {
+		const siteType = getSiteType( state );
 		const siteTopic = getSiteVerticalName( state );
-		const isButtonDisabled = ! siteTopic || null == getVerticals( state, siteTopic );
+		const isButtonDisabled = ! siteTopic || null == getVerticals( state, siteTopic, siteType );
 
 		return {
 			siteTopic,
+			siteType,
 			siteSlug: getSiteVerticalSlug( state ),
 			isUserInput: getSiteVerticalIsUserInput( state ),
 			isButtonDisabled,

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -25,7 +25,7 @@ import {
 	getSiteVerticalParentId,
 } from 'state/signup/steps/site-vertical/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSiteTypeId } from 'state/signup/steps/site-type/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
 
 /**
@@ -73,7 +73,7 @@ class SiteTopicForm extends Component {
 	};
 
 	render() {
-		const { isButtonDisabled, siteTopic, siteTypeId } = this.props;
+		const { isButtonDisabled, siteTopic, siteType } = this.props;
 		return (
 			<div className={ classNames( 'site-topic__content', { 'is-empty': ! siteTopic } ) }>
 				<form onSubmit={ this.onSubmit }>
@@ -83,7 +83,7 @@ class SiteTopicForm extends Component {
 							showPopular={ true }
 							searchValue={ siteTopic }
 							autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
-							siteTypeId={ siteTypeId }
+							siteType={ siteType }
 						/>
 						<Button
 							title={ this.props.translate( 'Continue' ) }
@@ -103,13 +103,13 @@ class SiteTopicForm extends Component {
 
 export default connect(
 	state => {
-		const siteTypeId = getSiteTypeId( state );
+		const siteType = getSiteType( state );
 		const siteTopic = getSiteVerticalName( state );
-		const isButtonDisabled = ! siteTopic || null == getVerticals( state, siteTopic, siteTypeId );
+		const isButtonDisabled = ! siteTopic || null == getVerticals( state, siteTopic, siteType );
 
 		return {
 			siteTopic,
-			siteTypeId,
+			siteType,
 			siteSlug: getSiteVerticalSlug( state ),
 			isUserInput: getSiteVerticalIsUserInput( state ),
 			isButtonDisabled,

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -25,7 +25,7 @@ export const requestVerticals = action =>
 			path: '/verticals',
 			query: {
 				search: action.search.trim(),
-				site_type: action.siteType,
+				site_type: action.siteTypeId,
 				limit: action.limit,
 				include_preview: true,
 			},
@@ -33,8 +33,8 @@ export const requestVerticals = action =>
 		action
 	);
 
-export const storeVerticals = ( { search, siteType = '' }, verticals ) =>
-	setVerticals( search, siteType, verticals );
+export const storeVerticals = ( { search, siteTypeId }, verticals ) =>
+	setVerticals( search, siteTypeId, verticals );
 export const showVerticalsRequestError = () =>
 	errorNotice(
 		translate( 'We encountered an error on fetching data from our server. Please try again.' )

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -25,7 +25,7 @@ export const requestVerticals = action =>
 			path: '/verticals',
 			query: {
 				search: action.search.trim(),
-				site_type: action.siteType.trim(),
+				site_type: action.siteType,
 				limit: action.limit,
 				include_preview: true,
 			},

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -16,6 +16,7 @@ import { convertToCamelCase } from 'state/data-layer/utils';
 import { errorNotice } from 'state/notices/actions';
 import { setVerticals } from 'state/signup/verticals/actions';
 import { SIGNUP_VERTICALS_REQUEST } from 'state/action-types';
+import { getSiteTypeId } from 'state/signup/steps/site-type/selectors';
 
 export const requestVerticals = action =>
 	http(
@@ -25,7 +26,7 @@ export const requestVerticals = action =>
 			path: '/verticals',
 			query: {
 				search: action.search.trim(),
-				site_type: action.siteType,
+				site_type: action.siteTypeId,
 				limit: action.limit,
 				include_preview: true,
 			},
@@ -40,13 +41,22 @@ export const showVerticalsRequestError = () =>
 		translate( 'We encountered an error on fetching data from our server. Please try again.' )
 	);
 
+const verticalsHandlers = dispatchRequest( {
+	fetch: requestVerticals,
+	onSuccess: storeVerticals,
+	onError: showVerticalsRequestError,
+	fromApi: convertToCamelCase,
+} );
+
 registerHandlers( 'state/data-layer/wpcom/signup/verticals', {
+	// The action provides just siteType, but to call requestVerticals we need
+	// a numeric siteTypeId. Since passing around both would be inconvenient,
+	// we retrieve it here based on the siteType slug just to provide it to requestVerticals.
 	[ SIGNUP_VERTICALS_REQUEST ]: [
-		dispatchRequest( {
-			fetch: requestVerticals,
-			onSuccess: storeVerticals,
-			onError: showVerticalsRequestError,
-			fromApi: convertToCamelCase,
-		} ),
+		( store, action ) =>
+			verticalsHandlers( store, {
+				...action,
+				siteTypeId: getSiteTypeId( store.getState(), action.siteType ),
+			} ),
 	],
 } );

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -25,7 +25,7 @@ export const requestVerticals = action =>
 			path: '/verticals',
 			query: {
 				search: action.search.trim(),
-				site_type: action.siteTypeId,
+				site_type: action.siteType,
 				limit: action.limit,
 				include_preview: true,
 			},
@@ -33,8 +33,8 @@ export const requestVerticals = action =>
 		action
 	);
 
-export const storeVerticals = ( { search, siteTypeId }, verticals ) =>
-	setVerticals( search, siteTypeId, verticals );
+export const storeVerticals = ( { search, siteType = '' }, verticals ) =>
+	setVerticals( search, siteType, verticals );
 export const showVerticalsRequestError = () =>
 	errorNotice(
 		translate( 'We encountered an error on fetching data from our server. Please try again.' )

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -25,6 +25,7 @@ export const requestVerticals = action =>
 			path: '/verticals',
 			query: {
 				search: action.search.trim(),
+				site_type: action.siteType.trim(),
 				limit: action.limit,
 				include_preview: true,
 			},
@@ -32,7 +33,8 @@ export const requestVerticals = action =>
 		action
 	);
 
-export const storeVerticals = ( { search }, verticals ) => setVerticals( search, verticals );
+export const storeVerticals = ( { search, siteType = '' }, verticals ) =>
+	setVerticals( search, siteType, verticals );
 export const showVerticalsRequestError = () =>
 	errorNotice(
 		translate( 'We encountered an error on fetching data from our server. Please try again.' )

--- a/client/state/data-layer/wpcom/signup/verticals/test/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/test/index.js
@@ -12,7 +12,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 	test( 'requestVerticals()', () => {
 		const mockAction = {
 			search: 'Foo',
-			siteType: 'business',
+			siteTypeId: 1,
 			limit: 7,
 		};
 
@@ -24,7 +24,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 					path: '/verticals',
 					query: {
 						search: mockAction.search,
-						site_type: mockAction.siteType,
+						site_type: mockAction.siteTypeId,
 						limit: mockAction.limit,
 						include_preview: true,
 					},

--- a/client/state/data-layer/wpcom/signup/verticals/test/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/test/index.js
@@ -12,6 +12,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 	test( 'requestVerticals()', () => {
 		const mockAction = {
 			search: 'Foo',
+			siteType: 'business',
 			limit: 7,
 		};
 
@@ -23,6 +24,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 					path: '/verticals',
 					query: {
 						search: mockAction.search,
+						site_type: mockAction.siteType,
 						limit: mockAction.limit,
 						include_preview: true,
 					},
@@ -34,12 +36,18 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 
 	test( 'storeVerticals()', () => {
 		const search = 'Profit!';
+		const siteType = 'business';
 		const verticals = [
 			{ id: 0, verticalName: 'More Profit!' },
 			{ id: 1, verticalName: 'Superfluous Profit!' },
 		];
 
-		expect( storeVerticals( { search }, verticals ) ).toEqual( setVerticals( search, verticals ) );
+		expect( storeVerticals( { search }, verticals ) ).toEqual(
+			setVerticals( search, '', verticals )
+		);
+		expect( storeVerticals( { search, siteType }, verticals ) ).toEqual(
+			setVerticals( search, siteType, verticals )
+		);
 	} );
 
 	test( 'showVerticalsRequestError()', () => {

--- a/client/state/data-layer/wpcom/signup/verticals/test/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/test/index.js
@@ -12,7 +12,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 	test( 'requestVerticals()', () => {
 		const mockAction = {
 			search: 'Foo',
-			siteType: 'business',
+			siteTypeId: 1,
 			limit: 7,
 		};
 
@@ -24,7 +24,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 					path: '/verticals',
 					query: {
 						search: mockAction.search,
-						site_type: mockAction.siteType,
+						site_type: mockAction.siteTypeId,
 						limit: mockAction.limit,
 						include_preview: true,
 					},
@@ -36,17 +36,17 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 
 	test( 'storeVerticals()', () => {
 		const search = 'Profit!';
-		const siteType = 'business';
+		const siteTypeId = 1;
 		const verticals = [
 			{ id: 0, verticalName: 'More Profit!' },
 			{ id: 1, verticalName: 'Superfluous Profit!' },
 		];
 
 		expect( storeVerticals( { search }, verticals ) ).toEqual(
-			setVerticals( search, '', verticals )
+			setVerticals( search, undefined, verticals )
 		);
-		expect( storeVerticals( { search, siteType }, verticals ) ).toEqual(
-			setVerticals( search, siteType, verticals )
+		expect( storeVerticals( { search, siteTypeId }, verticals ) ).toEqual(
+			setVerticals( search, siteTypeId, verticals )
 		);
 	} );
 

--- a/client/state/data-layer/wpcom/signup/verticals/test/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/test/index.js
@@ -12,7 +12,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 	test( 'requestVerticals()', () => {
 		const mockAction = {
 			search: 'Foo',
-			siteTypeId: 1,
+			siteType: 'business',
 			limit: 7,
 		};
 
@@ -24,7 +24,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 					path: '/verticals',
 					query: {
 						search: mockAction.search,
-						site_type: mockAction.siteTypeId,
+						site_type: mockAction.siteType,
 						limit: mockAction.limit,
 						include_preview: true,
 					},
@@ -36,17 +36,17 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 
 	test( 'storeVerticals()', () => {
 		const search = 'Profit!';
-		const siteTypeId = 1;
+		const siteType = 'business';
 		const verticals = [
 			{ id: 0, verticalName: 'More Profit!' },
 			{ id: 1, verticalName: 'Superfluous Profit!' },
 		];
 
 		expect( storeVerticals( { search }, verticals ) ).toEqual(
-			setVerticals( search, undefined, verticals )
+			setVerticals( search, '', verticals )
 		);
-		expect( storeVerticals( { search, siteTypeId }, verticals ) ).toEqual(
-			setVerticals( search, siteTypeId, verticals )
+		expect( storeVerticals( { search, siteType }, verticals ) ).toEqual(
+			setVerticals( search, siteType, verticals )
 		);
 	} );
 

--- a/client/state/signup/steps/site-type/selectors.js
+++ b/client/state/signup/steps/site-type/selectors.js
@@ -6,6 +6,19 @@
 
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+
 export function getSiteType( state ) {
 	return get( state, 'signup.steps.siteType', '' );
+}
+
+export function getSiteTypeId( state, siteType = null ) {
+	if ( ! siteType ) {
+		siteType = getSiteType( state );
+	}
+	return getSiteTypePropertyValue( 'slug', siteType, 'id' );
 }

--- a/client/state/signup/steps/site-type/selectors.js
+++ b/client/state/signup/steps/site-type/selectors.js
@@ -6,16 +6,6 @@
 
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
-
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
-
 export function getSiteType( state ) {
 	return get( state, 'signup.steps.siteType', '' );
-}
-
-export function getSiteTypeId( state ) {
-	return getSiteTypePropertyValue( 'slug', getSiteType( state ), 'id' );
 }

--- a/client/state/signup/steps/site-type/selectors.js
+++ b/client/state/signup/steps/site-type/selectors.js
@@ -6,6 +6,16 @@
 
 import { get } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
+
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+
 export function getSiteType( state ) {
 	return get( state, 'signup.steps.siteType', '' );
+}
+
+export function getSiteTypeId( state ) {
+	return getSiteTypePropertyValue( 'slug', getSiteType( state ), 'id' );
 }

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -9,7 +9,7 @@ import { get, find } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { getSiteTypeId } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
 
 export function getSiteVerticalName( state ) {
@@ -17,9 +17,9 @@ export function getSiteVerticalName( state ) {
 }
 
 export function getSiteVerticalData( state ) {
-	const siteType = getSiteType( state );
+	const siteTypeId = getSiteTypeId( state );
 	const verticalName = getSiteVerticalName( state );
-	const verticals = getVerticals( state, verticalName, siteType );
+	const verticals = getVerticals( state, verticalName, siteTypeId );
 
 	const match = find(
 		verticals,
@@ -34,7 +34,7 @@ export function getSiteVerticalData( state ) {
 		isUserInputVertical: true,
 		parent: '',
 		preview: '',
-		siteType,
+		siteTypeId,
 		verticalId: '',
 		verticalName,
 		verticalSlug: verticalName,

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -9,6 +9,7 @@ import { get, find } from 'lodash';
 /**
  * Internal dependencies
  */
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
 
 export function getSiteVerticalName( state ) {
@@ -16,8 +17,9 @@ export function getSiteVerticalName( state ) {
 }
 
 export function getSiteVerticalData( state ) {
+	const siteType = getSiteType( state );
 	const verticalName = getSiteVerticalName( state );
-	const verticals = getVerticals( state, verticalName );
+	const verticals = getVerticals( state, verticalName, siteType );
 
 	const match = find(
 		verticals,
@@ -32,6 +34,7 @@ export function getSiteVerticalData( state ) {
 		isUserInputVertical: true,
 		parent: '',
 		preview: '',
+		siteType,
 		verticalId: '',
 		verticalName,
 		verticalSlug: verticalName,

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -9,7 +9,7 @@ import { get, find } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getSiteTypeId } from 'state/signup/steps/site-type/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
 
 export function getSiteVerticalName( state ) {
@@ -17,9 +17,9 @@ export function getSiteVerticalName( state ) {
 }
 
 export function getSiteVerticalData( state ) {
-	const siteTypeId = getSiteTypeId( state );
+	const siteType = getSiteType( state );
 	const verticalName = getSiteVerticalName( state );
-	const verticals = getVerticals( state, verticalName, siteTypeId );
+	const verticals = getVerticals( state, verticalName, siteType );
 
 	const match = find(
 		verticals,
@@ -34,7 +34,7 @@ export function getSiteVerticalData( state ) {
 		isUserInputVertical: true,
 		parent: '',
 		preview: '',
-		siteTypeId,
+		siteType,
 		verticalId: '',
 		verticalName,
 		verticalSlug: verticalName,

--- a/client/state/signup/steps/site-vertical/test/selectors.js
+++ b/client/state/signup/steps/site-vertical/test/selectors.js
@@ -15,20 +15,22 @@ import {
 
 describe( 'selectors', () => {
 	const verticals = {
-		felice: [
-			{
-				verticalName: 'felice',
-				verticalSlug: 'felice',
-				preview: '<!--gutenberg-besties-forever <p>Fist bump!</p>-->',
-			},
-		],
-		contento: [
-			{
-				verticalName: 'contento',
-				verticalSlug: 'contento',
-				preview: '<!--gutenberg-loves-you <p>High five!</p>-->',
-			},
-		],
+		'': {
+			felice: [
+				{
+					verticalName: 'felice',
+					verticalSlug: 'felice',
+					preview: '<!--gutenberg-besties-forever <p>Fist bump!</p>-->',
+				},
+			],
+			contento: [
+				{
+					verticalName: 'contento',
+					verticalSlug: 'contento',
+					preview: '<!--gutenberg-loves-you <p>High five!</p>-->',
+				},
+			],
+		},
 	};
 
 	const state = {
@@ -81,7 +83,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return site vertical from the state', () => {
-			expect( getSiteVerticalPreview( state ) ).toEqual( verticals.felice[ 0 ].preview );
+			expect( getSiteVerticalPreview( state ) ).toEqual( verticals[ '' ].felice[ 0 ].preview );
 		} );
 	} );
 	describe( '', () => {
@@ -109,6 +111,7 @@ describe( 'selectors', () => {
 			isUserInputVertical: true,
 			parent: '',
 			preview: '',
+			siteType: '',
 			verticalId: '',
 			verticalName: '',
 			verticalSlug: '',
@@ -119,7 +122,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return direct match', () => {
-			expect( getSiteVerticalData( state ) ).toEqual( verticals.felice[ 0 ] );
+			expect( getSiteVerticalData( state ) ).toEqual( verticals[ '' ].felice[ 0 ] );
 		} );
 	} );
 } );

--- a/client/state/signup/steps/site-vertical/test/selectors.js
+++ b/client/state/signup/steps/site-vertical/test/selectors.js
@@ -15,7 +15,7 @@ import {
 
 describe( 'selectors', () => {
 	const verticals = {
-		'': {
+		1: {
 			felice: [
 				{
 					verticalName: 'felice',
@@ -36,6 +36,7 @@ describe( 'selectors', () => {
 	const state = {
 		signup: {
 			steps: {
+				siteType: 'business',
 				siteVertical: {
 					id: 'p4u',
 					name: 'felice',
@@ -83,7 +84,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return site vertical from the state', () => {
-			expect( getSiteVerticalPreview( state ) ).toEqual( verticals[ '' ].felice[ 0 ].preview );
+			expect( getSiteVerticalPreview( state ) ).toEqual( verticals[ 1 ].felice[ 0 ].preview );
 		} );
 	} );
 	describe( '', () => {
@@ -111,7 +112,7 @@ describe( 'selectors', () => {
 			isUserInputVertical: true,
 			parent: '',
 			preview: '',
-			siteType: '',
+			siteTypeId: null,
 			verticalId: '',
 			verticalName: '',
 			verticalSlug: '',
@@ -122,7 +123,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return direct match', () => {
-			expect( getSiteVerticalData( state ) ).toEqual( verticals[ '' ].felice[ 0 ] );
+			expect( getSiteVerticalData( state ) ).toEqual( verticals[ 1 ].felice[ 0 ] );
 		} );
 	} );
 } );

--- a/client/state/signup/steps/site-vertical/test/selectors.js
+++ b/client/state/signup/steps/site-vertical/test/selectors.js
@@ -15,7 +15,7 @@ import {
 
 describe( 'selectors', () => {
 	const verticals = {
-		1: {
+		'': {
 			felice: [
 				{
 					verticalName: 'felice',
@@ -36,7 +36,6 @@ describe( 'selectors', () => {
 	const state = {
 		signup: {
 			steps: {
-				siteType: 'business',
 				siteVertical: {
 					id: 'p4u',
 					name: 'felice',
@@ -84,7 +83,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return site vertical from the state', () => {
-			expect( getSiteVerticalPreview( state ) ).toEqual( verticals[ 1 ].felice[ 0 ].preview );
+			expect( getSiteVerticalPreview( state ) ).toEqual( verticals[ '' ].felice[ 0 ].preview );
 		} );
 	} );
 	describe( '', () => {
@@ -112,7 +111,7 @@ describe( 'selectors', () => {
 			isUserInputVertical: true,
 			parent: '',
 			preview: '',
-			siteTypeId: null,
+			siteType: '',
 			verticalId: '',
 			verticalName: '',
 			verticalSlug: '',
@@ -123,7 +122,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return direct match', () => {
-			expect( getSiteVerticalData( state ) ).toEqual( verticals[ 1 ].felice[ 0 ] );
+			expect( getSiteVerticalData( state ) ).toEqual( verticals[ '' ].felice[ 0 ] );
 		} );
 	} );
 } );

--- a/client/state/signup/steps/site-vertical/test/selectors.js
+++ b/client/state/signup/steps/site-vertical/test/selectors.js
@@ -15,7 +15,7 @@ import {
 
 describe( 'selectors', () => {
 	const verticals = {
-		'': {
+		business: {
 			felice: [
 				{
 					verticalName: 'felice',
@@ -36,6 +36,7 @@ describe( 'selectors', () => {
 	const state = {
 		signup: {
 			steps: {
+				siteType: 'business',
 				siteVertical: {
 					id: 'p4u',
 					name: 'felice',
@@ -83,7 +84,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return site vertical from the state', () => {
-			expect( getSiteVerticalPreview( state ) ).toEqual( verticals[ '' ].felice[ 0 ].preview );
+			expect( getSiteVerticalPreview( state ) ).toEqual( verticals.business.felice[ 0 ].preview );
 		} );
 	} );
 	describe( '', () => {
@@ -122,7 +123,7 @@ describe( 'selectors', () => {
 		} );
 
 		test( 'should return direct match', () => {
-			expect( getSiteVerticalData( state ) ).toEqual( verticals[ '' ].felice[ 0 ] );
+			expect( getSiteVerticalData( state ) ).toEqual( verticals.business.felice[ 0 ] );
 		} );
 	} );
 } );

--- a/client/state/signup/verticals/actions.js
+++ b/client/state/signup/verticals/actions.js
@@ -11,13 +11,15 @@ import 'state/data-layer/wpcom/signup/verticals';
  * Action creator: Request verticals data.
  *
  * @param {String} search The search term for requesting the matching verticals.
+ * @param {String} siteType Site type relevant for given search term
  * @param {Number} limit The maximum number of vertical items.
  *
  * @return {Object} The action object.
  */
-export const requestVerticals = ( search, limit ) => ( {
+export const requestVerticals = ( search, siteType, limit ) => ( {
 	type: SIGNUP_VERTICALS_REQUEST,
 	search,
+	siteType,
 	limit,
 } );
 
@@ -25,12 +27,14 @@ export const requestVerticals = ( search, limit ) => ( {
  * Action creator: Store verticals found for a given search term in the state tree.
  *
  * @param {String} search The search term which the verticals data matching with.
+ * @param {String} siteType Site type relevant for given search term
  * @param {Array} verticals The verticals data matches with the given search term.
  *
  * @return {Object} The action object.
  */
-export const setVerticals = ( search, verticals ) => ( {
+export const setVerticals = ( search, siteType, verticals ) => ( {
 	type: SIGNUP_VERTICALS_SET,
 	search,
+	siteType,
 	verticals,
 } );

--- a/client/state/signup/verticals/actions.js
+++ b/client/state/signup/verticals/actions.js
@@ -11,15 +11,15 @@ import 'state/data-layer/wpcom/signup/verticals';
  * Action creator: Request verticals data.
  *
  * @param {String} search The search term for requesting the matching verticals.
- * @param {Number} siteTypeId Site type ID relevant for given search term
+ * @param {String} siteType Site type relevant for given search term
  * @param {Number} limit The maximum number of vertical items.
  *
  * @return {Object} The action object.
  */
-export const requestVerticals = ( search, siteTypeId, limit ) => ( {
+export const requestVerticals = ( search, siteType, limit ) => ( {
 	type: SIGNUP_VERTICALS_REQUEST,
 	search,
-	siteTypeId,
+	siteType,
 	limit,
 } );
 
@@ -27,14 +27,14 @@ export const requestVerticals = ( search, siteTypeId, limit ) => ( {
  * Action creator: Store verticals found for a given search term in the state tree.
  *
  * @param {String} search The search term which the verticals data matching with.
- * @param {Number} siteTypeId Site type ID relevant for given search term
+ * @param {String} siteType Site type relevant for given search term
  * @param {Array} verticals The verticals data matches with the given search term.
  *
  * @return {Object} The action object.
  */
-export const setVerticals = ( search, siteTypeId, verticals ) => ( {
+export const setVerticals = ( search, siteType, verticals ) => ( {
 	type: SIGNUP_VERTICALS_SET,
 	search,
-	siteTypeId,
+	siteType,
 	verticals,
 } );

--- a/client/state/signup/verticals/actions.js
+++ b/client/state/signup/verticals/actions.js
@@ -11,15 +11,15 @@ import 'state/data-layer/wpcom/signup/verticals';
  * Action creator: Request verticals data.
  *
  * @param {String} search The search term for requesting the matching verticals.
- * @param {String} siteType Site type relevant for given search term
+ * @param {Number} siteTypeId Site type ID relevant for given search term
  * @param {Number} limit The maximum number of vertical items.
  *
  * @return {Object} The action object.
  */
-export const requestVerticals = ( search, siteType, limit ) => ( {
+export const requestVerticals = ( search, siteTypeId, limit ) => ( {
 	type: SIGNUP_VERTICALS_REQUEST,
 	search,
-	siteType,
+	siteTypeId,
 	limit,
 } );
 
@@ -27,14 +27,14 @@ export const requestVerticals = ( search, siteType, limit ) => ( {
  * Action creator: Store verticals found for a given search term in the state tree.
  *
  * @param {String} search The search term which the verticals data matching with.
- * @param {String} siteType Site type relevant for given search term
+ * @param {Number} siteTypeId Site type ID relevant for given search term
  * @param {Array} verticals The verticals data matches with the given search term.
  *
  * @return {Object} The action object.
  */
-export const setVerticals = ( search, siteType, verticals ) => ( {
+export const setVerticals = ( search, siteTypeId, verticals ) => ( {
 	type: SIGNUP_VERTICALS_SET,
 	search,
-	siteType,
+	siteTypeId,
 	verticals,
 } );

--- a/client/state/signup/verticals/reducer.js
+++ b/client/state/signup/verticals/reducer.js
@@ -7,8 +7,15 @@ import { createReducer } from 'state/utils';
 import { SIGNUP_VERTICALS_SET } from 'state/action-types';
 
 export default createReducer( null, {
-	[ SIGNUP_VERTICALS_SET ]: ( state, action ) => ( {
-		...state,
-		[ action.search.trim().toLowerCase() ]: action.verticals,
-	} ),
+	[ SIGNUP_VERTICALS_SET ]: ( state, action ) => {
+		const siteType = action.siteType.trim().toLowerCase();
+		const previousData = state ? state[ siteType ] : {};
+		return {
+			...state,
+			[ siteType ]: {
+				...previousData,
+				[ action.search.trim().toLowerCase() ]: action.verticals,
+			},
+		};
+	},
 } );

--- a/client/state/signup/verticals/reducer.js
+++ b/client/state/signup/verticals/reducer.js
@@ -8,11 +8,11 @@ import { SIGNUP_VERTICALS_SET } from 'state/action-types';
 
 export default createReducer( null, {
 	[ SIGNUP_VERTICALS_SET ]: ( state, action ) => {
-		const siteTypeId = action.siteTypeId;
-		const previousData = state ? state[ siteTypeId ] : {};
+		const siteType = action.siteType;
+		const previousData = state ? state[ siteType ] : {};
 		return {
 			...state,
-			[ siteTypeId ]: {
+			[ siteType ]: {
 				...previousData,
 				[ action.search.trim().toLowerCase() ]: action.verticals,
 			},

--- a/client/state/signup/verticals/reducer.js
+++ b/client/state/signup/verticals/reducer.js
@@ -8,11 +8,11 @@ import { SIGNUP_VERTICALS_SET } from 'state/action-types';
 
 export default createReducer( null, {
 	[ SIGNUP_VERTICALS_SET ]: ( state, action ) => {
-		const siteType = action.siteType;
-		const previousData = state ? state[ siteType ] : {};
+		const siteTypeId = action.siteTypeId;
+		const previousData = state ? state[ siteTypeId ] : {};
 		return {
 			...state,
-			[ siteType ]: {
+			[ siteTypeId ]: {
 				...previousData,
 				[ action.search.trim().toLowerCase() ]: action.verticals,
 			},

--- a/client/state/signup/verticals/reducer.js
+++ b/client/state/signup/verticals/reducer.js
@@ -9,7 +9,7 @@ import { SIGNUP_VERTICALS_SET } from 'state/action-types';
 export default createReducer( null, {
 	[ SIGNUP_VERTICALS_SET ]: ( state, action ) => {
 		const siteType = action.siteType;
-		const previousData = state ? state[ siteType ] : {};
+		const previousData = state ? state[ siteType ] : null;
 		return {
 			...state,
 			[ siteType ]: {

--- a/client/state/signup/verticals/reducer.js
+++ b/client/state/signup/verticals/reducer.js
@@ -8,7 +8,7 @@ import { SIGNUP_VERTICALS_SET } from 'state/action-types';
 
 export default createReducer( null, {
 	[ SIGNUP_VERTICALS_SET ]: ( state, action ) => {
-		const siteType = action.siteType.trim().toLowerCase();
+		const siteType = action.siteType;
 		const previousData = state ? state[ siteType ] : {};
 		return {
 			...state,

--- a/client/state/signup/verticals/selectors.js
+++ b/client/state/signup/verticals/selectors.js
@@ -5,5 +5,5 @@
  */
 import { get } from 'lodash';
 
-export const getVerticals = ( state, searchTerm = '', siteType = '' ) =>
-	get( state, [ 'signup', 'verticals', siteType, searchTerm.trim().toLowerCase() ], null );
+export const getVerticals = ( state, searchTerm = '', siteTypeId ) =>
+	get( state, [ 'signup', 'verticals', siteTypeId, searchTerm.trim().toLowerCase() ], null );

--- a/client/state/signup/verticals/selectors.js
+++ b/client/state/signup/verticals/selectors.js
@@ -6,13 +6,4 @@
 import { get } from 'lodash';
 
 export const getVerticals = ( state, searchTerm = '', siteType = '' ) =>
-	get(
-		state,
-		[
-			'signup',
-			'verticals',
-			( siteType || '' ).trim().toLowerCase(),
-			searchTerm.trim().toLowerCase(),
-		],
-		null
-	);
+	get( state, [ 'signup', 'verticals', siteType, searchTerm.trim().toLowerCase() ], null );

--- a/client/state/signup/verticals/selectors.js
+++ b/client/state/signup/verticals/selectors.js
@@ -5,5 +5,5 @@
  */
 import { get } from 'lodash';
 
-export const getVerticals = ( state, searchTerm = '', siteTypeId ) =>
-	get( state, [ 'signup', 'verticals', siteTypeId, searchTerm.trim().toLowerCase() ], null );
+export const getVerticals = ( state, searchTerm = '', siteType = '' ) =>
+	get( state, [ 'signup', 'verticals', siteType, searchTerm.trim().toLowerCase() ], null );

--- a/client/state/signup/verticals/selectors.js
+++ b/client/state/signup/verticals/selectors.js
@@ -5,5 +5,14 @@
  */
 import { get } from 'lodash';
 
-export const getVerticals = ( state, searchTerm = '' ) =>
-	get( state, [ 'signup', 'verticals', searchTerm.trim().toLowerCase() ], null );
+export const getVerticals = ( state, searchTerm = '', siteType = '' ) =>
+	get(
+		state,
+		[
+			'signup',
+			'verticals',
+			( siteType || '' ).trim().toLowerCase(),
+			searchTerm.trim().toLowerCase(),
+		],
+		null
+	);

--- a/client/state/signup/verticals/test/actions.js
+++ b/client/state/signup/verticals/test/actions.js
@@ -9,25 +9,29 @@ import { requestVerticals, setVerticals } from '../actions';
 describe( 'state/signup/verticals/actions', () => {
 	test( 'requestVerticals', () => {
 		const search = 'Foo',
+			siteType = 'Business',
 			limit = 7;
 
-		expect( requestVerticals( search, limit ) ).toEqual( {
+		expect( requestVerticals( search, siteType, limit ) ).toEqual( {
 			type: SIGNUP_VERTICALS_REQUEST,
 			search,
+			siteType,
 			limit,
 		} );
 	} );
 
 	test( 'setVerticals', () => {
 		const search = 'Foo';
+		const siteType = 'Business';
 		const verticals = [
 			{ id: 0, verticalName: 'vertical 1' },
 			{ id: 1, verticalName: 'vertical 2' },
 		];
 
-		expect( setVerticals( search, verticals ) ).toEqual( {
+		expect( setVerticals( search, siteType, verticals ) ).toEqual( {
 			type: SIGNUP_VERTICALS_SET,
 			search,
+			siteType,
 			verticals,
 		} );
 	} );

--- a/client/state/signup/verticals/test/actions.js
+++ b/client/state/signup/verticals/test/actions.js
@@ -9,29 +9,29 @@ import { requestVerticals, setVerticals } from '../actions';
 describe( 'state/signup/verticals/actions', () => {
 	test( 'requestVerticals', () => {
 		const search = 'Foo',
-			siteTypeId = 2,
+			siteType = 'Business',
 			limit = 7;
 
-		expect( requestVerticals( search, siteTypeId, limit ) ).toEqual( {
+		expect( requestVerticals( search, siteType, limit ) ).toEqual( {
 			type: SIGNUP_VERTICALS_REQUEST,
 			search,
-			siteTypeId,
+			siteType,
 			limit,
 		} );
 	} );
 
 	test( 'setVerticals', () => {
 		const search = 'Foo';
-		const siteTypeId = 3;
+		const siteType = 'Business';
 		const verticals = [
 			{ id: 0, verticalName: 'vertical 1' },
 			{ id: 1, verticalName: 'vertical 2' },
 		];
 
-		expect( setVerticals( search, siteTypeId, verticals ) ).toEqual( {
+		expect( setVerticals( search, siteType, verticals ) ).toEqual( {
 			type: SIGNUP_VERTICALS_SET,
 			search,
-			siteTypeId,
+			siteType,
 			verticals,
 		} );
 	} );

--- a/client/state/signup/verticals/test/actions.js
+++ b/client/state/signup/verticals/test/actions.js
@@ -9,29 +9,29 @@ import { requestVerticals, setVerticals } from '../actions';
 describe( 'state/signup/verticals/actions', () => {
 	test( 'requestVerticals', () => {
 		const search = 'Foo',
-			siteType = 'Business',
+			siteTypeId = 2,
 			limit = 7;
 
-		expect( requestVerticals( search, siteType, limit ) ).toEqual( {
+		expect( requestVerticals( search, siteTypeId, limit ) ).toEqual( {
 			type: SIGNUP_VERTICALS_REQUEST,
 			search,
-			siteType,
+			siteTypeId,
 			limit,
 		} );
 	} );
 
 	test( 'setVerticals', () => {
 		const search = 'Foo';
-		const siteType = 'Business';
+		const siteTypeId = 3;
 		const verticals = [
 			{ id: 0, verticalName: 'vertical 1' },
 			{ id: 1, verticalName: 'vertical 2' },
 		];
 
-		expect( setVerticals( search, siteType, verticals ) ).toEqual( {
+		expect( setVerticals( search, siteTypeId, verticals ) ).toEqual( {
 			type: SIGNUP_VERTICALS_SET,
 			search,
-			siteType,
+			siteTypeId,
 			verticals,
 		} );
 	} );

--- a/client/state/signup/verticals/test/reducer.js
+++ b/client/state/signup/verticals/test/reducer.js
@@ -13,16 +13,20 @@ describe( 'state/signup/verticals/reducer', () => {
 
 	test( 'should associate a trimmed and lowercase search string to the verticals array.', () => {
 		const search = 'Foo';
+		const siteType = 'business';
 		const verticals = [ { id: 0, verticalName: 'Coffee' }, { id: 1, verticalName: 'Tea' } ];
 
 		expect(
 			reducer( undefined, {
 				type: SIGNUP_VERTICALS_SET,
 				search,
+				siteType,
 				verticals,
 			} )
 		).toEqual( {
-			foo: verticals,
+			business: {
+				foo: verticals,
+			},
 		} );
 	} );
 } );

--- a/client/state/signup/verticals/test/reducer.js
+++ b/client/state/signup/verticals/test/reducer.js
@@ -13,18 +13,18 @@ describe( 'state/signup/verticals/reducer', () => {
 
 	test( 'should associate a trimmed and lowercase search string to the verticals array.', () => {
 		const search = 'Foo';
-		const siteType = 'business';
+		const siteTypeId = 1;
 		const verticals = [ { id: 0, verticalName: 'Coffee' }, { id: 1, verticalName: 'Tea' } ];
 
 		expect(
 			reducer( undefined, {
 				type: SIGNUP_VERTICALS_SET,
 				search,
-				siteType,
+				siteTypeId,
 				verticals,
 			} )
 		).toEqual( {
-			business: {
+			1: {
 				foo: verticals,
 			},
 		} );

--- a/client/state/signup/verticals/test/reducer.js
+++ b/client/state/signup/verticals/test/reducer.js
@@ -13,18 +13,18 @@ describe( 'state/signup/verticals/reducer', () => {
 
 	test( 'should associate a trimmed and lowercase search string to the verticals array.', () => {
 		const search = 'Foo';
-		const siteTypeId = 1;
+		const siteType = 'business';
 		const verticals = [ { id: 0, verticalName: 'Coffee' }, { id: 1, verticalName: 'Tea' } ];
 
 		expect(
 			reducer( undefined, {
 				type: SIGNUP_VERTICALS_SET,
 				search,
-				siteTypeId,
+				siteType,
 				verticals,
 			} )
 		).toEqual( {
-			1: {
+			business: {
 				foo: verticals,
 			},
 		} );

--- a/client/state/signup/verticals/test/selectors.js
+++ b/client/state/signup/verticals/test/selectors.js
@@ -15,24 +15,32 @@ describe( 'state/signup/verticals/selectors', () => {
 		const state = {
 			signup: {
 				verticals: {
-					[ searchTerm ]: [
-						{ id: 0, verticalName: 'Ah!' },
-						{ id: 1, verticalName: 'I am selected!' },
-					],
+					business: {
+						[ searchTerm ]: [
+							{ id: 0, verticalName: 'Ah!' },
+							{ id: 1, verticalName: 'I am selected!' },
+						],
+					},
 				},
 			},
 		};
 
 		test( 'should return the stored verticals data.', () => {
-			expect( getVerticals( state, searchTerm ) ).toEqual( state.signup.verticals[ searchTerm ] );
+			expect( getVerticals( state, searchTerm, 'business' ) ).toEqual(
+				state.signup.verticals.business[ searchTerm ]
+			);
 		} );
 
 		test( 'should return null if it does not exist', () => {
-			expect( getVerticals( state, 'Aaa' ) ).toBeNull();
+			expect( getVerticals( state, 'Aaa', 'business' ) ).toBeNull();
+			expect( getVerticals( state, searchTerm, '' ) ).toBeNull();
+			expect( getVerticals( state, searchTerm ) ).toBeNull();
 		} );
 
 		test( 'should return correct results from mixed case and untrimmed value', () => {
-			expect( getVerticals( state, ' COOL ' ) ).toEqual( state.signup.verticals[ searchTerm ] );
+			expect( getVerticals( state, ' COOL ', ' BUSINESS ' ) ).toEqual(
+				state.signup.verticals.business[ searchTerm ]
+			);
 		} );
 	} );
 } );

--- a/client/state/signup/verticals/test/selectors.js
+++ b/client/state/signup/verticals/test/selectors.js
@@ -38,7 +38,7 @@ describe( 'state/signup/verticals/selectors', () => {
 		} );
 
 		test( 'should return correct results from mixed case and untrimmed value', () => {
-			expect( getVerticals( state, ' COOL ', ' BUSINESS ' ) ).toEqual(
+			expect( getVerticals( state, ' COOL ', 'business' ) ).toEqual(
 				state.signup.verticals.business[ searchTerm ]
 			);
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Since we're adding a support for Professional and Blogger site types, we need a way to store segment-specific verticals. This PR updates all relevant places and changes the state structure from:

```js
signup: {
    verticals: {
        restaurant: [
             { /* ... */ }
        ]
    }
}
```

To

```js
signup: {
    verticals: {
        4: {
           restaurant: [
             { /* ... */ }
           ]
        },
        1: {
           restaurant: [
             { /* ... */ }
           ]
        }
    }
}
```

#### Testing instructions

This is just a state layer update so there isn't a real new feature to test. Instead we're just confirming nothing got broken in the process:

1. Go to `/start/onboarding` and choose a business segment.
2. Type in and select a few different verticals, confirm in Network tab that http request contains `site_type=1` (or any other segment ID) in query
3. Use a back button and choose business segment again, confirm the site preview still works
4. Inspect state and the following actions in redux devtools: `SIGNUP_VERTICALS_SET`, `SIGNUP_VERTICALS_REQUEST`. Confirm they contain `siteTypeId` when verticals lookup is performed. Confirm the state is shaped like in the PR description above.
5. Finish the signup, confirm a proper starter site was created.
6. Go to `/start/main` and confirm verticals picker works there. Finish she signup flow, confirm a new site was created.

