### PR TITLE
Signup: Add a "Start with theme" option to the logged-out Theme Showcase

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -289,6 +289,7 @@ class ThemeSheet extends React.Component {
 
 		const { siteSlug, id } = this.props;
 		const sitePart = siteSlug ? `/${ siteSlug }` : '';
+		const themeSignupOptions = this.props.options.signup;
 
 		const nav = (
 			<NavTabs label="Details">
@@ -301,6 +302,13 @@ class ThemeSheet extends React.Component {
 						{ filterStrings[ section ] }
 					</NavItem>
 				) ) }
+				{ this.props.isLoggedIn && this.isLoaded() && (
+					<NavItem
+						path={ themeSignupOptions.getUrl ? themeSignupOptions.getUrl( this.props.id ) : null }
+					>
+						{ themeSignupOptions.label }
+					</NavItem>
+				) }
 				{ this.shouldRenderPreviewButton() ? (
 					<NavItem
 						path={ this.props.demo_uri }

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -142,7 +142,7 @@ const preview = {
 	action: themePreview,
 };
 
-const signupLabel = i18n.translate( 'Pick this design', {
+const signupLabel = i18n.translate( 'Start with this design', {
 	comment: 'when signing up for a WordPress.com account with a selected theme',
 } );
 
@@ -150,7 +150,7 @@ const signup = {
 	label: signupLabel,
 	extendedLabel: signupLabel,
 	getUrl: getThemeSignupUrl,
-	hideForTheme: state => getCurrentUser( state ),
+	hideForTheme: false,
 };
 
 const separator = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds a "Start with [theme]" option to the showcase.

#### Testing instructions

* Open the theme showcase when logged out:
* http://calypso.localhost:3000/themes - check that the "Pick this design" option is now "Start with this design"
<img width="739" alt="Screenshot 2019-06-12 at 18 16 59" src="https://user-images.githubusercontent.com/275961/59396600-672cf880-8d3e-11e9-8bc7-ccc7613745fd.png">

* http://calypso.localhost:3000/theme/calm-business - check that the "Pick this design" option is now "Start with this design"
<img width="427" alt="Screenshot 2019-06-12 at 18 17 13" src="https://user-images.githubusercontent.com/275961/59396590-5da39080-8d3e-11e9-9ccf-03a1967e9a2b.png">

Now do the same when logged in:
* http://calypso.localhost:3000/themes - check that the "Start with this design" option is still present
<img width="390" alt="Screenshot 2019-06-12 at 18 16 47" src="https://user-images.githubusercontent.com/275961/59396614-72802400-8d3e-11e9-9d60-743b4743a530.png">

* http://calypso.localhost:3000/theme/calm-business - check that the "Start with this design" option is now present in the Nav bar
<img width="769" alt="Screenshot 2019-06-12 at 18 16 39" src="https://user-images.githubusercontent.com/275961/59396618-790e9b80-8d3e-11e9-9753-923738cf3f40.png">
