### PR TITLE
Fix text colour for site preview

### DIFF
--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -99,6 +99,11 @@ export function getIframeSource(
 					transition: opacity 1s ease-in;
 				}	
 
+				.wp-block-cover__inner-container h2 {
+					z-index: 2;
+					position: relative;
+				}
+
 				@media only screen and (min-width: 768px) {
 					/*
 						Some of the themes use js to dynamically set the height of the banner


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes the colour of text in the site preview.

**Before**
<img width="1621" alt="Screen Shot 2019-06-07 at 3 02 26 PM" src="https://user-images.githubusercontent.com/6981253/59127442-a40b8080-8935-11e9-8285-ec5e0b526e06.png">


**After**
<img width="1621" alt="Screen Shot 2019-06-07 at 3 05 27 PM" src="https://user-images.githubusercontent.com/6981253/59127464-b5548d00-8935-11e9-837a-7c832eed15e2.png">


#### Testing instructions

* visit `/start/onboarding`
* pick the business segment
* Pick any vertical from the list and confirm the text in the cover image is white.


cc @Automattic/zelda 
