### PR TITLE
Update order details and activity log strokes

### DIFF
--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -31,7 +31,7 @@
 		}
 
 		.foldable-card__expand {
-			border-left: 1px var( --color-neutral-0 ) solid;
+			border-left: 1px var( --color-neutral-50 ) solid;
 		}
 	}
 }

--- a/client/components/foldable-card/style.scss
+++ b/client/components/foldable-card/style.scss
@@ -134,7 +134,7 @@ button.foldable-card__action {
 .foldable-card.is-expanded .foldable-card__content {
 	display: block;
 	padding: 16px;
-	border-top: 1px solid var( --color-neutral-0 );
+	border-top: 1px solid var( --color-neutral-50 );
 }
 
 .foldable-card.is-compact .foldable-card.is-expanded .foldable-card__content {

--- a/client/extensions/woocommerce/app/order/order-details/style.scss
+++ b/client/extensions/woocommerce/app/order/order-details/style.scss
@@ -1,7 +1,7 @@
 .order-details__table {
 	margin: 0 -24px;
 	box-shadow: none;
-	border-bottom: 1px solid var( --color-neutral-0 );
+	border-bottom: 1px solid var( --color-neutral-50 );
 
 	.order-details__item-sku {
 		display: block;

--- a/client/extensions/woocommerce/app/order/style.scss
+++ b/client/extensions/woocommerce/app/order/style.scss
@@ -76,7 +76,7 @@
 .order-fulfillment {
 	margin: 0 -16px;
 	padding: 16px;
-	border-top: 1px solid var( --color-neutral-0 );
+	border-top: 1px solid var( --color-neutral-50 );
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes strokes that are too subtle on the order screen

Before:

![before](https://cldup.com/CopnF_EFPF-2000x2000.png)

After:

![after](https://cldup.com/mYrwsZjWwj.png)

#### Testing instructions

* Navigate to an order screen on a site with Store on WP.com enabled.
* Check the strokes.

Fixes #33964
