### PR TITLE
Guided Tours Step: Await `wait` when warranted

### DIFF
--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -114,10 +114,7 @@ export default class Step extends Component< Props, State > {
 
 	async componentWillReceiveProps( nextProps: Props, nextContext ) {
 		const shouldScrollTo = nextProps.shouldScrollTo && this.props.name !== nextProps.name;
-
-		if ( nextProps.wait !== this.props.wait ) {
-			await this.wait( nextProps, nextContext );
-		}
+		await this.wait( nextProps, nextContext );
 
 		this.setStepSection( nextContext );
 		this.quitIfInvalidRoute( nextProps, nextContext );

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -103,6 +103,10 @@ export default class Step extends Component< Props, State > {
 		this.skipIfInvalidContext( this.props, this.context );
 		this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
 		this.setStepPosition( this.props );
+		// The following should be legit usage of `setState`, since it's called
+		// asynchronously after `await`ing `this.wait()`.
+		// (We need it since `this.render()` might be called in the meantime.)
+		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { initialized: true } );
 		window.addEventListener( 'resize', this.onScrollOrResize );
 		this.watchTarget();

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -94,39 +94,37 @@ export default class Step extends Component< Props, State > {
 	 */
 	isUpdatingPosition: boolean = false;
 
-	async componentDidMount() {
-		await this.wait( this.props, this.context );
-
-		this.start();
-		this.setStepSection( this.context, { init: true } );
-		debug( 'Step#componentDidMount: stepSection:', this.stepSection );
-		this.skipIfInvalidContext( this.props, this.context );
-		this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
-		this.setStepPosition( this.props );
-		this.setState( { initialized: true } );
-		window.addEventListener( 'resize', this.onScrollOrResize );
-		this.watchTarget();
-
+	componentDidMount() {
+		this.wait( this.props, this.context ).then( () => {
+			this.start();
+			this.setStepSection( this.context, { init: true } );
+			debug( 'Step#componentDidMount: stepSection:', this.stepSection );
+			this.skipIfInvalidContext( this.props, this.context );
+			this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
+			this.setStepPosition( this.props );
+			this.setState( { initialized: true } );
+			window.addEventListener( 'resize', this.onScrollOrResize );
+			this.watchTarget();
+		} );
 		if ( this.props.keepRepositioning ) {
 			this.repositionInterval = setInterval( this.onScrollOrResize, 3000 );
 		}
 	}
 
-	async componentWillReceiveProps( nextProps: Props, nextContext ) {
+	componentWillReceiveProps( nextProps: Props, nextContext ) {
 		const shouldScrollTo = nextProps.shouldScrollTo && this.props.name !== nextProps.name;
-		await this.wait( nextProps, nextContext );
-
-		this.setStepSection( nextContext );
-		this.quitIfInvalidRoute( nextProps, nextContext );
-		this.skipIfInvalidContext( nextProps, nextContext );
-		if ( this.scrollContainer ) {
-			this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
-		}
-		this.scrollContainer = query( nextProps.scrollContainer )[ 0 ] || window;
-		this.scrollContainer.addEventListener( 'scroll', this.onScrollOrResize );
-		this.setStepPosition( nextProps, shouldScrollTo );
-		this.watchTarget();
-
+		this.wait( nextProps, nextContext ).then( () => {
+			this.setStepSection( nextContext );
+			this.quitIfInvalidRoute( nextProps, nextContext );
+			this.skipIfInvalidContext( nextProps, nextContext );
+			if ( this.scrollContainer ) {
+				this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
+			}
+			this.scrollContainer = query( nextProps.scrollContainer )[ 0 ] || window;
+			this.scrollContainer.addEventListener( 'scroll', this.onScrollOrResize );
+			this.setStepPosition( nextProps, shouldScrollTo );
+			this.watchTarget();
+		} );
 		if ( ! nextProps.keepRepositioning ) {
 			clearInterval( this.repositionInterval );
 		} else if ( ! this.repositionInterval ) {

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -94,37 +94,39 @@ export default class Step extends Component< Props, State > {
 	 */
 	isUpdatingPosition: boolean = false;
 
-	componentDidMount() {
-		this.wait( this.props, this.context ).then( () => {
-			this.start();
-			this.setStepSection( this.context, { init: true } );
-			debug( 'Step#componentDidMount: stepSection:', this.stepSection );
-			this.skipIfInvalidContext( this.props, this.context );
-			this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
-			this.setStepPosition( this.props );
-			this.setState( { initialized: true } );
-			window.addEventListener( 'resize', this.onScrollOrResize );
-			this.watchTarget();
-		} );
+	async componentDidMount() {
+		await this.wait( this.props, this.context );
+
+		this.start();
+		this.setStepSection( this.context, { init: true } );
+		debug( 'Step#componentDidMount: stepSection:', this.stepSection );
+		this.skipIfInvalidContext( this.props, this.context );
+		this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
+		this.setStepPosition( this.props );
+		this.setState( { initialized: true } );
+		window.addEventListener( 'resize', this.onScrollOrResize );
+		this.watchTarget();
+
 		if ( this.props.keepRepositioning ) {
 			this.repositionInterval = setInterval( this.onScrollOrResize, 3000 );
 		}
 	}
 
-	componentWillReceiveProps( nextProps: Props, nextContext ) {
+	async componentWillReceiveProps( nextProps: Props, nextContext ) {
 		const shouldScrollTo = nextProps.shouldScrollTo && this.props.name !== nextProps.name;
-		this.wait( nextProps, nextContext ).then( () => {
-			this.setStepSection( nextContext );
-			this.quitIfInvalidRoute( nextProps, nextContext );
-			this.skipIfInvalidContext( nextProps, nextContext );
-			if ( this.scrollContainer ) {
-				this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
-			}
-			this.scrollContainer = query( nextProps.scrollContainer )[ 0 ] || window;
-			this.scrollContainer.addEventListener( 'scroll', this.onScrollOrResize );
-			this.setStepPosition( nextProps, shouldScrollTo );
-			this.watchTarget();
-		} );
+		await this.wait( nextProps, nextContext );
+
+		this.setStepSection( nextContext );
+		this.quitIfInvalidRoute( nextProps, nextContext );
+		this.skipIfInvalidContext( nextProps, nextContext );
+		if ( this.scrollContainer ) {
+			this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );
+		}
+		this.scrollContainer = query( nextProps.scrollContainer )[ 0 ] || window;
+		this.scrollContainer.addEventListener( 'scroll', this.onScrollOrResize );
+		this.setStepPosition( nextProps, shouldScrollTo );
+		this.watchTarget();
+
 		if ( ! nextProps.keepRepositioning ) {
 			clearInterval( this.repositionInterval );
 		} else if ( ! this.repositionInterval ) {

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -114,7 +114,10 @@ export default class Step extends Component< Props, State > {
 
 	async componentWillReceiveProps( nextProps: Props, nextContext ) {
 		const shouldScrollTo = nextProps.shouldScrollTo && this.props.name !== nextProps.name;
-		await this.wait( nextProps, nextContext );
+
+		if ( nextProps.wait !== this.props.wait ) {
+			await this.wait( nextProps, nextContext );
+		}
 
 		this.setStepSection( nextContext );
 		this.quitIfInvalidRoute( nextProps, nextContext );

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -77,8 +77,6 @@ export default class Step extends Component< Props, State > {
 
 	stepSection: string = null;
 
-	mounted: boolean = false;
-
 	repositionInterval: ReturnType< typeof setInterval > | null = null;
 
 	scrollContainer: Element | null = null;
@@ -97,7 +95,6 @@ export default class Step extends Component< Props, State > {
 	isUpdatingPosition: boolean = false;
 
 	componentDidMount() {
-		this.mounted = true;
 		this.wait( this.props, this.context ).then( () => {
 			this.start();
 			this.setStepSection( this.context, { init: true } );
@@ -105,9 +102,7 @@ export default class Step extends Component< Props, State > {
 			this.skipIfInvalidContext( this.props, this.context );
 			this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
 			this.setStepPosition( this.props );
-			if ( this.mounted ) {
-				this.setState( { initialized: true } );
-			}
+			this.setState( { initialized: true } );
 			window.addEventListener( 'resize', this.onScrollOrResize );
 			this.watchTarget();
 		} );
@@ -138,8 +133,6 @@ export default class Step extends Component< Props, State > {
 	}
 
 	componentWillUnmount() {
-		this.mounted = false;
-
 		window.removeEventListener( 'resize', this.onScrollOrResize );
 		if ( this.scrollContainer ) {
 			this.scrollContainer.removeEventListener( 'scroll', this.onScrollOrResize );

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -96,23 +96,18 @@ export default class Step extends Component< Props, State > {
 	 */
 	isUpdatingPosition: boolean = false;
 
-	componentWillMount() {
+	componentDidMount() {
+		this.mounted = true;
 		this.wait( this.props, this.context ).then( () => {
 			this.start();
 			this.setStepSection( this.context, { init: true } );
-			debug( 'Step#componentWillMount: stepSection:', this.stepSection );
+			debug( 'Step#componentDidMount: stepSection:', this.stepSection );
 			this.skipIfInvalidContext( this.props, this.context );
 			this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
 			this.setStepPosition( this.props );
 			if ( this.mounted ) {
 				this.setState( { initialized: true } );
 			}
-		} );
-	}
-
-	componentDidMount() {
-		this.mounted = true;
-		this.wait( this.props, this.context ).then( () => {
 			window.addEventListener( 'resize', this.onScrollOrResize );
 			this.watchTarget();
 		} );

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -174,8 +174,6 @@ export default class Step extends Component< Props, State > {
 	safeSetState( state: State ) {
 		if ( this.mounted ) {
 			this.setState( state );
-		} else {
-			this.state = { ...this.state, ...state };
 		}
 	}
 

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -103,10 +103,6 @@ export default class Step extends Component< Props, State > {
 		this.skipIfInvalidContext( this.props, this.context );
 		this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
 		this.setStepPosition( this.props );
-		// The following should be legit usage of `setState`, since it's called
-		// asynchronously after `await`ing `this.wait()`.
-		// (We need it since `this.render()` might be called in the meantime.)
-		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { initialized: true } );
 		window.addEventListener( 'resize', this.onScrollOrResize );
 		this.watchTarget();

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -104,7 +104,9 @@ export default class Step extends Component< Props, State > {
 			this.skipIfInvalidContext( this.props, this.context );
 			this.scrollContainer = query( this.props.scrollContainer )[ 0 ] || window;
 			this.setStepPosition( this.props );
-			this.safeSetState( { initialized: true } );
+			if ( this.mounted ) {
+				this.setState( { initialized: true } );
+			}
 		} );
 	}
 
@@ -142,7 +144,6 @@ export default class Step extends Component< Props, State > {
 
 	componentWillUnmount() {
 		this.mounted = false;
-		this.safeSetState( { initialized: false } );
 
 		window.removeEventListener( 'resize', this.onScrollOrResize );
 		if ( this.scrollContainer ) {
@@ -169,12 +170,6 @@ export default class Step extends Component< Props, State > {
 		}
 
 		return Promise.resolve();
-	}
-
-	safeSetState( state: State ) {
-		if ( this.mounted ) {
-			this.setState( state );
-		}
 	}
 
 	watchTarget() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prior to this change, `this.wait()` was unconditionally called from `componentWillReceiveProps`, i.e. upons every prop change. This is unnecessary, and problematic for all the changes we're planning to make to `wait` (see e.g. #33369) due to the async nature of `this.wait()` -- we might be calling new promises while the old ones might not yet have resolved.

The central change of this PR is thus to only call `this.wait()` from `componentWillReceiveProps` if the corresponding `wait()` prop has changed.

That change however requires a number of preparatory changes. 
Among them:
- Merge function body of  `componenWillMount` (deprecated!) into `componentDidMount`
- This allows us to drop `this.mounted`, and simplify `initialized` state handling.
- Rather than calling `this.wait().then()`, we `await this.wait()` (which is equivalent). This requires making `componentDidMount` and `componentWillReceiveProps` `async`, which to the best of my knowledge is legit. This makes it much easier to call `this.wait()` only conditionally.
 
#### Testing instructions

Verify that Guided Tours still work, e.g. for onboarding checklists. Specifically, check Tours that make use of `wait`:

- Create a new jurassic.ninja site, connect to WordPress.com (using the link from the green connect button and appending `&calypso_env=development`, and selecting the Premium plan)
- In the Security checklist, locate the 'Automatic Plugin Updates' step, and click 'Do It!'
- Verify that the Guided Tour instructing you to enable the autoupdates toggle for the Jetpack plugin works.

- For a WP.com site without Gutenberg enabled, go to `calypso.localhost:3000/post/:site?tour=checklistPublishPost`
- Make sure the sidebar is collapsed before interacting with the Guided Tour (click the gear icon if it's expanded)
- Click the 'All done, continue' button on the Tour's first step
- Verify that the sidebar is expanded, and a Tour step bubble points to the 'Categories & Tags' panel.
- Follow the Tour and make sure it works.

You can verify that `this.wait()` is called more sparingly now by applying this patch and watching your browser console:

```diff
diff --git a/client/layout/guided-tours/config-elements/step.tsx b/client/layout/guided-tours/config-elements/step.tsx
index 5042018acc..2545b62ad7 100644
--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -159,6 +159,7 @@ export default class Step extends Component< Props, State > {
        }
 
        wait( props: Props, context ) {
+               console.log( 'this.wait' );
                if ( isFunction( props.wait ) ) {
                        const ret = props.wait( { reduxStore: context.store } );
                        if ( isFunction( get( ret, 'then' ) ) ) {
```
