### PR TITLE
css: migrate blocks/post-likes styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -15,7 +15,6 @@
 @import 'blocks/nps-survey/style';
 @import 'blocks/login/style';
 @import 'blocks/post-item/style';
-@import 'blocks/post-likes/style';
 @import 'blocks/sharing-preview-pane/style';
 @import 'blocks/site-address-changer/style';
 @import 'blocks/term-form-dialog/style';

--- a/client/blocks/post-likes/index.jsx
+++ b/client/blocks/post-likes/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -16,6 +14,11 @@ import QueryPostLikes from 'components/data/query-post-likes';
 import countPostLikes from 'state/selectors/count-post-likes';
 import getPostLikes from 'state/selectors/get-post-likes';
 import { recordGoogleEvent } from 'state/analytics/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class PostLikes extends React.PureComponent {
 	static defaultProps = {

--- a/client/blocks/post-likes/popover.jsx
+++ b/client/blocks/post-likes/popover.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -15,6 +13,11 @@ import Popover from 'components/popover';
 import PostLikes from './index';
 import getPostLikes from 'state/selectors/get-post-likes';
 import countPostLikes from 'state/selectors/count-post-likes';
+
+/**
+ * Style dependencies
+ */
+import './popover.scss';
 
 function PostLikesPopover( props ) {
 	const {

--- a/client/blocks/post-likes/popover.scss
+++ b/client/blocks/post-likes/popover.scss
@@ -1,6 +1,4 @@
-$post-like-padding: 3px;
-$post-like-width: 24px + $post-like-padding * 2;
-$post-likes-per-popover-row: 12;
+@import './variables.scss';
 
 .post-likes-popover {
 	.post-likes {

--- a/client/blocks/post-likes/popover.scss
+++ b/client/blocks/post-likes/popover.scss
@@ -1,0 +1,17 @@
+$post-like-padding: 3px;
+$post-like-width: 24px + $post-like-padding * 2;
+$post-likes-per-popover-row: 12;
+
+.post-likes-popover {
+	.post-likes {
+		padding: $post-like-padding;
+		max-width: $post-like-width * $post-likes-per-popover-row;
+		max-height: 400px;
+		text-align: left;
+
+		&.has-display-names {
+			max-width: 250px;
+			max-height: 340px;
+		}
+	}
+}

--- a/client/blocks/post-likes/style.scss
+++ b/client/blocks/post-likes/style.scss
@@ -1,6 +1,4 @@
-$post-like-padding: 3px;
-$post-like-width: 24px + $post-like-padding * 2;
-$post-likes-per-popover-row: 12;
+@import './variables.scss';
 
 .post-likes {
 	font-size: 13px;

--- a/client/blocks/post-likes/style.scss
+++ b/client/blocks/post-likes/style.scss
@@ -1,5 +1,3 @@
-/** @format */
-
 $post-like-padding: 3px;
 $post-like-width: 24px + $post-like-padding * 2;
 $post-likes-per-popover-row: 12;
@@ -67,20 +65,6 @@ $post-likes-per-popover-row: 12;
 			border-color: transparent;
 			@include placeholder();
 			margin: 5px;
-		}
-	}
-}
-
-.post-likes-popover {
-	.post-likes {
-		padding: $post-like-padding;
-		max-width: $post-like-width * $post-likes-per-popover-row;
-		max-height: 400px;
-		text-align: left;
-
-		&.has-display-names {
-			max-width: 250px;
-			max-height: 340px;
 		}
 	}
 }

--- a/client/blocks/post-likes/variables.scss
+++ b/client/blocks/post-likes/variables.scss
@@ -1,0 +1,3 @@
+$post-like-padding: 3px;
+$post-like-width: 24px + $post-like-padding * 2;
+$post-likes-per-popover-row: 12;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `blocks/post-likes` styles

#### Testing instructions

`<PostLikes />` is used in a bunch of places. A good one to start is Devdocs. Make sure it looks & behaves exactly like on master. It's also used on:

- Stats (Posts & Pages): go to `/stats` and click on a post (or page)

<img width="332" alt="Screenshot 2019-06-04 at 16 42 57" src="https://user-images.githubusercontent.com/9202899/58912401-eccdfa00-86e7-11e9-97f5-6a6f624e5275.png">

- Popover is shown e.g. when you hover over the like button in reader

<img width="297" alt="Screenshot 2019-06-04 at 16 47 07" src="https://user-images.githubusercontent.com/9202899/58912596-71207d00-86e8-11e9-87b4-d9836215c215.png">


Fixes #33604 (part of #27515)
