### PR TITLE
Signup: Updating HTML around preview content to reflect theme changes and fixing Safari

### DIFF
--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -11,12 +11,7 @@ import { debounce } from 'lodash';
 /**
  * Internal dependencies
  */
-import {
-	getIframeSource,
-	getIframePageContent,
-	isIE,
-	revokeObjectURL,
-} from 'components/signup-site-preview/utils';
+import { getIframeSource, isIE, revokeObjectURL } from 'components/signup-site-preview/utils';
 
 export default class SignupSitePreviewIframe extends Component {
 	static propTypes = {
@@ -74,12 +69,7 @@ export default class SignupSitePreviewIframe extends Component {
 		}
 
 		if ( this.props.content.title !== nextProps.content.title ) {
-			this.setIframeElementContent( '.site-builder__title', nextProps.content.title );
-			return false;
-		}
-
-		if ( this.props.content.tagline !== nextProps.content.tagline ) {
-			this.setIframeElementContent( '.site-builder__description', nextProps.content.tagline );
+			this.setIframeElementContent( '.signup-site-preview__title', nextProps.content.title );
 			return false;
 		}
 
@@ -95,10 +85,10 @@ export default class SignupSitePreviewIframe extends Component {
 		if ( ! this.iframe.current ) {
 			return;
 		}
-		const element = this.iframe.current.contentWindow.document.querySelector( '.entry' );
+		const element = this.iframe.current.contentWindow.document.querySelector( '.entry-content' );
 
 		if ( element ) {
-			element.innerHTML = getIframePageContent( content );
+			element.innerHTML = content.body;
 			this.props.resize && this.setContainerHeight();
 		}
 	}

--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -11,23 +11,6 @@ export function isIE() {
 }
 
 /**
- * Returns entry content HTML
- *
- * @param  {Object} content Object containing `title`, `tagline` and `body` strings
- * @return {String}         The HTML source.
- */
-export function getIframePageContent( { body, title, tagline } ) {
-	return `
-		<div class="entry-content">
-			<div class="site-builder__header">
-				<h1 class="site-builder__title">${ title }</h1>
-				<h2 class="site-builder__description">${ tagline }</h2>
-			</div>
-			${ body }
-		</div>`;
-}
-
-/**
  * Returns CSS link HTML
  *
  * @param  {String} url 	The css file path
@@ -115,6 +98,19 @@ export function getIframeSource(
 					}
 				}
 
+
+				/*
+					Fixes a weird bug in Safari, despite the markup and CSS
+					being the same, the gallery images for the default Professional site (m4) 
+					are stretched. Issue #33758.
+					This should be a temp fix until we can either locate the problem or
+					we update the theme CSS.
+				*/
+				.wp-block-gallery .blocks-gallery-image figure, 
+				.wp-block-gallery .blocks-gallery-item figure {
+				   flex-direction: column;
+				   height: auto;
+				}
 				
 				.is-loading .wp-block-cover,
 				.is-loading img {
@@ -133,11 +129,20 @@ export function getIframeSource(
 			scrolling ? '' : 'no-scrolling'
 		}">
 			<div id="page" class="site">
+				<header id="masthead" class="site-header">
+					<div class="site-branding-container">
+						<div class="site-branding">
+							<p class="site-title signup-site-preview__title">${ content.title }</p>
+						</div>
+					</div>
+				</header>
 				<div id="content" class="site-content">
 					<section id="primary" class="content-area">
 						<main id="main" class="site-main">
 							<article class="page type-page status-publish hentry entry">
-								${ getIframePageContent( content ) }
+								<div class="entry-content">
+									${ content.body }
+								</div>
 							</article>
 						</div>
 					</section>

--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -82,14 +82,9 @@ export function getIframeSource(
 					transition: opacity 1s ease-in;
 				}	
 
-				.wp-block-cover__inner-container h2 {
-					z-index: 2;
-					position: relative;
-				}
-
 				@media only screen and (min-width: 768px) {
 					/*
-						Some of the themes use js to dynamically set the height of the banner
+						Some of the themes (business sophisticated) use js to dynamically set the height of the banner
 						Let's set a fixed max-height.
 					*/
 					.entry .entry-content .wp-block-cover-image, 
@@ -97,7 +92,6 @@ export function getIframeSource(
 						min-height: 500px !important;
 					}
 				}
-
 
 				/*
 					Fixes a weird bug in Safari, despite the markup and CSS


### PR DESCRIPTION
## Changes proposed in this Pull Request

To keep abreast of the dazzling updates to our base vertical site themes, we're updating the `<header />` and site title markup, and also removing the tagline/description from body content.

While we're at it, to prevent undue trauma to our beloved users of Safari, we've included a temporary CSS bugfix for Safari bug until we work out what the 👿 is going on. See Issue #33758

**Before adding temporary Safari CSS lolly**
<img width="400" alt="Screen Shot 2019-06-09 at 10 08 01 am" src="https://user-images.githubusercontent.com/6458278/59153573-8eb26580-8a9f-11e9-9520-1ee6715c1954.png">

**After adding temporary Safari CSS lolly**
<img width="400" alt="Screen Shot 2019-06-09 at 10 05 51 am" src="https://user-images.githubusercontent.com/6458278/59153575-91ad5600-8a9f-11e9-97d2-7118a56f3f6c.png">


## Testing instructions

Apply D29251-code

Check the onboarding flow in Signup for both **Business** and **Professional** segments.

Does the site preview appear like it should? 

Can you create a site? 

Does the Professional preview work in Safari? 

Is Led Zeppelin's _The Song Remains the Same_, live at Madison Square Garden (1976) the best rock and roll video ever made? You decide! 

Fixes #33758
