### PR TITLE
Jetpack checklist: hide redundant performance CTAs

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -76,7 +76,9 @@ export class ProductPurchaseFeaturesList extends Component {
 					liveChatButtonEventName={ 'calypso_livechat_my_plan_ecommerce' }
 				/>
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
-				<JetpackSearch selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist/performance' ) && (
+					<JetpackSearch selectedSite={ selectedSite } />
+				) }
 				<GoogleVouchers selectedSite={ selectedSite } />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<GoogleMyBusiness selectedSite={ selectedSite } />
@@ -109,7 +111,9 @@ export class ProductPurchaseFeaturesList extends Component {
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
 				) }
-				<JetpackSearch selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist/performance' ) && (
+					<JetpackSearch selectedSite={ selectedSite } />
+				) }
 				<GoogleVouchers selectedSite={ selectedSite } />
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<GoogleMyBusiness selectedSite={ selectedSite } />
@@ -187,7 +191,7 @@ export class ProductPurchaseFeaturesList extends Component {
 		} = this.props;
 		return (
 			<Fragment>
-				{ supportsJetpackSiteAccelerator && (
+				{ ! isEnabled( 'jetpack/checklist/performance' ) && supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
 				<SiteActivity />
@@ -210,10 +214,12 @@ export class ProductPurchaseFeaturesList extends Component {
 		} = this.props;
 		return (
 			<Fragment>
-				{ supportsJetpackSiteAccelerator && (
+				{ ! isEnabled( 'jetpack/checklist/performance' ) && supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
-				<JetpackVideo selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist/performance' ) && (
+					<JetpackVideo selectedSite={ selectedSite } />
+				) }
 				<MonetizeSite selectedSite={ selectedSite } />
 				<SiteActivity />
 				<JetpackPublicize selectedSite={ selectedSite } />
@@ -243,7 +249,7 @@ export class ProductPurchaseFeaturesList extends Component {
 
 		return (
 			<Fragment>
-				{ supportsJetpackSiteAccelerator && (
+				{ ! isEnabled( 'jetpack/checklist/performance' ) && supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
 				<SiteActivity />
@@ -265,12 +271,16 @@ export class ProductPurchaseFeaturesList extends Component {
 		} = this.props;
 		return (
 			<Fragment>
-				{ supportsJetpackSiteAccelerator && (
+				{ ! isEnabled( 'jetpack/checklist/performance' ) && supportsJetpackSiteAccelerator && (
 					<JetpackSiteAccelerator selectedSite={ selectedSite } />
 				) }
-				<JetpackSearch selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist/performance' ) && (
+					<JetpackSearch selectedSite={ selectedSite } />
+				) }
 				<SiteActivity />
-				<JetpackVideo selectedSite={ selectedSite } />
+				{ ! isEnabled( 'jetpack/checklist/performance' ) && (
+					<JetpackVideo selectedSite={ selectedSite } />
+				) }
 				<MonetizeSite selectedSite={ selectedSite } />
 				<MobileApps />
 				<JetpackPublicize selectedSite={ selectedSite } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Hides redundant performance CTAs under Jetpack checklist when performance checklist is enabled.

Resolves https://github.com/Automattic/wp-calypso/issues/33783

#### Testing instructions

- Have a site with Jetpack plan
- Open `http://calypso.localhost:3000/plans/my-plan/:site`
- Observe no CTAs related to jetpack video, -search or - site accelerator 

You should see this:

<img width="1130" alt="Screenshot 2019-06-10 at 15 59 04" src="https://user-images.githubusercontent.com/87168/59196956-c0f3be00-8b98-11e9-9253-7a55020d993b.png">
