### PR TITLE
Types: Add definitions to i18n-calypso

### DIFF
--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -4,6 +4,7 @@
 	"description": "i18n JavaScript library on top of Jed originally used in Calypso",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
+	"types": "types/index.d.ts",
 	"sideEffects": false,
 	"repository": {
 		"type": "git",

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -38,15 +38,15 @@ declare namespace i18nCalypso {
 
 	export type TranslatedString = string;
 
-	export function translate( oringinal: string ): TranslatedString;
+	export function translate( original: string ): TranslatedString;
 	export function translate(
-		oringinal: string,
+		original: string,
 		plural: string,
 		options: TranslateOptions & { count: number }
 	): TranslatedString;
-	export function translate( oringinal: string, options: TranslateOptions ): TranslatedString;
+	export function translate( original: string, options: TranslateOptions ): TranslatedString;
 	export function translate(
-		oringinal: string,
+		original: string,
 		plural: string,
 		options: TranslateOptions
 	): TranslatedString;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -1,0 +1,23 @@
+// Type definitions for i18n-calypso
+// Project: i18n-calypso
+
+declare namespace i18nCalypso {
+	export type Substitutions = string | string[] | { [placeholder: string]: string };
+
+	export interface ComponentInterpolations {
+		[placeholder: string]: React.ReactElement;
+	}
+
+	export interface TranslateOptions {
+		args?: Substitutions;
+		components?: ComponentInterpolations;
+	}
+
+	export function translate( oringinal: string );
+	export function translate( oringinal: string, plural: string );
+	export function translate( oringinal: string, options: TranslateOptions );
+	export function translate( oringinal: string, plural: string, options: TranslateOptions );
+}
+
+export = i18nCalypso;
+export as namespace i18nCalypso;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -8,7 +8,12 @@ import { ComponentClass, ComponentType, ReactElement } from 'react';
 import moment from 'moment';
 
 declare namespace i18nCalypso {
-	export type Substitutions = string | string[] | { [placeholder: string]: string };
+	export type Substitution = string | number;
+
+	export type Substitutions =
+		| Substitution
+		| Substitution[]
+		| { [placeholder: string]: Substitution };
 
 	export interface ComponentInterpolations {
 		[placeholder: string]: ReactElement;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -62,6 +62,7 @@ declare namespace i18nCalypso {
 	export function numberFormat( number: number, options: NumberFormatOptions );
 
 	export interface LocalizeProps {
+		locale: string;
 		translate: typeof translate;
 		numberFormat: typeof numberFormat;
 		moment: typeof moment;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -70,7 +70,7 @@ declare namespace i18nCalypso {
 
 	export function localize< P >(
 		component: ComponentType< P >
-	): React.Component< P & LocalizedComponentProps >;
+	): ComponentType< P & LocalizedComponentProps >;
 }
 
 export = i18nCalypso;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -4,7 +4,7 @@
 /**
  * External dependencies
  */
-import { ComponentType } from 'react';
+import { ComponentClass, ComponentType } from 'react';
 import moment from 'moment';
 
 declare namespace i18nCalypso {
@@ -62,15 +62,23 @@ declare namespace i18nCalypso {
 	export function numberFormat( number: number, numberOfDecimalPlaces: number );
 	export function numberFormat( number: number, options: NumberFormatOptions );
 
-	export interface LocalizedComponentProps {
+	export interface LocalizeProps {
 		translate: typeof translate;
 		numberFormat: typeof numberFormat;
 		moment: typeof moment;
 	}
 
-	export function localize< P >(
-		component: ComponentType< P >
-	): ComponentType< P & LocalizedComponentProps >;
+	// Infers prop type from component C
+	export type GetProps< C > = C extends ComponentType< infer P > ? P : never;
+
+	export type WithoutLocalizedProps< OrigProps > = Pick<
+		OrigProps,
+		Exclude< keyof OrigProps, keyof LocalizeProps >
+	>;
+
+	export type LocalizedComponent< C > = ComponentClass< WithoutLocalizedProps< GetProps< C > > >;
+
+	export function localize< C >( component: C ): LocalizedComponent< C >;
 }
 
 export = i18nCalypso;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -7,28 +7,14 @@
 import * as React from 'react';
 import moment from 'moment';
 
-interface InterpolateComponentsOptions {
-	mixedString: string;
-	components: i18nCalypso.ComponentInterpolations;
-	throwErrors?: boolean;
-}
-
-declare function interpolateComponents(
-	options: InterpolateComponentsOptions
-): string | React.ReactFragment;
-
 declare namespace i18nCalypso {
-	export interface NormalizedTranslateArgs extends TranslateOptions {
-		original: string;
-		components?: ComponentInterpolations;
-	}
-
-	export type TranslateHook = (
-		translation: string | React.ReactFragment,
-		options:
-			| NormalizedTranslateArgs
-			| ( NormalizedTranslateArgs & { plural: string; count: number } )
-	) => ReturnType< typeof translate >;
+	type NormalizedTranslateArgs =
+		| ( TranslateOptions & { original: string } )
+		| ( TranslateOptions & {
+				original: string;
+				plural: string;
+				count: number;
+		  } );
 
 	export type Substitution = string | number;
 
@@ -53,36 +39,32 @@ declare namespace i18nCalypso {
 		comment?: string;
 
 		/**
+		 * Components to be interpolated in the translated string.
+		 */
+		components?: ComponentInterpolations;
+
+		/**
 		 * Provides the ability for the translator to provide a different translation for the same text in two locations (dependent on context). Usually context should only be used after a string has been discovered to require different translations. If you want to provide help on how to translate (which is highly appreciated!), please use a comment.
 		 */
 		context?: string;
 	}
 
-	export type TranslationWithComponents = ReturnType< typeof interpolateComponents >;
+	// This deprecated signature is still supported
+	export interface DeprecatedTranslateOptions extends TranslateOptions {
+		original: string | { single: string; plural: string; count: number };
+	}
 
-	export function translate( original: string ): string;
+	// Translate hooks force us to open up this type.
+	export type TranslateResult = string | React.ReactFragment;
 
-	export function translate(
-		options: TranslateOptions & { original: string } & { components: ComponentInterpolations }
-	): TranslationWithComponents;
-	export function translate( options: TranslateOptions & { original: string } ): string;
-
-	export function translate(
-		original: string,
-		options: TranslateOptions & { components: ComponentInterpolations }
-	): TranslationWithComponents;
-	export function translate( original: string, options: TranslateOptions ): string;
-
-	export function translate(
-		original: string,
-		plural: string,
-		options: TranslateOptions & { count: number } & { components: ComponentInterpolations }
-	): TranslationWithComponents;
+	export function translate( options: DeprecatedTranslateOptions ): TranslateResult;
+	export function translate( original: string ): TranslateResult;
+	export function translate( original: string, options: TranslateOptions ): TranslateResult;
 	export function translate(
 		original: string,
 		plural: string,
 		options: TranslateOptions & { count: number }
-	): string;
+	): TranslateResult;
 
 	export function hasTranslation( original: string ): boolean;
 
@@ -117,6 +99,11 @@ declare namespace i18nCalypso {
 	export function localize< C >( component: C ): LocalizedComponent< C >;
 
 	export function useTranslate(): typeof translate;
+
+	export type TranslateHook = (
+		translation: TranslateResult,
+		options: NormalizedTranslateArgs
+	) => TranslateResult;
 
 	export function registerTranslateHook( hook: TranslateHook ): void;
 }

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -4,14 +4,14 @@
 /**
  * External dependencies
  */
-import { ComponentClass, ComponentType } from 'react';
+import { ComponentClass, ComponentType, ReactElement } from 'react';
 import moment from 'moment';
 
 declare namespace i18nCalypso {
 	export type Substitutions = string | string[] | { [placeholder: string]: string };
 
 	export interface ComponentInterpolations {
-		[placeholder: string]: React.ReactElement;
+		[placeholder: string]: ReactElement;
 	}
 
 	export interface TranslateOptions {

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -1,6 +1,12 @@
 // Type definitions for i18n-calypso
 // Project: i18n-calypso
 
+/**
+ * External dependencies
+ */
+import { ComponentType } from 'react';
+import moment from 'moment';
+
 declare namespace i18nCalypso {
 	export type Substitutions = string | string[] | { [placeholder: string]: string };
 
@@ -9,14 +15,62 @@ declare namespace i18nCalypso {
 	}
 
 	export interface TranslateOptions {
+		/**
+		 * Arguments you would pass into sprintf to be run against the text for string substitution.
+		 */
 		args?: Substitutions;
+
+		/**
+		 * Components for interpolation in the provided string.
+		 */
 		components?: ComponentInterpolations;
+
+		/**
+		 * Comment that will be shown to the translator for anything that may need to be explained about the translation.
+		 */
+		comment?: string;
+
+		/**
+		 * Provides the ability for the translator to provide a different translation for the same text in two locations (dependent on context). Usually context should only be used after a string has been discovered to require different translations. If you want to provide help on how to translate (which is highly appreciated!), please use a comment.
+		 */
+		context?: string;
 	}
 
-	export function translate( oringinal: string );
-	export function translate( oringinal: string, plural: string );
-	export function translate( oringinal: string, options: TranslateOptions );
-	export function translate( oringinal: string, plural: string, options: TranslateOptions );
+	export type TranslatedString = string;
+
+	export function translate( oringinal: string ): TranslatedString;
+	export function translate(
+		oringinal: string,
+		plural: string,
+		options: TranslateOptions & { count: number }
+	): TranslatedString;
+	export function translate( oringinal: string, options: TranslateOptions ): TranslatedString;
+	export function translate(
+		oringinal: string,
+		plural: string,
+		options: TranslateOptions
+	): TranslatedString;
+
+	export function hasTranslation( original: string ): boolean;
+
+	export interface NumberFormatOptions {
+		decimals?: number;
+		decPoint?: string;
+		thousandsSep?: string;
+	}
+
+	export function numberFormat( number: number, numberOfDecimalPlaces: number );
+	export function numberFormat( number: number, options: NumberFormatOptions );
+
+	export interface LocalizedComponentProps {
+		translate: typeof translate;
+		numberFormat: typeof numberFormat;
+		moment: typeof moment;
+	}
+
+	export function localize< P >(
+		component: ComponentType< P >
+	): React.Component< P & LocalizedComponentProps >;
 }
 
 export = i18nCalypso;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -27,7 +27,7 @@ declare namespace i18nCalypso {
 		translation: string | React.ReactFragment,
 		options:
 			| NormalizedTranslateArgs
-			| ( NormalizedTranslateArgs & { plural: Substitution; count: number } )
+			| ( NormalizedTranslateArgs & { plural: string; count: number } )
 	) => ReturnType< typeof translate >;
 
 	export type Substitution = string | number;

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -41,20 +41,14 @@ declare namespace i18nCalypso {
 		context?: string;
 	}
 
-	export type TranslatedString = string;
-
-	export function translate( original: string ): TranslatedString;
+	export function translate( original: string ): string;
 	export function translate(
 		original: string,
 		plural: string,
 		options: TranslateOptions & { count: number }
-	): TranslatedString;
-	export function translate( original: string, options: TranslateOptions ): TranslatedString;
-	export function translate(
-		original: string,
-		plural: string,
-		options: TranslateOptions
-	): TranslatedString;
+	): string;
+	export function translate( original: string, options: TranslateOptions ): string;
+	export function translate( original: string, plural: string, options: TranslateOptions ): string;
 
 	export function hasTranslation( original: string ): boolean;
 

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -79,6 +79,8 @@ declare namespace i18nCalypso {
 	export type LocalizedComponent< C > = ComponentClass< WithoutLocalizedProps< GetProps< C > > >;
 
 	export function localize< C >( component: C ): LocalizedComponent< C >;
+
+	export function useTranslate(): typeof translate;
 }
 
 export = i18nCalypso;


### PR DESCRIPTION
i18n-calypso is used all over Calypso. Let's add types!

The typecheck job currently has [52 errors](https://circleci.com/gh/Automattic/wp-calypso/313942), 11 are from not having i18n-calypso definitions, so we'll get less noise there in addition to hints in our editors.

[41 errors](https://circleci.com/gh/Automattic/wp-calypso/314513) with this 🎉 

## Testing

Try using it in a `tsx` file in Calypso. Try adding stuff that should typecheck. See if the suggestions are working well. Here's an interesting starting point:

```tsx
import i18n, { translate } from 'i18n-calypso';
import * as i18n_ from 'i18n-calypso';

translate( 'Hi!' );
translate( 'Hi, %s', { args: 'Ebeneezer' } );
translate( 'Hi, %s', { args: [ 'Ebeneezer' ] } );
translate( 'Hi, %(you)s', { args: { you: 'Ebeneezer' } } );

i18n.translate( 'I feel {{em}}very{{/em}} strongly about this.', {
	components: {
		em: <em />,
	},
} );

i18n_.translate(
	'Your subscription will expire in %(numberOfDays)d day.',
	'Your subscription will expire in %(numberOfDays)d days.',
	{
		count: 2,
		args: {
			numberOfDays: '2', // string | number is allowed
		},
	}
);

const C = i18n.localize(
	class extends React.Component< {} > {
		render() {
			return null;
		}
	}
);
const m = C.props.moment();
m.toISOString();
const d = m.toDate();

i18n.localize( props => null );
i18n.localize( props => <em /> );
i18n.localize( props => React.createElement( 'em' ) );
```

You may need to restart tsserver in your editor when changing to this branch for the definitions to be picked up (run "TypeScript: Restart TS Server" command in VS Code).