### PR TITLE
FormSettingExplanation: import the style file + few minor style issues

### DIFF
--- a/client/components/forms/form-setting-explanation/index.jsx
+++ b/client/components/forms/form-setting-explanation/index.jsx
@@ -3,36 +3,28 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { omit } from 'lodash';
 
-export default class extends React.Component {
-	static displayName = 'FormSettingExplanation';
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
-	static propTypes = {
-		noValidate: PropTypes.bool,
-		isIndented: PropTypes.bool,
-		className: PropTypes.string,
-	};
+function FormSettingExplanation( { className, noValidate, isIndented, ...rest } ) {
+	const classes = classNames( 'form-setting-explanation', className, {
+		'no-validate': noValidate,
+		'is-indented': isIndented,
+	} );
 
-	static defaultProps = {
-		noValidate: false,
-		isIndented: false,
-	};
-
-	render() {
-		const classes = classNames( this.props.className, 'form-setting-explanation', {
-			'no-validate': this.props.noValidate,
-			'is-indented': this.props.isIndented,
-		} );
-
-		return (
-			<p { ...omit( this.props, 'className', 'noValidate', 'isIndented' ) } className={ classes }>
-				{ this.props.children }
-			</p>
-		);
-	}
+	return <p { ...rest } className={ classes } />;
 }
+
+FormSettingExplanation.propTypes = {
+	className: PropTypes.string,
+	noValidate: PropTypes.bool,
+	isIndented: PropTypes.bool,
+};
+
+export default FormSettingExplanation;

--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -154,23 +154,6 @@
 	hyphens: auto;
 }
 
-.purchase-detail__info {
-	margin-left: 8px;
-	margin-top: 8px;
-
-	@include breakpoint( '>660px' ) {
-		margin-top: 0;
-	}
-}
-
-.purchase-detail__info-icon-container {
-	display: inline-block;
-	margin-top: 2px;
-	margin-right: 4px;
-	float: left;
-	height: 14px;
-}
-
 .purchase-detail__required-notice {
 	background-color: var( --color-warning );
 	color: var( --color-white );

--- a/client/components/purchase-detail/tip-info.jsx
+++ b/client/components/purchase-detail/tip-info.jsx
@@ -1,20 +1,21 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
+import classNames from 'classnames';
 
-const TipInfo = ( { info = '', className = '' } ) => {
-	className += ' purchase-detail__info form-setting-explanation';
+/**
+ * Style dependencies
+ */
+import './tip-info.scss';
+
+const TipInfo = ( { info = '', className } ) => {
+	const classes = classNames( 'purchase-detail__info', className );
 	return (
-		<div className={ className }>
-			<span className="purchase-detail__info-icon-container">
-				<Gridicon size={ 12 } icon="info-outline" />
-			</span>
+		<div className={ classes }>
+			<Gridicon size={ 12 } icon="info-outline" className="purchase-detail__info-icon" />
 			{ info }
 		</div>
 	);

--- a/client/components/purchase-detail/tip-info.scss
+++ b/client/components/purchase-detail/tip-info.scss
@@ -1,0 +1,20 @@
+.purchase-detail__info {
+	color: var( --color-text-subtle );
+	font-size: 13px;
+	font-style: italic;
+	font-weight: 400;
+	margin-left: 8px;
+	margin-top: 8px;
+
+	@include breakpoint( '>660px' ) {
+		margin-top: 0;
+	}
+}
+
+.purchase-detail__info-icon {
+	display: inline-block;
+	margin-top: 2px;
+	margin-right: 4px;
+	float: left;
+	height: 14px;
+}

--- a/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/google-voucher/index.jsx
@@ -15,6 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import ClipboardButtonInput from 'components/clipboard-button-input';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import PurchaseButton from 'components/purchase-detail/purchase-button';
 import TipInfo from 'components/purchase-detail/tip-info';
 import Dialog from 'components/dialog';
@@ -192,7 +193,7 @@ class GoogleVoucherDetails extends Component {
 				<ClipboardButtonInput value={ code } disabled={ ! code } />
 
 				<div className="google-voucher__copy-code">
-					<p className="google-voucher__explanation form-setting-explanation">
+					<FormSettingExplanation className="google-voucher__explanation">
 						{ this.props.translate(
 							'Copy this unique, one-time use code to your clipboard and setup your Google Ads account. {{a}}View help guide{{/a}}',
 							{
@@ -208,7 +209,7 @@ class GoogleVoucherDetails extends Component {
 								},
 							}
 						) }
-					</p>
+					</FormSettingExplanation>
 
 					<PurchaseButton
 						className="google-voucher__setup-google-adwords"

--- a/client/my-sites/site-settings/speed-up-site-settings.jsx
+++ b/client/my-sites/site-settings/speed-up-site-settings.jsx
@@ -14,6 +14,7 @@ import { connect } from 'react-redux';
 import Card from 'components/card';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormFieldset from 'components/forms/form-fieldset';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite } from 'state/sites/selectors';
 import isJetpackModuleActive from 'state/selectors/is-jetpack-module-active';
@@ -73,12 +74,12 @@ class SpeedUpSiteSettings extends Component {
 							) }
 							link="http://jetpack.com/support/site-accelerator/"
 						/>
-						<p className="site-settings__feature-description form-setting-explanation">
+						<FormSettingExplanation className="site-settings__feature-description">
 							{ translate(
 								'Load pages faster by allowing Jetpack to optimize your images and serve your images ' +
 									'and static files (like CSS and JavaScript) from our global network of servers.'
 							) }
-						</p>
+						</FormSettingExplanation>
 						<CompactFormToggle
 							checked={ siteAcceleratorStatus }
 							disabled={ isRequestingOrSaving || photonModuleUnavailable }

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -500,6 +500,7 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 
 .site-settings__speed-up-site-settings {
 	p.site-settings__feature-description {
+		margin-top: 0;
 		margin-bottom: 1.5em;
 	}
 }


### PR DESCRIPTION
The `FormSettingExplanation` component didn't import the `style.scss` module and therefore the explanations went unstyled. This PR fixes that. The explanations should now be in small italic subtly gray type.

I also rewrote the `FormSettingExplanation` component to a functional component (after checking there are no refs to it) and replaced Lodash `omit` with object destructuring and rest properties.

The second commit replaces two usages of plain `<p className="form-setting-explanation">` with the actual `FormSettingExplanation` component. That guarantees that the styles are present.

The third commit removes the `form-setting-explanation` classname from `PurchaseDetail`'s `TipInfo` component and copies the relevant styles. The `TipInfo` is technically not a form explanation at all.

**How to test:**
Go to `/my-plan/:business-site` and check the Google Ads Credit's `TipInfo` (the small text with info icon):
<img width="509" alt="Screenshot 2019-06-14 at 15 09 04" src="https://user-images.githubusercontent.com/664258/59511381-6a4af480-8eb6-11e9-8ad1-a218a0303039.png">

Check various `FormSettingExplanation` instances that are all around Site Settings and also in Woo Store:
<img width="646" alt="Screenshot 2019-06-14 at 14 14 07" src="https://user-images.githubusercontent.com/664258/59511422-8189e200-8eb6-11e9-968c-60c1e5c36ae2.png">
