### PR TITLE
Update site preview iframe to use Gutenberg v5.9.0 CSS

### DIFF
--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -57,18 +57,18 @@ export function getIframeSource(
 			<link rel="dns-prefetch" href="//s0.wp.com">
 			<link rel="dns-prefetch" href="//fonts.googleapis.com">
 			<title>${ content.title } – ${ content.tagline }</title>
-			<link type="text/css" media="all" rel="stylesheet" href="https://s0.wp.com/wp-content/plugins/gutenberg-core/v5.8.0/build/block-library/style.css" />
+			<link type="text/css" media="all" rel="stylesheet" href="https://s0.wp.com/wp-content/plugins/gutenberg-core/v5.9.0/build/block-library/style.css" />
 			${ getCSSLinkHtml( cssUrl ) }
 			${ getCSSLinkHtml( fontUrl ) }
 			<style type="text/css">
 				body {
 					padding-bottom: 25px;
 				}
-				
+
 				.no-scrolling {
 					overflow: hidden;
 				}
-				
+
 				.is-loading {
 					position: relative;
 					background: white;
@@ -76,18 +76,18 @@ export function getIframeSource(
 				.is-loading .site {
 					opacity: 0;
 				}
-				
+
 				.site {
 					opacity: 1;
 					transition: opacity 1s ease-in;
-				}	
+				}
 
 				@media only screen and (min-width: 768px) {
 					/*
 						Some of the themes (business sophisticated) use js to dynamically set the height of the banner
 						Let's set a fixed max-height.
 					*/
-					.entry .entry-content .wp-block-cover-image, 
+					.entry .entry-content .wp-block-cover-image,
 					.entry .entry-content .wp-block-cover {
 						min-height: 500px !important;
 					}
@@ -95,23 +95,23 @@ export function getIframeSource(
 
 				/*
 					Fixes a weird bug in Safari, despite the markup and CSS
-					being the same, the gallery images for the default Professional site (m4) 
+					being the same, the gallery images for the default Professional site (m4)
 					are stretched. Issue #33758.
 					This should be a temp fix until we can either locate the problem or
 					we update the theme CSS.
 				*/
-				.wp-block-gallery .blocks-gallery-image figure, 
+				.wp-block-gallery .blocks-gallery-image figure,
 				.wp-block-gallery .blocks-gallery-item figure {
 				   flex-direction: column;
 				   height: auto;
 				}
-				
+
 				.is-loading .wp-block-cover,
 				.is-loading img {
 					animation: loading-animation 1.5s infinite;
 					background-color: rgba( 0, 0, 0, 0.1 ) !important;
 				}
-				
+
 				@keyframes loading-animation {
 					0%   { background-color: rgba( 0, 0, 0, 0.7 ); }
 					50%  { background-color: rgba( 0, 0, 0, 1 ); }


### PR DESCRIPTION
This change also cleans up a bit of whitespace, according to our editorconfig rules.

#### Changes proposed in this Pull Request

* Update site preview iframe to use Gutenberg v5.9.0 CSS
* Remove whitespace in `client/components/signup-site-preview/utils.js`.

Note that after upgrading to v5.9.0, we still need our CSS overrides to fix the Flexbox issue in Safari: https://github.com/Automattic/wp-calypso/blob/master/client/components/signup-site-preview/utils.js#L103

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to create a new site at: http://calypso.localhost:3000/start/
* Check that the site preview looks correct for Business and Professional plans across Safari, Firefox, Chrome, IE11. There should be no visual change from v5.8.0.
