### PR TITLE
Jetpack checklist: add tour

### DIFF
--- a/client/layout/guided-tours/all-tours.js
+++ b/client/layout/guided-tours/all-tours.js
@@ -4,15 +4,8 @@
  * Internal dependencies
  */
 
-import combineTours from 'layout/guided-tours/config-elements/combine-tours';
 import { ActivityLogJetpackIntroTour } from 'layout/guided-tours/tours/activity-log-jetpack-intro-tour';
 import { ActivityLogWpcomIntroTour } from 'layout/guided-tours/tours/activity-log-wpcom-intro-tour';
-import { MainTour } from 'layout/guided-tours/tours/main-tour';
-import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
-import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integration-tour';
-import { SimplePaymentsTour } from 'layout/guided-tours/tours/simple-payments-tour';
-import { EditorBasicsTour } from 'layout/guided-tours/tours/editor-basics-tour';
-import { MediaBasicsTour } from 'layout/guided-tours/tours/media-basics-tour';
 import { ChecklistAboutPageTour } from 'layout/guided-tours/tours/checklist-about-page-tour';
 import { ChecklistContactPageTour } from 'layout/guided-tours/tours/checklist-contact-page-tour';
 import { ChecklistDomainRegisterTour } from 'layout/guided-tours/tours/checklist-domain-register-tour';
@@ -22,12 +15,20 @@ import { ChecklistSiteTaglineTour } from 'layout/guided-tours/tours/checklist-si
 import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site-title-tour';
 import { ChecklistUserAvatarTour } from 'layout/guided-tours/tours/checklist-user-avatar-tour';
 import { ChecklistUserEmailTour } from 'layout/guided-tours/tours/checklist-user-email-tour';
+import { EditorBasicsTour } from 'layout/guided-tours/tours/editor-basics-tour';
+import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integration-tour';
 import { JetpackBackupsRewindTour } from 'layout/guided-tours/tours/jetpack-backups-rewind-tour';
 import { JetpackBasicTour } from 'layout/guided-tours/tours/jetpack-basic-tour';
+import { JetpackChecklistTour } from 'layout/guided-tours/tours/jetpack-checklist-tour';
 import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
 import { JetpackPluginUpdatesTour } from 'layout/guided-tours/tours/jetpack-plugin-updates-tour';
 import { JetpackSignInTour } from 'layout/guided-tours/tours/jetpack-sign-in-tour';
+import { MainTour } from 'layout/guided-tours/tours/main-tour';
+import { MediaBasicsTour } from 'layout/guided-tours/tours/media-basics-tour';
 import { SimplePaymentsEmailTour } from 'layout/guided-tours/tours/simple-payments-email-tour';
+import { SimplePaymentsTour } from 'layout/guided-tours/tours/simple-payments-tour';
+import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
+import combineTours from 'layout/guided-tours/config-elements/combine-tours';
 
 export default combineTours( {
 	activityLogJetpackIntroTour: ActivityLogJetpackIntroTour,
@@ -41,16 +42,17 @@ export default combineTours( {
 	checklistSiteTitle: ChecklistSiteTitleTour,
 	checklistUserAvatar: ChecklistUserAvatarTour,
 	checklistUserEmail: ChecklistUserEmailTour,
+	editorBasicsTour: EditorBasicsTour,
+	gdocsIntegrationTour: GDocsIntegrationTour,
 	jetpack: JetpackBasicTour,
 	jetpackBackupsRewind: JetpackBackupsRewindTour,
+	jetpackChecklistTour: JetpackChecklistTour,
 	jetpackMonitoring: JetpackMonitoringTour,
 	jetpackPluginUpdates: JetpackPluginUpdatesTour,
 	jetpackSignIn: JetpackSignInTour,
 	main: MainTour,
-	editorBasicsTour: EditorBasicsTour,
 	mediaBasicsTour: MediaBasicsTour,
-	tutorialSitePreview: TutorialSitePreviewTour,
-	gdocsIntegrationTour: GDocsIntegrationTour,
-	simplePaymentsTour: SimplePaymentsTour,
 	simplePaymentsEmailTour: SimplePaymentsEmailTour,
+	simplePaymentsTour: SimplePaymentsTour,
+	tutorialSitePreview: TutorialSitePreviewTour,
 } );

--- a/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import meta from './meta';
+import { ButtonRow, makeTour, Next, Quit, Step, Tour } from 'layout/guided-tours/config-elements';
+
+export const JetpackChecklistTour = makeTour(
+	<Tour { ...meta }>
+		<Step
+			arrow="bottom-left"
+			name="init"
+			placement="above"
+			style={ {
+				marginTop: '-20px',
+			} }
+			target={ '.checklist__header-main' }
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"This is your security checklist that'll help you quickly set up Jetpack. " +
+								'Pick and choose the features that you want.'
+						) }
+					</p>
+					<ButtonRow>
+						<Next step="finish">{ translate( 'Got it' ) }</Next>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step
+			arrow="bottom-right"
+			name="finish"
+			placement="above"
+			style={ {
+				marginTop: '-25px',
+			} }
+			target="jetpack-checklist-wpadmin-link"
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"After you're done setting everything up, you can return to your WordPress " +
+								'admin here or continue using the WordPress.com dashboard.'
+						) }
+					</p>
+					<ButtonRow>
+						<Quit primary>{ translate( 'Got it' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Fragment } from 'react';
+import React from 'react';
 
 /**
  * Internal dependencies
@@ -21,7 +21,7 @@ export const JetpackChecklistTour = makeTour(
 			target={ '.checklist__header-main' }
 		>
 			{ ( { translate } ) => (
-				<Fragment>
+				<>
 					<p>
 						{ translate(
 							"This is your security checklist that'll help you quickly set up Jetpack. " +
@@ -31,7 +31,7 @@ export const JetpackChecklistTour = makeTour(
 					<ButtonRow>
 						<Next step="finish">{ translate( 'Got it' ) }</Next>
 					</ButtonRow>
-				</Fragment>
+				</>
 			) }
 		</Step>
 
@@ -45,7 +45,7 @@ export const JetpackChecklistTour = makeTour(
 			target="jetpack-checklist-wpadmin-link"
 		>
 			{ ( { translate } ) => (
-				<Fragment>
+				<>
 					<p>
 						{ translate(
 							"After you're done setting everything up, you can return to your WordPress " +
@@ -55,7 +55,7 @@ export const JetpackChecklistTour = makeTour(
 					<ButtonRow>
 						<Quit primary>{ translate( 'Got it' ) }</Quit>
 					</ButtonRow>
-				</Fragment>
+				</>
 			) }
 		</Step>
 	</Tour>

--- a/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-checklist-tour/index.js
@@ -49,7 +49,7 @@ export const JetpackChecklistTour = makeTour(
 					<p>
 						{ translate(
 							"After you're done setting everything up, you can return to your WordPress " +
-								'admin here or continue using the WordPress.com dashboard.'
+								'admin here or continue using this dashboard.'
 						) }
 					</p>
 					<ButtonRow>

--- a/client/layout/guided-tours/tours/jetpack-checklist-tour/meta.js
+++ b/client/layout/guided-tours/tours/jetpack-checklist-tour/meta.js
@@ -1,0 +1,4 @@
+export default {
+	name: 'jetpackChecklistTour',
+	version: '20190527',
+};

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -4,7 +4,7 @@
 import { connect } from 'react-redux';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { localize } from 'i18n-calypso';
-import React from 'react';
+import React, { Component } from 'react';
 
 /**
  * Internal dependencies
@@ -16,64 +16,67 @@ import Button from 'components/button';
 
 import './style.scss';
 
-export function ThankYouCard( {
-	children,
-	illustration,
-	showCalypsoIntro,
-	showContinueButton,
-	showHideMessage,
-	siteSlug,
-	title,
-	translate,
-} ) {
-
-	const startChecklistTour = () => {
+export class ThankYouCard extends Component {
+	startChecklistTour = () => {
 		if ( isDesktop() ) {
 			this.props.requestGuidedTour( 'jetpackChecklistTour' );
 		}
 	};
 
-	return (
-		<div className="current-plan-thank-you">
-			{ illustration && (
-				<img
-					alt=""
-					aria-hidden="true"
-					className="current-plan-thank-you__illustration"
-					src={ illustration }
-				/>
-			) }
-			{ title && <h1 className="current-plan-thank-you__title">{ title }</h1> }
-			{ children }
-			{ showCalypsoIntro && (
-				<p>
-					{ preventWidows(
-						translate(
-							'This is your new WordPress.com dashboard. You can manage your site ' +
-								'here, or return to your self-hosted WordPress dashboard using the ' +
-								'link at the bottom of your checklist.'
-						)
-					) }
-				</p>
-			) }
-			{ showContinueButton && (
-				<Button
-					href={ `/plans/my-plan/${ siteSlug }` }
-					onClick={ startChecklistTour }
-					primary
-				>
-					{ translate( 'Continue' ) }
-				</Button>
-			) }
-			{ showHideMessage && (
-				<p>
-					<a href={ `/plans/my-plan/${ siteSlug }` } onClick={ startChecklistTour }>
-						{ translate( 'Hide message' ) }
-					</a>
-				</p>
-			) }
-		</div>
-	);
+	render() {
+		const {
+			children,
+			illustration,
+			showCalypsoIntro,
+			showContinueButton,
+			showHideMessage,
+			siteSlug,
+			title,
+			translate,
+		} = this.props;
+
+		return (
+			<div className="current-plan-thank-you">
+				{ illustration && (
+					<img
+						alt=""
+						aria-hidden="true"
+						className="current-plan-thank-you__illustration"
+						src={ illustration }
+					/>
+				) }
+				{ title && <h1 className="current-plan-thank-you__title">{ title }</h1> }
+				{ children }
+				{ showCalypsoIntro && (
+					<p>
+						{ preventWidows(
+							translate(
+								'This is your new WordPress.com dashboard. You can manage your site ' +
+									'here, or return to your self-hosted WordPress dashboard using the ' +
+									'link at the bottom of your checklist.'
+							)
+						) }
+					</p>
+				) }
+				{ showContinueButton && (
+					<Button
+						href={ `/plans/my-plan/${ siteSlug }` }
+						onClick={ this.startChecklistTour }
+						primary
+					>
+						{ translate( 'Continue' ) }
+					</Button>
+				) }
+				{ showHideMessage && (
+					<p>
+						<a href={ `/plans/my-plan/${ siteSlug }` } onClick={ this.startChecklistTour }>
+							{ translate( 'Hide message' ) }
+						</a>
+					</p>
+				) }
+			</div>
+		);
+	}
 }
 
 export default connect(

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -9,7 +9,9 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import { isDesktop } from 'lib/viewport';
 import { preventWidows } from 'lib/formatting';
+import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import Button from 'components/button';
 
 import './style.scss';
@@ -24,6 +26,13 @@ export function ThankYouCard( {
 	title,
 	translate,
 } ) {
+
+	const startChecklistTour = () => {
+		if ( isDesktop() ) {
+			this.props.requestGuidedTour( 'jetpackChecklistTour' );
+		}
+	};
+
 	return (
 		<div className="current-plan-thank-you">
 			{ illustration && (
@@ -48,21 +57,28 @@ export function ThankYouCard( {
 				</p>
 			) }
 			{ showContinueButton && (
-				<Button primary href={ `/plans/my-plan/${ siteSlug }` }>
+				<Button
+					href={ `/plans/my-plan/${ siteSlug }` }
+					onClick={ startChecklistTour }
+					primary
+				>
 					{ translate( 'Continue' ) }
 				</Button>
 			) }
 			{ showHideMessage && (
 				<p>
-					<a href={ `/plans/my-plan/${ siteSlug }` }>{ translate( 'Hide message' ) }</a>
+					<a href={ `/plans/my-plan/${ siteSlug }` } onClick={ startChecklistTour }>
+						{ translate( 'Hide message' ) }
+					</a>
 				</p>
 			) }
 		</div>
 	);
 }
 
-export default connect( state => {
-	return {
+export default connect(
+	state => ( {
 		siteSlug: getSelectedSiteSlug( state ),
-	};
-} )( localize( ThankYouCard ) );
+	} ),
+	{ requestGuidedTour }
+)( localize( ThankYouCard ) );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/footer.js
@@ -13,7 +13,12 @@ import Card from 'components/card';
 const JetpackChecklistFooter = ( { translate, handleWpAdminLink, wpAdminUrl } ) => (
 	<Card compact className="jetpack-checklist__footer">
 		<p>{ translate( 'Return to your self-hosted WordPress dashboard.' ) }</p>
-		<Button compact href={ wpAdminUrl } onClick={ handleWpAdminLink }>
+		<Button
+			compact
+			data-tip-target="jetpack-checklist-wpadmin-link"
+			href={ wpAdminUrl }
+			onClick={ handleWpAdminLink }
+		>
 			{ translate( 'Return to WP Admin' ) }
 		</Button>
 	</Card>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds Jetpack checklist tour

Resolves https://github.com/Automattic/wp-calypso/issues/33285

<img width="1180" alt="Screenshot 2019-05-29 at 12 24 05" src="https://user-images.githubusercontent.com/87168/58545792-ad496e80-820c-11e9-9253-f43b835e7077.png">

<img width="1179" alt="Screenshot 2019-05-29 at 11 59 17" src="https://user-images.githubusercontent.com/87168/58544037-38c10080-8209-11e9-80ca-cc9e643a3de6.png">

#### Testing instructions

- Have a Jetpack connected site
- Open `/plans/my-plan/:site?thank-you`
- Click "continue" and you should see the checklist with two tasks:
  - One pointing to the checklist itself
  - One to the wp-admin link at the footer of the checklist
