### PR TITLE
Checklist: Infer loading state from getRequest().isLoading

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
@@ -21,7 +21,7 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { setNeverShowBannerStatus } from './never-show';
 import { recordTracksEvent } from 'state/analytics/actions';
-import getSiteChecklistIsLoading from 'state/selectors/get-site-checklist-is-loading';
+import isSiteChecklistLoading from 'state/selectors/is-site-checklist-loading';
 
 /**
  * Style dependencies
@@ -127,7 +127,7 @@ const mapStateToProps = state => {
 	return {
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
-		isLoading: getSiteChecklistIsLoading( state, siteId ),
+		isLoading: isSiteChecklistLoading( state, siteId ),
 	};
 };
 

--- a/client/state/checklist/actions.js
+++ b/client/state/checklist/actions.js
@@ -35,6 +35,11 @@ export function receiveSiteChecklist( siteId, checklist ) {
 export const requestSiteChecklist = siteId => ( {
 	type: SITE_CHECKLIST_REQUEST,
 	siteId,
+	meta: {
+		dataLayer: {
+			trackRequest: true,
+		},
+	},
 } );
 
 /**

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -6,19 +6,8 @@ import {
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	SITE_CHECKLIST_RECEIVE,
 	SITE_CHECKLIST_TASK_UPDATE,
-	SITE_CHECKLIST_REQUEST,
 } from 'state/action-types';
 import { items as itemSchemas } from './schema';
-
-function isLoading( state = false, { type } ) {
-	switch ( type ) {
-		case SITE_CHECKLIST_REQUEST:
-			return true;
-		case SITE_CHECKLIST_RECEIVE:
-			return false;
-	}
-	return state;
-}
 
 const markChecklistTaskComplete = ( state, taskId ) => ( {
 	...state,
@@ -43,7 +32,6 @@ items.schema = itemSchemas;
 
 const reducer = combineReducers( {
 	items,
-	isLoading,
 } );
 
 export default keyedReducer( 'siteId', reducer );

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -25,6 +25,11 @@ export const fetchChecklist = action =>
 			query: {
 				http_envelope: 1,
 			},
+			meta: {
+				dataLayer: {
+					trackRequest: true,
+				},
+			},
 		},
 		action
 	);

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -25,11 +25,6 @@ export const fetchChecklist = action =>
 			query: {
 				http_envelope: 1,
 			},
-			meta: {
-				dataLayer: {
-					trackRequest: true,
-				},
-			},
 		},
 		action
 	);

--- a/client/state/selectors/get-site-checklist-is-loading.js
+++ b/client/state/selectors/get-site-checklist-is-loading.js
@@ -3,8 +3,13 @@
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getRequest from 'state/selectors/get-request';
+import { requestSiteChecklist } from 'state/checklist/actions';
 
 /**
  * Returns the loading state for the checklist API call
@@ -14,5 +19,14 @@ import { get } from 'lodash';
  * @return {Bool}    Whether the checklist is loading
  */
 export default function getSiteChecklistIsLoading( state, siteId ) {
-	return get( state.checklist, [ siteId, 'isLoading' ], false );
+	const isLoading = get( state.checklist, [ siteId, 'isLoading' ], false );
+	const isLoadingDerived = getRequest( state, requestSiteChecklist( siteId ) ).isLoading;
+	console.log(
+		'isLoading',
+		isLoading,
+		isLoadingDerived,
+		requestSiteChecklist( siteId ),
+		getRequest( state, requestSiteChecklist( siteId ) )
+	);
+	return isLoading;
 }

--- a/client/state/selectors/get-site-checklist-is-loading.js
+++ b/client/state/selectors/get-site-checklist-is-loading.js
@@ -21,12 +21,6 @@ import { requestSiteChecklist } from 'state/checklist/actions';
 export default function getSiteChecklistIsLoading( state, siteId ) {
 	const isLoading = get( state.checklist, [ siteId, 'isLoading' ], false );
 	const isLoadingDerived = getRequest( state, requestSiteChecklist( siteId ) ).isLoading;
-	console.log(
-		'isLoading',
-		isLoading,
-		isLoadingDerived,
-		requestSiteChecklist( siteId ),
-		getRequest( state, requestSiteChecklist( siteId ) )
-	);
+	console.log( 'isLoading', isLoading, isLoadingDerived );
 	return isLoading;
 }

--- a/client/state/selectors/get-site-checklist-is-loading.js
+++ b/client/state/selectors/get-site-checklist-is-loading.js
@@ -1,10 +1,3 @@
-/** @format */
-
-/**
- * External dependencies
- */
-import { get } from 'lodash';
-
 /**
  * Internal dependencies
  */
@@ -19,8 +12,5 @@ import { requestSiteChecklist } from 'state/checklist/actions';
  * @return {Bool}    Whether the checklist is loading
  */
 export default function getSiteChecklistIsLoading( state, siteId ) {
-	const isLoading = get( state.checklist, [ siteId, 'isLoading' ], false );
-	const isLoadingDerived = getRequest( state, requestSiteChecklist( siteId ) ).isLoading;
-	console.log( 'isLoading', isLoading, isLoadingDerived );
-	return isLoading;
+	return getRequest( state, requestSiteChecklist( siteId ) ).isLoading;
 }

--- a/client/state/selectors/is-site-checklist-loading.js
+++ b/client/state/selectors/is-site-checklist-loading.js
@@ -11,6 +11,6 @@ import { requestSiteChecklist } from 'state/checklist/actions';
  * @param  {Number}  siteId Site ID
  * @return {Bool}    Whether the checklist is loading
  */
-export default function getSiteChecklistIsLoading( state, siteId ) {
+export default function isSiteChecklistLoading( state, siteId ) {
 	return getRequest( state, requestSiteChecklist( siteId ) ).isLoading;
 }

--- a/client/state/selectors/test/is-site-checklist-loading.js
+++ b/client/state/selectors/test/is-site-checklist-loading.js
@@ -3,11 +3,11 @@
 /**
  * Internal dependencies
  */
-import getSiteChecklistIsLoading from 'state/selectors/get-site-checklist-is-loading';
+import isSiteChecklistLoading from 'state/selectors/is-site-checklist-loading';
 
-describe( 'getSiteChecklistIsLoading()', () => {
+describe( 'isSiteChecklistLoading()', () => {
 	test( 'should return `false` by default', () => {
-		const isLoading = getSiteChecklistIsLoading( {}, 1234567 );
+		const isLoading = isSiteChecklistLoading( {}, 1234567 );
 		expect( isLoading ).toEqual( false );
 	} );
 
@@ -19,7 +19,7 @@ describe( 'getSiteChecklistIsLoading()', () => {
 				},
 			},
 		};
-		const isLoading = getSiteChecklistIsLoading( state, 1234567 );
+		const isLoading = isSiteChecklistLoading( state, 1234567 );
 		expect( isLoading ).toEqual( true );
 	} );
 } );

--- a/client/state/selectors/test/is-site-checklist-loading.js
+++ b/client/state/selectors/test/is-site-checklist-loading.js
@@ -4,22 +4,30 @@
  * Internal dependencies
  */
 import isSiteChecklistLoading from 'state/selectors/is-site-checklist-loading';
+import { getRequestKey } from 'state/data-layer/wpcom-http/utils';
+import { requestSiteChecklist } from 'state/checklist/actions';
 
 describe( 'isSiteChecklistLoading()', () => {
 	test( 'should return `false` by default', () => {
-		const isLoading = isSiteChecklistLoading( {}, 1234567 );
+		const state = {
+			dataRequests: {},
+		};
+		const isLoading = isSiteChecklistLoading( state, 1234567 );
 		expect( isLoading ).toEqual( false );
 	} );
 
 	test( 'should return isLoading value', () => {
+		const siteId = 1234567;
+		const action = requestSiteChecklist( siteId );
 		const state = {
-			checklist: {
-				1234567: {
-					isLoading: true,
+			dataRequests: {
+				[ getRequestKey( action ) ]: {
+					status: 'pending',
 				},
 			},
 		};
-		const isLoading = isSiteChecklistLoading( state, 1234567 );
+
+		const isLoading = isSiteChecklistLoading( state, siteId );
 		expect( isLoading ).toEqual( true );
 	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change the implementation of `getSiteChecklistIsLoading` to use `getRequest( state, requestSiteChecklist( siteId ) ).isLoading`, which, thanks to the data layer, gives us the state of the network request linked to `requestSiteChecklist` for free (simply by adding [this `meta`](https://github.com/Automattic/wp-calypso/pull/33307/files#diff-92188755dca7f701eb8dcddc91b449afR38) to the action -- thanks @sirreal for reminding me!). This allows us to remove the `isLoading` reducer.

Furthermore, rename the `getSiteChecklistIsLoading` selector to `isSiteChecklistLoading` to align with our established pattern.
 
#### Testing instructions

For a reasonably new WP.com site, go to `http://calypso.localhost:3000/stats/day/:site`. Verify that the checklist banner shows up, possibly after a short wait, but that it doesn't flash between different completion percentages. (Illustrative GIFs at #30258)
