### PR TITLE
Happiness Support: Prevent widows on the support card manually.

### DIFF
--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -65,21 +65,17 @@ export class HappinessSupport extends Component {
 		const components = {
 			strong: <strong />,
 		};
-		const text = isJetpackFreePlan
-			? translate(
-					'{{strong}}Need help?{{/strong}} Search our support site to find out about your site, your account, and how to make the most of WordPress.',
-					{ components }
-			  )
-			: translate(
-					'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your account.',
-					{ components }
-			  );
-
-		if ( Array.isArray( text ) && 'string' === typeof text[ text.length - 1 ] ) {
-			text.push( preventWidows( text.pop() ) );
-		}
-
-		return text;
+		return preventWidows(
+			isJetpackFreePlan
+				? translate(
+						'{{strong}}Need help?{{/strong}} Search our support site to find out about your site, your account, and how to make the most of WordPress.',
+						{ components }
+				  )
+				: translate(
+						'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your account.',
+						{ components }
+				  )
+		);
 	}
 
 	getSupportButtons() {

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -66,12 +66,18 @@ export class HappinessSupport extends Component {
 		};
 		return isJetpackFreePlan
 			? translate(
-					'{{strong}}Need help?{{/strong}} Search our support site to find out about your site, your account, and how to make the most of WordPress.',
-					{ components }
+					'{{strong}}Need help?{{/strong}} Search our support site to find out about your site, your account, and how to make the most of\xa0WordPress.',
+					{
+						components,
+						comment: '\xa0 is a non-breaking space character',
+					}
 			  )
 			: translate(
-					'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your account.',
-					{ components }
+					'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your\xa0account.',
+					{
+						components,
+						comment: '\xa0 is a non-breaking space character',
+					}
 			  );
 	}
 

--- a/client/components/happiness-support/index.jsx
+++ b/client/components/happiness-support/index.jsx
@@ -25,6 +25,7 @@ import {
 import HappychatButton from 'components/happychat/button';
 import HappychatConnection from 'components/happychat/connection-connected';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { preventWidows } from 'lib/formatting';
 
 /**
  * Style dependencies
@@ -64,21 +65,21 @@ export class HappinessSupport extends Component {
 		const components = {
 			strong: <strong />,
 		};
-		return isJetpackFreePlan
+		const text = isJetpackFreePlan
 			? translate(
-					'{{strong}}Need help?{{/strong}} Search our support site to find out about your site, your account, and how to make the most of\xa0WordPress.',
-					{
-						components,
-						comment: '\xa0 is a non-breaking space character',
-					}
+					'{{strong}}Need help?{{/strong}} Search our support site to find out about your site, your account, and how to make the most of WordPress.',
+					{ components }
 			  )
 			: translate(
-					'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your\xa0account.',
-					{
-						components,
-						comment: '\xa0 is a non-breaking space character',
-					}
+					'{{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your account.',
+					{ components }
 			  );
+
+		if ( Array.isArray( text ) && 'string' === typeof text[ text.length - 1 ] ) {
+			text.push( preventWidows( text.pop() ) );
+		}
+
+		return text;
 	}
 
 	getSupportButtons() {

--- a/client/components/happiness-support/test/index.jsx
+++ b/client/components/happiness-support/test/index.jsx
@@ -39,7 +39,7 @@ describe( 'HappinessSupport', () => {
 		const content = wrapper.find( 'p.happiness-support__description' );
 		expect( content ).to.have.length( 1 );
 		expect( content.props().children ).to.equal(
-			'Translated: {{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your account.'
+			'Translated: {{strong}}Need help?{{/strong}} A Happiness Engineer can answer questions about your site and your\xA0account.'
 		);
 	} );
 

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -59,7 +59,7 @@ export function preventWidows( text, wordsToKeep = 2 ) {
 			// Handle strings with interpolated components by only acting on the last element.
 			if ( typeof text[ text.length - 1 ] === 'string' ) {
 				const endingText = text.pop();
-				const startingWhitespace = endingText.replace( /^(\s+).*$/, '$1' );
+				const startingWhitespace = endingText.replace( /^(\s+)?.*$/, '$1' );
 				// The whitespace between component and text would be stripped by preventWidows.
 				text.push( startingWhitespace );
 				text.push( preventWidows( endingText, wordsToKeep ) );

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -55,6 +55,10 @@ export function stripHTML( string ) {
  */
 export function preventWidows( text, wordsToKeep = 2 ) {
 	if ( typeof text !== 'string' ) {
+		if ( Array.isArray( text ) ) {
+			// Handle strings with interpolated components by only acting on the last element.
+			text.push( preventWidows( text.pop(), wordsToKeep ) );
+		}
 		return text;
 	}
 
@@ -168,7 +172,7 @@ export function wpautop( pee ) {
 	pee = pee.replace( new RegExp( '(</?(?:' + blocklist + ')[^>]*>)\\s*<br />', 'gi' ), '$1' );
 	pee = pee.replace( /<br \/>(\s*<\/?(?:p|li|div|dl|dd|dt|th|pre|td|ul|ol)>)/gi, '$1' );
 	pee = pee.replace(
-		/(?:<p>|<br ?\/?>)*\s*\[caption([^\[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi,
+		/(?:<p>|<br ?\/?>)*\s*\[caption([^[]+)\[\/caption\]\s*(?:<\/p>|<br ?\/?>)*/gi,
 		'[caption$1[/caption]'
 	);
 
@@ -245,7 +249,7 @@ export function removep( html ) {
 	// Fix some block element newline issues
 	html = html.replace( /\s*<div/g, '\n<div' );
 	html = html.replace( /<\/div>\s*/g, '</div>\n' );
-	html = html.replace( /\s*\[caption([^\[]+)\[\/caption\]\s*/gi, '\n\n[caption$1[/caption]\n\n' );
+	html = html.replace( /\s*\[caption([^[]+)\[\/caption\]\s*/gi, '\n\n[caption$1[/caption]\n\n' );
 	html = html.replace( /caption\]\n\n+\[caption/g, 'caption]\n\n[caption' );
 
 	html = html.replace(

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -2,7 +2,7 @@
 /**
  * External Dependencies
  */
-import { trimEnd } from 'lodash';
+import { trim } from 'lodash';
 import stripTags from 'striptags';
 
 /**
@@ -54,15 +54,21 @@ export function stripHTML( string ) {
  * @return {string}             the widow-prevented string
  */
 export function preventWidows( text, wordsToKeep = 2 ) {
-	if ( typeof text === 'string' ) {
+	if ( typeof text !== 'string' ) {
 		if ( Array.isArray( text ) ) {
 			// Handle strings with interpolated components by only acting on the last element.
-			text.push( preventWidows( text.pop(), wordsToKeep ) );
+			if ( typeof text[ text.length - 1 ] === 'string' ) {
+				const endingText = text.pop();
+				const startingWhitespace = endingText.replace( /^(\s+).*$/, '$1' );
+				// The whitespace between component and text would be stripped by preventWidows.
+				text.push( startingWhitespace );
+				text.push( preventWidows( endingText, wordsToKeep ) );
+			}
 		}
 		return text;
 	}
 
-	text = text && trimEnd( text );
+	text = text && trim( text );
 	if ( ! text ) {
 		return text;
 	}

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -59,9 +59,9 @@ export function preventWidows( text, wordsToKeep = 2 ) {
 			// Handle strings with interpolated components by only acting on the last element.
 			if ( typeof text[ text.length - 1 ] === 'string' ) {
 				const endingText = text.pop();
-				const startingWhitespace = endingText.replace( /^(\s+)?.*$/, '$1' );
+				const startingWhitespace = endingText.match( /^\s+/ );
 				// The whitespace between component and text would be stripped by preventWidows.
-				text.push( startingWhitespace );
+				startingWhitespace && text.push( startingWhitespace[ 0 ] );
 				text.push( preventWidows( endingText, wordsToKeep ) );
 			}
 		}

--- a/client/lib/formatting/index.js
+++ b/client/lib/formatting/index.js
@@ -2,7 +2,7 @@
 /**
  * External Dependencies
  */
-import { trim } from 'lodash';
+import { trimEnd } from 'lodash';
 import stripTags from 'striptags';
 
 /**
@@ -54,7 +54,7 @@ export function stripHTML( string ) {
  * @return {string}             the widow-prevented string
  */
 export function preventWidows( text, wordsToKeep = 2 ) {
-	if ( typeof text !== 'string' ) {
+	if ( typeof text === 'string' ) {
 		if ( Array.isArray( text ) ) {
 			// Handle strings with interpolated components by only acting on the last element.
 			text.push( preventWidows( text.pop(), wordsToKeep ) );
@@ -62,7 +62,7 @@ export function preventWidows( text, wordsToKeep = 2 ) {
 		return text;
 	}
 
-	text = text && trim( text );
+	text = text && trimEnd( text );
 	if ( ! text ) {
 		return text;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hacky fix to work around the preventWidows bug where strings with React components (in this case, `strong`) cannot be parsed by `preventWidows()`.
* This PR changes the last space in the string to a non-breaking space character (`\xa0`). Would this work as an interim solution?

#### Testing instructions

* Switch to this PR, navigate to `/plans` on a Business site.
* The last two words in the Priority Support card should have a non-breaking space to prevent widows.

Fixes #33474
