### PR TITLE
FSE: adds CSS conditional to account for full screen editor mode

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -10,10 +10,16 @@
 	width: 1px;
 	word-wrap: normal !important;
 }
+
+// Full screen modal
 .page-template-modal {
 	width: 100%;
 	height: 100vh;
+}
 
+// When not full screen account for sidebar
+body:not( .is-fullscreen-mode ) .page-template-modal {
+	
 	@media screen and ( min-width: 783px ) {
 		width: calc( 100% - 65px );
 		left: 50px;
@@ -47,7 +53,7 @@
 	.components-base-control__label {
 		@include screen-reader-text();
 	}
-	
+
 	.template-selector-control__options {
 		display: grid;
 		// stylelint-disable-next-line unit-whitelist


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes https://github.com/Automattic/wp-calypso/issues/33421

Adds CSS conditional to handle the display of Modal appropriately when in full-screen editor mode.

#### Testing instructions

* In the Editor toggle "Full Screen Mode" 
![Screen Shot 2019-05-29 at 15 02 05](https://user-images.githubusercontent.com/444434/58563275-be9d7580-8222-11e9-928b-949ba7b39e17.png)
* Create a new Page
* See that Modal is full width on all viewports
* Disable "Full Screen Mode"
* Create a new Page
* See that Modal accounts for sidebar on all viewports where it is displayed



