### PR TITLE
woo product checklist: Updating action verbiage

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup/tasks.js
+++ b/client/extensions/woocommerce/app/dashboard/setup/tasks.js
@@ -98,7 +98,7 @@ class SetupTasks extends Component {
 						title={ translate( 'Add a product' ) }
 						buttonText={ translate( 'Add a product' ) }
 						completedTitle={ translate( 'You have added a product' ) }
-						completedButtonText={ translate( 'View products' ) }
+						completedButtonText={ translate( 'Add another product' ) }
 						description={ translate( 'Start by adding the first product to your\u00a0store.' ) }
 						duration={ translate( '%d minute', '%d minutes', { count: 3, args: [ 3 ] } ) }
 						completed={ hasProducts }


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/33266

The first task in the Store on-boarding task list is to add a product which sends folks to the add product screen. Once a product has been added and you return to the Dashboard. 

**Previously:**
Actionable text said "View products" but took the customer to an "add product" screen.

![1](https://cldup.com/t4SSNN--B3-3000x3000.png)

**Now:**
Actionable text says "add another product" and takes the customer to the "add product" screen.

<img width="1673" alt="Screen Shot 2019-06-11 at 4 59 50 PM" src="https://user-images.githubusercontent.com/214813/59314465-632fa680-8c6a-11e9-9d45-158a88bdf0c8.png">

