### PR TITLE
Type: Add types to keyedReducer state util

### DIFF
--- a/client/state/action-types.js
+++ b/client/state/action-types.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * Any new action type should be added to the set of exports below, with the
  * value mirroring its exported name.
@@ -1200,3 +1199,8 @@ export const WORDADS_EARNINGS_REQUEST = 'WORDADS_EARNINGS_REQUEST';
 export const WORDADS_EARNINGS_RECEIVE = 'WORDADS_EARNINGS_RECEIVE';
 export const WPCOM_HTTP_REQUEST = 'WPCOM_HTTP_REQUEST';
 export const WPORG_PLUGIN_DATA_RECEIVE = 'WPORG_PLUGIN_DATA_RECEIVE';
+
+/**
+ * A special Calypso init action type. This should not be used for regular Redux work.
+ */
+export const __CALYPSO_INIT__ = '@@calypso/INIT';

--- a/client/state/utils.ts
+++ b/client/state/utils.ts
@@ -20,7 +20,7 @@ import LRU from 'lru';
 /**
  * Internal dependencies
  */
-import { APPLY_STORED_STATE, DESERIALIZE, SERIALIZE } from 'state/action-types';
+import { APPLY_STORED_STATE, DESERIALIZE, SERIALIZE, __CALYPSO_INIT__ } from 'state/action-types';
 import { SerializationResult } from 'state/serialization-result';
 import warn from 'lib/warn';
 
@@ -61,7 +61,7 @@ export function isValidStateWithSchema( state, schema, debugInfo ) {
 	return valid;
 }
 
-type CalypsoInitAction = Action< '@@calypso/INIT' >;
+type CalypsoInitAction = Action< typeof __CALYPSO_INIT__ >;
 
 interface KeyedState< S > {
 	[key: string]: S;
@@ -143,7 +143,7 @@ export const keyedReducer = < S = any, A extends Action = AnyAction >(
 		);
 	}
 
-	const initialState = reducer( undefined, { type: '@@calypso/INIT' } );
+	const initialState = reducer( undefined, { type: __CALYPSO_INIT__ } );
 
 	const wrappedReducer = (
 		state: KeyedState< S > = {},
@@ -262,7 +262,7 @@ export const withEnhancers = ( actionCreator, enhancers ) => ( ...args ) => (
 };
 
 function getInitialState( reducer ) {
-	return reducer( undefined, { type: '@@calypso/INIT' } );
+	return reducer( undefined, { type: __CALYPSO_INIT__ } );
 }
 
 function isValidSerializedState( schema, reducer, state ) {


### PR DESCRIPTION
Add types to `keyedReducer` state util.

- Add types
- Use `Object.keys(…).reducer` over `_.reduce` because it can be typed.