### PR TITLE
Reader: Ensure tag follow and unfollow button is fully clickable

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -42,6 +42,7 @@ $z-layers: (
 		'.reader-search-card': 0,
 		'.reader-featured-image': 0,
 		'.reader-post-card__title': 0,
+		'.tag-stream__header-follow': 0,
 		'.reader-feed-header': 0,
 		'.reader-feed-header__back-and-follow': 0,
 		'.reader-recommended-sites__recommended-site-dismiss': 1,
@@ -293,6 +294,9 @@ $z-layers: (
 	),
 	'reader-card-follow-button-parent': (
 		'.reader__card.card .follow-button': 1
+	),
+	'.tag-stream__header-follow': (
+		'button.button.follow-button.has-icon..is-following': 1
 	)
 );
 

--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -296,7 +296,7 @@ $z-layers: (
 		'.reader__card.card .follow-button': 1
 	),
 	'.tag-stream__header-follow': (
-		'button.button.follow-button.has-icon..is-following': 1
+		'.follow-button': 1
 	)
 );
 

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -14,7 +14,7 @@
 }
 
 .tag-stream__header .follow-button {
-	z-index: z-index( '.tag-stream__header-follow', 'button.button.follow-button.has-icon..is-following' );
+	z-index: z-index( '.tag-stream__header-follow', '.follow-button' );
 
 	@include breakpoint( '<660px' ) {
 		margin: 12px 20px 0 15px;

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -14,6 +14,7 @@
 }
 
 .tag-stream__header .follow-button {
+	z-index: 1;
 
 	@include breakpoint( '<660px' ) {
 		margin: 12px 20px 0 15px;

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -14,7 +14,7 @@
 }
 
 .tag-stream__header .follow-button {
-	z-index: 1;
+	z-index: z-index( '.tag-stream__header-follow', 'button.button.follow-button.has-icon..is-following' );
 
 	@include breakpoint( '<660px' ) {
 		margin: 12px 20px 0 15px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Increase `z-index` of tag follow button in the reader to ensure it remains clickable when the 'Back' button is visible.

#### Testing instructions

1. Head to https://wordpress.com/tag/cheese
2. Interact with the tag follow and unfollow button at the top right of the screen
3. Notice not all of it is clickable when the 'back' button is present (as per screenshot below)
4. Pull down this PR
5. Test again, it should be easier to click

<img width="841" alt="Screenshot 2019-06-11 at 11 40 19" src="https://user-images.githubusercontent.com/411945/59357146-281b8a80-8cdf-11e9-97f9-50f2b98d3c00.png">


Fixes #33762
