### PR TITLE
Update HeaderButton component

### DIFF
--- a/client/components/header-button/style.scss
+++ b/client/components/header-button/style.scss
@@ -3,7 +3,6 @@
 	border: none;
 	border-radius: 0;
 	display: flex;
-	flex-direction: column;
 	font-weight: normal;
 	justify-content: center;
 	min-width: 140px;
@@ -13,13 +12,15 @@
 	&:hover {
 		background-color: var( --color-neutral-0 );
 	}
-}
 
-.header-button .gridicon.gridicons-cloud-upload {
-	top: 6px;
+	.gridicon {
+		top: auto;
+		margin-top: 0;
+		width: 24px;
+		height: 24px;
+	}
 }
 
 .header-button__text {
-	margin-top: 3px;
 	white-space: nowrap;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* display icon and text side by side
* increase the icon size from 18px to 24px
* remove extra top margins and positioning to make sure both icon and text are aligned.

#### Testing instructions
I did my best to identify the spots where this component is being used, and it looks like like it's currently only in the dev docs, and on the plugins page. 
1. Navigate to https://wordpress.com/plugins/{site}
2. Note the appearance of the "Upload plugin" button.

Before:
![image](https://user-images.githubusercontent.com/4550351/58675805-49a07c00-8399-11e9-884a-767cea79ee74.png)

After:
![image](https://user-images.githubusercontent.com/4550351/58675837-663cb400-8399-11e9-9e1f-7bfacea562a6.png)


Fixes #32949
