### PR TITLE
Guided Tours: Fix Jetpack Plugin Autoupdate Tour

### DIFF
--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.js
@@ -23,15 +23,17 @@ import {
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackPluginUpdatesTour = makeTour(
-	<Tour { ...meta }>
+	<Tour
+		{ ...meta }
+		when={ state => {
+			const site = getSelectedSite( state );
+			const res =
+				! PluginsStore.isFetchingSite( site ) && !! PluginsStore.getSitePlugin( site, 'jetpack' );
+			return res;
+		} }
+	>
 		<Step
 			name="init"
-			when={ state => {
-				const site = getSelectedSite( state );
-				const res =
-					! PluginsStore.isFetchingSite( site ) && !! PluginsStore.getSitePlugin( site, 'jetpack' );
-				return res;
-			} }
 			target=".plugin-item-jetpack .form-toggle__switch"
 			arrow="top-left"
 			placement="below"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Guided Tours: Fix Jetpack Plugin Autoupdate Tour

This is achieved by moving the `when` prop from the initial `Step` to the `Tour` component. Turns out we were _doing it wrong_:tm: (see https://github.com/Automattic/wp-calypso/issues/32168#issuecomment-495158376 and [Guided Tours docs](https://github.com/Automattic/wp-calypso/blob/master/client/layout/guided-tours/docs/API.md)):

> For `Tour`:
>> `when` (function, optional): This is a Redux selector function. Use this to define conditions for the tour to start. Can be overridden by adding a `tour` query argument to the URL like so: `?tour=tourName`, in which case the tour will be triggered even if `when` would evaluate to `false`. This is useful for sending along a tour via email or chat. On the other hand, the framework will try to not trigger a tour multiple times (see `toursSeen` in [ARCHITECTURE.md](./ARCHITECTURE.md)). *Note:* you can reset the tours history by adding `?tour=reset` to the URL.
>
> For `Step`:
>> `when`: (function, optional) This is a Redux selector that can prevent a step from showing when it evaluates to false. When using `when` you should also set the `next` prop to tell Guided Tours the name of the step it should skip to. If you omit this prop, step will be rendered as expected. Example usage would be to show a certain step only for non-mobile environments: `when={ not( isMobile ) }`

#### Testing instructions

- Start Calypso locally, using this branch
- Create a new jurassic.ninja site
- Locate the 'Connect to WP.com' button in wp-admin, copy its link target, and append `&calypso_env=development` to it. Navigate to that URL.
- Select a paid plan
- On the 'Thank You' page, locate the 'Automatic Plugin Updates' task, and click the 'Do it!' button next to it
- _Verify that a Guided Tour bubble points you to the Jetpack plugin's Autoupdate Toggle_
- Enable the Autoupdates Toggle for the Jetpack plugin, as advised by the Guided Tour
- Go back to the checklist, as advised by the Guided Tour
- Verify that the 'Automatic Plugin Updates' task is now marked as completed (possibly after a _very_ brief delay)

(Partial) fix for #32168
