### PR TITLE
JP Checklist: Fix Site Accelerator Task Completed Link Target

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
@@ -74,8 +74,7 @@ export const JETPACK_PERFORMANCE_CHECKLIST_TASKS: Readonly< ChecklistTasksetUi >
 		description: translate(
 			'Serve your images and static files through our global CDN and whatch your page load time drop.'
 		),
-		getUrl: ( siteSlug, isComplete ) =>
-			isComplete ? `/media/${ siteSlug }` : `/settings/performance/${ siteSlug }`,
+		getUrl: siteSlug => `/settings/performance/${ siteSlug }`,
 		completedButtonText: translate( 'Configure' ),
 		completedTitle: translate(
 			'Site accelerator is serving your images and static files through our global CDN.'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

JP Checklist: Fix Site Accelerator Task Completed Link Target

Per #33168:

> The "do it" button should link to /settings/performance/ [...]
> Once the task is completed, the button is replaced by a "configure" link that links to the same page.

#### Testing instructions

- Start Calypso locally, using this branch
- Create a new jurassic.ninja site
- Locate the 'Connect to WP.com' button in wp-admin, copy its link target, and append `&calypso_env=development` to it. Navigate to that URL.
- Select a paid plan
- On the 'Thank You' page, locate the Performance checklist
- Locate the Site Accelerator task, and click the 'Do it!' button next to it
- You're taken to the performance settings page. Locate the Site Accelerator toggle, and enable it.
- Go back to the checklist
- Verify that the task is now marked as completed (possibly after reloading)
- Verify that it now has a 'Configure' link.
- Click it, and verify that it takes you back to the performance settings page.
