### PR TITLE
Popover Menu: Use slightly darker color for Gridicons

### DIFF
--- a/client/components/popover/style.scss
+++ b/client/components/popover/style.scss
@@ -201,7 +201,7 @@
 
 	// with gridicons
 	.gridicon {
-		color: var( --color-neutral-200 );
+		color: var( --color-text-subtle );
 		vertical-align: bottom;
 		margin-right: 8px;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a component-level change, so will apply to many different instances of this component across Calypso. 
* Use a slightly darker color for the Gridicons on the popup menu for better legibility and to avoid them looking inactive. Uses `--color-text-subtle` instead of `--color-neutral-200`

**Before**

<img width="828" alt="Screen Shot 2019-06-11 at 4 44 42 PM" src="https://user-images.githubusercontent.com/2124984/59314045-527e3100-8c68-11e9-903f-084677efd60b.png">

**After**

<img width="829" alt="Screen Shot 2019-06-11 at 4 28 02 PM" src="https://user-images.githubusercontent.com/2124984/59314029-3ed2ca80-8c68-11e9-8d63-76fe13e9d465.png">

#### Testing instructions

* Switch to this PR
* Go to the Reader; click on the three-dots menu under a post; note visual changes to the popover menu icon colors
* Go to Pages; click on the three-dots menu for a page, and note visual changes to the menu icon colors.
* Go to Posts: click on the three-dots menu for a post, and note visual changes to the menu icon colors.
* Test other instances of the Popover Menu.

Fixes #32228 and Automattic/muriel#106
