### PR TITLE
Migrate CSS for post-excerpt

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -30,7 +30,6 @@
 @import 'components/mobile-back-to-sidebar/style';
 @import 'components/notice/style';
 @import 'components/popover/style';
-@import 'components/post-excerpt/style';
 @import 'components/rewind-credentials-form/style';
 @import 'components/section-nav/style';
 @import 'components/segmented-control/style';

--- a/client/components/post-excerpt/index.jsx
+++ b/client/components/post-excerpt/index.jsx
@@ -8,6 +8,11 @@ import classnames from 'classnames';
 import AutoDirection from 'components/auto-direction';
 import Emojify from 'components/emojify';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class PostExcerpt extends React.Component {
 	static propTypes = {
 		content: PropTypes.string.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate CSS for post-excerpt

#### Testing instructions

* Check the post excerpts used in the reader. Should look like they do now.
* Good example: https://wordpress.com/read/feeds/24808863/posts/2302830168

Refs #27515
