### PR TITLE
Adapt podcast stats module for file downloads

### DIFF
--- a/client/lib/wpcom-undocumented/lib/site.js
+++ b/client/lib/wpcom-undocumented/lib/site.js
@@ -15,7 +15,7 @@ const debug = debugFactory( 'calypso:wpcom-undocumented:site' );
 const resources = [
 	[ 'statsEvents', 'posts/' ],
 	[ 'statsInsights', 'stats/insights', '1.1' ],
-	[ 'statsPodcastDownloads', 'stats/podcast-downloads', '1.1' ],
+	[ 'statsFileDownloads', 'stats/file-downloads', '1.1' ],
 	[ 'statsAds', 'wordads/stats', '1.1' ],
 	[ 'sshCredentialsNew', 'ssh-credentials/new', '1.1', 'post' ],
 	[ 'sshCredentialsMine', 'ssh-credentials/mine', '1.1' ],
@@ -26,10 +26,10 @@ const resources = [
 
 const list = function( resourceOptions ) {
 	return function( query, fn ) {
-		let path,
-			subpath = resourceOptions.subpath;
+		let subpath = resourceOptions.subpath;
 
 		// Handle replacement of '/:var' in the subpath with value from query
+		/* eslint-disable no-useless-escape */
 		subpath = subpath.replace( /\/:([^\/]+)/g, function( match, property ) {
 			let replacement;
 			if ( 'undefined' !== typeof query[ property ] ) {
@@ -39,10 +39,11 @@ const list = function( resourceOptions ) {
 			}
 			return '/';
 		} );
+		/* eslint-enable no-useless-escape */
 
 		query.apiVersion = resourceOptions.apiVersion;
 
-		path = '/sites/' + this._id + '/' + subpath;
+		const path = '/sites/' + this._id + '/' + subpath;
 
 		debug( 'calling undocumented site api path', path );
 		debug( 'query', query );
@@ -57,7 +58,7 @@ const list = function( resourceOptions ) {
 
 // Walk for each resource and create related method
 resources.forEach( function( resource ) {
-	let name = resource[ 0 ],
+	const name = resource[ 0 ],
 		resourceOptions = {
 			subpath: resource[ 1 ],
 			apiVersion: resource[ 2 ] || '1',
@@ -242,9 +243,9 @@ UndocumentedSite.prototype.getGuidedTransferStatus = function() {
 };
 
 /**
- * Requests the status of a guided transfer
+ * Saves guided transfer host details
  *
- * @param {int} siteId  The site ID
+ * @param {Object} hostDetails  Host details
  * @returns {Promise} Resolves to the response containing the transfer status
  */
 UndocumentedSite.prototype.saveGuidedTransferHostDetails = function( hostDetails ) {

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -303,7 +303,7 @@ export default {
 			'authors',
 			'videoplays',
 			'videodetails',
-			'podcastdownloads',
+			'filedownloads',
 			'searchterms',
 			'annualstats',
 		];

--- a/client/my-sites/stats/index.js
+++ b/client/my-sites/stats/index.js
@@ -115,7 +115,7 @@ export default function() {
 			'authors',
 			'videoplays',
 			'videodetails',
-			'podcastdownloads',
+			'filedownloads',
 			'searchterms',
 			'annualstats',
 		];

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -31,12 +31,11 @@ import StickyPanel from 'components/sticky-panel';
 import JetpackColophon from 'components/jetpack-colophon';
 import config from 'config';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { getSiteOption, isJetpackSite, getSitePlanSlug } from 'state/sites/selectors';
+import { isJetpackSite, getSitePlanSlug } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import PrivacyPolicyBanner from 'blocks/privacy-policy-banner';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import QueryKeyringConnections from 'components/data/query-keyring-connections';
-
 import memoizeLast from 'lib/memoize-last';
 
 function updateQueryString( query = {} ) {
@@ -125,7 +124,7 @@ class StatsSite extends Component {
 	};
 
 	render() {
-		const { date, hasPodcasts, isJetpack, siteId, slug } = this.props;
+		const { date, isJetpack, siteId, slug } = this.props;
 
 		const queryDate = date.format( 'YYYY-MM-DD' );
 		const { period, endOf } = this.props.period;
@@ -148,14 +147,14 @@ class StatsSite extends Component {
 				/>
 			);
 		}
-		if ( config.isEnabled( 'manage/stats/podcasts' ) && hasPodcasts ) {
+		if ( config.isEnabled( 'manage/stats/file-downloads' ) ) {
 			podcastList = (
 				<StatsModule
-					path="podcastdownloads"
-					moduleStrings={ moduleStrings.podcastdownloads }
+					path="filedownloads"
+					moduleStrings={ moduleStrings.filedownloads }
 					period={ this.props.period }
 					query={ query }
-					statType="statsPodcastDownloads"
+					statType="statsFileDownloads"
 					showSummaryLink
 				/>
 			);
@@ -278,12 +277,6 @@ export default connect(
 
 		return {
 			isJetpack,
-			hasPodcasts:
-				// Podcasting category slug
-				// TODO: remove when settings API is updated for new option
-				!! getSiteOption( state, siteId, 'podcasting_archive' ) ||
-				// Podcasting category ID
-				!! getSiteOption( state, siteId, 'podcasting_category_id' ),
 			siteId,
 			slug: getSelectedSiteSlug( state ),
 			planSlug: getSitePlanSlug( state, siteId ),

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -86,14 +86,14 @@ export default function() {
 		} ),
 	};
 
-	statsStrings.podcastdownloads = {
-		title: translate( 'Podcasts', { context: 'Stats: title of module' } ),
-		item: translate( 'Episodes', { context: 'Stats: module row header for podcast.' } ),
+	statsStrings.filedownloads = {
+		title: translate( 'File Downloads', { context: 'Stats: title of module' } ),
+		item: translate( 'Files', { context: 'Stats: module row header for file downloads.' } ),
 		value: translate( 'Downloads', {
-			context: 'Stats: module row header for number of downloads per podcast episode.',
+			context: 'Stats: module row header for number of downloads per file.',
 		} ),
-		empty: translate( 'No episodes downloaded', {
-			context: 'Stats: Info box label when the Podcasts module is empty',
+		empty: translate( 'No files downloaded', {
+			context: 'Stats: Info box label when the file downloads module is empty',
 		} ),
 	};
 

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -158,16 +158,16 @@ class StatsSummary extends Component {
 				);
 				break;
 
-			case 'podcastdownloads':
-				title = translate( 'Podcasts' );
+			case 'filedownloads':
+				title = translate( 'File Downloads' );
 				summaryView = (
 					<StatsModule
-						key="podcastdownloads-summary"
-						path="podcastdownloads"
-						moduleStrings={ StatsStrings.podcastdownloads }
+						key="filedownloads-summary"
+						path="filedownloads"
+						moduleStrings={ StatsStrings.filedownloads }
 						period={ this.props.period }
 						query={ query }
-						statType="statsPodcastDownloads"
+						statType="statsFileDownloads"
 						summary
 					/>
 				);

--- a/client/state/stats/lists/actions.js
+++ b/client/state/stats/lists/actions.js
@@ -24,6 +24,7 @@ import { includes } from 'lodash';
  * @param  {String} statType Stat Key
  * @param  {Object} query    Stats query
  * @param  {Array}  data     Stat Data
+ * @param  {Object} date	 Date
  * @return {Object}          Action object
  */
 export function receiveSiteStats( siteId, statType, query, data, date ) {
@@ -56,7 +57,7 @@ export function requestSiteStats( siteId, statType, query ) {
 		} );
 		const isUndocumented = includes(
 			[
-				'statsPodcastDownloads',
+				'statsFileDownloads',
 				'statsAds',
 				'statsOrders',
 				'statsTopSellers',

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1800,22 +1800,22 @@ describe( 'utils', () => {
 			} );
 		} );
 
-		describe( 'statsPodcastDownloads()', () => {
+		describe( 'statsFileDownloads()', () => {
 			test( 'should return an empty array if data is null', () => {
-				expect( normalizers.statsPodcastDownloads() ).toEqual( [] );
+				expect( normalizers.statsFileDownloads() ).toEqual( [] );
 			} );
 
 			test( 'should return an empty array if query.period is null', () => {
-				expect( normalizers.statsPodcastDownloads( {}, { date: '2016-12-25' } ) ).toEqual( [] );
+				expect( normalizers.statsFileDownloads( {}, { date: '2016-12-25' } ) ).toEqual( [] );
 			} );
 
 			test( 'should return an empty array if query.date is null', () => {
-				expect( normalizers.statsPodcastDownloads( {}, { period: 'day' } ) ).toEqual( [] );
+				expect( normalizers.statsFileDownloads( {}, { period: 'day' } ) ).toEqual( [] );
 			} );
 
 			test( 'should properly parse day period response', () => {
 				expect(
-					normalizers.statsPodcastDownloads(
+					normalizers.statsFileDownloads(
 						{
 							date: '2017-01-12',
 							days: {
@@ -1849,7 +1849,7 @@ describe( 'utils', () => {
 							},
 						],
 						label: 'My awesome podcast',
-						page: '/stats/day/podcastdownloads/en.blog.wordpress.com?post=10',
+						page: '/stats/day/filedownloads/en.blog.wordpress.com?post=10',
 						value: 3939,
 					},
 				] );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import {
 	sortBy,
 	toPairs,
@@ -117,7 +116,7 @@ export function buildExportArray( data, parent = null ) {
 		return [];
 	}
 	const label = parent ? parent + ' > ' + data.label : data.label;
-	const escapedLabel = label.replace( /\"/, '""' );
+	const escapedLabel = label.replace( /\"/, '""' ); // eslint-disable-line no-useless-escape
 	let exportData = [ [ '"' + escapedLabel + '"', data.value ] ];
 
 	if ( data.children ) {
@@ -289,9 +288,10 @@ export function parseChartData( payload, nullAttributes = [] ) {
  * @return {Object} - moment date object
  */
 export function parseUnitPeriods( unit, period ) {
+	const splitYearWeek = period.split( '-W' );
+
 	switch ( unit ) {
 		case 'week':
-			const splitYearWeek = period.split( '-W' );
 			return moment()
 				.isoWeekYear( splitYearWeek[ 0 ] )
 				.isoWeek( splitYearWeek[ 1 ] )
@@ -962,7 +962,7 @@ export const normalizers = {
 	},
 
 	/*
-	 * Returns a normalized statsPodcastDownloads array, ready for use in stats-module
+	 * Returns a normalized statsFileDownloads array, ready for use in stats-module
 	 *
 	 * @param  {Object} data   Stats data
 	 * @param  {Object} query  Stats query
@@ -970,7 +970,7 @@ export const normalizers = {
 	 * @param  {Object} site   Site Object
 	 * @return {Array}         Parsed data array
 	 */
-	statsPodcastDownloads( data, query, siteId, site ) {
+	statsFileDownloads( data, query, siteId, site ) {
 		if ( ! data || ! query.period || ! query.date ) {
 			return [];
 		}
@@ -980,7 +980,7 @@ export const normalizers = {
 
 		return statsData.map( item => {
 			const detailPage = site
-				? '/stats/' + query.period + '/podcastdownloads/' + site.slug + '?post=' + item.post_id
+				? '/stats/' + query.period + '/filedownloads/' + site.slug + '?post=' + item.post_id
 				: null;
 			return {
 				label: item.title,

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -288,10 +288,11 @@ export function parseChartData( payload, nullAttributes = [] ) {
  * @return {Object} - moment date object
  */
 export function parseUnitPeriods( unit, period ) {
-	const splitYearWeek = period.split( '-W' );
+	let splitYearWeek;
 
 	switch ( unit ) {
 		case 'week':
+			splitYearWeek = period.split( '-W' );
 			return moment()
 				.isoWeekYear( splitYearWeek[ 0 ] )
 				.isoWeek( splitYearWeek[ 1 ] )

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -85,7 +85,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/stats": true,
-		"manage/stats/podcasts": true,
+		"manage/stats/file-downloads": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/development.json
+++ b/config/development.json
@@ -110,7 +110,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/stats": true,
-		"manage/stats/podcasts": true,
+		"manage/stats/file-downloads": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -84,7 +84,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/stats": true,
-		"manage/stats/podcasts": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/8148 (Sept 2016), a new 'podcast stats' module was added to My Sites > Stats behind a feature flag. This was never used in production.

This PR adapts the work done on podcast stats for a new 'File Downloads' panel.

<img width="1075" alt="Screen Shot 2019-06-04 at 15 37 52" src="https://user-images.githubusercontent.com/17325/58849563-e1c29c00-86de-11e9-97be-3fbb6534d05d.png">
<img width="385" alt="Screen Shot 2019-06-04 at 15 37 45" src="https://user-images.githubusercontent.com/17325/58849565-e25b3280-86de-11e9-9203-1f3f2f90a59d.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit My Sites > Stats for one of your sites (http://calypso.localhost:3000/stats/day/). Check that the new File Downloads module is present.

The associated API endpoint has been added in D29096-code, but the backend is still being worked on, so no stats will appear yet.