### PR TITLE
Make sure "Manage Purchases" is selected in the sidebar nav when any …

### DIFF
--- a/client/me/purchases/paths.js
+++ b/client/me/purchases/paths.js
@@ -8,6 +8,10 @@ export const billingHistory = purchasesRoot + '/billing';
 
 export const upcomingCharges = purchasesRoot + '/upcoming';
 
+export const pendingPayments = purchasesRoot + '/pending';
+
+export const myMemberships = purchasesRoot + '/memberships';
+
 export function billingHistoryReceipt( receiptId ) {
 	if ( process.env.NODE_ENV !== 'production' ) {
 		if ( 'undefined' === typeof receiptId ) {

--- a/client/me/purchases/purchases-list/header/index.jsx
+++ b/client/me/purchases/purchases-list/header/index.jsx
@@ -14,7 +14,13 @@ import { localize } from 'i18n-calypso';
  */
 import NavItem from 'components/section-nav/item';
 import NavTabs from 'components/section-nav/tabs';
-import { billingHistory, upcomingCharges, purchasesRoot } from '../../paths.js';
+import {
+	billingHistory,
+	upcomingCharges,
+	pendingPayments,
+	myMemberships,
+	purchasesRoot,
+} from '../../paths.js';
 import SectionNav from 'components/section-nav';
 import config from 'config';
 import getPastBillingTransactions from 'state/selectors/get-past-billing-transactions';
@@ -24,6 +30,12 @@ const PurchasesHeader = ( { section, translate } ) => {
 
 	if ( section === 'purchases' ) {
 		text = translate( 'Purchases' );
+	} else if ( section === 'upcoming' ) {
+		text = translate( 'Upcoming Charges' );
+	} else if ( section === 'pending' ) {
+		text = translate( 'Pending Payments' );
+	} else if ( section === 'memberships' ) {
+		text = translate( 'My Memberships' );
 	}
 
 	return (
@@ -42,12 +54,12 @@ const PurchasesHeader = ( { section, translate } ) => {
 				</NavItem>
 
 				{ config.isEnabled( 'async-payments' ) && (
-					<NavItem path={ purchasesRoot + '/pending' } selected={ section === 'pending' }>
+					<NavItem path={ pendingPayments } selected={ section === 'pending' }>
 						{ translate( 'Pending Payments' ) }
 					</NavItem>
 				) }
 
-				<NavItem path={ purchasesRoot + '/memberships' } selected={ section === 'memberships' }>
+				<NavItem path={ myMemberships } selected={ section === 'memberships' }>
 					{ translate( 'My Memberships' ) }
 				</NavItem>
 			</NavTabs>

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -13,7 +13,14 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import config from 'config';
 import ProfileGravatar from 'me/profile-gravatar';
-import { addCreditCard, billingHistory, purchasesRoot } from 'me/purchases/paths';
+import {
+	addCreditCard,
+	billingHistory,
+	upcomingCharges,
+	pendingPayments,
+	myMemberships,
+	purchasesRoot,
+} from 'me/purchases/paths';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarHeading from 'layout/sidebar/heading';
@@ -80,6 +87,9 @@ class MeSidebar extends React.Component {
 			[ purchasesRoot ]: 'purchases',
 			[ billingHistory ]: 'purchases',
 			[ addCreditCard ]: 'purchases',
+			[ upcomingCharges ]: 'purchases',
+			[ pendingPayments ]: 'purchases',
+			[ myMemberships ]: 'purchases',
 			'/me/chat': 'happychat',
 			'/me/site-blocks': 'site-blocks',
 		};


### PR DESCRIPTION
…of the tabs are active.

#### Changes proposed in this Pull Request
"Manage purchases" is selected when visitng "Purchases" or "Billing history" tabs, but not when in "Upcoming Payments", "Pending Payments", or "My Memberships" tabs.
I added missing paths to paths.js file, so that "Manage Purchases" remains the selected item in the sidebar nav, whenever any of the tabs within are accessed.

This solves part of the issue, I'm still working on addressing the mobile drop-down behaviour.

#### Testing instructions
* Navigate to https://wordpress.com/me/purchases
* Switch between the tabs on the left. Regardless of tab selected, "Manage Purchases" should stay selected in the sidebar nav on the left.

Fixes #33217
