### PR TITLE
FSE: updates to replace refs to “radio” with “template”

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -18,7 +18,7 @@ function TemplateSelectorControl( {
 	onClick,
 	templates = [],
 } ) {
-	const id = `inspector-radio-control-${ instanceId }`;
+	const id = `template-selector-control-${ instanceId }`;
 	const handleButtonClick = event => onClick( event.target.value );
 
 	if ( isEmpty( templates ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updating a string reference

#### Testing instructions
* Create new Page
* See Modal
* Inspect DOM and see that there are no references to `radio` within the `id` attribute of the `button` elements

![Screen Shot 2019-05-30 at 09 54 33](https://user-images.githubusercontent.com/444434/58621295-f22edd00-82c0-11e9-8dd9-ba8313c6aa02.png)



