### PR TITLE
Fixed navigation plan label

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -122,7 +122,7 @@
 		-webkit-tap-highlight-color: rgba( var( --color-neutral-700-rgb ), 0.2 );
 
 		.sidebar__menu-link-secondary-text {
-			padding: 3px 8px 4px;
+			padding: 4px 8px;
 			margin-right: 8px;
 			align-self: center;
 			font-weight: 600;


### PR DESCRIPTION
Fixed the plan section of the nav drawer displaying the plan 1px off vertical center.

## URL 
https://wordpress.com/plans/my-plan/
(and pick a site with a plan) 

## Before
<img width="286" alt="Screen Shot 2019-06-12 at 3 22 29 PM" src="https://user-images.githubusercontent.com/49699157/59390396-f974d280-8d25-11e9-88aa-238e41a18620.png">


## After
<img width="286" alt="Screen Shot 2019-06-12 at 3 22 35 PM" src="https://user-images.githubusercontent.com/49699157/59390412-01cd0d80-8d26-11e9-9d26-7559d26408e2.png">

