### PR TITLE
Full Site Editing: Add Site Logo Block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -30,6 +30,7 @@ function a8c_load_full_site_editing() {
 	require_once __DIR__ . '/full-site-editing/blocks/navigation-menu/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/post-content/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/template/index.php';
+	require_once __DIR__ . '/full-site-editing/blocks/site-logo/index.php';
 	require_once __DIR__ . '/full-site-editing/class-a8c-rest-templates-controller.php';
 	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
 	require_once __DIR__ . '/full-site-editing/utils/class-a8c-wp-template.php';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
@@ -10,11 +10,11 @@ import { addQueryArgs } from '@wordpress/url';
 
 function SiteLogoEdit( { className } ) {
 	const navigateToCustomerSiteIdentity = () => {
-		const siteIdenityLink = addQueryArgs( 'customize.php', {
+		const siteIdentityLink = addQueryArgs( 'customize.php', {
 			'autofocus[section]': 'title_tagline',
 			return: window.location.href,
 		} );
-		window.location.href = siteIdenityLink;
+		window.location.href = siteIdentityLink;
 	};
 
 	return (

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
@@ -2,12 +2,14 @@
  * External dependencies
  */
 import { IconButton, ServerSideRender, Toolbar } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Component, Fragment, createRef } from '@wordpress/element';
 import { BlockControls } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 class SiteLogoEdit extends Component {
+	siteLogo = createRef();
+
 	navigateToCustomerSiteIdentity() {
 		const siteIdenityLink = addQueryArgs( 'customize.php', {
 			'autofocus[section]': 'title_tagline',
@@ -28,7 +30,11 @@ class SiteLogoEdit extends Component {
 						/>
 					</Toolbar>
 				</BlockControls>
-				<ServerSideRender block="a8c/site-logo" attributes={ { addSiteLink: false } } />
+				<ServerSideRender
+					ref={ this.siteLogo }
+					block="a8c/site-logo"
+					attributes={ { editorPreview: true } }
+				/>
 			</Fragment>
 		);
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
@@ -1,3 +1,4 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 /**
  * External dependencies
  */
@@ -8,16 +9,24 @@ import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 function SiteLogoEdit( { className } ) {
-	const siteIdentityUrl = addQueryArgs( 'customize.php', {
-		'autofocus[section]': 'title_tagline',
-		return: window.location.href,
-	} );
+	const navigateToCustomerSiteIdentity = () => {
+		const siteIdenityLink = addQueryArgs( 'customize.php', {
+			'autofocus[section]': 'title_tagline',
+			return: window.location.href,
+		} );
+		window.location.href = siteIdenityLink;
+	};
 
 	return (
 		<Fragment>
 			<BlockControls>
 				<Toolbar>
-					<IconButton icon="edit" label={ __( 'Edit Site Logo' ) } href={ siteIdentityUrl } />
+					<IconButton
+						className={ 'components-toolbar__control' }
+						icon="edit"
+						label={ __( 'Edit Site Logo' ) }
+						onClick={ navigateToCustomerSiteIdentity }
+					/>
 				</Toolbar>
 			</BlockControls>
 			<ServerSideRender

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
@@ -2,14 +2,12 @@
  * External dependencies
  */
 import { IconButton, ServerSideRender, Toolbar } from '@wordpress/components';
-import { Component, Fragment, createRef } from '@wordpress/element';
+import { Component, Fragment } from '@wordpress/element';
 import { BlockControls } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 class SiteLogoEdit extends Component {
-	siteLogo = createRef();
-
 	navigateToCustomerSiteIdentity() {
 		const siteIdenityLink = addQueryArgs( 'customize.php', {
 			'autofocus[section]': 'title_tagline',
@@ -30,11 +28,7 @@ class SiteLogoEdit extends Component {
 						/>
 					</Toolbar>
 				</BlockControls>
-				<ServerSideRender
-					ref={ this.siteLogo }
-					block="a8c/site-logo"
-					attributes={ { editorPreview: true } }
-				/>
+				<ServerSideRender block="a8c/site-logo" attributes={ { editorPreview: true } } />
 			</Fragment>
 		);
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
@@ -2,36 +2,31 @@
  * External dependencies
  */
 import { IconButton, ServerSideRender, Toolbar } from '@wordpress/components';
-import { Component, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { BlockControls } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
-class SiteLogoEdit extends Component {
-	navigateToCustomerSiteIdentity() {
-		const siteIdenityLink = addQueryArgs( 'customize.php', {
-			'autofocus[section]': 'title_tagline',
-			return: window.location.href,
-		} );
-		window.location.href = siteIdenityLink;
-	}
+function SiteLogoEdit( { className } ) {
+	const siteIdentityUrl = addQueryArgs( 'customize.php', {
+		'autofocus[section]': 'title_tagline',
+		return: window.location.href,
+	} );
 
-	render() {
-		return (
-			<Fragment>
-				<BlockControls>
-					<Toolbar>
-						<IconButton
-							icon="edit"
-							label={ __( 'Edit Site Logo' ) }
-							onClick={ this.navigateToCustomerSiteIdentity }
-						/>
-					</Toolbar>
-				</BlockControls>
-				<ServerSideRender block="a8c/site-logo" attributes={ { editorPreview: true } } />
-			</Fragment>
-		);
-	}
+	return (
+		<Fragment>
+			<BlockControls>
+				<Toolbar>
+					<IconButton icon="edit" label={ __( 'Edit Site Logo' ) } href={ siteIdentityUrl } />
+				</Toolbar>
+			</BlockControls>
+			<ServerSideRender
+				className={ className }
+				block="a8c/site-logo"
+				attributes={ { editorPreview: true } }
+			/>
+		</Fragment>
+	);
 }
 
 export default SiteLogoEdit;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/edit.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { IconButton, ServerSideRender, Toolbar } from '@wordpress/components';
+import { Component, Fragment } from '@wordpress/element';
+import { BlockControls } from '@wordpress/editor';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+class SiteLogoEdit extends Component {
+	navigateToCustomerSiteIdentity() {
+		const siteIdenityLink = addQueryArgs( 'customize.php', {
+			'autofocus[section]': 'title_tagline',
+			return: window.location.href,
+		} );
+		window.location.href = siteIdenityLink;
+	}
+
+	render() {
+		return (
+			<Fragment>
+				<BlockControls>
+					<Toolbar>
+						<IconButton
+							icon="edit"
+							label={ __( 'Edit Site Logo' ) }
+							onClick={ this.navigateToCustomerSiteIdentity }
+						/>
+					</Toolbar>
+				</BlockControls>
+				<ServerSideRender block="a8c/site-logo" attributes={ { addSiteLink: false } } />
+			</Fragment>
+		);
+	}
+}
+
+export default SiteLogoEdit;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import edit from './edit';
+import './style.scss';
 
 registerBlockType( 'a8c/site-logo', {
 	title: __( 'Site Logo' ),

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.js
@@ -18,7 +18,7 @@ registerBlockType( 'a8c/site-logo', {
 	category: 'layout',
 	keywords: [ __( 'logo' ), __( 'icon' ), __( 'site' ) ],
 	edit: () => {
-		return <ServerSideRender block="a8c/site-logo" />;
+		return <ServerSideRender block="a8c/site-logo" attributes={ { addSiteLink: false } } />;
 	},
 	save: () => null,
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.js
@@ -7,8 +7,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import './style.scss';
-import './edit.scss';
 import edit from './edit';
 
 registerBlockType( 'a8c/site-logo', {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { ServerSideRender } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+import './edit.scss';
+
+registerBlockType( 'a8c/site-logo', {
+	title: __( 'Site Logo' ),
+	description: __( 'Site Logo' ),
+	icon: 'format-image',
+	category: 'layout',
+	keywords: [ __( 'logo' ), __( 'icon' ), __( 'site' ) ],
+	edit: () => {
+		return <ServerSideRender block="a8c/site-logo" />;
+	},
+	save: () => null,
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.js
@@ -3,13 +3,13 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-import { ServerSideRender } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 import './edit.scss';
+import edit from './edit';
 
 registerBlockType( 'a8c/site-logo', {
 	title: __( 'Site Logo' ),
@@ -17,8 +17,6 @@ registerBlockType( 'a8c/site-logo', {
 	icon: 'format-image',
 	category: 'layout',
 	keywords: [ __( 'logo' ), __( 'icon' ), __( 'site' ) ],
-	edit: () => {
-		return <ServerSideRender block="a8c/site-logo" attributes={ { addSiteLink: false } } />;
-	},
+	edit,
 	save: () => null,
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Render site-logo block file.
+ *
+ * @package full-site-editing
+ */
+
+/**
+ * Renders a site-logo.
+ *
+ * @param array  $attributes Block attributes.
+ * @param string $content    Block content.
+ * @return string
+ */
+function render_site_logo( $attributes, $content ) {
+
+	if ( ! function_exists( 'get_custom_logo' ) || ! function_exists( 'has_custom_logo' ) ) {
+		return '';
+	}
+
+	if ( ! has_custom_logo() ) {
+		return '';
+	}
+
+	return get_custom_logo();
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.php
@@ -13,6 +13,13 @@
  * @return string
  */
 function render_site_logo( $attributes, $content ) {
+	if ( $attributes[ 'editorPreview' ] === true ) {
+		return render_site_logo_editor_preview( $attributes, $content );
+	}
+	return render_site_logo_publish( $attributes, $content );
+}
+
+function render_site_logo_publish( $attributes, $content ) {
 
 	if ( ! function_exists( 'get_custom_logo' ) || ! function_exists( 'has_custom_logo' ) ) {
 		return '';
@@ -22,18 +29,23 @@ function render_site_logo( $attributes, $content ) {
 		return '';
 	}
 
-	$add_site_link = $attributes['addSiteLink'];
-
 	//publish view
-	if ( $add_site_link ) {
-		return get_custom_logo();
+	return get_custom_logo();
+}
+
+function render_site_logo_editor_preview( $attributes, $content ) {
+
+	if ( ! function_exists( 'get_custom_logo' ) || ! function_exists( 'has_custom_logo' ) ) {
+		return sprintf( '<div class="components-placeholder"><div class="components-placeholder__label">%1$s</div></components-placeholder__label><div class="components-placeholder__instructions">%2$s</div></div>', __( 'Site Logo', 'full-site-editing' ), __( 'No Logo Support!', 'full-site-editing' ) );
 	}
 
-	//edit view
+	if ( ! has_custom_logo() ) {
+		return sprintf( '<div class="components-placeholder has-no-logo"><div class="components-placeholder__label">%1$s</div></components-placeholder__label><div class="components-placeholder__instructions">%2$s</div></div>', __( 'Site Logo', 'full-site-editing' ), __( 'Click on the Edit button to select a Site Logo', 'full-site-editing' ) );
+	}
+
+	//render without wrapping link to avoid, navigation away from the editor
 	$custom_logo_id = get_theme_mod( 'custom_logo' );
 	return wp_get_attachment_image( $custom_logo_id , 'full', false, array(
 		'class'    => 'custom-logo',
 	) );
-
-
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.php
@@ -20,7 +20,6 @@ function render_site_logo( $attributes, $content ) {
 }
 
 function render_site_logo_publish( $attributes, $content ) {
-
 	if ( ! function_exists( 'get_custom_logo' ) || ! function_exists( 'has_custom_logo' ) ) {
 		return '';
 	}
@@ -33,13 +32,12 @@ function render_site_logo_publish( $attributes, $content ) {
 }
 
 function render_site_logo_editor_preview( $attributes, $content ) {
-
 	if ( ! function_exists( 'get_custom_logo' ) || ! function_exists( 'has_custom_logo' ) ) {
 		return sprintf( '<div class="components-placeholder"><div class="components-placeholder__label">%1$s</div></components-placeholder__label><div class="components-placeholder__instructions">%2$s</div></div>', __( 'Site Logo', 'full-site-editing' ), __( 'No Logo Support!', 'full-site-editing' ) );
 	}
 
 	if ( ! has_custom_logo() ) {
-		return sprintf( '<div class="components-placeholder has-no-logo"><div class="components-placeholder__label">%1$s</div></components-placeholder__label><div class="components-placeholder__instructions">%2$s</div></div>', __( 'Site Logo', 'full-site-editing' ), __( 'Click on the Edit button to select a Site Logo', 'full-site-editing' ) );
+		return sprintf( '<div class="components-placeholder has-no-logo"><div class="components-placeholder__label">%1$s</div></components-placeholder__label><div class="components-placeholder__instructions">%2$s</div></div>', __( 'Site Logo', 'full-site-editing' ), __( 'Click on the Edit button to select a Site Logo.', 'full-site-editing' ) );
 	}
 
 	return get_custom_logo();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.php
@@ -22,5 +22,18 @@ function render_site_logo( $attributes, $content ) {
 		return '';
 	}
 
-	return get_custom_logo();
+	$add_site_link = $attributes['addSiteLink'];
+
+	//publish view
+	if ( $add_site_link ) {
+		return get_custom_logo();
+	}
+
+	//edit view
+	$custom_logo_id = get_theme_mod( 'custom_logo' );
+	return wp_get_attachment_image( $custom_logo_id , 'full', false, array(
+		'class'    => 'custom-logo',
+	) );
+
+
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/index.php
@@ -29,7 +29,6 @@ function render_site_logo_publish( $attributes, $content ) {
 		return '';
 	}
 
-	//publish view
 	return get_custom_logo();
 }
 
@@ -43,9 +42,5 @@ function render_site_logo_editor_preview( $attributes, $content ) {
 		return sprintf( '<div class="components-placeholder has-no-logo"><div class="components-placeholder__label">%1$s</div></components-placeholder__label><div class="components-placeholder__instructions">%2$s</div></div>', __( 'Site Logo', 'full-site-editing' ), __( 'Click on the Edit button to select a Site Logo', 'full-site-editing' ) );
 	}
 
-	//render without wrapping link to avoid, navigation away from the editor
-	$custom_logo_id = get_theme_mod( 'custom_logo' );
-	return wp_get_attachment_image( $custom_logo_id , 'full', false, array(
-		'class'    => 'custom-logo',
-	) );
+	return get_custom_logo();
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-logo/style.scss
@@ -1,0 +1,3 @@
+.wp-block-a8c-site-logo {
+  pointer-events: none;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -350,6 +350,12 @@ class Full_Site_Editing {
 		register_block_type(
 			'a8c/site-logo',
 			array(
+				'attributes'      => array(
+					'addSiteLink'    => array(
+						'type'      => 'boolean',
+						'default'   => true,
+					),
+				),
 				'render_callback' => 'render_site_logo',
 			)
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -351,9 +351,9 @@ class Full_Site_Editing {
 			'a8c/site-logo',
 			array(
 				'attributes'      => array(
-					'addSiteLink'    => array(
+					'editorPreview'    => array(
 						'type'      => 'boolean',
-						'default'   => true,
+						'default'   => false,
 					),
 				),
 				'render_callback' => 'render_site_logo',

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -346,6 +346,13 @@ class Full_Site_Editing {
 				'render_callback' => 'render_template_block',
 			)
 		);
+
+		register_block_type(
+			'a8c/site-logo',
+			array(
+				'render_callback' => 'render_site_logo',
+			)
+		);
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
@@ -4,4 +4,5 @@
 import './blocks/navigation-menu';
 import './blocks/post-content';
 import './blocks/template';
+import './blocks/site-logo';
 import './plugins/template-selector-sidebar';


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/33108 This adds a dynamic Site Logo block that links to the customizer.

![editing](https://user-images.githubusercontent.com/1270189/59454721-90de3200-8dc7-11e9-8cd1-0a176550618c.gif)

<img width="714" alt="Screen Shot 2019-06-13 at 10 17 05 AM" src="https://user-images.githubusercontent.com/1270189/59453367-95edb200-8dc4-11e9-879e-79f864372114.png">

<img width="703" alt="Screen Shot 2019-06-13 at 10 41 46 AM" src="https://user-images.githubusercontent.com/1270189/59454866-e0246280-8dc7-11e9-83f6-f71ade617cb4.png">

We can follow up in future PRs to add related endpoints:
- so we can use a JS placeholder in the edit view
- set the theme site logo within the block editor

High Level Questions
=====

<img width="300" alt="Screen Shot 2019-06-11 at 4 41 57 PM" src="https://user-images.githubusercontent.com/1270189/59316331-c6253b80-8c72-11e9-9e58-5e63afaa7407.png">

- We're essentially re-creating some functionality here that mimics Media&Text if we follow mocks. Do we need an explicit site-logo block here, or should we pre-fill the header template with theme information?
- If we do want an explicit block is there an easier method for wrapping data needs? Mainly the only modification here would be to wrap Media&Text to pre-populate the image with theme site-logo data if that's set. Ideally we wouldn't cause a nesting layer here though.
- If we decide to not use dynamic blocks, should the related endpoint be namespaced to the plugin, or to an existing wpcom namespace? (I still need to verify if we need any additional middleware work if we go down this plugin namespace path).

Testing Instructions
=====

- Checkout this branch locally. From the Calypso root directly run `npx lerna run build --scope='@automattic/full-site-editing'`
-  Simlink into your local WordPress instance:
For example:
```
ln -s ~/Dev/wp-calypso/apps/full-site-editing/full-site-editing-plugin/ ~/Dev/wordpress/wp-content/plugins/full-site-editing-plugin
ln -s ~/Dev/wp-calypso/apps/full-site-editing/blank-theme/ ~/Dev/wordpress/wp-content/themes/blank-theme
```
- If you have a working Gutenberg development environment an alternative is adding paths to volumes in docker-compose.yml for example:
```
    volumes:
      - wordpress_data:/var/www/html
      - .:/var/www/html/wp-content/plugins/gutenberg
      - ./packages/e2e-tests/plugins:/var/www/html/wp-content/plugins/gutenberg-test-plugins
      - ./packages/e2e-tests/mu-plugins:/var/www/html/wp-content/mu-plugins
      - ../wp-calypso/apps/full-site-editing/full-site-editing-plugin:/var/www/html/wp-content/plugins/full-site-editing-plugin
      - ../wp-calypso/apps/full-site-editing/blank-theme:/var/www/html/wp-content/themes/blank-theme
```
- visit /wp-admin/plugins.php and activate the Full Site Editing Plugin
- navigate to /wp-admin/post-new.php?post_type=page
- Try adding the site logo block. The value should reflect the current site logo block
- Clicking on edit redirects to the Site Identity section in Customizer

Additional background
====

- Site Logos are stored per site, per theme. This is set as part of a set of theme mods as a site option. https://developer.wordpress.org/reference/functions/get_theme_mods/ internal usage is normally get_theme_mod( 'custom_logo' ). There are multiple backing implementations.
- What can be modified depends on the theme/styling. So some themes might allow for sizing, but others like Twenty Nineteen only allow one to select a logo and that's it.

In the long run a block like this likely only needs to exist during the transition period were we'd like to support more Themes while pieces transition to full block page templates. After logic is removed from the PHP header, I can't think of a good reason not to use a normal image in a template_part "header".

When that happens, the theme will not implement https://developer.wordpress.org/themes/functionality/custom-logo/ and instead the template_part "header" could have an image block placeholder.

See also:
https://developer.wordpress.org/themes/functionality/custom-logo/
https://developer.wordpress.org/reference/functions/the_custom_logo/