### PR TITLE
Retest the Blogger Plan Hide test

### DIFF
--- a/client/lib/abtest/README.md
+++ b/client/lib/abtest/README.md
@@ -34,6 +34,7 @@ There are also several optional configuration settings available:
 
 * `localeTargets` - By default, tests only run on users where the locale is set to English. You can also run for all locales by setting `localeTargets` to 'any', or to an array of a specific locale or locales  `localeTargets: ['de']`
 Don't forget: any test that runs for locales other than English means strings will need to be translated.
+* `localeExceptions` - Allow tests to run for all locales except the specified. `localeTargets: ['en']`
 * `countryCodeTargets` - (array) Only run tests for users from specific countries. You'll need to pass the current user country to the abtest method when calling it.
 * `assignmentMethod` - By default, test variations are assigned using a random number generator. You can also assign test variations using the 'userId'. Using the userId to assign test variations will still assign a random assignment; however, it ensures the user is assigned the same assignment in the event their local storage gets cleared or is compromised. This includes cases where they manually clear their local storage, use multiple devices, or use an incognito window (storageless browser). This assignment method should not be used if a user does not have a userId by the time the AB test starts.
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -143,4 +143,13 @@ export default {
 		allowExistingUsers: true,
 		localeTargets: 'any',
 	},
+	hideBloggerPlanNonEn: {
+		datestamp: '20190613',
+		variations: {
+			hide: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		localeTargets: 'any',
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -151,5 +151,6 @@ export default {
 		},
 		defaultVariation: 'control',
 		localeTargets: 'any',
+		localeExceptions: [ 'en' ],
 	},
 };

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -120,6 +120,15 @@ ABTest.prototype.init = function( name, geoLocation ) {
 		}
 	}
 
+	this.localeExceptions = false;
+	if (
+		testConfig.localeExceptions &&
+		isArray( testConfig.localeExceptions ) &&
+		every( testConfig.localeExceptions, langSlugIsValid )
+	) {
+		this.localeExceptions = testConfig.localeExceptions;
+	}
+
 	const variationDatestamp = testConfig.datestamp;
 
 	this.name = name;
@@ -220,6 +229,11 @@ ABTest.prototype.isEligibleForAbTest = function() {
 	}
 
 	if ( this.localeTargets && ! isUsingGivenLocales( this.localeTargets, this.experimentId ) ) {
+		return false;
+	} else if (
+		this.localeExceptions &&
+		isUsingGivenLocales( this.localeExceptions, this.experimentId )
+	) {
 		return false;
 	}
 

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -8,6 +8,7 @@ import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
+import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -34,7 +35,14 @@ import CartData from 'components/data/cart';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 import { isEnabled } from 'config';
-import { plansLink, planMatches, findPlansKeys, getPlan, isFreePlan } from 'lib/plans';
+import {
+	plansLink,
+	planMatches,
+	findPlansKeys,
+	getPlan,
+	isFreePlan,
+	isBloggerPlan,
+} from 'lib/plans';
 import Button from 'components/button';
 import SegmentedControl from 'components/segmented-control';
 import SegmentedControlItem from 'components/segmented-control/item';
@@ -128,9 +136,20 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getPlansForPlanFeatures() {
-		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan } = this.props;
+		const {
+			displayJetpackPlans,
+			intervalType,
+			selectedPlan,
+			hideFreePlan,
+			sitePlanSlug,
+		} = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
+
+		const hideBloggerPlan =
+			! isBloggerPlan( selectedPlan ) &&
+			! isBloggerPlan( sitePlanSlug ) &&
+			abtest( 'hideBloggerPlanNonEn' ) === 'hide';
 
 		let term;
 		if ( intervalType === 'monthly' ) {
@@ -169,12 +188,12 @@ export class PlansFeaturesMain extends Component {
 		} else {
 			plans = [
 				findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
-				findPlansKeys( { group, term, type: TYPE_BLOGGER } )[ 0 ],
+				hideBloggerPlan ? null : findPlansKeys( { group, term, type: TYPE_BLOGGER } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PREMIUM } )[ 0 ],
 				findPlansKeys( { group, term: businessPlanTerm, type: TYPE_BUSINESS } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_ECOMMERCE } )[ 0 ],
-			];
+			].filter( el => el !== null );
 		}
 
 		if ( hideFreePlan ) {
@@ -446,6 +465,7 @@ const guessCustomerType = ( state, props ) => {
 export default connect(
 	( state, props ) => {
 		const siteId = get( props.site, [ 'ID' ] );
+		const sitePlan = getSitePlan( state, siteId );
 
 		return {
 			// This is essentially a hack - discounts are the only endpoint that we can rely on both on /plans and
@@ -459,6 +479,7 @@ export default connect(
 			isChatAvailable: isHappychatAvailable( state ),
 			siteId: siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
+			sitePlanSlug: sitePlan && sitePlan.product_slug,
 		};
 	},
 	{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We tested the Blogger Plan for 'en' users only and we were supposed to test for other locales too. This test will restart the test for non-en locales only.

The `localeExceptions` are added because we expect that similar tests will be performed in the future and also because it's a bit inconvenient to add 140+ locales in the config.

#### Testing instructions

1. Set your browser language to something other than English. (For Chrome, go to Settings and search for Languages, add a language or move it to the top)
2. Sign up with a new site
3. You should be assigned to the new test (confirm the assignment is triggered)

<img width="616" alt="Screenshot 2019-06-13 at 14 31 22" src="https://user-images.githubusercontent.com/82778/59429213-fb06cf00-8de7-11e9-93ed-404182a0edf0.png">


4. Change the variation to see that both variations work fine
5. Go to logged in /plans and make sure both variations work

6. Set your browser language to English
7. Sign up with a new user. Make sure that user didn't get assigned to a variation of the test

*

Fixes #
