### PR TITLE
Simplify `My Plan` page title text and fix typo

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -68,7 +68,7 @@ class CurrentPlan extends Component {
 	getHeaderWording( planConstObj ) {
 		const { translate } = this.props;
 
-		const title = translate( 'Your site is on a %(planName)s plan', {
+		const title = translate( 'My Plan: %(planName)s', {
 			args: {
 				planName: planConstObj.getTitle(),
 			},


### PR DESCRIPTION
## Changes proposed in this Pull Request

Changes the My Plan page title to be simpler and fix an article typo (_a_ vs _an_) as shown below. 

Before: “**Your site is on a eCommerce plan**”

After: “**Your plan: eCommerce**”

## Testing instructions

1. Log into wpcom and visit or setup a new site with an eCommerce plan.
2. Visit the My Plans page, and check that the title matches the _after_ string mentioned above.

## Other notes

This solution also prevents us from having to write new translation strings. We already have a translation string for “My Plans” in other parts of Calypso so it seems we can appropriate that for this.

Fixes #33039
