### PR TITLE
Simplifies the masterbar so that it is hidden on the checkout pages.

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -193,14 +193,13 @@ export default connect( state => {
 	const siteId = getSelectedSiteId( state );
 	const isJetpackLogin = currentRoute === '/log-in/jetpack';
 	const isJetpack = isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId );
-	const noMasterbarForCheckout = isJetpack && startsWith( currentRoute, '/checkout' );
+	const noMasterbarForCheckout = startsWith( currentRoute, '/checkout' );
 	const noMasterbarForRoute = isJetpackLogin || noMasterbarForCheckout;
 	const noMasterbarForSection = 'signup' === sectionName || 'jetpack-connect' === sectionName;
 	const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
 	const isJetpackWooCommerceFlow =
 		'jetpack-connect' === sectionName &&
 		'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' );
-
 	return {
 		masterbarIsHidden:
 			! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,


### PR DESCRIPTION
## Changes proposed in this Pull Request

Simplifies the masterbar for the checkout pages to be hidden. This includes it being hidden for the Thank You page as well.

The issue initially wanted to remove the masterbar only for the eCommerce plan, but after consulting with @scruffian we found that it would make more sense to remove it for the checkout pages for all cases.

### Before

![](https://user-images.githubusercontent.com/2124984/58972702-22c4ba00-878c-11e9-84e8-531c9530bfee.png)

### After

![](https://cldup.com/TUORHSYeDO.png)

#### Testing instructions

- Sign up for a new plan, and proceed to the Checkout page.
- You should no longer see the masterbar on the checkout page.
- Once completing the purchase, the thank you page should load without the masterbar being present.

Fixes #33038
