### PR TITLE
Display an informational message when the user is redirected to the recurring payments page after cancelling a Stripe connection attempt

### DIFF
--- a/client/my-sites/earn/controller.js
+++ b/client/my-sites/earn/controller.js
@@ -28,6 +28,7 @@ export default {
 		context.primary = React.createElement( Main, {
 			section: context.params.section,
 			path: context.path,
+			query: context.query,
 		} );
 		next();
 	},

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -32,6 +32,7 @@ class EarningsMain extends Component {
 	static propTypes = {
 		section: PropTypes.string.isRequired,
 		site: PropTypes.object,
+		query: PropTypes.object,
 	};
 
 	getSelectedText() {
@@ -83,7 +84,7 @@ class EarningsMain extends Component {
 					</AdsWrapper>
 				);
 			case 'memberships':
-				return <MembershipsSection section={ this.props.section } />;
+				return <MembershipsSection section={ this.props.section } query={ this.props.query } />;
 			case 'memberships-products':
 				return <MembershipsProductsSection section={ this.props.section } />;
 			default:
@@ -107,6 +108,14 @@ class EarningsMain extends Component {
 			'memberships-products': translate( 'Memberships' ),
 		};
 
+		// Remove any query parameters from the path before using it to
+		// identify which navigation tab is the active one.
+		let currentPath = this.props.path;
+		const queryStartPosition = currentPath.indexOf( '?' );
+		if ( queryStartPosition > -1 ) {
+			currentPath = currentPath.substring( 0, queryStartPosition );
+		}
+
 		return (
 			<Main className="earn">
 				<PageViewTracker
@@ -122,7 +131,7 @@ class EarningsMain extends Component {
 								<NavItem
 									key={ filterItem.id }
 									path={ filterItem.path }
-									selected={ filterItem.path === this.props.path }
+									selected={ filterItem.path === currentPath }
 								>
 									{ filterItem.title }
 								</NavItem>

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -262,6 +262,14 @@ class MembershipsSection extends Component {
 	renderConnectStripe() {
 		return (
 			<div>
+				{ this.props.query.stripe_connect_cancelled && (
+					<Notice
+						showDismiss={ false }
+						text={ this.props.translate(
+							'The attempt to connect to Stripe has been cancelled. You can connect again at any time.'
+						) }
+					/>
+				) }
 				<SectionHeader label={ this.props.translate( 'Stripe Connection' ) } />
 				<Card>
 					<div className="memberships__module-content module-content">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a user attempts to connect to Stripe while configuring recurring payments, and then cancels the attempt on Stripe's end, we will be redirecting them back to the main Memberships (soon to be renamed Recurring Payments) page with a `stripe_connect_cancelled` query parameter in the URL.

This pull request displays a special message to the user in that case.

#### Testing instructions

Visit `http://calypso.localhost:3000/earn/memberships/[site]?stripe_connect_cancelled=1` where `[site]` is your site slug.  Look for the message as in the screenshot below:

![Screenshot from 2019-05-30 17-16-49](https://user-images.githubusercontent.com/235183/58665847-c8e17180-82ff-11e9-8202-339f775f6f2b.png)

