### PR TITLE
"Visit site" CTA casing

### DIFF
--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -159,7 +159,7 @@ class PreviewToolbar extends Component {
 							rel="noopener noreferrer"
 							onClick={ this.handleEditorWebPreviewExternalClick }
 						>
-							{ translate( 'Visit Site' ) }
+							{ translate( 'Visit site' ) }
 						</Button>
 					) }
 					<div className="web-preview__toolbar-tray">{ this.props.children }</div>


### PR DESCRIPTION
Updating pink button to reflect sentence case standards.

#### Changes proposed in this Pull Request

* Change button copy from title to sentence casing 
* Found in /view, main CTA (pink button) 

#### Testing instructions
* Go to https://wordpress.com/view/wordpress.com
* See top right corner, where pink CTA reads "Visit Site"

BEFORE
<img width="1665" alt="visit site cta" src="https://user-images.githubusercontent.com/3373750/59391407-08a94f80-8d29-11e9-83f6-5d923f571f6d.png">

AFTER
<img width="1647" alt="visit site cta fixed" src="https://user-images.githubusercontent.com/3373750/59391406-08a94f80-8d29-11e9-9d0a-afdcf3a078c8.png">

Fixes #33863 
