### PR TITLE
PlanFeatures: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -42,5 +42,4 @@
 @import 'layout/sidebar/style';
 @import 'lib/preferences-helper/style';
 @import 'me/sidebar-navigation/style';
-@import 'my-sites/plan-features/style';
 @import 'my-sites/sidebar-navigation/style';

--- a/client/my-sites/plan-features/actions.jsx
+++ b/client/my-sites/plan-features/actions.jsx
@@ -6,7 +6,7 @@
 
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { noop } from 'lodash';
+import { get, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -25,7 +25,7 @@ const PlanFeaturesActions = ( {
 	availableForPurchase = true,
 	canPurchase,
 	className,
-	currentSitePlan,
+	currentSitePlanSlug,
 	current = false,
 	forceDisplayButton = false,
 	freePlan = false,
@@ -93,21 +93,21 @@ const PlanFeaturesActions = ( {
 				},
 			} );
 		}
-		const isCurrentPlanMonthly = currentSitePlan && isMonthly( currentSitePlan.productSlug );
+
 		if (
-			isCurrentPlanMonthly &&
-			getPlanClass( planType ) === getPlanClass( currentSitePlan.productSlug )
+			isMonthly( currentSitePlanSlug ) &&
+			getPlanClass( planType ) === getPlanClass( currentSitePlanSlug )
 		) {
 			buttonText = translate( 'Upgrade to Yearly' );
 		}
 
 		const handleUpgradeButtonClick = () => {
 			if ( isPlaceholder ) {
-				return noop();
+				return;
 			}
 
 			trackTracksEvent( 'calypso_plan_features_upgrade_click', {
-				current_plan: currentSitePlan && currentSitePlan.productSlug,
+				current_plan: currentSitePlanSlug,
 				upgrading_to: planType,
 			} );
 
@@ -140,6 +140,7 @@ PlanFeaturesActions.propTypes = {
 	canPurchase: PropTypes.bool.isRequired,
 	className: PropTypes.string,
 	current: PropTypes.bool,
+	currentSitePlanSlug: PropTypes.string,
 	forceDisplayButton: PropTypes.bool,
 	freePlan: PropTypes.bool,
 	isPlaceholder: PropTypes.bool,
@@ -152,15 +153,15 @@ PlanFeaturesActions.propTypes = {
 };
 
 export default connect(
-	( state, ownProps ) => {
-		const { isInSignup } = ownProps;
-		const selectedSiteId = isInSignup ? null : getSelectedSiteId( state );
+	( state, { isInSignup } ) => {
+		if ( isInSignup ) {
+			return { currentSitePlanSlug: null };
+		}
+
+		const selectedSiteId = getSelectedSiteId( state );
 		const currentSitePlan = getCurrentPlan( state, selectedSiteId );
-		return {
-			currentSitePlan,
-		};
+		const currentSitePlanSlug = get( currentSitePlan, 'productSlug', null );
+		return { currentSitePlanSlug };
 	},
-	{
-		recordTracksEvent,
-	}
+	{ recordTracksEvent }
 )( localize( PlanFeaturesActions ) );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -67,6 +67,11 @@ import {
 import { getPlanFeaturesObject } from 'lib/plans/features-list';
 import PlanFeaturesScroller from './scroller';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class PlanFeatures extends Component {
 	render() {
 		const { isInSignup, planProperties, plans, selectedPlan, withScroll } = this.props;


### PR DESCRIPTION
The `PlanFeatures` component is used in Signup, Jetpack Connect and the Plans section. Styled slightly differently at each place.

I got a bit carried away by a small refactor of the `currentSitePlan` code and figured out it's worth shipping. The way to test is to buy a montly Jetpack plan and then check that the same plan in the "Yearly billing" tab has a button labeled with "Upgrade to Yearly":

<img width="799" alt="Screenshot 2019-06-06 at 18 55 28" src="https://user-images.githubusercontent.com/664258/59105853-e49dd680-8902-11e9-994c-9205b0890300.png">
