### PR TITLE
Migrate css for logged-out-form and subcomponents

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -47,7 +47,6 @@
 @import 'components/info-popover/style';
 @import 'components/keyed-suggestions/style';
 @import 'components/legend-item/style';
-@import 'components/logged-out-form/style';
 @import 'components/locale-suggestions/style';
 @import 'components/main/style';
 @import 'components/mobile-back-to-sidebar/style';

--- a/client/components/logged-out-form/back-link.jsx
+++ b/client/components/logged-out-form/back-link.jsx
@@ -15,6 +15,11 @@ import { localizeUrl } from 'lib/i18n-utils';
 import safeProtocolUrl from 'lib/safe-protocol-url';
 import Gridicon from 'gridicons';
 
+/**
+ * Style dependencies
+ */
+import './link-item.scss';
+
 function LoggedOutFormBackLink( props ) {
 	const { locale, oauth2Client, translate, recordClick } = props;
 

--- a/client/components/logged-out-form/footer.jsx
+++ b/client/components/logged-out-form/footer.jsx
@@ -13,6 +13,11 @@ import classnames from 'classnames';
  */
 import Card from 'components/card';
 
+/**
+ * Style dependencies
+ */
+import './footer.scss';
+
 class LoggedOutFormFooter extends Component {
 	static propTypes = {
 		children: PropTypes.node.isRequired,

--- a/client/components/logged-out-form/footer.scss
+++ b/client/components/logged-out-form/footer.scss
@@ -1,0 +1,19 @@
+.logged-out-form__footer {
+	box-shadow: none;
+	background: none;
+	margin: 16px -16px -16px;
+	padding: 16px;
+
+	&.is-blended {
+		background: none;
+		border-top: none;
+		padding-top: 0;
+	}
+
+	.button.is-primary {
+		float: none;
+		margin: 0;
+		width: 100%;
+		@include elevation( 1dp );
+	}
+}

--- a/client/components/logged-out-form/index.jsx
+++ b/client/components/logged-out-form/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -13,6 +11,11 @@ import { omit } from 'lodash';
  * Internal dependencies
  */
 import Card from 'components/card';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export default class LoggedOutForm extends React.Component {
 	static propTypes = {

--- a/client/components/logged-out-form/link-item.jsx
+++ b/client/components/logged-out-form/link-item.jsx
@@ -7,6 +7,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 
+/**
+ * Style dependencies
+ */
+import './link-item.scss';
+
 export default function LoggedOutFormLinkItem( props ) {
 	return (
 		<a { ...props } className={ classnames( 'logged-out-form__link-item', props.className ) }>

--- a/client/components/logged-out-form/link-item.scss
+++ b/client/components/logged-out-form/link-item.scss
@@ -1,0 +1,35 @@
+.logged-out-form__link-item {
+	color: var( --color-neutral-500 );
+	display: block;
+	font-family: $sans;
+	font-size: 13px;
+	padding: 8px 16px;
+	cursor: pointer;
+	text-decoration: underline;
+
+	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings ) .layout:not( .dops ) &,
+	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings ) .layout.gravatar & {
+		color: var( --color-white );
+
+		&:hover {
+			color: var( --color-neutral-100 );
+		}
+	}
+
+	&:last-child {
+		border-bottom: none;
+	}
+
+	&:visited {
+		color: var( --color-neutral-500 );
+	}
+
+	&:hover {
+		color: var( --color-accent );
+	}
+
+	.gridicon {
+		position: relative;
+		top: 3px;
+	}
+}

--- a/client/components/logged-out-form/links.jsx
+++ b/client/components/logged-out-form/links.jsx
@@ -9,6 +9,11 @@ import React from 'react';
 import classnames from 'classnames';
 import { omit } from 'lodash';
 
+/**
+ * Style dependencies
+ */
+import './links.scss';
+
 export default class LoggedOutFormLinks extends React.Component {
 	static propTypes = {
 		children: PropTypes.node.isRequired,

--- a/client/components/logged-out-form/links.scss
+++ b/client/components/logged-out-form/links.scss
@@ -1,0 +1,14 @@
+.logged-out-form__links {
+	margin: 0 auto;
+	max-width: 330px;
+	text-align: center;
+
+	&::before {
+		content: '';
+		display: block;
+		width: 80px;
+		background: rgba( var( --color-white-rgb ), 0.3 );
+		height: 2px;
+		margin: 0 auto 8px;
+	}
+}

--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -6,73 +6,8 @@
 	@include elevation( 2dp );
 }
 
-.logged-out-form__footer {
-	box-shadow: none;
-	background: none;
-	margin: 16px -16px -16px;
-	padding: 16px;
 
-	&.is-blended {
-		background: none;
-		border-top: none;
-		padding-top: 0;
-	}
 
-	.button.is-primary {
-		float: none;
-		margin: 0;
-		width: 100%;
-		@include elevation( 1dp );
-	}
-}
 
-.logged-out-form__links {
-	margin: 0 auto;
-	max-width: 330px;
-	text-align: center;
 
-	&::before {
-		content: '';
-		display: block;
-		width: 80px;
-		background: rgba( var( --color-white-rgb ), 0.3 );
-		height: 2px;
-		margin: 0 auto 8px;
-	}
-}
 
-.logged-out-form__link-item {
-	color: var( --color-neutral-500 );
-	display: block;
-	font-family: $sans;
-	font-size: 13px;
-	padding: 8px 16px;
-	cursor: pointer;
-	text-decoration: underline;
-
-	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings ) .layout:not( .dops ) &,
-	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings ) .layout.gravatar & {
-		color: var( --color-white );
-
-		&:hover {
-			color: var( --color-neutral-100 );
-		}
-	}
-
-	&:last-child {
-		border-bottom: none;
-	}
-
-	&:visited {
-		color: var( --color-neutral-500 );
-	}
-
-	&:hover {
-		color: var( --color-accent );
-	}
-
-	.gridicon {
-		position: relative;
-		top: 3px;
-	}
-}


### PR DESCRIPTION
These are used piecemeal by the logout form

#### Changes proposed in this Pull Request

* Migrate css for logged-out-form and subcomponents

#### Testing instructions

* Validate that the logged out forms look the same as before

refs #27515
