### PR TITLE
Guided tour: Make Jetpack auto-updates tour appear correctly

### DIFF
--- a/client/layout/guided-tours/config-elements/step.js
+++ b/client/layout/guided-tours/config-elements/step.js
@@ -116,7 +116,9 @@ export default class Step extends Component {
 			this.setStepSection( nextContext );
 			this.quitIfInvalidRoute( nextProps, nextContext );
 			this.skipIfInvalidContext( nextProps, nextContext );
-			this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
+			if ( this.scrollContainer ) {
+				this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
+			}
 			this.scrollContainer = query( nextProps.scrollContainer )[ 0 ] || window;
 			this.scrollContainer.addEventListener( 'scroll', this.onScrollOrResize );
 			this.setStepPosition( nextProps, shouldScrollTo );

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -44,13 +44,12 @@ export const JetpackPluginUpdatesTour = makeTour(
 						return resolve();
 					}
 
-					const waitForElement = () =>
-						setTimeout( () => {
-							if ( document.querySelector( JETPACK_TOGGLE_SELECTOR ) ) {
-								return resolve();
-							}
-							waitForElement();
-						}, 125 );
+					const waitForElement = () => {
+						if ( document.querySelector( JETPACK_TOGGLE_SELECTOR ) ) {
+							return resolve();
+						}
+						setTimeout( waitForElement, 125 );
+					};
 
 					waitForElement();
 				} )

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -44,32 +44,15 @@ export const JetpackPluginUpdatesTour = makeTour(
 						return resolve();
 					}
 
-					const primaryContainer = document.querySelector( '#primary' );
-					if ( typeof MutationObserver === 'undefined' || ! primaryContainer ) {
-						return setTimeout( resolve, 2000 );
-					}
-
-					new MutationObserver( ( mutationRecords, observer ) => {
-						mutationRecords.some( mutationRecord => {
-							if ( mutationRecord.type === 'childList' && mutationRecord.addedNodes.length ) {
-								if (
-									Array.from( mutationRecord.addedNodes ).some(
-										node =>
-											node.nodeType === Node.ELEMENT_NODE &&
-											( node as Element ).classList.contains( 'plugin-item-jetpack' )
-									)
-								) {
-									resolve();
-									observer.disconnect();
-									return true;
-								}
+					const waitForElement = () =>
+						setTimeout( () => {
+							if ( document.querySelector( JETPACK_TOGGLE_SELECTOR ) ) {
+								return resolve();
 							}
-							return false;
-						} );
-					} ).observe( primaryContainer, {
-						childList: true,
-						subtree: true,
-					} );
+							waitForElement();
+						}, 125 );
+
+					waitForElement();
 				} )
 			}
 			style={ {


### PR DESCRIPTION
Add a `wait` prop to the autoupdates tour step to ensure that the elements the tour requires are present when the Step is started.

Follow up to #33258 (via https://github.com/Automattic/wp-calypso/pull/33258#issuecomment-495199966)

#### Testing instructions

* Clear application state
* Visit `My Plan` page for a Jetpack site (`/plans/my-plan/SITE_SLUG`)
* Quickly start the _Automatic Plugin Updates_ task (click "Do it!"):
  ![Screen Shot 2019-05-27 at 18 23 24](https://user-images.githubusercontent.com/841763/58431110-9f7cd780-80ac-11e9-938d-0514b1746266.png)
* The Step should appear _after_ the placeholders are replaced with the plugin content:
  ![doit](https://user-images.githubusercontent.com/841763/58431207-0b5f4000-80ad-11e9-9595-b9562dc01738.gif)
  Previously this was unreliable.
