### PR TITLE
Skip "Sign up for free subdomain site" test

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1274,7 +1274,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe( 'Sign up for free subdomain site @parallel', function() {
+	describe.skip( 'Sign up for free subdomain site @parallel', function() {
 		const blogName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ blogName }.art.blog`;
 


### PR DESCRIPTION
Temporarily skip "Sign up for free subdomain site".

The test is failing after https://github.com/Automattic/wp-calypso/pull/33470 was merged.

