### PR TITLE
Full Site Editing: add edit overlay to template part on hover

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -12,7 +12,7 @@ import { IconButton, Placeholder, Toolbar } from '@wordpress/components';
 import { compose, withState } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { BlockControls } from '@wordpress/editor';
-import { Fragment, RawHTML } from '@wordpress/element';
+import { Fragment, RawHTML, useState, useEffect, useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -33,12 +33,28 @@ const TemplateEdit = compose(
 )( ( { attributes, isEditing, template, setAttributes, setState } ) => {
 	const { align, templateId } = attributes;
 
+	const templateBlockRef = useRef( null );
+
 	const toggleEditing = () => setState( { isEditing: ! isEditing } );
 
 	const onSelectTemplate = ( { id } ) => {
 		setState( { isEditing: false } );
 		setAttributes( { templateId: id } );
 	};
+
+	const [ isHovered, setIsHovered ] = useState( false );
+	const handleMouseOver = () => setIsHovered( true );
+	const handleMouseOut = () => setIsHovered( false );
+
+	useEffect( () => {
+		templateBlockRef.current.addEventListener( 'mouseover', handleMouseOver );
+		templateBlockRef.current.addEventListener( 'mouseout', handleMouseOut );
+
+		return () => {
+			templateBlockRef.current.removeEventListener( 'mouseover', handleMouseOver );
+			templateBlockRef.current.removeEventListener( 'mouseout', handleMouseOut );
+		};
+	}, [ templateBlockRef.current ] );
 
 	const showToggleButton = ! isEditing || !! templateId;
 	const showPlaceholder = isEditing || ! templateId;
@@ -61,6 +77,7 @@ const TemplateEdit = compose(
 				</BlockControls>
 			) }
 			<div
+				ref={ templateBlockRef }
 				className={ classNames( 'template-block', {
 					[ `align${ align }` ]: align,
 				} ) }
@@ -86,9 +103,12 @@ const TemplateEdit = compose(
 					</Placeholder>
 				) }
 				{ showContent && (
-					<RawHTML className="template-block__content">
-						{ get( template, [ 'content', 'rendered' ] ) }
-					</RawHTML>
+					<Fragment>
+						<RawHTML className="template-block__content">
+							{ get( template, [ 'content', 'rendered' ] ) }
+						</RawHTML>
+						{ isHovered && <div className="template-block__content_overlay" /> }
+					</Fragment>
 				) }
 			</div>
 		</Fragment>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -1,4 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+/* global fullSiteEditing */
 /**
  * External dependencies
  */
@@ -24,13 +25,16 @@ import './style.scss';
 const TemplateEdit = compose(
 	withSelect( ( select, { attributes } ) => {
 		const { getEntityRecord } = select( 'core' );
+		const { getCurrentPostId } = select( 'core/editor' );
+
 		const { templateId } = attributes;
 		return {
+			currentPostId: getCurrentPostId(),
 			template: templateId && getEntityRecord( 'postType', 'wp_template_part', templateId ),
 		};
 	} ),
 	withState( { isEditing: false } )
-)( ( { attributes, isEditing, template, setAttributes, setState } ) => {
+)( ( { attributes, currentPostId, isEditing, template, setAttributes, setState } ) => {
 	const { align, templateId } = attributes;
 
 	const toggleEditing = () => setState( { isEditing: ! isEditing } );
@@ -43,10 +47,11 @@ const TemplateEdit = compose(
 	const showToggleButton = ! isEditing || !! templateId;
 	const showPlaceholder = isEditing || ! templateId;
 	const showContent = ! isEditing && !! templateId;
+	const isTemplate = 'wp_template' === fullSiteEditing.editorPostType;
 
 	return (
 		<Fragment>
-			{ showToggleButton && (
+			{ showToggleButton && isTemplate && (
 				<BlockControls>
 					<Toolbar>
 						<IconButton
@@ -78,7 +83,7 @@ const TemplateEdit = compose(
 								postType="wp_template_part"
 							/>
 							{ !! template && (
-								<a href={ `?post=${ templateId }&action=edit` }>
+								<a href={ `?post=${ templateId }&action=edit&fse_parent_post=${ currentPostId }` }>
 									{ sprintf( __( 'Edit "%s"' ), get( template, [ 'title', 'rendered' ], '' ) ) }
 								</a>
 							) }
@@ -90,22 +95,21 @@ const TemplateEdit = compose(
 						<RawHTML className="template-block__content">
 							{ get( template, [ 'content', 'rendered' ] ) }
 						</RawHTML>
-						<div className="template-block__overlay">
-							<p>
-								{ __(
+						{ ! isTemplate && (
+							<Placeholder
+								className="template-block__overlay"
+								instructions={ __(
 									'This block is part of your site template and may appear on multiple pages.'
 								) }
-							</p>
-							<Button href={ `?post=${ templateId }&action=edit` } isDefault>
-								{ sprintf( __( 'Edit %s' ), get( template, [ 'title', 'rendered' ], '' ) ) }
-							</Button>
-							<a
-								className="template-block__overlay__edit"
-								href={ `?post=${ templateId }&action=edit` }
 							>
-								{ sprintf( __( 'Edit %s' ), get( template, [ 'title', 'rendered' ], '' ) ) }
-							</a>
-						</div>
+								<Button
+									href={ `?post=${ templateId }&action=edit&fse_parent_post=${ currentPostId }` }
+									isDefault
+								>
+									{ sprintf( __( 'Edit %s' ), get( template, [ 'title', 'rendered' ], '' ) ) }
+								</Button>
+							</Placeholder>
+						) }
 					</Fragment>
 				) }
 			</div>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -12,7 +12,7 @@ import { IconButton, Placeholder, Toolbar } from '@wordpress/components';
 import { compose, withState } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { BlockControls } from '@wordpress/editor';
-import { Fragment, RawHTML, useState, useEffect, useRef } from '@wordpress/element';
+import { Fragment, RawHTML } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -33,28 +33,12 @@ const TemplateEdit = compose(
 )( ( { attributes, isEditing, template, setAttributes, setState } ) => {
 	const { align, templateId } = attributes;
 
-	const templateBlockRef = useRef( null );
-
 	const toggleEditing = () => setState( { isEditing: ! isEditing } );
 
 	const onSelectTemplate = ( { id } ) => {
 		setState( { isEditing: false } );
 		setAttributes( { templateId: id } );
 	};
-
-	const [ isHovered, setIsHovered ] = useState( false );
-	const handleMouseOver = () => setIsHovered( true );
-	const handleMouseOut = () => setIsHovered( false );
-
-	useEffect( () => {
-		templateBlockRef.current.addEventListener( 'mouseover', handleMouseOver );
-		templateBlockRef.current.addEventListener( 'mouseout', handleMouseOut );
-
-		return () => {
-			templateBlockRef.current.removeEventListener( 'mouseover', handleMouseOver );
-			templateBlockRef.current.removeEventListener( 'mouseout', handleMouseOut );
-		};
-	}, [ templateBlockRef.current ] );
 
 	const showToggleButton = ! isEditing || !! templateId;
 	const showPlaceholder = isEditing || ! templateId;
@@ -77,7 +61,6 @@ const TemplateEdit = compose(
 				</BlockControls>
 			) }
 			<div
-				ref={ templateBlockRef }
 				className={ classNames( 'template-block', {
 					[ `align${ align }` ]: align,
 				} ) }
@@ -107,7 +90,11 @@ const TemplateEdit = compose(
 						<RawHTML className="template-block__content">
 							{ get( template, [ 'content', 'rendered' ] ) }
 						</RawHTML>
-						{ isHovered && <div className="template-block__content_overlay" /> }
+						<div className="template-block__overlay">
+							<a href={ `?post=${ templateId }&action=edit` }>
+								{ sprintf( __( 'Edit "%s"' ), get( template, [ 'title', 'rendered' ], '' ) ) }
+							</a>
+						</div>
 					</Fragment>
 				) }
 			</div>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -8,7 +8,7 @@ import { get } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { IconButton, Placeholder, Toolbar } from '@wordpress/components';
+import { Button, IconButton, Placeholder, Toolbar } from '@wordpress/components';
 import { compose, withState } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { BlockControls } from '@wordpress/editor';
@@ -91,8 +91,19 @@ const TemplateEdit = compose(
 							{ get( template, [ 'content', 'rendered' ] ) }
 						</RawHTML>
 						<div className="template-block__overlay">
-							<a href={ `?post=${ templateId }&action=edit` }>
-								{ sprintf( __( 'Edit "%s"' ), get( template, [ 'title', 'rendered' ], '' ) ) }
+							<p>
+								{ __(
+									'This block is part of your site template and may appear on multiple pages.'
+								) }
+							</p>
+							<Button href={ `?post=${ templateId }&action=edit` } isDefault>
+								{ sprintf( __( 'Edit %s' ), get( template, [ 'title', 'rendered' ], '' ) ) }
+							</Button>
+							<a
+								className="template-block__overlay__edit"
+								href={ `?post=${ templateId }&action=edit` }
+							>
+								{ sprintf( __( 'Edit %s' ), get( template, [ 'title', 'rendered' ], '' ) ) }
 							</a>
 						</div>
 					</Fragment>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -3,6 +3,12 @@
  */
 $dark-gray-500: #555d66;
 $blue-wordpress-700: #00669b;
+$blue-medium-100: #e5f5fa;
+
+// Fonts & basics
+$default-font: -apple-system, BlinkMacSystemFont,'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,'Helvetica Neue', sans-serif;
+$default-font-size: 13px;
+$default-line-height: 1.4;
 
 .template-block {
 	min-height: 150px;
@@ -35,24 +41,26 @@ $blue-wordpress-700: #00669b;
 }
 
 .template-block__overlay {
-	display: none;
+	display: grid /*none*/;
 	place-items: center;
 	position: absolute;
 	top: 0;
 	left: 0;
 	width: 100%;
 	height: 100%;
-	background-color: rgba( $dark-gray-500, 0.7 );
+	background-color: rgba( $dark-gray-500, 0.8 );
+	font-family: $default-font;
+	font-size: $default-font-size;
+}
 
-	a {
-		display: block;
-		background: white;
-		color: $blue-wordpress-700;
-		padding: 5px 10px;
-		border: solid 1px $blue-wordpress-700;
+.template-block__overlay__edit {
+	display: block;
+	background: $blue-medium-100;
+	color: $blue-wordpress-700;
+	padding: 5px 10px;
+	border: solid 1px $blue-wordpress-700;
 
-		&:hover {
-			text-decoration: none;
-		}
+	&:hover {
+		box-shadow: none;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -35,8 +35,4 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-
-	.components-placeholder__instructions {
-		color: white;
-	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -1,20 +1,8 @@
-/**
- * Colors
- */
-$dark-gray-500: #555d66;
-$blue-wordpress-700: #00669b;
-$blue-medium-100: #e5f5fa;
-
-// Fonts & basics
-$default-font: -apple-system, BlinkMacSystemFont,'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell,'Helvetica Neue', sans-serif;
-$default-font-size: 13px;
-$default-line-height: 1.4;
-
 .template-block {
-	min-height: 150px;
+	min-height: 200px;
 
 	&:hover .template-block__overlay {
-		display: grid;
+		display: flex;
 	}
 }
 
@@ -41,26 +29,14 @@ $default-line-height: 1.4;
 }
 
 .template-block__overlay {
-	display: grid /*none*/;
-	place-items: center;
+	display: none;
 	position: absolute;
 	top: 0;
 	left: 0;
 	width: 100%;
 	height: 100%;
-	background-color: rgba( $dark-gray-500, 0.8 );
-	font-family: $default-font;
-	font-size: $default-font-size;
-}
 
-.template-block__overlay__edit {
-	display: block;
-	background: $blue-medium-100;
-	color: $blue-wordpress-700;
-	padding: 5px 10px;
-	border: solid 1px $blue-wordpress-700;
-
-	&:hover {
-		box-shadow: none;
+	.components-placeholder__instructions {
+		color: white;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -1,3 +1,17 @@
+/**
+ * Colors
+ */
+$dark-gray-500: #555d66;
+$blue-wordpress-700: #00669b;
+
+.template-block {
+	min-height: 150px;
+
+	&:hover .template-block__overlay {
+		display: grid;
+	}
+}
+
 .template-block.alignfull {
 	padding: 0 12px;
 }
@@ -17,5 +31,28 @@
 		content: '';
 		clear: both;
 		display: table;
+	}
+}
+
+.template-block__overlay {
+	display: none;
+	place-items: center;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	background-color: rgba( $dark-gray-500, 0.7 );
+
+	a {
+		display: block;
+		background: white;
+		color: $blue-wordpress-700;
+		padding: 5px 10px;
+		border: solid 1px $blue-wordpress-700;
+
+		&:hover {
+			text-decoration: none;
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds an _Edit_ button to the _Template Part_ block that appears on hover (maybe not the best accessibility). This button is shown only when the _Template Part_ is loaded in the context of a post or page (as implemented on #33885). When the _Template Part_ block is loaded on a `wp_template`, no changes are made.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a _Template Part_. We'll assume it's called `Header`.
* Create a _Template_, with the `Header` template part and a _Post Content_ block. We'll assume it's called `My Template`.
* Verify that there are no regressions when creating a _Template_.
* Create a Page and assign the `My Template` _Template_ to it. We'll assume it's called `My Page`.
* Checkout #33885 (to get _Template Parts_ on Pages support) and merge this branch into it.
* Edit `My Page`, and verify that, when moving the mouse over the _Template Part_, a placeholder overlay appears with an _Edit_ button. There should be no _Edit_ button on the block toolbar.
* Click the _Edit_ button on the overlay and verify that it loads the _Template Part_ edit view.

Fixes #33628 
Depends on #33885 
Friend of #33997 