### PR TITLE
Checklist: Enable "phase2" in all environments

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -81,6 +81,7 @@
 		"network-connection": true,
 		"onboarding-checklist": false,
 		"onboarding-checklist/email-setup": true,
+		"onboarding-checklist/phase2": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -88,6 +88,7 @@
 		"nps-survey/notice": true,
 		"onboarding-checklist": true,
 		"onboarding-checklist/email-setup": true,
+		"onboarding-checklist/phase2": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -90,6 +90,7 @@
 		"nps-survey/notice": true,
 		"onboarding-checklist": true,
 		"onboarding-checklist/email-setup": true,
+		"onboarding-checklist/phase2": true,
 		"perfmon": true,
 		"persist-redux": true,
 		"plans/personal-plan": true,


### PR DESCRIPTION
Enables flag added in #33222 to enable the minimal "Phase 2" checklist in Calypso in all environments

#### Changes proposed in this Pull Request

* Enable config flag in horizon, staging, & production

#### Testing instructions

* For this diff, just eyeballing should be enough
* Test in conjunction with D29525-code
