### PR TITLE
Fix typo on verification code

### DIFF
--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -176,7 +176,7 @@ export class PasswordlessStep extends Component {
 			<LoggedOutForm onSubmit={ this.verifyUser } noValidate>
 				{ this.renderNotice() }
 				<ValidationFieldset errorMessages={ this.state.errorMessages }>
-					<FormLabel htmlFor="code">{ this.props.translate( 'Verifcation code' ) }</FormLabel>
+					<FormLabel htmlFor="code">{ this.props.translate( 'Verification code' ) }</FormLabel>
 					<FormTextInput
 						autoCapitalize={ 'off' }
 						className="passwordless__code"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes the spelling of "verification"

#### Testing instructions

- Go to http://calypso.localhost:3000/start/simple
- Enter a new email address
- On the next step check that the word "Verification" is spelt correctly