### PR TITLE
The site logo test was not successful

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -112,16 +112,6 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	checklistSiteLogo: {
-		datestamp: '20190305',
-		variations: {
-			icon: 50,
-			logo: 50,
-		},
-		defaultVariation: 'icon',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	builderReferralHelpBanner: {
 		datestamp: '20190304',
 		variations: {

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -72,7 +72,6 @@ class WpcomChecklistComponent extends PureComponent {
 			address_picked: this.renderAddressPickedTask,
 			blogname_set: this.renderBlogNameSetTask,
 			site_icon_set: this.renderSiteIconSetTask,
-			site_logo_set: this.renderSiteLogoSetTask,
 			blogdescription_set: this.renderBlogDescriptionSetTask,
 			avatar_uploaded: this.renderAvatarUploadedTask,
 			contact_page_updated: this.renderContactPageUpdatedTask,
@@ -454,27 +453,6 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Upload a site icon' ) }
-			/>
-		);
-	};
-
-	renderSiteLogoSetTask = ( TaskComponent, baseProps, task ) => {
-		const { translate, siteSlug } = this.props;
-
-		return (
-			<TaskComponent
-				{ ...baseProps }
-				bannerImageSrc="/calypso/images/stats/tasks/upload-icon.svg"
-				completedButtonText={ translate( 'Change' ) }
-				completedTitle={ translate( 'You uploaded a logo' ) }
-				description={ translate( 'Help people recognize your brand!' ) }
-				duration={ translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ) }
-				onClick={ this.handleTaskStart( {
-					task,
-					url: `/customize/identity/${ siteSlug }`,
-				} ) }
-				onDismiss={ this.handleTaskDismiss( task.id ) }
-				title={ translate( 'Upload your logo' ) }
 			/>
 		);
 	};

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -11,7 +11,6 @@ import config from 'config';
  */
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { getVerticalTaskList } from './vertical-task-list';
-import { abtest } from 'lib/abtest';
 
 const debug = debugModule( 'calypso:wpcom-task-list' );
 
@@ -54,14 +53,7 @@ function getTasks( { taskStatuses, designType, isSiteUnlaunched, siteSegment, si
 			addTask( 'post_published' );
 		}
 
-		// If there is a site segment and
-		// the user has already completed the logo task or
-		// if it's the AB variant
-		if ( hasTask( 'site_logo_set' ) && segmentSlug && 'logo' === abtest( 'checklistSiteLogo' ) ) {
-			addTask( 'site_logo_set' );
-		} else {
-			addTask( 'site_icon_set' );
-		}
+		addTask( 'site_icon_set' );
 	}
 
 	addTask( 'custom_domain_registered' );


### PR DESCRIPTION
We introduced this test in #31198 and it stayed running a bit longer than necessary because of team switches and changes. It's time to end the test, returning the situation to what it was before the test.

There's also a server change for flagging the task which is not essential to end the test.

#### Changes proposed in this Pull Request

Remove the A/B test

#### Testing instructions

1. On a recently created site that still has the checklist not followed, go to calypso.localhost:3000/checklist
2. Make sure the Site Logo task appears
3. Follow the task, add site logo. Make sure the task is checked as complete

*

Fixes #
