### PR TITLE
Disabled Buttons: Increase Colour Contrast

### DIFF
--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -73,7 +73,7 @@ button {
 	&[disabled],
 	&:disabled,
 	&.disabled {
-		color: var( --color-neutral-50 );
+		color: var( --color-neutral-200 );
 		background-color: var( --color-white );
 		border-color: var( --color-neutral-50 );
 		cursor: default;
@@ -96,7 +96,7 @@ button {
 		line-height: 1;
 
 		&:disabled {
-			color: var( --color-neutral-50 );
+			color: var( --color-neutral-200 );
 		}
 		.gridicon {
 			top: 5px;
@@ -153,7 +153,7 @@ button {
 	&[disabled],
 	&:disabled,
 	&.disabled {
-		color: var( --color-neutral-50 );
+		color: var( --color-neutral-200 );
 		background-color: var( --color-white );
 		border-color: var( --color-neutral-50 );
 	}
@@ -184,7 +184,7 @@ button {
 
 	&[disabled],
 	&:disabled {
-		color: var( --color-neutral-50 );
+		color: var( --color-neutral-200 );
 		background-color: var( --color-white );
 		border-color: var( --color-neutral-50 );
 	}
@@ -202,7 +202,7 @@ button {
 
 	&[disabled],
 	&:disabled {
-		color: var( --color-neutral-50 );
+		color: var( --color-neutral-200 );
 		background-color: var( --color-white );
 		border-color: var( --color-neutral-50 );
 	}
@@ -239,7 +239,7 @@ button {
 
 	&[disabled],
 	&:disabled {
-		color: var( --color-neutral-50 );
+		color: var( --color-neutral-200 );
 		cursor: default;
 
 		&:active,
@@ -256,7 +256,7 @@ button {
 		}
 
 		&[disabled] {
-			color: var( --color-error-50 );
+			color: var( --color-error-200 );
 		}
 	}
 
@@ -275,7 +275,7 @@ button {
 		}
 
 		&[disabled] {
-			color: var( --color-neutral-50 );
+			color: var( --color-neutral-200 );
 		}
 	}
 

--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -179,7 +179,7 @@
 	}
 
 	&[disabled] {
-		color: var( --color-neutral-0 );
+		color: var( --color-neutral-200 );
 		.gridicon {
 			color: var( --color-neutral-0 );
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Increases the colour contrast of disabled states from -50 to -200 to be easier to read.


### Buttons

**Current:**

<img width="824" alt="Screenshot 2019-05-27 at 14 19 20" src="https://user-images.githubusercontent.com/43215253/58422426-6fbcd800-808a-11e9-998c-b99660910b87.png">

**Proposed:**

<img width="814" alt="Screenshot 2019-05-27 at 14 18 38" src="https://user-images.githubusercontent.com/43215253/58422398-5ddb3500-808a-11e9-928c-c8fbb6d16671.png">

### Split Buttons

**Current:**

<img width="734" alt="Screenshot 2019-05-27 at 14 20 28" src="https://user-images.githubusercontent.com/43215253/58422553-bf9b9f00-808a-11e9-8ee9-f6817a48878a.png">

**Proposed:**

<img width="556" alt="Screenshot 2019-05-27 at 14 20 03" src="https://user-images.githubusercontent.com/43215253/58422560-c5918000-808a-11e9-9a5a-c9d4e5c02d94.png">

### Spinner Buttons

**Current:**

<img width="295" alt="Screenshot 2019-05-27 at 14 21 23" src="https://user-images.githubusercontent.com/43215253/58422568-d04c1500-808a-11e9-8fd1-4fc969e5183a.png">

**Proposed:**

<img width="295" alt="Screenshot 2019-05-27 at 14 21 13" src="https://user-images.githubusercontent.com/43215253/58422576-d510c900-808a-11e9-9f59-ad59dc138b23.png">

For the input example that @simison mentioned, different PR for that in #32457.

cc @drw158, @flootr, @blowery 

Fixes #26982
