### PR TITLE
Clarify TOS copy in signup

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -611,7 +611,7 @@ class SignupForm extends Component {
 			return (
 				<p className="signup-form__terms-of-service-link">
 					{ this.props.translate(
-						'By creating an account via any of the options below, you agree to our {{a}}Terms of Service{{/a}}.',
+						'By creating an account, you agree to our {{a}}Terms of Service{{/a}}.',
 						{
 							components: {
 								a: tosLink,

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -64,7 +64,7 @@ class SocialSignupForm extends Component {
 				{ ! this.props.compact && (
 					<p>
 						{ preventWidows(
-							this.props.translate( 'Or connect your existing profile to get started faster.' )
+							this.props.translate( 'Or create an account with your Google profile.' )
 						) }
 					</p>
 				) }

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -14,7 +14,7 @@
 }
 
 .signup-form__terms-of-service-link {
-	font-size: 11px;
+	font-size: 12px;
 	margin: 0 0 20px;
 	text-align: center;
 


### PR DESCRIPTION
## Changes proposed in this Pull Request
Updated copy to clarify that *any* account creation method is subject to the TOS.

### Before
![before](https://user-images.githubusercontent.com/3238155/59310253-a97d0980-8c5a-11e9-8adc-77f5515235a5.png)

### After
<img width="471" alt="after" src="https://user-images.githubusercontent.com/3238155/59310263-b26ddb00-8c5a-11e9-95e2-69d4fdd53947.png">

### Testing instructions

* Go to /start/user **while logged out** to view.

Fixes #33289 
