### PR TITLE
Signup: Enable site style step for professionals

### DIFF
--- a/client/lib/signup/page-builder.js
+++ b/client/lib/signup/page-builder.js
@@ -20,7 +20,7 @@ export function getEditHomeUrl( siteSlug ) {
 }
 
 export function isEligibleForPageBuilder( segment, flowName ) {
-	return 'en' === getLocaleSlug() && 1 === segment && 'onboarding-for-business' === flowName;
+	return 'en' === getLocaleSlug() && 1 === segment && 'onboarding' === flowName;
 }
 
 export function isBlockEditorSectionInTest( state ) {
@@ -35,5 +35,5 @@ export function isBlockEditorSectionInTest( state ) {
  */
 export function siteQualifiesForPageBuilder( state, siteId ) {
 	const segment = getSiteOption( state, siteId, 'site_segment' );
-	return isEligibleForPageBuilder( segment, 'onboarding-for-business' );
+	return isEligibleForPageBuilder( segment, 'onboarding' );
 }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -180,7 +180,7 @@ export function createSiteWithCart(
 		newSiteParams.find_available_url = true;
 		newSiteParams.options.nux_import_engine = importEngine;
 	} else if (
-		flowName === 'onboarding-for-business' &&
+		flowName === 'onboarding' &&
 		'remove' === getABTestVariation( 'removeDomainsStepFromOnboarding' )
 	) {
 		/*

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -112,7 +112,7 @@ export function generateFlows( {
 			],
 			destination: getChecklistDestination,
 			description: 'The improved onboarding flow.',
-			lastModified: '2019-04-30',
+			lastModified: '2019-06-05',
 		},
 
 		// We don't yet show the previews for the 'blog' segment

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -106,6 +106,7 @@ export function generateFlows( {
 				'site-type',
 				'site-topic-with-preview',
 				'site-title-with-preview',
+				'site-style-with-preview',
 				'domains-with-preview',
 				'plans',
 			],
@@ -119,21 +120,6 @@ export function generateFlows( {
 			steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains', 'plans' ],
 			destination: getChecklistDestination,
 			description: 'The improved onboarding flow.',
-			lastModified: '2019-04-30',
-		},
-
-		'onboarding-for-business': {
-			steps: [
-				'user',
-				'site-type',
-				'site-topic-with-preview',
-				'site-title-with-preview',
-				'site-style-with-preview',
-				'domains-with-preview',
-				'plans',
-			],
-			destination: getChecklistDestination,
-			description: 'The improved onboarding flow for business site types.',
 			lastModified: '2019-04-30',
 		},
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -241,10 +241,7 @@ const Flows = {
 	 * @return {Object} A filtered flow object
 	 */
 	getABTestFilteredFlow( flowName, flow ) {
-		if (
-			'onboarding-for-business' === flowName &&
-			'remove' === abtest( 'removeDomainsStepFromOnboarding' )
-		) {
+		if ( 'onboarding' === flowName && 'remove' === abtest( 'removeDomainsStepFromOnboarding' ) ) {
 			flow = Flows.removeStepFromFlow( 'domains-with-preview', flow );
 			flow = replaceStepInFlow( flow, 'site-title-with-preview', 'site-title-without-domains' );
 

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -17,7 +17,6 @@ import { saveSignupStep } from 'state/signup/progress/actions';
 
 const siteTypeToFlowname = {
 	'online-store': 'ecommerce-onboarding',
-	business: 'onboarding-for-business',
 	blog: 'onboarding-blog',
 };
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Today, we're:

- consolidating the `*-with-preview` steps to `onboarding`
- ensuring that **Professional** and **Business** site types follow the `onboarding` flow
- removing the `onboarding-for-business` flow 
- removing references to the `onboarding-for-business`, and, where applicable, replacing them with `onboarding` 
- contemplating why The Doobie Brothers broke up in 1982 

![Jun-05-2019 10-48-41](https://user-images.githubusercontent.com/6458278/58922742-8f858780-877f-11e9-90ac-052e14309af3.gif)

## Testing instructions

While listening to the song _[What A fool Believes](https://www.youtube.com/watch?v=dJe1iUuAW4M) (1979)_:

1. Run through the onboarding flow at http://calypso.localhost:3000/start/onboarding
2. Select **Professional** as your site type, and carry onto the site style step.
3. Switch styles, create a site.
4. Repeat, but this time select **Business**

#### Expectations

- [ ] Both **Professional** and **Business** should use the `onboarding` flow.
- [ ] **Professional** should feature the site style step at which you can switch styles. Those styles are then reflected in the created site.
- [ ] Blog should continue to use the `onboarding-for-blog` step for now
- [ ] Your appreciation for 70s rock should have slightly increased 

