### PR TITLE
Starer Page Templates: Add translation calls

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -76,6 +76,7 @@ class Starter_Page_Templates {
 		}
 
 		wp_enqueue_script( 'starter-page-templates' );
+		wp_set_script_translations( 'starter-page-templates', 'full-site-editing' );
 
 		$default_info      = array(
 			'title'    => get_bloginfo( 'name' ),

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -69,7 +69,7 @@ const PageTemplateModal = withState( {
 	<div>
 		{ isOpen && (
 			<Modal
-				title={ __( 'Select Page Template' ) }
+				title={ __( 'Select Page Template', 'full-site-editing' ) }
 				onRequestClose={ () => setState( { isOpen: false } ) }
 				className="page-template-modal"
 			>
@@ -77,11 +77,21 @@ const PageTemplateModal = withState( {
 					<form className="page-template-modal__form">
 						<fieldset className="page-template-modal__list">
 							<legend className="page-template-modal__intro">
-								<p>{ __( 'Pick a Template that matches the purpose of your page.' ) }</p>
-								<p>{ __( 'You can customise each Template to meet your needs.' ) }</p>
+								<p>
+									{ __(
+										'Pick a Template that matches the purpose of your page.',
+										'full-site-editing'
+									) }
+								</p>
+								<p>
+									{ __(
+										'You can customise each Template to meet your needs.',
+										'full-site-editing'
+									) }
+								</p>
 							</legend>
 							<TemplateSelectorControl
-								label={ __( 'Template' ) }
+								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ Object.values( verticalTemplates ).map( template => ( {
 									label: template.title,
 									value: template.slug,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -85,7 +85,7 @@ const PageTemplateModal = withState( {
 								</p>
 								<p>
 									{ __(
-										'You can customise each Template to meet your needs.',
+										'You can customize each Template to meet your needs.',
 										'full-site-editing'
 									) }
 								</p>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,10 +1,20 @@
 /**
+ * External dependencies
+ */
+import { keyBy, map, has } from 'lodash';
+import { __ } from '@wordpress/i18n';
+import { withState } from '@wordpress/compose';
+import { Modal } from '@wordpress/components';
+import { registerPlugin } from '@wordpress/plugins';
+import { dispatch } from '@wordpress/data';
+import { parse as parseBlocks } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import replacePlaceholders from './utils/replace-placeholders';
 import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
-import { keyBy, map, has } from 'lodash';
 
 // TODO: remove once we have proper previews from API
 if ( window.starterPageTemplatesConfig ) {
@@ -33,72 +43,66 @@ if ( window.starterPageTemplatesConfig ) {
 	);
 }
 
-( function( wp, config = {} ) {
-	const registerPlugin = wp.plugins.registerPlugin;
-	const { Modal } = wp.components;
-	const { withState } = wp.compose;
+const { siteInformation = {}, templates = [] } = window.starterPageTemplatesConfig;
+const editorDispatcher = dispatch( 'core/editor' );
 
-	const { siteInformation = {}, templates = [] } = config;
+const insertTemplate = template => {
+	// Skip inserting if there's nothing to insert.
+	if ( ! has( template, 'content' ) ) {
+		return;
+	}
 
-	const insertTemplate = template => {
-		// Skip inserting if there's nothing to insert.
-		if ( ! has( template, 'content' ) ) {
-			return;
-		}
+	// set title
+	editorDispatcher.editPost( { title: replacePlaceholders( template.title, siteInformation ) } );
 
-		// set title
-		wp.data
-			.dispatch( 'core/editor' )
-			.editPost( { title: replacePlaceholders( template.title, siteInformation ) } );
+	// load content
+	const templateString = replacePlaceholders( template.content, siteInformation );
+	const blocks = parseBlocks( templateString );
+	editorDispatcher.insertBlocks( blocks );
+};
 
-		// load content
-		const templateString = replacePlaceholders( template.content, siteInformation );
-		const blocks = wp.blocks.parse( templateString );
-		wp.data.dispatch( 'core/editor' ).insertBlocks( blocks );
-	};
+const PageTemplateModal = withState( {
+	isOpen: true,
+	isLoading: false,
+	verticalTemplates: keyBy( templates, 'slug' ),
+} )( ( { isOpen, verticalTemplates, setState } ) => (
+	<div>
+		{ isOpen && (
+			<Modal
+				title={ __( 'Select Page Template' ) }
+				onRequestClose={ () => setState( { isOpen: false } ) }
+				className="page-template-modal"
+			>
+				<div className="page-template-modal__inner">
+					<form className="page-template-modal__form">
+						<fieldset className="page-template-modal__list">
+							<legend className="page-template-modal__intro">
+								<p>{ __( 'Pick a Template that matches the purpose of your page.' ) }</p>
+								<p>{ __( 'You can customise each Template to meet your needs.' ) }</p>
+							</legend>
+							<TemplateSelectorControl
+								label={ __( 'Template' ) }
+								templates={ Object.values( verticalTemplates ).map( template => ( {
+									label: template.title,
+									value: template.slug,
+									preview: template.preview && template.preview.src,
+									previewAlt: template.preview && template.preview.alt,
+								} ) ) }
+								onClick={ newTemplate => {
+									setState( { isOpen: false } );
+									insertTemplate( verticalTemplates[ newTemplate ] );
+								} }
+							/>
+						</fieldset>
+					</form>
+				</div>
+			</Modal>
+		) }
+	</div>
+) );
 
-	const PageTemplateModal = withState( {
-		isOpen: true,
-		isLoading: false,
-		verticalTemplates: keyBy( templates, 'slug' ),
-	} )( ( { isOpen, verticalTemplates, setState } ) => (
-		<div>
-			{ isOpen && (
-				<Modal
-					title="Select Page Template"
-					onRequestClose={ () => setState( { isOpen: false } ) }
-					className="page-template-modal"
-				>
-					<div className="page-template-modal__inner">
-						<form className="page-template-modal__form">
-							<fieldset className="page-template-modal__list">
-								<legend className="page-template-modal__intro">
-									<p>Pick a Template that matches the purpose of your page.</p>
-									<p>You can customise each Template to meet your needs.</p>
-								</legend>
-								<TemplateSelectorControl
-									label="Template"
-									templates={ Object.values( verticalTemplates ).map( template => ( {
-										label: template.title,
-										value: template.slug,
-										preview: template.preview && template.preview.src,
-										previewAlt: template.preview && template.preview.alt,
-									} ) ) }
-									onClick={ newTemplate => {
-										setState( { isOpen: false } );
-										insertTemplate( verticalTemplates[ newTemplate ] );
-									} }
-								/>
-							</fieldset>
-						</form>
-					</div>
-				</Modal>
-			) }
-		</div>
-	) );
-	registerPlugin( 'page-templates', {
-		render: function() {
-			return <PageTemplateModal />;
-		},
-	} );
-} )( window.wp, window.starterPageTemplatesConfig );
+registerPlugin( 'page-templates', {
+	render: function() {
+		return <PageTemplateModal />;
+	},
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders.js
@@ -7,7 +7,7 @@ const PLACEHOLDER_DEFAULTS = {
 	Address: _x( '123 Main St', 'default address', 'full-site-editing' ),
 	Phone: _x( '555-555-5555', 'default phone number', 'full-site-editing' ),
 	CompanyName: _x( 'Your Company Name', 'default company name', 'full-site-editing' ),
-	Vertical: __( 'Business' ),
+	Vertical: _x( 'Business', 'default vertical name', 'full-site-editing' ),
 };
 
 const KEY_MAP = {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders.js
@@ -1,9 +1,12 @@
-const __ = a => a;
+/**
+ * External dependencies
+ */
+import { _x } from '@wordpress/i18n';
 
 const PLACEHOLDER_DEFAULTS = {
-	Address: '123 Main St',
-	Phone: '555-555-5555',
-	CompanyName: __( 'Your Company Name' ),
+	Address: _x( '123 Main St', 'default address', 'full-site-editing' ),
+	Phone: _x( '555-555-5555', 'default phone number', 'full-site-editing' ),
+	CompanyName: _x( 'Your Company Name', 'default company name', 'full-site-editing' ),
 	Vertical: __( 'Business' ),
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- adds translation calls, mainly in JS
- adds translation text domain to JS file
- refactors imports to use `@wordpress/x` instead of `window.wp.x`
- removes the main closure (webpack adds its own)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- try plugin as you normally would
- confirm in code all translations in JS and PHP are properly marked so with `__` or `_x` and contain the correct domain `full-site-editing`

Fixes #33348
