### PR TITLE
FSE: Fix all phpcs errors

### DIFF
--- a/apps/full-site-editing/blank-theme/footer-blank.php
+++ b/apps/full-site-editing/blank-theme/footer-blank.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Footer template.
+ *
+ * @package full-site-editing
+ */
+
+?>
 	</div><!-- #content -->
 
 </div><!-- #page -->

--- a/apps/full-site-editing/blank-theme/functions.php
+++ b/apps/full-site-editing/blank-theme/functions.php
@@ -1,5 +1,13 @@
 <?php
+/**
+ * Footer template.
+ *
+ * @package full-site-editing
+ */
 
+/**
+ * Theme setup.
+ */
 function fse_blank_theme_setup() {
 	$style_file = is_rtl()
 		? 'blank-theme.rtl.css'
@@ -8,6 +16,9 @@ function fse_blank_theme_setup() {
 }
 add_action( 'after_setup_theme', 'fse_blank_theme_setup' );
 
+/**
+ * Enqueue scripts and styles.
+ */
 function fse_blank_theme_enqueue_script_and_style() {
 	wp_enqueue_style(
 		'twentynineteen-style',

--- a/apps/full-site-editing/blank-theme/functions.php
+++ b/apps/full-site-editing/blank-theme/functions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Footer template.
+ * Functions file.
  *
  * @package full-site-editing
  */

--- a/apps/full-site-editing/blank-theme/header-blank.php
+++ b/apps/full-site-editing/blank-theme/header-blank.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Header template.
+ *
+ * @package full-site-editing
+ */
+
+?>
 <!doctype html>
 <html <?php language_attributes(); ?>>
 <head>

--- a/apps/full-site-editing/blank-theme/page.php
+++ b/apps/full-site-editing/blank-theme/page.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Page template.
+ *
+ * @package full-site-editing
+ */
 
 get_header( 'blank' );
 ?>
@@ -7,30 +12,35 @@ get_header( 'blank' );
 		<main id="main" class="site-main">
 
 			<?php
-			if ( have_posts() ) {
+			if ( have_posts() ) :
 				the_post();
 
-				$post_id = get_the_ID();
-				$template_id = get_post_meta( $post_id, '_wp_template_id', true );
+				$page_id     = get_the_ID();
+				$template_id = get_post_meta( $page_id, '_wp_template_id', true );
 
-				$template = $template_id && $template_id !== $post_id ? get_post( $template_id ) : null;
+				$template = $template_id && $template_id !== $page_id ? get_post( $template_id ) : null;
 
-				if ( isset( $template ) ) { ?>
+				if ( isset( $template ) ) :
+					?>
 
 						<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 							<div class="entry-content">
-								<?php echo apply_filters( 'the_content', $template->post_content ); ?>
+								<?php
+									// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+									echo apply_filters( 'the_content', $template->post_content );
+								?>
 							</div><!-- .entry-content -->
 						</article><!-- #post-<?php the_ID(); ?> -->
 
-				<?php } else {
+					<?php
+				else :
 					get_template_part( 'template-parts/content/content', 'page' );
 
-					if ( comments_open() || get_comments_number() ) {
+					if ( comments_open() || get_comments_number() ) :
 						comments_template();
-					}
-				}
-			}
+					endif;
+				endif;
+			endif;
 			?>
 
 		</main><!-- #main -->

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.php
@@ -13,13 +13,13 @@
  * @return string
  */
 function render_post_content_block( $attributes, $content ) {
-	// Early return to avoid infinite loops in the REST API
+	// Early return to avoid infinite loops in the REST API.
 	if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
 		return $content;
 	}
 
-	$post_id = get_the_ID();
-	$post_type = get_post_type();
+	$post_id     = get_the_ID();
+	$post_type   = get_post_type();
 	$template_id = get_post_meta( $post_id, '_wp_template_id', true );
 
 	// Early return to avoid the infinite loop of a template rendering itself.
@@ -32,8 +32,11 @@ function render_post_content_block( $attributes, $content ) {
 	ob_start();
 	?>
 
-		<div class="post-content<?php echo $align; ?>">
-			<?php echo apply_filters( 'the_content', get_the_content() );  ?>
+		<div class="post-content<?php echo esc_attr( $align ); ?>">
+			<?php
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo apply_filters( 'the_content', get_the_content() );
+			?>
 		</div><!-- .post-content -->
 
 	<?php

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.php
@@ -16,7 +16,6 @@ function render_template_block( $attributes ) {
 		return;
 	}
 
-	$parent_post_id = get_the_ID();
 	$template = get_post( $attributes['templateId'] );
 
 	$align = isset( $attributes['align'] ) ? ' align' . $attributes['align'] : '';
@@ -25,8 +24,11 @@ function render_template_block( $attributes ) {
 	ob_start();
 	?>
 
-		<div class="template-part<?php echo $align; ?>">
-			<?php echo apply_filters( 'the_content', get_the_content() );  ?>
+		<div class="template-part<?php echo esc_attr( $align ); ?>">
+			<?php
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo apply_filters( 'the_content', get_the_content() );
+			?>
 		</div><!-- .template-part -->
 
 	<?php


### PR DESCRIPTION
This should remove all phpcs errors.

To test, run `phpcs` from `/apps/full-site-editing`.

I'm not sure if the `esc_attr()` calls will remove the leading whitespace and break the class name, I still have to test that.

See #33425.