### PR TITLE
Migrate text-diff CSS to webpack.

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -64,7 +64,6 @@
 @import 'components/sites-popover/style';
 @import 'components/social-icons/style';
 @import 'components/stat-update-indicator/style';
-@import 'components/text-diff/style';
 @import 'components/tooltip/style';
 @import 'components/wizard/style';
 @import 'components/environment-badge/style';

--- a/client/components/text-diff/index.jsx
+++ b/client/components/text-diff/index.jsx
@@ -8,6 +8,11 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { isArray, isEmpty, map, partialRight } from 'lodash';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const addLinesToOperations = operations => {
 	if ( ! isArray( operations ) || isEmpty( operations ) ) {
 		return operations;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Migrate text-diff CSS to webpack.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

These styles are overridden in the context of the revision history split view.  To test, go to a post in the classic editor, choose "History" from the top bar, and toggle the view mode to "Split".  The deleted lines should be hidden on the secondary/right-hand pane.  The additions should be hidden on the primary/left-hand pane.  Ensure those styles from `editor-diff-viewer` (which is already migrated) are still applied correctly.

Fixes #33653