### PR TITLE
css: migrate blocks/follow-button styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -11,7 +11,6 @@
 @import 'auth/style';
 @import 'blocks/conversation-caterpillar/style';
 @import 'blocks/conversations/style';
-@import 'blocks/follow-button/style';
 @import 'blocks/support-article-dialog/style';
 @import 'blocks/nps-survey/style';
 @import 'blocks/login/style';

--- a/client/blocks/follow-button/button.jsx
+++ b/client/blocks/follow-button/button.jsx
@@ -10,6 +10,11 @@ import { noop } from 'lodash';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class FollowButton extends React.Component {
 	static propTypes = {
 		following: PropTypes.bool.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `blocks/follow-button` styles

#### Testing instructions

The `<FollowButton />` component is used throughout the reader. Smoke testing the reader and checking various places if the button still looks the same as on master should be sufficient. You can also check devdocs.

<img width="276" alt="Screenshot 2019-06-04 at 12 37 58" src="https://user-images.githubusercontent.com/9202899/58906463-ec2e6700-86d9-11e9-9aab-acca03d956a1.png">


fixes #33594 (part of #27515)
