### PR TITLE
Fix/dont show gsuite stats nudge after gsuite purchase

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-apps-details.jsx
@@ -6,17 +6,21 @@
 
 import React from 'react';
 import i18n from 'i18n-calypso';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
+import { dismissNudge } from 'blocks/gsuite-stats-nudge/actions';
 import { GOOGLE_APPS_LEARNING_CENTER } from 'lib/url/support';
 import PurchaseDetail from 'components/purchase-detail';
 import userFactory from 'lib/user';
 
 const user = userFactory();
 
-const GoogleAppsDetails = () => {
+const GoogleAppsDetails = props => {
+	props.dismissNudge();
+
 	return (
 		<PurchaseDetail
 			icon="mail"
@@ -48,4 +52,9 @@ const GoogleAppsDetails = () => {
 	);
 };
 
-export default GoogleAppsDetails;
+export default connect(
+	null,
+	{
+		dismissNudge,
+	}
+)( GoogleAppsDetails );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Dismisses stats banner for G Suite on purchase of G Suite

#### Testing instructions

* Have site w/o G Suite but has custom domain
* Observe the G Suite banner on the stats page
* Purchase G Suite
* Use the "My Sites" button in top left to get back to stats page of that site
* Observe banner is gone.
