### PR TITLE
JP Checklist: Update Performance Related Tasks after completion

### DIFF
--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -17,7 +17,7 @@ const markChecklistTaskComplete = ( state, taskId ) => ( {
 const moduleTaskMap = {
 	lazy_images: 'jetpack_lazy_images',
 	monitor: 'jetpack_monitor',
-	// Both photon and photon-cdn mark the Site Accelerator Task as enabled
+	// Both photon and photon-cdn mark the Site Accelerator Task as completed
 	photon: 'jetpack_site_accelerator',
 	'photon-cdn': 'jetpack_site_accelerator',
 	search: 'jetpack_search',

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -4,6 +4,7 @@
 import { combineReducers, keyedReducer } from 'state/utils';
 import {
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
+	JETPACK_MODULE_DEACTIVATE_SUCCESS,
 	SITE_CHECKLIST_RECEIVE,
 	SITE_CHECKLIST_TASK_UPDATE,
 } from 'state/action-types';
@@ -33,6 +34,17 @@ function items( state = {}, action ) {
 		case JETPACK_MODULE_ACTIVATE_SUCCESS:
 			if ( moduleTaskMap.hasOwnProperty( action.moduleSlug ) ) {
 				return markChecklistTaskComplete( state, moduleTaskMap[ action.moduleSlug ] );
+			}
+			break;
+		case JETPACK_MODULE_DEACTIVATE_SUCCESS:
+			if ( action.moduleSlug === 'photon' || action.moduleSlug === 'photon-cdn' ) {
+				// We can't know if the other module is still active, so we don't change
+				// Site Accelerator task completion state.
+				return;
+			}
+
+			if ( moduleTaskMap.hasOwnProperty( action.moduleSlug ) ) {
+				return toggleChecklistTask( state, moduleTaskMap[ action.moduleSlug ] );
 			}
 			break;
 	}

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -14,6 +14,16 @@ const markChecklistTaskComplete = ( state, taskId ) => ( {
 	tasks: { ...state.tasks, [ taskId ]: true },
 } );
 
+const moduleTaskMap = {
+	lazy_images: 'jetpack_lazy_images',
+	monitor: 'jetpack_monitor',
+	// Both photon and photon-cdn mark the Site Accelerator Task as enabled
+	photon: 'jetpack_site_accelerator',
+	'photon-cdn': 'jetpack_site_accelerator',
+	search: 'jetpack_search',
+	videopress: 'jetpack_video_hosting',
+};
+
 function items( state = {}, action ) {
 	switch ( action.type ) {
 		case SITE_CHECKLIST_RECEIVE:
@@ -21,8 +31,8 @@ function items( state = {}, action ) {
 		case SITE_CHECKLIST_TASK_UPDATE:
 			return markChecklistTaskComplete( state, action.taskId );
 		case JETPACK_MODULE_ACTIVATE_SUCCESS:
-			if ( action.moduleSlug === 'monitor' ) {
-				return markChecklistTaskComplete( state, 'jetpack_monitor' );
+			if ( moduleTaskMap.hasOwnProperty( action.moduleSlug ) ) {
+				return markChecklistTaskComplete( state, moduleTaskMap[ action.moduleSlug ] );
 			}
 			break;
 	}

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -15,11 +15,11 @@ import {
 } from 'state/action-types';
 import { items as itemSchemas } from './schema';
 
-const toggleChecklistTask = ( state, taskId ) => ( {
+const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 	...state,
 	tasks: {
 		...state.tasks,
-		[ taskId ]: { completed: ! get( state.tasks, [ taskId, 'completed' ], false ) },
+		[ taskId ]: { ...get( state.tasks, [ taskId ] ), completed },
 	},
 } );
 
@@ -38,10 +38,10 @@ function items( state = {}, action ) {
 		case SITE_CHECKLIST_RECEIVE:
 			return action.checklist;
 		case SITE_CHECKLIST_TASK_UPDATE:
-			return toggleChecklistTask( state, action.taskId );
+			return setChecklistTaskCompletion( state, action.taskId, true );
 		case JETPACK_MODULE_ACTIVATE_SUCCESS:
 			if ( moduleTaskMap.hasOwnProperty( action.moduleSlug ) ) {
-				return toggleChecklistTask( state, moduleTaskMap[ action.moduleSlug ] );
+				return setChecklistTaskCompletion( state, moduleTaskMap[ action.moduleSlug ], true );
 			}
 			break;
 		case JETPACK_MODULE_DEACTIVATE_SUCCESS:
@@ -52,7 +52,7 @@ function items( state = {}, action ) {
 			}
 
 			if ( moduleTaskMap.hasOwnProperty( action.moduleSlug ) ) {
-				return toggleChecklistTask( state, moduleTaskMap[ action.moduleSlug ] );
+				return setChecklistTaskCompletion( state, moduleTaskMap[ action.moduleSlug ], false );
 			}
 			break;
 	}

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import { combineReducers, keyedReducer } from 'state/utils';
@@ -10,9 +15,12 @@ import {
 } from 'state/action-types';
 import { items as itemSchemas } from './schema';
 
-const markChecklistTaskComplete = ( state, taskId ) => ( {
+const toggleChecklistTask = ( state, taskId ) => ( {
 	...state,
-	tasks: { ...state.tasks, [ taskId ]: { completed: true } },
+	tasks: {
+		...state.tasks,
+		[ taskId ]: { completed: ! get( state.tasks, [ taskId, 'completed' ], false ) },
+	},
 } );
 
 const moduleTaskMap = {
@@ -30,10 +38,10 @@ function items( state = {}, action ) {
 		case SITE_CHECKLIST_RECEIVE:
 			return action.checklist;
 		case SITE_CHECKLIST_TASK_UPDATE:
-			return markChecklistTaskComplete( state, action.taskId );
+			return toggleChecklistTask( state, action.taskId );
 		case JETPACK_MODULE_ACTIVATE_SUCCESS:
 			if ( moduleTaskMap.hasOwnProperty( action.moduleSlug ) ) {
-				return markChecklistTaskComplete( state, moduleTaskMap[ action.moduleSlug ] );
+				return toggleChecklistTask( state, moduleTaskMap[ action.moduleSlug ] );
 			}
 			break;
 		case JETPACK_MODULE_DEACTIVATE_SUCCESS:

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -11,7 +11,7 @@ import { items as itemSchemas } from './schema';
 
 const markChecklistTaskComplete = ( state, taskId ) => ( {
 	...state,
-	tasks: { ...state.tasks, [ taskId ]: true },
+	tasks: { ...state.tasks, [ taskId ]: { completed: true } },
 } );
 
 const moduleTaskMap = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Mark performance related tasks as complete right when enabling the corresponding Jetpack Module (using the respective toggles on the performance settings screen).

Previously, a user returning to the checklist after enabling that toggle would see the corresponding checklist item as still to-be-completed.

This solution extends a prior one which was specific to the Downtime Monitoring (Security) task (#33193).

#### Testing instructions

- Start Calypso locally, using this branch
- Create a new jurassic.ninja site
- Locate the 'Connect to WP.com' button in wp-admin, copy its link target, and append `&calypso_env=development` to it. Navigate to that URL.
- Select a paid plan
- On the 'Thank You' page, locate the Performance checklist
- Select any task from it, and click the 'Do it!' button next to it
- You're taken to the performance settings page. Locate the toggle relevant to the task you selected from the checklist, and enable it.
- Go back to the checklist
- Verify that the task is now marked as completed (possibly after a _very_ brief delay)

~Note that after a reload, the tasks will be shown as incomplete again. To change that behavior, we need to make a server-side change, D29166-code.~ Deployed :heavy_check_mark: 