### PR TITLE
Uploading a new profile pic suddenly mentions Gravatar

### DIFF
--- a/client/my-sites/importer/style.scss
+++ b/client/my-sites/importer/style.scss
@@ -178,6 +178,7 @@
 
 .importer__mapping-description {
 	margin-bottom: 16px;
+	text-align: left;
 
 	strong {
 		white-space: nowrap;

--- a/client/state/notices/middleware.js
+++ b/client/state/notices/middleware.js
@@ -91,10 +91,12 @@ export const onBillingReceiptEmailSendSuccess = () =>
 export const onGravatarReceiveImageFailure = action => errorNotice( action.errorMessage );
 
 export const onGravatarUploadRequestFailure = () =>
-	errorNotice( translate( 'Hmm, your new Gravatar was not saved. Please try uploading again.' ) );
+	errorNotice(
+		translate( 'Hmm, your new profile photo was not saved. Please try uploading again.' )
+	);
 
 export const onGravatarUploadRequestSuccess = () =>
-	successNotice( translate( 'You successfully uploaded a new Gravatar — looking sharp!' ) );
+	successNotice( translate( 'You successfully uploaded a new profile photo — looking sharp!' ) );
 
 export const onDeleteInvitesFailure = action => ( dispatch, getState ) => {
 	for ( const inviteId of action.inviteIds ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
- the fix was about making the language around profile photos consistent, so I used this copy as the starting point:

<img width="201" alt="Screen Shot 2019-06-11 at 4 01 26 PM" src="https://user-images.githubusercontent.com/1301932/59312510-4000f900-8c62-11e9-9776-f9680d6711f5.png">
- then I changed anything user-facing in that area of the product that used "gravatar" to "profile photo"

- the result is this:
<img width="565" alt="Screen Shot 2019-06-11 at 3 59 38 PM" src="https://user-images.githubusercontent.com/1301932/59312440-fc0df400-8c61-11e9-8492-56e7ff1a03a5.png">
- another one that says: 'Hmm, your new profile photo was not saved. Please try uploading again.'