### PR TITLE
Enable i18n/translation-scanner in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -40,6 +40,7 @@
 		"happychat": true,
 		"help": true,
 		"help/courses": true,
+		"i18n/translation-scanner": true,
 		"jetpack/api-cache": false,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enable the Calypso aspect of the Translation Recorder tool.

#### Testing instructions

The feature is live already live in wpcalypso & horizon, so we can verify it works there. Note this won't work on a mobile, as it relies on the browser to transfer the cookie between windows:

Open the recording tool on translate.wordpress.com. For example, french is at https://translate.wordpress.com/projects/wpcom/fr/default/recording/

1. Open Calypso in another window (Do this before starting recording to get a focused scan, or afterwards to get a whole lot of strings).
2. Hit "Start Recording" on the Translation Recorder page (optional: hit "Start over" to clear out previously scanned strings).
3. Navigate around calypso
4. Refresh the Translate Recorder page and check for some strings - We're expecting to miss a few strings that are translated ahead of time (e.g. Product names), but we should be able to find most of the rendered strings.

![translation scanner demo2](https://user-images.githubusercontent.com/5952255/59314716-e3e9b380-8cf9-11e9-8a82-807ea5a3ad27.gif)
