### PR TITLE
Checklist: Add jetpack/checklist/performance feature flag

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -76,6 +76,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/checklist": true,
+		"jetpack/checklist/performance": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/remote-install": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,6 +45,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/checklist": true,
+		"jetpack/checklist/performance": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,6 +56,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/checklist": true,
+		"jetpack/checklist/performance": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,


### PR DESCRIPTION
Enables a new `jetpack/checklist/performance` feature flag on dev/stage/wpcalypso (the latter is calypso.live's env).

Not much by itself, merge this branch to yours when starting work on a new performance checklist task. Safe to land on its own.

paObgF-89-p2