### PR TITLE
Update tooltip to popover on stats page

### DIFF
--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -6,7 +6,6 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
 import { connect } from 'react-redux';
@@ -14,11 +13,11 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Tooltip from 'components/tooltip';
 import getSiteStatsQueryDate from 'state/selectors/get-site-stats-query-date';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
 import { isAutoRefreshAllowedForQuery } from 'state/stats/lists/utils';
+import InfoPopover from 'components/info-popover';
 
 /**
  * Style dependencies
@@ -129,7 +128,6 @@ class StatsDatePicker extends Component {
 				{ translate( 'Last update: %(time)s', {
 					args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
 				} ) }
-				<Gridicon icon="info-outline" size={ 18 } />
 			</span>
 		);
 	}
@@ -179,23 +177,11 @@ class StatsDatePicker extends Component {
 					<div className="stats-section-title">
 						<h3>{ sectionTitle }</h3>
 						{ showQueryDate && isAutoRefreshAllowedForQuery( query ) && (
-							<div
-								className="stats-date-picker__refresh-status"
-								ref={ this.bindStatusIndicator }
-								onMouseEnter={ this.showTooltip }
-								onMouseLeave={ this.hideTooltip }
-							>
-								<span className="stats-date-picker__update-date">
-									{ this.renderQueryDate() }
-									<Tooltip
-										isVisible={ this.state.isTooltipVisible }
-										onClose={ this.hideTooltip }
-										position="bottom"
-										context={ this.statusIndicator }
-									>
-										{ translate( 'Auto-refreshing every 30 minutes' ) }
-									</Tooltip>
-								</span>
+							<div className="stats-date-picker__refresh-status">
+								<span className="stats-date-picker__update-date">{ this.renderQueryDate() }</span>
+								<InfoPopover position="bottom right">
+									{ translate( 'Auto-refreshing every 30 minutes' ) }
+								</InfoPopover>
 							</div>
 						) }
 					</div>

--- a/client/my-sites/stats/stats-date-picker/style.scss
+++ b/client/my-sites/stats/stats-date-picker/style.scss
@@ -1,14 +1,14 @@
 .stats-date-picker__refresh-status {
 	line-height: 16px;
 
+	.info-popover {
+			margin-left: 6px;
+			position: relative;
+			top: 3px;
+
 	.stats-date-picker__update-date {
 		color: var( --color-neutral-light );
 		display: inline-block;
 		font-size: 13px;
-
-		.gridicon {
-			padding: 0 5px;
-			vertical-align: bottom;
-		}
 	}
 }


### PR DESCRIPTION
## The issue

URL: https://wordpress.com/stats/day/testingground728.blog

On the stats page of Calypso we have a tooltip that uses a hover instead of select action.

I saw that another page uses a different method that seems to be a better pattern. My guess is this was created later on.

Comparison popover can be seen on: https://wordpress.com/settings/general/testingground728.blog

Updated CSS and code to bring the new popover design into the stats page.

## Screenshots

**Before:**
<img width="1552" alt="Before" src="https://user-images.githubusercontent.com/3411173/59392153-7ce4f280-8d2b-11e9-87d0-0231eec1dc48.png">

**After:**
<img width="1552" alt="After" src="https://user-images.githubusercontent.com/3411173/59392156-840c0080-8d2b-11e9-8998-e7fcc9098b42.png">

**Comparison on another page:**
<img width="1552" alt="Comparison" src="https://user-images.githubusercontent.com/3411173/59392164-8a01e180-8d2b-11e9-84f3-705acd716122.png">

Related to this issue: https://github.com/Automattic/wp-calypso/issues/33831