### PR TITLE
Stats: Make sure popover text under ellipsis menu is visible

### DIFF
--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -502,7 +502,6 @@ ul.module-content-list-item-action-submenu {
 	// Action wrapper, what's actually selected
 	.module-content-list-item-action-wrapper {
 		@extend %mobile-interface-element;
-		opacity: 0;
 		text-align: center;
 		margin: 0;
 		line-height: inherit;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes popover texts in Stats mobile to make sure they are visible.

**Before:**
<img width="363" alt="Screenshot 2019-06-13 10 27 45" src="https://user-images.githubusercontent.com/4924246/59454054-1bbe2d00-8dc6-11e9-8bf3-ef16f133da17.png">

**After:**
<img width="402" alt="Screenshot 2019-06-13 10 30 02" src="https://user-images.githubusercontent.com/4924246/59454107-398b9200-8dc6-11e9-814f-b4f9dd01a090.png">

#### Testing instructions

1. On mobile, go to: http://calypso.localhost:3000/stats/day/en.blog.wordpress.com
2. Click on one of the ellipsis icons to display the popover (You can find this in the Posts & Pages and Referrers modules).
3. Make sure texts within the popover are visible. 