### PR TITLE
Security: Update description on password card

### DIFF
--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -59,8 +59,8 @@ class Security extends React.Component {
 				<Card className="me-security-settings security__settings">
 					<p>
 						{ translate(
-							'To update your password enter a new one below. Your password should be at least six characters long. ' +
-								'To make it stronger, use upper and lower case letters, numbers and symbols like ! " ? $ % ^ & ).'
+							'To update your password enter a new one below. ' +
+								'Strong passwords have at least six characters, and use upper and lower case letters, numbers, and symbols like ! ” ? $ % ^ & ).'
 						) }
 					</p>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes #33293.

Refine Password card description copy to fit on two lines instead of three. 

**Before/After screenshots:**
<img width="1296" alt="Screen Shot 2019-06-13 at 12 19 57 AM" src="https://user-images.githubusercontent.com/204742/59412482-61510a80-8d72-11e9-9059-4bcd87ad9802.png">


**New copy to be used:**
>To update your password enter a new one below. Strong passwords have at least six characters, and use upper and lower case letters, numbers, and symbols like ! ” ? $ % ^ & ).

Pinging @obi2020, @Automattic/editorial, and @MichaelArestad for review.


#### Testing instructions

* Check out this branch
* Go to http://calypso.localhost:3000/me/security 
* Confirm that you see the type fix on the Password card 