### PR TITLE
Codeowners: Fix TypeScript rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,7 +66,7 @@
 /test @Automattic/team-calypso
 
 # Types, TypeScript, and type annotations
-*.ts *.tsx docs/coding-guidelines/typescript* @Automattic/type-review
+**/*.ts **/*.tsx docs/coding-guidelines/typescript* @Automattic/type-review
 
 # G Suite
 /client/blocks/gsuite-stats-nudge @Automattic/amber

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,7 +66,9 @@
 /test @Automattic/team-calypso
 
 # Types, TypeScript, and type annotations
-**/*.ts **/*.tsx docs/coding-guidelines/typescript* @Automattic/type-review
+*.ts @Automattic/type-review
+*.tsx @Automattic/type-review
+/docs/coding-guidelines/typescript* @Automattic/type-review
 
 # G Suite
 /client/blocks/gsuite-stats-nudge @Automattic/amber


### PR DESCRIPTION
Fix TypeScript codeowners to be 1 pattern followed by 1+ reviewers. `.tsx` files were never matched because they were in the reviewer part of the rule.

> A CODEOWNERS file uses a pattern that follows the same rules used in gitignore files. The pattern is followed by one or more GitHub usernames or team names using the standard @username or @org/team-name format. You can also refer to a user by an email address that has been added to their GitHub account, for example user@example.com.

https://help.github.com/en/articles/about-code-owners#codeowners-syntax