### PR TITLE
Atomic: overhaul eligibility hold warnings copy

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -23,7 +23,9 @@ function getHoldMessages( siteSlug, translate ) {
 	return {
 		TRANSFER_ALREADY_EXISTS: {
 			title: translate( 'Installation in progress' ),
-			description: translate( 'Please wait for installation to complete and try again.' ),
+			description: translate(
+				'Just a minute! Please wait until the installation is finished, then try again.'
+			),
 		},
 		NO_JETPACK_SITES: {
 			title: translate( 'Not available for Jetpack sites' ),
@@ -36,42 +38,42 @@ function getHoldMessages( siteSlug, translate ) {
 		SITE_PRIVATE: {
 			title: translate( 'Public site needed' ),
 			description: translate(
-				'Change your site\'s Privacy settings to "Public" or "Hidden" (not "Private") to clear this issue.'
+				'Change your site\'s Privacy settings to "Public" or "Hidden" (not "Private.")'
 			),
 			supportUrl: localizeUrl( 'https://en.support.wordpress.com/settings/privacy-settings/' ),
 		},
 		SITE_GRAYLISTED: {
 			title: translate( 'Ongoing site dispute' ),
 			description: translate(
-				"Contact us to review your site's standing and resolve the dispute to clear this issue."
+				"Contact us to review your site's standing and resolve the dispute."
 			),
 			supportUrl: localizeUrl( 'https://en.support.wordpress.com/suspended-blogs/' ),
 		},
 		NON_ADMIN_USER: {
-			title: translate( 'Site owned by a different user' ),
+			title: translate( 'Site owner only' ),
 			description: translate( 'Only the site owner can use this feature.' ),
 			supportUrl: localizeUrl( 'https://en.support.wordpress.com/user-roles/' ),
 		},
 		NOT_DOMAIN_OWNER: {
-			title: translate( 'Domain owned by a different user' ),
+			title: translate( 'Domain owner only' ),
 			description: translate(
-				'The primary domain is owned by a different user. Change the primary domain, or contact support to transfer the primary domain to yourself to clear this issue.'
+				'The primary domain on this site is owned by a different user. Change the primary domain to one that you own, or contact support to have this domain transferred to you.'
 			),
 			supportUrl: localizeUrl( 'https://en.support.wordpress.com/domains/' ),
 		},
 		NO_WPCOM_NAMESERVERS: {
-			title: translate( 'Domain should use WordPress.com name servers' ),
+			title: translate( 'Domain not using WordPress.com name servers' ),
 			description: translate(
-				'Set your domain to use WordPress.com name servers to clear this issue. Contact your domain provider for more information about changing name servers.'
+				"This domain is not using WordPress.com name servers, so it's not pointing to your site. Change your name servers over at your domain provider's. If you're not sure how to do that, contact them for help."
 			),
 			supportUrl:
 				'https://en.support.wordpress.com/domains/map-existing-domain/' +
 				'#2-ask-your-domain-provider-to-update-your-dns-settings',
 		},
 		NOT_RESOLVING_TO_WPCOM: {
-			title: translate( 'Domain should point to WordPress.com' ),
+			title: translate( 'Domain pointing to a different site' ),
 			description: translate(
-				"Your domain is not pointing to your WordPress.com site. Reset your domain's A records to clear this issue."
+				"Your domain is not properly set up to point to your site. Reset your domain's A records in the Domains section to fix this."
 			),
 			supportUrl: localizeUrl(
 				'https://en.support.wordpress.com/move-domain/setting-custom-a-records/'
@@ -80,19 +82,19 @@ function getHoldMessages( siteSlug, translate ) {
 		NO_SSL_CERTIFICATE: {
 			title: translate( 'Certificate installation in progress' ),
 			description: translate(
-				'We are setting up a digital certificate to allow secure browsing on your site using "HTTPS". Please try again in a few minutes.'
+				'Hold tight! We are setting up a digital certificate to allow secure browsing on your site, using "HTTPS". Please try again in a few minutes.'
 			),
 		},
 		EMAIL_UNVERIFIED: {
 			title: translate( 'Confirm your email address' ),
 			description: translate(
-				'We sent you a link to confirm your email address when you signed up. Check your email and click the link to confirm your address and clear this issue.'
+				"Check your email for a message we sent you when you signed up. Click the link inside to confirm your email address. You may have to check your email client's spam folder."
 			),
 		},
 		EXCESSIVE_DISK_SPACE: {
 			title: translate( 'Upload not available' ),
 			description: translate(
-				'This site is not currently eligible for installing themes and plugins. Please contact support to clear this issue.'
+				'This site is not currently eligible to install themes and plugins. Please contact our support team for help.'
 			),
 			supportUrl: localizeUrl( 'https://wordpress.com/help/contact' ),
 		},

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -144,7 +144,7 @@ export const HoldList = ( { holds, isPlaceholder, siteSlug, translate } ) => {
 										href={ holdMessages[ hold ].supportUrl }
 										rel="noopener noreferrer"
 									>
-										{ translate( 'Learn More' ) }
+										{ translate( 'Help' ) }
 									</Button>
 								</div>
 							) }

--- a/client/blocks/eligibility-warnings/hold-list.jsx
+++ b/client/blocks/eligibility-warnings/hold-list.jsx
@@ -23,80 +23,78 @@ function getHoldMessages( siteSlug, translate ) {
 	return {
 		TRANSFER_ALREADY_EXISTS: {
 			title: translate( 'Installation in progress' ),
-			description: translate(
-				'Please wait for the other installation to complete, then try again.'
-			),
-			supportUrl: localizeUrl( 'https://wordpress.com/help' ),
+			description: translate( 'Please wait for installation to complete and try again.' ),
 		},
 		NO_JETPACK_SITES: {
-			title: translate( 'Jetpack site not supported' ),
+			title: translate( 'Not available for Jetpack sites' ),
 			description: translate( 'Try using a different site.' ),
 		},
 		NO_VIP_SITES: {
-			title: translate( 'VIP site not supported' ),
+			title: translate( 'Not available for VIP sites' ),
 			description: translate( 'Try using a different site.' ),
 		},
 		SITE_PRIVATE: {
-			title: translate( 'Private site not supported' ),
-			description: translate( 'Make your site public or hidden to resolve.' ),
-			supportUrl: localizeUrl( `/settings/general/${ siteSlug }` ),
+			title: translate( 'Public site needed' ),
+			description: translate(
+				'Change your site\'s Privacy settings to "Public" or "Hidden" (not "Private") to clear this issue.'
+			),
+			supportUrl: localizeUrl( 'https://en.support.wordpress.com/settings/privacy-settings/' ),
 		},
 		SITE_GRAYLISTED: {
-			title: translate( 'Flagged site not supported' ),
-			description: translate( "Contact us to review your site's standing to resolve." ),
+			title: translate( 'Ongoing site dispute' ),
+			description: translate(
+				"Contact us to review your site's standing and resolve the dispute to clear this issue."
+			),
 			supportUrl: localizeUrl( 'https://en.support.wordpress.com/suspended-blogs/' ),
 		},
 		NON_ADMIN_USER: {
-			title: translate( 'Site owner access required' ),
-			description: translate( 'Only site owners are allowed to use this feature.' ),
+			title: translate( 'Site owned by a different user' ),
+			description: translate( 'Only the site owner can use this feature.' ),
 			supportUrl: localizeUrl( 'https://en.support.wordpress.com/user-roles/' ),
 		},
 		NOT_DOMAIN_OWNER: {
-			title: translate( 'Not a custom domain owner' ),
+			title: translate( 'Domain owned by a different user' ),
 			description: translate(
-				'You must be the owner of the primary domain subscription to use this feature.'
+				'The primary domain is owned by a different user. Change the primary domain, or contact support to transfer the primary domain to yourself to clear this issue.'
 			),
 			supportUrl: localizeUrl( 'https://en.support.wordpress.com/domains/' ),
 		},
 		NO_WPCOM_NAMESERVERS: {
-			title: translate( 'Domain not using WordPress.com name servers' ),
+			title: translate( 'Domain should use WordPress.com name servers' ),
 			description: translate(
-				'Your domain must use WordPress.com name servers to support custom code. ' +
-					'Ask your domain provider to update your DNS settings.'
+				'Set your domain to use WordPress.com name servers to clear this issue. Contact your domain provider for more information about changing name servers.'
 			),
 			supportUrl:
 				'https://en.support.wordpress.com/domains/map-existing-domain/' +
 				'#2-ask-your-domain-provider-to-update-your-dns-settings',
 		},
 		NOT_RESOLVING_TO_WPCOM: {
-			title: translate( 'Domain not pointing to WordPress.com servers' ),
+			title: translate( 'Domain should point to WordPress.com' ),
 			description: translate(
-				'We cannot manage your site because your domain does not point to WordPress.com servers. ' +
-					"Follow the instructions to reset your domain's A records to resolve this."
+				"Your domain is not pointing to your WordPress.com site. Reset your domain's A records to clear this issue."
 			),
 			supportUrl: localizeUrl(
 				'https://en.support.wordpress.com/move-domain/setting-custom-a-records/'
 			),
 		},
 		NO_SSL_CERTIFICATE: {
-			title: translate( 'Security certificate required' ),
+			title: translate( 'Certificate installation in progress' ),
 			description: translate(
-				'We are setting up a security certificate for your domain now. Please try again in a few minutes.'
+				'We are setting up a digital certificate to allow secure browsing on your site using "HTTPS". Please try again in a few minutes.'
 			),
 		},
 		EMAIL_UNVERIFIED: {
-			title: translate( 'Unconfirmed email' ),
+			title: translate( 'Confirm your email address' ),
 			description: translate(
-				'You must have verified your email address with WordPress.com to install custom code. ' +
-					'Please check your email to confirm your address.'
+				'We sent you a link to confirm your email address when you signed up. Check your email and click the link to confirm your address and clear this issue.'
 			),
 		},
 		EXCESSIVE_DISK_SPACE: {
-			title: translate( "We can't proceed with this upload" ),
+			title: translate( 'Upload not available' ),
 			description: translate(
-				'This site is not currently eligible for installing themes and plugins. Please contact support to straighten things out.'
+				'This site is not currently eligible for installing themes and plugins. Please contact support to clear this issue.'
 			),
-			supportUrl: localizeUrl( 'https://en.support.wordpress.com/help-support-options/' ),
+			supportUrl: localizeUrl( 'https://wordpress.com/help/contact' ),
 		},
 	};
 }
@@ -144,7 +142,7 @@ export const HoldList = ( { holds, isPlaceholder, siteSlug, translate } ) => {
 										href={ holdMessages[ hold ].supportUrl }
 										rel="noopener noreferrer"
 									>
-										{ translate( 'Resolve' ) }
+										{ translate( 'Learn More' ) }
 									</Button>
 								</div>
 							) }

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -126,11 +126,11 @@ export const EligibilityWarnings = ( {
 
 			<Card className="eligibility-warnings__confirm-box">
 				<div className="eligibility-warnings__confirm-text">
-					{ ! isEligible && translate( 'The errors above must be resolved before proceeding. ' ) }
+					{ ! isEligible && translate( 'Please clear all issues above to proceed.' ) }
 					{ isEligible &&
 						warnings.length > 0 &&
 						translate( 'If you proceed you will no longer be able to use these features. ' ) }
-					{ translate( 'Have questions? Please {{a}}contact support{{/a}}.', {
+					{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
 						components: {
 							a: (
 								<a


### PR DESCRIPTION
This PR updates copy on the eligibility holds screen – the screen we show when there are blockers to convert a site to Atomic. 

The copy changes focus on reducing jargon and maintaining consistency. This table summarizes all changed strings:

| Before                                                       | After                                                        |
| ------------------------------------------------------------ | ------------------------------------------------------------ |
| The errors above must be resolved before proceeding. Have questions? Please contact support. | Please clear all the above issues to proceed. Questions? [Contact support](#) for help. |
| **Installation in progress**<br/>Please wait for the other installation to complete, then try again.<br/>https://wordpress.com/help | **Installation in progress**<br/>Just a minute! Please wait until the installation is finished, then try again.<br/>(no link) |
| **Jetpack site not supported**<br/>Try using a different site.<br/>(no link) | **Not available for Jetpack sites**<br/>Try using a different site.<br/>(no link) |
| **VIP site not supported**<br/>Try using a different site.<br/>(no link) | **Not available for VIP sites**<br/>Try using a different site.<br/>(no link) |
| **Private site not supported**<br/>Make your site public or hidden to resolve.<br/>/settings/general/${ siteSlug } | **Public site needed**<br/>Change your site's Privacy settings to "Public" or "Hidden" (not "Private") to clear this issue.<br/>https://en.support.wordpress.com/settings/privacy-settings/ |
| **Flagged site not supported**<br/>Contact us to review your site's standing to resolve.<br/>https://en.support.wordpress.com/suspended-blogs/ | **Ongoing site dispute**<br/>Contact us to review your site's standing and resolve the dispute.<br/>https://en.support.wordpress.com/suspended-blogs/ |
| **Site owner access required**<br/>Only site owners are allowed to use this feature.<br/>https://en.support.wordpress.com/user-roles/ | **Site owner only**<br/>Only the site owner can use this feature.<br/>https://en.support.wordpress.com/user-roles/ |
| **Not a custom domain owner**<br/>You must be the owner of the primary domain subscription to use this feature.<br/>https://en.support.wordpress.com/domains/ | **Domain owner only**<br/>The primary domain on this site is owned by a different user. Change the primary domain to one that you own, or contact support to have this domain transferred to you.<br/>https://en.support.wordpress.com/domains/ |
| **Domain not using WordPress.com name servers**<br/>Your domain must use WordPress.com name servers to support custom code. Ask your domain provider to update your DNS settings.<br/>https://en.support.wordpress.com/domains/map-existing-domain/#2-ask-your-domain-provider-to-update-your-dns-settings | **Domain should use WordPress.com name servers**<br/>This domain is not using WordPress.com name servers, so it\'s not pointing to your site. Change your name servers over at your domain provider\'s. If you\'re not sure how to do that, contact them for help.<br/>https://en.support.wordpress.com/domains/map-existing-domain/#2-ask-your-domain-provider-to-update-your-dns-settings |
| **Domain not pointing to WordPress.com servers**<br/>We cannot manage your site because your domain does not point to WordPress.com servers. Follow the instructions to reset your domain's A records to resolve this.<br/>https://en.support.wordpress.com/move-domain/setting-custom-a-records/ | **Domain pointing to a different site**<br/>Your domain is not properly set up to point to your site. Reset your domain's A records in the Domains section to fix this.<br/>https://en.support.wordpress.com/move-domain/setting-custom-a-records/ |
| **Security certificate required**<br/>We are setting up a security certificate for your domain now. Please try again in a few minutes.<br/>(no link) | **Certificate installation in progress**<br/>Hold tight! We are setting up a digital certificate to allow secure browsing on your site, using "HTTPS". Please try again in a few minutes.<br/>(no link) |
| **Unconfirmed email**<br/>You must have verified your email address with WordPress.com to install custom code. Please check your email to confirm your address.<br/>(no link) | **Confirm your email address**<br/>Check your email for a message we sent you when you signed up. Click the link inside to confirm your email address. You may have to check your email client\'s spam folder.<br/>(no link) |
| **We can't proceed with this upload**<br/>This site is not currently eligible for installing themes and plugins. Please contact support to straighten things out.<br/>https://en.support.wordpress.com/help-support-options/ | **Upload not available**<br/>This site is not currently eligible to install themes and plugins. Please contact our support team for help.<br/>https://wordpress.com/help/contact |

An easy way to get to this screen is to try to upload a plugin on a free (Simple) site. Here's what it looks like now:

![image](https://user-images.githubusercontent.com/426518/59396218-8aef3f00-8d3c-11e9-8474-41a766847a04.png)

Thanks @michelleweber and @obi2020 for humanizing this more.