### PR TITLE
Full Site Editing: Use the template title instead of its id as selector initial value

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -73,7 +73,7 @@ const TemplateEdit = compose(
 					>
 						<div className="template-block__selector">
 							<PostAutocomplete
-								initialValue={ templateId }
+								initialValue={ get( template, [ 'title', 'rendered' ] ) }
 								onSelectPost={ onSelectTemplate }
 								postType="wp_template_part"
 							/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix a regression on the Template Part block's selector initial value, which was accidentally set as the template ID instead of its title.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up the Full Site Editing plugin.
* Create a Template, insert a Template Part block, and select a template part.
* Save the Template and reload the page.
* The Template Part block should show the template part preview. Switch into edit mode.
* The autocomplete selector should be pre-filled with the template part title instead of its ID.
