### PR TITLE
Domain Suggestions: Make sure placeholder doesn't have any padding

### DIFF
--- a/client/components/domains/featured-domain-suggestions/placeholder.scss
+++ b/client/components/domains/featured-domain-suggestions/placeholder.scss
@@ -13,6 +13,7 @@
 
 	.domain-registration-suggestion__title {
 		height: 22px;
+		padding: 0;
 		width: 60%;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add `padding: 0` to `.domain-registration-suggestion__title` in order to avoid overflowing.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new [WordPress.com site](https://wordpress.com/start)
* Step 4 (Domain), notice the suggestions' placeholder. Does it overflow?

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/58340729-64786b00-7e44-11e9-9f40-be93b0b25df1.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/58340736-6b06e280-7e44-11e9-95c8-c3c2a8732352.png)


Fixes #33021 