### PR TITLE
Pre-commit hook: enforce stylelint

### DIFF
--- a/bin/pre-commit-hook.js
+++ b/bin/pre-commit-hook.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -28,6 +26,16 @@ function parseGitDiffToPathArray( command ) {
 		.split( '\n' )
 		.map( name => name.trim() )
 		.filter( name => /(?:\.json|\.[jt]sx?|\.scss)$/.test( name ) );
+}
+
+function linterFailure() {
+	console.log(
+		chalk.red( 'COMMIT ABORTED:' ),
+		'The linter reported some problems. ' +
+			'If you are aware of them and it is OK, ' +
+			'repeat the commit command with --no-verify to avoid this check.'
+	);
+	process.exit( 1 );
 }
 
 // grab a list of all the files staged to commit
@@ -83,12 +91,7 @@ if ( toStylelint.length ) {
 	} );
 
 	if ( lintResult.status ) {
-		console.log(
-			chalk.yellow( 'STYLELINT:' ),
-			'The linter reported some problems. Please consider fixing them.'
-		);
-		//process.exit( 1 );
-		// do not abort the commit for now. Maybe in the future...
+		linterFailure();
 	}
 }
 
@@ -100,12 +103,6 @@ if ( toEslint.length ) {
 	} );
 
 	if ( lintResult.status ) {
-		console.log(
-			chalk.red( 'COMMIT ABORTED:' ),
-			'The linter reported some problems. ' +
-				'If you are aware of them and it is OK, ' +
-				'repeat the commit command with --no-verify to avoid this check.'
-		);
-		process.exit( 1 );
+		linterFailure();
 	}
 }


### PR DESCRIPTION
A quick change to enforce `stylelint`.

Since there are 0 `stylelint` errors in Calypso (`npx run lint:css`) after https://github.com/Automattic/wp-calypso/pull/33353 is merged, we could start enforcing the linter's results.

Are there any reasons not to? I'm assuming previously we didn't because there were quite a few of these.

#### Changes proposed in this Pull Request

* Fail to commit on `stylelint` failure

#### Testing instructions

- Change a .scss file so that:
  - stylelint complains (e.g. use illegal unit `1fr` somewhere): commit should fail
  - stylelint doesn't complain
- Change a .js file so that:
  - eslint complains (e.g. mess up imports): commit should fail
  - eslint doesn't complain
