### PR TITLE
FSE: fixes basic a11y issues

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -32,29 +32,31 @@ function TemplateSelectorControl( {
 			help={ help }
 			className={ classnames( className, 'template-selector-control' ) }
 		>
-			{ templates.map( ( option, index ) => (
-				<div key={ `${ id }-${ index }` } className="template-selector-control__option">
-					<button
-						type="button"
-						id={ `${ id }-${ index }` }
-						className="template-selector-control__label"
-						value={ option.value }
-						onClick={ handleButtonClick }
-						aria-describedby={ help ? `${ id }__help` : undefined }
-					>
-						<div className="template-selector-control__media-wrap">
-							{ option.preview && (
-								<img
-									className="template-selector-control__media"
-									src={ option.preview }
-									alt={ 'Preview of ' + option.label }
-								/>
-							) }
-						</div>
-						{ option.label }
-					</button>
-				</div>
-			) ) }
+			<ul className="template-selector-control__options">
+				{ templates.map( ( option, index ) => (
+					<li key={ `${ id }-${ index }` } className="template-selector-control__option">
+						<button
+							type="button"
+							id={ `${ id }-${ index }` }
+							className="template-selector-control__label"
+							value={ option.value }
+							onClick={ handleButtonClick }
+							aria-describedby={ help ? `${ id }__help` : undefined }
+						>
+							<div className="template-selector-control__media-wrap">
+								{ option.preview && (
+									<img
+										className="template-selector-control__media"
+										src={ option.preview }
+										alt={ 'Preview of ' + option.label }
+									/>
+								) }
+							</div>
+							{ option.label }
+						</button>
+					</li>
+				) ) }
+			</ul>
 		</BaseControl>
 	);
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -33,31 +33,29 @@ function TemplateSelectorControl( {
 			className={ classnames( className, 'template-selector-control' ) }
 		>
 			<ul className="template-selector-control__options">
-				{ templates.map( ( option, index ) => {
-					return (
-						<li key={ `${ id }-${ index }` } className="template-selector-control__option">
-							<button
-								type="button"
-								id={ `${ id }-${ index }` }
-								className="template-selector-control__label"
-								value={ option.value }
-								onClick={ handleButtonClick }
-								aria-describedby={ help ? `${ id }__help` : undefined }
-							>
-								<div className="template-selector-control__media-wrap">
-									{ option.preview && (
-										<img
-											className="template-selector-control__media"
-											src={ option.preview }
-											alt={ option.previewAlt || '' }
-										/>
-									) }
-								</div>
-								{ option.label }
-							</button>
-						</li>
-					);
-				} ) }
+				{ templates.map( ( option, index ) => (
+					<li key={ `${ id }-${ index }` } className="template-selector-control__option">
+						<button
+							type="button"
+							id={ `${ id }-${ index }` }
+							className="template-selector-control__label"
+							value={ option.value }
+							onClick={ handleButtonClick }
+							aria-describedby={ help ? `${ id }__help` : undefined }
+						>
+							<div className="template-selector-control__media-wrap">
+								{ option.preview && (
+									<img
+										className="template-selector-control__media"
+										src={ option.preview }
+										alt={ option.previewAlt || '' }
+									/>
+								) }
+							</div>
+							{ option.label }
+						</button>
+					</li>
+				) ) }
 			</ul>
 		</BaseControl>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -34,7 +34,6 @@ function TemplateSelectorControl( {
 		>
 			<ul className="template-selector-control__options">
 				{ templates.map( ( option, index ) => {
-					const altText = option.previewAlt || 'Preview of ' + option.label;
 					return (
 						<li key={ `${ id }-${ index }` } className="template-selector-control__option">
 							<button
@@ -50,7 +49,7 @@ function TemplateSelectorControl( {
 										<img
 											className="template-selector-control__media"
 											src={ option.preview }
-											alt={ altText }
+											alt={ option.previewAlt || '' }
 										/>
 									) }
 								</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -33,29 +33,32 @@ function TemplateSelectorControl( {
 			className={ classnames( className, 'template-selector-control' ) }
 		>
 			<ul className="template-selector-control__options">
-				{ templates.map( ( option, index ) => (
-					<li key={ `${ id }-${ index }` } className="template-selector-control__option">
-						<button
-							type="button"
-							id={ `${ id }-${ index }` }
-							className="template-selector-control__label"
-							value={ option.value }
-							onClick={ handleButtonClick }
-							aria-describedby={ help ? `${ id }__help` : undefined }
-						>
-							<div className="template-selector-control__media-wrap">
-								{ option.preview && (
-									<img
-										className="template-selector-control__media"
-										src={ option.preview }
-										alt={ 'Preview of ' + option.label }
-									/>
-								) }
-							</div>
-							{ option.label }
-						</button>
-					</li>
-				) ) }
+				{ templates.map( ( option, index ) => {
+					const altText = option.previewAlt || 'Preview of ' + option.label;
+					return (
+						<li key={ `${ id }-${ index }` } className="template-selector-control__option">
+							<button
+								type="button"
+								id={ `${ id }-${ index }` }
+								className="template-selector-control__label"
+								value={ option.value }
+								onClick={ handleButtonClick }
+								aria-describedby={ help ? `${ id }__help` : undefined }
+							>
+								<div className="template-selector-control__media-wrap">
+									{ option.preview && (
+										<img
+											className="template-selector-control__media"
+											src={ option.preview }
+											alt={ altText }
+										/>
+									) }
+								</div>
+								{ option.label }
+							</button>
+						</li>
+					);
+				} ) }
 			</ul>
 		</BaseControl>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -9,10 +9,20 @@ import { keyBy, map, has } from 'lodash';
 // TODO: remove once we have proper previews from API
 if ( window.starterPageTemplatesConfig ) {
 	const PREVIEWS_BY_SLUG = {
-		home: 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-home-2.png',
-		menu: 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-menu-2.png',
-		'contact-us':
-			'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-contactus-2.png',
+		home: {
+			src: 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-home-2.png',
+			alt:
+				'Full width hero banner, followed by alternating text and image sections, followed by a Get in Touch area',
+		},
+		menu: {
+			src: 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-menu-2.png',
+			alt: '',
+		},
+		'contact-us': {
+			src:
+				'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-contactus-2.png',
+			alt: '',
+		},
 	};
 	window.starterPageTemplatesConfig.templates = map(
 		window.starterPageTemplatesConfig.templates,
@@ -71,7 +81,8 @@ if ( window.starterPageTemplatesConfig ) {
 									templates={ Object.values( verticalTemplates ).map( template => ( {
 										label: template.title,
 										value: template.slug,
-										preview: template.preview,
+										preview: template.preview && ( template.preview.src || '' ),
+										previewAlt: template.preview && ( template.preview.alt || '' ),
 									} ) ) }
 									onClick={ newTemplate => {
 										setState( { isOpen: false } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -60,12 +60,12 @@ if ( window.starterPageTemplatesConfig ) {
 					className="page-template-modal"
 				>
 					<div className="page-template-modal__inner">
-						<div className="page-template-modal__intro">
-							<p>Pick a Template that matches the purpose of your page.</p>
-							<p>You can customise each Template to meet your needs.</p>
-						</div>
 						<form className="page-template-modal__form">
 							<fieldset className="page-template-modal__list">
+								<legend className="page-template-modal__intro">
+									<p>Pick a Template that matches the purpose of your page.</p>
+									<p>You can customise each Template to meet your needs.</p>
+								</legend>
 								<TemplateSelectorControl
 									label="Template"
 									templates={ Object.values( verticalTemplates ).map( template => ( {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -81,8 +81,8 @@ if ( window.starterPageTemplatesConfig ) {
 									templates={ Object.values( verticalTemplates ).map( template => ( {
 										label: template.title,
 										value: template.slug,
-										preview: template.preview && ( template.preview.src || '' ),
-										previewAlt: template.preview && ( template.preview.alt || '' ),
+										preview: template.preview && template.preview.src,
+										previewAlt: template.preview && template.preview.alt,
 									} ) ) }
 									onClick={ newTemplate => {
 										setState( { isOpen: false } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -43,15 +43,16 @@
 .page-template-modal__list {
 	padding: 1.5em 0;
 
-	.components-base-control__field {
+
+	.components-base-control__label {
+		@include screen-reader-text();
+	}
+	
+	.template-selector-control__options {
 		display: grid;
 		// stylelint-disable-next-line unit-whitelist
 		grid-template-columns: repeat( auto-fit, minmax( 200px, 1fr ) );
 		grid-gap: 1.5em;
-	}
-
-	.components-base-control__label {
-		@include screen-reader-text();
 	}
 
 	.template-selector-control__label {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves form description within fieldset as per [advice here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label)
* Utilises `<ul>` so that the number of Template options is announced to non-sighted users prior to them embarking on tabbing through the options
* Adds ability to define Template preview image `alt` text via the API data rather than having it hard coded into the Template. This allows authors to describe their Template layout so that non-sighted users can _perceive_ the Template prior to insertion. (note this may be better implemented as an `aria-described-by` on the `<button>` which references a longer explanation)
* Default to empty alt if no `alt` is provided for the Template preview image as per [advice here](https://www.scottohara.me/blog/2019/05/22/contextual-images-svgs-and-a11y.html)