### PR TITLE
Removed checklist expand/contract toggle, and cleaned up type spacing

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -16,7 +16,7 @@
 		flex: 1 1;
 		flex-direction: column;
 		align-items: stretch;
-		padding: 16px 24px;
+		padding: 13px 24px 16px;
 		@include breakpoint( '<480px' ) {
 			padding: 16px;
 		}
@@ -24,7 +24,7 @@
 
 	&-secondary {
 		align-items: stretch;
-		display: flex;
+		display: none;
 		flex-direction: row;
 		flex: 2 1;
 		justify-content: flex-end;
@@ -225,7 +225,7 @@
 	&-title-link.button {
 		padding: 0;
 		color: var( --color-primary );
-		font-weight: 400;
+		font-weight: 500;
 		font-size: 16px;
 	}
 
@@ -403,4 +403,8 @@
 
 .checklist__task-title {
 	text-align: left;
+}
+
+.checklist__task-description {
+	margin-bottom: 0.4em;
 }


### PR DESCRIPTION
The toggle had little value. It didn’t work when all task were incomplete, and didn’t add value when some tasks were complete, and others weren’t. So removed it completely. The UX is now more direct.

Also cleaned up spacing between the task description & estimated time, and increased the font-weight for the link button.

#### Changes proposed in this Pull Request

* We remove the expand/contract UI (has little value)
* Reduce padding between description and time estimate
* Bold the product title link


Fixes #

**Before**
<img width="710" alt="Screen Shot 2019-06-13 at 4 32 45 PM" src="https://user-images.githubusercontent.com/1382943/59474542-21cf0080-8dfc-11e9-864e-9c56b70288f3.png">

**After**
<img width="708" alt="Screen Shot 2019-06-13 at 4 36 25 PM" src="https://user-images.githubusercontent.com/1382943/59474548-298ea500-8dfc-11e9-9d56-4a63ed1e8a1b.png">
