### PR TITLE
Signup Mockup: use current Gutenberg core block styles.

### DIFF
--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -57,7 +57,7 @@ export function getIframeSource(
 			<link rel="dns-prefetch" href="//s0.wp.com">
 			<link rel="dns-prefetch" href="//fonts.googleapis.com">
 			<title>${ content.title } – ${ content.tagline }</title>
-			<link type="text/css" media="all" rel="stylesheet" href="https://s0.wp.com/wp-content/plugins/gutenberg-core/build/block-library/style.css" />
+			<link type="text/css" media="all" rel="stylesheet" href="https://s0.wp.com/wp-content/plugins/gutenberg-core/v5.8.0/build/block-library/style.css" />
 			${ getCSSLinkHtml( cssUrl ) }
 			${ getCSSLinkHtml( fontUrl ) }
 			<style type="text/css">


### PR DESCRIPTION
This updates the core block styles used in the Signup mockup to use the same version as the site front-end.

Before | After
------------ | -------------
![Screen Shot 2019-06-12 at 3 08 35 PM](https://user-images.githubusercontent.com/942359/59389813-30e27f80-8d24-11e9-94b8-e69d885f50b6.png) | ![Screen Shot 2019-06-12 at 3 08 57 PM](https://user-images.githubusercontent.com/942359/59389783-18726500-8d24-11e9-8075-e6d1fca53eb2.png)

**To test:**
- navigate to http://calypso.localhost:3000/start/
- choose the "business" segment
- select a vertical from the popular verticals list
- make sure that the mockup's cover image text renders above the image's gradient and that the rest of the preview looks as expected
