### PR TITLE
Jetpack performance checklist: enable on wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -57,7 +57,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
 		"jetpack/checklist": true,
-		"jetpack/checklist/performance": false,
+		"jetpack/checklist/performance": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable Jetpack performance checklist on wpcalypso env 

#### Testing instructions

Not sure how to test wpcalypso flag changes :-/ Maybe with calypso-live branches?

Generally:
- Open `/plans/my-plan/:site` with Jetpack site and observe all performance checklist things appear:

<img width="745" alt="Screenshot 2019-06-07 at 18 38 19" src="https://user-images.githubusercontent.com/87168/59116139-89480480-8953-11e9-9fbb-3eb2482b9165.png">
