### PR TITLE
Update the Upgrade My Site Link to Contain a Coupon

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/test/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/test/upgrade-at-step.jsx
@@ -56,7 +56,9 @@ describe( 'UpgradeATStep', () => {
 			<UpgradeATStep recordTracksEvent={ noop } translate={ noop } selectedSite={ selectedSite } />
 		);
 
-		expect( wrapper.find( 'Button' ).props().href ).to.equal( '/checkout/site_slug/business' );
+		expect( wrapper.find( 'Button' ).props().href ).to.equal(
+			'/checkout/site_slug/business?coupon=BIZC25'
+		);
 	} );
 
 	test( 'should fire tracks event when button is clicked', () => {

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upgrade-at-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upgrade-at-step.jsx
@@ -36,7 +36,7 @@ export class UpgradeATStep extends Component {
 
 	render() {
 		const { translate, selectedSite } = this.props;
-		const href = `/checkout/${ selectedSite.slug }/business`;
+		const href = `/checkout/${ selectedSite.slug }/business?coupon=BIZC25`;
 
 		return (
 			<div>


### PR DESCRIPTION
Users trying to cancel a sub-Business plan are offered an upsell to go to Business in case the cancellation reason is that they need plugins. The dialog asks them to manually enter a coupon code. We can now add the coupon to the link, there's no need to manually enter it.

This is a low-volume test that's been around for over 2 years. I think that the missing coupon in the link actually breaks the test as it's a bit annoying to click and be asked to pay more than what was offered.

#### Changes proposed in this Pull Request

Add the coupon to the link

#### Testing instructions

1. Buy Premium
2. Go to me/purchases and cancel it. In the cancellation dialog add that you are canceling because of plugins and themes.
3. Click Upgrade

<img width="565" alt="Screenshot 2019-06-10 at 16 06 52" src="https://user-images.githubusercontent.com/82778/59197653-7e32e580-8b9a-11e9-93de-0f509ef33f6e.png">

You should see a checkout with 25% off + the Bundle Upsell discount for upgrading from one plan to another.

<img width="302" alt="Screenshot 2019-06-10 at 16 13 22" src="https://user-images.githubusercontent.com/82778/59197742-b33f3800-8b9a-11e9-9214-7cc26f459465.png">

The checkout has an unrelated bug that's probably also breaking the test - the area with 1-2 year terms contains prices without the coupon code applied.

Fixes #
