### PR TITLE
Check for empty element before using.

### DIFF
--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -545,7 +545,9 @@ export class SecurePaymentForm extends Component {
 
 		if ( 'variantRightColumn' === abtest( 'showCheckoutCartRight' ) ) {
 			const element = document.getElementsByClassName( 'formatted-header__title' )[ 0 ];
-			element.textContent = headerText;
+			if ( element ) {
+				element.textContent = headerText;
+			}
 			return;
 		}
 		return <FormattedHeader headerText={ headerText } />;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #32832, the header text shown for the `showCheckoutCartRight` is pulled from an element that doesn't always exist (for example in the domains only flow). This causes an error on the secure checkout page that prevents users from checking out.

There may be a better way to handle this in the long term, but this should be ok for the duration of the A/B test.

#### Testing instructions

Try to purchase only a domain starting from /domains. Make sure you can get to the checkout page without an error specifying that you can't access `textContent` of undefined.