### PR TITLE
css: migrate components/legend-item styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -15,7 +15,6 @@
 @import 'components/date-picker/style';
 @import 'components/dialog/style';
 @import 'components/info-popover/style';
-@import 'components/legend-item/style';
 @import 'components/locale-suggestions/style';
 @import 'components/main/style';
 @import 'components/mobile-back-to-sidebar/style';

--- a/client/components/legend-item/index.js
+++ b/client/components/legend-item/index.js
@@ -7,6 +7,11 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { noop } from 'lodash';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const SVG_SIZE = 30;
 
 class LegendItem extends Component {

--- a/client/components/legend-item/index.js
+++ b/client/components/legend-item/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -11,6 +9,8 @@ import { noop } from 'lodash';
  * Style dependencies
  */
 import './style.scss';
+
+export { default as LegendItemPlaceholder } from './placeholder';
 
 const SVG_SIZE = 30;
 

--- a/client/components/legend-item/placeholder.js
+++ b/client/components/legend-item/placeholder.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */

--- a/client/components/pie-chart/legend-placeholder.js
+++ b/client/components/pie-chart/legend-placeholder.js
@@ -10,7 +10,7 @@ import { get, maxBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import LegendItemPlaceholder from 'components/legend-item/placeholder';
+import { LegendItemPlaceholder } from 'components/legend-item';
 
 function getLongestName( dataSeriesInfo ) {
 	return get( maxBy( dataSeriesInfo, 'name.length' ), 'name', '' );

--- a/client/components/pie-chart/style.scss
+++ b/client/components/pie-chart/style.scss
@@ -69,19 +69,3 @@
 	@include placeholder();
 	fill: var( --color-neutral-0 );
 }
-
-.pie-chart__placeholder-legend-item {
-	display: flex;
-	margin-top: 22px;
-}
-
-.pie-chart__placeholder-legend-item-detail {
-	flex: 0 0 100%;
-}
-
-.pie-chart__placeholder-legend-item-detail-element {
-	@include placeholder();
-	width: 90%;
-	height: 20px;
-	margin-bottom: 14px;
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate `components/legend-item` styles to be processed by webpack

#### Testing instructions

**Note:** To be able to test this you need to have a _verified_ business connected to your WP.com site. Otherwise you won't see the charts.

* Open [calypso.live](https://calypso.live/?branch=update/css-legend-item) on `/stats` and choose the _"Google My Business"_ section
* Make sure legend items for all the charts look the same as on master (see screenshots below)

<img width="132" alt="Screenshot 2019-06-26 at 09 20 43" src="https://user-images.githubusercontent.com/9202899/60159962-a22a3400-97f4-11e9-9f93-2c96d182177a.png">
<img width="366" alt="Screenshot 2019-06-26 at 09 20 47" src="https://user-images.githubusercontent.com/9202899/60159963-a22a3400-97f4-11e9-9ff1-1fecbabcb15d.png">
<img width="451" alt="Screenshot 2019-06-26 at 09 20 53" src="https://user-images.githubusercontent.com/9202899/60159964-a22a3400-97f4-11e9-9fcb-a944e465e17d.png">


Fixes #33717 (part of #27515)
