### PR TITLE
Full Site Editing: replace page areas with template parts

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -20,6 +20,8 @@ function a8c_load_full_site_editing() {
 	require_once __DIR__ . '/full-site-editing/blocks/template/index.php';
 	require_once __DIR__ . '/full-site-editing/class-a8c-rest-templates-controller.php';
 	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
+	require_once __DIR__ . '/full-site-editing/utils/class-a8c-wp-template.php';
+	require_once __DIR__ . '/full-site-editing/utils/replace-template-parts.php';
 
 	Full_Site_Editing::get_instance();
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -25,6 +25,14 @@ class Full_Site_Editing {
 		add_action( 'init', array( $this, 'register_meta_template_id' ) );
 		add_action( 'rest_api_init', array( $this, 'allow_searching_for_templates' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_script_and_style' ), 100 );
+
+		add_action( 'wp_head', function() {
+			ob_start( 'a8c_fse_replace_template_parts' );
+		} );
+
+		add_action( 'wp_footer', function() {
+			ob_end_flush();
+		} );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Class A8C_WP_Template
+ */
+class A8C_WP_Template {
+	const TEMPLATE_META_KEY = '_wp_template_id';
+
+	private $current_post_id;
+	private $template_id;
+
+	public function __construct( $post_id = null ) {
+		if ( $post_id === null ) {
+			$post_id = get_post()->ID;
+		}
+
+		$this->current_post_id = $post_id;
+		$this->template_id = get_post_meta( $this->current_post_id, self::TEMPLATE_META_KEY, true );
+	}
+
+	public function get_template_content() {
+		if ( empty( $this->template_id ) ) {
+			return null;
+		}
+
+		$template_post = get_post( $this->template_id );
+
+		return $template_post === null ? null : $template_post->post_content;
+	}
+
+	public function get_template_blocks() {
+		$template_content = $this->get_template_content();
+
+		$template_blocks = parse_blocks( $template_content );
+
+		return is_array( $template_blocks ) ? $template_blocks : [];
+	}
+
+	/**
+	 * Returns the post ID of the template part CPT that represents the Header in this template.
+	 *
+	 * This is simplified for now and we are just assuming that the first template part in every
+	 * template will represent the Header.
+	 *
+	 * @return null|int Header template part ID if it exists or null otherwise.
+	 */
+	public function get_header_id() {
+		$template_blocks = $this->get_template_blocks();
+
+		if ( empty( $template_blocks ) ) {
+			return null;
+		}
+
+		// TODO: Incorporate wp_template_part taxonomy checks
+		if ( ! isset( $template_blocks[0]['attrs']['templateId'] ) ) {
+			return null;
+		}
+
+		return $template_blocks[0]['attrs']['templateId'];
+	}
+
+	/**
+	 * Returns the post ID of the template part CPT that represents the Footer in this template.
+	 *
+	 * This is simplified for now and we are just assuming that the last template part in every
+	 * template will represent the Footer.
+	 *
+	 * @return null|int Footer template part ID if it exists or null otherwise.
+	 */
+	public function get_footer_id() {
+		$template_blocks = $this->get_template_blocks();
+
+		// TODO: Incorporate wp_template_part taxonomy checks
+		if ( ! isset( end( $template_blocks )['attrs']['templateId'] ) ) {
+			return null;
+		}
+
+		return end( $template_blocks )['attrs']['templateId'];
+	}
+
+	public function get_header_content() {
+		$header_id = $this->get_header_id();
+
+		if ( $header_id === null ) {
+			return null;
+		}
+
+		$header = get_post( $header_id );
+
+		if ( $header === null ) {
+			return null;
+		}
+
+		return $header->post_content;
+	}
+
+
+	public function get_footer_content() {
+		$footer_id = $this->get_footer_id();
+
+		if ( $footer_id === null ) {
+			return null;
+		}
+
+		$footer = get_post( $footer_id );
+
+		if ( $footer === null ) {
+			return null;
+		}
+
+		return $footer->post_content;
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/replace-template-parts.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/replace-template-parts.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Callback function that will be executed before the output buffer is flushed.
+ *
+ * It is processing the final HTML before it's sent to the user and replacing different
+ * page areas with appropriate template parts (wp_template_part CPT) depending on the
+ * template (wp_template CPT) that has been assigned to the current page.
+ *
+ * @param $html HTML code passed by output buffer.
+ *
+ * @return string HTML code with replaced header node if it exists.
+ */
+function a8c_fse_replace_template_parts( $html ) {
+	$page_template = new A8C_WP_Template();
+
+	// Array that defines replacement pairs. 'xpath_query' specifies the element from the original HTML
+	// that should be replaced, and 'fse_content' contains the replacement HTML code.
+	$replacements = [
+		'header' => [
+			// Query the first <header> element that contains the 'site-header' class.
+			// Note that this is not always the direct descendant of <body> since it's sometimes wrapped in a <div>.
+			'xpath_query' => "(/html/body//header[@class='site-header'])[1]",
+			'fse_content' => $page_template->get_header_content(),
+		],
+		'footer' => [
+			// Query the first <footer> element that contains the 'site-footer' class.
+			'xpath_query' => "(/html/body//footer[@class='site-footer'])[1]",
+			'fse_content' => $page_template->get_footer_content(),
+		],
+	];
+
+	$doc = new DOMDocument;
+	$doc->preserveWhiteSpace = false;
+	@$doc->loadHTML( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8') );
+
+	$temp_doc = new DOMDocument;
+	$temp_doc->preserveWhiteSpace = false;
+
+	foreach( $replacements as $replacement ) {
+		if ( empty( $replacement['xpath_query'] ) || empty( $replacement['fse_content'] ) ) {
+			continue;
+		}
+
+		$xpath = new DOMXPath( $doc );
+		$candidate_nodes = $xpath->query( $replacement['xpath_query'] );
+
+		if ( $candidate_nodes->length === 0 ) {
+			continue;
+		}
+
+		$node_to_replace = $candidate_nodes[0];
+
+		@$temp_doc->loadHTML( mb_convert_encoding( $replacement['fse_content'], 'HTML-ENTITIES', 'UTF-8' ) );
+
+		$fse_node = $doc->importNode( $temp_doc->documentElement, true );
+		$node_to_replace->parentNode->replaceChild( $fse_node, $node_to_replace );
+	}
+
+	return $doc->saveHTML();
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Introduces functionality that aims to replace the default header and footer with appropriate template parts that are defined in a page template.

This solution is based on the one proposed in paAmJe-rq-p2 with some improvements to the parsing logic.

Unfortunately I wasn't able to find a better way to replace these parts of the page by relying on existing filters and actions. I don't think this is possible with what's currently available in core and given how themes are organized.

#### Testing instructions

**Note:** Template creation and assignment is manual at this stage, but the plan is to automate this during site creation step and hide the template CPTs from the user. I'm leaving this exposed for now for easier testing.

* I've been developing and testing this with a local WP install in Gutenberg docker setup (instructions available here PCYsg-ly5-p2).
* For start, switch to Twenty Nineteen theme.
* Create two new Template Parts and insert some test content into them. I'll assume that they are titled with `Header` and `Footer`.
* Create a new Template CPT (let's call it `Default Template`) and add the following blocks into it:
  * Template Part (select `Header` from previous step)
  * Content Slot
  * Template Part (select `Footer` from previous step)
* Create a test page and assign the previously created `Default Template` to it.

<img width="287" alt="Screenshot 2019-06-07 at 03 19 23" src="https://user-images.githubusercontent.com/1182160/59075838-1303bd80-88d3-11e9-968f-20a566b3211f.png">

* View the page and verify that the header and footer have been replaced with previously created template parts.
* Test with other themes - it should work as long as they use `<header>` and `<footer>` tags.
* Test on Dotcom.



Fixes https://github.com/Automattic/wp-calypso/issues/33512
