### PR TITLE
Temporarily disable the use of variation_front for domain suggestions.

### DIFF
--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,13 +1,5 @@
 /** @format */
-/**
- * Internal dependencies
- */
-import { isUsingGivenLocales } from 'lib/abtest';
 
 export const getSuggestionsVendor = () => {
-	if ( isUsingGivenLocales( [ 'en' ] ) ) {
-		return 'variation_front';
-	}
-
 	return 'variation2_front';
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are temporarily switching from the `variation_front` domain suggestion provider to the `variation2_front` provider while we investigate issues with inadequate search results being returned.

#### Testing instructions
Build this branch and make sure that an adequate number of search results are returned from /domains/add and in NUX.

Check to make sure that `variation2_front` is sent as the vendor in the request to the `/suggestions?` endpoint.
