### PR TITLE
Map jetpack mailing list categories to iterable message types

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -112,6 +112,14 @@ class MainComponent extends React.Component {
 			return this.props.translate( 'Community' );
 		} else if ( 'digest' === category ) {
 			return this.props.translate( 'Digests' );
+		} else if ( 'jetpack_marketing' === category ) {
+			return this.props.translate( 'Jetpack Suggestions' );
+		} else if ( 'jetpack_research' === category ) {
+			return this.props.translate( 'Jetpack Research' );
+		} else if ( 'jetpack_promotion' === category ) {
+			return this.props.translate( 'Jetpack Promotions' );
+		} else if ( 'jetpack_news' === category ) {
+			return this.props.translate( 'Jetpack News' );
 		}
 
 		return category;
@@ -133,6 +141,16 @@ class MainComponent extends React.Component {
 			return this.props.translate(
 				'Popular content from the blogs you follow, and reports on your own site and its performance.'
 			);
+		} else if ( 'jetpack_marketing' === category ) {
+			return this.props.translate( 'Tips for getting the most out of Jetpack.' );
+		} else if ( 'jetpack_research' === category ) {
+			return this.props.translate(
+				'Opportunities to participate in Jetpack research and surveys.'
+			);
+		} else if ( 'jetpack_promotion' === category ) {
+			return this.props.translate( 'Promotions and deals on upgrades.' );
+		} else if ( 'jetpack_news' === category ) {
+			return this.props.translate( 'Jetpack news and announcements.' );
 		}
 
 		return null;
@@ -157,6 +175,14 @@ class MainComponent extends React.Component {
 				return 'promotion';
 			case '20785':
 				return 'news';
+			case '22504':
+				return 'jetpack_marketing';
+			case '22507':
+				return 'jetpack_research';
+			case '22506':
+				return 'jetpack_promotion';
+			case '22505':
+				return 'jetpack_news';
 			default:
 				return this.props.category;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a user clicks an unsubscribe link in an Iterable email for a specific message type (category), this will show the appropriate information for the corresponding mailing list category on our end.
* It also works to show the correct category info when unsubscribing from internal (non-Iterable) emails.

More info: paOlDU-3d-p2

#### Testing instructions

* On the backend, apply the patch at D28519-code.
* Visit the following links and confirm that you're successfully unsubscribed from each category (You'll see a message: "Unsubscribed from CATEGORY").

**Using Iterable message type ids**

jetpack_marketing / 22504 (Jetpack Suggestions)
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=22504&hmac=72bea548c28a658378b72c8bdc001ebaa0353679

jetpack_research / 22507
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=22507&hmac=0b0e39c93e194386dc0dcb6bf409f9e9bb3ad1a2

jetpack_promotion / 22506
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=22506&hmac=67130e8b081cca01ccb5df89131c35106ae493a8

jetpack_news / 22505
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=22505&hmac=d4738e2427961a9ae7a509b66d32a69b983e3293

**Using category names**

jetpack_marketing / 22504 (Jetpack Suggestions)
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=jetpack_marketing&hmac=4c5382f164ade68c6a25e4f4049af630699b3a54

jetpack_research / 22507
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=jetpack_research&hmac=2c2c1a95edcf5627759db72c8a6f98bcb0bdfbf5

jetpack_promotion / 22506
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=jetpack_promotion&hmac=5a94f96e969afe20c071a66c14b695b206ede875

jetpack_news / 22505
http://calypso.localhost:3000/mailing-lists/unsubscribe?email=tpfraz%2Btravistestunsubv1%40gmail.com&category=jetpack_news&hmac=6744fc9d6db99c65e0fa2feed7c15456c6defa85
