### PR TITLE
css: migrate components/keyed-suggestions styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -46,7 +46,6 @@
 @import 'components/forms/sortable-list/style';
 @import 'components/image/style';
 @import 'components/info-popover/style';
-@import 'components/keyed-suggestions/style';
 @import 'components/legend-item/style';
 @import 'components/logged-out-form/style';
 @import 'components/locale-suggestions/style';

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -31,9 +31,9 @@ function SuggestionsButtonAll( props ) {
 	}
 
 	return (
-		<span className="keyed-suggestions__category-show-all" onClick={ click }>
+		<button className="keyed-suggestions__category-show-all" onClick={ click }>
 			{ props.label }
-		</span>
+		</button>
 	);
 }
 
@@ -125,7 +125,7 @@ class KeyedSuggestions extends React.Component {
 				event.preventDefault();
 				break;
 			case 'Enter':
-				if ( !! this.state.currentSuggestion ) {
+				if ( this.state.currentSuggestion ) {
 					this.props.suggest( this.state.currentSuggestion );
 					return true;
 				}

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -329,6 +329,7 @@ class KeyedSuggestions extends React.Component {
 						'has-highlight': hasHighlight,
 					} );
 					return (
+						/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/mouse-events-have-key-events */
 						<span
 							className={ className }
 							onMouseDown={ this.onMouseDown }
@@ -345,6 +346,7 @@ class KeyedSuggestions extends React.Component {
 								</span>
 							) }
 						</span>
+						/* eslint-enable jsx-a11y/no-static-element-interactions, jsx-a11y/mouse-events-have-key-events */
 					);
 				} )
 			);

--- a/client/components/keyed-suggestions/index.jsx
+++ b/client/components/keyed-suggestions/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -22,6 +19,11 @@ import {
 } from 'lodash';
 import classNames from 'classnames';
 import i18n from 'i18n-calypso';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 function SuggestionsButtonAll( props ) {
 	function click() {

--- a/client/components/keyed-suggestions/style.scss
+++ b/client/components/keyed-suggestions/style.scss
@@ -9,6 +9,8 @@
 	border-top: 0;
 	padding: 4px 8px;
 	font-size: 13px;
+	display: flex;
+	align-items: center;
 
 	.keyed-suggestions__category-name {
 		text-transform: uppercase;
@@ -19,10 +21,11 @@
 		margin-left: 6px;
 		text-transform: uppercase;
 		color: var( --color-text-subtle );
+		flex: 1;
 	}
 
 	.keyed-suggestions__category-show-all {
-		float: right;
+		font-size: 13px;
 		cursor: pointer;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate migrate `components/keyed-suggestions` styles to be processed by webpack

#### Testing instructions

* Go to `/themes` and use the search input field
* Are keyed suggestions displayed correctly underneath? Are the styles preserved?

<img width="276" alt="Screenshot 2019-06-05 at 10 43 17" src="https://user-images.githubusercontent.com/9202899/58965537-c14a1e80-877e-11e9-8d4f-dde021f27e57.png">

Fixes #33647 (part of #27515)
