### PR TITLE
Remove obsolete code from the pluginsUpsellLandingPage test

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -45,7 +45,6 @@ import isAutomatedTransferActive from 'state/selectors/is-automated-transfer-act
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import QueryEligibility from 'components/data/query-atat-eligibility';
 import { isATEnabled } from 'lib/automated-transfer';
-import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -592,13 +591,7 @@ export class PluginMeta extends Component {
 
 	handleUpgradeNudgeClick = () => {
 		const { slug } = this.props;
-		let href = `/plans/${ slug }?feature=${ FEATURE_UPLOAD_PLUGINS }`;
-		if (
-			config.isEnabled( 'upsell/nudge-a-palooza' ) &&
-			abtest( 'pluginsUpsellLandingPage' ) === 'test'
-		) {
-			href = '/feature/plugins/' + slug;
-		}
+		const href = `/plans/${ slug }?feature=${ FEATURE_UPLOAD_PLUGINS }`;
 		page.redirect( href );
 	};
 

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -26,7 +26,6 @@ import QueryEligibility from 'components/data/query-atat-eligibility';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
 import { initiateAutomatedTransferWithPluginZip } from 'state/automated-transfer/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
 import getPluginUploadError from 'state/selectors/get-plugin-upload-error';
 import getPluginUploadProgress from 'state/selectors/get-plugin-upload-progress';
 import getUploadedPluginId from 'state/selectors/get-uploaded-plugin-id';
@@ -45,10 +44,6 @@ import {
 } from 'state/automated-transfer/selectors';
 import { successNotice } from 'state/notices/actions';
 import { transferStates } from 'state/automated-transfer/constants';
-import { abtest } from 'lib/abtest';
-import { hasFeature } from 'state/sites/plans/selectors';
-import redirectIf from 'my-sites/feature-upsell/redirect-if';
-import config from 'config';
 
 class PluginUpload extends React.Component {
 	state = {
@@ -216,17 +211,5 @@ const flowRightArgs = [
 	),
 	localize,
 ];
-
-if ( config.isEnabled( 'upsell/nudge-a-palooza' ) ) {
-	flowRightArgs.push(
-		redirectIf(
-			( state, siteId ) =>
-				! isJetpackSite( state, siteId ) &&
-				! hasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS ) &&
-				abtest( 'pluginsUpsellLandingPage' ) === 'test',
-			'/feature/plugins'
-		)
-	);
-}
 
 export default flowRight( ...flowRightArgs )( PluginUpload );

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -414,13 +414,7 @@ export class PluginsBrowser extends Component {
 
 	handleUpgradeNudgeClick = () => {
 		const { siteSlug } = this.props;
-		let href = `/checkout/${ siteSlug }/business`;
-		if (
-			isEnabled( 'upsell/nudge-a-palooza' ) &&
-			abtest( 'pluginsUpsellLandingPage' ) === 'test'
-		) {
-			href = '/feature/plugins/' + siteSlug;
-		}
+		const href = `/checkout/${ siteSlug }/business`;
 		page.redirect( href );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This removes obsolete code that wasn't removed in https://github.com/Automattic/wp-calypso/pull/27244

#### Testing instructions

* There should be no changes, just check Calypso still runs.