### PR TITLE
Billing History: Fix overlapping filter drop-downs

### DIFF
--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -95,7 +95,7 @@
 }
 
 .billing-history__transactions tbody .billing-history__date {
-	width: 140px;
+	width: 150px;
 	padding: 12px;
 }
 
@@ -409,11 +409,11 @@ textarea.billing-history__billing-details-editable {
 	}
 }
 
-.billing-history__date {
-	width: 170px;
-}
-
 .billing-history__transactions-header-select-dropdown {
 	padding: 8px 12px;
 	position: absolute;
+
+	&:nth-child( 2 ) {
+		left: 170px;
+	}
 }

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -84,13 +84,13 @@ class TransactionsHeader extends React.Component {
 		return (
 			<thead>
 				<tr className="billing-history__header-row">
-					<th className="billing-history__date billing-history__header-column">
+					<th
+						className="billing-history__date billing-history__trans-app billing-history__header-column"
+						colSpan="3"
+					>
 						{ this.renderDatePopover() }
-					</th>
-					<th className="billing-history__trans-app billing-history__header-column">
 						{ this.renderAppsPopover() }
 					</th>
-					<th className="billing-history__search-field billing-history__header-column" />
 				</tr>
 			</thead>
 		);

--- a/client/me/billing-history/transactions-table.jsx
+++ b/client/me/billing-history/transactions-table.jsx
@@ -168,7 +168,7 @@ class TransactionsTable extends React.Component {
 
 			return (
 				<tr key={ transaction.id } className="billing-history__transaction">
-					<td>{ transactionDate }</td>
+					<td className="billing-history__date">{ transactionDate }</td>
 					<td className="billing-history__trans-app">
 						<div className="billing-history__trans-wrap">
 							<div className="billing-history__service-description">


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* consolidated table heading into a single cell, spanning three columns
* adjusted the position of the application type filter
* style adjustments to keep the table looking neat on desktop as well

#### Testing instructions
1. Starting at URL: https://wordpress.com/me/purchases/billing
2. Make browser window 780px wide or smaller, or open dev tools.
3. Check if the filtering drop-downs are overlapping (they should not). Check both desktop and mobile.

Before:

![image](https://user-images.githubusercontent.com/4550351/59084563-0b79fe00-893f-11e9-9a9b-235fd635c2c2.png)

After:

![image](https://user-images.githubusercontent.com/4550351/59084610-319f9e00-893f-11e9-9c12-9a5985a03cae.png)

Fixes #33722
