### PR TITLE
Add space between between toggle and label

### DIFF
--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -276,6 +276,7 @@ class TermFormDialog extends Component {
 				<FormLabel>
 					<FormToggle checked={ isTopLevel } onChange={ this.onTopLevelChange } />
 					<span>
+						&nbsp;
 						{ translate( 'Top level %(term)s', {
 							args: { term: labels.singular_name },
 							context: 'Terms: New term being created is top level',

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -20,7 +20,6 @@ import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormToggle from 'components/forms/form-toggle';
-import FormLabel from 'components/forms/form-label';
 import FormLegend from 'components/forms/form-legend';
 import FormFieldset from 'components/forms/form-fieldset';
 import { isMobile } from 'lib/viewport';
@@ -273,9 +272,8 @@ class TermFormDialog extends Component {
 
 		return (
 			<FormFieldset>
-				<FormLabel>
-					<FormToggle checked={ isTopLevel } onChange={ this.onTopLevelChange } />
-					<span className="term-form-dialog__label">
+				<FormToggle checked={ isTopLevel } onChange={ this.onTopLevelChange }>
+					<span>
 						{ translate( 'Top level %(term)s', {
 							args: { term: labels.singular_name },
 							context: 'Terms: New term being created is top level',
@@ -292,7 +290,7 @@ class TermFormDialog extends Component {
 							} ) }
 						</span>
 					) }
-				</FormLabel>
+				</FormToggle>
 				{ ! isTopLevel && (
 					<div className="term-form-dialog__parent-tree-selector">
 						<FormLegend>

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -275,8 +275,7 @@ class TermFormDialog extends Component {
 			<FormFieldset>
 				<FormLabel>
 					<FormToggle checked={ isTopLevel } onChange={ this.onTopLevelChange } />
-					<span>
-						&nbsp;
+					<span className="term-form-dialog__label">
 						{ translate( 'Top level %(term)s', {
 							args: { term: labels.singular_name },
 							context: 'Terms: New term being created is top level',

--- a/client/blocks/term-form-dialog/style.scss
+++ b/client/blocks/term-form-dialog/style.scss
@@ -21,10 +21,6 @@
 	resize: vertical;
 }
 
-.term-form-dialog__label {
-	margin-left: 12px;
-}
-
 .term-form-dialog__top-level-description {
 	color: var( --color-text-subtle );
 	display: block;

--- a/client/blocks/term-form-dialog/style.scss
+++ b/client/blocks/term-form-dialog/style.scss
@@ -21,6 +21,10 @@
 	resize: vertical;
 }
 
+.term-form-dialog__label {
+	margin-left: 12px;
+}
+
 .term-form-dialog__top-level-description {
 	color: var( --color-text-subtle );
 	display: block;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a space between a toggle and a label.

#### Testing instructions

* Go to `http://calypso.localhost:3000/settings/taxonomies/category/[site name]`.
* Add a new category.
* See some space between the toggle switch and its label.

**Before**

<img width="306" alt="before" src="https://user-images.githubusercontent.com/435/58602999-05a85c80-825d-11e9-998d-6a10240824d3.png">

**After**

<img width="308" alt="image" src="https://user-images.githubusercontent.com/435/58956151-ad48f180-876b-11e9-842d-451a1f8323f3.png">

Fixes #33141
