### PR TITLE
Sidebar: Removes import-in-sidebar feature flag

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -478,9 +478,7 @@ export class MySitesSidebar extends Component {
 			<SidebarItem
 				label={ this.props.translate( 'Settings' ) }
 				selected={
-					itemLinkMatches( '/settings', path ) &&
-					( ! isEnabled( 'manage/import-in-sidebar' ) ||
-						! itemLinkMatches( '/settings/import', path ) )
+					itemLinkMatches( '/settings', path ) && ! itemLinkMatches( '/settings/import', path )
 				}
 				link={ siteSettingsLink }
 				onNavigate={ this.trackSettingsClick }

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -60,7 +60,6 @@ class ToolsMenu extends PureComponent {
 			label: translate( 'Import' ),
 			capability: 'manage_options',
 			queryable: ! isJetpack,
-			config: 'manage/import-in-sidebar',
 			link: '/settings/import', // @TODO make it a top level section & add a redirect
 			paths: [ '/settings/import' ],
 			wpAdminLink: 'import.php',
@@ -121,9 +120,7 @@ class ToolsMenu extends PureComponent {
 			menuItems.push( this.getPluginItem() );
 		}
 
-		if ( config.isEnabled( 'manage/import-in-sidebar' ) ) {
-			menuItems.push( this.getImportItem() );
-		}
+		menuItems.push( this.getImportItem() );
 
 		return <ul>{ menuItems.map( this.renderMenuItem, this ) }</ul>;
 	}

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -51,7 +51,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/import-in-sidebar": true,
 		"manage/pages": true,
 		"manage/plan-features": false,
 		"manage/plugins": true,

--- a/config/development.json
+++ b/config/development.json
@@ -95,7 +95,6 @@
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/import-in-sidebar": true,
 		"manage/import-to-jetpack": true,
 		"manage/import/site-importer-endpoints": true,
 		"manage/pages": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -57,7 +57,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/import-in-sidebar": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,

--- a/config/production.json
+++ b/config/production.json
@@ -58,7 +58,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/import-in-sidebar": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -61,7 +61,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/import-in-sidebar": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -73,7 +73,6 @@
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/import-in-sidebar": true,
 		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the import-in-sidebar feature flag, which was true for all environments.

#### Testing instructions

* Import section appears in the Calypso sidebar (under Tools)
* Import section loads without error
* Import section is highlighted in the sidebar when loaded
* Settings section (under Manage) is not highlighted when import section is loaded

The is preparatory work for moving Import and Export out of the settings section: https://github.com/Automattic/wp-calypso/pull/33181.
