### PR TITLE
css: migrate credit-card-form styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -72,7 +72,6 @@
 @import 'components/tooltip/style';
 @import 'components/wizard/style';
 @import 'components/environment-badge/style';
-@import 'blocks/credit-card-form/style';
 @import 'layout/guided-tours/style';
 @import 'components/happychat/style';
 @import 'components/happychat/agent-w/style';

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -24,7 +24,6 @@
 @import 'blocks/stats-navigation/style';
 @import 'components/button/style';
 @import 'components/card/style';
-@import 'components/credit-card-form-fields/style';
 @import 'components/date-picker/style';
 @import 'components/dialog/style';
 @import 'components/forms/form-button/style';

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -11,7 +9,7 @@ import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
@@ -28,6 +26,11 @@ import { AUTO_RENEWAL, MANAGE_PURCHASES } from 'lib/url/support';
 import getCountries from 'state/selectors/get-countries';
 import QueryPaymentCountries from 'components/data/query-countries/payments';
 import { localizeUrl } from 'lib/i18n-utils';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const wpcom = wpcomFactory.undocumented();
 

--- a/client/blocks/credit-card-form/loading-placeholder.jsx
+++ b/client/blocks/credit-card-form/loading-placeholder.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/blocks/credit-card-form/style.scss
+++ b/client/blocks/credit-card-form/style.scss
@@ -1,5 +1,3 @@
-/** @format */
-
 .credit-card-form__content {
 	margin-bottom: 0;
 }

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -20,6 +18,11 @@ import { Input } from 'my-sites/domains/components/form';
 import InfoPopover from 'components/info-popover';
 import { maskField, unmaskField, getCreditCardType } from 'lib/checkout';
 import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export class CreditCardFormFields extends React.Component {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `blocks/credit-card-form` styles

#### Testing instructions

**Note:** this PR migrates styles for `<CreditCardForm />` which provides the general structure of that form _and_ the form fields (they're in `<CreditCardFormFields />`).

Make sure the credit card form looks the same as on master, even in different viewport sizes (mobile, tablet, desktop, etc). You can see it in devdocs or _Manage Purchases > Click on plan > Add Credit Card_.

Fixes #33619 
Fixes #33631 
part of #27515
