### PR TITLE
css: migrate blocks/gdpr-banner styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -14,7 +14,6 @@
 @import 'blocks/conversations/style';
 @import 'blocks/domain-to-plan-nudge/style';
 @import 'blocks/follow-button/style';
-@import 'blocks/gdpr-banner/style';
 @import 'blocks/support-article-dialog/style';
 @import 'blocks/like-button/style';
 @import 'blocks/nps-survey/style';

--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -20,6 +19,11 @@ import { bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { decodeEntities, preventWidows } from 'lib/formatting';
 import { isCurrentUserMaybeInGdprZone } from 'lib/analytics/utils';
 import { isWpMobileApp } from 'lib/mobile-app';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
 
 const SIX_MONTHS = 6 * 30 * 24 * 60 * 60;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate styles for `blocks/gdpr-banner` component

#### Testing instructions

You should be able to test the `<GdprBanner />` component on calypso.live where it should show up unless the `sensitive_pixel_option` cookie is set, in this case you can remove the cookie via devtools.

<img width="817" alt="Screenshot 2019-06-04 at 12 20 18" src="https://user-images.githubusercontent.com/9202899/58896000-25a7a800-86c3-11e9-8bd4-98a97162ce0b.png">


Fixes #33587 (part of #27515)
