### PR TITLE
Jetpack Settings: Fix Downtime Monitoring Toggle activation

### DIFF
--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -31,9 +31,8 @@ export const items = createReducer(
 			...state,
 			[ siteId ]: checklist,
 		} ),
-		[ SITE_CHECKLIST_TASK_UPDATE ]: ( state, { siteId, taskId } ) => {
-			return markChecklistTaskComplete( state, { siteId, taskId } );
-		},
+		[ SITE_CHECKLIST_TASK_UPDATE ]: ( state, { siteId, taskId } ) =>
+			markChecklistTaskComplete( state, { siteId, taskId } ),
 		[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: ( state, { moduleSlug, siteId } ) => {
 			if ( moduleSlug === 'monitor' ) {
 				return markChecklistTaskComplete( state, { siteId, taskId: 'jetpack_monitor' } );

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -23,7 +23,7 @@ export const items = createReducer(
 			[ siteId ]: checklist,
 		} ),
 		[ SITE_CHECKLIST_TASK_UPDATE ]: ( state, { siteId, taskId } ) => {
-			const siteState = state[ siteId ];
+			const siteState = state[ siteId ] || {};
 			const tasks = { ...siteState.tasks, [ taskId ]: true };
 			return {
 				...state,
@@ -32,7 +32,7 @@ export const items = createReducer(
 		},
 		[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: ( state, { moduleSlug, siteId } ) => {
 			if ( moduleSlug === 'monitor' ) {
-				const siteState = state[ siteId ];
+				const siteState = state[ siteId ] || {};
 				const tasks = { ...siteState.tasks, jetpack_monitor: true };
 				return {
 					...state,

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -15,6 +15,15 @@ export const isLoading = createReducer( false, {
 	[ SITE_CHECKLIST_RECEIVE ]: () => false,
 } );
 
+function markChecklistTaskComplete( state, { siteId, taskId } ) {
+	const siteState = state[ siteId ] || {};
+	const tasks = { ...siteState.tasks, [ taskId ]: true };
+	return {
+		...state,
+		[ siteId ]: { ...siteState, tasks },
+	};
+}
+
 export const items = createReducer(
 	{},
 	{
@@ -23,21 +32,11 @@ export const items = createReducer(
 			[ siteId ]: checklist,
 		} ),
 		[ SITE_CHECKLIST_TASK_UPDATE ]: ( state, { siteId, taskId } ) => {
-			const siteState = state[ siteId ] || {};
-			const tasks = { ...siteState.tasks, [ taskId ]: true };
-			return {
-				...state,
-				[ siteId ]: { ...siteState, tasks },
-			};
+			return markChecklistTaskComplete( state, { siteId, taskId } );
 		},
 		[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: ( state, { moduleSlug, siteId } ) => {
 			if ( moduleSlug === 'monitor' ) {
-				const siteState = state[ siteId ] || {};
-				const tasks = { ...siteState.tasks, jetpack_monitor: true };
-				return {
-					...state,
-					[ siteId ]: { ...siteState, tasks },
-				};
+				return markChecklistTaskComplete( state, { siteId, taskId: 'jetpack_monitor' } );
 			}
 			return state;
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Jetpack Settings: Fix Downtime Monitoring Toggle activation

#### Testing instructions

- In your browser's dev toolbar, navigate to the 'Application' tab. Select IndexedDB > calypso > calypso_store, right click to 'Clear'.
- Reload the page. Check the 'Redux' tab in your dev toolbar: Select the very last action in the log, and inspect its state. Verify that `checklist.items` is empty.
- For a Jetpack site of your choice, go to `http://calypso.localhost:3000/settings/security/:site`
- Enable the 'Jetpack Monitoring' toggle. (If it's currently enabled, disable first, then re-enable).
- Verify that there are no errors.
- Reload to verify that the module activation state persists

Fixes #33237

#### Follow-up

I'll file a follow-up PR to use `keyedReducer` here, which is a natural fit for this issue.