### PR TITLE
(5P) Adds meta and Gutenberg sidebar Plugin for template preview and desc

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -22,6 +22,7 @@ class Starter_Page_Templates {
 	 */
 	private function __construct() {
 		add_action( 'init', array( $this, 'register_scripts' ) );
+		add_action( 'init', array( $this, 'register_sidebar_preview_meta_fields' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_assets' ) );
 	}
 
@@ -81,7 +82,7 @@ class Starter_Page_Templates {
 		$screen = get_current_screen();
 
 		// Return early if we don't meet conditions to show templates.
-		if ( 'page' !== $screen->id || 'add' !== $screen->action ) {
+		if ( 'page' !== $screen->id  ) {
 			return;
 		}
 
@@ -118,6 +119,7 @@ class Starter_Page_Templates {
 		$config    = array(
 			'siteInformation' => array_merge( $default_info, $site_info ),
 			'templates'       => array_merge( $default_templates, $vertical_templates ),
+			'showMeta'		  => apply_filters('a8c_fse_spt_should_register_sidebar_preview_meta', $should_register_meta ),
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );
 
@@ -176,4 +178,39 @@ class Starter_Page_Templates {
 
 		return $language;
 	}
+
+	public function register_sidebar_preview_meta_fields() {
+		$should_register_meta = false;
+
+		if (! apply_filters('a8c_fse_spt_should_register_sidebar_preview_meta', $should_register_meta ) ) {
+			return;
+		}
+
+		register_meta( 'post', 'hs_template_preview', array(
+			'object_subtype' => 'page',
+		    'show_in_rest' => true,
+		    'single' => true,
+		    'type' => 'string',
+		    'description'    => __('URL of a preview image (from a remote source) to associated with this Template', 'full-site-editing' ),
+		    'sanitize_callback' => array( $this, 'sanitize_hs_template_preview')
+		) );
+
+		register_meta( 'post', 'hs_template_description', array(
+			'object_subtype' => 'page',
+		    'show_in_rest' => true,
+		    'single' => true,
+		    'type' => 'string',
+		    'description'    => __('Description of the Template contents for non-sighted users', 'full-site-editing' ),
+		    'sanitize_callback' => array( $this, 'sanitize_hs_template_description')
+		) );
+
+	}
+
+	public function sanitize_hs_template_preview( $url ) {
+		return esc_url_raw($url);
+	} 
+
+	public function sanitize_hs_template_description( $url ) {
+		return sanitize_text_field($url);
+	} 
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/index.js
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 import './page-template-modal';
+import './page-template-meta';

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-meta/components/meta-field.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-meta/components/meta-field.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { withDispatch, withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { TextControl, TextareaControl } from '@wordpress/components';
+
+export const MetaField = ( { label, inputType, type, metaFieldValue, setMetaFieldValue } ) => {
+	const FormComponent = type === 'textarea' ? TextareaControl : TextControl;
+
+	return (
+		<FormComponent
+			label={ label }
+			type={ inputType || 'text' }
+			value={ metaFieldValue }
+			rows="5"
+			onChange={ setMetaFieldValue }
+		/>
+	);
+};
+
+export default compose( [
+	withSelect( ( select, { metaFieldKey } ) => {
+		const metaFieldValue = select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ metaFieldKey ];
+
+		return {
+			metaFieldValue,
+		};
+	} ),
+	withDispatch( ( dispatch, { metaFieldKey } ) => {
+		return {
+			setMetaFieldValue: function( value ) {
+				dispatch( 'core/editor' ).editPost( {
+					meta: {
+						[ metaFieldKey ]: value,
+					},
+				} );
+			},
+		};
+	} ),
+] )( MetaField );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-meta/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-meta/index.js
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+import { PluginSidebar } from '@wordpress/edit-post';
+import { __ } from '@wordpress/i18n';
+import { PanelBody } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import MetaField from './components/meta-field';
+
+export const Sidebar = () => {
+	return (
+		<PluginSidebar
+			name="fse-spt-sidebar"
+			title={ __( 'Starter Page Templates' ) }
+			icon="wordpress-alt"
+		>
+			<PanelBody title="Template Preview Details">
+				<MetaField label="Preview URL" inputType="url" metaFieldKey="hs_template_preview" />
+
+				<MetaField
+					label="Preview Description"
+					type="textarea"
+					metaFieldKey="hs_template_description"
+				/>
+			</PanelBody>
+		</PluginSidebar>
+	);
+};
+
+if ( window.starterPageTemplatesConfig.showMeta ) {
+	registerPlugin( 'page-templates-sidebar', {
+		render: function() {
+			return <Sidebar />;
+		},
+	} );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* (Conditionally) registers x2 meta fields for preview image and description
* Registers new Gutenberg sidebar Plugin to display meta data

#### Testing instructions
Nothing will work unless you add a filter within your env to force the meta to be registered

```php
add_filter('a8c_fse_spt_should_register_sidebar_preview_meta', '__return_true');
```


* Go to your site
* Start a new Page
* Dismiss modal
* See WordPress logo in top right
![Screen Shot 2019-06-07 at 12 34 06](https://user-images.githubusercontent.com/444434/59101325-926bae00-8920-11e9-9fed-f17eb3ed0418.png)
* Click to reveal custom sidebar
* Type content in meta boxes (please try evil XSS stuff as well in order to break it!)
* Hit Publish or Save Draft
* Refresh
* Confirm meta data is saved and field displays what you just typed in


See also `D29171-code`
