### PR TITLE
Extracting analytics to a package

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -45,9 +45,7 @@ import {
 	recordAddToCart,
 	recordOrder,
 } from 'lib/analytics/ad-tracking';
-
 import { updateQueryParamsTracking } from 'lib/analytics/sem';
-
 import { statsdTimingUrl } from 'lib/analytics/statsd';
 
 /**


### PR DESCRIPTION
Analytics currently depends on some other parts of Calypso
- config
- lib/mixins/emitter
- state/action-types

The ad-tracking section also depends on:
- lib/products-values
- lib/user
- client/utils

The page-view-tracker uses:
- lib/route
- state/analytics/actions
- state/utils
- state/ui/selectors
- state/sites/selectors

With tracking tool and Track component view use:
- state/analytics/actions



#### Changes proposed in this Pull Request

*

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
