### PR TITLE
Adjust copies by auto renewal toggle

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -157,6 +157,10 @@ function isPaidWithCredits( purchase ) {
 	return 'undefined' !== typeof purchase.payment && 'credits' === purchase.payment.type;
 }
 
+function hasPaymentMethod( purchase ) {
+	return 'undefined' !== typeof purchase.payment && null != purchase.payment.type;
+}
+
 function isPendingTransfer( purchase ) {
 	return purchase.pendingTransfer;
 }
@@ -415,6 +419,7 @@ export {
 	isPaidWithPayPalDirect,
 	isPaidWithPaypal,
 	isPaidWithCredits,
+	hasPaymentMethod,
 	isExpired,
 	isExpiring,
 	isIncludedWithPlan,

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -13,6 +13,7 @@ import {
 	isRemovable,
 	isCancelable,
 	isPaidWithCredits,
+	hasPaymentMethod,
 	maybeWithinRefundPeriod,
 	subscribedWithinPastWeek,
 } from '../index';
@@ -90,6 +91,27 @@ describe( 'index', () => {
 		} );
 		test( 'should be false when payment not set on purchase', () => {
 			expect( isPaidWithCredits( {} ) ).to.be.false;
+		} );
+	} );
+	describe( '#hasPaymentMethod', () => {
+		test( 'should be false if no payment data at all', () => {
+			expect( hasPaymentMethod( {} ) ).to.be.false;
+		} );
+		test( 'should be false if no payment type', () => {
+			expect(
+				hasPaymentMethod( {
+					payment: {},
+				} )
+			).to.be.false;
+		} );
+		test( 'should be true if a payment type is available', () => {
+			expect(
+				hasPaymentMethod( {
+					payment: {
+						type: 'paypal',
+					},
+				} )
+			).to.be.true;
 		} );
 	} );
 	describe( '#maybeWithinRefundPeriod', () => {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -12,8 +12,9 @@ import { connect } from 'react-redux';
  */
 import { isExpiring } from 'lib/purchases';
 import { disableAutoRenew, enableAutoRenew } from 'lib/upgrades/actions';
-import { isFetchingSitePurchases } from 'state/purchases/selectors';
-import { fetchSitePurchases } from 'state/purchases/actions';
+import { getCurrentUserId } from 'state/current-user/selectors';
+import { isFetchingUserPurchases } from 'state/purchases/selectors';
+import { fetchUserPurchases } from 'state/purchases/actions';
 import AutoRenewDisablingDialog from './auto-renew-disabling-dialog';
 import FormToggle from 'components/forms/form-toggle';
 
@@ -23,11 +24,11 @@ class AutoRenewToggle extends Component {
 		siteDomain: PropTypes.string.isRequired,
 		planName: PropTypes.string.isRequired,
 		isEnabled: PropTypes.bool.isRequired,
-		fetchingSitePurchases: PropTypes.bool,
+		fetchingUserPurchases: PropTypes.bool,
 	};
 
 	static defaultProps = {
-		fetchingSitePurchases: false,
+		fetchingUserPurchases: false,
 	};
 
 	state = {
@@ -44,7 +45,8 @@ class AutoRenewToggle extends Component {
 
 	onToggleAutoRenew = () => {
 		const {
-			purchase: { id: purchaseId, siteId },
+			purchase: { id: purchaseId },
+			currentUserId,
 			isEnabled,
 		} = this.props;
 
@@ -66,13 +68,13 @@ class AutoRenewToggle extends Component {
 				isRequesting: false,
 			} );
 			if ( success ) {
-				this.props.fetchSitePurchases( siteId );
+				this.props.fetchUserPurchases( currentUserId );
 			}
 		} );
 	};
 
 	isUpdatingAutoRenew = () => {
-		return this.state.isRequesting || this.props.fetchingSitePurchases;
+		return this.state.isRequesting || this.props.fetchingUserPurchases;
 	};
 
 	getToggleUiStatus() {
@@ -108,10 +110,11 @@ class AutoRenewToggle extends Component {
 
 export default connect(
 	( state, { purchase } ) => ( {
-		fetchingSitePurchases: isFetchingSitePurchases( state ),
+		fetchingUserPurchases: isFetchingUserPurchases( state ),
 		isEnabled: ! isExpiring( purchase ),
+		currentUserId: getCurrentUserId( state ),
 	} ),
 	{
-		fetchSitePurchases,
+		fetchUserPurchases,
 	}
 )( AutoRenewToggle );

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -25,6 +25,7 @@ import {
 	getName,
 	getRenewalPrice,
 	handleRenewNowClick,
+	hasPaymentMethod,
 	isCancelable,
 	isExpired,
 	isExpiring,
@@ -197,9 +198,22 @@ class ManagePurchase extends Component {
 				return null;
 			}
 
-			const text = renewing ? translate( 'Edit Payment Method' ) : translate( 'Add Credit Card' );
+			const textEdit = translate( 'Edit Payment Method' );
+			const textAdd = translate( 'Add Credit Card' );
 
-			return <CompactCard href={ path }>{ text }</CompactCard>;
+			// With the self-serving auto-renewal toggle enabled, the payment data should be always there.
+			// Thus, to show "edit" or "add" text will depend on whether or not there is a payment method already.
+			if ( config.isEnabled( 'autorenewal-toggle' ) ) {
+				return (
+					<CompactCard href={ path }>
+						{ hasPaymentMethod( purchase ) ? textEdit : textAdd }
+					</CompactCard>
+				);
+			}
+
+			// Before rolling out the auto-renewal toggle, the only way that our users can "re-enable" auto-renewal
+			// is to add a new payment method to a purchase. That's why the text presenting here relating to the renewal status.
+			return <CompactCard href={ path }>{ renewing ? textEdit : textAdd }</CompactCard>;
 		}
 
 		return null;

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -23,6 +23,7 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isRenewable,
+	hasPaymentMethod,
 	showCreditCardExpiringWarning,
 	isPaidWithCredits,
 	subscribedWithinPastWeek,
@@ -52,6 +53,19 @@ class PurchaseNotice extends Component {
 				return translate(
 					'You purchased %(purchaseName)s with credits. Please add a credit card before your ' +
 						"plan expires %(expiry)s so that you don't lose out on your paid features!",
+					{
+						args: {
+							purchaseName: getName( purchase ),
+							expiry: moment( purchase.expiryMoment ).fromNow(),
+						},
+					}
+				);
+			}
+
+			if ( config.isEnabled( 'autorenewal-toggle' ) && hasPaymentMethod( purchase ) ) {
+				return translate(
+					'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
+						"Please enable auto-renewal so you don't lose out on your paid features!",
 					{
 						args: {
 							purchaseName: getName( purchase ),

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -124,7 +124,12 @@ class PurchaseNotice extends Component {
 			);
 		}
 
-		return <NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>;
+		// With the toggle, it doesn't make much sense to have this button.
+		return (
+			! config.isEnabled( 'autorenewal-toggle' ) && (
+				<NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>
+			)
+		);
 	}
 
 	trackImpression( warning ) {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -27,6 +27,7 @@ import {
 	isRenewing,
 	isSubscription,
 	paymentLogoType,
+	hasPaymentMethod,
 } from 'lib/purchases';
 import {
 	isPlan,
@@ -193,7 +194,7 @@ class PurchaseMeta extends Component {
 			return translate( 'Included with plan' );
 		}
 
-		if ( typeof purchase.payment.type !== 'undefined' ) {
+		if ( hasPaymentMethod( purchase ) ) {
 			let paymentInfo = null;
 
 			if ( purchase.payment.type === 'credits' ) {
@@ -208,6 +209,13 @@ class PurchaseMeta extends Component {
 						cardExpiry: purchase.payment.expiryMoment.format( 'MMMM YYYY' ),
 					},
 				} );
+			}
+
+			// Before code-D29008, the purchase info endpoint excluded the payment info
+			// if the auto-renewal is off. This is for emulating the behavior before rolling out the toggle,
+			// so that users can at least still re-enable the auto-renewal through adding a new payment method.
+			if ( ! config.isEnabled( 'autorenewal-toggle' ) && ! isRenewing( purchase ) ) {
+				return translate( 'None' );
 			}
 
 			return (


### PR DESCRIPTION
*This PR is part of the attempt of adding a self-serving plan subscription autorenewal toggle. For more details, please refer to p2-p9jf6J-1GZ*

#### Changes proposed in this Pull Request

With code-D29008, the `GET /me/purchases/` endpoint will return the attached payment method regardless the auto-renewal enabling status. As this would cause confusion before we roll out the toggle to the production, this PR implements alternating copies accordingly. 

In general, this PR contains the below updates & fixes:

1. The expiring notice:
The current one, with the `autorenewal-toggle` feature flag off:
![image](https://user-images.githubusercontent.com/1842898/58792343-9351c680-8626-11e9-8ae0-d782584ddb53.png)

With `autorenewal-toggle` feature flag on, the copy is updated and the `renew now` notice button is removed:
![image](https://user-images.githubusercontent.com/1842898/58792263-67364580-8626-11e9-8bb1-26bde1ddb8f9.png)

2. With the feature flag on, the "add / edit payment method" button alternates according to the existence of the payment method data. 

3. The payment method meta data section is showing the payment data regardless the auto-renewal status with the feature flag on, while it is intentionally hidden to emulate the behavior before code-D29008. 

4. Replaced fetching site purchases by fetching user purchases, since the later contains the proper payment data while the former intentionally excludes them.

#### Dependency
code-D29008

#### Testing instructions

1. With the `autorenewal-toggle` feature flag on and code-D29008 applied, go to the purchase management page(`/me/purchases/{site slug}/{purchase id}`). 
1. Turn off the auto-renewal, and see the updated notice appear and the payment data persists.
1. With the `autorenewal-toggle` feature flag on and without code-D29008, make sure everything work the current way.
1. With the `autorenewal-toggle` feature flag off, make sure everything work the current way, with or without code-D29008.