### PR TITLE
Fix proptype warning for login links when SSR'd

### DIFF
--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -36,7 +36,7 @@ export class LoginLinks extends React.Component {
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
 		privateSite: PropTypes.bool,
-		query: PropTypes.object,
+		query: PropTypes.oneOf( [ PropTypes.object, PropTypes.bool ] ),
 		recordTracksEvent: PropTypes.func.isRequired,
 		resetMagicLoginRequestForm: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -36,7 +36,7 @@ export class LoginLinks extends React.Component {
 		locale: PropTypes.string.isRequired,
 		oauth2Client: PropTypes.object,
 		privateSite: PropTypes.bool,
-		query: PropTypes.oneOf( [ PropTypes.object, PropTypes.bool ] ),
+		query: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ),
 		recordTracksEvent: PropTypes.func.isRequired,
 		resetMagicLoginRequestForm: PropTypes.func.isRequired,
 		translate: PropTypes.func.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a proptype warning when loading login links at /log-in via SSR

#### Testing instructions

* Spin up a dev build
* Hit /log-in
* No warnings should appear in the server console about invalid proptypes

