### PR TITLE
Signup: do not display the preview for blog site types

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -67,6 +67,7 @@ import { submitSiteVertical } from 'state/signup/steps/site-vertical/actions';
 import getSiteId from 'state/selectors/get-site-id';
 import { isCurrentPlanPaid, getSitePlanSlug } from 'state/sites/selectors';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 
 // Current directory dependencies
 import steps from './config/steps';
@@ -114,6 +115,7 @@ class Signup extends React.Component {
 		flowName: PropTypes.string,
 		stepName: PropTypes.string,
 		pageTitle: PropTypes.string,
+		siteType: PropTypes.string,
 		stepSectionName: PropTypes.string,
 	};
 
@@ -617,9 +619,8 @@ class Signup extends React.Component {
 						redirectTo={ this.state.redirectTo }
 					/>
 				) }
-				{ get( steps[ this.props.stepName ], 'props.showSiteMockups', false ) && (
-					<SiteMockups stepName={ this.props.stepName } />
-				) }
+				{ get( steps[ this.props.stepName ], 'props.showSiteMockups', false ) &&
+					'blog' !== this.props.siteType && <SiteMockups stepName={ this.props.stepName } /> }
 			</div>
 		);
 	}
@@ -643,6 +644,7 @@ export default connect(
 			sitePlanSlug: getSitePlanSlug( state, siteId ),
 			siteDomains,
 			siteId,
+			siteType: getSiteType( state ),
 		};
 	},
 	{


### PR DESCRIPTION
## Changes proposed in this Pull Request

This is a temp fix to prevent displaying the site style preview for **Blog** sites until the interim work for Blogs is complete (very, nearly, quite, rather soonish)

**Bad** 😱 
![Jun-14-2019 07-52-10](https://user-images.githubusercontent.com/6458278/59469882-651b8480-8e79-11e9-8877-0742dc0117fd.gif)

## Testing instructions

1. Go to `/start/onboarding` and select **Business** as your site type, continue
2. Copy and paste the current URL, e.g., `{env_domain}/start/site-topic-with-preview` where `env_domain` is either https://wordpress.com or http://calypso.localhost:3000
3. Go back and select **Blog** as your site type
4. Paste the URL into your address bar and GO!

The preview should however still show for **Business** and **Professional** sites