### PR TITLE
Guided Transfers: CSS Migration

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -50,7 +50,6 @@
 @import 'me/sidebar-navigation/style';
 @import 'my-sites/checklist/wpcom-checklist/checklist-navigation/style';
 @import 'my-sites/customize/style';
-@import 'my-sites/guided-transfer/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/posts/style';
 @import 'my-sites/sidebar/style';

--- a/client/my-sites/guided-transfer/guided-transfer.jsx
+++ b/client/my-sites/guided-transfer/guided-transfer.jsx
@@ -18,6 +18,11 @@ import Main from 'components/main';
 import QuerySiteGuidedTransfer from 'components/data/query-site-guided-transfer';
 import TransferUnavailableCard from './transfer-unavailable-card';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const guidedTransferHosts = {
 	bluehost: {
 		label: i18n.translate( 'Bluehost' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Just migrates the rest of the exporter (guided transfers) as part of #27515

#### Testing instructions

Visit `/export/guided/site` and verify the styles are identical.

<img width="763" alt="Screenshot 2019-06-07 at 06 19 43" src="https://user-images.githubusercontent.com/43215253/59082753-76e6b000-88ec-11e9-87ad-a2594b20ef06.png">

cc @flootr, @blowery, @jsnajdr 

Fixes https://github.com/Automattic/wp-calypso/issues/33741