### PR TITLE
CSS: Migrate my-sites/media-library/upload-button

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -89,7 +89,6 @@
 @import 'my-sites/customize/style';
 @import 'my-sites/exporter/style';
 @import 'my-sites/guided-transfer/style';
-@import 'my-sites/media-library/upload-button';
 @import 'my-sites/pages/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/post-relative-time-status/style';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `my-sites/media-library/upload-button` from `_components.scss`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open _Media_ from the sidebar or select to add an image in a post. Look at `Add new` button. Is it the same as on production? 

Fixes #33662

Refs #27515
