### PR TITLE
css: migrate plan-price styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -119,7 +119,6 @@
 @import 'my-sites/plan-compare-card/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/plan-interval-discount/style';
-@import 'my-sites/plan-price/style';
 @import 'my-sites/plans-features-main/style';
 @import 'my-sites/plans/style';
 @import 'my-sites/post-relative-time-status/style';

--- a/client/my-sites/plan-price/index.jsx
+++ b/client/my-sites/plan-price/index.jsx
@@ -15,6 +15,11 @@ import { getCurrencyObject } from '@automattic/format-currency';
  */
 import Badge from 'components/badge';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class PlanPrice extends Component {
 	render() {
 		const {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate styles for the `<PlanPrice />` component

#### Testing instructions

The `<PlanPrice />` component is used on _Manage Purchases > Plan Details_ or in the header of the plan page for a site which doesn't have an active plan. Make sure the pricing tag displays correctly on those occurrences.

Part of #27515.

Fixes #33567
