### PR TITLE
Starter Page Templates: add vertical placeholder handling

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders.js
@@ -4,12 +4,14 @@ const PLACEHOLDER_DEFAULTS = {
 	Address: '123 Main St',
 	Phone: '555-555-5555',
 	CompanyName: __( 'Your Company Name' ),
+	Vertical: __( 'Business' ),
 };
 
 const KEY_MAP = {
 	CompanyName: 'title',
 	Address: 'address',
 	Phone: 'phone',
+	Vertical: 'vertical',
 };
 
 const replacePlaceholders = ( pageContent, siteInformation = {} ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- adds handling for `{{Vertical}}` placeholder
- it will be replaced either by value from the API like "Business & Services" for our default vertical or I've picked "Business" as the most generic placeholder value if there is nothing from the API (shouldn't happen but I like to play it safe)
- vertical name is already passed from the API as part of my previous work: https://github.com/Automattic/wp-calypso/blob/214ae47a03974b93dc2973e1b8a65a151b725c07/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php#L82

#### Testing instructions

- I have added `{{Vertical}}` into our "Home" template so please insert that one
- In the "Get in Touch" section, you should see it being replaced. You should never see raw `{{Vertical}}` in the page

| Before | After |
| - | -
| <img width="795" alt="Screenshot 2019-05-29 at 12 30 08" src="https://user-images.githubusercontent.com/156676/58551409-37470680-8210-11e9-94b9-b1d7fd9f4131.png"> | <img width="352" alt="Screenshot 2019-05-29 at 12 35 47" src="https://user-images.githubusercontent.com/156676/58551432-4a59d680-8210-11e9-97fb-a8a5e6a47b61.png">

