### PR TITLE
Tightens up inconsistent spacing on My Profile page

### DIFF
--- a/client/me/profile/style.scss
+++ b/client/me/profile/style.scss
@@ -1,16 +1,32 @@
 .me-profile-settings .edit-gravatar {
 	text-align: center;
 
-	@include breakpoint( '>960px' ) {
+	@include breakpoint('>960px') {
 		float: left;
 		margin-right: 40px;
 		margin-bottom: 20px;
 	}
 }
 
+@media ( min-width: 961px ) {
+	.me-profile-settings .edit-gravatar {
+	    margin-bottom: 0;
+	}
+}
+
 .me-profile-settings .form-fieldset:nth-child( 1 ),
 .me-profile-settings .form-fieldset:nth-child( 2 ) {
-	@include breakpoint( '>960px' ) {
+	@include breakpoint('>960px') {
 		clear: right;
+	}
+}
+
+.me-profile-settings__info-text {
+	margin-bottom: 0;
+}
+
+.profile-links__list {
+	.profile-link:last-of-type {
+		margin-bottom: 0;
 	}
 }


### PR DESCRIPTION
See #33821. A few of the form fields on the My Profile page were inconsistent; this tightens up and evens out the spacing between those fields.

#### Steps to reproduce
1. Starting at URL: Go to https://wordpress.com/me/
2. Observe the inconsistent spacing between form fields -- varies slightly between tight and loose.

#### What I expected
The spacing to be even throughout the form.

#### What happened instead

The spacing between form fields varies.

#### Browser / OS version

All

#### Screenshot / Video

<img width="777" alt="Screen Shot 2019-06-11 at 3 20 35 PM" src="https://user-images.githubusercontent.com/1385492/59310840-84899600-8c5c-11e9-9edc-61603445b958.png">

<img width="797" alt="Screen Shot 2019-06-11 at 3 20 44 PM" src="https://user-images.githubusercontent.com/1385492/59310860-90755800-8c5c-11e9-8ef8-5f5a99431961.png">

Fixes #33821