### PR TITLE
Sharing Preview Pane: CSS Migration

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -13,7 +13,6 @@
 @import 'blocks/nps-survey/style';
 @import 'blocks/login/style';
 @import 'blocks/post-item/style';
-@import 'blocks/sharing-preview-pane/style';
 @import 'blocks/site-address-changer/style';
 @import 'blocks/term-tree-selector/style';
 @import 'blocks/upload-image/style';

--- a/client/blocks/sharing-preview-pane/index.jsx
+++ b/client/blocks/sharing-preview-pane/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -27,6 +25,11 @@ import { getCurrentUserId } from 'state/current-user/selectors';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import getSiteIconUrl from 'state/selectors/get-site-icon-url';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const serviceNames = {
 	facebook: 'Facebook',

--- a/client/blocks/sharing-preview-pane/style.scss
+++ b/client/blocks/sharing-preview-pane/style.scss
@@ -4,10 +4,6 @@
 	width: 100%;
 }
 
-.card.post-share__sharing-preview-modal {
-	padding: 0;
-}
-
 .dialog.card.post-share__sharing-preview-modal {
 	margin: 0 auto;
 	max-width: 865px;
@@ -26,6 +22,7 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	padding: 0;
 }
 
 .post-share__sharing-preview-modal-header {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Just a simple import/migration of the Sharing Preview Pane as part of #27515

#### Testing instructions

1. Visit the posts page on a Business Plan site
2. Click the three dots on the right of a post
3. Click Share
4. Click Preview
5. Verify the styling is identical (except for the fixed padding)

<img width="926" alt="Screenshot 2019-06-13 at 11 03 34" src="https://user-images.githubusercontent.com/43215253/59424007-1d3e2400-8dcb-11e9-9d69-2d954db4bd10.png">

cc @jsnajdr, @blowery, @flootr 