### PR TITLE
Updating info-popover icon to accessible color

### DIFF
--- a/client/components/info-popover/style.scss
+++ b/client/components/info-popover/style.scss
@@ -1,7 +1,7 @@
 .info-popover {
 	.gridicon {
 		cursor: pointer;
-		color: var( --color-neutral-200 );
+		color: var( --color-text-subtle );
 	}
 
 	.accessible-focus &:focus,


### PR DESCRIPTION
Thanks to @michaelarestad and @sixhours for help on this!

The info icon for infopopover wasn't an accessible color, so we've switched it to color-text-subtle. It may make sense to do another color, but it's a good start since this is a Calypso color currently approved for text.

## Before

![Before](https://user-images.githubusercontent.com/3411173/59394172-a0ac3680-8d33-11e9-991d-4170ee7906af.png)

## After

![After](https://user-images.githubusercontent.com/3411173/59394183-a570ea80-8d33-11e9-8838-a6065f9b5351.png)
