### PR TITLE
Build: Quiet down output from clean:packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,7 @@
 		"clean": "npm run -s clean:build && npm run -s clean:devdocs && npm run -s clean:public && npm run -s clean:packages",
 		"clean:build": "npx rimraf build server/bundler/*.json .babel-cache",
 		"clean:devdocs": "npx rimraf server/devdocs/search-index.js server/devdocs/proptypes-index.json server/devdocs/components-usage-stats.json",
-		"clean:packages": "npx lerna run clean",
+		"clean:packages": "npx lerna run clean --stream",
 		"clean:public": "npx rimraf public",
 		"distclean": "npm run -s clean && npx rimraf node_modules packages/*/node_modules test/e2e/node_modules",
 		"docker": "docker run -it --name wp-calypso --rm -p 80:3000 wp-calypso",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Use `--stream` to mimic how we run `build-packages`. This results in a tighter output when running `npm run clean`.

#### Testing instructions

* Try `npm run clean`. It should have more condensed output.

