### PR TITLE
Posts: Use a single icon only for viewing external posts

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/view.jsx
@@ -65,10 +65,9 @@ class PostActionsEllipsisMenuView extends Component {
 			<PopoverMenuItem
 				href={ previewUrl }
 				onClick={ this.previewPost }
-				icon="visible"
+				icon={ ! isPreviewable ? 'external' : 'visible' }
 				target="_blank"
 				rel="noopener noreferrer"
-				isExternalLink={ ! isPreviewable }
 			>
 				{ includes( [ 'publish', 'private' ], status )
 					? translate( 'View', { context: 'verb' } )


### PR DESCRIPTION
#### Changes proposed in this Pull Request
 
Currently, when on a Jetpack site, "View" in the ellipsis menu has two icons.

#### Testing instructions

1. Go to Posts: https://wpcalypso.wordpress.com/posts/[site]
2. Check if "View" only has single icon instead of two

**Before:**
<img width="216" alt="Screenshot 2019-06-13 13 55 05" src="https://user-images.githubusercontent.com/4924246/59466719-dc520980-8de2-11e9-9984-45d725a1704a.png">

**After:**
<img width="220" alt="Screenshot 2019-06-13 13 55 39" src="https://user-images.githubusercontent.com/4924246/59466749-effd7000-8de2-11e9-9bd6-05775bd90092.png">

Thanks @sixhours for your help!