### PR TITLE
Plans: Update preselected plans

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -135,4 +135,12 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	popularPlanBy: {
+		datestamp: '20190529',
+		variations: {
+			siteType: 50,
+			customerType: 50,
+		},
+		defaultVariation: 'siteType',
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -138,8 +138,8 @@ export default {
 	popularPlanBy: {
 		datestamp: '20190529',
 		variations: {
-			siteType: 50,
-			customerType: 50,
+			siteType: 0,
+			customerType: 100,
 		},
 		defaultVariation: 'siteType',
 	},

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -496,9 +496,27 @@ export const getPopularPlanSpec = ( { customerType, isJetpack, siteType, abtest 
 	return spec;
 };
 
-export const chooseDefaultCustomerType = ( { currentCustomerType, selectedPlan, currentPlan } ) => {
+export const chooseDefaultCustomerType = ( {
+	currentCustomerType,
+	selectedPlan,
+	currentPlan,
+	siteType,
+	abtest,
+} ) => {
 	if ( currentCustomerType ) {
 		return currentCustomerType;
+	}
+
+	if ( abtest( 'popularPlanBy' ) === 'siteType' ) {
+		// Choose the tab that will make the "POPULAR" label visible when the
+		// page is first loaded.
+		switch ( siteType ) {
+			case 'blog':
+			case 'professional':
+				return 'personal';
+			default:
+				return 'business';
+		}
 	}
 
 	const group = GROUP_WPCOM;

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -495,3 +495,30 @@ export const getPopularPlanSpec = ( { customerType, isJetpack, siteType, abtest 
 
 	return spec;
 };
+
+export const chooseDefaultCustomerType = ( { currentCustomerType, selectedPlan, currentPlan } ) => {
+	if ( currentCustomerType ) {
+		return currentCustomerType;
+	}
+
+	const group = GROUP_WPCOM;
+	const businessPlanSlugs = [
+		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_PREMIUM } )[ 0 ],
+		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_PREMIUM } )[ 0 ],
+		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_BUSINESS } )[ 0 ],
+		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_BUSINESS } )[ 0 ],
+		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_ECOMMERCE } )[ 0 ],
+		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_ECOMMERCE } )[ 0 ],
+	]
+		.map( planKey => getPlan( planKey ) )
+		.map( plan => plan.getStoreSlug() );
+
+	if ( selectedPlan ) {
+		return businessPlanSlugs.includes( selectedPlan ) ? 'business' : 'personal';
+	} else if ( currentPlan ) {
+		const isPlanInBusinessGroup = businessPlanSlugs.indexOf( currentPlan.product_slug ) !== -1;
+		return isPlanInBusinessGroup ? 'business' : 'personal';
+	}
+
+	return 'personal';
+};

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -476,3 +476,22 @@ export const getPopularPlanType = siteType => {
 			return TYPE_BUSINESS;
 	}
 };
+
+export const getPopularPlanSpec = ( { customerType, isJetpack, siteType, abtest } ) => {
+	const spec = {
+		type: TYPE_BUSINESS,
+		group: isJetpack ? GROUP_JETPACK : GROUP_WPCOM,
+	};
+
+	// Not sure why, but things break if the abtest lib is imported in this file
+	if ( ! siteType || abtest( 'popularPlanBy' ) === 'customerType' ) {
+		if ( customerType === 'personal' ) {
+			spec.type = TYPE_PREMIUM;
+		}
+		return spec;
+	}
+
+	spec.type = getPopularPlanType( siteType );
+
+	return spec;
+};

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -465,3 +465,14 @@ export function getPlanTermLabel( planName, translate ) {
 			return translate( 'Two year subscription' );
 	}
 }
+
+export const getPopularPlanType = siteType => {
+	switch ( siteType ) {
+		case 'blog':
+			return TYPE_PERSONAL;
+		case 'professional':
+			return TYPE_PREMIUM;
+		default:
+			return TYPE_BUSINESS;
+	}
+};

--- a/client/lib/plans/test/choose-default-customer-type.js
+++ b/client/lib/plans/test/choose-default-customer-type.js
@@ -1,0 +1,50 @@
+/** @format */
+/**
+ * Internal dependencies
+ */
+import { chooseDefaultCustomerType } from '..';
+
+describe( 'chooseDefaultCustomerType', () => {
+	describe( 'popularPlanBy A/B test === siteType', () => {
+		const abtest = test => {
+			expect( test ).toBe( 'popularPlanBy' );
+			return 'siteType';
+		};
+
+		test( 'chooses "personal" if the site type is "blog"', () => {
+			const customerType = chooseDefaultCustomerType( {
+				siteType: 'blog',
+				abtest,
+			} );
+
+			expect( customerType ).toBe( 'personal' );
+		} );
+
+		test( 'chooses "personal" if the site type is "professional"', () => {
+			const customerType = chooseDefaultCustomerType( {
+				siteType: 'professional',
+				abtest,
+			} );
+
+			expect( customerType ).toBe( 'personal' );
+		} );
+
+		test( 'chooses "business" if the site type is "business"', () => {
+			const customerType = chooseDefaultCustomerType( {
+				siteType: 'business',
+				abtest,
+			} );
+
+			expect( customerType ).toBe( 'business' );
+		} );
+
+		test( 'chooses "business" if the site type is "online-store"', () => {
+			const customerType = chooseDefaultCustomerType( {
+				siteType: 'online-store',
+				abtest,
+			} );
+
+			expect( customerType ).toBe( 'business' );
+		} );
+	} );
+} );

--- a/client/lib/plans/test/get-popular-plan-type.js
+++ b/client/lib/plans/test/get-popular-plan-type.js
@@ -1,0 +1,25 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getPopularPlanType } from '..';
+import { TYPE_BUSINESS, TYPE_PERSONAL, TYPE_PREMIUM } from '../constants';
+
+describe( 'getPopularPlanType()', () => {
+	test( 'Should return TYPE_PERSONAL for personal site type', () => {
+		expect( getPopularPlanType( 'blog' ) ).to.equal( TYPE_PERSONAL );
+	} );
+
+	test( 'Should return TYPE_PREMIUM for business site type', () => {
+		expect( getPopularPlanType( 'professional' ) ).to.equal( TYPE_PREMIUM );
+	} );
+
+	test( 'Should return TYPE_BUSINESS for business site type', () => {
+		expect( getPopularPlanType( 'business' ) ).to.equal( TYPE_BUSINESS );
+	} );
+} );

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -454,13 +454,13 @@ export default connect(
 			// universal.
 			withWPPlanTabs: isDiscountActive( getDiscountByName( 'new_plans' ), state ),
 			plansWithScroll: ! props.displayJetpackPlans && props.plansWithScroll,
-			customerType: customerType,
+			customerType,
 			domains: getDecoratedSiteDomains( state, siteId ),
 			isChatAvailable: isHappychatAvailable( state ),
 			isJetpack: isJetpackSite( state, siteId ),
-			siteId: siteId,
+			siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
-			siteType: siteType,
+			siteType,
 		};
 	},
 	{

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -35,6 +35,7 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isEnabled } from 'config';
 import {
+	chooseDefaultCustomerType,
 	findPlansKeys,
 	getPlan,
 	getPopularPlanSpec,
@@ -429,44 +430,20 @@ PlansFeaturesMain.defaultProps = {
 	plansWithScroll: false,
 };
 
-const guessCustomerType = ( state, props ) => {
-	if ( props.customerType ) {
-		return props.customerType;
-	}
-
-	const site = props.site;
-	const currentPlan = getSitePlan( state, get( site, [ 'ID' ] ) );
-	const selectedPlan = props.selectedPlan;
-
-	const group = GROUP_WPCOM;
-	const businessPlanSlugs = [
-		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_PREMIUM } )[ 0 ],
-		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_PREMIUM } )[ 0 ],
-		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_BUSINESS } )[ 0 ],
-		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_BUSINESS } )[ 0 ],
-		findPlansKeys( { group, term: TERM_ANNUALLY, type: TYPE_ECOMMERCE } )[ 0 ],
-		findPlansKeys( { group, term: TERM_BIENNIALLY, type: TYPE_ECOMMERCE } )[ 0 ],
-	]
-		.map( planKey => getPlan( planKey ) )
-		.map( plan => plan.getStoreSlug() );
-
-	if ( selectedPlan ) {
-		return businessPlanSlugs.includes( selectedPlan ) ? 'business' : 'personal';
-	} else if ( currentPlan ) {
-		const isPlanInBusinessGroup = businessPlanSlugs.indexOf( currentPlan.product_slug ) !== -1;
-		return isPlanInBusinessGroup ? 'business' : 'personal';
-	}
-
-	return 'personal';
-};
-
 export default connect(
 	( state, props ) => {
 		const siteId = get( props.site, [ 'ID' ] );
+		const currentPlan = getSitePlan( state, siteId );
 
 		const siteType = props.isInSignup
 			? getSignupSiteType( state )
 			: getSiteTypePropertyValue( 'id', getSiteOption( state, siteId, 'site_segment' ), 'slug' );
+
+		const customerType = chooseDefaultCustomerType( {
+			currentCustomerType: props.customerType,
+			selectedPlan: props.selectedPlan,
+			currentPlan,
+		} );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and
@@ -475,7 +452,7 @@ export default connect(
 			// universal.
 			withWPPlanTabs: isDiscountActive( getDiscountByName( 'new_plans' ), state ),
 			plansWithScroll: ! props.displayJetpackPlans && props.plansWithScroll,
-			customerType: guessCustomerType( state, props ),
+			customerType: customerType,
 			domains: getDecoratedSiteDomains( state, siteId ),
 			isChatAvailable: isHappychatAvailable( state ),
 			isJetpack: isJetpackSite( state, siteId ),

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -55,6 +55,7 @@ import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getTld } from 'lib/domains';
 import { isDiscountActive } from 'state/selectors/get-active-discount.js';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
+import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -99,6 +100,20 @@ export class PlansFeaturesMain extends Component {
 
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
+
+		const popularPlanSpec =
+			! siteType || abtest( 'popularPlanBy' ) === 'customerType'
+				? {
+						// Control experience
+						type: customerType === 'personal' ? TYPE_PREMIUM : TYPE_BUSINESS,
+						group: GROUP_WPCOM,
+				  }
+				: {
+						// Testing suggesting plans by siteType
+						type: getPopularPlanType( siteType ),
+						group: GROUP_WPCOM,
+				  };
+
 		return (
 			<div
 				className={ classNames(
@@ -128,10 +143,7 @@ export class PlansFeaturesMain extends Component {
 					withDiscount={ withDiscount }
 					discountEndDate={ discountEndDate }
 					withScroll={ plansWithScroll }
-					popularPlanSpec={ {
-						type: getPopularPlanType( siteType ),
-						group: GROUP_WPCOM,
-					} }
+					popularPlanSpec={ popularPlanSpec }
 					siteId={ siteId }
 				/>
 			</div>

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -50,12 +50,13 @@ import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import { getDiscountByName } from 'lib/discounts';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
-import { getSitePlan, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { getSiteOption, getSitePlan, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import { getSiteType as getSignupSiteType } from 'state/signup/steps/site-type/selectors';
 import { getTld } from 'lib/domains';
 import { isDiscountActive } from 'state/selectors/get-active-discount.js';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
 import { abtest } from 'lib/abtest';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 /**
  * Style dependencies
@@ -463,6 +464,10 @@ export default connect(
 	( state, props ) => {
 		const siteId = get( props.site, [ 'ID' ] );
 
+		const siteType = props.isInSignup
+			? getSignupSiteType( state )
+			: getSiteTypePropertyValue( 'id', getSiteOption( state, siteId, 'site_segment' ), 'slug' );
+
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and
 			// during the signup, and we're going to remove the code soon after the test. Also, since this endpoint is
@@ -476,7 +481,7 @@ export default connect(
 			isJetpack: isJetpackSite( state, siteId ),
 			siteId: siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
-			siteType: getSiteType( state ),
+			siteType: siteType,
 		};
 	},
 	{

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -443,6 +443,8 @@ export default connect(
 			currentCustomerType: props.customerType,
 			selectedPlan: props.selectedPlan,
 			currentPlan,
+			siteType,
+			abtest,
 		} );
 
 		return {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -34,7 +34,14 @@ import CartData from 'components/data/cart';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isEnabled } from 'config';
-import { plansLink, planMatches, findPlansKeys, getPlan, isFreePlan } from 'lib/plans';
+import {
+	plansLink,
+	planMatches,
+	findPlansKeys,
+	getPlan,
+	getPopularPlanType,
+	isFreePlan,
+} from 'lib/plans';
 import Button from 'components/button';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
@@ -44,6 +51,7 @@ import isHappychatAvailable from 'state/happychat/selectors/is-happychat-availab
 import { getDiscountByName } from 'lib/discounts';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
 import { getSitePlan, getSiteSlug } from 'state/sites/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getTld } from 'lib/domains';
 import { isDiscountActive } from 'state/selectors/get-active-discount.js';
 import { selectSiteId as selectHappychatSiteId } from 'state/help/actions';
@@ -85,6 +93,7 @@ export class PlansFeaturesMain extends Component {
 			withDiscount,
 			discountEndDate,
 			siteId,
+			siteType,
 			plansWithScroll,
 		} = this.props;
 
@@ -120,7 +129,7 @@ export class PlansFeaturesMain extends Component {
 					discountEndDate={ discountEndDate }
 					withScroll={ plansWithScroll }
 					popularPlanSpec={ {
-						type: customerType === 'personal' ? TYPE_PREMIUM : TYPE_BUSINESS,
+						type: getPopularPlanType( siteType ),
 						group: GROUP_WPCOM,
 					} }
 					siteId={ siteId }
@@ -461,6 +470,7 @@ export default connect(
 			isChatAvailable: isHappychatAvailable( state ),
 			siteId: siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
+			siteType: getSiteType( state ),
 		};
 	},
 	{

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -35,12 +35,12 @@ import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isEnabled } from 'config';
 import {
-	plansLink,
-	planMatches,
 	findPlansKeys,
 	getPlan,
 	getPopularPlanType,
 	isFreePlan,
+	planMatches,
+	plansLink,
 } from 'lib/plans';
 import Button from 'components/button';
 import SegmentedControl from 'components/segmented-control';

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -37,7 +37,7 @@ import { isEnabled } from 'config';
 import {
 	findPlansKeys,
 	getPlan,
-	getPopularPlanType,
+	getPopularPlanSpec,
 	isFreePlan,
 	planMatches,
 	plansLink,
@@ -50,7 +50,7 @@ import HappychatConnection from 'components/happychat/connection-connected';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import { getDiscountByName } from 'lib/discounts';
 import { getDecoratedSiteDomains } from 'state/sites/domains/selectors';
-import { getSitePlan, getSiteSlug } from 'state/sites/selectors';
+import { getSitePlan, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getTld } from 'lib/domains';
 import { isDiscountActive } from 'state/selectors/get-active-discount.js';
@@ -86,6 +86,7 @@ export class PlansFeaturesMain extends Component {
 			displayJetpackPlans,
 			domainName,
 			isInSignup,
+			isJetpack,
 			isLandingPage,
 			isLaunchPage,
 			onUpgradeClick,
@@ -100,19 +101,6 @@ export class PlansFeaturesMain extends Component {
 
 		const plans = this.getPlansForPlanFeatures();
 		const visiblePlans = this.getVisiblePlansForPlanFeatures( plans );
-
-		const popularPlanSpec =
-			! siteType || abtest( 'popularPlanBy' ) === 'customerType'
-				? {
-						// Control experience
-						type: customerType === 'personal' ? TYPE_PREMIUM : TYPE_BUSINESS,
-						group: GROUP_WPCOM,
-				  }
-				: {
-						// Testing suggesting plans by siteType
-						type: getPopularPlanType( siteType ),
-						group: GROUP_WPCOM,
-				  };
 
 		return (
 			<div
@@ -143,7 +131,12 @@ export class PlansFeaturesMain extends Component {
 					withDiscount={ withDiscount }
 					discountEndDate={ discountEndDate }
 					withScroll={ plansWithScroll }
-					popularPlanSpec={ popularPlanSpec }
+					popularPlanSpec={ getPopularPlanSpec( {
+						abtest,
+						customerType,
+						isJetpack,
+						siteType,
+					} ) }
 					siteId={ siteId }
 				/>
 			</div>
@@ -480,6 +473,7 @@ export default connect(
 			customerType: guessCustomerType( state, props ),
 			domains: getDecoratedSiteDomains( state, siteId ),
 			isChatAvailable: isHappychatAvailable( state ),
+			isJetpack: isJetpackSite( state, siteId ),
 			siteId: siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
 			siteType: getSiteType( state ),

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -323,7 +323,7 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		} );
 	} );
 
-	test( 'Should highlight proper popular plan for business site type', () => {
+	test( 'Should highlight proper popular plan for professional site type', () => {
 		const instance = new PlansFeaturesMain( {
 			siteType: 'professional',
 		} );
@@ -334,7 +334,7 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		} );
 	} );
 
-	test( 'Should highlight proper popular plan for professional site type', () => {
+	test( 'Should highlight proper popular plan for business site type', () => {
 		const instance = new PlansFeaturesMain( {
 			siteType: 'business',
 		} );

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -45,6 +45,7 @@ import React from 'react';
  */
 import { PlansFeaturesMain } from '../index';
 import {
+	GROUP_WPCOM,
 	PLAN_FREE,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_BUSINESS,
@@ -68,7 +69,8 @@ import {
 	TYPE_ECOMMERCE,
 	TYPE_FREE,
 	TERM_ANNUALLY,
-	GROUP_WPCOM,
+	TYPE_PERSONAL,
+	TYPE_PREMIUM,
 } from 'lib/plans/constants';
 
 const props = {
@@ -308,6 +310,39 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		expect(
 			comp.find( 'SegmentedControlItem[path="?customerType=personal"]' ).props().selected
 		).toBe( false );
+	} );
+
+	test( 'Should highlight proper popular plan for blog site type', () => {
+		const instance = new PlansFeaturesMain( {
+			siteType: 'blog',
+		} );
+		const comp = shallow( instance.render() );
+		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
+			type: TYPE_PERSONAL,
+			group: GROUP_WPCOM,
+		} );
+	} );
+
+	test( 'Should highlight proper popular plan for business site type', () => {
+		const instance = new PlansFeaturesMain( {
+			siteType: 'professional',
+		} );
+		const comp = shallow( instance.render() );
+		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
+			type: TYPE_PREMIUM,
+			group: GROUP_WPCOM,
+		} );
+	} );
+
+	test( 'Should highlight proper popular plan for professional site type', () => {
+		const instance = new PlansFeaturesMain( {
+			siteType: 'business',
+		} );
+		const comp = shallow( instance.render() );
+		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
+			type: TYPE_BUSINESS,
+			group: GROUP_WPCOM,
+		} );
 	} );
 } );
 

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -344,6 +344,37 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 			group: GROUP_WPCOM,
 		} );
 	} );
+
+	test( 'Should highlight proper popular plan for empty site type and personal customer type', () => {
+		const instance = new PlansFeaturesMain( {
+			customerType: 'personal',
+		} );
+		const comp = shallow( instance.render() );
+		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
+			type: TYPE_PREMIUM,
+			group: GROUP_WPCOM,
+		} );
+	} );
+
+	test( 'Should highlight proper popular plan for empty site type and business customer type', () => {
+		const instance = new PlansFeaturesMain( {
+			customerType: 'business',
+		} );
+		const comp = shallow( instance.render() );
+		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
+			type: TYPE_BUSINESS,
+			group: GROUP_WPCOM,
+		} );
+	} );
+
+	test( 'Should highlight proper popular plan for empty site type and empty customer type', () => {
+		const instance = new PlansFeaturesMain( {} );
+		const comp = shallow( instance.render() );
+		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {
+			type: TYPE_BUSINESS,
+			group: GROUP_WPCOM,
+		} );
+	} );
 } );
 
 describe( 'PlansFeaturesMain.getPlansFromProps', () => {

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -312,7 +312,7 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		).toBe( false );
 	} );
 
-	test( 'Should highlight proper popular plan for blog site type', () => {
+	test( 'Highlights TYPE_PERSONAL as popular plan for blog site type', () => {
 		const instance = new PlansFeaturesMain( {
 			siteType: 'blog',
 		} );
@@ -323,7 +323,7 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		} );
 	} );
 
-	test( 'Should highlight proper popular plan for professional site type', () => {
+	test( 'Highlights TYPE_PREMIUM as popular plan for professional site type', () => {
 		const instance = new PlansFeaturesMain( {
 			siteType: 'professional',
 		} );
@@ -334,7 +334,7 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		} );
 	} );
 
-	test( 'Should highlight proper popular plan for business site type', () => {
+	test( 'Highlights TYPE_BUSINESS as popular plan for business site type', () => {
 		const instance = new PlansFeaturesMain( {
 			siteType: 'business',
 		} );
@@ -345,7 +345,7 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		} );
 	} );
 
-	test( 'Should highlight proper popular plan for empty site type and personal customer type', () => {
+	test( 'Highlights TYPE_PREMIUM as popular plan for empty site type and personal customer type', () => {
 		const instance = new PlansFeaturesMain( {
 			customerType: 'personal',
 		} );
@@ -356,7 +356,7 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		} );
 	} );
 
-	test( 'Should highlight proper popular plan for empty site type and business customer type', () => {
+	test( 'Highlights TYPE_BUSINESS as popular plan for empty site type and business customer type', () => {
 		const instance = new PlansFeaturesMain( {
 			customerType: 'business',
 		} );
@@ -367,7 +367,7 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		} );
 	} );
 
-	test( 'Should highlight proper popular plan for empty site type and empty customer type', () => {
+	test( 'Highlights TYPE_BUSINESS as popular plan for empty site type and empty customer type', () => {
 		const instance = new PlansFeaturesMain( {} );
 		const comp = shallow( instance.render() );
 		expect( comp.find( 'PlanFeatures' ).props().popularPlanSpec ).toEqual( {

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -53,6 +53,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'show_on_front',
 	'signup_is_store',
 	'site_goals',
+	'site_segment',
 	'software_version',
 	'timezone',
 	'upgraded_filetypes_enabled',


### PR DESCRIPTION
For discussion: p8Eqe3-Cr-p2

### Changes proposed in this Pull Request

* New function in `lib/plans`: `getPopularPlanType`.  Takes a site type and returns the type of plan to recommend as "Popular"
* Tests for the above function
* Tests for its usage by the `PlanFeaturesMain` / `PlanFeatures` components

#### Blog

| Before | After |
|---|---|
| ![plans-blog-before](https://user-images.githubusercontent.com/1587282/58494089-4e1f2780-8142-11e9-98dd-e1cf60b7188c.png) | ![plans-blog-after](https://user-images.githubusercontent.com/1587282/58494105-55463580-8142-11e9-9fd5-ee07ab264824.png) |

### Testing instructions

#### Automated tests
* Validate test methodology
* Confirm tests pass: `npm run test-client "client/(lib/plans|my-sites/plans-features-main)"`

#### Manual tests

* Run this branch & browse to `/start`
* Select `Blog` as your "site type"
* Complete the flow to the point you're asked to pick a plan
  * The `Personal` plan should be highlighted as "Popular" and its button styled as primary
* Click back until you're at the site type screen
* Select `Professional`
* Complete the flow to the point you're asked to pick a plan
  * The `Premium` plan should be highlighted as "Popular" and its button styled as primary
* Click back until you're at the site type screen
* Select `Business`
* Complete the flow to the point you're asked to pick a plan
  * The `Business` plan should be highlighted as "Popular" and its button styled as primary
* Click back until you're at the site type screen
* Select `Online Store`
* Complete the flow to the point you're asked to pick a plan
  * The `Business` plan should be highlighted as "Popular" and its button styled as primary

Fixes https://github.com/Automattic/zelda-private/issues/26
