### PR TITLE
Move action on privacy page to the bottom of section.

### DIFF
--- a/client/me/privacy/main.jsx
+++ b/client/me/privacy/main.jsx
@@ -80,9 +80,33 @@ const Privacy = createReactClass( {
 				<SectionHeader label={ translate( 'Usage Information' ) } />
 				<Card className="privacy__settings">
 					<form onChange={ markChanged } onSubmit={ this.submitForm }>
-						<p>{ translate( 'We are committed to your privacy and security.' ) }</p>
-
 						<FormFieldset>
+							<p>{ translate( 'We are committed to your privacy and security.' ) }</p>
+							<p>
+								{ translate(
+									'This information helps us improve our products, make marketing to you more ' +
+										'relevant, personalize your WordPress.com experience, and more as detailed in ' +
+										'our {{privacyPolicyLink}}privacy policy{{/privacyPolicyLink}}.',
+									{
+										components: {
+											privacyPolicyLink,
+										},
+									}
+								) }
+							</p>
+							<p>
+								{ translate(
+									'We use other tracking tools, including some from third parties. ' +
+										'{{cookiePolicyLink}}Read about these{{/cookiePolicyLink}} and how to ' +
+										'control them.',
+									{
+										components: {
+											cookiePolicyLink,
+										},
+									}
+								) }
+							</p>
+							<hr />
 							<p>
 								<FormToggle
 									id="tracks_opt_out"
@@ -100,32 +124,6 @@ const Privacy = createReactClass( {
 										}
 									) }
 								</FormToggle>
-							</p>
-
-							<p>
-								{ translate(
-									'This information helps us improve our products, make marketing to you more ' +
-										'relevant, personalize your WordPress.com experience, and more as detailed in ' +
-										'our {{privacyPolicyLink}}privacy policy{{/privacyPolicyLink}}.',
-									{
-										components: {
-											privacyPolicyLink,
-										},
-									}
-								) }
-							</p>
-
-							<p>
-								{ translate(
-									'We use other tracking tools, including some from third parties. ' +
-										'{{cookiePolicyLink}}Read about these{{/cookiePolicyLink}} and how to ' +
-										'control them.',
-									{
-										components: {
-											cookiePolicyLink,
-										},
-									}
-								) }
 							</p>
 						</FormFieldset>
 


### PR DESCRIPTION
This PR changes the positioning of the action on the privacy settings page to the bottom, and adds a separator to make sure it stands out from the rest of the copy.

<img width="740" alt="Screen Shot 2019-06-13 at 4 19 48 PM" src="https://user-images.githubusercontent.com/5881557/59473496-83d93700-8df7-11e9-8307-b6ada61a119f.png">

**Test Instructions**

Go to https://wordpress.com/me/privacy

- - -
Fixes #33834
