### PR TITLE
Fix compact tinymce component styling on edit product screen

### DIFF
--- a/client/extensions/woocommerce/components/compact-tinymce/style.scss
+++ b/client/extensions/woocommerce/components/compact-tinymce/style.scss
@@ -10,7 +10,6 @@
 
 	.mce-edit-area {
 		margin-bottom: 4px;
-		padding-top: 36px;
 		padding-left: 8px;
 	}
 

--- a/client/extensions/woocommerce/components/compact-tinymce/style.scss
+++ b/client/extensions/woocommerce/components/compact-tinymce/style.scss
@@ -4,32 +4,42 @@
 		border-right-color: var( --color-neutral-100 );
 	}
 
+	.mce-panel {
+		background: #fff;
+	}
+
 	.mce-edit-area {
-		border: 1px solid var( --color-neutral-100 ) !important;
 		margin-bottom: 4px;
 		padding-top: 36px;
 		padding-left: 8px;
 	}
 
 	div.mce-toolbar-grp {
-		background-color: rgba( var( --color-white-rgb ), 0.92 );
-		border-color: var( --color-neutral-100 );
-		border-style: solid;
-		border-width: 1px;
-		padding: 0;
+		background-color: #f0f0f0;
+		padding: 4px;
 		overflow-x: auto;
 		margin: 0 auto;
 	}
 
+	.mce-flow-layout-item {
+		margin: 2px;
+	}
+
 	.mce-toolbar .mce-btn-group .mce-btn.mce-listbox {
-		margin: 0 2px 0 0;
+		margin: 0;
 		padding: 0 8px;
 		vertical-align: top;
-		border-right: 1px solid var( --color-neutral-100 );
-		height: 36px;
 
-		@include breakpoint( '<660px' ) {
-			height: 44px;
+		&:hover {
+			border-left-color: var( --color-neutral-100 );
+		}
+	}
+
+	.mce-btn-group .mce-btn {
+		margin-left: 4px;
+
+		&:hover {
+			background: var( --color-white );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the styling on the product description editor

#### Testing instructions

* Navigate to a site with Store on WP.com and edit a product
* Notice the product description input is no longer borked.

Fixes #33934

Before:

![before](https://cldup.com/yGG4eGil_D-3000x3000.png)

After:

![after](https://cldup.com/0kISO7NN7B-3000x3000.png)
