### PR TITLE
e2e: removing skip and comment from #33402

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1274,12 +1274,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	/*
-		Since D28758-code, we require a specific site_segment id to return blog-specific verticals. For blogs it's `4`.
-		We now need to supply the verticals endpoint with a `site_type` parameter to return accurate results.
-		Skipping this test until we can get a fix in.
-	 */
-	describe.skip( 'Sign up for free subdomain site @parallel', function() {
+	describe( 'Sign up for free subdomain site @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ blogName }.art.blog`;
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR reinstates the e2e tests skipped in Automattic/wp-calypso#33402

Fixes https://github.com/Automattic/zelda-private/issues/41

## Dependencies

~~D28854-code~~ ✅ 

## Testing instructions

Watch the Circle CI and be mesmerized by all the 💚 