### PR TITLE
Fix margin-bottom on application password container

### DIFF
--- a/client/me/application-passwords/index.jsx
+++ b/client/me/application-passwords/index.jsx
@@ -215,7 +215,7 @@ class ApplicationPasswords extends Component {
 				<Card>
 					{ newAppPassword ? this.renderNewAppPassword() : this.renderNewAppPasswordForm() }
 
-					<p>
+					<p className="application-passwords__nobot">
 						{ translate(
 							'With Two-Step Authentication active, you can generate a custom password for ' +
 								'each third-party application you authorize to use your WordPress.com account. ' +

--- a/client/me/application-passwords/style.scss
+++ b/client/me/application-passwords/style.scss
@@ -39,3 +39,7 @@
 .application-passwords__new-password-help {
 	text-align: center;
 }
+
+.application-passwords__nobot {
+	margin-bottom: 0;
+}


### PR DESCRIPTION
## URL

https://wordpress.com/me/security/two-step

## Screenshot

![](https://d1jfzjx68gj8xs.cloudfront.net/items/1K2u2K1A08092L0E0x3t/Screen%20Recording%202019-05-23%20at%2004.44%20PM.gif)

## Issue

There is more padding below the paragraph and above it.

## Proposal

If we drop that additional padding from the paragraph element, this container will look more balanced.

Fixes #33295
