### PR TITLE
Checklist - make all buttons secondary

### DIFF
--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -19,7 +19,6 @@ import Spinner from 'components/spinner';
 
 class Task extends PureComponent {
 	static propTypes = {
-		buttonPrimary: PropTypes.bool,
 		buttonText: PropTypes.node,
 		completed: PropTypes.bool,
 		completedButtonText: PropTypes.node,
@@ -145,7 +144,6 @@ class Task extends PureComponent {
 
 	render() {
 		const {
-			buttonPrimary,
 			buttonText,
 			completed,
 			completedButtonText,
@@ -207,7 +205,6 @@ class Task extends PureComponent {
 						className="checklist__task-action"
 						href={ href }
 						onClick={ onClick }
-						primary={ buttonPrimary }
 						target={ target }
 					>
 						{ taskActionButtonText }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Makes all checklist buttons secondary
* This might be a bit overkill so I'm going to make an alternative PR just in case :)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a site on a Business plan
* Install a plugin
* Navigate to Store
* You will see a checklist in the store NUX

#### Before
![image](https://user-images.githubusercontent.com/1123119/59310600-be0dd180-8c5b-11e9-95dd-f273116639d3.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/59310587-b77f5a00-8c5b-11e9-9144-50e029df5e78.png)


Fixes #33262
