### PR TITLE
Fix site style options margins issue caused by Forms CSS migration

### DIFF
--- a/client/signup/steps/site-style/style.scss
+++ b/client/signup/steps/site-style/style.scss
@@ -34,8 +34,8 @@
 	// Get things to line up.
 	&.form-label {
 		display: inline-block;
+		margin-bottom: 0;
 	}
-	margin: 0;
 	text-align: center;
 
 	// Default to a white background, but
@@ -52,7 +52,9 @@
 
 		// This fixes an annoyance with using
 		// display: inline-block above.
-		margin-bottom: -5px;
+		&.form-label {
+			margin-bottom: -5px;
+		}
 
 		// Make the SVGs a little bigger since
 		// we've got the room.


### PR DESCRIPTION
Following on from #33725, this change fixes up margin issues with the site style options buttons, caused by `.form-label` overriding attributes set in `.site-style__option-label`.

#### Changes proposed in this Pull Request

* Add `margin-bottom` rules to `&.form-label` within `.site-style__option-label` so that the `.form-label` margins are overridden.

This change brings the site style buttons back to how they looked before the changes caused by the Forms CSS migration.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to create a new site, and select the Business plan
* After entering a business name it will take you to step 4: Choose a style
* The style buttons and Continue buttons should be better aligned vertically. On mobile screen widths, there should be no margins between the style buttons. See screenshots below:

Before (mobile)

![image](https://user-images.githubusercontent.com/14988353/59088925-3e76be80-894c-11e9-9267-d039701d426e.png)

After (mobile)

![image](https://user-images.githubusercontent.com/14988353/59088949-4afb1700-894c-11e9-9280-707d3179ced9.png)

Before (desktop)

![image](https://user-images.githubusercontent.com/14988353/59088966-55b5ac00-894c-11e9-8fcc-aaefc20e7739.png)

After (desktop)

![image](https://user-images.githubusercontent.com/14988353/59088986-623a0480-894c-11e9-94b3-0adb2d6b16a8.png)
