### PR TITLE
Add new Jetpack mailing list categories to me/notifications/updates page

### DIFF
--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -176,7 +176,7 @@ class WPCOMNotifications extends React.Component {
 	};
 
 	renderPlaceholder = () => {
-		return <p className="notification-settings-wpcom-settings__placeholder">&nbsp;</p>;
+		return <p className="wpcom-settings__notification-settings-placeholder">&nbsp;</p>;
 	};
 
 	render() {

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -30,6 +30,7 @@ import {
 } from 'state/notification-settings/selectors';
 import EmailCategory from './email-category';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import hasJetpackSites from 'state/selectors/has-jetpack-sites';
 
 /**
  * Module variables
@@ -41,6 +42,10 @@ const options = {
 	promotion: 'promotion',
 	news: 'news',
 	digest: 'digest',
+	jetpack_marketing: 'jetpack_marketing',
+	jetpack_research: 'jetpack_research',
+	jetpack_promotion: 'jetpack_promotion',
+	jetpack_news: 'jetpack_news',
 };
 
 class WPCOMNotifications extends React.Component {
@@ -71,6 +76,10 @@ class WPCOMNotifications extends React.Component {
 							'privacy, and purchase transactions, but you can get some helpful extras, too.'
 					) }
 				</p>
+
+				<FormSectionHeading>
+					{ this.props.translate( 'Email from WordPress.com' ) }
+				</FormSectionHeading>
 
 				<EmailCategory
 					name={ options.marketing }
@@ -121,6 +130,46 @@ class WPCOMNotifications extends React.Component {
 					) }
 				/>
 
+				{ this.props.hasJetpackSites ? (
+					<>
+						<FormSectionHeading>
+							{ this.props.translate( 'Email from Jetpack' ) }
+						</FormSectionHeading>
+
+						<EmailCategory
+							name={ options.jetpack_marketing }
+							isEnabled={ get( settings, options.jetpack_marketing ) }
+							title={ translate( 'Suggestions' ) }
+							description={ translate( 'Tips for getting the most out of Jetpack.' ) }
+						/>
+
+						<EmailCategory
+							name={ options.jetpack_research }
+							isEnabled={ get( settings, options.jetpack_research ) }
+							title={ translate( 'Research' ) }
+							description={ translate(
+								'Opportunities to participate in Jetpack research and surveys.'
+							) }
+						/>
+
+						<EmailCategory
+							name={ options.jetpack_promotion }
+							isEnabled={ get( settings, options.jetpack_promotion ) }
+							title={ translate( 'Promotions' ) }
+							description={ translate( 'Promotions and deals on upgrades.' ) }
+						/>
+
+						<EmailCategory
+							name={ options.jetpack_news }
+							isEnabled={ get( settings, options.jetpack_news ) }
+							title={ translate( 'News' ) }
+							description={ translate( 'Jetpack news and announcements.' ) }
+						/>
+					</>
+				) : (
+					''
+				) }
+
 				<ActionButtons onSave={ this.saveSettings } disabled={ ! this.props.hasUnsavedChanges } />
 			</div>
 		);
@@ -143,9 +192,6 @@ class WPCOMNotifications extends React.Component {
 				<Navigation path={ this.props.path } />
 
 				<Card>
-					<FormSectionHeading>
-						{ this.props.translate( 'Email from WordPress.com' ) }
-					</FormSectionHeading>
 					{ this.props.settings ? this.renderWpcomPreferences() : this.renderPlaceholder() }
 				</Card>
 			</Main>
@@ -157,6 +203,7 @@ export default connect(
 	state => ( {
 		settings: getNotificationSettings( state, 'wpcom' ),
 		hasUnsavedChanges: hasUnsavedNotificationSettingsChanges( state, 'wpcom' ),
+		hasJetpackSites: hasJetpackSites( state ),
 	} ),
 	{ fetchSettings, toggleWPcomEmailSetting, saveSettings }
 )( localize( WPCOMNotifications ) );

--- a/client/me/notification-settings/wpcom-settings/style.scss
+++ b/client/me/notification-settings/wpcom-settings/style.scss
@@ -1,4 +1,4 @@
-.notification-settings-wpcom-settings__placeholder {
+.wpcom-settings__notification-settings-placeholder {
 	animation: loading-fade 1.6s ease-in-out infinite;
 	background-color: var( --color-neutral-0 );
 	line-height: 1;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add new mailing list categories for Jetpack
More info: paOlDU-3d-p2

#### Testing instructions

* Apply the backend diff D28504-code
* Sandbox `public-api.wordpress.com`
* With an account that has at least one Jetpack site, visit http://calypso.localhost:3000/me/notifications/updates
* You should see the new Jetpack categories
![wpcom-me-notifications-page-with-jetpack-e-highlight](https://user-images.githubusercontent.com/690843/58129608-f414e400-7bce-11e9-9195-6b02fd56434e.png)

* Uncheck the Jetpack "Research" category and click "Save Settings".
* You should see a "Settings saved successfully!" message
* On the backend, check the user attribute to make sure it was properly set
```
echo get_user_attribute( 64547124, 'notifications_wpcom_email_jetpack_research' );
1
```
* Visit the same page using an account that **does not** have a Jetpack site, you should **not** see the new categories.
