### PR TITLE
Signup: Add default copy for siteTopicLabel for the site topic step

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -24,6 +24,7 @@ const getSiteTypePropertyDefaults = propertyKey =>
 			siteTitlePlaceholder: i18n.translate( 'default siteTitlePlaceholder' ),
 			// Site topic step
 			siteTopicHeader: i18n.translate( 'What is your site about?' ),
+			siteTopicLabel: i18n.translate( 'What is your site about?' ),
 			siteTopicSubheader: i18n.translate(
 				"We'll add relevant content to your site to help you get started."
 			),

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -134,6 +134,7 @@ export function getAllSiteTypes() {
 			siteTitleLabel: i18n.translate( 'What is your name?' ),
 			siteTitlePlaceholder: i18n.translate( 'E.g., John Appleseed' ),
 			siteTopicHeader: i18n.translate( 'What type of work do you do?' ),
+			siteTopicLabel: i18n.translate( 'What type of work do you do?' ),
 			siteTopicInputPlaceholder: i18n.translate( 'Enter your job title or choose one from below.' ),
 			domainsStepSubheader: i18n.translate(
 				'Enter your name or some keywords that describe yourself to get started.'


### PR DESCRIPTION
## Changes proposed in this Pull Request

We added some new copy and default copy for the onboarding steps in #33312 

This PR adds default copy for `siteTopicLabel` for the site topic step so that we can display something in `aria-label`

Required by #33047 

## Testing instructions

None. We don't yet use this value.
