### PR TITLE
Starter Page Templates: API integration

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -18,13 +18,6 @@ class Starter_Page_Templates {
 	private static $instance = null;
 
 	/**
-	 * Transient key.
-	 *
-	 * @var string
-	 */
-	private static $transient_key = 'starter_page_templates';
-
-	/**
 	 * Starter_Page_Templates constructor.
 	 */
 	private function __construct() {
@@ -119,19 +112,19 @@ class Starter_Page_Templates {
 	 * Fetch vertical data from the API or return cached version if available.
 	 */
 	public function fetch_vertical_data() {
-		$vertical_templates = get_transient( self::$transient_key );
 		$vertical_id        = get_site_option( 'site_vertical', 'default' );
+		$transient_key		= 'starter_page_templates_' . $vertical_id;
+		$vertical_templates = get_transient( $transient_key );
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
-		if ( false === $vertical_templates || $vertical_id !== $vertical_templates['vertical_id'] ) {
+		if ( false === $vertical_templates ) {
 			$request_url = 'https://public-api.wordpress.com/wpcom/v2/verticals/' . $vertical_id . '/templates';
 			$response    = wp_remote_get( esc_url_raw( $request_url ) );
 			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 				return false;
 			}
-			$vertical_templates                = json_decode( wp_remote_retrieve_body( $response ), true );
-			$vertical_templates['vertical_id'] = $vertical_id; // Add vertical_id so we can later compare it.
-			set_transient( self::$transient_key, $vertical_templates, 60 * 60 * 3 );
+			$vertical_templates = json_decode( wp_remote_retrieve_body( $response ), true );
+			set_transient( $transient_key, $vertical_templates, 60 * 60 * 3 );
 		}
 
 		return $vertical_templates;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -71,7 +71,7 @@ class Starter_Page_Templates {
 		$vertical_templates = $vertical_data['templates'];
 
 		// Bail early if we have no templates to offer.
-		if ( count( $vertical_templates ) === 0 ) {
+		if ( empty( $vertical_templates ) ) {
 			return;
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -22,8 +22,7 @@ class Starter_Page_Templates {
 	 */
 	private function __construct() {
 		add_action( 'init', array( $this, 'register_scripts' ) );
-		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_scripts' ) );
-		add_action( 'enqueue_block_assets', array( $this, 'enqueue_styles' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_assets' ) );
 	}
 
 	/**
@@ -53,9 +52,9 @@ class Starter_Page_Templates {
 	}
 
 	/**
-	 * Enqueue block editor scripts.
+	 * Enqueue block editor assets.
 	 */
-	public function enqueue_scripts() {
+	public function enqueue_assets() {
 		$screen = get_current_screen();
 
 		// Return early if we don't meet conditions to show templates.
@@ -63,7 +62,7 @@ class Starter_Page_Templates {
 			return;
 		}
 		
-		// Load templates for this site
+		// Load templates for this site.
 		$vertical_name = null;
 		$vertical_templates = array();
 		
@@ -76,7 +75,7 @@ class Starter_Page_Templates {
 			$vertical_templates = $api_response['templates'];
 		}
 		
-		// Bail early if we have no templates to offer
+		// Bail early if we have no templates to offer.
 		if ( count($vertical_templates) === 0 ) {
 			return;
 		}
@@ -100,12 +99,8 @@ class Starter_Page_Templates {
 			'templates'       => array_merge( $default_templates, $vertical_templates ),
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );
-	}
-
-	/**
-	 * Enqueue styles.
-	 */
-	public function enqueue_styles() {
+		
+		// Enqueue styles.
 		$style_file = is_rtl()
 			? 'starter-page-templates.rtl.css'
 			: 'starter-page-templates.css';

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -116,7 +116,7 @@ class Starter_Page_Templates {
 	}
 
 	/**
-	 * Enqueue block editor assets.
+	 * Fetch vertical data from the API or return cached version if available.
 	 */
 	public function fetch_vertical_data() {
 		$vertical_templates = get_transient( self::$transient_key );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -91,7 +91,6 @@ class Starter_Page_Templates {
 			array(
 				'title'   => 'Blank',
 				'slug'    => 'blank',
-				'content' => '',
 			),
 			
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -62,72 +62,43 @@ class Starter_Page_Templates {
 		if ( 'page' !== $screen->id || 'add' !== $screen->action ) {
 			return;
 		}
+		
+		// Load templates for this site
+		$vertical_name = null;
+		$vertical_templates = array();
+		
+		$vertical_id = get_site_option( 'site_vertical', 'default' );
+		$request_url = 'https://public-api.wordpress.com/wpcom/v2/verticals/' . $vertical_id . '/templates';
+		$response = wp_remote_get( esc_url_raw( $request_url ) );
+		if ( 200 === wp_remote_retrieve_response_code( $response ) ) {
+			$api_response = json_decode( wp_remote_retrieve_body( $response ), true );
+			$vertical_name = $api_response['vertical'];
+			$vertical_templates = $api_response['templates'];
+		}
+		
+		// Bail early if we have no templates to offer
+		if ( count($vertical_templates) === 0 ) {
+			return;
+		}
 
 		wp_enqueue_script( 'starter-page-templates' );
 
 		$default_info = array(
 			'title' => get_bloginfo( 'name' ),
+			'vertical' => $vertical_name,
+		);
+		$default_templates = array(
+			array(
+				'title'   => 'Blank',
+				'slug'    => 'blank',
+				'content' => '',
+			),
+			
 		);
 		$site_info    = get_site_option( 'site_contact_info', array() );
 		$config       = array(
 			'siteInformation' => array_merge( $default_info, $site_info ),
-			'templates'       => array(
-				array(
-					'title'   => '',
-					'slug'    => 'blank',
-					'label'   => 'Blank',
-					'content' => '',
-					'preview' => 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-blank.png',
-				),
-				array(
-					'title'   => 'Home',
-					'slug'    => 'home',
-					'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce680d73300009801731614' )['body'] )->body->content,
-					'preview' => 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-home.jpg',
-				),
-				array(
-					'title'   => 'Menu',
-					'slug'    => 'menu',
-					'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce681173300006600731617' )['body'] )->body->content,
-					'preview' => 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-menu.jpg',
-				),
-				array(
-					'title'   => 'Contact Us',
-					'slug'    => 'contact',
-					'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce681763300004b3573161a' )['body'] )->body->content,
-					'preview' => 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-contactus.jpg',
-				),
-				array(
-					'title'   => 'Home 2',
-					'slug'    => 'home-2',
-					'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce680d73300009801731614' )['body'] )->body->content,
-					'preview' => 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-home-2.png',
-				),
-				array(
-					'title'   => 'Menu 2',
-					'slug'    => 'menu-2',
-					'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce681173300006600731617' )['body'] )->body->content,
-					'preview' => 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-menu-2.png',
-				),
-				array(
-					'title'   => 'Contact Us 2',
-					'slug'    => 'contact-2',
-					'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce681763300004b3573161a' )['body'] )->body->content,
-					'preview' => 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-contactus-2.png',
-				),
-				array(
-					'title'   => 'Menu 3',
-					'slug'    => 'menu-3',
-					'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce681173300006600731617' )['body'] )->body->content,
-					'preview' => 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-menu.jpg',
-				),
-				array(
-					'title'   => 'Contact Us 3',
-					'slug'    => 'contact-3',
-					'content' => json_decode( wp_remote_get( 'http://www.mocky.io/v2/5ce681763300004b3573161a' )['body'] )->body->content,
-					'preview' => 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-contactus.jpg',
-				),
-			),
+			'templates'       => array_merge( $default_templates, $vertical_templates ),
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -64,7 +64,7 @@ class Starter_Page_Templates {
 
 		// Load templates for this site.
 		$vertical_data = $this->fetch_vertical_data();
-		if ( ! $vertical_data ) {
+		if ( empty( $vertical_data ) ) {
 			return;
 		}
 		$vertical_name      = $vertical_data['vertical'];
@@ -110,10 +110,12 @@ class Starter_Page_Templates {
 
 	/**
 	 * Fetch vertical data from the API or return cached version if available.
+	 *
+	 * @return array Containing vertical name and template list or nothing if an error occurred.
 	 */
 	public function fetch_vertical_data() {
 		$vertical_id        = get_site_option( 'site_vertical', 'default' );
-		$transient_key		= 'starter_page_templates_' . $vertical_id;
+		$transient_key      = 'starter_page_templates_' . $vertical_id;
 		$vertical_templates = get_transient( $transient_key );
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
@@ -121,7 +123,7 @@ class Starter_Page_Templates {
 			$request_url = 'https://public-api.wordpress.com/wpcom/v2/verticals/' . $vertical_id . '/templates';
 			$response    = wp_remote_get( esc_url_raw( $request_url ) );
 			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-				return false;
+				return array();
 			}
 			$vertical_templates = json_decode( wp_remote_retrieve_body( $response ), true );
 			set_transient( $transient_key, $vertical_templates, DAY_IN_SECONDS );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -88,7 +88,7 @@ class Starter_Page_Templates {
 			),
 
 		);
-		$site_info = get_site_option( 'site_contact_info', array() );
+		$site_info = get_option( 'site_contact_info', array() );
 		$config    = array(
 			'siteInformation' => array_merge( $default_info, $site_info ),
 			'templates'       => array_merge( $default_templates, $vertical_templates ),
@@ -114,7 +114,7 @@ class Starter_Page_Templates {
 	 * @return array Containing vertical name and template list or nothing if an error occurred.
 	 */
 	public function fetch_vertical_data() {
-		$vertical_id        = get_site_option( 'site_vertical', 'default' );
+		$vertical_id        = get_option( 'site_vertical', 'default' );
 		$transient_key      = 'starter_page_templates_' . $vertical_id;
 		$vertical_templates = get_transient( $transient_key );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -124,7 +124,7 @@ class Starter_Page_Templates {
 				return false;
 			}
 			$vertical_templates = json_decode( wp_remote_retrieve_body( $response ), true );
-			set_transient( $transient_key, $vertical_templates, 60 * 60 * 3 );
+			set_transient( $transient_key, $vertical_templates, DAY_IN_SECONDS );
 		}
 
 		return $vertical_templates;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -42,7 +42,15 @@ function TemplateSelectorControl( {
 						onClick={ handleButtonClick }
 						aria-describedby={ help ? `${ id }__help` : undefined }
 					>
-						<img className="template-selector-control__media" src={ option.preview } alt="" />
+						<div className="template-selector-control__media-wrap">
+							{ option.preview && (
+								<img
+									className="template-selector-control__media"
+									src={ option.preview }
+									alt={ 'Preview of ' + option.label }
+								/>
+							) }
+						</div>
 						{ option.label }
 					</button>
 				</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -15,7 +15,7 @@ import { keyBy } from 'lodash';
 
 	const insertTemplate = template => {
 		// Skip inserting if there's nothing to insert.
-		if ( ! template.title && ! template.content ) {
+		if ( ! template.content ) {
 			return;
 		}
 
@@ -52,7 +52,7 @@ import { keyBy } from 'lodash';
 								<TemplateSelectorControl
 									label="Template"
 									templates={ Object.values( verticalTemplates ).map( template => ( {
-										label: template.label || template.title,
+										label: template.title,
 										value: template.slug,
 										preview: template.preview,
 									} ) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -4,7 +4,24 @@
 import replacePlaceholders from './utils/replace-placeholders';
 import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
-import { keyBy } from 'lodash';
+import { keyBy, map } from 'lodash';
+
+// TODO: remove once we have proper previews from API
+if ( window.starterPageTemplatesConfig ) {
+	const PREVIEWS_BY_SLUG = {
+		home: 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-home-2.png',
+		menu: 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-menu-2.png',
+		'contact-us':
+			'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-contactus-2.png',
+	};
+	window.starterPageTemplatesConfig.templates = map(
+		window.starterPageTemplatesConfig.templates,
+		template => {
+			template.preview = PREVIEWS_BY_SLUG[ template.slug ];
+			return template;
+		}
+	);
+}
 
 ( function( wp, config = {} ) {
 	const registerPlugin = wp.plugins.registerPlugin;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -4,7 +4,7 @@
 import replacePlaceholders from './utils/replace-placeholders';
 import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
-import { keyBy, map } from 'lodash';
+import { keyBy, map, has } from 'lodash';
 
 // TODO: remove once we have proper previews from API
 if ( window.starterPageTemplatesConfig ) {
@@ -32,7 +32,7 @@ if ( window.starterPageTemplatesConfig ) {
 
 	const insertTemplate = template => {
 		// Skip inserting if there's nothing to insert.
-		if ( ! template.content ) {
+		if ( ! has( template, 'content' ) ) {
 			return;
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -85,10 +85,10 @@
 		padding-bottom: 90%;
 		box-sizing: content-box;
 		position: relative;
+		pointer-events: none;
 	}
 
 	.template-selector-control__media {
-		pointer-events: none;
 		width: 100%;
 		display: block;
 		position: absolute;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -82,7 +82,8 @@
 		background: #f6f6f6;
 		border-radius: 4px;
 		overflow: hidden;
-		padding-bottom: 88%;
+		padding-bottom: 90%;
+		box-sizing: content-box;
 		position: relative;
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -82,7 +82,7 @@
 		background: #f6f6f6;
 		border-radius: 4px;
 		overflow: hidden;
-		padding-bottom: 90%;
+		padding-bottom: 88%;
 		position: relative;
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -56,6 +56,7 @@
 
 	.template-selector-control__label {
 		display: block;
+		width: 100%;
 		text-align: center;
 		border: 1px solid transparent;
 		padding: 2em;
@@ -73,14 +74,25 @@
 		}
 	}
 
-	.template-selector-control__media {
-		pointer-events: none;
-		max-width: 100%;
+	.template-selector-control__media-wrap {
+		width: 100%;
 		display: block;
 		margin: 0 auto 2em;
 		border: 1px solid rgba( 25, 30, 35, 0.2 );
+		background: #f6f6f6;
 		border-radius: 4px;
 		overflow: hidden;
+		padding-bottom: 90%;
+		position: relative;
+	}
+
+	.template-selector-control__media {
+		pointer-events: none;
+		width: 100%;
+		display: block;
+		position: absolute;
+		top: 0;
+		left: 0;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* connects the plugin to a proper API
  * if API fails or returns no templates, no modal will be shown
  * if there are templates, a Blank template will be inserted at the beginning of the list
* simplifies how the Blank template is handled (removed `label` prop, title back in `title`, `content` is completely removed)
* template previews are now fully optional and a grey box shows by default (same as what Blank looked like)
* blank.png was removed in favor of the new fully CSS-based blank preview
* temporary code added to the top of our index.js that fills previews for known slugs

#### Testing instructions

* Add a new page and check the templates

#### Further considerations


* Do we care about the order of templates? Home would feel logical as a first template after Blank. Most likely something we can do in the API - frontend uses the same order.
* Where should previews live and how are they defined? I'll create a separate issue for this point

Fixes #33278 