### PR TITLE
Verticals Removing vertical preview requirement

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -115,7 +115,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	searchForVerticalMatches = ( value = '' ) =>
 		find(
 			this.props.verticals,
-			item => item.verticalName.toLowerCase() === value.toLowerCase().trim() && !! item.preview
+			item => item.verticalName.toLowerCase() === value.toLowerCase().trim()
 		);
 
 	/**


### PR DESCRIPTION
## Changes proposed in this Pull Request

Until **Blog** and **Professional** verticals have a site preview (they will soon) let's just search for slug match and not check if the results contain a preview.

We have to do this so we can properly store the id and other vertical info in `state.signup.steps.siteVertical`. The id is required for tracking purposes and, in the future, making sure we match the right preview content from the annotations.

The backend ensures that we have a preview anyway.

## Testing instructions

Head over to http://calypso.localhost:3000/start/onboarding and select **Blog** or **Professional**
Select a popular topic or search for a vertical and select a result.
Check `state.signup.steps.siteVertical` to make sure we're saving the `id`
