### PR TITLE
Guided Tour: Add an Upgrade button to the Simple Payments tour

### DIFF
--- a/client/layout/guided-tours/config-elements/site-link.js
+++ b/client/layout/guided-tours/config-elements/site-link.js
@@ -21,11 +21,13 @@ class SiteLink extends Component {
 		href: PropTypes.string,
 		isButton: PropTypes.bool,
 		isPrimaryButton: PropTypes.bool,
+		newWindow: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		isButton: false,
 		isPrimaryButton: true,
+		newWindow: false,
 	};
 
 	static contextTypes = contextTypes;
@@ -37,12 +39,18 @@ class SiteLink extends Component {
 	};
 
 	render() {
-		const { children, href, siteSlug, isButton, isPrimaryButton } = this.props;
+		const { children, href, siteSlug, isButton, isPrimaryButton, newWindow } = this.props;
 		const siteHref = href.replace( ':site', siteSlug );
+		const siteTarget = newWindow ? '_blank' : null;
 
 		if ( isButton ) {
 			return (
-				<Button primary={ isPrimaryButton } onClick={ this.onClick } href={ siteHref }>
+				<Button
+					primary={ isPrimaryButton }
+					onClick={ this.onClick }
+					href={ siteHref }
+					target={ siteTarget }
+				>
 					{ children }
 				</Button>
 			);

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -139,6 +139,11 @@
 		&:focus {
 			border-color: rgba( var( --color-white-rgb ), 0.3 );
 		}
+
+		.gridicon {
+			margin-top: -2px;
+			vertical-align: inherit;
+		}
 	}
 }
 

--- a/client/layout/guided-tours/style.scss
+++ b/client/layout/guided-tours/style.scss
@@ -132,7 +132,13 @@
 	}
 
 	a.button {
+		border-bottom-width: 2px;
 		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			border-color: rgba( var( --color-white-rgb ), 0.3 );
+		}
 	}
 }
 

--- a/client/layout/guided-tours/tours/simple-payments-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour/index.js
@@ -3,8 +3,8 @@
 /**
  * External dependencies
  */
-
 import React, { Fragment } from 'react';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -49,8 +49,10 @@ export const SimplePaymentsTour = makeTour(
 							isButton
 							isPrimaryButton={ false }
 							href={ '/plans/:site?customerType=business' }
+							newWindow
 						>
-							{ translate( 'Upgrade' ) }
+							<Gridicon icon="external" />
+							<span>{ translate( 'Upgrade' ) }</span>
 						</SiteLink>
 					</ButtonRow>
 					<Link href="https://en.support.wordpress.com/simple-payments">

--- a/client/layout/guided-tours/tours/simple-payments-tour/index.js
+++ b/client/layout/guided-tours/tours/simple-payments-tour/index.js
@@ -10,7 +10,15 @@ import React, { Fragment } from 'react';
  * Internal dependencies
  */
 import meta from './meta';
-import { makeTour, Tour, Step, ButtonRow, Link, Quit } from 'layout/guided-tours/config-elements';
+import {
+	makeTour,
+	Tour,
+	Step,
+	ButtonRow,
+	SiteLink,
+	Link,
+	Quit,
+} from 'layout/guided-tours/config-elements';
 
 export const SimplePaymentsTour = makeTour(
 	<Tour { ...meta }>
@@ -37,6 +45,13 @@ export const SimplePaymentsTour = makeTour(
 					</p>
 					<ButtonRow>
 						<Quit primary>{ translate( 'Got it, thanks!' ) }</Quit>
+						<SiteLink
+							isButton
+							isPrimaryButton={ false }
+							href={ '/plans/:site?customerType=business' }
+						>
+							{ translate( 'Upgrade' ) }
+						</SiteLink>
 					</ButtonRow>
 					<Link href="https://en.support.wordpress.com/simple-payments">
 						{ translate( 'Learn more about Simple Payments.' ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a button that links to the plans
* Fix Guided Tours link button to match correct border bottom and add a proper hover/focus state

#### Testing instructions

* Site with a free plan,
* In the Calypso editor (not blocks!), click on the inline help
* Then "Collect Payments and Donation" > "Start Tour"
* You should now see the Guided Tour "tooltip"
* Do you see the "Upgrade" button?
* Does it redirect you to the plans page?

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/59110452-13ce3b00-8937-11e9-8cce-2439130d2fa9.png)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/59117562-f5237080-8945-11e9-8560-5a3292b4ca19.png)

Fixes #33531, fixes #33532