### PR TITLE
CSS: Migrate directly styles to new CSS pipeline

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -88,7 +88,6 @@
 @import 'layout/nps-survey-notice/style';
 @import 'layout/sidebar/style';
 @import 'lib/accept/style';
-@import 'lib/directly/style';
 @import 'lib/abtest/test-helper/style';
 @import 'lib/preferences-helper/style';
 @import 'mailing-lists/style';

--- a/client/lib/directly/index.js
+++ b/client/lib/directly/index.js
@@ -18,6 +18,11 @@ import config from 'config';
 import { loadScript } from '@automattic/load-script';
 import wpcom from 'lib/wp';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const DIRECTLY_RTM_SCRIPT_URL = 'https://widgets.wp.com/directly/embed.js';
 const DIRECTLY_ASSETS_BASE_URL = 'https://www.directly.com';
 let directlyPromise;


### PR DESCRIPTION
This does not migrate the directly styles that are imported into the directly iframe.

#### Changes proposed in this Pull Request

* Migrate directly css styles

#### Testing instructions

* Login as a user with no paid accounts
* Click the help button in the bottom right, click contact us
* ask a question

Refs #27515
