### PR TITLE
i18n: Load user translations

### DIFF
--- a/client/lib/i18n-utils/README.md
+++ b/client/lib/i18n-utils/README.md
@@ -8,3 +8,16 @@ I18n-related utilities, for use both client- and server-side.
 ```js
 import i18nUtils from 'lib/i18n-utils';
 ```
+
+### Loading Waiting User Translations
+
+Intended primarily for reviewers, Calypso can be instructed to load waiting
+translations for a specific user from translate.wordpress.com using the
+query parameter `?load-user-translations=username`.
+
+E.g. https://wordpress.com/start/user/es?load-user-translations=exampleusername
+
+In addition, `project` (default `wpcom`), `translationSet` (default: `default`)
+and/or `locale` (default current locale) can be used to load specific
+translations, for example `&locale=de&translationSet=formal` to select formal
+german strings, or `&project=test` to load test strings from the test project.

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -125,10 +125,20 @@ function applyUserWaitingTranslations( currentLocaleSlug ) {
 		'load-user-translations': username,
 		project = 'wpcom',
 		translationSet = 'default',
+		translationStatus = 'current',
 		locale = currentLocaleSlug,
 	} = parsedURL.query;
 
 	if ( ! username ) {
+		return;
+	}
+
+	if ( ! includes( [ 'current', 'waiting' ], translationStatus ) ) {
+		return;
+	}
+
+	if ( 'waiting' === translationStatus ) {
+		// TODO only allow loading your own waiting translations. Disallow loading them for now.
 		return;
 	}
 
@@ -143,7 +153,7 @@ function applyUserWaitingTranslations( currentLocaleSlug ) {
 
 	const query = {
 		'filters[user_login]': username,
-		'filters[status]': 'waiting',
+		'filters[status]': translationStatus,
 		format: 'json',
 	};
 

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -7,8 +7,6 @@ import request from 'superagent';
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
 import { map, includes } from 'lodash';
-
-//TMP
 import { parse as parseUrl, format as formatUrl } from 'url';
 
 /**
@@ -117,10 +115,8 @@ export default function switchLocale( localeSlug ) {
 }
 
 function applyUserWaitingTranslations( currentLocaleSlug ) {
-	// Check for username query param
-	// TODO: Use page middleware instead of location
 	const parsedURL = parseUrl( location.search, true );
-	// TODO: improve the names of these params
+
 	const {
 		'load-user-translations': username,
 		project = 'wpcom',

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -111,12 +111,12 @@ export default function switchLocale( localeSlug ) {
 
 			setLocaleInDOM( domLocaleSlug, !! language.rtl );
 
-			patchLocale( targetLocaleSlug );
+			applyUserWaitingTranslations( targetLocaleSlug );
 		} );
 	}
 }
 
-function patchLocale( currentLocaleSlug ) {
+function applyUserWaitingTranslations( currentLocaleSlug ) {
 	// Check for username query param
 	// TODO: Use page middleware instead of location
 	const parsedURL = parseUrl( location.search, true );

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -9,7 +9,7 @@ import debugFactory from 'debug';
 import { map, includes } from 'lodash';
 
 //TMP
-import { parse as parseUrl } from 'url';
+import { parse as parseUrl, format as formatUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -128,16 +128,34 @@ function applyUserWaitingTranslations( currentLocaleSlug ) {
 		locale = currentLocaleSlug,
 	} = parsedURL.query;
 
-	const format = 'json';
-
 	if ( ! username ) {
 		return;
 	}
 
+	const pathname = [
+		'api',
+		'projects',
+		project,
+		locale,
+		translationSet,
+		'export-translations',
+	].join( '/' );
+
+	const query = {
+		'filters[user_login]': username,
+		'filters[status]': 'waiting',
+		format: 'json',
+	};
+
+	const requestUrl = formatUrl( {
+		protocol: 'https:',
+		host: 'translate.wordpress.com',
+		pathname,
+		query,
+	} );
+
 	request
-		.get(
-			`https://translate.wordpress.com/api/projects/${ project }/${ locale }/${ translationSet }/export-translations?filters%5Bstatus%5D=waiting&filters%5Buser_login%5D=${ username }&format=${ format }`
-		)
+		.get( requestUrl )
 		.set( 'Accept', 'application/json' )
 		.withCredentials()
 		.then( res => {

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -115,6 +115,10 @@ export default function switchLocale( localeSlug ) {
 }
 
 function applyUserWaitingTranslations( currentLocaleSlug ) {
+	if ( ! location || ! location.search ) {
+		return;
+	}
+
 	const parsedURL = parseUrl( location.search, true );
 
 	const {

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -164,7 +164,7 @@ function applyUserWaitingTranslations( currentLocaleSlug ) {
 		query,
 	} );
 
-	request
+	return request
 		.get( requestUrl )
 		.set( 'Accept', 'application/json' )
 		.withCredentials()


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the option to load and display any user's waiting translations in place of the current accepted ones.

#### Testing instructions

Add a `?load-user-translations=username` query parameter when loading calypso to load that user's waiting translations.  You can specify optional `locale`, `project` and `translationSet` arguments (so you can load waiting strings from the test project, de_formal, or even a different locale).

![Translations___French___WordPress_com___GlotPress_-_julesaus_dev_dfw_wordpress_com_and_Planes_‹_julesauspremiumtest_—_WordPress_com](https://user-images.githubusercontent.com/5952255/58154248-82af6100-7cb4-11e9-867c-87f3cc15a554.jpg)

Logged out: (e.g. http://calypso.localhost:3000/start/user/fr?load-user-translations=julesaus&project=test )

![Translations___French__France____Test___GlotPress_-_julesaus_dev_dfw_wordpress_com_and_Créer_un_site_—_WordPress_com_and___a8c_wp-calypso_client_blocks_signup-form_index_jsx_—_wp-calypso](https://user-images.githubusercontent.com/5952255/58248470-8ff54a00-7d9f-11e9-9d5e-081228450acc.jpg)

Happily, we already transfer the params across, so user translations are reloaded if you click on e.g. "Également disponible en Français" (also available in)