### PR TITLE
Posts: CSS Migration

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -52,7 +52,6 @@
 @import 'my-sites/customize/style';
 @import 'my-sites/guided-transfer/style';
 @import 'my-sites/plan-features/style';
-@import 'my-sites/posts/style';
 @import 'my-sites/sidebar/style';
 @import 'my-sites/sidebar-navigation/style';
 @import 'my-sites/importer/style';

--- a/client/my-sites/posts/main.jsx
+++ b/client/my-sites/posts/main.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -28,6 +26,11 @@ import {
 	isJetpackSite,
 	siteHasMinimumJetpackVersion,
 } from 'state/sites/selectors';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class PostsMain extends React.Component {
 	UNSAFE_componentWillMount() {

--- a/client/my-sites/posts/style.scss
+++ b/client/my-sites/posts/style.scss
@@ -1,12 +1,3 @@
-.posts.main {
-	display: block;
-	max-width: 720px;
-}
-
-.posts__primary {
-	max-width: 720px;
-}
-
 .posts .section-nav .gravatar {
 	margin-left: 6px;
 	vertical-align: middle;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There's very little CSS, especially since half of it can be removed as those styles are inherited from the Main component, so this should be a fairly safe one to migrate. 

#### Testing instructions

On a site with multiple authors, visit `/posts` and notice no change with the Gravatar positioning. That's the only impact I can find this stylesheet has, I'm not too sure where the `post__total-views` class is used but it seems to be. 

<img width="729" alt="Screenshot 2019-06-09 at 20 19 57" src="https://user-images.githubusercontent.com/43215253/59163105-f7c3c880-8af3-11e9-9228-7fcae11e86b1.png">

cc @jsnajdr, @blowery, @flootr 

Part of #27515
Closes #33773
