### PR TITLE
Coupons: add more coupons to the auto-apply list

### DIFF
--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -183,8 +183,18 @@ export function getRememberedCoupon() {
 		debug( 'No coupons found in localStorage: ', coupons );
 		return null;
 	}
-
-	const COUPON_CODE_WHITELIST = [ 'PATREON' ];
+	const COUPON_CODE_WHITELIST = [
+		'ALT',
+		'FIVERR',
+		'GENEA',
+		'KITVISA',
+		'LINKEDIN',
+		'PATREON',
+		'ROCKETLAWYER',
+		'SAFE',
+		'SBDC',
+		'TXAM',
+	];
 	const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
 	const now = Date.now();
 	debug( 'Found coupons in localStorage: ', coupons );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR extends the list of auto-applied coupon codes from #33357. 

#### Testing instructions

- checkout this branch
- open a new incognito window
- visit the landing page for a coupon that was added, e.g., https://wordpress.com/fiverr, and note the currently displayed coupon code
- visit http://calypso.localhost:3000/start/user?coupon=THE_COUPON_CODE (replace with the code from the landing page)
- ensure that localStorage.getItem( 'marketing-coupons' ) returns an object that has the coupon as a key and for that key an integer number as its value (should be the current timestamp in ms)
- go through signup and on the plans selection page, select a paid plan
- ensure that in checkout the coupon is automatically applied
- ensure no errors in the JavaScript console (that aren't there in master -- I did get an error on the domain selection page unrelated to this proposed change)
- repeat the above for the other added coupons -- landing page list below. 

List of landing pages in order of coupons, excluding PATREON since that was part of #33357. 

- https://wordpress.com/alt-oasis
- https://wordpress.com/fiverr
- https://wordpress.com/genea-bloggers
- https://wordpress.com/visa
- https://wordpress.com/linkedin-learning
- https://wordpress.com/rocketlawyer
- https://wordpress.com/safer-internet
- https://wordpress.com/sbdc
- https://wordpress.com/iaa.tamu
