### PR TITLE
nux - updates to copy in onboarding steps

### DIFF
--- a/client/components/signup-site-preview/component.jsx
+++ b/client/components/signup-site-preview/component.jsx
@@ -25,7 +25,7 @@ function MockupChromeMobile() {
 	return (
 		<div className="signup-site-preview__chrome-mobile">
 			<span className="signup-site-preview__chrome-label">
-				{ translate( 'Phone', {
+				{ translate( 'Phone Preview', {
 					comment: 'Label for a phone-sized preview of a website',
 				} ) }
 			</span>

--- a/client/components/signup-site-preview/style.scss
+++ b/client/components/signup-site-preview/style.scss
@@ -157,7 +157,7 @@
 		font-weight: 600;
 		color: var( --color-neutral-500 );
 		display: block;
-		width: 60px;
+		width: 50%;
 		background: var( --color-neutral-0 );
 		border-radius: 16px;
 	}

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -14,9 +14,9 @@ const getSiteTypePropertyDefaults = propertyKey =>
 		{
 			// General copy
 			siteMockupHelpTipCopy: i18n.translate(
-				'Scroll down to see your site. You’ll be able to edit and customize it when setup is complete.'
+				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."
 			),
-			siteMockupHelpTipCopyBottom: i18n.translate( 'Scroll up to continue.' ),
+			siteMockupHelpTipCopyBottom: i18n.translate( 'Scroll back up to continue.' ),
 			// Site title step
 			siteTitleLabel: i18n.translate( 'Give your site a name' ),
 			siteTitleSubheader: i18n.translate(

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -16,6 +16,7 @@ const getSiteTypePropertyDefaults = propertyKey =>
 			siteMockupHelpTipCopy: i18n.translate(
 				'Scroll down to see your site. You’ll be able to edit and customize it when setup is complete.'
 			),
+			siteMockupHelpTipCopyBottom: i18n.translate( 'Scroll up to continue.' ),
 			// Site title step
 			siteTitleLabel: i18n.translate( 'Give your site a name' ),
 			siteTitleSubheader: i18n.translate(

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -14,7 +14,7 @@ const getSiteTypePropertyDefaults = propertyKey =>
 		{
 			// General copy
 			siteMockupHelpTipCopy: i18n.translate(
-				'Scroll down to see your site. Once you complete setup you’ll be able to customize it further.'
+				'Scroll down to see your site. You’ll be able to edit and customize it when setup is complete.'
 			),
 			// Site title step
 			siteTitleLabel: i18n.translate( 'Give your site a name' ),

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -42,6 +42,17 @@ function SiteMockupHelpTip( { siteType } ) {
 	);
 }
 
+function SiteMockupHelpTipBottom( { siteType } ) {
+	const helpTipCopy =
+		getSiteTypePropertyValue( 'slug', siteType, 'siteMockupHelpTipCopyBottom' ) || '';
+	return (
+		<div className="site-mockup__help-tip">
+			<Gridicon icon="chevron-up" />
+			<p>{ helpTipCopy }</p>
+		</div>
+	);
+}
+
 class SiteMockups extends Component {
 	static propTypes = {
 		siteStyle: PropTypes.string,
@@ -155,6 +166,7 @@ class SiteMockups extends Component {
 					/>
 					<SignupSitePreview defaultViewportDevice="phone" { ...otherProps } />
 				</div>
+				{ shouldShowHelpTip && <SiteMockupHelpTipBottom siteType={ siteType } /> }
 			</div>
 		);
 	}

--- a/client/signup/site-mockup/style.scss
+++ b/client/signup/site-mockup/style.scss
@@ -33,11 +33,16 @@
 	transition: all 300ms cubic-bezier( 0.08, 0.74, 0.44, 1.07 );
 	transition-delay: 200ms;
 
+	&:last-child {
+		margin-bottom: 24px;
+	}
+	
 	p {
 		margin: 0 auto;
 		max-width: 420px;
 		line-height: 1.4;
 	}
+
 
 	// Hide the tip until a vertical is selected.
 	.is-empty & {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Copy updated for Business Site Preview pages to reflect feedback from design research sessions
* Copy and chevron added to Site Preview pages to route users back to the top of the page per feedback from design research sessions

#### Testing instructions

* To find the pages, go to Wordpress.com and create a new site. 
* From Step 1 select "Business" as the site type
* Copy changes are visible in Steps 2 & 3

Before: “Scroll down to see your site. Once you complete setup you’ll be able to customize it further."
After: “Scroll down to see your site. You’ll be able to edit and customize it when setup is complete.”

Before: Previews say "WEBSITE PREVIEW" and "PHONE"
After: Previews say "WEBSITE PREVIEW" and "PHONE PREVIEW"

Before: No bottom copy to site preview page
After: Up chevron and "Scroll up to continue."

**Before**
<img width="1431" alt="Screen Shot 2019-06-11 at 4 57 48 PM" src="https://user-images.githubusercontent.com/6179338/59314418-1a77ed80-8c6a-11e9-903a-d88fdd002d97.png">
<img width="1095" alt="Screen Shot 2019-06-11 at 4 58 00 PM" src="https://user-images.githubusercontent.com/6179338/59314420-1d72de00-8c6a-11e9-9025-47a535450249.png">


**After**
<img width="1431" alt="Screen Shot 2019-06-11 at 4 54 46 PM" src="https://user-images.githubusercontent.com/6179338/59314383-ee5c6c80-8c69-11e9-81bc-05b2dc0d5ac2.png">
<img width="1192" alt="Screen Shot 2019-06-11 at 4 56 13 PM" src="https://user-images.githubusercontent.com/6179338/59314389-f3b9b700-8c69-11e9-8fbd-72bf6d5c5594.png">


#fixtheflows

