### PR TITLE
Removing logic that dumps customers to WP admin

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/setup/store-location.js
+++ b/client/extensions/woocommerce/app/dashboard/setup/store-location.js
@@ -22,9 +22,6 @@ import {
 import { bumpStat } from 'woocommerce/lib/analytics';
 import { errorNotice } from 'state/notices/actions';
 import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
-// Commenting out for now because country logic for dumping to wp-admin is being removoed
-// remove this code if it doesn't cause conflicts.
-//import { isStoreManagementSupportedInCalypsoForCountry } from 'woocommerce/lib/countries';
 import {
 	areLocationsLoaded,
 	getAllCountries,
@@ -155,14 +152,8 @@ class StoreLocationSetupView extends Component {
 
 	onNext = event => {
 		const {
-			// Commenting out for now, remove if no conflict with removing logic
-			// elsewhere in file
-			//adminURL,
 			countries,
 			currentUserEmailVerified,
-			// Commenting out for now, remove if no conflict with removing logic
-			// elsewhere in file
-			//onRequestRedirect,
 			pushDefaultsForCountry,
 			siteId,
 			translate,
@@ -192,17 +183,6 @@ class StoreLocationSetupView extends Component {
 			// mc stat 32 char max :P
 			this.props.bumpStat( 'calypso_woo_store_setup_country', this.state.address.country );
 
-			// Original: If we don't support a calypso experience yet for this country, let
-			// them complete setup with the wp-admin WooCommerce wizard
-			// Revised: Removing functionality due to no longer being needed. Commenting out for now
-			// to ensure that the dependencies in the same file are ok to also be commented out.
-			/*
-			if ( ! isStoreManagementSupportedInCalypsoForCountry( this.state.address.country ) ) {
-				const storeSetupURL =
-					adminURL + 'admin.php?page=wc-setup&step=store_setup&activate_error=false&from=calypso';
-				onRequestRedirect( storeSetupURL );
-			}
-			*/
 			return setSetStoreAddressDuringInitialSetup( siteId, true );
 		};
 

--- a/client/extensions/woocommerce/app/dashboard/setup/store-location.js
+++ b/client/extensions/woocommerce/app/dashboard/setup/store-location.js
@@ -22,7 +22,9 @@ import {
 import { bumpStat } from 'woocommerce/lib/analytics';
 import { errorNotice } from 'state/notices/actions';
 import getContactDetailsCache from 'state/selectors/get-contact-details-cache';
-import { isStoreManagementSupportedInCalypsoForCountry } from 'woocommerce/lib/countries';
+// Commenting out for now because country logic for dumping to wp-admin is being removoed
+// remove this code if it doesn't cause conflicts.
+//import { isStoreManagementSupportedInCalypsoForCountry } from 'woocommerce/lib/countries';
 import {
 	areLocationsLoaded,
 	getAllCountries,
@@ -153,10 +155,14 @@ class StoreLocationSetupView extends Component {
 
 	onNext = event => {
 		const {
-			adminURL,
+			// Commenting out for now, remove if no conflict with removing logic
+			// elsewhere in file
+			//adminURL,
 			countries,
 			currentUserEmailVerified,
-			onRequestRedirect,
+			// Commenting out for now, remove if no conflict with removing logic
+			// elsewhere in file
+			//onRequestRedirect,
 			pushDefaultsForCountry,
 			siteId,
 			translate,
@@ -186,14 +192,17 @@ class StoreLocationSetupView extends Component {
 			// mc stat 32 char max :P
 			this.props.bumpStat( 'calypso_woo_store_setup_country', this.state.address.country );
 
-			// If we don't support a calypso experience yet for this country, let
+			// Original: If we don't support a calypso experience yet for this country, let
 			// them complete setup with the wp-admin WooCommerce wizard
+			// Revised: Removing functionality due to no longer being needed. Commenting out for now
+			// to ensure that the dependencies in the same file are ok to also be commented out.
+			/*
 			if ( ! isStoreManagementSupportedInCalypsoForCountry( this.state.address.country ) ) {
 				const storeSetupURL =
 					adminURL + 'admin.php?page=wc-setup&step=store_setup&activate_error=false&from=calypso';
 				onRequestRedirect( storeSetupURL );
 			}
-
+			*/
 			return setSetStoreAddressDuringInitialSetup( siteId, true );
 		};
 


### PR DESCRIPTION
Currently there's logic that will send non US/Canada business plan customers directly to the WP-admin when they begin onboarding. They're sent without a warning that they'll be in a new context.

However, currently US/Canada customers get an appropriate notice letting them know what's about to happen.

This fix removes the logic and makes it so that all customers (regardless of location) are presented with the notice and told about the switch the WP-admin.

In order to pass pre-commit hook I needed to comment out other lines of code as well. I can't tell if they are causing conflicts elsewhere so I absolutely would welcome a review on this. Thank you!

This PR is for the following issue: https://github.com/Automattic/wp-calypso/issues/33261