### PR TITLE
Remove the Blogger plan test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -140,14 +140,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	hideBloggerPlan: {
-		datestamp: '20190521',
-		variations: {
-			hide: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-	},
 	showApplePay: {
 		datestamp: '20190529',
 		variations: {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -8,7 +8,6 @@ import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -34,7 +33,7 @@ import CartData from 'components/data/cart';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isEnabled } from 'config';
-import { plansLink, planMatches, findPlansKeys, getPlan, isBloggerPlan } from 'lib/plans';
+import { plansLink, planMatches, findPlansKeys, getPlan } from 'lib/plans';
 import Button from 'components/button';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
@@ -128,19 +127,9 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getPlansForPlanFeatures() {
-		const {
-			displayJetpackPlans,
-			intervalType,
-			selectedPlan,
-			hideFreePlan,
-			sitePlanSlug,
-		} = this.props;
+		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan } = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
-		const hideBloggerPlan =
-			! isBloggerPlan( selectedPlan ) &&
-			! isBloggerPlan( sitePlanSlug ) &&
-			abtest( 'hideBloggerPlan' ) === 'hide';
 
 		let term;
 		if ( intervalType === 'monthly' ) {
@@ -175,12 +164,12 @@ export class PlansFeaturesMain extends Component {
 		} else {
 			plans = [
 				findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
-				hideBloggerPlan ? null : findPlansKeys( { group, term, type: TYPE_BLOGGER } )[ 0 ],
+				findPlansKeys( { group, term, type: TYPE_BLOGGER } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PREMIUM } )[ 0 ],
 				findPlansKeys( { group, term: businessPlanTerm, type: TYPE_BUSINESS } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_ECOMMERCE } )[ 0 ],
-			].filter( el => el !== null );
+			];
 		}
 
 		if ( hideFreePlan ) {
@@ -435,7 +424,6 @@ const guessCustomerType = ( state, props ) => {
 export default connect(
 	( state, props ) => {
 		const siteId = get( props.site, [ 'ID' ] );
-		const sitePlan = getSitePlan( state, siteId );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and
@@ -449,7 +437,6 @@ export default connect(
 			isChatAvailable: isHappychatAvailable( state ),
 			siteId: siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
-			sitePlanSlug: sitePlan && sitePlan.product_slug,
 		};
 	},
 	{


### PR DESCRIPTION
We are analyzing the test results and ending the test so that it doesn't pollute the test data for other tests.

#### Changes proposed in this Pull Request

This will end the test. It undoes the changes in #33185 with some exceptions - we are not adding back an unnecessary style.

#### Testing instructions

1. Try the logged in /plans page. There should be two tabs with plans visible with 3 plans in the first tab. The hideBloggerPlan test shouldn't be available in the abtests dev menu.
2. Try the logged out signup flow. The Blogger plan should be available and the test should not be.

*

Fixes #
