### PR TITLE
Earn Section: Rename Memberships to Recurring Payments.

### DIFF
--- a/client/my-sites/earn/index.js
+++ b/client/my-sites/earn/index.js
@@ -13,7 +13,16 @@ import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page( '/earn', siteSelection, sites, makeLayout, clientRender );
-	page( '/earn/memberships', siteSelection, sites, makeLayout, clientRender );
+	page( '/earn/payments', siteSelection, sites, makeLayout, clientRender );
+	// This is legacy, we are leaving it here because it may have been public
+	page(
+		'/earn/memberships/:site_id',
+		( { params } ) => page.redirect( '/earn/payments/' + params.site_id ),
+		makeLayout,
+		clientRender
+	);
+	page( '/earn/memberships', () => page.redirect( '/earn/payments' ), makeLayout, clientRender );
+
 	page( '/earn/ads-settings', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/ads-earnings', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/:site_id', earnController.redirectToAdsEarnings, makeLayout, clientRender );

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -61,9 +61,9 @@ class EarningsMain extends Component {
 		} );
 		if ( config.isEnabled( 'memberships' ) ) {
 			tabs.push( {
-				title: translate( 'Memberships' ),
-				path: '/earn/memberships' + pathSuffix,
-				id: 'memberships',
+				title: translate( 'Recurring Payments' ),
+				path: '/earn/payments' + pathSuffix,
+				id: 'payments',
 			} );
 		}
 		return tabs;
@@ -83,9 +83,9 @@ class EarningsMain extends Component {
 						<AdsSettings />
 					</AdsWrapper>
 				);
-			case 'memberships':
+			case 'payments':
 				return <MembershipsSection section={ this.props.section } query={ this.props.query } />;
-			case 'memberships-products':
+			case 'payments-products':
 				return <MembershipsProductsSection section={ this.props.section } />;
 			default:
 				return null;
@@ -104,8 +104,8 @@ class EarningsMain extends Component {
 		const layoutTitles = {
 			earnings: translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
 			settings: translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
-			memberships: translate( 'Memberships' ),
-			'memberships-products': translate( 'Memberships' ),
+			payments: translate( 'Recurring Payments' ),
+			'payments-products': translate( 'Recurring Payments plans' ),
 		};
 
 		// Remove any query parameters from the path before using it to

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -85,7 +85,7 @@ class EarningsMain extends Component {
 				);
 			case 'payments':
 				return <MembershipsSection section={ this.props.section } query={ this.props.query } />;
-			case 'payments-products':
+			case 'payments-plans':
 				return <MembershipsProductsSection section={ this.props.section } />;
 			default:
 				return null;
@@ -105,7 +105,7 @@ class EarningsMain extends Component {
 			earnings: translate( '%(wordads)s Earnings', { args: { wordads: adsProgramName } } ),
 			settings: translate( '%(wordads)s Settings', { args: { wordads: adsProgramName } } ),
 			payments: translate( 'Recurring Payments' ),
-			'payments-products': translate( 'Recurring Payments plans' ),
+			'payments-plans': translate( 'Recurring Payments plans' ),
 		};
 
 		// Remove any query parameters from the path before using it to

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -187,10 +187,10 @@ class MembershipsSection extends Component {
 		return (
 			<div>
 				<SectionHeader label={ this.props.translate( 'Settings' ) } />
-				<CompactCard href={ '/earn/memberships-products/' + this.props.siteSlug }>
+				<CompactCard href={ '/earn/payments-products/' + this.props.siteSlug }>
 					<QueryMembershipProducts siteId={ this.props.siteId } />
 					<div className="memberships__module-products-title">
-						{ this.props.translate( 'Membership Amounts' ) }
+						{ this.props.translate( 'Recurring Payments plans' ) }
 					</div>
 					<div className="memberships__module-products-list">
 						<Gridicon icon="tag" size={ 12 } className="memberships__module-products-list-icon" />

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -187,7 +187,7 @@ class MembershipsSection extends Component {
 		return (
 			<div>
 				<SectionHeader label={ this.props.translate( 'Settings' ) } />
-				<CompactCard href={ '/earn/payments-products/' + this.props.siteSlug }>
+				<CompactCard href={ '/earn/payments-plans/' + this.props.siteSlug }>
 					<QueryMembershipProducts siteId={ this.props.siteId } />
 					<div className="memberships__module-products-title">
 						{ this.props.translate( 'Recurring Payments plans' ) }

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -286,7 +286,7 @@ class MembershipsProductsSection extends Component {
 
 				<SectionHeader>
 					<Button primary compact onClick={ () => this.openProductDialog( null ) }>
-						{ this.props.translate( 'Add new amount' ) }
+						{ this.props.translate( 'Add new plan' ) }
 					</Button>
 				</SectionHeader>
 				{ this.props.products.map( product => (

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -278,8 +278,8 @@ class MembershipsProductsSection extends Component {
 		return (
 			<div>
 				<QueryMembershipProducts siteId={ this.props.siteId } />
-				<HeaderCake backHref={ '/earn/memberships/' + this.props.siteSlug }>
-					{ this.props.translate( 'Membership Amounts' ) }
+				<HeaderCake backHref={ '/earn/payments/' + this.props.siteSlug }>
+					{ this.props.translate( 'Recurring Payments plans' ) }
 				</HeaderCake>
 				{ this.renderEditDialog() }
 

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -204,14 +204,15 @@ class MembershipsProductsSection extends Component {
 			>
 				<FormSectionHeading>
 					{ this.state.editedProductId && this.props.translate( 'Edit' ) }
-					{ ! this.state.editedProductId && this.props.translate( 'Add New Membership Amount' ) }
+					{ ! this.state.editedProductId &&
+						this.props.translate( 'Add New Recurring Payment plan' ) }
 				</FormSectionHeading>
 				<p>
 					{ this.state.editedProductId &&
-						this.props.translate( 'Edit your existing membership button.' ) }
+						this.props.translate( 'Edit your existing Recurring Payments plan.' ) }
 					{ ! this.state.editedProductId &&
 						this.props.translate(
-							'Each amount you add will create a separate membership button. You can create multiple buttons.'
+							'Each amount you add will create a separate Recurring Payments plan. You can create multiple plans.'
 						) }
 				</p>
 				<FormFieldset>


### PR DESCRIPTION
This renames Memberships to Recurring payments in the Earn section.

### Screenshots

<img width="791" alt="Zrzut ekranu 2019-05-30 o 20 27 00" src="https://user-images.githubusercontent.com/3775068/58655662-e07a2380-831a-11e9-8a17-e9da44757141.png">

<img width="778" alt="Zrzut ekranu 2019-05-30 o 20 50 54" src="https://user-images.githubusercontent.com/3775068/58656505-aa3da380-831c-11e9-8cbc-9e7bda439d24.png">


<img width="748" alt="Zrzut ekranu 2019-05-30 o 20 36 04" src="https://user-images.githubusercontent.com/3775068/58655681-ecfe7c00-831a-11e9-895b-5e82de592e93.png">

### Testing instructions

- You will need a site that had memberships before, sandbox what is needed
- Build with `ENABLE_FEATURES=memberships npm run start`

Test urls:
- http://calypso.localhost:3000/earn/payments/
- http://calypso.localhost:3000/earn/payments/$site
- http://calypso.localhost:3000/earn/payments-plans/$site
- http://calypso.localhost:3000/earn/memberships/
- http://calypso.localhost:3000/earn/memberships-products/$site

Confirm that the URL from Jetpack is working https://github.com/Automattic/jetpack/blob/master/extensions/blocks/recurring-payments/edit.jsx#L335

I dont know what else.
