### PR TITLE
left-align centered text in importers authorship review step

### DIFF
--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -178,6 +178,7 @@
 
 .importer__mapping-description {
 	margin-bottom: 16px;
+	text-align: left;
 
 	strong {
 		white-space: nowrap;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* make center-aligned text left aligned, in the authorship review step that appears in a file-based import.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to import
* pick WordPress, Medium, Squarespace, or Blogger
* import with a file: https://fieldguide.automattic.com/imports-and-exports/resources-for-testing-importers/
* keep going in the process til you see the authorship page:
<img width="1440" alt="Screen Shot 2019-06-11 at 3 24 03 PM" src="https://user-images.githubusercontent.com/1301932/59311119-39bc4e00-8c5d-11e9-815c-0b40ba53f82d.png">

Fixes #
