### PR TITLE
Guided Tours: Add Tours for JP Performance Checklist

### DIFF
--- a/client/layout/guided-tours/all-tours.js
+++ b/client/layout/guided-tours/all-tours.js
@@ -24,6 +24,7 @@ import { JetpackLazyImagesTour } from 'layout/guided-tours/tours/jetpack-lazy-im
 import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
 import { JetpackPluginUpdatesTour } from 'layout/guided-tours/tours/jetpack-plugin-updates-tour';
 import { JetpackSignInTour } from 'layout/guided-tours/tours/jetpack-sign-in-tour';
+import { JetpackSiteAcceleratorTour } from 'layout/guided-tours/tours/jetpack-site-accelerator-tour';
 import { JetpackVideoHostingTour } from 'layout/guided-tours/tours/jetpack-video-hosting-tour';
 import { MainTour } from 'layout/guided-tours/tours/main-tour';
 import { MediaBasicsTour } from 'layout/guided-tours/tours/media-basics-tour';
@@ -53,6 +54,7 @@ export default combineTours( {
 	jetpackMonitoring: JetpackMonitoringTour,
 	jetpackPluginUpdates: JetpackPluginUpdatesTour,
 	jetpackSignIn: JetpackSignInTour,
+	jetpackSiteAccelerator: JetpackSiteAcceleratorTour,
 	jetpackVideoHosting: JetpackVideoHostingTour,
 	main: MainTour,
 	mediaBasicsTour: MediaBasicsTour,

--- a/client/layout/guided-tours/all-tours.js
+++ b/client/layout/guided-tours/all-tours.js
@@ -20,6 +20,7 @@ import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integratio
 import { JetpackBackupsRewindTour } from 'layout/guided-tours/tours/jetpack-backups-rewind-tour';
 import { JetpackBasicTour } from 'layout/guided-tours/tours/jetpack-basic-tour';
 import { JetpackChecklistTour } from 'layout/guided-tours/tours/jetpack-checklist-tour';
+import { JetpackLazyImagesTour } from 'layout/guided-tours/tours/jetpack-lazy-images-tour';
 import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
 import { JetpackPluginUpdatesTour } from 'layout/guided-tours/tours/jetpack-plugin-updates-tour';
 import { JetpackSignInTour } from 'layout/guided-tours/tours/jetpack-sign-in-tour';
@@ -47,6 +48,7 @@ export default combineTours( {
 	jetpack: JetpackBasicTour,
 	jetpackBackupsRewind: JetpackBackupsRewindTour,
 	jetpackChecklistTour: JetpackChecklistTour,
+	jetpackLazyImages: JetpackLazyImagesTour,
 	jetpackMonitoring: JetpackMonitoringTour,
 	jetpackPluginUpdates: JetpackPluginUpdatesTour,
 	jetpackSignIn: JetpackSignInTour,

--- a/client/layout/guided-tours/all-tours.js
+++ b/client/layout/guided-tours/all-tours.js
@@ -23,6 +23,7 @@ import { JetpackChecklistTour } from 'layout/guided-tours/tours/jetpack-checklis
 import { JetpackLazyImagesTour } from 'layout/guided-tours/tours/jetpack-lazy-images-tour';
 import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
 import { JetpackPluginUpdatesTour } from 'layout/guided-tours/tours/jetpack-plugin-updates-tour';
+import { JetpackSearchTour } from 'layout/guided-tours/tours/jetpack-search-tour';
 import { JetpackSignInTour } from 'layout/guided-tours/tours/jetpack-sign-in-tour';
 import { JetpackSiteAcceleratorTour } from 'layout/guided-tours/tours/jetpack-site-accelerator-tour';
 import { JetpackVideoHostingTour } from 'layout/guided-tours/tours/jetpack-video-hosting-tour';
@@ -53,6 +54,7 @@ export default combineTours( {
 	jetpackLazyImages: JetpackLazyImagesTour,
 	jetpackMonitoring: JetpackMonitoringTour,
 	jetpackPluginUpdates: JetpackPluginUpdatesTour,
+	jetpackSearch: JetpackSearchTour,
 	jetpackSignIn: JetpackSignInTour,
 	jetpackSiteAccelerator: JetpackSiteAcceleratorTour,
 	jetpackVideoHosting: JetpackVideoHostingTour,

--- a/client/layout/guided-tours/all-tours.js
+++ b/client/layout/guided-tours/all-tours.js
@@ -24,6 +24,7 @@ import { JetpackLazyImagesTour } from 'layout/guided-tours/tours/jetpack-lazy-im
 import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
 import { JetpackPluginUpdatesTour } from 'layout/guided-tours/tours/jetpack-plugin-updates-tour';
 import { JetpackSignInTour } from 'layout/guided-tours/tours/jetpack-sign-in-tour';
+import { JetpackVideoHostingTour } from 'layout/guided-tours/tours/jetpack-video-hosting-tour';
 import { MainTour } from 'layout/guided-tours/tours/main-tour';
 import { MediaBasicsTour } from 'layout/guided-tours/tours/media-basics-tour';
 import { SimplePaymentsEmailTour } from 'layout/guided-tours/tours/simple-payments-email-tour';
@@ -52,6 +53,7 @@ export default combineTours( {
 	jetpackMonitoring: JetpackMonitoringTour,
 	jetpackPluginUpdates: JetpackPluginUpdatesTour,
 	jetpackSignIn: JetpackSignInTour,
+	jetpackVideoHosting: JetpackVideoHostingTour,
 	main: MainTour,
 	mediaBasicsTour: MediaBasicsTour,
 	simplePaymentsEmailTour: SimplePaymentsEmailTour,

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -25,6 +25,7 @@ import jetpackBackupsRewind from 'layout/guided-tours/tours/jetpack-backups-rewi
 import jetpackLazyImages from 'layout/guided-tours/tours/jetpack-lazy-images-tour/meta';
 import jetpackMonitoring from 'layout/guided-tours/tours/jetpack-monitoring-tour/meta';
 import jetpackPluginUpdates from 'layout/guided-tours/tours/jetpack-plugin-updates-tour/meta';
+import jetpackSearch from 'layout/guided-tours/tours/jetpack-search-tour/meta';
 import jetpackSignIn from 'layout/guided-tours/tours/jetpack-sign-in-tour/meta';
 import jetpackSiteAccelerator from 'layout/guided-tours/tours/jetpack-site-accelerator-tour/meta';
 import jetpackVideoHosting from 'layout/guided-tours/tours/jetpack-video-hosting-tour/meta';
@@ -47,6 +48,7 @@ export default {
 	jetpackLazyImages,
 	jetpackMonitoring,
 	jetpackPluginUpdates,
+	jetpackSearch,
 	jetpackSignIn,
 	jetpackSiteAccelerator,
 	jetpackVideoHosting,

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -26,6 +26,7 @@ import jetpackLazyImages from 'layout/guided-tours/tours/jetpack-lazy-images-tou
 import jetpackMonitoring from 'layout/guided-tours/tours/jetpack-monitoring-tour/meta';
 import jetpackPluginUpdates from 'layout/guided-tours/tours/jetpack-plugin-updates-tour/meta';
 import jetpackSignIn from 'layout/guided-tours/tours/jetpack-sign-in-tour/meta';
+import jetpackVideoHosting from 'layout/guided-tours/tours/jetpack-video-hosting-tour/meta';
 import simplePaymentsEmailTour from 'layout/guided-tours/tours/simple-payments-email-tour/meta';
 
 export default {
@@ -46,6 +47,7 @@ export default {
 	jetpackMonitoring,
 	jetpackPluginUpdates,
 	jetpackSignIn,
+	jetpackVideoHosting,
 	main,
 	editorBasicsTour,
 	mediaBasicsTour,

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -22,6 +22,7 @@ import checklistUserAvatar from 'layout/guided-tours/tours/checklist-user-avatar
 import checklistUserEmail from 'layout/guided-tours/tours/checklist-user-email-tour/meta';
 import jetpack from 'layout/guided-tours/tours/jetpack-basic-tour/meta';
 import jetpackBackupsRewind from 'layout/guided-tours/tours/jetpack-backups-rewind-tour/meta';
+import jetpackLazyImages from 'layout/guided-tours/tours/jetpack-lazy-images-tour/meta';
 import jetpackMonitoring from 'layout/guided-tours/tours/jetpack-monitoring-tour/meta';
 import jetpackPluginUpdates from 'layout/guided-tours/tours/jetpack-plugin-updates-tour/meta';
 import jetpackSignIn from 'layout/guided-tours/tours/jetpack-sign-in-tour/meta';
@@ -41,6 +42,7 @@ export default {
 	checklistUserEmail,
 	jetpack,
 	jetpackBackupsRewind,
+	jetpackLazyImages,
 	jetpackMonitoring,
 	jetpackPluginUpdates,
 	jetpackSignIn,

--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -26,6 +26,7 @@ import jetpackLazyImages from 'layout/guided-tours/tours/jetpack-lazy-images-tou
 import jetpackMonitoring from 'layout/guided-tours/tours/jetpack-monitoring-tour/meta';
 import jetpackPluginUpdates from 'layout/guided-tours/tours/jetpack-plugin-updates-tour/meta';
 import jetpackSignIn from 'layout/guided-tours/tours/jetpack-sign-in-tour/meta';
+import jetpackSiteAccelerator from 'layout/guided-tours/tours/jetpack-site-accelerator-tour/meta';
 import jetpackVideoHosting from 'layout/guided-tours/tours/jetpack-video-hosting-tour/meta';
 import simplePaymentsEmailTour from 'layout/guided-tours/tours/simple-payments-email-tour/meta';
 
@@ -47,6 +48,7 @@ export default {
 	jetpackMonitoring,
 	jetpackPluginUpdates,
 	jetpackSignIn,
+	jetpackSiteAccelerator,
 	jetpackVideoHosting,
 	main,
 	editorBasicsTour,

--- a/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import meta from './meta';
+import {
+	ButtonRow,
+	Continue,
+	makeTour,
+	Quit,
+	SiteLink,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+export const JetpackLazyImagesTour = makeTour(
+	<Tour { ...meta }>
+		<Step
+			name="init"
+			target=".jetpack-lazy-images-settings .form-toggle__switch"
+			arrow="top-left"
+			placement="below"
+			style={ {
+				animationDelay: '0.7s',
+				zIndex: 1,
+			} }
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( "Let's boost load times for your site by lazy-loading images." ) }</p>
+					<ButtonRow>
+						<Continue
+							target=".jetpack-lazy-images-settings .form-toggle__switch"
+							step="finish"
+							click
+							hidden
+						/>
+						<SiteLink href="/plans/my-plan/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="finish" placement="right">
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Excellent, you’re done!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Lazy image loading has been enabled. Would you like to continue setting up performance features for your site?'
+						) }
+					</p>
+					<ButtonRow>
+						<SiteLink isButton href="/plans/my-plan/:site">
+							{ translate( "Yes, let's do it." ) }
+						</SiteLink>
+						<Quit>{ translate( 'No thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/jetpack-lazy-images-tour/meta.js
+++ b/client/layout/guided-tours/tours/jetpack-lazy-images-tour/meta.js
@@ -1,0 +1,4 @@
+export default {
+	name: 'jetpackLazyImages',
+	version: '20190607',
+};

--- a/client/layout/guided-tours/tours/jetpack-search-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-search-tour/index.js
@@ -1,0 +1,81 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import meta from './meta';
+import {
+	ButtonRow,
+	Continue,
+	makeTour,
+	Quit,
+	SiteLink,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+export const JetpackSearchTour = makeTour(
+	<Tour { ...meta }>
+		<Step
+			name="init"
+			target=".jetpack-search-settings .form-toggle__switch"
+			arrow="top-left"
+			placement="below"
+			style={ {
+				animationDelay: '0.7s',
+				zIndex: 1,
+			} }
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							"Let's enable Jetpack Search " +
+								'to replace WordPress built-in search with a faster, filterable search.'
+						) }
+					</p>
+					<ButtonRow>
+						<Continue
+							target=".jetpack-search-settings .form-toggle__switch"
+							step="finish"
+							click
+							hidden
+						/>
+						<SiteLink href="/plans/my-plan/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="finish" placement="right">
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Excellent, you’re done!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Jetpack Search has been enabled. Would you like to continue setting up performance features for your site?'
+						) }
+					</p>
+					<ButtonRow>
+						<SiteLink isButton href="/plans/my-plan/:site">
+							{ translate( "Yes, let's do it." ) }
+						</SiteLink>
+						<Quit>{ translate( 'No thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/jetpack-search-tour/meta.js
+++ b/client/layout/guided-tours/tours/jetpack-search-tour/meta.js
@@ -1,0 +1,4 @@
+export default {
+	name: 'jetpackSearch',
+	version: '20190609',
+};

--- a/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
@@ -1,0 +1,76 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import meta from './meta';
+import {
+	ButtonRow,
+	Continue,
+	makeTour,
+	Quit,
+	SiteLink,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+export const JetpackSiteAcceleratorTour = makeTour(
+	<Tour { ...meta }>
+		<Step
+			name="init"
+			target=".jetpack-site-accelerator-settings .form-toggle__switch"
+			arrow="top-left"
+			placement="below"
+			style={ {
+				animationDelay: '0.7s',
+				zIndex: 1,
+			} }
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>{ translate( 'Activate this toggle to enable Site Accelerator' ) }</p>
+					<ButtonRow>
+						<Continue
+							target=".jetpack-site-accelerator-settings .form-toggle__switch"
+							step="finish"
+							click
+							hidden
+						/>
+						<SiteLink href="/plans/my-plan/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="finish" placement="right">
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Excellent, you’re done!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Site Accelerator has been enabled. Would you like to continue setting up performance features for your site?'
+						) }
+					</p>
+					<ButtonRow>
+						<SiteLink isButton href="/plans/my-plan/:site">
+							{ translate( "Yes, let's do it." ) }
+						</SiteLink>
+						<Quit>{ translate( 'No thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/meta.js
+++ b/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/meta.js
@@ -1,0 +1,4 @@
+export default {
+	name: 'jetpackSiteAccelerator',
+	version: '20190609',
+};

--- a/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import React, { Fragment } from 'react';
+import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import meta from './meta';
+import {
+	ButtonRow,
+	Continue,
+	makeTour,
+	Quit,
+	SiteLink,
+	Step,
+	Tour,
+} from 'layout/guided-tours/config-elements';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+export const JetpackVideoHostingTour = makeTour(
+	<Tour { ...meta }>
+		<Step
+			name="init"
+			target=".jetpack-video-hosting-settings .form-toggle__switch"
+			arrow="top-left"
+			placement="below"
+			style={ {
+				animationDelay: '0.7s',
+				zIndex: 1,
+			} }
+		>
+			{ ( { translate } ) => (
+				<Fragment>
+					<p>
+						{ translate(
+							'Activate this toggle to use our fast WordPress.com servers to host your videos, ad-free.'
+						) }
+					</p>
+					<ButtonRow>
+						<Continue
+							target=".jetpack-video-hosting-settings .form-toggle__switch"
+							step="finish"
+							click
+							hidden
+						/>
+						<SiteLink href="/plans/my-plan/:site">
+							{ translate( 'Return to the checklist' ) }
+						</SiteLink>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+
+		<Step name="finish" placement="right">
+			{ ( { translate } ) => (
+				<Fragment>
+					<h1 className="tours__title">
+						<span className="tours__completed-icon-wrapper">
+							<Gridicon icon="checkmark" className="tours__completed-icon" />
+						</span>
+						{ translate( 'Excellent, you’re done!' ) }
+					</h1>
+					<p>
+						{ translate(
+							'Video hosting has been enabled. Would you like to continue setting up performance features for your site?'
+						) }
+					</p>
+					<ButtonRow>
+						<SiteLink isButton href="/plans/my-plan/:site">
+							{ translate( "Yes, let's do it." ) }
+						</SiteLink>
+						<Quit>{ translate( 'No thanks.' ) }</Quit>
+					</ButtonRow>
+				</Fragment>
+			) }
+		</Step>
+	</Tour>
+);

--- a/client/layout/guided-tours/tours/jetpack-video-hosting-tour/meta.js
+++ b/client/layout/guided-tours/tours/jetpack-video-hosting-tour/meta.js
@@ -1,0 +1,4 @@
+export default {
+	name: 'jetpackVideoHosting',
+	version: '20190609',
+};

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
@@ -91,6 +91,7 @@ export const JETPACK_PERFORMANCE_CHECKLIST_TASKS: Readonly< ChecklistTasksetUi >
 		completedButtonText: translate( 'Upload images' ),
 		completedTitle: translate( 'Lazy load images is improving your site speed.' ),
 		duration: getJetpackChecklistTaskDuration( 1 ),
+		tourId: 'jetpackLazyImages',
 	},
 };
 

--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
@@ -80,6 +80,7 @@ export const JETPACK_PERFORMANCE_CHECKLIST_TASKS: Readonly< ChecklistTasksetUi >
 			'Site accelerator is serving your images and static files through our global CDN.'
 		),
 		duration: getJetpackChecklistTaskDuration( 1 ),
+		tourId: 'jetpackSiteAccelerator',
 	},
 	jetpack_lazy_images: {
 		title: translate( 'Lazy Load Images' ),

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -234,7 +234,10 @@ class JetpackChecklist extends PureComponent< Props > {
 									? `/media/${ siteSlug }`
 									: `/settings/performance/${ siteSlug }`
 							}
-							onClick={ this.handleTaskStart( { taskId: 'jetpack_video_hosting' } ) }
+							onClick={ this.handleTaskStart( {
+								taskId: 'jetpack_video_hosting',
+								tourId: 'jetpackVideoHosting',
+							} ) }
 						/>
 					) }
 					{ isEnabled( 'jetpack/checklist/performance' ) && isProfessional && (

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -257,7 +257,10 @@ class JetpackChecklist extends PureComponent< Props > {
 									? this.props.widgetCustomizerPaneUrl
 									: `/settings/performance/${ siteSlug }`
 							}
-							onClick={ this.handleTaskStart( { taskId: 'jetpack_search' } ) }
+							onClick={ this.handleTaskStart( {
+								taskId: 'jetpack_search',
+								tourId: 'jetpackSearch',
+							} ) }
 						/>
 					) }
 				</Checklist>

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -64,7 +64,7 @@ class MediaSettingsPerformance extends Component {
 
 		return (
 			isVideoPressAvailable && (
-				<FormFieldset className="site-settings__formfieldset">
+				<FormFieldset className="site-settings__formfieldset jetpack-video-hosting-settings">
 					<SupportInfo
 						text={ translate( 'Hosts your video files on the global WordPress.com servers.' ) }
 						link="https://jetpack.com/support/videopress/"

--- a/client/my-sites/site-settings/search.jsx
+++ b/client/my-sites/site-settings/search.jsx
@@ -129,7 +129,8 @@ class Search extends Component {
 		} = this.props;
 
 		return (
-			<FormFieldset>
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+			<FormFieldset className="jetpack-search-settings">
 				{ this.renderInfoLink( 'https://jetpack.com/support/search/' ) }
 
 				<JetpackModuleToggle

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -103,7 +103,7 @@ class SpeedUpSiteSettings extends Component {
 					</FormFieldset>
 
 					{ siteIsJetpack && (
-						<FormFieldset className="site-settings__formfieldset has-divider is-top-only">
+						<FormFieldset className="site-settings__formfieldset has-divider is-top-only jetpack-lazy-images-settings">
 							<SupportInfo
 								text={ translate(
 									"Delays the loading of images until they are visible in the visitor's browser."

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -64,7 +64,7 @@ class SpeedUpSiteSettings extends Component {
 		return (
 			<div className="site-settings__module-settings site-settings__speed-up-site-settings">
 				<Card>
-					<FormFieldset className="site-settings__formfieldset">
+					<FormFieldset className="site-settings__formfieldset jetpack-site-accelerator-settings">
 						<SupportInfo
 							text={ translate(
 								"Jetpack's global Content Delivery Network (CDN) optimizes " +

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -24,7 +24,7 @@ const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 } );
 
 const moduleTaskMap = {
-	lazy_images: 'jetpack_lazy_images',
+	'lazy-images': 'jetpack_lazy_images',
 	monitor: 'jetpack_monitor',
 	// Both photon and photon-cdn mark the Site Accelerator Task as completed
 	photon: 'jetpack_site_accelerator',


### PR DESCRIPTION
We've discussed making one tour for all tasks (see p1559901034028500-slack-onboarding-exp), but since this will require some more design and engineering decisions, I'm starting out with individual tours.

#### Changes proposed in this Pull Request

Guided Tours: Add Tours for JP Performance Checklist

![performance-checklist](https://user-images.githubusercontent.com/96308/59114627-daea9200-8947-11e9-89e5-1b246b47db2a.gif)

#### Known Issues/Follow-up Items

- Both the Video Hosting and Search toggles fail (visible in the video). This is a known issue, see p1559832260010200-slack-jetpack and p1559844038015700-slack-jetpack
- Per https://github.com/Automattic/wp-calypso/issues/33171#issuecomment-494464632, currently using copy that I came up with myself, loosely based on the little help icon blurbs. Awaiting suggestions for better copy :grimacing: /cc @jeffgolenski 

#### Testing instructions

- Start Calypso locally, using this branch
- Create a new jurassic.ninja site
- Locate the 'Connect to WP.com' button in wp-admin, copy its link target, and append `&calypso_env=development` to it. Navigate to that URL.
- Select a the Professinal plan
- On the 'Thank You' page, locate the Performance checklist
- Select any task from it, and click the 'Do it!' button next to it
- You're taken to the performance settings page.
- Verify that there's a Guided Tour explaining what to do. Do the instructions make sense?
- Follow the Tour's instructions
- At the end of the tour, choose "Yes, let's do it" to return to the checklist
- Repeat for a different tour

Closes #33168 #33169 #33170 #33171