### PR TITLE
css: migrate components/mini-site-preview styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -51,7 +51,6 @@
 @import 'components/logged-out-form/style';
 @import 'components/locale-suggestions/style';
 @import 'components/main/style';
-@import 'components/mini-site-preview/style';
 @import 'components/mobile-back-to-sidebar/style';
 @import 'components/notice/style';
 @import 'components/popover/style';

--- a/client/components/mini-site-preview/index.jsx
+++ b/client/components/mini-site-preview/index.jsx
@@ -1,10 +1,14 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const MiniSitePreview = ( { className, imageSrc } ) =>
 	imageSrc ? (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `components/mini-site-preview` styles to be processed by webpack

#### Testing instructions

* Select a site and go to _Tools > Import_
* Now choose either GoDaddy or Wix and hit _Start import_
* Provide a URL for a site of the given type and hit _Continue_
* Is the preview shown correctly? Are styles for the site preview preserved?

Fixes #33643 (part of #27515)
