### PR TITLE
Fix margin under style options

### DIFF
--- a/client/signup/steps/site-style/style.scss
+++ b/client/signup/steps/site-style/style.scss
@@ -34,6 +34,7 @@
 	// Get things to line up.
 	&.form-label {
 		display: inline-block;
+		margin-bottom: 0;
 	}
 	margin: 0;
 	text-align: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a spacing issue on the style step introduced in another PR

**Before**
<img width="1906" alt="Screen Shot 2019-06-07 at 2 43 52 PM" src="https://user-images.githubusercontent.com/6981253/59126490-378f8200-8933-11e9-8378-d39045616450.png">


**After**
<img width="1906" alt="Screen Shot 2019-06-07 at 2 45 15 PM" src="https://user-images.githubusercontent.com/6981253/59126495-3bbb9f80-8933-11e9-89cb-00eec49973d3.png">


#### Testing instructions

* visit `/start/onboarding`
* make your way to the style step.

cc @Automattic/zelda 