### PR TITLE
Jetpack checklist: add introduction to .com dashboard

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
@@ -7,12 +7,12 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { preventWidows } from 'lib/formatting';
 import ThankYouCard from './thank-you-card';
 
 const FreePlanThankYouCard = ( { translate } ) => (
 	<ThankYouCard
 		illustration="/calypso/images/illustrations/security.svg"
+		showCalypsoIntro
 		showContinueButton
 		title={ translate( 'Welcome to Jetpack Free!' ) }
 	>
@@ -20,15 +20,6 @@ const FreePlanThankYouCard = ( { translate } ) => (
 			{ translate( "We've automatically begun to protect your site from attacks." ) }
 			<br />
 			{ translate( "You're now ready to finish the rest of the checklist." ) }
-		</p>
-		<p>
-			{ preventWidows(
-				translate(
-					'This is your new WordPress.com dashboard. You can manage your site ' +
-						'here, or return to your self-hosted WordPress dashboard using the ' +
-						'link at the bottom of your checklist.'
-				)
-			) }
 		</p>
 	</ThankYouCard>
 );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/free-plan-thank-you-card.js
@@ -7,6 +7,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { preventWidows } from 'lib/formatting';
 import ThankYouCard from './thank-you-card';
 
 const FreePlanThankYouCard = ( { translate } ) => (
@@ -19,6 +20,15 @@ const FreePlanThankYouCard = ( { translate } ) => (
 			{ translate( "We've automatically begun to protect your site from attacks." ) }
 			<br />
 			{ translate( "You're now ready to finish the rest of the checklist." ) }
+		</p>
+		<p>
+			{ preventWidows(
+				translate(
+					'This is your new WordPress.com dashboard. You can manage your site ' +
+						'here, or return to your self-hosted WordPress dashboard using the ' +
+						'link at the bottom of your checklist.'
+				)
+			) }
 		</p>
 	</ThankYouCard>
 );

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -157,6 +157,7 @@ export class PaidPlanThankYouCard extends Component {
 				{ installState === INSTALL_STATE_COMPLETE && (
 					<ThankYouCard
 						illustration={ securityIllustration }
+						showCalypsoIntro
 						showContinueButton
 						title={ translate( 'So long spam, hello backups!' ) }
 					>
@@ -167,15 +168,6 @@ export class PaidPlanThankYouCard extends Component {
 							<br />
 							{ preventWidows(
 								translate( "You're now ready to finish the rest of the checklist." )
-							) }
-						</p>
-						<p>
-							{ preventWidows(
-								translate(
-									'This is your new WordPress.com dashboard. You can manage your site ' +
-										'here, or return to your self-hosted WordPress dashboard using the ' +
-										'link at the bottom of your checklist.'
-								)
 							) }
 						</p>
 					</ThankYouCard>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -169,6 +169,15 @@ export class PaidPlanThankYouCard extends Component {
 								translate( "You're now ready to finish the rest of the checklist." )
 							) }
 						</p>
+						<p>
+							{ preventWidows(
+								translate(
+									'This is your new WordPress.com dashboard. You can manage your site ' +
+										'here, or return to your self-hosted WordPress dashboard using the ' +
+										'link at the bottom of your checklist.'
+								)
+							) }
+						</p>
 					</ThankYouCard>
 				) }
 			</Fragment>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/thank-you-card.js
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 /**
  * Internal dependencies
  */
+import { preventWidows } from 'lib/formatting';
 import Button from 'components/button';
 import Card from 'components/card';
 
@@ -17,9 +18,10 @@ export class ThankYouCard extends Component {
 		const {
 			children,
 			illustration,
-			siteSlug,
+			showCalypsoIntro,
 			showContinueButton,
 			showHideMessage,
+			siteSlug,
 			title,
 			translate,
 		} = this.props;
@@ -37,6 +39,17 @@ export class ThankYouCard extends Component {
 					) }
 					{ title && <h1 className="current-plan-thank-you-card__title">{ title }</h1> }
 					{ children }
+					{ showCalypsoIntro && (
+						<p>
+							{ preventWidows(
+								translate(
+									'This is your new WordPress.com dashboard. You can manage your site ' +
+										'here, or return to your self-hosted WordPress dashboard using the ' +
+										'link at the bottom of your checklist.'
+								)
+							) }
+						</p>
+					) }
 					{ showContinueButton && (
 						<Button primary href={ `/plans/my-plan/${ siteSlug }` }>
 							{ translate( 'Continue' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add introduction to WordPress.com dashboard in checklist's thank-you page.

The first step in https://github.com/Automattic/wp-calypso/issues/33285 (see https://github.com/Automattic/wp-calypso/issues/33285#issuecomment-495383451)

#### Testing instructions

- Have Jetpack sites with a free and paid plan.
- Open `calypso.localhost:3000/plans/my-plan/:site?thank-you`
- In both cases you should see this:
   
<img width="1097" alt="Screenshot 2019-05-24 at 09 46 28" src="https://user-images.githubusercontent.com/87168/58307968-eb0f5700-7e08-11e9-9297-3a0db0bbc466.png">

I didn't add this for special error states now since percentages of users hitting those are low and we have better solution than this copy in the plans.
That's also why I didn't worry about having the same string twice in two different components; I've understood we might remove this with the guided tour. Happy to move it to `ThankYouCard` component tho, it's a quick change.