### PR TITLE
Purchase Detail: Make sure description doesn't return a widow

### DIFF
--- a/client/components/purchase-detail/index.jsx
+++ b/client/components/purchase-detail/index.jsx
@@ -15,6 +15,7 @@ import { noop } from 'lodash';
  */
 import PurchaseButton from './purchase-button';
 import TipInfo from './tip-info';
+import { preventWidows } from 'lib/formatting';
 
 /**
  * Style dependencies
@@ -118,7 +119,7 @@ export default class PurchaseDetail extends PureComponent {
 					<div className="purchase-detail__image">{ this.renderIcon() }</div>
 					<div className="purchase-detail__text">
 						<h3 className="purchase-detail__title">{ title }</h3>
-						<div className="purchase-detail__description">{ description }</div>
+						<div className="purchase-detail__description">{ preventWidows( description ) }</div>
 						{ this.renderBody() }
 					</div>
 				</div>


### PR DESCRIPTION

#### Changes proposed in this Pull Request

* Add a `preventWidows` to the description.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/plans/my-plan/`
* Check all the feature cards. Do you see any widows? (try resizing your browser)

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/58637568-a98c1980-82ea-11e9-8b5e-aef08118d8a8.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/58637575-b1e45480-82ea-11e9-9761-38ef8ce4d306.png)

See #33040
