### PR TITLE
Stats: URL should use site slug instead of site ID

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -104,13 +104,13 @@ export class MySitesSidebar extends Component {
 	};
 
 	stats() {
-		const { siteId, canUserViewStats, path, translate } = this.props;
+		const { site, siteId, canUserViewStats, path, translate } = this.props;
 
 		if ( siteId && ! canUserViewStats ) {
 			return null;
 		}
 
-		const statsLink = getStatsPathForTab( 'day', siteId );
+		const statsLink = getStatsPathForTab( 'day', site ? site.slug : siteId );
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<SidebarItem


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use site slug, if available, when calling `getStatsPathForTab()`.

#### Testing instructions

1. Open My Sites.
2. Hover over Stats sidebar menu item. It's URL should end with site slug.

<img width="407" alt="screenshot_674" src="https://user-images.githubusercontent.com/127594/58139361-2c2c1f00-7bef-11e9-93cb-24e85d881c5c.png">

3. Press Stats side menu item. Page URL should end with site slug.

<img width="523" alt="screenshot_675" src="https://user-images.githubusercontent.com/127594/58139319-0e5eba00-7bef-11e9-8edd-06935809ace7.png">

*

Fixes #33031
