### PR TITLE
Signup: Enable site preview for the blog segment

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -115,14 +115,6 @@ export function generateFlows( {
 			lastModified: '2019-06-05',
 		},
 
-		// We don't yet show the previews for the 'blog' segment
-		'onboarding-blog': {
-			steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains', 'plans' ],
-			destination: getChecklistDestination,
-			description: 'The improved onboarding flow.',
-			lastModified: '2019-04-30',
-		},
-
 		'onboarding-dev': {
 			steps: [
 				'user',

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -67,7 +67,6 @@ import { submitSiteVertical } from 'state/signup/steps/site-vertical/actions';
 import getSiteId from 'state/selectors/get-site-id';
 import { isCurrentPlanPaid, getSitePlanSlug } from 'state/sites/selectors';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
 
 // Current directory dependencies
 import steps from './config/steps';
@@ -115,7 +114,6 @@ class Signup extends React.Component {
 		flowName: PropTypes.string,
 		stepName: PropTypes.string,
 		pageTitle: PropTypes.string,
-		siteType: PropTypes.string,
 		stepSectionName: PropTypes.string,
 	};
 
@@ -619,8 +617,9 @@ class Signup extends React.Component {
 						redirectTo={ this.state.redirectTo }
 					/>
 				) }
-				{ get( steps[ this.props.stepName ], 'props.showSiteMockups', false ) &&
-					'blog' !== this.props.siteType && <SiteMockups stepName={ this.props.stepName } /> }
+				{ get( steps[ this.props.stepName ], 'props.showSiteMockups', false ) && (
+					<SiteMockups stepName={ this.props.stepName } />
+				) }
 			</div>
 		);
 	}
@@ -644,7 +643,6 @@ export default connect(
 			sitePlanSlug: getSitePlanSlug( state, siteId ),
 			siteDomains,
 			siteId,
-			siteType: getSiteType( state ),
 		};
 	},
 	{

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -17,7 +17,6 @@ import { saveSignupStep } from 'state/signup/progress/actions';
 
 const siteTypeToFlowname = {
 	'online-store': 'ecommerce-onboarding',
-	blog: 'onboarding-blog',
 };
 
 class SiteType extends Component {

--- a/test/e2e/lib/pages/signup/site-style-page.js
+++ b/test/e2e/lib/pages/signup/site-style-page.js
@@ -1,0 +1,26 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
+ * Internal dependencies
+ */
+import * as driverHelper from '../../driver-helper.js';
+
+import AsyncBaseContainer from '../../async-base-container';
+
+export default class SiteStylePage extends AsyncBaseContainer {
+	constructor( driver ) {
+		super( driver, By.css( '.site-style__form-wrapper' ) );
+	}
+
+	async submitForm() {
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			By.css( '.site-style__form-wrapper button.is-primary' )
+		);
+	}
+}

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -31,6 +31,7 @@ import ImportFromURLPage from '../lib/pages/signup/import-from-url-page';
 import SiteTypePage from '../lib/pages/signup/site-type-page';
 import SiteTopicPage from '../lib/pages/signup/site-topic-page';
 import SiteTitlePage from '../lib/pages/signup/site-title-page';
+import SiteStylePage from '../lib/pages/signup/site-style-page';
 import LoginPage from '../lib/pages/login-page';
 import MagicLoginPage from '../lib/pages/magic-login-page';
 import ReaderPage from '../lib/pages/reader-page';
@@ -1684,6 +1685,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await siteTitlePage.submitForm();
 		} );
 
+		step( 'Can see the "Site style" page, and continue with the default style', async function() {
+			const siteTitlePage = await SiteStylePage.Expect( driver );
+			return await siteTitlePage.submitForm();
+		} );
+
 		step(
 			'Can then see the domains page, and Can search for a blog name, can see and select a free .wordpress address in the results',
 			async function() {
@@ -1792,6 +1798,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step( 'Can see the "Site title" page, and enter the site title', async function() {
 			const siteTitlePage = await SiteTitlePage.Expect( driver );
 			await siteTitlePage.enterSiteTitle( blogName );
+			return await siteTitlePage.submitForm();
+		} );
+
+		step( 'Can see the "Site style" page, and continue with the default style', async function() {
+			const siteTitlePage = await SiteStylePage.Expect( driver );
 			return await siteTitlePage.submitForm();
 		} );
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This change is the final step in releasing Blog previews to the wilderness.

<img width="500" alt="Screen Shot 2019-06-14 at 10 20 41 am" src="https://user-images.githubusercontent.com/6458278/59475420-c732b480-8e8e-11e9-97a9-c4d910b0adae.png">

<img width="500" alt="Screen Shot 2019-06-14 at 10 24 24 am" src="https://user-images.githubusercontent.com/6458278/59475421-c732b480-8e8e-11e9-80a9-91695452f9c8.png">


## Testing instructions

1. Apply `D28616-code`
2. Head to http://calypso.localhost:3000/start/onboarding
3. Select **Blog** as your site type
4. Go through the flow and create a site

The flow should contain the same steps as Business and Professional. 

The preview should appear and give an indication of the final, headstarted site.

Fixes https://github.com/Automattic/zelda-private/issues/3
