### PR TITLE
Sidebar: remove target=_blank from WP admin link

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -144,12 +144,13 @@
 
 		// External indicator for sections that aren't available in Calypso
 		&.gridicons-external {
+			height: 18px;
+			left: auto;
+			margin: 0;
 			position: absolute;
 			right: 15px;
-			left: auto;
+			top: auto;
 			z-index: z-index( 'icon-parent', '.sidebar__menu .gridicon.gridicons-external' );
-			height: 18px;
-			margin-right: 0;
 		}
 	}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -12,10 +12,12 @@ import { format as formatUrl, parse as parseUrl } from 'url';
 /**
  * Internal dependencies
  */
-import Button from 'components/button';
 import { isEnabled } from 'config';
+import Button from 'components/button';
 import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
+import ExternalLink from 'components/external-link';
+import JetpackLogo from 'components/jetpack-logo';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarItem from 'layout/sidebar/item';
@@ -24,7 +26,6 @@ import SidebarRegion from 'layout/sidebar/region';
 import SiteMenu from './site-menu';
 import StatsSparkline from 'blocks/stats-sparkline';
 import ToolsMenu from './tools-menu';
-import JetpackLogo from 'components/jetpack-logo';
 import { isFreeTrial, isPersonal, isPremium, isBusiness, isEcommerce } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -510,16 +511,16 @@ export class MySitesSidebar extends Component {
 				  } )
 				: site.options.admin_url;
 
-		/* eslint-disable wpcalypso/jsx-classname-namespace*/
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<li className="wp-admin">
-				<a onClick={ this.trackWpadminClick } href={ adminUrl }>
+				<ExternalLink href={ adminUrl } icon onClick={ this.trackWpadminClick }>
 					<Gridicon icon="my-sites" size={ 24 } />
 					<span className="menu-link-text">{ this.props.translate( 'WP Admin' ) }</span>
-				</a>
+				</ExternalLink>
 			</li>
 		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace*/
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 
 	// Check for cases where WP Admin links should appear, where we need support for legacy reasons (VIP, older users, testing).

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -513,15 +513,9 @@ export class MySitesSidebar extends Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace*/
 		return (
 			<li className="wp-admin">
-				<a
-					onClick={ this.trackWpadminClick }
-					href={ adminUrl }
-					target="_blank"
-					rel="noopener noreferrer"
-				>
+				<a onClick={ this.trackWpadminClick } href={ adminUrl }>
 					<Gridicon icon="my-sites" size={ 24 } />
 					<span className="menu-link-text">{ this.props.translate( 'WP Admin' ) }</span>
-					<Gridicon icon="external" size={ 24 } />
 				</a>
 			</li>
 		);


### PR DESCRIPTION
Removes `target=_blank` from the sidebar WP Admin link; 

- Customer's intent when pressing this button is not to visit another site (like support document) and come back to Calypso. They're leaving one admin dashboard for another. It's confusing to end up with two admin dashboard in two separate tabs.
- WP Admin should be seen as "just another page in their dashboard experience", just like Reader or Customizer.
- It's ok (albeit unfortunate) if the URL and UI are very different without new tabs-switch. So are iframed Customizer, iframed post-editor and the rest of Calypso kinda different looking, too.
- New tab breaks natural back/forward browser flow
- Tabs are kinda annoying on mobile.

#### Changes proposed in this Pull Request

* Remove `target=_blank` from the sidebar WP Admin link
* Remove `external` icon

#### Testing instructions
Have a Jetpack site connected (e.g. http://jurassic.ninja/?create)

Sidebar Before

<img width="245" alt="Screenshot 2019-05-24 at 10 13 49" src="https://user-images.githubusercontent.com/87168/58309348-a5548d80-7e0c-11e9-883e-0de6ae48d21e.png">

Sidebar After

<img width="298" alt="Screenshot 2019-05-24 at 10 05 19" src="https://user-images.githubusercontent.com/87168/58309335-9a99f880-7e0c-11e9-9743-cd4eaa3d5e07.png">
