### PR TITLE
Remove Google+ from Store social share

### DIFF
--- a/client/extensions/woocommerce/components/share-widget/index.js
+++ b/client/extensions/woocommerce/components/share-widget/index.js
@@ -50,17 +50,6 @@ class ShareWidget extends Component {
 				},
 			},
 			{
-				icon: 'google-plus',
-				urlProperties: {
-					scheme: 'https',
-					hostname: 'plus.google.com',
-					pathname: '/share',
-					query: {
-						url: urlToShare,
-					},
-				},
-			},
-			{
 				icon: 'linkedin',
 				urlProperties: {
 					scheme: 'https',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*Removes Google+ icon/option in the Store dashboard social share card.

![https://cld.wthms.co/GzcEJV+](https://cld.wthms.co/GzcEJV+)
Direct Link: https://cld.wthms.co/GzcEJV 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*Go to Store dashboard, requires setup checklist to be complete. 
https://wordpress.com/store/yourteststore.com

Google+ option should no longer be there: 
![https://cld.wthms.co/xpBZkX+](https://cld.wthms.co/xpBZkX+)
Direct Link: https://cld.wthms.co/xpBZkX 

Fixes #33927 
