### PR TITLE
Add aria-label to the toggle sidebar button

### DIFF
--- a/client/post-editor/editor-ground-control/index.jsx
+++ b/client/post-editor/editor-ground-control/index.jsx
@@ -74,6 +74,11 @@ export class EditorGroundControl extends React.Component {
 		return this.props.translate( 'Preview' );
 	}
 
+	getToggleSidebarLabel() {
+		const { translate, isSidebarOpened } = this.props;
+		return isSidebarOpened ? translate( 'Close post settings' ) : translate( 'Open post settings' );
+	}
+
 	getVerificationNoticeLabel() {
 		const { translate, publishButtonStatus } = this.props;
 
@@ -116,6 +121,7 @@ export class EditorGroundControl extends React.Component {
 					borderless
 					className="editor-ground-control__toggle-sidebar"
 					onClick={ this.props.toggleSidebar }
+					aria-label={ this.getToggleSidebarLabel() }
 				>
 					<Gridicon icon="cog" />
 				</Button>
@@ -143,7 +149,7 @@ export class EditorGroundControl extends React.Component {
 	}
 
 	getCloseButtonPath() {
-		const editorPathRegex = /^(\/block-editor)?\/(post|page|(edit\/[^\/]+))(\/|$)/i;
+		const editorPathRegex = /^(\/block-editor)?\/(post|page|(edit\/[^/]+))(\/|$)/i;
 		// find the last non-editor path in routeHistory, default to "all posts"
 		const lastNonEditorPath = findLast(
 			this.props.routeHistory,


### PR DESCRIPTION
I'd like to get familiar with the codebase, and I found that this button didn't have a label. So I added it.

There're other accessibility issues with this component, like the lack of `aria-expanded`, `aria-haspoup` and `aria-controls` attributes and the lack of focus management (focus should probably go into the settings sidebar, so users don't get lost when clicking on this button). I can open a separate issue for these and address them once I get more used to the codebase.

#### Changes proposed in this Pull Request

* Add `aria-label` to the toggle post settings button

#### Testing instructions

* Click on `Add new post`
* Inspect the button with a gear icon

#### Before

![image](https://user-images.githubusercontent.com/3068563/58362013-10cc4880-7e69-11e9-8a7d-def4ce442dc6.png)

#### After

![image](https://user-images.githubusercontent.com/3068563/58362028-3f4a2380-7e69-11e9-8d90-9272fb69b0a9.png)

![image](https://user-images.githubusercontent.com/3068563/58362035-51c45d00-7e69-11e9-8cbe-78e556f4a909.png)
