### PR TITLE
Update post selector to use new CSS pipeline

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -121,7 +121,6 @@
 @import 'my-sites/plans-features-main/style';
 @import 'my-sites/plans/style';
 @import 'my-sites/post-relative-time-status/style';
-@import 'my-sites/post-selector/style';
 @import 'my-sites/posts/style';
 @import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';

--- a/client/my-sites/post-selector/index.jsx
+++ b/client/my-sites/post-selector/index.jsx
@@ -13,6 +13,11 @@ import { reduce, snakeCase } from 'lodash';
  */
 import PostSelectorPosts from './selector';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class extends React.PureComponent {
 	static displayName = 'PostSelector';
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate post selector css styles


#### Testing instructions

* Ensure that the post selector still works and looks good. It can be found when using the classic editor and adding link in html or visual view. It can also be seen on the page editor to select a parent page or to copy a post in the classic editor
