### PR TITLE
Migrate social icons CSS to webpack.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -62,7 +62,6 @@
 @import 'components/select-dropdown/style';
 @import 'components/site-selector/style';
 @import 'components/sites-popover/style';
-@import 'components/social-icons/style';
 @import 'components/stat-update-indicator/style';
 @import 'components/text-diff/style';
 @import 'components/tooltip/style';

--- a/client/components/social-icons/facebook.jsx
+++ b/client/components/social-icons/facebook.jsx
@@ -9,6 +9,11 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { omit } from 'lodash';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class FacebookIcon extends PureComponent {
 	static propTypes = {
 		isDisabled: PropTypes.bool,

--- a/client/components/social-icons/google.jsx
+++ b/client/components/social-icons/google.jsx
@@ -3,11 +3,15 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { omit } from 'lodash';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export default class GoogleIcon extends PureComponent {
 	static propTypes = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migration social-icons CSS to webpack.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to `/me/security/social-login` and ensure the social service icon(s) render as expected.

Fixes #33649