### PR TITLE
Auto-renewal Toggle: show a notice when there is an error on toggling auto-renewal.

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -6,6 +6,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -17,6 +18,7 @@ import { isFetchingUserPurchases } from 'state/purchases/selectors';
 import { fetchUserPurchases } from 'state/purchases/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
+import { errorNotice } from 'state/notices/actions';
 import AutoRenewDisablingDialog from './auto-renew-disabling-dialog';
 import FormToggle from 'components/forms/form-toggle';
 
@@ -29,6 +31,7 @@ class AutoRenewToggle extends Component {
 		isAtomicSite: PropTypes.bool.isRequired,
 		fetchingUserPurchases: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
+		errorNotice: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {
@@ -53,6 +56,7 @@ class AutoRenewToggle extends Component {
 			currentUserId,
 			isEnabled,
 			isAtomicSite,
+			translate,
 		} = this.props;
 
 		const updateAutoRenew = isEnabled ? disableAutoRenew : enableAutoRenew;
@@ -67,9 +71,16 @@ class AutoRenewToggle extends Component {
 			this.setState( {
 				isRequesting: false,
 			} );
-			if ( success ) {
-				this.props.fetchUserPurchases( currentUserId );
+
+			if ( ! success ) {
+				this.props.errorNotice(
+					isTogglingToward
+						? translate( "We've failed to enable auto-renewal for you. Please try again later." )
+						: translate( "We've failed to disable auto-renewal for you. Please try again later." )
+				);
 			}
+
+			this.props.fetchUserPurchases( currentUserId );
 		} );
 
 		this.props.recordTracksEvent( 'calypso_purchases_manage_purchase_toggle_auto_renew', {
@@ -138,5 +149,6 @@ export default connect(
 	{
 		fetchUserPurchases,
 		recordTracksEvent,
+		errorNotice,
 	}
-)( AutoRenewToggle );
+)( localize( AutoRenewToggle ) );

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -75,8 +75,8 @@ class AutoRenewToggle extends Component {
 			if ( ! success ) {
 				this.props.errorNotice(
 					isTogglingToward
-						? translate( "We've failed to enable auto-renewal for you. Please try again later." )
-						: translate( "We've failed to disable auto-renewal for you. Please try again later." )
+						? translate( "We've failed to enable auto-renewal for you. Please try again." )
+						: translate( "We've failed to disable auto-renewal for you. Please try again." )
 				);
 			}
 


### PR DESCRIPTION
_This PR is part of the attempt of adding a self-serving plan subscription autorenewal toggle. For more details, please refer to p2-p9jf6J-1GZ_

#### Changes proposed in this Pull Request

This PR adds an error notice for notifying users when there is an unexpected error occurred on toggling auto-renewal:

An error occurs on enabling:
<img width="932" alt="螢幕快照 2019-06-06 下午12 41 49" src="https://user-images.githubusercontent.com/1842898/59007511-46096b00-8859-11e9-8eca-9bb189553157.png">

An error occurs on disabling:
<img width="927" alt="螢幕快照 2019-06-06 下午12 41 35" src="https://user-images.githubusercontent.com/1842898/59007521-4d307900-8859-11e9-9052-6e1222d7ae8f.png">

#### Dependency
https://github.com/Automattic/wp-calypso/pull/33568

#### Testing instructions

Unfortunately there isn't an easy way to mimic the error response on top of my head.
What I did was:

1. Update the endpoint code of `/upgrades/{purchaseId}/disable-auto-renew` to always return error.
1. Try to disable auto-renewal on a subscription, and the error notice should appear.
1. Update the endpoint code of `/upgrades/{purchaseId}/enable-auto-renew` to always return error.
1. Try to enable auto-renewal on a subscription, and the error notice should appear.