### PR TITLE
PostRelativeTimeStatus: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -92,7 +92,6 @@
 @import 'my-sites/media-library/upload-button';
 @import 'my-sites/pages/style';
 @import 'my-sites/plan-features/style';
-@import 'my-sites/post-relative-time-status/style';
 @import 'my-sites/posts/style';
 @import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -15,7 +15,7 @@ import Gridicon from 'gridicons';
 import { isFrontPage, isPostsPage } from 'state/pages/selectors';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import canCurrentUser from 'state/selectors/can-current-user';
-import { getEditorPath } from 'state/ui/editor/selectors';
+import getEditorUrl from 'state/selectors/get-editor-url';
 
 /**
  * Style dependencies
@@ -27,7 +27,7 @@ const getContentLink = ( state, siteId, page ) => {
 	let contentLinkTarget = '_blank';
 
 	if ( canCurrentUser( state, siteId, 'edit_pages' ) && page.status !== 'trash' ) {
-		contentLinkURL = getEditorPath( state, siteId, page.ID );
+		contentLinkURL = getEditorUrl( state, siteId, page.ID, 'page' );
 		contentLinkTarget = null;
 	} else if ( page.status === 'trash' ) {
 		contentLinkURL = null;

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -36,6 +36,8 @@ const getContentLink = ( state, siteId, page ) => {
 	return { contentLinkURL, contentLinkTarget };
 };
 
+const ICON_SIZE = 12;
+
 function PageCardInfo( {
 	translate,
 	moment,
@@ -46,44 +48,40 @@ function PageCardInfo( {
 	siteUrl,
 	contentLink,
 } ) {
-	const iconSize = 12;
-	const renderFutureTimestamp = function() {
+	const renderTimestamp = function() {
 		if ( page.status === 'future' ) {
 			return (
 				<PostRelativeTimeStatus
 					post={ page }
 					link={ contentLink.contentLinkURL }
 					target={ contentLink.contentLinkTarget }
-					gridiconSize={ iconSize }
+					gridiconSize={ ICON_SIZE }
 				/>
 			);
 		}
 
-		return null;
+		return (
+			<span className="page-card-info__item">
+				<Gridicon icon="time" size={ ICON_SIZE } className="page-card-info__item-icon" />
+				<span className="page-card-info__item-text">{ moment( page.modified ).fromNow() }</span>
+			</span>
+		);
 	};
 
 	return (
 		<div className="page-card-info">
 			{ siteUrl && <div className="page-card-info__site-url">{ siteUrl }</div> }
 			<div>
-				{ showTimestamp &&
-					( renderFutureTimestamp() || (
-						<span className="page-card-info__item">
-							<Gridicon icon="time" size={ iconSize } className="page-card-info__item-icon" />
-							<span className="page-card-info__item-text">
-								{ moment( page.modified ).fromNow() }
-							</span>
-						</span>
-					) ) }
+				{ showTimestamp && renderTimestamp() }
 				{ isFront && (
 					<span className="page-card-info__item">
-						<Gridicon icon="house" size={ iconSize } className="page-card-info__item-icon" />
+						<Gridicon icon="house" size={ ICON_SIZE } className="page-card-info__item-icon" />
 						<span className="page-card-info__item-text">{ translate( 'Front page' ) }</span>
 					</span>
 				) }
 				{ isPosts && (
 					<span className="page-card-info__item">
-						<Gridicon icon="posts" size={ iconSize } className="page-card-info__item-icon" />
+						<Gridicon icon="posts" size={ ICON_SIZE } className="page-card-info__item-icon" />
 						<span className="page-card-info__item-text">{ translate( 'Your latest posts' ) }</span>
 					</span>
 				) }

--- a/client/my-sites/pages/page-card-info/style.scss
+++ b/client/my-sites/pages/page-card-info/style.scss
@@ -2,15 +2,6 @@
 	color: var( --color-text-subtle );
 	font-size: 12px;
 	vertical-align: middle;
-
-	a,
-	&.post-actions__relative-time {
-		color: var( --color-text-subtle );
-
-		&:hover {
-			color: var( --color-accent );
-		}
-	}
 }
 
 .page-card-info__item {

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -473,7 +473,7 @@ class Page extends Component {
 					</a>
 					<PageCardInfo
 						page={ page }
-						showTimestamp={ this.props.hierarchical }
+						showTimestamp
 						siteUrl={ this.props.multisite && this.getSiteDomain() }
 					/>
 				</div>

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -12,6 +12,7 @@ import React from 'react';
  * Internal dependencies
  */
 import Gridicon from 'gridicons';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 class PostRelativeTime extends React.PureComponent {
 	static displayName = 'PostRelativeTime';
@@ -135,4 +136,4 @@ class PostRelativeTime extends React.PureComponent {
 	}
 }
 
-export default localize( PostRelativeTime );
+export default localize( withLocalizedMoment( PostRelativeTime ) );

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -116,6 +116,7 @@ class PostRelativeTime extends React.PureComponent {
 			const rel = this.props.target === '_blank' ? 'noopener noreferrer' : null;
 			innerText = (
 				<a
+					className="post-relative-time-status__link"
 					href={ this.props.link }
 					target={ this.props.target }
 					rel={ rel }

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -129,9 +129,9 @@ class PostRelativeTime extends React.PureComponent {
 		}
 
 		return (
-			<p className={ relativeTimeClass } title={ time }>
+			<div className={ relativeTimeClass } title={ time }>
 				{ innerText }
-			</p>
+			</div>
 		);
 	}
 }

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -11,6 +11,11 @@ import React from 'react';
 import Gridicon from 'gridicons';
 import { withLocalizedMoment } from 'components/localized-moment';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PostRelativeTime extends React.PureComponent {
 	static propTypes = {
 		post: PropTypes.object.isRequired,

--- a/client/my-sites/post-relative-time-status/index.jsx
+++ b/client/my-sites/post-relative-time-status/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -15,8 +12,6 @@ import Gridicon from 'gridicons';
 import { withLocalizedMoment } from 'components/localized-moment';
 
 class PostRelativeTime extends React.PureComponent {
-	static displayName = 'PostRelativeTime';
-
 	static propTypes = {
 		post: PropTypes.object.isRequired,
 		includeNonDraftStatuses: PropTypes.bool,
@@ -31,23 +26,22 @@ class PostRelativeTime extends React.PureComponent {
 		target: null,
 	};
 
-	getTimestamp = () => {
-		const status = this.props.post.status;
-
-		let time;
-		if ( status === 'draft' || status === 'pending' ) {
-			time = this.props.post.modified;
-		} else if ( status !== 'new' ) {
-			time = this.props.post.date;
+	getTimestamp() {
+		switch ( this.props.post.status ) {
+			case 'new':
+				return null;
+			case 'draft':
+			case 'pending':
+				return this.props.post.modified;
+			default:
+				return this.props.post.date;
 		}
+	}
 
-		return time;
-	};
-
-	getRelativeTimeText = () => {
+	getRelativeTimeText() {
 		const time = this.getTimestamp();
 		if ( ! time ) {
-			return;
+			return null;
 		}
 
 		return (
@@ -58,13 +52,13 @@ class PostRelativeTime extends React.PureComponent {
 				</time>
 			</span>
 		);
-	};
+	}
 
-	getStatusText = () => {
-		let status = this.props.post.status,
-			statusClassName = 'post-relative-time-status__status',
-			statusIcon = 'aside',
-			statusText;
+	getStatusText() {
+		const status = this.props.post.status;
+		let statusClassName = 'post-relative-time-status__status';
+		let statusIcon = 'aside';
+		let statusText;
 
 		if ( this.props.post.sticky ) {
 			statusText = this.props.translate( 'sticky' );
@@ -99,19 +93,20 @@ class PostRelativeTime extends React.PureComponent {
 				</span>
 			);
 		}
-	};
+	}
 
 	render() {
-		let timeText = this.getRelativeTimeText(),
-			statusText = this.getStatusText(),
-			relativeTimeClass = timeText ? 'post-relative-time-status' : null,
-			innerText = (
-				<span>
-					{ timeText }
-					{ statusText }
-				</span>
-			),
-			time = this.getTimestamp();
+		const timeText = this.getRelativeTimeText();
+		const statusText = this.getStatusText();
+		const relativeTimeClass = timeText ? 'post-relative-time-status' : null;
+		const time = this.getTimestamp();
+
+		let innerText = (
+			<span>
+				{ timeText }
+				{ statusText }
+			</span>
+		);
 
 		if ( this.props.link ) {
 			const rel = this.props.target === '_blank' ? 'noopener noreferrer' : null;

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -23,6 +23,10 @@
 	}
 }
 
+a.post-relative-time-status__link {
+	color: var( --color-text-subtle );
+}
+
 .post-relative-time-status__time,
 .post-relative-time-status__status {
 	display: inline-block;

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -1,7 +1,7 @@
 .post-relative-time-status {
 	.gridicon {
 		display: inline-block;
-		margin: -4px 8px 0 0;
+		margin: 0 4px 0 0;
 		vertical-align: middle;
 	}
 
@@ -33,27 +33,12 @@ a.post-relative-time-status__link {
 	margin-right: ( 11 / 12 ) * 1em;
 }
 
-.post-relative-time-status__time-text {
-	display: inline-block;
+.post-relative-time-status__time-text,
+.post-relative-time-status__status-text {
+	vertical-align: middle;
+	display: inline-block; // makes the ::first-letter apply
 
 	&::first-letter {
 		text-transform: capitalize;
-	}
-}
-
-.post-relative-time-status__status-text {
-	text-transform: capitalize;
-}
-
-p.post-relative-time-status {
-	margin-bottom: 0;
-
-	& .post-relative-time-status__time-text,
-	.post-relative-time-status__status-text {
-		vertical-align: middle;
-	}
-
-	& .gridicon {
-		margin: 0 4px 0 0;
 	}
 }

--- a/client/post-editor/style.scss
+++ b/client/post-editor/style.scss
@@ -124,10 +124,6 @@
 	}
 }
 
-.post-editor .draft .post-relative-time-status {
-	display: none;
-}
-
 // Component <Editor>
 .post-editor__content-editor {
 	position: relative;


### PR DESCRIPTION
The component is used only at one place: pages scheduled to be published in future:

<img width="635" alt="Screenshot 2019-06-05 at 11 23 33" src="https://user-images.githubusercontent.com/664258/58969172-4801fa00-8785-11e9-8582-25208cc96192.png">

Besides the migration I did plenty of little changes here:
- show the time/status in the first place: it used to be completely hidden
- the `href` of the link is the same both for title and the time/status: `.../block-editor/...` if Gutenberg is enabled. It used to point to the Classic Editor URL (`/page/...`)
- link doesn't have accent color on hover
