### PR TITLE
Jetpack Checklist: Turn Reducer into keyedReducer

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
@@ -127,7 +127,7 @@ const mapStateToProps = state => {
 	return {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
-		isLoading: getSiteChecklistIsLoading( state ),
+		isLoading: getSiteChecklistIsLoading( state, siteId ),
 	};
 };
 

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer } from 'state/utils';
 import {
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	SITE_CHECKLIST_RECEIVE,
@@ -20,26 +20,26 @@ function isLoading( state = false, { type } ) {
 	return state;
 }
 
-const markChecklistTaskComplete = ( state, { taskId } ) => ( {
+const markChecklistTaskComplete = ( state, taskId ) => ( {
 	...state,
 	tasks: { ...state.tasks, [ taskId ]: true },
 } );
 
-export const items = createReducer(
-	{},
-	{
-		[ SITE_CHECKLIST_RECEIVE ]: ( state, { checklist } ) => checklist,
-		[ SITE_CHECKLIST_TASK_UPDATE ]: ( state, { taskId } ) =>
-			markChecklistTaskComplete( state, { taskId } ),
-		[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: ( state, { moduleSlug } ) => {
-			if ( moduleSlug === 'monitor' ) {
-				return markChecklistTaskComplete( state, { taskId: 'jetpack_monitor' } );
+function items( state = {}, action ) {
+	switch ( action.type ) {
+		case SITE_CHECKLIST_RECEIVE:
+			return action.checklist;
+		case SITE_CHECKLIST_TASK_UPDATE:
+			return markChecklistTaskComplete( state, action.taskId );
+		case JETPACK_MODULE_ACTIVATE_SUCCESS:
+			if ( action.moduleSlug === 'monitor' ) {
+				return markChecklistTaskComplete( state, 'jetpack_monitor' );
 			}
-			return state;
-		},
-	},
-	itemSchemas
-);
+			break;
+	}
+	return state;
+}
+items.schema = itemSchemas;
 
 const reducer = combineReducers( {
 	items,

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -10,10 +10,15 @@ import {
 } from 'state/action-types';
 import { items as itemSchemas } from './schema';
 
-export const isLoading = createReducer( false, {
-	[ SITE_CHECKLIST_REQUEST ]: () => true,
-	[ SITE_CHECKLIST_RECEIVE ]: () => false,
-} );
+function isLoading( state = false, { type } ) {
+	switch ( type ) {
+		case SITE_CHECKLIST_REQUEST:
+			return true;
+		case SITE_CHECKLIST_RECEIVE:
+			return false;
+	}
+	return state;
+}
 
 const markChecklistTaskComplete = ( state, { taskId } ) => ( {
 	...state,

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, keyedReducer } from 'state/utils';
 import {
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	SITE_CHECKLIST_RECEIVE,
@@ -15,27 +15,20 @@ export const isLoading = createReducer( false, {
 	[ SITE_CHECKLIST_RECEIVE ]: () => false,
 } );
 
-function markChecklistTaskComplete( state, { siteId, taskId } ) {
-	const siteState = state[ siteId ] || {};
-	const tasks = { ...siteState.tasks, [ taskId ]: true };
-	return {
-		...state,
-		[ siteId ]: { ...siteState, tasks },
-	};
-}
+const markChecklistTaskComplete = ( state, { taskId } ) => ( {
+	...state,
+	tasks: { ...state.tasks, [ taskId ]: true },
+} );
 
 export const items = createReducer(
 	{},
 	{
-		[ SITE_CHECKLIST_RECEIVE ]: ( state, { siteId, checklist } ) => ( {
-			...state,
-			[ siteId ]: checklist,
-		} ),
-		[ SITE_CHECKLIST_TASK_UPDATE ]: ( state, { siteId, taskId } ) =>
-			markChecklistTaskComplete( state, { siteId, taskId } ),
-		[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: ( state, { moduleSlug, siteId } ) => {
+		[ SITE_CHECKLIST_RECEIVE ]: ( state, { checklist } ) => checklist,
+		[ SITE_CHECKLIST_TASK_UPDATE ]: ( state, { taskId } ) =>
+			markChecklistTaskComplete( state, { taskId } ),
+		[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: ( state, { moduleSlug } ) => {
 			if ( moduleSlug === 'monitor' ) {
-				return markChecklistTaskComplete( state, { siteId, taskId: 'jetpack_monitor' } );
+				return markChecklistTaskComplete( state, { taskId: 'jetpack_monitor' } );
 			}
 			return state;
 		},
@@ -43,7 +36,9 @@ export const items = createReducer(
 	itemSchemas
 );
 
-export default combineReducers( {
+const reducer = combineReducers( {
 	items,
 	isLoading,
 } );
+
+export default keyedReducer( 'siteId', reducer );

--- a/client/state/checklist/schema.js
+++ b/client/state/checklist/schema.js
@@ -1,11 +1,10 @@
-/** @format */
 export const items = {
 	type: 'object',
-	additionalProperties: false,
-	patternProperties: {
-		// Site Id
-		'^\\d+$': {
-			type: 'object',
-		},
+	additionalProperties: true,
+	properties: {
+		designType: { type: 'string' },
+		segment: { type: 'integer' },
+		tasks: { type: 'object' },
+		verticals: { type: 'array' },
 	},
 };

--- a/client/state/selectors/get-site-checklist-is-loading.js
+++ b/client/state/selectors/get-site-checklist-is-loading.js
@@ -10,8 +10,9 @@ import { get } from 'lodash';
  * Returns the loading state for the checklist API call
  *
  * @param  {Object}  state  Global state tree
+ * @param  {Number}  siteId Site ID
  * @return {Bool}    Whether the checklist is loading
  */
-export default function getSiteChecklistIsLoading( state ) {
-	return get( state.checklist, 'isLoading', false );
+export default function getSiteChecklistIsLoading( state, siteId ) {
+	return get( state.checklist, [ siteId, 'isLoading' ], false );
 }

--- a/client/state/selectors/get-site-checklist.js
+++ b/client/state/selectors/get-site-checklist.js
@@ -14,5 +14,5 @@ import { get } from 'lodash';
  * @return {Object}        Site settings
  */
 export default function getSiteChecklist( state, siteId ) {
-	return get( state.checklist.items, [ siteId ], null );
+	return get( state.checklist, [ siteId, 'items' ], null );
 }

--- a/client/state/selectors/test/get-site-checklist-is-loading.js
+++ b/client/state/selectors/test/get-site-checklist-is-loading.js
@@ -7,17 +7,19 @@ import getSiteChecklistIsLoading from 'state/selectors/get-site-checklist-is-loa
 
 describe( 'getSiteChecklistIsLoading()', () => {
 	test( 'should return `false` by default', () => {
-		const isLoading = getSiteChecklistIsLoading( {} );
+		const isLoading = getSiteChecklistIsLoading( {}, 1234567 );
 		expect( isLoading ).toEqual( false );
 	} );
 
 	test( 'should return isLoading value', () => {
 		const state = {
 			checklist: {
-				isLoading: true,
+				1234567: {
+					isLoading: true,
+				},
 			},
 		};
-		const isLoading = getSiteChecklistIsLoading( state );
+		const isLoading = getSiteChecklistIsLoading( state, 1234567 );
 		expect( isLoading ).toEqual( true );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Use `keyedReducer` to key by `siteId`. This allows us to rely on the `items`' reducer's default `state` arg (`{}`), and thus to remove the [manual `|| {}` fallback](https://github.com/Automattic/wp-calypso/compare/update/jetpack-checklist-keyed-reducer?expand=1#diff-0c8c68f71be23c8ded46a59c076439c1L19), and to simplify the reducer overall.

Consequently, we also need to change the schema, and the `getSiteChecklistIsLoading` selector to accept a `siteId` arg (which makes sense anyway).

Follow-up to #33246.

#### Testing instructions

- Verify that the checklist still works.
- Verify that all occurrences of `getSiteChecklistIsLoading` have been changed to accept `siteId` as their second arg. 
- Follow testing instructions in #33246 to verify there's no regression wrt the module toggle.
