### PR TITLE
css: migrate post-edit-button styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -20,7 +20,6 @@
 @import 'blocks/nps-survey/style';
 @import 'blocks/login/style';
 @import 'blocks/payment-methods/style';
-@import 'blocks/post-edit-button/style';
 @import 'blocks/post-item/style';
 @import 'blocks/post-likes/style';
 @import 'blocks/sharing-preview-pane/style';

--- a/client/blocks/post-edit-button/index.jsx
+++ b/client/blocks/post-edit-button/index.jsx
@@ -14,6 +14,11 @@ import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { getEditURL } from 'state/posts/utils';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const PostEditButton = ( { post, site, iconSize, onClick, translate } ) => {
 	const editUrl = getEditURL( post, site );
 	return (

--- a/client/blocks/post-edit-button/style.scss
+++ b/client/blocks/post-edit-button/style.scss
@@ -1,9 +1,9 @@
 .post-edit-button {
+	display: inline-flex;
 	align-items: center;
 	box-sizing: border-box;
 	color: var( --color-text-subtle );
 	cursor: pointer;
-	display: inline-flex;
 	list-style-type: none;
 	padding: 4px;
 	position: relative;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `<PostEditButton />` styles

#### Testing instructions

The `<PostEditButton />` component is only used at `<ReaderPostActions />`. For me the easiest way to test this was to apply the diff mentioned below and searching for my own username in reader (see below):

```diff
diff --git a/client/blocks/reader-post-actions/index.jsx b/client/blocks/reader-post-actions/index.jsx
index b3a61b0c9f..bbe6407a2c 100644
--- a/client/blocks/reader-post-actions/index.jsx
+++ b/client/blocks/reader-post-actions/index.jsx
@@ -69,7 +69,7 @@ const ReaderPostActions = props => {
                                        </ReaderVisitLink>
                                </li>
                        ) }
-                       { showEdit && site && userCan( 'edit_post', post ) && (
+                       { true && site && userCan( 'edit_post', post ) && (
                                <li className="reader-post-actions__item">
                                        <PostEditButton
                                                post={ post }
```

This is how it should look like:

<img width="361" alt="Screenshot 2019-06-04 at 10 21 46" src="https://user-images.githubusercontent.com/9202899/58887251-4405a780-86b3-11e9-872e-3b74753ed444.png">


fixes #33575 (part of #27515)
