### PR TITLE
Recurring Payments: warn about price being immutable

### DIFF
--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -231,7 +231,7 @@ class MembershipsProductsSection extends Component {
 					{ this.state.editedProductId && (
 						<Notice
 							text={ this.props.translate(
-								'New product price will not affect existing subscribers. They will always be charged at an original price.'
+								'Updating the price will not affect existing subscribers, who will pay what they were originally charged.'
 							) }
 							showDismiss={ false }
 						/>
@@ -358,7 +358,8 @@ class MembershipsProductsSection extends Component {
 					</p>
 					<Notice
 						text={ this.props.translate(
-							'Deleting a product does not cancel the subscription for users already subscribed. They will continue to be charged even after you delete it.'
+							'Deleting a product does not cancel the subscription for existing subscribers.{{br/}}They will continue to be charged even after you delete it.',
+							{ components: { br: <br /> } }
 						) }
 						showDismiss={ false }
 					/>

--- a/client/my-sites/earn/memberships/products.jsx
+++ b/client/my-sites/earn/memberships/products.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import formatCurrency from '@automattic/format-currency';
+import Notice from 'components/notice';
 /**
  * Internal dependencies
  */
@@ -227,6 +228,14 @@ class MembershipsProductsSection extends Component {
 				</p>
 				<FormFieldset>
 					<FormLabel htmlFor="currency">{ this.props.translate( 'Select price' ) }</FormLabel>
+					{ this.state.editedProductId && (
+						<Notice
+							text={ this.props.translate(
+								'New product price will not affect existing subscribers. They will always be charged at an original price.'
+							) }
+							showDismiss={ false }
+						/>
+					) }
 					<FormCurrencyInput
 						name="currency"
 						id="currency"
@@ -347,6 +356,12 @@ class MembershipsProductsSection extends Component {
 							),
 						} ) }
 					</p>
+					<Notice
+						text={ this.props.translate(
+							'Deleting a product does not cancel the subscription for users already subscribed. They will continue to be charged even after you delete it.'
+						) }
+						showDismiss={ false }
+					/>
 				</Dialog>
 			</div>
 		);


### PR DESCRIPTION
In Recurring payments, changing price affects only new customers. So is deleting.
This adds a notice reminding of that.

<img width="823" alt="Zrzut ekranu 2019-06-7 o 15 17 34" src="https://user-images.githubusercontent.com/3775068/59106743-70315a80-8937-11e9-9a1a-fb294ef2103b.png">
<img width="709" alt="Zrzut ekranu 2019-06-7 o 15 17 22" src="https://user-images.githubusercontent.com/3775068/59106744-70c9f100-8937-11e9-92f3-2419580f0cfb.png">
