### PR TITLE
Adjust template modal size and overlay

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -69,6 +69,7 @@ class PageTemplateModal extends Component {
 				title={ __( 'Select Page Template', 'full-site-editing' ) }
 				onRequestClose={ this.closeModal }
 				className="page-template-modal"
+				overlayClassName="page-template-modal-screen-overlay"
 			>
 				<div className="page-template-modal__inner">
 					<form className="page-template-modal__form">

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -16,25 +16,32 @@
 	background-color: hsla( 0, 0%, 0%, 0.7 );
 }
 
+// When not in fullscreen mode allow space for WP.org sidebar
+body:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
+	
+	@media screen and ( min-width: 783px ) {
+		left: 36px;
+	}
+
+	@media screen and ( min-width: 961px ) {
+		left: 160px;
+	}
+}
+
+// Allow space for admin bar if present and not in full screen mode
+body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
+	top: 46px;
+
+	@media screen and ( min-width: 783px ) {
+		top: 32px;
+	}
+	
+}
+
 // Full screen modal
 .page-template-modal {
 	width: 100%;
 	height: 100vh;
-}
-
-// When not full screen account for sidebar
-body:not( .is-fullscreen-mode ) .page-template-modal {
-	
-	@media screen and ( min-width: 783px ) {
-		width: calc( 100% - 65px );
-		left: 50px;
-		transform: translateY( -50% );
-	}
-
-	@media screen and ( min-width: 960px ) {
-		width: calc( 100% - 200px );
-		left: 180px;
-	}
 }
 
 .page-template-modal .components-modal__header-heading-container {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -59,6 +59,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 .page-template-modal__intro {
 	text-align: center;
+	margin-left: auto;
+	margin-right: auto;
 }
 
 .page-template-modal__list {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -11,6 +11,11 @@
 	word-wrap: normal !important;
 }
 
+// Modal Overlay
+.page-template-modal-screen-overlay {
+	background-color: hsla( 0, 0%, 0%, 0.7 );
+}
+
 // Full screen modal
 .page-template-modal {
 	width: 100%;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -14,6 +14,7 @@
 // Modal Overlay
 .page-template-modal-screen-overlay {
 	background-color: hsla( 0, 0%, 0%, 0.7 );
+	animation: none;
 }
 
 // When not in fullscreen mode allow space for WP.org sidebar
@@ -43,6 +44,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	width: 100%;
 	height: 100vh;
 	max-width: 800px;
+	animation: none;
 }
 
 .page-template-modal .components-modal__header-heading-container {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -42,6 +42,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 .page-template-modal {
 	width: 100%;
 	height: 100vh;
+	max-width: 800px;
 }
 
 .page-template-modal .components-modal__header-heading-container {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/33494

#### Changes proposed in this Pull Request

* Adjusts overlay colour of Modal to be darker as per https://github.com/Automattic/wp-calypso/issues/33494#issuecomment-498351674
* Sets the size of the overlay so that it does not obscure sidebar or admin bar on WP.org
* Sets max-width of `800px` on Modal itself to avoid it getting too large
* Removes Modal animation

#### Testing instructions

* Create new Page
* See new Modal overlay color matches that requested in https://github.com/Automattic/wp-calypso/issues/33494#issuecomment-498351674
* See that on WP.org the overlay does not obscure the sidebar and/or the admin bar (test across different viewport widths)
* Check that with admin bar removed the modal still looks correct (ie: no space between overlay and top of screen)
* Switch to `Full Screen Mode` (within Editor) and then create a new Page
* Verify that in Full Screen Modal the modal looks ok
* Check that Modal animation is removed on initial creation

