### PR TITLE
Onboarding: Show preview for "Professional" segment

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -101,6 +101,21 @@ export function generateFlows( {
 		},
 
 		onboarding: {
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'domains-with-preview',
+				'plans',
+			],
+			destination: getChecklistDestination,
+			description: 'The improved onboarding flow.',
+			lastModified: '2019-04-30',
+		},
+
+		// We don't yet show the previews for the 'blog' segment
+		'onboarding-blog': {
 			steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains', 'plans' ],
 			destination: getChecklistDestination,
 			description: 'The improved onboarding flow.',

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -15,6 +15,12 @@ import StepWrapper from 'signup/step-wrapper';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 
+const siteTypeToFlowname = {
+	'online-store': 'ecommerce-onboarding',
+	business: 'onboarding-for-business',
+	blog: 'onboarding-blog',
+};
+
 class SiteType extends Component {
 	componentDidMount() {
 		SignupActions.saveSignupStep( {
@@ -67,15 +73,8 @@ export default connect(
 		submitStep: siteTypeValue => {
 			dispatch( submitSiteType( siteTypeValue ) );
 
-			if ( 'online-store' === siteTypeValue ) {
-				flowName = 'ecommerce-onboarding';
-			}
-
-			if ( 'business' === siteTypeValue ) {
-				flowName = 'onboarding-for-business';
-			}
-
-			goToNextStep( flowName );
+			// Modify the flowname if the site type matches an override.
+			goToNextStep( siteTypeToFlowname[ siteTypeValue ] || flowName );
 		},
 	} )
 )( localize( SiteType ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables the site preview for the professional segment, leaving only the blog segment without the preview. 

It does so by:
- Adding a new (temporary) flow 'onboarding-blog'
- Updating the regular 'onboarding' flow to show the preview
- Diverting to the new flow when the blog segment is selected

I also slightly tweaked how we get the `flowName` we want to divert to.

We're currently blocked on enabling the preview for the blog segment. Once we're unblocked we can do away with the new temporary flow, and remove all of the `-with-preview` suffixes. Details on the blocking block™️  at paAmJe-ml-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start at http://calypso.localhost:3000/start/onboarding
- Select the professional option
- Select one of the given verticals (or type a topic)
  - You should see the site preview appear with content relevant to that vertical.
- Go back to the start of this flow and go through the other segments
  - Each should work as expected - we see a preview for all but the blog segment.

Fixes https://github.com/Automattic/zelda-private/issues/9