### PR TITLE
Missing whitespace on eligibility holds screen

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -126,7 +126,9 @@ export const EligibilityWarnings = ( {
 
 			<Card className="eligibility-warnings__confirm-box">
 				<div className="eligibility-warnings__confirm-text">
-					{ ! isEligible && translate( 'Please clear all issues above to proceed. ' ) }
+					{ ! isEligible && translate( 'Please clear all issues above to proceed. ', {
+						comment: 'Keep an extra space at the end of the sentence after the period.'
+					} ) }
 					{ isEligible &&
 						warnings.length > 0 &&
 						translate( 'If you proceed you will no longer be able to use these features. ' ) }

--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -126,7 +126,7 @@ export const EligibilityWarnings = ( {
 
 			<Card className="eligibility-warnings__confirm-box">
 				<div className="eligibility-warnings__confirm-text">
-					{ ! isEligible && translate( 'Please clear all issues above to proceed.' ) }
+					{ ! isEligible && translate( 'Please clear all issues above to proceed. ' ) }
 					{ isEligible &&
 						warnings.length > 0 &&
 						translate( 'If you proceed you will no longer be able to use these features. ' ) }


### PR DESCRIPTION
This PR adds back missing whitespace that was removed in #33910 



Before:

<img width="748" alt="RanBook 2019-06-13 at 16 43 57" src="https://user-images.githubusercontent.com/426518/59474122-7ec9b700-8dfa-11e9-97d2-7a9d5faa489a.png">


After:

<img width="757" alt="RanBook 2019-06-13 at 16 44 25" src="https://user-images.githubusercontent.com/426518/59474133-8ab57900-8dfa-11e9-95e4-0c8c10493e8d.png">

(Missing space is after the first sentence.)

To test, try to upload a plugin on a free site to get to this screen.