### PR TITLE
Classic Editor: Fix click stealing when adding tags

### DIFF
--- a/client/post-editor/editor-categories-tags/accordion.jsx
+++ b/client/post-editor/editor-categories-tags/accordion.jsx
@@ -89,13 +89,12 @@ export class EditorCategoriesTagsAccordion extends Component {
 
 		return (
 			<AccordionSection>
-				<EditorDrawerLabel helpText={ helpText } labelText={ translate( 'Tags' ) }>
-					{ isTermsSupported ? (
-						<TermTokenField taxonomyName="post_tag" />
-					) : (
-						this.renderJetpackNotice()
-					) }
-				</EditorDrawerLabel>
+				<EditorDrawerLabel helpText={ helpText } labelText={ translate( 'Tags' ) } />
+				{ isTermsSupported ? (
+					<TermTokenField taxonomyName="post_tag" />
+				) : (
+					this.renderJetpackNotice()
+				) }
 			</AccordionSection>
 		);
 	}


### PR DESCRIPTION
Fixes #33606

#### Changes proposed in this Pull Request

* Stop wrapping the tag label around the entire section, instead limit it to the tag text itself

#### Testing instructions

* Pull up a post in the classic editor
* Verify that you can add tags to the post

Fixes #33606
