### PR TITLE
Change click method for `ensureSaved()`

### DIFF
--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -239,7 +239,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async ensureSaved() {
-		await driverHelper.clickIfPresent( this.driver, By.css( '.editor-post-save-draft' ) );
+		await driverHelper.clickWhenClickable( this.driver, By.css( '.editor-post-save-draft' ) );
 		const savedSelector = By.css( 'span.is-saved' );
 
 		return await driverHelper.waitTillPresentAndDisplayed( this.driver, savedSelector );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change the method for clicking on Save post. 

#### Testing instructions

Make sure that tests are green in CircleCI.

Fixes #
Hopefully, it should fix failures like [this](https://circleci.com/gh/Automattic/wp-calypso/305292).
