### PR TITLE
eCommerce Plan Thank You: replace email verification notices

### DIFF
--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -139,6 +139,10 @@ PlanThankYouCard.propTypes = {
 	action: PropTypes.node,
 	buttonText: PropTypes.string,
 	buttonUrl: PropTypes.string,
+	/**
+	 * Description can be either a string or object to allow either a bare
+	 * string or a description that contains HTML and other components.
+	 **/
 	description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 	heading: PropTypes.string,
 	plan: PropTypes.object,

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -75,12 +75,26 @@ class PlanThankYouCard extends Component {
 	}
 
 	renderDescription() {
-		const { description, translate } = this.props;
+		const { description, descriptionWithHTML, translate } = this.props;
 		if ( description ) {
 			return description;
 		}
 
+		if ( descriptionWithHTML ) {
+			// If there is a descriptionWithHTML, we shouldn't render a default description
+			return null;
+		}
+
 		return translate( "Now that we've taken care of the plan, it's time to see your new site." );
+	}
+
+	renderDescriptionWithHTML() {
+		const { descriptionWithHTML } = this.props;
+		if ( descriptionWithHTML ) {
+			return descriptionWithHTML;
+		}
+
+		return null;
 	}
 
 	renderHeading() {
@@ -122,6 +136,7 @@ class PlanThankYouCard extends Component {
 					price={ this.renderPlanPrice() }
 					heading={ this.renderHeading() }
 					description={ this.renderDescription() }
+					descriptionWithHTML={ this.renderDescriptionWithHTML() }
 					buttonUrl={ this.getButtonUrl() }
 					buttonText={ this.renderButtonText() }
 					icon={ this.renderPlanIcon() }
@@ -137,6 +152,7 @@ PlanThankYouCard.propTypes = {
 	buttonText: PropTypes.string,
 	buttonUrl: PropTypes.string,
 	description: PropTypes.string,
+	descriptionWithHTML: PropTypes.object,
 	heading: PropTypes.string,
 	plan: PropTypes.object,
 	siteId: PropTypes.number.isRequired,

--- a/client/blocks/plan-thank-you-card/index.jsx
+++ b/client/blocks/plan-thank-you-card/index.jsx
@@ -75,26 +75,12 @@ class PlanThankYouCard extends Component {
 	}
 
 	renderDescription() {
-		const { description, descriptionWithHTML, translate } = this.props;
+		const { description, translate } = this.props;
 		if ( description ) {
 			return description;
 		}
 
-		if ( descriptionWithHTML ) {
-			// If there is a descriptionWithHTML, we shouldn't render a default description
-			return null;
-		}
-
 		return translate( "Now that we've taken care of the plan, it's time to see your new site." );
-	}
-
-	renderDescriptionWithHTML() {
-		const { descriptionWithHTML } = this.props;
-		if ( descriptionWithHTML ) {
-			return descriptionWithHTML;
-		}
-
-		return null;
 	}
 
 	renderHeading() {
@@ -126,6 +112,8 @@ class PlanThankYouCard extends Component {
 
 	render() {
 		const { siteId } = this.props;
+		const description = this.renderDescription();
+
 		return (
 			<div className={ classnames( 'plan-thank-you-card', this.getPlanClass() ) }>
 				<QuerySites siteId={ siteId } />
@@ -135,8 +123,8 @@ class PlanThankYouCard extends Component {
 					name={ this.renderPlanName() }
 					price={ this.renderPlanPrice() }
 					heading={ this.renderHeading() }
-					description={ this.renderDescription() }
-					descriptionWithHTML={ this.renderDescriptionWithHTML() }
+					description={ 'string' === typeof description ? description : null }
+					descriptionWithHTML={ 'object' === typeof description ? description : null }
 					buttonUrl={ this.getButtonUrl() }
 					buttonText={ this.renderButtonText() }
 					icon={ this.renderPlanIcon() }
@@ -151,8 +139,7 @@ PlanThankYouCard.propTypes = {
 	action: PropTypes.node,
 	buttonText: PropTypes.string,
 	buttonUrl: PropTypes.string,
-	description: PropTypes.string,
-	descriptionWithHTML: PropTypes.object,
+	description: PropTypes.oneOfType( [ PropTypes.string, PropTypes.object ] ),
 	heading: PropTypes.string,
 	plan: PropTypes.object,
 	siteId: PropTypes.number.isRequired,

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -16,10 +16,28 @@ import PlanThankYouCard from 'blocks/plan-thank-you-card';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanClass } from 'lib/plans';
+import { getCurrentUserEmail, isCurrentUserEmailVerified } from 'state/current-user/selectors';
 
 class AtomicStoreThankYouCard extends Component {
-	renderAction() {
-		const { site, translate } = this.props;
+	resendEmail = () => {
+		//@todo: resend email
+	};
+
+	renderAction = () => {
+		const { isEmailVerified, site, translate } = this.props;
+
+		if ( ! isEmailVerified ) {
+			return (
+				<div className="checkout-thank-you__atomic-store-action-buttons">
+					<button
+						className={ classNames( 'button', 'thank-you-card__button' ) }
+						onClick={ this.resendEmail }
+					>
+						{ translate( 'Resend Email' ) }
+					</button>
+				</div>
+			);
+		}
 
 		return (
 			<div className="checkout-thank-you__atomic-store-action-buttons">
@@ -30,6 +48,31 @@ class AtomicStoreThankYouCard extends Component {
 					{ translate( 'Create your store!' ) }
 				</a>
 			</div>
+		);
+	};
+
+	renderDescription() {
+		const { emailAddress, isEmailVerified, translate } = this.props;
+
+		if ( ! isEmailVerified ) {
+			return (
+				<Fragment>
+					<div>
+						{ translate(
+							'Now that we have taken care of your plan, we need to verify your email address to create your store.'
+						) }
+					</div>
+					<div className="checkout-thank-you__atomic-store-email-instruction">
+						{ translate( 'Please click the link in the email we sent to %(emailAddress)s.', {
+							args: { emailAddress },
+						} ) }
+					</div>
+				</Fragment>
+			);
+		}
+
+		return translate(
+			"Now that we've taken care of the plan, it's time to start setting up your store"
 		);
 	}
 
@@ -44,9 +87,7 @@ class AtomicStoreThankYouCard extends Component {
 					siteId={ siteId }
 					action={ this.renderAction() }
 					heading={ translate( 'Thank you for your purchase!' ) }
-					description={ translate(
-						"Now that we've taken care of the plan, it's time to start setting up your store"
-					) }
+					description={ this.renderDescription() }
 				/>
 			</div>
 		);
@@ -58,10 +99,14 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const plan = getCurrentPlan( state, siteId );
 	const planClass = plan && plan.productSlug ? getPlanClass( plan.productSlug ) : '';
+	const emailAddress = getCurrentUserEmail( state );
+	const isEmailVerified = isCurrentUserEmailVerified( state );
 
 	return {
 		siteId,
 		site,
+		emailAddress,
+		isEmailVerified,
 		planClass,
 	};
 } )( localize( AtomicStoreThankYouCard ) );

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -150,7 +150,6 @@ class AtomicStoreThankYouCard extends Component {
 		const { translate, siteId, planClass } = this.props;
 
 		const classes = classNames( 'checkout-thank-you__atomic-store', planClass );
-		const description = this.renderDescription();
 
 		return (
 			<div className={ classes }>
@@ -158,8 +157,7 @@ class AtomicStoreThankYouCard extends Component {
 					siteId={ siteId }
 					action={ this.renderAction() }
 					heading={ translate( 'Thank you for your purchase!' ) }
-					description={ 'string' === typeof description ? description : null }
-					descriptionWithHTML={ 'object' === typeof description ? description : null }
+					description={ this.renderDescription() }
 				/>
 			</div>
 		);

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -38,9 +38,7 @@ class AtomicStoreThankYouCard extends Component {
 		}
 	}
 
-	checkVerification = () => {
-		user.fetch();
-	};
+	checkVerification = () => user.fetch();
 
 	resendEmail = () => {
 		const { translate } = this.props;

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -22,9 +22,9 @@ import { getCurrentUserEmail, isCurrentUserEmailVerified } from 'state/current-u
 import { errorNotice, removeNotice } from 'state/notices/actions';
 import userFactory from 'lib/user';
 
-const VERIFY_EMAIL_ERRROR_NOTICE = 'ecommerce-verify-email-error';
+const VERIFY_EMAIL_ERROR_NOTICE = 'ecommerce-verify-email-error';
 
-const userLib = userFactory();
+const user = userFactory();
 
 class AtomicStoreThankYouCard extends Component {
 	state = {
@@ -32,8 +32,14 @@ class AtomicStoreThankYouCard extends Component {
 		emailSent: false,
 	};
 
+	componentDidUpdate( prevProps ) {
+		if ( this.props.isEmailVerified && ! prevProps.isEmailVerified ) {
+			this.props.removeNotice( VERIFY_EMAIL_ERROR_NOTICE );
+		}
+	}
+
 	checkVerification = () => {
-		userLib.fetch();
+		user.fetch();
 	};
 
 	resendEmail = () => {
@@ -43,15 +49,18 @@ class AtomicStoreThankYouCard extends Component {
 			return;
 		}
 
-		this.setState( { pendingVerificationResend: true } );
+		this.setState( {
+			emailSent: false,
+			pendingVerificationResend: true,
+		} );
 
-		userLib.sendVerificationEmail( ( error, response ) => {
-			this.props.removeNotice( VERIFY_EMAIL_ERRROR_NOTICE );
+		user.sendVerificationEmail( ( error, response ) => {
+			this.props.removeNotice( VERIFY_EMAIL_ERROR_NOTICE );
 			if ( error ) {
 				this.props.errorNotice(
 					translate( "Couldn't resend verification email. Please try again." ),
 					{
-						id: VERIFY_EMAIL_ERRROR_NOTICE,
+						id: VERIFY_EMAIL_ERROR_NOTICE,
 					}
 				);
 			}
@@ -108,12 +117,6 @@ class AtomicStoreThankYouCard extends Component {
 			</div>
 		);
 	};
-
-	componentDidUpdate( prevProps ) {
-		if ( this.props.isEmailVerified && ! prevProps.isEmailVerified ) {
-			this.props.removeNotice( VERIFY_EMAIL_ERRROR_NOTICE );
-		}
-	}
 
 	renderDescription() {
 		const { emailAddress, isEmailVerified, translate } = this.props;

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -144,6 +144,7 @@ class AtomicStoreThankYouCard extends Component {
 		const { translate, siteId, planClass } = this.props;
 
 		const classes = classNames( 'checkout-thank-you__atomic-store', planClass );
+		const description = this.renderDescription();
 
 		return (
 			<div className={ classes }>
@@ -151,7 +152,8 @@ class AtomicStoreThankYouCard extends Component {
 					siteId={ siteId }
 					action={ this.renderAction() }
 					heading={ translate( 'Thank you for your purchase!' ) }
-					description={ this.renderDescription() }
+					description={ 'string' === typeof description ? description : null }
+					descriptionWithHTML={ 'object' === typeof description ? description : null }
 				/>
 			</div>
 		);

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -34,6 +34,10 @@ class AtomicStoreThankYouCard extends Component {
 	state = { resendStatus: RESEND_NOT_SENT };
 
 	componentDidUpdate( prevProps ) {
+		/**
+		 * This clears the  error in the event the email is verified in another tab
+		 * or another browser and the isEmailVerified props is updated via polling.
+		 */
 		if ( this.props.isEmailVerified && ! prevProps.isEmailVerified ) {
 			this.props.removeNotice( VERIFY_EMAIL_ERROR_NOTICE );
 		}
@@ -44,6 +48,9 @@ class AtomicStoreThankYouCard extends Component {
 	resendEmail = () => {
 		const { translate } = this.props;
 		const { resendStatus } = this.state;
+
+		this.props.removeNotice( VERIFY_EMAIL_ERROR_NOTICE );
+
 		if ( RESEND_PENDING === resendStatus ) {
 			return;
 		}
@@ -51,7 +58,6 @@ class AtomicStoreThankYouCard extends Component {
 		this.setState( { resendStatus: RESEND_PENDING } );
 
 		user.sendVerificationEmail( error => {
-			this.props.removeNotice( VERIFY_EMAIL_ERROR_NOTICE );
 			if ( error ) {
 				this.props.errorNotice(
 					translate( "Couldn't resend verification email. Please try again." ),

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -77,6 +77,7 @@ import { fetchAtomicTransfer } from 'state/atomic-transfer/actions';
 import { transferStates } from 'state/atomic-transfer/constants';
 import getAtomicTransfer from 'state/selectors/get-atomic-transfer';
 import isFetchingTransfer from 'state/selectors/is-fetching-atomic-transfer';
+import getSiteSlug from 'state/sites/selectors/get-site-slug.js';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
@@ -170,6 +171,17 @@ export class CheckoutThankYou extends React.Component {
 			this.props.selectedSite
 		) {
 			this.props.refreshSitePlans( this.props.selectedSite );
+		}
+	}
+
+	componentDidUpdate( prevProps ) {
+		const { receiptId, selectedSiteSlug } = this.props;
+
+		// Update route when an ecommerce site goes Atomic and site slug changes
+		// from 'wordpress.com` to `wpcomstaging.com`.
+		if ( selectedSiteSlug && selectedSiteSlug !== prevProps.selectedSiteSlug ) {
+			const receiptPath = receiptId ? `/${ receiptId }` : '';
+			page( `/checkout/thank-you/${ selectedSiteSlug }${ receiptPath }` );
 		}
 	}
 
@@ -605,6 +617,7 @@ export default connect(
 				transferStates.COMPLETED ===
 				get( getAtomicTransfer( state, siteId ), 'status', transferStates.PENDING ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
+			selectedSiteSlug: getSiteSlug( state, siteId ),
 		};
 	},
 	dispatch => {

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -402,8 +402,6 @@ export class CheckoutThankYou extends React.Component {
 			return (
 				<Main className="checkout-thank-you">
 					<PageViewTracker { ...this.getAnalyticsProperties() } title="Checkout Thank You" />
-					{ this.renderConfirmationNotice() }
-					{ this.renderVerifiedEmailRequired() }
 					<AtomicStoreThankYouCard siteId={ this.props.selectedSite.ID } />
 				</Main>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -190,6 +190,11 @@
 	}
 }
 
+// eCommerce Plan Thank You styles
+.checkout-thank-you__atomic-store-email-instruction {
+	margin-top: 18px;
+}
+
 // Footer Subcomponent styles
 .checkout-thank-you__footer {
 	padding: 32px 20px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the two notices on the eCommerce Thank You page
* Updates the wording to indicate confirmation is required if email hasn't been confirmed
* Displays "Resend Email" button in place of "Create Store" if email hasn't been confirmed

Before:
![image](https://user-images.githubusercontent.com/363749/59620502-a5396c00-90f2-11e9-9e4a-c76ef2d08293.png)

After:
![image](https://user-images.githubusercontent.com/363749/59620424-6c00fc00-90f2-11e9-89b9-48139150635a.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Begin signup as a new user from `/start`.
* Create a new user, and then select "Online store" when asked what kind of site you are building.
* Select a domain, and then on the plans page, select the "eCommerce" plan.
* Continue purchasing the plan.
* After you've completed the purchase of your plan, you should be taken to the thank-you page, and see instructions to click the link in your email.
* Before you verify your email address, click on "Resend email" and verify you receive an additional email verification.
* Verify your email. The thank-you page should refresh and you should see a button labeled "Create your store!"

Note: once you've completed the flow once, you can copy the URL on the thank-you page and reload the page. You can change your email verification status manually.

![image](https://user-images.githubusercontent.com/363749/59620989-da928980-90f3-11e9-8c09-7b7820ebe609.png)


Fixes #33541
