### PR TITLE
Fixed search icon size for mobile screen

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -400,5 +400,9 @@
 
 	.search.is-expanded-to-container {
 		height: 50px;
+
+		@include breakpoint( '<480px' ) {
+			height: 46px;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #33838

#### Changes proposed in this Pull Request

Minor changes of search icon size on mobile only, so it fits the container instead of overlapping it.

## Before 

<img width="343" alt="Screen Shot 2019-06-12 at 2 40 39 PM" src="https://user-images.githubusercontent.com/28450084/59388229-16a6a280-8d20-11e9-962c-d5a9c92cf830.png">

## After 

<img width="377" alt="Screen Shot 2019-06-12 at 2 34 12 PM" src="https://user-images.githubusercontent.com/28450084/59388126-d810e800-8d1f-11e9-91a5-c50fdd18bed8.png">


#### Testing instructions

On mobile
Create a site on a Business plan
Install a plugin
Navigate to Store
Navigate to "Products"

