### PR TITLE
Change first letter in legends

### DIFF
--- a/client/me/notification-settings/blogs-settings/header.jsx
+++ b/client/me/notification-settings/blogs-settings/header.jsx
@@ -9,6 +9,9 @@ import React, { PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
 import { countBy, map, omit, values, flatten } from 'lodash';
 import Gridicon from 'gridicons';
+/* eslint-disable jsx-a11y/anchor-is-valid */
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-static-element-interactions */
 
 /**
  * Internal dependencies
@@ -65,14 +68,14 @@ class BlogSettingsHeader extends PureComponent {
 		);
 
 		if ( ! onCount ) {
-			return this.props.translate( 'no notifications' );
+			return this.props.translate( 'No notifications' );
 		}
 
 		if ( ! offCount ) {
-			return this.props.translate( 'all notifications' );
+			return this.props.translate( 'All notifications' );
 		}
 
-		return this.props.translate( 'some notifications' );
+		return this.props.translate( 'Some notifications' );
 	};
 
 	render() {


### PR DESCRIPTION
URL: wordpress.com/me/notifications

## Changes proposed in this Pull Request

Screenshot of change:

![Annotation on 2019-5-2](https://user-images.githubusercontent.com/3411173/59314629-fec11700-8c6a-11e9-9008-48f4e06de5e8.png)

Changing legend to capitalize first letter of all notifications. It balances the sections out better by not having all lowercase, just looks better.

Props to @dreiris for help on working through this as we try to figure out how bottles work!

Ran into three pre-commit hooks that we're going to punt, to be addressed later.