### PR TITLE
Recurring Payments /earn: visual improvements

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -49,59 +49,63 @@ class MembershipsSection extends Component {
 	componentDidMount() {
 		this.fetchNextSubscriberPage( false, true );
 	}
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.siteId !== this.props.siteId ) {
+			// Site Id changed
+			this.fetchNextSubscriberPage( false, true );
+		}
+	}
 	renderEarnings() {
 		const { translate } = this.props;
 		return (
-			<Card>
+			<div>
+				<SectionHeader label={ this.props.translate( 'Earnings' ) } />
 				<QueryMembershipsEarnings siteId={ this.props.siteId } />
-				<div className="memberships__module-header module-header">
-					<h1 className="memberships__module-header-title module-header-title">
-						{ translate( 'Earnings' ) }
-					</h1>
-				</div>
-				<div className="memberships__module-content module-content">
-					<ul className="memberships__earnings-breakdown-list">
-						<li className="memberships__earnings-breakdown-item">
-							<span className="memberships__earnings-breakdown-label">
-								{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
-							</span>
-							<span className="memberships__earnings-breakdown-value">
-								{ formatCurrency( this.props.total, this.props.currency ) }
-							</span>
-						</li>
-						<li className="memberships__earnings-breakdown-item">
-							<span className="memberships__earnings-breakdown-label">
-								{ translate( 'Last 30 days', { context: 'Sum of earnings over last 30 days' } ) }
-							</span>
-							<span className="memberships__earnings-breakdown-value">
-								{ formatCurrency( this.props.lastMonth, this.props.currency ) }
-							</span>
-						</li>
-						<li className="memberships__earnings-breakdown-item">
-							<span className="memberships__earnings-breakdown-label">
-								{ translate( 'Next month', {
-									context: 'Forecast for the subscriptions due in the next 30 days',
-								} ) }
-							</span>
-							<span className="memberships__earnings-breakdown-value">
-								{ formatCurrency( this.props.forecast, this.props.currency ) }
-							</span>
-						</li>
-					</ul>
-				</div>
-				<div className="memberships__earnings-breakdown-notes">
-					{ translate(
-						'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Stripe charges are typically %(stripe)s.',
-						{
-							args: {
-								commission: '' + parseFloat( this.props.commission ) * 100 + '%',
-								stripe: '2.9%+30c',
-							},
-							components: { em: <em />, br: <br /> },
-						}
-					) }
-				</div>
-			</Card>
+				<Card>
+					<div className="memberships__module-content module-content">
+						<ul className="memberships__earnings-breakdown-list">
+							<li className="memberships__earnings-breakdown-item">
+								<span className="memberships__earnings-breakdown-label">
+									{ translate( 'Total earnings', { context: 'Sum of earnings' } ) }
+								</span>
+								<span className="memberships__earnings-breakdown-value">
+									{ formatCurrency( this.props.total, this.props.currency ) }
+								</span>
+							</li>
+							<li className="memberships__earnings-breakdown-item">
+								<span className="memberships__earnings-breakdown-label">
+									{ translate( 'Last 30 days', { context: 'Sum of earnings over last 30 days' } ) }
+								</span>
+								<span className="memberships__earnings-breakdown-value">
+									{ formatCurrency( this.props.lastMonth, this.props.currency ) }
+								</span>
+							</li>
+							<li className="memberships__earnings-breakdown-item">
+								<span className="memberships__earnings-breakdown-label">
+									{ translate( 'Next month', {
+										context: 'Forecast for the subscriptions due in the next 30 days',
+									} ) }
+								</span>
+								<span className="memberships__earnings-breakdown-value">
+									{ formatCurrency( this.props.forecast, this.props.currency ) }
+								</span>
+							</li>
+						</ul>
+					</div>
+					<div className="memberships__earnings-breakdown-notes">
+						{ translate(
+							'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Stripe charges are typically %(stripe)s.',
+							{
+								args: {
+									commission: '' + parseFloat( this.props.commission ) * 100 + '%',
+									stripe: '2.9%+30c',
+								},
+								components: { em: <em />, br: <br /> },
+							}
+						) }
+					</div>
+				</Card>
+			</div>
 		);
 	}
 
@@ -157,30 +161,48 @@ class MembershipsSection extends Component {
 
 	renderSubscriberList() {
 		return (
-			<Card>
-				<div className="memberships__module-header module-header">
-					<h1 className="memberships__module-header-title module-header-title">
-						{ this.props.translate( 'Subscribers' ) }
-					</h1>
-				</div>
-				<div className="memberships__module-content module-content">
-					<div>
-						{ orderBy( Object.values( this.props.subscribers ), [ 'id' ], [ 'desc' ] ).map( sub =>
-							this.renderSubscriber( sub )
+			<div>
+				<SectionHeader label={ this.props.translate( 'Subscribers' ) } />
+				{ Object.values( this.props.subscribers ).length === 0 && (
+					<Card>
+						{ this.props.translate(
+							"You haven't added any subscribers. {{a}}Learn more{{/a}} about recurring payments.",
+							{
+								components: {
+									a: (
+										<a
+											href="https://en.support.wordpress.com/recurring-payments-button/"
+											target="_blank"
+											rel="noreferrer noopener"
+										/>
+									),
+								},
+							}
 						) }
-					</div>
-					<InfiniteScroll
-						nextPageMethod={ triggeredByInteraction =>
-							this.fetchNextSubscriberPage( triggeredByInteraction, false )
-						}
-					/>
-				</div>
-				<div className="memberships__module-footer">
-					<Button onClick={ this.downloadSubscriberList }>
-						{ this.props.translate( 'Download list as CSV' ) }
-					</Button>
-				</div>
-			</Card>
+					</Card>
+				) }
+				{ Object.values( this.props.subscribers ).length > 0 && (
+					<Card>
+						<div className="memberships__module-content module-content">
+							<div>
+								{ orderBy( Object.values( this.props.subscribers ), [ 'id' ], [ 'desc' ] ).map(
+									sub => this.renderSubscriber( sub )
+								) }
+							</div>
+							<InfiniteScroll
+								nextPageMethod={ triggeredByInteraction =>
+									this.fetchNextSubscriberPage( triggeredByInteraction, false )
+								}
+							/>
+						</div>
+						<div className="memberships__module-footer">
+							<Button onClick={ this.downloadSubscriberList }>
+								{ this.props.translate( 'Download list as CSV' ) }
+							</Button>
+						</div>
+					</Card>
+				) }
+			</div>
 		);
 	}
 

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -21,7 +21,6 @@
 
 .memberships__earnings-breakdown-list {
 	margin: 0;
-	border-top: 1px solid var( --color-neutral-0 );
 }
 
 
@@ -44,20 +43,14 @@
 	padding: 5px 0 10px;
 	list-style-type: none;
 	text-align: center;
-	border-left: 1px solid var( --color-neutral-0 );
 
 	@include breakpoint( '<480px' ) {
 		width: auto;
 		float: none;
 		padding: 10px 24px;
 		text-align: left;
-		border: 0;
-		border-top: 1px solid var( --color-neutral-0 );
 	}
 
-	&:first-child {
-		border: 0;
-	}
 }
 
 .memberships__earnings-breakdown-label {


### PR DESCRIPTION
Following changes here:

- use header for cards
- show a placeholder for when user has no subscribers
- rerequest the new susbcriber list when changign a site via site picker (previously when you loaded one site, then changed the site via picker, the sub list was empty)

![Zrzut ekranu 2019-06-2 o 09 04 42](https://user-images.githubusercontent.com/3775068/58758042-de2fe900-8515-11e9-89b0-69b3a5a4ac97.png)
