### PR TITLE
Color Schemes: Add Midnight color scheme

### DIFF
--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -56,5 +56,12 @@ export default function( translate ) {
 				cssClass: 'is-sunset',
 			},
 		},
+		{
+			label: translate( 'Midnight' ),
+			value: 'midnight',
+			thumbnail: {
+				cssClass: 'is-midnight',
+			},
+		},
 	] );
 }

--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -56,7 +56,7 @@ export default function( translate ) {
 				cssClass: 'is-sunset',
 			},
 		},
-		{
+		config.isEnabled( 'me/account/color-schemes/midnight' ) && {
 			label: translate( 'Midnight' ),
 			value: 'midnight',
 			thumbnail: {

--- a/client/blocks/color-scheme-picker/style.scss
+++ b/client/blocks/color-scheme-picker/style.scss
@@ -27,4 +27,8 @@
 		background-image: url( '/calypso/images/color-schemes/color-scheme-thumbnail-sunset.svg' );
 	}
 
+	&.is-midnight {
+		background-image: url( '/calypso/images/color-schemes/color-scheme-thumbnail-midnight.svg' );
+	}
+
 }

--- a/config/development.json
+++ b/config/development.json
@@ -115,6 +115,7 @@
 		"me/account/color-scheme-picker": true,
 		"me/account/color-schemes/ocean": true,
 		"me/account/color-schemes/sunset": true,
+		"me/account/color-schemes/midnight": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -93,6 +93,7 @@
 		"me/account/color-schemes/laser-black": false,
 		"me/account/color-schemes/ocean": true,
 		"me/account/color-schemes/sunset": true,
+		"me/account/color-schemes/midnight": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,

--- a/packages/calypso-color-schemes/src/shared/_color-schemes.scss
+++ b/packages/calypso-color-schemes/src/shared/_color-schemes.scss
@@ -1442,7 +1442,7 @@
 		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-red-700 )};
 		--sidebar-menu-hover-color: #{$muriel-white};
 
- 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
 		--button-is-borderless-color: #{$muriel-gray-500};
 		--count-border-color: #{$muriel-white};
 		--count-color: #{$muriel-white};
@@ -1479,7 +1479,7 @@
 		--color-primary-900: #{$muriel-gray-900};
 		--color-primary-900-rgb: #{hex-to-rgb( $muriel-gray-900 )};
 
- 		--color-accent: #{$muriel-blue-400};
+		--color-accent: #{$muriel-blue-400};
 		--color-accent-rgb: #{hex-to-rgb( $muriel-blue-400 )};
 		--color-accent-dark: #{$muriel-blue-700};
 		--color-accent-dark-rgb: #{hex-to-rgb( $muriel-blue-700 )};
@@ -1508,12 +1508,12 @@
 		--color-accent-900: #{$muriel-blue-900};
 		--color-accent-900-rgb: #{hex-to-rgb( $muriel-blue-900 )};
 
- 		--color-text: #{$muriel-gray-900};
+		--color-text: #{$muriel-gray-900};
 		--color-text-subtle: #{$muriel-gray-600};
 		--color-surface: #{$muriel-white};
 		--color-surface-backdrop: #{$muriel-gray-0};
 
- 		--color-link: #{$muriel-red-600};
+		--color-link: #{$muriel-red-600};
 		--color-link-rgb: #{hex-to-rgb( $muriel-red-600 )};
 		--color-link-dark: #{$muriel-red-700};
 		--color-link-dark-rgb: #{hex-to-rgb( $muriel-red-700 )};
@@ -1542,10 +1542,10 @@
 		--color-link-900: #{$muriel-red-900};
 		--color-link-900-rgb: #{hex-to-rgb( $muriel-red-900 )};
 
- 		--color-button-primary-background-hover: #{$muriel-blue-500};
+		--color-button-primary-background-hover: #{$muriel-blue-500};
 		--color-button-primary-scary-background-hover: #{$muriel-hot-red-400};
 
- 		--masterbar-color: #{$muriel-white};
+		--masterbar-color: #{$muriel-white};
 		--masterbar-border-color: #{$muriel-gray-700};
 		--masterbar-item-new-editor-background: #{$muriel-gray-500};
 		--masterbar-item-new-editor-hover-background: #{$muriel-gray-600};
@@ -1553,7 +1553,7 @@
 		--masterbar-toggle-drafts-editor-border-color: #{$muriel-gray-100};
 		--masterbar-toggle-drafts-editor-hover-background: #{$muriel-gray-400};
 
- 		--sidebar-background: #{$muriel-gray-800};
+		--sidebar-background: #{$muriel-gray-800};
 		--sidebar-background-gradient: #{hex-to-rgb( $muriel-gray-800 )};
 		--sidebar-secondary-background: #{$muriel-white};
 		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
@@ -1571,7 +1571,7 @@
 		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-gray-700 )};
 		--sidebar-menu-hover-color: #{$muriel-white};
 
- 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
 		--button-is-borderless-color: #{$muriel-gray-600};
 		--count-border-color: #{$muriel-gray-600};
 		--count-color: #{$muriel-gray-600};

--- a/packages/calypso-color-schemes/src/shared/_color-schemes.scss
+++ b/packages/calypso-color-schemes/src/shared/_color-schemes.scss
@@ -1442,10 +1442,139 @@
 		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-red-700 )};
 		--sidebar-menu-hover-color: #{$muriel-white};
 
-		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+ 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
 		--button-is-borderless-color: #{$muriel-gray-500};
 		--count-border-color: #{$muriel-white};
 		--count-color: #{$muriel-white};
 		--profile-gravatar-user-secondary-info-color: #{$muriel-red-50};
+	}
+
+	&.is-midnight {
+		--color-primary: #{$muriel-gray-700};
+		--color-primary-rgb: #{hex-to-rgb( $muriel-gray-700 )};
+		--color-primary-light: #{$muriel-gray-500};
+		--color-primary-light-rgb: #{hex-to-rgb( $muriel-gray-500 )};
+		--color-primary-dark: #{$muriel-gray-800};
+		--color-primary-dark-rgb: #{hex-to-rgb( $muriel-gray-800 )};
+		--color-primary-0: #{$muriel-gray-0};
+		--color-primary-0-rgb: #{hex-to-rgb( $muriel-gray-0 )};
+		--color-primary-50: #{$muriel-gray-50};
+		--color-primary-50-rgb: #{hex-to-rgb( $muriel-gray-50 )};
+		--color-primary-100: #{$muriel-gray-100};
+		--color-primary-100-rgb: #{hex-to-rgb( $muriel-gray-100 )};
+		--color-primary-200: #{$muriel-gray-200};
+		--color-primary-200-rgb: #{hex-to-rgb( $muriel-gray-200 )};
+		--color-primary-300: #{$muriel-gray-300};
+		--color-primary-300-rgb: #{hex-to-rgb( $muriel-gray-300 )};
+		--color-primary-400: #{$muriel-gray-400};
+		--color-primary-400-rgb: #{hex-to-rgb( $muriel-gray-400 )};
+		--color-primary-500: #{$muriel-gray-500};
+		--color-primary-500-rgb: #{hex-to-rgb( $muriel-gray-500 )};
+		--color-primary-600: #{$muriel-gray-600};
+		--color-primary-600-rgb: #{hex-to-rgb( $muriel-gray-600 )};
+		--color-primary-700: #{$muriel-gray-700};
+		--color-primary-700-rgb: #{hex-to-rgb( $muriel-gray-700 )};
+		--color-primary-800: #{$muriel-gray-800};
+		--color-primary-800-rgb: #{hex-to-rgb( $muriel-gray-800 )};
+		--color-primary-900: #{$muriel-gray-900};
+		--color-primary-900-rgb: #{hex-to-rgb( $muriel-gray-900 )};
+
+ 		--color-accent: #{$muriel-blue-400};
+		--color-accent-rgb: #{hex-to-rgb( $muriel-blue-400 )};
+		--color-accent-dark: #{$muriel-blue-700};
+		--color-accent-dark-rgb: #{hex-to-rgb( $muriel-blue-700 )};
+		--color-accent-light: #{$muriel-blue-300};
+		--color-accent-light-rgb: #{hex-to-rgb( $muriel-blue-300 )};
+		--color-accent-0: #{$muriel-blue-0};
+		--color-accent-0-rgb: #{hex-to-rgb( $muriel-blue-0 )};
+		--color-accent-50: #{$muriel-blue-50};
+		--color-accent-50-rgb: #{hex-to-rgb( $muriel-blue-50 )};
+		--color-accent-100: #{$muriel-blue-100};
+		--color-accent-100-rgb: #{hex-to-rgb( $muriel-blue-100 )};
+		--color-accent-200: #{$muriel-blue-200};
+		--color-accent-200-rgb: #{hex-to-rgb( $muriel-blue-200 )};
+		--color-accent-300: #{$muriel-blue-300};
+		--color-accent-300-rgb: #{hex-to-rgb( $muriel-blue-300 )};
+		--color-accent-400: #{$muriel-blue-400};
+		--color-accent-400-rgb: #{hex-to-rgb( $muriel-blue-400 )};
+		--color-accent-500: #{$muriel-blue-500};
+		--color-accent-500-rgb: #{hex-to-rgb( $muriel-blue-500 )};
+		--color-accent-600: #{$muriel-blue-600};
+		--color-accent-600-rgb: #{hex-to-rgb( $muriel-blue-600 )};
+		--color-accent-700: #{$muriel-blue-700};
+		--color-accent-700-rgb: #{hex-to-rgb( $muriel-blue-700 )};
+		--color-accent-800: #{$muriel-blue-800};
+		--color-accent-800-rgb: #{hex-to-rgb( $muriel-blue-800 )};
+		--color-accent-900: #{$muriel-blue-900};
+		--color-accent-900-rgb: #{hex-to-rgb( $muriel-blue-900 )};
+
+ 		--color-text: #{$muriel-gray-900};
+		--color-text-subtle: #{$muriel-gray-600};
+		--color-surface: #{$muriel-white};
+		--color-surface-backdrop: #{$muriel-gray-0};
+
+ 		--color-link: #{$muriel-red-600};
+		--color-link-rgb: #{hex-to-rgb( $muriel-red-600 )};
+		--color-link-dark: #{$muriel-red-700};
+		--color-link-dark-rgb: #{hex-to-rgb( $muriel-red-700 )};
+		--color-link-light: #{$muriel-red-300};
+		--color-link-light-rgb: #{hex-to-rgb( $muriel-red-300 )};
+		--color-link-0: #{$muriel-red-0};
+		--color-link-0-rgb: #{hex-to-rgb( $muriel-red-0 )};
+		--color-link-50: #{$muriel-red-50};
+		--color-link-50-rgb: #{hex-to-rgb( $muriel-red-50 )};
+		--color-link-100: #{$muriel-red-100};
+		--color-link-100-rgb: #{hex-to-rgb( $muriel-red-100 )};
+		--color-link-200: #{$muriel-red-200};
+		--color-link-200-rgb: #{hex-to-rgb( $muriel-red-200 )};
+		--color-link-300: #{$muriel-red-300};
+		--color-link-300-rgb: #{hex-to-rgb( $muriel-red-300 )};
+		--color-link-400: #{$muriel-red-400};
+		--color-link-400-rgb: #{hex-to-rgb( $muriel-red-400 )};
+		--color-link-500: #{$muriel-red-500};
+		--color-link-500-rgb: #{hex-to-rgb( $muriel-red-500 )};
+		--color-link-600: #{$muriel-red-600};
+		--color-link-600-rgb: #{hex-to-rgb( $muriel-red-600 )};
+		--color-link-700: #{$muriel-red-700};
+		--color-link-700-rgb: #{hex-to-rgb( $muriel-red-700 )};
+		--color-link-800: #{$muriel-red-800};
+		--color-link-800-rgb: #{hex-to-rgb( $muriel-red-800 )};
+		--color-link-900: #{$muriel-red-900};
+		--color-link-900-rgb: #{hex-to-rgb( $muriel-red-900 )};
+
+ 		--color-button-primary-background-hover: #{$muriel-blue-500};
+		--color-button-primary-scary-background-hover: #{$muriel-hot-red-400};
+
+ 		--masterbar-color: #{$muriel-white};
+		--masterbar-border-color: #{$muriel-gray-700};
+		--masterbar-item-new-editor-background: #{$muriel-gray-500};
+		--masterbar-item-new-editor-hover-background: #{$muriel-gray-600};
+		--masterbar-toggle-drafts-editor-background: #{$muriel-gray-600};
+		--masterbar-toggle-drafts-editor-border-color: #{$muriel-gray-100};
+		--masterbar-toggle-drafts-editor-hover-background: #{$muriel-gray-400};
+
+ 		--sidebar-background: #{$muriel-gray-800};
+		--sidebar-background-gradient: #{hex-to-rgb( $muriel-gray-800 )};
+		--sidebar-secondary-background: #{$muriel-white};
+		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
+		--sidebar-border-color: #{$muriel-gray-700};
+		--sidebar-text-color: #{$muriel-white};
+		--sidebar-gridicon-fill: #{$muriel-white};
+		--sidebar-heading-color: #{$muriel-gray-100};
+		--sidebar-footer-button-color: #{$muriel-gray-900};
+		--sidebar-menu-link-secondary-text-color: #{$muriel-gray-300};
+		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-800 )};
+		--sidebar-menu-selected-background-color: #{$muriel-red-600};
+		--sidebar-menu-selected-a-color: #{$muriel-white};
+		--sidebar-menu-selected-a-first-child-after-background: #{hex-to-rgb( $muriel-red-600 )};
+		--sidebar-menu-hover-background: #{$muriel-gray-700};
+		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-gray-700 )};
+		--sidebar-menu-hover-color: #{$muriel-white};
+
+ 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+		--button-is-borderless-color: #{$muriel-gray-600};
+		--count-border-color: #{$muriel-gray-600};
+		--count-color: #{$muriel-gray-600};
+		--profile-gravatar-user-secondary-info-color: #{$muriel-gray-300};
 	}
 }

--- a/static/images/color-schemes/color-scheme-thumbnail-midnight.svg
+++ b/static/images/color-schemes/color-scheme-thumbnail-midnight.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 240 160" style="enable-background:new 0 0 240 160;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#F6F6F6;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#2B2D2F;}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#A82620;}
+	.st3{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;fill:#B0B5B8;}
+	.st5{fill-rule:evenodd;clip-rule:evenodd;fill:#46799A;}
+	.st6{fill-rule:evenodd;clip-rule:evenodd;fill:#3D4145;}
+</style>
+<g>
+	<path class="st0" d="M70,20h170v140H70V20z"/>
+	<path class="st1" d="M0,20h70v140H0V20z"/>
+	<path class="st2" d="M0,86h70v16H0V86z"/>
+	<path class="st3" d="M7,91h55v6H7V91z"/>
+	<path class="st3" d="M7,75h37v6H7V75z M7,107h29v6H7V107z M7,123h45v6H7V123z"/>
+	<circle class="st4" cx="35.5" cy="45.5" r="16.5"/>
+	<path class="st3" d="M90,36h130v107H90V36z"/>
+	<path class="st5" d="M163,48h42c1.7,0,3,1.3,3,3v10c0,1.7-1.3,3-3,3h-42c-1.7,0-3-1.3-3-3V51C160,49.3,161.3,48,163,48z"/>
+	<path class="st6" d="M0,0h240v20H0V0z"/>
+</g>
+</svg>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new Calypso dashboard color scheme, Midnight, based on the /wp-admin color scheme of the same name.

**Preview**

<img width="1280" alt="Screen Shot 2019-05-30 at 12 24 32 PM" src="https://user-images.githubusercontent.com/2124984/58647602-eac5fe80-82d5-11e9-937d-d5017edfe2ca.png">

#### Testing instructions

* Switch to this PR
* Navigate to Me -> Account Settings and switch to the Midnight color scheme
* Test for color contrast and visual bugs across Calypso
