### PR TITLE
Gutenbergify page selection layout &  fix linter complaints

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -14,13 +14,13 @@
 	width: 100%;
 	height: 100vh;
 
-	@media screen and (min-width: 783px) {
+	@media screen and ( min-width: 783px ) {
 		width: calc( 100% - 65px );
 		left: 50px;
 		transform: translateY( -50% );
 	}
 
-	@media screen and (min-width: 960px) {
+	@media screen and ( min-width: 960px ) {
 		width: calc( 100% - 200px );
 		left: 180px;
 	}
@@ -76,7 +76,7 @@
 		max-width: 100%;
 		display: block;
 		margin: 0 auto 2em;
-		border: 1px solid rgba(25,30,35,.2);
+		border: 1px solid rgba( 25, 30, 35, 0.2 );
 		border-radius: 4px;
 		overflow: hidden;
 	}
@@ -87,20 +87,20 @@
 	flex-direction: column;
 	align-items: center;
 
-	@media screen and (min-width: 960px) {
+	@media screen and ( min-width: 960px ) {
 		flex-direction: row;
 		justify-content: flex-end;
 	}
 }
 
 .page-template-modal__action {
-	@media screen and (max-width: 960px) {
+	@media screen and ( max-width: 960px ) {
 		margin-bottom: 1em;
 	}
 }
 
 .page-template-modal__action-use {
-	@media screen and (min-width: 960px) {
+	@media screen and ( min-width: 960px ) {
 		margin-right: 1em;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -56,14 +56,18 @@
 	.template-selector-control__label {
 		display: block;
 		text-align: center;
-		border: 1px solid #999;
+		border: 1px solid transparent;
 		padding: 2em;
 		border-radius: 4px;
 
-		&:hover,
+		&:hover {
+			background: #f3f4f5;
+		}
+
 		&:focus {
-			border-color: #333;
-			box-shadow: 0 3px 3px #999;
+			box-shadow: 0 0 0 2px #00a0d2;
+			outline: 2px solid transparent;
+			outline-offset: -2px;
 		}
 	}
 
@@ -72,6 +76,9 @@
 		max-width: 100%;
 		display: block;
 		margin: 0 auto 2em;
+		border: 1px solid rgba(25,30,35,.2);
+		border-radius: 4px;
+		overflow: hidden;
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -59,6 +59,7 @@
 		border: 1px solid transparent;
 		padding: 2em;
 		border-radius: 4px;
+		cursor: pointer;
 
 		&:hover {
 			background: #f3f4f5;


### PR DESCRIPTION
### This PR

- Brings the page selection layout in line with the style variant selection layout of Gutenberg blocks
- fixes a few linter complaints

### Screenshot

- First item shows the :focus state
- Second item shows the :hover state
- Other items show the default state

<img width="1091" alt="Screen Shot 2019-05-27 at 17 48 37" src="https://user-images.githubusercontent.com/1562646/58430584-38f6ba00-80aa-11e9-8e08-17172333a965.png">