### PR TITLE
My Plan: Remove additional margin from Jetpack plan notice

### DIFF
--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -38,10 +38,6 @@
 	width: 100%;
 	margin-top: -20px;
 	text-align: left;
-
-	.current-plan__header-content:not( .is-jetpack-free ) & {
-		margin-bottom: 45px;
-	}
 }
 
 .current-plan__header-heading,

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -38,6 +38,10 @@
 	width: 100%;
 	margin-top: -20px;
 	text-align: left;
+
+	.current-plan__header:not( .is-jetpack-free ) & {
+		margin-bottom: 45px;
+	}
 }
 
 .current-plan__header-heading,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before:

<img width="1064" alt="Screenshot 2019-06-12 at 12 14 45" src="https://user-images.githubusercontent.com/411945/59379729-3764fd00-8d0c-11e9-90c5-52c18d041624.png">

After:

<img width="1070" alt="Screenshot 2019-06-12 at 12 18 51" src="https://user-images.githubusercontent.com/411945/59379756-4b106380-8d0c-11e9-8aa5-7fbf53e2b265.png">

#### Testing instructions

1. Grab a Jetpack site on a free plan
2. Heading to Plan -> My Plan
3. Check the margin on the plan card

Fixes #33454 
