### PR TITLE
 css: migrate me/notification-settings/comment-settings styles 

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -75,7 +75,6 @@
 @import 'lib/preferences-helper/style';
 @import 'me/happychat/style';
 @import 'me/notification-settings/blogs-settings/style';
-@import 'me/notification-settings/comment-settings/style';
 @import 'me/notification-settings/push-notification-settings/style';
 @import 'me/notification-settings/settings-form/style';
 @import 'me/sidebar-navigation/style';

--- a/client/me/notification-settings/comment-settings/index.jsx
+++ b/client/me/notification-settings/comment-settings/index.jsx
@@ -48,7 +48,7 @@ class NotificationCommentsSettings extends Component {
 			);
 		}
 
-		return <p className="notification-settings-comment-settings__placeholder">&nbsp;</p>;
+		return <p className="comment-settings__notification-settings-placeholder">&nbsp;</p>;
 	};
 
 	render() {
@@ -67,9 +67,7 @@ class NotificationCommentsSettings extends Component {
 				<Navigation path={ path } />
 
 				<Card>
-					<FormSectionHeading className="is-primary">
-						{ translate( 'Comments on other sites' ) }
-					</FormSectionHeading>
+					<FormSectionHeading>{ translate( 'Comments on other sites' ) }</FormSectionHeading>
 					<p>
 						{ translate( 'Control your notification settings when you comment on other blogs.' ) }
 					</p>

--- a/client/me/notification-settings/comment-settings/index.jsx
+++ b/client/me/notification-settings/comment-settings/index.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -24,6 +23,11 @@ import {
 	getNotificationSettings,
 	hasUnsavedNotificationSettingsChanges,
 } from 'state/notification-settings/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class NotificationCommentsSettings extends Component {
 	componentDidMount() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `me/notification-settings/comment-settings` styles to be processed by webpack

#### Testing instructions

* Go to your profile and click on _Notification Settings > Comments_
* Hit refresh
* Do you see a placeholder and does it look the same as on master (see screenshot below)? - You may need to throttle your connection via devtools

Fixes #33660 (part of #27515)
