### PR TITLE
Component: Wrap section header with long titles

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -1,15 +1,11 @@
 .section-header.card {
+	align-items: flex-start;
 	display: flex;
-	align-items: center;
+	flex-flow: row wrap;
+	line-height: 28px;
 	padding-top: 11px;
 	padding-bottom: 11px;
 	position: relative;
-	line-height: 28px;
-
-	@include breakpoint( '<480px' ) {
-		align-items: flex-start;
-		flex-flow: row wrap;
-	}
 
 	&::after {
 		content: '';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I realized I didn't entirely fix this in: https://github.com/Automattic/wp-calypso/pull/33905

`SectionHeader`s with long titles need to wrap so it doesn't look like this:

<img width="648" alt="Screenshot 2019-06-13 09 49 16" src="https://user-images.githubusercontent.com/4924246/59451700-e82cd400-8dc0-11e9-8912-8772a28c5615.png">

In the previous fix, I only applied the wrapping to `<480px`, but this just needs to be applied in any narrow viewport to avoid it looking like the above screenshot.

#### Testing instructions

1. Visit any page with a `SectionHeader` that has a long label. In this example, it's https://wpcalypso.wordpress.com/people/email-followers/en.blog.wordpress.com.
2. Make sure the label and action buttons wrap in narrow viewports like:

<img width="643" alt="Screenshot 2019-06-13 09 55 45" src="https://user-images.githubusercontent.com/4924246/59451920-76a15580-8dc1-11e9-985e-4870c5a84329.png">

Short labels are still unaffected by this change:
<img width="541" alt="Screenshot 2019-06-13 09 56 03" src="https://user-images.githubusercontent.com/4924246/59451933-7ef99080-8dc1-11e9-9a53-239051de427c.png">

