### PR TITLE
Making the email input field active on load in WordPress.com sign up.

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -520,6 +520,7 @@ class SignupForm extends Component {
 					autoCapitalize="off"
 					autoCorrect="off"
 					className="signup-form__input"
+					autofocus="true"
 					disabled={
 						this.state.submitting || !! this.props.disabled || !! this.props.disableEmailInput
 					}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Making the email input field active on load in sign up whenever the sign up button is clicked on our homepage and landing pages.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Apply patch
* Make sure you're logged out for the WordPress.com homepage, or use one of our landing pages, like https://wordpress.com/launch/
*  Click the Get Started button on the top right, or any of the sign up buttons.
*  Make sure the email input field is active so you can type in it on page load on Step 1 of the sign up flow.

Fixes #33846
