### PR TITLE
Color Schemes: Add Ocean color scheme

### DIFF
--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -41,5 +41,12 @@ export default function( translate ) {
 				cssClass: 'is-sakura',
 			},
 		},
+		{
+			label: translate( 'Ocean' ),
+			value: 'ocean',
+			thumbnail: {
+				cssClass: 'is-ocean',
+			},
+		},
 	] );
 }

--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -3,6 +3,7 @@
  * External dependencies
  */
 import { compact } from 'lodash';
+import config from 'config';
 
 export default function( translate ) {
 	return compact( [
@@ -41,7 +42,7 @@ export default function( translate ) {
 				cssClass: 'is-sakura',
 			},
 		},
-		{
+		config.isEnabled( 'me/account/color-schemes/ocean' ) && {
 			label: translate( 'Ocean' ),
 			value: 'ocean',
 			thumbnail: {

--- a/client/blocks/color-scheme-picker/style.scss
+++ b/client/blocks/color-scheme-picker/style.scss
@@ -19,4 +19,8 @@
 		background-image: url( '/calypso/images/color-schemes/color-scheme-thumbnail-sakura.svg' );
 	}
 
+	&.is-ocean {
+		background-image: url( '/calypso/images/color-schemes/color-scheme-thumbnail-ocean.svg' );
+	}
+
 }

--- a/config/development.json
+++ b/config/development.json
@@ -113,6 +113,7 @@
 		"me/account": true,
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
+		"me/account/color-schemes/ocean": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -91,6 +91,7 @@
 		"me/account-close": true,
 		"me/account/color-scheme-picker": true,
 		"me/account/color-schemes/laser-black": false,
+		"me/account/color-schemes/ocean": true,
 		"me/find-friends": false,
 		"me/my-profile": true,
 		"me/notifications": true,

--- a/packages/calypso-color-schemes/src/shared/_color-schemes.scss
+++ b/packages/calypso-color-schemes/src/shared/_color-schemes.scss
@@ -1284,39 +1284,39 @@
 		--color-link-900: #{$muriel-celadon-900};
 		--color-link-900-rgb: #{hex-to-rgb( $muriel-celadon-900 )};
 
-		--color-button-primary-background-hover: #{$muriel-hot-blue-400};
+		--color-button-primary-background-hover: #{$muriel-celadon-600};
 		--color-button-primary-scary-background-hover: #{$muriel-hot-red-400};
 
 		--masterbar-color: #{$muriel-white};
-		--masterbar-border-color: #{$muriel-celadon-700};
+		--masterbar-border-color: #{$muriel-blue-700};
 		--masterbar-item-new-editor-background: #{$muriel-gray-500};
 		--masterbar-item-new-editor-hover-background: #{$muriel-gray-600};
 		--masterbar-toggle-drafts-editor-background: #{$muriel-gray-600};
 		--masterbar-toggle-drafts-editor-border-color: #{$muriel-gray-100};
 		--masterbar-toggle-drafts-editor-hover-background: #{$muriel-gray-400};
 
-		--sidebar-background: #{$muriel-pink-100};
-		--sidebar-background-gradient: #{hex-to-rgb( $muriel-pink-100 )};
+		--sidebar-background: #{$muriel-blue-500};
+		--sidebar-background-gradient: #{hex-to-rgb( $muriel-blue-500 )};
 		--sidebar-secondary-background: #{$muriel-white};
 		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
-		--sidebar-border-color: #{$muriel-pink-200};
-		--sidebar-text-color: #{$muriel-pink-800};
-		--sidebar-gridicon-fill: #{$muriel-pink-600};
-		--sidebar-heading-color: #{$muriel-pink-700};
-		--sidebar-footer-button-color: #{$muriel-gray-900};
-		--sidebar-menu-link-secondary-text-color: #{$muriel-pink-700};
-		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-pink-100 )};
-		--sidebar-menu-selected-background-color: #{$muriel-hot-blue-50};
-		--sidebar-menu-selected-a-color: #{$muriel-hot-blue-600};
-		--sidebar-menu-selected-a-first-child-after-background: #{hex-to-rgb( $muriel-hot-blue-50 )};
-		--sidebar-menu-hover-background: #{$muriel-pink-400};
-		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-pink-400 )};
+		--sidebar-border-color: #{$muriel-blue-400};
+		--sidebar-text-color: #{$muriel-white};
+		--sidebar-gridicon-fill: #{$muriel-white};
+		--sidebar-heading-color: #{$muriel-blue-50};
+		--sidebar-footer-button-color: #{$muriel-blue-50};
+		--sidebar-menu-link-secondary-text-color: #{$muriel-blue-50};
+		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-blue-500 )};
+		--sidebar-menu-selected-background-color: #{$muriel-yellow-300};
+		--sidebar-menu-selected-a-color: #{$muriel-blue-800};
+		--sidebar-menu-selected-a-first-child-after-background: #{hex-to-rgb( $muriel-yellow-300 )};
+		--sidebar-menu-hover-background: #{$muriel-blue-600};
+		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-blue-600 )};
 		--sidebar-menu-hover-color: #{$muriel-white};
 
 		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
 		--button-is-borderless-color: #{$muriel-gray-500};
 		--count-border-color: #{$muriel-gray-500};
 		--count-color: #{$muriel-gray-500};
-		--profile-gravatar-user-secondary-info-color: #{$muriel-pink-700};
+		--profile-gravatar-user-secondary-info-color: #{$muriel-blue-50};
 	}
 }

--- a/packages/calypso-color-schemes/src/shared/_color-schemes.scss
+++ b/packages/calypso-color-schemes/src/shared/_color-schemes.scss
@@ -1194,10 +1194,10 @@
 	&.is-ocean {
 		--color-primary: #{$muriel-blue-700};
 		--color-primary-rgb: #{hex-to-rgb( $muriel-blue-700 )};
-		--color-primary-light: #{$muriel-blue-400};
-		--color-primary-light-rgb: #{hex-to-rgb( $muriel-blue-400 )};
-		--color-primary-dark: #{$muriel-blue-700};
-		--color-primary-dark-rgb: #{hex-to-rgb( $muriel-blue-700 )};
+		--color-primary-light: #{$muriel-blue-500};
+		--color-primary-light-rgb: #{hex-to-rgb( $muriel-blue-500 )};
+		--color-primary-dark: #{$muriel-blue-900};
+		--color-primary-dark-rgb: #{hex-to-rgb( $muriel-blue-900 )};
 		--color-primary-0: #{$muriel-blue-0};
 		--color-primary-0-rgb: #{hex-to-rgb( $muriel-blue-0 )};
 		--color-primary-50: #{$muriel-blue-50};

--- a/packages/calypso-color-schemes/src/shared/_color-schemes.scss
+++ b/packages/calypso-color-schemes/src/shared/_color-schemes.scss
@@ -1190,4 +1190,133 @@
 		--count-color: #{$muriel-gray-500};
 		--profile-gravatar-user-secondary-info-color: #{$muriel-pink-700};
 	}
+
+	&.is-ocean {
+		--color-primary: #{$muriel-blue-700};
+		--color-primary-rgb: #{hex-to-rgb( $muriel-blue-700 )};
+		--color-primary-light: #{$muriel-blue-400};
+		--color-primary-light-rgb: #{hex-to-rgb( $muriel-blue-400 )};
+		--color-primary-dark: #{$muriel-blue-700};
+		--color-primary-dark-rgb: #{hex-to-rgb( $muriel-blue-700 )};
+		--color-primary-0: #{$muriel-blue-0};
+		--color-primary-0-rgb: #{hex-to-rgb( $muriel-blue-0 )};
+		--color-primary-50: #{$muriel-blue-50};
+		--color-primary-50-rgb: #{hex-to-rgb( $muriel-blue-50 )};
+		--color-primary-100: #{$muriel-blue-100};
+		--color-primary-100-rgb: #{hex-to-rgb( $muriel-blue-100 )};
+		--color-primary-200: #{$muriel-blue-200};
+		--color-primary-200-rgb: #{hex-to-rgb( $muriel-blue-200 )};
+		--color-primary-300: #{$muriel-blue-300};
+		--color-primary-300-rgb: #{hex-to-rgb( $muriel-blue-300 )};
+		--color-primary-400: #{$muriel-blue-400};
+		--color-primary-400-rgb: #{hex-to-rgb( $muriel-blue-400 )};
+		--color-primary-500: #{$muriel-blue-500};
+		--color-primary-500-rgb: #{hex-to-rgb( $muriel-blue-500 )};
+		--color-primary-600: #{$muriel-blue-600};
+		--color-primary-600-rgb: #{hex-to-rgb( $muriel-blue-600 )};
+		--color-primary-700: #{$muriel-blue-700};
+		--color-primary-700-rgb: #{hex-to-rgb( $muriel-blue-700 )};
+		--color-primary-800: #{$muriel-blue-800};
+		--color-primary-800-rgb: #{hex-to-rgb( $muriel-blue-800 )};
+		--color-primary-900: #{$muriel-blue-900};
+		--color-primary-900-rgb: #{hex-to-rgb( $muriel-blue-900 )};
+
+		--color-accent: #{$muriel-celadon-500};
+		--color-accent-rgb: #{hex-to-rgb( $muriel-celadon-500 )};
+		--color-accent-dark: #{$muriel-celadon-700};
+		--color-accent-dark-rgb: #{hex-to-rgb( $muriel-celadon-700 )};
+		--color-accent-light: #{$muriel-celadon-300};
+		--color-accent-light-rgb: #{hex-to-rgb( $muriel-celadon-300 )};
+		--color-accent-0: #{$muriel-celadon-0};
+		--color-accent-0-rgb: #{hex-to-rgb( $muriel-celadon-0 )};
+		--color-accent-50: #{$muriel-celadon-50};
+		--color-accent-50-rgb: #{hex-to-rgb( $muriel-celadon-50 )};
+		--color-accent-100: #{$muriel-celadon-100};
+		--color-accent-100-rgb: #{hex-to-rgb( $muriel-celadon-100 )};
+		--color-accent-200: #{$muriel-celadon-200};
+		--color-accent-200-rgb: #{hex-to-rgb( $muriel-celadon-200 )};
+		--color-accent-300: #{$muriel-celadon-300};
+		--color-accent-300-rgb: #{hex-to-rgb( $muriel-celadon-300 )};
+		--color-accent-400: #{$muriel-celadon-400};
+		--color-accent-400-rgb: #{hex-to-rgb( $muriel-celadon-400 )};
+		--color-accent-500: #{$muriel-celadon-500};
+		--color-accent-500-rgb: #{hex-to-rgb( $muriel-celadon-500 )};
+		--color-accent-600: #{$muriel-celadon-600};
+		--color-accent-600-rgb: #{hex-to-rgb( $muriel-celadon-600 )};
+		--color-accent-700: #{$muriel-celadon-700};
+		--color-accent-700-rgb: #{hex-to-rgb( $muriel-celadon-700 )};
+		--color-accent-800: #{$muriel-celadon-800};
+		--color-accent-800-rgb: #{hex-to-rgb( $muriel-celadon-800 )};
+		--color-accent-900: #{$muriel-celadon-900};
+		--color-accent-900-rgb: #{hex-to-rgb( $muriel-celadon-900 )};
+
+		--color-text: #{$muriel-gray-900};
+		--color-text-subtle: #{$muriel-gray-600};
+		--color-surface: #{$muriel-white};
+		--color-surface-backdrop: #{$muriel-gray-0};
+
+		--color-link: #{$muriel-celadon-500};
+		--color-link-rgb: #{hex-to-rgb( $muriel-celadon-500 )};
+		--color-link-dark: #{$muriel-celadon-700};
+		--color-link-dark-rgb: #{hex-to-rgb( $muriel-celadon-700 )};
+		--color-link-light: #{$muriel-celadon-300};
+		--color-link-light-rgb: #{hex-to-rgb( $muriel-celadon-300 )};
+		--color-link-0: #{$muriel-celadon-0};
+		--color-link-0-rgb: #{hex-to-rgb( $muriel-celadon-0 )};
+		--color-link-50: #{$muriel-celadon-50};
+		--color-link-50-rgb: #{hex-to-rgb( $muriel-celadon-50 )};
+		--color-link-100: #{$muriel-celadon-100};
+		--color-link-100-rgb: #{hex-to-rgb( $muriel-celadon-100 )};
+		--color-link-200: #{$muriel-celadon-200};
+		--color-link-200-rgb: #{hex-to-rgb( $muriel-celadon-200 )};
+		--color-link-300: #{$muriel-celadon-300};
+		--color-link-300-rgb: #{hex-to-rgb( $muriel-celadon-300 )};
+		--color-link-400: #{$muriel-celadon-400};
+		--color-link-400-rgb: #{hex-to-rgb( $muriel-celadon-400 )};
+		--color-link-500: #{$muriel-celadon-500};
+		--color-link-500-rgb: #{hex-to-rgb( $muriel-celadon-500 )};
+		--color-link-600: #{$muriel-celadon-600};
+		--color-link-600-rgb: #{hex-to-rgb( $muriel-celadon-600 )};
+		--color-link-700: #{$muriel-celadon-700};
+		--color-link-700-rgb: #{hex-to-rgb( $muriel-celadon-700 )};
+		--color-link-800: #{$muriel-celadon-800};
+		--color-link-800-rgb: #{hex-to-rgb( $muriel-celadon-800 )};
+		--color-link-900: #{$muriel-celadon-900};
+		--color-link-900-rgb: #{hex-to-rgb( $muriel-celadon-900 )};
+
+		--color-button-primary-background-hover: #{$muriel-hot-blue-400};
+		--color-button-primary-scary-background-hover: #{$muriel-hot-red-400};
+
+		--masterbar-color: #{$muriel-white};
+		--masterbar-border-color: #{$muriel-celadon-700};
+		--masterbar-item-new-editor-background: #{$muriel-gray-500};
+		--masterbar-item-new-editor-hover-background: #{$muriel-gray-600};
+		--masterbar-toggle-drafts-editor-background: #{$muriel-gray-600};
+		--masterbar-toggle-drafts-editor-border-color: #{$muriel-gray-100};
+		--masterbar-toggle-drafts-editor-hover-background: #{$muriel-gray-400};
+
+		--sidebar-background: #{$muriel-pink-100};
+		--sidebar-background-gradient: #{hex-to-rgb( $muriel-pink-100 )};
+		--sidebar-secondary-background: #{$muriel-white};
+		--sidebar-secondary-background-gradient: #{hex-to-rgb( $muriel-white )};
+		--sidebar-border-color: #{$muriel-pink-200};
+		--sidebar-text-color: #{$muriel-pink-800};
+		--sidebar-gridicon-fill: #{$muriel-pink-600};
+		--sidebar-heading-color: #{$muriel-pink-700};
+		--sidebar-footer-button-color: #{$muriel-gray-900};
+		--sidebar-menu-link-secondary-text-color: #{$muriel-pink-700};
+		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-pink-100 )};
+		--sidebar-menu-selected-background-color: #{$muriel-hot-blue-50};
+		--sidebar-menu-selected-a-color: #{$muriel-hot-blue-600};
+		--sidebar-menu-selected-a-first-child-after-background: #{hex-to-rgb( $muriel-hot-blue-50 )};
+		--sidebar-menu-hover-background: #{$muriel-pink-400};
+		--sidebar-menu-hover-background-gradient: #{hex-to-rgb( $muriel-pink-400 )};
+		--sidebar-menu-hover-color: #{$muriel-white};
+
+		// TODO: once we replace the current default theme with Classic Bright, we can remove these and increase consistency by using the sidebar colors instead
+		--button-is-borderless-color: #{$muriel-gray-500};
+		--count-border-color: #{$muriel-gray-500};
+		--count-color: #{$muriel-gray-500};
+		--profile-gravatar-user-secondary-info-color: #{$muriel-pink-700};
+	}
 }

--- a/static/images/color-schemes/color-scheme-thumbnail-ocean.svg
+++ b/static/images/color-schemes/color-scheme-thumbnail-ocean.svg
@@ -4,7 +4,7 @@
 	 viewBox="0 0 240 160" style="enable-background:new 0 0 240 160;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#F6F6F6;}
-	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#46799A;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#016087;}
 	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#E9CA7A;}
 	.st3{fill-rule:evenodd;clip-rule:evenodd;fill:#1D232F;}
 	.st4{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}

--- a/static/images/color-schemes/color-scheme-thumbnail-ocean.svg
+++ b/static/images/color-schemes/color-scheme-thumbnail-ocean.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 240 160" style="enable-background:new 0 0 240 160;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#F6F6F6;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#46799A;}
+	.st2{fill-rule:evenodd;clip-rule:evenodd;fill:#E9CA7A;}
+	.st3{fill-rule:evenodd;clip-rule:evenodd;fill:#1D232F;}
+	.st4{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st5{fill-rule:evenodd;clip-rule:evenodd;fill:#B0B5B8;}
+	.st6{fill-rule:evenodd;clip-rule:evenodd;fill:#007565;}
+	.st7{fill-rule:evenodd;clip-rule:evenodd;fill:#23354B;}
+</style>
+<g>
+	<path class="st0" d="M70,20h170v140H70V20z"/>
+	<path class="st1" d="M0,20h70v140H0V20z"/>
+	<path class="st2" d="M0,86h70v16H0V86z"/>
+	<path class="st3" d="M7,91h55v6H7V91z"/>
+	<path class="st4" d="M7,75h37v6H7V75z M7,107h29v6H7V107z M7,123h45v6H7V123z"/>
+	<circle class="st5" cx="35.5" cy="45.5" r="16.5"/>
+	<path class="st4" d="M90,36h130v107H90V36z"/>
+	<path class="st6" d="M163,48h42c1.7,0,3,1.3,3,3v10c0,1.7-1.3,3-3,3h-42c-1.7,0-3-1.3-3-3V51C160,49.3,161.3,48,163,48z"/>
+	<path class="st7" d="M0,0h240v20H0V0z"/>
+</g>
+</svg>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a new color scheme, Ocean, based on the /wp-admin color scheme of the same name.

**Preview**

<img width="1277" alt="Screen Shot 2019-06-06 at 3 33 22 PM" src="https://user-images.githubusercontent.com/2124984/59061059-832d2780-8870-11e9-9a49-cb929f4c7d31.png">

#### Testing instructions

* Switch to this PR and navigate to Me -> Account Settings
* Activate the Ocean color scheme under Dashboard Color Schemes
* Test for color contrast issues and other visual bugs throughout Calypso.