### PR TITLE
 Tests: Run jest-codemods on client/components

### DIFF
--- a/client/components/button/test/index.js
+++ b/client/components/button/test/index.js
@@ -39,10 +39,8 @@ describe( 'Button', () => {
 			const iconType = 'arrow-left';
 			const icon = <Gridicon size={ 18 } icon={ iconType } />;
 			const button = shallow( <Button>{ icon }</Button> );
-			expect( button ).toEqual( expect.arrayContaining( [ icon ] ) );
-			expect( button.find( Gridicon ) )
-				.to.have.prop( 'icon' )
-				.toBe( iconType );
+			expect( button.contains( icon ) ).toBe( true );
+			expect( button.find( Gridicon ).prop( 'icon' ) ).toBe( iconType );
 		} );
 	} );
 
@@ -51,9 +49,7 @@ describe( 'Button', () => {
 			const button = shallow( <Button href="https://wordpress.com/" /> );
 
 			expect( button ).toMatch( 'a' );
-			expect( button )
-				.to.have.prop( 'href' )
-				.toBe( 'https://wordpress.com/' );
+			expect( button.prop( 'href' ) ).toBe( 'https://wordpress.com/' );
 		} );
 
 		test( 'ignores type prop and renders a link without type attribute', () => {
@@ -67,29 +63,17 @@ describe( 'Button', () => {
 				<Button href="https://wordpress.com/" target="_blank" rel="noopener noreferrer" />
 			);
 
-			expect( button )
-				.to.have.prop( 'target' )
-				.toBe( '_blank' );
-			expect( button )
-				.to.have.prop( 'rel' )
-				.toMatch( /\bnoopener\b/ );
-			expect( button )
-				.to.have.prop( 'rel' )
-				.toMatch( /\bnoreferrer\b/ );
+			expect( button.prop( 'target' ) ).toBe( '_blank' );
+			expect( button.prop( 'rel' ) ).toMatch( /\bnoopener\b/ );
+			expect( button.prop( 'rel' ) ).toMatch( /\bnoreferrer\b/ );
 		} );
 
 		test( 'adds noopener noreferrer rel if target is specified', () => {
 			const button = shallow( <Button href="https://wordpress.com/" target="_blank" /> );
 
-			expect( button )
-				.to.have.prop( 'target' )
-				.toBe( '_blank' );
-			expect( button )
-				.to.have.prop( 'rel' )
-				.toMatch( /\bnoopener\b/ );
-			expect( button )
-				.to.have.prop( 'rel' )
-				.toMatch( /\bnoreferrer\b/ );
+			expect( button.prop( 'target' ) ).toBe( '_blank' );
+			expect( button.prop( 'rel' ) ).toMatch( /\bnoopener\b/ );
+			expect( button.prop( 'rel' ) ).toMatch( /\bnoreferrer\b/ );
 		} );
 	} );
 
@@ -102,9 +86,7 @@ describe( 'Button', () => {
 		} );
 
 		test( 'renders button with type attribute set to "button" by default', () => {
-			expect( button )
-				.to.have.prop( 'type' )
-				.toBe( 'button' );
+			expect( button.prop( 'type' ) ).toBe( 'button' );
 		} );
 
 		test( 'renders button with type attribute set to type prop if specified', () => {
@@ -113,9 +95,7 @@ describe( 'Button', () => {
 				<Button target="_blank" rel="noopener noreferrer" type={ typeProp } />
 			);
 
-			expect( submitButton )
-				.to.have.prop( 'type' )
-				.toBe( typeProp );
+			expect( submitButton.prop( 'type' ) ).toBe( typeProp );
 		} );
 
 		test( 'renders button without rel and target attributes', () => {

--- a/client/components/button/test/index.js
+++ b/client/components/button/test/index.js
@@ -32,7 +32,7 @@ describe( 'Button', () => {
 
 		test( 'disabled', () => {
 			const button = shallow( <Button disabled /> );
-			expect( button ).to.be.disabled;
+			expect( button.prop( 'disabled' ) ).toBe( true );
 		} );
 
 		test( 'with child', () => {

--- a/client/components/button/test/index.js
+++ b/client/components/button/test/index.js
@@ -55,7 +55,7 @@ describe( 'Button', () => {
 		test( 'ignores type prop and renders a link without type attribute', () => {
 			const button = shallow( <Button href="https://wordpress.com/" type="submit" /> );
 
-			expect( button ).to.not.have.prop( 'type' );
+			expect( button.prop( 'type' ) ).toBeUndefined();
 		} );
 
 		test( 'including target and rel props renders a link with target and rel attributes', () => {
@@ -82,7 +82,7 @@ describe( 'Button', () => {
 
 		test( 'renders as a button', () => {
 			expect( button ).toMatch( 'button' );
-			expect( button ).to.not.have.prop( 'href' );
+			expect( button.prop( 'href' ) ).toBeUndefined();
 		} );
 
 		test( 'renders button with type attribute set to "button" by default', () => {
@@ -99,8 +99,8 @@ describe( 'Button', () => {
 		} );
 
 		test( 'renders button without rel and target attributes', () => {
-			expect( button ).to.not.have.prop( 'target' );
-			expect( button ).to.not.have.prop( 'rel' );
+			expect( button.prop( 'target' ) ).toBeUndefined();
+			expect( button.prop( 'rel' ) ).toBeUndefined();
 		} );
 	} );
 } );

--- a/client/components/button/test/index.js
+++ b/client/components/button/test/index.js
@@ -15,19 +15,19 @@ describe( 'Button', () => {
 	describe( 'renders', () => {
 		test( 'with modifiers', () => {
 			const button = shallow( <Button scary primary borderless compact /> );
-			expect( button ).to.have.className( 'is-compact' );
-			expect( button ).to.have.className( 'is-primary' );
-			expect( button ).to.have.className( 'is-scary' );
-			expect( button ).to.have.className( 'is-borderless' );
+			expect( button.hasClass( 'is-compact' ) ).toBe( true );
+			expect( button.hasClass( 'is-primary' ) ).toBe( true );
+			expect( button.hasClass( 'is-scary' ) ).toBe( true );
+			expect( button.hasClass( 'is-borderless' ) ).toBe( true );
 		} );
 
 		test( 'without modifiers', () => {
 			const button = shallow( <Button /> );
-			expect( button ).to.have.className( 'button' );
-			expect( button ).to.not.have.className( 'is-compact' );
-			expect( button ).to.not.have.className( 'is-primary' );
-			expect( button ).to.not.have.className( 'is-scary' );
-			expect( button ).to.not.have.className( 'is-borderless' );
+			expect( button.hasClass( 'button' ) ).toBe( true );
+			expect( button.hasClass( 'is-compact' ) ).toBe( false );
+			expect( button.hasClass( 'is-primary' ) ).toBe( false );
+			expect( button.hasClass( 'is-scary' ) ).toBe( false );
+			expect( button.hasClass( 'is-borderless' ) ).toBe( false );
 		} );
 
 		test( 'disabled', () => {

--- a/client/components/button/test/index.js
+++ b/client/components/button/test/index.js
@@ -48,7 +48,7 @@ describe( 'Button', () => {
 		test( 'renders as a link', () => {
 			const button = shallow( <Button href="https://wordpress.com/" /> );
 
-			expect( button ).toMatch( 'a' );
+			expect( button.type() ).toBe( 'a' );
 			expect( button.prop( 'href' ) ).toBe( 'https://wordpress.com/' );
 		} );
 
@@ -81,7 +81,7 @@ describe( 'Button', () => {
 		const button = shallow( <Button target="_blank" rel="noopener noreferrer" /> );
 
 		test( 'renders as a button', () => {
-			expect( button ).toMatch( 'button' );
+			expect( button.type() ).toBe( 'button' );
 			expect( button.prop( 'href' ) ).toBeUndefined();
 		} );
 

--- a/client/components/button/test/index.js
+++ b/client/components/button/test/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import Gridicon from 'gridicons';
 import React from 'react';
@@ -40,10 +39,10 @@ describe( 'Button', () => {
 			const iconType = 'arrow-left';
 			const icon = <Gridicon size={ 18 } icon={ iconType } />;
 			const button = shallow( <Button>{ icon }</Button> );
-			expect( button ).to.contain( icon );
+			expect( button ).toEqual( expect.arrayContaining( [ icon ] ) );
 			expect( button.find( Gridicon ) )
 				.to.have.prop( 'icon' )
-				.equal( iconType );
+				.toBe( iconType );
 		} );
 	} );
 
@@ -51,10 +50,10 @@ describe( 'Button', () => {
 		test( 'renders as a link', () => {
 			const button = shallow( <Button href="https://wordpress.com/" /> );
 
-			expect( button ).to.match( 'a' );
+			expect( button ).toMatch( 'a' );
 			expect( button )
 				.to.have.prop( 'href' )
-				.equal( 'https://wordpress.com/' );
+				.toBe( 'https://wordpress.com/' );
 		} );
 
 		test( 'ignores type prop and renders a link without type attribute', () => {
@@ -70,13 +69,13 @@ describe( 'Button', () => {
 
 			expect( button )
 				.to.have.prop( 'target' )
-				.equal( '_blank' );
+				.toBe( '_blank' );
 			expect( button )
 				.to.have.prop( 'rel' )
-				.match( /\bnoopener\b/ );
+				.toMatch( /\bnoopener\b/ );
 			expect( button )
 				.to.have.prop( 'rel' )
-				.match( /\bnoreferrer\b/ );
+				.toMatch( /\bnoreferrer\b/ );
 		} );
 
 		test( 'adds noopener noreferrer rel if target is specified', () => {
@@ -84,13 +83,13 @@ describe( 'Button', () => {
 
 			expect( button )
 				.to.have.prop( 'target' )
-				.equal( '_blank' );
+				.toBe( '_blank' );
 			expect( button )
 				.to.have.prop( 'rel' )
-				.match( /\bnoopener\b/ );
+				.toMatch( /\bnoopener\b/ );
 			expect( button )
 				.to.have.prop( 'rel' )
-				.match( /\bnoreferrer\b/ );
+				.toMatch( /\bnoreferrer\b/ );
 		} );
 	} );
 
@@ -98,14 +97,14 @@ describe( 'Button', () => {
 		const button = shallow( <Button target="_blank" rel="noopener noreferrer" /> );
 
 		test( 'renders as a button', () => {
-			expect( button ).to.match( 'button' );
+			expect( button ).toMatch( 'button' );
 			expect( button ).to.not.have.prop( 'href' );
 		} );
 
 		test( 'renders button with type attribute set to "button" by default', () => {
 			expect( button )
 				.to.have.prop( 'type' )
-				.equal( 'button' );
+				.toBe( 'button' );
 		} );
 
 		test( 'renders button with type attribute set to type prop if specified', () => {
@@ -116,7 +115,7 @@ describe( 'Button', () => {
 
 			expect( submitButton )
 				.to.have.prop( 'type' )
-				.equal( typeProp );
+				.toBe( typeProp );
 		} );
 
 		test( 'renders button without rel and target attributes', () => {

--- a/client/components/data/media-list-data/test/utils.js
+++ b/client/components/data/media-list-data/test/utils.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
- * External dependencies
+ * Internal dependencies
  */
-
 import utils from '../utils';
 
 describe( 'utils', () => {

--- a/client/components/data/media-list-data/test/utils.js
+++ b/client/components/data/media-list-data/test/utils.js
@@ -4,11 +4,6 @@
  * External dependencies
  */
 
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import utils from '../utils';
 
 describe( 'utils', () => {
@@ -16,31 +11,31 @@ describe( 'utils', () => {
 		test( 'should return an empty string for an unknown filter', () => {
 			const baseType = utils.getMimeBaseTypeFromFilter( 'unknown' );
 
-			expect( baseType ).to.equal( '' );
+			expect( baseType ).toBe( '' );
 		} );
 
 		test( 'should return "image/" for "images"', () => {
 			const baseType = utils.getMimeBaseTypeFromFilter( 'images' );
 
-			expect( baseType ).to.equal( 'image/' );
+			expect( baseType ).toBe( 'image/' );
 		} );
 
 		test( 'should return "audio/" for "audio"', () => {
 			const baseType = utils.getMimeBaseTypeFromFilter( 'audio' );
 
-			expect( baseType ).to.equal( 'audio/' );
+			expect( baseType ).toBe( 'audio/' );
 		} );
 
 		test( 'should return "video/" for "videos"', () => {
 			const baseType = utils.getMimeBaseTypeFromFilter( 'videos' );
 
-			expect( baseType ).to.equal( 'video/' );
+			expect( baseType ).toBe( 'video/' );
 		} );
 
 		test( 'should return "application/" for "documents"', () => {
 			const baseType = utils.getMimeBaseTypeFromFilter( 'documents' );
 
-			expect( baseType ).to.equal( 'application/' );
+			expect( baseType ).toBe( 'application/' );
 		} );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/eu-address-fieldset.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -30,17 +29,17 @@ describe( 'EU Address Fieldset', () => {
 
 	test( 'should render correctly with default props', () => {
 		const wrapper = shallow( <EuAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '.eu-address-fieldset' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.eu-address-fieldset' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render expected input components', () => {
 		const wrapper = shallow( <EuAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 1 );
+		expect( wrapper.find( '[name="city"]' ) ).toHaveLength( 1 );
+		expect( wrapper.find( '[name="postal-code"]' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render a state select components', () => {
 		const wrapper = shallow( <EuAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 0 );
+		expect( wrapper.find( '[name="state"]' ) ).toHaveLength( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/region-address-fieldsets.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -46,9 +45,9 @@ describe( 'Region Address Fieldsets', () => {
 
 	test( 'should render `<UsAddressFieldset />` with default props', () => {
 		const wrapper = shallow( <RegionAddressFieldsets { ...defaultProps } /> );
-		expect( wrapper.find( 'UsAddressFieldset' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="address-1"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="address-2"]' ) ).to.have.length( 1 );
+		expect( wrapper.find( 'UsAddressFieldset' ) ).toHaveLength( 1 );
+		expect( wrapper.find( '[name="address-1"]' ) ).toHaveLength( 1 );
+		expect( wrapper.find( '[name="address-2"]' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render `<UkAddressFieldset />` with a UK region countryCode', () => {
@@ -58,7 +57,7 @@ describe( 'Region Address Fieldsets', () => {
 				countryCode={ CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( wrapper.find( 'UkAddressFieldset' ) ).to.have.length( 1 );
+		expect( wrapper.find( 'UkAddressFieldset' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render `<EuAddressFieldset />` with an EU region countryCode', () => {
@@ -68,7 +67,7 @@ describe( 'Region Address Fieldsets', () => {
 				countryCode={ CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( wrapper.find( 'EuAddressFieldset' ) ).to.have.length( 1 );
+		expect( wrapper.find( 'EuAddressFieldset' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render `<UsAddressFieldset />` with an EU region country that has states', () => {
@@ -78,8 +77,8 @@ describe( 'Region Address Fieldsets', () => {
 				countryCode={ CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( wrapper.find( 'UsAddressFieldset' ) ).to.have.length( 1 );
-		expect( wrapper.find( 'EuAddressFieldset' ) ).to.have.length( 0 );
+		expect( wrapper.find( 'UsAddressFieldset' ) ).toHaveLength( 1 );
+		expect( wrapper.find( 'EuAddressFieldset' ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render `<UsAddressFieldset />` with a UK region country that has states', () => {
@@ -89,7 +88,7 @@ describe( 'Region Address Fieldsets', () => {
 				countryCode={ CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES[ 0 ] }
 			/>
 		);
-		expect( wrapper.find( 'UsAddressFieldset' ) ).to.have.length( 1 );
-		expect( wrapper.find( 'UkAddressFieldset' ) ).to.have.length( 0 );
+		expect( wrapper.find( 'UsAddressFieldset' ) ).toHaveLength( 1 );
+		expect( wrapper.find( 'UkAddressFieldset' ) ).toHaveLength( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/uk-address-fieldset.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -30,17 +29,17 @@ describe( 'UK Address Fieldset', () => {
 
 	test( 'should render correctly with default props', () => {
 		const wrapper = shallow( <UkAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '.uk-address-fieldset' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.uk-address-fieldset' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render expected input components', () => {
 		const wrapper = shallow( <UkAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 1 );
+		expect( wrapper.find( '[name="city"]' ) ).toHaveLength( 1 );
+		expect( wrapper.find( '[name="postal-code"]' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should not render a state select components', () => {
 		const wrapper = shallow( <UkAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 0 );
+		expect( wrapper.find( '[name="state"]' ) ).toHaveLength( 0 );
 	} );
 } );

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/test/us-address-fieldset.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -31,13 +30,13 @@ describe( 'US Address Fieldset', () => {
 
 	test( 'should render correctly with default props', () => {
 		const wrapper = shallow( <UsAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '.us-address-fieldset' ) ).to.have.length( 1 );
+		expect( wrapper.find( '.us-address-fieldset' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should render expected input components', () => {
 		const wrapper = shallow( <UsAddressFieldset { ...defaultProps } /> );
-		expect( wrapper.find( '[name="city"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="state"]' ) ).to.have.length( 1 );
-		expect( wrapper.find( '[name="postal-code"]' ) ).to.have.length( 1 );
+		expect( wrapper.find( '[name="city"]' ) ).toHaveLength( 1 );
+		expect( wrapper.find( '[name="state"]' ) ).toHaveLength( 1 );
+		expect( wrapper.find( '[name="postal-code"]' ) ).toHaveLength( 1 );
 	} );
 } );

--- a/client/components/domains/domain-suggestion/test/index.js
+++ b/client/components/domains/domain-suggestion/test/index.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { noop } from 'lodash';
 import React from 'react';
@@ -29,7 +28,7 @@ describe( 'Domain Suggestion', () => {
 				/>
 			);
 
-			expect( domainSuggestion.props()[ 'data-e2e-domain' ] ).to.equal( 'example.com' );
+			expect( domainSuggestion.props()[ 'data-e2e-domain' ] ).toBe( 'example.com' );
 		} );
 	} );
 } );

--- a/client/components/domains/registrant-extra-info/test/fr-form.js
+++ b/client/components/domains/registrant-extra-info/test/fr-form.js
@@ -69,7 +69,7 @@ describe( 'fr-form', () => {
 				[ 'GBHA9997' ],
 			];
 
-			validVatPatterns.forEach( ( [ pattern, description ] ) =>
+			validVatPatterns.forEach( ( [ pattern ] ) =>
 				expect( sanitizeVat( pattern ) ).toEqual( pattern.toUpperCase() )
 			);
 		} );

--- a/client/components/domains/registrant-extra-info/test/fr-form.js
+++ b/client/components/domains/registrant-extra-info/test/fr-form.js
@@ -2,11 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { sanitizeVat } from '../fr-form';
 
 describe( 'fr-form', () => {
@@ -22,7 +17,7 @@ describe( 'fr-form', () => {
 			];
 
 			vatPatterns.forEach( ( { before, after } ) =>
-				expect( sanitizeVat( before ) ).to.eql( after )
+				expect( sanitizeVat( before ) ).toEqual( after )
 			);
 		} );
 
@@ -75,7 +70,7 @@ describe( 'fr-form', () => {
 			];
 
 			validVatPatterns.forEach( ( [ pattern, description ] ) =>
-				expect( sanitizeVat( pattern ) ).to.eql( pattern.toUpperCase(), description )
+				expect( sanitizeVat( pattern ) ).toEqual( pattern.toUpperCase() )
 			);
 		} );
 	} );

--- a/client/components/domains/registrant-extra-info/test/fr-form.js
+++ b/client/components/domains/registrant-extra-info/test/fr-form.js
@@ -1,6 +1,5 @@
-/** @format */
 /**
- * External dependencies
+ * Internal dependencies
  */
 import { sanitizeVat } from '../fr-form';
 

--- a/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
+++ b/client/components/domains/registrant-extra-info/test/fr-validate-contact-details.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { omit, repeat } from 'lodash';
 
 /**
@@ -49,13 +48,13 @@ describe( 'validateContactDetails', () => {
 	}
 
 	test( 'should accept valid example data (sanity check)', () => {
-		expect( validateContactDetails( contactDetails ) ).to.eql( {} );
+		expect( validateContactDetails( contactDetails ) ).toEqual( {} );
 	} );
 
 	test( 'should handle missing extra', () => {
 		const testDetails = omit( contactDetails, 'extra' );
 
-		expect( validateContactDetails( testDetails ) ).to.have.property( 'extra' );
+		expect( validateContactDetails( testDetails ) ).toHaveProperty( 'extra' );
 	} );
 
 	test( 'should handle null extra', () => {
@@ -63,7 +62,7 @@ describe( 'validateContactDetails', () => {
 			extra: null,
 		} );
 
-		expect( validateContactDetails( testDetails ) ).to.have.property( 'extra' );
+		expect( validateContactDetails( testDetails ) ).toHaveProperty( 'extra' );
 	} );
 
 	// validateContactDetails data
@@ -87,21 +86,21 @@ describe( 'validateContactDetails', () => {
 			} );
 
 			test( 'should accept an organization', () => {
-				expect( validateContactDetails( organizationDetails ) ).to.eql( {} );
+				expect( validateContactDetails( organizationDetails ) ).toEqual( {} );
 			} );
 
 			test( 'should not be missing', () => {
 				const testDetails = omit( organizationDetails, 'organization' );
 
 				const result = validateContactDetails( testDetails );
-				expect( result ).to.have.property( 'organization' );
+				expect( result ).toHaveProperty( 'organization' );
 			} );
 
 			test( 'should not be empty', () => {
 				const testDetails = Object.assign( {}, organizationDetails, { organization: '' } );
 
 				const result = validateContactDetails( testDetails );
-				expect( result ).to.have.property( 'organization' );
+				expect( result ).toHaveProperty( 'organization' );
 			} );
 
 			test( 'should reject long strings', () => {
@@ -110,7 +109,7 @@ describe( 'validateContactDetails', () => {
 				} );
 
 				const result = validateContactDetails( testDetails );
-				expect( result ).to.have.property( 'organization' );
+				expect( result ).toHaveProperty( 'organization' );
 			} );
 
 			test( 'should reject invalid characters', () => {
@@ -119,7 +118,7 @@ describe( 'validateContactDetails', () => {
 				} );
 
 				const result = validateContactDetails( testDetails );
-				expect( result ).to.have.property( 'organization' );
+				expect( result ).toHaveProperty( 'organization' );
 			} );
 		} );
 
@@ -132,21 +131,21 @@ describe( 'validateContactDetails', () => {
 				const testDetails = omit( individualDetails, 'organization' );
 
 				const result = validateContactDetails( testDetails );
-				expect( result ).to.eql( {} );
+				expect( result ).toEqual( {} );
 			} );
 
 			test( 'should accept null organization', () => {
 				const testDetails = Object.assign( {}, individualDetails, { organization: '' } );
 
 				const result = validateContactDetails( testDetails );
-				expect( result ).to.eql( {} );
+				expect( result ).toEqual( {} );
 			} );
 
 			test( 'should accept empty organization', () => {
 				const testDetails = Object.assign( {}, individualDetails, { organization: '' } );
 
 				const result = validateContactDetails( testDetails );
-				expect( result ).to.eql( {} );
+				expect( result ).toEqual( {} );
 			} );
 		} );
 	} );
@@ -157,7 +156,8 @@ describe( 'validateContactDetails', () => {
 				const testDetails = contactWithExtraProperty( 'sirenSiret', sirenSiret );
 
 				const result = validateContactDetails( testDetails );
-				expect( result, `expected to accept '${ sirenSiret }'` ).to.eql( {} );
+				// expected to accept '${ sirenSiret }'
+				expect( result ).toEqual( {} );
 			} );
 		} );
 
@@ -173,10 +173,11 @@ describe( 'validateContactDetails', () => {
 				const testDetails = Object.assign( {}, contactDetails, { extra: { fr: { sirenSiret } } } );
 
 				const result = validateContactDetails( testDetails );
-				expect( result, `expected to reject '${ sirenSiret }'` )
-					.to.have.property( 'extra' )
+				// expected to reject '${ sirenSiret }'
+				expect( result )
+					.toHaveProperty( 'extra' )
 					.with.property( 'fr' )
-					.with.property( 'sirenSiret' );
+					.toHaveProperty( 'sirenSiret' );
 			} );
 		} );
 
@@ -184,7 +185,7 @@ describe( 'validateContactDetails', () => {
 			const testDetails = contactWithExtraProperty( 'sirenSiret', '' );
 
 			const result = validateContactDetails( testDetails );
-			expect( result ).to.eql( {} );
+			expect( result ).toEqual( {} );
 		} );
 
 		test( 'should accept a missing value', () => {
@@ -193,7 +194,7 @@ describe( 'validateContactDetails', () => {
 				extra: { fr: omit( contactDetails.extra.fr, 'sirenSiret' ) },
 			};
 
-			expect( validateContactDetails( testDetails ) ).to.eql( {} );
+			expect( validateContactDetails( testDetails ) ).toEqual( {} );
 		} );
 	} );
 
@@ -248,7 +249,8 @@ describe( 'validateContactDetails', () => {
 				const testDetails = contactWithExtraProperty( 'registrantVatId', registrantVatId );
 
 				const result = validateContactDetails( testDetails );
-				expect( result, `expected to accept '${ registrantVatId }'` ).to.eql( {} );
+				// expected to accept '${ registrantVatId }'
+				expect( result ).toEqual( {} );
 			} );
 		} );
 
@@ -259,10 +261,11 @@ describe( 'validateContactDetails', () => {
 				} );
 
 				const result = validateContactDetails( testDetails );
-				expect( result, `expected to reject '${ registrantVatId }'` )
-					.to.have.property( 'extra' )
+				// expected to reject '${ registrantVatId }'
+				expect( result )
+					.toHaveProperty( 'extra' )
 					.with.property( 'fr' )
-					.with.property( 'registrantVatId' );
+					.toHaveProperty( 'registrantVatId' );
 			} );
 		} );
 
@@ -270,7 +273,7 @@ describe( 'validateContactDetails', () => {
 			const testDetails = contactWithExtraProperty( 'registrantVatId', '' );
 
 			const result = validateContactDetails( testDetails );
-			expect( result ).to.eql( {} );
+			expect( result ).toEqual( {} );
 		} );
 
 		test( 'should accept a missing value', () => {
@@ -279,7 +282,7 @@ describe( 'validateContactDetails', () => {
 				extra: { fr: omit( contactDetails.extra.fr, 'registrantVatId' ) },
 			};
 
-			expect( validateContactDetails( testDetails ) ).to.eql( {} );
+			expect( validateContactDetails( testDetails ) ).toEqual( {} );
 		} );
 	} );
 
@@ -293,7 +296,8 @@ describe( 'validateContactDetails', () => {
 				const testDetails = contactWithExtraProperty( 'trademarkNumber', trademarkNumber );
 
 				const result = validateContactDetails( testDetails );
-				expect( result, `expected to accept '${ trademarkNumber }'` ).to.eql( {} );
+				// expected to accept '${ trademarkNumber }'
+				expect( result ).toEqual( {} );
 			} );
 		} );
 
@@ -305,10 +309,11 @@ describe( 'validateContactDetails', () => {
 
 				const result = validateContactDetails( testDetails );
 
-				expect( result, `expected to reject '${ trademarkNumber }'` )
-					.to.have.property( 'extra' )
+				// expected to reject '${ trademarkNumber }'
+				expect( result )
+					.toHaveProperty( 'extra' )
 					.with.property( 'fr' )
-					.with.property( 'trademarkNumber' );
+					.toHaveProperty( 'trademarkNumber' );
 			} );
 		} );
 
@@ -316,7 +321,7 @@ describe( 'validateContactDetails', () => {
 			const testDetails = contactWithExtraProperty( 'trademarkNumber', '' );
 
 			const result = validateContactDetails( testDetails );
-			expect( result ).to.eql( {} );
+			expect( result ).toEqual( {} );
 		} );
 
 		test( 'should accept a missing value', () => {
@@ -325,7 +330,7 @@ describe( 'validateContactDetails', () => {
 				extra: omit( contactDetails.extra, 'trademarkNumber' ),
 			};
 
-			expect( validateContactDetails( testDetails ) ).to.eql( {} );
+			expect( validateContactDetails( testDetails ) ).toEqual( {} );
 		} );
 	} );
 } );

--- a/client/components/domains/registrant-extra-info/test/index.js
+++ b/client/components/domains/registrant-extra-info/test/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 
@@ -21,22 +20,22 @@ describe( 'Switcher Form', () => {
 	test( 'should render correct form for fr', () => {
 		const wrapper = shallow( <RegistrantExtraInfoForm tld="fr" /> );
 
-		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).to.have.length( 1 );
-		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).to.have.length( 0 );
+		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).toHaveLength( 1 );
+		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render correct form for ca', () => {
 		const wrapper = shallow( <RegistrantExtraInfoForm tld="ca" /> );
 
-		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).to.have.length( 1 );
-		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).to.have.length( 0 );
+		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).toHaveLength( 1 );
+		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should render correct form for uk', () => {
 		const wrapper = shallow( <RegistrantExtraInfoForm tld="uk" /> );
 
-		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).to.have.length( 0 );
-		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).to.have.length( 0 );
-		expect( wrapper.find( RegistrantExtraInfoUkForm ) ).to.have.length( 1 );
+		expect( wrapper.find( RegistrantExtraInfoCaForm ) ).toHaveLength( 0 );
+		expect( wrapper.find( RegistrantExtraInfoFrForm ) ).toHaveLength( 0 );
+		expect( wrapper.find( RegistrantExtraInfoUkForm ) ).toHaveLength( 1 );
 	} );
 } );

--- a/client/components/marketing-survey/cancel-purchase-form/test/enriched-survey-data.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/enriched-survey-data.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { moment } from 'i18n-calypso';
 
 /**
@@ -14,7 +13,7 @@ jest.mock( 'lib/analytics', () => ( {} ) );
 
 describe( 'enrichedSurveyData', () => {
 	test( 'should duplicate survey data if no site or purchase are provided', () => {
-		expect( enrichedSurveyData( { key: 'value' }, moment() ) ).to.deep.equal( {
+		expect( enrichedSurveyData( { key: 'value' }, moment() ) ).toEqual( {
 			key: 'value',
 			purchase: null,
 			purchaseId: null,
@@ -24,7 +23,7 @@ describe( 'enrichedSurveyData', () => {
 	test( 'should add purchase id and slug to survey data if purchase is provided', () => {
 		const site = null;
 		const purchase = { id: 'purchase id', productSlug: 'product slug' };
-		expect( enrichedSurveyData( { key: 'value' }, moment(), site, purchase ).purchase ).to.equal(
+		expect( enrichedSurveyData( { key: 'value' }, moment(), site, purchase ).purchase ).toBe(
 			'product slug'
 		);
 	} );
@@ -35,7 +34,7 @@ describe( 'enrichedSurveyData', () => {
 		expect(
 			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase )
 				.daysSincePurchase
-		).to.equal( 10 );
+		).toBe( 10 );
 	} );
 
 	test( 'should add daysSinceSiteCreation to survey data when site.options.created_at is provided', () => {
@@ -46,6 +45,6 @@ describe( 'enrichedSurveyData', () => {
 		expect(
 			enrichedSurveyData( {}, moment( '2017-01-19T03:00:00+00:00' ), site, purchase )
 				.daysSinceSiteCreation
-		).to.equal( 10 );
+		).toBe( 10 );
 	} );
 } );

--- a/client/components/marketing-survey/cancel-purchase-form/test/initial-survey-state.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/initial-survey-state.js
@@ -1,7 +1,5 @@
-/** @format */
-
 /**
- * External dependencies
+ * Internal dependencies
  */
 import initialSurveyState from '../initial-survey-state';
 

--- a/client/components/marketing-survey/cancel-purchase-form/test/initial-survey-state.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/initial-survey-state.js
@@ -3,16 +3,11 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import initialSurveyState from '../initial-survey-state';
 
 describe( 'initialSurveyState', () => {
 	test( 'should contain null values for questions one and two', () => {
-		expect( initialSurveyState() ).to.deep.equal( {
+		expect( initialSurveyState() ).toEqual( {
 			questionOneRadio: null,
 			questionTwoRadio: null,
 		} );

--- a/client/components/marketing-survey/cancel-purchase-form/test/is-survey-filled-in.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/is-survey-filled-in.js
@@ -3,16 +3,11 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import isSurveyFilledIn from '../is-survey-filled-in';
 
 describe( 'isSurveyFilledIn', () => {
 	test( 'should return false when no questions are answered', () => {
-		expect( isSurveyFilledIn( {} ) ).to.equal( false );
+		expect( isSurveyFilledIn( {} ) ).toBe( false );
 	} );
 
 	test( 'should return true when question one and two are answered', () => {
@@ -21,7 +16,7 @@ describe( 'isSurveyFilledIn', () => {
 				questionOneRadio: 'tooHard',
 				questionTwoRadio: 'tooHard',
 			} )
-		).to.equal( true );
+		).toBe( true );
 	} );
 
 	test( 'should return true when question one is answered and there are no options for question two', () => {
@@ -30,7 +25,7 @@ describe( 'isSurveyFilledIn', () => {
 				questionOneRadio: 'tooHard',
 				questionTwoOrder: [],
 			} )
-		).to.equal( true );
+		).toBe( true );
 	} );
 
 	test( 'should return false when question one is another reason and there is no text', () => {
@@ -40,7 +35,7 @@ describe( 'isSurveyFilledIn', () => {
 				questionOneText: '',
 				questionTwoRadio: 'tooHard',
 			} )
-		).to.equal( false );
+		).toBe( false );
 	} );
 
 	test( 'should return false when question two is another reason and there is no text', () => {
@@ -50,7 +45,7 @@ describe( 'isSurveyFilledIn', () => {
 				questionTwoRadio: 'anotherReasonTwo',
 				questionTwoText: '',
 			} )
-		).to.equal( false );
+		).toBe( false );
 	} );
 
 	test( 'should return true when question one and two are another reason and both have text', () => {
@@ -61,6 +56,6 @@ describe( 'isSurveyFilledIn', () => {
 				questionTwoRadio: 'anotherReasonTwo',
 				questionTwoText: 'the reason',
 			} )
-		).to.equal( true );
+		).toBe( true );
 	} );
 } );

--- a/client/components/marketing-survey/cancel-purchase-form/test/is-survey-filled-in.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/is-survey-filled-in.js
@@ -1,7 +1,5 @@
-/** @format */
-
 /**
- * External dependencies
+ * Internal dependencies
  */
 import isSurveyFilledIn from '../is-survey-filled-in';
 

--- a/client/components/marketing-survey/cancel-purchase-form/test/next-step.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/next-step.js
@@ -3,25 +3,20 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import nextStep from '../next-step';
 
 describe( 'nextStep', () => {
 	const steps = [ 'a', 'b', 'c' ];
 
 	test( 'should return final step if current step is unknown', () => {
-		expect( nextStep( 'unknown', steps ) ).to.equal( 'c' );
+		expect( nextStep( 'unknown', steps ) ).toBe( 'c' );
 	} );
 
 	test( 'should return final step if current step is final step', () => {
-		expect( nextStep( 'c', steps ) ).to.equal( 'c' );
+		expect( nextStep( 'c', steps ) ).toBe( 'c' );
 	} );
 
 	test( 'should return next step current step is earlier step', () => {
-		expect( nextStep( 'a', steps ) ).to.equal( 'b' );
+		expect( nextStep( 'a', steps ) ).toBe( 'b' );
 	} );
 } );

--- a/client/components/marketing-survey/cancel-purchase-form/test/next-step.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/next-step.js
@@ -1,7 +1,5 @@
-/** @format */
-
 /**
- * External dependencies
+ * Internal dependencies
  */
 import nextStep from '../next-step';
 

--- a/client/components/marketing-survey/cancel-purchase-form/test/previous-step.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/previous-step.js
@@ -1,7 +1,5 @@
-/** @format */
-
 /**
- * External dependencies
+ * Internal dependencies
  */
 import previousStep from '../previous-step';
 

--- a/client/components/marketing-survey/cancel-purchase-form/test/previous-step.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/previous-step.js
@@ -3,25 +3,20 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import previousStep from '../previous-step';
 
 describe( 'previousStep', () => {
 	const steps = [ 'a', 'b', 'c' ];
 
 	test( 'should return initial step if current step is unknown', () => {
-		expect( previousStep( 'unknown', steps ) ).to.equal( 'a' );
+		expect( previousStep( 'unknown', steps ) ).toBe( 'a' );
 	} );
 
 	test( 'should return initial step if current step is initial step', () => {
-		expect( previousStep( 'a', steps ) ).to.equal( 'a' );
+		expect( previousStep( 'a', steps ) ).toBe( 'a' );
 	} );
 
 	test( 'should return previous step current step is subsequent step', () => {
-		expect( previousStep( 'c', steps ) ).to.equal( 'b' );
+		expect( previousStep( 'c', steps ) ).toBe( 'b' );
 	} );
 } );

--- a/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
@@ -2,11 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import * as steps from '../steps';
 import stepsForProductAndSurvey from '../steps-for-product-and-survey';
 import { abtest } from 'lib/abtest';
@@ -27,7 +22,7 @@ const DEFAULT_STEPS_WITH_BUSINESS_AT_STEP = [
 
 describe( 'stepsForProductAndSurvey', () => {
 	test( 'should return default steps if no state or product', () => {
-		expect( stepsForProductAndSurvey() ).to.deep.equal( DEFAULT_STEPS );
+		expect( stepsForProductAndSurvey() ).toEqual( DEFAULT_STEPS );
 	} );
 
 	describe( 'question one answer is not "could not install" and precancellation chat turned "On"', () => {
@@ -38,84 +33,84 @@ describe( 'stepsForProductAndSurvey', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
+			).toEqual( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
 		test( 'should include happychat step if product is personal plan and happychat is available (2y)', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
+			).toEqual( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
 		test( 'should not include happychat step if product is personal plan but happychat is not available', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is personal plan but happychat is not available (2y)', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should include happychat step if product is premium plan and happychat is available', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
+			).toEqual( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
 		test( 'should include happychat step if product is premium plan and happychat is available (2y)', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
+			).toEqual( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
 		test( 'should not include happychat step if product is premium plan but happychat is not available', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is premium plan but happychat is not available (2y)', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should include happychat step if product is business plan and happychat is available', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
+			).toEqual( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
 		test( 'should include happychat step if product is business plan and happychat is available (2y)', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
+			).toEqual( steps.DEFAULT_STEPS_WITH_HAPPYCHAT );
 		} );
 
 		test( 'should include happychat step if product is business plan but happychat is not available', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should include happychat step if product is business plan but happychat is not available (2y)', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 	} );
 
@@ -127,42 +122,42 @@ describe( 'stepsForProductAndSurvey', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is personal plan and happychat is available (2y)', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is premium plan and happychat is available', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is premium plan and happychat is available (2y)', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is business plan and happychat is available', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is business plan and happychat is available (2y)', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).toEqual( DEFAULT_STEPS );
 		} );
 	} );
 
@@ -172,7 +167,7 @@ describe( 'stepsForProductAndSurvey', () => {
 		test( 'should include AT upgrade step if product is personal plan and abtest variant is show', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'show' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual(
 				DEFAULT_STEPS_WITH_UPGRADE_AT_STEP
 			);
 		} );
@@ -180,7 +175,7 @@ describe( 'stepsForProductAndSurvey', () => {
 		test( 'should include AT upgrade step if product is personal plan and abtest variant is show (2y)', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'show' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual(
 				DEFAULT_STEPS_WITH_UPGRADE_AT_STEP
 			);
 		} );
@@ -188,19 +183,19 @@ describe( 'stepsForProductAndSurvey', () => {
 		test( 'should not include AT upgrade step if product is personal plan and abtest variant is hide', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should not include AT upgrade step if product is personal plan and abtest variant is hide (2y)', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should include AT upgrade step if product is premium plan and abtest variant is show', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'show' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual(
 				DEFAULT_STEPS_WITH_UPGRADE_AT_STEP
 			);
 		} );
@@ -208,7 +203,7 @@ describe( 'stepsForProductAndSurvey', () => {
 		test( 'should include AT upgrade step if product is premium plan and abtest variant is show (2y)', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'show' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual(
 				DEFAULT_STEPS_WITH_UPGRADE_AT_STEP
 			);
 		} );
@@ -216,19 +211,19 @@ describe( 'stepsForProductAndSurvey', () => {
 		test( 'should not include AT upgrade step if product is premium plan and abtest variant is hide', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should not include AT upgrade step if product is premium plan and abtest variant is hide (2y)', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should include business AT step if product is personal plan and abtest variant is show', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
 			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'show' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual(
 				DEFAULT_STEPS_WITH_BUSINESS_AT_STEP
 			);
 		} );
@@ -236,7 +231,7 @@ describe( 'stepsForProductAndSurvey', () => {
 		test( 'should include business AT step if product is personal plan and abtest variant is show (2y)', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'show' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual(
 				DEFAULT_STEPS_WITH_BUSINESS_AT_STEP
 			);
 		} );
@@ -244,13 +239,13 @@ describe( 'stepsForProductAndSurvey', () => {
 		test( 'should not include business AT step if product is business plan and abtest variant is hide', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
 			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual( DEFAULT_STEPS );
 		} );
 
 		test( 'should not include business AT step if product is business plan and abtest variant is hide (2y)', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).toEqual( DEFAULT_STEPS );
 		} );
 	} );
 } );

--- a/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
@@ -1,6 +1,5 @@
-/** @format */
 /**
- * External dependencies
+ * Internal dependencies
  */
 import * as steps from '../steps';
 import stepsForProductAndSurvey from '../steps-for-product-and-survey';

--- a/client/components/post-schedule/test/index.js
+++ b/client/components/post-schedule/test/index.js
@@ -3,11 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import {
 	is12hr,
 	isValidGMTOffset,
@@ -19,23 +14,23 @@ import {
 
 describe( 'is12hr', () => {
 	test( 'Should return true for a 12-hour time format', () => {
-		expect( is12hr( 'F j, Y, g:i a' ) ).to.be.true;
-		expect( is12hr( 'h:i' ) ).to.be.true;
+		expect( is12hr( 'F j, Y, g:i a' ) ).toBe( true );
+		expect( is12hr( 'h:i' ) ).toBe( true );
 	} );
 
 	test( 'Should return false for a 24-hour time', () => {
-		expect( is12hr( 'H:i:s' ) ).to.be.false;
-		expect( is12hr( 'G:i' ) ).to.be.false;
+		expect( is12hr( 'H:i:s' ) ).toBe( false );
+		expect( is12hr( 'G:i' ) ).toBe( false );
 	} );
 } );
 
 describe( 'gmtOffset', () => {
 	test( 'Should return true for a valid gtm offset', () => {
-		expect( isValidGMTOffset( 2 ) ).to.be.true;
+		expect( isValidGMTOffset( 2 ) ).toBe( true );
 	} );
 
 	test( 'Should return false for an invalid gtm offset', () => {
-		expect( isValidGMTOffset( '2' ) ).to.be.false;
+		expect( isValidGMTOffset( '2' ) ).toBe( false );
 	} );
 } );
 
@@ -45,78 +40,78 @@ describe( 'getLocalizedDate', () => {
 
 	test( 'Should return a date localized at Amsterdam (utc: 60 minutes)', () => {
 		const nowInAmsterdam = getLocalizedDate( now, 'Europe/Amsterdam' );
-		expect( nowInAmsterdam.utcOffset() ).to.equal( 60 );
+		expect( nowInAmsterdam.utcOffset() ).toBe( 60 );
 	} );
 
 	test( 'Should return a date localized at New York (utc: -300 minutes)', () => {
 		const nowInNewYork = getLocalizedDate( now, 'America/New_York' );
-		expect( nowInNewYork.utcOffset() ).to.equal( -300 );
+		expect( nowInNewYork.utcOffset() ).toBe( -300 );
 	} );
 
 	test( 'Should return a date localized at UTC+3:30 (utc: 210 minutes)', () => {
 		const NowAtUTC3_30 = getLocalizedDate( now, false, 210 );
-		expect( NowAtUTC3_30.utcOffset() ).to.equal( 210 );
+		expect( NowAtUTC3_30.utcOffset() ).toBe( 210 );
 	} );
 } );
 
 describe( 'convertHoursToHHMM', () => {
 	test( 'Should convert 3.1 hours to `3:06`', () => {
-		expect( convertHoursToHHMM( 3.1 ) ).to.equal( '+3:06' );
+		expect( convertHoursToHHMM( 3.1 ) ).toBe( '+3:06' );
 	} );
 
 	test( 'Should convert 3 hours to `3`', () => {
-		expect( convertHoursToHHMM( 3 ) ).to.equal( '+3' );
+		expect( convertHoursToHHMM( 3 ) ).toBe( '+3' );
 	} );
 
 	test( 'Should convert -3.1 hours to `-3:06`', () => {
-		expect( convertHoursToHHMM( -3.1 ) ).to.equal( '-3:06' );
+		expect( convertHoursToHHMM( -3.1 ) ).toBe( '-3:06' );
 	} );
 
 	test( 'Should convert -3 hours to `3`', () => {
-		expect( convertHoursToHHMM( -3 ) ).to.equal( '-3' );
+		expect( convertHoursToHHMM( -3 ) ).toBe( '-3' );
 	} );
 } );
 
 describe( 'convertMinutesToHHMM', () => {
 	test( 'Should convert 186 minutes to `3:06`', () => {
-		expect( convertMinutesToHHMM( 186 ) ).to.equal( '+3:06' );
+		expect( convertMinutesToHHMM( 186 ) ).toBe( '+3:06' );
 	} );
 
 	test( 'Should convert 180 minutes to `3`', () => {
-		expect( convertMinutesToHHMM( 180 ) ).to.equal( '+3' );
+		expect( convertMinutesToHHMM( 180 ) ).toBe( '+3' );
 	} );
 
 	test( 'Should convert -186 minutes to `-3:06`', () => {
-		expect( convertMinutesToHHMM( -186 ) ).to.equal( '-3:06' );
+		expect( convertMinutesToHHMM( -186 ) ).toBe( '-3:06' );
 	} );
 
 	test( 'Should convert -180 minutes to `-3`', () => {
-		expect( convertMinutesToHHMM( -180 ) ).to.equal( '-3' );
+		expect( convertMinutesToHHMM( -180 ) ).toBe( '-3' );
 	} );
 
 	test( 'Should convert 0 minutes to `0`', () => {
-		expect( convertMinutesToHHMM( 0 ) ).to.equal( '0' );
+		expect( convertMinutesToHHMM( 0 ) ).toBe( '0' );
 	} );
 
 	test( 'Should convert -0 minutes to `0`', () => {
-		expect( convertMinutesToHHMM( -0 ) ).to.equal( '0' );
+		expect( convertMinutesToHHMM( -0 ) ).toBe( '0' );
 	} );
 } );
 
 describe( 'parseAndValidateNumber', () => {
 	test( 'Should return `false` when the value is a string', () => {
-		expect( parseAndValidateNumber( 'ab' ) ).to.be.false;
+		expect( parseAndValidateNumber( 'ab' ) ).toBe( false );
 	} );
 
 	test( 'Should return `false` when the value is a negative number', () => {
-		expect( parseAndValidateNumber( -10 ) ).to.be.false;
+		expect( parseAndValidateNumber( -10 ) ).toBe( false );
 	} );
 
 	test( 'Should return a 4 when the value is `04`', () => {
-		expect( parseAndValidateNumber( '04' ) ).to.equal( 4 );
+		expect( parseAndValidateNumber( '04' ) ).toBe( 4 );
 	} );
 
 	test( 'Should return a 99 when the value is `99`', () => {
-		expect( parseAndValidateNumber( '99' ) ).to.equal( 99 );
+		expect( parseAndValidateNumber( '99' ) ).toBe( 99 );
 	} );
 } );

--- a/client/components/post-schedule/test/index.js
+++ b/client/components/post-schedule/test/index.js
@@ -1,7 +1,5 @@
-/** @format */
-
 /**
- * External dependencies
+ * Internal dependencies
  */
 import {
 	is12hr,

--- a/client/components/rating/test/index.js
+++ b/client/components/rating/test/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { each } from 'lodash';
 import React from 'react';
@@ -18,7 +17,7 @@ describe( '<Rating />', () => {
 			const wrapper = shallow( <Rating /> );
 
 			const component = wrapper.find( 'div.rating' );
-			expect( component.props().style.width ).to.equal( '120px' ); // 24 * 5 = 120;
+			expect( component.props().style.width ).toBe( '120px' ); // 24 * 5 = 120;
 		} );
 
 		test( 'should use size if passed', () => {
@@ -26,7 +25,7 @@ describe( '<Rating />', () => {
 				wrapper = shallow( <Rating size={ size } /> );
 
 			const component = wrapper.find( 'div.rating' );
-			expect( component.props().style.width ).to.equal( size * 5 + 'px' );
+			expect( component.props().style.width ).toBe( size * 5 + 'px' );
 		} );
 
 		test( 'should use size in each star', () => {
@@ -35,7 +34,7 @@ describe( '<Rating />', () => {
 				wrapper = shallow( <Rating rating={ rating } size={ size } /> );
 
 			wrapper.find( 'svg' ).forEach( node => {
-				expect( node.props().style.width ).to.equal( size + 'px' );
+				expect( node.props().style.width ).toBe( size + 'px' );
 			} );
 		} );
 	} );
@@ -46,8 +45,8 @@ describe( '<Rating />', () => {
 				wrapper = shallow( <Rating size={ size } /> );
 
 			const component = wrapper.find( 'div.rating__overlay' );
-			expect( component.props().style.clipPath ).to.equal( 'inset(0 ' + size * 5 + 'px 0 0 )' );
-			expect( component.props().style.clip ).to.equal( 'rect(0, 0px, ' + size + 'px, 0)' );
+			expect( component.props().style.clipPath ).toBe( 'inset(0 ' + size * 5 + 'px 0 0 )' );
+			expect( component.props().style.clip ).toBe( 'rect(0, 0px, ' + size + 'px, 0)' );
 		} );
 
 		test( 'should render rating clipping mask properly', () => {
@@ -60,10 +59,10 @@ describe( '<Rating />', () => {
 				const maskPosition = ( roundRating / 100 ) * ratingWidth;
 				const clipPathMaskPosition = ratingWidth - ( roundRating / 100 ) * ratingWidth;
 				const component = wrapper.find( 'div.rating__overlay' );
-				expect( component.props().style.clipPath ).to.equal(
+				expect( component.props().style.clipPath ).toBe(
 					'inset(0 ' + clipPathMaskPosition + 'px 0 0 )'
 				);
-				expect( component.props().style.clip ).to.equal(
+				expect( component.props().style.clip ).toBe(
 					'rect(0, ' + maskPosition + 'px, ' + size + 'px, 0)'
 				);
 			} );

--- a/client/components/remove-button/test/index.js
+++ b/client/components/remove-button/test/index.js
@@ -2,7 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import Gridicon from 'gridicons';
 import { identity, noop } from 'lodash';
@@ -25,7 +24,7 @@ describe( 'Remove Button', () => {
 	test( 'should render the icon', () => {
 		const wrapper = shallow( <RemoveButton onRemove={ noop } translate={ identity } /> );
 
-		expect( wrapper.find( Gridicon ) ).to.have.length( 1 );
+		expect( wrapper.find( Gridicon ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should call the provided callback when the button is clicked', () => {
@@ -33,6 +32,6 @@ describe( 'Remove Button', () => {
 		const wrapper = shallow( <RemoveButton onRemove={ onRemove } translate={ identity } /> );
 
 		wrapper.find( Button ).simulate( 'click' );
-		expect( onRemove.calledOnce ).to.equal( true );
+		expect( onRemove.calledOnce ).toBe( true );
 	} );
 } );

--- a/client/components/select-dropdown/test/index.js
+++ b/client/components/select-dropdown/test/index.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
@@ -20,25 +19,25 @@ describe( 'index', () => {
 	describe( 'component rendering', () => {
 		test( 'should render a list with the provided options', () => {
 			const dropdown = mountDropdown();
-			expect(
-				dropdown.find( '.select-dropdown__options li.select-dropdown__label' ).text()
-			).to.eql( 'Statuses' );
+			expect( dropdown.find( '.select-dropdown__options li.select-dropdown__label' ).text() ).toBe(
+				'Statuses'
+			);
 			expect(
 				dropdown.find( '.select-dropdown__options li.select-dropdown__option' )
-			).to.have.lengthOf( 4 );
+			).toHaveLength( 4 );
 		} );
 
 		test( 'should render a separator in place of any falsy option', () => {
 			const dropdown = mountDropdown();
 			expect(
 				dropdown.find( '.select-dropdown__options li.select-dropdown__separator' )
-			).to.have.lengthOf( 1 );
+			).toHaveLength( 1 );
 		} );
 
 		test( 'should be initially closed', () => {
 			const dropdown = shallowRenderDropdown();
-			expect( dropdown.find( '.select-dropdown' ) ).to.have.lengthOf( 1 );
-			expect( dropdown.find( '.select-dropdown.is-open' ) ).to.be.empty;
+			expect( dropdown.find( '.select-dropdown' ) ).toHaveLength( 1 );
+			expect( dropdown.find( '.select-dropdown.is-open' ) ).toHaveLength( 0 );
 		} );
 
 		test( 'should execute toggleDropdown when clicked', () => {
@@ -58,20 +57,20 @@ describe( 'index', () => {
 				disabled: true,
 			} );
 
-			expect( dropdown.find( '.select-dropdown.is-disabled' ) ).to.have.lengthOf( 1 );
+			expect( dropdown.find( '.select-dropdown.is-disabled' ) ).toHaveLength( 1 );
 
 			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
 
 			sinon.assert.called( toggleDropdownSpy );
 
-			expect( dropdown.find( '.select-dropdown.is-open' ) ).to.be.empty;
+			expect( dropdown.find( '.select-dropdown.is-open' ) ).toHaveLength( 0 );
 
 			// Repeat to be sure
 			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
 
 			sinon.assert.called( toggleDropdownSpy );
 
-			expect( dropdown.find( '.select-dropdown.is-open' ) ).to.be.empty;
+			expect( dropdown.find( '.select-dropdown.is-open' ) ).toHaveLength( 0 );
 
 			toggleDropdownSpy.restore();
 		} );
@@ -91,18 +90,18 @@ describe( 'index', () => {
 		test( 'should return the initially selected value (if any)', () => {
 			const dropdown = shallowRenderDropdown( { initialSelected: 'drafts' } );
 			const initialSelectedValue = dropdown.instance().getInitialSelectedItem();
-			expect( initialSelectedValue ).to.equal( 'drafts' );
+			expect( initialSelectedValue ).toBe( 'drafts' );
 		} );
 
 		test( "should return `undefined`, when there aren't options", () => {
 			const dropdown = shallow( <SelectDropdown /> );
-			expect( dropdown.instance().getInitialSelectedItem() ).to.be.undefined;
+			expect( dropdown.instance().getInitialSelectedItem() ).toBeUndefined();
 		} );
 
 		test( "should return the first not-label option, when there isn't a preselected value", () => {
 			const dropdown = shallowRenderDropdown();
 			const initialSelectedValue = dropdown.instance().getInitialSelectedItem();
-			expect( initialSelectedValue ).to.equal( 'published' );
+			expect( initialSelectedValue ).toBe( 'published' );
 		} );
 	} );
 
@@ -110,13 +109,13 @@ describe( 'index', () => {
 		test( 'should return the initially selected text (if any)', () => {
 			const dropdown = shallowRenderDropdown( { selectedText: 'Drafts' } );
 			const initialSelectedText = dropdown.instance().getSelectedText();
-			expect( initialSelectedText ).to.equal( 'Drafts' );
+			expect( initialSelectedText ).toBe( 'Drafts' );
 		} );
 
 		test( 'should return the `label` associated to the selected option', () => {
 			const dropdown = shallowRenderDropdown();
 			const initialSelectedText = dropdown.instance().getSelectedText();
-			expect( initialSelectedText ).to.equal( 'Published' );
+			expect( initialSelectedText ).toBe( 'Published' );
 		} );
 
 		test( "should return the `label` associated to the initial selected option, when there isn't any selected option", () => {
@@ -133,7 +132,7 @@ describe( 'index', () => {
 			const initialSelectedText = dropdown.instance().getSelectedText();
 
 			sinon.assert.calledOnce( getInitialSelectedItemStub );
-			expect( initialSelectedText ).to.equal( 'Scheduled' );
+			expect( initialSelectedText ).toBe( 'Scheduled' );
 
 			getInitialSelectedItemStub.restore();
 		} );
@@ -252,7 +251,7 @@ describe( 'index', () => {
 			sinon.assert.calledOnce( setStateSpy );
 			sinon.assert.calledWith( setStateSpy, { isOpen: false } );
 
-			expect( fakeContext.focused ).to.be.undefined;
+			expect( fakeContext.focused ).toBeUndefined();
 		} );
 	} );
 

--- a/client/components/select-dropdown/test/item.js
+++ b/client/components/select-dropdown/test/item.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
@@ -20,27 +19,27 @@ describe( 'item', () => {
 	describe( 'component rendering', () => {
 		test( 'should render a list entry', () => {
 			const dropdownItem = shallow( <SelectDropdownItem>Published</SelectDropdownItem> );
-			expect( dropdownItem.is( 'li.select-dropdown__option' ) ).to.be.true;
+			expect( dropdownItem.is( 'li.select-dropdown__option' ) ).toBe( true );
 		} );
 
 		test( 'should contain a link', () => {
 			const dropdownItem = shallow( <SelectDropdownItem>Published</SelectDropdownItem> );
-			expect( dropdownItem.children( 'a.select-dropdown__item' ).length ).to.eql( 1 );
-			expect( dropdownItem.find( 'span.select-dropdown__item-text' ).text() ).to.eql( 'Published' );
+			expect( dropdownItem.children( 'a.select-dropdown__item' ).length ).toBe( 1 );
+			expect( dropdownItem.find( 'span.select-dropdown__item-text' ).text() ).toBe( 'Published' );
 		} );
 
 		test( 'should not have `tabindex` attribute, when the parent dropdown is closed', () => {
 			const dropdownItem = shallow(
 				<SelectDropdownItem isDropdownOpen={ false }>Published</SelectDropdownItem>
 			);
-			expect( dropdownItem.children( { tabIndex: 0 } ).length ).to.eql( 0 );
+			expect( dropdownItem.children( { tabIndex: 0 } ).length ).toBe( 0 );
 		} );
 
 		test( 'should have `tabindex` attribute set to `0`, only when the parent dropdown is open (issue#9206)', () => {
 			const dropdownItem = shallow(
 				<SelectDropdownItem isDropdownOpen={ true }>Published</SelectDropdownItem>
 			);
-			expect( dropdownItem.children( { tabIndex: 0 } ).length ).to.eql( 1 );
+			expect( dropdownItem.children( { tabIndex: 0 } ).length ).toBe( 1 );
 		} );
 	} );
 
@@ -54,7 +53,7 @@ describe( 'item', () => {
 			);
 
 			const link = dropdownItem.children( 'a.select-dropdown__item' );
-			expect( link.hasClass( 'is-disabled' ) ).to.be.true;
+			expect( link.hasClass( 'is-disabled' ) ).toBe( true );
 
 			link.simulate( 'click' );
 			sinon.assert.notCalled( onClickSpy );

--- a/client/components/seo/meta-title-editor/test/index.js
+++ b/client/components/seo/meta-title-editor/test/index.js
@@ -2,18 +2,13 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { nativeToRaw, rawToNative, fromApi, toApi } from '../mappings';
 
 describe( 'SEO', () => {
 	describe( 'Title Format Editor', () => {
 		describe( '#nativeToRaw', () => {
 			test( 'should produce empty formats', () => {
-				expect( nativeToRaw( [] ) ).to.eql( [] );
+				expect( nativeToRaw( [] ) ).toEqual( [] );
 			} );
 
 			test( 'should produce plain-text strings', () => {
@@ -23,7 +18,7 @@ describe( 'SEO', () => {
 						{ type: 'string', value: ' a ' },
 						{ type: 'string', value: 'string' },
 					] )
-				).to.eql( [ { type: 'string', value: 'just a string' } ] );
+				).toEqual( [ { type: 'string', value: 'just a string' } ] );
 			} );
 
 			test( 'should convert token formats', () => {
@@ -33,7 +28,7 @@ describe( 'SEO', () => {
 						{ type: 'string', value: ' | ' },
 						{ type: 'postTitle' },
 					] )
-				).to.eql( [
+				).toEqual( [
 					{ type: 'token', value: 'site_name' },
 					{ type: 'string', value: ' | ' },
 					{ type: 'token', value: 'post_title' },
@@ -43,11 +38,11 @@ describe( 'SEO', () => {
 
 		describe( '#rawToNative', () => {
 			test( 'should handle empty strings', () => {
-				expect( rawToNative( [] ) ).to.eql( [] );
+				expect( rawToNative( [] ) ).toEqual( [] );
 			} );
 
 			test( 'should handle plain strings', () => {
-				expect( rawToNative( [ { type: 'string', value: 'just a string' } ] ) ).to.eql( [
+				expect( rawToNative( [ { type: 'string', value: 'just a string' } ] ) ).toEqual( [
 					{ type: 'string', value: 'just a string' },
 				] );
 			} );
@@ -59,7 +54,7 @@ describe( 'SEO', () => {
 						{ type: 'string', value: ' | ' },
 						{ type: 'token', value: 'post_title' },
 					] )
-				).to.eql( [
+				).toEqual( [
 					{ type: 'siteName' },
 					{ type: 'string', value: ' | ' },
 					{ type: 'postTitle' },
@@ -69,7 +64,7 @@ describe( 'SEO', () => {
 
 		describe( '#fromApi', () => {
 			test( 'should produce empty formats', () => {
-				expect( fromApi( {} ) ).to.eql( {} );
+				expect( fromApi( {} ) ).toEqual( {} );
 			} );
 
 			test( 'should remap keys and values', () => {
@@ -85,7 +80,7 @@ describe( 'SEO', () => {
 							{ type: 'token', value: 'site_name' },
 						],
 					} )
-				).to.eql( {
+				).toEqual( {
 					frontPage: [ { type: 'siteName' }, { type: 'string', value: ' is awesome!' } ],
 					posts: [ { type: 'postTitle' }, { type: 'string', value: ' | ' }, { type: 'siteName' } ],
 				} );
@@ -94,7 +89,7 @@ describe( 'SEO', () => {
 
 		describe( '#toApi', () => {
 			test( 'should produce empty formats', () => {
-				expect( toApi( {} ) ).to.eql( {} );
+				expect( toApi( {} ) ).toEqual( {} );
 			} );
 
 			test( 'should remap keys and values', () => {
@@ -107,7 +102,7 @@ describe( 'SEO', () => {
 							{ type: 'siteName' },
 						],
 					} )
-				).to.eql( {
+				).toEqual( {
 					front_page: [
 						{ type: 'token', value: 'site_name' },
 						{ type: 'string', value: ' is awesome!' },

--- a/client/components/seo/meta-title-editor/test/index.js
+++ b/client/components/seo/meta-title-editor/test/index.js
@@ -1,6 +1,5 @@
-/** @format */
 /**
- * External dependencies
+ * Internal dependencies
  */
 import { nativeToRaw, rawToNative, fromApi, toApi } from '../mappings';
 

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -110,7 +110,7 @@ describe( 'index', () => {
 	} );
 
 	describe( 'getSelectedSite', () => {
-		xit( 'should return a site on the basis of the component `selectedSiteSlug` state property', function() {
+		it.skip( 'should return a site on the basis of the component `selectedSiteSlug` state property', function() {
 			const fakeState = {
 				selectedSiteId: 42,
 			};

--- a/client/components/sites-dropdown/test/index.js
+++ b/client/components/sites-dropdown/test/index.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import { noop } from 'lodash';
 import React from 'react';
@@ -23,8 +22,8 @@ describe( 'index', () => {
 	describe( 'component rendering', () => {
 		test( 'should render a dropdown component initially closed', () => {
 			const sitesDropdown = shallow( <SitesDropdown /> );
-			expect( sitesDropdown.hasClass( 'sites-dropdown' ) ).to.equal( true );
-			expect( sitesDropdown.hasClass( 'is-open' ) ).to.equal( false );
+			expect( sitesDropdown.hasClass( 'sites-dropdown' ) ).toBe( true );
+			expect( sitesDropdown.hasClass( 'is-open' ) ).toBe( false );
 		} );
 
 		test( 'with multiple sites, should toggle the dropdown when it is clicked', () => {
@@ -33,8 +32,8 @@ describe( 'index', () => {
 
 			sitesDropdown.find( '.sites-dropdown__selected' ).simulate( 'click' );
 			sinon.assert.calledOnce( toggleOpenSpy );
-			expect( sitesDropdown.hasClass( 'has-multiple-sites' ) ).to.equal( true );
-			expect( sitesDropdown.hasClass( 'is-open' ) ).to.equal( true );
+			expect( sitesDropdown.hasClass( 'has-multiple-sites' ) ).toBe( true );
+			expect( sitesDropdown.hasClass( 'is-open' ) ).toBe( true );
 
 			toggleOpenSpy.restore();
 		} );
@@ -45,8 +44,8 @@ describe( 'index', () => {
 
 			sitesDropdown.find( '.sites-dropdown__selected' ).simulate( 'click' );
 			sinon.assert.calledOnce( toggleOpenSpy );
-			expect( sitesDropdown.hasClass( 'has-multiple-sites' ) ).to.equal( false );
-			expect( sitesDropdown.hasClass( 'is-open' ) ).to.equal( false );
+			expect( sitesDropdown.hasClass( 'has-multiple-sites' ) ).toBe( false );
+			expect( sitesDropdown.hasClass( 'is-open' ) ).toBe( false );
 
 			toggleOpenSpy.restore();
 		} );
@@ -55,7 +54,7 @@ describe( 'index', () => {
 	describe( 'component state', () => {
 		test( 'should initially consider as selected the selectedOrPrimarySiteId prop', () => {
 			const sitesDropdown = shallow( <SitesDropdown selectedSiteId={ 1234567 } /> );
-			expect( sitesDropdown.instance().state.selectedSiteId ).to.be.equal( 1234567 );
+			expect( sitesDropdown.instance().state.selectedSiteId ).toBe( 1234567 );
 		} );
 	} );
 
@@ -116,7 +115,7 @@ describe( 'index', () => {
 				selectedSiteId: 42,
 			};
 			const selectedSite = SitesDropdown.prototype.getSelectedSite.call( { state: fakeState } );
-			expect( selectedSite ).to.be.eql( {
+			expect( selectedSite ).toEqual( {
 				ID: 42,
 				slug: 'foo.wordpress.com',
 			} );

--- a/client/components/support-info/test/index.js
+++ b/client/components/support-info/test/index.js
@@ -7,7 +7,6 @@
  * External dependencies
  */
 import React from 'react';
-import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
 /**
@@ -25,12 +24,10 @@ describe( 'SupportInfo', () => {
 	const wrapper = shallow( <SupportInfo { ...testProps } /> ).dive();
 
 	it( 'should have a proper "Learn more" link', () => {
-		expect( wrapper.find( 'ExternalLink' ).get( 0 ).props.href ).to.be.equal( 'https://foo.com/' );
+		expect( wrapper.find( 'ExternalLink' ).get( 0 ).props.href ).toBe( 'https://foo.com/' );
 	} );
 
 	it( 'should have a proper "Privacy Information" link', () => {
-		expect( wrapper.find( 'ExternalLink' ).get( 1 ).props.href ).to.be.equal(
-			'https://foo.com/privacy/'
-		);
+		expect( wrapper.find( 'ExternalLink' ).get( 1 ).props.href ).toBe( 'https://foo.com/privacy/' );
 	} );
 } );

--- a/client/components/tinymce/plugins/contact-form/test/validations.js
+++ b/client/components/tinymce/plugins/contact-form/test/validations.js
@@ -1,7 +1,5 @@
-/** @format */
-
 /**
- * External dependencies
+ * Internal dependencies
  */
 import { validateFormFields, validateSettingsToEmail } from '../dialog/validations';
 

--- a/client/components/tinymce/plugins/contact-form/test/validations.js
+++ b/client/components/tinymce/plugins/contact-form/test/validations.js
@@ -3,17 +3,12 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { validateFormFields, validateSettingsToEmail } from '../dialog/validations';
 
 describe( 'contact form validations', () => {
 	describe( '#validateFormFields()', () => {
 		test( 'should fail on an empty form', () => {
-			expect( validateFormFields( [] ) ).to.be.false;
+			expect( validateFormFields( [] ) ).toBe( false );
 		} );
 
 		test( 'should accept a single valid field', () => {
@@ -24,7 +19,7 @@ describe( 'contact form validations', () => {
 						label: 'something',
 					},
 				] )
-			).to.be.true;
+			).toBe( true );
 		} );
 
 		test( 'should fail on a single invalid field', () => {
@@ -35,7 +30,7 @@ describe( 'contact form validations', () => {
 						label: '',
 					},
 				] )
-			).to.be.false;
+			).toBe( false );
 		} );
 
 		test( 'should require a label in every field', () => {
@@ -54,7 +49,7 @@ describe( 'contact form validations', () => {
 						label: '',
 					},
 				] )
-			).to.be.false;
+			).toBe( false );
 		} );
 
 		test( 'should fail if a radio does not have options', () => {
@@ -65,7 +60,7 @@ describe( 'contact form validations', () => {
 						label: 'a',
 					},
 				] )
-			).to.be.false;
+			).toBe( false );
 		} );
 
 		test( 'should fail if a select does not have options', () => {
@@ -76,7 +71,7 @@ describe( 'contact form validations', () => {
 						label: 'a',
 					},
 				] )
-			).to.be.false;
+			).toBe( false );
 		} );
 
 		test( 'should accept a complex form', () => {
@@ -106,34 +101,35 @@ describe( 'contact form validations', () => {
 						options: 'x,y,z',
 					},
 				] )
-			).to.be.true;
+			).toBe( true );
 		} );
 	} );
 
 	describe( '#validateSettingsToEmail()', () => {
 		test( 'should validate a single e-mail', () => {
-			expect( validateSettingsToEmail( 'something@example.com' ) ).to.be.true;
+			expect( validateSettingsToEmail( 'something@example.com' ) ).toBe( true );
 		} );
 
 		test( 'should accept an empty string', () => {
-			expect( validateSettingsToEmail( '' ) ).to.be.true;
+			expect( validateSettingsToEmail( '' ) ).toBe( true );
 		} );
 
 		test( 'should fail on invalid e-mail', () => {
-			expect( validateSettingsToEmail( 'hocus_pocus' ) ).to.be.false;
+			expect( validateSettingsToEmail( 'hocus_pocus' ) ).toBe( false );
 		} );
 
 		test( 'should validate multiple comma-separated e-mails', () => {
-			expect( validateSettingsToEmail( 'something@example.com,another@example.com' ) ).to.be.true;
+			expect( validateSettingsToEmail( 'something@example.com,another@example.com' ) ).toBe( true );
 		} );
 
 		test( 'should ignore trailing and leading whitespace', () => {
-			expect( validateSettingsToEmail( '  something@example.com ,  another@example.com  ' ) ).to.be
-				.true;
+			expect( validateSettingsToEmail( '  something@example.com ,  another@example.com  ' ) ).toBe(
+				true
+			);
 		} );
 
 		test( 'should fail if one e-mail is invalid', () => {
-			expect( validateSettingsToEmail( 'something@example.com, hocus_pocus' ) ).to.be.false;
+			expect( validateSettingsToEmail( 'something@example.com, hocus_pocus' ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/components/tinymce/plugins/media/restrict-size/test/index.js
+++ b/client/components/tinymce/plugins/media/restrict-size/test/index.js
@@ -6,8 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
 describe( 'restrictSize', () => {
 	let getMaxWidth, resetImages, setImages;
 
@@ -33,19 +31,19 @@ describe( 'restrictSize', () => {
 		test( 'should return the multiple of the root device ratio if available', () => {
 			window.devicePixelRatio = 1.5;
 
-			expect( getMaxWidth() ).to.equal( 1020 );
+			expect( getMaxWidth() ).toBe( 1020 );
 		} );
 
 		test( 'should return twice the base if the device resolution matches the retina media query', () => {
 			window.devicePixelRatio = undefined;
 			window.matchMedia = () => ( { matches: true } );
 
-			expect( getMaxWidth() ).to.equal( 1360 );
+			expect( getMaxWidth() ).toBe( 1360 );
 		} );
 
 		test( 'should return the base max width if the device is not retina-capable', () => {
 			window.devicePixelRatio = undefined;
-			expect( getMaxWidth() ).to.equal( 680 );
+			expect( getMaxWidth() ).toBe( 680 );
 		} );
 	} );
 
@@ -54,7 +52,7 @@ describe( 'restrictSize', () => {
 			const value = resetImages(
 				'<p><img src="https://wordpress.com/2015/11/forest.jpg?w=680" data-wpmedia-src="https://wordpress.com/2015/11/forest.jpg?w=1024" class="alignnone size-large wp-image-5823" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>'
 			);
-			expect( value ).to.equal(
+			expect( value ).toBe(
 				'<p><img src="https://wordpress.com/2015/11/forest.jpg?w=1024" class="alignnone size-large wp-image-5823" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>'
 			);
 		} );
@@ -63,7 +61,7 @@ describe( 'restrictSize', () => {
 			const value = resetImages(
 				'<p><img src="https://example.com/bird.jpg?w=680" data-wpmedia-src="https://example.com/bird.jpg"><img src="https://example.com/forest.jpg?w=680" data-wpmedia-src="https://example.com/forest.jpg"></p>'
 			);
-			expect( value ).to.equal(
+			expect( value ).toBe(
 				'<p><img src="https://example.com/bird.jpg"><img src="https://example.com/forest.jpg"></p>'
 			);
 		} );
@@ -72,7 +70,7 @@ describe( 'restrictSize', () => {
 			const value = resetImages(
 				'<p><img src="https://example.com/bird.jpg?w=300"><img src="https://example.com/forest.jpg?w=680" data-wpmedia-src="https://example.com/forest.jpg"></p>'
 			);
-			expect( value ).to.equal(
+			expect( value ).toBe(
 				'<p><img src="https://example.com/bird.jpg?w=300"><img src="https://example.com/forest.jpg"></p>'
 			);
 		} );
@@ -83,7 +81,7 @@ describe( 'restrictSize', () => {
 			const value = setImages(
 				'<p><img src="https://wordpress.com/2015/11/forest.jpg?w=1024" class="alignnone size-large wp-image-5823" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>'
 			);
-			expect( value ).to.equal(
+			expect( value ).toBe(
 				'<p><img src="https://wordpress.com/2015/11/forest.jpg?w=680" data-wpmedia-src="https://wordpress.com/2015/11/forest.jpg?w=1024" class="alignnone size-large wp-image-5823" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>'
 			);
 		} );
@@ -92,7 +90,7 @@ describe( 'restrictSize', () => {
 			const value = setImages(
 				'<p><img class="alignnone size-large wp-image-5823" src="https://wordpress.com/2015/11/forest.jpg?w=680" data-wpmedia-src="https://wordpress.com/2015/11/forest.jpg?w=1024" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>'
 			);
-			expect( value ).to.equal(
+			expect( value ).toBe(
 				'<p><img class="alignnone size-large wp-image-5823" src="https://wordpress.com/2015/11/forest.jpg?w=680" data-wpmedia-src="https://wordpress.com/2015/11/forest.jpg?w=1024" alt="forest" width="1024" height="683" data-mce-src="https://wordpress.com/2015/11/forest.jpg?w=680" data-mce-selected="1"></p>'
 			);
 		} );
@@ -101,7 +99,7 @@ describe( 'restrictSize', () => {
 			const value = setImages(
 				'<p><img src="https://wordpress.com/2015/11/forest.jpg" alt="forest" class="alignnone size-thumbnail wp-image-5823" data-mce-selected="1"></p>'
 			);
-			expect( value ).to.equal(
+			expect( value ).toBe(
 				'<p><img src="https://wordpress.com/2015/11/forest.jpg?w=680" data-wpmedia-src="https://wordpress.com/2015/11/forest.jpg" alt="forest" class="alignnone size-thumbnail wp-image-5823" data-mce-selected="1"></p>'
 			);
 		} );
@@ -111,7 +109,7 @@ describe( 'restrictSize', () => {
 				'<p><img src="https://wordpress.com/2015/11/forest.jpg" alt="forest" class="alignnone size-thumbnail"></p>';
 
 			const value = setImages( markup );
-			expect( value ).to.equal( markup );
+			expect( value ).toBe( markup );
 		} );
 	} );
 } );

--- a/client/components/tinymce/plugins/wpcom-sourcecode/test/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/test/plugin.js
@@ -2,11 +2,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
-
-/**
- * Internal dependencies
- */
 import { wrapPre, unwrapPre } from '../plugin';
 
 jest.mock( 'tinymce/tinymce', () => ( {} ) );
@@ -18,7 +13,7 @@ describe( 'wpcom-sourcecode', () => {
 				content: '[code lang="javascript"]const noop = () => {};[/code]',
 			} );
 
-			expect( wrapped ).to.equal(
+			expect( wrapped ).toBe(
 				'<pre>[code lang="javascript"]const noop = () =&gt; {};[/code]</pre>'
 			);
 		} );
@@ -29,7 +24,7 @@ describe( 'wpcom-sourcecode', () => {
 				initial: true,
 			} );
 
-			expect( wrapped ).to.equal(
+			expect( wrapped ).toBe(
 				'<pre>[code lang="javascript"]const noop = () =&gt; {};[/code]</pre>'
 			);
 		} );
@@ -41,7 +36,7 @@ describe( 'wpcom-sourcecode', () => {
 				load: true,
 			} );
 
-			expect( wrapped ).to.equal(
+			expect( wrapped ).toBe(
 				'<pre>[code lang="javascript"]const noop = () =&gt; {};[/code]</pre>'
 			);
 		} );
@@ -51,7 +46,7 @@ describe( 'wpcom-sourcecode', () => {
 				content: '[sourcecode lang="javascript"]const noop = () => {};[/sourcecode]',
 			} );
 
-			expect( wrapped ).to.equal(
+			expect( wrapped ).toBe(
 				'<pre>[sourcecode lang="javascript"]const noop = () =&gt; {};[/sourcecode]</pre>'
 			);
 		} );
@@ -63,9 +58,7 @@ describe( 'wpcom-sourcecode', () => {
 				content: '<pre>[code lang="javascript"]const noop = () =&gt; {};[/code]</pre>',
 			} );
 
-			expect( unwrapped ).to.equal(
-				'<p>[code lang="javascript"]const noop = () => {};[/code]</p>'
-			);
+			expect( unwrapped ).toBe( '<p>[code lang="javascript"]const noop = () => {};[/code]</p>' );
 		} );
 
 		test( 'should unwrap a sourcecode shortcode', () => {
@@ -73,7 +66,7 @@ describe( 'wpcom-sourcecode', () => {
 				content: '<pre>[sourcecode lang="javascript"]const noop = () =&gt; {};[/sourcecode]</pre>',
 			} );
 
-			expect( unwrapped ).to.equal(
+			expect( unwrapped ).toBe(
 				'<p>[sourcecode lang="javascript"]const noop = () => {};[/sourcecode]</p>'
 			);
 		} );
@@ -84,7 +77,7 @@ describe( 'wpcom-sourcecode', () => {
 					'<p>foo</p><p><pre>[sourcecode lang="javascript"]const noop = () =&gt; {};[/sourcecode]</pre></p><p>bar</p>',
 			} );
 
-			expect( unwrapped ).to.equal(
+			expect( unwrapped ).toBe(
 				'<p>foo</p><p>[sourcecode lang="javascript"]const noop = () => {};[/sourcecode]</p><p>bar</p>'
 			);
 		} );

--- a/client/components/tinymce/plugins/wpcom-sourcecode/test/plugin.js
+++ b/client/components/tinymce/plugins/wpcom-sourcecode/test/plugin.js
@@ -1,6 +1,5 @@
-/** @format */
 /**
- * External dependencies
+ * Internal dependencies
  */
 import { wrapPre, unwrapPre } from '../plugin';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Tests: Run [jest-codemods](https://github.com/skovhus/jest-codemods) on client/components

To replace `chai`'s `expect` with `jest'`s own.

#### Testing instructions

```
npm run test-client client/components/
```
