### PR TITLE
Sidebar & JP Checklist: Fix links to JP wp-admin

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -179,7 +179,7 @@ export default connect(
 		let wpAdminUrl = get( site, 'options.admin_url' );
 		wpAdminUrl = wpAdminUrl
 			? formatUrl( {
-					...parseUrl( wpAdminUrl ),
+					...parseUrl( wpAdminUrl + 'admin.php' ),
 					query: { page: 'jetpack' },
 					hash: '/my-plan',
 			  } )

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -498,7 +498,7 @@ export class MySitesSidebar extends Component {
 		const adminUrl =
 			this.props.isJetpack && ! this.props.isAtomicSite && ! this.props.isVip
 				? formatUrl( {
-						...parseUrl( site.options.admin_url ),
+						...parseUrl( site.options.admin_url + 'admin.php' ),
 						query: { page: 'jetpack' },
 						hash: '/my-plan',
 				  } )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Sidebar & JP Checklist: Fix links to JP wp-admin

#### Testing instructions

1. Starting at URL: `http://calypso.localhost:3000/plans/my-plan/:site` where `:site` is a Jetpack site.
2. Click on the WP Admin link at the bottom of the sidebar.
3. Verify that `https://:site/wp-admin/admin.php?page=jetpack#/my-plan` is opened
4. Go back to `http://calypso.localhost:3000/plans/my-plan/:site`
5. Locate the 'Return to WP Admin' button at the bottom of the checklist and click it.
6. Verify that it also takes you to `https://:site/wp-admin/admin.php?page=jetpack#/my-plan`

Fixes #33277 (see there for more detail)
