### PR TITLE
Reader: Fix Manage following header cake

### DIFF
--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -69,10 +69,6 @@ class FollowingManage extends Component {
 		width: 800,
 	};
 
-	componentWillUnmount() {
-		recommendationsSeed = random( 0, 1000 );
-	}
-
 	// TODO make this common between our different search pages?
 	updateQuery = newValue => {
 		this.scrollToTop();
@@ -134,6 +130,7 @@ class FollowingManage extends Component {
 	}
 
 	componentWillUnmount() {
+		recommendationsSeed = random( 0, 1000 );
 		window.removeEventListener( 'resize', this.resizeListener );
 		clearInterval( this.windowScrollerRef );
 	}

--- a/client/reader/following-manage/index.jsx
+++ b/client/reader/following-manage/index.jsx
@@ -209,7 +209,7 @@ class FollowingManage extends Component {
 			<Fragment>
 				<div className="following-manage__header">
 					<HeaderCake backHref={ '/' }>
-						<h1>{ translate( 'Follow Something New' ) }</h1>
+						<h1>{ translate( 'Manage Followed Sites' ) }</h1>
 					</HeaderCake>
 				</div>
 				<ReaderMain className="following-manage">

--- a/client/reader/following-manage/style.scss
+++ b/client/reader/following-manage/style.scss
@@ -1,6 +1,6 @@
-.following-manage__header .card {
-		box-shadow: none;
-		margin: 0;
+.following-manage__header {
+	max-width: 720px;
+	margin: auto;
 }
 
 .following-manage .search {

--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -1,7 +1,3 @@
-.is-reader-page .layout__content {
-	padding-top: 47px;
-}
-
 .is-group-reader .async-load {
 	margin: 30px auto;
 	width: 50%;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes: https://github.com/Automattic/wp-calypso/issues/33177

Since the link to Manage has been moved from the sidebar to within the following stream, the header cake component has been added to be able to return your stream. However, the alignment looks off.

This PR:
1. Adds back the header cake border
2. Updates copy from "Follow something new" to the actual name of the page, "Manage Followed Sites"

#### Testing instructions

1. Go to Reader
2. Click on Manage: http://calypso.localhost:3000/following/manage

**Before:**
<img width="872" alt="Screenshot 2019-06-11 16 39 21" src="https://user-images.githubusercontent.com/4924246/59313861-79883300-8c67-11e9-8d70-62f0f963348b.png">

**After:**
<img width="757" alt="Screenshot 2019-06-11 16 23 18" src="https://user-images.githubusercontent.com/4924246/59313864-7e4ce700-8c67-11e9-995f-ec73d25965e4.png">

Another alternative I tried was to add the text as a form label instead, but I think retaining the current header cake style works better:

<img width="757" alt="Screenshot 2019-06-11 15 55 30" src="https://user-images.githubusercontent.com/4924246/59314011-2e225480-8c68-11e9-9f56-3f3ba63324a1.png">

We could also make this particular header cake work like the segmented control component with a collapsed Search functionality, but that'll require more work which would have to tackled in a separate PR.
<img width="743" alt="Screenshot 2019-06-11 16 54 48" src="https://user-images.githubusercontent.com/4924246/59314312-a0dfff80-8c69-11e9-8fbc-c3602608fda7.png">

