### PR TITLE
Fix domains signup display issue on IE11

### DIFF
--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -35,6 +35,7 @@
 	width: 100%;
 
 	.button.domain-suggestion__action {
+		flex-grow: 0;
 		margin-left: 0;
 		margin-top: 1em;
 		text-align: center;
@@ -55,10 +56,10 @@
 
 	.domain-suggestion__content {
 		display: flex;
-		flex-basis: 100%;
+		flex-basis: auto;
 		flex-direction: column;
 		justify-content: flex-start;
-		flex-grow: 2;
+		flex-grow: 1;
 		margin-top: 0;
 	}
 


### PR DESCRIPTION
Due to the IE11 bug with how it handles flex-basis, this change sets flex-basis to auto for the domain suggestion content. Issue reported in #33443 

#### Changes proposed in this Pull Request

* For the domains signup suggestion content, swap `flex-basis: 100%` out for `flex-basis: auto`. This is a workaround for [IE11's bug](https://github.com/philipwalton/flexbugs#7-flex-basis-doesnt-account-for-box-sizingborder-box) with how it deals with flex-basis.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In IE11, go to create a new site.
* At the step http://calypso.localhost:3000/start/onboarding-blog/domains, the domain suggestions box (the two larger boxes with the Select buttons) should look like the screenshots below, and not the screenshot from issue: https://github.com/Automattic/wp-calypso/issues/33443
* Ensure styling is still correct across Safari, Firefox, Chrome

#### Safari screenshot

![image](https://user-images.githubusercontent.com/14988353/59005873-946f3780-8862-11e9-9e94-1723dd36a00e.png)

#### IE 11 screenshot (Browerstack)

![image](https://user-images.githubusercontent.com/14988353/59005961-f4fe7480-8862-11e9-8e23-3cea68fec4d0.png)

Fixes #33443 
