### PR TITLE
[e2e-woo] Use different button for "Add a product"

### DIFF
--- a/test/e2e/lib/components/store-sidebar-component.js
+++ b/test/e2e/lib/components/store-sidebar-component.js
@@ -53,10 +53,8 @@ export default class StoreSidebarComponent extends AsyncBaseContainer {
 	}
 
 	addProduct() {
-		return driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( 'li.products a.sidebar__button' )
-		);
+		this.selectProducts();
+		return driverHelper.selectElementByText( this.driver, By.css( '.button' ), 'Add a product' );
 	}
 
 	settingsLinkDisplayed() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Update selector for adding a new product. 

'Add' buttons from store sidebar were removed in [this PR](https://github.com/Automattic/wp-calypso/pull/33901), which caused Woo canary [test to fail](https://circleci.com/gh/Automattic/wp-calypso/324414). 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make sure that Woo tests are passing in CircleCI. If you want to run Woo tests locally you can do that with command `mocha specs-woocommerce/`.

