### PR TITLE
Update title and descriptions of 'News" mailing list categories.

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -113,7 +113,7 @@ class MainComponent extends React.Component {
 		} else if ( 'digest' === category ) {
 			return this.props.translate( 'Digests' );
 		} else if ( 'news' === category ) {
-			return this.props.translate( 'WordPress.com Newsletter' );
+			return this.props.translate( 'Newsletter' );
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Jetpack Suggestions' );
 		} else if ( 'jetpack_research' === category ) {
@@ -144,9 +144,7 @@ class MainComponent extends React.Component {
 				'Popular content from the blogs you follow, and reports on your own site and its performance.'
 			);
 		} else if ( 'news' === category ) {
-			return this.props.translate(
-				'The official WordPress.com newsletter, providing you with the latest news, announcements, and product spotlights.'
-			);
+			return this.props.translate( 'WordPress.com news, announcements, and product spotlights.' );
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Tips for getting the most out of Jetpack.' );
 		} else if ( 'jetpack_research' === category ) {
@@ -156,9 +154,7 @@ class MainComponent extends React.Component {
 		} else if ( 'jetpack_promotion' === category ) {
 			return this.props.translate( 'Promotions and deals on upgrades.' );
 		} else if ( 'jetpack_news' === category ) {
-			return this.props.translate(
-				'The official Jetpack newsletter, providing you with the latest news, announcements, and product spotlights.'
-			);
+			return this.props.translate( 'Jetpack news, announcements, and product spotlights.' );
 		}
 
 		return null;

--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -112,6 +112,8 @@ class MainComponent extends React.Component {
 			return this.props.translate( 'Community' );
 		} else if ( 'digest' === category ) {
 			return this.props.translate( 'Digests' );
+		} else if ( 'news' === category ) {
+			return this.props.translate( 'WordPress.com Newsletter' );
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Jetpack Suggestions' );
 		} else if ( 'jetpack_research' === category ) {
@@ -119,7 +121,7 @@ class MainComponent extends React.Component {
 		} else if ( 'jetpack_promotion' === category ) {
 			return this.props.translate( 'Jetpack Promotions' );
 		} else if ( 'jetpack_news' === category ) {
-			return this.props.translate( 'Jetpack News' );
+			return this.props.translate( 'Jetpack Newsletter' );
 		}
 
 		return category;
@@ -141,6 +143,10 @@ class MainComponent extends React.Component {
 			return this.props.translate(
 				'Popular content from the blogs you follow, and reports on your own site and its performance.'
 			);
+		} else if ( 'news' === category ) {
+			return this.props.translate(
+				'The official WordPress.com newsletter, providing you with the latest news, announcements, and product spotlights.'
+			);
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Tips for getting the most out of Jetpack.' );
 		} else if ( 'jetpack_research' === category ) {
@@ -150,7 +156,9 @@ class MainComponent extends React.Component {
 		} else if ( 'jetpack_promotion' === category ) {
 			return this.props.translate( 'Promotions and deals on upgrades.' );
 		} else if ( 'jetpack_news' === category ) {
-			return this.props.translate( 'Jetpack news and announcements.' );
+			return this.props.translate(
+				'The official Jetpack newsletter, providing you with the latest news, announcements, and product spotlights.'
+			);
 		}
 
 		return null;

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -119,7 +119,7 @@ class WPCOMNotifications extends React.Component {
 				<EmailCategory
 					name={ options.news }
 					isEnabled={ get( settings, options.news ) }
-					title={ translate( 'The official WordPress.com newsletter' ) }
+					title={ translate( 'Newsletter' ) }
 					description={ translate( 'WordPress.com news, announcements, and product spotlights.' ) }
 				/>
 
@@ -165,7 +165,7 @@ class WPCOMNotifications extends React.Component {
 						<EmailCategory
 							name={ options.jetpack_news }
 							isEnabled={ get( settings, options.jetpack_news ) }
-							title={ translate( 'The official Jetpack newsletter' ) }
+							title={ translate( 'Newsletter' ) }
 							description={ translate( 'Jetpack news, announcements, and product spotlights.' ) }
 						/>
 					</>

--- a/client/me/notification-settings/wpcom-settings/index.jsx
+++ b/client/me/notification-settings/wpcom-settings/index.jsx
@@ -119,8 +119,8 @@ class WPCOMNotifications extends React.Component {
 				<EmailCategory
 					name={ options.news }
 					isEnabled={ get( settings, options.news ) }
-					title={ translate( 'News' ) }
-					description={ translate( 'WordPress.com news and announcements.' ) }
+					title={ translate( 'The official WordPress.com newsletter' ) }
+					description={ translate( 'WordPress.com news, announcements, and product spotlights.' ) }
 				/>
 
 				<EmailCategory
@@ -165,8 +165,8 @@ class WPCOMNotifications extends React.Component {
 						<EmailCategory
 							name={ options.jetpack_news }
 							isEnabled={ get( settings, options.jetpack_news ) }
-							title={ translate( 'News' ) }
-							description={ translate( 'Jetpack news and announcements.' ) }
+							title={ translate( 'The official Jetpack newsletter' ) }
+							description={ translate( 'Jetpack news, announcements, and product spotlights.' ) }
 						/>
 					</>
 				) : (


### PR DESCRIPTION
This change applies a more proper title and description to the “News” mailing list categories / message types, which are currently (and only ever have been) used for the periodical newsletter mailings. 

This should bring greater clarity to the purpose of this particular message type.

This change affects both WordPress.com and Jetpack message types.

**Testing Plan**
1) Visit the unsubscribe URLs provided below.
2) Confirm that the unsubscribe action works, as expected.
3) Confirm that the title and description of each message type is correctly updated, according to the code.

* http://calypso.localhost:3000/mailing-lists/unsubscribe?email=codefourcomics%40gmail.com&category=20785&hmac=8da22f1deb8e3e9a094fb6822ad6102a7ec5b1db

* http://calypso.localhost:3000/mailing-lists/unsubscribe?email=codefourcomics%40gmail.com&category=22505&hmac=2024c0adfc7c297ecf5a489c01d097f922ebcf15
