### PR TITLE
Recurring Payments: Show earn section always

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -31,7 +31,7 @@ export function canAccessWordads( site ) {
 	return false;
 }
 
-export function canAccessEarnSection( site ) {
+export function canAccessAds( site ) {
 	return canAccessWordads( site ) || canUpgradeToUseWordAds( site );
 }
 

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
 import {
 	isWordadsInstantActivationEligible,
 	canUpgradeToUseWordAds,
-	canAccessEarnSection,
+	canAccessAds,
 } from 'lib/ads/utils';
 import { isPremium, isBusiness, isEcommerce } from 'lib/products-values';
 import FeatureExample from 'components/feature-example';
@@ -68,7 +68,7 @@ class AdsWrapper extends Component {
 		const { siteSlug, site } = this.props;
 		const siteFragment = getSiteFragment( page.current );
 
-		if ( siteSlug && site && ! canAccessEarnSection( site ) ) {
+		if ( siteSlug && site && ! canAccessAds( site ) ) {
 			page( '/stats/' + siteSlug );
 		} else if ( ! siteFragment ) {
 			page( '/earn/' );
@@ -223,7 +223,7 @@ class AdsWrapper extends Component {
 			site.jetpack &&
 			( isPremium( site.plan ) || isBusiness( site.plan ) || isEcommerce( site.plan ) );
 
-		if ( ! canAccessEarnSection( site ) ) {
+		if ( ! canAccessAds( site ) ) {
 			return null;
 		}
 

--- a/client/my-sites/earn/index.js
+++ b/client/my-sites/earn/index.js
@@ -25,7 +25,12 @@ export default function() {
 
 	page( '/earn/ads-settings', siteSelection, sites, makeLayout, clientRender );
 	page( '/earn/ads-earnings', siteSelection, sites, makeLayout, clientRender );
-	page( '/earn/:site_id', earnController.redirectToAdsEarnings, makeLayout, clientRender );
+	page(
+		'/earn/:site_id',
+		( { params } ) => page.redirect( '/earn/payments/' + params.site_id ),
+		makeLayout,
+		clientRender
+	);
 	// These are legacy URLs to redirect if they are present anywhere on the web.
 	page( '/ads/earnings/:site_id', earnController.redirectToAdsEarnings, makeLayout, clientRender );
 	page( '/ads/settings/:site_id', earnController.redirectToAdsSettings, makeLayout, clientRender );

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -27,6 +27,7 @@ import AdsWrapper from './ads/wrapper';
 import MembershipsSection from './memberships';
 import MembershipsProductsSection from './memberships/products';
 import config from 'config';
+import { canAccessAds } from 'lib/ads/utils';
 
 class EarningsMain extends Component {
 	static propTypes = {
@@ -48,17 +49,6 @@ class EarningsMain extends Component {
 		const { siteSlug, translate } = this.props;
 		const pathSuffix = siteSlug ? '/' + siteSlug : '';
 		const tabs = [];
-
-		tabs.push( {
-			title: translate( 'Ads Earnings' ),
-			path: '/earn/ads-earnings' + pathSuffix,
-			id: 'ads-earnings',
-		} );
-		tabs.push( {
-			title: translate( 'Ads Settings' ),
-			path: '/earn/ads-settings' + pathSuffix,
-			id: 'ads-settings',
-		} );
 		if ( config.isEnabled( 'memberships' ) ) {
 			tabs.push( {
 				title: translate( 'Recurring Payments' ),
@@ -66,6 +56,20 @@ class EarningsMain extends Component {
 				id: 'payments',
 			} );
 		}
+
+		if ( canAccessAds( this.props.site ) ) {
+			tabs.push( {
+				title: translate( 'Ads Earnings' ),
+				path: '/earn/ads-earnings' + pathSuffix,
+				id: 'ads-earnings',
+			} );
+			tabs.push( {
+				title: translate( 'Ads Settings' ),
+				path: '/earn/ads-settings' + pathSuffix,
+				id: 'ads-settings',
+			} );
+		}
+
 		return tabs;
 	}
 

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -351,7 +351,7 @@ class MembershipsSection extends Component {
 			);
 		}
 
-		if ( ! userCan( 'switch_themes', this.props.site ) ) {
+		if ( ! userCan( 'manage_options', this.props.site ) ) {
 			return (
 				<div>
 					{ this.renderOnboarding() }

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -34,6 +34,7 @@ import SectionHeader from 'components/section-header';
 import QueryMembershipProducts from 'components/data/query-memberships';
 import CompactCard from 'components/card/compact';
 import Gridicon from 'components/gridicon';
+import { userCan } from 'lib/site/utils';
 
 /**
  * Style dependencies
@@ -349,6 +350,22 @@ class MembershipsSection extends Component {
 				</div>
 			);
 		}
+
+		if ( ! userCan( 'switch_themes', this.props.site ) ) {
+			return (
+				<div>
+					{ this.renderOnboarding() }
+					<Notice
+						status="is-warning"
+						text={ this.props.translate(
+							'Only site administrators can edit Recurring Payments settings.'
+						) }
+						showDismiss={ false }
+					/>
+				</div>
+			);
+		}
+
 		return (
 			<div>
 				<QueryMembershipsSettings siteId={ this.props.siteId } />

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -58,7 +58,6 @@ import {
 	toggleMySitesSidebarManageMenu,
 } from 'state/my-sites/sidebar/actions';
 import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
-import { canAccessEarnSection } from 'lib/ads/utils';
 import isVipSite from 'state/selectors/is-vip-site';
 
 export class MySitesSidebar extends Component {
@@ -176,10 +175,7 @@ export class MySitesSidebar extends Component {
 	};
 
 	earn() {
-		const { path, translate, site } = this.props;
-		if ( ! canAccessEarnSection( site ) ) {
-			return null;
-		}
+		const { path, translate } = this.props;
 
 		return (
 			<SidebarItem


### PR DESCRIPTION
This shows earn section regardless of the wordads status.
Previously "Earn" section was only visible for sites that were "wordads instant activation" eligigble.

Now it shows for everyone, but the default is recurring payments.
The ads tabs hide accordingly.


![Zrzut ekranu 2019-06-2 o 07 49 21](https://user-images.githubusercontent.com/3775068/58757342-167dfa00-850b-11e9-9ec3-3e824c0a8638.png)

![Zrzut ekranu 2019-06-2 o 08 11 50](https://user-images.githubusercontent.com/3775068/58757563-6b6f3f80-850e-11e9-8b10-7339b85917ff.png)


### Testing instruction
- pick a site on personal plan that has no wordads
- see the "Earn" section

