### PR TITLE
render remove-purchase button to only show when refunding not possible

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -205,6 +205,20 @@ class ManagePurchase extends Component {
 		return null;
 	}
 
+	renderRemovePurchase() {
+		if ( isRefundable( this.props.purchase ) ) {
+			return null;
+		}
+		return (
+			<RemovePurchase
+				hasLoadedSites={ this.props.hasLoadedSites }
+				hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }
+				site={ this.props.site }
+				purchase={ this.props.purchase }
+			/>
+		);
+	}
+
 	renderCancelPurchaseNavItem() {
 		const { isAtomicSite, purchase, translate } = this.props;
 		const { id } = purchase;
@@ -368,7 +382,7 @@ class ManagePurchase extends Component {
 			return this.renderPlaceholder();
 		}
 
-		const { purchase, siteId, site } = this.props;
+		const { purchase, siteId } = this.props;
 		const classes = classNames( 'manage-purchase__info', {
 			'is-expired': purchase && isExpired( purchase ),
 			'is-personal': isPersonal( purchase ),
@@ -405,12 +419,7 @@ class ManagePurchase extends Component {
 				{ this.renderRenewNowNavItem() }
 				{ this.renderEditPaymentMethodNavItem() }
 				{ this.renderCancelPurchaseNavItem() }
-				<RemovePurchase
-					hasLoadedSites={ this.props.hasLoadedSites }
-					hasLoadedUserPurchasesFromServer={ this.props.hasLoadedUserPurchasesFromServer }
-					site={ site }
-					purchase={ purchase }
-				/>
+				{ this.renderRemovePurchase() }
 			</Fragment>
 		);
 	}

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -205,7 +205,7 @@ class ManagePurchase extends Component {
 		return null;
 	}
 
-	renderRemovePurchase() {
+	renderRemovePurchaseNavItem() {
 		if ( isRefundable( this.props.purchase ) ) {
 			return null;
 		}
@@ -419,7 +419,7 @@ class ManagePurchase extends Component {
 				{ this.renderRenewNowNavItem() }
 				{ this.renderEditPaymentMethodNavItem() }
 				{ this.renderCancelPurchaseNavItem() }
-				{ this.renderRemovePurchase() }
+				{ this.renderRemovePurchaseNavItem() }
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, in the "Manage Purchases" section, it is possible for both a "Remove" and a "Cancel and Refund" button to appear simultaneously under limited circumstances; such as after cancelling auto-renew just after a purchase. This causes problems for support staff since removing the service without doing a refund forces the customer to contact support to manually get his/her money back.

This change simply moves the rendering of the RemovePurchase component to a function and that function determines if service is still in eligible for a refund. If it is refundable, then the RemovePurchase component is not returned. Any service that is refundable already gets a component via the `renderCancelPurchaseNavItem()` function. (The wording/action changes based on what kind of service is being cancelled.)

#### Testing instructions

I tested the change against multiple purchases on Calypso running against a sandbox to verify operation. I checked both new purchases in the refund window as well as older legacy accounts that were outside the refund window.

For reviewers at a8c, my trello ticket: https://trello.com/c/mRKS4Fij/32-cancel-and-refund-and-remove-links-on-subscriptions-should-never-be-shown-at-the-same-time
