### PR TITLE
PlanCompareCard: fixup and migrate CSS styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -116,7 +116,6 @@
 @import 'my-sites/pages/style';
 @import 'my-sites/pages/blog-posts-page/style';
 @import 'my-sites/pages/page-card-info/style';
-@import 'my-sites/plan-compare-card/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/plan-interval-discount/style';
 @import 'my-sites/plan-price/style';

--- a/client/my-sites/plan-compare-card/index.jsx
+++ b/client/my-sites/plan-compare-card/index.jsx
@@ -19,9 +19,12 @@ import Button from 'components/button';
 import Card from 'components/card';
 import Ribbon from 'components/ribbon';
 
-class PlanCompareCard extends React.Component {
-	static displayName = 'PlanCompareCard';
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
+class PlanCompareCard extends React.Component {
 	static propTypes = {
 		className: PropTypes.string,
 		onClick: PropTypes.func,

--- a/client/my-sites/plan-compare-card/item.jsx
+++ b/client/my-sites/plan-compare-card/item.jsx
@@ -9,9 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 
-export default class extends React.Component {
-	static displayName = 'PlanCompareCardItem';
-
+export default class PlanCompareCardItem extends React.Component {
 	static propTypes = {
 		highlight: PropTypes.bool,
 		unavailable: PropTypes.bool,

--- a/client/my-sites/plan-compare-card/item.jsx
+++ b/client/my-sites/plan-compare-card/item.jsx
@@ -29,9 +29,7 @@ export default class PlanCompareCardItem extends React.Component {
 		return (
 			<li className={ classes }>
 				{ showCheckmark && (
-					<span className="plan-compare-card__item-checkmark">
-						<Gridicon size={ 18 } icon="checkmark" />
-					</span>
+					<Gridicon size={ 18 } icon="checkmark" className="plan-compare-card__item-checkmark" />
 				) }
 				{ this.props.children }
 			</li>

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -60,12 +60,7 @@
 }
 
 .plan-compare-card-item {
-	display: flex;
 	list-style-type: none;
-	
-	strong:first-of-type {
-		margin-right: 5px;
-	}
 }
 
 .plan-compare-card-item.is-highlight {

--- a/client/my-sites/plan-compare-card/style.scss
+++ b/client/my-sites/plan-compare-card/style.scss
@@ -75,8 +75,7 @@
 
 .plan-compare-card__item-checkmark {
 	margin-right: 6px;
-	vertical-align: middle;
-	line-height: 16px;
+	vertical-align: text-bottom;
 }
 
 .plan-compare-card__button-checkmark {


### PR DESCRIPTION
First, remove the somewhat silly `strong { margin-right: 5px }` style. It's needed because the parent `li` element has `display: flex`. Then the two child elements become flex items rather than inline text. There is no space between even though the markup contains a space:
```jsx
<li><strong>Daily</strong> Backups</li>
```

The styles were added by @johnHackworth back in #14283 to "align checkboxes correctly". But after this patch, all the checkboxes are still fine.

There is only one usage of this component today, in the Earn section:

<img width="497" alt="Screenshot 2019-05-27 at 11 47 15" src="https://user-images.githubusercontent.com/664258/58411710-32018480-8075-11e9-87b1-e4b649bbb045.png">

Cc: @torres126 