### PR TITLE
FSE: pass error messages to frontend

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -88,7 +88,7 @@ class Starter_Page_Templates {
 		// Load templates for this site.
 		$vertical_data = $this->fetch_vertical_data();
 		if ( empty( $vertical_data ) ) {
-			$this->pass_error_to_frontend( __( 'No data received from the vertical API. Skipped showing modal window with template selection.' ) );
+			$this->pass_error_to_frontend( __( 'No data received from the vertical API. Skipped showing modal window with template selection.', 'full-site-editing' ) );
 			return;
 		}
 		$vertical_name      = $vertical_data['vertical'];
@@ -96,7 +96,7 @@ class Starter_Page_Templates {
 
 		// Bail early if we have no templates to offer.
 		if ( empty( $vertical_templates ) ) {
-			$this->pass_error_to_frontend( __( 'No templates available. Skipped showing modal window with template selection.' ) );
+			$this->pass_error_to_frontend( __( 'No templates available. Skipped showing modal window with template selection.', 'full-site-editing' ) );
 			return;
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -49,13 +49,6 @@ class Starter_Page_Templates {
 			filemtime( plugin_dir_path( __FILE__ ) . 'dist/starter-page-templates.js' ),
 			true
 		);
-		wp_register_script(
-			'starter-page-templates-error',
-			null,
-			array(),
-			'1.O',
-			true
-		);
 	}
 
 	/**
@@ -64,6 +57,13 @@ class Starter_Page_Templates {
 	 * @param string $message Error message.
 	 */
 	public function pass_error_to_frontend( $message ) {
+		wp_register_script(
+			'starter-page-templates-error',
+			null,
+			array(),
+			'1.O',
+			true
+		);
 		wp_add_inline_script(
 			'starter-page-templates-error',
 			sprintf(

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -49,6 +49,29 @@ class Starter_Page_Templates {
 			filemtime( plugin_dir_path( __FILE__ ) . 'dist/starter-page-templates.js' ),
 			true
 		);
+		wp_register_script(
+			'starter-page-templates-error',
+			null,
+			array(),
+			'1.O',
+			true
+		);
+	}
+
+	/**
+	 * Pass error message to frontend JavaScript console.
+	 *
+	 * @param string $message Error message.
+	 */
+	public function pass_error_to_frontend( $message ) {
+		wp_add_inline_script(
+			'starter-page-templates-error',
+			sprintf(
+				'console.warn(%s);',
+				wp_json_encode( $message )
+			)
+		);
+		wp_enqueue_script( 'starter-page-templates-error' );
 	}
 
 	/**
@@ -65,6 +88,7 @@ class Starter_Page_Templates {
 		// Load templates for this site.
 		$vertical_data = $this->fetch_vertical_data();
 		if ( empty( $vertical_data ) ) {
+			$this->pass_error_to_frontend( __( 'No data received from the vertical API. Skipped showing modal window with template selection.' ) );
 			return;
 		}
 		$vertical_name      = $vertical_data['vertical'];
@@ -72,6 +96,7 @@ class Starter_Page_Templates {
 
 		// Bail early if we have no templates to offer.
 		if ( empty( $vertical_templates ) ) {
+			$this->pass_error_to_frontend( __( 'No templates available. Skipped showing modal window with template selection.' ) );
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds error handling that passes an error message from backend into `console.warn` on the frontend. Previously, in cases or error or no templates we just silently didn't show the modal.

#### Testing instructions

The easiest way to simulate broken requests is to update the API call to use non-existent URL. Make sure you also update the cache key, otherwise you might still be getting data for another 24 hours until it clears.

This is how I've tested:

<img width="835" alt="Screenshot 2019-05-29 at 13 27 10" src="https://user-images.githubusercontent.com/156676/58554199-a889b800-8216-11e9-8cbf-1302b84d47ed.png">

Once your API and cache are broken, try adding a new Page in wp-admin. You should see a message in devtools like this:

<img width="502" alt="Screenshot 2019-05-29 at 13 36 35" src="https://user-images.githubusercontent.com/156676/58554256-cc4cfe00-8216-11e9-9a87-7d4be56261fd.png">
