### PR TITLE
Search: Fix SectionNav Search component height

### DIFF
--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -399,6 +399,10 @@
 	}
 
 	.search.is-expanded-to-container {
-		height: 50px;
+		height: 46px;
+
+		@include breakpoint ( '>660px' ) {
+			height: 50px;
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While fixing: https://github.com/Automattic/wp-calypso/pull/33905, we noticed that the if the `SectionNav` has a Search feature, it has a white background that sticks out of the component:
