### PR TITLE
Language Picker: Fix Search in Container

### DIFF
--- a/client/components/language-picker/modal.scss
+++ b/client/components/language-picker/modal.scss
@@ -43,6 +43,13 @@
 		flex: none;
 		margin-bottom: 0;
 		z-index: 10;
+		
+		@include breakpoint( '<660px' ) {
+			.search.has-focus {
+				margin: 0 4px;
+				width: calc(100% - 8px);
+			}
+		}
 	}
 }
 

--- a/client/components/language-picker/modal.scss
+++ b/client/components/language-picker/modal.scss
@@ -30,6 +30,7 @@
 		flex-direction: column;
 		flex: auto;
 		min-height: 0; // permits the .language-picker__modal-list to shrink below its min height
+		overflow: inherit;
 		padding: 0;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This includes the changes in #33925 for the Language Picker too; it's just intended to be an improvement so that the borders/box shadow is visible. There's discussion in that issue against directly changing the modal itself and just overriding when necessary. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
1. Enter your Account Settings. 
2. Use the Language Picker 
3. Search at the top 
4. Compare 

**Before:**

<img width="1529" alt="Screenshot_2019-06-14_at_07 16 15" src="https://user-images.githubusercontent.com/43215253/59490728-53d47700-8e7d-11e9-93b4-b8f12c160ecd.png">

**After:**

<img width="1504" alt="Screenshot_2019-06-14_at_07 16 53" src="https://user-images.githubusercontent.com/43215253/59490689-428b6a80-8e7d-11e9-920f-ae2561df5912.png">

cc @drw158, @MichaelArestad, @alaczek 
