### PR TITLE
Replace createReducer with keyedReducer for signup verticals

### DIFF
--- a/client/state/signup/verticals/reducer.js
+++ b/client/state/signup/verticals/reducer.js
@@ -3,19 +3,15 @@
 /**
  * Internal dependencies
  */
-import { createReducer } from 'state/utils';
+import { keyedReducer } from 'state/utils';
 import { SIGNUP_VERTICALS_SET } from 'state/action-types';
 
-export default createReducer( null, {
-	[ SIGNUP_VERTICALS_SET ]: ( state, action ) => {
-		const siteType = action.siteType;
-		const previousData = state ? state[ siteType ] : null;
+export default keyedReducer( 'siteType', ( state = null, action ) => {
+	if ( action.type === SIGNUP_VERTICALS_SET ) {
 		return {
 			...state,
-			[ siteType ]: {
-				...previousData,
-				[ action.search.trim().toLowerCase() ]: action.verticals,
-			},
+			[ action.search.trim().toLowerCase() ]: action.verticals,
 		};
-	},
+	}
+	return state;
 } );

--- a/client/state/signup/verticals/test/reducer.js
+++ b/client/state/signup/verticals/test/reducer.js
@@ -7,8 +7,8 @@ import reducer from '../reducer';
 import { SIGNUP_VERTICALS_SET } from 'state/action-types';
 
 describe( 'state/signup/verticals/reducer', () => {
-	test( 'should default to `null`', () => {
-		expect( reducer( undefined, {} ) ).toEqual( null );
+	test( 'should default to an empty object', () => {
+		expect( reducer( undefined, {} ) ).toEqual( {} );
 	} );
 
 	test( 'should associate a trimmed and lowercase search string to the verticals array.', () => {


### PR DESCRIPTION
This change means that when the reducer is called with `undefined` passed in as the state, the result will be an empty object, instead of `null`. This doesn't seem to have a negative consequence, and the `getVerticals` selector already handles an empty object as `null`. Other reducers in signup also use `createReducer` so they could also be candidates for moving to `keyedReducer` instead.

The background behind this PR is that `combineReducer` can have unnecessary overhead in cases like this one, and using `keyedReducer` makes for a more readable reducer, with logical control flow via an if statement.

#### Changes proposed in this Pull Request

* Replace `createReducer` with `keyedReducer` for the signup verticals reducer.
* Update the unit test for the reducer being called with `undefined`. Because the `keyedReducer` function will return an empty object when given an `undefined` state, this test has been updated to expect an empty object.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to create a new site: http://calypso.localhost:3000/start/
* Select a site type (e.g Business)
* In step 2 "What does your business do", start typing a vertical (e.g. Photography). The site preview should appear.
* Change the search term to a different vertical (e.g. Fashion Designer). The site preview should update to that vertical.
* Test with the other site types to make sure they work, too (Blog, Professional)
