### PR TITLE
Sidebar: remove "external" icon in WP Admin link

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -512,7 +512,7 @@ export class MySitesSidebar extends Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<li className="wp-admin">
-				<ExternalLink href={ adminUrl } icon onClick={ this.trackWpadminClick }>
+				<ExternalLink href={ adminUrl } onClick={ this.trackWpadminClick }>
 					<Gridicon icon="my-sites" size={ 24 } />
 					<span className="menu-link-text">{ this.props.translate( 'WP Admin' ) }</span>
 				</ExternalLink>


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/33301 we switched "WP Admin" link in Calypso sidebar to _not_ open in new tab.

We left the "external" icon in place because we concluded it might mean "external site" (i.e. in different URL than WordPress.com) rather than "new tab". 

After some feedback (p1559299679020600-slack-calypso), we concluded it might actually mean "new tab", so here we are removing the icon.

Earlier similar PR: https://github.com/Automattic/wp-calypso/pull/33124 (and issue https://github.com/Automattic/wp-calypso/issues/33088) which links to wp.com from wp.com but in a new tab and _with_ the icon (screenshots in the PR might be outdated).


#### Changes proposed in this Pull Request

- Remove "external" icon from the WP Admin link in the sidebar

#### Testing instructions

- Have a Jetpack site connected with wp.com
- On any page with sidebar visible, see no more icon:

![image](https://user-images.githubusercontent.com/87168/58704867-1c15fb80-83b6-11e9-8477-1e7e0952f828.png)


#### Previously:

![image](https://user-images.githubusercontent.com/87168/58704920-47004f80-83b6-11e9-8fe8-0a649f342586.png)
