### PR TITLE
List End: Update Background Colour

### DIFF
--- a/client/components/list-end/style.scss
+++ b/client/components/list-end/style.scss
@@ -14,7 +14,7 @@
 		fill: var( --color-neutral-light );
 		position: relative;
 		top: -13px;
-		background: var( --color-neutral-0 );
+		background: var( --color-surface-backdrop );
 		padding: 0 8px;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the variable of the List End component to the surface backdrop variable for the reasons mentioned in the original issue. 

#### Testing instructions

Verify the colour of the Line End component, for example, on the Me page, and check it's using the right variable.

<img width="843" alt="Screenshot 2019-05-29 at 19 32 51" src="https://user-images.githubusercontent.com/43215253/58582017-c112c600-8248-11e9-8e26-9853dddbe6a0.png">

cc @sixhours, @flootr, @blowery 

Fixes #33433
