### PR TITLE
Handle redirect payments in Apple Pay without white-screening

### DIFF
--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -34,6 +34,7 @@ import {
 	INPUT_VALIDATION,
 	RECEIVED_PAYMENT_KEY_RESPONSE,
 	RECEIVED_WPCOM_RESPONSE,
+	REDIRECTING_FOR_AUTHORIZATION,
 	SUBMITTING_PAYMENT_KEY_REQUEST,
 	SUBMITTING_WPCOM_REQUEST,
 } from 'lib/store-transactions/step-types';
@@ -142,6 +143,7 @@ export class WebPaymentBox extends React.Component {
 				return ongoingState();
 
 			case SUBMITTING_WPCOM_REQUEST:
+			case REDIRECTING_FOR_AUTHORIZATION:
 				return completingState();
 
 			case RECEIVED_WPCOM_RESPONSE:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

During internal testing of Apple Pay, one user was sent through a payment redirect flow (e.g. to be redirected to their bank for further authorization before the payment could be processed).  They wound up getting a white screen in Calypso due to `Unknown transaction step: redirecting-for-authorization`.

In general, I don't think we expect Apple Pay users to be redirected in this way; part of the point of Apple Pay is that the user has already been verified.  The particular case above was most likely due to a different, server-side bug that has since been fixed.

That said, we should attempt to handle the payment redirect flow, just in case.  This pull request fixes it -- luckily the fix seems pretty simple.

#### Testing instructions

This is difficult to test for real since you need to get a credit card into Apple Pay that would run into the problem.  The best way I found to approximate it was to hack the response coming from the `me/transactions` API endpoint to have a `redirect_url` property set to `https://example.com`, then do an Apple Pay purchase and verify that you get redirected to `https://example.com` at the end, rather than seeing a white screen.

p7DVsv-6xD-p2#comment-20434

