### PR TITLE
CSS: Migrate blocks/site style

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -109,4 +109,3 @@
 @import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';
 @import 'my-sites/importer/style';
-@import 'blocks/site/style';

--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -19,6 +19,11 @@ import SiteIndicator from 'my-sites/site-indicator';
 import { getSite, getSiteSlug, isSitePreviewable } from 'state/sites/selectors';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class Site extends React.Component {
 	static defaultProps = {
 		// onSelect callback


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate styles for `blocks/site`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on _Switch site_ and look at the sites list. Does style look good? Is it the same as on production?
* Select one site. Look at the current site card at the top of the sidebar. Does style look good? Is it the same as on production?

Fixes #33614

Refs #27515
