### PR TITLE
Add error events

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -50,6 +50,7 @@ export class PaidPlanThankYouCard extends Component {
 		} else if ( site && ! site.hasMinimumJetpackVersion ) {
 			this.recordAutoconfigTracksEventOnce( 'calypso_plans_autoconfig_error', {
 				error: 'jetpack_version_too_old',
+				jetpack_version: get( site, [ 'options', 'jetpack_version' ], 'unknown' ),
 			} );
 		} else if ( site && site.isSecondaryNetworkSite ) {
 			this.recordAutoconfigTracksEventOnce( 'calypso_plans_autoconfig_error', {

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -26,18 +26,15 @@ const INSTALL_STATE_COMPLETE = 1;
 const INSTALL_STATE_INCOMPLETE = 2;
 
 export class PaidPlanThankYouCard extends Component {
-	state = {
-		tracksEventSent: false,
-	};
+	tracksEventSent = false;
 
 	recordAutoconfigTracksEvent( eventName, options = {} ) {
-		if ( ! this.state.tracksEventSent ) {
-			this.setState( { tracksEventSent: true }, () => {
-				this.props.recordTracksEvent( eventName, {
-					checklist_name: 'jetpack',
-					location: 'JetpackChecklist',
-					...options,
-				} );
+		if ( ! this.tracksEventSent ) {
+			this.tracksEventSent = true;
+			this.props.recordTracksEvent( eventName, {
+				checklist_name: 'jetpack',
+				location: 'JetpackChecklist',
+				...options,
 			} );
 		}
 	}

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -26,12 +26,20 @@ const INSTALL_STATE_COMPLETE = 1;
 const INSTALL_STATE_INCOMPLETE = 2;
 
 export class PaidPlanThankYouCard extends Component {
+	state = {
+		tracksEventSent: false,
+	};
+
 	recordAutoconfigTracksEvent( eventName, options = {} ) {
-		this.props.recordTracksEvent( eventName, {
-			checklist_name: 'jetpack',
-			location: 'JetpackChecklist',
-			...options,
-		} );
+		if ( ! this.state.tracksEventSent ) {
+			this.setState( { tracksEventSent: true }, () => {
+				this.props.recordTracksEvent( eventName, {
+					checklist_name: 'jetpack',
+					location: 'JetpackChecklist',
+					...options,
+				} );
+			} );
+		}
 	}
 
 	componentDidUpdate( prevProps ) {

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -28,7 +28,7 @@ const INSTALL_STATE_INCOMPLETE = 2;
 export class PaidPlanThankYouCard extends Component {
 	tracksEventSent = false;
 
-	recordAutoconfigTracksEvent( eventName, options = {} ) {
+	recordAutoconfigTracksEventOnce( eventName, options = {} ) {
 		if ( ! this.tracksEventSent ) {
 			this.tracksEventSent = true;
 			this.props.recordTracksEvent( eventName, {
@@ -46,18 +46,17 @@ export class PaidPlanThankYouCard extends Component {
 			prevProps.installState !== INSTALL_STATE_COMPLETE &&
 			installState === INSTALL_STATE_COMPLETE
 		) {
-			this.recordAutoconfigTracksEvent( 'calypso_plans_autoconfig_success' );
+			this.recordAutoconfigTracksEventOnce( 'calypso_plans_autoconfig_success' );
 		} else if ( site && ! site.hasMinimumJetpackVersion ) {
-			this.recordAutoconfigTracksEvent( 'calypso_plans_autoconfig_error', {
+			this.recordAutoconfigTracksEventOnce( 'calypso_plans_autoconfig_error', {
 				error: 'jetpack_version_too_old',
-				jetpack_version: get( site, [ 'options', 'jetpack_version' ] ),
 			} );
 		} else if ( site && site.isSecondaryNetworkSite ) {
-			this.recordAutoconfigTracksEvent( 'calypso_plans_autoconfig_error', {
+			this.recordAutoconfigTracksEventOnce( 'calypso_plans_autoconfig_error', {
 				error: 'secondary_network_site',
 			} );
 		} else if ( site && ! site.canUpdateFiles ) {
-			this.recordAutoconfigTracksEvent( 'calypso_plans_autoconfig_error', {
+			this.recordAutoconfigTracksEventOnce( 'calypso_plans_autoconfig_error', {
 				error: 'cannot_update_files',
 			} );
 		}

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.js
@@ -194,11 +194,22 @@ export class JetpackProductInstall extends Component {
 		 */
 		const period = this.shouldRefetchInstallationStatus() ? EVERY_FIVE_SECONDS : EVERY_SECOND;
 
+		const hasErrorInstalling =
+			! this.shouldRefetchInstallationStatus() && this.installationHasRecoverableErrors();
+
+		if ( hasErrorInstalling ) {
+			this.recordAutoconfigTracksEvent( 'calypso_plans_autoconfig_error', {
+				checklist_name: 'jetpack',
+				error: 'installation_error',
+				location: 'JetpackChecklist',
+			} );
+		}
+
 		return (
 			<Fragment>
 				<QueryPluginKeys siteId={ siteId } />
 
-				{ ! this.shouldRefetchInstallationStatus() && this.installationHasRecoverableErrors() && (
+				{ hasErrorInstalling && (
 					<Notice
 						status="is-error"
 						text={ translate( 'Oops! An error has occurred while setting up your plan.' ) }

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.js
@@ -9,6 +9,7 @@ import { includes, some } from 'lodash';
 /**
  * Internal dependencies
  */
+import { recordTracksEvent } from 'state/analytics/actions';
 import getJetpackProductInstallProgress from 'state/selectors/get-jetpack-product-install-progress';
 import getJetpackProductInstallStatus from 'state/selectors/get-jetpack-product-install-status';
 import Interval, { EVERY_SECOND, EVERY_FIVE_SECONDS } from 'lib/interval';
@@ -198,7 +199,7 @@ export class JetpackProductInstall extends Component {
 			! this.shouldRefetchInstallationStatus() && this.installationHasRecoverableErrors();
 
 		if ( hasErrorInstalling ) {
-			this.recordAutoconfigTracksEvent( 'calypso_plans_autoconfig_error', {
+			this.props.recordTracksEvent( 'calypso_plans_autoconfig_error', {
 				checklist_name: 'jetpack',
 				error: 'installation_error',
 				location: 'JetpackChecklist',
@@ -242,6 +243,7 @@ export default connect(
 		};
 	},
 	{
+		recordTracksEvent,
 		requestJetpackProductInstallStatus,
 		startJetpackProductInstall,
 	}

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.js
@@ -56,6 +56,7 @@ const MAX_RETRIES = 3;
 export class JetpackProductInstall extends Component {
 	state = {
 		startedInstallation: false,
+		tracksEventSent: false,
 	};
 
 	retries = 0;
@@ -198,11 +199,13 @@ export class JetpackProductInstall extends Component {
 		const hasErrorInstalling =
 			! this.shouldRefetchInstallationStatus() && this.installationHasRecoverableErrors();
 
-		if ( hasErrorInstalling ) {
-			this.props.recordTracksEvent( 'calypso_plans_autoconfig_error', {
-				checklist_name: 'jetpack',
-				error: 'installation_error',
-				location: 'JetpackChecklist',
+		if ( hasErrorInstalling && ! this.state.tracksEventSent ) {
+			this.setState( { tracksEventSent: true }, () => {
+				this.props.recordTracksEvent( 'calypso_plans_autoconfig_error', {
+					checklist_name: 'jetpack',
+					error: 'installation_error',
+					location: 'JetpackChecklist',
+				} );
 			} );
 		}
 

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.js
@@ -56,10 +56,10 @@ const MAX_RETRIES = 3;
 export class JetpackProductInstall extends Component {
 	state = {
 		startedInstallation: false,
-		tracksEventSent: false,
 	};
 
 	retries = 0;
+	tracksEventSent = false;
 
 	componentDidMount() {
 		this.requestInstallationStatus();
@@ -199,13 +199,12 @@ export class JetpackProductInstall extends Component {
 		const hasErrorInstalling =
 			! this.shouldRefetchInstallationStatus() && this.installationHasRecoverableErrors();
 
-		if ( hasErrorInstalling && ! this.state.tracksEventSent ) {
-			this.setState( { tracksEventSent: true }, () => {
-				this.props.recordTracksEvent( 'calypso_plans_autoconfig_error', {
-					checklist_name: 'jetpack',
-					error: 'installation_error',
-					location: 'JetpackChecklist',
-				} );
+		if ( hasErrorInstalling && ! this.tracksEventSent ) {
+			this.tracksEventSent = true;
+			this.props.recordTracksEvent( 'calypso_plans_autoconfig_error', {
+				checklist_name: 'jetpack',
+				error: 'installation_error',
+				location: 'JetpackChecklist',
 			} );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add error tracks events

**Question:** how to best ensure these runs just once — update state with `tracksEventSent`?

#### Testing instructions

- Have a new or old Jetpack site, disable e.g. file modifications to trigger one of the errors: `define( 'DISALLOW_FILE_MODS', true );` in `wp-config.php` or a `mu-plugins` file.
- Enable tracks in development mode in calypso by dropping this to console: `localStorage.debug = 'calypso:analytics:tracks'`
- End up via connect flow, or open directly `http://calypso.localhost:3000/plans/my-plan/:site?thank-you`
- Confirm that error tracks event is sent only once

I haven't yet figured out how to enter that generic error notification. :-/ See https://github.com/Automattic/wp-calypso/pull/33228#issuecomment-494825550
