### PR TITLE
Onboarding: Update segment specific copy items and add fallbacks

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -38,7 +38,8 @@ const getSiteTypePropertyDefaults = propertyKey =>
 				'This will help you get started with a theme you might like. You can change it later.'
 			),
 		},
-		propertyKey
+		propertyKey,
+		null
 	);
 
 /**

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -9,6 +9,38 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 
+const getSiteTypePropertyDefaults = propertyKey =>
+	get(
+		{
+			// General copy
+			siteMockupHelpTipCopy: i18n.translate(
+				'Scroll down to see your site. Once you complete setup you’ll be able to customize it further.'
+			),
+			// Site title step
+			siteTitleLabel: i18n.translate( 'Give your site a name' ),
+			siteTitleSubheader: i18n.translate(
+				'This will appear at the top of your site and can be changed at anytime.'
+			),
+			siteTitlePlaceholder: i18n.translate( 'default siteTitlePlaceholder' ),
+			// Site topic step
+			siteTopicHeader: i18n.translate( 'What is your site about?' ),
+			siteTopicSubheader: i18n.translate(
+				"We'll add relevant content to your site to help you get started."
+			),
+			siteTopicInputPlaceholder: i18n.translate( 'Enter a topic or choose one from below.' ),
+			// Domains step
+			domainsStepHeader: i18n.translate( 'Give your site an address' ),
+			domainsStepSubheader: i18n.translate(
+				'Enter a keyword that describes your site to get started.'
+			),
+			// Site styles step
+			siteStyleSubheader: i18n.translate(
+				'This will help you get started with a theme you might like. You can change it later.'
+			),
+		},
+		propertyKey
+	);
+
 /**
  * Looks up site types array for item match and returns a property value
  *
@@ -24,7 +56,8 @@ import { find, get } from 'lodash';
  */
 export function getSiteTypePropertyValue( key, value, property, siteTypes = getAllSiteTypes() ) {
 	const siteTypeProperties = find( siteTypes, { [ key ]: value } );
-	return get( siteTypeProperties, property, null );
+
+	return get( siteTypeProperties, property ) || getSiteTypePropertyDefaults( property );
 }
 
 /**
@@ -47,10 +80,23 @@ export function getAllSiteTypes() {
 			description: i18n.translate( 'Share and discuss ideas, updates, or creations.' ),
 			theme: 'pub/independent-publisher-2',
 			designType: 'blog',
-			siteTitleLabel: i18n.translate( 'What would you like to call your blog?' ),
+			siteTitleLabel: i18n.translate( "Tell us your blog's name" ),
 			siteTitlePlaceholder: i18n.translate( "E.g., Stevie's blog " ),
+			siteTitleSubheader: i18n.translate(
+				'This will appear at the top of your blog and can be changed at anytime.'
+			),
 			siteTopicHeader: i18n.translate( 'What is your blog about?' ),
 			siteTopicLabel: i18n.translate( 'What will your blog be about?' ),
+			siteTopicSubheader: i18n.translate(
+				"We'll add relevant content to your blog to help you get started."
+			),
+			siteMockupHelpTipCopy: i18n.translate(
+				'Scroll down to see your blog. Once you complete setup you’ll be able to customize it further.'
+			),
+			domainsStepHeader: i18n.translate( 'Give your blog an address' ),
+			domainsStepSubheader: i18n.translate(
+				"Enter your blog's name or some keywords that describe it to get started."
+			),
 		},
 		{
 			id: 1, // This value must correspond with its sibling in the /segments API results
@@ -60,10 +106,13 @@ export function getAllSiteTypes() {
 			description: i18n.translate( 'Promote products and services.' ),
 			theme: 'pub/professional-business',
 			designType: 'page',
-			siteTitleLabel: i18n.translate( 'What is the name of your business?' ),
+			siteTitleLabel: i18n.translate( 'Tell us your business’s name' ),
 			siteTitlePlaceholder: i18n.translate( 'E.g., Vail Renovations' ),
 			siteTopicHeader: i18n.translate( 'What does your business do?' ),
 			siteTopicLabel: i18n.translate( 'What type of business do you have?' ),
+			domainsStepSubheader: i18n.translate(
+				"Enter your business's name or some keywords that describe it to get started."
+			),
 			customerType: 'business',
 		},
 		{
@@ -77,7 +126,10 @@ export function getAllSiteTypes() {
 			siteTitleLabel: i18n.translate( 'What is your name?' ),
 			siteTitlePlaceholder: i18n.translate( 'E.g., John Appleseed' ),
 			siteTopicHeader: i18n.translate( 'What type of work do you do?' ),
-			siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
+			siteTopicInputPlaceholder: i18n.translate( 'Enter your job title or choose one from below.' ),
+			domainsStepSubheader: i18n.translate(
+				'Enter your name or some keywords that describe yourself to get started.'
+			),
 		},
 		{
 			id: 3, // This value must correspond with its sibling in the /segments API results

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -24,20 +24,19 @@ import { getSiteStyleOptions, getThemeCssUri } from 'lib/signup/site-styles';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getLocaleSlug, getLanguage } from 'lib/i18n-utils';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 
-function SiteMockupHelpTip() {
+function SiteMockupHelpTip( { siteType } ) {
+	const helpTipCopy = getSiteTypePropertyValue( 'slug', siteType, 'siteMockupHelpTipCopy' ) || '';
+
 	return (
 		<div className="site-mockup__help-tip">
-			<p>
-				{ translate(
-					'Scroll down to see your website. Once you complete setup you’ll be able to customize it further.'
-				) }
-			</p>
+			<p>{ helpTipCopy }</p>
 			<Gridicon icon="chevron-down" />
 		</div>
 	);
@@ -118,6 +117,7 @@ class SiteMockups extends Component {
 			fontUrl,
 			shouldShowHelpTip,
 			siteStyle,
+			siteType,
 			title,
 			themeSlug,
 			verticalPreviewContent,
@@ -145,7 +145,7 @@ class SiteMockups extends Component {
 
 		return (
 			<div className={ siteMockupClasses }>
-				{ shouldShowHelpTip && <SiteMockupHelpTip /> }
+				{ shouldShowHelpTip && <SiteMockupHelpTip siteType={ siteType } /> }
 				<div className="site-mockup__devices">
 					<SignupSitePreview
 						defaultViewportDevice="desktop"

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { defer, endsWith, get, isEmpty } from 'lodash';
+import { defer, endsWith, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 
 /**
@@ -36,11 +36,13 @@ import Notice from 'components/notice';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { setDesignType } from 'state/signup/steps/design-type/actions';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getDomainProductSlug } from 'lib/domains';
 import QueryProductsList from 'components/data/query-products-list';
 import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 import { getSite } from 'state/sites/selectors';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 /**
  * Style dependencies
@@ -516,10 +518,24 @@ class DomainsStep extends React.Component {
 	};
 
 	getSubHeaderText() {
-		const { translate } = this.props;
+		const { flowName, siteType, translate } = this.props;
+		const onboardingSubHeaderCopy =
+			siteType &&
+			includes( [ 'onboarding-for-business', 'onboarding' ], flowName ) &&
+			getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
+
+		if ( onboardingSubHeaderCopy ) {
+			return onboardingSubHeaderCopy;
+		}
+
 		return 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName
 			? translate( 'Use a domain you already own with your new WordPress.com site.' )
 			: translate( "Enter your site's name or some keywords that describe it to get started." );
+	}
+
+	getHeaderText() {
+		const { headerText, siteType } = this.props;
+		return getSiteTypePropertyValue( 'slug', siteType, 'domainsStepHeader' ) || headerText;
 	}
 
 	getAnalyticsSection() {
@@ -589,6 +605,7 @@ class DomainsStep extends React.Component {
 			backLabelText = translate( 'Back to Site' );
 		}
 
+		const headerText = this.getHeaderText();
 		const fallbackSubHeaderText = this.getSubHeaderText();
 
 		return (
@@ -598,9 +615,9 @@ class DomainsStep extends React.Component {
 				backUrl={ backUrl }
 				positionInFlow={ this.props.positionInFlow }
 				signupProgress={ this.props.signupProgress }
-				headerText={ this.props.headerText }
-				subHeaderText={ this.props.subHeaderText }
-				fallbackHeaderText={ translate( 'Give your site an address.' ) }
+				headerText={ headerText }
+				subHeaderText={ fallbackSubHeaderText }
+				fallbackHeaderText={ headerText }
 				fallbackSubHeaderText={ fallbackSubHeaderText }
 				stepContent={
 					<div>
@@ -664,6 +681,7 @@ export default connect(
 			siteGoals: getSiteGoals( state ),
 			surveyVertical: getSurveyVertical( state ),
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
+			siteType: getSiteType( state ),
 		};
 	},
 	{

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -26,6 +26,7 @@ import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSiteStyleOptions } from 'lib/signup/site-styles';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 /**
  * Style dependencies
@@ -129,9 +130,9 @@ export class SiteStyleStep extends Component {
 			translate,
 		} = this.props;
 		const headerText = translate( 'Choose a style' );
-		const subHeaderText = translate(
-			"Choose a style for your site's theme. Don't worry, you can always change it later."
-		);
+		// for the time being we just want to fall back to the default value.
+		// If we come to add segment specific copy for this item, update the first 2 args.
+		const subHeaderText = getSiteTypePropertyValue( null, null, 'siteStyleSubheader' );
 
 		return (
 			<div>

--- a/client/signup/steps/site-style/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-style/test/__snapshots__/index.js.snap
@@ -4,7 +4,7 @@ exports[`<SiteStyleStep /> should render 1`] = `
 <div>
   <Localized(StepWrapper)
     fallbackHeaderText="Choose a style"
-    fallbackSubHeaderText="Choose a style for your site's theme. Don't worry, you can always change it later."
+    fallbackSubHeaderText="This will help you get started with a theme you might like. You can change it later."
     headerText="Choose a style"
     stepContent={
       <div
@@ -63,7 +63,7 @@ exports[`<SiteStyleStep /> should render 1`] = `
         </form>
       </div>
     }
-    subHeaderText="Choose a style for your site's theme. Don't worry, you can always change it later."
+    subHeaderText="This will help you get started with a theme you might like. You can change it later."
   />
 </div>
 `;

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -137,13 +137,12 @@ class SiteTitleStep extends Component {
 			positionInFlow,
 			showSiteMockups,
 			signupProgress,
+			siteType,
 			stepName,
-			translate,
 		} = this.props;
-		const headerText = translate( "Tell us your site's name" );
-		const subHeaderText = translate(
-			'This will appear at the top of your site and can be changed at anytime.'
-		);
+		const headerText = getSiteTypePropertyValue( 'slug', siteType, 'siteTitleLabel' );
+		const subHeaderText = getSiteTypePropertyValue( 'slug', siteType, 'siteTitleSubheader' );
+
 		return (
 			<div>
 				<StepWrapper

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -27,6 +27,7 @@ import {
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 /**
  * Style dependencies
@@ -74,11 +75,15 @@ class SiteTopicForm extends Component {
 
 	render() {
 		const { isButtonDisabled, siteTopic, siteType } = this.props;
+		const suggestionSearchInputPlaceholder =
+			getSiteTypePropertyValue( 'slug', siteType, 'siteTopicInputPlaceholder' ) || '';
+
 		return (
 			<div className={ classNames( 'site-topic__content', { 'is-empty': ! siteTopic } ) }>
 				<form onSubmit={ this.onSubmit }>
 					<FormFieldset>
 						<SiteVerticalsSuggestionSearch
+							placeholder={ suggestionSearchInputPlaceholder }
 							onChange={ this.onSiteTopicChange }
 							showPopular={ true }
 							searchValue={ siteTopic }

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -42,22 +42,11 @@ class SiteTopicStep extends Component {
 		} );
 	}
 
-	getTextFromSiteType() {
-		// once we have more granular copies per segments, these should only be used for the default case.
+	render() {
 		const headerText =
 			getSiteTypePropertyValue( 'slug', this.props.siteType, 'siteTopicHeader' ) || '';
-		const commonSubHeaderText = this.props.translate(
-			'This information helps us build the best site for your needs.'
-		);
-
-		return {
-			headerText,
-			commonSubHeaderText,
-		};
-	}
-
-	render() {
-		const { headerText, commonSubHeaderText } = this.getTextFromSiteType();
+		const subHeaderText =
+			getSiteTypePropertyValue( 'slug', this.props.siteType, 'siteTopicSubheader' ) || '';
 
 		return (
 			<div>
@@ -67,8 +56,8 @@ class SiteTopicStep extends Component {
 					positionInFlow={ this.props.positionInFlow }
 					headerText={ headerText }
 					fallbackHeaderText={ headerText }
-					subHeaderText={ commonSubHeaderText }
-					fallbackSubHeaderText={ commonSubHeaderText }
+					subHeaderText={ subHeaderText }
+					fallbackSubHeaderText={ subHeaderText }
 					signupProgress={ this.props.signupProgress }
 					stepContent={ <SiteTopicForm submitForm={ this.props.submitSiteTopic } /> }
 					showSiteMockups={ this.props.showSiteMockups }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to bring the copy in each step of the onboarding flow up to date with the current requirements.

One of the issues to tackle while doing so was to be sure we had defaults to fall back to when copy items werent specified for particular site types, and a machanism for defering to those defaults.
I chose to expand on `getSiteTypePropertyValue`, allowing it to return a default property if one exists.

#### Testing instructions

Starting at http://calypso.localhost:3000/start/onboarding, go through the flows of each segment, making sure each copy item shows up correctly as before (but with the copy edits noted below).

As this PR also updates copy items (I can split, if folk would prefer), please go through each step, under each segment selection, and check that the copy updates are all correct...

Here are some references to the original (private) cards, you can use these to cross reference the updated copy found here with those noted in those cards:

**Site Title Step**: 
https://github.com/Automattic/zelda-private/issues/23

This step should see the following updates:

**Defaults**
- Title `Give your site a name`

**Blog Segment**

- Title/Heading: `Tell us your blog’s name`
- Subtitle/Subheader: `This will appear at the top of your blog and can be changed at anytime.`

**Business Segment**

- Title/Heading: `Tell us your business’s name`

**Professional Segment**

- Title/Heading: `What is your name?`


**Site Style Step**
https://github.com/Automattic/zelda-private/issues/24

This step should see the following updates:

**Defaults**
- Subtitle/Subheader: "This will help you get started with a theme you might like. You can change it later."

**Site Topic Step**
https://github.com/Automattic/zelda-private/issues/22

This step should see the following updates:

**Defaults**
- Title/Header: `What is your site about?`
- Subtitle/Subheader: `We'll add relevant content to your site to help you get started.`
- Input field placeholder copy: `Enter a topic or choose one from below.`
- Scroll down to preview: `Scroll down to see your site. Once you complete setup you’ll be able to customize it further.`

**blog overrides**

- Title/Header: `What is your blog about?`
- Subtitle/Subheader: `We'll add relevant content to your blog to help you get started.`
- Scroll down to preview: `Scroll down to see your blog. Once you complete setup you’ll be able to customize it further.`

**business overrides**

- Title/Header: `What does your business do?`

**professional overrides**

-  Title/Header: `What type of work do you do?`
- Input field placeholder copy: `Enter your job title or choose one from below.`

**Domains Step**
https://github.com/Automattic/zelda-private/issues/25

This step should see the following updates:

**Defaults**

- Title/Heading: `Give your site an address`
- Subtitle/Subheading: `Enter a keyword that describes your site to get started.`

**Blog**

- Title/Heading: `Give your blog an address`
- Subtitle/Subheading: `Enter your blog's name or some keywords that describe it to get started.`

**Business**

- Title/Heading: `Give your site an address`
- Subtitle/Subheading: `Enter your business's name or some keywords that describe it to get started.`

**Professional**

- Title/Heading: `Give your site an address`
- Subtitle/Subheading: `Enter your name or some keywords that describe yourself to get started.`

