### PR TITLE
Removed redundant notices when updating account recovery methods

### DIFF
--- a/client/me/security-account-recovery/index.jsx
+++ b/client/me/security-account-recovery/index.jsx
@@ -84,7 +84,7 @@ const SecurityAccountRecovery = props => (
 				deleteEmail={ props.deleteAccountRecoveryEmail }
 				isLoading={ props.accountRecoveryEmailActionInProgress }
 			/>
-			{ props.shouldPromptEmailValidationNotice && (
+			{ props.shouldPromptEmailValidationNotice && ! props.hasSentEmailValidation && (
 				<RecoveryEmailValidationNotice
 					onResend={ props.resendAccountRecoveryEmailValidation }
 					hasSent={ props.hasSentEmailValidation }

--- a/client/me/security-account-recovery/recovery-phone-validation-notice.jsx
+++ b/client/me/security-account-recovery/recovery-phone-validation-notice.jsx
@@ -52,20 +52,20 @@ class RecoveryPhoneValidationNotice extends Component {
 
 		return (
 			<form onSubmit={ this.onSubmit }>
-				<Notice
-					className="security-account-recovery__validation-notice"
-					status="is-warning"
-					text={ translate(
-						'Please validate your recovery SMS number. Check your phone for a validation code.'
-					) }
-					showDismiss={ false }
-				>
-					{ ! hasSent && (
+				{ ! hasSent && (
+					<Notice
+						className="security-account-recovery__validation-notice"
+						status="is-warning"
+						text={ translate(
+							'Please validate your recovery SMS number. Check your phone for a validation code.'
+						) }
+						showDismiss={ false }
+					>
 						<NoticeAction href="#" onClick={ this.props.onResend }>
 							{ translate( 'Resend' ) }
 						</NoticeAction>
-					) }
-				</Notice>
+					</Notice>
+				) }
 
 				<FormLabel className="security-account-recovery__recovery-phone-validation-label">
 					{ translate( 'Enter the code you receive via SMS:' ) }


### PR DESCRIPTION
When a user updates their recovery email or phone, they now see one success / error notice instead of two. 

#### Changes proposed in this Pull Request

* On initial save, they see the global notice. When the page is subsequently refreshed, they see the inline notice if they still need to validate their email/phone.

#### Testing instructions

* Go to /me/security/account-recovery
* Update either the recovery email or recovery phone number
* On initial save, you should see a global notice, like this:

<img width="998" alt="Screen Shot 2019-06-11 at 5 21 55 PM" src="https://user-images.githubusercontent.com/3238155/59315171-7bed8b80-8c6d-11e9-8ec5-49781b0e55c3.png">

* On subsequent page reload, you should see an inline notice, like so:

<img width="945" alt="Screen Shot 2019-06-11 at 5 22 08 PM" src="https://user-images.githubusercontent.com/3238155/59315186-8c9e0180-8c6d-11e9-92e2-cbc200b36f5b.png">


Fixes #33859 
