### PR TITLE
RedirectWhenLoggedIn: remove legacy React lifecycles

### DIFF
--- a/client/components/redirect-when-logged-in/index.jsx
+++ b/client/components/redirect-when-logged-in/index.jsx
@@ -50,7 +50,7 @@ class RedirectWhenLoggedIn extends React.Component {
 		return true;
 	}
 
-	storageEventHandler( e ) {
+	storageEventHandler = e => {
 		if ( e.key !== 'wpcom_user' ) {
 			return;
 		}
@@ -59,10 +59,10 @@ class RedirectWhenLoggedIn extends React.Component {
 			if ( this.isUserLoggedIn( newUser ) ) {
 				this.doTheRedirect();
 			}
-		} catch ( ex ) {}
-	}
+		} catch {}
+	};
 
-	componentWillMount() {
+	componentDidMount() {
 		const { currentUser, delayAtMount } = this.props;
 
 		if ( this.isUserLoggedIn( currentUser ) ) {
@@ -76,12 +76,12 @@ class RedirectWhenLoggedIn extends React.Component {
 			return;
 		}
 		debug( 'adding storage event listener' );
-		window.addEventListener( 'storage', this.storageEventHandler.bind( this ) );
+		window.addEventListener( 'storage', this.storageEventHandler );
 	}
 
 	componentWillUnmount() {
 		debug( 'removing storage event listener' );
-		window.removeEventListener( 'storage', this.storageEventHandler.bind( this ) );
+		window.removeEventListener( 'storage', this.storageEventHandler );
 	}
 
 	render() {


### PR DESCRIPTION
Little cleanup of the `RedirectWhenLoggedIn` component. Stop using legacy React lifecycle method (willMount). Prefer arrow functions as instance properties to calling `bind`. The `bind` calls don't even work, because each of them returns a different value and `removeEventListener` needs to be passed exactly the same function that was passed to `addEventListener`. The listener is not removed otherwise.

**How to test:**
It's used during magic login to redirect to `/` in case I'm logged in, and also redirects also if I log in in another tab.

Found when working on #32982 and can be submitted as separate independent PR.