### PR TITLE
Jetpack checklist: fix image shown on thank-you page for free sites

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
@@ -11,14 +11,7 @@ import ThankYouCard from './thank-you-card';
 
 const FreePlanThankYouCard = ( { translate } ) => (
 	<ThankYouCard
-		illustration={
-			<img
-				alt=""
-				aria-hidden="true"
-				className="current-plan-thank-you-card__illustration"
-				src="/calypso/images/illustrations/security.svg"
-			/>
-		}
+		illustration="/calypso/images/illustrations/security.svg"
 		showContinueButton
 		title={ translate( 'Welcome to Jetpack Free!' ) }
 	>


### PR DESCRIPTION
Fixes an issue introduced with the Jetpack checklist where no image was shown in the flow after selecting a free plan.

Introduced with https://github.com/Automattic/wp-calypso/pull/33232


#### Testing instructions

- Have Jetpack free site
- Open `/plans/my-plan/:site?thank-you`
- Confirm you see an image in the place where before you'd see broken image:
    <img width="1074" alt="Screenshot 2019-05-23 at 11 40 20" src="https://user-images.githubusercontent.com/87168/58238266-a1af0100-7d4f-11e9-85a6-99b500639938.png">
