### PR TITLE
Marketing: Show permission requirement notice for non-admin users

### DIFF
--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -16,6 +16,7 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import config from 'config';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import DocumentHead from 'components/data/document-head';
+import EmptyContent from 'components/empty-content';
 import { getSiteSlug, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
@@ -33,6 +34,7 @@ import { FEATURE_NO_ADS } from 'lib/plans/constants';
 import './style.scss';
 
 export const Sharing = ( {
+	canManageOptions,
 	contentComponent,
 	path,
 	showButtons,
@@ -85,6 +87,20 @@ export const Sharing = ( {
 
 	const selected = find( filters, { route: path } );
 
+	if ( ! canManageOptions ) {
+		return (
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			<Main wideLayout className="sharing">
+				<DocumentHead title={ translate( 'Sharing' ) } />
+				<SidebarNavigation />
+				<EmptyContent
+					title={ translate( 'You are not authorized to view this page' ) }
+					illustration={ '/calypso/images/illustrations/illustration-404.svg' }
+				/>
+			</Main>
+		);
+	}
+
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="sharing">
@@ -133,6 +149,7 @@ export default connect( state => {
 		isJetpackMinimumVersion( state, siteId, '3.4-dev' );
 
 	return {
+		canManageOptions,
 		showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
 		showConnections: ! siteId || ! isJetpack || isJetpackModuleActive( state, siteId, 'publicize' ),
 		showTraffic: !! siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show a permission notice for non-admin user roles when trying to access the Marketing section of a site.

<img width="1426" alt="Screen Shot 2019-05-21 at 1 56 47 PM" src="https://user-images.githubusercontent.com/448298/58119273-971a2d80-7bd0-11e9-8d0d-c5c7104247e0.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch.
* Visit a site as an admin.
* Visit `Tools > Marketing` from the sidebar.
* Confirm you can see and update these settings.
* Visit the same page on a site with other user roles - `editor`, `author`, and `contributor`.
* Confirm you see the permission notice instead of the page loading.

Fixes #33032
