### PR TITLE
Fix TypeScript ESLint config (avoid extend field in overrides)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,9 +36,16 @@ module.exports = {
 			},
 		},
 		merge(
+			// ESLint doesn't allow the `extends` field inside `overrides`, so we need to compose
+			// the TypeScript config manually using internal bits from various plugins
 			{},
-			require( '@typescript-eslint/eslint-plugin' ).configs.recommended,
+			// base TypeScript config: parser options, add plugin with rules
+			require( '@typescript-eslint/eslint-plugin' ).configs.base,
+			// basic recommended rules config from the TypeScript plugin
+			{ rules: require( '@typescript-eslint/eslint-plugin' ).configs.recommended.rules },
+			// Prettier rules config
 			require( 'eslint-config-prettier/@typescript-eslint' ),
+			// Our own overrides
 			{
 				files: [ '**/*.ts', '**/*.tsx' ],
 				rules: {


### PR DESCRIPTION
Renovating the `@typescript-eslint/eslint-config` in #32955 broke linting in master:
```
Prettier formatting staged file: client/my-sites/posts/main.jsx
Error: ESLint configuration in /Users/jsnajdr/src/wp-calypso/.eslintrc.js is invalid:
	- Unexpected top-level property "overrides[2].extends".
```

The reason is that ESLint doesn't support `extends` field in an `overrides` spec. The `eslint-config` package, however, changed:
```
// recommended.json
{
  parser: "@typescript-eslint/parser",
  rules: {
    ...
  }
}
```
to:
```
// base.json
{
  parser: "@typescript-eslint/parser"
}

// recommended.json
{
  extends: "./configs/base.json",
  rules: {
    ...
  }
}
```

This patch changes how we construct out TypeScript overrides config from the individual bits. It's not pretty, as we rely on internal details of the plugin, but I don't see any better solution.

**How to test:**
Check that linting from command line was broken before this patch and is fixed after.