### PR TITLE
Load user translations after user locale bootstrap

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -8,7 +8,7 @@ import debugFactory from 'debug';
 import page from 'page';
 import { parse } from 'qs';
 import url from 'url';
-import { startsWith } from 'lodash';
+import { get, startsWith } from 'lodash';
 import React from 'react';
 import ReactDom from 'react-dom';
 import store from 'store';
@@ -46,6 +46,7 @@ import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 import { setLocale, setLocaleRawData } from 'state/ui/language/actions';
 import { setNextLayoutFocus, activateNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import setupGlobalKeyboardShortcuts from 'lib/keyboard-shortcuts/global';
+import { loadUserUndeployedTranslations } from 'lib/i18n-utils/switch-locale';
 
 const debug = debugFactory( 'calypso' );
 
@@ -159,6 +160,11 @@ export const locales = ( currentUser, reduxStore ) => {
 	if ( window.i18nLocaleStrings ) {
 		const i18nLocaleStringsObject = JSON.parse( window.i18nLocaleStrings );
 		reduxStore.dispatch( setLocaleRawData( i18nLocaleStringsObject ) );
+		const languageSlug = get( i18nLocaleStringsObject, [ '', 'localeSlug' ] );
+		if ( languageSlug ) {
+			debug( 'Checking for load-user-translations parameter' );
+			loadUserUndeployedTranslations( languageSlug );
+		}
 	}
 
 	// Use current user's locale if it was not bootstrapped (non-ssr pages)

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -109,12 +109,12 @@ export default function switchLocale( localeSlug ) {
 
 			setLocaleInDOM( domLocaleSlug, !! language.rtl );
 
-			applyUserWaitingTranslations( targetLocaleSlug );
+			loadUserUndeployedTranslations( targetLocaleSlug );
 		} );
 	}
 }
 
-function applyUserWaitingTranslations( currentLocaleSlug ) {
+export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 	if ( ! location || ! location.search ) {
 		return;
 	}


### PR DESCRIPTION
This PR fixes the load-user-locale feature when logged-in on production by adding the logic to the `wpcom-user-bootstrap` execution flow.

#### Testing Preparations: Enabling wpcom-user-bootstrap in dev

The specific problem is that the `wpcom-user-bootstrap` feature, which is disabled in dev, so In order to test, we'll need to turn it on. 

1. Set `"wpcom-user-bootstrap": true` in `config/development.json`
2. Provide a `config/secrets.json` with 3 values:
   1. `wpcom_calypso_rest_api_key`
   1. `wpcom_calypso_support_session_rest_api_key`, 
   1. `wordpress_logged_in_cookie`

The `bin/calypso-secrets` script on a sandbox will generate the 2 rest keys, and api keys we need, but you'll need to grab the `wordpress_logged_in` value from your browser session and add it to `secrets.json` using the key `wordpress_logged_in_cookie`. (Pro tip: If you miss the addition of the `_cookie` to the name, you're gonna have a bad time). (In Chrome, you can find this in DevTools/Application/Storage/Cookies/https://public-api.wordpress.com)

You can confirm that bootstrapping is happening by adding `localStorage.setItem('debug', 'calypso');` and noting the "Checking for load-user-translations parameter" message, or just by checking for the existence of the `window.i18nLocaleStrings` variable.

#### Testing Instructions

Once `wpcom-user-bootstrap` is working, We'll also need accepted-but-not-deployed translations to load from translate.wordpress.com

Ideally we'd test with different strings, but If you don't have commit access, use [my test strings](https://translate.wordpress.com/projects/test/fr/default/?filters%5Bterm%5D=&filters%5Bterm_scope%5D=scope_any&filters%5Bstatus%5D=current&filters%5Buser_login%5D=julesaus&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc#) with `?locale=fr&load-user-translations=julesaus&project=test`:

![Stat117gy_‹_julesauspremiumtest_—_WordPress_com](https://user-images.githubusercontent.com/5952255/58467876-cf48df80-817f-11e9-9e78-285bf1a365e9.jpg)
