### PR TITLE
Checkout: Show cart to the right of payments box

### DIFF
--- a/client/components/data/store-connection/index.jsx
+++ b/client/components/data/store-connection/index.jsx
@@ -8,12 +8,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { isEqual } from 'lodash';
 
-/**
- * Internal dependencies
- */
-
-import { abtest } from 'lib/abtest';
-
 class StoreConnection extends React.Component {
 	static propTypes = {
 		component: PropTypes.func,
@@ -76,15 +70,9 @@ class StoreConnection extends React.Component {
 			return React.createElement( this.props.component, this.state );
 		}
 
-		if ( 'variantRightColumn' === abtest( 'showCheckoutCartRight' ) ) {
-			return React.Children.map( this.props.children, child => {
-				return React.cloneElement( child, this.state );
-			} );
-		}
-
-		const child = React.Children.only( this.props.children );
-
-		return React.cloneElement( child, this.state );
+		return React.Children.map( this.props.children, child => {
+			return React.cloneElement( child, this.state );
+		} );
 	}
 }
 

--- a/client/layout/sidebar/index.jsx
+++ b/client/layout/sidebar/index.jsx
@@ -7,11 +7,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-
-/**
- * Internal dependencies
- */
-
 import SidebarRegion from './region';
 
 export default class extends React.Component {
@@ -19,7 +14,6 @@ export default class extends React.Component {
 
 	static propTypes = {
 		className: PropTypes.string,
-		hasSidebar: PropTypes.bool,
 		onClick: PropTypes.func,
 	};
 
@@ -30,15 +24,8 @@ export default class extends React.Component {
 
 		const clickHandler =
 			'undefined' === typeof this.props.onClick ? {} : { onClick: this.props.onClick };
-		const className = classNames(
-			this.props.className,
-			{
-				'has-regions': hasRegions,
-			},
-			{
-				sidebar: 'undefined' === typeof this.props.hasSidebar || this.props.hasSidebar,
-			}
-		);
+
+		const className = classNames( 'sidebar', this.props.className, { 'has-regions': hasRegions } );
 
 		return (
 			<ul className={ className } { ...clickHandler } data-tip-target="sidebar">

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -343,39 +343,44 @@
 }
 
 
-// The following is for moving cart contents to the right.
-// As implemented in the showCheckoutCartRight ab test.
-div.checkout__container .cart__header {
-	border-top: none;
-	border-bottom: 1px solid var( --color-border-subtle );
-}
+// The following is for moving cart contents to the right of payments box.
+div.checkout__container {
+	& .cart__header {
+		border-top: none;
+		border-bottom: 1px solid var( --color-border-subtle );
+	}
 
-div.checkout__container .secondary-cart .card {
-	box-shadow: none;
-}
+	& .secondary-cart .card {
+		box-shadow: none;
+	}
 
-div.checkout__container .section-header.card {
-	padding-top: 14px;
-	padding-bottom: 13px;
+	& .section-header.card {
+		padding-top: 14px;
+		padding-bottom: 13px;
+	}
+
+	& .jetpack-logo {
+		width: 100%;
+	}
 }
 
 @include breakpoint( '>660px' ) {
 	div.checkout__container {
 		display: flex;
 		align-items: flex-start;
-	}
 
-	div.checkout__container .main {
-		margin-right: 0;
-		width: 100%;
-	}
+		& .main {
+			margin-right: 0;
+			width: 100%;
+		}
 
-	div.checkout__container .secondary-cart {
-		margin: 0 auto;
-		margin-left: 20px;
-		margin-bottom: 16px;
-		width: 272px;
-		box-shadow: 0 1px 0 var( --color-border-subtle );
+		& .secondary-cart {
+			margin: 0 auto;
+			margin-left: 20px;
+			margin-bottom: 16px;
+			width: 272px;
+			box-shadow: 0 1px 0 var( --color-border-subtle );
+		}
 	}
 }
 
@@ -384,9 +389,5 @@ div.checkout__container .section-header.card {
 		margin-left: 0;
 	}
 }
-
-div.checkout__container .jetpack-logo {
-	width: 100%;
-}
-// end of showCheckoutCartRight ab test related CSS changes
+// end of show cart right related CSS changes
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -131,15 +131,6 @@ export default {
 		defaultVariation: 'noOffer',
 		allowExistingUsers: true,
 	},
-	showCheckoutCartRight: {
-		datestamp: '20190502',
-		variations: {
-			variantRightColumn: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	showApplePay: {
 		datestamp: '20190529',
 		variations: {

--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -19,11 +19,10 @@ import CartMessages from './cart-messages';
 import CartSummaryBar from 'my-sites/checkout/cart/cart-summary-bar';
 import CartPlanAdTheme from './cart-plan-ad-theme';
 import CartPlanDiscountAd from './cart-plan-discount-ad';
-import Sidebar from 'layout/sidebar';
 import CartBodyLoadingPlaceholder from 'my-sites/checkout/cart/cart-body/loading-placeholder';
 import { CART_ON_MOBILE_SHOW } from 'lib/upgrades/action-types';
 import scrollIntoViewport from 'lib/scroll-into-viewport';
-import { getSelectedSiteId, hasSidebar } from 'state/ui/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import JetpackLogo from 'components/jetpack-logo';
@@ -77,16 +76,16 @@ class SecondaryCart extends Component {
 
 		if ( ! cart.hasLoadedFromServer ) {
 			return (
-				<Sidebar className={ cartClasses } hasSidebar={ this.props.hasSidebar }>
+				<ul className={ cartClasses }>
 					<CartMessages cart={ cart } selectedSite={ selectedSite } />
 					<CartSummaryBar additionalClasses="cart-header" />
 					<CartBodyLoadingPlaceholder />
-				</Sidebar>
+				</ul>
 			);
 		}
 
 		return (
-			<Sidebar className={ cartClasses } hasSidebar={ this.props.hasSidebar }>
+			<ul className={ cartClasses }>
 				<CartMessages cart={ cart } selectedSite={ selectedSite } />
 				<CartSummaryBar additionalClasses="cart-header" />
 				<CartPlanAdTheme selectedSite={ selectedSite } cart={ cart } />
@@ -99,7 +98,7 @@ class SecondaryCart extends Component {
 				<CartPlanDiscountAd cart={ cart } selectedSite={ selectedSite } />
 
 				{ isJetpackNotAtomic && <JetpackLogo full /> }
-			</Sidebar>
+			</ul>
 		);
 	}
 }
@@ -110,6 +109,5 @@ export default connect( state => {
 	return {
 		isJetpackNotAtomic:
 			isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId ),
-		hasSidebar: hasSidebar( state ),
 	};
 } )( localize( SecondaryCart ) );

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -1,0 +1,58 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { localize } from 'i18n-calypso';
+import FormattedHeader from 'components/formatted-header';
+import Checkout from '../checkout';
+import CartData from 'components/data/cart';
+import CheckoutData from 'components/data/checkout';
+import SecondaryCart from '../cart/secondary-cart';
+
+class CheckoutContainer extends React.Component {
+	constructor() {
+		super();
+		this.state = {
+			headerText: '',
+		};
+	}
+
+	renderCheckoutHeader() {
+		return <FormattedHeader headerText={ this.state.headerText } />;
+	}
+
+	setHeaderText = newHeaderText => {
+		this.setState( { headerText: newHeaderText } );
+	};
+
+	render() {
+		const { product, purchaseId, feature, code, plan, selectedSite } = this.props;
+
+		return (
+			<>
+				{ this.renderCheckoutHeader() }
+				<div className="checkout__container">
+					<CheckoutData>
+						<Checkout
+							product={ product }
+							purchaseId={ purchaseId }
+							selectedFeature={ feature }
+							couponCode={ code }
+							plan={ plan }
+							setHeaderText={ this.setHeaderText }
+						/>
+						<CartData>
+							<SecondaryCart selectedSite={ selectedSite } />
+						</CartData>
+					</CheckoutData>
+				</div>
+			</>
+		);
+	}
+}
+
+export default localize( CheckoutContainer );

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -30,7 +30,7 @@ class CheckoutContainer extends React.Component {
 	};
 
 	render() {
-		const { product, purchaseId, feature, code, plan, selectedSite } = this.props;
+		const { product, purchaseId, feature, code, plan, selectedSite, reduxStore } = this.props;
 
 		return (
 			<>
@@ -44,6 +44,7 @@ class CheckoutContainer extends React.Component {
 							couponCode={ code }
 							plan={ plan }
 							setHeaderText={ this.setHeaderText }
+							reduxStore={ reduxStore }
 						/>
 						<CartData>
 							<SecondaryCart selectedSite={ selectedSite } />

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -605,6 +605,7 @@ export class Checkout extends React.Component {
 				paymentMethods={ this.paymentMethodsAbTestFilter() }
 				products={ this.props.productsList }
 				selectedSite={ selectedSite }
+				setHeaderText={ this.props.setHeaderText }
 				redirectTo={ this.getCheckoutCompleteRedirectPath }
 				handleCheckoutCompleteRedirect={ this.handleCheckoutCompleteRedirect }
 				handleCheckoutExternalRedirect={ this.handleCheckoutExternalRedirect }

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -540,20 +540,8 @@ export class SecurePaymentForm extends Component {
 	renderGreatChoiceHeader() {
 		const { translate } = this.props;
 		const headerText = translate( 'Great choice! How would you like to pay?' );
-<<<<<<< HEAD
 
-		if ( 'variantRightColumn' === abtest( 'showCheckoutCartRight' ) ) {
-			const element = document.getElementsByClassName( 'formatted-header__title' )[ 0 ];
-			if ( element ) {
-				element.textContent = headerText;
-			}
-			return;
-		}
-		return <FormattedHeader headerText={ headerText } />;
-=======
-		const element = document.getElementsByClassName( 'formatted-header__title' )[ 0 ];
-		element.textContent = headerText;
->>>>>>> First commit: Removing the showCartRight abtest and making the cart to the right as the control
+		this.props.setHeaderText( headerText );
 	}
 
 	render() {

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -39,8 +39,6 @@ import { INPUT_VALIDATION, REDIRECTING_FOR_AUTHORIZATION } from 'lib/store-trans
 import { getTld } from 'lib/domains';
 import { displayError, clear } from 'lib/upgrades/notices';
 import { removeNestedProperties } from 'lib/cart/store/cart-analytics';
-import FormattedHeader from 'components/formatted-header';
-import { abtest } from 'lib/abtest';
 
 /**
  * Module variables
@@ -542,6 +540,7 @@ export class SecurePaymentForm extends Component {
 	renderGreatChoiceHeader() {
 		const { translate } = this.props;
 		const headerText = translate( 'Great choice! How would you like to pay?' );
+<<<<<<< HEAD
 
 		if ( 'variantRightColumn' === abtest( 'showCheckoutCartRight' ) ) {
 			const element = document.getElementsByClassName( 'formatted-header__title' )[ 0 ];
@@ -551,6 +550,10 @@ export class SecurePaymentForm extends Component {
 			return;
 		}
 		return <FormattedHeader headerText={ headerText } />;
+=======
+		const element = document.getElementsByClassName( 'formatted-header__title' )[ 0 ];
+		element.textContent = headerText;
+>>>>>>> First commit: Removing the showCartRight abtest and making the cart to the right as the control
 	}
 
 	render() {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -15,10 +15,7 @@ import { getSiteBySlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import GSuiteNudge from 'my-sites/checkout/gsuite-nudge';
 import CheckoutContainer from './checkout/checkout-container';
-import Checkout from './checkout';
-import CheckoutData from 'components/data/checkout';
 import CartData from 'components/data/cart';
-import SecondaryCart from './cart/secondary-cart';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
 import ConciergeSessionNudge from './concierge-session-nudge';
@@ -49,30 +46,10 @@ export function checkout( context, next ) {
 			couponCode={ context.query.code || getRememberedCoupon() }
 			plan={ plan }
 			selectedSite={ selectedSite }
+			reduxStore={ context.store }
 		/>
 	);
 
-	next();
-}
-
-export function sitelessCheckout( context, next ) {
-	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
-	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
-
-	context.primary = (
-		<CheckoutData>
-			<Checkout
-				reduxStore={ context.store }
-				couponCode={ context.query.code || getRememberedCoupon() }
-			/>
-		</CheckoutData>
-	);
-
-	context.secondary = (
-		<CartData>
-			<SecondaryCart />
-		</CartData>
-	);
 	next();
 }
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -25,7 +25,6 @@ import ConciergeQuickstartSession from './concierge-quickstart-session';
 import { isGSuiteRestricted } from 'lib/gsuite';
 import { getRememberedCoupon } from 'lib/upgrades/actions';
 import FormattedHeader from 'components/formatted-header';
-import { abtest } from 'lib/abtest';
 
 export function checkout( context, next ) {
 	const { feature, plan, product } = context.params;
@@ -40,50 +39,28 @@ export function checkout( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Checkout' ) ) );
 
-	if ( 'variantRightColumn' === abtest( 'showCheckoutCartRight' ) ) {
-		context.store.dispatch( setSection( { name: 'checkout' }, { hasSidebar: false } ) );
-
-		context.primary = (
-			<>
-				<FormattedHeader />
-				<div className="checkout__container">
-					<CheckoutData>
-						<Checkout
-							product={ product }
-							purchaseId={ context.params.purchaseId }
-							selectedFeature={ feature }
-							couponCode={ context.query.code || getRememberedCoupon() }
-							plan={ plan }
-						/>
-						<CartData>
-							<SecondaryCart selectedSite={ selectedSite } />
-						</CartData>
-					</CheckoutData>
-				</div>
-			</>
-		);
-
-		next();
-		return;
-	}
+	context.store.dispatch( setSection( { name: 'checkout' }, { hasSidebar: false } ) );
 
 	context.primary = (
-		<CheckoutData>
-			<Checkout
-				product={ product }
-				purchaseId={ context.params.purchaseId }
-				selectedFeature={ feature }
-				couponCode={ context.query.code || getRememberedCoupon() }
-				plan={ plan }
-			/>
-		</CheckoutData>
+		<>
+			<FormattedHeader />
+			<div className="checkout__container">
+				<CheckoutData>
+					<Checkout
+						product={ product }
+						purchaseId={ context.params.purchaseId }
+						selectedFeature={ feature }
+						couponCode={ context.query.code }
+						plan={ plan }
+					/>
+					<CartData>
+						<SecondaryCart selectedSite={ selectedSite } />
+					</CartData>
+				</CheckoutData>
+			</div>
+		</>
 	);
 
-	context.secondary = (
-		<CartData>
-			<SecondaryCart selectedSite={ selectedSite } />
-		</CartData>
-	);
 	next();
 }
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -46,7 +46,7 @@ export function checkout( context, next ) {
 			product={ product }
 			purchaseId={ purchaseId }
 			selectedFeature={ feature }
-			couponCode={ context.query.code }
+			couponCode={ context.query.code || getRememberedCoupon() }
 			plan={ plan }
 			selectedSite={ selectedSite }
 		/>

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -14,6 +14,7 @@ import { setSection } from 'state/ui/actions';
 import { getSiteBySlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import GSuiteNudge from 'my-sites/checkout/gsuite-nudge';
+import CheckoutContainer from './checkout/checkout-container';
 import Checkout from './checkout';
 import CheckoutData from 'components/data/checkout';
 import CartData from 'components/data/cart';
@@ -24,10 +25,9 @@ import ConciergeSessionNudge from './concierge-session-nudge';
 import ConciergeQuickstartSession from './concierge-quickstart-session';
 import { isGSuiteRestricted } from 'lib/gsuite';
 import { getRememberedCoupon } from 'lib/upgrades/actions';
-import FormattedHeader from 'components/formatted-header';
 
 export function checkout( context, next ) {
-	const { feature, plan, product } = context.params;
+	const { feature, plan, product, purchaseId } = context.params;
 
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
@@ -42,23 +42,14 @@ export function checkout( context, next ) {
 	context.store.dispatch( setSection( { name: 'checkout' }, { hasSidebar: false } ) );
 
 	context.primary = (
-		<>
-			<FormattedHeader />
-			<div className="checkout__container">
-				<CheckoutData>
-					<Checkout
-						product={ product }
-						purchaseId={ context.params.purchaseId }
-						selectedFeature={ feature }
-						couponCode={ context.query.code }
-						plan={ plan }
-					/>
-					<CartData>
-						<SecondaryCart selectedSite={ selectedSite } />
-					</CartData>
-				</CheckoutData>
-			</div>
-		</>
+		<CheckoutContainer
+			product={ product }
+			purchaseId={ purchaseId }
+			selectedFeature={ feature }
+			couponCode={ context.query.code }
+			plan={ plan }
+			selectedSite={ selectedSite }
+		/>
 	);
 
 	next();

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -12,7 +12,6 @@ import {
 	checkoutPending,
 	checkoutThankYou,
 	gsuiteNudge,
-	sitelessCheckout,
 	conciergeSessionNudge,
 	conciergeQuickstartSession,
 } from './controller';
@@ -72,7 +71,7 @@ export default function() {
 		clientRender
 	);
 
-	page( '/checkout/no-site', noSite, sitelessCheckout, makeLayout, clientRender );
+	page( '/checkout/no-site', noSite, checkout, makeLayout, clientRender );
 
 	page(
 		'/checkout/features/:feature/:domain/:plan_name?',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Following the positive results in the `showCheckoutCartRight` abtest run in #32832  we will make the cart on the right as the new control. For more context, also check p8Eqe3-Bo-p2.

Visiting the checkout page(either with a WordPress.com or Jetpack product), the cart will now always be shown to the right of the payments box/domain contact form. 

#### Testing instructions

#### Scenario 1
1. Open the checkout page by adding a new domain and plan to cart.
2. Verify that the checkout page looks like in the screenshot below:
     * Cart is to the right
     * The left sidebar is hidden.
     * The cart box and domain contact form box are of equal height and aligned.
     * The domain contact form and the cart are center aligned to the page

![calypso localhost_3000_checkout_xaf993401859 wordpress com](https://user-images.githubusercontent.com/1269602/58864646-bc2f9580-86d2-11e9-90cf-887f24c7548c.png)

#### Scenario 2

After completing steps 1-3 above, proceed to the Checkout page and verify it looks like in the screenshot below. Few things to look out for:
    * The checkout box and the cart box height are equal and aligned.
    * The left sidebar is hidden.
    * The header _Great Choice! How would you like to pay?_ is center aligned to the page.
    * The checkout box and cart box are center aligned to the page.

![calypso localhost_3000_checkout_xaf993401859 wordpress com (1)](https://user-images.githubusercontent.com/1269602/58864674-d0739280-86d2-11e9-9452-137b5c4ed611.png)

#### Scenario 3

1. On a site having a paid plan and _no domain_, purchase a domain and proceed to checkout.
2. The checkout page should like in the screenshot below. As before, verify the UI looks proper (cart to the right, boxes aligned and so on).

![calypso localhost_3000_checkout_xaf993401859 wordpress com (2)](https://user-images.githubusercontent.com/1269602/58864706-dc5f5480-86d2-11e9-9db1-7be63b6e42fc.png)

#### Scenario 4

Open Reader and My Sites pages. Verify that the sidebar looks fine. Adding this scenario since this PR modifies the <Sidebar> component which is being used in other Calypso pages.


#### Scenario 5

Verify that the placeholder components showed while the page is loading (the ones with the flashing grey horizontal bars in the gif below) show cart on the right with proper alignment.

![giphy (1)](https://user-images.githubusercontent.com/1269602/58864764-f731c900-86d2-11e9-8225-7db582e52a84.gif)

#### Scenario 6

Add a Jetpack plan to your cart and verify that Jetpack checkout shows cart to the right.

![calypso localhost_3000_checkout_niranjan ngrok io (1)](https://user-images.githubusercontent.com/1269602/58865450-3280c780-86d4-11e9-8eac-98de2a3a5cb0.png)

#### Scenario 7

Try the domains only flow starting at http://calypso.localhost:3000/start/domain and verify that you are able to complete the purchase. 

#### Scenario 8

**Verify on mobile devices:**

**iPhone X (Jetpack):**

![jp_mob copy](https://user-images.githubusercontent.com/1269602/58865910-0a459880-86d5-11e9-955e-0216f720ac13.png)

**Galaxy S5:**

![wpcom_right](https://user-images.githubusercontent.com/1269602/58866004-3bbe6400-86d5-11e9-8ffc-5a20130644cd.png)

**iPad Pro:**

![ipad_right](https://user-images.githubusercontent.com/1269602/58866025-47aa2600-86d5-11e9-8532-318d49052c6c.png)

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**With Chat window open**

Desktop:

![calypso localhost_3000_checkout_niranjanumashankartest1 wordpress com (1)](https://user-images.githubusercontent.com/1269602/58866311-f484a300-86d5-11e9-8625-701296587362.png)

iPad:

![calypso localhost_3000_checkout_niranjanumashankartest1 wordpress com(iPad Pro) (1)](https://user-images.githubusercontent.com/1269602/58866323-fbabb100-86d5-11e9-9172-404b001b9cc7.png)

