### PR TITLE
Rewrite lib/mshots with native fetch.

### DIFF
--- a/client/lib/mshots/index.js
+++ b/client/lib/mshots/index.js
@@ -3,64 +3,51 @@
  */
 import { noop } from 'lodash';
 
-async function querymShotsEndpoint( options = {} ) {
-	const { maxRetries = 1, retryTimeout = 1000, currentRetries = 0 } = options;
-
+export async function loadmShotsPreview( options = {} ) {
+	const { maxRetries = 1, retryTimeout = 1000 } = options;
 	const url = options.url || '';
-	const resolve = options.resolve || noop;
-	const reject = options.reject || noop;
-
-	const mShotsEndpointUrl = `https://s0.wp.com/mshots/v1/${ url }`;
 
 	if ( ! url ) {
 		// TODO translate
-		reject( 'You must specify a site URL to be able to generate a preview of the site' );
-		return;
+		throw new Error( 'You must specify a site URL to be able to generate a preview of the site' );
 	}
 
-	try {
+	const mShotsEndpointUrl = `https://s0.wp.com/mshots/v1/${ url }`;
+
+	for ( let retries = 0; ; retries++ ) {
 		const response = await fetch( mShotsEndpointUrl, { method: 'GET' } );
 		const contentType = response.ok && response.headers.get( 'Content-Type' );
 
-		if (
-			// This confused me until I tried it out, so I figured I'd leave a comment.
-			// The mshots API takes a while to generate an image if it's a cache miss.
-			// In those situations, it returns a 307 redirecting to a default "loading" image.
-			// That image is a GIF, which is what we're checking for here...
-			( ! contentType || contentType === 'image/gif' ) &&
-			maxRetries > 0 &&
-			currentRetries < maxRetries
-		) {
-			// Still generating the preview or something failed in mShots. Retry.
-			setTimeout(
-				querymShotsEndpoint.bind( this, {
-					...options,
-					currentRetries: currentRetries + 1,
-				} ),
-				retryTimeout
-			);
-		} else if ( contentType === 'image/jpeg' ) {
-			// Successfully generated the preview.
+		// Successfully generated the preview.
+		if ( contentType && contentType === 'image/jpeg' ) {
 			try {
 				const blob = await response.blob();
-				resolve( window.URL.createObjectURL( blob ) );
+				return window.URL.createObjectURL( blob );
 			} catch ( e ) {
-				resolve( mShotsEndpointUrl );
+				return mShotsEndpointUrl;
 			}
-		} else {
-			reject();
 		}
-	} catch ( error ) {
-		reject( error ); // Pass through the reject notice.
+
+		// First attempt, no retries.
+		if ( ! maxRetries || maxRetries < 0 ) {
+			throw new Error( `Preview generation failed (no retries).` );
+		}
+
+		// Too many attempts.
+		if ( retries >= maxRetries ) {
+			throw new Error( `Preview generation still failing after ${ maxRetries } retries.` );
+		}
+
+		// Unexpected response.
+		if ( contentType && contentType !== 'image/gif' ) {
+			throw new Error( `Unexpected response while generating preview.` );
+		}
+
+		// Wait and retry.
+		await new Promise( resolve => setTimeout( resolve, retryTimeout ) );
 	}
 }
 
-export function loadmShotsPreview( options = {} ) {
-	return new Promise( ( resolve, reject ) => {
-		querymShotsEndpoint( { ...options, resolve, reject } );
-	} );
-}
-
 export function prefetchmShotsPreview( url ) {
-	querymShotsEndpoint( { url, currentRetries: 1 } );
+	loadmShotsPreview( { url, maxRetries: 0 } ).catch( noop );
 }


### PR DESCRIPTION
This is part of an effort to remove `superagent` from client code altogether, and replace it with native `fetch` functionality. This will eventually lead to being able to drop that dependency from the client-side bundle, thus improving loading performance.

#### Changes proposed in this Pull Request

* Reimplement `lib/mshots` using native `fetch` instead of `superagent`

#### Testing instructions

* Test the site importer functionality. Ensure that the previews are generated correctly.

