### PR TITLE
FSE : Use new API shape & add tracks calls

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -51,16 +51,16 @@ class Starter_Page_Templates {
 			true
 		);
 	}
-	
+
 	/**
 	 * Register meta field for storing the template identifier.
 	 */
 	public function register_meta_field() {
 		$args = array(
-			'type' => 'string',
-			'description' => 'Selected template',
-			'single' => true,
-			'show_in_rest' => true,
+			'type'           => 'string',
+			'description'    => 'Selected template',
+			'single'         => true,
+			'show_in_rest'   => true,
 			'object_subtype' => 'page',
 		);
 		// TODO: meta field name

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -113,7 +113,7 @@ class Starter_Page_Templates {
 		$vertical_templates = $vertical_data['templates'];
 
 		// Bail early if we have no templates to offer.
-		if ( empty( $vertical_templates ) ) {
+		if ( empty( $vertical_templates ) || empty( $vertical ) ) {
 			$this->pass_error_to_frontend( __( 'No templates available. Skipped showing modal window with template selection.', 'full-site-editing' ) );
 			return;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -51,6 +51,21 @@ class Starter_Page_Templates {
 			true
 		);
 	}
+	
+	/**
+	 * Register meta field for storing the template identifier.
+	 */
+	public function register_meta_field() {
+		$args = array(
+			'type' => 'string',
+			'description' => 'Selected template',
+			'single' => true,
+			'show_in_rest' => true,
+			'object_subtype' => 'page',
+		);
+		// TODO: meta field name
+		register_meta( 'post', 'starter_page_template', $args );
+	}
 
 	/**
 	 * Register meta field for storing the template identifier.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -160,7 +160,7 @@ class Starter_Page_Templates {
 	 */
 	public function fetch_vertical_data() {
 		$vertical_id        = get_option( 'site_vertical', 'default' );
-		$transient_key      = implode( '_', [ 'starter_page_templates', 'v2', $vertical_id, get_locale() ] );
+		$transient_key      = implode( '_', [ 'starter_page_templates', $vertical_id, get_locale() ] );
 		$vertical_templates = get_transient( $transient_key );
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -63,7 +63,6 @@ class Starter_Page_Templates {
 			'show_in_rest'   => true,
 			'object_subtype' => 'page',
 		);
-		// TODO: meta field name
 		register_meta( 'post', '_starter_page_template', $args );
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -64,7 +64,7 @@ class Starter_Page_Templates {
 			'object_subtype' => 'page',
 		);
 		// TODO: meta field name
-		register_meta( 'post', 'starter_page_template', $args );
+		register_meta( 'post', '_starter_page_template', $args );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -62,20 +62,6 @@ class Starter_Page_Templates {
 			'single'         => true,
 			'show_in_rest'   => true,
 			'object_subtype' => 'page',
-		);
-		register_meta( 'post', '_starter_page_template', $args );
-	}
-
-	/**
-	 * Register meta field for storing the template identifier.
-	 */
-	public function register_meta_field() {
-		$args = array(
-			'type'           => 'string',
-			'description'    => 'Selected template',
-			'single'         => true,
-			'show_in_rest'   => true,
-			'object_subtype' => 'page',
 			'auth_callback'  => function() {
 				return current_user_can( 'edit_posts' );
 			},

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -123,7 +123,7 @@ class Starter_Page_Templates {
 			$this->pass_error_to_frontend( __( 'No data received from the vertical API. Skipped showing modal window with template selection.', 'full-site-editing' ) );
 			return;
 		}
-		$vertical_name      = $vertical_data['vertical'];
+		$vertical           = $vertical_data['vertical'];
 		$vertical_templates = $vertical_data['templates'];
 
 		// Bail early if we have no templates to offer.
@@ -137,7 +137,7 @@ class Starter_Page_Templates {
 
 		$default_info      = array(
 			'title'    => get_bloginfo( 'name' ),
-			'vertical' => $vertical_name,
+			'vertical' => $vertical['name'],
 		);
 		$default_templates = array(
 			array(
@@ -150,6 +150,7 @@ class Starter_Page_Templates {
 		$config    = array(
 			'siteInformation' => array_merge( $default_info, $site_info ),
 			'templates'       => array_merge( $default_templates, $vertical_templates ),
+			'vertical'        => $vertical,
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );
 
@@ -173,7 +174,7 @@ class Starter_Page_Templates {
 	 */
 	public function fetch_vertical_data() {
 		$vertical_id        = get_option( 'site_vertical', 'default' );
-		$transient_key      = implode( '_', [ 'starter_page_templates', $vertical_id, get_locale() ] );
+		$transient_key      = implode( '_', [ 'starter_page_templates', 'v2', $vertical_id, get_locale() ] );
 		$vertical_templates = get_transient( $transient_key );
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, map, has } from 'lodash';
+import { keyBy, has } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { withState } from '@wordpress/compose';
 import { Modal } from '@wordpress/components';
@@ -15,35 +15,9 @@ import { parse as parseBlocks } from '@wordpress/blocks';
 import replacePlaceholders from './utils/replace-placeholders';
 import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
+import { trackDismiss, trackView, trackSelection } from './utils/tracking';
 
-// TODO: remove once we have proper previews from API
-if ( window.starterPageTemplatesConfig ) {
-	const PREVIEWS_BY_SLUG = {
-		home: {
-			src: 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-home-2.png',
-			alt:
-				'Full width hero banner, followed by alternating text and image sections, followed by a Get in Touch area',
-		},
-		menu: {
-			src: 'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-menu-2.png',
-			alt: '',
-		},
-		'contact-us': {
-			src:
-				'https://starterpagetemplatesprototype.files.wordpress.com/2019/05/starter-contactus-2.png',
-			alt: '',
-		},
-	};
-	window.starterPageTemplatesConfig.templates = map(
-		window.starterPageTemplatesConfig.templates,
-		template => {
-			template.preview = PREVIEWS_BY_SLUG[ template.slug ];
-			return template;
-		}
-	);
-}
-
-const { siteInformation = {}, templates = [] } = window.starterPageTemplatesConfig;
+const { siteInformation = {}, templates = [], vertical } = window.starterPageTemplatesConfig;
 const editorDispatcher = dispatch( 'core/editor' );
 const editorSelector = select( 'core/editor' );
 
@@ -59,7 +33,7 @@ const insertTemplate = template => {
 		title: replacePlaceholders( template.title, siteInformation ),
 		meta: {
 			...currentMeta,
-			_starter_page_template: template.slug, // TODO: change for the proper identifier
+			_starter_page_template: template.slug,
 		},
 	} );
 
@@ -73,54 +47,64 @@ const PageTemplateModal = withState( {
 	isOpen: true,
 	isLoading: false,
 	verticalTemplates: keyBy( templates, 'slug' ),
-} )( ( { isOpen, verticalTemplates, setState } ) => (
-	<div>
-		{ isOpen && (
-			<Modal
-				title={ __( 'Select Page Template', 'full-site-editing' ) }
-				onRequestClose={ () => setState( { isOpen: false } ) }
-				className="page-template-modal"
-			>
-				<div className="page-template-modal__inner">
-					<form className="page-template-modal__form">
-						<fieldset className="page-template-modal__list">
-							<legend className="page-template-modal__intro">
-								<p>
-									{ __(
-										'Pick a Template that matches the purpose of your page.',
-										'full-site-editing'
-									) }
-								</p>
-								<p>
-									{ __(
-										'You can customize each Template to meet your needs.',
-										'full-site-editing'
-									) }
-								</p>
-							</legend>
-							<TemplateSelectorControl
-								label={ __( 'Template', 'full-site-editing' ) }
-								templates={ Object.values( verticalTemplates ).map( template => ( {
-									label: template.title,
-									value: template.slug,
-									preview: template.preview && template.preview.src,
-									previewAlt: template.preview && template.preview.alt,
-								} ) ) }
-								onClick={ newTemplate => {
-									setState( { isOpen: false } );
-									insertTemplate( verticalTemplates[ newTemplate ] );
-								} }
-							/>
-						</fieldset>
-					</form>
-				</div>
-			</Modal>
-		) }
-	</div>
-) );
+} )( ( { isOpen, verticalTemplates, setState } ) => {
+	const closeModal = () => {
+		setState( { isOpen: false } );
+		trackDismiss( vertical.id );
+	};
+	const selectTemplate = newTemplate => {
+		insertTemplate( verticalTemplates[ newTemplate ] );
+		setState( { isOpen: false } );
+		trackSelection( vertical.id, newTemplate );
+	};
+	return (
+		<div>
+			{ isOpen && (
+				<Modal
+					title={ __( 'Select Page Template', 'full-site-editing' ) }
+					onRequestClose={ closeModal }
+					className="page-template-modal"
+				>
+					<div className="page-template-modal__inner">
+						<form className="page-template-modal__form">
+							<fieldset className="page-template-modal__list">
+								<legend className="page-template-modal__intro">
+									<p>
+										{ __(
+											'Pick a Template that matches the purpose of your page.',
+											'full-site-editing'
+										) }
+									</p>
+									<p>
+										{ __(
+											'You can customize each Template to meet your needs.',
+											'full-site-editing'
+										) }
+									</p>
+								</legend>
+								<TemplateSelectorControl
+									label={ __( 'Template', 'full-site-editing' ) }
+									templates={ Object.values( verticalTemplates ).map( template => ( {
+										label: template.title,
+										value: template.slug,
+										preview: template.preview && template.preview.src,
+										previewAlt: template.preview && template.preview.alt,
+									} ) ) }
+									onClick={ newTemplate => selectTemplate( newTemplate ) }
+								/>
+							</fieldset>
+						</form>
+					</div>
+				</Modal>
+			) }
+		</div>
+	);
+} );
 
 registerPlugin( 'page-templates', {
 	render: function() {
 		return <PageTemplateModal />;
 	},
 } );
+
+trackView( vertical.id );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { keyBy, has, map } from 'lodash';
+import { has, keyBy, map } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Modal } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { parse as parseBlocks } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 
@@ -16,7 +16,7 @@ import { Component } from '@wordpress/element';
 import replacePlaceholders from './utils/replace-placeholders';
 import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
-import { trackDismiss, trackView, trackSelection } from './utils/tracking';
+import { trackDismiss, trackSelection, trackView } from './utils/tracking';
 
 class PageTemplateModal extends Component {
 	state = {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -104,7 +104,7 @@ class PageTemplateModal extends Component {
 	}
 }
 
-const PageTemplateModalPlugin = compose(
+const PageTemplatesPlugin = compose(
 	withSelect( select => ( {
 		getMeta: () => select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
 	} ) ),
@@ -136,7 +136,7 @@ const { siteInformation = {}, templates = [], vertical } = window.starterPageTem
 registerPlugin( 'page-templates', {
 	render: function() {
 		return (
-			<PageTemplateModalPlugin
+			<PageTemplatesPlugin
 				verticalTemplates={ keyBy( templates, 'slug' ) }
 				vertical={ vertical }
 				siteInformation={ siteInformation }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { has, keyBy, map } from 'lodash';
+import { has, isEmpty, keyBy, map } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Modal } from '@wordpress/components';
@@ -25,7 +25,7 @@ class PageTemplateModal extends Component {
 
 	constructor( props ) {
 		super();
-		this.state.isOpen = props.initiallyOpened;
+		this.state.isOpen = ! isEmpty( props.templates );
 	}
 
 	componentDidMount() {
@@ -138,7 +138,6 @@ registerPlugin( 'page-templates', {
 	render: function() {
 		return (
 			<PageTemplatesPlugin
-				initiallyOpened={ templates.length > 0 }
 				templates={ keyBy( templates, 'slug' ) }
 				vertical={ vertical }
 				siteInformation={ siteInformation }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -87,8 +87,8 @@ const PageTemplateModal = withState( {
 									templates={ Object.values( verticalTemplates ).map( template => ( {
 										label: template.title,
 										value: template.slug,
-										preview: template.preview && template.preview.src,
-										previewAlt: template.preview && template.preview.alt,
+										preview: template.preview,
+										previewAlt: template.description,
 									} ) ) }
 									onClick={ newTemplate => selectTemplate( newTemplate ) }
 								/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -34,7 +34,7 @@ class PageTemplateModal extends Component {
 		this.setState( { isOpen: false } );
 		trackSelection( this.props.vertical.id, newTemplate );
 
-		const template = this.props.verticalTemplates[ newTemplate ];
+		const template = this.props.templates[ newTemplate ];
 
 		// Skip inserting if there's nothing to insert.
 		if ( ! has( template, 'content' ) ) {
@@ -56,10 +56,7 @@ class PageTemplateModal extends Component {
 	};
 
 	render() {
-		const { isOpen } = this.state;
-		const { verticalTemplates } = this.props;
-
-		if ( ! isOpen ) {
+		if ( ! this.state.isOpen ) {
 			return null;
 		}
 
@@ -88,7 +85,7 @@ class PageTemplateModal extends Component {
 							</legend>
 							<TemplateSelectorControl
 								label={ __( 'Template', 'full-site-editing' ) }
-								templates={ Object.values( verticalTemplates ).map( template => ( {
+								templates={ Object.values( this.props.templates ).map( template => ( {
 									label: template.title,
 									value: template.slug,
 									preview: template.preview,
@@ -137,7 +134,7 @@ registerPlugin( 'page-templates', {
 	render: function() {
 		return (
 			<PageTemplatesPlugin
-				verticalTemplates={ keyBy( templates, 'slug' ) }
+				templates={ keyBy( templates, 'slug' ) }
 				vertical={ vertical }
 				siteInformation={ siteInformation }
 			/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -20,9 +20,13 @@ import { trackDismiss, trackView, trackSelection } from './utils/tracking';
 
 class PageTemplateModal extends Component {
 	state = {
-		isOpen: true,
 		isLoading: false,
 	};
+
+	constructor( props ) {
+		super();
+		this.state.isOpen = props.initiallyOpened;
+	}
 
 	componentDidMount() {
 		if ( this.state.isOpen ) {
@@ -134,6 +138,7 @@ registerPlugin( 'page-templates', {
 	render: function() {
 		return (
 			<PageTemplatesPlugin
+				initiallyOpened={ templates.length > 0 }
 				templates={ keyBy( templates, 'slug' ) }
 				vertical={ vertical }
 				siteInformation={ siteInformation }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, has } from 'lodash';
+import { keyBy, has, map } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Modal } from '@wordpress/components';
@@ -89,7 +89,7 @@ class PageTemplateModal extends Component {
 							</legend>
 							<TemplateSelectorControl
 								label={ __( 'Template', 'full-site-editing' ) }
-								templates={ Object.values( this.props.templates ).map( template => ( {
+								templates={ map( this.props.templates, template => ( {
 									label: template.title,
 									value: template.slug,
 									preview: template.preview,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
@@ -1,0 +1,26 @@
+// Ensure Tracks Library
+window._tkq = window._tkq || [];
+
+export const trackView = vertical_id => {
+	window._tkq.push( [
+		'recordEvent',
+		'a8c_test_full_site_editing_template_selector_view',
+		{ vertical_id },
+	] );
+};
+
+export const trackDismiss = vertical_id => {
+	window._tkq.push( [
+		'recordEvent',
+		'a8c_test_full_site_editing_template_selector_dismiss',
+		{ vertical_id },
+	] );
+};
+
+export const trackSelection = ( vertical_id, template ) => {
+	window._tkq.push( [
+		'recordEvent',
+		'a8c_test_full_site_editing_template_selector_template_selected',
+		{ vertical_id, template },
+	] );
+};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* adds a support for the new API shape introduced with D29219-code and D29171-code
* calls Tracks for modal view, dismiss and template selection

#### Testing instructions

* make new page, use plugin as usual
* because we don't have Tracks loaded yet, you can print `window._tkq` to see what will get recorded
* you won't see any previews until D29171-code gets merged

Part of #33489
