### PR TITLE
Don't apply wide layout to store setup steps

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/index.js
+++ b/client/extensions/woocommerce/app/dashboard/index.js
@@ -243,9 +243,10 @@ class Dashboard extends Component {
 
 	render() {
 		const { className, finishedInstallOfRequiredPlugins, isSetupComplete, siteId } = this.props;
+		const useWideLayout = isSetupComplete ? true : false;
 
 		return (
-			<Main className={ classNames( 'dashboard', className ) } wideLayout>
+			<Main className={ classNames( 'dashboard', className ) } wideLayout={ useWideLayout }>
 				<ActionHeader breadcrumbs={ this.getBreadcrumb() } />
 				{ isSetupComplete ? this.renderDashboardContent() : this.renderDashboardSetupContent() }
 				{ finishedInstallOfRequiredPlugins && <QuerySettingsGeneral siteId={ siteId } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Store on WordPress.com setup steps currently use a wide layout. On larger screens this is overkill. This PR updates it to use the standard width layout on the `Main` component.

Fixes #33260
