### PR TITLE
add index to cart items key

### DIFF
--- a/client/my-sites/checkout/cart/cart-items.jsx
+++ b/client/my-sites/checkout/cart/cart-items.jsx
@@ -68,13 +68,13 @@ export class CartItems extends React.Component {
 			return;
 		}
 
-		let items = getAllCartItemsSorted( cart ).map( cartItem => {
+		let items = getAllCartItemsSorted( cart ).map( ( cartItem, index ) => {
 			return (
 				<CartItem
 					cart={ cart }
 					cartItem={ cartItem }
 					selectedSite={ this.props.selectedSite }
-					key={ cartItem.product_id + '-' + cartItem.meta }
+					key={ `${ cartItem.product_id }-${ cartItem.meta }-${ index }` }
 				/>
 			);
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

add index to cart items key, prevents key collusion with two cart items of G Suite Extra License for the same domain.

#### Testing instructions

1. checkout and boot calypso master brnach locally
2. Starting at URL: `/email/:domain/gsuite/add-users/:siteSlug`
3. Add a new G Suite user to the cart
4. return `/email/:domain/gsuite/add-users/:siteSlug`
5. open browser console
6. add additional user for same domain
7. observe no error

Fixes #33888
