### PR TITLE
Migrate payment methods block CSS to webpack.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -19,7 +19,6 @@
 @import 'blocks/like-button/style';
 @import 'blocks/nps-survey/style';
 @import 'blocks/login/style';
-@import 'blocks/payment-methods/style';
 @import 'blocks/post-item/style';
 @import 'blocks/post-likes/style';
 @import 'blocks/sharing-preview-pane/style';

--- a/client/blocks/payment-methods/index.jsx
+++ b/client/blocks/payment-methods/index.jsx
@@ -15,6 +15,11 @@ import PropTypes from 'prop-types';
 import PaymentLogo, { POSSIBLE_TYPES } from 'components/payment-logo';
 import { getEnabledPaymentMethods } from 'lib/cart-values';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 function PaymentMethods( { translate, cart } ) {
 	if ( ! cart.hasLoadedFromServer ) {
 		return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate styles for the payment-methods block to webpack.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `jetpack/connect/plans/[your-jetpack-site-domain]` where `[your-jetpack-site-domain]` is any connected or disconnected Jetpack site domain name.
2. Ensure the PaymentMethods block (labeled "Secure payment using:") is styled correctly.

Fixes #33586