### PR TITLE
Jetpack Checklist: Add hotjar trigger

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
@@ -28,7 +28,7 @@ interface TaskUiDescription {
 	readonly tourId?: string;
 }
 
-interface ChecklistTasksetUi {
+export interface ChecklistTasksetUi {
 	[taskId: string]: TaskUiDescription;
 }
 

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { Fragment, PureComponent, ReactElement, ReactNode } from 'react';
 import { connect } from 'react-redux';
-import { get, includes } from 'lodash';
+import { flowRight, get, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -40,6 +40,7 @@ import ChecklistSectionTitle from './checklist-section-title';
 import { URL } from 'types';
 import { getSitePlanSlug } from 'state/sites/plans/selectors';
 import { isBusinessPlan, isPremiumPlan } from 'lib/plans';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 
 /**
  * Style dependencies
@@ -270,7 +271,7 @@ class JetpackChecklist extends PureComponent< Props > {
 	}
 }
 
-export default connect(
+const connectComponent = connect(
 	state => {
 		const site = getSelectedSite( state );
 		const siteId = getSelectedSiteId( state );
@@ -313,4 +314,10 @@ export default connect(
 		recordTracksEvent,
 		requestGuidedTour,
 	}
-)( localize( JetpackChecklist ) );
+);
+
+export default flowRight(
+	connectComponent,
+	localize,
+	withTrackingTool( 'HotJar' )
+)( JetpackChecklist );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -62,6 +62,12 @@ interface Props {
 }
 
 class JetpackChecklist extends PureComponent< Props > {
+	componentDidMount() {
+		if ( typeof window !== 'undefined' && typeof window.hj === 'function' ) {
+			window.hj( 'trigger', 'plans_myplan_jetpack-checklist' );
+		}
+	}
+
 	isComplete( taskId: string ): boolean {
 		return get( this.props.taskStatuses, [ taskId, 'completed' ], false );
 	}


### PR DESCRIPTION
Add Hotjar trigger to Jetpack Checklist.

Closes #33712 

Notes:

This seems to be a fine one-off solution. It works in my testing.

If we need this more often, it would be better to use a different mechanism, for example the `withTrackingTool` HOC could be extended to fire a trigger.

## Testing

Make sure the checklist isn't broken.