### PR TITLE
Added to subline a line break to increase readablity of the link

### DIFF
--- a/client/components/formatted-header/style.scss
+++ b/client/components/formatted-header/style.scss
@@ -15,6 +15,12 @@
 	font-size: 24px;
 	margin: 0 0 5px;
 
+	@include breakpoint( '<660px' ) {
+		line-height: 1.2em;
+		padding: 0 10px;
+		margin-top: 24px;
+	}
+
 	@include breakpoint( '<480px' ) {
 		line-height: 1.2em;
 		padding: 0 10px;
@@ -27,6 +33,6 @@
 
 	@include breakpoint( '<480px' ) {
 		margin: 0;
-		padding: 0 20px;
+		padding: 0 20px 24px 0;
 	}
 }

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -271,10 +271,11 @@ class SectionImport extends Component {
 		const { jetpack: isJetpack } = site;
 		const headerText = translate( 'Import your content' );
 		const subHeaderText = translate(
-			'Bring content hosted elsewhere over to WordPress.com. ' +
+			'Bring content hosted elsewhere over to WordPress.com.{{br/}}' +
 				'{{a}}Find out what we currently support.{{/a}}',
 			{
 				components: {
+					br: <br />,
 					a: <ExternalLink href="https://en.support.wordpress.com/import/" />,
 				},
 			}

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -271,11 +271,10 @@ class SectionImport extends Component {
 		const { jetpack: isJetpack } = site;
 		const headerText = translate( 'Import your content' );
 		const subHeaderText = translate(
-			'Bring content hosted elsewhere over to WordPress.com.{{br/}}' +
+			'Bring content hosted elsewhere over to WordPress.com.' +
 				'{{a}}Find out what we currently support.{{/a}}',
 			{
 				components: {
-					br: <br />,
 					a: <ExternalLink href="https://en.support.wordpress.com/import/" />,
 				},
 			}

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -271,7 +271,7 @@ class SectionImport extends Component {
 		const { jetpack: isJetpack } = site;
 		const headerText = translate( 'Import your content' );
 		const subHeaderText = translate(
-			'Bring content hosted elsewhere over to WordPress.com.' +
+			'Bring content hosted elsewhere over to WordPress.com. ' +
 				'{{a}}Find out what we currently support.{{/a}}',
 			{
 				components: {

--- a/client/my-sites/importer/section-import.scss
+++ b/client/my-sites/importer/section-import.scss
@@ -10,5 +10,10 @@
 
 	.formatted-header__subtitle {
 		color: var( --color-neutral-dark );
+
+		a {
+			display: block;
+			width: 100%;
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Before**:

<img width="1432" alt="Screenshot 2019-06-13 at 15 33 58" src="https://user-images.githubusercontent.com/5120357/59471756-6a0e1300-8e3c-11e9-89c7-a05ab3ed5ebb.png">

**After:**

<img width="1424" alt="Screenshot 2019-06-13 at 15 28 38" src="https://user-images.githubusercontent.com/5120357/59471760-6d090380-8e3c-11e9-8eda-446367e5cf04.png">

The purpose of the change was to increase the readablity of the link.

#### Testing instructions

Visit the import page, via Tools > Import .

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #33928
