### PR TITLE
Full site editing: fix stylelint issues in starter-page-templates-editor.scss

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -14,13 +14,13 @@
 	width: 100%;
 	height: 100vh;
 
-	@media screen and (min-width: 783px) {
+	@media screen and ( min-width: 783px ) {
 		width: calc( 100% - 65px );
 		left: 50px;
 		transform: translateY( -50% );
 	}
 
-	@media screen and (min-width: 960px) {
+	@media screen and ( min-width: 960px ) {
 		width: calc( 100% - 200px );
 		left: 180px;
 	}
@@ -45,6 +45,7 @@
 
 	.components-base-control__field {
 		display: grid;
+		// stylelint-disable-next-line unit-whitelist
 		grid-template-columns: repeat( auto-fit, minmax( 200px, 1fr ) );
 		grid-gap: 1.5em;
 	}
@@ -86,20 +87,20 @@
 	flex-direction: column;
 	align-items: center;
 
-	@media screen and (min-width: 960px) {
+	@media screen and ( min-width: 960px ) {
 		flex-direction: row;
 		justify-content: flex-end;
 	}
 }
 
 .page-template-modal__action {
-	@media screen and (max-width: 960px) {
+	@media screen and ( max-width: 960px ) {
 		margin-bottom: 1em;
 	}
 }
 
 .page-template-modal__action-use {
-	@media screen and (min-width: 960px) {
+	@media screen and ( min-width: 960px ) {
 		margin-right: 1em;
 	}
 }


### PR DESCRIPTION
Just some `stylelint` issues I noticed; not a biggie — easy to make and these happen regularly since linting .scss files isn't enforced.

https://github.com/Automattic/wp-calypso/blob/f7951f0ca910030dead0a6371dd101f0fe449991/bin/pre-commit-hook.js#L85-L92

Since this is the only file with issues, we could fail commits on those errors right after this. :tada: https://github.com/Automattic/wp-calypso/pull/33354

#### Changes proposed in this Pull Request

* `npx stylelint apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss --fix`
* Disable `unit-whitelist` for one line because of used `fr` unit

#### Testing instructions

- Linter passes: `npm run lint:css`
- Full site editing plugin works as usual