### PR TITLE
Full Site Editing: display header preview alongside page content

### DIFF
--- a/apps/full-site-editing/blank-theme/page.php
+++ b/apps/full-site-editing/blank-theme/page.php
@@ -13,8 +13,6 @@ get_header( 'blank' );
 
 			<?php
 			if ( have_posts() ) :
-				the_post();
-
 				$page_id     = get_the_ID();
 				$template_id = get_post_meta( $page_id, '_wp_template_id', true );
 
@@ -34,6 +32,8 @@ get_header( 'blank' );
 
 					<?php
 				else :
+					the_post();
+
 					get_template_part( 'template-parts/content/content', 'page' );
 
 					if ( comments_open() || get_comments_number() ) :

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
@@ -3,6 +3,7 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -11,20 +12,20 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-if ( 'wp_template' === fullSiteEditing.editorPostType ) {
-	registerBlockType( 'a8c/post-content', {
-		title: __( 'Content Slot' ),
-		description: __( 'Placeholder for a post or a page.' ),
-		icon: 'layout',
-		category: 'layout',
-		supports: {
-			align: [ 'wide', 'full' ],
-			anchor: true,
-			html: false,
-			multiple: false,
-			reusable: false,
-		},
-		edit,
-		save: () => null,
-	} );
-}
+const isTemplatePostType = 'wp_template' === fullSiteEditing.editorPostType;
+
+registerBlockType( 'a8c/post-content', {
+	title: __( 'Content Slot' ),
+	description: __( 'Placeholder for a post or a page.' ),
+	icon: 'layout',
+	category: 'layout',
+	supports: {
+		align: [ 'wide', 'full' ],
+		anchor: true,
+		html: false,
+		multiple: false,
+		reusable: false,
+	},
+	edit: isTemplatePostType ? edit : () => <InnerBlocks />,
+	save: isTemplatePostType ? () => null : () => <InnerBlocks.Content />,
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -1,3 +1,4 @@
+/* global fullSiteEditing */
 /**
  * WordPress dependencies
  */
@@ -10,18 +11,20 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( 'a8c/template', {
-	title: __( 'Template Part' ),
-	description: __( 'Display a template part.' ),
-	icon: 'layout',
-	category: 'layout',
-	attributes: { templateId: { type: 'number' } },
-	supports: {
-		align: [ 'wide', 'full' ],
-		anchor: true,
-		html: false,
-		reusable: false,
-	},
-	edit,
-	save: () => null,
-} );
+if ( 'wp_template_part' !== fullSiteEditing.editorPostType ) {
+	registerBlockType( 'a8c/template', {
+		title: __( 'Template Part' ),
+		description: __( 'Display a template part.' ),
+		icon: 'layout',
+		category: 'layout',
+		attributes: { templateId: { type: 'number' } },
+		supports: {
+			align: [ 'wide', 'full' ],
+			anchor: true,
+			html: false,
+			reusable: false,
+		},
+		edit,
+		save: () => null,
+	} );
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -1,4 +1,3 @@
-/* global fullSiteEditing */
 /**
  * WordPress dependencies
  */
@@ -11,20 +10,18 @@ import { __ } from '@wordpress/i18n';
 import edit from './edit';
 import './style.scss';
 
-if ( 'wp_template' === fullSiteEditing.editorPostType ) {
-	registerBlockType( 'a8c/template', {
-		title: __( 'Template Part' ),
-		description: __( 'Display a template part.' ),
-		icon: 'layout',
-		category: 'layout',
-		attributes: { templateId: { type: 'number' } },
-		supports: {
-			align: [ 'wide', 'full' ],
-			anchor: true,
-			html: false,
-			reusable: false,
-		},
-		edit,
-		save: () => null,
-	} );
-}
+registerBlockType( 'a8c/template', {
+	title: __( 'Template Part' ),
+	description: __( 'Display a template part.' ),
+	icon: 'layout',
+	category: 'layout',
+	attributes: { templateId: { type: 'number' } },
+	supports: {
+		align: [ 'wide', 'full' ],
+		anchor: true,
+		html: false,
+		reusable: false,
+	},
+	edit,
+	save: () => null,
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -480,7 +480,7 @@ class Full_Site_Editing {
 			return $data;
 		}
 
-		$data['post_content'] = serialize_blocks( $post_content_blocks[ $post_content_key ]['innerBlocks'] );
+		$data['post_content'] = wp_slash( serialize_blocks( $post_content_blocks[ $post_content_key ]['innerBlocks'] ) );
 		return $data;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -16,6 +16,8 @@ class Full_Site_Editing {
 	 */
 	private static $instance = null;
 
+	private $template_post_types = [ 'wp_template', 'wp_template_part', 'wp_template_part_type' ];
+
 	/**
 	 * Full_Site_Editing constructor.
 	 */
@@ -39,6 +41,9 @@ class Full_Site_Editing {
 				ob_end_flush();
 			}
 		);
+
+		add_action( 'the_post', array( $this, 'merge_template_and_post' ) );
+		add_filter( 'wp_insert_post_data', array( $this, 'remove_template_components' ), 10, 2 );
 	}
 
 	/**
@@ -418,5 +423,128 @@ class Full_Site_Editing {
 		$close_button_url = apply_filters( 'a8c_fse_close_button_link', $close_button_url );
 
 		return $close_button_url;
+	}
+
+	/** This will merge the post content with the post template, modifiying the
+	 * $post parameter.
+	 *
+	 * @param WP_Post $post
+	 */
+	public function merge_template_and_post( $post ) {
+		//bail if not a REST API Request
+		if ( defined( 'REST_REQUEST' ) && ! REST_REQUEST ) {
+			return;
+		}
+
+		// bail if the post type is one of the template post types
+		if ( in_array( get_post_type( $post->ID ), $this->template_post_types ) ) {
+			return;
+		}
+
+		$template_id = get_post_meta( $post->ID, '_wp_template_id', true );
+		//bail if the post has no tempalte id assigned
+		if ( ! $template_id ) {
+			return;
+		}
+
+		$template = get_post( $template_id );
+		$wrapped_post_content = sprintf( '<!-- wp:a8c/post-content -->%s<!-- /wp:a8c/post-content -->', $post->post_content );
+		$post->post_content = str_replace( '<!-- wp:a8c/post-content /-->', $wrapped_post_content, $template->post_content );
+	}
+
+	/**
+	 * This will extract the inner blocks of the post content and
+	 * serialize them back to HTML for saving.
+	 *
+     * @param array $data    An array of slashed post data.
+	 * @param array $postarr An array of sanitized, but otherwise unmodified post data.
+	 */
+	public function remove_template_components( $data, $postarr ) {
+		// bail if the post type is one of the template post types
+		if ( in_array( $postarr['post_type'], $this->template_post_types ) ) {
+			return $data;
+		}
+
+		$post_content = wp_unslash( $data['post_content'] );
+
+		//bail if post content has no blocks
+		if( ! has_blocks( $post_content ) ) {
+			return $data;
+		}
+
+		$post_content_blocks = parse_blocks( wp_unslash( $data['post_content'] ) );
+		$post_content_key = array_search( 'a8c/post-content', array_column( $post_content_blocks, 'blockName' ) );
+
+		// bail if no post content block found
+		if( ! $post_content_key ) {
+			return $data;
+		}
+
+		$data['post_content'] = serialize_blocks( $post_content_blocks[ $post_content_key ]['innerBlocks'] );
+		return $data;
+	}
+}
+
+if ( ! function_exists( 'serialize_block' ) ) {
+	/**
+	 * Renders an HTML-serialized form of a block object
+	 * from https://core.trac.wordpress.org/ticket/47375
+	 *
+	 * should be available since WordPress 5.3.0
+	 *
+	 * @param array $block The block being rendered.
+	 * @return string The HTML-serialized form of the block
+	 */
+	function serialize_block( $block ) {
+		// Non-block content has no block name.
+		if ( null === $block['blockName'] ) {
+			return $block['innerHTML'];
+		}
+
+		$unwanted  = array( '--', '<', '>', '&', '\"' );
+		$wanted    = array( '\u002d\u002d', '\u003c', '\u003e', '\u0026', '\u0022' );
+
+		$name      = 0 === strpos( $block['blockName'], 'core/' ) ? substr( $block['blockName'], 5 ) : $block['blockName'];
+		$has_attrs = ! empty( $block['attrs'] );
+		$attrs     = $has_attrs ? str_replace( $unwanted, $wanted, wp_json_encode( $block['attrs'] ) ) : '';
+
+		// Early abort for void blocks holding no content.
+		if ( empty( $block['innerContent'] ) ) {
+			return $has_attrs
+				? "<!-- wp:{$name} {$attrs} /-->"
+				: "<!-- wp:{$name} /-->";
+		}
+
+		$output = $has_attrs
+			? "<!-- wp:{$name} {$attrs} -->\n"
+			: "<!-- wp:{$name} -->\n";
+
+		$inner_block_index = 0;
+		foreach ( $block['innerContent'] as $chunk ) {
+			$output .= null === $chunk
+				? serialize_block( $block['innerBlocks'][ $inner_block_index++ ] )
+				: $chunk;
+
+			$output .= "\n";
+		}
+
+		$output .= "<!-- /wp:{$name} -->";
+
+		return $output;
+	}
+}
+
+if ( ! function_exists( 'serialize_blocks' ) ) {
+	/**
+	 * Renders an HTML-serialized form of a list of block objects
+	 * from https://core.trac.wordpress.org/ticket/47375
+	 *
+	 * should be available since WordPress 5.3.0
+	 *
+	 * @param  array  $blocks The list of parsed block objects
+	 * @return string         The HTML-serialized form of the list of blocks
+	 */
+	function serialize_blocks( $blocks ) {
+		return implode( "\n\n", array_map( 'serialize_block', $blocks ) );
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -16,7 +16,7 @@ class Full_Site_Editing {
 	 */
 	private static $instance = null;
 
-	private $template_post_types = [ 'wp_template', 'wp_template_part', 'wp_template_part_type' ];
+	private $template_post_types = array( 'wp_template', 'wp_template_part', 'wp_template_part_type' );
 
 	/**
 	 * Full_Site_Editing constructor.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -472,7 +472,7 @@ class Full_Site_Editing {
 			return $data;
 		}
 
-		$post_content_blocks = parse_blocks( wp_unslash( $data['post_content'] ) );
+		$post_content_blocks = parse_blocks( $post_content );
 		$post_content_key = array_search( 'a8c/post-content', array_column( $post_content_blocks, 'blockName' ) );
 
 		// bail if no post content block found

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -16,7 +16,7 @@ class Full_Site_Editing {
 	 */
 	private static $instance = null;
 
-	private $template_post_types = array( 'wp_template', 'wp_template_part', 'wp_template_part_type' );
+	private $template_post_types = array( 'wp_template', 'wp_template_part' );
 
 	/**
 	 * Full_Site_Editing constructor.

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -34,6 +34,7 @@
 	"dependencies": {
 		"@wordpress/api-fetch": "^3.1.2",
 		"@wordpress/blocks": "^6.2.3",
+		"@wordpress/block-editor": "^2.0.3",
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",
 		"@wordpress/data": "^4.4.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables the display of template parts alongside content on the editor. To enable this functionality, we have to make certain assumptions about the way the editor will treat content from now on. When a post has a `wp_template_id` assigned, every block in `post_content` is now an `InnerBlock` of the `a8c/post-content` block. And when saving (autosave/preview/publish) on the `InnerBlock.Content` of `a8c/post-content` is saved. Everything else is discarded.

It does that by making the following changes:

* Template Blocks become available to all post types.
* Template and Post Content are merged on `the_post` filter for REST API Requests.
* Post Content is extracted from the `post-content` block before saving on `wp_insert_post_data`.

#### Things that are not covered by this PR and considerations while reviewing.

##### Better Block UX.

It's extremely easy to add blocks outside the _Content Slot_ (`a8c/post-content`), and because of everything outside the _Content Slot_ is not saved, the User could potentially lose work. At the moment, the only way to check that everything that's supposed to be saved is by using the _Preview_.

##### Better UX when selecting your template.

At the moment, when you first select a template, the template parts are not applied **live**. The same when you change a template. That's still a work in progress.

##### Editor Styles will affect the template parts.

Unless you test with the _Blank Theme_, expect the _editor styles_ of the theme to affect the template parts while editing, but they may not affect the final product (it's not a true WYSIWYG experience).

##### Templates and the other Templates.

When you create a page (on Gutenberg's dev environment at least), you are presented with a dialogue asking you to select a _Template_. Those templates have no relation to the `wp_template` CPT we use for this. They just prepopulate some content on the page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create at least one _Template Part_. For simplicity, we'll assume it's called `Header`. Add all the blocks you'd like to it.
* Create at least one _Template_ that uses the `Header` template part and a _Content Slot_. We'll assume it's called `My Template`.
* Create a new page. It doesn't matter which template you select (_Blank_ or _Home_). Add some content to that page.
* Preview your page. It should show using the default theme header and footer.
* Assign `My Template` to the Page by using the _Templates_ button on the toolbar, next to _Settings_.
* Preview the page again. Now it should show `My Template` `Header` part instead of the header.
* Refresh the editor. Now, the template parts should also appear on the editor.
* Modify the post content inside the _Content Slot_. Preview and save. All changes should persist.
* Deactivate the `Full Site Editing` plugin and verify that the pages content still show correctly and there are no _missing parts_ warnings when editing.

##### Testing on your WordPress.com sandbox.

Please, repeat the steps using your WordPress.com sandbox. You can find the instructions on the Field Guide (PCYsg-ly5-p2), under _Developing against WP.com sandbox_. Please sandbox the `public-api` and a _Simple Site_ and verify that there are no regressions.

Uses the code from https://core.trac.wordpress.org/ticket/47375 by @dmsnell that it's not available on WordPress core just yet.

Fixes #33627
