### PR TITLE
Happiness: Enable portugese locales for upwork support

### DIFF
--- a/client/state/selectors/is-eligible-for-upwork-support.ts
+++ b/client/state/selectors/is-eligible-for-upwork-support.ts
@@ -10,7 +10,18 @@ import { getCurrentUserLocale } from 'state/current-user/selectors';
 import getSitesItems from 'state/selectors/get-sites-items';
 import { isBusinessPlan, isEcommercePlan } from 'lib/plans';
 
-const UPWORK_LOCALES = [ 'es', 'es-cl', 'es-mx', 'fr', 'fr-ca', 'fr-be', 'fr-ch' ];
+const UPWORK_LOCALES = [
+	'es',
+	'es-cl',
+	'es-mx',
+	'fr',
+	'fr-ca',
+	'fr-be',
+	'fr-ch',
+	'pt',
+	'pt-pt',
+	'pt-br',
+];
 
 /**
  * @param state Global state tree

--- a/client/state/selectors/test/is-eligible-for-upwork-support.js
+++ b/client/state/selectors/test/is-eligible-for-upwork-support.js
@@ -79,4 +79,18 @@ describe( 'isEligibleForUpworkSupport()', () => {
 		};
 		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
 	} );
+
+	test( 'returns true for Portugese language users without Business and E-Commerce plans', () => {
+		const state = {
+			currentUser: { id: 1 },
+			sites: {
+				items: {
+					111: { plan: { product_slug: PLAN_FREE } },
+					222: { plan: { product_slug: PLAN_PREMIUM } },
+				},
+			},
+			users: { items: { 1: { localeSlug: 'pt' } } },
+		};
+		expect( isEligibleForUpworkSupport( state ) ).to.be.true;
+	} );
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds `pt`, `pt-br` and `pt-pt` locales as eligible for upwork support.

#### Testing instructions

- Ensure that Happychat has availability (by default development Calypso connects to staging Happychat)
- Sign into Calypso as a user that has at least one paid upgrade (like a Theme, or a paid plan) but does not have any site with a Business or eCommerce plan.
- Make sure your language setting is not a Portugese, Spanish or French one.
- Check the inline "Contact Us" form — it should be directing you to chat support ("Chat with us" on the button)
- Now change your language setting to `pt-pt` (Portugal).
- Re-open the inline "Contact Us" form — it should now direct you to email support even though Happychat is still available.
- Try the same thing with a user that has a Business or eCommerce plan — they should receive Chat support regardless of language setting.
