### PR TITLE
Magic Login: Make sure the "Email me a login link" form looks like the "Log in to your account" login form

### DIFF
--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -27,8 +27,20 @@
 		margin-bottom: 0;
 	}
 
-	.logged-out-form p {
-		margin-bottom: 20px;
+	.logged-out-form {
+		border-radius: 0;
+		box-shadow: 0 0 0 1px var( --color-border-subtle );
+		margin: 0 auto;
+		max-width: 400px;
+		padding: 16px;
+
+		@include breakpoint( '>480px' ) {
+			padding: 24px;
+		}
+
+		p {
+			margin-bottom: 20px;
+		}
 	}
 }
 
@@ -74,6 +86,7 @@
 		font-size: 14px;
 		font-weight: 500;
 		padding: 0 24px;
+		text-align: center;
 		text-decoration: none;
 
 		&:hover {

--- a/client/login/magic-login/style.scss
+++ b/client/login/magic-login/style.scss
@@ -56,7 +56,7 @@
 }
 
 .magic-login__email-fields {
-	margin: 10px 0;
+	margin: 0;
 }
 
 .magic-login__form-label {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* Update the card style
* Add a breakpoint for the paddings
* Make sure links in the footer are centered

#### Testing instructions

* Go to https://wordpress.com/log-in/link
* It should look similar to https://wordpress.com/log-in/

__Before:__

<img width="414" alt="Screenshot 2019-06-12 at 16 39 04" src="https://user-images.githubusercontent.com/177929/59393486-bcfaa400-8d30-11e9-8dff-6a55c1ac0fa7.png">

__After:__

<img width="529" alt="Screenshot 2019-06-12 at 16 35 51" src="https://user-images.githubusercontent.com/177929/59393504-c84dcf80-8d30-11e9-86a6-c7ea4bc6f4f7.png">


Fixes #33915 
