### PR TITLE
Add Convert to Blocks prompt to block editor

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -18,59 +18,46 @@ import tinymce from 'tinymce/tinymce';
 import { inIframe, sendMessage } from './utils';
 
 /**
- * Monitors Gutenburg for when an editor is opened with content originally authored in the classic editor.
+ * Monitors Gutenberg for when an editor is opened with content originally authored in the classic editor.
  *
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function triggerConversionPrompt( calypsoPort ) {
-	function addConversionListener( classicBlock ) {
-		// Listen for user response
-		calypsoPort.addEventListener( 'message', onConversionResponse, false );
-		calypsoPort.start();
+	const { port1, port2 } = new MessageChannel();
 
-		function onConversionResponse( message ) {
-			const action = get( message, 'data.action' );
-			const payload = get( message, 'data.payload' );
+	const unsubscribe = subscribe( () => {
+		const currentPost = select( 'core/editor' ).getCurrentPost();
+		const initialized = currentPost && currentPost.id;
 
-			if ( action !== 'conversionResponse' ) {
+		if ( ! initialized ) {
+			return;
+		}
+
+		unsubscribe();
+
+		const blocks = select( 'core/editor' ).getBlocks();
+		const eligible = blocks.length === 1 && blocks[ 0 ].name === 'core/freeform';
+
+		if ( ! eligible ) {
+			return;
+		}
+
+		calypsoPort.postMessage( { action: 'triggerConversionRequest' }, [ port2 ] );
+
+		port1.onmessage = ( { data: confirmed } ) => {
+			port1.close();
+
+			if ( confirmed !== true ) {
 				return;
 			}
 
-			// Removing the listener regardless of which action was taken
-			calypsoPort.removeEventListener( 'message', onConversionResponse, false );
-
-			// Converting the block if the user selected the "Convert" button in the prompt
-			if ( payload.confirmed === true ) {
-				const unsubscribe = subscribe( () => {
-					dispatch( 'core/editor' ).replaceBlock(
-						classicBlock.clientId,
-						rawHandler( {
-							HTML: classicBlock.originalContent,
-						} )
-					);
-
-					unsubscribe();
-				} );
-			}
-		}
-	}
-
-	// Check if the prompt should open
-	const unsubscribe = subscribe( () => {
-		const { isEditedPostDirty } = select( 'core/editor' );
-		const blocks = select( 'core/editor' ).getBlocks();
-
-		// Open when: editor is not dirty and there is a single classic block
-		if ( ! isEditedPostDirty() && blocks.length === 1 && blocks[ 0 ].name === 'core/freeform' ) {
-			calypsoPort.postMessage( {
-				action: 'openConversions',
-			} );
-
-			// Setup a listener for user response
-			addConversionListener( blocks[ 0 ] );
-
-			unsubscribe();
-		}
+			dispatch( 'core/editor' ).replaceBlock(
+				blocks[ 0 ].clientId,
+				rawHandler( {
+					HTML: blocks[ 0 ].originalContent,
+				} )
+			);
+		};
 	} );
 }
 

--- a/client/components/convert-to-blocks/index.jsx
+++ b/client/components/convert-to-blocks/index.jsx
@@ -1,0 +1,71 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ConvertToBlocksDialog extends Component {
+	static propTypes = {
+		close: PropTypes.func,
+		showDialog: PropTypes.bool,
+		confirmConversion: PropTypes.func,
+	};
+
+	shouldComponentUpdate( nextProps ) {
+		return this.props.showDialog !== nextProps.showDialog;
+	}
+
+	render() {
+		if ( this.props.isDirty ) {
+			return null;
+		}
+
+		const { translate, showDialog, close, confirmConversion } = this.props;
+
+		const buttons = [
+			{
+				action: 'convert',
+				isPrimary: true,
+				label: translate( 'Convert to Blocks' ),
+				onClick: confirmConversion,
+			},
+			{
+				action: 'cancel',
+				label: translate( 'Cancel' ),
+				onClick: close,
+			},
+		];
+
+		return (
+			<Dialog
+				additionalClassNames="editor__gutenberg-convert-blocks-dialog"
+				buttons={ buttons }
+				isVisible={ showDialog }
+				onClose={ close }
+			>
+				<h1>{ translate( 'Ready to try blocks?' ) }</h1>
+
+				<p>
+					{ translate(
+						'This post contains content you created using the older editor. For the best editing experience, we recommend converting this content to blocks.'
+					) }
+				</p>
+			</Dialog>
+		);
+	}
+}
+
+export default localize( ConvertToBlocksDialog );

--- a/client/components/convert-to-blocks/index.jsx
+++ b/client/components/convert-to-blocks/index.jsx
@@ -19,33 +19,26 @@ import './style.scss';
 
 class ConvertToBlocksDialog extends Component {
 	static propTypes = {
-		close: PropTypes.func,
 		showDialog: PropTypes.bool,
-		confirmConversion: PropTypes.func,
+		handleConversionResponse: PropTypes.func,
 	};
 
-	shouldComponentUpdate( nextProps ) {
-		return this.props.showDialog !== nextProps.showDialog;
-	}
+	close = action => {
+		this.props.handleResponse( action === 'convert' );
+	};
 
 	render() {
-		if ( this.props.isDirty ) {
-			return null;
-		}
-
-		const { translate, showDialog, close, confirmConversion } = this.props;
+		const { translate, showDialog } = this.props;
 
 		const buttons = [
 			{
 				action: 'convert',
 				isPrimary: true,
 				label: translate( 'Convert to Blocks' ),
-				onClick: confirmConversion,
 			},
 			{
 				action: 'cancel',
 				label: translate( 'Cancel' ),
-				onClick: close,
 			},
 		];
 
@@ -54,7 +47,7 @@ class ConvertToBlocksDialog extends Component {
 				additionalClassNames="editor__gutenberg-convert-blocks-dialog"
 				buttons={ buttons }
 				isVisible={ showDialog }
-				onClose={ close }
+				onClose={ this.close }
 			>
 				<h1>{ translate( 'Ready to try blocks?' ) }</h1>
 

--- a/client/components/convert-to-blocks/style.scss
+++ b/client/components/convert-to-blocks/style.scss
@@ -1,0 +1,7 @@
+.dialog.card.editor__gutenberg-convert-blocks-dialog {
+	max-width: 600px;
+
+	@include breakpoint( '<660px' ) {
+		max-width: 90%;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adding a "Covert to blocks?" prompt to content authored in the classic editor.
    * Prompt opens when the editor is opened containing a single classic block, which suggests that the content was previously authored in a classic editor.

#### Testing instructions

Manual testing flow:

* Create a post with a single classic block.
    * Ideally, through a classic editor to preserve authentic editing flow.
* Open post in the block editor.
* See "Covert to blocks?" prompt with two options: 'Close' or 'Convert to blocks'.
    * Click 'Close'. The modal will close.
    * Click 'Convert to Blocks'. The modal will close and the existing content will be converted to blocks.

Fixes #33043 

See: PCYsg-l4k-p2 for further testing instructions.