### PR TITLE
Rename webpack entrypoints: use entry- prefix

### DIFF
--- a/bin/loader-stats.js
+++ b/bin/loader-stats.js
@@ -27,7 +27,7 @@ if ( sectionChunks.length !== sectionsToCheck.length ) {
 const sectionsToLoad = [];
 sectionsToLoad.push( {
 	name: 'boot',
-	chunks: getChunkAndSiblings( 'build' ),
+	chunks: getChunkAndSiblings( 'entry-main' ),
 } );
 sectionChunks.forEach( section => {
 	sectionsToLoad.push( {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -313,7 +313,7 @@ function getDefaultContext( request ) {
 		requestFrom: request.query.from,
 		badge: false,
 		lang,
-		entrypoint: getFilesForEntrypoint( target, 'build' ),
+		entrypoint: getFilesForEntrypoint( target, 'entry-main' ),
 		manifest: getAssets( target ).manifests.manifest,
 		faviconURL: config( 'favicon_url' ),
 		isFluidWidth: !! config.isEnabled( 'fluid-width' ),
@@ -765,7 +765,7 @@ module.exports = function() {
 
 		const pageHtml = renderJsx( 'domains-landing', {
 			...ctx,
-			entrypoint: getFilesForEntrypoint( target, 'domainsLanding' ),
+			entrypoint: getFilesForEntrypoint( target, 'entry-domains-landing' ),
 		} );
 		res.send( pageHtml );
 	} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -156,8 +156,8 @@ const webpackConfig = {
 	bail: ! isDevelopment,
 	context: __dirname,
 	entry: {
-		build: [ path.join( __dirname, 'client', 'boot', 'app' ) ],
-		domainsLanding: [ path.join( __dirname, 'client', 'landing', 'domains' ) ],
+		'entry-main': [ path.join( __dirname, 'client', 'boot', 'app' ) ],
+		'entry-domains-landing': [ path.join( __dirname, 'client', 'landing', 'domains' ) ],
 	},
 	mode: isDevelopment ? 'development' : 'production',
 	devtool: process.env.SOURCEMAP || ( isDevelopment ? '#eval' : false ),
@@ -304,7 +304,9 @@ const webpackConfig = {
 
 if ( isDevelopment ) {
 	webpackConfig.plugins.push( new webpack.HotModuleReplacementPlugin() );
-	webpackConfig.entry.build.unshift( 'webpack-hot-middleware/client' );
+	for ( const entrypoint of Object.keys( webpackConfig.entry ) ) {
+		webpackConfig.entry[ entrypoint ].unshift( 'webpack-hot-middleware/client' );
+	}
 }
 
 if ( ! config.isEnabled( 'desktop' ) ) {


### PR DESCRIPTION
As we are adding new webpack entrypoints, it's time to put some naming convention in place. This PR renames the existing entrypoints:
- `build` -> `entry-main`
- `domainsLanding` -> `entry-domains-landing`

and establishes a convention with an `entry-` prefix for new ones:
- `entry-login`
- `entry-signup`
