### PR TITLE
CSS: Migrate blocks/image-selector style

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -114,4 +114,3 @@
 @import 'my-sites/sidebar-navigation/style';
 @import 'my-sites/importer/style';
 @import 'blocks/site/style';
-@import 'blocks/image-selector/style';

--- a/client/blocks/image-selector/index.jsx
+++ b/client/blocks/image-selector/index.jsx
@@ -23,6 +23,11 @@ import MediaStore from 'lib/media/store';
 import { localize } from 'i18n-calypso';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class ImageSelector extends Component {
 	static propTypes = {
 		className: PropTypes.string,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate styles for `blocks/image-selector`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* As @jsnajdr explained in the comment - "...the lack of usage makes it very safe"

Fixes #33611

Refs #27515
