### PR TITLE
Full Site Editing: add template taxonomy

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -157,6 +157,46 @@ class Full_Site_Editing {
 		);
 
 		register_taxonomy(
+			'wp_template_type',
+			'wp_template',
+			array(
+				'labels'             => array(
+					'name'              => _x( 'Template Types', 'taxonomy general name', 'full-site-editing' ),
+					'singular_name'     => _x( 'Template Type', 'taxonomy singular name', 'full-site-editing' ),
+					'menu_name'         => _x( 'Template Types', 'admin menu', 'full-site-editing' ),
+					'all_items'         => __( 'All Template Types', 'full-site-editing' ),
+					'edit_item'         => __( 'Edit Template Type', 'full-site-editing' ),
+					'view_item'         => __( 'View Template Type', 'full-site-editing' ),
+					'update_item'       => __( 'Update Template Type', 'full-site-editing' ),
+					'add_new_item'      => __( 'Add New Template Type', 'full-site-editing' ),
+					'new_item_name'     => __( 'New Template Type', 'full-site-editing' ),
+					'parent_item'       => __( 'Parent Template Type', 'full-site-editing' ),
+					'parent_item_colon' => __( 'Parent Template Type:', 'full-site-editing' ),
+					'search_items'      => __( 'Search Template Types', 'full-site-editing' ),
+					'not_found'         => __( 'No template types found.', 'full-site-editing' ),
+					'back_to_items'     => __( 'Back to template types', 'full-site-editing' ),
+				),
+				'public'             => false,
+				'publicly_queryable' => true,
+				'show_ui'            => true,
+				'show_in_menu'       => false,
+				'show_in_nav_menu'   => false,
+				'show_in_rest'       => true,
+				'rest_base'          => 'template_types',
+				'show_tagcloud'      => false,
+				'show_admin_column'  => true,
+				'hierarchical'       => true,
+				'rewrite'            => false,
+				'capabilities'       => array(
+					'manage_terms' => 'edit_theme_options',
+					'edit_terms'   => 'edit_theme_options',
+					'delete_terms' => 'edit_theme_options',
+					'assign_terms' => 'edit_theme_options',
+				),
+			)
+		);
+
+		register_taxonomy(
 			'wp_template_part_type',
 			'wp_template_part',
 			array(
@@ -196,7 +236,7 @@ class Full_Site_Editing {
 			)
 		);
 	}
-
+	
 	/**
 	 * Register post meta.
 	 */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add the Template taxonomy to align our code with latest data representation diagram:

![template-parts-5](https://user-images.githubusercontent.com/1182160/59113761-f81e6100-8945-11e9-9ddc-5e2985cc811a.png)

Previously only the taxonomy related to Template Parts has been added. These taxonomies are not used yet, but we'll need them in the future.

#### Testing instructions

* Just a smoke test of the plugin since these taxonomies are not used yet.