### PR TITLE
eCommerce signup flow: limit plans to business / eCommerce

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -68,6 +68,7 @@ $plan-features-sidebar-width: 272px;
 	display: block;
 	margin-left: auto;
 	margin-right: auto;
+	max-width: 800px;
 }
 
 .plan-features__table.has-1-cols {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -138,7 +138,7 @@ export class PlansFeaturesMain extends Component {
 			intervalType,
 			selectedPlan,
 			hideFreePlan,
-			plans: plansProp,
+			planTypes,
 		} = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
@@ -166,8 +166,8 @@ export class PlansFeaturesMain extends Component {
 		}
 
 		let plans;
-		if ( plansProp && plansProp.length ) {
-			plans = plansProp.map( type => findPlansKeys( { group, term, type } )[ 0 ] );
+		if ( planTypes && planTypes.length ) {
+			plans = planTypes.map( type => findPlansKeys( { group, term, type } )[ 0 ] );
 		} else if ( group === GROUP_JETPACK ) {
 			plans = [
 				findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
@@ -390,7 +390,7 @@ PlansFeaturesMain.propTypes = {
 	siteSlug: PropTypes.string,
 	withWPPlanTabs: PropTypes.bool,
 	plansWithScroll: PropTypes.bool,
-	plans: PropTypes.array,
+	planTypes: PropTypes.array,
 };
 
 PlansFeaturesMain.defaultProps = {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -188,8 +188,10 @@ export class PlansFeaturesMain extends Component {
 		return plans;
 	}
 
-	getPlansFromProps = ( group, term ) =>
-		this.props.planTypes.reduce( ( accum, type ) => {
+	getPlansFromProps( group, term ) {
+		const planTypes = this.props.planTypes || [];
+
+		return planTypes.reduce( ( accum, type ) => {
 			const plan = findPlansKeys( { group, term, type } )[ 0 ];
 
 			if ( ! plan ) {
@@ -200,6 +202,7 @@ export class PlansFeaturesMain extends Component {
 
 			return plan ? [ ...accum, plan ] : accum;
 		}, [] );
+	}
 
 	getVisiblePlansForPlanFeatures( plans ) {
 		const { displayJetpackPlans, customerType, plansWithScroll, withWPPlanTabs } = this.props;
@@ -407,7 +410,6 @@ PlansFeaturesMain.defaultProps = {
 	siteSlug: '',
 	withWPPlanTabs: false,
 	plansWithScroll: false,
-	planTypes: [],
 };
 
 const guessCustomerType = ( state, props ) => {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
+import warn from 'lib/warn';
 import PlanFeatures from 'my-sites/plan-features';
 import {
 	TYPE_FREE,
@@ -127,7 +128,7 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getPlansForPlanFeatures() {
-		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan, planTypes } = this.props;
+		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan } = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
 
@@ -153,9 +154,7 @@ export class PlansFeaturesMain extends Component {
 			term = TERM_ANNUALLY;
 		}
 
-		const plansFromProps = planTypes
-			.map( type => findPlansKeys( { group, term, type } )[ 0 ] )
-			.filter( plan => plan );
+		const plansFromProps = this.getPlansFromProps( group, term );
 
 		let plans;
 		if ( plansFromProps.length ) {
@@ -188,6 +187,19 @@ export class PlansFeaturesMain extends Component {
 
 		return plans;
 	}
+
+	getPlansFromProps = ( group, term ) =>
+		this.props.planTypes.reduce( ( accum, type ) => {
+			const plan = findPlansKeys( { group, term, type } )[ 0 ];
+
+			if ( ! plan ) {
+				warn(
+					`Invalid plan type, \`${ type }\`, provided to \`PlansFeaturesMain\` component. See plans constants for valid plan types.`
+				);
+			}
+
+			return plan ? [ ...accum, plan ] : accum;
+		}, [] );
 
 	getVisiblePlansForPlanFeatures( plans ) {
 		const { displayJetpackPlans, customerType, plansWithScroll, withWPPlanTabs } = this.props;

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -33,7 +33,13 @@ import CartData from 'components/data/cart';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isEnabled } from 'config';
-import { plansLink, planMatches, findPlansKeys, getPlan } from 'lib/plans';
+import {
+	plansLink,
+	planMatches,
+	findPlansKeys,
+	getPlan,
+	isFreePlan,
+} from 'lib/plans';
 import Button from 'components/button';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
@@ -132,7 +138,7 @@ export class PlansFeaturesMain extends Component {
 			intervalType,
 			selectedPlan,
 			hideFreePlan,
-			showOnlyEcommercePlans,
+			plans: plansProp,
 		} = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
@@ -160,11 +166,8 @@ export class PlansFeaturesMain extends Component {
 		}
 
 		let plans;
-		if ( showOnlyEcommercePlans ) {
-			plans = [
-				findPlansKeys( { group, term, type: TYPE_BUSINESS } )[ 0 ],
-				findPlansKeys( { group, term, type: TYPE_ECOMMERCE } )[ 0 ],
-			];
+		if ( plansProp && plansProp.length ) {
+			plans = plansProp.map( type => findPlansKeys( { group, term, type } )[ 0 ] );
 		} else if ( group === GROUP_JETPACK ) {
 			plans = [
 				findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
@@ -184,7 +187,7 @@ export class PlansFeaturesMain extends Component {
 		}
 
 		if ( hideFreePlan ) {
-			plans.shift();
+			plans = plans.filter( plan => ! isFreePlan( plan ) );
 		}
 
 		if ( ! isEnabled( 'plans/personal-plan' ) && ! displayJetpackPlans ) {
@@ -303,9 +306,9 @@ export class PlansFeaturesMain extends Component {
 	};
 
 	renderFreePlanBanner() {
-		const { hideFreePlan, showOnlyEcommercePlans, translate } = this.props;
+		const { hideFreePlan, translate } = this.props;
 		const className = 'is-free-plan';
-		if ( hideFreePlan || showOnlyEcommercePlans ) {
+		if ( hideFreePlan ) {
 			return null;
 		}
 
@@ -387,7 +390,7 @@ PlansFeaturesMain.propTypes = {
 	siteSlug: PropTypes.string,
 	withWPPlanTabs: PropTypes.bool,
 	plansWithScroll: PropTypes.bool,
-	showOnlyEcommercePlans: PropTypes.bool,
+	plans: PropTypes.array,
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -400,7 +403,6 @@ PlansFeaturesMain.defaultProps = {
 	siteSlug: '',
 	withWPPlanTabs: false,
 	plansWithScroll: false,
-	showOnlyEcommercePlans: false,
 };
 
 const guessCustomerType = ( state, props ) => {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -33,13 +33,7 @@ import CartData from 'components/data/cart';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isEnabled } from 'config';
-import {
-	plansLink,
-	planMatches,
-	findPlansKeys,
-	getPlan,
-	isFreePlan,
-} from 'lib/plans';
+import { plansLink, planMatches, findPlansKeys, getPlan, isFreePlan } from 'lib/plans';
 import Button from 'components/button';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
@@ -133,13 +127,7 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getPlansForPlanFeatures() {
-		const {
-			displayJetpackPlans,
-			intervalType,
-			selectedPlan,
-			hideFreePlan,
-			planTypes,
-		} = this.props;
+		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan, planTypes } = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
 
@@ -165,9 +153,13 @@ export class PlansFeaturesMain extends Component {
 			term = TERM_ANNUALLY;
 		}
 
+		const plansFromProps = planTypes
+			.map( type => findPlansKeys( { group, term, type } )[ 0 ] )
+			.filter( plan => plan );
+
 		let plans;
-		if ( planTypes && planTypes.length ) {
-			plans = planTypes.map( type => findPlansKeys( { group, term, type } )[ 0 ] );
+		if ( plansFromProps.length ) {
+			plans = plansFromProps;
 		} else if ( group === GROUP_JETPACK ) {
 			plans = [
 				findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
@@ -403,6 +395,7 @@ PlansFeaturesMain.defaultProps = {
 	siteSlug: '',
 	withWPPlanTabs: false,
 	plansWithScroll: false,
+	planTypes: [],
 };
 
 const guessCustomerType = ( state, props ) => {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -187,7 +187,7 @@ export class PlansFeaturesMain extends Component {
 		}
 
 		if ( hideFreePlan ) {
-			plans = plans.filter( plan => ! isFreePlan( plan ) );
+			plans = plans.filter( planSlug => ! isFreePlan( planSlug ) );
 		}
 
 		if ( ! isEnabled( 'plans/personal-plan' ) && ! displayJetpackPlans ) {

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -127,7 +127,13 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getPlansForPlanFeatures() {
-		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan } = this.props;
+		const {
+			displayJetpackPlans,
+			intervalType,
+			selectedPlan,
+			hideFreePlan,
+			showOnlyEcommercePlans,
+		} = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
 
@@ -154,7 +160,12 @@ export class PlansFeaturesMain extends Component {
 		}
 
 		let plans;
-		if ( group === GROUP_JETPACK ) {
+		if ( showOnlyEcommercePlans ) {
+			plans = [
+				findPlansKeys( { group, term, type: TYPE_BUSINESS } )[ 0 ],
+				findPlansKeys( { group, term, type: TYPE_ECOMMERCE } )[ 0 ],
+			];
+		} else if ( group === GROUP_JETPACK ) {
 			plans = [
 				findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ],
@@ -292,9 +303,9 @@ export class PlansFeaturesMain extends Component {
 	};
 
 	renderFreePlanBanner() {
-		const { translate } = this.props;
+		const { hideFreePlan, showOnlyEcommercePlans, translate } = this.props;
 		const className = 'is-free-plan';
-		if ( this.props.hideFreePlan ) {
+		if ( hideFreePlan || showOnlyEcommercePlans ) {
 			return null;
 		}
 
@@ -376,6 +387,7 @@ PlansFeaturesMain.propTypes = {
 	siteSlug: PropTypes.string,
 	withWPPlanTabs: PropTypes.bool,
 	plansWithScroll: PropTypes.bool,
+	showOnlyEcommercePlans: PropTypes.bool,
 };
 
 PlansFeaturesMain.defaultProps = {
@@ -388,6 +400,7 @@ PlansFeaturesMain.defaultProps = {
 	siteSlug: '',
 	withWPPlanTabs: false,
 	plansWithScroll: false,
+	showOnlyEcommercePlans: false,
 };
 
 const guessCustomerType = ( state, props ) => {

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -75,14 +75,6 @@ const props = {
 };
 
 describe( 'PlansFeaturesMain.renderFreePlanBanner()', () => {
-	test.skip( 'Should return null when called with showOnlyEcommercePlans props', () => {
-		const instance = new PlansFeaturesMain( {
-			...props,
-			showOnlyEcommercePlans: true,
-		} );
-		const freePlanBanner = instance.renderFreePlanBanner();
-		expect( freePlanBanner ).toBeNull();
-	} );
 	test( 'Should return null when called with hideFreePlan props', () => {
 		const instance = new PlansFeaturesMain( {
 			...props,

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -66,6 +66,7 @@ import {
 	PLAN_JETPACK_BUSINESS_MONTHLY,
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
+	TYPE_FREE,
 } from 'lib/plans/constants';
 
 const props = {
@@ -97,6 +98,15 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
 		const instance = new PlansFeaturesMain( {
 			...props,
 			planTypes: [ TYPE_BUSINESS, TYPE_ECOMMERCE ],
+		} );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_ECOMMERCE ] );
+	} );
+	test( 'Should render <PlanFeatures /> removing the free plan when hideFreePlan prop is present, regardless of its position', () => {
+		const instance = new PlansFeaturesMain( {
+			...props,
+			planTypes: [ TYPE_BUSINESS, TYPE_FREE, TYPE_ECOMMERCE ],
+			hideFreePlan: true,
 		} );
 		const plans = instance.getPlansForPlanFeatures();
 		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_ECOMMERCE ] );

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -67,6 +67,8 @@ import {
 	TYPE_BUSINESS,
 	TYPE_ECOMMERCE,
 	TYPE_FREE,
+	TERM_ANNUALLY,
+	GROUP_WPCOM,
 } from 'lib/plans/constants';
 
 const props = {
@@ -306,5 +308,31 @@ describe( 'PlansFeaturesMain.getPlansForPlanFeatures() with tabs', () => {
 		expect(
 			comp.find( 'SegmentedControlItem[path="?customerType=personal"]' ).props().selected
 		).toBe( false );
+	} );
+} );
+
+describe( 'PlansFeaturesMain.getPlansFromProps', () => {
+	const group = GROUP_WPCOM;
+	const term = TERM_ANNUALLY;
+
+	test( 'Should return an empty array if planTypes are not specified', () => {
+		const instance = new PlansFeaturesMain( { ...props } );
+		const plans = instance.getPlansFromProps( group, term );
+		expect( plans ).toEqual( [] );
+	} );
+
+	test( 'Should filter out invalid plan types and print a warning in the console', () => {
+		global.console.warn = jest.fn();
+		const NOT_A_PLAN = 'not-a-plan';
+		const instance = new PlansFeaturesMain( {
+			...props,
+			planTypes: [ NOT_A_PLAN, TYPE_BUSINESS, TYPE_ECOMMERCE ],
+		} );
+		const plans = instance.getPlansFromProps( group, term );
+
+		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_ECOMMERCE ] );
+		expect( global.console.warn ).toHaveBeenCalledWith(
+			`Invalid plan type, \`${ NOT_A_PLAN }\`, provided to \`PlansFeaturesMain\` component. See plans constants for valid plan types.`
+		);
 	} );
 } );

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -72,7 +72,7 @@ const props = {
 };
 
 describe( 'PlansFeaturesMain.renderFreePlanBanner()', () => {
-	test( 'Should return null when called with showOnlyEcommercePlans props', () => {
+	test.skip( 'Should return null when called with showOnlyEcommercePlans props', () => {
 		const instance = new PlansFeaturesMain( {
 			...props,
 			showOnlyEcommercePlans: true,
@@ -91,7 +91,7 @@ describe( 'PlansFeaturesMain.renderFreePlanBanner()', () => {
 } );
 
 describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
-	test( 'Should render <PlanFeatures /> with eCommerce plans when called with showOnlyEcommercePlans props', () => {
+	test.skip( 'Should render <PlanFeatures /> with eCommerce plans when called with showOnlyEcommercePlans props', () => {
 		const instance = new PlansFeaturesMain( {
 			...props,
 			showOnlyEcommercePlans: true,

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -71,7 +71,34 @@ const props = {
 	translate: x => x,
 };
 
+describe( 'PlansFeaturesMain.renderFreePlanBanner()', () => {
+	test( 'Should return null when called with showOnlyEcommercePlans props', () => {
+		const instance = new PlansFeaturesMain( {
+			...props,
+			showOnlyEcommercePlans: true,
+		} );
+		const freePlanBanner = instance.renderFreePlanBanner();
+		expect( freePlanBanner ).toBeNull();
+	} );
+	test( 'Should return null when called with hideFreePlan props', () => {
+		const instance = new PlansFeaturesMain( {
+			...props,
+			hideFreePlan: true,
+		} );
+		const freePlanBanner = instance.renderFreePlanBanner();
+		expect( freePlanBanner ).toBeNull();
+	} );
+} );
+
 describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
+	test( 'Should render <PlanFeatures /> with eCommerce plans when called with showOnlyEcommercePlans props', () => {
+		const instance = new PlansFeaturesMain( {
+			...props,
+			showOnlyEcommercePlans: true,
+		} );
+		const plans = instance.getPlansForPlanFeatures();
+		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_ECOMMERCE ] );
+	} );
 	test( 'Should render <PlanFeatures /> with Jetpack monthly plans when called with jetpack props', () => {
 		const instance = new PlansFeaturesMain( {
 			...props,

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -64,6 +64,8 @@ import {
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
+	TYPE_BUSINESS,
+	TYPE_ECOMMERCE,
 } from 'lib/plans/constants';
 
 const props = {
@@ -91,10 +93,10 @@ describe( 'PlansFeaturesMain.renderFreePlanBanner()', () => {
 } );
 
 describe( 'PlansFeaturesMain.getPlansForPlanFeatures()', () => {
-	test.skip( 'Should render <PlanFeatures /> with eCommerce plans when called with showOnlyEcommercePlans props', () => {
+	test( 'Should render <PlanFeatures /> with plans matching given planTypes when called with planTypes props', () => {
 		const instance = new PlansFeaturesMain( {
 			...props,
-			showOnlyEcommercePlans: true,
+			planTypes: [ TYPE_BUSINESS, TYPE_ECOMMERCE ],
 		} );
 		const plans = instance.getPlansForPlanFeatures();
 		expect( plans ).toEqual( [ PLAN_BUSINESS, PLAN_ECOMMERCE ] );

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -258,7 +258,7 @@ export function generateFlows( {
 		};
 
 		flows[ 'ecommerce-onboarding' ] = {
-			steps: [ 'user', 'site-type', 'domains', 'plans' ],
+			steps: [ 'user', 'site-type', 'domains', 'plans-ecommerce' ],
 			destination: getSiteDestination,
 			description: 'Signup flow for creating an online store with an Atomic site',
 			lastModified: '2018-11-21',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -18,6 +18,7 @@ const stepNameToModuleName = {
 	'from-url': 'import-url',
 	launch: 'launch-site',
 	plans: 'plans',
+	'plans-ecommerce': 'plans',
 	'plans-launch': 'plans',
 	'plans-personal': 'plans',
 	'plans-premium': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -10,7 +10,13 @@ import i18n from 'i18n-calypso';
  * Internal dependencies
  */
 import config from 'config';
-import { PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS } from 'lib/plans/constants';
+import {
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	PLAN_BUSINESS,
+	TYPE_BUSINESS,
+	TYPE_ECOMMERCE,
+} from 'lib/plans/constants';
 
 export function generateSteps( {
 	addPlanToCart = noop,
@@ -163,7 +169,9 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			fulfilledStepCallback: isPlanFulfilled,
 			props: {
-				showOnlyEcommercePlans: true,
+				allowSkip: false,
+				hideFreePlan: true,
+				plans: [ TYPE_BUSINESS, TYPE_ECOMMERCE ],
 			},
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -156,6 +156,17 @@ export function generateSteps( {
 			fulfilledStepCallback: isPlanFulfilled,
 		},
 
+		'plans-ecommerce': {
+			stepName: 'plans-ecommerce',
+			apiRequestFunction: addPlanToCart,
+			dependencies: [ 'siteSlug' ],
+			providesDependencies: [ 'cartItem' ],
+			fulfilledStepCallback: isPlanFulfilled,
+			props: {
+				showOnlyEcommercePlans: true,
+			},
+		},
+
 		'plans-personal': {
 			stepName: 'plans-personal',
 			apiRequestFunction: addPlanToCart,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -171,7 +171,7 @@ export function generateSteps( {
 			props: {
 				allowSkip: false,
 				hideFreePlan: true,
-				plans: [ TYPE_BUSINESS, TYPE_ECOMMERCE ],
+				planTypes: [ TYPE_BUSINESS, TYPE_ECOMMERCE ],
 			},
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -169,7 +169,6 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			fulfilledStepCallback: isPlanFulfilled,
 			props: {
-				allowSkip: false,
 				hideFreePlan: true,
 				planTypes: [ TYPE_BUSINESS, TYPE_ECOMMERCE ],
 			},

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -141,6 +141,7 @@ export class PlansStep extends Component {
 			hideFreePlan,
 			isLaunchPage,
 			selectedSite,
+			showOnlyEcommercePlans,
 		} = this.props;
 
 		return (
@@ -159,7 +160,15 @@ export class PlansStep extends Component {
 					customerType={ this.getCustomerType() }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 					plansWithScroll={ true }
+					showOnlyEcommercePlans={ showOnlyEcommercePlans }
 				/>
+				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
+				 * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --
+				 * unless we've already selected an option that implies a paid plan.
+				 * This is in particular true for domain names. */
+				hideFreePlan && ! showOnlyEcommercePlans && ! isDomainOnly && ! this.getDomainName() && (
+					<PlansSkipButton onClick={ this.handleFreePlanButtonClick } />
+				) }
 			</div>
 		);
 	}
@@ -225,10 +234,15 @@ PlansStep.propTypes = {
 	goToNextStep: PropTypes.func.isRequired,
 	hideFreePlan: PropTypes.bool,
 	selectedSite: PropTypes.object,
+	showOnlyEcommercePlans: PropTypes.bool,
 	stepName: PropTypes.string.isRequired,
 	stepSectionName: PropTypes.string,
 	customerType: PropTypes.string,
 	translate: PropTypes.func.isRequired,
+};
+
+PlansStep.defaultProps = {
+	showOnlyEcommercePlans: false,
 };
 
 /**

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -142,7 +142,7 @@ export class PlansStep extends Component {
 			hideFreePlan,
 			isLaunchPage,
 			selectedSite,
-			plans,
+			planTypes,
 		} = this.props;
 
 		return (
@@ -161,7 +161,7 @@ export class PlansStep extends Component {
 					customerType={ this.getCustomerType() }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 					plansWithScroll={ true }
-					plans={ plans }
+					planTypes={ planTypes }
 				/>
 				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
 				 * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --
@@ -240,6 +240,7 @@ PlansStep.propTypes = {
 	stepSectionName: PropTypes.string,
 	customerType: PropTypes.string,
 	translate: PropTypes.func.isRequired,
+	planTypes: PropTypes.array,
 };
 
 /**

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -137,7 +137,6 @@ export class PlansStep extends Component {
 
 	plansFeaturesList() {
 		const {
-			allowSkip,
 			disableBloggerPlanWithNonBlogDomain,
 			hideFreePlan,
 			isLaunchPage,
@@ -163,13 +162,6 @@ export class PlansStep extends Component {
 					plansWithScroll={ true }
 					planTypes={ planTypes }
 				/>
-				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
-				 * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --
-				 * unless we've already selected an option that implies a paid plan.
-				 * This is in particular true for domain names. */
-				hideFreePlan && allowSkip && ! isDomainOnly && ! this.getDomainName() && (
-					<PlansSkipButton onClick={ this.handleFreePlanButtonClick } />
-				) }
 			</div>
 		);
 	}
@@ -231,7 +223,6 @@ export class PlansStep extends Component {
 
 PlansStep.propTypes = {
 	additionalStepData: PropTypes.object,
-	allowSkip: PropTypes.bool,
 	disableBloggerPlanWithNonBlogDomain: PropTypes.bool,
 	goToNextStep: PropTypes.func.isRequired,
 	hideFreePlan: PropTypes.bool,
@@ -241,10 +232,6 @@ PlansStep.propTypes = {
 	customerType: PropTypes.string,
 	translate: PropTypes.func.isRequired,
 	planTypes: PropTypes.array,
-};
-
-PlansStep.defaultProps = {
-	allowSkip: true,
 };
 
 /**

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -137,11 +137,12 @@ export class PlansStep extends Component {
 
 	plansFeaturesList() {
 		const {
+			allowSkip,
 			disableBloggerPlanWithNonBlogDomain,
 			hideFreePlan,
 			isLaunchPage,
 			selectedSite,
-			showOnlyEcommercePlans,
+			plans,
 		} = this.props;
 
 		return (
@@ -160,13 +161,13 @@ export class PlansStep extends Component {
 					customerType={ this.getCustomerType() }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 					plansWithScroll={ true }
-					showOnlyEcommercePlans={ showOnlyEcommercePlans }
+					plans={ plans }
 				/>
 				{ /* The `hideFreePlan` means that we want to hide the Free Plan Info Column.
 				 * In most cases, we want to show the 'Start with Free' PlansSkipButton instead --
 				 * unless we've already selected an option that implies a paid plan.
 				 * This is in particular true for domain names. */
-				hideFreePlan && ! showOnlyEcommercePlans && ! isDomainOnly && ! this.getDomainName() && (
+				hideFreePlan && allowSkip && ! isDomainOnly && ! this.getDomainName() && (
 					<PlansSkipButton onClick={ this.handleFreePlanButtonClick } />
 				) }
 			</div>
@@ -230,19 +231,15 @@ export class PlansStep extends Component {
 
 PlansStep.propTypes = {
 	additionalStepData: PropTypes.object,
+	allowSkip: PropTypes.bool,
 	disableBloggerPlanWithNonBlogDomain: PropTypes.bool,
 	goToNextStep: PropTypes.func.isRequired,
 	hideFreePlan: PropTypes.bool,
 	selectedSite: PropTypes.object,
-	showOnlyEcommercePlans: PropTypes.bool,
 	stepName: PropTypes.string.isRequired,
 	stepSectionName: PropTypes.string,
 	customerType: PropTypes.string,
 	translate: PropTypes.func.isRequired,
-};
-
-PlansStep.defaultProps = {
-	showOnlyEcommercePlans: false,
 };
 
 /**

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -243,6 +243,10 @@ PlansStep.propTypes = {
 	planTypes: PropTypes.array,
 };
 
+PlansStep.defaultProps = {
+	allowSkip: true,
+};
+
 /**
  * Checks if the domainItem picked in the domain step is a top level .blog domain -
  * we only want to make Blogger plan available if it is.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Limit the plans available in the eCommerce signup flow to business / eCommerce
Before:
![image](https://user-images.githubusercontent.com/363749/59054973-71408a00-885a-11e9-8201-ae68f015c935.png)

After:
![image](https://user-images.githubusercontent.com/363749/59054877-376f8380-885a-11e9-8fe7-33b85098277b.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start the signup flow from `/start`
* Continue until you arrive at the `site-type` step:
![image](https://user-images.githubusercontent.com/363749/59055144-ced4d680-885a-11e9-8a5a-e1d38a85e94e.png)
* Select "Online store"
* Verify that only Business and eCommerce plans appear in the plan list.

Fixes #33543
