### PR TITLE
Full Site Editing: add filter to optionally disable FSE on other platforms

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -15,6 +15,17 @@
  * Load Full Site Editing.
  */
 function a8c_load_full_site_editing() {
+	/**
+	 * Can be used to disable Full Site Editing functionality.
+	 *
+	 * @since 0.1
+	 *
+	 * @param bool true if Full Site Editing should be disabled, false otherwise.
+	 */
+	if ( apply_filters( 'a8c_disable_full_site_editing', false ) ) {
+		return;
+	}
+
 	require_once __DIR__ . '/lib/feature-flags/feature-flags.php';
 	require_once __DIR__ . '/full-site-editing/blocks/post-content/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/template/index.php';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Allow FSE functionality to be conditionally disabled on different platforms (simulating feature flag essentially). This makes it consistent with Posts List Block and Starter Page Templates which offer a similar filter (see code bellow in the same file).

cc @obenland regarding our discussion in D29053-code.

#### Testing instructions

* Smoke test the plugin and make sure that everything still works.
* You can try adding the following filter somewhere in the execution path and verify that FSE is disabled:

```php
add_filter( 'a8c_disable_full_site_editing', '__return_true' );
```
