### PR TITLE
Add tracks identity

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -122,7 +122,7 @@ class Starter_Page_Templates {
 		$tracks_identity    = null;
 		$is_wpcom           = ( defined( 'IS_WPCOM' ) && IS_WPCOM );
 		$has_active_jetpack = ( class_exists( 'Jetpack' ) && Jetpack::is_active() );
-		if ( $has_active_jetpack && ! $is_wpcom &&  class_exists( 'Jetpack_Tracks_Client' ) ) {
+		if ( $has_active_jetpack && ! $is_wpcom && class_exists( 'Jetpack_Tracks_Client' ) ) {
 			$tracks_identity = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
 			wp_enqueue_script(
 				'jp-tracks',

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -181,9 +181,12 @@ class Starter_Page_Templates {
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
 		if ( false === $vertical_templates ) {
-			$request_url = add_query_arg( [
-				'_locale' => $this->get_iso_639_locale(),
-			], 'https://public-api.wordpress.com/wpcom/v2/verticals/' . $vertical_id . '/templates' );
+			$request_url = add_query_arg(
+				[
+					'_locale' => $this->get_iso_639_locale(),
+				],
+				'https://public-api.wordpress.com/wpcom/v2/verticals/' . $vertical_id . '/templates'
+			);
 			$response    = wp_remote_get( esc_url_raw( $request_url ) );
 			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
 				return array();

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -152,6 +152,7 @@ class Starter_Page_Templates {
 			'siteInformation' => array_merge( $default_info, $site_info ),
 			'templates'       => array_merge( $default_templates, $vertical_templates ),
 			'vertical'        => $vertical,
+			'tracksUserData'  => $tracks_identity,
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -118,6 +118,21 @@ class Starter_Page_Templates {
 			return;
 		}
 
+		// Load Tracks data if available.
+		$tracks_identity    = null;
+		$is_wpcom           = ( defined( 'IS_WPCOM' ) && IS_WPCOM );
+		$has_active_jetpack = ( class_exists( 'Jetpack' ) && Jetpack::is_active() );
+		if ( $has_active_jetpack && ! $is_wpcom &&  class_exists( 'Jetpack_Tracks_Client' ) ) {
+			$tracks_identity = Jetpack_Tracks_Client::get_connected_user_tracks_identity();
+			wp_enqueue_script(
+				'jp-tracks',
+				'//stats.wp.com/w.js',
+				array(),
+				gmdate( 'YW' ),
+				true
+			);
+		}
+
 		wp_enqueue_script( 'starter-page-templates' );
 		wp_set_script_translations( 'starter-page-templates', 'full-site-editing' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -16,7 +16,7 @@ import { Component } from '@wordpress/element';
 import replacePlaceholders from './utils/replace-placeholders';
 import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
-import { trackDismiss, trackSelection, trackView } from './utils/tracking';
+import { trackDismiss, trackSelection, trackView, initializeWithIdentity } from './utils/tracking';
 
 class PageTemplateModal extends Component {
 	state = {
@@ -132,7 +132,16 @@ const PageTemplatesPlugin = compose(
 )( PageTemplateModal );
 
 // Load config passed from backend.
-const { siteInformation = {}, templates = [], vertical } = window.starterPageTemplatesConfig;
+const {
+	siteInformation = {},
+	templates = [],
+	vertical,
+	tracksUserData,
+} = window.starterPageTemplatesConfig;
+
+if ( tracksUserData ) {
+	initializeWithIdentity( tracksUserData );
+}
 
 registerPlugin( 'page-templates', {
 	render: function() {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
@@ -1,26 +1,52 @@
 // Ensure Tracks Library
 window._tkq = window._tkq || [];
 
+let tracksIdentity = null;
+
+export const initializeWithIdentity = identity => {
+	tracksIdentity = identity;
+	window._tkq.push( [ 'identifyUser', identity.userid, identity.username ] );
+};
+
 export const trackView = vertical_id => {
+	if ( ! tracksIdentity ) {
+		return;
+	}
 	window._tkq.push( [
 		'recordEvent',
 		'a8c_test_full_site_editing_template_selector_view',
-		{ vertical_id },
+		{
+			blog_id: tracksIdentity.blogid,
+			vertical_id,
+		},
 	] );
 };
 
 export const trackDismiss = vertical_id => {
+	if ( ! tracksIdentity ) {
+		return;
+	}
 	window._tkq.push( [
 		'recordEvent',
 		'a8c_test_full_site_editing_template_selector_dismiss',
-		{ vertical_id },
+		{
+			blog_id: tracksIdentity.blogid,
+			vertical_id,
+		},
 	] );
 };
 
 export const trackSelection = ( vertical_id, template ) => {
+	if ( ! tracksIdentity ) {
+		return;
+	}
 	window._tkq.push( [
 		'recordEvent',
 		'a8c_test_full_site_editing_template_selector_template_selected',
-		{ vertical_id, template },
+		{
+			blog_id: tracksIdentity.blogid,
+			vertical_id,
+			template,
+		},
 	] );
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- check for an active Jetpack
- load user + site identity and pass it to our script
- add `identifyUser` call and add `blog_id` to all events
- enqueue w.js in environments where missing

#### Testing instructions

I have tested this code in:

1. core: no tracking (intentionally)
1. core + active jetpack: tracking, enqueues w.js
1. atomic v2: tracking, enqueues w.js
1. wpcom simple: tracking, uses w.js from `admin_stats_footer`

In all environments:
- create a new page and use the modal to pick a template (or dismiss it etc)
- show the source of `post-new.php` and confirm you can find `tracksUserData` and a **single** instance of `w.js` script
- while using the plugin, observe your Network tab in devtools and look for `t.gif` calls
  - confirm their URLs match tracking events as expected
- bewared of AdBlock and similar plugins. they can possibly block `w.js` or `t.gif` requests which makes it hard to debug

Fixes #33489 