### PR TITLE
Adding override end date for evergreen banners

### DIFF
--- a/client/lib/discounts/index.js
+++ b/client/lib/discounts/index.js
@@ -5,13 +5,13 @@
  */
 import activeDiscounts from './active-discounts';
 
-function getDiscountByName( discountName, endsAt ) {
+function getDiscountByName( discountName, endsAt = null ) {
 	const activeDiscount = activeDiscounts.find( function( discount ) {
 		if ( discountName !== discount.name ) {
 			return false;
 		}
 
-		if ( typeof endsAt !== 'undefined' ) discount.endsAt = endsAt;
+		discount.endsAt = endsAt || discount.endsAt;
 
 		const now = new Date();
 		if (

--- a/client/lib/discounts/index.js
+++ b/client/lib/discounts/index.js
@@ -5,11 +5,13 @@
  */
 import activeDiscounts from './active-discounts';
 
-function getDiscountByName( discountName ) {
+function getDiscountByName( discountName, endsAt ) {
 	const activeDiscount = activeDiscounts.find( function( discount ) {
 		if ( discountName !== discount.name ) {
 			return false;
 		}
+
+		if ( typeof endsAt !== 'undefined' ) discount.endsAt = endsAt;
 
 		const now = new Date();
 		if (

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -140,7 +140,7 @@ export class PlanFeatures extends Component {
 		if ( ! bannerContainer ) {
 			return false;
 		}
-		const activeDiscount = getDiscountByName( this.props.withDiscount );
+		const activeDiscount = getDiscountByName( this.props.withDiscount, this.props.discountEndDate );
 		return ReactDOM.createPortal(
 			<Notice
 				className="plan-features__notice-credits"
@@ -161,13 +161,13 @@ export class PlanFeatures extends Component {
 	}
 
 	hasDiscountNotice() {
-		const { canPurchase, hasPlaceholders, withDiscount } = this.props;
+		const { canPurchase, hasPlaceholders, withDiscount, discountEndDate } = this.props;
 		const bannerContainer = this.getBannerContainer();
 		if ( ! bannerContainer ) {
 			return false;
 		}
 
-		const activeDiscount = getDiscountByName( withDiscount );
+		const activeDiscount = getDiscountByName( withDiscount, discountEndDate );
 		if ( ! activeDiscount || hasPlaceholders || ! canPurchase ) {
 			return false;
 		}

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -78,6 +78,7 @@ export class PlansFeaturesMain extends Component {
 			selectedFeature,
 			selectedPlan,
 			withDiscount,
+			discountEndDate,
 			siteId,
 			plansWithScroll,
 		} = this.props;
@@ -111,6 +112,7 @@ export class PlansFeaturesMain extends Component {
 					selectedFeature={ selectedFeature }
 					selectedPlan={ selectedPlan }
 					withDiscount={ withDiscount }
+					discountEndDate={ discountEndDate }
 					withScroll={ plansWithScroll }
 					popularPlanSpec={ {
 						type: customerType === 'personal' ? TYPE_PREMIUM : TYPE_BUSINESS,

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -27,6 +27,7 @@ export default {
 					selectedFeature={ context.query.feature }
 					selectedPlan={ context.query.plan }
 					withDiscount={ context.query.discount }
+					discountEndDate={ context.query.ts }
 				/>
 			</CheckoutData>
 		);

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -106,6 +106,7 @@ class Plans extends React.Component {
 							selectedFeature={ this.props.selectedFeature }
 							selectedPlan={ this.props.selectedPlan }
 							withDiscount={ this.props.withDiscount }
+							discountEndDate={ this.props.discountEndDate }
 							site={ selectedSite }
 							plansWithScroll={ false }
 						/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added `ts` parameter as a timestamp to override end date for banners, particularly useful for evergreen banners sent via email.
 The `ts` parameter acts as an "end date" for the banner. Beyond the timestamp specified with `ts` the banner will not be shown. 

 E.g.: Sending a 2-day flash sale email with an evergreen coupon. Create a timestamp for the last day of the sale (see instructions below). Add `&ts=[TIMESTAMP]` to the link in the email. The banner will not be shown once the timestamp is reached, but it will be visible before that.

#### Testing instructions

* Create a timestamp some minutes in the future. Using the console, paste one of this line making sure to update the date/time:

  `> console.log(new Date('23 May 2019 14:04:00').getTime())`
   _or_
  `> console.log(new Date('2019-05-23 14:04:00').getTime())`

  It will return a number, that's the timestamp.

* Use the calypso.live link below, load the Plans section with the evergreen coupon `sale_wpsave20` and the timestamp just created:
`http://calypso.localhost:3000/plans/[SITE]?discount=sale_wpsave20&ts=[TIMESTAMP]`
 * Now create a timestamp based on the current time:
`>Date.now()`
* Use that timestamp to load the banner again. This time should be gone.



#### Caveats 
Currently, if the URL has the `discount` parameter but not the `ts` one, the banner will be always shown (no end date specified).