### PR TITLE
Store: Update all instances of title case to sentence case

### DIFF
--- a/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/index.js
+++ b/client/extensions/woocommerce/app/dashboard/widgets/inventory-widget/index.js
@@ -139,7 +139,7 @@ class InventoryWidget extends Component {
 		const props = {
 			width: this.props.width,
 			className: this.getClasses(),
-			title: translate( 'Inventory Alerts' ),
+			title: translate( 'Inventory alerts' ),
 			settingsPanel: InventoryControls,
 		};
 		if ( this.shouldShowImage() ) {

--- a/client/extensions/woocommerce/app/order/create.js
+++ b/client/extensions/woocommerce/app/order/create.js
@@ -130,7 +130,7 @@ class Order extends Component {
 
 		const breadcrumbs = [
 			<a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a>,
-			<span>{ translate( 'New Order' ) }</span>,
+			<span>{ translate( 'New order' ) }</span>,
 		];
 
 		return (
@@ -143,7 +143,7 @@ class Order extends Component {
 						busy={ isSaving }
 						disabled={ ! hasOrderEdits || isSaving }
 					>
-						{ translate( 'Save Order' ) }
+						{ translate( 'Save order' ) }
 					</Button>
 				</ActionHeader>
 

--- a/client/extensions/woocommerce/app/order/header.js
+++ b/client/extensions/woocommerce/app/order/header.js
@@ -132,7 +132,7 @@ class OrderActionHeader extends Component {
 
 		const buttons = [
 			<Button key="edit" primary onClick={ this.toggleEditing }>
-				{ translate( 'Edit Order' ) }
+				{ translate( 'Edit order' ) }
 			</Button>,
 		];
 
@@ -144,7 +144,7 @@ class OrderActionHeader extends Component {
 					busy={ isInvoiceSending }
 					disabled={ isInvoiceSending }
 				>
-					{ translate( 'Resend Invoice' ) }
+					{ translate( 'Resend invoice' ) }
 				</Button>
 			);
 		}
@@ -184,11 +184,11 @@ class OrderActionHeader extends Component {
 		const breadcrumbs = [
 			<a href={ getLink( '/store/orders/:site/', site ) }>{ translate( 'Orders' ) }</a>,
 			<span>
-				{ translate( 'Order %(orderId)s Details', { args: { orderId: `#${ orderId }` } } ) }
+				{ translate( 'Order %(orderId)s details', { args: { orderId: `#${ orderId }` } } ) }
 			</span>,
 		];
 
-		const primaryLabel = isEditing ? translate( 'Update' ) : translate( 'Edit Order' );
+		const primaryLabel = isEditing ? translate( 'Update' ) : translate( 'Edit order' );
 
 		return (
 			<ActionHeader breadcrumbs={ breadcrumbs } primaryLabel={ primaryLabel }>

--- a/client/extensions/woocommerce/app/order/order-activity-log/index.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/index.js
@@ -25,7 +25,7 @@ class OrderActivityLog extends Component {
 
 		return (
 			<div className="order-activity-log">
-				<SectionHeader label={ translate( 'Activity Log' ) } />
+				<SectionHeader label={ translate( 'Activity log' ) } />
 				<Card>
 					<OrderEvents orderId={ orderId } siteId={ siteId } />
 					<CreateOrderNote orderId={ orderId } siteId={ siteId } />

--- a/client/extensions/woocommerce/app/order/order-activity-log/new-note.js
+++ b/client/extensions/woocommerce/app/order/order-activity-log/new-note.js
@@ -74,11 +74,11 @@ class CreateOrderNote extends Component {
 				</FormFieldSet>
 				<div className="order-activity-log__new-note-type">
 					<FormSelect onChange={ this.setType } value={ this.state.type }>
-						<option value={ 'internal' }>{ translate( 'Private Note' ) }</option>
-						<option value={ 'email' }>{ translate( 'Send to Customer' ) }</option>
+						<option value={ 'internal' }>{ translate( 'Private note' ) }</option>
+						<option value={ 'email' }>{ translate( 'Send to customer' ) }</option>
 					</FormSelect>
 					<Button primary onClick={ this.saveNote } busy={ isNoteSaving } disabled={ isNoteSaving }>
-						{ translate( 'Add Note' ) }
+						{ translate( 'Add note' ) }
 					</Button>
 				</div>
 			</div>

--- a/client/extensions/woocommerce/app/order/order-customer/create.js
+++ b/client/extensions/woocommerce/app/order/order-customer/create.js
@@ -123,7 +123,7 @@ class OrderCustomerInfo extends Component {
 					onClick={ this.toggleDialog( 'billing' ) }
 					primary
 				>
-					{ translate( 'Add Billing Address' ) }
+					{ translate( 'Add billing address' ) }
 				</Button>
 			);
 		}
@@ -160,7 +160,7 @@ class OrderCustomerInfo extends Component {
 					onClick={ this.toggleDialog( 'shipping' ) }
 					primary
 				>
-					{ translate( 'Add Shipping Address' ) }
+					{ translate( 'Add shipping address' ) }
 				</Button>
 			);
 		}
@@ -186,19 +186,19 @@ class OrderCustomerInfo extends Component {
 
 		return (
 			<div className="order-customer__create order-customer">
-				<SectionHeader label={ translate( 'Customer Information' ) } />
+				<SectionHeader label={ translate( 'Customer information' ) } />
 				<Card>
 					<div className="order-customer__container">
 						<div className="order-customer__billing">
 							<h3 className="order-customer__billing-details">
-								{ translate( 'Billing Details' ) }
+								{ translate( 'Billing details' ) }
 							</h3>
 							{ this.renderBilling( order.billing ) }
 						</div>
 
 						<div className="order-customer__shipping">
 							<h3 className="order-customer__shipping-details">
-								{ translate( 'Shipping Details' ) }
+								{ translate( 'Shipping details' ) }
 							</h3>
 							{ this.renderShipping( order.shipping ) }
 						</div>

--- a/client/extensions/woocommerce/app/order/order-customer/dialog.js
+++ b/client/extensions/woocommerce/app/order/order-customer/dialog.js
@@ -224,7 +224,7 @@ class CustomerAddressDialog extends Component {
 				<FormFieldset>
 					<QueryPaymentCountries />
 					<FormPhoneMediaInput
-						label={ translate( 'Phone Number' ) }
+						label={ translate( 'Phone number' ) }
 						onChange={ this.onPhoneChange }
 						countryCode={ this.state.phoneCountry }
 						countriesList={ this.props.countriesList }
@@ -278,11 +278,11 @@ class CustomerAddressDialog extends Component {
 			>
 				<FormFieldset>
 					<FormLegend className="order-customer__billing-details">
-						{ isBilling ? translate( 'Billing Details' ) : translate( 'Shipping Details' ) }
+						{ isBilling ? translate( 'Billing details' ) : translate( 'Shipping details' ) }
 					</FormLegend>
 					<div className="order-customer__fieldset">
 						<div className="order-customer__field">
-							<FormLabel htmlFor="first_name">{ translate( 'First Name' ) }</FormLabel>
+							<FormLabel htmlFor="first_name">{ translate( 'First name' ) }</FormLabel>
 							<FormTextInput
 								id="first_name"
 								name="first_name"
@@ -291,7 +291,7 @@ class CustomerAddressDialog extends Component {
 							/>
 						</div>
 						<div className="order-customer__field">
-							<FormLabel htmlFor="last_name">{ translate( 'Last Name' ) }</FormLabel>
+							<FormLabel htmlFor="last_name">{ translate( 'Last name' ) }</FormLabel>
 							<FormTextInput
 								id="last_name"
 								name="last_name"

--- a/client/extensions/woocommerce/app/order/order-customer/index.js
+++ b/client/extensions/woocommerce/app/order/order-customer/index.js
@@ -130,12 +130,12 @@ class OrderCustomerInfo extends Component {
 
 		return (
 			<div className="order-customer">
-				<SectionHeader label={ translate( 'Customer Information' ) } />
+				<SectionHeader label={ translate( 'Customer information' ) } />
 				<Card>
 					<div className="order-customer__container">
 						<div className="order-customer__billing">
 							<h3 className="order-customer__billing-details">
-								{ translate( 'Billing Details' ) }
+								{ translate( 'Billing details' ) }
 								{ isEditable ? (
 									<Button
 										compact
@@ -162,7 +162,7 @@ class OrderCustomerInfo extends Component {
 
 						<div className="order-customer__shipping">
 							<h3 className="order-customer__shipping-details">
-								{ translate( 'Shipping Details' ) }
+								{ translate( 'Shipping details' ) }
 								{ isEditable ? (
 									<Button
 										compact

--- a/client/extensions/woocommerce/app/order/order-details/add-items.js
+++ b/client/extensions/woocommerce/app/order/order-details/add-items.js
@@ -38,10 +38,10 @@ class OrderAddItems extends Component {
 					primary={ isNewOrder }
 					onClick={ this.toggleDialog( 'product' ) }
 				>
-					{ translate( 'Add Product' ) }
+					{ translate( 'Add product' ) }
 				</Button>
 				<Button borderless onClick={ this.toggleDialog( 'fee' ) }>
-					{ translate( 'Add Fee' ) }
+					{ translate( 'Add fee' ) }
 				</Button>
 				<OrderFeeDialog
 					isVisible={ 'fee' === this.state.showDialog }

--- a/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/fee-dialog.js
@@ -107,7 +107,7 @@ class OrderFeeDialog extends Component {
 		const dialogButtons = [
 			<Button onClick={ closeDialog }>{ translate( 'Cancel' ) }</Button>,
 			<Button primary onClick={ this.handleFeeSave } disabled={ ! canSave }>
-				{ translate( 'Add Fee' ) }
+				{ translate( 'Add fee' ) }
 			</Button>,
 		];
 

--- a/client/extensions/woocommerce/app/order/order-details/index.js
+++ b/client/extensions/woocommerce/app/order/order-details/index.js
@@ -95,7 +95,7 @@ class OrderDetails extends Component {
 		return (
 			<div className="order-details">
 				<SectionHeader
-					label={ translate( 'Order %(orderId)s Details', {
+					label={ translate( 'Order %(orderId)s details', {
 						args: { orderId: isObject( order.id ) ? '' : `#${ order.id }` },
 					} ) }
 				>

--- a/client/extensions/woocommerce/app/order/order-details/product-dialog.js
+++ b/client/extensions/woocommerce/app/order/order-details/product-dialog.js
@@ -128,7 +128,7 @@ class OrderProductDialog extends Component {
 
 		// Fake 1 so the string is already at singular when the first item is selected
 		const productsCount = this.state.products.length ? this.state.products.length : 1;
-		const buttonLabel = translate( 'Add Product', 'Add Products', {
+		const buttonLabel = translate( 'Add product', 'Add products', {
 			count: productsCount,
 		} );
 

--- a/client/extensions/woocommerce/app/order/order-payment/index.js
+++ b/client/extensions/woocommerce/app/order/order-payment/index.js
@@ -100,9 +100,9 @@ class OrderPaymentCard extends Component {
 		if ( 'refunded' === order.status || codProcessing ) {
 			return null;
 		} else if ( isOrderWaitingPayment( order.status ) ) {
-			return <Button onClick={ this.markAsPaid }>{ translate( 'Mark as Paid' ) }</Button>;
+			return <Button onClick={ this.markAsPaid }>{ translate( 'Mark as paid' ) }</Button>;
 		}
-		return <Button onClick={ this.toggleDialog }>{ translate( 'Submit Refund' ) }</Button>;
+		return <Button onClick={ this.toggleDialog }>{ translate( 'Submit refund' ) }</Button>;
 	};
 
 	markAsPaid = () => {

--- a/client/extensions/woocommerce/app/orders/index.js
+++ b/client/extensions/woocommerce/app/orders/index.js
@@ -23,7 +23,7 @@ function Orders( { className, params, site, translate } ) {
 	if ( config.isEnabled( 'woocommerce/extension-orders-create' ) ) {
 		addButton = (
 			<Button primary href={ getLink( '/store/order/:site/', site ) }>
-				{ translate( 'New Order' ) }
+				{ translate( 'New order' ) }
 			</Button>
 		);
 	}

--- a/client/extensions/woocommerce/app/orders/orders-filter-nav.js
+++ b/client/extensions/woocommerce/app/orders/orders-filter-nav.js
@@ -31,11 +31,11 @@ class OrdersFilterNav extends Component {
 
 	render() {
 		const { translate, site, status } = this.props;
-		let currentSelection = translate( 'All Orders' );
+		let currentSelection = translate( 'All orders' );
 		if ( ORDER_UNPAID === status ) {
-			currentSelection = translate( 'Awaiting Payment' );
+			currentSelection = translate( 'Awaiting payment' );
 		} else if ( ORDER_UNFULFILLED === status ) {
-			currentSelection = translate( 'Awaiting Fulfillment' );
+			currentSelection = translate( 'Awaiting fulfillment' );
 		} else if ( ORDER_COMPLETED === status ) {
 			currentSelection = translate( 'Completed' );
 		}
@@ -44,19 +44,19 @@ class OrdersFilterNav extends Component {
 			<SectionNav selectedText={ currentSelection }>
 				<NavTabs label={ translate( 'Status' ) } selectedText={ currentSelection }>
 					<NavItem path={ getLink( '/store/orders/:site', site ) } selected={ 'any' === status }>
-						{ translate( 'All Orders' ) }
+						{ translate( 'All orders' ) }
 					</NavItem>
 					<NavItem
 						path={ getLink( `/store/orders/${ ORDER_UNPAID }/:site`, site ) }
 						selected={ ORDER_UNPAID === status }
 					>
-						{ translate( 'Awaiting Payment' ) }
+						{ translate( 'Awaiting payment' ) }
 					</NavItem>
 					<NavItem
 						path={ getLink( `/store/orders/${ ORDER_UNFULFILLED }/:site`, site ) }
 						selected={ ORDER_UNFULFILLED === status }
 					>
-						{ translate( 'Awaiting Fulfillment' ) }
+						{ translate( 'Awaiting fulfillment' ) }
 					</NavItem>
 					<NavItem
 						path={ getLink( `/store/orders/${ ORDER_COMPLETED }/:site`, site ) }

--- a/client/extensions/woocommerce/app/products/product-header.js
+++ b/client/extensions/woocommerce/app/products/product-header.js
@@ -67,14 +67,14 @@ const ProductHeader = ( { viewEnabled, onTrash, onSave, isBusy, translate, site,
 	const existing = product && ! isObject( product.id );
 	const viewButton = viewEnabled && renderViewButton( product, translate( 'View' ) );
 	const trashButton = renderTrashButton( onTrash, isBusy, translate( 'Delete' ) );
-	const saveLabel = existing ? translate( 'Update' ) : translate( 'Save & Publish' );
+	const saveLabel = existing ? translate( 'Update' ) : translate( 'Save & publish' );
 	const saveButton = renderSaveButton( onSave, isBusy, saveLabel );
 
 	const currentCrumb =
 		product && existing ? (
-			<span>{ translate( 'Edit Product' ) }</span>
+			<span>{ translate( 'Edit product' ) }</span>
 		) : (
-			<span>{ translate( 'Add New' ) }</span>
+			<span>{ translate( 'Add new' ) }</span>
 		);
 
 	const breadcrumbs = [

--- a/client/extensions/woocommerce/app/promotions/promotion-header.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-header.js
@@ -45,13 +45,13 @@ function renderSaveButton( onSave, isBusy, label ) {
 const PromotionHeader = ( { promotion, onSave, onTrash, isBusy, translate, site } ) => {
 	const existing = promotion && ! isObject( promotion.id );
 	const trashButton = renderTrashButton( onTrash, isBusy, translate( 'Delete' ) );
-	const saveLabel = existing ? translate( 'Update' ) : translate( 'Save & Publish' );
+	const saveLabel = existing ? translate( 'Update' ) : translate( 'Save & publish' );
 	const saveButton = renderSaveButton( onSave, isBusy, saveLabel );
 
 	const currentCrumb = existing ? (
-		<span>{ translate( 'Edit Promotion' ) }</span>
+		<span>{ translate( 'Edit promotion' ) }</span>
 	) : (
-		<span>{ translate( 'Add Promotion' ) }</span>
+		<span>{ translate( 'Add promotion' ) }</span>
 	);
 
 	const breadcrumbs = [

--- a/client/extensions/woocommerce/app/promotions/promotion-models.js
+++ b/client/extensions/woocommerce/app/promotions/promotion-models.js
@@ -67,9 +67,9 @@ const appliesToCoupon = {
 			component: (
 				<PromotionAppliesToField
 					selectionTypes={ [
-						{ labelText: translate( 'All Products' ), type: 'all' },
-						{ labelText: translate( 'Specific Products' ), type: 'productIds' },
-						{ labelText: translate( 'Product Categories' ), type: 'productCategoryIds' },
+						{ labelText: translate( 'All products' ), type: 'all' },
+						{ labelText: translate( 'Specific products' ), type: 'productIds' },
+						{ labelText: translate( 'Product categories' ), type: 'productCategoryIds' },
 					] }
 				/>
 			),
@@ -155,7 +155,7 @@ const EndDateField = props => {
 
 	return (
 		<DateField
-			labelText={ translate( 'End Date' ) }
+			labelText={ translate( 'End date' ) }
 			isEnableable
 			disabledDays={ [ { before: new Date( startDate ) } ] }
 			{ ...props }
@@ -169,11 +169,11 @@ const EndDateField = props => {
 const productSaleModel = {
 	appliesToProductSale,
 	productAndSalePrice: {
-		labelText: translate( 'Product & Sale Price' ),
+		labelText: translate( 'Product & sale price' ),
 		cssClass: 'promotions__promotion-form-card-primary',
 		fields: {
 			salePrice: {
-				component: <CurrencyField labelText={ translate( 'Product Sale Price' ) } isRequired />,
+				component: <CurrencyField labelText={ translate( 'Product sale price' ) } isRequired />,
 				validate: validateSalePrice,
 			},
 		},
@@ -263,7 +263,7 @@ const couponConditions = {
 const fixedProductModel = {
 	appliesToCoupon,
 	couponCodeAndDiscount: {
-		labelText: translate( 'Coupon Code & Discount' ),
+		labelText: translate( 'Coupon code & discount' ),
 		cssClass: 'promotions__promotion-form-card-primary',
 		fields: {
 			couponCode: {
@@ -273,7 +273,7 @@ const fixedProductModel = {
 			fixedDiscount: {
 				component: (
 					<CurrencyField
-						labelText={ translate( 'Product Discount', { comment: 'for coupon' } ) }
+						labelText={ translate( 'Product discount', { comment: 'for coupon' } ) }
 						isRequired
 					/>
 				),
@@ -293,7 +293,7 @@ const fixedProductModel = {
 const fixedCartModel = {
 	appliesWhenCoupon,
 	couponCodeAndDiscount: {
-		labelText: translate( 'Coupon Code & Discount' ),
+		labelText: translate( 'Coupon code & discount' ),
 		cssClass: 'promotions__promotion-form-card-primary',
 		fields: {
 			couponCode: {
@@ -303,7 +303,7 @@ const fixedCartModel = {
 			fixedDiscount: {
 				component: (
 					<CurrencyField
-						labelText={ translate( 'Cart Discount', { comment: 'for coupon' } ) }
+						labelText={ translate( 'Cart discount', { comment: 'for coupon' } ) }
 						isRequired
 					/>
 				),
@@ -323,7 +323,7 @@ const fixedCartModel = {
 const percentCartModel = {
 	appliesWhenCoupon,
 	couponCodeAndDiscount: {
-		labelText: translate( 'Coupon Code & Discount' ),
+		labelText: translate( 'Coupon code & discount' ),
 		cssClass: 'promotions__promotion-form-card-primary',
 		fields: {
 			couponCode: {
@@ -333,7 +333,7 @@ const percentCartModel = {
 			percentDiscount: {
 				component: (
 					<PercentField
-						labelText={ translate( 'Percent Cart Discount', { comment: 'for coupon' } ) }
+						labelText={ translate( 'Percent cart discount', { comment: 'for coupon' } ) }
 						isRequired
 					/>
 				),

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-bacs.js
@@ -127,13 +127,13 @@ class PaymentMethodBACS extends Component {
 					/>
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container">
-					<FormLabel>{ translate( 'Account Details' ) }</FormLabel>
+					<FormLabel>{ translate( 'Account details' ) }</FormLabel>
 					{ translate(
 						"These are the details of the bank account you'd like your customers to pay in to."
 					) }
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container">
-					<FormLabel>{ translate( 'Account Name' ) }</FormLabel>
+					<FormLabel>{ translate( 'Account name' ) }</FormLabel>
 					<FormTextInput
 						name="account_name"
 						onChange={ this.onEditAccountHandler }
@@ -144,7 +144,7 @@ class PaymentMethodBACS extends Component {
 					</FormSettingExplanation>
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container">
-					<FormLabel>{ translate( 'Bank Name' ) }</FormLabel>
+					<FormLabel>{ translate( 'Bank name' ) }</FormLabel>
 					<FormTextInput
 						name="bank_name"
 						onChange={ this.onEditAccountHandler }
@@ -152,7 +152,7 @@ class PaymentMethodBACS extends Component {
 					/>
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container">
-					<FormLabel>{ translate( 'Routing Number' ) }</FormLabel>
+					<FormLabel>{ translate( 'Routing number' ) }</FormLabel>
 					<FormPasswordInput
 						name="sort_code"
 						onChange={ this.onEditAccountHandler }
@@ -160,7 +160,7 @@ class PaymentMethodBACS extends Component {
 					/>
 				</FormFieldset>
 				<FormFieldset className="payments__method-edit-field-container">
-					<FormLabel>{ translate( 'Account Number' ) }</FormLabel>
+					<FormLabel>{ translate( 'Account number' ) }</FormLabel>
 					<FormPasswordInput
 						name="account_number"
 						onChange={ this.onEditAccountHandler }

--- a/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
+++ b/client/extensions/woocommerce/app/settings/payments/payment-method-item.js
@@ -220,7 +220,7 @@ class PaymentMethodItem extends Component {
 					{ method.informationUrl && (
 						<p className="payments__method-information">
 							<ExternalLink icon href={ method.informationUrl } target="_blank">
-								{ translate( 'More Information' ) }
+								{ translate( 'More information' ) }
 							</ExternalLink>
 						</p>
 					) }

--- a/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
+++ b/client/extensions/woocommerce/app/settings/payments/payments-location-currency.js
@@ -89,7 +89,7 @@ class SettingsPaymentsLocationCurrency extends Component {
 				<Card className="payments__address-currency-container">
 					<StoreAddress showLabel={ false } />
 					<div className="payments__currency-container">
-						<FormLabel>{ translate( 'Store Currency' ) }</FormLabel>
+						<FormLabel>{ translate( 'Store currency' ) }</FormLabel>
 						<FormSelect
 							className="payments__currency-select"
 							onChange={ this.onChange }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-origin.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-origin.js
@@ -19,7 +19,7 @@ const ShippingOrigin = ( { translate, onChange } ) => {
 	return (
 		<div className="shipping__origin">
 			<ExtendedHeader
-				label={ translate( 'Shipping Origin' ) }
+				label={ translate( 'Shipping origin' ) }
 				description={ translate( 'The address of where you will be shipping from.' ) }
 			/>
 			<Card className="shipping__origin-settings">

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone-list.js
@@ -102,7 +102,7 @@ class ShippingZoneList extends Component {
 				<QueryShippingZones siteId={ siteId } />
 				<QuerySettingsGeneral siteId={ siteId } />
 				<ExtendedHeader
-					label={ translate( 'Shipping Zones' ) }
+					label={ translate( 'Shipping zones' ) }
 					description={ translate(
 						'These are the regions you’ll ship to. ' +
 							'You can define different shipping methods for each region. '

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-header.js
@@ -32,9 +32,9 @@ const ShippingZoneHeader = ( {
 } ) => {
 	const currentCrumb =
 		zone && isNumber( zone.id ) ? (
-			<span>{ translate( 'Edit Shipping Zone' ) }</span>
+			<span>{ translate( 'Edit shipping zone' ) }</span>
 		) : (
-			<span>{ translate( 'Add new Shipping Zone' ) }</span>
+			<span>{ translate( 'Add new shipping zone' ) }</span>
 		);
 
 	const breadcrumbs = [

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/shipping-zone-location-dialog-settings.js
@@ -182,7 +182,7 @@ const ShippingZoneLocationDialogSettings = ( {
 	return (
 		<div className="shipping-zone__location-dialog-settings">
 			<FormFieldSet>
-				<FormLegend>{ translate( 'Shipping Zone settings' ) }</FormLegend>
+				<FormLegend>{ translate( 'Shipping zone settings' ) }</FormLegend>
 				{ renderRadios() }
 			</FormFieldSet>
 			{ renderDetailedSettings() }

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-wcs.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-wcs.js
@@ -144,7 +144,7 @@ class SettingsTaxesWooCommerceServices extends Component {
 		return (
 			<div className="taxes__nexus">
 				<ExtendedHeader
-					label={ translate( 'Store Address' ) }
+					label={ translate( 'Store address' ) }
 					description={ translate(
 						'The address of where your business is located for tax purposes.'
 					) }

--- a/client/extensions/woocommerce/components/address-view/index.js
+++ b/client/extensions/woocommerce/components/address-view/index.js
@@ -129,7 +129,7 @@ class AddressView extends Component {
 				onClick={ this.onClickShowAddressLine2 }
 			>
 				<Gridicon icon="plus-small" />
-				{ translate( 'Add Address Line 2' ) }
+				{ translate( 'Add address line 2' ) }
 			</Button>
 		);
 	};

--- a/client/extensions/woocommerce/components/order-status/README.md
+++ b/client/extensions/woocommerce/components/order-status/README.md
@@ -10,7 +10,7 @@ Some statuses don't have a shipping status: `cancelled`, `refunded`, and `failed
 ```jsx
 render: function() {
     return (
-        <SectionHeader label="Order Details">
+        <SectionHeader label="Order details">
             <OrderStatus order={ { status: 'pending' } } />
         </SectionHeader>
     );
@@ -42,7 +42,7 @@ OrderStatusSelect is a component that displays a dropdown of order statuses.
 ```jsx
 render: function() {
     return (
-        <SectionHeader label="Order Details">
+        <SectionHeader label="Order details">
             <OrderStatusSelect value={ this.state.status } onChange={ this.updateStatus } />
         </SectionHeader>
     );

--- a/client/extensions/woocommerce/index.js
+++ b/client/extensions/woocommerce/index.js
@@ -62,31 +62,31 @@ const getStorePages = () => {
 		{
 			container: ProductCreate,
 			configKey: 'woocommerce/extension-products',
-			documentTitle: translate( 'New Product' ),
+			documentTitle: translate( 'New product' ),
 			path: '/store/product/:site',
 		},
 		{
 			container: ProductUpdate,
 			configKey: 'woocommerce/extension-products',
-			documentTitle: translate( 'Edit Product' ),
+			documentTitle: translate( 'Edit product' ),
 			path: '/store/product/:site/:product_id',
 		},
 		{
 			container: ProductCategories,
 			configKey: 'woocommerce/extension-product-categories',
-			documentTitle: translate( 'Product Categories' ),
+			documentTitle: translate( 'Product categories' ),
 			path: '/store/products/categories/:site',
 		},
 		{
 			container: ProductCategoryUpdate,
 			configKey: 'woocommerce/extension-product-categories',
-			documentTitle: translate( 'Edit Product Category' ),
+			documentTitle: translate( 'Edit product category' ),
 			path: '/store/products/category/:site/:category_id',
 		},
 		{
 			container: ProductCategoryCreate,
 			configKey: 'woocommerce/extension-product-categories',
-			documentTitle: translate( 'New Product Category' ),
+			documentTitle: translate( 'New product category' ),
 			path: '/store/products/category/:site',
 		},
 		{
@@ -104,13 +104,13 @@ const getStorePages = () => {
 		{
 			container: Order,
 			configKey: 'woocommerce/extension-orders',
-			documentTitle: translate( 'Order Details' ),
+			documentTitle: translate( 'Order details' ),
 			path: '/store/order/:site/:order_id',
 		},
 		{
 			container: OrderCreate,
 			configKey: 'woocommerce/extension-orders-create',
-			documentTitle: translate( 'New Order' ),
+			documentTitle: translate( 'New order' ),
 			path: '/store/order/:site/',
 		},
 		{
@@ -122,13 +122,13 @@ const getStorePages = () => {
 		{
 			container: PromotionCreate,
 			configKey: 'woocommerce/extension-promotions',
-			documentTitle: translate( 'New Promotion' ),
+			documentTitle: translate( 'New promotion' ),
 			path: '/store/promotion/:site',
 		},
 		{
 			container: PromotionUpdate,
 			configKey: 'woocommerce/extension-promotions',
-			documentTitle: translate( 'Edit Promotion' ),
+			documentTitle: translate( 'Edit promotion' ),
 			path: '/store/promotion/:site/:promotion_id',
 		},
 		{
@@ -152,31 +152,31 @@ const getStorePages = () => {
 		{
 			container: SettingsPayments,
 			configKey: 'woocommerce/extension-settings',
-			documentTitle: translate( 'Payment Settings' ),
+			documentTitle: translate( 'Payment settings' ),
 			path: '/store/settings/:site',
 		},
 		{
 			container: SettingsPayments,
 			configKey: 'woocommerce/extension-settings-payments',
-			documentTitle: translate( 'Payment Settings' ),
+			documentTitle: translate( 'Payment settings' ),
 			path: '/store/settings/payments/:site',
 		},
 		{
 			container: Shipping,
 			configKey: 'woocommerce/extension-settings-shipping',
-			documentTitle: translate( 'Shipping Settings' ),
+			documentTitle: translate( 'Shipping settings' ),
 			path: '/store/settings/shipping/:site',
 		},
 		{
 			container: ShippingZone,
 			configKey: 'woocommerce/extension-settings-shipping',
-			documentTitle: translate( 'Shipping Settings' ),
+			documentTitle: translate( 'Shipping settings' ),
 			path: '/store/settings/shipping/zone/:site/:zone?',
 		},
 		{
 			container: SettingsTaxes,
 			configKey: 'woocommerce/extension-settings-tax',
-			documentTitle: translate( 'Tax Settings' ),
+			documentTitle: translate( 'Tax settings' ),
 			path: '/store/settings/taxes/:site',
 		},
 		{

--- a/client/extensions/woocommerce/woocommerce-services/components/labels-setup-notice/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/components/labels-setup-notice/index.js
@@ -46,7 +46,7 @@ const LabelsSetupNotice = ( {
 		return (
 			<Card className="labels-setup-notice is-warning">
 				{ translate(
-					'To begin fulfilling orders by printing your own label, add a payment method in {{a}}Shipping Settings{{/a}}',
+					'To begin fulfilling orders by printing your own label, add a payment method in {{a}}shipping settings{{/a}}',
 					{ components: { a: <a href={ getLink( '/store/settings/shipping/:site/', site ) } /> } }
 				) }
 			</Card>

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/index.js
@@ -79,7 +79,7 @@ class AccountSettingsRootView extends Component {
 			<div>
 				<QueryLabelSettings siteId={ siteId } />
 				<ExtendedHeader
-					label={ translate( 'Shipping Labels' ) }
+					label={ translate( 'Shipping labels' ) }
 					description={ translate(
 						'Print shipping labels yourself and save a trip to the post office.'
 					) }

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-settings.js
@@ -324,7 +324,7 @@ class ShippingLabels extends Component {
 		return (
 			<FormFieldSet>
 				<FormLabel className="label-settings__cards-label">
-					{ translate( 'Email Receipts' ) }
+					{ translate( 'Email receipts' ) }
 				</FormLabel>
 				<FormLabel>
 					<FormCheckbox

--- a/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/packages/edit-package.js
@@ -134,7 +134,7 @@ const EditPackage = props => {
 			</FormFieldset>
 			<FormFieldset>
 				<FormLabel>
-					{ translate( 'Inner Dimensions (L x W x H) %(dimensionUnit)s', {
+					{ translate( 'Inner dimensions (L x W x H) %(dimensionUnit)s', {
 						args: { dimensionUnit },
 					} ) }
 				</FormLabel>
@@ -152,7 +152,7 @@ const EditPackage = props => {
 			{ isOuterDimensionsVisible ? (
 				<FormFieldset>
 					<FormLabel>
-						{ translate( 'Outer Dimensions (L x W x H) %(dimensionUnit)s', {
+						{ translate( 'Outer dimensions (L x W x H) %(dimensionUnit)s', {
 							args: { dimensionUnit },
 						} ) }
 					</FormLabel>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Store is currently using majority sentence case with a few instances of title case in buttons, labels, and headings
* Updates all instances to use sentence case

**Before Example**
<img width="1667" alt="Before-Promotions" src="https://user-images.githubusercontent.com/712873/59474238-eb44b600-8dfa-11e9-9713-14cbf4b61d1c.png">

**After Example**

<img width="1668" alt="After-Promotions" src="https://user-images.githubusercontent.com/712873/59474342-38c12300-8dfb-11e9-8bdb-ee36913f5872.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
This PR touches most screens in Store
*  Navigate to http://calypso.localhost:3000/store/
*  Navigate through each screen in store checking that all buttons, titles, and labels are using sentence case

Fixes https://github.com/Automattic/wp-calypso/issues/33438
