### PR TITLE
Migrate term-form-dialog to the new CSS pipeline

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -15,7 +15,6 @@
 @import 'blocks/post-item/style';
 @import 'blocks/sharing-preview-pane/style';
 @import 'blocks/site-address-changer/style';
-@import 'blocks/term-form-dialog/style';
 @import 'blocks/term-tree-selector/style';
 @import 'blocks/upload-image/style';
 @import 'blocks/video-editor/style';

--- a/client/blocks/term-form-dialog/index.jsx
+++ b/client/blocks/term-form-dialog/index.jsx
@@ -30,6 +30,11 @@ import { getTerms } from 'state/terms/selectors';
 import { addTerm, updateTerm } from 'state/terms/actions';
 import { recordGoogleEvent, bumpStat } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class TermFormDialog extends Component {
 	static initialState = {
 		description: '',
@@ -344,7 +349,6 @@ class TermFormDialog extends Component {
 
 		return (
 			<Dialog
-				autoFocus={ false }
 				isVisible={ showDialog }
 				buttons={ buttons }
 				onClose={ this.closeDialog }
@@ -353,9 +357,9 @@ class TermFormDialog extends Component {
 				<FormSectionHeading>{ isNew ? labels.add_new_item : labels.edit_item }</FormSectionHeading>
 				<FormFieldset>
 					<FormTextInput
+						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus={ showDialog && ! isMobile() }
 						placeholder={ labels.new_item_name }
-						ref="termName"
 						isError={ isError }
 						onKeyUp={ this.validateInput }
 						value={ name }
@@ -372,7 +376,6 @@ class TermFormDialog extends Component {
 							} ) }
 						</FormLegend>
 						<FormTextarea
-							ref="termDescription"
 							onKeyUp={ this.validateInput }
 							value={ description }
 							onChange={ this.onDescriptionChange }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate the term form dialog styles to the new css pipeline

#### Testing instructions

* Make sure you can still add a new Category using the classic editor sidebar

refs #27515
