### PR TITLE
css: migrate me/notification-settings/wpcom-settings styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -84,7 +84,6 @@
 @import 'me/notification-settings/comment-settings/style';
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
-@import 'me/notification-settings/wpcom-settings/style';
 @import 'me/sidebar-navigation/style';
 @import 'me/sidebar/style';
 @import 'my-sites/checklist/style';

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -31,6 +29,11 @@ import {
 import EmailCategory from './email-category';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import hasJetpackSites from 'state/selectors/has-jetpack-sites';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 /**
  * Module variables


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `me/notification-settings/wpcom-settings` styles to be processed by webpack

#### Testing instructions

* Go to your profile and click on _Notification Settings > Updates_
* Hit refresh
* Do you see a placeholder and does it look the same as on master (see screenshot below)? - You may need to throttle your connection via devtools

<img width="758" alt="Screenshot 2019-06-05 at 08 43 22" src="https://user-images.githubusercontent.com/9202899/58957204-277a7580-876e-11e9-921d-7951604c2a5a.png">


Fixes #33637 (part of #27515)
