### PR TITLE
Store: Clean up some small screen issues

### DIFF
--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -148,6 +148,7 @@
 		.order-payment__action,
 		.order-fulfillment__action {
 			width: 100%;
+			justify-content: left;
 		}
 		.order-payment__label + .order-payment__action {
 			margin-top: 8px;

--- a/client/extensions/woocommerce/app/products/product-form.scss
+++ b/client/extensions/woocommerce/app/products/product-form.scss
@@ -977,5 +977,6 @@
 .products__product-form-delivery-details {
 	.form-setting-explanation {
 		max-width: 500px;
+		margin-bottom: 0;
 	}
 }

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/style.scss
@@ -222,6 +222,10 @@
 .packages__packages-row-dimensions {
 	width: 30%;
 	font-size: 14px;
+	
+	@include breakpoint( '<660px' ) {
+		font-size: 11px;
+	}
 }
 
 .packages__setting-explanation {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes 3 small UI issues so that things look better on a small screen. 

#### Testing instructions


## Part 1

1. Shrink your screen width to less than 660px wide.
2. Navigate to Store > Product > Add Product. 
3. Scroll down to Weight. 
4. Notice the uniform padding (no extra bottom padding below explanation text)

Before:
<img width="487" alt="Screen Shot 2019-06-13 at 11 39 53 AM" src="https://user-images.githubusercontent.com/5835847/59459405-93de2000-8dd1-11e9-95c5-02a3b7025ce2.png">
After:
<img width="473" alt="Screen Shot 2019-06-13 at 11 40 12 AM" src="https://user-images.githubusercontent.com/5835847/59459410-9476b680-8dd1-11e9-83b9-fecd2ad58ba8.png">


## Part 2


1. Shrink your screen width to less than 660px wide.
2. Navigate to Store > Settings > Shipping > Add Package > Service Package tab and expand one section. 
3. Notice the dimension sizing is a smaller font and you can now read it more easily. 

Before:
<img width="472" alt="Screen Shot 2019-06-13 at 11 47 48 AM" src="https://user-images.githubusercontent.com/5835847/59459412-950f4d00-8dd1-11e9-8842-b378cad7f9e2.png">
Before:
<img width="468" alt="Screen Shot 2019-06-13 at 11 47 20 AM" src="https://user-images.githubusercontent.com/5835847/59459411-950f4d00-8dd1-11e9-89d5-c33f53ec54ee.png">



## Part 3

1. Shrink your screen width to less than 660px wide.
2. Navigate to Store > Orders > Click into an order. 
3. Scroll down to Payment status. 
4. Notice the left aligned action button instead of centering.

Before:
<img width="381" alt="Screen Shot 2019-06-13 at 11 34 22 AM" src="https://user-images.githubusercontent.com/5835847/59459404-93de2000-8dd1-11e9-8938-508260173656.png">
After:
<img width="388" alt="Screen Shot 2019-06-13 at 11 34 10 AM" src="https://user-images.githubusercontent.com/5835847/59459402-92acf300-8dd1-11e9-9ab5-7769a5b734d4.png">
