### PR TITLE
E2E package.json script: run `npm ci`

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
 		"pretest-client": "npm run -s pretest",
 		"test-client": "jest -c=test/client/jest.config.js",
 		"test-client:watch": "npm run -s test-client -- --watch",
-		"test-e2e": "cd test/e2e && npm i && npm run test",
+		"test-e2e": "cd test/e2e && npm ci && npm run test",
 		"encrypt-e2e-config": "openssl enc -md sha1 -aes-256-cbc -pass env:CONFIG_KEY -out ./test/e2e/config/encrypted.enc -in ./test/e2e/config/local-$NODE_ENV.json",
 		"decrypt-e2e-config": "openssl enc -md sha1 -aes-256-cbc -d -pass env:CONFIG_KEY -in ./test/e2e/config/encrypted.enc -out ./test/e2e/config/local-$NODE_ENV.json",
 		"pretest-integration": "npm run -s pretest",


### PR DESCRIPTION
Instead of `npm i`, run `npm ci` which is faster and fails if the lockfile isn't up-to-date.

https://docs.npmjs.com/cli/ci
https://docs.npmjs.com/cli/install


#### Testing instructions

Running `npm run test-e2e` still works.