### PR TITLE
Guided Tours: Remove ie9 Element.prototype.matches polyfill

### DIFF
--- a/client/layout/guided-tours/tours/simple-payments-email-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-email-tour/index.js
@@ -35,11 +35,6 @@ const handleTargetDisappear = () => {
 	tourFirstStep.style.left = '-9999px';
 };
 
-// IE9+ polyfill for `Element.matches()` used in `DelegatingQuit`
-if ( ! Element.prototype.matches ) {
-	Element.prototype.matches = Element.prototype.msMatchesSelector;
-}
-
 class DelegatingQuit extends Quit {
 	addTargetListener = () => {
 		const { parentTarget } = this.props;


### PR DESCRIPTION
We don't support ie9 and don't need this.

https://developer.mozilla.org/en-US/docs/Web/API/Element/matches