### PR TITLE
fix: notification settings comments classname

### DIFF
--- a/client/me/notification-settings/comment-settings/style.scss
+++ b/client/me/notification-settings/comment-settings/style.scss
@@ -1,4 +1,4 @@
-.notification-settings-comment-settings__placeholder {
+.comment-settings__notification-settings-placeholder {
 	animation: loading-fade 1.6s ease-in-out infinite;
 	background-color: var( --color-neutral-0 );
 	line-height: 1;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the class name for the notifications settings comment placeholder (I forgot that in #33670)

#### Testing instructions

same as in #33670
