### PR TITLE
Change the z-index of the search field in the Purchases section.

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -85,6 +85,7 @@ $z-layers: (
 		'.web-preview__inner .spinner-line': 1,
 		'.google-my-business__close-icon': 1,
 		'.google-my-business__stats-nudge.dismissible-card__close-icon': 1,
+		'.is-section-purchases .search': 1,
 		'.editor-sidebar': 2,
 		'.editor-action-bar .editor-status-label': 2,
 		'.is-installing .theme': 2,

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -2,6 +2,10 @@
  * @component Search
  */
 
+.is-section-purchases .search {
+	z-index: z-index( 'root', '.is-section-purchases .search' );
+}
+
 .search {
 	display: flex;
 	flex: 1 1 auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* The search bar in the Manage Purchases > Billing History, and Manage Purchases > Upcoming Charges overlaps the nav drop-down above. This only happens when the tab navigation on top switches over to drop-down, so when the screen is between 660 to ~790px wide (when the nav drawer is still present). This PR adds an extra z-index rule targeting Manage Purchases section to prevent this behaviour.

#### Testing instructions
1. Starting at URL: https://wordpress.com/me/purchases/billing
1. Adjust your browser width to something between 660px and 790px.
3. Try switching the drop-down menu to Billing History, or Upcoming Charges.
4. Open the drop-down. The search bar should not be overlapping the drop-down.

Before:

![image](https://user-images.githubusercontent.com/4550351/58997436-fb2f2980-883f-11e9-9161-a9634495c734.png)

After:

![image](https://user-images.githubusercontent.com/4550351/58997463-1e59d900-8840-11e9-8eef-69a9194350ec.png)


Fixes #33218
