### PR TITLE
Auto-renewal Toggle: show different disabling copies accordingly

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -80,6 +80,23 @@ class AutoRenewDisablingDialog extends Component {
 							'%(expiryDate)s is a date string, e.g. May 14, 2020',
 					}
 				);
+			case 'atomic':
+				return translate(
+					'By canceling auto-renewal, your %(planName)s plan for %(siteDomain)s will expire on %(expiryDate)s. ' +
+						'When it does, you will lose plugins, themes, design customizations, and possibly some content. ' +
+						'To avoid that, turn auto-renewal back on or manually renew your plan before the expiration date.',
+					{
+						args: {
+							planName,
+							siteDomain,
+							expiryDate,
+						},
+						comment:
+							'%(planName)s is the name of a WordPress.com plan, e.g. Personal, Premium, Business. ' +
+							'%(siteDomain)s is a domain name, e.g. example.com, example.wordpress.com. ' +
+							'%(expiryDate)s is a date string, e.g. May 14, 2020',
+					}
+				);
 		}
 	}
 

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -21,7 +21,7 @@ class AutoRenewDisablingDialog extends Component {
 		translate: PropTypes.func.isRequired,
 		planName: PropTypes.string.isRequired,
 		siteDomain: PropTypes.string.isRequired,
-		expiryDate: PropTypes.string.isRequired,
+		purchase: PropTypes.object.isRequired,
 	};
 
 	getVariation() {
@@ -67,15 +67,16 @@ class AutoRenewDisablingDialog extends Component {
 				);
 			case 'domain':
 				return translate(
-					'By canceling auto-renewal, your domain %(siteDomain)s will expire on %(expiryDate)s. ' +
+					'By canceling auto-renewal, your domain %(domain)s will expire on %(expiryDate)s. ' +
 						'Once your domain expires, it could become unavailable, and may be impossible to get back on any domain registrar.',
 					{
 						args: {
-							siteDomain,
+							// in case of a domain registration, we need the actual domain bound to this purchase instead of the primary domain bound to the site.
+							domain: purchase.meta,
 							expiryDate,
 						},
 						comment:
-							'%(siteDomain)s is a domain name, e.g. example.com, example.wordpress.com. ' +
+							'%(domain)s is a domain name, e.g. example.com, example.wordpress.com. ' +
 							'%(expiryDate)s is a date string, e.g. May 14, 2020',
 					}
 				);

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -68,7 +68,9 @@ class AutoRenewDisablingDialog extends Component {
 			case 'domain':
 				return translate(
 					'By canceling auto-renewal, your domain %(domain)s will expire on %(expiryDate)s. ' +
-						'Once your domain expires, it could become unavailable, and may be impossible to get back on any domain registrar.',
+						"Once your domain expires, there is no guarantee that you'll be able to get it back – " +
+						'it could become unavailable and be impossible to purchase here, or at any other domain registrar. ' +
+						'To avoid that, turn auto-renewal back on or manually renew your domain before the expiration date.',
 					{
 						args: {
 							// in case of a domain registration, we need the actual domain bound to this purchase instead of the primary domain bound to the site.
@@ -113,7 +115,7 @@ class AutoRenewDisablingDialog extends Component {
 				<h2 className="auto-renew-disabling-dialog__header">{ translate( 'Before you go…' ) }</h2>
 				<p>{ description }</p>
 				<Button onClick={ onClose } primary>
-					{ translate( 'OK' ) }
+					{ translate( 'Confirm cancel auto-renewal' ) }
 				</Button>
 			</Dialog>
 		);

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -120,6 +120,6 @@ class AutoRenewDisablingDialog extends Component {
 	}
 }
 
-export default connect( state => ( {
-	isAtomicSite: isSiteAtomic( state ),
+export default connect( ( state, { purchase } ) => ( {
+	isAtomicSite: isSiteAtomic( state, purchase.siteId ),
 } ) )( localize( AutoRenewDisablingDialog ) );

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -115,7 +115,7 @@ class AutoRenewDisablingDialog extends Component {
 				<h2 className="auto-renew-disabling-dialog__header">{ translate( 'Before you go…' ) }</h2>
 				<p>{ description }</p>
 				<Button onClick={ onClose } primary>
-					{ translate( 'Confirm cancel auto-renewal' ) }
+					{ translate( 'Confirm cancellation' ) }
 				</Button>
 			</Dialog>
 		);

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -98,8 +98,8 @@ class AutoRenewToggle extends Component {
 				{ this.state.showAutoRenewDisablingDialog && (
 					<AutoRenewDisablingDialog
 						planName={ planName }
+						purchase={ purchase }
 						siteDomain={ siteDomain }
-						expiryDate={ purchase.expiryMoment.format( 'LL' ) }
 						onClose={ this.onCloseAutoRenewDisablingDialog }
 					/>
 				) }

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -29,12 +29,7 @@ import {
 	paymentLogoType,
 	hasPaymentMethod,
 } from 'lib/purchases';
-import {
-	isPlan,
-	isDomainRegistration,
-	isDomainTransfer,
-	isConciergeSession,
-} from 'lib/products-values';
+import { isDomainRegistration, isDomainTransfer, isConciergeSession } from 'lib/products-values';
 import { getPlan } from 'lib/plans';
 
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
@@ -309,12 +304,10 @@ class PurchaseMeta extends Component {
 			return null;
 		}
 
-		// The toggle is only available for the plan subscription for now, and will be gradully rolled out to
-		// domains and G suite.
 		if (
 			config.isEnabled( 'autorenewal-toggle' ) &&
-			purchase.renewMoment &&
-			isPlan( purchase ) &&
+			( isDomainRegistration( purchase ) || isSubscription( purchase ) ) &&
+			hasPaymentMethod( purchase ) &&
 			! isExpired( purchase )
 		) {
 			const dateSpan = <span className="manage-purchase__detail-date-span" />;

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -29,7 +29,12 @@ import {
 	paymentLogoType,
 	hasPaymentMethod,
 } from 'lib/purchases';
-import { isDomainRegistration, isDomainTransfer, isConciergeSession } from 'lib/products-values';
+import {
+	isDomainRegistration,
+	isDomainTransfer,
+	isConciergeSession,
+	isPlan,
+} from 'lib/products-values';
 import { getPlan } from 'lib/plans';
 
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
@@ -306,7 +311,7 @@ class PurchaseMeta extends Component {
 
 		if (
 			config.isEnabled( 'autorenewal-toggle' ) &&
-			( isDomainRegistration( purchase ) || isSubscription( purchase ) ) &&
+			( isDomainRegistration( purchase ) || isPlan( purchase ) ) &&
 			hasPaymentMethod( purchase ) &&
 			! isExpired( purchase )
 		) {


### PR DESCRIPTION
*This PR is part of the attempt of adding a self-serving plan subscription autorenewal toggle. For more details, please refer to p2-p9jf6J-1GZ*

#### Changes proposed in this Pull Request

This PR adds the different copies shown for disabling auto-renewal for the domain registration and the atomic site plan.

For a domain registration:
<img width="498" alt="螢幕快照 2019-06-04 下午5 10 29" src="https://user-images.githubusercontent.com/1842898/58866987-3d475680-86ec-11e9-9d2b-6754cd1a6a92.png">

For a atomic site plan:
![image](https://user-images.githubusercontent.com/1842898/58873388-d7150080-86f8-11e9-929b-c0fc6f28b680.png)

For a simple site plan, it should be what it is currently:
![image](https://user-images.githubusercontent.com/1842898/58867129-77b0f380-86ec-11e9-8c70-fdad7d5a0a72.png)

#### Dependency
#33537

#### Testing instructions

1. Disable auto-renewal on a domain registration from the purchase management page (`/me/purchases/{site domain}/{purchase id}`), and see the domain registration variation appear.
1. Do the same to an atomic site plan.
1. Do the same to a simple site plan.
