### PR TITLE
Remove the manage/plan-features feature flag

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -416,10 +416,6 @@ export function getBillingMonthsForTerm( term ) {
 	throw new Error( `Unknown term: ${ term }` );
 }
 
-export const isPlanFeaturesEnabled = () => {
-	return isEnabled( 'manage/plan-features' );
-};
-
 export function plansLink( url, siteSlug, intervalType, forceIntervalType = false ) {
 	const parsedUrl = urlParse( url );
 	if ( 'monthly' === intervalType || forceIntervalType ) {

--- a/client/my-sites/domains/domain-management/list/index.jsx
+++ b/client/my-sites/domains/domain-management/list/index.jsx
@@ -46,7 +46,6 @@ import TrackComponentView from 'lib/analytics/track-component-view';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
-import { isPlanFeaturesEnabled } from 'lib/plans';
 import DomainToPlanNudge from 'blocks/domain-to-plan-nudge';
 import { type } from 'lib/domains/constants';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
@@ -168,7 +167,7 @@ export class List extends React.Component {
 
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
-			<Main wideLayout={ isPlanFeaturesEnabled() }>
+			<Main wideLayout>
 				<DocumentHead title={ headerText } />
 				<SidebarNavigation />
 				<PlansNavigation cart={ this.props.cart } path={ this.props.context.path } />

--- a/client/my-sites/email/email-management/index.jsx
+++ b/client/my-sites/email/email-management/index.jsx
@@ -36,7 +36,6 @@ import EmptyContent from 'components/empty-content';
 import { domainManagementEdit, domainManagementList } from 'my-sites/domains/paths';
 import { emailManagement, emailManagementForwarding } from 'my-sites/email/paths';
 import { getSelectedDomain } from 'lib/domains';
-import { isPlanFeaturesEnabled } from 'lib/plans';
 import DocumentHead from 'components/data/document-head';
 import QueryGSuiteUsers from 'components/data/query-gsuite-users';
 import QuerySiteDomains from 'components/data/query-site-domains';
@@ -59,7 +58,7 @@ class EmailManagement extends React.Component {
 	render() {
 		const { selectedSiteId } = this.props;
 		return (
-			<Main className="email-management" wideLayout={ isPlanFeaturesEnabled() }>
+			<Main className="email-management" wideLayout>
 				{ selectedSiteId && <QueryGSuiteUsers siteId={ selectedSiteId } /> }
 				{ selectedSiteId && <QuerySiteDomains siteId={ selectedSiteId } /> }
 				<DocumentHead title={ this.props.translate( 'Email' ) } />

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -76,7 +76,6 @@
 		"manage/people/invites": true,
 		"manage/people/readers": true,
 		"manage/people/role-filtering": true,
-		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/plugins/setup": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -51,7 +51,6 @@
 		"manage/custom-post-types": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/plan-features": false,
 		"manage/plugins": true,
 		"manage/plugins/setup": false,
 		"manage/plugins/upload": true,

--- a/config/development.json
+++ b/config/development.json
@@ -101,7 +101,6 @@
 		"manage/import/site-importer-endpoints": true,
 		"manage/pages/set-front-page": true,
 		"manage/payment-methods": true,
-		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/plugins/setup": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -59,7 +59,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,
-		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/setup": true,
 		"manage/plugins/upload": true,

--- a/config/production.json
+++ b/config/production.json
@@ -59,7 +59,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/payment-methods": true,
-		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/browser": true,
 		"manage/plugins/setup": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -63,7 +63,6 @@
 		"manage/customize": true,
 		"manage/edit-user": true,
 		"manage/payment-methods": true,
-		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/setup": true,
 		"manage/plugins/upload": true,

--- a/config/test.json
+++ b/config/test.json
@@ -55,7 +55,6 @@
 		"mailchimp": true,
 		"manage/customize": true,
 		"manage/edit-user": true,
-		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/compatibility-warning": false,
 		"manage/plugins/setup": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -76,7 +76,6 @@
 		"manage/edit-user": true,
 		"manage/export/guided-transfer": true,
 		"manage/payment-methods": true,
-		"manage/plan-features": true,
 		"manage/plugins": true,
 		"manage/plugins/setup": true,
 		"manage/plugins/upload": true,


### PR DESCRIPTION
The flag is a remainder of past A/B test experiments (see #6781 for example) and doesn't do anything useful today.

All it does is that it sets `<Main wideLayout>` prop to `false` on desktop and to `true` everywhere else. Look at the `/plans/my-plan/:site` page:

<img width="873" alt="Screenshot 2019-06-05 at 21 29 17" src="https://user-images.githubusercontent.com/664258/59000570-10bd3880-87d9-11e9-8c2f-c5482c7af8ad.png">

and click through the four tabs. All of them should have wide layout. But in desktop app, the "Domains" and "Email" tabs have the narrow layout. We verified that with @blowery.

After this patch, all these tabs always have `wideLayout`.