### PR TITLE
Exporter: Migrate CSS

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -76,7 +76,6 @@
 @import 'me/sidebar-navigation/style';
 @import 'my-sites/checklist/wpcom-checklist/checklist-navigation/style';
 @import 'my-sites/customize/style';
-@import 'my-sites/exporter/style';
 @import 'my-sites/guided-transfer/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/posts/style';

--- a/client/my-sites/exporter/export-card/post-type-options.jsx
+++ b/client/my-sites/exporter/export-card/post-type-options.jsx
@@ -67,9 +67,9 @@ class PostTypeOptions extends React.PureComponent {
 
 		return (
 			<div className="export-card__option-fieldset">
-				<Label className="export-card__option-fieldset-legend">
+				<Label>
 					<FormRadio checked={ isEnabled } onChange={ onSelect } />
-					<span className="export-card__option-fieldset-legend-text">{ legend }</span>
+					<span>{ legend }</span>
 				</Label>
 
 				{ description && (

--- a/client/my-sites/exporter/guided-transfer-card/index.jsx
+++ b/client/my-sites/exporter/guided-transfer-card/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -24,6 +22,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getProductDisplayCost } from 'state/products-list/selectors';
 import InfoPopover from 'components/info-popover';
 import { GUIDED_TRANSFER } from 'lib/url/support';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const Feature = ( { children } ) => (
 	<li className="guided-transfer-card__feature-list-item">

--- a/client/my-sites/exporter/guided-transfer-card/style.scss
+++ b/client/my-sites/exporter/guided-transfer-card/style.scss
@@ -1,0 +1,122 @@
+.guided-transfer-card__options {
+	display: flex;
+	font-size: 14px;
+}
+
+.guided-transfer-card__options-header-title-container {
+	flex-grow: 1;
+}
+
+.guided-transfer-card__options-header-button-container {
+	margin: auto;
+}
+
+.guided-transfer-card__title {
+	font-size: 21px;
+	font-weight: 300;
+	color: var( --color-neutral-700 );
+	clear: left;
+}
+
+.guided-transfer-card__subtitle {
+	color: var( --color-neutral-light );
+	font-style: italic;
+	font-size: 14px;
+}
+
+.guided-transfer-card__price {
+	font-style: normal;
+	font-size: 18px;
+}
+
+.guided-transfer-card__details {
+	background-color: var( --color-neutral-0 );
+	font-size: 14px;
+}
+
+.guided-transfer-card__details-container {
+	display: flex;
+}
+
+.guided-transfer-card__details-title {
+	color: var( --color-neutral-700 );
+	font-weight: 600;
+	margin-bottom: 12px;
+}
+
+.guided-transfer-card__details-text {
+	flex-basis: 60%;
+	color: var( --color-text-subtle );
+}
+
+.guided-transfer-card__feature-list {
+	color: var( --color-success );
+	flex-basis: 40%;
+
+	.guided-transfer-card__feature-list-item {
+		list-style-type: none;
+		text-indent: -24px;
+		margin-bottom: 8px;
+	}
+
+	.guided-transfer-card__feature-icon {
+		margin-right: 6px;
+		margin-top: -4px;
+		vertical-align: middle;
+	}
+}
+
+.guided-transfer-card__feature-text {
+	color: var( --color-text-subtle );
+}
+
+.guided-transfer-card__in-progress {
+	padding-top: 32px;
+	padding-bottom: 32px;
+	font-size: 16px;
+	text-align: center;
+
+	@include breakpoint( '>660px' ) {
+		padding-left: 128px;
+		text-align: left;
+	}
+}
+
+.guided-transfer-card__in-progress-icon {
+	margin: 16px auto;
+	width: 48px;
+	height: 48px;
+	padding: 14px;
+	border-radius: 50%;
+	background-color: var( --color-neutral-500 );
+	color: var( --color-neutral-0 );
+
+	@include breakpoint( '>660px' ) {
+		position: absolute;
+		margin-left: -96px;
+		margin-top: 16px;
+	}
+}
+
+.guided-transfer-card__in-progress-title {
+	font-size: 24px;
+	font-weight: 300;
+	color: var( --color-neutral-700 );
+}
+
+.guided-transfer-card__unavailable-notice {
+	background-color: var( --color-neutral-700 );
+	border-radius: 3px;
+	color: var( --color-neutral-0 );
+	padding: 5px 12px;
+}
+
+.guided-transfer-card__unavailable-info-icon {
+	vertical-align: middle;
+	padding-left: 5px;
+}
+
+.guided-transfer-card__unavailable-info-icon.info-popover .gridicon:hover,
+.guided-transfer-card__unavailable-info-icon.info-popover.is_active .gridicon {
+	color: var( --color-neutral-0 );
+}

--- a/client/my-sites/exporter/guided-transfer-card/style.scss
+++ b/client/my-sites/exporter/guided-transfer-card/style.scss
@@ -19,7 +19,7 @@
 }
 
 .guided-transfer-card__subtitle {
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	font-style: italic;
 	font-size: 14px;
 }

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -15,6 +15,11 @@ import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/u
 import { isJetpackSite } from 'state/sites/selectors';
 import FormattedHeader from 'components/formatted-header';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const SectionExport = ( { isJetpack, site, translate } ) => (
 	<Main>
 		<FormattedHeader

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -77,12 +77,6 @@
 	}
 }
 
-// The following specificity is required to override the form-label selector:
-// .form-label input[type="checkbox"] + span { font-weight: normal }
-.export-card__option-fieldset-legend .export-card__option-fieldset-legend-text {
-	font-weight: bold;
-}
-
 .export-card__option-fieldset-description {
 	font-size: 14px;
 	color: var( --color-text-subtle );

--- a/client/my-sites/exporter/style.scss
+++ b/client/my-sites/exporter/style.scss
@@ -1,7 +1,3 @@
-.section-export {
-	padding-bottom: 100px;
-}
-
 .exporter__section-header {
 	&.formatted-header {
 		margin: 0 auto;
@@ -17,14 +13,7 @@
 	}
 }
 
-.export-card__title {
-	font-size: 21px;
-	font-weight: 300;
-	color: var( --color-neutral-700 );
-	margin-bottom: 16px;
-	clear: left;
-}
-
+.export-card__title,
 .export-media-card__title {
 	font-size: 21px;
 	font-weight: 300;
@@ -33,19 +22,12 @@
 	clear: left;
 }
 
-.export-card .foldable-card__header {
-	padding: 24px;
-}
-
+.export-card .foldable-card__header,
 .export-media-card .foldable-card__header {
 	padding: 24px;
 }
 
-.export-card__subtitle {
-	font-size: 14px;
-	color: var( --color-neutral-700 );
-}
-
+.export-card__subtitle,
 .export-media-card__subtitle {
 	font-size: 14px;
 	color: var( --color-neutral-700 );
@@ -103,7 +85,7 @@
 
 .export-card__option-fieldset-description {
 	font-size: 14px;
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	padding-left: 24px;
 	padding-right: 24px;
 }
@@ -115,127 +97,4 @@
 	select {
 		width: 100%;
 	}
-}
-
-.guided-transfer-card__options {
-	display: flex;
-	font-size: 14px;
-}
-
-.guided-transfer-card__options-header-title-container {
-	flex-grow: 1;
-}
-
-.guided-transfer-card__options-header-button-container {
-	margin: auto;
-}
-
-.guided-transfer-card__title {
-	font-size: 21px;
-	font-weight: 300;
-	color: var( --color-neutral-700 );
-	clear: left;
-}
-
-.guided-transfer-card__subtitle {
-	color: var( --color-neutral-light );
-	font-style: italic;
-	font-size: 14px;
-}
-
-.guided-transfer-card__price {
-	font-style: normal;
-	font-size: 18px;
-}
-
-.guided-transfer-card__details {
-	background-color: var( --color-neutral-0 );
-	font-size: 14px;
-}
-
-.guided-transfer-card__details-container {
-	display: flex;
-}
-
-.guided-transfer-card__details-title {
-	color: var( --color-neutral-700 );
-	font-weight: 600;
-	margin-bottom: 12px;
-}
-
-.guided-transfer-card__details-text {
-	flex-basis: 60%;
-	color: var( --color-neutral-light );
-}
-
-.guided-transfer-card__feature-list {
-	color: var( --color-success );
-	flex-basis: 40%;
-
-	.guided-transfer-card__feature-list-item {
-		list-style-type: none;
-		text-indent: -24px;
-		margin-bottom: 8px;
-	}
-
-	.guided-transfer-card__feature-icon {
-		margin-right: 6px;
-		margin-top: -4px;
-		vertical-align: middle;
-	}
-}
-
-.guided-transfer-card__feature-text {
-	color: var( --color-neutral-light );
-}
-
-.guided-transfer-card__in-progress {
-	padding-top: 32px;
-	padding-bottom: 32px;
-	font-size: 16px;
-	text-align: center;
-
-	@include breakpoint( '>660px' ) {
-		padding-left: 128px;
-		text-align: left;
-	}
-}
-
-.guided-transfer-card__in-progress-icon {
-	margin: 16px auto;
-	width: 48px;
-	height: 48px;
-	padding: 14px;
-	border-radius: 50%;
-	background-color: var( --color-neutral-500 );
-	color: var( --color-neutral-0 );
-
-	@include breakpoint( '>660px' ) {
-		position: absolute;
-		margin-left: -96px;
-		margin-top: 16px;
-	}
-}
-
-.guided-transfer-card__in-progress-title {
-	font-size: 24px;
-	font-weight: 300;
-	color: var( --color-neutral-700 );
-}
-
-.guided-transfer-card__unavailable-notice {
-	background-color: var( --color-neutral-700 );
-	border-radius: 3px;
-	color: var( --color-neutral-0 );
-	padding: 5px 12px;
-}
-
-.guided-transfer-card__unavailable-info-icon {
-	vertical-align: middle;
-	padding-left: 5px;
-}
-
-.guided-transfer-card__unavailable-info-icon.info-popover .gridicon:hover,
-.guided-transfer-card__unavailable-info-icon.info-popover.is_active .gridicon {
-	color: var( --color-neutral-0 );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Splits up the larger spreadsheet into a separate one for the Guided Transfer card (I think that's the best thing to do for this kind of stylesheet, let me know if not)
* Switches the disabled text with a variable of --neutral-200 to --text-subtle to follow what the rest of Calypso does (for accessibility reasons)
* Removes some duplicated and unnecessary/unused CSS
* Removes some CSS which was not (maybe ever?) specific enough to override what it intended to do

<img width="476" alt="Screenshot 2019-06-06 at 17 53 18" src="https://user-images.githubusercontent.com/43215253/59051750-8a126500-8885-11e9-9c48-d35c22b9a425.png">

This could be changed if the intention is for it to be bold, but the intention of this PR is not to change the design, and the specificity is currently preventing it from being bold on master.

#### Testing instructions

Visit `/export/` and verify that everything is exactly the same (except for the lighter text now using the --text-subtle variable).

<img width="901" alt="Screenshot 2019-06-06 at 18 06 52" src="https://user-images.githubusercontent.com/43215253/59052080-2c324d00-8886-11e9-8de1-0c2efdab6be7.png">

cc @blowery, @jsnajdr, @flootr 

Part of #27515
