### PR TITLE
Migrate draft list popup CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -90,7 +90,6 @@
 @import 'my-sites/checklist/style';
 @import 'my-sites/checklist/wpcom-checklist/checklist-navigation/style';
 @import 'my-sites/customize/style';
-@import 'my-sites/draft/style';
 @import 'my-sites/exporter/style';
 @import 'my-sites/guided-transfer/style';
 @import 'my-sites/media-library/upload-button';

--- a/client/my-sites/draft/index.jsx
+++ b/client/my-sites/draft/index.jsx
@@ -10,19 +10,22 @@ import classnames from 'classnames';
 import url from 'url';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import { flow, noop, get } from 'lodash';
+import { noop, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import CompactCard from 'components/card/compact';
-import Gridicon from 'gridicons';
 import photon from 'photon';
 import { hasTouch } from 'lib/touch-detect';
 import * as utils from 'state/posts/utils';
-import { getSite } from 'state/sites/selectors';
 import TimeSince from 'components/time-since';
 import { getEditorUrl } from 'state/selectors/get-editor-url';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class Draft extends Component {
 	static propTypes = {
@@ -86,13 +89,13 @@ class Draft extends Component {
 		return (
 			<CompactCard
 				className={ classes }
-				key={ 'draft-' + post.ID }
+				key={ post.ID }
 				href={ editPostURL }
 				onClick={ this.props.onTitleClick }
 			>
 				<h3 className="draft__title">{ title }</h3>
 				<TimeSince className="draft__time" date={ post.modified } />
-				{ image ? this.renderImage( imageUrl ) : null }
+				{ image && this.renderImage( imageUrl ) }
 			</CompactCard>
 		);
 	}
@@ -104,27 +107,15 @@ class Draft extends Component {
 
 	postPlaceholder() {
 		return (
+			/* eslint-disable jsx-a11y/heading-has-content */
 			<CompactCard className="draft is-placeholder">
 				<h3 className="draft__title" />
-				<div className="draft__actions">
-					<p className="post-relative-time-status">
-						<span className="time">
-							<Gridicon icon="time" size={ 18 } />
-							<span className="time-text" />
-						</span>
-					</p>
-				</div>
 			</CompactCard>
+			/* eslint-enable jsx-a11y/heading-has-content */
 		);
 	}
 }
 
-const mapState = ( state, { siteId, post } ) => ( {
-	site: getSite( state, siteId ),
+export default connect( ( state, { siteId, post } ) => ( {
 	editorUrl: getEditorUrl( state, siteId, get( post, 'ID' ) ),
-} );
-
-export default flow(
-	localize,
-	connect( mapState )
-)( Draft );
+} ) )( localize( Draft ) );

--- a/client/my-sites/draft/style.scss
+++ b/client/my-sites/draft/style.scss
@@ -22,10 +22,6 @@
 		.draft__title {
 			margin-right: 88px;
 		}
-
-		.draft__excerpt {
-			right: 88px;
-		}
 	}
 
 	&.is-selected {
@@ -57,29 +53,10 @@
 	color: var( --color-text-subtle );
 }
 
-.draft__excerpt {
-	display: block;
-	font-family: $serif;
-	font-size: 14px;
-	position: absolute;
-		top: 8px;
-		right: 16px;
-		left: 16px;
-	user-select: none;
-	opacity: 0;
-	transform: translateY( 60px );
-	transition: all 0.1s ease-in-out;
-}
-
 .draft__empty-text {
 	color: var( --color-neutral-500 );
 	font-weight: 400;
 	font-style: italic;
-}
-
-// Not ready for primetime
-.draft__actions {
-	display: none;
 }
 
 // Images


### PR DESCRIPTION
Also, the draft list has a turbulent history of various UI experiments and there's some unused code to remove:
- `draft__actions` and `draft__excerpt` are either not used, or hidden. Remove JS and CSS code
- the `site` prop is not used, no need to fetch it from Redux

**How to test:**
Verify the popup in masterbar. Check the loading placeholder, too.
<img width="319" alt="Screenshot 2019-06-05 at 09 25 27" src="https://user-images.githubusercontent.com/664258/58959931-1f253900-8774-11e9-8677-91fc7076716f.png">
