### PR TITLE
Jetpack checklist: add success event

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -54,7 +54,7 @@ export class PaidPlanThankYouCard extends Component {
 										{ translate( 'So long spam, hello backups!' ) }
 									</h1>
 									<p>
-										{ translate( 'We’ve finished setting up spam filtering and backups for you.' ) }
+										{ translate( "We've finished setting up spam filtering and backups for you." ) }
 										<br />
 										{ translate( "You're now ready to finish the rest of the checklist." ) }
 									</p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -23,7 +23,7 @@ export class PaidPlanThankYouCard extends Component {
 		return `/plans/my-plan/${ siteSlug }`;
 	}
 
-	componentDidUpdate() {
+	componentDidUpdate( prevProps ) {
 		if ( this.props.progressComplete === 100 ) {
 			this.props.recordTracksEvent( 'calypso_plans_autoconfig_success', {
 				checklist_name: 'jetpack',

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -8,18 +8,28 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
 import Button from 'components/button';
 import Card from 'components/card';
 import getJetpackProductInstallProgress from 'state/selectors/get-jetpack-product-install-progress';
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
 import ProgressBar from 'components/progress-bar';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 
 export class PaidPlanThankYouCard extends Component {
 	getMyPlanRoute() {
 		const { siteSlug } = this.props;
 
 		return `/plans/my-plan/${ siteSlug }`;
+	}
+
+	componentDidUpdate() {
+		if ( this.props.progressComplete === 100 ) {
+			this.props.recordTracksEvent( 'calypso_plans_autoconfig_success', {
+				checklist_name: 'jetpack',
+				location: 'JetpackChecklist',
+			} );
+		}
 	}
 
 	render() {
@@ -44,9 +54,7 @@ export class PaidPlanThankYouCard extends Component {
 										{ translate( 'So long spam, hello backups!' ) }
 									</h1>
 									<p>
-										{ translate(
-											'We’ve finished setting up spam filtering and backups for you.'
-										) }
+										{ translate( 'We’ve finished setting up spam filtering and backups for you.' ) }
 										<br />
 										{ translate( "You're now ready to finish the rest of the checklist." ) }
 									</p>
@@ -68,7 +76,7 @@ export class PaidPlanThankYouCard extends Component {
 									<p>{ translate( "Now let's make sure your site is protected." ) }</p>
 									<p>
 										{ translate(
-												"We're setting up spam filters and site backups for you first. Once that's done, our security checklist will guide you through the next steps."
+											"We're setting up spam filters and site backups for you first. Once that's done, our security checklist will guide you through the next steps."
 										) }
 									</p>
 
@@ -87,11 +95,14 @@ export class PaidPlanThankYouCard extends Component {
 	}
 }
 
-export default connect( state => {
-	const siteId = getSelectedSiteId( state );
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
 
-	return {
-		progressComplete: getJetpackProductInstallProgress( state, siteId ),
-		siteSlug: getSelectedSiteSlug( state ),
-	};
-} )( localize( PaidPlanThankYouCard ) );
+		return {
+			progressComplete: getJetpackProductInstallProgress( state, siteId ),
+			siteSlug: getSelectedSiteSlug( state ),
+		};
+	},
+	{ recordTracksEvent }
+)( localize( PaidPlanThankYouCard ) );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -24,7 +24,7 @@ export class PaidPlanThankYouCard extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.progressComplete === 100 ) {
+		if ( prevProps.progressComplete < 100 && this.props.progressComplete >= 100 ) {
 			this.props.recordTracksEvent( 'calypso_plans_autoconfig_success', {
 				checklist_name: 'jetpack',
 				location: 'JetpackChecklist',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add tracks event on vaultpress & akismet autoconfig success.
- No error event yet since we're not detecting that state. I have a follow-up PR for that stuff.

The event name is the same as in the previous flow:

https://github.com/Automattic/wp-calypso/blob/e052e6e604389350b649e1a2f31cffedd681cb37/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx#L528


#### Testing instructions

- Have a new or old Jetpack site
- End up via connect flow, or open directly `http://calypso.localhost:3000/plans/my-plan/:site?thank-you`
- Confirm that tracks event is sent only once