### PR TITLE
Plugins: end the pluginFeaturedTitle A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -80,14 +80,6 @@ export default {
 		},
 		defaultVariation: 'keep',
 	},
-	pluginFeaturedTitle: {
-		datestamp: '20190220',
-		variations: {
-			featured: 50,
-			recommended: 50,
-		},
-		defaultVariation: 'featured',
-	},
 	builderReferralHelpPopover: {
 		datestamp: '20190227',
 		variations: {

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -194,10 +194,6 @@ export class PluginsBrowser extends Component {
 					context: 'Category description for the plugin browser.',
 				} );
 			case 'featured':
-				if ( abtest( 'pluginFeaturedTitle' ) === 'recommended' ) {
-					return recommendedText;
-				}
-
 				return translate( 'Featured', {
 					context: 'Category description for the plugin browser.',
 				} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes the `pluginFeaturedTitle` A/B test added in https://github.com/Automattic/wp-calypso/pull/30887. We now have four months of data, and the plugin recommendation project is currently on hold.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Head to the plugins browser at http://calypso.localhost:3000/plugins. Ensure that the first box of plugins is titled 'Featured', as below:

<img width="1067" alt="Screen Shot 2019-06-10 at 11 41 24" src="https://user-images.githubusercontent.com/17325/59165764-17e79c00-8b75-11e9-8b37-7e64a5626223.png">
