### PR TITLE
Domains: Retest the impact of .blog subdomains

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -176,4 +176,14 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	hideDotBlogSubdomains: {
+		datestamp: '20190604',
+		variations: {
+			show: 50,
+			hide: 50,
+		},
+		defaultVariation: 'show',
+		allowExistingUsers: true,
+		localeTargets: 'any',
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -177,7 +177,7 @@ export default {
 		localeTargets: 'any',
 	},
 	hideDotBlogSubdomains: {
-		datestamp: '20190604',
+		datestamp: '20190613',
 		variations: {
 			show: 50,
 			hide: 50,

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defer, endsWith, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
+import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -331,19 +332,32 @@ class DomainsStep extends React.Component {
 	};
 
 	shouldIncludeDotBlogSubdomain() {
-		const { flowName, siteGoals, signupDependencies } = this.props;
+		const { flowName, isDomainOnly, siteGoals, signupDependencies } = this.props;
 		const siteGoalsArray = siteGoals ? siteGoals.split( ',' ) : [];
 
+		// 'subdomain' flow coming from .blog landing pages
+		if ( flowName === 'subdomain' ) {
+			return true;
+		}
+
+		// 'blog' flow, starting with blog themes
+		if ( flowName === 'blog' ) {
+			return true;
+		}
+
+		// No .blog subdomains for domain only sites
+		if ( isDomainOnly ) {
+			return false;
+		}
+
+		// If we detect a 'blog' site type from Signup data
 		return (
-			// 'subdomain' flow coming from .blog landing pages
-			flowName === 'subdomain' ||
-			// 'blog' flow, starting with blog themes
-			flowName === 'blog' ||
-			( ! this.props.isDomainOnly &&
-				// All flows where 'about' step is before 'domains' step, user picked only 'share' on the `about` step
-				( ( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 ) ||
-					// or users chose `Blog` as their site type
-					'blog' === get( signupDependencies, 'siteType' ) ) )
+			// All flows where 'about' step is before 'domains' step, user picked only 'share' on the `about` step
+			( ( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 ) ||
+				// Users choose `Blog` as their site type
+				'blog' === get( signupDependencies, 'siteType' ) ) &&
+			// Assign THE A/B test variation at the last moment, so we have a proper dataset split
+			'show' === abtest( 'hideDotBlogSubdomains' )
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Retest the impact of .blog subdomains on conversion to paid users.

Also refactor the `shouldIncludeDotBlogSubdomain()` method to be easier to read. 

#### Testing instructions

- Go to /start
- Select the `show` variation for the `hideDotBlogSubdomains` A/B test
- Pick Blog
- Input stuff until you're at the domains search screen
- Search for something
- See a `*.blog` subdomain as a free option

------------------------------------------------

- Go to /start
- Select the `hide` variation for the `hideDotBlogSubdomains` A/B test
- Pick Blog
- Input stuff until you're at the domains search screen
- Search for something
- See a `wordpress.com` subdomain as a free option