### PR TITLE
wpcalypso-async Babel transform: use the right AST form to create import() call

### DIFF
--- a/packages/babel-plugin-transform-wpcalypso-async/index.js
+++ b/packages/babel-plugin-transform-wpcalypso-async/index.js
@@ -101,9 +101,7 @@ module.exports = ( { types: t } ) => {
 						`webpackChunkName: "${ chunkName }"`,
 						false
 					);
-					const importCall = t.callExpression( t.identifier( 'import' ), [
-						argumentWithMagicComments,
-					] );
+					const importCall = t.callExpression( t.import(), [ argumentWithMagicComments ] );
 
 					let statement;
 					if ( callback ) {


### PR DESCRIPTION
Fixes a bug where the transform creates a `import()` statement by adding `types.identifier( 'import' )` to the AST. But dynamic `import()` is not an identifier. It's a special form that has its own AST type. The right way to create it is `types.import()`.

This caused trouble if other Babel transform tried to transform the `import()` call into something else. E.g., `babel-plugin-dynamic-import-node` transforms it into a Node.js-compatible code that uses `require` and promises.

Fixes failing tests in #33585 and unblocks it.