### PR TITLE
Add Warnings on Marketing Connection Page

### DIFF
--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import { times } from 'lodash';
 
@@ -17,6 +17,7 @@ import {
 	isKeyringServicesFetching,
 } from 'state/sharing/services/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import Notice from 'components/notice';
 import SectionHeader from 'components/section-header';
 import Service from './service';
 import * as Components from './services';
@@ -31,6 +32,18 @@ import './services-group.scss';
  * Module constants
  */
 const NUMBER_OF_PLACEHOLDERS = 4;
+
+const serviceWarningLevelToNoticeStatus = level => {
+	switch ( level ) {
+		case 'error':
+			return 'is-error';
+		case 'warning':
+			return 'is-warning';
+		case 'info':
+		default:
+			return 'is-info';
+	}
+};
 
 const SharingServicesGroup = ( { isFetching, services, title } ) => {
 	if ( ! services.length && ! isFetching ) {
@@ -47,6 +60,22 @@ const SharingServicesGroup = ( { isFetching, services, title } ) => {
 							const Component = Components.hasOwnProperty( service.ID )
 								? Components[ service.ID ]
 								: Service;
+
+							if ( service.warnings ) {
+								return (
+									<Fragment>
+										<Component key={ service.ID } service={ service } />
+										{ service.warnings.map( warning => (
+											<Notice
+												showDismiss={ false }
+												status={ serviceWarningLevelToNoticeStatus( warning.level ) }
+											>
+												{ warning.message }
+											</Notice>
+										) ) }
+									</Fragment>
+								);
+							}
 
 							return <Component key={ service.ID } service={ service } />;
 					  } )

--- a/client/my-sites/marketing/connections/services-group.jsx
+++ b/client/my-sites/marketing/connections/services-group.jsx
@@ -63,10 +63,11 @@ const SharingServicesGroup = ( { isFetching, services, title } ) => {
 
 							if ( service.warnings ) {
 								return (
-									<Fragment>
-										<Component key={ service.ID } service={ service } />
-										{ service.warnings.map( warning => (
+									<Fragment key={ service.ID }>
+										<Component service={ service } />
+										{ service.warnings.map( ( warning, index ) => (
 											<Notice
+												key={ `warning-${ index }` }
 												showDismiss={ false }
 												status={ serviceWarningLevelToNoticeStatus( warning.level ) }
 											>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Warnings on Marketing Connection Page

<img width="888" alt="Screen Shot 2019-06-05 at 1 18 37 PM" src="https://user-images.githubusercontent.com/2810519/58987830-39234380-8795-11e9-80fa-205f459b4865.png">

#### Testing instructions

~Requires D29129-code~

1. ~Sandbox `public-api.wordpress.com`~
2. Navigate to `/marketing/connections/:siteSlug`
3. Verify the warning in the above screenshot renders
