### PR TITLE
Store [mobile]: Shipping costs input field is displayed outside input box

### DIFF
--- a/client/extensions/woocommerce/app/order/order-details/row-total.js
+++ b/client/extensions/woocommerce/app/order/order-details/row-total.js
@@ -59,6 +59,7 @@ class OrderTotalRow extends Component {
 						onChange={ onChange }
 						initialValue={ initialValue }
 						value={ total }
+						noWrap="true"
 					/>
 				</TableItem>
 			</TableRow>

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -95,6 +95,10 @@
 
 	& + .form-setting-explanation {
 		padding-right: 55px;
+
+		@include breakpoint( '<660px' ) {
+			padding-right: 0;
+		}
 	}
 
 	.table-row {
@@ -184,6 +188,10 @@
 			// Increase width for PriceInput
 			width: 13em;
 			padding-right: 79px;
+
+			@include breakpoint( '<660px' ) {
+				padding-right: 24px;
+			}
 		}
 
 		.form-text-input-with-affixes {


### PR DESCRIPTION
fix issue 33849

#### Changes proposed in this Pull Request
On mobile, the shipping costs input field is displayed outside of its container, overlapping on the "Total" row and making it seems like they are the same line.

## Before
<img width="276" alt="Screen Shot 2019-06-12 at 2 52 06 PM" src="https://user-images.githubusercontent.com/28450084/59392801-da7a3e80-8d2d-11e9-86c5-b7c6a39c2a09.png">

##After
<img width="279" alt="Screen Shot 2019-06-12 at 4 16 09 PM" src="https://user-images.githubusercontent.com/28450084/59392812-e1a14c80-8d2d-11e9-9eea-d04a6a067878.png">


#### Testing instructions
On mobile
Create a site on a Business plan
Install a plugin
Navigate to Store
Navigate to "Orders"
Select "Add new order"

Fixes #33849
