### PR TITLE
Change the mobile promo copy

### DIFF
--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -46,7 +46,7 @@ const getRandomPromo = () => {
 		},
 		{
 			promoCode: 'a0006',
-			message: 'WordPress.com in the palm of your hands — download app for mobile.',
+			message: 'WordPress.com in the palm of your hands — download the mobile app.',
 			type: 'mobile',
 		},
 	];


### PR DESCRIPTION
Slight change from robotic copy: download app for mobile, to: download the mobile app.

Fixes #33290

*

#### Testing instructions

<!--
I was not able to reproduce the issue.
-->

*


