### PR TITLE
Jetpack performance checklist: Use correct url for completed task

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
@@ -74,8 +74,7 @@ export const JETPACK_PERFORMANCE_CHECKLIST_TASKS: Readonly< ChecklistTasksetUi >
 		description: translate(
 			'Serve your images and static files through our global CDN and whatch your page load time drop.'
 		),
-		getUrl: ( siteSlug, isComplete ) =>
-			isComplete ? `/media/${ siteSlug }` : `/settings/performance/${ siteSlug }`,
+		getUrl: siteSlug => `/settings/performance/${ siteSlug }`,
 		completedButtonText: translate( 'Configure' ),
 		completedTitle: translate(
 			'Site accelerator is serving your images and static files through our global CDN.'


### PR DESCRIPTION
The Site Accelerator task had the wrong URL when complete. Fix it.

#### Testing instructions

* Go to the Jetpack Checklist (`/plans/my-plan/SITE_SLUG` for a Jetpack site)
* See site accelerator is disabled
* Enable site accelerator
* Return to checklist
* Confirm that the completed link "configure" goes to the right place (performance settings)
