### PR TITLE
Stats: Improve Table Heading Contrast

### DIFF
--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -508,7 +508,7 @@ ul.module-header-actions {
 
 	thead th,
 	.stats-detail-weeks__date {
-		color: var( --color-neutral-light );
+		color: var( --color-text-subtle );
 	}
 
 	.stats-detail-weeks__date {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This switches the colour variable to --text-subtle, which I believe is the one usually used for exactly these cases as it passes the colour contrast ratio.

#### Testing instructions

Visit `/stats/day/annualstats/` and compare the title headings, ensuring they pass the colour ratio.

<img width="1033" alt="Screenshot 2019-05-29 at 19 26 41" src="https://user-images.githubusercontent.com/43215253/58581776-39c55280-8248-11e9-91a4-bce23b45524a.png">

cc @sixhours, @flootr, @blowery 

Fixes #33430