### PR TITLE
Domains: Make the Delete Domain Dialog box more resistant to accidents

### DIFF
--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -1,0 +1,213 @@
+/**
+ * External dependencies
+ */
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import FormSectionHeading from 'components/forms/form-section-heading';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import FormInputValidation from 'components/forms/form-input-validation';
+import FormCheckbox from 'components/forms/form-checkbox';
+import { CALYPSO_CONTACT } from 'lib/url/support';
+import { getName, isRefundable, maybeWithinRefundPeriod } from 'lib/purchases';
+
+class RemoveDomainDialog extends Component {
+	static propTypes = {
+		isRemoving: PropTypes.bool.isRequired,
+		isDialogVisible: PropTypes.bool.isRequired,
+		removePurchase: PropTypes.func.isRequired,
+		closeDialog: PropTypes.func.isRequired,
+		purchase: PropTypes.object,
+	};
+
+	state = {
+		step: 1,
+		domainValidated: false,
+		userAgreed: false,
+		showErrors: false,
+	};
+
+	renderFirstStep( productName ) {
+		const { translate, purchase } = this.props;
+
+		return (
+			<Fragment>
+				<FormSectionHeading>
+					{ translate( '{{strong}}Delete{{/strong}} %(domain)s and remove it from your account.', {
+						args: { domain: productName },
+						components: { strong: <strong /> },
+					} ) }
+				</FormSectionHeading>
+				<p>
+					{ translate(
+						'Deleting {{strong}}%(domain)s{{/strong}} is {{strong}}permanent{{/strong}}. ' +
+							'You will no longer own it, and it could be registered ' +
+							'by someone else.',
+						{
+							args: { domain: productName },
+							components: { strong: <strong /> },
+						}
+					) }
+				</p>
+				{ ! isRefundable( purchase ) && maybeWithinRefundPeriod( purchase ) && (
+					<p>
+						<strong>
+							{ translate(
+								"We're not able to refund this purchase automatically. " +
+									"If you're canceling within %(refundPeriodInDays)s days of " +
+									'purchase, {{contactLink}}contact us{{/contactLink}} to ' +
+									'request a refund.',
+								{
+									args: {
+										refundPeriodInDays: purchase.refundPeriodInDays,
+									},
+									components: {
+										contactLink: <a href={ CALYPSO_CONTACT } />,
+									},
+								}
+							) }
+						</strong>
+					</p>
+				) }
+			</Fragment>
+		);
+	}
+
+	onDomainChange = event => {
+		const productName = getName( this.props.purchase );
+		this.setState( { domainValidated: event.currentTarget.value === productName } );
+	};
+
+	onAgreeChange = event => {
+		this.setState( { userAgreed: event.target.checked } );
+	};
+
+	renderSecondStep( productName ) {
+		const { translate } = this.props;
+
+		return (
+			<Fragment>
+				<FormSectionHeading>
+					{ translate(
+						'{{strong}}Delete{{/strong}} this domain by typing "%(domain)s" into the field below:',
+						{
+							args: { domain: productName },
+							components: { strong: <strong /> },
+						}
+					) }
+				</FormSectionHeading>
+				<FormFieldset>
+					<FormLabel>
+						{ translate( 'Type your domain name to proceed', { context: 'Domain name' } ) }
+						<FormTextInput
+							name="domain"
+							isError={ this.state.showErrors && ! this.state.domainValidated }
+							onChange={ this.onDomainChange }
+						/>
+						{ this.state.showErrors && ! this.state.domainValidated && (
+							<FormInputValidation
+								text={ translate( 'The domain name you entered does not match.' ) }
+								isError
+							/>
+						) }
+					</FormLabel>
+				</FormFieldset>
+				<FormFieldset>
+					<FormLabel>
+						<FormCheckbox name="agree" value="true" onChange={ this.onAgreeChange } />
+						<span>
+							{ translate( 'I understand that this is permanent and irreversible.', {
+								context: 'Domain name',
+							} ) }
+						</span>
+					</FormLabel>
+
+					{ this.state.showErrors && ! this.state.userAgreed && (
+						<FormInputValidation
+							text={ translate(
+								"You need to confirm that you understand the action you're performing."
+							) }
+							isError
+						/>
+					) }
+				</FormFieldset>
+
+				<p>
+					{ translate(
+						'Deleting {{strong}}%(domain)s{{/strong}} is {{strong}}permanent{{/strong}}. ' +
+							'You will no longer own it, and it could be registered ' +
+							'by someone else.',
+						{
+							args: { domain: productName },
+							components: { strong: <strong /> },
+						}
+					) }
+				</p>
+			</Fragment>
+		);
+	}
+
+	nextStep = closeDialog => {
+		switch ( this.state.step ) {
+			case 1:
+				this.setState( { step: 2 } );
+				break;
+			case 2:
+				if ( this.state.domainValidated && this.state.userAgreed ) {
+					this.props.removePurchase( closeDialog );
+				} else {
+					this.setState( { showErrors: true } );
+				}
+				break;
+		}
+	};
+
+	close = () => {
+		this.props.closeDialog();
+		this.setState( { step: 1 } );
+	};
+
+	render() {
+		const { purchase, translate, chatButton } = this.props;
+		const productName = getName( purchase );
+		const buttons = [
+			{
+				action: 'cancel',
+				disabled: this.props.isRemoving,
+				label: translate( 'Keep this Domain' ),
+			},
+			{
+				action: 'remove',
+				disabled: this.props.isRemoving,
+				isPrimary: true,
+				label: translate( 'Delete this Domain' ),
+				onClick: this.nextStep,
+			},
+		];
+
+		if ( chatButton ) {
+			buttons.unshift( chatButton );
+		}
+
+		return (
+			<Dialog
+				buttons={ buttons }
+				className="remove-domain-dialog__dialog"
+				isVisible={ this.props.isDialogVisible }
+				onClose={ this.close }
+			>
+				{ this.state.step === 1 && this.renderFirstStep( productName ) }
+				{ this.state.step === 2 && this.renderSecondStep( productName ) }
+			</Dialog>
+		);
+	}
+}
+
+export default localize( RemoveDomainDialog );

--- a/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
+++ b/client/me/purchases/remove-purchase/remove-domain-dialog/index.jsx
@@ -96,7 +96,7 @@ class RemoveDomainDialog extends Component {
 			<Fragment>
 				<FormSectionHeading>
 					{ translate(
-						'{{strong}}Delete{{/strong}} this domain by typing "%(domain)s" into the field below:',
+						'{{strong}}Delete{{/strong}} this domain by typing “%(domain)s” into the field below:',
 						{
 							args: { domain: productName },
 							components: { strong: <strong /> },
@@ -104,20 +104,21 @@ class RemoveDomainDialog extends Component {
 					) }
 				</FormSectionHeading>
 				<FormFieldset>
-					<FormLabel>
+					<FormLabel htmlFor="remove-domain-dialog__form-domain">
 						{ translate( 'Type your domain name to proceed', { context: 'Domain name' } ) }
-						<FormTextInput
-							name="domain"
-							isError={ this.state.showErrors && ! this.state.domainValidated }
-							onChange={ this.onDomainChange }
-						/>
-						{ this.state.showErrors && ! this.state.domainValidated && (
-							<FormInputValidation
-								text={ translate( 'The domain name you entered does not match.' ) }
-								isError
-							/>
-						) }
 					</FormLabel>
+					<FormTextInput
+						name="domain"
+						id="remove-domain-dialog__form-domain"
+						isError={ this.state.showErrors && ! this.state.domainValidated }
+						onChange={ this.onDomainChange }
+					/>
+					{ this.state.showErrors && ! this.state.domainValidated && (
+						<FormInputValidation
+							text={ translate( 'The domain name you entered does not match.' ) }
+							isError
+						/>
+					) }
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel>
@@ -155,6 +156,9 @@ class RemoveDomainDialog extends Component {
 	}
 
 	nextStep = closeDialog => {
+		if ( this.props.isRemoving ) {
+			return;
+		}
 		switch ( this.state.step ) {
 			case 1:
 				this.setState( { step: 2 } );
@@ -170,6 +174,9 @@ class RemoveDomainDialog extends Component {
 	};
 
 	close = () => {
+		if ( this.props.isRemoving ) {
+			return;
+		}
 		this.props.closeDialog();
 		this.setState( { step: 1 } );
 	};
@@ -185,8 +192,8 @@ class RemoveDomainDialog extends Component {
 			},
 			{
 				action: 'remove',
-				disabled: this.props.isRemoving,
 				isPrimary: true,
+				additionalClassNames: this.props.isRemoving ? 'is-busy' : '',
 				label: translate( 'Delete this Domain' ),
 				onClick: this.nextStep,
 			},


### PR DESCRIPTION
We've updated the Delete Domain Dialog to require the user to enter their domain name and explicitly click on a checkbox in order to cancel their domain name. We do that because we had several incidents of users cancelling their domain name by accident.

#### Changes proposed in this Pull Request

* update the design and flow of the Delete Domain Dialog

#### Testing instructions

* Apply the PR
* Open Calypso and go to purchases.
* Click on a domain purchase and then on "Remove Domain"
* A dialog box should appear. Click on "Delete this Domain"
* A confirmation dialog box should appear. Enter your domain name and click on the checkbox.
* When you click on the "Delete this Domian" again it'll cancel the domain purchase

see: p99Zz8-Av-p2