### PR TITLE
Analytics: Disable hotjar for e2e

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import cookie from 'cookie';
 import debug from 'debug';
 import { parse } from 'qs';
@@ -45,10 +42,9 @@ import {
 	recordAddToCart,
 	recordOrder,
 } from 'lib/analytics/ad-tracking';
-
 import { updateQueryParamsTracking } from 'lib/analytics/sem';
-
 import { statsdTimingUrl } from 'lib/analytics/statsd';
+import { isE2ETest } from 'lib/e2e';
 
 /**
  * Module variables
@@ -708,6 +704,7 @@ const analytics = {
 		addHotJarScript: function() {
 			if (
 				! config( 'hotjar_enabled' ) ||
+				isE2ETest() ||
 				doNotTrack() ||
 				isPiiUrl() ||
 				! mayWeTrackCurrentUserGdpr()

--- a/client/lib/e2e/index.js
+++ b/client/lib/e2e/index.js
@@ -1,8 +1,0 @@
-/** @format */
-
-// All end-to-end tests use a custom user agent containing this string.
-export const E2E_USER_AGENT = 'wp-e2e-tests';
-
-export function isE2ETest() {
-	return new RegExp( E2E_USER_AGENT ).test( navigator.userAgent );
-}

--- a/client/lib/e2e/index.ts
+++ b/client/lib/e2e/index.ts
@@ -1,0 +1,6 @@
+// All end-to-end tests use a custom user agent containing this string.
+const E2E_USER_AGENT = 'wp-e2e-tests';
+
+export function isE2ETest(): boolean {
+	return typeof navigator !== 'undefined' && navigator.userAgent.includes( E2E_USER_AGENT );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* E2e tests may skew hotjar data. Disable hotjar when e2e is detected.

#### Testing instructions

* Make sure a page using HotJar isn't broken (`/plans/my-plan/SITE_SLUG` for a Jetpack site)