### PR TITLE
Sidebar: Expand active section when page is loaded

### DIFF
--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -26,6 +26,7 @@ export default class SidebarItem extends React.Component {
 		onNavigate: PropTypes.func,
 		icon: PropTypes.string,
 		materialIcon: PropTypes.string,
+		sectionIsExpanded: PropTypes.bool,
 		selected: PropTypes.bool,
 		expandSection: PropTypes.func,
 		preloadSectionName: PropTypes.string,

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -26,7 +26,6 @@ export default class SidebarItem extends React.Component {
 		onNavigate: PropTypes.func,
 		icon: PropTypes.string,
 		materialIcon: PropTypes.string,
-		sectionIsExpanded: PropTypes.bool,
 		selected: PropTypes.bool,
 		expandSection: PropTypes.func,
 		preloadSectionName: PropTypes.string,

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -26,9 +26,8 @@ export default class SidebarItem extends React.Component {
 		onNavigate: PropTypes.func,
 		icon: PropTypes.string,
 		materialIcon: PropTypes.string,
-		sectionIsExpanded: PropTypes.bool,
 		selected: PropTypes.bool,
-		toggleSection: PropTypes.func,
+		expandSection: PropTypes.func,
 		preloadSectionName: PropTypes.string,
 		forceInternalLink: PropTypes.bool,
 		testTarget: PropTypes.string,
@@ -45,15 +44,10 @@ export default class SidebarItem extends React.Component {
 	};
 
 	componentDidMount() {
-		const { toggleSection } = this.props;
+		const { expandSection, selected } = this.props;
 
-		// props.sectionIsExpanded is initialized as `null`, which means it's not yet expanded.
-		const sectionIsNotExpanded =
-			this.props.sectionIsExpanded === null || this.props.sectionIsExpanded === false;
-		const selected = this.props.selected === true;
-
-		if ( isFunction( toggleSection ) && selected && sectionIsNotExpanded ) {
-			toggleSection();
+		if ( isFunction( expandSection ) && selected ) {
+			expandSection();
 		}
 	}
 

--- a/client/layout/sidebar/item.jsx
+++ b/client/layout/sidebar/item.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import Gridicon from 'gridicons';
+import { isFunction } from 'lodash';
 
 /**
  * Internal dependencies
@@ -25,7 +26,9 @@ export default class SidebarItem extends React.Component {
 		onNavigate: PropTypes.func,
 		icon: PropTypes.string,
 		materialIcon: PropTypes.string,
+		sectionIsExpanded: PropTypes.bool,
 		selected: PropTypes.bool,
+		toggleSection: PropTypes.func,
 		preloadSectionName: PropTypes.string,
 		forceInternalLink: PropTypes.bool,
 		testTarget: PropTypes.string,
@@ -40,6 +43,19 @@ export default class SidebarItem extends React.Component {
 			preload( this.props.preloadSectionName );
 		}
 	};
+
+	componentDidMount() {
+		const { toggleSection } = this.props;
+
+		// props.sectionIsExpanded is initialized as `null`, which means it's not yet expanded.
+		const sectionIsNotExpanded =
+			this.props.sectionIsExpanded === null || this.props.sectionIsExpanded === false;
+		const selected = this.props.selected === true;
+
+		if ( isFunction( toggleSection ) && selected && sectionIsNotExpanded ) {
+			toggleSection();
+		}
+	}
 
 	render() {
 		const isExternalLink = isExternal( this.props.link );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -601,6 +601,8 @@ export class MySitesSidebar extends Component {
 		this.onNavigate();
 	};
 
+	toggleSection = memoize( id => () => this.props.toggleSection( id ) );
+
 	renderSidebarMenus() {
 		if ( this.props.isDomainOnly ) {
 			return (

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -48,8 +48,8 @@ import { getStatsPathForTab } from 'lib/route';
 import { itemLinkMatches } from './utils';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import {
-	expandMySitesSidebarSection,
-	toggleMySitesSidebarSection,
+	expandMySitesSidebarSection as expandSection,
+	toggleMySitesSidebarSection as toggleSection,
 } from 'state/my-sites/sidebar/actions';
 import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
 import isVipSite from 'state/selectors/is-vip-site';
@@ -75,6 +75,16 @@ export class MySitesSidebar extends Component {
 		isJetpack: PropTypes.bool,
 		isAtomicSite: PropTypes.bool,
 	};
+
+	expandSiteSection = () => this.props.expandSection( SIDEBAR_SECTION_SITE );
+
+	expandDesignSection = () => this.props.expandSection( SIDEBAR_SECTION_DESIGN );
+
+	expandToolsSection = () => this.props.expandSection( SIDEBAR_SECTION_TOOLS );
+
+	expandManageSection = () => this.props.expandSection( SIDEBAR_SECTION_MANAGE );
+
+	toggleSection = memoize( id => () => this.props.toggleSection( id ) );
 
 	onNavigate = () => {
 		this.props.setNextLayoutFocus( 'content' );
@@ -151,14 +161,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	activity() {
-		const {
-			siteId,
-			canUserViewActivity,
-			expandToolsSection,
-			path,
-			translate,
-			siteSuffix,
-		} = this.props;
+		const { siteId, canUserViewActivity, path, translate, siteSuffix } = this.props;
 
 		if ( ! siteId ) {
 			return null;
@@ -177,7 +180,7 @@ export class MySitesSidebar extends Component {
 				link={ activityLink }
 				onNavigate={ this.trackActivityClick }
 				icon="history"
-				expandSection={ expandToolsSection }
+				expandSection={ this.expandToolsSection }
 			/>
 		);
 	}
@@ -188,7 +191,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	earn() {
-		const { expandToolsSection, path, translate } = this.props;
+		const { path, translate } = this.props;
 
 		return (
 			<SidebarItem
@@ -198,7 +201,7 @@ export class MySitesSidebar extends Component {
 				onNavigate={ this.trackEarnClick }
 				icon="money"
 				tipTarget="earn"
-				expandSection={ expandToolsSection }
+				expandSection={ this.expandToolsSection }
 			/>
 		);
 	}
@@ -209,7 +212,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	themes() {
-		const { expandDesignSection, path, site, translate, canUserEditThemeOptions } = this.props;
+		const { path, site, translate, canUserEditThemeOptions } = this.props;
 
 		if ( site && ! canUserEditThemeOptions ) {
 			return null;
@@ -225,13 +228,13 @@ export class MySitesSidebar extends Component {
 				icon="customize"
 				preloadSectionName="customize"
 				forceInternalLink
-				expandSection={ expandDesignSection }
+				expandSection={ this.expandDesignSection }
 			/>
 		);
 	}
 
 	design() {
-		const { expandDesignSection, path, site, translate, canUserEditThemeOptions } = this.props,
+		const { path, site, translate, canUserEditThemeOptions } = this.props,
 			jetpackEnabled = isEnabled( 'manage/themes-jetpack' );
 		let themesLink;
 
@@ -257,7 +260,7 @@ export class MySitesSidebar extends Component {
 					icon="customize"
 					preloadSectionName="customize"
 					forceInternalLink
-					expandSection={ expandDesignSection }
+					expandSection={ this.expandDesignSection }
 				/>
 				<SidebarItem
 					label={ translate( 'Themes' ) }
@@ -267,7 +270,7 @@ export class MySitesSidebar extends Component {
 					icon="customize"
 					preloadSectionName="themes"
 					forceInternalLink
-					expandSection={ expandDesignSection }
+					expandSection={ this.expandDesignSection }
 				/>
 			</ul>
 		);
@@ -279,7 +282,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	upgrades() {
-		const { expandManageSection, path, translate, canUserManageOptions } = this.props;
+		const { path, translate, canUserManageOptions } = this.props;
 		const domainsLink = '/domains/manage' + this.props.siteSuffix;
 
 		if ( ! this.props.siteId ) {
@@ -303,7 +306,7 @@ export class MySitesSidebar extends Component {
 				icon="domains"
 				preloadSectionName="domains"
 				tipTarget="domains"
-				expandSection={ expandManageSection }
+				expandSection={ this.expandManageSection }
 			/>
 		);
 	}
@@ -422,7 +425,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	marketing() {
-		const { expandToolsSection, path, site } = this.props;
+		const { path, site } = this.props;
 		const marketingLink = '/marketing' + this.props.siteSuffix;
 
 		if ( site && ! this.props.canUserPublishPosts ) {
@@ -442,7 +445,7 @@ export class MySitesSidebar extends Component {
 				icon="speaker"
 				preloadSectionName="marketing"
 				tipTarget="marketing"
-				expandSection={ expandToolsSection }
+				expandSection={ this.expandToolsSection }
 			/>
 		);
 	}
@@ -453,7 +456,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	users() {
-		const { expandManageSection, translate, path, site, canUserListUsers } = this.props;
+		const { translate, path, site, canUserListUsers } = this.props;
 
 		if ( ! site || ! canUserListUsers ) {
 			return null;
@@ -468,7 +471,7 @@ export class MySitesSidebar extends Component {
 				icon="user"
 				preloadSectionName="people"
 				tipTarget="people"
-				expandSection={ expandManageSection }
+				expandSection={ this.expandManageSection }
 			/>
 		);
 	}
@@ -479,7 +482,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	siteSettings() {
-		const { expandManageSection, path, site, canUserManageOptions } = this.props;
+		const { path, site, canUserManageOptions } = this.props;
 		const siteSettingsLink = '/settings/general' + this.props.siteSuffix;
 
 		if ( site && ! canUserManageOptions ) {
@@ -499,7 +502,7 @@ export class MySitesSidebar extends Component {
 				icon="cog"
 				preloadSectionName="settings"
 				tipTarget="settings"
-				expandSection={ expandManageSection }
+				expandSection={ this.expandManageSection }
 			/>
 		);
 	}
@@ -597,8 +600,6 @@ export class MySitesSidebar extends Component {
 		this.trackMenuItemClick( 'domain_settings' );
 		this.onNavigate();
 	};
-
-	toggleSection = memoize( id => () => this.props.toggleSection( id ) );
 
 	renderSidebarMenus() {
 		if ( this.props.isDomainOnly ) {
@@ -750,9 +751,7 @@ export default connect(
 		recordTracksEvent,
 		setLayoutFocus,
 		setNextLayoutFocus,
-		toggleSection: toggleMySitesSidebarSection,
-		expandDesignSection: expandMySitesSidebarSection.bind( MySitesSidebar, SIDEBAR_SECTION_DESIGN ),
-		expandToolsSection: expandMySitesSidebarSection.bind( MySitesSidebar, SIDEBAR_SECTION_TOOLS ),
-		expandManageSection: expandMySitesSidebarSection.bind( MySitesSidebar, SIDEBAR_SECTION_MANAGE ),
+		expandSection,
+		toggleSection,
 	}
 )( localize( MySitesSidebar ) );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -47,7 +47,10 @@ import {
 import { getStatsPathForTab } from 'lib/route';
 import { itemLinkMatches } from './utils';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
-import { toggleMySitesSidebarSection } from 'state/my-sites/sidebar/actions';
+import {
+	expandMySitesSidebarSection,
+	toggleMySitesSidebarSection,
+} from 'state/my-sites/sidebar/actions';
 import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
 import isVipSite from 'state/selectors/is-vip-site';
 import {
@@ -148,7 +151,14 @@ export class MySitesSidebar extends Component {
 	};
 
 	activity() {
-		const { siteId, canUserViewActivity, path, translate, siteSuffix } = this.props;
+		const {
+			siteId,
+			canUserViewActivity,
+			expandToolsSection,
+			path,
+			translate,
+			siteSuffix,
+		} = this.props;
 
 		if ( ! siteId ) {
 			return null;
@@ -167,6 +177,7 @@ export class MySitesSidebar extends Component {
 				link={ activityLink }
 				onNavigate={ this.trackActivityClick }
 				icon="history"
+				expandSection={ expandToolsSection }
 			/>
 		);
 	}
@@ -177,7 +188,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	earn() {
-		const { path, translate } = this.props;
+		const { expandToolsSection, path, translate } = this.props;
 
 		return (
 			<SidebarItem
@@ -187,6 +198,7 @@ export class MySitesSidebar extends Component {
 				onNavigate={ this.trackEarnClick }
 				icon="money"
 				tipTarget="earn"
+				expandSection={ expandToolsSection }
 			/>
 		);
 	}
@@ -197,7 +209,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	themes() {
-		const { path, site, translate, canUserEditThemeOptions } = this.props;
+		const { expandDesignSection, path, site, translate, canUserEditThemeOptions } = this.props;
 
 		if ( site && ! canUserEditThemeOptions ) {
 			return null;
@@ -213,12 +225,13 @@ export class MySitesSidebar extends Component {
 				icon="customize"
 				preloadSectionName="customize"
 				forceInternalLink
+				expandSection={ expandDesignSection }
 			/>
 		);
 	}
 
 	design() {
-		const { path, site, translate, canUserEditThemeOptions } = this.props,
+		const { expandDesignSection, path, site, translate, canUserEditThemeOptions } = this.props,
 			jetpackEnabled = isEnabled( 'manage/themes-jetpack' );
 		let themesLink;
 
@@ -244,6 +257,7 @@ export class MySitesSidebar extends Component {
 					icon="customize"
 					preloadSectionName="customize"
 					forceInternalLink
+					expandSection={ expandDesignSection }
 				/>
 				<SidebarItem
 					label={ translate( 'Themes' ) }
@@ -253,6 +267,7 @@ export class MySitesSidebar extends Component {
 					icon="customize"
 					preloadSectionName="themes"
 					forceInternalLink
+					expandSection={ expandDesignSection }
 				/>
 			</ul>
 		);
@@ -264,7 +279,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	upgrades() {
-		const { path, translate, canUserManageOptions } = this.props;
+		const { expandManageSection, path, translate, canUserManageOptions } = this.props;
 		const domainsLink = '/domains/manage' + this.props.siteSuffix;
 
 		if ( ! this.props.siteId ) {
@@ -288,6 +303,7 @@ export class MySitesSidebar extends Component {
 				icon="domains"
 				preloadSectionName="domains"
 				tipTarget="domains"
+				expandSection={ expandManageSection }
 			/>
 		);
 	}
@@ -406,7 +422,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	marketing() {
-		const { path, site } = this.props;
+		const { expandToolsSection, path, site } = this.props;
 		const marketingLink = '/marketing' + this.props.siteSuffix;
 
 		if ( site && ! this.props.canUserPublishPosts ) {
@@ -426,6 +442,7 @@ export class MySitesSidebar extends Component {
 				icon="speaker"
 				preloadSectionName="marketing"
 				tipTarget="marketing"
+				expandSection={ expandToolsSection }
 			/>
 		);
 	}
@@ -436,7 +453,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	users() {
-		const { translate, path, site, canUserListUsers } = this.props;
+		const { expandManageSection, translate, path, site, canUserListUsers } = this.props;
 
 		if ( ! site || ! canUserListUsers ) {
 			return null;
@@ -451,6 +468,7 @@ export class MySitesSidebar extends Component {
 				icon="user"
 				preloadSectionName="people"
 				tipTarget="people"
+				expandSection={ expandManageSection }
 			/>
 		);
 	}
@@ -461,7 +479,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	siteSettings() {
-		const { path, site, canUserManageOptions } = this.props;
+		const { expandManageSection, path, site, canUserManageOptions } = this.props;
 		const siteSettingsLink = '/settings/general' + this.props.siteSuffix;
 
 		if ( site && ! canUserManageOptions ) {
@@ -481,6 +499,7 @@ export class MySitesSidebar extends Component {
 				icon="cog"
 				preloadSectionName="settings"
 				tipTarget="settings"
+				expandSection={ expandManageSection }
 			/>
 		);
 	}
@@ -732,5 +751,8 @@ export default connect(
 		setLayoutFocus,
 		setNextLayoutFocus,
 		toggleSection: toggleMySitesSidebarSection,
+		expandDesignSection: expandMySitesSidebarSection.bind( MySitesSidebar, SIDEBAR_SECTION_DESIGN ),
+		expandToolsSection: expandMySitesSidebarSection.bind( MySitesSidebar, SIDEBAR_SECTION_TOOLS ),
+		expandManageSection: expandMySitesSidebarSection.bind( MySitesSidebar, SIDEBAR_SECTION_MANAGE ),
 	}
 )( localize( MySitesSidebar ) );

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -161,7 +161,14 @@ export class MySitesSidebar extends Component {
 	};
 
 	activity() {
-		const { siteId, canUserViewActivity, path, translate, siteSuffix } = this.props;
+		const {
+			siteId,
+			canUserViewActivity,
+			expandToolsSection,
+			path,
+			translate,
+			siteSuffix,
+		} = this.props;
 
 		if ( ! siteId ) {
 			return null;
@@ -191,7 +198,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	earn() {
-		const { path, translate } = this.props;
+		const { expandToolsSection, path, translate } = this.props;
 
 		return (
 			<SidebarItem
@@ -212,7 +219,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	themes() {
-		const { path, site, translate, canUserEditThemeOptions } = this.props;
+		const { expandDesignSection, path, site, translate, canUserEditThemeOptions } = this.props;
 
 		if ( site && ! canUserEditThemeOptions ) {
 			return null;
@@ -234,7 +241,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	design() {
-		const { path, site, translate, canUserEditThemeOptions } = this.props,
+		const { expandDesignSection, path, site, translate, canUserEditThemeOptions } = this.props,
 			jetpackEnabled = isEnabled( 'manage/themes-jetpack' );
 		let themesLink;
 
@@ -282,7 +289,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	upgrades() {
-		const { path, translate, canUserManageOptions } = this.props;
+		const { expandManageSection, path, translate, canUserManageOptions } = this.props;
 		const domainsLink = '/domains/manage' + this.props.siteSuffix;
 
 		if ( ! this.props.siteId ) {
@@ -425,7 +432,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	marketing() {
-		const { path, site } = this.props;
+		const { expandToolsSection, path, site } = this.props;
 		const marketingLink = '/marketing' + this.props.siteSuffix;
 
 		if ( site && ! this.props.canUserPublishPosts ) {
@@ -456,7 +463,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	users() {
-		const { translate, path, site, canUserListUsers } = this.props;
+		const { expandManageSection, translate, path, site, canUserListUsers } = this.props;
 
 		if ( ! site || ! canUserListUsers ) {
 			return null;
@@ -482,7 +489,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	siteSettings() {
-		const { path, site, canUserManageOptions } = this.props;
+		const { expandManageSection, path, site, canUserManageOptions } = this.props;
 		const siteSettingsLink = '/settings/general' + this.props.siteSuffix;
 
 		if ( site && ! canUserManageOptions ) {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -161,14 +161,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	activity() {
-		const {
-			siteId,
-			canUserViewActivity,
-			expandToolsSection,
-			path,
-			translate,
-			siteSuffix,
-		} = this.props;
+		const { siteId, canUserViewActivity, path, translate, siteSuffix } = this.props;
 
 		if ( ! siteId ) {
 			return null;
@@ -198,7 +191,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	earn() {
-		const { expandToolsSection, path, translate } = this.props;
+		const { path, translate } = this.props;
 
 		return (
 			<SidebarItem
@@ -219,7 +212,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	themes() {
-		const { expandDesignSection, path, site, translate, canUserEditThemeOptions } = this.props;
+		const { path, site, translate, canUserEditThemeOptions } = this.props;
 
 		if ( site && ! canUserEditThemeOptions ) {
 			return null;
@@ -241,7 +234,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	design() {
-		const { expandDesignSection, path, site, translate, canUserEditThemeOptions } = this.props,
+		const { path, site, translate, canUserEditThemeOptions } = this.props,
 			jetpackEnabled = isEnabled( 'manage/themes-jetpack' );
 		let themesLink;
 
@@ -289,7 +282,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	upgrades() {
-		const { expandManageSection, path, translate, canUserManageOptions } = this.props;
+		const { path, translate, canUserManageOptions } = this.props;
 		const domainsLink = '/domains/manage' + this.props.siteSuffix;
 
 		if ( ! this.props.siteId ) {
@@ -432,7 +425,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	marketing() {
-		const { expandToolsSection, path, site } = this.props;
+		const { path, site } = this.props;
 		const marketingLink = '/marketing' + this.props.siteSuffix;
 
 		if ( site && ! this.props.canUserPublishPosts ) {
@@ -463,7 +456,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	users() {
-		const { expandManageSection, translate, path, site, canUserListUsers } = this.props;
+		const { translate, path, site, canUserListUsers } = this.props;
 
 		if ( ! site || ! canUserListUsers ) {
 			return null;
@@ -489,7 +482,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	siteSettings() {
-		const { expandManageSection, path, site, canUserManageOptions } = this.props;
+		const { path, site, canUserManageOptions } = this.props;
 		const siteSettingsLink = '/settings/general' + this.props.siteSuffix;
 
 		if ( site && ! canUserManageOptions ) {
@@ -607,8 +600,6 @@ export class MySitesSidebar extends Component {
 		this.trackMenuItemClick( 'domain_settings' );
 		this.onNavigate();
 	};
-
-	toggleSection = memoize( id => () => this.props.toggleSection( id ) );
 
 	renderSidebarMenus() {
 		if ( this.props.isDomainOnly ) {

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -32,6 +32,8 @@ import { canCurrentUser as canCurrentUserStateSelector } from 'state/selectors/c
 import { itemLinkMatches } from './utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isVipSite from 'state/selectors/is-vip-site';
+import { SIDEBAR_SECTION_SITE } from 'my-sites/sidebar/constants';
+import { expandMySitesSidebarSection } from 'state/my-sites/sidebar/actions';
 
 class SiteMenu extends PureComponent {
 	static propTypes = {
@@ -125,7 +127,7 @@ class SiteMenu extends PureComponent {
 	};
 
 	renderMenuItem( menuItem ) {
-		const { canCurrentUser, siteId, siteAdminUrl } = this.props;
+		const { canCurrentUser, expandSiteSection, siteId, siteAdminUrl } = this.props;
 
 		if ( siteId && ! canCurrentUser( menuItem.capability ) ) {
 			return null;
@@ -201,6 +203,7 @@ class SiteMenu extends PureComponent {
 				postType={ menuItem.name === 'plugins' ? null : menuItem.name }
 				tipTarget={ `side-menu-${ menuItem.name }` }
 				forceInternalLink={ menuItem.forceInternalLink }
+				expandSection={ expandSiteSection }
 			/>
 		);
 	}
@@ -289,7 +292,10 @@ export default connect(
 		siteSlug: getSiteSlug( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 	} ),
-	{ recordTracksEvent },
+	{
+		recordTracksEvent,
+		expandSiteSection: expandMySitesSidebarSection.bind( SiteMenu, SIDEBAR_SECTION_SITE ),
+	},
 	null,
 	{ areStatePropsEqual: compareProps( { ignore: [ 'canCurrentUser' ] } ) }
 )( localize( SiteMenu ) );

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -33,7 +33,7 @@ import { itemLinkMatches } from './utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isVipSite from 'state/selectors/is-vip-site';
 import { SIDEBAR_SECTION_SITE } from 'my-sites/sidebar/constants';
-import { expandMySitesSidebarSection } from 'state/my-sites/sidebar/actions';
+import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 
 class SiteMenu extends PureComponent {
 	static propTypes = {
@@ -126,8 +126,10 @@ class SiteMenu extends PureComponent {
 		this.props.onNavigate();
 	};
 
+	expandSiteSection = () => this.props.expandSection( SIDEBAR_SECTION_SITE );
+
 	renderMenuItem( menuItem ) {
-		const { canCurrentUser, expandSiteSection, siteId, siteAdminUrl } = this.props;
+		const { canCurrentUser, siteId, siteAdminUrl } = this.props;
 
 		if ( siteId && ! canCurrentUser( menuItem.capability ) ) {
 			return null;
@@ -203,7 +205,7 @@ class SiteMenu extends PureComponent {
 				postType={ menuItem.name === 'plugins' ? null : menuItem.name }
 				tipTarget={ `side-menu-${ menuItem.name }` }
 				forceInternalLink={ menuItem.forceInternalLink }
-				expandSection={ expandSiteSection }
+				expandSection={ this.expandSiteSection }
 			/>
 		);
 	}
@@ -292,10 +294,7 @@ export default connect(
 		siteSlug: getSiteSlug( state, siteId ),
 		isVip: isVipSite( state, siteId ),
 	} ),
-	{
-		recordTracksEvent,
-		expandSiteSection: expandMySitesSidebarSection.bind( SiteMenu, SIDEBAR_SECTION_SITE ),
-	},
+	{ expandSection, recordTracksEvent },
 	null,
 	{ areStatePropsEqual: compareProps( { ignore: [ 'canCurrentUser' ] } ) }
 )( localize( SiteMenu ) );

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -129,7 +129,7 @@ class SiteMenu extends PureComponent {
 	expandSiteSection = () => this.props.expandSection( SIDEBAR_SECTION_SITE );
 
 	renderMenuItem( menuItem ) {
-		const { canCurrentUser, siteId, siteAdminUrl } = this.props;
+		const { canCurrentUser, expandSiteSection, siteId, siteAdminUrl } = this.props;
 
 		if ( siteId && ! canCurrentUser( menuItem.capability ) ) {
 			return null;

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -129,7 +129,7 @@ class SiteMenu extends PureComponent {
 	expandSiteSection = () => this.props.expandSection( SIDEBAR_SECTION_SITE );
 
 	renderMenuItem( menuItem ) {
-		const { canCurrentUser, expandSiteSection, siteId, siteAdminUrl } = this.props;
+		const { canCurrentUser, siteId, siteAdminUrl } = this.props;
 
 		if ( siteId && ! canCurrentUser( menuItem.capability ) ) {
 			return null;

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -22,6 +22,8 @@ import { canCurrentUser as canCurrentUserStateSelector } from 'state/selectors/c
 import canCurrentUserManagePlugins from 'state/selectors/can-current-user-manage-plugins';
 import { itemLinkMatches } from './utils';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { toggleMySitesSidebarToolsMenu } from 'state/my-sites/sidebar/actions';
+import { isToolsMenuOpen } from 'state/my-sites/sidebar/selectors';
 
 class ToolsMenu extends PureComponent {
 	static propTypes = {
@@ -95,7 +97,7 @@ class ToolsMenu extends PureComponent {
 	};
 
 	renderMenuItem( menuItem ) {
-		const { canCurrentUser, siteId, siteAdminUrl } = this.props;
+		const { canCurrentUser, isToolsExpanded, siteId, siteAdminUrl } = this.props;
 
 		if ( siteId && ! canCurrentUser( menuItem.capability ) ) {
 			return null;
@@ -125,6 +127,8 @@ class ToolsMenu extends PureComponent {
 				postType={ menuItem.name === 'plugins' ? null : menuItem.name }
 				tipTarget={ `side-menu-${ menuItem.name }` }
 				forceInternalLink={ menuItem.forceInternalLink }
+				sectionIsExpanded={ isToolsExpanded }
+				toggleSection={ this.props.toggleMySitesSidebarToolsMenu }
 			/>
 		);
 	}
@@ -150,11 +154,12 @@ export default connect(
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		canCurrentUser: partial( canCurrentUserStateSelector, state, siteId ),
 		isJetpack: isJetpackSite( state, siteId ),
+		isToolsExpanded: isToolsMenuOpen( state ),
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 	} ),
-	{ recordTracksEvent },
+	{ recordTracksEvent, toggleMySitesSidebarToolsMenu },
 	null,
 	{ areStatePropsEqual: compareProps( { ignore: [ 'canCurrentUser' ] } ) }
 )( localize( ToolsMenu ) );

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -99,7 +99,7 @@ class ToolsMenu extends PureComponent {
 	expandToolsSection = () => this.props.expandSection( SIDEBAR_SECTION_TOOLS );
 
 	renderMenuItem( menuItem ) {
-		const { canCurrentUser, siteId, siteAdminUrl } = this.props;
+		const { canCurrentUser, isToolsExpanded, siteId, siteAdminUrl } = this.props;
 
 		if ( siteId && ! canCurrentUser( menuItem.capability ) ) {
 			return null;
@@ -155,6 +155,7 @@ export default connect(
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		canCurrentUser: partial( canCurrentUserStateSelector, state, siteId ),
 		isJetpack: isJetpackSite( state, siteId ),
+		isToolsExpanded: isToolsMenuOpen( state ),
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -99,7 +99,7 @@ class ToolsMenu extends PureComponent {
 	expandToolsSection = () => this.props.expandSection( SIDEBAR_SECTION_TOOLS );
 
 	renderMenuItem( menuItem ) {
-		const { canCurrentUser, isToolsExpanded, siteId, siteAdminUrl } = this.props;
+		const { canCurrentUser, siteId, siteAdminUrl } = this.props;
 
 		if ( siteId && ! canCurrentUser( menuItem.capability ) ) {
 			return null;
@@ -155,7 +155,6 @@ export default connect(
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		canCurrentUser: partial( canCurrentUserStateSelector, state, siteId ),
 		isJetpack: isJetpackSite( state, siteId ),
-		isToolsExpanded: isToolsMenuOpen( state ),
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -22,7 +22,7 @@ import { canCurrentUser as canCurrentUserStateSelector } from 'state/selectors/c
 import canCurrentUserManagePlugins from 'state/selectors/can-current-user-manage-plugins';
 import { itemLinkMatches } from './utils';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { expandMySitesSidebarSection } from 'state/my-sites/sidebar/actions';
+import { expandMySitesSidebarSection as expandSection } from 'state/my-sites/sidebar/actions';
 import { SIDEBAR_SECTION_TOOLS } from 'my-sites/sidebar/constants';
 
 class ToolsMenu extends PureComponent {
@@ -96,8 +96,10 @@ class ToolsMenu extends PureComponent {
 		this.props.onNavigate();
 	};
 
+	expandToolsSection = () => this.props.expandSection( SIDEBAR_SECTION_TOOLS );
+
 	renderMenuItem( menuItem ) {
-		const { canCurrentUser, expandToolsSection, siteId, siteAdminUrl } = this.props;
+		const { canCurrentUser, siteId, siteAdminUrl } = this.props;
 
 		if ( siteId && ! canCurrentUser( menuItem.capability ) ) {
 			return null;
@@ -127,7 +129,7 @@ class ToolsMenu extends PureComponent {
 				postType={ menuItem.name === 'plugins' ? null : menuItem.name }
 				tipTarget={ `side-menu-${ menuItem.name }` }
 				forceInternalLink={ menuItem.forceInternalLink }
-				expandSection={ expandToolsSection }
+				expandSection={ this.expandToolsSection }
 			/>
 		);
 	}
@@ -157,10 +159,7 @@ export default connect(
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 	} ),
-	{
-		recordTracksEvent,
-		expandToolsSection: expandMySitesSidebarSection.bind( ToolsMenu, SIDEBAR_SECTION_TOOLS ),
-	},
+	{ expandSection, recordTracksEvent },
 	null,
 	{ areStatePropsEqual: compareProps( { ignore: [ 'canCurrentUser' ] } ) }
 )( localize( ToolsMenu ) );

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -22,8 +22,8 @@ import { canCurrentUser as canCurrentUserStateSelector } from 'state/selectors/c
 import canCurrentUserManagePlugins from 'state/selectors/can-current-user-manage-plugins';
 import { itemLinkMatches } from './utils';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { toggleMySitesSidebarToolsMenu } from 'state/my-sites/sidebar/actions';
-import { isToolsMenuOpen } from 'state/my-sites/sidebar/selectors';
+import { expandMySitesSidebarSection } from 'state/my-sites/sidebar/actions';
+import { SIDEBAR_SECTION_TOOLS } from 'my-sites/sidebar/constants';
 
 class ToolsMenu extends PureComponent {
 	static propTypes = {
@@ -97,7 +97,7 @@ class ToolsMenu extends PureComponent {
 	};
 
 	renderMenuItem( menuItem ) {
-		const { canCurrentUser, isToolsExpanded, siteId, siteAdminUrl } = this.props;
+		const { canCurrentUser, expandToolsSection, siteId, siteAdminUrl } = this.props;
 
 		if ( siteId && ! canCurrentUser( menuItem.capability ) ) {
 			return null;
@@ -127,8 +127,7 @@ class ToolsMenu extends PureComponent {
 				postType={ menuItem.name === 'plugins' ? null : menuItem.name }
 				tipTarget={ `side-menu-${ menuItem.name }` }
 				forceInternalLink={ menuItem.forceInternalLink }
-				sectionIsExpanded={ isToolsExpanded }
-				toggleSection={ this.props.toggleMySitesSidebarToolsMenu }
+				expandSection={ expandToolsSection }
 			/>
 		);
 	}
@@ -154,12 +153,14 @@ export default connect(
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		canCurrentUser: partial( canCurrentUserStateSelector, state, siteId ),
 		isJetpack: isJetpackSite( state, siteId ),
-		isToolsExpanded: isToolsMenuOpen( state ),
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
 	} ),
-	{ recordTracksEvent, toggleMySitesSidebarToolsMenu },
+	{
+		recordTracksEvent,
+		expandToolsSection: expandMySitesSidebarSection.bind( ToolsMenu, SIDEBAR_SECTION_TOOLS ),
+	},
 	null,
 	{ areStatePropsEqual: compareProps( { ignore: [ 'canCurrentUser' ] } ) }
 )( localize( ToolsMenu ) );


### PR DESCRIPTION
NOTE: depends on companion PR: #33556

#### Changes proposed in this Pull Request

* Auto expand the sidebar section when page loads to reveal active sidebar item

![Auto-expand sidebar section](https://user-images.githubusercontent.com/1699996/58732178-57182f00-83b6-11e9-89eb-f9533f8d17de.gif)

#### Testing instructions

* Navigate to each item in the sidebar within a collapsible section
    - Sites: Pages, Posts, Media, Comments
    - Design: Themes
    - Tools: Plugins, Import, Marketing, Earn, Activity
    - Manage: Domain, People, settings
* Collapse the sidebar section for the active sidebar item
* Reload the page
* See that the section is automatically expanded

Fixes #33105
