### PR TITLE
Checklist: Disable Jetpack perf checklist for more visible environments

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -45,7 +45,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/checklist": true,
-		"jetpack/checklist/performance": true,
+		"jetpack/checklist/performance": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -56,7 +56,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/checklist": true,
-		"jetpack/checklist/performance": true,
+		"jetpack/checklist/performance": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,


### PR DESCRIPTION
Disable in stage and wpcalypso.

The feature is very early stage and it makes sense to leave it dev-only.

Follow-up #33545 