### PR TITLE
Add outbound domain transfer management landing page.

### DIFF
--- a/client/landing/domains/content-card/index.jsx
+++ b/client/landing/domains/content-card/index.jsx
@@ -3,6 +3,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -20,6 +21,7 @@ class DomainsLandingContentCard extends Component {
 	static propTypes = {
 		title: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ).isRequired,
 		message: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
+		messageAlignCenter: PropTypes.bool,
 		actionTitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 		actionCallback: PropTypes.func,
 		actionPrimary: PropTypes.bool,
@@ -38,6 +40,7 @@ class DomainsLandingContentCard extends Component {
 		actionBusy: false,
 		alternateActionPrimary: false,
 		alternateActionBusy: false,
+		messageAlignCenter: false,
 	};
 
 	renderPlaceholder = () => {
@@ -57,6 +60,7 @@ class DomainsLandingContentCard extends Component {
 		const {
 			title,
 			message,
+			messageAlignCenter,
 			actionTitle,
 			actionCallback,
 			actionPrimary,
@@ -73,10 +77,14 @@ class DomainsLandingContentCard extends Component {
 			return this.renderPlaceholder();
 		}
 
+		const messageClasses = classNames( 'content-card__message', {
+			message_align_center: messageAlignCenter,
+		} );
+
 		return (
 			<CompactCard className="content-card">
 				{ <h2 className="content-card__title">{ title }</h2> }
-				{ message && <h3 className="content-card__message">{ message }</h3> }
+				{ message && <h3 className={ messageClasses }>{ message }</h3> }
 				{ actionTitle && (
 					<Button
 						className="content-card__action-button"

--- a/client/landing/domains/content-card/index.jsx
+++ b/client/landing/domains/content-card/index.jsx
@@ -22,12 +22,22 @@ class DomainsLandingContentCard extends Component {
 		message: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 		actionTitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 		actionCallback: PropTypes.func,
+		actionPrimary: PropTypes.bool,
+		actionBusy: PropTypes.bool,
+		alternateActionTitle: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
+		alternateActionCallback: PropTypes.func,
+		alternateActionPrimary: PropTypes.bool,
+		alternateActionBusy: PropTypes.bool,
 		footer: PropTypes.oneOfType( [ PropTypes.string, PropTypes.node ] ),
 		isLoading: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isLoading: false,
+		actionPrimary: true,
+		actionBusy: false,
+		alternateActionPrimary: false,
+		alternateActionBusy: false,
 	};
 
 	renderPlaceholder = () => {
@@ -44,7 +54,20 @@ class DomainsLandingContentCard extends Component {
 	};
 
 	render() {
-		const { title, message, actionTitle, actionCallback, footer, isLoading } = this.props;
+		const {
+			title,
+			message,
+			actionTitle,
+			actionCallback,
+			actionPrimary,
+			actionBusy,
+			alternateActionTitle,
+			alternateActionCallback,
+			alternateActionPrimary,
+			alternateActionBusy,
+			footer,
+			isLoading,
+		} = this.props;
 
 		if ( isLoading ) {
 			return this.renderPlaceholder();
@@ -55,8 +78,25 @@ class DomainsLandingContentCard extends Component {
 				{ <h2 className="content-card__title">{ title }</h2> }
 				{ message && <h3 className="content-card__message">{ message }</h3> }
 				{ actionTitle && (
-					<Button className="content-card__action-button" primary onClick={ actionCallback }>
+					<Button
+						className="content-card__action-button"
+						busy={ actionBusy }
+						disabled={ actionBusy }
+						primary={ actionPrimary }
+						onClick={ actionCallback }
+					>
 						{ actionTitle }
+					</Button>
+				) }
+				{ alternateActionTitle && (
+					<Button
+						className="content-card__alternate-action-button"
+						busy={ alternateActionBusy }
+						disabled={ alternateActionBusy }
+						primary={ alternateActionPrimary }
+						onClick={ alternateActionCallback }
+					>
+						{ alternateActionTitle }
 					</Button>
 				) }
 				{ footer && <p className="content-card__footer">{ footer }</p> }

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -20,6 +20,10 @@
 		margin-bottom: 40px;
 		text-align: left;
 
+		&.message_align_center {
+			text-align: center;
+		}
+
 		@include breakpoint( '<660px' ) {
 			font-size: 16px;
 		}

--- a/client/landing/domains/content-card/style.scss
+++ b/client/landing/domains/content-card/style.scss
@@ -18,6 +18,7 @@
 		font-size: 22px;
 		font-weight: 300;
 		margin-bottom: 40px;
+		text-align: left;
 
 		@include breakpoint( '<660px' ) {
 			font-size: 16px;
@@ -35,8 +36,13 @@
 		}
 	}
 
-	.content-card__action-button {
+	.content-card__action-button,
+	content-card__alternate-action-button {
 		margin-bottom: 40px;
+	}
+
+	.content-card__alternate-action-button {
+		margin-left: 16px;
 	}
 
 	&.content-card__loading-placeholder {

--- a/client/landing/domains/index.jsx
+++ b/client/landing/domains/index.jsx
@@ -10,6 +10,7 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import RegistrantVerificationPage from './registrant-verification';
+import TransferAwayConfirmationPage from './transfer-away-confirmation';
 import InvalidActionPage from './invalid-action';
 import Main from 'components/main';
 
@@ -30,6 +31,11 @@ class DomainsLandingPage extends Component {
 		return <RegistrantVerificationPage domain={ domain } email={ email } token={ token } />;
 	}
 
+	renderTransferAwayConfirmation() {
+		const { domain, email, token } = this.props.query;
+		return <TransferAwayConfirmationPage domain={ domain } email={ email } token={ token } />;
+	}
+
 	renderUnknownActionContent() {
 		return <InvalidActionPage />;
 	}
@@ -38,6 +44,9 @@ class DomainsLandingPage extends Component {
 		switch ( this.props.action ) {
 			case 'registrant-verification':
 				return this.renderRegistrantVerificationContent();
+
+			case 'transfer-away-confirmation':
+				return this.renderTransferAwayConfirmation();
 
 			case 'unknown-action':
 			default:

--- a/client/landing/domains/index.jsx
+++ b/client/landing/domains/index.jsx
@@ -32,8 +32,14 @@ class DomainsLandingPage extends Component {
 	}
 
 	renderTransferAwayConfirmation() {
-		const { domain, email, token } = this.props.query;
-		return <TransferAwayConfirmationPage domain={ domain } email={ email } token={ token } />;
+		const { domain, recipient_id, token } = this.props.query;
+		return (
+			<TransferAwayConfirmationPage
+				domain={ domain }
+				recipientId={ recipient_id }
+				token={ token }
+			/>
+		);
 	}
 
 	renderUnknownActionContent() {

--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -166,6 +166,7 @@ class RegistrantVerificationPage extends Component {
 		return {
 			title: translate( 'Uh oh!' ),
 			message: translate( 'Hmm. Something went wrong.' ),
+			messageAlignCenter: true,
 			actionTitle: null,
 			actionCallback: null,
 			footer: defaultErrorFooter,
@@ -230,6 +231,7 @@ class RegistrantVerificationPage extends Component {
 				<DomainsLandingContentCard
 					title={ this.state.title }
 					message={ this.state.message }
+					messageAlignCenter={ this.state.messageAlignCenter }
 					actionTitle={ this.state.actionTitle }
 					actionCallback={ this.state.actionCallback }
 					footer={ this.state.footer }

--- a/client/landing/domains/transfer-away-confirmation/index.jsx
+++ b/client/landing/domains/transfer-away-confirmation/index.jsx
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import DomainsLandingHeader from '../header';
+import DomainsLandingContentCard from '../content-card';
+// import { CALYPSO_CONTACT } from 'lib/url/support';
+import { acceptTransfer, declineTransfer } from 'lib/upgrades/actions';
+import wp from 'lib/wp';
+
+const wpcom = wp.undocumented();
+
+class TransferAwayConfirmationPage extends Component {
+	static propTypes = {
+		domain: PropTypes.string.isRequired,
+		email: PropTypes.string.isRequired,
+		token: PropTypes.string.isRequired,
+	};
+
+	state = {
+		isLoading: false,
+		isProcessingRequest: false,
+		success: false,
+		error: false,
+	};
+
+	constructor( props ) {
+		super( props );
+		this.state = this.getLoadingState();
+	}
+
+	componentWillMount() {
+		const { domain, email, token } = this.props;
+		wpcom.domainsVerifyOutbountTransferConfirmationState( domain, email, token ).then(
+			() => {
+				this.setState( this.getVerificationSuccessState() );
+			},
+			error => {
+				this.setErrorState( error );
+			}
+		);
+	}
+
+	getLoadingState = () => {
+		const { translate } = this.props;
+		return {
+			isLoading: true,
+			title: translate( 'Verifying your contact information…' ),
+			message: 'Loading…',
+			actionTitle: null,
+			actionCallback: null,
+			footer: 'Loading…',
+		};
+	};
+
+	onAcceptTransferComplete = error => {
+		this.setState( { isProcessingRequest: false, error } );
+	};
+
+	acceptTransfer = () => {
+		this.setState( { isProcessingRequest: true } );
+		acceptTransfer( this.props.domain, this.onAcceptTransferComplete );
+	};
+
+	onCancelTransferComplete = error => {
+		this.setState( { isProcessingRequest: false, error } );
+	};
+
+	declineTransfer = () => {
+		this.setState( { isProcessingRequest: true } );
+		declineTransfer( this.props.domain, this.onCancelTransferComplete );
+	};
+
+	getDefaultState = () => {
+		const { domain, translate } = this.props;
+		return {
+			title: translate( 'Manage your Domain Transfer' ),
+			message: translate(
+				'You have requested to transfer {{strong}}%(domain)s{{/strong}} away from WordPress.com to another registration provider.{{br/}}{{br/}}' +
+					'If you take no action, the domain transfer will process automatically within seven days of when it was started.{{br/}}{{br/}}' +
+					'To cancel this transfer and keep your domain at WordPress.com, click the “Cancel Transfer” button.{{br/}}{{br/}}' +
+					'To process this transfer immediately instead of waiting, click the “Accept Transfer” button.',
+				{
+					args: {
+						domain: domain,
+					},
+					components: {
+						strong: <strong />,
+						br: <br />,
+					},
+				}
+			),
+			actionTitle: 'Accept Transfer',
+			actionCallback: this.acceptTransfer,
+			alternateActionTitle: 'Cancel Transfer',
+			alternateActionCallback: this.declineTransfer,
+			isLoading: false,
+		};
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<div className="transfer-away-confirmation">
+				<DomainsLandingHeader title={ translate( 'Domain Transfer Managment' ) } />
+				<DomainsLandingContentCard
+					title={ this.state.title }
+					message={ this.state.message }
+					actionTitle={ this.state.actionTitle }
+					actionCallback={ this.state.actionCallback }
+					actionPrimary={ false }
+					actionBusy={ this.state.isProcessingRequest }
+					alternateActionTitle={ this.state.alternateActionTitle }
+					alternateActionCallback={ this.state.alternateActionCallback }
+					alternateActionPrimary={ false }
+					alternateActionBusy={ this.state.isProcessingRequest }
+					footer={ this.state.footer }
+					isLoading={ this.state.isLoading }
+				/>
+			</div>
+		);
+	}
+}
+
+export default localize( TransferAwayConfirmationPage );

--- a/client/landing/domains/transfer-away-confirmation/index.jsx
+++ b/client/landing/domains/transfer-away-confirmation/index.jsx
@@ -10,8 +10,7 @@ import { localize } from 'i18n-calypso';
  */
 import DomainsLandingHeader from '../header';
 import DomainsLandingContentCard from '../content-card';
-// import { CALYPSO_CONTACT } from 'lib/url/support';
-import { acceptTransfer, declineTransfer } from 'lib/upgrades/actions';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import wp from 'lib/wp';
 
 const wpcom = wp.undocumented();
@@ -37,9 +36,9 @@ class TransferAwayConfirmationPage extends Component {
 
 	componentWillMount() {
 		const { domain, email, token } = this.props;
-		wpcom.domainsVerifyOutbountTransferConfirmationState( domain, email, token ).then(
+		wpcom.domainsVerifyOutboundTransferConfirmation( domain, email, token ).then(
 			() => {
-				this.setState( this.getVerificationSuccessState() );
+				this.setState( this.getConfirmationSelectState() );
 			},
 			error => {
 				this.setErrorState( error );
@@ -51,33 +50,40 @@ class TransferAwayConfirmationPage extends Component {
 		const { translate } = this.props;
 		return {
 			isLoading: true,
-			title: translate( 'Verifying your contact information…' ),
+			title: translate( 'Manage your Domain Transfer' ),
 			message: 'Loading…',
 			actionTitle: null,
 			actionCallback: null,
-			footer: 'Loading…',
 		};
 	};
 
 	onAcceptTransferComplete = error => {
-		this.setState( { isProcessingRequest: false, error } );
+		if ( error ) {
+			this.setErrorState( { error: 'accept_transfer_failed' } );
+		} else {
+			this.setSuccessState( 'accept_transfer_success' );
+		}
 	};
 
 	acceptTransfer = () => {
 		this.setState( { isProcessingRequest: true } );
-		acceptTransfer( this.props.domain, this.onAcceptTransferComplete );
+		wpcom.acceptTransfer( this.props.domain, this.onAcceptTransferComplete );
 	};
 
 	onCancelTransferComplete = error => {
-		this.setState( { isProcessingRequest: false, error } );
+		if ( error ) {
+			this.setErrorState( { error: 'cancel_transfer_failed' } );
+		} else {
+			this.setSuccessState( 'cancel_transfer_success' );
+		}
 	};
 
-	declineTransfer = () => {
+	cancelTransfer = () => {
 		this.setState( { isProcessingRequest: true } );
-		declineTransfer( this.props.domain, this.onCancelTransferComplete );
+		wpcom.declineTransfer( this.props.domain, this.onCancelTransferComplete );
 	};
 
-	getDefaultState = () => {
+	getConfirmationSelectState = () => {
 		const { domain, translate } = this.props;
 		return {
 			title: translate( 'Manage your Domain Transfer' ),
@@ -96,12 +102,180 @@ class TransferAwayConfirmationPage extends Component {
 					},
 				}
 			),
+			messageAlignCenter: false,
 			actionTitle: 'Accept Transfer',
 			actionCallback: this.acceptTransfer,
 			alternateActionTitle: 'Cancel Transfer',
-			alternateActionCallback: this.declineTransfer,
+			alternateActionCallback: this.cancelTransfer,
 			isLoading: false,
 		};
+	};
+
+	getWhoisErrorState = () => {
+		const { translate } = this.props;
+
+		return {
+			message: translate(
+				"Something went wrong.{{br/}}{{br/}}We couldn't get the transfer status for your domain.{{br/}}Please try again in a few hours.",
+				{
+					components: {
+						br: <br />,
+					},
+				}
+			),
+		};
+	};
+
+	getExpiredTokenErrorState = () => {
+		const { translate } = this.props;
+
+		return {
+			message: translate(
+				'This email has expired.{{br/}}{{br/}}If it has been over seven days since you have started your transfer and it has not yet completed, please {{a}}{{strong}}contact support{{/strong}}{{/a}}.',
+				{
+					components: {
+						a: <a href={ CALYPSO_CONTACT } />,
+						br: <br />,
+						strong: <strong />,
+					},
+				}
+			),
+			footer: null,
+		};
+	};
+
+	getNotPendingTransferErrorState = () => {
+		const { translate } = this.props;
+
+		return {
+			title: translate( 'Domain not awaiting transfer.' ),
+			message: translate(
+				'This domain is no longer pending transfer.{{br/}}{{br/}}If your transfer has completed successfully or you previously cancelled your domain transfer, there is nothing else you need to do.',
+				{
+					components: {
+						br: <br />,
+					},
+				}
+			),
+		};
+	};
+
+	getDefaultErrorState = () => {
+		const { translate } = this.props;
+		const defaultErrorFooter = translate(
+			"If you're having trouble managing your domain transfer, please {{a}}{{strong}}contact support{{/strong}}{{/a}}.",
+			{
+				components: {
+					a: <a href={ CALYPSO_CONTACT } />,
+					strong: <strong />,
+				},
+			}
+		);
+
+		return {
+			title: translate( 'Uh oh!' ),
+			message: translate( 'Hmm. Something went wrong.' ),
+			messageAlignCenter: true,
+			actionTitle: null,
+			actionCallback: null,
+			alternateActionTitle: null,
+			alternateActionCallback: null,
+			footer: defaultErrorFooter,
+			isLoading: false,
+			isProcessingRequest: false,
+		};
+	};
+
+	setErrorState = error => {
+		let errorState;
+
+		switch ( error.error ) {
+			case 'email_mismatch':
+				errorState = this.getEmailMismatchState();
+				break;
+
+			case 'token_expired':
+				errorState = this.getExpiredTokenErrorState();
+				break;
+
+			case 'whois_status_error':
+				errorState = this.getWhoisErrorState();
+				break;
+
+			case 'no_pending_transfer':
+				errorState = this.getNotPendingTransferErrorState();
+				break;
+		}
+
+		this.setState( {
+			...this.getDefaultErrorState(),
+			...errorState,
+		} );
+	};
+
+	getAcceptTransferSuccessState = () => {
+		const { translate } = this.props;
+
+		return {
+			message: translate(
+				'Congratulations!{{br/}}{{br/}}You have successfully expedited your domain transfer. There is nothing else you need to do.',
+				{
+					components: {
+						br: <br />,
+					},
+				}
+			),
+		};
+	};
+
+	getCancelTransferSuccessState = () => {
+		const { translate } = this.props;
+
+		return {
+			message: translate(
+				'Congratulations!{{br/}}{{br/}}You have successfully cancelled your domain transfer. There is nothing else you need to do.',
+				{
+					components: {
+						br: <br />,
+					},
+				}
+			),
+		};
+	};
+
+	getDefaultSuccessState = () => {
+		const { translate } = this.props;
+
+		return {
+			title: translate( 'Success!' ),
+			messageAlignCenter: true,
+			actionTitle: null,
+			actionCallback: null,
+			alternateActionTitle: null,
+			alternateActionCallback: null,
+			footer: null,
+			isLoading: false,
+			isProcessingRequest: false,
+		};
+	};
+
+	setSuccessState = success => {
+		let successState;
+
+		switch ( success ) {
+			case 'accept_transfer_success':
+				successState = this.getAcceptTransferSuccessState();
+				break;
+
+			case 'cancel_transfer_success':
+				successState = this.getCancelTransferSuccessState();
+				break;
+		}
+
+		this.setState( {
+			...this.getDefaultSuccessState(),
+			...successState,
+		} );
 	};
 
 	render() {
@@ -109,10 +283,11 @@ class TransferAwayConfirmationPage extends Component {
 
 		return (
 			<div className="transfer-away-confirmation">
-				<DomainsLandingHeader title={ translate( 'Domain Transfer Managment' ) } />
+				<DomainsLandingHeader title={ translate( 'Domain Transfer Management' ) } />
 				<DomainsLandingContentCard
 					title={ this.state.title }
 					message={ this.state.message }
+					messageAlignCenter={ this.state.messageAlignCenter }
 					actionTitle={ this.state.actionTitle }
 					actionCallback={ this.state.actionCallback }
 					actionPrimary={ false }

--- a/client/landing/domains/transfer-away-confirmation/index.jsx
+++ b/client/landing/domains/transfer-away-confirmation/index.jsx
@@ -234,7 +234,7 @@ class TransferAwayConfirmationPage extends Component {
 				errorState = this.getExpiredTokenErrorState();
 				break;
 
-			case 'whois_status_error':
+			case 'whois_error':
 				errorState = this.getWhoisErrorState();
 				break;
 

--- a/client/landing/domains/transfer-away-confirmation/index.jsx
+++ b/client/landing/domains/transfer-away-confirmation/index.jsx
@@ -15,6 +15,12 @@ import wp from 'lib/wp';
 
 const wpcom = wp.undocumented();
 
+const VerifyConfirmationCommand = {
+	acceptTransfer: 'accept-transfer',
+	denyTransfer: 'deny-transfer',
+	verifyEmail: 'verify-email',
+};
+
 class TransferAwayConfirmationPage extends Component {
 	static propTypes = {
 		domain: PropTypes.string.isRequired,
@@ -36,7 +42,9 @@ class TransferAwayConfirmationPage extends Component {
 
 	componentWillMount() {
 		const { domain, recipientId, token } = this.props;
-		wpcom.domainsVerifyOutboundTransferConfirmation( domain, recipientId, token ).then(
+		const { verifyEmail } = VerifyConfirmationCommand;
+
+		wpcom.domainsVerifyOutboundTransferConfirmation( domain, recipientId, token, verifyEmail ).then(
 			() => {
 				this.setState( this.getConfirmationSelectState() );
 			},
@@ -57,30 +65,40 @@ class TransferAwayConfirmationPage extends Component {
 		};
 	};
 
-	onAcceptTransferComplete = error => {
-		if ( error ) {
-			this.setErrorState( { error: 'accept_transfer_failed' } );
-		} else {
-			this.setSuccessState( 'accept_transfer_success' );
-		}
-	};
-
 	acceptTransfer = () => {
-		this.setState( { isProcessingRequest: true } );
-		wpcom.acceptTransfer( this.props.domain, this.onAcceptTransferComplete );
-	};
+		const { domain, recipientId, token } = this.props;
+		const { acceptTransfer } = VerifyConfirmationCommand;
 
-	onCancelTransferComplete = error => {
-		if ( error ) {
-			this.setErrorState( { error: 'cancel_transfer_failed' } );
-		} else {
-			this.setSuccessState( 'cancel_transfer_success' );
-		}
+		this.setState( { isProcessingRequest: true } );
+
+		wpcom
+			.domainsVerifyOutboundTransferConfirmation( domain, recipientId, token, acceptTransfer )
+			.then(
+				() => {
+					this.setSuccessState( 'accept_transfer_success' );
+				},
+				() => {
+					this.setErrorState( { error: 'accept_transfer_failed' } );
+				}
+			);
 	};
 
 	cancelTransfer = () => {
+		const { domain, recipientId, token } = this.props;
+		const { denyTransfer } = VerifyConfirmationCommand;
+
 		this.setState( { isProcessingRequest: true } );
-		wpcom.declineTransfer( this.props.domain, this.onCancelTransferComplete );
+
+		wpcom
+			.domainsVerifyOutboundTransferConfirmation( domain, recipientId, token, denyTransfer )
+			.then(
+				() => {
+					this.setSuccessState( 'cancel_transfer_success' );
+				},
+				() => {
+					this.setErrorState( { error: 'cancel_transfer_failed' } );
+				}
+			);
 	};
 
 	getConfirmationSelectState = () => {

--- a/client/landing/domains/transfer-away-confirmation/index.jsx
+++ b/client/landing/domains/transfer-away-confirmation/index.jsx
@@ -18,7 +18,7 @@ const wpcom = wp.undocumented();
 class TransferAwayConfirmationPage extends Component {
 	static propTypes = {
 		domain: PropTypes.string.isRequired,
-		email: PropTypes.string.isRequired,
+		recipientId: PropTypes.string.isRequired,
 		token: PropTypes.string.isRequired,
 	};
 
@@ -35,8 +35,8 @@ class TransferAwayConfirmationPage extends Component {
 	}
 
 	componentWillMount() {
-		const { domain, email, token } = this.props;
-		wpcom.domainsVerifyOutboundTransferConfirmation( domain, email, token ).then(
+		const { domain, recipientId, token } = this.props;
+		wpcom.domainsVerifyOutboundTransferConfirmation( domain, recipientId, token ).then(
 			() => {
 				this.setState( this.getConfirmationSelectState() );
 			},
@@ -108,6 +108,24 @@ class TransferAwayConfirmationPage extends Component {
 			alternateActionTitle: 'Cancel Transfer',
 			alternateActionCallback: this.cancelTransfer,
 			isLoading: false,
+		};
+	};
+
+	getEmailMismatchState = () => {
+		const { domain, translate } = this.props;
+
+		return {
+			message: translate(
+				'This email address is different from the one we have on record for {{strong}}%(domain)s{{/strong}}.',
+				{
+					args: {
+						domain: domain,
+					},
+					components: {
+						strong: <strong />,
+					},
+				}
+			),
 		};
 	};
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2444,11 +2444,13 @@ Undocumented.prototype.domainsVerifyRegistrantEmail = function( domain, email, t
 Undocumented.prototype.domainsVerifyOutboundTransferConfirmation = function(
 	domain,
 	recipientId,
-	token
+	token,
+	command
 ) {
 	return this.wpcom.req.get( `/domains/${ domain }/outbound-transfer-confirmation-check`, {
 		recipient_id: recipientId,
 		token,
+		command,
 	} );
 };
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2441,4 +2441,15 @@ Undocumented.prototype.domainsVerifyRegistrantEmail = function( domain, email, t
 	return this.wpcom.req.get( `/domains/${ domain }/verify-email`, { email, token } );
 };
 
+Undocumented.prototype.domainGetOutboundTransferConfirmationState = function(
+	domain,
+	email,
+	token
+) {
+	return this.wpcom.req.get( `/domains/${ domain }/outbound-transfer-confirmation-state`, {
+		email,
+		token,
+	} );
+};
+
 export default Undocumented;

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2443,11 +2443,11 @@ Undocumented.prototype.domainsVerifyRegistrantEmail = function( domain, email, t
 
 Undocumented.prototype.domainsVerifyOutboundTransferConfirmation = function(
 	domain,
-	email,
+	recipientId,
 	token
 ) {
 	return this.wpcom.req.get( `/domains/${ domain }/outbound-transfer-confirmation-check`, {
-		email,
+		recipient_id: recipientId,
 		token,
 	} );
 };

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -2441,12 +2441,12 @@ Undocumented.prototype.domainsVerifyRegistrantEmail = function( domain, email, t
 	return this.wpcom.req.get( `/domains/${ domain }/verify-email`, { email, token } );
 };
 
-Undocumented.prototype.domainGetOutboundTransferConfirmationState = function(
+Undocumented.prototype.domainsVerifyOutboundTransferConfirmation = function(
 	domain,
 	email,
 	token
 ) {
-	return this.wpcom.req.get( `/domains/${ domain }/outbound-transfer-confirmation-state`, {
+	return this.wpcom.req.get( `/domains/${ domain }/outbound-transfer-confirmation-check`, {
 		email,
 		token,
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We need to add a landing page for users to accept/cancel their outbound domain transfers now that we're handling all of the messaging for this action on our own.

#### Testing instructions

Depends on D29035-code and D29088-code

* Follow the testing instructions in the two diffs that this PR depends on to generate a URL with the required domain and token parameters.
* Make sure that the page loads correctly.
* Try to simulate the error conditions in the initial request to `outbound-transfer-confirmation-check` (see D29088-code) and make sure that meaningful errors are shown.
* Try to simulate both successful and error conditions when accepting/canceling the transfer and make sure that meaningful messages are shown in both cases.
