### PR TITLE
Inline Help: Adjust footer to allow longer labels

### DIFF
--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -292,13 +292,14 @@
 	background: var( --color-neutral-0 );
 	border-top: 1px solid var( --color-neutral-100 );
 	border-radius: 0 0 4px 4px;
+	display: flex;
+	flex-direction: column;
 
 	.button.is-borderless.inline-help__more-button,
 	.button.is-borderless.inline-help__contact-button,
 	.button.is-borderless.inline-help__back-to-help-button,
 	.button.is-borderless.inline-help__cancel-button {
 		text-align: left;
-		width: 50%;
 		position: relative;
 		padding: 12px 8px 12px 46px;
 
@@ -326,7 +327,7 @@
 	}
 
 	.button.is-borderless.inline-help__contact-button {
-		padding-right: 24px;
+		padding-right: 36px;
 	}
 
 	// Hide/Show buttons as needed

--- a/client/blocks/inline-help/style.scss
+++ b/client/blocks/inline-help/style.scss
@@ -293,7 +293,9 @@
 	border-top: 1px solid var( --color-neutral-100 );
 	border-radius: 0 0 4px 4px;
 	display: flex;
-	flex-direction: column;
+	flex-direction: row;
+	justify-content: space-between;
+	flex-wrap: wrap;
 
 	.button.is-borderless.inline-help__more-button,
 	.button.is-borderless.inline-help__contact-button,
@@ -327,7 +329,7 @@
 	}
 
 	.button.is-borderless.inline-help__contact-button {
-		padding-right: 36px;
+		padding-right: 40px;
 	}
 
 	// Hide/Show buttons as needed


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adjust footer in Inline Help so the layout is vertical instead of horizontal.
* Add padding to the right of the "Contact us" button so the chevron never overlaps.

The footer in the Inline Help popover broke line very weirdly when the label was too long, which could happen depending on the language selected for the UI. This PR adjusts the layout so it's vertical, making it more scalable (labels can be much longer now) and more consistent (it looks the same regardless of the language selected).

Before: 
![image](https://user-images.githubusercontent.com/820374/59388294-45247d80-8d20-11e9-81c1-24ff37dbaa7f.png)


After:
![image](https://user-images.githubusercontent.com/820374/59388250-28884580-8d20-11e9-8366-0455cd08a655.png)

#### Testing instructions

* Go to Calypso.
* Open the Inline Help by clicking on the `?` icon on the lower-right corner.
* Make sure it looks fine regardless of your UI language.

Fixes #33460 