### PR TITLE
Send the correct processor country when opening an Apple Pay payment sheet

### DIFF
--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -10,7 +10,7 @@ import { localize } from 'i18n-calypso';
 import config from 'config';
 import Gridicon from 'gridicons';
 import debugFactory from 'debug';
-import { overSome, rearg, some } from 'lodash';
+import { overSome, some } from 'lodash';
 
 /**
  * Internal dependencies
@@ -80,6 +80,8 @@ export class WebPaymentBox extends React.Component {
 		onSubmit: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
+
+	state = { processorCountry: 'US' };
 
 	constructor() {
 		super();
@@ -170,7 +172,7 @@ export class WebPaymentBox extends React.Component {
 					merchantIdentifier: APPLE_PAY_MERCHANT_IDENTIFIER,
 					merchantCapabilities: [ 'supports3DS', 'supportsCredit', 'supportsDebit' ],
 					supportedNetworks: SUPPORTED_NETWORKS,
-					countryCode: 'US',
+					countryCode: this.state.processorCountry,
 				},
 			},
 		];
@@ -351,6 +353,47 @@ export class WebPaymentBox extends React.Component {
 	};
 
 	/**
+	 * @param {string} fieldName The name of the country select field.
+	 * @param {string} selectedCountryCode The selected country.
+	 */
+	updateSelectedCountry = ( fieldName, selectedCountryCode ) => {
+		setTaxCountryCode( selectedCountryCode );
+
+		// Apple Pay needs the country where the payment will be processed
+		// (https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951833-countrycode),
+		// so call the Paygate configuration API endpoint to get that. This
+		// information is only needed when the user clicks the button to buy
+		// something and opens the Apple Pay payment sheet, so it is somewhat
+		// wasteful to call it here (every time a new country is selected);
+		// however, it is necessary because browsers will only open a payment
+		// sheet in direct response to user input (see
+		// https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/show),
+		// so we can't delay the opening of the payment sheet on waiting for
+		// the response to this API call.
+		wpcom.undocumented().paygateConfiguration(
+			{
+				request_type: 'new_purchase',
+				country: selectedCountryCode,
+				// The endpoint also accepts an optional credit card brand in
+				// cases where the processor country might depend on the card
+				// brand used, but unfortunately we can't send that because we
+				// don't know it yet (it's a chicken and egg problem; the user
+				// only selects a credit card once the Apple Pay payment sheet
+				// is open, but we need to send Apple Pay the processor country
+				// in order to open the payment sheet). Fortunately, in most
+				// cases this won't have a practical effect.
+			},
+			function( configError, configuration ) {
+				let processorCountry = 'US';
+				if ( ! configError && configuration.processor === 'stripe_ie' ) {
+					processorCountry = 'IE';
+				}
+				this.setState( { processorCountry } );
+			}.bind( this )
+		);
+	};
+
+	/**
 	 * @param {object} event  Event object.
 	 */
 	updateSelectedPostalCode = event => {
@@ -444,7 +487,7 @@ export class WebPaymentBox extends React.Component {
 								name="country"
 								label={ translate( 'Country', { textOnly: true } ) }
 								countriesList={ countriesList }
-								onCountrySelected={ rearg( setTaxCountryCode, [ 1 ] ) }
+								onCountrySelected={ this.updateSelectedCountry }
 								value={ countryCode }
 								eventFormName="Checkout Form"
 							/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The information sent to Apple Pay when opening a payment sheet includes the two-letter country code of the country in which the payment will be processed (https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951833-countrycode).  In the future, at least, if not now, it looks like this will sometimes be important for being able to successfully process the payment, given PSD2 requirements.

We are currently setting the processor country to `US`, but that isn't always correct.  This pull request makes it so we send the correct value (or at least as correct as we can) based on the information returned by the Paygate configuration endpoint.

As described in the code comments, there is a chicken-and-egg problem which prevents us from being 100% sure that the country we send is correct: The Paygate configuration endpoint allows for the possibility that payments will be processed in different countries depending on the credit card brand, but we can't know the credit card brand at the point we're opening the Apple Pay payment sheet, since the user only selects it inside Apple Pay.  (There are mechanisms to be notified by Apple Pay of the credit card brand once it has been selected, but there doesn't appear to be any way to update the `countryCode` afterwards based on that.)  However, this does the best we can, and in most cases it should be the correct country.

#### Testing instructions

This is hard to test directly since I haven't seen a case myself where a payment would fail if the wrong country were sent to Apple Pay.  However, you can at least put a debug statement inside `WebPaymentBox.getPaymentRequestForApplePay()` to show the country code being sent to Apple Pay, and then start an Apple Pay purchase and watch how the country code differs based on the billing country that you selected before opening the Apple Pay payment sheet.