### PR TITLE
Added link on Powered By WooCommerce to go to WooCommerce.com

### DIFF
--- a/client/extensions/woocommerce/components/woocommerce-colophon/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-colophon/index.js
@@ -4,6 +4,7 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
+import ExternalLink from 'components/external-link';
 
 /**
  * Internal dependencies
@@ -13,13 +14,13 @@ import WooCommerceLogo from '../woocommerce-logo';
 const WooCommerceColophon = ( { translate } ) => {
 	return (
 		<div className="woocommerce-colophon">
-			<span>
+			<ExternalLink icon={ false } href="https://woocommerce.com">
 				{ translate( 'Powered by {{WooCommerceLogo /}}', {
 					components: {
 						WooCommerceLogo: <WooCommerceLogo height={ 32 } width={ 120 } />,
 					},
 				} ) }
-			</span>
+			</ExternalLink>
 		</div>
 	);
 };

--- a/client/extensions/woocommerce/components/woocommerce-colophon/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-colophon/index.js
@@ -14,7 +14,7 @@ import WooCommerceLogo from '../woocommerce-logo';
 const WooCommerceColophon = ( { translate } ) => {
 	return (
 		<div className="woocommerce-colophon">
-			<ExternalLink icon={ false } href="https://woocommerce.com">
+			<ExternalLink icon={ false } target="_blank" href="https://woocommerce.com">
 				{ translate( 'Powered by {{WooCommerceLogo /}}', {
 					components: {
 						WooCommerceLogo: <WooCommerceLogo height={ 32 } width={ 120 } />,

--- a/client/extensions/woocommerce/components/woocommerce-colophon/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-colophon/index.js
@@ -14,7 +14,7 @@ import WooCommerceLogo from '../woocommerce-logo';
 const WooCommerceColophon = ( { translate } ) => {
 	return (
 		<div className="woocommerce-colophon">
-			<ExternalLink icon={ false } target="_blank" href="https://woocommerce.com">
+			<ExternalLink icon={ false } href="https://woocommerce.com">
 				{ translate( 'Powered by {{WooCommerceLogo /}}', {
 					components: {
 						WooCommerceLogo: <WooCommerceLogo height={ 32 } width={ 120 } />,

--- a/client/extensions/woocommerce/components/woocommerce-colophon/style.scss
+++ b/client/extensions/woocommerce/components/woocommerce-colophon/style.scss
@@ -3,7 +3,7 @@
 	text-align: center;
 	color: var( --color-text-subtle );
 
-	span {
+	span, a {
 		display: inline-block;
 		vertical-align: top;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a link to Powered by WooCommerce text and logo to go to WooCommerce.com

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*Requires WooCommerce to be installed on WordPress.com
- Go to any store admin page in Calypso
- At the bottom see Powered by WooCommerce
- Select to open link

Fixes #33398 
