### PR TITLE
CSS: Migrate conversations stream and caterpillar

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -9,8 +9,6 @@
 @import 'layout/style';
 
 @import 'auth/style';
-@import 'blocks/conversation-caterpillar/style';
-@import 'blocks/conversations/style';
 @import 'blocks/support-article-dialog/style';
 @import 'blocks/nps-survey/style';
 @import 'blocks/login/style';

--- a/client/blocks/conversation-caterpillar/index.jsx
+++ b/client/blocks/conversation-caterpillar/index.jsx
@@ -18,6 +18,11 @@ import { POST_COMMENT_DISPLAY_TYPES } from 'state/comments/constants';
 import { isAncestor } from 'blocks/comments/utils';
 import GravatarCaterpillar from 'components/gravatar-caterpillar';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const MAX_GRAVATARS_TO_DISPLAY = 10;
 const NUMBER_TO_EXPAND = 10;
 

--- a/client/blocks/conversation-caterpillar/style.scss
+++ b/client/blocks/conversation-caterpillar/style.scss
@@ -3,11 +3,6 @@
 }
 
 .conversation-caterpillar__count {
-	display: flex;
-	flex-shrink: 0;
-}
-
-.conversation-caterpillar__count {
 	cursor: pointer;
 	color: var( --color-primary );
 	display: flex;
@@ -34,8 +29,4 @@
 		padding: 0;
 		text-align: left;
 	}
-}
-
-.conversations__stream .conversation-caterpillar {
-	margin-top: 20px;
 }

--- a/client/blocks/conversations/list.jsx
+++ b/client/blocks/conversations/list.jsx
@@ -29,6 +29,11 @@ import { getErrorKey } from 'state/comments/utils';
 import { getCurrentUserId } from 'state/current-user/selectors';
 
 /**
+ * Style dependencies
+ */
+import './list.scss';
+
+/**
  * ConversationsCommentList is the component that represents all of the comments for a conversations-stream
  * Some of it is boilerplate stolen from PostCommentList (all the activeXCommentId bits) but the special
  * convos parts are related to:

--- a/client/blocks/conversations/list.scss
+++ b/client/blocks/conversations/list.scss
@@ -1,0 +1,12 @@
+
+
+.conversations__comment-list-ul {
+	list-style-type: none;
+	margin-left: 0;
+}
+
+.conversations__comment-list-ul .comments__form-closed {
+	border-top: 0;
+	padding-top: 0;
+	text-align: left;
+}

--- a/client/reader/conversations/stream.js
+++ b/client/reader/conversations/stream.js
@@ -13,6 +13,11 @@ import DocumentHead from 'components/data/document-head';
 import ConversationsIntro from './intro';
 import ConversationsEmptyContent from 'blocks/conversations/empty';
 
+/**
+ * Style dependencies
+ */
+import './stream.scss';
+
 export default function( props ) {
 	const isInternal = get( props, 'store.id' ) === 'conversations-a8c';
 	const emptyContent = <ConversationsEmptyContent />;

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -74,15 +74,8 @@
 	white-space: nowrap;
 }
 
-.conversations__comment-list-ul {
-	list-style-type: none;
-	margin-left: 0;
-}
-
-.conversations__comment-list-ul .comments__form-closed {
-	border-top: 0;
-	padding-top: 0;
-	text-align: left;
+.conversations__stream .conversation-caterpillar {
+	margin-top: 20px;
 }
 
 .is-group-reader .conversations__stream .like-button__label-status {
@@ -98,3 +91,4 @@
 		margin-top: 70px;
 	}
 }
+


### PR DESCRIPTION


#### Changes proposed in this Pull Request

* Migrates the Conversations stream and caterpillar to the new CSS build pipeline. 
* Also reorgs many rules for the stream to better align with usage.

#### Testing instructions

* Try using the Conversations view in Reader. Should look the same as prod.
* Check conversations components in devdocs. Should look the same as before.

Refs #27515
