### PR TITLE
ChecklistNavigation: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -42,7 +42,5 @@
 @import 'layout/sidebar/style';
 @import 'lib/preferences-helper/style';
 @import 'me/sidebar-navigation/style';
-@import 'my-sites/checklist/wpcom-checklist/checklist-navigation/style';
 @import 'my-sites/plan-features/style';
 @import 'my-sites/sidebar-navigation/style';
-

--- a/client/my-sites/checklist/wpcom-checklist/checklist-navigation/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-navigation/index.jsx
@@ -17,6 +17,11 @@ import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class ChecklistNavigation extends Component {
 	static propTypes = {
 		siteSlug: PropTypes.string,
@@ -42,10 +47,10 @@ export class ChecklistNavigation extends Component {
 	render() {
 		const { siteSlug, translate, showNotification, taskList } = this.props;
 
-		const buttonClasses = {
+		const buttonClasses = classNames( 'checklist-navigation__count', {
 			'has-notification': showNotification,
-			'checklist-navigation__count': true,
-		};
+		} );
+
 		const { total, completed } = taskList.getCompletionStatus();
 		const checklistLink = '/checklist/' + siteSlug;
 
@@ -61,7 +66,7 @@ export class ChecklistNavigation extends Component {
 						{ translate( 'Continue Site Setup' ) }
 					</span>
 
-					<span className={ classNames( buttonClasses ) }>
+					<span className={ buttonClasses }>
 						{ translate( '%(complete)d/%(total)d', {
 							comment: 'Numerical progress indicator, like 5/9',
 							args: {


### PR DESCRIPTION
Straightforward migration of the `ChecklistNavigation` component. You can see it in the inline help popover on checklist-eligible sites (the "Continue Site Setup" box with progress bar):

<img width="327" alt="Screenshot 2019-06-13 at 15 44 19" src="https://user-images.githubusercontent.com/664258/59438474-e2041b00-8df3-11e9-8200-3c239450eebc.png">
