### PR TITLE
Reader: Make "More on WordPress" link colors consistent

### DIFF
--- a/client/blocks/reader-author-link/style.scss
+++ b/client/blocks/reader-author-link/style.scss
@@ -1,5 +1,5 @@
 .reader-author-link {
-	color: var( --color-text-subtle );
+	color: var( --color-primary );
 }
 
 .reader-author-link:hover,

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -22,8 +22,13 @@
 	color: var( --color-primary );
 	font-family: $sans;
 
-	&:hover {
-		color: var( --color-primary-light );
+	&:hover,
+	&:active {
+		color: var( --color-accent );
+	}
+
+	&:focus {
+		color: var( --color-text-subtle );
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, Author and Site links under "More on WordPress" are inconsistent. This PR fixes that, making sure link colors are blue and pink on hover and active.

#### Testing instructions

1. Go to Reader
2. Click on a post (this will take you to full post)
3. Scroll down to the bottom of the post and make sure their link colors are consistent

**Before:**
<img width="742" alt="Screenshot 2019-06-13 16 48 48" src="https://user-images.githubusercontent.com/4924246/59474828-3364d800-8dfd-11e9-9562-145d8236e153.png">

**After:**
<img width="738" alt="Screenshot 2019-06-13 17 04 19" src="https://user-images.githubusercontent.com/4924246/59474844-4b3c5c00-8dfd-11e9-82c9-956eaf9f4034.png">
