### PR TITLE
Fix Apple Pay icon display on Jetpack Connect plans page

### DIFF
--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -869,6 +869,13 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 		border-radius: 1px;
 	}
 
+	.payment-logo.is-apple-pay {
+		height: 22px;
+		background-size: 34px auto;
+		width: 34px;
+		margin-top: 0;
+	}
+
 	.jetpack-connect__main-error .empty-content {
 		padding-bottom: 24px;
 		background-color: var( --color-white );


### PR DESCRIPTION
The Apple Pay icon in the list of payment methods looks a bit lopsided when viewing the plans page in the Jetpack Connect flow.  Essentially, there are some layout differences between this and the main plans page, and the interplay between the dark border of the Apple Pay icon and the dark background of the Jetpack Connect plans page has an effect here too.

This pull request adds some CSS to specifically override the Apple Pay icon styling on the Jetpack Connect plans page (similar to what is already done to override the styling of the PayPal icon next to it).

Before:

![before](https://user-images.githubusercontent.com/235183/58524354-f90d0100-8195-11e9-8399-82fd40f88b12.png)

After:

![after](https://user-images.githubusercontent.com/235183/58524355-f90d0100-8195-11e9-97f2-330dbcdcf982.png)