### PR TITLE
Update > to Continue

### DIFF
--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -15,7 +15,6 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import Button from 'components/button';
-import Gridicon from 'gridicons';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
@@ -113,7 +112,7 @@ export class SiteStyleStep extends Component {
 						type="submit"
 						primary
 					>
-						<Gridicon icon="arrow-right" />
+						{ this.props.translate( 'Continue' ) }
 					</Button>
 				</div>
 			</form>

--- a/client/signup/steps/site-style/style.scss
+++ b/client/signup/steps/site-style/style.scss
@@ -149,7 +149,7 @@
 
 	.button {
 		width: auto;
-		padding: 5px 8px;
+		padding: 8px;
 
 		.gridicon {
 			height: 24px;

--- a/client/signup/steps/site-style/test/__snapshots__/index.js.snap
+++ b/client/signup/steps/site-style/test/__snapshots__/index.js.snap
@@ -54,10 +54,7 @@ exports[`<SiteStyleStep /> should render 1`] = `
               title="Continue"
               type="submit"
             >
-              <t
-                icon="arrow-right"
-                size={24}
-              />
+              Continue
             </Button>
           </div>
         </form>

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -122,7 +121,7 @@ class SiteTitleStep extends Component {
 								type="submit"
 								onClick={ this.handleSubmit }
 							>
-								<Gridicon icon="arrow-right" />
+								{ this.props.translate( 'Continue' ) }
 							</Button>{' '}
 						</FormFieldset>
 					</div>

--- a/client/signup/steps/site-title/style.scss
+++ b/client/signup/steps/site-title/style.scss
@@ -22,7 +22,7 @@
 
 	input {
 		// Extra padding to account for the button
-		padding: 10px 100px 12px 16px;
+		padding: 10px 90px 12px 16px;
 
 		// Match the radious of the fieldset
 		border-radius: 4px;
@@ -35,6 +35,7 @@
 		@include breakpoint( '<660px' ) {
 			padding-top: 15px;
 			padding-bottom: 15px;
+			padding-right: 100px;
 
 			// The rounded borders look strange on
 			// smaller screens.
@@ -44,10 +45,6 @@
 		&:focus {
 			box-shadow: 0 0 0 3px var( --color-accent-light );
 		}
-	}
-
-	button {
-		@include elevation ( 1dp );
 	}
 
 	.card {
@@ -87,7 +84,7 @@
 		top: 3px;
 		right: 3px;
 		width: auto;
-		padding: 5px 8px;
+		padding: 8px;
 		transition: none;
 
 		.gridicon {
@@ -101,7 +98,7 @@
 body.is-section-signup {
 	.site-title__wrapper .site-title__field-control button.button {
 		@include breakpoint( '<660px' ) {
-			padding: 9px 12px;
+			padding: 12px;
 		}
 	}
 }

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -97,7 +96,7 @@ class SiteTopicForm extends Component {
 							disabled={ isButtonDisabled }
 							primary
 						>
-							<Gridicon icon="arrow-right" />
+							{ this.props.translate( 'Continue' ) }
 						</Button>
 					</FormFieldset>
 				</form>

--- a/client/signup/steps/site-topic/style.scss
+++ b/client/signup/steps/site-topic/style.scss
@@ -22,7 +22,7 @@ body.is-section-jetpack-connect .site-topic__content {
 	input {
 		// Extra padding to account for the button and
 		// the search icon.
-		padding: 10px 64px 12px 42px;
+		padding: 10px 90px 12px 42px;
 
 		// Trying out a rounded input
 		border-radius: 4px;
@@ -33,7 +33,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		@include breakpoint( '<660px' ) {
 			// On smaller screens the buttons get bigger,
 			// so this input needs to get bigger, too.
-			padding: 15px 64px 15px 42px;
+			padding: 15px 100px 15px 42px;
 
 			// The rounded borders look strange on
 			// smaller screens.
@@ -69,8 +69,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		position: absolute;
 		top: 3px;
 		right: 3px;
-		padding: 5px 8px;
-		@include elevation ( 1dp );
+		padding: 8px;
 
 		&[disabled] {
 			opacity: 0;
@@ -82,7 +81,7 @@ body.is-section-jetpack-connect .site-topic__content {
 		}
 
 		@include breakpoint( '<660px' ) {
-			padding: 9px 12px;
+			padding: 12px;
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes the `>` button on our signup steps to `Continue` for better clarity. In some recent usability tests, we saw people glossing over the `>` button and not being clear on how to proceed.

#### Before
![image](https://user-images.githubusercontent.com/6981253/58650930-f9181880-82dd-11e9-8967-5f603646026b.png)

*Yes I see that busted text in the mobile preview. We have an issue open for that.*

#### After
![image](https://user-images.githubusercontent.com/6981253/58650867-d0901e80-82dd-11e9-8004-341aee67f1b8.png)

*Yes I see that busted text in the mobile preview. We have an issue open for that.*


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* visit `/start/onboarding`
* navigate through site topic, site title, and site style steps on mobile and desktop to ensure nothing looks broken.

cc @shaunandrews @ianstewart