### PR TITLE
Sharing Buttons: Update the buttons on the edit tray to look like Claypso compact buttons

### DIFF
--- a/client/my-sites/marketing/buttons/tray.jsx
+++ b/client/my-sites/marketing/buttons/tray.jsx
@@ -176,12 +176,7 @@ class SharingButtonsTray extends React.Component {
 		if ( this.state.isReordering ) {
 			const buttons = this.getButtonsOfCurrentVisibility().map( function( button ) {
 				return (
-					<ButtonsPreviewButton
-						key={ button.ID }
-						button={ button }
-						enabled={ true }
-						style={ this.props.style }
-					/>
+					<ButtonsPreviewButton key={ button.ID } button={ button } enabled={ true } style="text" />
 				);
 			}, this );
 
@@ -191,7 +186,7 @@ class SharingButtonsTray extends React.Component {
 			<ButtonsPreviewButtons
 				buttons={ this.props.buttons }
 				visibility={ this.props.visibility }
-				style={ this.props.style }
+				style="text"
 				showMore={ false }
 				onButtonClick={ this.onButtonClick }
 			/>

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -492,6 +492,7 @@
 }
 
 .sharing-buttons-tray__buttons {
+	@include clear-fix;
 	@include breakpoint( '<480px' ) {
 		margin-right: -16px;
 	}
@@ -962,6 +963,43 @@
 
 	&.is-bottom {
 		margin: 14px 0 0;
+
+		.sharing-buttons-preview-button {
+			border-width: 1px 1px 2px;
+			font-weight: 500;
+			box-shadow: none;
+			box-sizing: border-box;
+			line-height: 1;
+			border-radius: 4px;
+			padding: 7px;
+			float: left;
+			color: var( --color-neutral-50 );
+			background-color: var( --color-white );
+			border-color: var( --color-neutral-50 );
+			&:hover {
+				border-color: var( --color-neutral-100 );
+				color: var( --color-neutral-100 );
+			}
+			&:active {
+				border-width: 2px 1px 1px;
+			}
+
+			&.is-enabled {
+				color: var( --color-text-subtle );
+				background-color: var( --color-white );
+				border-color: var( --color-neutral-100 );
+				&:hover {
+					border-color: var( --color-neutral-200 );
+					color: var( --color-neutral-700 );
+				}
+			}
+
+			.sharing-buttons-preview-button__service {
+				line-height: inherit;
+				margin: 0;
+			}
+		}
+
 		@include breakpoint( '<480px' ) {
 			margin: 15px -8px 0;
 		}
@@ -1028,45 +1066,9 @@
 .sharing-buttons-preview__panel-content .sharing-buttons-preview-button {
 	margin-top: 8px;
 	cursor: pointer;
-	opacity: 0.6;
 	@include breakpoint( '<480px' ) {
 		margin: 18px 18px 0 0;
 	}
-
-	&:hover {
-		opacity: 0.8;
-	}
-
-	&.style-icon {
-		opacity: 0.4;
-	}
-
-	&.style-icon:hover {
-		border: none;
-		opacity: 0.7;
-	}
-
-	&.is-enabled {
-		opacity: 1;
-	}
-
-	/* These icons have a light background and need special treatment to stay readable. */
-	&.style-icon.share-email,
-	&.style-icon.share-print {
-		opacity: 0.6;
-
-		&:hover {
-			opacity: 0.9;
-		}
-
-		&.is-enabled {
-			opacity: 1;
-		}
-	}
-}
-
-.sharing-buttons-preview__panel.is-reordering .sharing-buttons-preview-button.is-enabled {
-	opacity: 1;
 }
 
 .sharing-buttons-preview__panel.is-reordering


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Stop using Sharing button styles and instead use Calypso's (inc. disabled state)

_Hypothesis: by doing so, it's visually more evident to dissociate the active buttons from the disabled ones._

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Tools > Marketing > Sharing buttons
* Click on "Edit sharing buttons" (and "Add more button")
* Does it work as expected? Is it easier to differentiate the buttons? 

__Before:__

![1 before](https://user-images.githubusercontent.com/177929/59314435-34193500-8c6a-11e9-8d8c-5d734a971a3f.gif)

__After:__

![2 after](https://user-images.githubusercontent.com/177929/59314429-2bc0fa00-8c6a-11e9-89e4-2db677d2fb4b.gif)

See #32375