### PR TITLE
Jetpack checklist: correct completed configuration link for site accelerator

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
@@ -74,8 +74,7 @@ export const JETPACK_PERFORMANCE_CHECKLIST_TASKS: Readonly< ChecklistTasksetUi >
 		description: translate(
 			'Serve your images and static files through our global CDN and whatch your page load time drop.'
 		),
-		getUrl: ( siteSlug, isComplete ) =>
-			isComplete ? `/media/${ siteSlug }` : `/settings/performance/${ siteSlug }`,
+		getUrl: siteSlug => `/settings/performance/${ siteSlug }`,
 		completedButtonText: translate( 'Configure' ),
 		completedTitle: translate(
 			'Site accelerator is serving your images and static files through our global CDN.'


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't redirect to `/media` when clicking "configure" for completed site accelerator task

<img width="737" alt="Screenshot 2019-06-07 at 12 36 46" src="https://user-images.githubusercontent.com/87168/59095599-977d2d00-8921-11e9-9ba2-9e4650603985.png">


#### Testing instructions

- Have a Jetpack site
- Open `http://calypso.localhost:3000/plans/my-plan/:site`
- Finish site accelerator task
- Press config
- You should end up to settings page, not in the media page