### PR TITLE
Re-enable variation_front (dot) for domain suggestions

### DIFF
--- a/client/lib/domains/suggestions/index.js
+++ b/client/lib/domains/suggestions/index.js
@@ -1,5 +1,13 @@
 /** @format */
+/**
+ * Internal dependencies
+ */
+import { isUsingGivenLocales } from 'lib/abtest';
 
 export const getSuggestionsVendor = () => {
+	if ( isUsingGivenLocales( [ 'en' ] ) ) {
+		return 'variation_front';
+	}
+
 	return 'variation2_front';
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Switch back to the `variation_front` domain suggestion provider from the alternative `variation2_front` provider. Switching to the alternative provider was a temporary measure while we experienced inadequate search results being returned from `variant_front`.

Reverts Automattic/wp-calypso#33310.

#### Testing instructions
Build this branch and make sure that an adequate number of search results are returned from /domains/add and in NUX.

Check to make sure that `variation_front` is sent as the vendor in the request to the `/suggestions?` endpoint.
