### PR TITLE
FSE remove default button styles

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -77,6 +77,7 @@ body:not( .is-fullscreen-mode ) .page-template-modal {
 		}
 
 		&:focus {
+			background: #f3f4f5;
 			box-shadow: 0 0 0 2px #00a0d2;
 			outline: 2px solid transparent;
 			outline-offset: -2px;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -69,6 +69,8 @@ body:not( .is-fullscreen-mode ) .page-template-modal {
 		padding: 2em;
 		border-radius: 4px;
 		cursor: pointer;
+		background: none;
+		appearance: none;
 
 		&:hover {
 			background: #f3f4f5;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the default button styling applied by (some) browsers to `button` elements
* Ensure `hover` and `focus` styles are consistent

#### Testing instructions

* Create new Page
* Check in FF, Android Chrome, iOS Safari that buttons do not have a default gray background applied 
* Check that `hover` and `focus` interactions still show a background
* Check that `focus` also has a background applied _as well_ as additional outline and box shadow

See original report at https://github.com/Automattic/wp-calypso/issues/33304#issue-448082755
