### PR TITLE
Added top margin to plugins upload icon

### DIFF
--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -48,6 +48,10 @@
 
 		@include breakpoint( '>480px' ) {
 			flex: none;
+
+			&:first-child {
+				margin-top: 4px;
+			}
 		}
 	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -49,7 +49,7 @@
 		@include breakpoint( '>480px' ) {
 			flex: none;
 
-			&:first-child {
+			.gridicon {
 				margin-top: 4px;
 			}
 		}

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -46,12 +46,12 @@
 			border-right: 1px solid rgba( var( --color-neutral-100-rgb ), 0.5 );
 		}
 
+		.gridicon {
+			margin-top: 4px;
+		}
+
 		@include breakpoint( '>480px' ) {
 			flex: none;
-
-			.gridicon {
-				margin-top: 4px;
-			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a top margin to `gridicons-cloud-upload` to fix vertical alginment 

#### Testing instructions

* Go to `https://wordpress.com/plugins/{siteName}`

**Before fix:**
<img width="252" alt="Screen Shot 2019-06-11 at 4 39 06 PM" src="https://user-images.githubusercontent.com/3276087/59313868-84db5e80-8c67-11e9-9390-6e6c32fad045.png">

**After fix:**
<img width="218" alt="Screen Shot 2019-06-11 at 4 39 17 PM" src="https://user-images.githubusercontent.com/3276087/59313891-a0df0000-8c67-11e9-833d-888c553300b1.png">


Fixes #33598
