### PR TITLE
Priority support card - place the icon on the left.

### DIFF
--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -128,8 +128,10 @@ export class HappinessSupport extends Component {
 
 	renderIllustration() {
 		return (
-			<div className="happiness-support__illustration">
-				<img alt="" src="/calypso/images/illustrations/dotcom-support.svg" />
+			<div className="happiness-support__image">
+				<div className="happiness-support__icon">
+					<img alt="" src="/calypso/images/illustrations/dotcom-support.svg" />
+				</div>
 			</div>
 		);
 	}
@@ -164,11 +166,11 @@ export class HappinessSupport extends Component {
 			<div className={ classNames( 'happiness-support', classes ) }>
 				{ this.renderIllustration() }
 
-				<h3 className="happiness-support__heading">{ this.getHeadingText() }</h3>
-
-				<p className="happiness-support__text">{ this.getSupportText() }</p>
-
-				{ this.getSupportButtons() }
+				<div className="happiness-support__text">
+					<h3 className="happiness-support__heading">{ this.getHeadingText() }</h3>
+					<p className="happiness-support__description">{ this.getSupportText() }</p>
+					{ this.getSupportButtons() }
+				</div>
 			</div>
 		);
 	}

--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -1,3 +1,11 @@
+.happiness-support {
+	display: flex;
+
+	@include breakpoint( '<660px' ) {
+		flex-wrap: wrap;
+	}
+}
+
 .happiness-support.is-placeholder {
 	.happiness-support__heading,
 	.happiness-support__text {
@@ -12,7 +20,7 @@
 		width: 82%;
 	}
 
-	.happiness-support__illustration {
+	.happiness-support__image {
 		display: none;
 	}
 
@@ -29,39 +37,40 @@
 	font-size: 21px;
 }
 
-.happiness-support__text {
+.happiness-support__description {
 	color: var( --color-text-subtle );
 	margin-bottom: 16px;
 	margin-top: 16px;
 }
 
-.happiness-support__illustration {
-	float: right;
-	width: 150px;
-	margin-left: 30px;
-	text-align: center;
+.happiness-support__image {
+	flex-shrink: 0;
+	margin: 0 auto;
+	width: 128px;
 
-	@include breakpoint( '<660px' ) {
-		width: 68px;
+	@include breakpoint( '>660px' ) {
+		width: 178px;
+	}
+}
+
+.happiness-support__icon {
+	margin-bottom: 20px;
+
+	@include breakpoint( '>660px' ) {
+		width: 150px;
+		margin: 0 auto;
 	}
 }
 
 .happiness-support__buttons {
-	clear: both;
-
-	@include breakpoint( '<660px' ) {
-		margin-top: 6px;
-		text-align: center;
-	}
+	width: 100%;
 
 	.button {
 		@include breakpoint( '<660px' ) {
-			margin-top: 10px;
 			width: 80%;
 		}
 
 		@include breakpoint( '>660px' ) {
-			margin-top: 10px;
 
 			&:first-of-type {
 				margin-right: 16px;
@@ -72,5 +81,9 @@
 	.happiness-support__support-button {
 		padding-bottom: 11px;
 		padding-top: 2px;
+
+		@include breakpoint( '<660px' ) {
+			margin-top: 16px;
+		}
 	}
 }

--- a/client/components/happiness-support/style.scss
+++ b/client/components/happiness-support/style.scss
@@ -74,6 +74,7 @@
 
 			&:first-of-type {
 				margin-right: 16px;
+				margin-bottom: 6px;
 			}
 		}
 	}

--- a/client/components/happiness-support/test/index.jsx
+++ b/client/components/happiness-support/test/index.jsx
@@ -36,7 +36,7 @@ describe( 'HappinessSupport', () => {
 	} );
 
 	test( 'should render translated help content', () => {
-		const content = wrapper.find( 'p.happiness-support__text' );
+		const content = wrapper.find( 'p.happiness-support__description' );
 		expect( content ).to.have.length( 1 );
 		expect( content.props().children ).to.equal(
 			'Translated: {{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your account.'

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -192,12 +192,12 @@
 
 // Footer Subcomponent styles
 .checkout-thank-you__footer {
-	font-size: 16px;
 	padding: 32px 20px;
-	text-align: left;
 
 	@include breakpoint( '>660px' ) {
+		font-size: 16px;
 		padding: 60px 24px;
+		text-align: left;
 	}
 
 	.happiness-support {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* change markup of the "Priority support" card to facilitate implementing flexbox, and match to other feature cards on the plan page
* style adjustments for the post-upgrade/purchase "Thank you" page (make sure the support card content is centred)

#### Testing instructions
1. Navigate to https://wordpress.com/plans/my-plan/{site} (make sure the plan is Personal, or above)
2. Take a look at the "Priority support" card - make sure the placement of image, text, and spacing is the same as in other cards.
3. Test on mobile as well - image should be centred, while the text and buttons are left aligned.
4. Upgrade plan and verify the layout of the "Priority support" card matches other cards on both desktop and mobile.

#### Note
The icon color changes are in #33115. It alsoe changes the name of the support illustration to `dotcom-support.svg` -- this is already reflected in this PR, but should be merged only after #33115.

Desktop before:
![image](https://user-images.githubusercontent.com/4550351/58220927-197f2a80-7d54-11e9-80c6-55462e2e0f1c.png)

Desktop after:
![image](https://user-images.githubusercontent.com/4550351/58220937-269c1980-7d54-11e9-9d95-b3ea8c8a8537.png)


Mobile before:
![image](https://user-images.githubusercontent.com/4550351/58220876-ed63a980-7d53-11e9-9c47-280302f633e3.png)

Mobile after:
![image](https://user-images.githubusercontent.com/4550351/58220736-5dbdfb00-7d53-11e9-92ae-1b22cf344357.png)

Fixes #33006
