### PR TITLE
Me: Fix chevron alignment in Notifications

### DIFF
--- a/client/me/notification-settings/blogs-settings/style.scss
+++ b/client/me/notification-settings/blogs-settings/style.scss
@@ -37,13 +37,11 @@
 }
 
 .blogs-settings__header-expand {
-	@extend %notification-settings-blog-settings-flexbox;
-	display: none;
-	color: var( --color-neutral-0 );
+	position: relative;
+		top: 4px;
 
-	@include breakpoint( '>480px' ) {
-		display: flex;
-	}
+	@extend %notification-settings-blog-settings-flexbox;
+	color: var( --color-neutral-0 );
 }
 
 .notification-settings-blog-settings-placeholder__blog {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes: https://github.com/Automattic/wp-calypso/issues/33682

1. Align chevron icon to its label
2. Display chevron icon on mobile. It's currently hidden making it less obvious that this element is clickable.

#### Testing instructions

1. Go to: http://calypso.localhost:3000/me/notifications
2. Make sure the chevron icon is aligned with its label (all notifications)
3. Make sure chevron icon is displayed on mobile

**Before:**
<img width="738" alt="Screenshot 2019-06-12 17 06 07" src="https://user-images.githubusercontent.com/4924246/59394394-65f6ce00-8d34-11e9-97d4-c37ffd207630.png">
<img width="398" alt="Screenshot 2019-06-12 17 06 40" src="https://user-images.githubusercontent.com/4924246/59394410-7444ea00-8d34-11e9-86db-97c8a2c2625b.png">

**After:**
<img width="735" alt="Screenshot 2019-06-12 17 07 04" src="https://user-images.githubusercontent.com/4924246/59394450-8e7ec800-8d34-11e9-9bb9-d132c87303ed.png">
<img width="394" alt="Screenshot 2019-06-12 17 07 23" src="https://user-images.githubusercontent.com/4924246/59394459-92124f00-8d34-11e9-8fb8-551781d0533e.png">

