### PR TITLE
Add login entrypoint

### DIFF
--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 
@@ -32,7 +29,6 @@ const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, redirectUri }
  * `context.primary` and `context.secondary` to populate it.
  */
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );
-export const makeLoggedOutLayout = makeLayout;
 
 export function redirectLoggedIn( { isLoggedIn, res }, next ) {
 	// TODO: Make it work also for development env

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -44,16 +44,6 @@ export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } )
 
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );
 
-const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, redirectUri } ) => (
-	<ReduxProvider store={ store }>
-		<MomentProvider>
-			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
-		</MomentProvider>
-	</ReduxProvider>
-);
-
-export const makeLoggedOutLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );
-
 /**
  * Isomorphic routing helper, client side
  *

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import { parse } from 'qs';
+import page from 'page';
+import url from 'url';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import config from 'config';
+import { setCurrentUser } from 'state/current-user/actions';
+
+const debug = debugFactory( 'calypso' );
+
+export function setupContextMiddleware() {
+	page( '*', ( context, next ) => {
+		// page.js url parsing is broken so we had to disable it with `decodeURLComponents: false`
+		const parsed = url.parse( context.canonicalPath, true );
+		context.prevPath = parsed.path === context.path ? false : parsed.path;
+		context.query = parsed.query;
+
+		context.hashstring = ( parsed.hash && parsed.hash.substring( 1 ) ) || '';
+		// set `context.hash` (we have to parse manually)
+		if ( context.hashstring ) {
+			try {
+				context.hash = parse( context.hashstring );
+			} catch ( e ) {
+				debug( 'failed to query-string parse `location.hash`', e );
+				context.hash = {};
+			}
+		} else {
+			context.hash = {};
+		}
+
+		// client version of the isomorphic method for redirecting to another page
+		context.redirect = ( httpCode, newUrl = null ) => {
+			if ( isNaN( httpCode ) && ! newUrl ) {
+				newUrl = httpCode;
+			}
+
+			return page.replace( newUrl, context.state, false, false );
+		};
+
+		// Break routing and do full load for logout link in /me
+		if ( context.pathname === '/wp-login.php' ) {
+			window.location.href = context.path;
+			return;
+		}
+
+		next();
+	} );
+}
+
+export const configureReduxStore = ( currentUser, reduxStore ) => {
+	debug( 'Executing Calypso configure Redux store.' );
+
+	if ( currentUser.get() ) {
+		// Set current user in Redux store
+		reduxStore.dispatch( setCurrentUser( currentUser.get() ) );
+		currentUser.on( 'change', () => {
+			reduxStore.dispatch( setCurrentUser( currentUser.get() ) );
+		} );
+	}
+
+	if ( config.isEnabled( 'network-connection' ) ) {
+		asyncRequire( 'lib/network-connection', networkConnection =>
+			networkConnection.init( reduxStore )
+		);
+	}
+};
+
+export function setupMiddlewares( currentUser, reduxStore ) {
+	setupContextMiddleware( reduxStore );
+}

--- a/client/landing/login/common.js
+++ b/client/landing/login/common.js
@@ -53,6 +53,26 @@ export function setupContextMiddleware() {
 	} );
 }
 
+function renderDevHelpers( reduxStore ) {
+	if ( config.isEnabled( 'dev/test-helper' ) ) {
+		const testHelperEl = document.querySelector( '.environment.is-tests' );
+		if ( testHelperEl ) {
+			asyncRequire( 'lib/abtest/test-helper', testHelper => {
+				testHelper( testHelperEl );
+			} );
+		}
+	}
+
+	if ( config.isEnabled( 'dev/preferences-helper' ) ) {
+		const prefHelperEl = document.querySelector( '.environment.is-prefs' );
+		if ( prefHelperEl ) {
+			asyncRequire( 'lib/preferences-helper', prefHelper => {
+				prefHelper( prefHelperEl, reduxStore );
+			} );
+		}
+	}
+}
+
 export const configureReduxStore = ( currentUser, reduxStore ) => {
 	debug( 'Executing Calypso configure Redux store.' );
 
@@ -73,4 +93,5 @@ export const configureReduxStore = ( currentUser, reduxStore ) => {
 
 export function setupMiddlewares( currentUser, reduxStore ) {
 	setupContextMiddleware( reduxStore );
+	renderDevHelpers( reduxStore );
 }

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -1,0 +1,63 @@
+/**
+ * Global polyfills
+ */
+import 'boot/polyfills';
+import { hydrate, render } from 'controller/web-util';
+
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+import page from 'page';
+
+/**
+ * Internal dependencies
+ */
+import createStore from './store';
+import { setupMiddlewares, configureReduxStore } from './common';
+import initLoginSection from 'login';
+import userFactory from 'lib/user';
+
+const debug = debugFactory( 'calypso' );
+
+import 'assets/stylesheets/style.scss';
+// goofy import for environment badge, which is SSR'd
+import 'components/environment-badge/style.scss';
+
+// Create Redux store
+const store = createStore();
+
+setupMiddlewares( store );
+
+page( '*', ( context, next ) => {
+	context.store = store;
+	next();
+} );
+
+page.exit( '*', ( context, next ) => {
+	context.store = store;
+	next();
+} );
+
+initLoginSection( ( route, ...handlers ) => page( route, ...handlers, renderHandler ) );
+function renderHandler( context, next ) {
+	( context.serverSideRender ? hydrate : render )( context );
+	next();
+}
+
+const boot = currentUser => {
+	debug( "Starting Calypso. Let's do this." );
+
+	configureReduxStore( currentUser, store );
+	setupMiddlewares( currentUser, store );
+	page.start( { decodeURLComponents: false } );
+};
+
+window.AppBoot = () => {
+	const user = userFactory();
+	if ( user.initialized ) {
+		boot( user );
+	} else {
+		user.once( 'change', () => boot( user ) );
+	}
+};

--- a/client/landing/login/index.js
+++ b/client/landing/login/index.js
@@ -2,7 +2,7 @@
  * Global polyfills
  */
 import 'boot/polyfills';
-import { hydrate, render } from 'controller/web-util';
+import { render } from 'controller/web-util';
 
 /**
  * External dependencies
@@ -27,29 +27,23 @@ import 'components/environment-badge/style.scss';
 // Create Redux store
 const store = createStore();
 
-setupMiddlewares( store );
-
-page( '*', ( context, next ) => {
-	context.store = store;
-	next();
-} );
-
-page.exit( '*', ( context, next ) => {
-	context.store = store;
-	next();
-} );
-
-initLoginSection( ( route, ...handlers ) => page( route, ...handlers, renderHandler ) );
-function renderHandler( context, next ) {
-	( context.serverSideRender ? hydrate : render )( context );
-	next();
-}
-
 const boot = currentUser => {
 	debug( "Starting Calypso. Let's do this." );
 
 	configureReduxStore( currentUser, store );
 	setupMiddlewares( currentUser, store );
+
+	page( '*', ( context, next ) => {
+		context.store = store;
+		next();
+	} );
+
+	page.exit( '*', ( context, next ) => {
+		context.store = store;
+		next();
+	} );
+
+	initLoginSection( ( route, ...handlers ) => page( route, ...handlers, render ) );
 	page.start( { decodeURLComponents: false } );
 };
 

--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { createStore, applyMiddleware, compose } from 'redux';
+import thunkMiddleware from 'redux-thunk';
+
+/**
+ * Internal dependencies
+ */
+import wpcomApiMiddleware from 'state/data-layer/wpcom-api-middleware';
+import { reducer as httpData, enhancer as httpDataEnhancer } from 'state/data-layer/http-data';
+import { combineReducers } from 'state/utils';
+import application from 'state/application/reducer';
+import documentHead from 'state/document-head/reducer';
+import login from 'state/login/reducer';
+import language from 'state/ui/language/reducer';
+import route from 'state/ui/route/reducer';
+import masterbarVisibility from 'state/ui/masterbar-visibility/reducer';
+import section from 'state/ui/section/reducer';
+import notices from 'state/notices/reducer';
+import i18n from 'state/i18n/reducer';
+import users from 'state/users/reducer';
+import currentUser from 'state/current-user/reducer';
+
+// Create Redux store
+const reducer = combineReducers( {
+	application,
+	documentHead,
+	httpData,
+	login,
+	notices,
+	i18n,
+	users,
+	currentUser,
+	ui: combineReducers( {
+		language,
+		route,
+		masterbarVisibility,
+		section,
+	} ),
+} );
+
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
+export default () =>
+	createStore(
+		reducer,
+		composeEnhancers( httpDataEnhancer, applyMiddleware( thunkMiddleware, wpcomApiMiddleware ) )
+	);

--- a/client/landing/login/store.js
+++ b/client/landing/login/store.js
@@ -21,6 +21,7 @@ import notices from 'state/notices/reducer';
 import i18n from 'state/i18n/reducer';
 import users from 'state/users/reducer';
 import currentUser from 'state/current-user/reducer';
+import preferences from 'state/preferences/reducer';
 
 // Create Redux store
 const reducer = combineReducers( {
@@ -32,6 +33,7 @@ const reducer = combineReducers( {
 	i18n,
 	users,
 	currentUser,
+	preferences,
 	ui: combineReducers( {
 		language,
 		route,

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -25,6 +22,11 @@ import getCurrentQueryArguments from 'state/selectors/get-current-query-argument
 import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import GdprBanner from 'blocks/gdpr-banner';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 // Returns true if given section should display sidebar for logged out users.
 const hasSidebar = section => {

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -1,13 +1,15 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import config from 'config';
 import webRouter from './index.web';
 import { lang } from './controller';
 import { makeLayout, redirectLoggedIn, setUpLocale } from 'controller';
+
+/**
+ * Re-exports
+ */
+export { LOGIN_SECTION_DEFINITION } from './index.web';
 
 export default router => {
 	if ( config.isEnabled( 'login/magic-login' ) ) {

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -1,4 +1,11 @@
 /**
+ * External dependencies
+ */
+import React from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { MomentProvider } from 'components/localized-moment/context';
+
+/**
  * Internal dependencies
  */
 import config from 'config';
@@ -11,15 +18,37 @@ import {
 	redirectDefaultLocale,
 } from './controller';
 import { setShouldServerSideRenderLogin } from './ssr';
-import { makeLoggedOutLayout } from 'controller';
-import { setUpLocale } from 'controller/shared';
+import { setUpLocale, setSection, makeLayoutMiddleware } from 'controller/shared';
 import { redirectLoggedIn } from 'controller/web-util';
+import LayoutLoggedOut from 'layout/logged-out';
+
+export const LOGIN_SECTION_DEFINITION = {
+	name: 'login',
+	paths: [ '/log-in' ],
+	module: 'login',
+	enableLoggedOut: true,
+	secondary: false,
+	isomorphic: true,
+};
+
+const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } ) => {
+	return (
+		<ReduxProvider store={ store }>
+			<MomentProvider>
+				<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
+			</MomentProvider>
+		</ReduxProvider>
+	);
+};
+
+const makeLoggedOutLayout = makeLayoutMiddleware( ReduxWrappedLayout );
 
 export default router => {
 	if ( config.isEnabled( 'login/magic-login' ) ) {
 		router(
 			`/log-in/link/use/${ lang }`,
 			setUpLocale,
+			setSection( LOGIN_SECTION_DEFINITION ),
 			redirectLoggedIn,
 			magicLoginUse,
 			makeLoggedOutLayout
@@ -28,6 +57,7 @@ export default router => {
 		router(
 			`/log-in/link/${ lang }`,
 			setUpLocale,
+			setSection( LOGIN_SECTION_DEFINITION ),
 			redirectLoggedIn,
 			magicLogin,
 			makeLoggedOutLayout
@@ -47,6 +77,7 @@ export default router => {
 			redirectJetpack,
 			redirectDefaultLocale,
 			setUpLocale,
+			setSection( LOGIN_SECTION_DEFINITION ),
 			login,
 			setShouldServerSideRenderLogin,
 			makeLoggedOutLayout

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -44,9 +44,9 @@ $image-height: 47px;
 .wp-login__links,
 .wp-login__footer {
 	a,
+	a:visited,
 	button {
 		color: var( --color-neutral-50 );
-		text-decoration: none;
 
 		body.is-section-signup & {
 			color: var( --color-text-inverted );
@@ -75,10 +75,6 @@ $image-height: 47px;
 
 		&:last-child {
 			border-bottom: none;
-		}
-
-		body.is-section-signup & {
-			color: var( --color-text-inverted );
 		}
 	}
 
@@ -157,7 +153,8 @@ $image-height: 47px;
 	@include jetpack-connect-colors();
 }
 
-.layout.is-jetpack-woocommerce-flow, .layout.is-wccom-oauth-flow {
+.layout.is-jetpack-woocommerce-flow,
+.layout.is-wccom-oauth-flow {
 	@include woocommerce-colors();
 }
 
@@ -247,7 +244,7 @@ $image-height: 47px;
 	}
 
 	.login__form {
-		@include elevation ( 2dp );
+		@include elevation( 2dp );
 		padding-bottom: 0;
 		padding-top: 8px;
 	}

--- a/client/sections.js
+++ b/client/sections.js
@@ -373,14 +373,6 @@ const sections = [
 		group: 'me',
 	},
 	{
-		name: 'login',
-		paths: [ '/log-in' ],
-		module: 'login',
-		enableLoggedOut: true,
-		secondary: false,
-		isomorphic: true,
-	},
-	{
 		name: 'auth',
 		paths: [ '/oauth-login', '/authorize', '/api/oauth/token' ],
 		module: 'auth',

--- a/test/e2e/lib/pages/login-page.js
+++ b/test/e2e/lib/pages/login-page.js
@@ -28,7 +28,7 @@ export default class LoginPage extends AsyncBaseContainer {
 		const passwordSelector = By.css( '#password' );
 
 		await driverHelper.waitTillPresentAndDisplayed( driver, userNameSelector );
-		await driverHelper.waitTillFocused( driver, userNameSelector );
+		// await driverHelper.waitTillFocused( driver, userNameSelector );
 		await driverHelper.setWhenSettable( driver, userNameSelector, username );
 		await this.driver.sleep( 1000 );
 		await driver.findElement( userNameSelector ).sendKeys( Key.ENTER );

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -1062,8 +1062,7 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"optional": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
@@ -4972,8 +4971,7 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4991,13 +4989,11 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -5010,18 +5006,15 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -5124,8 +5117,7 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -5135,7 +5127,6 @@
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -5148,20 +5139,17 @@
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -5178,7 +5166,6 @@
 				"mkdirp": {
 					"version": "0.5.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -5251,8 +5238,7 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -5262,7 +5248,6 @@
 				"once": {
 					"version": "1.4.0",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -5338,8 +5323,7 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -5369,7 +5353,6 @@
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -5387,7 +5370,6 @@
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -5426,13 +5408,11 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				},
 				"yallist": {
 					"version": "3.0.3",
-					"bundled": true,
-					"optional": true
+					"bundled": true
 				}
 			}
 		},
@@ -5542,7 +5522,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"optional": true,
 			"requires": {
 				"is-glob": "^2.0.0"
 			},
@@ -5550,14 +5529,12 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"optional": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"optional": true,
 					"requires": {
 						"is-extglob": "^1.0.0"
 					}
@@ -5953,7 +5930,6 @@
 					"version": "0.4.2",
 					"resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
 					"integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-					"optional": true,
 					"requires": {
 						"hoek": "0.9.x"
 					}
@@ -5970,8 +5946,7 @@
 				"hoek": {
 					"version": "0.9.1",
 					"resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-					"integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-					"optional": true
+					"integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
 				}
 			}
 		},
@@ -7764,7 +7739,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"optional": true,
 			"requires": {
 				"remove-trailing-separator": "^1.0.1"
 			}
@@ -8128,8 +8102,7 @@
 				"is-extglob": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"optional": true
+					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 				},
 				"is-glob": {
 					"version": "2.0.1",
@@ -9681,8 +9654,7 @@
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-			"optional": true
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"repeat-element": {
 			"version": "1.1.3",
@@ -10443,13 +10415,11 @@
 			"dependencies": {
 				"commander": {
 					"version": "2.15.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-					"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+					"bundled": true
 				},
 				"config": {
 					"version": "1.28.0",
-					"resolved": "https://registry.npmjs.org/config/-/config-1.28.0.tgz",
-					"integrity": "sha1-ZmdABTqBSJkF8mCHyGVjlMGTUH0=",
+					"bundled": true,
 					"requires": {
 						"json5": "0.4.0",
 						"os-homedir": "1.0.2"
@@ -10457,16 +10427,14 @@
 				},
 				"debug": {
 					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"bundled": true,
 					"requires": {
 						"ms": "2.0.0"
 					}
 				},
 				"glob": {
 					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+					"bundled": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -10478,13 +10446,11 @@
 				},
 				"json5": {
 					"version": "0.4.0",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz",
-					"integrity": "sha1-BUNS5MTIDIbAkjh31EneF2pzLI0="
+					"bundled": true
 				},
 				"mocha": {
 					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-					"integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+					"bundled": true,
 					"requires": {
 						"browser-stdout": "1.3.1",
 						"commander": "2.15.1",
@@ -10501,13 +10467,11 @@
 				},
 				"ms": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"bundled": true
 				},
 				"supports-color": {
 					"version": "5.4.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"bundled": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -178,6 +178,7 @@ const webpackConfig = {
 	entry: {
 		'entry-main': [ path.join( __dirname, 'client', 'boot', 'app' ) ],
 		'entry-domains-landing': [ path.join( __dirname, 'client', 'landing', 'domains' ) ],
+		'entry-login': [ path.join( __dirname, 'client', 'landing', 'login' ) ],
 	},
 	mode: isDevelopment ? 'development' : 'production',
 	devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),


### PR DESCRIPTION
This change extracts login into its own entrypoint, with the minimal required set of reducers and dependencies. This greatly reduces the amount of JS (and thus, time) required to boot `/log-in`.

This PR is largely based off of @jsnajdr's #32927.

This PR *appears* to work, but I'm not sure how to test the functionality extensively, beyond attempting login with 2FA and generating/using a magic link. Those all work, and so do E2E tests. I'm not sure what else to look for, which is where hopefully you come in! Thank you! 🙇 

#### Changes proposed in this Pull Request

* Create new entrypoint for login.
* Add login entrypoint bootup files, including templates and store initialisation.
* Remove login from regular sections list.
* Extract common utilities from `client/controller/index.web.js` to `client/controller/util-web.js`.
* Extract `ui.section` and `ui.masterbarVisibility` reducers into their own modules.

#### Testing instructions

* Test as much login functionality as possible with the live branch. Magic login, wpcom login, 2FA, etc., should all be tested.
