### PR TITLE
People: Wrap label and actions in SectionHeader mobile

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -1,4 +1,3 @@
-
 .section-header.card {
 	display: flex;
 	align-items: center;
@@ -6,6 +5,11 @@
 	padding-bottom: 11px;
 	position: relative;
 	line-height: 28px;
+
+	@include breakpoint( '<480px' ) {
+		align-items: flex-start;
+		flex-flow: row wrap;
+	}
 
 	&::after {
 		content: '';
@@ -22,6 +26,11 @@
 	flex-grow: 1;
 	position: relative;
 	overflow: hidden;
+
+	@include breakpoint( '<480px' ) {
+		line-height: 1.4;
+		margin: 4px 0;
+	}
 
 	&::before {
 		@include long-content-fade();

--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -32,10 +32,6 @@
 		margin: 4px 0;
 	}
 
-	&::before {
-		@include long-content-fade();
-	}
-
 	.count {
 		margin-left: 8px;
 	}

--- a/client/my-sites/people/people-list-section-header/style.scss
+++ b/client/my-sites/people/people-list-section-header/style.scss
@@ -1,26 +1,10 @@
-.section-header.card {
+.people-list-section-header__add-button.is-compact {
 
 	@include breakpoint( '<480px' ) {
-		align-items: flex-start;
-		flex-flow: row wrap;
-	}
+		font-size: 0;
 
-	.section-header__label {
-
-		@include breakpoint( '<480px' ) {
-			line-height: 1.4;
-			margin: 4px 0;
-		}
-	}
-
-	.people-list-section-header__add-button.is-compact {
-
-		@include breakpoint( '<480px' ) {
-			font-size: 0;
-
-			.gridicon {
-				margin-right: 0;
-			}
+		.gridicon {
+			margin-right: 0;
 		}
 	}
 }

--- a/client/my-sites/people/people-list-section-header/style.scss
+++ b/client/my-sites/people/people-list-section-header/style.scss
@@ -1,8 +1,26 @@
-.people-list-section-header__add-button.is-compact {
+.section-header.card {
+
 	@include breakpoint( '<480px' ) {
-		font-size: 0;
-		.gridicon {
-			margin-right: 0;
+		align-items: flex-start;
+		flex-flow: row wrap;
+	}
+
+	.section-header__label {
+
+		@include breakpoint( '<480px' ) {
+			line-height: 1.4;
+			margin: 4px 0;
+		}
+	}
+
+	.people-list-section-header__add-button.is-compact {
+
+		@include breakpoint( '<480px' ) {
+			font-size: 0;
+
+			.gridicon {
+				margin-right: 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes: https://github.com/Automattic/wp-calypso/issues/33683

#### Testing instructions

1. Find a site with a lot of followers (eg: en.blog)
1. On mobile view, head over to: http://calypso.localhost:3000/people/team/[site]
2. When `SectionHeader` label is long, notice how two columns are still being displayed when it should wrap

**Before:**
<img width="344" alt="Screenshot 2019-06-12 15 27 22" src="https://user-images.githubusercontent.com/4924246/59390611-acddc700-8d26-11e9-8f37-ba0e5082c7e3.png">

**After:**
<img width="339" alt="Screenshot 2019-06-12 15 27 59" src="https://user-images.githubusercontent.com/4924246/59390620-b109e480-8d26-11e9-88a3-43d639d1f069.png">

