### PR TITLE
Onboarding: Remove the onboarding specific check for subheader

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -33,6 +33,9 @@ const getSiteTypePropertyDefaults = propertyKey =>
 			domainsStepSubheader: i18n.translate(
 				'Enter a keyword that describes your site to get started.'
 			),
+			domainsStepTransferringSubheader: i18n.translate(
+				'Use a domain you already own with your new WordPress.com site.'
+			),
 			// Site styles step
 			siteStyleSubheader: i18n.translate(
 				'This will help you get started with a theme you might like. You can change it later.'
@@ -97,6 +100,9 @@ export function getAllSiteTypes() {
 			domainsStepHeader: i18n.translate( 'Give your blog an address' ),
 			domainsStepSubheader: i18n.translate(
 				"Enter your blog's name or some keywords that describe it to get started."
+			),
+			domainsStepTransferringSubheader: i18n.translate(
+				'Use a domain you already own with your new WordPress.com blog.'
 			),
 		},
 		{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -518,17 +518,11 @@ class DomainsStep extends React.Component {
 	};
 
 	getSubHeaderText() {
-		const { siteType, translate } = this.props;
-		const onboardingSubHeaderCopy =
-			siteType && getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
+		const { siteType, stepSectionName } = this.props;
 
-		if ( onboardingSubHeaderCopy ) {
-			return onboardingSubHeaderCopy;
-		}
-
-		return 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName
-			? translate( 'Use a domain you already own with your new WordPress.com site.' )
-			: translate( "Enter your site's name or some keywords that describe it to get started." );
+		return 'transfer' === stepSectionName || 'mapping' === stepSectionName
+			? getSiteTypePropertyValue( 'slug', siteType, 'domainsStepTransferringSubheader' )
+			: getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
 	}
 
 	getHeaderText() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { defer, endsWith, get, includes, isEmpty } from 'lodash';
+import { defer, endsWith, get, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 
 /**
@@ -518,11 +518,9 @@ class DomainsStep extends React.Component {
 	};
 
 	getSubHeaderText() {
-		const { flowName, siteType, translate } = this.props;
+		const { siteType, translate } = this.props;
 		const onboardingSubHeaderCopy =
-			siteType &&
-			includes( [ 'onboarding-for-business', 'onboarding' ], flowName ) &&
-			getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
+			siteType && getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
 
 		if ( onboardingSubHeaderCopy ) {
 			return onboardingSubHeaderCopy;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As a follow up to #33312, this PR removes the extra checks that I put in place to make sure we were in an onboarding flow - the same copy can be used in the same domains step in other flows without issue, so long as we don't bash transfer/mapping check already in place.

This fork in the flow, the "Already own a domain?" is one we should take care to keep in mind - I know I personally wouldn't have checked it if it weren't for spotting it in the code.
We might wish to give segment specific copy here, too.

Related to that - I noticed that the file where the segment specific properties and copy live, `lib/signup/site-type.js` doesn't feel like it's named correctly, given the responsibilities it now has.
When we come to clean up some code, renaming and reorganising this area might be a good candidate for janitorial work :)

#### Testing instructions

Go through the onboarding flow: http://calypso.localhost:3000/start/onboarding
Make sure the right copy is shown on the domains step, as mentioned here: #33312

Then, test the "Already own a domain?" fork by clicking that link... The header/subheader copy should remain as before until you click one of the 2 options... after that you should see copy like so: "'Use a domain you already own with your new WordPress.com site.'"

As you can see, the trouble here is that this copy isn't specific to the flow ("your new WordPress.com blog" would be better fitting.

I'm happy to fix that up as part of this PR - what do you think @fditrapani, @adamziel? Shall I just follow the same pattern? I think it's only the blog segment that would need a copy update here. 