### PR TITLE
Migrate css for NPS Survey notice

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -72,7 +72,6 @@
 @import 'components/happychat/style';
 @import 'components/happychat/agent-w/style';
 @import 'layout/community-translator/style';
-@import 'layout/nps-survey-notice/style';
 @import 'layout/sidebar/style';
 @import 'lib/abtest/test-helper/style';
 @import 'lib/preferences-helper/style';

--- a/client/layout/nps-survey-notice/index.jsx
+++ b/client/layout/nps-survey-notice/index.jsx
@@ -31,6 +31,11 @@ import {
 import { isSupportSession } from 'state/support/selectors';
 import analytics from 'lib/analytics';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const SURVEY_NAME = 'calypso-global-notice-radio-buttons-v1';
 
 class NpsSurveyNotice extends Component {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate css for NPS Survey notice

#### Testing instructions

* On a dev instance, run `npsSurvey()` in the dev console. That will make the NPS Survey appear. Validate it looks correct. For this case, it just has to have max-width of 480px;

refs #27515
