### PR TITLE
Pages: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -84,7 +84,6 @@
 @import 'my-sites/customize/style';
 @import 'my-sites/exporter/style';
 @import 'my-sites/guided-transfer/style';
-@import 'my-sites/pages/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/posts/style';
 @import 'my-sites/sidebar/style';

--- a/client/my-sites/pages/controller.js
+++ b/client/my-sites/pages/controller.js
@@ -1,24 +1,14 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 
 /**
  * Internal Dependencies
  */
-import Pages from 'my-sites/pages/main';
+import Pages from './main';
 
-const controller = {
-	pages: function( context, next ) {
-		context.primary = React.createElement( Pages, {
-			status: context.params.status,
-			search: context.query.s,
-		} );
-		next();
-	},
-};
-
-export default controller;
+export function pages( context, next ) {
+	context.primary = <Pages status={ context.params.status } search={ context.query.s } />;
+	next();
+}

--- a/client/my-sites/pages/index.js
+++ b/client/my-sites/pages/index.js
@@ -8,38 +8,29 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection } from 'my-sites/controller';
-import pagesController from './controller';
-import config from 'config';
+import { pages } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { getSiteFragment } from 'lib/route';
 
 export default function() {
-	if ( config.isEnabled( 'manage/pages' ) ) {
-		page(
-			'/pages/:status(published|drafts|scheduled|trashed)/:domain?',
-			siteSelection,
-			navigation,
-			pagesController.pages,
-			makeLayout,
-			clientRender
-		);
+	page(
+		'/pages/:status(published|drafts|scheduled|trashed)/:domain?',
+		siteSelection,
+		navigation,
+		pages,
+		makeLayout,
+		clientRender
+	);
 
-		page(
-			'/pages/:domain?',
-			siteSelection,
-			navigation,
-			pagesController.pages,
-			makeLayout,
-			clientRender
-		);
+	page( '/pages/:domain?', siteSelection, navigation, pages, makeLayout, clientRender );
 
-		page( '/pages/*', ( { path } ) => {
-			const siteFragment = getSiteFragment( path );
-			if ( siteFragment ) {
-				return page.redirect( `/pages/${ siteFragment }` );
-			}
+	page( '/pages/*', ( { path } ) => {
+		const siteFragment = getSiteFragment( path );
+		if ( siteFragment ) {
+			page.redirect( `/pages/${ siteFragment }` );
+			return;
+		}
 
-			return page.redirect( '/pages' );
-		} );
-	}
+		page.redirect( '/pages' );
+	} );
 }

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -8,16 +8,13 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import React from 'react';
-import debugFactory from 'debug';
 import titlecase from 'to-title-case';
 
 /**
  * Internal dependencies
  */
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
-import config from 'config';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import DocumentHead from 'components/data/document-head';
-import notices from 'notices';
 import urlSearch from 'lib/url-search';
 import Main from 'components/main';
 import NavItem from 'components/section-nav/item';
@@ -28,7 +25,6 @@ import Search from 'components/search';
 import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 
-const debug = debugFactory( 'calypso:my-sites:pages:pages' );
 const statuses = [ 'published', 'drafts', 'scheduled', 'trashed' ];
 
 class PagesMain extends React.Component {
@@ -42,18 +38,6 @@ class PagesMain extends React.Component {
 	static defaultProps = {
 		perPage: 20,
 	};
-
-	componentWillMount() {
-		this._setWarning( this.props.site );
-	}
-
-	componentDidMount() {
-		debug( 'Pages React component mounted.' );
-	}
-
-	componentWillUpdate() {
-		this._setWarning( this.props.site );
-	}
 
 	getAnalyticsPath() {
 		const { status, siteId } = this.props;
@@ -157,28 +141,9 @@ class PagesMain extends React.Component {
 			);
 		} );
 	}
-
-	_setWarning( selectedSite ) {
-		const { translate } = this.props;
-		if ( selectedSite && selectedSite.jetpack && ! selectedSite.hasMinimumJetpackVersion ) {
-			notices.warning(
-				translate(
-					'Jetpack %(version)s is required to take full advantage of all page editing features.',
-					{
-						args: { version: config( 'jetpack_min_version' ) },
-					}
-				),
-				{
-					button: translate( 'Update now' ),
-					href: selectedSite.options.admin_url + 'plugins.php?plugin_status=upgrade',
-				}
-			);
-		}
-	}
 }
 
 const mapState = state => ( {
-	site: getSelectedSite( state ),
 	siteId: getSelectedSiteId( state ),
 } );
 

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -25,6 +25,11 @@ import Search from 'components/search';
 import SectionNav from 'components/section-nav';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const statuses = [ 'published', 'drafts', 'scheduled', 'trashed' ];
 
 class PagesMain extends React.Component {

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -74,8 +74,7 @@ class PagesMain extends React.Component {
 	}
 
 	render() {
-		const { doSearch, search, translate } = this.props;
-		const status = this.props.status || 'published';
+		const { doSearch, siteId, search, status = 'published', translate } = this.props;
 
 		const filterStrings = {
 			published: translate( 'Published', { context: 'Filter label for pages list' } ),
@@ -120,7 +119,7 @@ class PagesMain extends React.Component {
 						delaySearch={ true }
 					/>
 				</SectionNav>
-				<PageList { ...this.props } />
+				<PageList siteId={ siteId } status={ status } search={ search } />
 			</Main>
 		);
 	}

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -35,6 +35,7 @@ import { getSite } from 'state/sites/selectors';
 import getEditorUrl from 'state/selectors/get-editor-url';
 import SectionHeader from 'components/section-header';
 import Button from 'components/button';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 function preloadEditor() {
 	preload( 'post-editor' );
@@ -428,5 +429,6 @@ const mapState = ( state, { query, siteId } ) => ( {
 
 const ConnectedPages = flowRight(
 	connect( mapState ),
-	localize
+	localize,
+	withLocalizedMoment
 )( Pages );

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -140,11 +140,11 @@ class Pages extends Component {
 	};
 
 	_insertTimeMarkers( pages ) {
-		const markedPages = [],
-			now = this.props.moment();
+		const markedPages = [];
+		const now = this.props.moment();
 		let lastMarker;
 
-		const buildMarker = function( pageDate ) {
+		const buildMarker = pageDate => {
 			pageDate = this.props.moment( pageDate );
 			const days = now.diff( pageDate, 'days' );
 			if ( days <= 0 ) {
@@ -154,11 +154,11 @@ class Pages extends Component {
 				return this.props.translate( 'Yesterday' );
 			}
 			return pageDate.from( now );
-		}.bind( this );
+		};
 
-		pages.forEach( function( page ) {
-			const date = this.props.moment( page.date ),
-				marker = buildMarker( date );
+		pages.forEach( page => {
+			const date = this.props.moment( page.date );
+			const marker = buildMarker( date );
 			if ( lastMarker !== marker ) {
 				markedPages.push(
 					<div key={ 'marker-' + date.unix() } className="pages__page-list-header">
@@ -168,7 +168,7 @@ class Pages extends Component {
 			}
 			lastMarker = marker;
 			markedPages.push( page );
-		}, this );
+		} );
 
 		return markedPages;
 	}
@@ -358,7 +358,7 @@ class Pages extends Component {
 			// we're listing in reverse chrono. use the markers.
 			pages = this._insertTimeMarkers( pages );
 		}
-		const rows = pages.map( function( page ) {
+		const rows = pages.map( page => {
 			if ( ! ( 'site_ID' in page ) ) {
 				return page;
 			}
@@ -373,7 +373,7 @@ class Pages extends Component {
 					multisite={ this.props.siteId === null }
 				/>
 			);
-		}, this );
+		} );
 
 		if ( this.props.loading ) {
 			this.addLoadingRows( rows, 1 );

--- a/client/my-sites/post-relative-time-status/style.scss
+++ b/client/my-sites/post-relative-time-status/style.scss
@@ -6,20 +6,17 @@
 	}
 
 	// Apply colors on /posts/* cards
-	.pages__page-list &,
-	.posts__list & {
-		.is-sticky {
-			color: var( --color-primary );
-		}
-		.is-pending {
-			color: var( --color-warning );
-		}
-		.is-scheduled {
-			color: var( --color-accent );
-		}
-		.is-trash {
-			color: var( --color-error );
-		}
+	.is-sticky {
+		color: var( --color-primary );
+	}
+	.is-pending {
+		color: var( --color-warning );
+	}
+	.is-scheduled {
+		color: var( --color-accent );
+	}
+	.is-trash {
+		color: var( --color-error );
 	}
 }
 

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -76,7 +76,6 @@ class SiteMenu extends PureComponent {
 				label: translate( 'Pages' ),
 				capability: 'edit_pages',
 				queryable: true,
-				config: 'manage/pages',
 				link: '/pages',
 				wpAdminLink: 'edit.php?post_type=page',
 				showOnAllMySites: true,

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -71,7 +71,6 @@
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/people": true,
 		"manage/people/invites": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -51,7 +51,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/pages": true,
 		"manage/plan-features": false,
 		"manage/plugins": true,
 		"manage/plugins/setup": false,

--- a/config/development.json
+++ b/config/development.json
@@ -99,7 +99,6 @@
 		"manage/export/guided-transfer": true,
 		"manage/import-to-jetpack": true,
 		"manage/import/site-importer-endpoints": true,
-		"manage/pages": true,
 		"manage/pages/set-front-page": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -58,7 +58,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,

--- a/config/production.json
+++ b/config/production.json
@@ -58,7 +58,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -62,7 +62,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,

--- a/config/test.json
+++ b/config/test.json
@@ -55,7 +55,6 @@
 		"mailchimp": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/pages": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -75,7 +75,6 @@
 		"manage/custom-post-types": true,
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
-		"manage/pages": true,
 		"manage/payment-methods": true,
 		"manage/plan-features": true,
 		"manage/plugins": true,


### PR DESCRIPTION
Plus a handful of little cleanups in the Pages section. See individual commit messages for details.

One that's interesting for @tyxla: the Pages list displayed a warning when Jetpack didn't have a minimum version of 3.3. That's pretty ancient, isn't it? I removed the check in 0b0cdba.

**How to test:**
Test various scenarios in Pages:
- published, drafts, scheduled, trash tabs
- hierarchical and chronological view
- there's a "multisite" view that's active when "All Sites" are selected. Displays site icon and title.