### PR TITLE
Fix payment logo example.

### DIFF
--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -17,8 +17,8 @@ const genVendors = flow(
 	filter( type => type !== 'placeholder' ),
 
 	map( type => ( { type, isCompact: false } ) ),
-	concat( [ { type: 'paypal', isCompact: true } ] ),
-	sortBy( [ 'type', 'isCompact' ] )
+	arr => concat( arr, [ { type: 'paypal', isCompact: true } ] ),
+	arr => sortBy( arr, [ 'type', 'isCompact' ] )
 );
 
 const VENDORS = genVendors( POSSIBLE_TYPES );

--- a/client/components/payment-logo/docs/example.jsx
+++ b/client/components/payment-logo/docs/example.jsx
@@ -14,9 +14,9 @@ import PaymentLogo, { POSSIBLE_TYPES } from '../index';
 
 const genVendors = flow(
 	// 'placeholder' is a special case that needs to be demonstrated separately
-	filter( type => type !== 'placeholder' ),
+	arr => filter( arr, type => type !== 'placeholder' ),
 
-	map( type => ( { type, isCompact: false } ) ),
+	arr => map( arr, type => ( { type, isCompact: false } ) ),
 	arr => concat( arr, [ { type: 'paypal', isCompact: true } ] ),
 	arr => sortBy( arr, [ 'type', 'isCompact' ] )
 );


### PR DESCRIPTION
Devdocs design was using an older version of lodash. With the changes in #32019 that's no longer the case. This change updates the code to work in lodash v4.

#### Changes proposed in this Pull Request

* Update payment logo example code to work with lodash v4.

#### Testing instructions

* Open devdocs design, ensure it doesn't crash.
* Open the payment logo example, ensure it works correctly.
