### PR TITLE
Fix display block issue with site style form labels

### DIFF
--- a/client/signup/steps/site-style/style.scss
+++ b/client/signup/steps/site-style/style.scss
@@ -32,7 +32,9 @@
 .site-style__option-label {
 	cursor: pointer;
 	// Get things to line up.
-	display: inline-block;
+	&.form-label {
+		display: inline-block;
+	}
 	margin: 0;
 	text-align: center;
 


### PR DESCRIPTION
Due to the recent Form CSS migrations (#31818), `.form-label` was overriding the `display: inline-block` setting in `.site-style__option-label`. This change adds further specificity to `.site-style__option-label` to ensure that it is `inline-block`, instead of `block`.

#### Changes proposed in this Pull Request

* Add `&.form-label` specificity to `.site-style__option-label` so that `.form-label`'s display attribute is correctly overridden to `inline-block`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to create a new site, and select the Business plan
* After entering a business name it will take you to step 4: *Choose a style*
* The style buttons should be displayed horizontally in `display: inline-block` instead of a vertical list (`block`)

Before:

![image](https://user-images.githubusercontent.com/14988353/59082814-209f5e80-8938-11e9-9520-b58c278879d0.png)

After:

![image](https://user-images.githubusercontent.com/14988353/59082900-7a078d80-8938-11e9-91a6-86eebcae6179.png)
