### PR TITLE
Signup: Add/signup preview content placeholder parsing

### DIFF
--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -11,7 +11,12 @@ import { debounce } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getIframeSource, isIE, revokeObjectURL } from 'components/signup-site-preview/utils';
+import {
+	getIframeSource,
+	isIE,
+	revokeObjectURL,
+	replaceTemplatePlaceholders,
+} from 'components/signup-site-preview/utils';
 
 export default class SignupSitePreviewIframe extends Component {
 	static propTypes = {
@@ -73,6 +78,11 @@ export default class SignupSitePreviewIframe extends Component {
 			return false;
 		}
 
+		if ( this.props.content.placeholderData !== nextProps.content.placeholderData ) {
+			this.setIframeBodyContent( nextProps.content );
+			return false;
+		}
+
 		if ( this.props.content.body !== nextProps.content.body ) {
 			this.setIframeBodyContent( nextProps.content );
 			return false;
@@ -88,7 +98,7 @@ export default class SignupSitePreviewIframe extends Component {
 		const element = this.iframe.current.contentWindow.document.querySelector( '.entry-content' );
 
 		if ( element ) {
-			element.innerHTML = content.body;
+			element.innerHTML = replaceTemplatePlaceholders( content.body, content.placeholderData );
 			this.props.resize && this.setContainerHeight();
 		}
 	}

--- a/client/components/signup-site-preview/test/utils.js
+++ b/client/components/signup-site-preview/test/utils.js
@@ -1,0 +1,42 @@
+/** @format */
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getCSSLinkHtml, replaceTemplatePlaceholders } from '../utils';
+
+describe( 'utils', () => {
+	describe( 'replaceTemplatePlaceholders()', () => {
+		test( 'should parse placeholders', () => {
+			expect( replaceTemplatePlaceholders( 'Hi, {{Name}}!', { Name: 'Terry' } ) ).toEqual(
+				'Hi, Terry!'
+			);
+			expect( replaceTemplatePlaceholders( 'Hi, {{Name}}!', { Name: '' } ) ).toEqual( 'Hi, !' );
+			expect(
+				replaceTemplatePlaceholders( 'Hi, {{Name}}. {{Name}} is {{Adjective}}!', {
+					Name: 'Terry',
+					Adjective: 'great',
+				} )
+			).toEqual( 'Hi, Terry. Terry is great!' );
+		} );
+		test( 'should return content when content is not a string and placeholder data not an object', () => {
+			expect( replaceTemplatePlaceholders() ).toBeUndefined();
+			expect( replaceTemplatePlaceholders( 123, { Name: 'Terry' } ) ).toEqual( 123 );
+			expect( replaceTemplatePlaceholders( '{{Blah}}', undefined ) ).toEqual( '{{Blah}}' );
+		} );
+	} );
+
+	describe( 'getCSSLinkHtml()', () => {
+		test( 'should return css link markup', () => {
+			expect( getCSSLinkHtml( 'http://a.b.c' ) ).toEqual(
+				'<link type="text/css" media="all" rel="stylesheet" href="http://a.b.c" />'
+			);
+		} );
+		test( 'should return empty string if no url is passed', () => {
+			expect( getCSSLinkHtml() ).toEqual( '' );
+		} );
+	} );
+} );

--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -31,6 +31,31 @@ export function revokeObjectURL( objectUrl ) {
 }
 
 /**
+ * Parses a string and replaces `{{PlaceholderKey}}` with the corresponding values in `placeholderData`.
+ * Usage:
+ *
+ *     replaceTemplatePlaceholders( 'Hi, {{Name}}!', { Name: 'Terry' } ); // returns 'Hi, Terry!
+ *
+ * @param  {String} content         The content containing {{placeholders}}
+ * @param  {Object} placeholderData Placeholder key value pairs
+ * @return {String}                 The parsed content
+ */
+export function replaceTemplatePlaceholders( content, placeholderData ) {
+	if ( 'string' !== typeof content || 'object' !== typeof placeholderData ) {
+		return content;
+	}
+
+	const keys = Object.keys( placeholderData );
+
+	if ( keys.length ) {
+		for ( const key of keys ) {
+			content = content.replace( new RegExp( '{{' + key + '}}', 'gi' ), placeholderData[ key ] );
+		}
+	}
+	return content;
+}
+
+/**
  * Returns a WordPress page shell HTML
  *
  * @param  {Object}  content   Object containing `title`, `tagline` and `body` strings
@@ -135,7 +160,7 @@ export function getIframeSource(
 						<main id="main" class="site-main">
 							<article class="page type-page status-publish hentry entry">
 								<div class="entry-content">
-									${ content.body }
+									${ replaceTemplatePlaceholders( content.body, content.placeholderData ) }
 								</div>
 							</article>
 						</div>

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -132,6 +132,7 @@ class SiteMockups extends Component {
 			title,
 			themeSlug,
 			verticalPreviewContent,
+			verticalSlug,
 		} = this.props;
 
 		const siteMockupClasses = classNames( 'site-mockup__wrap', {
@@ -145,7 +146,9 @@ class SiteMockups extends Component {
 			cssUrl: getThemeCssUri( themeSlug, isRtl ),
 			content: {
 				title,
-				tagline: translate( 'You’ll be able to customize this to your needs.' ),
+				placeholderData: {
+					Vertical: verticalSlug || '',
+				},
 				body: this.getContent( verticalPreviewContent ),
 			},
 			langSlug,

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -17,7 +17,6 @@ import { saveSignupStep } from 'state/signup/progress/actions';
 
 const siteTypeToFlowname = {
 	'online-store': 'ecommerce-onboarding',
-	blog: 'onboarding-blog',
 };
 
 class SiteType extends Component {


### PR DESCRIPTION
## Changes proposed in this Pull Request

The blog annotation returns `{{Vertical}}` in the content body. 

Allowing such unprocessed placeholders to display on the frontend might cause much head-scratching and even minor increases in blood pressure.

This PR enables template parsing, and specifically replaces `{{Vertical}}` with the user's chosen vertical. Where there is no vertical, we replace the placeholder with `''`.

**Before**

<img width="500" alt="Screen Shot 2019-06-13 at 3 17 11 pm" src="https://user-images.githubusercontent.com/6458278/59408800-298ca600-8df8-11e9-91bd-0bed1e5d91ee.png">

**After**
<img width="500" alt="Screen Shot 2019-06-13 at 3 51 52 pm" src="https://user-images.githubusercontent.com/6458278/59408801-298ca600-8df8-11e9-9842-c277e0e4d441.png">

## Dependencies

https://github.com/Automattic/zelda-private/issues/69

## Testing instructions

Apply patch `D29400-code` to get a Blog annotation with a `{{Vertical}}` placeholder.

Sandbox `public-api.wordpress.com`

Comment out `blog: 'onboarding-blog',` in https://github.com/Automattic/wp-calypso/blob/master/client/signup/steps/site-type/index.jsx#L20, e.g., 

```
const siteTypeToFlowname = {
	'online-store': 'ecommerce-onboarding',
	// blog: 'onboarding-blog',
};
```

This ensures that we show the site preview for Blog sites.

Head over to http://calypso.localhost:3000/start/site-type and select **Blog**

`Welcome to my new {{Vertical}} blog` should be `Welcome to my new XYZ blog`, where `XYZ` is the slug of the site topic you have selected!


Check it also doesn't break **Business** or **Professional**. <sub>Pretty please!</sub> 🍰 
