### PR TITLE
Jetpack checklist: add checklist tour's meta to config

### DIFF
--- a/client/layout/guided-tours/config.js
+++ b/client/layout/guided-tours/config.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
@@ -22,6 +20,7 @@ import checklistUserAvatar from 'layout/guided-tours/tours/checklist-user-avatar
 import checklistUserEmail from 'layout/guided-tours/tours/checklist-user-email-tour/meta';
 import jetpack from 'layout/guided-tours/tours/jetpack-basic-tour/meta';
 import jetpackBackupsRewind from 'layout/guided-tours/tours/jetpack-backups-rewind-tour/meta';
+import jetpackChecklist from 'layout/guided-tours/tours/jetpack-checklist-tour/meta';
 import jetpackLazyImages from 'layout/guided-tours/tours/jetpack-lazy-images-tour/meta';
 import jetpackMonitoring from 'layout/guided-tours/tours/jetpack-monitoring-tour/meta';
 import jetpackPluginUpdates from 'layout/guided-tours/tours/jetpack-plugin-updates-tour/meta';
@@ -45,6 +44,7 @@ export default {
 	checklistUserEmail,
 	jetpack,
 	jetpackBackupsRewind,
+	jetpackChecklist,
 	jetpackLazyImages,
 	jetpackMonitoring,
 	jetpackPluginUpdates,


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/33373 I added a new tour for Jetpack checklist.

I noticed that meta wasn't imported in the config file for tours. I didn't really dig into yet what this does: the tour is working just fine without this change...

cc @sgomes who might know

#### Changes proposed in this Pull Request

* Pulls `meta.js` of Jetpack checklist tour to tours config


#### Testing instructions

- Have a Jetpack site
- Open `http://calypso.localhost:3000/plans/my-plan/SITE?thank-you`
- Observe the tour popup show up