### PR TITLE
Checklist: Try putting the checklist on the plans/my-plan page

### DIFF
--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import page from 'page';
+import { isEnabled } from 'config';
 
 /**
  * Internal Dependencies
@@ -23,7 +24,7 @@ export function currentPlan( context, next ) {
 		return null;
 	}
 
-	if ( isFreePlan( selectedSite.plan ) ) {
+	if ( isFreePlan( selectedSite.plan ) && ! isEnabled( 'onboarding-checklist/phase2--my-plan' ) ) {
 		page.redirect( `/plans/${ selectedSite.slug }` );
 
 		return null;

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -14,7 +14,7 @@ import { invoke } from 'lodash';
 import Button from 'components/button';
 import Card from 'components/card';
 import PlanIcon from 'components/plans/plan-icon';
-import { isFreeJetpackPlan } from 'lib/products-values';
+import { isFreePlan, isFreeJetpackPlan } from 'lib/products-values';
 import { managePurchase } from 'me/purchases/paths';
 
 export class CurrentPlanHeader extends Component {
@@ -31,7 +31,7 @@ export class CurrentPlanHeader extends Component {
 	renderPurchaseInfo() {
 		const { currentPlan, siteSlug, isExpiring, translate } = this.props;
 
-		if ( ! currentPlan || isFreeJetpackPlan( currentPlan ) ) {
+		if ( ! currentPlan || isFreeJetpackPlan( currentPlan ) || isFreePlan( currentPlan ) ) {
 			return null;
 		}
 
@@ -62,8 +62,20 @@ export class CurrentPlanHeader extends Component {
 		);
 	}
 
+	renderUpsell() {
+		const { currentPlan, siteSlug, translate } = this.props;
+
+		if ( currentPlan && ( isFreeJetpackPlan( currentPlan ) || isFreePlan( currentPlan ) ) ) {
+			return (
+				<div className="current-plan__compare-plans">
+					<Button href={ `/plans/${ siteSlug }` }>{ translate( 'Compare Plans' ) }</Button>
+				</div>
+			);
+		}
+	}
+
 	render() {
-		const { currentPlan, isPlaceholder, siteSlug, tagLine, title, translate } = this.props;
+		const { currentPlan, isPlaceholder, tagLine, title } = this.props;
 
 		const currentPlanSlug = currentPlan && currentPlan.productSlug;
 
@@ -97,11 +109,7 @@ export class CurrentPlanHeader extends Component {
 						</div>
 					</div>
 					{ this.renderPurchaseInfo() }
-					{ currentPlan && isFreeJetpackPlan( currentPlan ) && siteSlug && (
-						<div className="current-plan__compare-plans">
-							<Button href={ `/plans/${ siteSlug }` }>{ translate( 'Compare Plans' ) }</Button>
-						</div>
-					) }
+					{ this.renderUpsell() }
 				</div>
 			</div>
 		);

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -40,6 +40,8 @@ import { isEnabled } from 'config';
 import QueryJetpackPlugins from 'components/data/query-jetpack-plugins';
 import PaidPlanThankYouCard from './current-plan-thank-you-card/paid-plan-thank-you-card';
 import FreePlanThankYouCard from './current-plan-thank-you-card/free-plan-thank-you-card';
+import QuerySiteChecklist from 'components/data/query-site-checklist';
+import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 
 /**
  * Style dependencies
@@ -89,6 +91,36 @@ class CurrentPlan extends Component {
 		};
 	}
 
+	renderChecklist() {
+		const { isJetpack, selectedSiteId, showJetpackChecklist, showThankYou } = this.props;
+
+		if ( ! isJetpack /* && abtest(..) === ''*/ ) {
+			return (
+				<>
+					{ selectedSiteId && <QuerySiteChecklist siteId={ selectedSiteId } /> }
+					<WpcomChecklist updateCompletion={ () => {} } />
+				</>
+			);
+		}
+
+		if ( showJetpackChecklist ) {
+			return (
+				<Fragment>
+					<QueryJetpackPlugins siteIds={ [ selectedSiteId ] } />
+					{ showThankYou ? (
+						<FeatureExample role="presentation">
+							<JetpackChecklist />
+						</FeatureExample>
+					) : (
+						<JetpackChecklist />
+					) }
+				</Fragment>
+			);
+		}
+
+		return null;
+	}
+
 	render() {
 		const {
 			currentPlan,
@@ -100,7 +132,6 @@ class CurrentPlan extends Component {
 			selectedSite,
 			selectedSiteId,
 			shouldShowDomainWarnings,
-			showJetpackChecklist,
 			showThankYou,
 			translate,
 		} = this.props;
@@ -163,18 +194,7 @@ class CurrentPlan extends Component {
 					/>
 				) }
 
-				{ showJetpackChecklist && (
-					<Fragment>
-						<QueryJetpackPlugins siteIds={ [ selectedSiteId ] } />
-						{ showThankYou ? (
-							<FeatureExample role="presentation">
-								<JetpackChecklist />
-							</FeatureExample>
-						) : (
-							<JetpackChecklist />
-						) }
-					</Fragment>
-				) }
+				{ this.renderChecklist() }
 
 				{ ! showThankYou && (
 					<Fragment>

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -12,6 +12,7 @@
 	box-shadow: 0 0 0 1px rgba( var( --color-neutral-100-rgb ), 0.5 ),
 		0 1px 2px var( --color-neutral-0 );
 
+	// @TODO apply this styling for the simple free sites as well
 	.is-jetpack-free & {
 		@include breakpoint( '>800px' ) {
 			display: flex;

--- a/config/development.json
+++ b/config/development.json
@@ -133,6 +133,7 @@
 		"onboarding-checklist": true,
 		"onboarding-checklist/email-setup": true,
 		"onboarding-checklist/phase2": true,
+		"onboarding-checklist/phase2--my-plan": true,
 		"perfmon": false,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -107,6 +107,7 @@
 		"onboarding-checklist": true,
 		"onboarding-checklist/email-setup": true,
 		"onboarding-checklist/phase2": true,
+		"onboarding-checklist/phase2--my-plan": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
Try out putting the WPCOM checklist on the `/plans/my-plan` page as it is currently shown in Jetpack flows.

This is based on the "phase2" PR, but there's no real reason it needs to be.

#### Changes proposed in this Pull Request

* Add a new feature flag enabled in dev and wpcalypso
* When browsing to `/plans/my-plan` on a free non-jetpack site, don't redirect to `/plans` when the flag is enabled
* Pull the `Compare Plans` upsell button from render into a function & make it work on non-jetpack free plans
* Don't show "purchase info" on non-jetpack free plans
* Pull the checklist render from render to a function & render the "WPCOM" checklist if not Jetpack

#### Testing instructions

* Browse to `/plans/my-plan/<non-jetpack-site-here>`
