### PR TITLE
Remove code for old twoYearPlanByDefault test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -80,14 +80,6 @@ export default {
 		},
 		defaultVariation: 'keep',
 	},
-	twoYearPlanByDefault: {
-		datestamp: '20190207',
-		variations: {
-			originalFlavor: 100,
-			twoYearFlavor: 0,
-		},
-		defaultVariation: 'originalFlavor',
-	},
 	pluginFeaturedTitle: {
 		datestamp: '20190220',
 		variations: {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -38,7 +38,6 @@ import {
 	getMonthlyPlanByYearly,
 	getPlanPath,
 	isFreePlan,
-	getBiennialPlan,
 	getPlanClass,
 } from 'lib/plans';
 import {
@@ -733,18 +732,6 @@ export const calculatePlanCredits = ( state, siteId, planProperties ) =>
 const hasPlaceholders = planProperties =>
 	planProperties.filter( planProps => planProps.isPlaceholder ).length > 0;
 
-const maybeGetBiennialPlanSlugVersion = planSlug => {
-	// Test defaulting to the 2 year option for wpcom plans
-	if (
-		planMatches( planSlug, { group: GROUP_WPCOM } ) &&
-		'twoYearFlavor' === abtest( 'twoYearPlanByDefault' )
-	) {
-		planSlug = getBiennialPlan( planSlug ) || planSlug;
-	}
-
-	return planSlug;
-};
-
 /* eslint-disable wpcalypso/redux-no-bound-selectors */
 export default connect(
 	( state, ownProps ) => {
@@ -842,9 +829,7 @@ export default connect(
 					isPlaceholder,
 					onUpgradeClick: onUpgradeClick
 						? () => {
-								const planSlug = maybeGetBiennialPlanSlugVersion(
-									getPlanSlug( state, planProductId )
-								);
+								const planSlug = getPlanSlug( state, planProductId );
 
 								onUpgradeClick( getCartItemForPlan( planSlug ) );
 						  }
@@ -853,9 +838,7 @@ export default connect(
 									return;
 								}
 
-								const planSlug = maybeGetBiennialPlanSlugVersion( plan );
-
-								page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( planSlug ) || '' }` );
+								page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( plan ) || '' }` );
 						  },
 					planConstantObj,
 					planName: plan,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove code for an old test that was already rolled back.

#### Testing instructions

1. Create a new site. Proceed through the steps, choosing any paid plan.
2. Once you get to the checkout step, you should have the "annual subscription" version of the plan in your cart.
<img width="267" alt="Screen Shot 2019-06-03 at 2 19 53 PM" src="https://user-images.githubusercontent.com/690843/58835456-e4ec5800-860a-11e9-80d5-cc46e384d75b.png">

3. Remove the plan from your cart.
4. From the /plans page (which you should have been automatically redirected to), again choose any paid plan.
5. You should again have the "annual subscription" version of the plan in your cart.