### PR TITLE
Build: Remove the ability to turn off code-splitting

### DIFF
--- a/client/components/jetpack-header/test/index.js
+++ b/client/components/jetpack-header/test/index.js
@@ -39,7 +39,7 @@ describe( 'JetpackHeader', () => {
 	test( 'should render a co-branded logo when passed a known partner slug', () => {
 		const wrapper = mount( <JetpackHeader partnerSlug="dreamhost" /> );
 		expect( wrapper.find( 'Localized(JetpackPartnerLogoGroup)' ) ).toHaveLength( 1 );
-		expect( wrapper.find( 'JetpackDreamhostLogo' ) ).toHaveLength( 1 );
+		expect( wrapper.find( 'AsyncLoad' ) ).toHaveLength( 1 );
 	} );
 
 	test( 'should override width on JetpackLogo when width provided but no partner slug', () => {

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -59,12 +59,6 @@ class Desktop extends React.Component {
 						}
 						type="text/css"
 					/>
-					<link
-						rel="stylesheet"
-						type="text/css"
-						data-webpack={ true }
-						href={ `/calypso/fallback/build.${ isRTL ? 'rtl.css' : 'css' }` }
-					/>
 					{ entrypoint[ csskey ].map( cssChunkLink ) }
 					<link rel="stylesheet" id="desktop-css" href="/desktop/wordpress-desktop.css" />
 				</Head>
@@ -128,7 +122,6 @@ class Desktop extends React.Component {
 						/>
 					) }
 
-					<script src="/calypso/fallback/build.js" />
 					{ entrypoint.js.map( asset => (
 						<script key={ asset } src={ asset } />
 					) ) }

--- a/client/document/desktop.jsx
+++ b/client/document/desktop.jsx
@@ -17,10 +17,14 @@ import getStylesheet from './utils/stylesheet';
 import WordPressLogo from 'components/wordpress-logo';
 import { jsonStringifyForHtml } from '../../server/sanitize';
 
+const cssChunkLink = asset => (
+	<link key={ asset } rel="stylesheet" type="text/css" data-webpack={ true } href={ asset } />
+);
 class Desktop extends React.Component {
 	render() {
 		const {
 			app,
+			entrypoint,
 			faviconURL,
 			i18nLocaleScript,
 			isRTL,
@@ -39,6 +43,7 @@ class Desktop extends React.Component {
 			devDocsURL,
 			feedbackURL,
 		} = this.props;
+		const csskey = isRTL ? 'css.rtl' : 'css.ltr';
 		return (
 			<html
 				lang={ lang }
@@ -60,6 +65,7 @@ class Desktop extends React.Component {
 						data-webpack={ true }
 						href={ `/calypso/fallback/build.${ isRTL ? 'rtl.css' : 'css' }` }
 					/>
+					{ entrypoint[ csskey ].map( cssChunkLink ) }
 					<link rel="stylesheet" id="desktop-css" href="/desktop/wordpress-desktop.css" />
 				</Head>
 				<body className={ classNames( { rtl: isRTL } ) }>
@@ -123,6 +129,9 @@ class Desktop extends React.Component {
 					) }
 
 					<script src="/calypso/fallback/build.js" />
+					{ entrypoint.js.map( asset => (
+						<script key={ asset } src={ asset } />
+					) ) }
 					<script src="/desktop/desktop-app.js" />
 					{ i18nLocaleScript && <script src={ i18nLocaleScript } /> }
 					<script type="text/javascript">startApp();</script>

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -24,7 +24,7 @@
 		"automated-transfer": true,
 		"blogger-plan": false,
 		"calypsoify/gutenberg": false,
-		"code-splitting": false,
+		"code-splitting": true,
 		"comments/filters-in-posts": true,
 		"comments/moderation-tools-in-posts": true,
 		"comments/management/threaded-view": false,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -18,7 +18,7 @@
 		"blogger-plan": false,
 		"calypsoify/gutenberg": false,
 		"catch-js-errors": false,
-		"code-splitting": false,
+		"code-splitting": true,
 		"desktop": true,
 		"desktop-promo": false,
 		"domains/cctlds": true,

--- a/config/test.json
+++ b/config/test.json
@@ -34,7 +34,7 @@
 		"calypsoify/gutenberg": true,
 		"calypsoify/plugins": true,
 		"catch-js-errors": false,
-		"code-splitting": false,
+		"code-splitting": true,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": true,

--- a/package.json
+++ b/package.json
@@ -217,7 +217,7 @@
 		"build-client-evergreen": "cross-env-shell BROWSERSLIST_ENV=evergreen NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
 		"build-client-both": "npm run build-client-fallback && npm run build-client-evergreen",
 		"build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client-both",
-		"build-client-if-desktop": "node -e \"(process.env.CALYPSO_ENV === 'desktop' || process.env.CALYPSO_ENV === 'desktop-development') && process.exit(1)\" || npm run build-client-fallback",
+		"build-client-if-desktop": "node -e \"(process.env.CALYPSO_ENV === 'desktop' || process.env.CALYPSO_ENV === 'desktop-development') && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client-fallback",
 		"build-packages": "npx lerna run prepare --stream",
 		"clean": "npm run -s clean:build && npm run -s clean:devdocs && npm run -s clean:public && npm run -s clean:packages",
 		"clean:build": "npx rimraf build server/bundler/*.json .babel-cache",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,6 @@ const shouldMinify =
 const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
 const shouldEmitStatsWithReasons = process.env.EMIT_STATS === 'withreasons';
 const shouldCheckForCycles = process.env.CHECK_CYCLES === 'true';
-const codeSplit = config.isEnabled( 'code-splitting' );
 const isCalypsoClient = process.env.BROWSERSLIST_ENV !== 'server';
 const isDesktop = calypsoEnv === 'desktop' || calypsoEnv === 'desktop-development';
 
@@ -171,12 +170,12 @@ const webpackConfig = {
 	},
 	optimization: {
 		splitChunks: {
-			chunks: codeSplit ? 'all' : 'async',
+			chunks: ! isDesktop ? 'all' : 'async',
 			name: !! ( isDevelopment || shouldEmitStats ),
 			maxAsyncRequests: 20,
 			maxInitialRequests: 5,
 		},
-		runtimeChunk: codeSplit ? { name: 'manifest' } : false,
+		runtimeChunk: ! isDesktop ? { name: 'manifest' } : false,
 		moduleIds: 'named',
 		chunkIds: isDevelopment || shouldEmitStats ? 'named' : 'natural',
 		minimize: shouldMinify,
@@ -260,7 +259,6 @@ const webpackConfig = {
 	},
 	node: false,
 	plugins: _.compact( [
-		! codeSplit && new webpack.optimize.LimitChunkCountPlugin( { maxChunks: 1 } ),
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 			global: 'window',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -170,12 +170,12 @@ const webpackConfig = {
 	},
 	optimization: {
 		splitChunks: {
-			chunks: ! isDesktop ? 'all' : 'async',
+			chunks: 'all',
 			name: !! ( isDevelopment || shouldEmitStats ),
 			maxAsyncRequests: 20,
 			maxInitialRequests: 5,
 		},
-		runtimeChunk: ! isDesktop ? { name: 'manifest' } : false,
+		runtimeChunk: isDesktop ? false : { name: 'manifest' },
 		moduleIds: 'named',
 		chunkIds: isDevelopment || shouldEmitStats ? 'named' : 'natural',
 		minimize: shouldMinify,


### PR DESCRIPTION
We only really support turning off code splitting for the desktop app, and the method we use to push everything back into one file has a significant perf and correctness penalty. Instead, always use code splitting and teach the desktop build how to use it.

#### Changes proposed in this Pull Request

* Also do not seperate the manifest for the desktop build.
* Remove LimitCountChunkPlugin

#### Testing instructions

* Calypso should work the same as usual for a normal build
* Check out this branch inside the desktop app's develop branch. Make sure it still builds and works.

