### PR TITLE
Checklist: Minimal "Phase 2" functionality behind a flag

### DIFF
--- a/client/components/checklist/checklist.js
+++ b/client/components/checklist/checklist.js
@@ -15,6 +15,7 @@ import TaskPlaceholder from './task-placeholder';
 
 export default class Checklist extends PureComponent {
 	static propTypes = {
+		phase2: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 		progressText: PropTypes.string,
 		updateCompletion: PropTypes.func,
@@ -71,6 +72,7 @@ export default class Checklist extends PureComponent {
 				className={ classNames( 'checklist', {
 					'is-expanded': ! this.state.hideCompleted,
 					'hide-completed': this.state.hideCompleted,
+					'checklist-phase2': this.props.phase2,
 				} ) }
 			>
 				<ChecklistHeader

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { find, get, some, includes, forEach } from 'lodash';
 import { isDesktop } from 'lib/viewport';
 import { localize } from 'i18n-calypso';
+import { isEnabled } from 'config';
 
 /**
  * Internal dependencies
@@ -1048,6 +1049,7 @@ export default connect(
 
 		return {
 			designType: getSiteOption( state, siteId, 'design_type' ),
+			phase2: !! ( isEnabled( 'tasks-onboarding-phase2' ) && siteChecklist.phase2 ),
 			siteId,
 			siteSlug,
 			siteSegment: get( siteChecklist, 'segment' ),

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -257,6 +257,7 @@ class WpcomChecklistComponent extends PureComponent {
 
 	render() {
 		const {
+			phase2,
 			siteId,
 			taskStatuses,
 			taskUrls,
@@ -307,6 +308,7 @@ class WpcomChecklistComponent extends PureComponent {
 					setStoredTask={ setStoredTask }
 					storedTask={ storedTask }
 					taskList={ taskList }
+					phase2={ phase2 }
 				>
 					{ taskList.getAll().map( task => this.renderTask( task ) ) }
 				</ChecklistComponent>

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -1051,7 +1051,7 @@ export default connect(
 
 		return {
 			designType: getSiteOption( state, siteId, 'design_type' ),
-			phase2: !! ( isEnabled( 'onboarding-checklist/phase2' ) && siteChecklist.phase2 ),
+			phase2: !! ( isEnabled( 'onboarding-checklist/phase2' ) && get( siteChecklist, 'phase2' ) ),
 			siteId,
 			siteSlug,
 			siteSegment: get( siteChecklist, 'segment' ),

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -1051,7 +1051,7 @@ export default connect(
 
 		return {
 			designType: getSiteOption( state, siteId, 'design_type' ),
-			phase2: !! ( isEnabled( 'tasks-onboarding-phase2' ) && siteChecklist.phase2 ),
+			phase2: !! ( isEnabled( 'onboarding-checklist/phase2' ) && siteChecklist.phase2 ),
 			siteId,
 			siteSlug,
 			siteSegment: get( siteChecklist, 'segment' ),

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, memoize, omit, pick, isBoolean } from 'lodash';
+import { get, isBoolean, memoize, omit, pick } from 'lodash';
 import debugModule from 'debug';
 import config from 'config';
 
@@ -134,7 +134,10 @@ class WpcomTaskList {
 }
 
 export const getTaskList = memoize(
-	params => new WpcomTaskList( getTasks( params ) ),
+	params =>
+		params && params.phase2 && params.taskStatuses && params.taskStatuses.length
+			? new WpcomTaskList( params.taskStatuses ) // Use the server response, Luke
+			: new WpcomTaskList( getTasks( params ) ),
 	params => {
 		const key = pick( params, [
 			'taskStatuses',

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { get, isBoolean, memoize, omit, pick } from 'lodash';
+import { get, isBoolean, memoize, omit, pick, size } from 'lodash';
 import debugModule from 'debug';
 import config from 'config';
 
@@ -15,7 +15,20 @@ import { abtest } from 'lib/abtest';
 
 const debug = debugModule( 'calypso:wpcom-task-list' );
 
-function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, siteVerticals } ) {
+function getTasks( {
+	designType,
+	isSiteUnlaunched,
+	phase2,
+	siteSegment,
+	siteVerticals,
+	taskStatuses,
+} ) {
+	// The getTasks function can be removed when we make a full switch to "phase 2"
+	if ( phase2 && size( taskStatuses ) ) {
+		// Use the server response, Luke
+		return taskStatuses;
+	}
+
 	const tasks = [];
 	const segmentSlug = getSiteTypePropertyValue( 'id', siteSegment, 'slug' );
 
@@ -134,10 +147,7 @@ class WpcomTaskList {
 }
 
 export const getTaskList = memoize(
-	params =>
-		params && params.phase2 && params.taskStatuses && params.taskStatuses.length
-			? new WpcomTaskList( params.taskStatuses ) // Use the server response, Luke
-			: new WpcomTaskList( getTasks( params ) ),
+	params => new WpcomTaskList( getTasks( params ) ),
 	params => {
 		const key = pick( params, [
 			'taskStatuses',

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-
+import { isEnabled } from 'config';
 import { noop } from 'lodash';
 
 /**
@@ -21,7 +21,7 @@ export const fetchChecklist = action =>
 		{
 			path: `/sites/${ action.siteId }/checklist`,
 			method: 'GET',
-			apiNamespace: 'rest/v1',
+			apiNamespace: isEnabled( 'onboarding-checklist/phase2' ) ? 'rest/v1.1' : 'rest/v1',
 			query: {
 				http_envelope: 1,
 			},

--- a/config/development.json
+++ b/config/development.json
@@ -132,6 +132,7 @@
 		"oauth": false,
 		"onboarding-checklist": true,
 		"onboarding-checklist/email-setup": true,
+		"onboarding-checklist/phase2": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,6 +106,7 @@
 		"nps-survey/notice": true,
 		"onboarding-checklist": true,
 		"onboarding-checklist/email-setup": true,
+		"onboarding-checklist/phase2": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
We have designs on running a simpler set of 4 checklist items for new customers onboarding to WordPress.com.

See:
* https://wp.me/paObgF-aE
* Automattic/zelda-private/issues/4

We also want to continue showing the current experience to existing customers -- at least for some amount of time so the checklist does not change while they're progressing through it.

This PR varies the logic such that we can show the "phase2" experience alongside the existing one and seeks to rely solely on the API response to comprise the tasks that are rendered when showing the "phase2" experience so we can more easily share more logic amongst Calypso & the mobile apps, etc.

**NOTE:** All changes in this PR & server-side change are only intended to be visible in a development environment when you follow the instructions below.  It should change nothing elsewhere.

| Before (Production behavior) | After (dev env & server patched) |
|---|---|
| <img width="771" alt="Screen Shot 2019-05-23 at 10 37 00 AM" src="https://user-images.githubusercontent.com/1587282/58262026-6f99a100-7d47-11e9-92c4-d89a6b49e846.png"> | <img width="756" alt="Screen Shot 2019-05-23 at 10 37 25 AM" src="https://user-images.githubusercontent.com/1587282/58262040-76281880-7d47-11e9-9e22-1c8d6970f205.png"> |

**NOTE:** The email verification step is actually last in the list -- completed items get placed at the top of the list and this PR doesn't change that or other styles

#### Changes proposed in this Pull Request

* If the config flag is not enabled, do nothing. It's currently enabled in `development` by default
* If the config flag is enabled and the server includes a `phase2` key in the response, use the task list as-is -- the server already formed it correctly for the display components
* Pass the phase2 prop to the `Checklist` component so it can add a `checklist-phase2` class to the element. This will let us add custom styling enhancements that don't affect the other experience

#### Testing instructions

* Apply D28533-code on your sandbox
* Sandbox the REST API
* Run this branch with the config flag enabled: `DISABLE_FEATURES=onboarding-checklist/phase2 npm run start`
* Visit http://calypso.localhost:3000/checklist for various users and sites and compare with what is being shown in production
  * The experiences should be identical in the two environments
* Follow the instructions in D28533-code to add the filter (thus enabling "phase2" in the API response)
* Repeat the above (run checklist on various sites) -- there should be no change as the flag is not enabled
* Run Calypso **WITH** the config flag enabled: `npm run start`
* Visit http://calypso.localhost:3000/checklist for various users and sites
  * The "minimal" checklist experience should be shown (4 items)

