### PR TITLE
Jetpack plugin setup: consolidate `*_autoconfig_error` events

### DIFF
--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -67,9 +67,12 @@ class PlansSetup extends React.Component {
 	static displayName = 'PlanSetup';
 	sentTracks = false;
 
-	trackConfigFinished = ( eventName, options = null ) => {
+	trackConfigFinished = ( eventName, options = {} ) => {
 		if ( ! this.sentTracks ) {
-			analytics.tracks.recordEvent( eventName, options );
+			analytics.tracks.recordEvent( eventName, {
+				location: 'jetpackPluginSetup',
+				...options,
+			} );
 		}
 		this.sentTracks = true;
 	};
@@ -188,7 +191,9 @@ class PlansSetup extends React.Component {
 	};
 
 	renderNoJetpackSiteSelected = () => {
-		this.trackConfigFinished( 'calypso_plans_autoconfig_error_wordpresscom' );
+		this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
+			error: 'wordpresscom',
+		} );
 		return (
 			<JetpackManageErrorPage
 				siteId={ this.props.siteId }
@@ -208,18 +213,26 @@ class PlansSetup extends React.Component {
 
 		if ( reasons && reasons.length > 0 ) {
 			reason = reasons[ 0 ];
-			this.trackConfigFinished( 'calypso_plans_autoconfig_error_filemod', { error: reason } );
+			this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
+				error: 'cannot_update_files',
+				reason,
+			} );
 		} else if ( ! site.hasMinimumJetpackVersion ) {
 			reason = translate( 'You need to update your version of Jetpack.' );
-			this.trackConfigFinished( 'calypso_plans_autoconfig_error_jpversion', {
+			this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
+				error: 'jetpack_version_too_old',
 				jetpack_version: site.options.jetpack_version,
 			} );
 		} else if ( ! site.isMainNetworkSite ) {
 			reason = translate( "We can't install plugins on multisite sites." );
-			this.trackConfigFinished( 'calypso_plans_autoconfig_error_multisite' );
+			this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
+				error: 'secondary_network_site',
+			} );
 		} else if ( site.options.is_multi_network ) {
 			reason = translate( "We can't install plugins on multi-network sites." );
-			this.trackConfigFinished( 'calypso_plans_autoconfig_error_multinetwork' );
+			this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
+				error: 'multinetwork',
+			} );
 		}
 
 		return (
@@ -245,7 +258,7 @@ class PlansSetup extends React.Component {
 	};
 
 	renderPluginsPlaceholders = () => {
-		const placeholderCount = !! this.props.whitelist ? 1 : 2;
+		const placeholderCount = this.props.whitelist ? 1 : 2;
 		return range( placeholderCount ).map( i => <PluginItem key={ 'placeholder-' + i } /> );
 	};
 
@@ -293,6 +306,7 @@ class PlansSetup extends React.Component {
 		}
 
 		if ( 'done' === plugin.status ) {
+			// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 			return <div className="plugin-item__finished">{ this.getStatusText( plugin ) }</div>;
 		}
 
@@ -356,6 +370,8 @@ class PlansSetup extends React.Component {
 			</NoticeAction>
 		);
 
+		const errorMessage = get( plugin, 'error.message', '' );
+
 		switch ( plugin.status ) {
 			case 'install':
 				return (
@@ -385,9 +401,15 @@ class PlansSetup extends React.Component {
 					/>
 				);
 			default:
-				const errorMessage = get( plugin, 'error.message', '' ).replace( /<.[^<>]*?>/g, '' );
 				return (
-					<Notice { ...statusProps } text={ errorMessage || translate( 'An error occured.' ) } />
+					<Notice
+						{ ...statusProps }
+						text={
+							errorMessage
+								? errorMessage.replace( /<.[^<>]*?>/g, '' )
+								: translate( 'An error occured.' )
+						}
+					/>
 				);
 		}
 	};
@@ -398,11 +420,13 @@ class PlansSetup extends React.Component {
 		} else if ( plugin.error !== null ) {
 			return null;
 		} else if ( plugin.status !== 'done' ) {
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			return (
 				<div className="plugin-item__actions">
 					<Spinner />
 				</div>
 			);
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		}
 
 		return null;
@@ -418,7 +442,10 @@ class PlansSetup extends React.Component {
 			tracksData[ item.slug ] = item.error.name + ': ' + item.error.message;
 		} );
 
-		this.trackConfigFinished( 'calypso_plans_autoconfig_error_plugin', tracksData );
+		this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
+			...tracksData,
+			error: 'plugin',
+		} );
 
 		if ( pluginsWithErrors.length === 1 ) {
 			noticeText = translate(

--- a/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
+++ b/client/my-sites/plugins/jetpack-plugins-setup/index.jsx
@@ -221,7 +221,7 @@ class PlansSetup extends React.Component {
 			reason = translate( 'You need to update your version of Jetpack.' );
 			this.trackConfigFinished( 'calypso_plans_autoconfig_error', {
 				error: 'jetpack_version_too_old',
-				jetpack_version: site.options.jetpack_version,
+				jetpack_version: get( site, [ 'options', 'jetpack_version' ], 'unknown' ),
 			} );
 		} else if ( ! site.isMainNetworkSite ) {
 			reason = translate( "We can't install plugins on multisite sites." );


### PR DESCRIPTION
This makes it easier to compare tracks events coming from checklist vs plugin setup routes.

#### Changes proposed in this Pull Request

* Consolidates all `*_autoconfig_error` events across Jetpack plugin setup and Jetpack onboarding checklist (`client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js`).

* All events from this flow now have `location: jetpackPluginSetup` while the checklist has `location: JetpackChecklist`

* Fixes some linting issues.


#### Testing instructions

- Enable tracks in development mode in calypso by dropping this to console: `localStorage.debug = 'calypso:analytics:tracks'`
- Have a Jetpack site with a paid plan
- Disable file modifications your site with `define( 'DISALLOW_FILE_MODS', true );` in `wp-config.php` or mu-plugins file.
- On your site, disable VaultPress or Akismet 
- Go to jetpack dash and copy URLs of one of the "set up" buttons:
    <img width="1120" alt="Screenshot 2019-06-05 at 14 27 44" src="https://user-images.githubusercontent.com/87168/58954482-fd42ab00-87a1-11e9-8c29-f623794a5d8f.png">
- Replace `wordpress.com` with `calypso.localhost:3000` and open the URL

Confirm that:
- Can you see tracks error fired once?
- Do linting fixes make sense?
- Errors are similar to what's in `client/my-sites/plans/current-plan/current-plan-thank-you/paid-plan-thank-you.js`