### PR TITLE
Domains: Prefer vertical id over survey vertical value for domains suggestions

### DIFF
--- a/client/components/data/query-domains-suggestions/index.jsx
+++ b/client/components/data/query-domains-suggestions/index.jsx
@@ -21,7 +21,8 @@ function getQueryObject( props ) {
 		query: props.query,
 		recommendation_context: props.recommendationContext,
 		vendor: props.vendor,
-		vertical: props.surveyVertical,
+		vertical: props.verticalId || props.surveyVertical,
+		siteType: props.siteType,
 	};
 }
 

--- a/client/components/data/query-domains-suggestions/index.jsx
+++ b/client/components/data/query-domains-suggestions/index.jsx
@@ -22,7 +22,6 @@ function getQueryObject( props ) {
 		recommendation_context: props.recommendationContext,
 		vendor: props.vendor,
 		vertical: props.verticalId || props.surveyVertical,
-		siteType: props.siteType,
 	};
 }
 

--- a/client/components/data/query-domains-suggestions/index.jsx
+++ b/client/components/data/query-domains-suggestions/index.jsx
@@ -21,7 +21,7 @@ function getQueryObject( props ) {
 		query: props.query,
 		recommendation_context: props.recommendationContext,
 		vendor: props.vendor,
-		vertical: props.verticalId || props.surveyVertical,
+		vertical: props.vertical,
 	};
 }
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -125,7 +125,7 @@ function getQueryObject( props ) {
 		quantity: SUGGESTION_QUANTITY,
 		vendor: props.vendor,
 		includeSubdomain: props.includeWordPressDotCom || props.includeDotBlogSubdomain,
-		surveyVertical: props.surveyVertical,
+		surveyVertical: props.verticalId || props.surveyVertical,
 	};
 }
 
@@ -152,6 +152,7 @@ class RegisterDomainStep extends React.Component {
 		deemphasiseTlds: PropTypes.array,
 		recordFiltersSubmit: PropTypes.func.isRequired,
 		recordFiltersReset: PropTypes.func.isRequired,
+		verticalId: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -788,7 +789,7 @@ class RegisterDomainStep extends React.Component {
 			include_dotblogsubdomain: false,
 			tld_weight_overrides: getTldWeightOverrides( this.props.designType ),
 			vendor: this.props.vendor,
-			vertical: this.props.surveyVertical,
+			vertical: this.props.verticalId || this.props.surveyVertical,
 			recommendation_context: get( this.props, 'selectedSite.name', '' )
 				.replace( ' ', ',' )
 				.toLocaleLowerCase(),
@@ -886,7 +887,7 @@ class RegisterDomainStep extends React.Component {
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
 			vendor: 'dot',
-			vertical: this.props.surveyVertical,
+			vertical: this.props.verticalId || this.props.surveyVertical,
 			...this.getActiveFiltersForAPI(),
 		};
 

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -125,7 +125,7 @@ function getQueryObject( props ) {
 		quantity: SUGGESTION_QUANTITY,
 		vendor: props.vendor,
 		includeSubdomain: props.includeWordPressDotCom || props.includeDotBlogSubdomain,
-		surveyVertical: props.verticalId || props.surveyVertical,
+		vertical: props.vertical,
 	};
 }
 
@@ -140,7 +140,6 @@ class RegisterDomainStep extends React.Component {
 		suggestion: PropTypes.string,
 		domainsWithPlansOnly: PropTypes.bool,
 		isSignupStep: PropTypes.bool,
-		surveyVertical: PropTypes.string,
 		includeWordPressDotCom: PropTypes.bool,
 		includeDotBlogSubdomain: PropTypes.bool,
 		showExampleSuggestions: PropTypes.bool,
@@ -152,7 +151,7 @@ class RegisterDomainStep extends React.Component {
 		deemphasiseTlds: PropTypes.array,
 		recordFiltersSubmit: PropTypes.func.isRequired,
 		recordFiltersReset: PropTypes.func.isRequired,
-		verticalId: PropTypes.string,
+		vertical: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -176,17 +175,14 @@ class RegisterDomainStep extends React.Component {
 		if ( props.initialState ) {
 			this.state = { ...this.state, ...props.initialState };
 
-			if (
-				this.state.lastSurveyVertical &&
-				this.state.lastSurveyVertical !== props.surveyVertical
-			) {
+			if ( this.state.lastVertical && this.state.lastVertical !== props.vertical ) {
 				this.state.loadingResults = true;
 
 				if ( props.includeWordPressDotCom || props.includeDotBlogSubdomain ) {
 					this.state.loadingSubdomainResults = true;
 				}
 
-				delete this.state.lastSurveyVertical;
+				delete this.state.lastVertical;
 			}
 
 			if ( props.suggestion ) {
@@ -789,7 +785,7 @@ class RegisterDomainStep extends React.Component {
 			include_dotblogsubdomain: false,
 			tld_weight_overrides: getTldWeightOverrides( this.props.designType ),
 			vendor: this.props.vendor,
-			vertical: this.props.verticalId || this.props.surveyVertical,
+			vertical: this.props.vertical,
 			recommendation_context: get( this.props, 'selectedSite.name', '' )
 				.replace( ' ', ',' )
 				.toLocaleLowerCase(),
@@ -887,7 +883,7 @@ class RegisterDomainStep extends React.Component {
 			include_dotblogsubdomain: this.props.includeDotBlogSubdomain,
 			tld_weight_overrides: null,
 			vendor: 'dot',
-			vertical: this.props.verticalId || this.props.surveyVertical,
+			vertical: this.props.vertical,
 			...this.getActiveFiltersForAPI(),
 		};
 
@@ -961,7 +957,7 @@ class RegisterDomainStep extends React.Component {
 		this.setState(
 			{
 				lastQuery: searchQuery,
-				lastSurveyVertical: this.props.surveyVertical,
+				lastVertical: this.props.vertical,
 				lastFilters: this.state.filters,
 			},
 			this.save

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -43,6 +43,9 @@ import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 import { getSite } from 'state/sites/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getSiteVerticalId } from 'state/signup/steps/site-vertical/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
+
 
 /**
  * Style dependencies
@@ -65,6 +68,8 @@ class DomainsStep extends React.Component {
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
+		siteType: PropTypes.number,
+		verticalId: PropTypes.string,
 	};
 
 	static contextTypes = {
@@ -416,6 +421,8 @@ class DomainsStep extends React.Component {
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
 				showSkipButton={ this.props.showSkipButton }
+				siteType={ this.props.siteType }
+				verticalId={ this.props.verticalId }
 				onSkip={ this.handleSkip }
 			/>
 		);
@@ -669,7 +676,9 @@ export default connect(
 	( state, ownProps ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
-
+		const siteType = getSiteType( state );
+		const verticalId = getSiteVerticalId( state );
+console.log( 'siteType verticalId', siteType, verticalId );
 		return {
 			designType: getDesignType( state ),
 			// no user = DOMAINS_WITH_PLANS_ONLY
@@ -679,9 +688,10 @@ export default connect(
 			productsList,
 			productsLoaded,
 			siteGoals: getSiteGoals( state ),
+			siteType,
+			verticalId,
 			surveyVertical: getSurveyVertical( state ),
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
-			siteType: getSiteType( state ),
 		};
 	},
 	{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -22,7 +22,6 @@ import { getStepUrl } from 'signup/utils';
 import StepWrapper from 'signup/step-wrapper';
 import { cartItems } from 'lib/cart-values';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import { getSurveyVertical } from 'state/signup/steps/survey/selectors.js';
 import { getUsernameSuggestion } from 'lib/signup/step-actions';
 import {
 	recordAddDomainButtonClick,
@@ -42,8 +41,8 @@ import QueryProductsList from 'components/data/query-products-list';
 import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 import { getSite } from 'state/sites/selectors';
+import { getVerticalForDomainSuggestions } from 'state/signup/steps/site-vertical/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
-import { getSiteVerticalId } from 'state/signup/steps/site-vertical/selectors';
 
 /**
  * Style dependencies
@@ -66,7 +65,7 @@ class DomainsStep extends React.Component {
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
-		verticalId: PropTypes.string,
+		vertical: PropTypes.string,
 	};
 
 	static contextTypes = {
@@ -411,14 +410,13 @@ class DomainsStep extends React.Component {
 				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
 				isSignupStep
 				showExampleSuggestions={ showExampleSuggestions }
-				surveyVertical={ this.props.surveyVertical }
 				suggestion={ initialQuery }
 				designType={ this.getDesignType() }
 				vendor={ getSuggestionsVendor() }
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
 				showSkipButton={ this.props.showSkipButton }
-				verticalId={ this.props.verticalId }
+				vertical={ this.props.vertical }
 				onSkip={ this.handleSkip }
 			/>
 		);
@@ -682,8 +680,8 @@ export default connect(
 			productsList,
 			productsLoaded,
 			siteGoals: getSiteGoals( state ),
-			verticalId: getSiteVerticalId( state ),
-			surveyVertical: getSurveyVertical( state ),
+			siteType: getSiteType( state ),
+			vertical: getVerticalForDomainSuggestions( state ),
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
 		};
 	},

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -44,8 +44,6 @@ import { getSuggestionsVendor } from 'lib/domains/suggestions';
 import { getSite } from 'state/sites/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { getSiteVerticalId } from 'state/signup/steps/site-vertical/selectors';
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
-
 
 /**
  * Style dependencies
@@ -68,7 +66,6 @@ class DomainsStep extends React.Component {
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
-		siteType: PropTypes.number,
 		verticalId: PropTypes.string,
 	};
 
@@ -421,7 +418,6 @@ class DomainsStep extends React.Component {
 				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
 				selectedSite={ this.props.selectedSite }
 				showSkipButton={ this.props.showSkipButton }
-				siteType={ this.props.siteType }
 				verticalId={ this.props.verticalId }
 				onSkip={ this.handleSkip }
 			/>
@@ -676,9 +672,7 @@ export default connect(
 	( state, ownProps ) => {
 		const productsList = getAvailableProductsList( state );
 		const productsLoaded = ! isEmpty( productsList );
-		const siteType = getSiteType( state );
-		const verticalId = getSiteVerticalId( state );
-console.log( 'siteType verticalId', siteType, verticalId );
+
 		return {
 			designType: getDesignType( state ),
 			// no user = DOMAINS_WITH_PLANS_ONLY
@@ -688,8 +682,7 @@ console.log( 'siteType verticalId', siteType, verticalId );
 			productsList,
 			productsLoaded,
 			siteGoals: getSiteGoals( state ),
-			siteType,
-			verticalId,
+			verticalId: getSiteVerticalId( state ),
 			surveyVertical: getSurveyVertical( state ),
 			selectedSite: getSite( state, ownProps.signupDependencies.siteSlug ),
 		};

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -11,6 +11,7 @@ import { get, find } from 'lodash';
  */
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
+import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
 
 export function getSiteVerticalName( state ) {
 	return get( state, 'signup.steps.siteVertical.name', '' );
@@ -60,4 +61,10 @@ export function getSiteVerticalSlug( state ) {
 
 export function getSiteVerticalIsUserInput( state ) {
 	return get( state, 'signup.steps.siteVertical.isUserInput', true );
+}
+
+// Used to fill `vertical` param to pass to to `/domains/suggestions`
+// client/signup/steps/domains/index.jsx
+export function getVerticalForDomainSuggestions( state ) {
+	return getSiteVerticalId( state ) || getSurveyVertical( state );
 }

--- a/client/state/signup/steps/site-vertical/test/selectors.js
+++ b/client/state/signup/steps/site-vertical/test/selectors.js
@@ -11,6 +11,7 @@ import {
 	getSiteVerticalPreview,
 	getSiteVerticalParentId,
 	getSiteVerticalData,
+	getVerticalForDomainSuggestions,
 } from '../selectors';
 
 describe( 'selectors', () => {
@@ -43,6 +44,11 @@ describe( 'selectors', () => {
 					slug: 'happy',
 					isUserInput: false,
 					parentId: 'gluecklich',
+				},
+				survey: {
+					vertical: 'test-survey',
+					otherText: 'test-other-text',
+					siteType: 'test-site-type',
 				},
 			},
 			verticals,
@@ -124,6 +130,32 @@ describe( 'selectors', () => {
 
 		test( 'should return direct match', () => {
 			expect( getSiteVerticalData( state ) ).toEqual( verticals.business.felice[ 0 ] );
+		} );
+	} );
+
+	describe( 'getVerticalForDomainSuggestions', () => {
+		test( 'should return empty string as a default state', () => {
+			expect( getVerticalForDomainSuggestions( { signup: undefined } ) ).toEqual( '' );
+		} );
+
+		test( 'should return vertical id first', () => {
+			expect( getVerticalForDomainSuggestions( state ) ).toEqual( 'p4u' );
+		} );
+
+		test( 'should return survey vertical if vertical id not available', () => {
+			expect(
+				getVerticalForDomainSuggestions( {
+					signup: {
+						steps: {
+							survey: {
+								vertical: 'test-survey',
+								otherText: 'test-other-text',
+								siteType: 'test-site-type',
+							},
+						},
+					},
+				} )
+			).toEqual( 'test-survey' );
 		} );
 	} );
 } );


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR allows us to make better `.blog` suggestions by prioritizing passing a vertical id as opposed to the survey vertical value.

D24910-code introduced the `vertical` parameter to `domains/suggestions` to get blog subdomain suggestions.

The backend will first try to perform a vertical lookup via ID to check whether the vertical supports a blog subdomain. Since all our verticals have unique ids, passing the id will be faster, leaner, better, stronger! 💪 

## Testing instructions

1. Fire up http://calypso.localhost:3000/start/onboarding
2. Select Blog as your site type
3. Select either food, travel, art, health, sport as your site topic
4. At domains, search (or redo a search) for a domain that pleases you.
5. There should be `{blah...}.food.blog` suggestion, or `{blah...}.art.blog` suggestion and so on.

cc @Automattic/cobalt to make sure we can offer free blog domains `*.[food|travel|art...].blog in the normal signup flow.


