### PR TITLE
css: migrate my-sites/pages/blog-posts-page styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -98,7 +98,6 @@
 @import 'my-sites/guided-transfer/style';
 @import 'my-sites/media-library/upload-button';
 @import 'my-sites/pages/style';
-@import 'my-sites/pages/blog-posts-page/style';
 @import 'my-sites/pages/page-card-info/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/post-relative-time-status/style';

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -17,6 +15,11 @@ import classNames from 'classnames';
  */
 import Card from 'components/card';
 import { getSiteFrontPageType, getSitePostsPage, getSiteFrontPage } from 'state/sites/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class BlogPostsPage extends React.Component {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `my-sites/pages/blog-posts-page` styles to be processed by webpack

#### Testing instructions

* Open a site and go to `/pages`
* Make sure the `<BlogPostsPage />` component looks the same as on master (see below)

<img width="762" alt="Screenshot 2019-06-05 at 08 16 21" src="https://user-images.githubusercontent.com/9202899/58955610-6f979900-876a-11e9-98ae-04a561b5f045.png">


Fixes #33634 (part of #27515)
