### PR TITLE
Migrate pagination CSS and correct some eslint warnings

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -76,7 +76,6 @@
 @import 'components/social-icons/style';
 @import 'components/stat-update-indicator/style';
 @import 'components/text-diff/style';
-@import 'components/pagination/style';
 @import 'components/tooltip/style';
 @import 'components/wizard/style';
 @import 'components/environment-badge/style';

--- a/client/components/pagination/docs/example.jsx
+++ b/client/components/pagination/docs/example.jsx
@@ -28,9 +28,9 @@ class PaginationExample extends Component {
 	render() {
 		return (
 			<div>
-				<a className="docs__design-toggle button" onClick={ this.toggleCompact }>
+				<button className="docs__design-toggle button" onClick={ this.toggleCompact }>
 					{ this.state.compact ? 'Normal' : 'Compact' }
-				</a>
+				</button>
 				<Pagination
 					compact={ this.state.compact }
 					page={ this.state.page }

--- a/client/components/pagination/index.jsx
+++ b/client/components/pagination/index.jsx
@@ -13,6 +13,11 @@ import classnames from 'classnames';
  */
 import PaginationPage from './pagination-page';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Pagination extends Component {
 	static propTypes = {
 		compact: PropTypes.bool,


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Migrate pagination CSS to webpack and fix some eslint warnings found in the related devdocs example.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the Pagination component in devdocs and ensure the "Compact"/"Normal" size toggle still works.
* Ensure pagination styles are preserved elsewhere in the app (for example, on the Comments page).

Fixes #33591
