### PR TITLE
[WIP] Signup: Make onboarding flow the default

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -696,7 +696,7 @@ class SignupForm extends Component {
 	}
 
 	footerLink() {
-		const { flowName, translate } = this.props;
+		const { translate } = this.props;
 
 		if ( this.props.positionInFlow !== 0 ) {
 			return;
@@ -709,9 +709,7 @@ class SignupForm extends Component {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href={ logInUrl }>
-					{ [ 'onboarding', 'onboarding-dev' ].includes( flowName )
-						? translate( 'Log in to create a site for your existing account.' )
-						: translate( 'Already have a WordPress.com account?' ) }
+					{ translate( 'Log in to create a site for your existing account.' ) }
 				</LoggedOutFormLinkItem>
 				{ this.props.oauth2Client && (
 					<LoggedOutFormBackLink

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,15 +1,5 @@
 /** @format */
 export default {
-	improvedOnboarding: {
-		datestamp: '20190314',
-		variations: {
-			main: 0,
-			onboarding: 100,
-		},
-		defaultVariation: 'main',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',
 		variations: {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -401,9 +401,7 @@ export class Checkout extends React.Component {
 					plan: 'paid',
 				} );
 
-				const destination = abtest( 'improvedOnboarding' ) === 'onboarding' ? 'view' : 'checklist';
-
-				return `/${ destination }/${ selectedSiteSlug }?d=gsuite`;
+				return `/view/${ selectedSiteSlug }?d=gsuite`;
 			}
 
 			// Maybe show either the G Suite or Concierge Session upsell pages
@@ -447,7 +445,7 @@ export class Checkout extends React.Component {
 			if ( this.props.redirectToPageBuilder ) {
 				return getEditHomeUrl( selectedSiteSlug );
 			}
-			const destination = abtest( 'improvedOnboarding' ) === 'main' ? 'checklist' : 'view';
+			const destination = 'view';
 
 			return `/${ destination }/${ selectedSiteSlug }${ queryParam }`;
 		}

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -24,7 +24,6 @@ import { addItem, removeItem } from 'lib/upgrades/actions';
 import { getAllCartItems } from 'lib/cart-values/cart-items';
 import { isDotComPlan } from 'lib/products-values';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -41,11 +40,9 @@ export class GSuiteNudge extends React.Component {
 	handleClickSkip = () => {
 		const { siteSlug, receiptId, isEligibleForChecklist } = this.props;
 
-		const destination = abtest( 'improvedOnboarding' ) === 'onboarding' ? 'view' : 'checklist';
-
 		page(
 			isEligibleForChecklist
-				? `/${ destination }/${ siteSlug }`
+				? `/view/${ siteSlug }`
 				: `/checkout/thank-you/${ siteSlug }/${ receiptId }`
 		);
 	};

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -124,9 +124,27 @@ export function generateFlows( {
 				'site-style-with-preview',
 				'domains-with-preview',
 				'plans',
-			],			destination: getChecklistDestination,
+			],
+			destination: getChecklistDestination,
 			description: 'The default onboarding flow',
 			lastModified: '2019-06-18',
+		},
+
+		// We are keeping this flow for now while we
+		// ensure that there are no direct links to /start/onboarding
+		onboarding: {
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'site-style-with-preview',
+				'domains-with-preview',
+				'plans',
+			],
+			destination: getChecklistDestination,
+			description: 'The improved onboarding flow.',
+			lastModified: '2019-06-05',
 		},
 
 		'delta-discover': {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -116,13 +116,6 @@ export function generateFlows( {
 		},
 
 		main: {
-			steps: [ 'user', 'about', 'domains', 'plans' ],
-			destination: getChecklistDestination,
-			description: 'The current best performing flow in AB tests',
-			lastModified: '2019-04-30',
-		},
-
-		onboarding: {
 			steps: [
 				'user',
 				'site-type',
@@ -131,25 +124,9 @@ export function generateFlows( {
 				'site-style-with-preview',
 				'domains-with-preview',
 				'plans',
-			],
-			destination: getChecklistDestination,
-			description: 'The improved onboarding flow.',
-			lastModified: '2019-06-05',
-		},
-
-		'onboarding-dev': {
-			steps: [
-				'user',
-				'site-type',
-				'site-topic-with-preview',
-				'site-title-with-preview',
-				'site-style-with-preview',
-				'domains-with-preview',
-				'plans',
-			],
-			destination: getChecklistDestination,
-			description: 'A temporary flow for holding under-development steps',
-			lastModified: '2019-04-30',
+			],			destination: getChecklistDestination,
+			description: 'The default onboarding flow',
+			lastModified: '2019-06-18',
 		},
 
 		'delta-discover': {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -8,7 +8,6 @@ import { assign, get, includes, indexOf, reject } from 'lodash';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
 import { abtest } from 'lib/abtest';
@@ -105,9 +104,7 @@ const Flows = {
 	filterFlowName,
 	filterDestination,
 
-	defaultFlowName: config.isEnabled( 'signup/onboarding-flow' )
-		? abtest( 'improvedOnboarding' )
-		: 'main',
+	defaultFlowName: 'main',
 	resumingFlow: false,
 	excludedSteps: [],
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { defer, endsWith, get, includes, isEmpty } from 'lodash';
+import { defer, endsWith, get, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 import { abtest } from 'lib/abtest';
 
@@ -534,11 +534,9 @@ class DomainsStep extends React.Component {
 	};
 
 	getSubHeaderText() {
-		const { flowName, siteType, translate } = this.props;
+		const { siteType, translate } = this.props;
 		const onboardingSubHeaderCopy =
-			siteType &&
-			includes( [ 'onboarding-for-business', 'onboarding' ], flowName ) &&
-			getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
+			siteType && getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
 
 		if ( onboardingSubHeaderCopy ) {
 			return onboardingSubHeaderCopy;

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -177,13 +177,7 @@ export class PlansStep extends Component {
 			siteSlug,
 		} = this.props;
 
-		let headerText = this.props.headerText || translate( "Pick a plan that's right for you." );
-
-		//Temporary header for onboarding-dev flow
-		if ( 'onboarding-dev' === flowName ) {
-			headerText = translate( 'Pick your plan' );
-		}
-
+		const headerText = this.props.headerText || translate( "Pick a plan that's right for you." );
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
 		const subHeaderText = this.props.subHeaderText;
 		let backUrl, backLabelText;

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -139,12 +139,9 @@ export class UserStep extends Component {
 		} else if ( 1 === getFlowSteps( flowName ).length ) {
 			// Displays specific sub header if users only want to create an account, without a site
 			subHeaderText = translate( 'Welcome to the WordPress.com community.' );
-		} else if ( 'onboarding-dev' === flowName ) {
-			// Displays no sub header for onboarding-dev flow
-			subHeaderText = '';
 		}
 
-		if ( positionInFlow === 0 && [ 'onboarding', 'onboarding-dev' ].includes( flowName ) ) {
+		if ( positionInFlow === 0 ) {
 			subHeaderText = translate( 'First, create your WordPress.com account.' );
 		}
 
@@ -239,10 +236,6 @@ export class UserStep extends Component {
 				comment:
 					"'clientTitle' is the name of the app that uses WordPress.com Connect (e.g. 'Akismet' or 'VaultPress')",
 			} );
-		}
-
-		if ( 'onboarding-dev' === flowName ) {
-			return translate( 'Make something great' );
 		}
 
 		return headerText;

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1641,18 +1641,13 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for a free WordPress.com site via the new onboarding flow @parallel', () => {
+	describe( 'Sign up for a free WordPress.com site via the default onboarding flow @parallel', () => {
 		const userName = dataHelper.getNewBlogName();
 		const blogName = dataHelper.getNewBlogName();
 		const emailAddress = dataHelper.getEmailAddress( blogName, signupInboxId );
 
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
-			return await overrideABTests.setOverriddenABTests(
-				driver,
-				'improvedOnboarding',
-				'onboarding'
-			);
 		} );
 
 		step( 'Can visit the start page', async function() {
@@ -1738,11 +1733,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
-			return await overrideABTests.setOverriddenABTests(
-				driver,
-				'improvedOnboarding',
-				'onboarding'
-			);
 		} );
 
 		step( 'Can enter the account flow and see the account details page', async function() {


### PR DESCRIPTION
## Changes proposed in this Pull Request

💀 Making `onboarding` the main flow and hazardously removing references to the improvedOnboarding AB test and `onboarding-dev` flows. 

### To do

- [ ] Any analytics that need attending to?
- [ ] Update e2e tests
- [ ] Not a blocker for this PR (assuming we keep the `onboarding` flow temporarily, but we should update the CTA urls on https://wordpress.com/websites/create/restaurant/ and other vertical sites. It's one change in one file.

## Testing instructions

To come