### PR TITLE
Stats Date Picker - removed tooltip and made text always visible

### DIFF
--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -6,7 +6,6 @@
 
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
 import { connect } from 'react-redux';
@@ -14,7 +13,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Tooltip from 'components/tooltip';
 import getSiteStatsQueryDate from 'state/selectors/get-site-stats-query-date';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isRequestingSiteStatsForQuery } from 'state/stats/lists/selectors';
@@ -126,10 +124,12 @@ class StatsDatePicker extends Component {
 		const isToday = today.isSame( date, 'day' );
 		return (
 			<span>
-				{ translate( 'Last update: %(time)s', {
+				{ translate( '{{b}}Last update: %(time)s{{/b}} (Refreshes every 30 minutes)', {
 					args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
+					components: {
+						b: <span className="stats-date-picker__last-update" />,
+					},
 				} ) }
-				<Gridicon icon="info-outline" size={ 18 } />
 			</span>
 		);
 	}
@@ -179,23 +179,8 @@ class StatsDatePicker extends Component {
 					<div className="stats-section-title">
 						<h3>{ sectionTitle }</h3>
 						{ showQueryDate && isAutoRefreshAllowedForQuery( query ) && (
-							<div
-								className="stats-date-picker__refresh-status"
-								ref={ this.bindStatusIndicator }
-								onMouseEnter={ this.showTooltip }
-								onMouseLeave={ this.hideTooltip }
-							>
-								<span className="stats-date-picker__update-date">
-									{ this.renderQueryDate() }
-									<Tooltip
-										isVisible={ this.state.isTooltipVisible }
-										onClose={ this.hideTooltip }
-										position="bottom"
-										context={ this.statusIndicator }
-									>
-										{ translate( 'Auto-refreshing every 30 minutes' ) }
-									</Tooltip>
-								</span>
+							<div className="stats-date-picker__refresh-status">
+								<span className="stats-date-picker__update-date">{ this.renderQueryDate() }</span>
 							</div>
 						) }
 					</div>

--- a/client/my-sites/stats/stats-date-picker/index.jsx
+++ b/client/my-sites/stats/stats-date-picker/index.jsx
@@ -124,7 +124,7 @@ class StatsDatePicker extends Component {
 		const isToday = today.isSame( date, 'day' );
 		return (
 			<span>
-				{ translate( '{{b}}Last update: %(time)s{{/b}} (Refreshes every 30 minutes)', {
+				{ translate( '{{b}}Last update: %(time)s{{/b}} (Updates every 30 minutes)', {
 					args: { time: isToday ? date.format( 'LT' ) : date.fromNow() },
 					components: {
 						b: <span className="stats-date-picker__last-update" />,

--- a/client/my-sites/stats/stats-date-picker/style.scss
+++ b/client/my-sites/stats/stats-date-picker/style.scss
@@ -2,7 +2,7 @@
 	line-height: 16px;
 
 	.stats-date-picker__update-date {
-		color: var( --color-neutral-light );
+		color: var( --color-text-subtle );
 		display: inline-block;
 		font-size: 13px;
 
@@ -11,4 +11,8 @@
 			vertical-align: bottom;
 		}
 	}
+}
+
+.stats-date-picker__last-update {
+	color: var( --color-neutral-700 );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes tooltip
* Migrates the tooltip text next to the "Last Updated" text

#### Testing instructions
* Go to `https://wordpress.com/stats/day/YOURSITE`

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Before
![image](https://user-images.githubusercontent.com/1123119/59392736-90915880-8d2d-11e9-9d5c-cd88ade4c1c7.png)

#### After
![image](https://user-images.githubusercontent.com/1123119/59392726-896a4a80-8d2d-11e9-8695-03276509458a.png)


Fixes #33831 