### PR TITLE
Remove "Add" links on store menu items. #33894

### DIFF
--- a/client/extensions/woocommerce/store-sidebar/index.js
+++ b/client/extensions/woocommerce/store-sidebar/index.js
@@ -34,9 +34,7 @@ import { getSelectedSiteWithFallback } from 'woocommerce/state/sites/selectors';
 import { getSetStoreAddressDuringInitialSetup } from 'woocommerce/state/sites/setup-choices/selectors';
 import { isLoaded as arePluginsLoaded } from 'state/plugins/installed/selectors';
 import { isStoreManagementSupportedInCalypsoForCountry } from 'woocommerce/lib/countries';
-import { recordTrack } from 'woocommerce/lib/analytics';
 import Sidebar from 'layout/sidebar';
-import SidebarButton from 'layout/sidebar/button';
 import SidebarItem from 'layout/sidebar/item';
 import SidebarMenu from 'layout/sidebar/menu';
 import SidebarSeparator from 'layout/sidebar/separator';
@@ -113,21 +111,12 @@ class StoreSidebar extends Component {
 	products = () => {
 		const { site, siteSuffix, translate } = this.props;
 		const link = '/store/products' + siteSuffix;
-		const addLink = '/store/product' + siteSuffix;
-		const selected = this.isItemLinkSelected( [
-			link,
-			addLink,
-			'/store/products/categories' + siteSuffix,
-		] );
+		const selected = this.isItemLinkSelected( [ link, '/store/products/categories' + siteSuffix ] );
 		const classes = classNames( {
 			products: true,
 			'is-placeholder': ! site,
 			selected,
 		} );
-
-		const recordAddClick = () => {
-			recordTrack( 'calypso_woocommerce_sidebar_add_product_click' );
-		};
 
 		return (
 			<SidebarItem
@@ -135,11 +124,7 @@ class StoreSidebar extends Component {
 				icon="product"
 				label={ translate( 'Products' ) }
 				link={ link }
-			>
-				<SidebarButton disabled={ ! site } href={ addLink } onClick={ recordAddClick }>
-					{ translate( 'Add' ) }
-				</SidebarButton>
-			</SidebarItem>
+			/>
 		);
 	};
 
@@ -191,17 +176,12 @@ class StoreSidebar extends Component {
 
 		const { site, siteSuffix, translate } = this.props;
 		const link = '/store/promotions' + siteSuffix;
-		const addLink = '/store/promotion' + siteSuffix;
-		const selected = this.isItemLinkSelected( [ link, addLink ] );
+		const selected = this.isItemLinkSelected( [ link ] );
 		const classes = classNames( {
 			promotions: true,
 			'is-placeholder': ! site,
 			selected,
 		} );
-
-		const recordPromotionClick = () => {
-			recordTrack( 'calypso_woocommerce_sidebar_add_promotion_click' );
-		};
 
 		return (
 			<SidebarItem
@@ -209,11 +189,7 @@ class StoreSidebar extends Component {
 				icon="gift"
 				label={ translate( 'Promotions' ) }
 				link={ link }
-			>
-				<SidebarButton disabled={ ! site } href={ addLink } onClick={ recordPromotionClick }>
-					{ translate( 'Add' ) }
-				</SidebarButton>
-			</SidebarItem>
+			/>
 		);
 	};
 

--- a/client/extensions/woocommerce/style.scss
+++ b/client/extensions/woocommerce/style.scss
@@ -116,6 +116,10 @@
 .store-sidebar__sidebar {
 	display: block;
 
+	a {
+		font-weight: 600;
+	}
+
 	.store-sidebar__ground-control {
 		align-items: center;
 		background-color: var( --color-white );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the "Add" links in the store menu items.

This aligns the store nav with the general site management navigation, which was recently updated and removed all sidebar buttons.

Also updates the font-weight to match the core navigation.

#### Testing instructions

* On a site with Store on WP.com enabled, navigate to the Store management section.
* Notice the "Add" sidebar buttons have been removed.

Before:

![before](https://cldup.com/tub6m_EnVT-3000x3000.png)

After:

![after](https://cldup.com/t78_Y7eD-4-3000x3000.png)

Fixes #33894
