### PR TITLE
FSE: Add a site description block.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -29,6 +29,7 @@ function a8c_load_full_site_editing() {
 	require_once __DIR__ . '/lib/feature-flags/class-a8c-full-site-editing-feature-flags.php';
 	require_once __DIR__ . '/full-site-editing/blocks/navigation-menu/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/post-content/index.php';
+	require_once __DIR__ . '/full-site-editing/blocks/site-description/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/template/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/site-logo/index.php';
 	require_once __DIR__ . '/full-site-editing/class-a8c-rest-templates-controller.php';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -6,7 +6,7 @@
 /**
  * WordPress dependencies
  */
-import { TextControl } from '@wordpress/components';
+import { PlainText } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
@@ -69,7 +69,7 @@ class SiteDescriptionEdit extends Component {
 		const { isSelected } = this.props;
 		if ( isSelected ) {
 			return (
-				<TextControl
+				<PlainText
 					className="wp-block-a8c-site-description"
 					value={ this.state.value }
 					onChange={ value => this.setState( { value } ) }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -10,8 +10,6 @@ import { PlainText } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { withSelect } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -36,26 +34,6 @@ class SiteDescriptionEdit extends Component {
 		}
 	}
 
-	componentDidUpdate( prevProps ) {
-		if (
-			prevProps.isSaving === false &&
-			this.props.isSaving === true &&
-			this.state.fromApi !== this.state.value
-		) {
-			try {
-				apiFetch( {
-					path: '/wp/v2/settings',
-					method: 'POST',
-					data: {
-						description: this.state.value,
-					},
-				} );
-			} catch ( error ) {
-				this.handleApiError( true );
-			}
-		}
-	}
-
 	handleApiError( post = false ) {
 		if ( post ) {
 			this.props.setAttributes( {
@@ -66,7 +44,11 @@ class SiteDescriptionEdit extends Component {
 	}
 
 	render() {
-		const { attributes: { description }, isSelected, setAttributes } = this.props;
+		const {
+			attributes: { description },
+			isSelected,
+			setAttributes,
+		} = this.props;
 		if ( isSelected ) {
 			return (
 				<PlainText
@@ -82,11 +64,4 @@ class SiteDescriptionEdit extends Component {
 	}
 }
 
-export default compose( [
-	withSelect( select => {
-		const { isSavingPost } = select( 'core/editor' );
-		return {
-			isSaving: isSavingPost(),
-		};
-	} ),
-] )( SiteDescriptionEdit );
+export default SiteDescriptionEdit;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -1,0 +1,31 @@
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+/**
+ * External dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { IconButton, ServerSideRender, Toolbar } from '@wordpress/components';
+import { BlockControls } from '@wordpress/editor';
+import { Fragment } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+
+const SiteDescriptionEdit = () => {
+	return (
+		<Fragment>
+			<BlockControls>
+				<Toolbar>
+					<IconButton icon="edit" label={ __( 'Edit Menu' ) } />
+				</Toolbar>
+			</BlockControls>
+			<ServerSideRender block="a8c/site-description" />
+		</Fragment>
+	);
+};
+
+export default SiteDescriptionEdit;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -6,7 +6,7 @@
 /**
  * WordPress dependencies
  */
-import { PlainText } from '@wordpress/editor';
+import { TextControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
@@ -17,12 +17,12 @@ import apiFetch from '@wordpress/api-fetch';
 
 class SiteDescriptionEdit extends Component {
 	state = {
-		description: null,
+		description: __( 'Site description loading…' ),
 	};
 
 	componentDidMount() {
 		apiFetch( { path: '/wp/v2/settings' } ).then( ( { description } ) => {
-			this.setState( { description: description } );
+			this.setState( { description } );
 		} );
 	}
 
@@ -30,15 +30,16 @@ class SiteDescriptionEdit extends Component {
 		const { isSelected } = this.props;
 		if ( isSelected ) {
 			return (
-				<PlainText
+				<TextControl
 					className="wp-block-a8c-site-description"
 					value={ this.state.description }
-					placeholder={ __( 'Site Title…' ) }
-					aria-label={ __( 'SiteTitle' ) }
+					onChange={ description => this.setState( { description } ) }
+					placeholder={ __( 'Site Description' ) }
+					aria-label={ __( 'Site Description' ) }
 				/>
 			);
 		}
-		return <p className="site-description">{ this.state.title }</p>;
+		return <p className="site-description">{ this.state.description }</p>;
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -6,26 +6,40 @@
 /**
  * WordPress dependencies
  */
-import { IconButton, ServerSideRender, Toolbar } from '@wordpress/components';
-import { BlockControls } from '@wordpress/editor';
-import { Fragment } from '@wordpress/element';
+import { PlainText } from '@wordpress/editor';
+import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 
-const SiteDescriptionEdit = () => {
-	return (
-		<Fragment>
-			<BlockControls>
-				<Toolbar>
-					<IconButton icon="edit" label={ __( 'Edit Menu' ) } />
-				</Toolbar>
-			</BlockControls>
-			<ServerSideRender block="a8c/site-description" />
-		</Fragment>
-	);
-};
+class SiteDescriptionEdit extends Component {
+	state = {
+		description: null,
+	};
+
+	componentDidMount() {
+		apiFetch( { path: '/wp/v2/settings' } ).then( ( { description } ) => {
+			this.setState( { description: description } );
+		} );
+	}
+
+	render() {
+		const { isSelected } = this.props;
+		if ( isSelected ) {
+			return (
+				<PlainText
+					className="wp-block-a8c-site-description"
+					value={ this.state.description }
+					placeholder={ __( 'Site Title…' ) }
+					aria-label={ __( 'SiteTitle' ) }
+				/>
+			);
+		}
+		return <p className="site-description">{ this.state.title }</p>;
+	}
+}
 
 export default SiteDescriptionEdit;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -16,30 +16,24 @@ class SiteDescriptionEdit extends Component {
 	};
 
 	componentDidMount() {
-		try {
-			apiFetch( { path: '/wp/v2/settings' } ).then( ( { description } ) => {
+		apiFetch( { path: '/wp/v2/settings' } )
+			.then( ( { description } ) => {
 				this.setState( {
 					fromApi: description,
 					description,
 				} );
-			} );
-		} catch ( error ) {
-			this.handleApiError();
-		}
+			} )
+			.catch( this.handleApiError );
 	}
 
 	componentDidUpdate( prevProps ) {
 		const { description, fromApi } = this.state;
 		if ( ! prevProps.isSaving && this.props.isSaving && fromApi !== description ) {
-			try {
-				apiFetch( {
-					path: '/wp/v2/settings',
-					method: 'POST',
-					data: { description },
-				} );
-			} catch ( error ) {
-				this.handleApiError( true );
-			}
+			apiFetch( {
+				path: '/wp/v2/settings',
+				method: 'POST',
+				data: { description },
+			} ).catch( () => this.handleApiError( true ) );
 		}
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -20,16 +20,16 @@ import { compose } from '@wordpress/compose';
 class SiteDescriptionEdit extends Component {
 	state = {
 		fromApi: null,
-		value: __( 'Site description loading…' ),
 	};
 
 	componentDidMount() {
+		const { setAttributes } = this.props;
 		try {
 			apiFetch( { path: '/wp/v2/settings' } ).then( ( { description } ) => {
 				this.setState( {
 					fromApi: description,
-					value: description,
 				} );
+				setAttributes( { description } );
 			} );
 		} catch ( error ) {
 			this.handleApiError();
@@ -58,27 +58,27 @@ class SiteDescriptionEdit extends Component {
 
 	handleApiError( post = false ) {
 		if ( post ) {
-			this.setState( {
-				value: this.state.fromApi,
+			this.props.setAttributes( {
+				description: this.state.fromApi,
 			} );
 		}
 		// trigger notice
 	}
 
 	render() {
-		const { isSelected } = this.props;
+		const { attributes: { description }, isSelected, setAttributes } = this.props;
 		if ( isSelected ) {
 			return (
 				<PlainText
 					className="wp-block-a8c-site-description"
-					value={ this.state.value }
-					onChange={ value => this.setState( { value } ) }
+					value={ description }
+					onChange={ value => setAttributes( { description: value } ) }
 					placeholder={ __( 'Site Description' ) }
 					aria-label={ __( 'Site Description' ) }
 				/>
 			);
 		}
-		return <p className="site-description">{ this.state.value }</p>;
+		return <p className="site-description">{ description }</p>;
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -10,6 +10,8 @@ import { TextControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -43,4 +45,13 @@ class SiteDescriptionEdit extends Component {
 	}
 }
 
-export default SiteDescriptionEdit;
+export default compose( [
+	withSelect( ( select ) => {
+		const {
+			isSavingPost,
+		} = select( 'core/editor' );
+		return {
+			isSaving: isSavingPost(),
+		};
+	} ),
+] )( SiteDescriptionEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -2,20 +2,12 @@
 /**
  * External dependencies
  */
-
-/**
- * WordPress dependencies
- */
 import { PlainText } from '@wordpress/editor';
 import { Component } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-
-/**
- * Internal dependencies
- */
 
 class SiteDescriptionEdit extends Component {
 	state = {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
@@ -20,6 +20,12 @@ registerBlockType( 'a8c/site-description', {
 		multiple: false,
 		reusable: false,
 	},
+	attributes: {
+		description: {
+			default: __( 'Site description loading…' ),
+			type: 'string',
+		},
+	},
 	edit,
 	save: () => null,
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import './style.scss';
+
+registerBlockType( 'a8c/site-description', {
+	title: __( 'Site Description' ),
+	description: __( 'Site description, also known as the tagline.' ),
+	icon: 'layout',
+	category: 'layout',
+	supports: {
+		html: false,
+		multiple: false,
+		reusable: false,
+	},
+	edit,
+	save: () => null,
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
@@ -11,7 +11,7 @@ import edit from './edit';
 import './style.scss';
 
 registerBlockType( 'a8c/site-description', {
-	title: __( 'Site Description' ),
+	title: __( 'Site Description2' ),
 	description: __( 'Site description, also known as the tagline.' ),
 	icon: 'layout',
 	category: 'layout',
@@ -19,12 +19,6 @@ registerBlockType( 'a8c/site-description', {
 		html: false,
 		multiple: false,
 		reusable: false,
-	},
-	attributes: {
-		description: {
-			default: __( 'Site description loading…' ),
-			type: 'string',
-		},
 	},
 	edit,
 	save: () => null,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
@@ -16,7 +16,7 @@ function render_site_description_block( $attributes, $content ) {
 	ob_start();
 	?>
 	<p class="site-description">
-		<?php echo get_bloginfo( 'description', 'display' ); ?>
+		<?php bloginfo( 'description' ); ?>
 	</p>
 	<?php
 	return ob_get_clean();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
@@ -8,11 +8,9 @@
 /**
  * Renders the site description (tagline) block.
  *
- * @param array  $attributes Block attributes.
- * @param string $content    Block content.
  * @return string
  */
-function render_site_description_block( $attributes, $content ) {
+function render_site_description_block() {
 	ob_start();
 	?>
 	<p class="site-description">

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
@@ -10,10 +10,16 @@
  *
  * @return string
  */
-function render_site_description_block() {
+function render_site_description_block( $attributes ) {
 	ob_start();
+
+	$class = 'site-description wp-block-a8c-site-description';
+	if ( isset( $attributes['className'] ) ) {
+		$class .= ' ' . $attributes['className'];
+	}
+
 	?>
-	<p class="site-description">
+	<p class="<?php echo esc_attr( $class ); ?>">
 		<?php bloginfo( 'description' ); ?>
 	</p>
 	<?php

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Render site description file.
+ *
+ * @package full-site-editing
+ */
+
+/**
+ * Renders the site description (tagline) block.
+ *
+ * @param array  $attributes Block attributes.
+ * @param string $content    Block content.
+ * @return string
+ */
+function render_site_description_block( $attributes, $content ) {
+	ob_start();
+	?>
+	<p class="site-description">
+		<?php echo get_bloginfo( 'description', 'display' ); ?>
+	</p>
+	<?php
+	return ob_get_clean();
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
@@ -1,4 +1,6 @@
-.site-description {
+.editor-styles-wrapper .wp-block-a8c-site-description,
+.editor-styles-wrapper .wp-block-a8c-site-description:focus,
+.editor-styles-wrapper .site-description {
     display: inline;
 	color: #767676;
 	font-size: 1.125em;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
@@ -1,10 +1,10 @@
-.editor-styles-wrapper .wp-block-a8c-site-description,
-.editor-styles-wrapper .wp-block-a8c-site-description:focus,
-.editor-styles-wrapper .site-description {
-    display: inline;
-	color: #767676;
-	font-size: 1.125em;
-	font-weight: normal;
-	letter-spacing: -0.01em;
-    margin: 0;
+.block-editor .wp-block-a8c-site-description {
+	&, &:focus {
+		display: inline;
+		color: #767676;
+		font-size: 1.125em;
+		font-weight: normal;
+		letter-spacing: -0.01em;
+		margin: 0;
+	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
@@ -1,0 +1,8 @@
+.site-description {
+    display: inline;
+	color: #767676;
+	font-size: 1.125em;
+	font-weight: normal;
+	letter-spacing: -0.01em;
+    margin: 0;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -312,7 +312,7 @@ class Full_Site_Editing {
 		wp_enqueue_style(
 			'a8c-full-site-editing-style',
 			plugins_url( 'dist/' . $style_file, __FILE__ ),
-			array(),
+			'wp-edit-post',
 			filemtime( plugin_dir_path( __FILE__ ) . 'dist/' . $style_file )
 		);
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -342,6 +342,13 @@ class Full_Site_Editing {
 		);
 
 		register_block_type(
+			'a8c/site-description',
+			array(
+				'render_callback' => 'render_site_description_block',
+			)
+		);
+
+		register_block_type(
 			'a8c/template',
 			array(
 				'render_callback' => 'render_template_block',

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
@@ -3,6 +3,7 @@
  */
 import './blocks/navigation-menu';
 import './blocks/post-content';
+import './blocks/site-description';
 import './blocks/template';
 import './blocks/site-logo';
 import './plugins/template-selector-sidebar';

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -33,6 +33,7 @@
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^3.1.2",
+		"@wordpress/block-editor": "^2.2.0",
 		"@wordpress/blocks": "^6.2.3",
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Let's add a basic site description block, for use with Full Site Editing.

#### Testing instructions

* Load your FSE testing environment with this branch active.
* Add a "Site Description" block anywhere you like (it's not yet scoped to anything in particular).
* Verify that the Edit preview represents the same data and styling as on the site's front-end.

Fixes #33107 .
