### PR TITLE
People: Email followers "invite" link is inconsistent and hard to read

### DIFF
--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -151,7 +151,7 @@ const Followers = localize(
 			return (
 				<Button primary={ isPrimary } href={ `/people/new/${ site.domain }` }>
 					<Gridicon icon="user-add" />
-					{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
+					<span>{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }</span>
 				</Button>
 			);
 		}

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -192,7 +192,6 @@ const Followers = localize(
 					emptyTitle = preventWidows( this.props.translate( 'No WordPress.com followers yet.' ) );
 				}
 				return <EmptyContent title={ emptyTitle } action={ this.renderInviteFollowersAction() } />;
-				// return <EmptyContent title={ emptyTitle } />;
 			}
 
 			let headerText;

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -10,6 +10,7 @@ import React, { Component } from 'react';
 import deterministicStringify from 'json-stable-stringify';
 import { omit } from 'lodash';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -144,6 +145,17 @@ const Followers = localize(
 			return ! this.props.followers.length && ! this.props.fetching;
 		}
 
+		renderInviteFollowersAction( isPrimary = true ) {
+			const { site, translate } = this.props;
+
+			return (
+				<Button primary={ isPrimary } href={ `/people/new/${ site.domain }` }>
+					<Gridicon icon="user-add" />
+					{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
+				</Button>
+			);
+		}
+
 		isLastPage() {
 			return (
 				this.props.totalFollowers <= this.props.followers.length ||
@@ -172,32 +184,15 @@ const Followers = localize(
 
 			let emptyTitle;
 			if ( this.siteHasNoFollowers() ) {
-				const inviteLink = '/people/new/' + this.props.site.domain;
-
 				if ( this.props.fetchOptions && 'email' === this.props.fetchOptions.type ) {
 					emptyTitle = preventWidows(
-						this.props.translate(
-							'No one is following you by email yet, but you can {{a}}invite up to 10 at a time{{/a}}. test',
-							{
-								components: {
-									a: <a href={ inviteLink } />,
-								},
-							}
-						)
+						this.props.translate( 'No one is following you by email yet.' )
 					);
 				} else {
-					emptyTitle = preventWidows(
-						this.props.translate(
-							'No WordPress.com followers yet, but you can {{a}}invite up to 10 at a time{{/a}}.',
-							{
-								components: {
-									a: <a href={ inviteLink } />,
-								},
-							}
-						)
-					);
+					emptyTitle = preventWidows( this.props.translate( 'No WordPress.com followers yet.' ) );
 				}
-				return <EmptyContent title={ emptyTitle } />;
+				return <EmptyContent title={ emptyTitle } action={ this.renderInviteFollowersAction() } />;
+				// return <EmptyContent title={ emptyTitle } />;
 			}
 
 			let headerText;

--- a/client/my-sites/people/followers-list/index.jsx
+++ b/client/my-sites/people/followers-list/index.jsx
@@ -177,7 +177,7 @@ const Followers = localize(
 				if ( this.props.fetchOptions && 'email' === this.props.fetchOptions.type ) {
 					emptyTitle = preventWidows(
 						this.props.translate(
-							'No one is following you by email yet, but you can {{a}}invite up to 10 at a time{{/a}}.',
+							'No one is following you by email yet, but you can {{a}}invite up to 10 at a time{{/a}}. test',
 							{
 								components: {
 									a: <a href={ inviteLink } />,

--- a/client/my-sites/people/followers-list/style.scss
+++ b/client/my-sites/people/followers-list/style.scss
@@ -1,5 +1,4 @@
-.empty-content.has-title-only .empty-content__title,
-.is-section-people .empty-content__title {
+.is-section-people .empty-content .empty-content__title {
 	font-size: 22px;
 	margin-bottom: 16px;
 }

--- a/client/my-sites/people/followers-list/style.scss
+++ b/client/my-sites/people/followers-list/style.scss
@@ -1,3 +1,5 @@
+.empty-content.has-title-only .empty-content__title,
 .is-section-people .empty-content__title {
 	font-size: 22px;
+	margin-bottom: 16px;
 }

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -214,22 +214,25 @@ class PeopleInvites extends React.PureComponent {
 	}
 
 	renderEmptyContent() {
-		return <EmptyContent title={ null } action={ this.renderInviteUsersAction() } />;
+		const emptyTitle = this.props.translate(
+			'Invite people to follow your site or help you manage it.'
+		);
+		return <EmptyContent title={ emptyTitle } action={ this.renderInviteUsersAction() } />;
 	}
 
 	renderInviteUsersAction( isPrimary = true ) {
 		const { site, translate } = this.props;
 
 		return (
-			<div className="people-invites__invite-users-action">
-				<div className="people-invites__invite-users-message">
-					{ translate( 'Invite people to follow your site or help you manage it.' ) }
-				</div>
-				<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
-					<Gridicon icon="user-add" />
-					{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
-				</Button>
-			</div>
+			// <div className="people-invites__invite-users-action">
+			// 	<div className="people-invites__invite-users-message">
+			// 		{ translate( 'Invite people to follow your site or help you manage it.' ) }
+			// 	</div>
+			<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
+				<Gridicon icon="user-add" />
+				{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
+			</Button>
+			// </div>
 		);
 	}
 

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -226,7 +226,7 @@ class PeopleInvites extends React.PureComponent {
 		return (
 			<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
 				<Gridicon icon="user-add" />
-				{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
+				<span>{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }</span>
 			</Button>
 		);
 	}

--- a/client/my-sites/people/people-invites/index.jsx
+++ b/client/my-sites/people/people-invites/index.jsx
@@ -224,15 +224,10 @@ class PeopleInvites extends React.PureComponent {
 		const { site, translate } = this.props;
 
 		return (
-			// <div className="people-invites__invite-users-action">
-			// 	<div className="people-invites__invite-users-message">
-			// 		{ translate( 'Invite people to follow your site or help you manage it.' ) }
-			// 	</div>
 			<Button primary={ isPrimary } href={ `/people/new/${ site.slug }` }>
 				<Gridicon icon="user-add" />
 				{ translate( 'Invite', { context: 'Verb. Button to invite more users.' } ) }
 			</Button>
-			// </div>
 		);
 	}
 

--- a/client/my-sites/people/people-invites/style.scss
+++ b/client/my-sites/people/people-invites/style.scss
@@ -2,33 +2,6 @@
 	padding: 0;
 }
 
-// .people-invites__invite-users-action {
-// 	.people-invites__invite-users-message {
-// 		margin-bottom: 16px;
-
-// 		.empty-content & {
-// 			font-size: 22px;
-// 		}
-// 	}
-
-// 	.button {
-// 		.gridicon {
-// 			margin-right: 4px;
-// 		}
-// 	}
-
-// 	.people-invites__pending & {
-// 		text-align: center;
-// 		margin: 50px 0;
-// 		@include breakpoint( '<960px' ) {
-// 			margin: 40px 0;
-// 		}
-// 		@include breakpoint( '<480px' ) {
-// 			margin: 30px 0;
-// 		}
-// 	}
-// }
-
 .people-invites__max-items-notice {
 	text-align: center;
 	margin: 16px 0;

--- a/client/my-sites/people/people-invites/style.scss
+++ b/client/my-sites/people/people-invites/style.scss
@@ -2,32 +2,32 @@
 	padding: 0;
 }
 
-.people-invites__invite-users-action {
-	.people-invites__invite-users-message {
-		margin-bottom: 16px;
+// .people-invites__invite-users-action {
+// 	.people-invites__invite-users-message {
+// 		margin-bottom: 16px;
 
-		.empty-content & {
-			font-size: 22px;
-		}
-	}
+// 		.empty-content & {
+// 			font-size: 22px;
+// 		}
+// 	}
 
-	.button {
-		.gridicon {
-			margin-right: 4px;
-		}
-	}
+// 	.button {
+// 		.gridicon {
+// 			margin-right: 4px;
+// 		}
+// 	}
 
-	.people-invites__pending & {
-		text-align: center;
-		margin: 50px 0;
-		@include breakpoint( '<960px' ) {
-			margin: 40px 0;
-		}
-		@include breakpoint( '<480px' ) {
-			margin: 30px 0;
-		}
-	}
-}
+// 	.people-invites__pending & {
+// 		text-align: center;
+// 		margin: 50px 0;
+// 		@include breakpoint( '<960px' ) {
+// 			margin: 40px 0;
+// 		}
+// 		@include breakpoint( '<480px' ) {
+// 			margin: 30px 0;
+// 		}
+// 	}
+// }
 
 .people-invites__max-items-notice {
 	text-align: center;


### PR DESCRIPTION
Related: https://github.com/Automattic/wp-calypso/issues/33708


When the Email Followers page (under the people nav item) is empty, a link is provided within the text that is difficult to read. It's also inconsistent with the standard wordpress.com design pattern of the primary button for pages that are empty. See the graphic below.

![email-followers-link](https://user-images.githubusercontent.com/214813/59059097-1f086480-886c-11e9-8a36-4e5b403610c1.jpg)



I'll be picking this bottle up by adding a primary button to this empty page and removing the text link