### PR TITLE
Revert "Marketing: Show permission requirement notice for non-admin users"

### DIFF
--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -15,7 +15,6 @@ import { localize } from 'i18n-calypso';
 import canCurrentUser from 'state/selectors/can-current-user';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
 import DocumentHead from 'components/data/document-head';
-import EmptyContent from 'components/empty-content';
 import { getSiteSlug, isJetpackMinimumVersion, isJetpackSite } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import Main from 'components/main';
@@ -33,7 +32,6 @@ import { FEATURE_NO_ADS } from 'lib/plans/constants';
 import './style.scss';
 
 export const Sharing = ( {
-	canManageOptions,
 	contentComponent,
 	path,
 	showButtons,
@@ -84,20 +82,6 @@ export const Sharing = ( {
 
 	const selected = find( filters, { route: path } );
 
-	if ( ! canManageOptions ) {
-		return (
-			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-			<Main wideLayout className="sharing">
-				<DocumentHead title={ translate( 'Sharing' ) } />
-				<SidebarNavigation />
-				<EmptyContent
-					title={ translate( 'You are not authorized to view this page' ) }
-					illustration={ '/calypso/images/illustrations/illustration-404.svg' }
-				/>
-			</Main>
-		);
-	}
-
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="sharing">
@@ -146,7 +130,6 @@ export default connect( state => {
 		isJetpackMinimumVersion( state, siteId, '3.4-dev' );
 
 	return {
-		canManageOptions,
 		showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
 		showConnections: ! siteId || ! isJetpack || isJetpackModuleActive( state, siteId, 'publicize' ),
 		showTraffic: !! siteId,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Revert #33210 (see https://github.com/Automattic/wp-calypso/pull/33210#issuecomment-499735135 for context)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Visit Tools > Marketing from the sidebar.
* Confirm the page loads for all user roles.
