### PR TITLE
Full Site Editing: override close button URL for Template Part CPTs

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -302,6 +302,7 @@ class Full_Site_Editing {
 			array(
 				'editorPostType' => get_current_screen()->post_type,
 				'featureFlags'   => $feature_flags->get_flags(),
+				'closeButtonUrl' => $this->get_close_button_url(),
 			)
 		);
 
@@ -368,5 +369,41 @@ class Full_Site_Editing {
 
 		// Setting this to `public` will allow it to be found in the search endpoint.
 		$post_type->public = true;
+	}
+
+	/**
+	 * Returns the URL for the Gutenberg close button.
+	 *
+	 * In some cases we want to override the default value which would take us to post listing
+	 * for a given post type. For example, when navigating back from Header, we want to show the
+	 * parent page editing view, and not the Template Part CPT list.
+	 *
+	 * @return null|string Override URL string if it should be inserted, or null otherwise.
+	 */
+	public function get_close_button_url() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! isset( $_GET['fse_parent_post'] ) ) {
+			return null;
+		}
+
+		$parent_post_id = absint( $_GET['fse_parent_post'] );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( empty( $parent_post_id ) ) {
+			return null;
+		}
+
+		$close_button_url = get_edit_post_link( $parent_post_id );
+
+		/**
+		 * Filter the Gutenberg's close button URL when editing Template Part CPTs.
+		 *
+		 * @since 0.1
+		 *
+		 * @param string Current close button URL.
+		 */
+		$close_button_url = apply_filters( 'a8c_fse_close_button_link', $close_button_url );
+
+		return $close_button_url;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
@@ -5,3 +5,4 @@ import './blocks/navigation-menu';
 import './blocks/post-content';
 import './blocks/template';
 import './plugins/template-selector-sidebar';
+import './plugins/close-button-override';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
@@ -1,0 +1,24 @@
+/* global fullSiteEditing */
+
+/**
+ * External dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+domReady( () => {
+	// We only want this override when closing Template Part CPT (e.g. header) to navigate back to parent page.
+	if ( 'wp_template_part' !== fullSiteEditing.editorPostType ) {
+		return;
+	}
+
+	// Keep the default URL if the override hasn't been provided by the plugin.
+	if ( ! fullSiteEditing.closeButtonUrl ) {
+		return;
+	}
+
+	const closeButton = document.querySelector( '.edit-post-fullscreen-mode-close__toolbar a' );
+
+	if ( closeButton ) {
+		closeButton.href = fullSiteEditing.closeButtonUrl;
+	}
+} );

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -37,6 +37,7 @@
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",
 		"@wordpress/data": "^4.4.0",
+		"@wordpress/dom-ready": "^2.4.0",
 		"@wordpress/edit-post": "^3.3.4",
 		"@wordpress/editor": "^9.2.4",
 		"@wordpress/element": "^2.3.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes https://github.com/Automattic/wp-calypso/issues/33632
Depends on https://github.com/Automattic/wp-calypso/pull/33953 - This approach assumes that `fse_parent_post` parameter will be passed via URL parameter when navigating to Header from the parent page (should be appended to `Edit` button URL).

Overrides the Gutenberg's close button URL when editing Template Part CPTs. The purpose of this is to be able to navigate back from the Header editing view, to the parent page view.

#### Testing instructions

* For close button to be visible, make sure to switch Gutenberg to fullscreen mode.
* Create a test page and note its ID. I'll refer to it as `page_id` in the following steps.
* Publish a new Template Part by navigating to `wp-admin/post-new.php?post_type=wp_template_part`.
* Manually add `fse_parent_post` parameter to the URL and reload the page. It should look something like `wp-admin/post.php?post=59&action=edit&fse_parent_post={page_id}`
* Click on the close button and verify that you are taken to the parent page (`page_id`) editing view.
* Verify that this override doesn't occur on other post types.


