### PR TITLE
Plans: update free CTA during onboarding

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -309,7 +309,7 @@ export class PlansFeaturesMain extends Component {
 				<div className="plans-features-main__banner-content">
 					{ translate( 'Not sure yet?' ) }
 					<Button className={ className } onClick={ this.handleFreePlanButtonClick } borderless>
-						{ translate( 'Start with the Free plan' ) }
+						{ translate( 'Start with a free site' ) }
 					</Button>
 				</div>
 			</div>


### PR DESCRIPTION
Following up on #33191, this is a small change to how the free offering is described:

Before:

> Start with the Free plan

After:

> Start with a free site

#### Testing instructions

Switch to this branch.
Start a new site and reach the plan comparison screen in the flow.
Verify that you see the new copy.

