### PR TITLE
Make Quickstart session page visible when logged out

### DIFF
--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -241,6 +241,7 @@ function createListener( store, selector, callback ) {
 
 // Subscribe to the Redux store to get updates about the selected site
 getReduxStore().then( store => {
-	CartStore.setSelectedSiteId( getSelectedSiteId( store.getState() ) );
+	const selectedSiteId = getSelectedSiteId( store.getState() );
+	selectedSiteId && CartStore.setSelectedSiteId( selectedSiteId );
 	store.subscribe( createListener( store, getSelectedSiteId, CartStore.setSelectedSiteId ) );
 } );

--- a/client/my-sites/checkout/cart/cart-messages.jsx
+++ b/client/my-sites/checkout/cart/cart-messages.jsx
@@ -16,7 +16,7 @@ import { getNewMessages } from 'lib/cart-values';
 class CartMessages extends PureComponent {
 	static propTypes = {
 		cart: PropTypes.object.isRequired,
-		selectedSite: PropTypes.object.isRequired,
+		selectedSite: PropTypes.object,
 
 		// connected
 		translate: PropTypes.func.isRequired,

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -15,6 +15,7 @@ import React from 'react';
 import analytics from 'lib/analytics';
 import { shouldShowTax, hasPendingPayment, getEnabledPaymentMethods } from 'lib/cart-values';
 import {
+	conciergeSessionItem,
 	domainMapping,
 	planItem as getCartItemForPlan,
 	themeItem,
@@ -269,7 +270,7 @@ export class Checkout extends React.Component {
 	}
 
 	addNewItemToCart() {
-		const { planSlug } = this.props;
+		const { planSlug, cart } = this.props;
 
 		let cartItem, cartMeta;
 
@@ -285,6 +286,13 @@ export class Checkout extends React.Component {
 		if ( startsWith( this.props.product, 'domain-mapping' ) ) {
 			cartMeta = this.props.product.split( ':' )[ 1 ];
 			cartItem = domainMapping( { domain: cartMeta } );
+		}
+
+		if ( startsWith( this.props.product, 'quickstart-session' ) ) {
+			cartItem = ! hasConciergeSession( cart ) && conciergeSessionItem();
+			analytics.tracks.recordEvent( 'calypso_concierge_session_upsell_accept_button_click', {
+				section: 'checkout',
+			} );
 		}
 
 		if ( cartItem ) {
@@ -433,7 +441,7 @@ export class Checkout extends React.Component {
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
 			if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
-				return `/checkout/${ selectedSiteSlug }/add-quickstart-session/${ receiptId }`;
+				return `/checkout/${ selectedSiteSlug }/offer-quickstart-session/${ receiptId }`;
 			}
 		}
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -290,9 +290,6 @@ export class Checkout extends React.Component {
 
 		if ( startsWith( this.props.product, 'concierge-session' ) ) {
 			cartItem = ! hasConciergeSession( cart ) && conciergeSessionItem();
-			analytics.tracks.recordEvent( 'calypso_concierge_session_upsell_accept_button_click', {
-				section: 'checkout',
-			} );
 		}
 
 		if ( cartItem ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -288,7 +288,7 @@ export class Checkout extends React.Component {
 			cartItem = domainMapping( { domain: cartMeta } );
 		}
 
-		if ( startsWith( this.props.product, 'quickstart-session' ) ) {
+		if ( startsWith( this.props.product, 'concierge-session' ) ) {
 			cartItem = ! hasConciergeSession( cart ) && conciergeSessionItem();
 			analytics.tracks.recordEvent( 'calypso_concierge_session_upsell_accept_button_click', {
 				section: 'checkout',

--- a/client/my-sites/checkout/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/concierge-quickstart-session/index.jsx
@@ -68,7 +68,7 @@ export class ConciergeQuickstartSession extends React.Component {
 			translate,
 			receiptId,
 		} = this.props;
-		const title = translate( 'Checkout ‹ Support Session', {
+		const title = translate( 'Checkout ‹ Quick Start Session', {
 			comment: '"Checkout" is the part of the site where a user is preparing to make a purchase.',
 		} );
 

--- a/client/my-sites/checkout/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/concierge-quickstart-session/index.jsx
@@ -313,7 +313,7 @@ export class ConciergeQuickstartSession extends React.Component {
 					<Button
 						primary
 						className="concierge-quickstart-session__get-started-button"
-						onClick={ this.handleClickAccept }
+						onClick={ () => this.handleClickAccept( 'get_started' ) }
 					>
 						{ translate( 'Get Started!' ) }
 					</Button>
@@ -329,7 +329,7 @@ export class ConciergeQuickstartSession extends React.Component {
 						<Button
 							primary
 							className="concierge-quickstart-session__accept-offer-button"
-							onClick={ this.handleClickAccept }
+							onClick={ () => this.handleClickAccept( 'accept' ) }
 						>
 							{ translate( 'Yes, I want a WordPress Expert by my side!', {
 								args: {
@@ -352,7 +352,7 @@ export class ConciergeQuickstartSession extends React.Component {
 			redirectToPageBuilder,
 		} = this.props;
 
-		trackUpsellButtonClick( 'decline' );
+		trackUpsellButtonClick( `calypso_offer_quickstart_upsell_decline_button_click` );
 
 		if ( ! receiptId ) {
 			// Send the user to a generic page (not post-purchase related).
@@ -371,16 +371,17 @@ export class ConciergeQuickstartSession extends React.Component {
 		}
 	};
 
-	handleClickAccept = () => {
-		page( `/checkout/${ this.props.siteSlug }/concierge-session` );
+	handleClickAccept = buttonAction => {
+		const { trackUpsellButtonClick, siteSlug } = this.props;
+
+		trackUpsellButtonClick( `calypso_offer_quickstart_upsell_${ buttonAction }_button_click` );
+		page( `/checkout/${ siteSlug }/concierge-session` );
 	};
 }
 
-const trackUpsellButtonClick = buttonAction => {
-	// Track calypso_concierge_session_upsell_decline_button_click  event
-	return recordTracksEvent( `calypso_concierge_session_upsell_${ buttonAction }_button_click`, {
-		section: 'checkout',
-	} );
+const trackUpsellButtonClick = eventName => {
+	// Track concierge session get started / accept / decline events
+	return recordTracksEvent( eventName, { section: 'checkout' } );
 };
 
 export default connect(

--- a/client/my-sites/checkout/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/concierge-quickstart-session/index.jsx
@@ -46,9 +46,18 @@ import './style.scss';
 
 export class ConciergeQuickstartSession extends React.Component {
 	static propTypes = {
-		receiptId: PropTypes.number,
-		selectedSiteId: PropTypes.number.isRequired,
+		receiptId: PropTypes.string,
+		selectedSiteId: PropTypes.number,
 	};
+
+	componentDidMount() {
+		// If the param value is 'add', then we will add the concierge session item to cart and proceed to checkout,
+		// without rendering the UI. We use this method when a logged out user clicks 'Get Started' on the concierge
+		// offer page.
+		if ( 'add' === this.props.receiptId ) {
+			this.handleClickAccept();
+		}
+	}
 
 	render() {
 		const {
@@ -63,14 +72,6 @@ export class ConciergeQuickstartSession extends React.Component {
 			comment: '"Checkout" is the part of the site where a user is preparing to make a purchase.',
 		} );
 
-		// If the param value is 'add', then we will add the concierge session item to cart and proceed to checkout,
-		// without showing any UI. We use this method when a logged out user clicks 'Get Started' on the concierge
-		// offer page.
-		if ( 'add' === receiptId ) {
-			this.renderPlaceholders();
-			this.handleClickAccept();
-			return null;
-		}
 		return (
 			<Main className="concierge-quickstart-session">
 				<PageViewTracker
@@ -425,10 +426,10 @@ export default connect(
 			productCost: getProductCost( state, 'concierge-session' ),
 			productDisplayCost: getProductDisplayCost( state, 'concierge-session' ),
 			isLoggedIn: isUserLoggedIn( state ),
+			redirectLoggedOut,
 		};
 	},
 	{
 		trackUpsellButtonClick,
-		redirectLoggedOut,
 	}
 )( localize( ConciergeQuickstartSession ) );

--- a/client/my-sites/checkout/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/concierge-quickstart-session/index.jsx
@@ -372,7 +372,7 @@ export class ConciergeQuickstartSession extends React.Component {
 	};
 
 	handleClickAccept = () => {
-		page( `/checkout/${ this.props.siteSlug }/quickstart-session` );
+		page( `/checkout/${ this.props.siteSlug }/concierge-session` );
 	};
 }
 

--- a/client/my-sites/checkout/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/concierge-quickstart-session/index.jsx
@@ -37,7 +37,6 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { localize } from 'i18n-calypso';
 import { isRequestingSitePlans, getPlansBySiteId } from 'state/sites/plans/selectors';
 import analytics from 'lib/analytics';
-import { redirectLoggedOut } from 'controller';
 
 /**
  * Style dependencies
@@ -356,12 +355,11 @@ export class ConciergeQuickstartSession extends React.Component {
 	}
 
 	/**
-	 * Redirect user to the login page with the appropriate redirect_to param,
-	 * when they click 'Get Started' on the Quickstart session offer page while logged out.
+	 * Redirect user to the login page when they click 'Get Started' on
+	 * the Quickstart session offer page while logged out.
 	 */
 	handleRedirect = () => {
-		const redirectPath = this.props.path + '/add';
-		this.props.redirectLoggedOut( { path: redirectPath, store: this.props.reduxStore } );
+		page( `${ this.props.path }/add` );
 	};
 
 	handleClickDecline = () => {
@@ -426,7 +424,6 @@ export default connect(
 			productCost: getProductCost( state, 'concierge-session' ),
 			productDisplayCost: getProductDisplayCost( state, 'concierge-session' ),
 			isLoggedIn: isUserLoggedIn( state ),
-			redirectLoggedOut,
 		};
 	},
 	{

--- a/client/my-sites/checkout/concierge-quickstart-session/style.scss
+++ b/client/my-sites/checkout/concierge-quickstart-session/style.scss
@@ -140,4 +140,8 @@
 			float: right;
 		}
 	}
+
+	&__footer &__get-started-button {
+		width: 100%;
+	}
 }

--- a/client/my-sites/checkout/concierge-quickstart-session/style.scss
+++ b/client/my-sites/checkout/concierge-quickstart-session/style.scss
@@ -141,7 +141,7 @@
 		}
 	}
 
-	&__footer &__get-started-button {
+	.concierge-quickstart-session__footer .concierge-quickstart-session__get-started-button {
 		width: 100%;
 	}
 }

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -21,8 +21,6 @@ import QuerySitePlans from 'components/data/query-site-plans';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import CompactCard from 'components/card/compact';
 import Button from 'components/button';
-import { addItem } from 'lib/upgrades/actions';
-import { conciergeSessionItem } from 'lib/cart-values/cart-items';
 import { siteQualifiesForPageBuilder, getEditHomeUrl } from 'lib/signup/page-builder';
 import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
 import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
@@ -34,6 +32,7 @@ import {
 	isProductsListFetching,
 } from 'state/products-list/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import { localize } from 'i18n-calypso';
 import { isRequestingSitePlans, getPlansBySiteId } from 'state/sites/plans/selectors';
 import analytics from 'lib/analytics';
@@ -46,7 +45,6 @@ import './style.scss';
 export class ConciergeSessionNudge extends React.Component {
 	static propTypes = {
 		receiptId: PropTypes.number,
-		selectedSiteId: PropTypes.number.isRequired,
 	};
 
 	render() {
@@ -333,18 +331,12 @@ export class ConciergeSessionNudge extends React.Component {
 	};
 
 	handleClickAccept = () => {
-		const { siteSlug, trackUpsellButtonClick } = this.props;
-
-		trackUpsellButtonClick( 'accept' );
-
-		addItem( conciergeSessionItem() );
-
-		page( `/checkout/${ siteSlug }` );
+		page( `/checkout/${ this.props.siteSlug }/quickstart-session` );
 	};
 }
 
 const trackUpsellButtonClick = buttonAction => {
-	// Track calypso_concierge_session_upsell_decline_button_click and calypso_concierge_session_upsell_accept_button_click events
+	// Track calypso_concierge_session_upsell_decline_button_click  event
 	return recordTracksEvent( `calypso_concierge_session_upsell_${ buttonAction }_button_click`, {
 		section: 'checkout',
 	} );
@@ -352,19 +344,22 @@ const trackUpsellButtonClick = buttonAction => {
 
 export default connect(
 	( state, props ) => {
-		const { selectedSiteId } = props;
+		const { siteSlugParam } = props;
+		const selectedSiteId = getSelectedSiteId( state );
 		const productsList = getProductsList( state );
 		const sitePlans = getPlansBySiteId( state ).data;
+		const siteSlug = selectedSiteId ? getSiteSlug( state, selectedSiteId ) : siteSlugParam;
 		return {
 			currencyCode: getCurrentUserCurrencyCode( state ),
 			isLoading: isProductsListFetching( state ) || isRequestingSitePlans( state, selectedSiteId ),
 			hasProductsList: Object.keys( productsList ).length > 0,
 			hasSitePlans: sitePlans && sitePlans.length > 0,
-			siteSlug: getSiteSlug( state, selectedSiteId ),
 			isEligibleForChecklist: isEligibleForDotcomChecklist( state, selectedSiteId ),
 			redirectToPageBuilder: siteQualifiesForPageBuilder( state, selectedSiteId ),
 			productCost: getProductCost( state, 'concierge-session' ),
 			productDisplayCost: getProductDisplayCost( state, 'concierge-session' ),
+			siteSlug,
+			selectedSiteId,
 		};
 	},
 	{

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -290,7 +290,7 @@ export class ConciergeSessionNudge extends React.Component {
 				<Button
 					primary
 					className="concierge-session-nudge__accept-offer-button"
-					onClick={ this.handleClickAccept }
+					onClick={ () => this.handleClickAccept( 'accept' ) }
 				>
 					{ translate( 'Reserve a call for %(amount)s', {
 						args: {
@@ -311,7 +311,7 @@ export class ConciergeSessionNudge extends React.Component {
 			redirectToPageBuilder,
 		} = this.props;
 
-		trackUpsellButtonClick( 'decline' );
+		trackUpsellButtonClick( `calypso_concierge_session_upsell_decline_button_click` );
 
 		if ( ! receiptId ) {
 			// Send the user to a generic page (not post-purchase related).
@@ -330,16 +330,17 @@ export class ConciergeSessionNudge extends React.Component {
 		}
 	};
 
-	handleClickAccept = () => {
-		page( `/checkout/${ this.props.siteSlug }/concierge-session` );
+	handleClickAccept = buttonAction => {
+		const { trackUpsellButtonClick, siteSlug } = this.props;
+
+		trackUpsellButtonClick( `calypso_concierge_session_upsell_${ buttonAction }_button_click` );
+		page( `/checkout/${ siteSlug }/concierge-session` );
 	};
 }
 
-const trackUpsellButtonClick = buttonAction => {
-	// Track calypso_concierge_session_upsell_decline_button_click  event
-	return recordTracksEvent( `calypso_concierge_session_upsell_${ buttonAction }_button_click`, {
-		section: 'checkout',
-	} );
+const trackUpsellButtonClick = eventName => {
+	// Track concierge session get started / accept / decline events
+	return recordTracksEvent( eventName, { section: 'checkout' } );
 };
 
 export default connect(

--- a/client/my-sites/checkout/concierge-session-nudge/index.jsx
+++ b/client/my-sites/checkout/concierge-session-nudge/index.jsx
@@ -331,7 +331,7 @@ export class ConciergeSessionNudge extends React.Component {
 	};
 
 	handleClickAccept = () => {
-		page( `/checkout/${ this.props.siteSlug }/quickstart-session` );
+		page( `/checkout/${ this.props.siteSlug }/concierge-session` );
 	};
 }
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -12,7 +12,7 @@ import { get, isEmpty } from 'lodash';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
 import { getSiteBySlug } from 'state/sites/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import GSuiteNudge from 'my-sites/checkout/gsuite-nudge';
 import CheckoutContainer from './checkout/checkout-container';
 import CartData from 'components/data/cart';
@@ -127,15 +127,15 @@ export function conciergeSessionNudge( context, next ) {
 	);
 
 	const state = context.store.getState();
-	const selectedSite = getSelectedSite( state );
+	const selectedSiteId = getSelectedSiteId( state );
 
-	if ( ! selectedSite ) {
+	if ( ! selectedSiteId ) {
 		return null;
 	}
 
 	context.primary = (
 		<CartData>
-			<ConciergeSessionNudge receiptId={ Number( receiptId ) } selectedSiteId={ selectedSite.ID } />
+			<ConciergeSessionNudge receiptId={ Number( receiptId ) } selectedSiteId={ selectedSiteId } />
 		</CartData>
 	);
 
@@ -149,8 +149,7 @@ export function conciergeQuickstartSession( context, next ) {
 	);
 
 	const state = context.store.getState();
-	const selectedSite = getSelectedSite( state );
-	const selectedSiteId = selectedSite && selectedSite.ID;
+	const selectedSiteId = getSelectedSiteId( state );
 
 	context.primary = (
 		<CartData>

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -152,10 +152,6 @@ export function conciergeQuickstartSession( context, next ) {
 	const selectedSite = getSelectedSite( state );
 	const selectedSiteId = selectedSite && selectedSite.ID;
 
-	// if ( ! selectedSite ) {
-	// 	return null;
-	// }
-
 	context.primary = (
 		<CartData>
 			<ConciergeQuickstartSession

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -12,7 +12,7 @@ import { get, isEmpty } from 'lodash';
 import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
 import { getSiteBySlug } from 'state/sites/selectors';
-import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import { getSelectedSite } from 'state/ui/selectors';
 import GSuiteNudge from 'my-sites/checkout/gsuite-nudge';
 import CheckoutContainer from './checkout/checkout-container';
 import CartData from 'components/data/cart';
@@ -121,21 +121,14 @@ export function gsuiteNudge( context, next ) {
 }
 
 export function conciergeSessionNudge( context, next ) {
-	const { receiptId } = context.params;
+	const { receiptId, site } = context.params;
 	context.store.dispatch(
 		setSection( { name: 'concierge-session-nudge' }, { hasSidebar: false } )
 	);
 
-	const state = context.store.getState();
-	const selectedSiteId = getSelectedSiteId( state );
-
-	if ( ! selectedSiteId ) {
-		return null;
-	}
-
 	context.primary = (
 		<CartData>
-			<ConciergeSessionNudge receiptId={ Number( receiptId ) } selectedSiteId={ selectedSiteId } />
+			<ConciergeSessionNudge receiptId={ Number( receiptId ) } siteSlugParam={ site } />
 		</CartData>
 	);
 
@@ -143,21 +136,18 @@ export function conciergeSessionNudge( context, next ) {
 }
 
 export function conciergeQuickstartSession( context, next ) {
-	const { receiptId } = context.params;
+	const { receiptId, site } = context.params;
+
 	context.store.dispatch(
 		setSection( { name: 'concierge-quickstart-session' }, { hasSidebar: false } )
 	);
 
-	const state = context.store.getState();
-	const selectedSiteId = getSelectedSiteId( state );
-
 	context.primary = (
 		<CartData>
 			<ConciergeQuickstartSession
-				receiptId={ receiptId }
-				selectedSiteId={ selectedSiteId }
+				receiptId={ Number( receiptId ) }
+				siteSlugParam={ site }
 				path={ context.path }
-				reduxStore={ context.store }
 			/>
 		</CartData>
 	);

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -143,6 +143,7 @@ export function conciergeSessionNudge( context, next ) {
 }
 
 export function conciergeQuickstartSession( context, next ) {
+	console.log( 'in conciergeQuickstartSession' );
 	const { receiptId } = context.params;
 	context.store.dispatch(
 		setSection( { name: 'concierge-quickstart-session' }, { hasSidebar: false } )
@@ -150,16 +151,17 @@ export function conciergeQuickstartSession( context, next ) {
 
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
+	const selectedSiteId = selectedSite && selectedSite.ID;
 
-	if ( ! selectedSite ) {
-		return null;
-	}
+	// if ( ! selectedSite ) {
+	// 	return null;
+	// }
 
 	context.primary = (
 		<CartData>
 			<ConciergeQuickstartSession
 				receiptId={ Number( receiptId ) }
-				selectedSiteId={ selectedSite.ID }
+				selectedSiteId={ selectedSiteId }
 			/>
 		</CartData>
 	);

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -143,7 +143,6 @@ export function conciergeSessionNudge( context, next ) {
 }
 
 export function conciergeQuickstartSession( context, next ) {
-	console.log( 'in conciergeQuickstartSession' );
 	const { receiptId } = context.params;
 	context.store.dispatch(
 		setSection( { name: 'concierge-quickstart-session' }, { hasSidebar: false } )
@@ -160,8 +159,10 @@ export function conciergeQuickstartSession( context, next ) {
 	context.primary = (
 		<CartData>
 			<ConciergeQuickstartSession
-				receiptId={ Number( receiptId ) }
+				receiptId={ receiptId }
 				selectedSiteId={ selectedSiteId }
+				path={ context.path }
+				reduxStore={ context.store }
 			/>
 		</CartData>
 	);

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -29,7 +29,7 @@ export default function() {
 
 	if ( isLoggedOut ) {
 		page(
-			'/checkout/:site/add-quickstart-session',
+			'/checkout/:site/offer-quickstart-session',
 			conciergeQuickstartSession,
 			makeLayout,
 			clientRender
@@ -117,7 +117,7 @@ export default function() {
 		);
 
 		page(
-			'/checkout/:site/add-quickstart-session/pending/:orderId',
+			'/checkout/:site/offer-quickstart-session/pending/:orderId',
 			siteSelection,
 			checkoutPending,
 			makeLayout,
@@ -125,7 +125,7 @@ export default function() {
 		);
 
 		page(
-			'/checkout/:site/add-quickstart-session/:receiptId?',
+			'/checkout/:site/offer-quickstart-session/:receiptId?',
 			siteSelection,
 			conciergeQuickstartSession,
 			makeLayout,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -31,14 +31,18 @@ export default function() {
 	if ( isLoggedOut ) {
 		console.log( 'in index.js isLoggedOut' );
 		page(
-			'/checkout/:site?/add-random',
-			// siteSelection,
-			conciergeQuickstartSession,
+			// '/checkout/:site/add-quickstart-session/:orderId',
+			'/checkout/add-random',
+			siteSelection,
+			checkoutPending,
 			makeLayout,
 			clientRender
 		);
+
+		return;
 	}
 
+	// Show these paths only for logged in users
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',
 		siteSelection,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -29,7 +29,7 @@ export default function() {
 
 	if ( isLoggedOut ) {
 		page(
-			'/checkout/:site/add-quickstart-session/:receiptId?',
+			'/checkout/:site/add-quickstart-session',
 			conciergeQuickstartSession,
 			makeLayout,
 			clientRender

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -19,9 +19,25 @@ import SiftScience from 'lib/siftscience';
 import { makeLayout, render as clientRender } from 'controller';
 import { noSite, siteSelection } from 'my-sites/controller';
 import config from 'config';
+import userFactory from 'lib/user';
 
 export default function() {
+	console.log( 'in checkout index.js' );
 	SiftScience.recordUser();
+
+	const user = userFactory();
+	const isLoggedOut = ! user.get();
+
+	if ( isLoggedOut ) {
+		console.log( 'in index.js isLoggedOut' );
+		page(
+			'/checkout/:site?/add-random',
+			// siteSelection,
+			conciergeQuickstartSession,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	page(
 		'/checkout/thank-you/no-site/pending/:orderId',
@@ -102,14 +118,6 @@ export default function() {
 			'/checkout/:site/add-quickstart-session/pending/:orderId',
 			siteSelection,
 			checkoutPending,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/checkout/:site/add-quickstart-session/:receiptId?',
-			siteSelection,
-			conciergeQuickstartSession,
 			makeLayout,
 			clientRender
 		);

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -16,28 +16,26 @@ import {
 	conciergeQuickstartSession,
 } from './controller';
 import SiftScience from 'lib/siftscience';
-import { makeLayout, render as clientRender } from 'controller';
+import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
 import { noSite, siteSelection } from 'my-sites/controller';
 import config from 'config';
 import userFactory from 'lib/user';
 
 export default function() {
-	console.log( 'in checkout index.js' );
 	SiftScience.recordUser();
 
 	const user = userFactory();
 	const isLoggedOut = ! user.get();
 
 	if ( isLoggedOut ) {
-		console.log( 'in index.js isLoggedOut' );
 		page(
-			// '/checkout/:site/add-quickstart-session/:orderId',
-			'/checkout/add-random',
-			siteSelection,
-			checkoutPending,
+			'/checkout/:site/add-quickstart-session/:receiptId?',
+			conciergeQuickstartSession,
 			makeLayout,
 			clientRender
 		);
+
+		page( '/checkout*', redirectLoggedOut );
 
 		return;
 	}
@@ -122,6 +120,14 @@ export default function() {
 			'/checkout/:site/add-quickstart-session/pending/:orderId',
 			siteSelection,
 			checkoutPending,
+			makeLayout,
+			clientRender
+		);
+
+		page(
+			'/checkout/:site/add-quickstart-session/:receiptId?',
+			siteSelection,
+			conciergeQuickstartSession,
 			makeLayout,
 			clientRender
 		);

--- a/client/sections.js
+++ b/client/sections.js
@@ -251,6 +251,7 @@ const sections = [
 		module: 'my-sites/checkout',
 		secondary: true,
 		group: 'sites',
+		enableLoggedOut: true,
 	},
 	{
 		name: 'plans',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Shows the Quickstart session page even to a logged out user. 

Navigating to `http://calypso.localhost:3000/checkout/SITE_SLUG/add-quickstart-session` while logged out will show the Quickstart Session offer page with a `Get Started` button. With Calypso live, you can instead navigate to `https://hash-7387affcb976116ea8f0a9d85df15ae16b5ea495.calypso.live/checkout/SITE_SLUG/add-quickstart-session`

![calypso localhost_3000_checkout_iop280518100 wordpress com_add-quickstart-session](https://user-images.githubusercontent.com/1269602/59347690-e1578000-8d32-11e9-9950-1d26fc7d3740.png)


Clicking `Get Started` should take you to the Log In page. After successful signing in, you should be redirected to the Order Summary page with the Support Session already added to cart. Check this [recording](https://media.giphy.com/media/VEc4Uunvcv6K4wO9xH/giphy.mp4).

Please note that for the Order Summary page to be shown, the SITE_SLUG should be a valid slug for the account that you are signing in. 



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**

* Log out of WP.com and navigate to `http://calypso.localhost:3000/checkout/SITE_SLUG/add-quickstart-session` OR `https://hash-7387affcb976116ea8f0a9d85df15ae16b5ea495.calypso.live./checkout/SITE_SLUG/add-quickstart-session`. The SITE_SLUG should be a valid slug associated with the account that you plan to sign in with.
* Verify from the previous step that you can see the Quickstart session offer page with a "Get Started"
  button.
* Click the "Get Started" button, and verify that you are taken to a Log In page.
* Sign in with your account, and verify that you are taken to the Order Summary page with the support session item already added to cart. 
* Complete payment and verify that the purchase succeeds.

**Scenario 2**

* While logged in to WP.com, verify that `http://calypso.localhost:3000/checkout/SITE_SLUG/add-quickstart-session` opens the Quickstart session offer page with Accept and Decline buttons as shown below:

![calypso localhost_3000_checkout_iop280518100 wordpress com_add-quickstart-session (1)](https://user-images.githubusercontent.com/1269602/59348913-000b4600-8d36-11e9-9942-a639660274c9.png)

Complete the checkout process and verify that the purchase is successful

**Scenario 3**

Verify _Scenario 1_ on a mobile device. Verify that alignments are proper and nothing stands out as abnormal.

**Scenario 4**

While logged out, visiting any other /checkout route should redirect to the log in page. So try the following routes:

http://calypso.localhost:3000/checkout
http://calypso.localhost:3000/checkout/SITE_SLUG/add-support-session
http://calypso.localhost:3000/checkout/SITE_SLUG/add-support-session
http://calypso.localhost:3000/checkout/thank-you/no-site

While logged in, verify that all the above routes redirect to their respective destinations. Note that while logged in, `http://calypso.localhost:3000/checkout` without a plan or product will redirect to 
/plans.

**Scenario 5**

Try accessing the logged out offer page from different locations (USA, UK, Japan etc) using a VPN service, and verify that the currency denomination changes for these different locations.