### PR TITLE
Navigation: Hide empty Tools sidebar menu

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -602,6 +602,7 @@ export class MySitesSidebar extends Component {
 			);
 		}
 
+		const tools = !! this.tools() || !! this.marketing() || !! this.earn() || !! this.activity();
 		const manage = !! this.upgrades() || !! this.users() || !! this.siteSettings();
 
 		return (
@@ -634,17 +635,19 @@ export class MySitesSidebar extends Component {
 					</ExpandableSidebarMenu>
 				) : null }
 
-				<ExpandableSidebarMenu
-					onClick={ this.props.toggleMySitesSidebarToolsMenu }
-					expanded={ this.props.isToolsOpen }
-					title={ this.props.translate( 'Tools' ) }
-					materialIcon="build"
-				>
-					{ this.tools() }
-					{ this.marketing() }
-					{ this.earn() }
-					{ this.activity() }
-				</ExpandableSidebarMenu>
+				{ tools && (
+					<ExpandableSidebarMenu
+						onClick={ this.props.toggleMySitesSidebarToolsMenu }
+						expanded={ this.props.isToolsOpen }
+						title={ this.props.translate( 'Tools' ) }
+						materialIcon="build"
+					>
+						{ this.tools() }
+						{ this.marketing() }
+						{ this.earn() }
+						{ this.activity() }
+					</ExpandableSidebarMenu>
+				) }
 
 				{ manage && (
 					<ExpandableSidebarMenu

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -88,6 +88,12 @@ export class MySitesSidebar extends Component {
 	}
 
 	tools() {
+		const { canUserManageOptions } = this.props;
+
+		if ( ! canUserManageOptions ) {
+			return null;
+		}
+
 		return (
 			<ToolsMenu
 				siteId={ this.props.siteId }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hide Tools menu if it doesn't have menu items.

#### Testing instructions

1. You'll need a test WPCOM site with a second test user.

2. As **Contributor**, Calypso sidebar should not show **Tools** nor **Manage** menu.

<img width="275" alt="screenshot_680" src="https://user-images.githubusercontent.com/127594/58294845-0b93ce80-7d81-11e9-81e9-29cd225dfafe.png">

3. As **Editor** or **Author**, Calypso sidebar should show **Tools** menu with only **Marketing** menu item:

<img width="274" alt="screenshot_677" src="https://user-images.githubusercontent.com/127594/58294816-eb640f80-7d80-11e9-9d03-40990449ab70.png">

4. As **Admin**, Calypso sidebar should show Tools and Manage menu.

<img width="272" alt="screenshot_679" src="https://user-images.githubusercontent.com/127594/58294788-c96a8d00-7d80-11e9-9717-5ccf034f4a39.png">

*

Fixes #33033
