### PR TITLE
Enable Apple Pay on production with an A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -174,4 +174,14 @@ export default {
 		},
 		defaultVariation: 'control',
 	},
+	showApplePay: {
+		datestamp: '20190529',
+		variations: {
+			hide: 50,
+			show: 50,
+		},
+		defaultVariation: 'hide',
+		allowExistingUsers: true,
+		localeTargets: 'any',
+	},
 };

--- a/client/lib/web-payment/index.js
+++ b/client/lib/web-payment/index.js
@@ -6,6 +6,11 @@
 import config from 'config';
 
 /**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+
+/**
  * Web Payment method identifiers.
  */
 export const WEB_PAYMENT_BASIC_CARD_METHOD = 'basic-card';
@@ -54,7 +59,7 @@ export function isApplePayAvailable() {
  *                         if none can be detected.
  */
 export function detectWebPaymentMethod() {
-	if ( isApplePayAvailable() ) {
+	if ( isApplePayAvailable() && abtest( 'showApplePay' ) === 'show' ) {
 		return WEB_PAYMENT_APPLE_PAY_METHOD;
 	}
 

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -19,7 +19,8 @@ import Button from 'components/button';
 import PaymentCountrySelect from 'components/payment-country-select';
 import CartCoupon from 'my-sites/checkout/cart/cart-coupon';
 import Input from 'my-sites/domains/components/form/input';
-import { getTaxCountryCode, getTaxPostalCode, shouldShowTax } from 'lib/cart-values';
+import analytics from 'lib/analytics';
+import { cartItems, getTaxCountryCode, getTaxPostalCode, shouldShowTax } from 'lib/cart-values';
 import { isWpComBusinessPlan, isWpComEcommercePlan } from 'lib/plans';
 import {
 	detectWebPaymentMethod,
@@ -272,12 +273,21 @@ export class WebPaymentBox extends React.Component {
 		switch ( paymentMethod ) {
 			case WEB_PAYMENT_APPLE_PAY_METHOD:
 				{
+					const is_renewal = cartItems.hasRenewalItem( this.props.cart );
+					analytics.tracks.recordEvent( 'calypso_checkout_apple_pay_open_payment_sheet', {
+						is_renewal,
+					} );
+
 					const paymentRequest = this.getPaymentRequestForApplePay();
 
 					try {
 						paymentRequest
 							.show()
 							.then( paymentResponse => {
+								analytics.tracks.recordEvent( 'calypso_checkout_apple_pay_submit_payment_sheet', {
+									is_renewal,
+								} );
+
 								const { payerName, details } = paymentResponse;
 								const { token } = details;
 

--- a/config/production.json
+++ b/config/production.json
@@ -82,7 +82,7 @@
 		"me/my-profile": true,
 		"me/notifications": true,
 		"me/trophies": false,
-		"my-sites/checkout/web-payment/apple-pay": false,
+		"my-sites/checkout/web-payment/apple-pay": true,
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,


### PR DESCRIPTION
This pull request enables Apple Pay on production with a 50/50 A/B test, meaning that 50% of users whose devices support Apple Pay will see it.  It currently assumes May 29 as the start date of the A/B test.

To ensure that we can determine if users are running into problems with Apple Pay or abandoning the payment process altogether, it also adds tracking events to check when the Apple Pay payment sheet is opened and when it is submitted.
