### PR TITLE
Recurring Payments: Fix a missing word in the Stripe Connection text

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -275,7 +275,7 @@ class MembershipsSection extends Component {
 					<div className="memberships__module-content module-content">
 						<p>
 							{ this.props.translate(
-								'Start collecting subscription payments! Recurring payments are processed through Stripe. Click the button below to create a new account or to connect existing Stripe account.'
+								'Start collecting subscription payments! Recurring payments are processed through Stripe. Click the button below to create a new account or to connect an existing Stripe account.'
 							) }
 						</p>
 						<StripeConnectButton href={ this.props.connectUrl } target="_blank">


### PR DESCRIPTION
The word "an" is missing in the text you see at `/earn/payments/[site]` when you haven't connected a Stripe account yet.

This fixes it :)