### PR TITLE
Plans Scroller: use scroll-padding CSS property to align the snap points

### DIFF
--- a/client/my-sites/plan-features/scroller.jsx
+++ b/client/my-sites/plan-features/scroller.jsx
@@ -221,7 +221,7 @@ export default class PlanFeaturesScroller extends PureComponent {
 		};
 	}
 
-	renderStyle( { styleWeights, borderSpacing, paneWidth, visibleIndex, visibleCount } ) {
+	renderStyle( { styleWeights, visibleIndex, visibleCount } ) {
 		const { cellSelector, planCount } = this.props;
 
 		if ( ! styleWeights ) {
@@ -230,9 +230,6 @@ export default class PlanFeaturesScroller extends PureComponent {
 
 		return (
 			<>
-				<style>
-					{ `.plan-features__header::before { left: ${ -paneWidth - borderSpacing / 2 }px }` }
-				</style>
 				{ styleWeights.map( ( weight, index ) => {
 					const selector = `${ cellSelector }:nth-child(${ index + 1 })`;
 					const opacity = round( weight * ( 1 - MIN_PLAN_OPACITY ) + MIN_PLAN_OPACITY, 2 );
@@ -290,7 +287,7 @@ export default class PlanFeaturesScroller extends PureComponent {
 		const disabledLeft = 0 === vars.visibleIndex;
 		const disabledRight = planCount === vars.visibleIndex + vars.visibleCount;
 		const containerClass = classNames( 'plan-features__scroller-container', {
-			'scroll-snap-disabled': this.state.scrollSnapDisabled,
+			'scroll-snap-enabled': ! this.state.scrollSnapDisabled,
 		} );
 
 		return (
@@ -312,7 +309,11 @@ export default class PlanFeaturesScroller extends PureComponent {
 						<Gridicon icon="arrow-left" size={ 24 } />
 					</Button>
 				</div>
-				<div className="plan-features__scroller-wrapper" ref={ this.setWrapperRef }>
+				<div
+					className="plan-features__scroller-wrapper"
+					style={ { scrollPadding: `0 ${ vars.paneWidth + vars.borderSpacing / 2 }px` } }
+					ref={ this.setWrapperRef }
+				>
 					<div
 						className="plan-features__scroller"
 						style={ { width: vars.scrollerWidth, padding: vars.scrollerPadding } }

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -841,21 +841,10 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 		&.is-ecommerce-plan {
 			border-color: var( --color-plan-ecommerce );
 		}
-	}
 
-	/* scroll stops */
-	.plan-features__header::before {
-		content: '';
-		position: absolute;
-		top: 0;
-		height: 0;
-		width: 0;
-		scroll-snap-align: start;
-		scroll-snap-coordinate: 0% 0%;
-
-		.scroll-snap-disabled & {
-			content: none;
-			overflow: hidden;
+		/* scroll stops */
+		.scroll-snap-enabled & {
+			scroll-snap-align: start;
 		}
 	}
 


### PR DESCRIPTION
The Plans Scroller wants the scrolling to be snapped not to the edge of the scrolling element, but to a narrower area between the left/right arrows:

<img width="811" alt="Screenshot 2019-05-24 at 12 27 17" src="https://user-images.githubusercontent.com/664258/58322171-7d6f2500-7e20-11e9-8e67-69aeb4344d2a.png">

That's currently implemented using absolutely-positioned invisible divs with certain offsets. This PR refactors that to use the `scroll-padding` CSS property that's a perfect fit for our purposes. It adds "padding" inside the scroll area that influences the scroll snap points and nothing else.

Note that I use `scroll-padding: 0 123px` instead of `scroll-padding-left: 123px`. The latter doesn't work well in RTL mode.

I also changed the `scroll-snap-disabled` CSS class to `scroll-snap-enabled` to avoid `:not()` operators.

**How to test:**
Test the plans scroller (the fastest way to get there is to use the `/start/plan-no-domain` flow) on various browsers. I tested IE11 and `scroll-padding` worked perfectly there, too.