### PR TITLE
Jetpack checklist: stop installing when detecting uninstallable site state

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx
@@ -295,8 +295,7 @@ export class JetpackThankYouCard extends Component {
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error_filemod', { error: reason } );
 		} else if ( selectedSite.hasMinimumJetpackVersion === false ) {
 			reason = translate(
-				'We are unable to set up your plan because your site has an older version of Jetpack. ' +
-					'Please upgrade Jetpack.'
+				'Unfortunately, we are unable to set up your plan because your site has an older version of Jetpack. Please upgrade Jetpack.'
 			);
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error_jpversion', {
 				jetpack_version: selectedSite.options.jetpack_version,

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
@@ -1,48 +1,32 @@
 /**
  * External dependencies
  */
-import { connect } from 'react-redux';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { localize } from 'i18n-calypso';
-import React, { Component } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
-import Card from 'components/card';
+import ThankYouCard from './thank-you-card';
 
-export class FreePlanThankYouCard extends Component {
-	render() {
-		const { siteSlug, translate } = this.props;
-		return (
-			<Card className="current-plan-thank-you-card__main">
-				<div className="current-plan-thank-you-card__content">
-					<img
-						className="current-plan-thank-you-card__illustration"
-						alt=""
-						aria-hidden="true"
-						src="/calypso/images/illustrations/security.svg"
-					/>
-					<h1 className="current-plan-thank-you-card__title">
-						{ translate( 'Welcome to Jetpack Free!' ) }
-					</h1>
-					<p>
-						{ translate( "We've automatically begun to protect your site from attacks." ) }
-						<br />
-						{ translate( "You're now ready to finish the rest of the checklist." ) }
-					</p>
-					<Button primary href={ `/plans/my-plan/${ siteSlug }` }>
-						{ translate( 'Continue' ) }
-					</Button>
-				</div>
-			</Card>
-		);
-	}
-}
+const FreePlanThankYouCard = ( { translate } ) => (
+	<ThankYouCard
+		illustration={
+			<img
+				alt=""
+				aria-hidden="true"
+				className="current-plan-thank-you-card__illustration"
+				src="/calypso/images/illustrations/security.svg"
+			/>
+		}
+		title={ translate( 'Welcome to Jetpack Free!' ) }
+	>
+		<p>
+			{ translate( "We've automatically begun to protect your site from attacks." ) }
+			<br />
+			{ translate( "You're now ready to finish the rest of the checklist." ) }
+		</p>
+	</ThankYouCard>
+);
 
-export default connect( state => {
-	return {
-		siteSlug: getSelectedSiteSlug( state ),
-	};
-} )( localize( FreePlanThankYouCard ) );
+export default localize( FreePlanThankYouCard );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 import React, { Component, Fragment } from 'react';
 
@@ -15,14 +14,12 @@ import { getSiteFileModDisableReason } from 'lib/site/utils';
 import { isJetpackSiteMainNetworkSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
 import { SETTING_UP_PREMIUM_SERVICES } from 'lib/url/support';
 import getJetpackProductInstallProgress from 'state/selectors/get-jetpack-product-install-progress';
-import getJetpackProductInstallStatus from 'state/selectors/get-jetpack-product-install-status';
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
 import ProgressBar from 'components/progress-bar';
 import ThankYouCard from './thank-you-card';
 
 const INSTALL_STATE_COMPLETE = 1;
 const INSTALL_STATE_UNCOMPLETE = 2;
-const INSTALL_STATE_ERRORED = 3;
 
 export class PaidPlanThankYouCard extends Component {
 	componentDidUpdate( prevProps ) {
@@ -139,19 +136,6 @@ export class PaidPlanThankYouCard extends Component {
 						</p>
 					</ThankYouCard>
 				) }
-				{ installState === INSTALL_STATE_ERRORED && (
-					<ThankYouCard
-						illustration={ securityIllustration }
-						showContinueButton
-						title={ translate( 'So long spam, hello backups!' ) }
-					>
-						<p>
-							{ translate( 'Error' ) }
-							<br />
-							{ translate( 'Error' ) }
-						</p>
-					</ThankYouCard>
-				) }
 			</Fragment>
 		);
 	}
@@ -162,17 +146,10 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 
 	const installProgress = getJetpackProductInstallProgress( state, siteId );
-	const productInstallStatus = getJetpackProductInstallStatus( state, siteId );
 
 	let installState;
-	// @TODO we'll need a way to detect actual error states here
-	if (
-		productInstallStatus &&
-		! includes( [ 'installed', 'skipped' ], productInstallStatus.akismet_status ) &&
-		! includes( [ 'installed', 'skipped' ], productInstallStatus.vaultpress_status )
-	) {
-		installState = INSTALL_STATE_ERRORED;
-	} else if ( installProgress === 100 ) {
+	// @TODO we'll need a way to detect generic error states here and add `INSTALL_STATE_ERRORED`
+	if ( installProgress === 100 ) {
 		installState = INSTALL_STATE_COMPLETE;
 	} else {
 		installState = INSTALL_STATE_UNCOMPLETE;

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -2,17 +2,20 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 import { localize } from 'i18n-calypso';
+import { parse as parseUrl } from 'url';
 import React, { Component, Fragment } from 'react';
 
 /**
  * Internal dependencies
  */
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSiteFileModDisableReason } from 'lib/site/utils';
 import { isJetpackSiteMainNetworkSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
 import { SETTING_UP_PREMIUM_SERVICES } from 'lib/url/support';
+import Button from 'components/button';
 import getJetpackProductInstallProgress from 'state/selectors/get-jetpack-product-install-progress';
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
 import ProgressBar from 'components/progress-bar';
@@ -36,10 +39,11 @@ export class PaidPlanThankYouCard extends Component {
 			fileModDisableReason,
 			hasMinimumJetpackVersion,
 			installProgress,
+			installState,
 			isSiteMainNetworkSite,
 			isSiteMultiSite,
+			siteSlug,
 			translate,
-			installState,
 		} = this.props;
 
 		const securityIllustration = '/calypso/images/illustrations/security.svg';
@@ -67,16 +71,13 @@ export class PaidPlanThankYouCard extends Component {
 				<ThankYouCard
 					illustration={ fireworksIllustration }
 					title={ translate( 'Thank you for your purchase!' ) }
-					showContinueButton
 				>
+					<p>{ translate( "Unfortunately, we can't modify files on your site, so you'll need to set up your plan features manually." ) }</p>
+					<p>{ translate( "Don't worry. We'll quickly guide you through the setup process." ) }</p>
 					<p>
-						{ translate( "We can't modify files on your site." ) }
-						<br />
-						{ translate( 'You will have to {{link}}set up your plan manually{{/link}}.', {
-							components: {
-								link: <a href={ SETTING_UP_PREMIUM_SERVICES } />,
-							},
-						} ) }
+						<Button primary href={ SETTING_UP_PREMIUM_SERVICES } target="_blank">
+							{ translate( 'Set up features' ) }
+						</Button>
 					</p>
 				</ThankYouCard>
 			);
@@ -86,15 +87,14 @@ export class PaidPlanThankYouCard extends Component {
 			return (
 				<ThankYouCard
 					illustration={ fireworksIllustration }
-					showContinueButton
 					title={ translate( 'Thank you for your purchase!' ) }
 				>
+					<p>{ translate( "Unfortunately, your site is part of a multi-site network, but is not the main network site. You'll need to set up your plan features manually." ) }</p>
+					<p>{ translate( "Don't worry. We'll quickly guide you through the setup process." ) }</p>
 					<p>
-						{ translate(
-							"We can't modify files on your site. You will have to set up your plan manually."
-						) }
-						<br />
-						{ translate( "We'll guide you through it." ) }
+						<Button primary href={ SETTING_UP_PREMIUM_SERVICES } target="_blank">
+							{ translate( 'Set up features' ) }
+						</Button>
 					</p>
 				</ThankYouCard>
 			);
@@ -119,7 +119,7 @@ export class PaidPlanThankYouCard extends Component {
 						<ProgressBar isPulsing total={ 100 } value={ installProgress || 0 } />
 
 						<p>
-							<a href={ this.getMyPlanRoute() }>{ translate( 'Hide message' ) }</a>
+							<a href={ `/plans/my-plan/${ siteSlug }` }>{ translate( 'Hide message' ) }</a>
 						</p>
 					</ThankYouCard>
 				) }
@@ -162,5 +162,6 @@ export default connect( state => {
 		installState,
 		isSiteMainNetworkSite: isJetpackSiteMainNetworkSite( state, siteId ),
 		isSiteMultiSite: isJetpackSiteMultiSite( state, siteId ),
+		siteSlug: getSelectedSiteSlug( state ),
 	};
 }, { recordTracksEvent } )( localize( PaidPlanThankYouCard ) );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -25,7 +25,7 @@ import ProgressBar from 'components/progress-bar';
 import ThankYouCard from './thank-you-card';
 
 const INSTALL_STATE_COMPLETE = 1;
-const INSTALL_STATE_UNCOMPLETE = 2;
+const INSTALL_STATE_INCOMPLETE = 2;
 
 export class PaidPlanThankYouCard extends Component {
 	componentDidUpdate( prevProps ) {
@@ -153,7 +153,7 @@ export class PaidPlanThankYouCard extends Component {
 			<Fragment>
 				<JetpackProductInstall />
 
-				{ installState === INSTALL_STATE_UNCOMPLETE && (
+				{ installState === INSTALL_STATE_INCOMPLETE && (
 					<ThankYouCard
 						illustration={ fireworksIllustration }
 						showHideMessage
@@ -204,7 +204,7 @@ export default connect( state => {
 	if ( installProgress === 100 ) {
 		installState = INSTALL_STATE_COMPLETE;
 	} else {
-		installState = INSTALL_STATE_UNCOMPLETE;
+		installState = INSTALL_STATE_INCOMPLETE;
 	}
 
 	return {

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -78,6 +78,7 @@ export class PaidPlanThankYouCard extends Component {
 						<p>
 							<Button primary href={ wpAdminPluginsUrl } target="_blank">
 								<span>{ translate( 'Upgrade Jetpack' ) }</span>
+								{ ' ' }
 								<Gridicon icon="external" />
 							</Button>
 						</p>
@@ -109,6 +110,7 @@ export class PaidPlanThankYouCard extends Component {
 					<p>
 						<Button primary href={ SETTING_UP_PREMIUM_SERVICES } target="_blank">
 							<span>{ translate( 'Set up features' ) }</span>
+							{ ' ' }
 							<Gridicon icon="external" />
 						</Button>
 					</p>
@@ -139,6 +141,7 @@ export class PaidPlanThankYouCard extends Component {
 					<p>
 						<Button primary href={ SETTING_UP_PREMIUM_SERVICES } target="_blank">
 							<span>{ translate( 'Set up features' ) }</span>
+							{ ' ' }
 							<Gridicon icon="external" />
 						</Button>
 					</p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -176,7 +176,7 @@ export class PaidPlanThankYouCard extends Component {
 					>
 						<p>
 							{ preventWidows(
-								translate( 'We’ve finished setting up spam filtering and backups for you.' )
+								translate( "We've finished setting up spam filtering and backups for you." )
 							) }
 							<br />
 							{ preventWidows(

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -74,8 +74,8 @@ export class PaidPlanThankYouCard extends Component {
 			);
 		}
 
-		// We cannot install anything for this site
-		if ( ! site.canUpdateFiles ) {
+		// Non-main site at multisite, cannot install anything
+		if ( site.isSecondaryNetworkSite ) {
 			return (
 				<ThankYouCard
 					illustration={ fireworksIllustration }
@@ -85,7 +85,7 @@ export class PaidPlanThankYouCard extends Component {
 					<p>
 						{ preventWidows(
 							translate(
-								"Unfortunately, we can't modify files on your site, so you'll need to set up your plan features manually."
+								"Unfortunately, your site is part of a multi-site network, but is not the main network site. You'll need to set up your plan features manually."
 							)
 						) }
 					</p>
@@ -103,8 +103,8 @@ export class PaidPlanThankYouCard extends Component {
 			);
 		}
 
-		// Non-main site at multisite, cannot install anything
-		if ( site.isSecondaryNetworkSite ) {
+		// We cannot install anything for this site
+		if ( ! site.canUpdateFiles ) {
 			return (
 				<ThankYouCard
 					illustration={ fireworksIllustration }
@@ -114,7 +114,7 @@ export class PaidPlanThankYouCard extends Component {
 					<p>
 						{ preventWidows(
 							translate(
-								"Unfortunately, your site is part of a multi-site network, but is not the main network site. You'll need to set up your plan features manually."
+								"Unfortunately, we can't modify files on your site, so you'll need to set up your plan features manually."
 							)
 						) }
 					</p>
@@ -176,23 +176,26 @@ export class PaidPlanThankYouCard extends Component {
 	}
 }
 
-export default connect( state => {
-	const site = getSelectedSite( state );
-	const siteId = getSelectedSiteId( state );
+export default connect(
+	state => {
+		const site = getSelectedSite( state );
+		const siteId = getSelectedSiteId( state );
 
-	const installProgress = getJetpackProductInstallProgress( state, siteId );
+		const installProgress = getJetpackProductInstallProgress( state, siteId );
 
-	let installState;
-	// @TODO we'll need a way to detect generic error states here and add `INSTALL_STATE_ERRORED`
-	if ( installProgress === 100 ) {
-		installState = INSTALL_STATE_COMPLETE;
-	} else {
-		installState = INSTALL_STATE_INCOMPLETE;
-	}
+		let installState;
+		// @TODO we'll need a way to detect generic error states here and add `INSTALL_STATE_ERRORED`
+		if ( installProgress === 100 ) {
+			installState = INSTALL_STATE_COMPLETE;
+		} else {
+			installState = INSTALL_STATE_INCOMPLETE;
+		}
 
-	return {
-		installProgress,
-		installState,
-		site,
-	};
-}, { recordTracksEvent } )( localize( PaidPlanThankYouCard ) );
+		return {
+			installProgress,
+			installState,
+			site,
+		};
+	},
+	{ recordTracksEvent }
+)( localize( PaidPlanThankYouCard ) );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -1,28 +1,30 @@
 /**
  * External dependencies
  */
-import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
+import { includes } from 'lodash';
 import { localize } from 'i18n-calypso';
+import React, { Component, Fragment } from 'react';
 
 /**
  * Internal dependencies
  */
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
-import Button from 'components/button';
-import Card from 'components/card';
+import { getSiteFileModDisableReason } from 'lib/site/utils';
+import { isJetpackSiteMainNetworkSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
+import { SETTING_UP_PREMIUM_SERVICES } from 'lib/url/support';
 import getJetpackProductInstallProgress from 'state/selectors/get-jetpack-product-install-progress';
+import getJetpackProductInstallStatus from 'state/selectors/get-jetpack-product-install-status';
 import JetpackProductInstall from 'my-sites/plans/current-plan/jetpack-product-install';
 import ProgressBar from 'components/progress-bar';
+import ThankYouCard from './thank-you-card';
+
+const INSTALL_STATE_COMPLETE = 1;
+const INSTALL_STATE_UNCOMPLETE = 2;
+const INSTALL_STATE_ERRORED = 3;
 
 export class PaidPlanThankYouCard extends Component {
-	getMyPlanRoute() {
-		const { siteSlug } = this.props;
-
-		return `/plans/my-plan/${ siteSlug }`;
-	}
-
 	componentDidUpdate( prevProps ) {
 		if ( prevProps.progressComplete < 100 && this.props.progressComplete >= 100 ) {
 			this.props.recordTracksEvent( 'calypso_plans_autoconfig_success', {
@@ -33,76 +35,155 @@ export class PaidPlanThankYouCard extends Component {
 	}
 
 	render() {
-		const { progressComplete, translate } = this.props;
+		const {
+			fileModDisableReason,
+			hasMinimumJetpackVersion,
+			installProgress,
+			isSiteMainNetworkSite,
+			isSiteMultiSite,
+			translate,
+			installState,
+		} = this.props;
+
+		const securityIllustration = '/calypso/images/illustrations/security.svg';
+		const fireworksIllustration = '/calypso/images/illustrations/fireworks.svg';
+
+		if ( ! hasMinimumJetpackVersion ) {
+			return (
+				<ThankYouCard
+					illustration={ fireworksIllustration }
+					showContinueButton
+					title={ translate( 'Thank you for your purchase!' ) }
+				>
+					<p>
+						{ translate(
+							'We are unable to set up your plan because your site has an older version of Jetpack. Please upgrade Jetpack.'
+						) }
+					</p>
+				</ThankYouCard>
+			);
+		}
+
+		// We cannot install anything for this site
+		if ( fileModDisableReason && fileModDisableReason.length > 0 ) {
+			return (
+				<ThankYouCard
+					illustration={ fireworksIllustration }
+					title={ translate( 'Thank you for your purchase!' ) }
+					showContinueButton
+				>
+					<p>
+						{ translate( "We can't modify files on your site." ) }
+						<br />
+						{ translate( 'You will have to {{link}}set up your plan manually{{/link}}.', {
+							components: {
+								link: <a href={ SETTING_UP_PREMIUM_SERVICES } />,
+							},
+						} ) }
+					</p>
+				</ThankYouCard>
+			);
+		}
+
+		if ( isSiteMultiSite && ! isSiteMainNetworkSite ) {
+			return (
+				<ThankYouCard
+					illustration={ fireworksIllustration }
+					showContinueButton
+					title={ translate( 'Thank you for your purchase!' ) }
+				>
+					<p>
+						{ translate(
+							"We can't modify files on your site. You will have to set up your plan manually."
+						) }
+						<br />
+						{ translate( "We'll guide you through it." ) }
+					</p>
+				</ThankYouCard>
+			);
+		}
 
 		return (
 			<Fragment>
 				<JetpackProductInstall />
 
-				{ progressComplete !== null && (
-					<Card className="current-plan-thank-you-card__main">
-						<div className="current-plan-thank-you-card__content">
-							{ progressComplete === 100 ? (
-								<Fragment>
-									<img
-										className="current-plan-thank-you-card__illustration"
-										alt=""
-										aria-hidden="true"
-										src="/calypso/images/illustrations/security.svg"
-									/>
-									<h1 className="current-plan-thank-you-card__title">
-										{ translate( 'So long spam, hello backups!' ) }
-									</h1>
-									<p>
-										{ translate( "We've finished setting up spam filtering and backups for you." ) }
-										<br />
-										{ translate( "You're now ready to finish the rest of the checklist." ) }
-									</p>
-									<Button primary href={ this.getMyPlanRoute() }>
-										{ translate( 'Continue' ) }
-									</Button>
-								</Fragment>
-							) : (
-								<Fragment>
-									<img
-										className="current-plan-thank-you-card__illustration"
-										alt=""
-										aria-hidden="true"
-										src="/calypso/images/illustrations/fireworks.svg"
-									/>
-									<h1 className="current-plan-thank-you-card__title">
-										{ translate( 'Thank you for your purchase!' ) }
-									</h1>
-									<p>{ translate( "Now let's make sure your site is protected." ) }</p>
-									<p>
-										{ translate(
-											"We're setting up spam filters and site backups for you first. Once that's done, our security checklist will guide you through the next steps."
-										) }
-									</p>
-
-									<ProgressBar isPulsing total={ 100 } value={ progressComplete || 0 } />
-
-									<p>
-										<a href={ this.getMyPlanRoute() }>{ translate( 'Hide message' ) }</a>
-									</p>
-								</Fragment>
+				{ installState === INSTALL_STATE_UNCOMPLETE && (
+					<ThankYouCard
+						illustration={ fireworksIllustration }
+						title={ translate( 'Thank you for your purchase!' ) }
+					>
+						<p>{ translate( "Now let's make sure your site is protected." ) }</p>
+						<p>
+							{ translate(
+								"We're setting up spam filters and site backups for you first. Once that's done, our security checklist will guide you through the next steps."
 							) }
-						</div>
-					</Card>
+						</p>
+
+						<ProgressBar isPulsing total={ 100 } value={ installProgress || 0 } />
+
+						<p>
+							<a href={ this.getMyPlanRoute() }>{ translate( 'Hide message' ) }</a>
+						</p>
+					</ThankYouCard>
+				) }
+				{ installState === INSTALL_STATE_COMPLETE && (
+					<ThankYouCard
+						illustration={ securityIllustration }
+						showContinueButton
+						title={ translate( 'So long spam, hello backups!' ) }
+					>
+						<p>
+							{ translate( 'We’ve finished setting up spam filtering and backups for you.' ) }
+							<br />
+							{ translate( "You're now ready to finish the rest of the checklist." ) }
+						</p>
+					</ThankYouCard>
+				) }
+				{ installState === INSTALL_STATE_ERRORED && (
+					<ThankYouCard
+						illustration={ securityIllustration }
+						showContinueButton
+						title={ translate( 'So long spam, hello backups!' ) }
+					>
+						<p>
+							{ translate( 'Error' ) }
+							<br />
+							{ translate( 'Error' ) }
+						</p>
+					</ThankYouCard>
 				) }
 			</Fragment>
 		);
 	}
 }
 
-export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
+export default connect( state => {
+	const site = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
 
-		return {
-			progressComplete: getJetpackProductInstallProgress( state, siteId ),
-			siteSlug: getSelectedSiteSlug( state ),
-		};
-	},
-	{ recordTracksEvent }
-)( localize( PaidPlanThankYouCard ) );
+	const installProgress = getJetpackProductInstallProgress( state, siteId );
+	const productInstallStatus = getJetpackProductInstallStatus( state, siteId );
+
+	let installState;
+	// @TODO we'll need a way to detect actual error states here
+	if (
+		productInstallStatus &&
+		! includes( [ 'installed', 'skipped' ], productInstallStatus.akismet_status ) &&
+		! includes( [ 'installed', 'skipped' ], productInstallStatus.vaultpress_status )
+	) {
+		installState = INSTALL_STATE_ERRORED;
+	} else if ( installProgress === 100 ) {
+		installState = INSTALL_STATE_COMPLETE;
+	} else {
+		installState = INSTALL_STATE_UNCOMPLETE;
+	}
+
+	return {
+		fileModDisableReason: getSiteFileModDisableReason( site, 'modifyFiles' ),
+		hasMinimumJetpackVersion: site.hasMinimumJetpackVersion,
+		installProgress,
+		installState,
+		isSiteMainNetworkSite: isJetpackSiteMainNetworkSite( state, siteId ),
+		isSiteMultiSite: isJetpackSiteMultiSite( state, siteId ),
+	};
+}, { recordTracksEvent } )( localize( PaidPlanThankYouCard ) );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -13,8 +13,6 @@ import React, { Component, Fragment } from 'react';
  */
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteFileModDisableReason } from 'lib/site/utils';
-import { isJetpackSiteMainNetworkSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
 import { preventWidows } from 'lib/formatting';
 import { SETTING_UP_PREMIUM_SERVICES } from 'lib/url/support';
 import { untrailingslashit } from 'lib/route';
@@ -38,22 +36,13 @@ export class PaidPlanThankYouCard extends Component {
 	}
 
 	render() {
-		const {
-			fileModDisableReason,
-			hasMinimumJetpackVersion,
-			installProgress,
-			installState,
-			isSiteMainNetworkSite,
-			isSiteMultiSite,
-			site,
-			translate,
-		} = this.props;
+		const { installProgress, installState, site, translate } = this.props;
 
 		const securityIllustration = '/calypso/images/illustrations/security.svg';
 		const fireworksIllustration = '/calypso/images/illustrations/fireworks.svg';
 
 		// Jetpack is too old
-		if ( ! hasMinimumJetpackVersion ) {
+		if ( ! site.hasMinimumJetpackVersion ) {
 			// Link to "Plugins" page in wp-admin
 			let wpAdminPluginsUrl = get( site, 'options.admin_url' );
 			wpAdminPluginsUrl = wpAdminPluginsUrl
@@ -77,9 +66,7 @@ export class PaidPlanThankYouCard extends Component {
 					{ wpAdminPluginsUrl && (
 						<p>
 							<Button primary href={ wpAdminPluginsUrl } target="_blank">
-								<span>{ translate( 'Upgrade Jetpack' ) }</span>
-								{ ' ' }
-								<Gridicon icon="external" />
+								<span>{ translate( 'Upgrade Jetpack' ) }</span> <Gridicon icon="external" />
 							</Button>
 						</p>
 					) }
@@ -88,7 +75,7 @@ export class PaidPlanThankYouCard extends Component {
 		}
 
 		// We cannot install anything for this site
-		if ( fileModDisableReason && fileModDisableReason.length > 0 ) {
+		if ( ! site.canUpdateFiles ) {
 			return (
 				<ThankYouCard
 					illustration={ fireworksIllustration }
@@ -109,9 +96,7 @@ export class PaidPlanThankYouCard extends Component {
 					</p>
 					<p>
 						<Button primary href={ SETTING_UP_PREMIUM_SERVICES } target="_blank">
-							<span>{ translate( 'Set up features' ) }</span>
-							{ ' ' }
-							<Gridicon icon="external" />
+							<span>{ translate( 'Set up features' ) }</span> <Gridicon icon="external" />
 						</Button>
 					</p>
 				</ThankYouCard>
@@ -119,7 +104,7 @@ export class PaidPlanThankYouCard extends Component {
 		}
 
 		// Non-main site at multisite, cannot install anything
-		if ( isSiteMultiSite && ! isSiteMainNetworkSite ) {
+		if ( site.isSecondaryNetworkSite ) {
 			return (
 				<ThankYouCard
 					illustration={ fireworksIllustration }
@@ -140,9 +125,7 @@ export class PaidPlanThankYouCard extends Component {
 					</p>
 					<p>
 						<Button primary href={ SETTING_UP_PREMIUM_SERVICES } target="_blank">
-							<span>{ translate( 'Set up features' ) }</span>
-							{ ' ' }
-							<Gridicon icon="external" />
+							<span>{ translate( 'Set up features' ) }</span> <Gridicon icon="external" />
 						</Button>
 					</p>
 				</ThankYouCard>
@@ -208,12 +191,8 @@ export default connect( state => {
 	}
 
 	return {
-		fileModDisableReason: getSiteFileModDisableReason( site, 'modifyFiles' ),
-		hasMinimumJetpackVersion: site.hasMinimumJetpackVersion,
 		installProgress,
 		installState,
-		isSiteMainNetworkSite: isJetpackSiteMainNetworkSite( state, siteId ),
-		isSiteMultiSite: isJetpackSiteMultiSite( state, siteId ),
 		site,
 	};
 }, { recordTracksEvent } )( localize( PaidPlanThankYouCard ) );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/thank-you-card.js
@@ -14,7 +14,15 @@ import Card from 'components/card';
 
 export class ThankYouCard extends Component {
 	render() {
-		const { children, illustration, siteSlug, showContinueButton, title, translate } = this.props;
+		const {
+			children,
+			illustration,
+			siteSlug,
+			showContinueButton,
+			showHideMessage,
+			title,
+			translate,
+		} = this.props;
 
 		return (
 			<Card className="current-plan-thank-you-card__main">
@@ -33,6 +41,11 @@ export class ThankYouCard extends Component {
 						<Button primary href={ `/plans/my-plan/${ siteSlug }` }>
 							{ translate( 'Continue' ) }
 						</Button>
+					) }
+					{ showHideMessage && (
+						<p>
+							<a href={ `/plans/my-plan/${ siteSlug }` }>{ translate( 'Hide message' ) }</a>
+						</p>
 					) }
 				</div>
 			</Card>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/thank-you-card.js
@@ -1,0 +1,47 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { localize } from 'i18n-calypso';
+import React, { Component } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+
+export class ThankYouCard extends Component {
+	render() {
+		const { children, illustration, siteSlug, showContinueButton, title, translate } = this.props;
+
+		return (
+			<Card className="current-plan-thank-you-card__main">
+				<div className="current-plan-thank-you-card__content">
+					{ illustration && (
+						<img
+							alt=""
+							aria-hidden="true"
+							className="current-plan-thank-you-card__illustration"
+							src={ illustration }
+						/>
+					) }
+					{ title && <h1 className="current-plan-thank-you-card__title">{ title }</h1> }
+					{ children }
+					{ showContinueButton && (
+						<Button primary href={ `/plans/my-plan/${ siteSlug }` }>
+							{ translate( 'Continue' ) }
+						</Button>
+					) }
+				</div>
+			</Card>
+		);
+	}
+}
+
+export default connect( state => {
+	return {
+		siteSlug: getSelectedSiteSlug( state ),
+	};
+} )( localize( ThankYouCard ) );


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/33153

Show error and stop installation when we detect that plugins cannot be auto-installed on the site.

#### Old Jetpack:
<img width="1052" alt="Screenshot 2019-05-22 at 11 49 36" src="https://user-images.githubusercontent.com/87168/58164963-7cf35480-7c8f-11e9-9f29-2d918681f4bf.png">

Links to `wp-admin/plugins.php` in new tab
Click "Hide message" to get to checklist.

#### Multisite:
<img width="1059" alt="Screenshot 2019-05-22 at 11 47 13" src="https://user-images.githubusercontent.com/87168/58164966-7d8beb00-7c8f-11e9-8097-ed887b13e913.png">

Links to https://jetpack.com/support/installing-vaultpress-akismet/ in new tab.
Click "Hide message" to get to checklist/

#### Cannot modify files:
<img width="1055" alt="Screenshot 2019-05-22 at 12 49 25" src="https://user-images.githubusercontent.com/87168/58165251-10c52080-7c90-11e9-9837-8d42c29443bf.png">

Links to https://jetpack.com/support/installing-vaultpress-akismet/ in new tab
Click "Hide message" to get to checklist/

#### When everything goes well, screens should stay the same as before:

<img width="943" alt="Screenshot 2019-05-22 at 11 48 22" src="https://user-images.githubusercontent.com/87168/58164964-7cf35480-7c8f-11e9-9059-d0e4014f3958.png">
<img width="1055" alt="Screenshot 2019-05-22 at 11 47 47" src="https://user-images.githubusercontent.com/87168/58164965-7d8beb00-7c8f-11e9-8cf5-38e9ea10b1ba.png">


## TODO in follow up PRs:
- handle generic install errors, this address some of the very specific situations only
- add Tracks events
- Show error states in the checklist, now those spinners just keep spinning:
    <img src="https://user-images.githubusercontent.com/87168/58169242-f3488480-7c98-11e9-828f-9e4fd79e375c.png" alt="" width="300"/>
- offer guidance/better stats in the checklist itself. Related to https://github.com/Automattic/wp-calypso/issues/32562
- Maybe better graphics or different copy for error states as noted in https://github.com/Automattic/wp-calypso/issues/33153#issuecomment-494460607

## Changes proposed in this Pull Request

* Refactor some visuals from "thank you" cards to `ThankYouCard`
* Add error states for:
  - too old Jetpack
  - multisites
  - No rights to modify files
* Change showing install progress to be stateful instead of ternary; we'll add here a 3rd `INSTALL_STATE_ERRORED` state

Happy to split errors & component refactoring to separate PRs if that makes for easier review.

## Testing instructions

Have a Jetpack site with a plan and open `http://calypso.localhost:3000/plans/my-plan/:site?thank-you`

Since there are quite a lot of scenarios to test and we're not really testing if relevant APIs and `site` object is accurate (I'd expect they are accurate since we see these track events from the old flow), you might just want to add `true ||` to each condition in `client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js` to test them manually and observe visuals.

Otherwise, to confirm that we're _using_ the APIs the right way, you'll have to set up:
-  too old Jetpack version, 
- multisite where the site is not a main site,
- and lastly, the one that's pretty easy to replicate:
    Add `DISALLOW_FILE_MODS` constant to your `mu-plugins` file (on Docker setup in `docker/mu-plugins/`):
    ```php
    define( 'DISALLOW_FILE_MODS', true );
    ```

I've copied these error states from [`/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx`](https://github.com/Automattic/wp-calypso/blob/be715d74242040f96682617c6fc3d9a3f7ddb7a3/client/my-sites/checkout/checkout-thank-you/jetpack-thank-you-card.jsx#L291-L335) and left out these two since they never seem to happen:
- _"Your site is part of a multi-network."_
- _"Jetpack Manage must be enabled for us to auto-configure your %(plan)s plan."_
