### PR TITLE
Adds tracking to Powered by WooCommerce link

### DIFF
--- a/client/extensions/woocommerce/components/woocommerce-colophon/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-colophon/index.js
@@ -24,12 +24,7 @@ class WooCommerceColophon extends React.Component {
 	render() {
 		return (
 			<div className="woocommerce-colophon">
-				<ExternalLink
-					icon={ false }
-					target="_blank"
-					onClick={ this.onClick }
-					href="https://woocommerce.com"
-				>
+				<ExternalLink icon={ false } onClick={ this.onClick } href="https://woocommerce.com">
 					{ this.props.translate( 'Powered by {{WooCommerceLogo /}}', {
 						components: {
 							WooCommerceLogo: <WooCommerceLogo height={ 32 } width={ 120 } />,

--- a/client/extensions/woocommerce/components/woocommerce-colophon/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-colophon/index.js
@@ -3,26 +3,45 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import ExternalLink from 'components/external-link';
 
 /**
  * Internal dependencies
  */
+import { recordTracksEvent } from 'state/analytics/actions';
+
 import WooCommerceLogo from '../woocommerce-logo';
 
-const WooCommerceColophon = ( { translate } ) => {
-	return (
-		<div className="woocommerce-colophon">
-			<ExternalLink icon={ false } href="https://woocommerce.com">
-				{ translate( 'Powered by {{WooCommerceLogo /}}', {
-					components: {
-						WooCommerceLogo: <WooCommerceLogo height={ 32 } width={ 120 } />,
-					},
-				} ) }
-			</ExternalLink>
-		</div>
-	);
-};
+class WooCommerceColophon extends React.Component {
+	static displayName = 'WooCommerceColophon';
 
-export default localize( WooCommerceColophon );
+	onClick = () => {
+		this.props.recordTracksEvent( 'calypso_store_woocommercecolophon_click' );
+	};
+
+	render() {
+		return (
+			<div className="woocommerce-colophon">
+				<ExternalLink
+					icon={ false }
+					target="_blank"
+					onClick={ this.onClick }
+					href="https://woocommerce.com"
+				>
+					{ this.props.translate( 'Powered by {{WooCommerceLogo /}}', {
+						components: {
+							WooCommerceLogo: <WooCommerceLogo height={ 32 } width={ 120 } />,
+						},
+					} ) }
+				</ExternalLink>
+			</div>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{ recordTracksEvent }
+)( localize( WooCommerceColophon ) );

--- a/client/extensions/woocommerce/components/woocommerce-colophon/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-colophon/index.js
@@ -5,11 +5,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-import ExternalLink from 'components/external-link';
 
 /**
  * Internal dependencies
  */
+import ExternalLink from 'components/external-link';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 import WooCommerceLogo from '../woocommerce-logo';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*adds tracking to click on Powered by WooCommerce on store pages.
*contains changes from #33845 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*Requires WooCommerce installed on WordPress.com 
- Load any store page
- Enable analytics debugging in console with: `localStorage.setItem('debug', 'calypso:analytics:*');`
- Select Powered by WooCommerce at the bottom
- You should see a line in the console that contains the tracking event: `calypso_store_woocommercecolophon_click`


Fixes #
