### PR TITLE
Centered Plans Cost Per Month Text

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -857,10 +857,10 @@ body.is-section-signup #primary .segmented-control.is-customer-type-toggle {
 	}
 
 	.plan-features__header-billing-info {
-		display: flex;
+		display: block;
 		color: var( --color-text-subtle );
 		align-items: center;
-		text-align: initial;
+		text-align: center;
 	}
 
 	.plan-features__pricing {


### PR DESCRIPTION
Before:
<img width="1598" alt="image" src="https://user-images.githubusercontent.com/7773109/59393072-d864af80-8d2e-11e9-817b-b30eec63899b.png">

After:
<img width="1620" alt="image" src="https://user-images.githubusercontent.com/7773109/59394004-e6b4ca80-8d32-11e9-8404-c99714c55be7.png">


#### Steps to reproduce
1. walk through signup process until you get to pick a plan

#### What I expected

Centered price + text + button

#### What happened instead

Centered price + button but not text

#### Browser / OS version

Any/All

#### Screenshot / Video

See the "X per month billed annually" text is left-justified which looks weird with the text above and the buttons below. Should be centered.

<img width="1598" alt="image" src="https://user-images.githubusercontent.com/7773109/59393072-d864af80-8d2e-11e9-817b-b30eec63899b.png">
