### PR TITLE
Logged Out Form: Fix current style to match WordPress.com login screen

### DIFF
--- a/client/components/logged-out-form/footer.scss
+++ b/client/components/logged-out-form/footer.scss
@@ -14,6 +14,5 @@
 		float: none;
 		margin: 0;
 		width: 100%;
-		@include elevation( 1dp );
 	}
 }

--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -2,7 +2,7 @@
 	max-width: 400px;
 
 	p {
-		margin-bottom: 1.5em;
+		margin-bottom: 20px;
 	}
 
 	.form-fieldset {

--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -1,13 +1,9 @@
 .logged-out-form {
-	margin: 0 auto 16px;
-	max-width: 360px;
-	padding: 16px;
-	border-radius: 3px;
-	@include elevation( 2dp );
+	p {
+		margin-bottom: 1.5em;
+	}
+
+	.form-fieldset {
+		margin: 0;
+	}
 }
-
-
-
-
-
-

--- a/client/components/logged-out-form/style.scss
+++ b/client/components/logged-out-form/style.scss
@@ -1,4 +1,6 @@
 .logged-out-form {
+	max-width: 400px;
+
 	p {
 		margin-bottom: 1.5em;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove custom styles for the card
* Add padding to the paragraph
* Remove margins from the fieldset

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in to WordPress.com by using the "[Email me a login link](http://wordpress.com/log-in/link)" form
* It should now look similar to the [standard login page](https://wordpress.com/log-in).

__Before:__

<img width="481" alt="Screenshot 2019-06-12 at 15 15 07" src="https://user-images.githubusercontent.com/177929/59390131-37bdc200-8d25-11e9-9549-852af2241540.png">

__After:__

<img width="520" alt="Screenshot 2019-06-12 at 15 15 23" src="https://user-images.githubusercontent.com/177929/59390142-3db3a300-8d25-11e9-94ad-8e5ac1e8d783.png">

Fixes #33864
