### PR TITLE
css: migrate blocks/stats-navigation styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -21,7 +21,6 @@
 @import 'blocks/term-tree-selector/style';
 @import 'blocks/upload-image/style';
 @import 'blocks/video-editor/style';
-@import 'blocks/stats-navigation/style';
 @import 'components/button/style';
 @import 'components/card/style';
 @import 'components/credit-card-form-fields/style';

--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External Dependencies
  */
@@ -19,6 +18,11 @@ import isSiteStore from 'state/selectors/is-site-store';
 import { getSiteOption } from 'state/sites/selectors';
 import { navItems, intervals as intervalConstants } from './constants';
 import config from 'config';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class StatsNavigation extends Component {
 	static propTypes = {

--- a/client/blocks/stats-navigation/intervals.js
+++ b/client/blocks/stats-navigation/intervals.js
@@ -13,6 +13,11 @@ import { intervals } from './constants';
 import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
 
+/**
+ * Style dependencies
+ */
+import './intervals.scss';
+
 const Intervals = props => {
 	const { selected, pathTemplate, className, standalone } = props;
 	const classes = classnames( 'stats-navigation__intervals', className, {

--- a/client/blocks/stats-navigation/intervals.scss
+++ b/client/blocks/stats-navigation/intervals.scss
@@ -1,0 +1,11 @@
+.stats-navigation__intervals.segmented-control {
+	&.is-standalone {
+		max-width: 100%;
+		margin: 8px 9px;
+
+		@include breakpoint( '>480px' ) {
+			max-width: 400px;
+			margin: 16px auto;
+		}
+	}
+}

--- a/client/blocks/stats-navigation/style.scss
+++ b/client/blocks/stats-navigation/style.scss
@@ -35,15 +35,3 @@
 		}
 	}
 }
-
-.stats-navigation__intervals.segmented-control {
-	&.is-standalone {
-		max-width: 100%;
-		margin: 8px 9px;
-
-		@include breakpoint( '>480px' ) {
-			max-width: 400px;
-			margin: 16px auto;
-		}
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `blocks/stats-navigation` styles

#### Testing instructions

Open up stats and verify the navigation bar at the top works as expected. There's different variations in `/stats` e.g. when you click on insights it shows a different version.

<img width="661" alt="Screenshot 2019-06-04 at 17 29 42" src="https://user-images.githubusercontent.com/9202899/58915156-62d55f80-86ee-11e9-97ca-82d5f8898b51.png">
<img width="557" alt="Screenshot 2019-06-04 at 17 29 47" src="https://user-images.githubusercontent.com/9202899/58915158-62d55f80-86ee-11e9-8107-4a00c850a34f.png">
<img width="562" alt="Screenshot 2019-06-04 at 17 29 52" src="https://user-images.githubusercontent.com/9202899/58915159-62d55f80-86ee-11e9-8120-464a5eeaa80a.png">


Fixes #33599 (part of #27515)
