### PR TITLE
Store checklist - make buttons secondary

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup/tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup/tasks.js
@@ -97,7 +97,6 @@ class SetupTasks extends Component {
 						) }
 						title={ translate( 'Add a product' ) }
 						buttonText={ translate( 'Add a product' ) }
-						buttonPrimary
 						completedTitle={ translate( 'You have added a product' ) }
 						completedButtonText={ translate( 'View products' ) }
 						description={ translate( 'Start by adding the first product to your\u00a0store.' ) }
@@ -111,7 +110,6 @@ class SetupTasks extends Component {
 						) }
 						title={ translate( 'Review shipping' ) }
 						buttonText={ translate( 'Review shipping' ) }
-						buttonPrimary
 						completedTitle={ translate( 'Shipping is set up' ) }
 						completedButtonText={ translate( 'View shipping' ) }
 						description={ translate( "We've set up shipping based on your store location." ) }
@@ -125,7 +123,6 @@ class SetupTasks extends Component {
 						) }
 						title={ translate( 'Review payments' ) }
 						buttonText={ translate( 'Review payments' ) }
-						buttonPrimary
 						completedTitle={ translate( 'Payments are set up' ) }
 						completedButtonText={ translate( 'Review payments' ) }
 						description={ translate( 'Choose how you would like your customers to pay you.' ) }
@@ -139,7 +136,6 @@ class SetupTasks extends Component {
 						) }
 						title={ translate( 'Review taxes' ) }
 						buttonText={ translate( 'Review taxes' ) }
-						buttonPrimary
 						completedTitle={ translate( 'Taxes are setup' ) }
 						completedButtonText={ translate( 'Review taxes' ) }
 						description={ translate( "We've set up automatic tax calculations for you." ) }
@@ -156,7 +152,6 @@ class SetupTasks extends Component {
 						) }
 						title={ translate( 'View and customize' ) }
 						buttonText={ translate( 'Customize' ) }
-						buttonPrimary
 						completedTitle={ translate( 'View and customize' ) }
 						completedButtonText={ translate( 'View and customize' ) }
 						description={ translate(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Makes all buttons specific to the store checklist secondary

#### Testing instructions


* Create a site on a Business plan
* Install a plugin
* Navigate to Store
* You will see a checklist in the store NUX

#### Before
![image](https://user-images.githubusercontent.com/1123119/59310600-be0dd180-8c5b-11e9-95dd-f273116639d3.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/59310587-b77f5a00-8c5b-11e9-9144-50e029df5e78.png)


Fixes #33262
