### PR TITLE
Auto-renewal Toggle: Add the follow-up confirming dialog for atomic sites.

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -24,6 +24,10 @@ class AutoRenewDisablingDialog extends Component {
 		purchase: PropTypes.object.isRequired,
 	};
 
+	state = {
+		showAtomicFollowUpDialog: false,
+	};
+
 	getVariation() {
 		const { purchase, isAtomicSite } = this.props;
 
@@ -102,12 +106,54 @@ class AutoRenewDisablingDialog extends Component {
 		}
 	}
 
-	onClickConfirm = () => this.props.onConfirm() || this.props.onClose();
+	onClickAtomicFollowUpConfirm = () => {
+		this.props.onConfirm() || this.props.onClose();
+	};
 
-	render() {
-		const { translate, onClose } = this.props;
+	renderAtomicFollowUpDialog = () => {
+		const { siteDomain, onClose, translate } = this.props;
 
+		const exportPath = '//' + siteDomain + '/wp-admin/export.php';
+
+		return (
+			<Dialog
+				isVisible={ true }
+				additionalClassNames="auto-renew-disabling-dialog atomic-follow-up"
+				onClose={ onClose }
+			>
+				<p>
+					{ translate(
+						"In order to proceed, we recommend that you download a backup of your site's content to avoid losing content in the future."
+					) }
+				</p>
+				<Button href={ exportPath } primary>
+					{ translate( 'Backup my content' ) }
+				</Button>
+				<Button onClick={ this.onClickAtomicFollowUpConfirm }>
+					{ translate( "I've already taken a backup, please cancel auto-renewal" ) }
+				</Button>
+				<Button onClick={ this.onClickAtomicFollowUpConfirm }>
+					{ translate( "I'm not interested in taking a backup, please cancel auto-renewal" ) }
+				</Button>
+			</Dialog>
+		);
+	};
+
+	onClickGeneralConfirm = () => {
+		if ( 'atomic' === this.getVariation() ) {
+			this.setState( {
+				showAtomicFollowUpDialog: true,
+			} );
+			return;
+		}
+
+		this.props.onConfirm() || this.props.onClose();
+	};
+
+	renderGeneralDialog = () => {
+		const { onClose, translate } = this.props;
 		const description = this.getCopy( this.getVariation() );
+
 		return (
 			<Dialog
 				isVisible={ true }
@@ -119,9 +165,14 @@ class AutoRenewDisablingDialog extends Component {
 				<Button onClick={ onClose } primary>
 					{ translate( 'Confirm cancellation' ) }
 				</Button>
-				<Button onClick={ this.onClickConfirm }>{ translate( 'Yes, please cancel it.' ) }</Button>
 			</Dialog>
 		);
+	};
+
+	render() {
+		return this.state.showAtomicFollowUpDialog
+			? this.renderAtomicFollowUpDialog()
+			: this.renderGeneralDialog();
 	}
 }
 

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -126,15 +126,23 @@ class AutoRenewDisablingDialog extends Component {
 						"In order to proceed, we recommend that you download a backup of your site's content to avoid losing content in the future."
 					) }
 				</p>
-				<Button href={ exportPath } primary>
-					{ translate( 'Backup my content' ) }
-				</Button>
-				<Button onClick={ this.onClickAtomicFollowUpConfirm }>
-					{ translate( "I've already taken a backup, please cancel auto-renewal" ) }
-				</Button>
-				<Button onClick={ this.onClickAtomicFollowUpConfirm }>
-					{ translate( "I'm not interested in taking a backup, please cancel auto-renewal" ) }
-				</Button>
+				<ul>
+					<li>
+						<Button href={ exportPath } primary>
+							{ translate( 'Backup my content' ) }
+						</Button>
+					</li>
+					<li>
+						<Button onClick={ this.onClickAtomicFollowUpConfirm }>
+							{ translate( "I've already taken a backup, please cancel auto-renewal" ) }
+						</Button>
+					</li>
+					<li>
+						<Button onClick={ this.onClickAtomicFollowUpConfirm }>
+							{ translate( "I'm not interested in taking a backup, please cancel auto-renewal" ) }
+						</Button>
+					</li>
+				</ul>
 			</Dialog>
 		);
 	};

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -123,23 +123,21 @@ class AutoRenewDisablingDialog extends Component {
 			>
 				<p>
 					{ translate(
-						"In order to proceed, we recommend that you download a backup of your site's content to avoid losing content in the future."
+						'Before you continue, we recommend downloading a backup of your site – ' +
+							"that way, you'll have your content to use on any future websites you create."
 					) }
 				</p>
 				<ul>
 					<li>
 						<Button href={ exportPath } primary>
-							{ translate( 'Backup my content' ) }
+							{ translate( 'Download a backup' ) }
 						</Button>
 					</li>
 					<li>
 						<Button onClick={ this.onClickAtomicFollowUpConfirm }>
-							{ translate( "I've already taken a backup, please cancel auto-renewal" ) }
-						</Button>
-					</li>
-					<li>
-						<Button onClick={ this.onClickAtomicFollowUpConfirm }>
-							{ translate( "I'm not interested in taking a backup, please cancel auto-renewal" ) }
+							{ translate(
+								"I don't need a backup OR I already have a backup. Cancel my auto-renewal."
+							) }
 						</Button>
 					</li>
 				</ul>

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -102,6 +102,8 @@ class AutoRenewDisablingDialog extends Component {
 		}
 	}
 
+	onClickConfirm = () => this.props.onConfirm() || this.props.onClose();
+
 	render() {
 		const { translate, onClose } = this.props;
 
@@ -117,6 +119,7 @@ class AutoRenewDisablingDialog extends Component {
 				<Button onClick={ onClose } primary>
 					{ translate( 'Confirm cancellation' ) }
 				</Button>
+				<Button onClick={ this.onClickConfirm }>{ translate( 'Yes, please cancel it.' ) }</Button>
 			</Dialog>
 		);
 	}

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -168,7 +168,7 @@ class AutoRenewDisablingDialog extends Component {
 			>
 				<h2 className="auto-renew-disabling-dialog__header">{ translate( 'Before you go…' ) }</h2>
 				<p>{ description }</p>
-				<Button onClick={ onClose } primary>
+				<Button onClick={ this.onClickGeneralConfirm } primary>
 					{ translate( 'Confirm cancellation' ) }
 				</Button>
 			</Dialog>

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
@@ -1,8 +1,10 @@
 .dialog.auto-renew-disabling-dialog {
 	max-width: 440px;
 
-	.button.is-primary {
-		margin-right: 24px;
+	.button {
+		margin-bottom: 8px;
+		padding: 8px 10px;
+		text-align: left;
 	}
 }
 

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
@@ -12,3 +12,12 @@
 	font-size: 24px;
 	margin-bottom: 14px;
 }
+
+.dialog.auto-renew-disabling-dialog.atomic-follow-up {
+	max-width: 600px;
+
+	ul {
+		list-style-type: none;
+		margin: 0;
+	}
+}

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
@@ -1,5 +1,9 @@
 .dialog.auto-renew-disabling-dialog {
 	max-width: 440px;
+
+	.button.is-primary {
+		margin-right: 24px;
+	}
 }
 
 .auto-renew-disabling-dialog__header {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -43,18 +43,12 @@ class AutoRenewToggle extends Component {
 		} );
 	};
 
-	onToggleAutoRenew = () => {
+	toggleAutoRenew = () => {
 		const {
 			purchase: { id: purchaseId },
 			currentUserId,
 			isEnabled,
 		} = this.props;
-
-		if ( isEnabled ) {
-			this.setState( {
-				showAutoRenewDisablingDialog: true,
-			} );
-		}
 
 		const updateAutoRenew = isEnabled ? disableAutoRenew : enableAutoRenew;
 
@@ -71,6 +65,19 @@ class AutoRenewToggle extends Component {
 				this.props.fetchUserPurchases( currentUserId );
 			}
 		} );
+	};
+
+	onToggleAutoRenew = () => {
+		const { isEnabled } = this.props;
+
+		if ( isEnabled ) {
+			this.setState( {
+				showAutoRenewDisablingDialog: true,
+			} );
+			return;
+		}
+
+		this.toggleAutoRenew();
 	};
 
 	isUpdatingAutoRenew = () => {
@@ -101,6 +108,7 @@ class AutoRenewToggle extends Component {
 						purchase={ purchase }
 						siteDomain={ siteDomain }
 						onClose={ this.onCloseAutoRenewDisablingDialog }
+						onConfirm={ this.toggleAutoRenew }
 					/>
 				) }
 			</>


### PR DESCRIPTION
_This PR is part of the attempt of adding a self-serving plan subscription autorenewal toggle. For more details, please refer to p2-p9jf6J-1GZ_

#### Changes proposed in this Pull Request

This PR contains two changes:

1. Delay the disabling after clicking the confirming button. Currently, the disabling happens right on toggling the auto-renewal off. Now it happens after confirming.
1. Add a follow-up dialog for the plan purchase associated with an atomic site:
![image](https://user-images.githubusercontent.com/1842898/58942296-15b9c200-87b0-11e9-8c49-66a074ad0f3f.png)
Here is a screencast of how to get to it:
![demo-atomic-follow-up](https://user-images.githubusercontent.com/1842898/58941201-dbe7bc00-87ad-11e9-9388-611e23bc7d67.gif)

#### Dependency
https://github.com/Automattic/wp-calypso/pull/33539


#### Testing instructions

1. Go to the purchase manage page (`/me/purchase/{site domain}/{purchase id}`) of a plan associated with an atomic site.
1. Disable auto-renewal and you should see the follow-up dialog.
1. From the follow-up dialog:
    1. Click on "Backup my content" should lead you to the export page.
    1. Click on the rest two should dismiss the dialog and disable auto-renewal.
1. Do the same to a non-atomic subscription. The usual disabling dialog should appear and the toggle should only go off after clicking the confirming button.