### PR TITLE
Marketing: add missing path property to Tracks events

### DIFF
--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -23,6 +23,7 @@ import JetpackModuleToggle from 'my-sites/site-settings/jetpack-module-toggle';
 import QueryJetpackModules from 'components/data/query-jetpack-modules';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import SettingsSectionHeader from 'my-sites/site-settings/settings-section-header';
+import getCurrentRouteParameterized from 'state/selectors/get-current-route-parameterized';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import { isJetpackSite } from 'state/sites/selectors';
@@ -205,7 +206,7 @@ class SiteVerification extends Component {
 	}
 
 	handleFormSubmit = event => {
-		const { siteId, translate, trackSiteVerificationUpdated } = this.props;
+		const { path, siteId, translate, trackSiteVerificationUpdated } = this.props;
 		const { dirtyFields } = this.state;
 
 		if ( ! event.isDefaultPrevented() && event.nativeEvent ) {
@@ -241,22 +242,22 @@ class SiteVerification extends Component {
 		};
 
 		this.props.saveSiteSettings( siteId, updatedOptions );
-		this.props.trackFormSubmitted();
+		this.props.trackFormSubmitted( { path } );
 
 		if ( dirtyFields.has( 'googleCode' ) ) {
-			trackSiteVerificationUpdated( 'google' );
+			trackSiteVerificationUpdated( 'google', path );
 		}
 
 		if ( dirtyFields.has( 'bingCode' ) ) {
-			trackSiteVerificationUpdated( 'bing' );
+			trackSiteVerificationUpdated( 'bing', path );
 		}
 
 		if ( dirtyFields.has( 'pinterestCode' ) ) {
-			trackSiteVerificationUpdated( 'pinterest' );
+			trackSiteVerificationUpdated( 'pinterest', path );
 		}
 
 		if ( dirtyFields.has( 'yandexCode' ) ) {
-			trackSiteVerificationUpdated( 'yandex' );
+			trackSiteVerificationUpdated( 'yandex', path );
 		}
 	};
 
@@ -441,15 +442,17 @@ export default connect(
 			site,
 			siteId,
 			siteIsJetpack: isJetpackSite( state, siteId ),
+			path: getCurrentRouteParameterized( state, siteId ),
 		};
 	},
 	{
 		requestSite,
 		requestSiteSettings,
 		saveSiteSettings,
-		trackSiteVerificationUpdated: service =>
+		trackSiteVerificationUpdated: ( service, path ) =>
 			recordTracksEvent( 'calypso_seo_tools_site_verification_updated', {
 				service,
+				path,
 			} ),
 		trackFormSubmitted: partial( recordTracksEvent, 'calypso_seo_settings_form_submit' ),
 	},

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -114,7 +114,7 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 
 		// Some Utils
 		handleSubmitForm = event => {
-			const { dirtyFields, fields, trackTracksEvent } = this.props;
+			const { dirtyFields, fields, trackTracksEvent, path } = this.props;
 
 			if ( ! event.isDefaultPrevented() && event.nativeEvent ) {
 				event.preventDefault();
@@ -123,18 +123,19 @@ const wrapSettingsForm = getFormSettings => SettingsForm => {
 			dirtyFields.map( function( value ) {
 				switch ( value ) {
 					case 'blogdescription':
-						trackTracksEvent( 'calypso_settings_site_tagline_updated' );
+						trackTracksEvent( 'calypso_settings_site_tagline_updated', { path } );
 						break;
 					case 'blogname':
-						trackTracksEvent( 'calypso_settings_site_title_updated' );
+						trackTracksEvent( 'calypso_settings_site_title_updated', { path } );
 						break;
 					case 'blog_public':
 						trackTracksEvent( 'calypso_settings_site_privacy_updated', {
 							privacy: fields.blog_public,
+							path,
 						} );
 						break;
 					case 'wga':
-						trackTracksEvent( 'calypso_seo_settings_google_analytics_updated' );
+						trackTracksEvent( 'calypso_seo_settings_google_analytics_updated', { path } );
 						break;
 				}
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This adds a missing path property to some Tracks events, which causes the blogid to be correctly logged by the Tracks framework.

#### Testing instructions

1. Checkout the branch and `npm run start`.
2. Ensure that analytics debugging is activated by running this in the browser console and then refreshing the page: `localStorage.setItem('debug', 'calypso:analytics:*');`
3. On an atomic site visit `marketing/traffic/:site`.
4. Change the Google Analytics tracking ID and click save. Verify that it fired a Tracks event with the correct `path` prop.
5. Paste something into each of the site verification services and click save. Verify that each service fired a Tracks event with the correct `path` prop.
6. On an atomic site visit `/settings/general/:site`.
7. Change the title and the tagline and click save. Verify that each change has a Tracks event with the correct `path` prop.
8. Change the privacy of the site and click save. Verify that it fired a Tracks event with the correct `path` prop.

