### PR TITLE
PieChartLegendPlaceholder: convert to stateless functional component

### DIFF
--- a/client/components/pie-chart/legend-placeholder.js
+++ b/client/components/pie-chart/legend-placeholder.js
@@ -3,58 +3,44 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
+import { get, maxBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import LegendItemPlaceholder from 'components/legend-item/placeholder';
 
-class PieChartLegendPlaceholder extends Component {
-	static propTypes = {
-		dataSeriesInfo: PropTypes.arrayOf(
-			PropTypes.shape( {
-				description: PropTypes.string,
-				name: PropTypes.string.isRequired,
-			} )
-		).isRequired,
-	};
-
-	static getDerivedStateFromProps( props, state ) {
-		const longestName = props.dataSeriesInfo.reduce(
-			( intermediateLongestName, currentValue ) =>
-				intermediateLongestName.length > currentValue.name.length
-					? intermediateLongestName
-					: currentValue.name,
-			''
-		);
-
-		return state.longestName !== longestName ? { longestName } : null;
-	}
-
-	state = {
-		longestName: '',
-	};
-
-	render() {
-		const { dataSeriesInfo } = this.props;
-		const { longestName } = this.state;
-
-		return (
-			<div className="pie-chart__placeholder-legend">
-				{ dataSeriesInfo.map( datumInfo => {
-					return (
-						<LegendItemPlaceholder
-							key={ datumInfo.name }
-							name={ longestName }
-							description={ datumInfo.description }
-						/>
-					);
-				} ) }
-			</div>
-		);
-	}
+function getLongestName( dataSeriesInfo ) {
+	return get( maxBy( dataSeriesInfo, 'name.length' ), 'name', '' );
 }
+
+function PieChartLegendPlaceholder( { dataSeriesInfo } ) {
+	const longestName = getLongestName( dataSeriesInfo );
+
+	return (
+		<div className="pie-chart__placeholder-legend">
+			{ dataSeriesInfo.map( datumInfo => {
+				return (
+					<LegendItemPlaceholder
+						key={ datumInfo.name }
+						name={ longestName }
+						description={ datumInfo.description }
+					/>
+				);
+			} ) }
+		</div>
+	);
+}
+
+PieChartLegendPlaceholder.propTypes = {
+	dataSeriesInfo: PropTypes.arrayOf(
+		PropTypes.shape( {
+			description: PropTypes.string,
+			name: PropTypes.string.isRequired,
+		} )
+	).isRequired,
+};
 
 export default PieChartLegendPlaceholder;


### PR DESCRIPTION
Noticed this when reviewing #33719: using local state for memoizing calculation of derived data (longest name in this case) is discouraged. And in this case the optimization is not really needed. This PR converts the `PieChartLegendPlaceholder` to a functional stateless component.

**How to test:**
The only place where this is used is Google My Business stats. You need to register a test business with Google and then open `/google-my-business/stats/:site`. If you don't want to go through the messy registration process, you can believe me that I tested it 😉 
