### PR TITLE
Earn: Allow eCommerce plans access to WordAds

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -5,7 +5,7 @@
  */
 
 import { userCan } from 'lib/site/utils';
-import { isBusiness, isPremium } from 'lib/products-values';
+import { isBusiness, isPremium, isEcommerce } from 'lib/products-values';
 
 /**
  * Returns true if the site has WordAds access
@@ -18,7 +18,9 @@ export function canAccessWordads( site ) {
 			return true;
 		}
 
-		const jetpackPremium = site.jetpack && ( isPremium( site.plan ) || isBusiness( site.plan ) );
+		const jetpackPremium =
+			site.jetpack &&
+			( isPremium( site.plan ) || isBusiness( site.plan ) || isEcommerce( site.plan ) );
 		return (
 			site.options &&
 			( site.options.wordads || jetpackPremium ) &&
@@ -46,7 +48,13 @@ export function isWordadsInstantActivationEligible( site ) {
 }
 
 export function canUpgradeToUseWordAds( site ) {
-	if ( site && ! site.options.wordads && ! isBusiness( site.plan ) && ! isPremium( site.plan ) ) {
+	if (
+		site &&
+		! site.options.wordads &&
+		! isBusiness( site.plan ) &&
+		! isPremium( site.plan ) &&
+		! isEcommerce( site.plan )
+	) {
 		return true;
 	}
 

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -11,11 +11,12 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import { isWordadsInstantActivationEligible, 
-		canUpgradeToUseWordAds, 
-		canAccessEarnSection 
+import {
+	isWordadsInstantActivationEligible,
+	canUpgradeToUseWordAds,
+	canAccessEarnSection,
 } from 'lib/ads/utils';
-import { isPremium, isBusiness } from 'lib/products-values';
+import { isPremium, isBusiness, isEcommerce } from 'lib/products-values';
 import FeatureExample from 'components/feature-example';
 import FormButton from 'components/forms/form-button';
 import Card from 'components/card';
@@ -198,7 +199,6 @@ class AdsWrapper extends Component {
 		);
 	}
 
-
 	renderjetpackUpsell() {
 		const { translate } = this.props;
 		return (
@@ -219,7 +219,9 @@ class AdsWrapper extends Component {
 
 	render() {
 		const { site, translate } = this.props;
-		const jetpackPremium = site.jetpack && ( isPremium( site.plan ) || isBusiness( site.plan ) );
+		const jetpackPremium =
+			site.jetpack &&
+			( isPremium( site.plan ) || isBusiness( site.plan ) || isEcommerce( site.plan ) );
 
 		if ( ! canAccessEarnSection( site ) ) {
 			return null;
@@ -236,7 +238,7 @@ class AdsWrapper extends Component {
 			);
 		} else if ( ! site.options.wordads && isWordadsInstantActivationEligible( site ) ) {
 			component = this.renderInstantActivationToggle( component );
-		} else if ( canUpgradeToUseWordAds( site ) && site.jetpack  && ! jetpackPremium ) {
+		} else if ( canUpgradeToUseWordAds( site ) && site.jetpack && ! jetpackPremium ) {
 			component = this.renderjetpackUpsell();
 		} else if ( canUpgradeToUseWordAds( site ) ) {
 			component = this.renderUpsell();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* eCommerce plans were unable to access WordAds settings, instead showing an upgrade nudge.  This pull request enables access to ads earnings and PayPal setup for eCommerce plans.

#### Testing instructions

* Create a new test site on the eCommerce Plan (or upgrade an existing site)
* Verify access to the Earn -> Ads Earnings and Earn -> Ads Settings tabs
* Verify access to the Marketing -> Traffic tab
