### PR TITLE
CSS: migrate mailing-list styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -76,7 +76,6 @@
 @import 'layout/sidebar/style';
 @import 'lib/abtest/test-helper/style';
 @import 'lib/preferences-helper/style';
-@import 'mailing-lists/style';
 @import 'me/happychat/style';
 @import 'me/notification-settings/blogs-settings/style';
 @import 'me/notification-settings/comment-settings/style';

--- a/client/mailing-lists/index.js
+++ b/client/mailing-lists/index.js
@@ -12,6 +12,11 @@ import page from 'page';
 import controller from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default function() {
 	// not putting category or email address in params, since `page`
 	// currently double-decodes the URI before doing route matching


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate mailing-list styles

#### Testing instructions

* Visit /mailing-list/unsubscribe and verify styles look the same as production
