### PR TITLE
Importers gh6470

### DIFF
--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -51,11 +51,13 @@ class ImporterError extends React.PureComponent {
 	};
 
 	getUploadError = () => {
-		const defaultError = this.props.translate( 'Unexpected error during the upload' );
+		const defaultError = this.props.translate(
+			'Oops! We ran into an unexpected error while uploading your file.'
+		);
 		const { description = '' } = this.props;
 
 		return this.props.translate(
-			'%(errorDescription)s{{br/}}Try another file or {{cs}}contact support{{/cs}}.',
+			'%(errorDescription)s{{br/}}Make sure you are using a valid WordPress export file in XML or ZIP format. If that does not work, {{cs}}contact Support{{/cs}}.',
 			{
 				args: {
 					errorDescription: description.length ? description : defaultError,

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -31,7 +31,7 @@ class ImporterError extends React.PureComponent {
 	contactSupport = event => {
 		event.preventDefault();
 		event.stopPropagation();
-		Page( '/help' );
+		Page( '/help/contact' );
 	};
 
 	getImportError = () => {


### PR DESCRIPTION
changes in this PR:
- specify in upload error message the valid file types
- if the error message specifies that the user is contacting support, change the link to go to support section instead of documentation section.

the original (stale) issue is here: https://github.com/Automattic/wp-calypso/issues/6470