### PR TITLE
Revert "Onboarding: Remove the onboarding specific check for subheader"

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -34,9 +34,6 @@ const getSiteTypePropertyDefaults = propertyKey =>
 			domainsStepSubheader: i18n.translate(
 				'Enter a keyword that describes your site to get started.'
 			),
-			domainsStepTransferringSubheader: i18n.translate(
-				'Use a domain you already own with your new WordPress.com site.'
-			),
 			// Site styles step
 			siteStyleSubheader: i18n.translate(
 				'This will help you get started with a theme you might like. You can change it later.'
@@ -101,9 +98,6 @@ export function getAllSiteTypes() {
 			domainsStepHeader: i18n.translate( 'Give your blog an address' ),
 			domainsStepSubheader: i18n.translate(
 				"Enter your blog's name or some keywords that describe it to get started."
-			),
-			domainsStepTransferringSubheader: i18n.translate(
-				'Use a domain you already own with your new WordPress.com blog.'
 			),
 		},
 		{

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -519,11 +519,17 @@ class DomainsStep extends React.Component {
 	};
 
 	getSubHeaderText() {
-		const { siteType, stepSectionName } = this.props;
+		const { siteType, translate } = this.props;
+		const onboardingSubHeaderCopy =
+			siteType && getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
 
-		return 'transfer' === stepSectionName || 'mapping' === stepSectionName
-			? getSiteTypePropertyValue( 'slug', siteType, 'domainsStepTransferringSubheader' )
-			: getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
+		if ( onboardingSubHeaderCopy ) {
+			return onboardingSubHeaderCopy;
+		}
+
+		return 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName
+			? translate( 'Use a domain you already own with your new WordPress.com site.' )
+			: translate( "Enter your site's name or some keywords that describe it to get started." );
 	}
 
 	getHeaderText() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { defer, endsWith, get, isEmpty } from 'lodash';
+import { defer, endsWith, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 
 /**
@@ -519,9 +519,11 @@ class DomainsStep extends React.Component {
 	};
 
 	getSubHeaderText() {
-		const { siteType, translate } = this.props;
+		const { flowName, siteType, translate } = this.props;
 		const onboardingSubHeaderCopy =
-			siteType && getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
+			siteType &&
+			includes( [ 'onboarding-for-business', 'onboarding' ], flowName ) &&
+			getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
 
 		if ( onboardingSubHeaderCopy ) {
 			return onboardingSubHeaderCopy;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#33470

Since #33470 one of our e2e tests has been failing and was `.skip`ped in #33517.
For the time being, I'm rolling back #33470 until the `onboarding-blog` flow is made redundant and removed.
