### PR TITLE
fixing jetpack checklist spelling error

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
@@ -72,7 +72,7 @@ export const JETPACK_PERFORMANCE_CHECKLIST_TASKS: Readonly< ChecklistTasksetUi >
 	jetpack_site_accelerator: {
 		title: translate( 'Site Accelerator' ),
 		description: translate(
-			'Serve your images and static files through our global CDN and whatch your page load time drop.'
+			'Serve your images and static files through our global CDN and watch your page load time drop.'
 		),
 		getUrl: siteSlug => `/settings/performance/${ siteSlug }`,
 		completedButtonText: translate( 'Configure' ),


### PR DESCRIPTION
Fixes: https://github.com/Automattic/wp-calypso/issues/33929

The site accelerator task says "whatch" instead of "watch" in the description.



Before:
<img width="1130" alt="Screen Shot 2019-06-12 at 4 46 07 PM" src="https://user-images.githubusercontent.com/214813/59393987-cc7aec80-8d32-11e9-9fb0-f170c938de3f.png">



After:

<img width="1132" alt="Screen Shot 2019-06-12 at 4 54 31 PM" src="https://user-images.githubusercontent.com/214813/59393976-c7b63880-8d32-11e9-8adf-0dd8a82d9042.png">
