### PR TITLE
Signup / Checkout: remember and auto-apply whitelisted coupons

### DIFF
--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { assign } from 'lodash';
+import debugModule from 'debug';
 
 /**
  * Internal dependencies
@@ -24,10 +25,17 @@ import {
 } from 'lib/upgrades/action-types';
 import Dispatcher from 'dispatcher';
 import { domainRegistration } from 'lib/cart-values/cart-items';
+import { urlParseAmpCompatible } from 'lib/analytics/utils';
 
 // We need to load the CartStore to make sure the store is registered with the
 // dispatcher even though it's not used directly here
 import 'lib/cart/store';
+
+/**
+ * Constants
+ */
+const debug = debugModule( 'calypso:signup:cart' );
+const MARKETING_COUPONS_KEY = 'marketing-coupons';
 
 export function disableCart() {
 	Dispatcher.handleViewAction( { type: CART_DISABLE } );
@@ -136,6 +144,76 @@ export function removeCoupon() {
 	Dispatcher.handleViewAction( {
 		type: CART_COUPON_REMOVE,
 	} );
+}
+
+export function saveCouponQueryArgument() {
+	// read coupon query argument, return early if there is none
+	const parsedUrl = urlParseAmpCompatible( location.href );
+	const couponCode = parsedUrl.query.coupon;
+	if ( ! couponCode ) {
+		return;
+	}
+
+	// read coupon list from localStorage, create new if it's not there yet, refresh existing
+	const couponsJson = localStorage.getItem( MARKETING_COUPONS_KEY );
+	const coupons = JSON.parse( couponsJson ) || {};
+	const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
+	const now = Date.now();
+	debug( 'Found coupons in localStorage: ', coupons );
+
+	coupons[ couponCode ] = now;
+
+	// delete coupons if they're older than a week
+	Object.keys( coupons ).forEach( key => {
+		if ( now > coupons[ key ] + ONE_WEEK_MILLISECONDS ) {
+			delete coupons[ key ];
+		}
+	} );
+
+	// write remembered coupons back to localStorage
+	debug( 'Storing coupons in localStorage: ', coupons );
+	localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
+}
+
+export function getRememberedCoupon() {
+	// read coupon list from localStorage, return early if it's not there
+	const couponsJson = localStorage.getItem( MARKETING_COUPONS_KEY );
+	const coupons = JSON.parse( couponsJson );
+	if ( ! coupons ) {
+		debug( 'No coupons found in localStorage: ', coupons );
+		return null;
+	}
+
+	const COUPON_CODE_WHITELIST = [ 'LEIFTEST', 'PATREON' ];
+	const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
+	const now = Date.now();
+	debug( 'Found coupons in localStorage: ', coupons );
+
+	// delete coupons if they're older than a week; find the most recent one
+	let mostRecentTimestamp = 0;
+	let mostRecentCouponCode = null;
+	Object.keys( coupons ).forEach( key => {
+		if ( now > coupons[ key ] + ONE_WEEK_MILLISECONDS ) {
+			delete coupons[ key ];
+		} else if ( coupons[ key ] > mostRecentTimestamp ) {
+			mostRecentCouponCode = key;
+			mostRecentTimestamp = coupons[ key ];
+		}
+	} );
+
+	// write remembered coupons back to localStorage
+	debug( 'Storing coupons in localStorage: ', coupons );
+	localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
+	if (
+		COUPON_CODE_WHITELIST.includes(
+			mostRecentCouponCode.substring( 0, mostRecentCouponCode.indexOf( '_' ) )
+		)
+	) {
+		debug( 'returning coupon code:', mostRecentCouponCode );
+		return mostRecentCouponCode;
+	}
+	debug( 'not returning any coupon code.' );
+	return null;
 }
 
 export function setTaxCountryCode( countryCode ) {

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -184,7 +184,7 @@ export function getRememberedCoupon() {
 		return null;
 	}
 
-	const COUPON_CODE_WHITELIST = [ 'LEIFTEST', 'PATREON' ];
+	const COUPON_CODE_WHITELIST = [ 'PATREON' ];
 	const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
 	const now = Date.now();
 	debug( 'Found coupons in localStorage: ', coupons );

--- a/client/lib/upgrades/actions/index.js
+++ b/client/lib/upgrades/actions/index.js
@@ -13,6 +13,7 @@ export {
 	addItems,
 	addPrivacyToAllDomains,
 	applyCoupon,
+	getRememberedCoupon,
 	removeCoupon,
 	disableCart,
 	removeDomainFromCart,
@@ -20,6 +21,7 @@ export {
 	removePrivacyFromAllDomains,
 	replaceCartWithItems,
 	replaceItem,
+	saveCouponQueryArgument,
 	showCartOnMobile,
 } from './cart';
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -126,6 +126,8 @@ export class Checkout extends React.Component {
 
 		if ( this.props.cart.hasLoadedFromServer && this.props.product ) {
 			this.addProductToCart();
+		} else if ( this.props.couponCode ) {
+			applyCoupon( this.props.couponCode );
 		}
 
 		window.scrollTo( 0, 0 );

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -5,7 +5,6 @@
 import i18n from 'i18n-calypso';
 import React from 'react';
 import { get, isEmpty } from 'lodash';
-import debugModule from 'debug';
 
 /**
  * Internal Dependencies
@@ -24,54 +23,9 @@ import CheckoutThankYouComponent from './checkout-thank-you';
 import ConciergeSessionNudge from './concierge-session-nudge';
 import ConciergeQuickstartSession from './concierge-quickstart-session';
 import { isGSuiteRestricted } from 'lib/gsuite';
+import { getRememberedCoupon } from 'lib/upgrades/actions';
 import FormattedHeader from 'components/formatted-header';
 import { abtest } from 'lib/abtest';
-
-/**
- * Constants
- */
-const debug = debugModule( 'calypso:checkout' );
-
-function getRememberedCoupon() {
-	// read coupon list from localStorage, return early if it's not there
-	const couponsJson = localStorage.getItem( 'marketing-coupons' );
-	const coupons = JSON.parse( couponsJson );
-	if ( ! coupons ) {
-		debug( 'No coupons found in localStorage: ', coupons );
-		return null;
-	}
-
-	const COUPON_CODE_WHITELIST = [ 'LEIFTEST', 'PATREON' ];
-	const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
-	const now = Date.now();
-	debug( 'Found coupons in localStorage: ', coupons );
-
-	// delete coupons if they're older than a week; find the most recent one
-	let mostRecentTimestamp = 0;
-	let mostRecentCouponCode = null;
-	Object.keys( coupons ).forEach( key => {
-		if ( now > coupons[ key ] + ONE_WEEK_MILLISECONDS ) {
-			delete coupons[ key ];
-		} else if ( coupons[ key ] > mostRecentTimestamp ) {
-			mostRecentCouponCode = key;
-			mostRecentTimestamp = coupons[ key ];
-		}
-	} );
-
-	// write remembered coupons back to localStorage
-	debug( 'Storing coupons in localStorage: ', coupons );
-	localStorage.setItem( 'marketing-couponlist', JSON.stringify( coupons ) );
-	if (
-		COUPON_CODE_WHITELIST.includes(
-			mostRecentCouponCode.substring( 0, mostRecentCouponCode.indexOf( '_' ) )
-		)
-	) {
-		debug( 'returning coupon code:', mostRecentCouponCode );
-		return mostRecentCouponCode;
-	}
-	debug( 'not returning any coupon code.' );
-	return null;
-}
 
 export function checkout( context, next ) {
 	const { feature, plan, product } = context.params;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -5,6 +5,7 @@
 import i18n from 'i18n-calypso';
 import React from 'react';
 import { get, isEmpty } from 'lodash';
+import debugModule from 'debug';
 
 /**
  * Internal Dependencies
@@ -25,6 +26,52 @@ import ConciergeQuickstartSession from './concierge-quickstart-session';
 import { isGSuiteRestricted } from 'lib/gsuite';
 import FormattedHeader from 'components/formatted-header';
 import { abtest } from 'lib/abtest';
+
+/**
+ * Constants
+ */
+const debug = debugModule( 'calypso:checkout' );
+
+function getRememberedCoupon() {
+	// read coupon list from localStorage, return early if it's not there
+	const couponsJson = localStorage.getItem( 'marketing-coupons' );
+	const coupons = JSON.parse( couponsJson );
+	if ( ! coupons ) {
+		debug( 'No coupons found in localStorage: ', coupons );
+		return null;
+	}
+
+	const COUPON_CODE_WHITELIST = [ 'LEIFTEST', 'PATREON' ];
+	const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
+	const now = Date.now();
+	debug( 'Found coupons in localStorage: ', coupons );
+
+	// delete coupons if they're older than a week; find the most recent one
+	let mostRecentTimestamp = 0;
+	let mostRecentCouponCode = null;
+	Object.keys( coupons ).forEach( key => {
+		if ( now > coupons[ key ] + ONE_WEEK_MILLISECONDS ) {
+			delete coupons[ key ];
+		} else if ( coupons[ key ] > mostRecentTimestamp ) {
+			mostRecentCouponCode = key;
+			mostRecentTimestamp = coupons[ key ];
+		}
+	} );
+
+	// write remembered coupons back to localStorage
+	debug( 'Storing coupons in localStorage: ', coupons );
+	localStorage.setItem( 'marketing-couponlist', JSON.stringify( coupons ) );
+	if (
+		COUPON_CODE_WHITELIST.includes(
+			mostRecentCouponCode.substring( 0, mostRecentCouponCode.indexOf( '_' ) )
+		)
+	) {
+		debug( 'returning coupon code:', mostRecentCouponCode );
+		return mostRecentCouponCode;
+	}
+	debug( 'not returning any coupon code.' );
+	return null;
+}
 
 export function checkout( context, next ) {
 	const { feature, plan, product } = context.params;
@@ -51,7 +98,7 @@ export function checkout( context, next ) {
 							product={ product }
 							purchaseId={ context.params.purchaseId }
 							selectedFeature={ feature }
-							couponCode={ context.query.code }
+							couponCode={ context.query.code || getRememberedCoupon() }
 							plan={ plan }
 						/>
 						<CartData>
@@ -72,7 +119,7 @@ export function checkout( context, next ) {
 				product={ product }
 				purchaseId={ context.params.purchaseId }
 				selectedFeature={ feature }
-				couponCode={ context.query.code }
+				couponCode={ context.query.code || getRememberedCoupon() }
 				plan={ plan }
 			/>
 		</CheckoutData>
@@ -92,7 +139,10 @@ export function sitelessCheckout( context, next ) {
 
 	context.primary = (
 		<CheckoutData>
-			<Checkout reduxStore={ context.store } />
+			<Checkout
+				reduxStore={ context.store }
+				couponCode={ context.query.code || getRememberedCoupon() }
+			/>
 		</CheckoutData>
 	);
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -46,7 +46,7 @@ import analytics from 'lib/analytics';
 import * as oauthToken from 'lib/oauth-token';
 import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
 import SignupFlowController from 'lib/signup/flow-controller';
-import { disableCart } from 'lib/upgrades/actions';
+import { disableCart, saveCouponQueryArgument } from 'lib/upgrades/actions';
 
 // State actions and selectors
 import { loadTrackingTool } from 'state/analytics/actions';
@@ -209,7 +209,7 @@ class Signup extends React.Component {
 
 	componentDidMount() {
 		debug( 'Signup component mounted' );
-		this.saveCouponQueryArgument();
+		saveCouponQueryArgument();
 		this.startTrackingForBusinessSite();
 		this.recordSignupStart();
 		this.preloadNextStep();
@@ -232,35 +232,6 @@ class Signup extends React.Component {
 		const filteredDestination = getDestination( destination, dependencies, this.props.flowName );
 		return this.handleFlowComplete( dependencies, filteredDestination );
 	};
-
-	saveCouponQueryArgument() {
-		// read coupon query argument, return early if there is none
-		const parsedUrl = urlParseAmpCompatible( location.href );
-		const couponCode = parsedUrl.query.coupon;
-		if ( ! couponCode ) {
-			return;
-		}
-
-		// read coupon list from localStorage, create new if it's not there yet, refresh existing
-		const couponsJson = localStorage.getItem( 'marketing-coupons' );
-		const coupons = JSON.parse( couponsJson ) || {};
-		const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
-		const now = Date.now();
-		debug( 'Found coupons in localStorage: ', coupons );
-
-		coupons[ couponCode ] = now;
-
-		// delete coupons if they're older than a week
-		Object.keys( coupons ).forEach( key => {
-			if ( now > coupons[ key ] + ONE_WEEK_MILLISECONDS ) {
-				delete coupons[ key ];
-			}
-		} );
-
-		// write remembered coupons back to localStorage
-		debug( 'Storing coupons in localStorage: ', coupons );
-		localStorage.setItem( 'marketing-coupons', JSON.stringify( coupons ) );
-	}
 
 	startTrackingForBusinessSite() {
 		const siteType = get( this.props.signupDependencies, 'siteType' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* if `/signup` is started with a `?coupon=...` query argument, we now save the coupon in `localStorage`
* in checkout, we look at the remembered coupons, find the most recently remembered one, check it against a whitelist, and then automatically apply it to the cart
* coupons remembered like this have a lifetime of a week

#### Testing instructions

* checkout this branch
* open a new incognito window
* visit `http://calypso.localhost:3000/start/user?coupon=PATREON_EBB0`
* ensure that `localStorage.getItem( 'marketing-coupons' )` returns an object that has `PATREON_EBB0` as a key and for that key an integer number as its value (should be the current timestamp in ms)
* go through signup and on the plans selection page, select a paid plan
* ensure that in checkout the coupon is automatically applied
* ensure no errors in the JavaScript console (that aren't there in `master` -- I did get an error on the domain selection page unrelated to this proposed change)

