### PR TITLE
Signup: Add vertical site preview defaults for Blog and Professional segments

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -18,7 +18,7 @@ import PopularTopics from 'components/site-verticals-suggestion-search/popular-t
 import QueryVerticals from 'components/data/query-verticals';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
-import { DEFAULT_VERTICAL_KEY } from 'state/signup/verticals/constants';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 /**
  * Style dependencies
@@ -29,6 +29,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	static propTypes = {
 		autoFocus: PropTypes.bool,
 		defaultVertical: PropTypes.object,
+		defaultVerticalSearchTerm: PropTypes.string,
 		onChange: PropTypes.func,
 		placeholder: PropTypes.string,
 		searchValue: PropTypes.string,
@@ -40,6 +41,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	static defaultProps = {
 		autoFocus: false,
 		defaultVertical: {},
+		defaultVerticalSearchTerm: '',
 		onChange: () => {},
 		placeholder: '',
 		searchValue: '',
@@ -170,7 +172,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	getSuggestions = () => this.state.candidateVerticals.map( vertical => vertical.verticalName );
 
 	render() {
-		const { autoFocus, placeholder, siteType, translate } = this.props;
+		const { autoFocus, defaultVerticalSearchTerm, placeholder, siteType, translate } = this.props;
 		const { inputValue, railcar } = this.state;
 		const shouldShowPopularTopics = this.shouldShowPopularTopics();
 		const placeholderText = shouldShowPopularTopics
@@ -189,7 +191,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 					siteType={ siteType }
 					debounceTime={ 300 }
 				/>
-				<QueryVerticals searchTerm={ DEFAULT_VERTICAL_KEY } siteType={ siteType } />
+				<QueryVerticals searchTerm={ defaultVerticalSearchTerm } siteType={ siteType } />
 				<SuggestionSearch
 					id="siteTopic"
 					placeholder={ placeholder || placeholderText }
@@ -208,14 +210,17 @@ export class SiteVerticalsSuggestionSearch extends Component {
 
 export default localize(
 	connect(
-		( state, ownProps ) => ( {
-			verticals: getVerticals( state, ownProps.searchValue, getSiteType( state ) ) || [],
-			defaultVertical: get(
-				getVerticals( state, DEFAULT_VERTICAL_KEY, getSiteType( state ) ),
-				'0',
-				{}
-			),
-		} ),
+		( state, ownProps ) => {
+			const siteType = getSiteType( state );
+			const defaultVerticalSearchTerm =
+				getSiteTypePropertyValue( 'slug', siteType, 'defaultVertical' ) || '';
+			return {
+				siteType,
+				defaultVerticalSearchTerm,
+				verticals: getVerticals( state, ownProps.searchValue, siteType ) || [],
+				defaultVertical: get( getVerticals( state, defaultVerticalSearchTerm, siteType ), '0', {} ),
+			};
+		},
 		null
 	)( SiteVerticalsSuggestionSearch )
 );

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -2,14 +2,14 @@
 
 exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
 <Fragment>
-  <Connect(QueryVerticals)
+  <QueryVerticals
     debounceTime={300}
     searchTerm=""
-    siteType=""
+    siteType="blog"
   />
-  <Connect(QueryVerticals)
-    searchTerm="business"
-    siteType=""
+  <QueryVerticals
+    searchTerm="eeek"
+    siteType="blog"
   />
   <SuggestionSearch
     autoFocus={false}

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -20,6 +20,8 @@ jest.mock( 'uuid', () => ( {
 	v4: () => 'fake-uuid',
 } ) );
 
+jest.mock( 'components/data/query-verticals', () => 'QueryVerticals' );
+
 const defaultProps = {
 	onChange: jest.fn(),
 	verticals: [
@@ -32,6 +34,7 @@ const defaultProps = {
 			verticalId: 'hoodoo',
 		},
 	],
+	defaultVerticalSearchTerm: 'eeek',
 	defaultVertical: {
 		verticalName: 'eeek',
 		verticalSlug: 'ooofff',
@@ -40,8 +43,9 @@ const defaultProps = {
 		parent: 'whoops',
 		verticalId: 'argh',
 	},
-	translate: str => str,
+	siteType: 'blog',
 	searchValue: '',
+	translate: str => str,
 };
 
 describe( '<SiteVerticalsSuggestionSearch />', () => {
@@ -66,6 +70,17 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 			<SiteVerticalsSuggestionSearch { ...defaultProps } showPopular={ true } />
 		);
 		expect( wrapper.find( PopularTopics ) ).toHaveLength( 1 );
+	} );
+
+	test( 'should pass default vertical search term to <QueryVerticals />', () => {
+		const wrapper = shallow(
+			<SiteVerticalsSuggestionSearch { ...defaultProps } showPopular={ true } />
+		);
+		const queryComponent = wrapper.find( 'QueryVerticals' ).at( 1 );
+
+		expect( queryComponent.length ).toBe( 1 );
+		expect( queryComponent.props().searchTerm ).toBe( defaultProps.defaultVerticalSearchTerm );
+		expect( queryComponent.props().siteType ).toBe( defaultProps.siteType );
 	} );
 
 	describe( 'searchForVerticalMatches()', () => {

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -42,6 +42,7 @@ export function getAllSiteTypes() {
 		{
 			id: 2, // This value must correspond with its sibling in the /segments API results
 			slug: 'blog',
+			defaultVertical: 'blogging', // used to conduct a vertical search and grab a default vertical for the segment
 			label: i18n.translate( 'Blog' ),
 			description: i18n.translate( 'Share and discuss ideas, updates, or creations.' ),
 			theme: 'pub/independent-publisher-2',
@@ -54,6 +55,7 @@ export function getAllSiteTypes() {
 		{
 			id: 1, // This value must correspond with its sibling in the /segments API results
 			slug: 'business',
+			defaultVertical: 'business',
 			label: i18n.translate( 'Business' ),
 			description: i18n.translate( 'Promote products and services.' ),
 			theme: 'pub/professional-business',
@@ -67,6 +69,7 @@ export function getAllSiteTypes() {
 		{
 			id: 4, // This value must correspond with its sibling in the /segments API results
 			slug: 'professional',
+			defaultVertical: 'designer',
 			label: i18n.translate( 'Professional' ),
 			description: i18n.translate( 'Showcase your portfolio and work.' ),
 			theme: 'pub/altofocus',
@@ -79,6 +82,7 @@ export function getAllSiteTypes() {
 		{
 			id: 3, // This value must correspond with its sibling in the /segments API results
 			slug: 'online-store',
+			defaultVertical: 'business',
 			label: i18n.translate( 'Online store' ),
 			description: i18n.translate( 'Sell your collection of products online.' ),
 			theme: 'pub/dara',

--- a/client/state/signup/verticals/constants.js
+++ b/client/state/signup/verticals/constants.js
@@ -1,3 +1,0 @@
-/** @format */
-
-export const DEFAULT_VERTICAL_KEY = 'business';


### PR DESCRIPTION
## Changes proposed in this Pull Request

Since D28758-code was merged, the **Blog** and **Professional** site segments have their very own verticals. 

Now is the time, dear viewers, to assign default verticals search terms for each segment. We do thing so we have back up vertical data in case the site topic step is skipped, or a custom site topic (for any reason) doesn't return a preview.

The Business segment's default vertical search term is `'business'`.

I've chosen some verticals from our offical list semi-randomly:

**Blog**: `'blogging'`
**Professional**: `'designer'`

Any suggestions on alternatives?

## Testing instructions

1. Fire up the branch and make a dash for `/start/onboarding`
2. Select **Business** as your site type
3. Check the network tab for a request to `/verticals`, and in particular the `search` parameter value and the response, which should be the default vertical search term and one or more segment-related verticals respectively.
4. Repeat the above steps for **Blog** and **Professional**
5. Relax! Put your feet up! 

Run the updated component's unit tests:

`npm run test-client client/components/site-verticals-suggestion-search`

Fixes https://github.com/Automattic/zelda-private/issues/31
