### PR TITLE
Memberships: proper currency stats

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -90,7 +90,7 @@ class MembershipsSection extends Component {
 				</div>
 				<div className="memberships__earnings-breakdown-notes">
 					{ translate(
-						'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Stripe charges are handled in your agreement, but its typically %(stripe)s.',
+						'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Stripe charges are typically %(stripe)s.',
 						{
 							args: {
 								commission: '' + parseFloat( this.props.commission ) * 100 + '%',

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -65,7 +65,7 @@ class MembershipsSection extends Component {
 								{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
 							</span>
 							<span className="memberships__earnings-breakdown-value">
-								{ formatCurrency( this.props.total, 'USD' ) /* TODO: make it multi-currency */ }
+								{ formatCurrency( this.props.total, this.props.currency ) }
 							</span>
 						</li>
 						<li className="memberships__earnings-breakdown-item">
@@ -73,7 +73,7 @@ class MembershipsSection extends Component {
 								{ translate( 'Last 30 days', { context: 'Sum of earnings over last 30 days' } ) }
 							</span>
 							<span className="memberships__earnings-breakdown-value">
-								{ formatCurrency( this.props.lastMonth, 'USD' ) /* TODO: make it multi-currency */ }
+								{ formatCurrency( this.props.lastMonth, this.props.currency ) }
 							</span>
 						</li>
 						<li className="memberships__earnings-breakdown-item">
@@ -83,10 +83,22 @@ class MembershipsSection extends Component {
 								} ) }
 							</span>
 							<span className="memberships__earnings-breakdown-value">
-								{ formatCurrency( this.props.forecast, 'USD' ) /* TODO: make it multi-currency */ }
+								{ formatCurrency( this.props.forecast, this.props.currency ) }
 							</span>
 						</li>
 					</ul>
+				</div>
+				<div className="memberships__earnings-breakdown-notes">
+					{ translate(
+						'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Stripe charges are handled in your agreement, but its typically %(stripe)s.',
+						{
+							args: {
+								commission: '' + parseFloat( this.props.commission ) * 100 + '%',
+								stripe: '2.9%+30c',
+							},
+							components: { em: <em />, br: <br /> },
+						}
+					) }
 				</div>
 			</Card>
 		);
@@ -317,6 +329,8 @@ const mapStateToProps = state => {
 		total: get( state, [ 'memberships', 'earnings', 'summary', siteId, 'total' ], 0 ),
 		lastMonth: get( state, [ 'memberships', 'earnings', 'summary', siteId, 'last_month' ], 0 ),
 		forecast: get( state, [ 'memberships', 'earnings', 'summary', siteId, 'forecast' ], 0 ),
+		currency: get( state, [ 'memberships', 'earnings', 'summary', siteId, 'currency' ], 'USD' ),
+		commission: get( state, [ 'memberships', 'earnings', 'summary', siteId, 'commission' ], '0.1' ),
 		totalSubscribers: get( state, [ 'memberships', 'subscribers', 'list', siteId, 'total' ], 0 ),
 		subscribers: get( state, [ 'memberships', 'subscribers', 'list', siteId, 'ownerships' ], {} ),
 		connectedAccountId: get(

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -196,3 +196,14 @@
 	color: var( --color-text-subtle );
 	font-size: 14px;
 }
+.memberships__earnings-breakdown-notes {
+	clear: both;
+	padding-top: 24px;
+	font-size: 12px;
+	line-height: 1.6;
+	font-style: italic;
+	text-align: center;
+}
+.memberships__earnings-breakdown-notes em {
+	font-weight: bold;
+}

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -198,6 +198,8 @@
 }
 .memberships__earnings-breakdown-notes {
 	clear: both;
+	color: var( --color-neutral-300 );
+	padding-bottom: 12px;
 	padding-top: 24px;
 	font-size: 12px;
 	line-height: 1.6;


### PR DESCRIPTION
This shows currency stats in user's default currency and translates sales to the same currency.
It also shows current wpcom commission.


## Screenshots

![Zrzut ekranu 2019-05-29 o 13 33 59](https://user-images.githubusercontent.com/3775068/58554470-4ed5bd80-8217-11e9-9015-89f7f0a2b996.png)

## Testing

There should be no real functional change. Just go to https://wordpress.com/earn/memberships/ and see if this looks ok
