### PR TITLE
Jetpack checklist: Fix some types

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/constants.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { translate } from 'i18n-calypso';
+import { translate, TranslateResult } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,17 +14,17 @@ import { SiteSlug, URL } from 'types';
  * @param  minutes Number of minutes.
  * @return Localized duration.
  */
-export function getJetpackChecklistTaskDuration( minutes: number ): string {
+export function getJetpackChecklistTaskDuration( minutes: number ): TranslateResult {
 	return translate( '%d minute', '%d minutes', { count: minutes, args: [ minutes ] } );
 }
 
 interface TaskUiDescription {
-	readonly title: string;
-	readonly description?: string;
-	readonly completedButtonText: string;
-	readonly completedTitle?: string;
+	readonly title: TranslateResult;
+	readonly description?: TranslateResult;
+	readonly completedButtonText: TranslateResult;
+	readonly completedTitle?: TranslateResult;
 	readonly getUrl: ( siteSlug: SiteSlug, isComplete?: boolean ) => URL;
-	readonly duration?: string;
+	readonly duration?: TranslateResult;
 	readonly tourId?: string;
 }
 

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -3,7 +3,7 @@
  */
 import React, { Fragment, PureComponent, ReactNode } from 'react';
 import { connect } from 'react-redux';
-import { flowRight, get, includes } from 'lodash';
+import { get, includes } from 'lodash';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -303,8 +303,4 @@ const connectComponent = connect(
 	}
 );
 
-export default flowRight(
-	connectComponent,
-	localize,
-	withTrackingTool( 'HotJar' )
-)( JetpackChecklist );
+export default connectComponent( localize( withTrackingTool( 'HotJar' )( JetpackChecklist ) ) );


### PR DESCRIPTION
Fix some type problems.
No functional changes.

#### Testing instructions
* Visit `/plans/my-plan/SITE_SLUG` for a Jetpack site.
* Checklist appears and works as expected.
* [Fewer type errors (79)](https://circleci.com/gh/Automattic/wp-calypso/325886) than [master (113)](https://circleci.com/gh/Automattic/wp-calypso/325817)