### PR TITLE
Checklist: Jetpack structure

### DIFF
--- a/client/components/checklist/README.md
+++ b/client/components/checklist/README.md
@@ -99,5 +99,5 @@ A Checklist expects its children to be a flat list of Task:
 </Checklist>
 ```
 
-Non-task children are not well supported, but they can include the `noCount` prop to prevent them
+Non-task children are not well supported, but they can include the `excludeFromCount` prop to prevent them
 from being included in the complete/total calculation.

--- a/client/components/checklist/README.md
+++ b/client/components/checklist/README.md
@@ -5,6 +5,10 @@ Checklist
 
 ## `Checklist` props
 
+### `className { string }`
+
+Additional class to add to the Checklist.
+
 ### `isPlaceholder { bool } - default: false`
 
 Render as a placeholder.
@@ -14,10 +18,6 @@ Render as a placeholder.
 Displayed in the checklist header, right on top of the progress bar.
 
 ## `Task` props
-
-### `className { string }`
-
-Provide a className to add to the Task classes.
 
 ### `completed { bool }`
 
@@ -65,11 +65,9 @@ Translate as `translate( '%d minutes', '%d minutes', { count: 2, args: [ 2 ] } )
 
 Task title
 
-### `noCount { boolean }`
-
-Checklists are flat lists of tasks which calculate completion by counting the children. A `<Task noCount />` can be used to insert presentational Tasks that should not be used in when counting tasks.
-
 ## Usage
+
+A Checklist expects its children to be a flat list of Task:
 
 ```jsx
 <Checklist>
@@ -100,3 +98,6 @@ Checklists are flat lists of tasks which calculate completion by counting the ch
 	/>
 </Checklist>
 ```
+
+Non-task children are not well supported, but they can include the `noCount` prop to prevent them
+from being included in the complete/total calculation.

--- a/client/components/checklist/README.md
+++ b/client/components/checklist/README.md
@@ -15,6 +15,10 @@ Displayed in the checklist header, right on top of the progress bar.
 
 ## `Task` props
 
+### `className { string }`
+
+Provide a className to add to the Task classes.
+
 ### `completed { bool }`
 
 Whether the task is complete.
@@ -60,6 +64,10 @@ Translate as `translate( '%d minutes', '%d minutes', { count: 2, args: [ 2 ] } )
 ### `title { node }`
 
 Task title
+
+### `noCount { boolean }`
+
+Checklists are flat lists of tasks which calculate completion by counting the children. A `<Task noCount />` can be used to insert presentational Tasks that should not be used in when counting tasks.
 
 ## Usage
 

--- a/client/components/checklist/checklist.js
+++ b/client/components/checklist/checklist.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -15,6 +14,7 @@ import TaskPlaceholder from './task-placeholder';
 
 export default class Checklist extends PureComponent {
 	static propTypes = {
+		className: PropTypes.string,
 		phase2: PropTypes.bool,
 		isPlaceholder: PropTypes.bool,
 		progressText: PropTypes.string,
@@ -38,7 +38,9 @@ export default class Checklist extends PureComponent {
 
 	calculateCompletion() {
 		const { children } = this.props;
-		const childrenArray = Children.toArray( children );
+		const childrenArray = Children.toArray( children ).filter(
+			task => task && task.props && ! task.props.noCount
+		);
 		const completedCount = childrenArray.reduce(
 			( count, task ) => ( true === task.props.completed ? count + 1 : count ),
 			0
@@ -69,7 +71,7 @@ export default class Checklist extends PureComponent {
 
 		return (
 			<div
-				className={ classNames( 'checklist', {
+				className={ classNames( 'checklist', this.props.className, {
 					'is-expanded': ! this.state.hideCompleted,
 					'hide-completed': this.state.hideCompleted,
 					'checklist-phase2': this.props.phase2,

--- a/client/components/checklist/checklist.js
+++ b/client/components/checklist/checklist.js
@@ -39,7 +39,7 @@ export default class Checklist extends PureComponent {
 	calculateCompletion() {
 		const { children } = this.props;
 		const childrenArray = Children.toArray( children ).filter(
-			task => task && task.props && ! task.props.noCount
+			task => task && task.props && ! task.props.excludeFromCount
 		);
 		const completedCount = childrenArray.reduce(
 			( count, task ) => ( true === task.props.completed ? count + 1 : count ),

--- a/client/my-sites/plans/current-plan/jetpack-checklist/checklist-section-title.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/checklist-section-title.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Card from 'components/card';
+
+const ChecklistSectionTitle: FunctionComponent< { noCount: true; title: string } > = ( {
+	title,
+} ) => (
+	<Card className="jetpack-checklist__task-section-title" compact>
+		<h2>{ title }</h2>
+	</Card>
+);
+
+export default ChecklistSectionTitle;

--- a/client/my-sites/plans/current-plan/jetpack-checklist/checklist-section-title.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/checklist-section-title.tsx
@@ -8,7 +8,7 @@ import React, { FunctionComponent } from 'react';
  */
 import Card from 'components/card';
 
-const ChecklistSectionTitle: FunctionComponent< { noCount: true; title: string } > = ( {
+const ChecklistSectionTitle: FunctionComponent< { excludeFromCount: true; title: string } > = ( {
 	title,
 } ) => (
 	<Card className="jetpack-checklist__task-section-title" compact>

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { translate } from 'i18n-calypso';
+import { SiteSlug } from 'client/types';
 
 /**
  * Returns the localized duration of a task in given minutes.
@@ -13,7 +14,21 @@ export function getJetpackChecklistTaskDuration( minutes ) {
 	return translate( '%d minute', '%d minutes', { count: minutes, args: [ minutes ] } );
 }
 
-export const JETPACK_CHECKLIST_TASKS = {
+interface TaskUiDescription {
+	readonly title: string;
+	readonly description?: string;
+	readonly completedButtonText: string;
+	readonly completedTitle?: string;
+	readonly getUrl: ( siteSlug: SiteSlug ) => string;
+	readonly duration?: string;
+	readonly tourId?: string;
+}
+
+interface ChecklistTasks {
+	[key: string]: TaskUiDescription;
+}
+
+export const JETPACK_SECURITY_CHECKLIST_TASKS: ChecklistTasks = {
 	jetpack_monitor: {
 		title: translate( 'Downtime Monitoring' ),
 		description: translate(
@@ -49,7 +64,11 @@ export const JETPACK_CHECKLIST_TASKS = {
 	},
 };
 
-export const JETPACK_CHECKLIST_TASK_AKISMET = {
+export const JETPACK_PERFORMANCE_CHECKLIST_TASKS: ChecklistTasks = {
+	// No tasks for this checklist yet…
+};
+
+export const JETPACK_CHECKLIST_TASK_AKISMET: TaskUiDescription = {
 	title: translate( "We're automatically turning on spam filtering." ),
 	completedButtonText: translate( 'View spam stats' ),
 	completedTitle: translate( "We've automatically turned on spam filtering." ),
@@ -57,13 +76,13 @@ export const JETPACK_CHECKLIST_TASK_AKISMET = {
 		`//${ siteSlug.replace( '::', '/' ) }/wp-admin/admin.php?page=akismet-key-config`,
 };
 
-export const JETPACK_CHECKLIST_TASK_PROTECT = {
+export const JETPACK_CHECKLIST_TASK_PROTECT: TaskUiDescription = {
 	title: translate( "We've automatically protected you from brute force login attacks." ),
 	completedButtonText: translate( 'Configure' ),
 	getUrl: siteSlug => `/settings/security/${ siteSlug }`,
 };
 
-export const JETPACK_CHECKLIST_TASK_BACKUPS_REWIND = {
+export const JETPACK_CHECKLIST_TASK_BACKUPS_REWIND: TaskUiDescription = {
 	title: translate( 'Backup and Scan' ),
 	description: translate(
 		"Connect your site's server to Jetpack to perform backups, restores, and security scans."
@@ -74,7 +93,7 @@ export const JETPACK_CHECKLIST_TASK_BACKUPS_REWIND = {
 	duration: getJetpackChecklistTaskDuration( 3 ),
 };
 
-export const JETPACK_CHECKLIST_TASK_BACKUPS_VAULTPRESS = {
+export const JETPACK_CHECKLIST_TASK_BACKUPS_VAULTPRESS: TaskUiDescription = {
 	title: translate( "We're automatically turning on Backup and Scan." ),
 	completedTitle: translate( "We've automatically turned on Backup and Scan." ),
 	completedButtonText: translate( 'View security dashboard' ),

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -75,14 +75,14 @@ class JetpackChecklist extends PureComponent {
 	 * and future iterations intend to remove the grouped tasks.
 	 *
 	 * In order to get the desired layout and behavior with the existing Checklist component,
-	 * it's necessary to add an element with the `noCount` prop. That requires the use of a
+	 * it's necessary to add an element with the `excludeFromCount` prop. That requires the use of a
 	 * render method rather than a "true" Component definition.
 	 *
 	 * @param {string} title The checklist title
 	 * @return {JSXElement} Section title element
 	 */
 	renderSectionTitle( title ) {
-		return <ChecklistSectionTitle noCount title={ title } />;
+		return <ChecklistSectionTitle excludeFromCount title={ title } />;
 	}
 
 	render() {

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.js
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.js
@@ -34,7 +34,7 @@ import {
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { isEnabled } from 'config';
-import Card from 'components/card';
+import ChecklistSectionTitle from './checklist-section-title';
 
 /**
  * Style dependencies
@@ -82,7 +82,7 @@ class JetpackChecklist extends PureComponent {
 	 * @return {JSXElement} Section title element
 	 */
 	renderSectionTitle( title ) {
-		return <SectionTitle noCount title={ title } />;
+		return <ChecklistSectionTitle noCount title={ title } />;
 	}
 
 	render() {
@@ -260,11 +260,3 @@ export default connect(
 		requestGuidedTour,
 	}
 )( localize( JetpackChecklist ) );
-
-function SectionTitle( { title } ) {
-	return (
-		<Card className="jetpack-checklist__task-section-title" compact>
-			<h2>{ title }</h2>
-		</Card>
-	);
-}

--- a/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
@@ -1,8 +1,17 @@
-// Tasks are sorted completed first, incomplete after
-// For as section, it should be section header, completed, incomplete
-// This loop allows us to override the original ordering with our section headers
-// It covers a limited number of tasks, where the upper bound (30) must be at least
 .jetpack-checklist {
+	// The Checklist component does not support the presentational section titles
+	// inside the current iteration of the Jetpack checklist. This design iteration
+	// is likely to be short lived, so rather than rework the structure of the shared
+	// component to support it, the Jetpack checklist receives some special treatment
+	// to implement the designs.
+	//
+	// Normally, a Checklist shows completed tasks before incomplete tasks.
+	// This loop ensures that section titles and the completed/incomplete tasks for
+	// each section are correctly ordered.
+	//
+	// `to` determines the upper limit for the 0-indexed position where a section-title
+	// may appear as the child of a checklist. Tasks beyond this limit will be
+	// handled correctly.
 	@for $i from 0 to 30 {
 		$base: ( $i * 10 );
 		.jetpack-checklist__task-section-title:nth-child( #{$i + 1} ) {

--- a/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/style.scss
@@ -1,3 +1,27 @@
+// Tasks are sorted completed first, incomplete after
+// For as section, it should be section header, completed, incomplete
+// This loop allows us to override the original ordering with our section headers
+// It covers a limited number of tasks, where the upper bound (30) must be at least
+.jetpack-checklist {
+	@for $i from 0 to 30 {
+		$base: ( $i * 10 );
+		.jetpack-checklist__task-section-title:nth-child( #{$i + 1} ) {
+			order: $base;
+			~ .checklist__task.is-completed {
+				order: ( $base + 1 );
+			}
+			~ .checklist__task {
+				order: ( $base + 2 );
+			}
+		}
+	}
+
+	.jetpack-checklist__task-section-title {
+		width: 100%;
+		font-weight: 500;
+	}
+}
+
 .jetpack-checklist__header {
 	display: flex;
 }


### PR DESCRIPTION
All appreciable changes are feature flagged.

- Implement and add section titles to the Jetpack checklist.
- A new static task is added under the performance section for demonstration purposes.
- Some changes to Checklist to handle presentational children. This is a simple approach that can be discarded easily. The shared Checklist components are modified in small ways to make this approach possible.

A Jetpack checklist-specific approach was preferred. This iteration uses groups of tasks under a section title which is not expected to be included in future iterations (p1559576746103900-slack-onboarding-exp). A quick and isolated approach was preferred.

Closes #33167 (paObgF-89-p2)
Uses new feature flag from #33545 (included)

## Screens

### Feature flag disabled (no change)

![flag-disabled](https://user-images.githubusercontent.com/841763/58853499-d2216400-869a-11e9-85f1-02a3efdb120d.png)

### Enabled

![enabled](https://user-images.githubusercontent.com/841763/58853502-d3eb2780-869a-11e9-89b3-5b8121d76fd3.png)

## Testing
- View the checklist with the feature flag disabled: `/plans/my-plan/SITE_SLUG` for a Jetpack site
- The checklist should work as expected
- View the checklist with the flag enabled (no flag necessary on calypso.live or dev): `/plans/my-plan/SITE_SLUG?flags=jetpack/checklist/performance` for a Jetpack site
- You should see the expected layout (see screenshot) with the correct total and completion for the tasks in the checklist. Try with different plans and completion progress.