### PR TITLE
Display size in bytes for CSS files that need to be migrated

### DIFF
--- a/bin/categorize-component-styles.js
+++ b/bin/categorize-component-styles.js
@@ -109,7 +109,8 @@ for ( const s of scored ) {
 		console.log( 'SCORE:', s.scores.score );
 		currentScore = s.scores.score;
 	}
-	console.log( s.component );
+	const stats = fs.statSync( `client/${ s.component }.scss` );
+	console.log( `${ s.component } (${ stats.size } bytes)` );
 	if ( s.scores.summary ) {
 		console.log( '  ', s.scores.summary );
 	}


### PR DESCRIPTION

#### Changes proposed in this Pull Request

Adds size of CSS files that still need to be migrated to webpack.  Makes it easier to spot files that would have a bigger impact.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run `bin/categorize-component-styles.js`.  Should see size in bytes following the style paths in the output.
