### PR TITLE
Checklist: On confirm email prompt, add a guided tour box

### DIFF
--- a/client/layout/guided-tours/all-tours.js
+++ b/client/layout/guided-tours/all-tours.js
@@ -21,6 +21,7 @@ import { ChecklistSiteIconTour } from 'layout/guided-tours/tours/checklist-site-
 import { ChecklistSiteTaglineTour } from 'layout/guided-tours/tours/checklist-site-tagline-tour';
 import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site-title-tour';
 import { ChecklistUserAvatarTour } from 'layout/guided-tours/tours/checklist-user-avatar-tour';
+import { ChecklistUserEmailTour } from 'layout/guided-tours/tours/checklist-user-email-tour';
 import { JetpackBackupsRewindTour } from 'layout/guided-tours/tours/jetpack-backups-rewind-tour';
 import { JetpackBasicTour } from 'layout/guided-tours/tours/jetpack-basic-tour';
 import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
@@ -39,6 +40,7 @@ export default combineTours( {
 	checklistSiteTagline: ChecklistSiteTaglineTour,
 	checklistSiteTitle: ChecklistSiteTitleTour,
 	checklistUserAvatar: ChecklistUserAvatarTour,
+	checklistUserEmail: ChecklistUserEmailTour,
 	jetpack: JetpackBasicTour,
 	jetpackBackupsRewind: JetpackBackupsRewindTour,
 	jetpackMonitoring: JetpackMonitoringTour,

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -19,6 +19,7 @@ import checklistSiteIcon from 'layout/guided-tours/tours/checklist-site-icon-tou
 import checklistSiteTagline from 'layout/guided-tours/tours/checklist-site-tagline-tour/meta';
 import checklistSiteTitle from 'layout/guided-tours/tours/checklist-site-title-tour/meta';
 import checklistUserAvatar from 'layout/guided-tours/tours/checklist-user-avatar-tour/meta';
+import checklistUserEmail from 'layout/guided-tours/tours/checklist-user-email-tour/meta';
 import jetpack from 'layout/guided-tours/tours/jetpack-basic-tour/meta';
 import jetpackBackupsRewind from 'layout/guided-tours/tours/jetpack-backups-rewind-tour/meta';
 import jetpackMonitoring from 'layout/guided-tours/tours/jetpack-monitoring-tour/meta';
@@ -37,6 +38,7 @@ export default {
 	checklistSiteTagline,
 	checklistSiteTitle,
 	checklistUserAvatar,
+	checklistUserEmail,
 	jetpack,
 	jetpackBackupsRewind,
 	jetpackMonitoring,

--- a/client/layout/guided-tours/tours/checklist-user-email-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-user-email-tour/index.js
@@ -1,0 +1,39 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React, { Fragment } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import meta from './meta';
+import { makeTour, Step, Tour } from 'layout/guided-tours/config-elements';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+export const ChecklistUserEmailTour = makeTour(
+	<Tour { ...meta }>
+		<Step
+			name="init"
+			target="#user_email"
+			placement="below"
+			arrow="top-left"
+			style={ {
+				animationDelay: '0.7s',
+			} }
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Make sure your email address is correct. ' +
+								'If not, change it here then click on Save Account Settings button below.'
+						) }
+					</p>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/checklist-user-email-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-user-email-tour/index.js
@@ -10,7 +10,7 @@ import React, { Fragment } from 'react';
  * Internal dependencies
  */
 import meta from './meta';
-import { makeTour, Step, Tour } from 'layout/guided-tours/config-elements';
+import { ButtonRow, makeTour, SiteLink, Step, Tour } from 'layout/guided-tours/config-elements';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const ChecklistUserEmailTour = makeTour(
@@ -28,10 +28,17 @@ export const ChecklistUserEmailTour = makeTour(
 				<Fragment>
 					<p>
 						{ translate(
-							'Make sure your email address is correct. ' +
-								'If not, change it here then click on Save Account Settings button below.'
+							'Correct typos in your email address, then press {{b}}Save Account Settings{{/b}} to save your changes.',
+							{
+								components: { b: <strong /> },
+							}
 						) }
 					</p>
+					<ButtonRow>
+						<SiteLink isButton={ true } href="/checklist/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
+					</ButtonRow>
 				</Fragment>
 			) }
 		</Step>

--- a/client/layout/guided-tours/tours/checklist-user-email-tour/meta.js
+++ b/client/layout/guided-tours/tours/checklist-user-email-tour/meta.js
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import { noop } from 'layout/guided-tours/utils';
+
+export default {
+	name: 'checklistUserEmail',
+	version: '20190515',
+	path: '/non-existent-route',
+	when: noop,
+};

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -375,7 +375,7 @@ class WpcomChecklistComponent extends PureComponent {
 						},
 						components: {
 							br: <br />,
-							changeButton: <a href="/me/account?tour=verifyEmailSetting" />,
+							changeButton: <a href="/me/account?tour=checklistUserEmail" />,
 						},
 					}
 				) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -375,7 +375,7 @@ class WpcomChecklistComponent extends PureComponent {
 						},
 						components: {
 							br: <br />,
-							changeButton: <a href="/me/account" />,
+							changeButton: <a href="/me/account?tour=verifyEmailSetting" />,
 						},
 					}
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds `checklistUserEmail` tour to help user correct typo in email address.

#### Testing instructions

---

**Full Test**

1. Edit `client/my-sites/checklist/wpcom-checklist/index.jsx` file, making following changes to force already completed email verification task to appear:

Change line 119 from:
```
const isEligibleForChecklist = isEligibleForDotcomChecklist( state, siteId );
```
to
```
const isEligibleForChecklist = true;
```
Insert following line at line 126:
```
taskStatuses.email_verified.completed = false;
```

2. `npm start` and navigate to http://calypso.localhost:3000/checklist/{your_site_domain}. You should see the checklist with incomplete email verification. Click on the **Change it here** link.

<img width="738" alt="screenshot_672" src="https://user-images.githubusercontent.com/127594/58137837-b0c76f00-7be8-11e9-848b-169384c3e521.png">

3. On the Profile page, you should see the Guided Tour step like this. Press the **Return to the checklist** button to get back to the checklist.

<img width="739" alt="screenshot_673" src="https://user-images.githubusercontent.com/127594/58137882-f1bf8380-7be8-11e9-9bfc-db4df2c88785.png">

---

**Destination-Only Test**

Test only the Profile page if full test is difficult to do for whatever reason.

1. Navigate to http://calypso.localhost:3000/me/account?tour=checklistUserEmail

Email address input field should look like this:

<img width="726" alt="screenshot_671" src="https://user-images.githubusercontent.com/127594/58130512-04c65980-7bd1-11e9-8826-8433b31514d2.png">


*

Fixes #32367
