### PR TITLE
Devdocs: fix and simplify PaymentLogo example

### DIFF
--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -3,44 +3,38 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
-import { concat, filter, flow, map, sortBy } from 'lodash';
+import { sortBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import PaymentLogo, { POSSIBLE_TYPES } from '../index';
 
-const genVendors = flow(
-	// 'placeholder' is a special case that needs to be demonstrated separately
-	filter( type => type !== 'placeholder' ),
-
-	map( type => ( { type, isCompact: false } ) ),
-	concat( [ { type: 'paypal', isCompact: true } ] ),
-	sortBy( [ 'type', 'isCompact' ] )
-);
-
-const VENDORS = genVendors( POSSIBLE_TYPES );
-
 class PaymentLogoExamples extends React.PureComponent {
 	static displayName = 'PaymentLogo';
 
 	render() {
+		const sortedVendors = sortBy( POSSIBLE_TYPES );
+
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<div className="payment-logo-example">
-				<p>Empty Placeholder</p>
+				<h3>Empty Placeholder</h3>
 
 				<PaymentLogo type="placeholder" />
 
-				<p>Supported Vendors</p>
+				<h3>Supported Vendors</h3>
 
-				{ VENDORS.map( ( { type, isCompact } ) => (
-					<div key={ [ type, isCompact ].join( '_' ) }>
-						<PaymentLogo type={ type } isCompact={ isCompact } />
-					</div>
-				) ) }
+				{ sortedVendors.map(
+					type =>
+						type !== 'placeholder' && (
+							<div key={ type } className="payment-logo__example">
+								<PaymentLogo type={ type } isCompact={ false } />
+								{ type === 'paypal' && <PaymentLogo type={ type } isCompact={ true } /> }
+							</div>
+						)
+				) }
 			</div>
 		);
 	}

--- a/client/components/payment-logo/style.scss
+++ b/client/components/payment-logo/style.scss
@@ -90,3 +90,11 @@
 		}
 	}
 }
+
+.payment-logo__example {
+	margin: 10px 0;
+
+	.is-compact {
+		margin-left: 10px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `PaymentLogo` component example is currently breaking Devdocs:

<img width="659" alt="Screen Shot 2019-06-12 at 10 29 32" src="https://user-images.githubusercontent.com/17325/59313364-c53cea00-8d04-11e9-985f-4e42fb4c84cc.png">

This PR fixes the payment logo example and also simplifies the example so it's easier for future maintainers to understand.

#### Testing instructions

Make sure http://calypso.localhost:3000/devdocs/design loads normally.

Make sure http://calypso.localhost:3000/devdocs/design/payment-logo shows a nice selection of payment logos (including the compact Paypal logo).

<img width="449" alt="Screen Shot 2019-06-12 at 11 26 38" src="https://user-images.githubusercontent.com/17325/59313413-fae1d300-8d04-11e9-937e-14a7df7e808a.png">
