### PR TITLE
Notification Settings: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -42,9 +42,6 @@
 @import 'layout/community-translator/style';
 @import 'layout/sidebar/style';
 @import 'lib/preferences-helper/style';
-@import 'me/notification-settings/blogs-settings/style';
-@import 'me/notification-settings/push-notification-settings/style';
-@import 'me/notification-settings/settings-form/style';
 @import 'me/sidebar-navigation/style';
 @import 'my-sites/checklist/wpcom-checklist/checklist-navigation/style';
 @import 'my-sites/plan-features/style';

--- a/client/me/notification-settings/blogs-settings/index.jsx
+++ b/client/me/notification-settings/blogs-settings/index.jsx
@@ -20,6 +20,11 @@ import InfiniteList from 'components/infinite-list';
 import Placeholder from './placeholder';
 import config from 'config';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const createPlaceholder = () => <Placeholder />;
 
 const getItemRef = ( { ID } ) => `blog-${ ID }`;

--- a/client/me/notification-settings/controller.js
+++ b/client/me/notification-settings/controller.js
@@ -51,7 +51,7 @@ export function updates( context, next ) {
 	next();
 }
 
-export function notificationSubscriptions( context, next ) {
+export function subscriptions( context, next ) {
 	// FIXME: Auto-converted from the Flux setTitle action. Please use <DocumentHead> instead.
 	context.store.dispatch( setTitle( i18n.translate( 'Notifications', { textOnly: true } ) ) );
 

--- a/client/me/notification-settings/index.js
+++ b/client/me/notification-settings/index.js
@@ -8,22 +8,13 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import * as controller from './controller';
-import { makeLayout, render as clientRender } from 'controller';
+import { notifications, comments, updates, subscriptions } from './controller';
 import { sidebar } from 'me/controller';
+import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
-	page( '/me/notifications', sidebar, controller.notifications, makeLayout, clientRender );
-
-	page( '/me/notifications/comments', sidebar, controller.comments, makeLayout, clientRender );
-
-	page( '/me/notifications/updates', sidebar, controller.updates, makeLayout, clientRender );
-
-	page(
-		'/me/notifications/subscriptions',
-		sidebar,
-		controller.notificationSubscriptions,
-		makeLayout,
-		clientRender
-	);
+	page( '/me/notifications', sidebar, notifications, makeLayout, clientRender );
+	page( '/me/notifications/comments', sidebar, comments, makeLayout, clientRender );
+	page( '/me/notifications/updates', sidebar, updates, makeLayout, clientRender );
+	page( '/me/notifications/subscriptions', sidebar, subscriptions, makeLayout, clientRender );
 }

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -27,9 +27,12 @@ import {
 } from 'state/push-notifications/selectors';
 import { toggleEnabled, toggleUnblockInstructions } from 'state/push-notifications/actions';
 
-class PushNotificationSettings extends React.Component {
-	static displayName = 'PushNotificationSettings';
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
+class PushNotificationSettings extends React.Component {
 	static propTypes = {
 		toggleEnabled: PropTypes.func.isRequired,
 		toggleUnblockInstructions: PropTypes.func.isRequired,
@@ -613,6 +616,7 @@ class PushNotificationSettings extends React.Component {
 		);
 
 		return (
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<Dialog
 				isVisible={ this.props.showDialog }
 				className=".notification-settings-push-notification-settings__instruction-dialog"
@@ -662,6 +666,7 @@ class PushNotificationSettings extends React.Component {
 					<ScreenReaderText>{ this.props.translate( 'Dismiss' ) }</ScreenReaderText>
 				</button>
 			</Dialog>
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		);
 	};
 
@@ -722,6 +727,7 @@ class PushNotificationSettings extends React.Component {
 				stateText = this.props.translate( 'Disabled' );
 
 				deniedText = (
+					/* eslint-disable wpcalypso/jsx-classname-namespace */
 					<Notice
 						className="notification-settings-push-notification-settings__instruction"
 						showDismiss={ false }
@@ -739,7 +745,7 @@ class PushNotificationSettings extends React.Component {
 											components: {
 												instructionsButton: (
 													<Button
-														className={ 'is-link' }
+														className="is-link"
 														onClick={ this.props.toggleUnblockInstructions }
 													/>
 												),
@@ -751,6 +757,7 @@ class PushNotificationSettings extends React.Component {
 							</div>
 						}
 					/>
+					/* eslint-enable wpcalypso/jsx-classname-namespace */
 				);
 				break;
 
@@ -759,6 +766,7 @@ class PushNotificationSettings extends React.Component {
 		}
 
 		return (
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<Card className="notification-settings-push-notification-settings__settings">
 				<h2 className="notification-settings-push-notification-settings__settings-heading">
 					<Gridicon
@@ -797,6 +805,7 @@ class PushNotificationSettings extends React.Component {
 
 				{ deniedText }
 			</Card>
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		);
 	}
 }

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -654,14 +654,13 @@ class PushNotificationSettings extends React.Component {
 						) }
 					/>
 				</div>
-				<span
-					tabIndex="0"
+				<button
 					className="notification-settings-push-notification-settings__instruction-dismiss"
 					onClick={ this.props.toggleUnblockInstructions }
 				>
 					<Gridicon icon="cross" size={ 24 } />
 					<ScreenReaderText>{ this.props.translate( 'Dismiss' ) }</ScreenReaderText>
-				</span>
+				</button>
 			</Dialog>
 		);
 	};

--- a/client/me/notification-settings/push-notification-settings/index.jsx
+++ b/client/me/notification-settings/push-notification-settings/index.jsx
@@ -619,7 +619,7 @@ class PushNotificationSettings extends React.Component {
 			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<Dialog
 				isVisible={ this.props.showDialog }
-				className=".notification-settings-push-notification-settings__instruction-dialog"
+				className="notification-settings-push-notification-settings__instruction-dialog"
 				onClose={ this.props.toggleUnblockInstructions }
 			>
 				<div className="notification-settings-push-notification-settings__instruction-content">

--- a/client/me/notification-settings/push-notification-settings/style.scss
+++ b/client/me/notification-settings/push-notification-settings/style.scss
@@ -31,6 +31,10 @@
 	&:focus {
 		color: var( --color-neutral-700 );
 	}
+
+	.gridicon {
+		display: block;
+	}
 }
 
 .notification-settings-push-notification-settings__instruction-content {

--- a/client/me/notification-settings/settings-form/actions.jsx
+++ b/client/me/notification-settings/settings-form/actions.jsx
@@ -13,9 +13,12 @@ import React from 'react';
  */
 import FormButton from 'components/forms/form-button';
 
-class NotificationSettingsFormActions extends React.PureComponent {
-	static displayName = 'NotificationSettingsFormActions';
+/**
+ * Style dependencies
+ */
+import './actions.scss';
 
+class NotificationSettingsFormActions extends React.PureComponent {
 	static propTypes = {
 		onSave: PropTypes.func.isRequired,
 		onSaveToAll: PropTypes.func,
@@ -25,6 +28,7 @@ class NotificationSettingsFormActions extends React.PureComponent {
 
 	render() {
 		return (
+			/* eslint-disable wpcalypso/jsx-classname-namespace */
 			<div className="notification-settings-form-actions">
 				{ this.props.isApplyAllVisible && (
 					<FormButton
@@ -40,6 +44,7 @@ class NotificationSettingsFormActions extends React.PureComponent {
 					{ this.props.translate( 'Save Settings' ) }
 				</FormButton>
 			</div>
+			/* eslint-enable wpcalypso/jsx-classname-namespace */
 		);
 	}
 }

--- a/client/me/notification-settings/settings-form/actions.scss
+++ b/client/me/notification-settings/settings-form/actions.scss
@@ -1,0 +1,33 @@
+.notification-settings-form-actions {
+	display: block;
+	border-top: solid 1px var( --color-neutral-0 );
+	padding: 15px 0;
+	text-align: right;
+
+	.form-fieldset {
+		margin-bottom: 10px;
+
+		@include breakpoint( '>480px' ) {
+			margin: 10px 0 0;
+			float: left;
+		}
+	}
+
+	.form-label {
+		text-align: left;
+	}
+
+	.form-button {
+		float: none;
+	}
+
+	@include breakpoint( '>480px' ) {
+		height: 55px;
+		padding: 15px 0 0;
+	}
+}
+
+.notification-settings-form-actions__save-to-all {
+	background: transparent;
+	color: var( --color-neutral-500 );
+}

--- a/client/me/notification-settings/settings-form/index.jsx
+++ b/client/me/notification-settings/settings-form/index.jsx
@@ -12,6 +12,11 @@ import React, { Component } from 'react';
 import Settings from './settings';
 import Actions from './actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class NotificationSettingsForm extends Component {
 	static propTypes = {
 		sourceId: PropTypes.oneOfType( [ PropTypes.string, PropTypes.number ] ).isRequired,

--- a/client/me/notification-settings/settings-form/style.scss
+++ b/client/me/notification-settings/settings-form/style.scss
@@ -102,37 +102,3 @@
 		}
 	}
 }
-
-.notification-settings-form-actions {
-	display: block;
-	border-top: solid 1px var( --color-neutral-0 );
-	padding: 15px 0;
-	text-align: right;
-
-	.form-fieldset {
-		margin-bottom: 10px;
-
-		@include breakpoint( '>480px' ) {
-			margin: 10px 0 0;
-			float: left;
-		}
-	}
-
-	.form-label {
-		text-align: left;
-	}
-
-	.form-button {
-		float: none;
-	}
-
-	@include breakpoint( '>480px' ) {
-		height: 55px;
-		padding: 15px 0 0;
-	}
-}
-
-.notification-settings-form-actions__save-to-all {
-	background: transparent;
-	color: var( --color-neutral-500 );
-}


### PR DESCRIPTION
Very straightforward, here's a list of things that are not 100% obvious:
- I did a little drive-by cleanup of controller imports
- `FormActions` got its own `actions.scss` file, everything else is straight 1:1 migration
- I fixed a11y (span to button) of the dismiss button of dialog that gives instructions how to enable desktop notifications: (you need to block them first to see this UI)

<img width="556" alt="Screenshot 2019-06-12 at 14 48 22" src="https://user-images.githubusercontent.com/664258/59353041-61c1b500-8d22-11e9-8001-8d7119342ba4.png">

**How to test:**
Go to `/me/notifications` and check all four tabs that are there.