### PR TITLE
Store selected template in post meta

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -51,16 +51,16 @@ class Starter_Page_Templates {
 			true
 		);
 	}
-	
+
 	/**
 	 * Register meta field for storing the template identifier.
 	 */
 	public function register_meta_field() {
 		$args = array(
-			'type' => 'string',
-			'description' => 'Selected template',
-			'single' => true,
-			'show_in_rest' => true,
+			'type'           => 'string',
+			'description'    => 'Selected template',
+			'single'         => true,
+			'show_in_rest'   => true,
 			'object_subtype' => 'page',
 		);
 		// TODO: meta field name

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -62,18 +62,11 @@ class Starter_Page_Templates {
 			'single'         => true,
 			'show_in_rest'   => true,
 			'object_subtype' => 'page',
-			'auth_callback'  => array( $this, 'meta_field_auth_callback' ),
+			'auth_callback'  => function() {
+				return current_user_can( 'edit_posts' );
+			},
 		);
 		register_meta( 'post', '_starter_page_template', $args );
-	}
-
-	/**
-	 * Allow meta field updates for users able to edit posts.
-	 *
-	 * @return boolean
-	 */
-	public function meta_field_auth_callback() {
-		return current_user_can( 'edit_posts' );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -63,7 +63,6 @@ class Starter_Page_Templates {
 			'show_in_rest'   => true,
 			'object_subtype' => 'page',
 		);
-		// TODO: meta field name
 		register_meta( 'post', '_starter_page_template', $args );
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -22,6 +22,7 @@ class Starter_Page_Templates {
 	 */
 	private function __construct() {
 		add_action( 'init', array( $this, 'register_scripts' ) );
+		add_action( 'init', array( $this, 'register_meta_field' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_assets' ) );
 	}
 
@@ -49,6 +50,21 @@ class Starter_Page_Templates {
 			filemtime( plugin_dir_path( __FILE__ ) . 'dist/starter-page-templates.js' ),
 			true
 		);
+	}
+	
+	/**
+	 * Register meta field for storing the template identifier.
+	 */
+	public function register_meta_field() {
+		$args = array(
+			'type' => 'string',
+			'description' => 'Selected template',
+			'single' => true,
+			'show_in_rest' => true,
+			'object_subtype' => 'page',
+		);
+		// TODO: meta field name
+		register_meta( 'post', 'starter_page_template', $args );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -64,7 +64,7 @@ class Starter_Page_Templates {
 			'object_subtype' => 'page',
 		);
 		// TODO: meta field name
-		register_meta( 'post', 'starter_page_template', $args );
+		register_meta( 'post', '_starter_page_template', $args );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -62,8 +62,18 @@ class Starter_Page_Templates {
 			'single'         => true,
 			'show_in_rest'   => true,
 			'object_subtype' => 'page',
+			'auth_callback'  => array( $this, 'meta_field_auth_callback' ),
 		);
 		register_meta( 'post', '_starter_page_template', $args );
+	}
+
+	/**
+	 * Allow meta field updates for users able to edit posts.
+	 *
+	 * @return boolean
+	 */
+	public function meta_field_auth_callback() {
+		return current_user_can( 'edit_posts' );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -59,7 +59,7 @@ const insertTemplate = template => {
 		title: replacePlaceholders( template.title, siteInformation ),
 		meta: {
 			...currentMeta,
-			starter_page_template: template.slug, // TODO: change for the proper identifier
+			_starter_page_template: template.slug, // TODO: change for the proper identifier
 		},
 	} );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { withState } from '@wordpress/compose';
 import { Modal } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
-import { dispatch } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { parse as parseBlocks } from '@wordpress/blocks';
 
 /**
@@ -45,6 +45,7 @@ if ( window.starterPageTemplatesConfig ) {
 
 const { siteInformation = {}, templates = [] } = window.starterPageTemplatesConfig;
 const editorDispatcher = dispatch( 'core/editor' );
+const editorSelector = select( 'core/editor' );
 
 const insertTemplate = template => {
 	// Skip inserting if there's nothing to insert.
@@ -52,10 +53,17 @@ const insertTemplate = template => {
 		return;
 	}
 
-	// set title
-	editorDispatcher.editPost( { title: replacePlaceholders( template.title, siteInformation ) } );
+	// Set post title and remember selected template in meta.
+	const currentMeta = editorSelector.getEditedPostAttribute( 'meta' );
+	editorDispatcher.editPost( {
+		title: replacePlaceholders( template.title, siteInformation ),
+		meta: {
+			...currentMeta,
+			starter_page_template: template.slug, // TODO: change for the proper identifier
+		},
+	} );
 
-	// load content
+	// Insert blocks.
 	const templateString = replacePlaceholders( template.content, siteInformation );
 	const blocks = parseBlocks( templateString );
 	editorDispatcher.insertBlocks( blocks );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Store selected template in post meta

#### Testing instructions

* create a new Page and pick a starter template other than Blank
* save the page (as a draft or publish, doesn't matter)
* open the editor again to edit the page and look up its meta (convenient `wp.data.select('core/editor').getEditedPostAttribute('meta')` in JS console)
* or confirm the meta presence in some other way you like
* in the meta, you should see the template slug like `menu` / `home` etc…

Part of #33489 