### PR TITLE
Site: fix the position of the lock icon

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -169,8 +169,6 @@
 
 .site__badge {
 	color: var( --color-neutral );
-	padding-right: 4px;
-	line-height: 0;
-	position: relative;
+	margin-right: 4px;
 	vertical-align: middle;
 }


### PR DESCRIPTION
I don't know when and how it happened, but the lock icon next to private site's title is off:

<img width="236" alt="Screenshot 2019-06-05 at 11 35 11" src="https://user-images.githubusercontent.com/664258/58970364-4df8da80-8787-11e9-865e-34898bf7f751.png">

This PR fixes that. After the patch:

<img width="233" alt="Screenshot 2019-06-05 at 11 45 06" src="https://user-images.githubusercontent.com/664258/58970415-6537c800-8787-11e9-934c-b14d7b9169d2.png">

The important change is removal of `line-height`. The other changes are just nice to have:
- `margin` is better in this case than `padding`, as it specifies whitespace outside the element
- `position: relative` doesn't seem to have any purpose