### PR TITLE
Checklist: Targeted placement step is mispositioned when window is too wide

### DIFF
--- a/client/layout/guided-tours/positioning.js
+++ b/client/layout/guided-tours/positioning.js
@@ -35,7 +35,12 @@ const helpers = {
 		return bottom + DIALOG_PADDING;
 	},
 	xAboveBelow: ( left, right ) => {
-		if ( left + DIALOG_WIDTH + DIALOG_PADDING < document.documentElement.clientWidth ) {
+		// Left align to target if target is on the left of body center.
+		// TODO: This hack should be removed because it's unnecessary and potentially problematic.
+		// Unnecessary because, given that placement is determined manually, alignment can also be specified.
+		// Potentially problematic because full document view is used instead of target content area.
+		const leftAlign = left + middle( left, right ) < document.documentElement.clientWidth / 2;
+		if ( leftAlign ) {
 			return left + DIALOG_PADDING;
 		} else if ( right - DIALOG_WIDTH - DIALOG_PADDING > 0 ) {
 			return right - DIALOG_WIDTH;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fix positioning for 'above' and 'below' placement so it doesn't misbehave when window width is greater than 1594.

#### Testing instructions

1. Visit http://calypso.localhost:3000/settings/general/blog.docuverse.com?tour=checklistSiteTagline and proceed to "Almost done..." step.
2. Try changing window width to wider than 1595.
3. Step shouldn't pop out of position now.

*

Fixes #33247
