### PR TITLE
Jetpack checklist: fix success event

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you-card/paid-plan-thank-you-card.js
@@ -27,7 +27,10 @@ const INSTALL_STATE_INCOMPLETE = 2;
 
 export class PaidPlanThankYouCard extends Component {
 	componentDidUpdate( prevProps ) {
-		if ( prevProps.progressComplete < 100 && this.props.progressComplete >= 100 ) {
+		if (
+			prevProps.installState !== INSTALL_STATE_COMPLETE &&
+			this.props.installState === INSTALL_STATE_COMPLETE
+		) {
 			this.props.recordTracksEvent( 'calypso_plans_autoconfig_success', {
 				checklist_name: 'jetpack',
 				location: 'JetpackChecklist',


### PR DESCRIPTION
Ensure we fire `calypso_plans_autoconfig_success` event.

I added the event initially in https://github.com/Automattic/wp-calypso/pull/33226 and broke it the next day, probably just not testing for this prop in https://github.com/Automattic/wp-calypso/pull/33228 or while rebasing.

#### Changes proposed in this Pull Request

* Fix buggy props checking in `componentDidUpdate`

#### Testing instructions

- Have a Jetpack site with a plan
- Open `http://calypso.localhost:3000/plans/my-plan/:site?thank-you`
- Confirm you see `calypso_plans_autoconfig_success` event fired _once_