### PR TITLE
Full Site Editing / Editor-in-Editor: Template Switcheroo

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template-wrapper/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template-wrapper/index.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+registerBlockType( 'a8c/template-wrapper', {
+	title: __( 'Template Wrapper' ),
+	description: __( 'Display a template part.' ),
+	icon: 'layout',
+	category: 'layout',
+	attributes: { position: { type: 'string' } },
+	supports: {
+		align: [ 'full' ],
+		html: false,
+		inserter: false,
+		reusable: false,
+	},
+	edit: () => <InnerBlocks />,
+	save: () => <InnerBlocks.Content />,
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template-wrapper/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template-wrapper/style.scss
@@ -1,0 +1,4 @@
+.editor-block-list__block[data-type="a8c/template-wrapper"] > .editor-block-list__block-edit::before {
+	background: #fff url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400"         fill-opacity=".1" ><rect x="200" width="200" height="200" /><rect y="200" width="200" height="200" /></svg>');
+	background-size: 30px 30px;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -11,20 +11,19 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-if ( 'wp_template' === fullSiteEditing.editorPostType ) {
-	registerBlockType( 'a8c/template', {
-		title: __( 'Template Part' ),
-		description: __( 'Display a template part.' ),
-		icon: 'layout',
-		category: 'layout',
-		attributes: { templateId: { type: 'number' } },
-		supports: {
-			align: [ 'wide', 'full' ],
-			anchor: true,
-			html: false,
-			reusable: false,
-		},
-		edit,
-		save: () => null,
-	} );
-}
+registerBlockType( 'a8c/template', {
+	title: __( 'Template Part' ),
+	description: __( 'Display a template part.' ),
+	icon: 'layout',
+	category: 'layout',
+	attributes: { templateId: { type: 'number' } },
+	supports: {
+		align: [ 'wide', 'full' ],
+		anchor: true,
+		html: false,
+		inserter: 'wp_template' === fullSiteEditing.editorPostType,
+		reusable: false,
+	},
+	edit,
+	save: () => null,
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -278,6 +278,8 @@ class Full_Site_Editing {
 				'render_callback' => 'render_template_block',
 			)
 		);
+
+		register_block_type( 'a8c/template-wrapper' );
 	}
 
 	/**
@@ -308,47 +310,46 @@ class Full_Site_Editing {
 		}
 
 		$template_id = get_post_meta( $postarr['ID'], '_wp_template_id', true );
+
 		if ( isset( $template_id ) && ! empty( $template_id ) ) {
 			$post_content = wp_unslash( $data['post_content'] );
-			$blocks = parse_blocks( $post_content );
 
-			$before_content = 'core/group' === $blocks[0]['blockName']
-				? $blocks[0]['innerBlocks']
-				: array();
-			$after_content = 'core/group' === $blocks[ count( $blocks ) - 1 ]['blockName']
-				? $blocks[ count( $blocks ) - 1 ]['innerBlocks']
-				: array();
+			preg_match_all(
+				'/<!-- wp:a8c\/template-wrapper[\s\S]+?wp:a8c\/template-wrapper -->/',
+				$post_content,
+				$template_parts
+			);
 
-			$updated_template_content = '';
-			foreach( $before_content as $block ) {
-				$updated_template_content .= render_block( $block );
-			}
-			$updated_template_content .= "\n\n<!-- wp:a8c/post-content /-->\n\n";
-			foreach( $after_content as $block ) {
-				$updated_template_content .= render_block( $block );
-			}
-
-			error_log( print_r( $updated_template_content, true ) );
-
-			// This implies that there are only two parts of the template, one before and one after the Post Content.
-			preg_match_all( '/<!-- wp:group[\s\S]+?wp:group -->/', $post_content, $template_parts );
-
-			$before_content = preg_replace( '/<!-- wp:group[\s\S]+?-->/', '', $template_parts[0][0] );
-			$before_content = str_replace( '<!-- /wp:group -->', '', $before_content );
-			$after_content = preg_replace( '/<!-- wp:group[\s\S]+?-->/', '', $template_parts[0][1] );
-			$after_content = str_replace( '<!-- /wp:group -->', '', $after_content );
+			$before_content = str_replace(
+				array(
+					'<!-- wp:a8c/template-wrapper {"position":"before","align":"full"} -->',
+					'<!-- /wp:a8c/template-wrapper -->',
+				),
+				'',
+				$template_parts[0][0]
+			);
+			$after_content = str_replace(
+				array(
+					'<!-- wp:a8c/template-wrapper {"position":"after","align":"full"} -->',
+					'<!-- /wp:a8c/template-wrapper -->',
+				),
+				'',
+				$template_parts[0][1]
+			);
 
 			$updated_template_content = $before_content . "\n\n<!-- wp:a8c/post-content /-->\n\n" . $after_content;
 
-			//error_log( print_r( $updated_template_content, true ) );
-
-			/*wp_update_post( array(
+			wp_update_post( array(
 				'ID'           => $template_id,
 				'post_content' => $updated_template_content,
-			) );*/
+			) );
 		}
 
-		$stripped_post_content = preg_replace( '/<!-- wp:group[\s\S]+?wp:group -->/', '', $data['post_content'] );
+		$stripped_post_content = preg_replace(
+			'/<!-- wp:a8c\/template-wrapper[\s\S]+?wp:a8c\/template-wrapper -->/',
+			'',
+			$data['post_content']
+		);
 		$data['post_content'] = $stripped_post_content;
 
 		return $data;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
@@ -3,4 +3,5 @@
  */
 import './blocks/post-content';
 import './blocks/template';
+import './plugins/editor-in-editor';
 import './plugins/template-selector-sidebar';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
@@ -3,5 +3,6 @@
  */
 import './blocks/post-content';
 import './blocks/template';
+import './blocks/template-wrapper';
 import './plugins/editor-in-editor';
 import './plugins/template-selector-sidebar';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-in-editor/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-in-editor/index.js
@@ -67,20 +67,20 @@ const EditorInEditor = compose(
 	const parsedTemplate = parseTemplate( template );
 
 	const beforeContent = createBlock(
-		'core/group',
+		'a8c/template-wrapper',
 		{
 			align: 'full',
-			customBackgroundColor: '#eeeeee',
+			position: 'before',
 		},
 		map( parsedTemplate.beforeContent, ( { name, attributes } ) => createBlock( name, attributes ) )
 	);
 	insertBlock( beforeContent, 0 );
 
 	const afterContent = createBlock(
-		'core/group',
+		'a8c/template-wrapper',
 		{
 			align: 'full',
-			customBackgroundColor: '#eeeeee',
+			position: 'after',
 		},
 		map( parsedTemplate.afterContent, ( { name, attributes } ) => createBlock( name, attributes ) )
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/plugins/editor-in-editor/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/plugins/editor-in-editor/index.js
@@ -1,0 +1,96 @@
+/* global fullSiteEditing */
+/**
+ * External dependencies
+ */
+import { forEach, get, map } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { createBlock, parse } from '@wordpress/blocks';
+import { compose } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { registerPlugin } from '@wordpress/plugins';
+
+function parseTemplate( template ) {
+	const templateBlocks = parse( get( template, [ 'content', 'raw' ] ) );
+
+	const beforeContent = [];
+	const afterContent = [];
+
+	let passedPostContent = false;
+	forEach( templateBlocks, block => {
+		const blockName = get( block, [ 'attributes', 'originalName' ] );
+		if ( 'a8c/post-content' === blockName ) {
+			passedPostContent = true;
+			return;
+		}
+		if ( 'core/missing' === block.name ) {
+			return;
+		}
+
+		if ( passedPostContent ) {
+			afterContent.push( block );
+		} else {
+			beforeContent.push( block );
+		}
+	} );
+
+	return { beforeContent, afterContent };
+}
+
+const EditorInEditor = compose(
+	withDispatch( dispatch => {
+		const { insertBlock } = dispatch( 'core/block-editor' );
+		return {
+			insertBlock,
+		};
+	} ),
+	withSelect( select => {
+		const { getEntityRecord } = select( 'core' );
+		const { getEditedPostAttribute, __unstableIsEditorReady: isEditorReady } = select(
+			'core/editor'
+		);
+
+		const templateId = get( getEditedPostAttribute( 'meta' ), '_wp_template_id' );
+
+		return {
+			isEditorReady,
+			template: templateId && getEntityRecord( 'postType', 'wp_template', templateId ),
+		};
+	} )
+)( ( { insertBlock, template } ) => {
+	if ( ! template ) {
+		return null;
+	}
+
+	const parsedTemplate = parseTemplate( template );
+
+	const beforeContent = createBlock(
+		'core/group',
+		{
+			align: 'full',
+			customBackgroundColor: '#eeeeee',
+		},
+		map( parsedTemplate.beforeContent, ( { name, attributes } ) => createBlock( name, attributes ) )
+	);
+	insertBlock( beforeContent, 0 );
+
+	const afterContent = createBlock(
+		'core/group',
+		{
+			align: 'full',
+			customBackgroundColor: '#eeeeee',
+		},
+		map( parsedTemplate.afterContent, ( { name, attributes } ) => createBlock( name, attributes ) )
+	);
+	insertBlock( afterContent );
+
+	return null;
+} );
+
+if ( 'page' === fullSiteEditing.editorPostType ) {
+	registerPlugin( 'fse-editor-in-editor', {
+		render: EditorInEditor,
+	} );
+}

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -33,6 +33,7 @@
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^3.1.2",
+		"@wordpress/block-editor": "^2.1.0",
 		"@wordpress/blocks": "^6.2.3",
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",


### PR DESCRIPTION
## ⚠️ DO NOT MERGE! ⚠️

**EXPLORATORY MATERIAL ONLY**

This is a very naïve approach with a brittle implementation.
It's not intended to be shipped to production, but hopefully some if it will turn out to be useful for other folks.

### The problem

We have templates, we can assign them to pages, and we can even [render the whole thing in the front end](https://github.com/Automattic/wp-calypso/pull/33128).

But we also want to be able to edit a page and its template in the very same editor.

### The solution proposed here

[**DEMO VIDEO**](https://cloudup.com/cezELSznlwz)

We currently have a scope constraint of limiting the template to:
- Template parts before the content (let's call this "header").
- The content.
- Template parts after the content (let's call this "footer").

This means that for now we don't need to care for templates with multiple content areas and template parts in the middle.

By parsing a template content, we know what is supposed to go before and what after the content.

#### On page editor load

When we edit a page, we prepend to the content the template header, and append after the content the template footer.
This is possible by creating a new Gutenberg plugin connected to `select( 'core/editor' ).__unstableIsEditorReady()` and `dispatch( 'core/block-editor' ).insertBlock()`.

We end up with an editor containing everything that is supposed to be rendered on the front-end, and we can even edit it all*!

_(* actually we _can't_ edit the Template Part block content, but only replace the selected template part)_

#### On save

We aren't supposed to save everything inside the page content, so we need to incept into the save process and tinker with the content.
The `wp_insert_post_data` filter lets us do exactly that.

In its callback we will then:
1) Update the template with whatever changes we did to it.
2) Remove the template from the page content before saving it.

For this we need some good regex skills that I don't have.
As a workaround, I've introduced a new block called `a8c/template-wrapper` whose only purpose is to wrap the template half before the content and the half after the content, so that it's easier to manipulate.

_(I gave the wrapper a nice checkered background so that it's clear what is part of the template and what isn't.)_

To update the template, we need to:
1) Match the wrapper before the content; remove the wrapper block pieces and only keep its innards.
2) Do the same for the wrapper after the content.
3) Concatenate the part before the content, `<!-- wp:a8c/post-content /-->`, and the part after the content.
4) Use this to update the template.

After which, we remove the entire wrappers from the page content, and save what's left.

#### Testing instructions

* Spin up the FSE plugin.
* Create some template parts.
* Create a template containing: something before the content (template parts or not), the Post Content block, something after the content.
* Create a page. Select "start with a blank page" to skip the Starter Page Templates that are unrelated to our case.
* Open the Template selector sidebar and select a template.
* ❗️ Make sure the editor gets prefilled by the template parts. (⚠️ Notice that it might not be clear where the "before content" ends and the "after content" starts, as they might not have vertical margins.)
* Add something **between** the two template halves. (⚠️ To be sure it's between, check if the new blocks are on a clear white background.)
* Save the page.
* Open the page in the front-end. (⚠️ Don't use the Preview button, because it would show the template parts as well - it's a known issue.)
* ❗️ Make sure you only see the actual page content, without any template parts.
* Back into the page editor, this time add something **inside** the template parts. (⚠️ To be sure it's inside, check if the new blocks are on a checkered background.)
* Save the page.
* Leave the editor and edit the template assigned to the page you've just left.
* ❗️ Make sure you see the template changes you've just saved in the page editor.