### PR TITLE
Signup: Remove invalid site_type parameter from verticals request

### DIFF
--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -28,7 +28,7 @@ export const requestVerticals = action =>
 			path: '/verticals',
 			query: {
 				search: action.search.trim(),
-				...( action.siteTypeId ? { site_type: action.siteTypeId } : {} ),
+				...( action.siteTypeId && { site_type: action.siteTypeId } ),
 				limit: action.limit,
 				include_preview: true,
 			},

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -18,6 +18,8 @@ import { setVerticals } from 'state/signup/verticals/actions';
 import { SIGNUP_VERTICALS_REQUEST } from 'state/action-types';
 import { getSiteTypeId } from 'state/signup/steps/site-type/selectors';
 
+// Some flows do not choose a site type before requesting verticals. In this
+// case don't send a site_type param to the API.
 export const requestVerticals = action =>
 	http(
 		{
@@ -26,7 +28,7 @@ export const requestVerticals = action =>
 			path: '/verticals',
 			query: {
 				search: action.search.trim(),
-				site_type: action.siteTypeId,
+				...( action.siteTypeId ? { site_type: action.siteTypeId } : {} ),
 				limit: action.limit,
 				include_preview: true,
 			},

--- a/client/state/data-layer/wpcom/signup/verticals/test/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/test/index.js
@@ -34,6 +34,15 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 		);
 	} );
 
+	test( 'requestVerticals() with missing siteTypeId', () => {
+		const mockAction = {
+			search: 'Foo',
+			limit: 7,
+		};
+
+		expect( requestVerticals( mockAction ) ).not.toHaveProperty( 'query.site_type' );
+	} );
+
 	test( 'storeVerticals()', () => {
 		const search = 'Profit!';
 		const siteType = 'business';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some flows do not choose a site type before requesting verticals from the API (e.g. 'desktop'). If the site type hasn't been choosen then don't send the site_type parameter as part of the request. The server can then choose how it wants to deal with this case (it happens to default to `site_type=1`).

On a side note: its always sending the `include_preview=true` parameter even though afaik that data isn't being used. Seems like something else we could tidy up.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/start/desktop`
* Type something in the topic field
* Confirm in network tab that `/wpcom/v2/verticals` responds with valid vertical information, not an error
* Confirm that no error notification appears in the top right like this:
<img width="1198" alt="image" src="https://user-images.githubusercontent.com/1500769/59400940-2b04a100-8ded-11e9-95ca-956c51c9eeeb.png">
