### PR TITLE
Fix trash post test by ensuring saved

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -790,7 +790,8 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 			step( 'Can enter post title and content', async function() {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
 				await gEditorComponent.enterTitle( blogPostTitle );
-				return await gEditorComponent.enterText( blogPostQuote );
+				await gEditorComponent.enterText( blogPostQuote );
+				return gEditorComponent.ensureSaved();
 			} );
 
 			step( 'Can trash the new post', async function() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The test `Calypso Gutenberg Editor: Posts (desktop) Trash Post` is failing a lot because the post isn't auto-saving quickly enough. Since we are just testing the trash functionality, added a step to ensure that the post is saved so the that trash option is available

#### Testing instructions

* Make sure the failing test passes in CI