### PR TITLE
People: Fix team list and follower list freezing while scrolling

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -160,10 +160,12 @@ export default class InfiniteList extends React.Component {
 		if ( ! this.isScrolling ) {
 			this.cancelAnimationFrame();
 			// updateScroll misbehaves when it's called syncronously from componentDidUpdate.
+			// Promise.resolve() is not used here intentionally to avoid the orignal problem which
+			// I suspect is a race condition introduced by changes in React fiber implementation.
 			setTimeout( () => {
-				this.updateScroll( {
-					triggeredByScroll: false,
-				} );
+				if ( this._isMounted ) {
+					this.updateScroll( { triggeredByScroll: false } );
+				}
 			}, 0 );
 		}
 	}

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -52,6 +52,11 @@ export default class InfiniteList extends React.Component {
 	_isMounted = false;
 	smartSetState = smartSetState;
 
+	namedRefs = {
+		topPlaceholder: React.createRef(),
+		bottomPlaceholder: React.createRef(),
+	};
+
 	componentWillMount() {
 		const url = page.current;
 		let newState, scrollTop;
@@ -296,8 +301,9 @@ export default class InfiniteList extends React.Component {
 	}
 
 	boundsForRef = ref => {
-		if ( ref in this.refs ) {
-			return ReactDom.findDOMNode( this.refs[ ref ] ).getBoundingClientRect();
+		if ( ref in this.namedRefs ) {
+			const node = this.namedRefs[ ref ].current;
+			return node ? node.getBoundingClientRect() : null;
 		}
 		return null;
 	};
@@ -379,14 +385,14 @@ export default class InfiniteList extends React.Component {
 		return (
 			<div { ...propsToTransfer }>
 				<div
-					ref="topPlaceholder"
+					ref={ this.namedRefs.topPlaceholder }
 					className={ spacerClassName }
 					style={ { height: this.state.topPlaceholderHeight } }
 				/>
 				{ itemsToRender }
 				{ this.props.renderTrailingItems() }
 				<div
-					ref="bottomPlaceholder"
+					ref={ this.namedRefs.bottomPlaceholder }
 					className={ spacerClassName }
 					style={ { height: this.state.bottomPlaceholderHeight } }
 				/>

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -154,9 +154,12 @@ export default class InfiniteList extends React.Component {
 		// we may have guessed item heights wrong - now we have real heights
 		if ( ! this.isScrolling ) {
 			this.cancelAnimationFrame();
-			this.updateScroll( {
-				triggeredByScroll: false,
-			} );
+			// updateScroll misbehaves when it's called syncronously from componentDidUpdate.
+			setTimeout( () => {
+				this.updateScroll( {
+					triggeredByScroll: false,
+				} );
+			}, 0 );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In `InfiniteList` class, wrapped call to `upscroll()` from `componentDidUpdate()` with setTimeout to prevent React state update stack from blowing.

NOTE: This patch is a stop gap remedy until InfiniteList is rewritten to be more React friendly or replaced with a third-party virtual list package.

#### Testing instructions

Test with a site with lots of users or followers. Use dotcom p2 if you're an Automattician and don't have a site with many users.

1. Navigate to Manage > People and select either Team or Followers.
2. Scroll through the list of users.

If the list of users or followers shouldn't freeze or blank out with this patch.

*

Fixes #23937
