### PR TITLE
Add formatted header with title to Add Shipping Zones Pages

### DIFF
--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -16,6 +16,7 @@ import page from 'page';
  * Internal dependencies
  */
 import accept from 'lib/accept';
+import FormattedHeader from 'components/formatted-header';
 import Main from 'components/main';
 import QueryShippingZones, {
 	areShippingZonesFullyLoaded,
@@ -149,6 +150,7 @@ class Shipping extends Component {
 				<QueryShippingZones siteId={ siteId } />
 				<QuerySettingsGeneral siteId={ siteId } />
 				<ShippingZoneHeader onSave={ this.onSave } onDelete={ this.onDelete } />
+				<FormattedHeader headerText="Add a Shipping Zone" />
 				{ ! isRestOfTheWorld && <ShippingZoneLocationList siteId={ siteId } /> }
 				<ShippingZoneMethodList siteId={ siteId } />
 				{ ! isRestOfTheWorld && <ShippingZoneName siteId={ siteId } /> }

--- a/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
+++ b/client/extensions/woocommerce/app/settings/shipping/shipping-zone/index.js
@@ -142,7 +142,7 @@ class Shipping extends Component {
 	}
 
 	render() {
-		const { className, isRestOfTheWorld, hasEdits, siteId } = this.props;
+		const { className, isRestOfTheWorld, hasEdits, siteId, translate } = this.props;
 
 		return (
 			<Main className={ classNames( 'shipping', className ) } wideLayout>
@@ -150,7 +150,7 @@ class Shipping extends Component {
 				<QueryShippingZones siteId={ siteId } />
 				<QuerySettingsGeneral siteId={ siteId } />
 				<ShippingZoneHeader onSave={ this.onSave } onDelete={ this.onDelete } />
-				<FormattedHeader headerText="Add a Shipping Zone" />
+				<FormattedHeader headerText={ translate( 'Add a Shipping Zone' ) } />
 				{ ! isRestOfTheWorld && <ShippingZoneLocationList siteId={ siteId } /> }
 				<ShippingZoneMethodList siteId={ siteId } />
 				{ ! isRestOfTheWorld && <ShippingZoneName siteId={ siteId } /> }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*Add formatted header component and title to screen

Before:

<img width="1919" alt="Screen Shot 2019-06-13 at 4 50 13 PM" src="https://user-images.githubusercontent.com/4500952/59474366-58584b80-8dfb-11e9-990e-f461a9ba3d87.png">

<img width="1535" alt="Screen Shot 2019-06-13 at 4 46 25 PM" src="https://user-images.githubusercontent.com/4500952/59474375-5f7f5980-8dfb-11e9-9be7-8ba5abb85ca3.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In store, navigate to settings
* Navigate to Shipping
* Click "Add zone" in the shipping zones section
* Note the title at the top of the screen using the formatted header component

Fixes #33267
