### PR TITLE
[e2e] Change importer selectors

### DIFF
--- a/test/e2e/lib/pages/import-page.js
+++ b/test/e2e/lib/pages/import-page.js
@@ -15,7 +15,7 @@ import AsyncBaseContainer from '../async-base-container';
 
 export default class ImportPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.importer__shell' ) );
+		super( driver, By.css( '.importer__site-importer-card' ) );
 	}
 
 	async previewSiteToBeImported() {

--- a/test/e2e/lib/pages/importer-page.js
+++ b/test/e2e/lib/pages/importer-page.js
@@ -19,7 +19,7 @@ export default class ImporterPage extends AsyncBaseContainer {
 	async importerIsDisplayed( importerClass ) {
 		return await DriverHelper.isElementPresent(
 			this.driver,
-			By.css( `.importer__shell .${ importerClass }` )
+			By.css( `.importer__file-importer-card .${ importerClass }` )
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* I changed importer selectors in PR [33687](https://github.com/Automattic/wp-calypso/pull/33687), in [this](https://github.com/Automattic/wp-calypso/pull/33687/commits/a68f8119441e3f1420abdbef4c3470118bd5d732) commit. That caused import e2e tests to start [failing](https://circleci.com/gh/Automattic/wp-calypso/323342). With this PR they should pass again. 

#### Testing instructions

* Make sure that `Verify Import Option` and `Import a site while signing up` are passing

