### PR TITLE
Recurring payments notice: Set proper external icon, so that the link opens on a new tab

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -278,7 +278,7 @@ class MembershipsSection extends Component {
 				>
 					<NoticeAction
 						href={ `https://support.wordpress.com/recurring-payments-button/` }
-						icon="external"
+						external
 					/>
 				</Notice>
 			</div>


### PR DESCRIPTION
Related chat about what external icons indicate (loading links on new tab vs same tab, or whether they just signify internal vs external links) - https://github.com/Automattic/wp-calypso/pull/33500

While I was on this discussion, I happened to stumble upon this external link loading on the new tab. This led me to updating this prop.

#### Changes proposed in this Pull Request

* Use `external` prop on `<NoticeAction>` instead of `icon` so that the link opens on a new tab. [[Component docs for reference](https://wpcalypso.wordpress.com/devdocs/design/notice)]

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the Calypso live branch available below.
- Visit `Tools > Earn` on the left sidebar.
- Look at the `Read more about the Recurring Payments feature.` notice available here.
- Click on the external icon available here.
- Note that it loads on a new tab. It should not load [this support document](https://en.support.wordpress.com/recurring-payments-button/) on the same tab.