### PR TITLE
e2e: Adding a skip to failing test (temporarily) and explanatory comment

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1274,7 +1274,12 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for free subdomain site @parallel', function() {
+	/*
+		Since D28758-code, we require a specific site_segment id to return blog-specific verticals. For blogs it's `4`.
+		We now need to supply the verticals endpoint with a `site_type` parameter to return accurate results.
+		Skipping this test until we can get a fix in.
+	 */
+	describe.skip( 'Sign up for free subdomain site @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ blogName }.art.blog`;
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Since D28758-code, we require a specific site_segment id to return blog-specific verticals. 

For blogs it's `4`.

Formerly, simply searching for `art` for example, would return a proper subdomain of `art` thereby allowing us to suggest `art.blog` domains.

We now need to supply the verticals endpoint with a `site_type` parameter to return accurate results.

Skipping this test until we can get a fix in.

## Testing instructions
None. Test is skipped.

