### PR TITLE
Types: Fix type errors

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -35,10 +35,6 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 	},
 } ) => {
 	const translate = useTranslate();
-	const contactText = translate( 'contact', {
-		context: 'part of e-mail address',
-		comment: 'As it would be part of an e-mail address contact@example.com',
-	} );
 
 	// use this to control setting the "touched" states below. That way the user will not see a bunch of
 	// "This field is required" errors pop at once
@@ -54,10 +50,15 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 	const hasFirstNameError = firstNameFieldTouched && null !== firstNameError;
 	const hasLastNameError = lastNameFieldTouched && null !== lastNameError;
 
+	const emailAddressPlaceholder = translate( 'e.g. contact', {
+		comment:
+			'An example of the local-part of an email address: "contact" in "contact@example.com".',
+	} );
+
 	const renderSingleDomain = () => {
 		return (
 			<FormTextInputWithAffixes
-				placeholder={ translate( 'e.g. %(example)s', { args: { example: contactText } } ) }
+				placeholder={ emailAddressPlaceholder }
 				value={ mailBox }
 				isError={ hasMailBoxError }
 				onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
@@ -75,7 +76,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 		return (
 			<Fragment>
 				<FormTextInput
-					placeholder={ translate( 'e.g. %(example)s', { args: { example: contactText } } ) }
+					placeholder={ emailAddressPlaceholder }
 					value={ mailBox }
 					isError={ hasMailBoxError }
 					onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {

--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -2,13 +2,13 @@
  * External dependencies
  */
 import emailValidator from 'email-validator';
-import i18n from 'i18n-calypso';
+import i18n, { TranslateResult } from 'i18n-calypso';
 import { includes, mapValues } from 'lodash';
 
 // exporting these in the big export below causes trouble
 export interface GSuiteNewUserField {
 	value: string;
-	error: string | null;
+	error: TranslateResult | null;
 }
 
 export interface GSuiteNewUser {

--- a/client/my-sites/marketing/tools/feature.tsx
+++ b/client/my-sites/marketing/tools/feature.tsx
@@ -11,11 +11,11 @@ import CardHeading from 'components/card-heading';
 
 interface Props {
 	children: ReactNode;
-	description: string;
-	disclaimer?: string;
+	description: ReactNode;
+	disclaimer?: ReactNode;
 	imageAlt?: string;
 	imagePath?: string;
-	title: string;
+	title: ReactNode;
 }
 
 const MarketingToolsFeature: FunctionComponent< Props > = ( {

--- a/client/my-sites/marketing/tools/google-adwords.tsx
+++ b/client/my-sites/marketing/tools/google-adwords.tsx
@@ -30,7 +30,7 @@ interface ConnectedProps {
 	isAtomic: boolean;
 	isJetpack: boolean;
 	isPremiumOrHigher: boolean;
-	recordTracksEvent: () => void;
+	recordTracksEvent: typeof recordTracksEventAction;
 	showCard: boolean;
 	siteId: number | null;
 	siteSlug: string | null;


### PR DESCRIPTION
Typing i18n-calypso (#33646) introduced a lot of valid type errors in Calypso. Some are easily addressed.

Fix a number of simple type errors. No functional changes.

#### Testing instructions

* [`typecheck` job has fewer errors (95)](https://circleci.com/gh/Automattic/wp-calypso/326024) than [current master(113)](https://circleci.com/gh/Automattic/wp-calypso/325997).
* I'm unfamiliar with the affected flows here and would appreciate help/instructions for testing.

With the exception of a change to eliminate a nested `translate`, the changes here are limited to types and should be very safe.

For posterity here are the testing instructions @cbauerman used:
1. Navigate to `/devdocs/design/g-suite-examples`
2. Test the following cases work:
a. "This field is required." error when the field is empty ( requires focus and one field with content )
b. Insert `12345678912345678912345678912345678912345678912345678912345678912` into the email field "Please provide a valid email address."
c. Insert `+` into the email field, confirm "Only number, letters, dashes, underscores, apostrophes and periods are allowed."
3. Navigate to `/marketing/tools/:siteSlug` confirm branch matches master