### PR TITLE
PoC: Add WPCC support to the passwordless user step

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -675,20 +675,21 @@ export function createPasswordlessUser( callback, { email } ) {
  * @param {function} callback Callback function
  * @param {object}   data     POST data object
  */
-export function verifyPasswordlessUser( callback, dependencies, data ) {
-	const { email, code } = data;
-
+export function verifyPasswordlessUser(
+	callback,
+	{ email, code, oauth2_client_id, oauth2_redirect }
+) {
 	wpcom.undocumented().usersEmailVerification(
 		assign(
 			{},
 			{ email, code },
 			// TODO Duplicated from line 499 please refactor
-			data.oauth2_client_id
+			oauth2_client_id
 				? {
-						oauth2_client_id: data.oauth2_client_id,
+						oauth2_client_id: oauth2_client_id,
 						// url of the WordPress.com authorize page for this OAuth2 client
 						// convert to legacy oauth2_redirect format: %s@https://public-api.wordpress.com/oauth2/authorize/...
-						oauth2_redirect: data.oauth2_redirect && '0@' + data.oauth2_redirect,
+						oauth2_redirect: oauth2_redirect && '0@' + oauth2_redirect,
 				  }
 				: null
 		),
@@ -703,9 +704,9 @@ export function verifyPasswordlessUser( callback, dependencies, data ) {
 				{},
 				{ email, username: email, bearer_token: response.token.access_token },
 				// TODO Duplicated from line 540 please refactor
-				data.oauth2_client_id
+				oauth2_client_id
 					? {
-							oauth2_client_id: data.oauth2_client_id,
+							oauth2_client_id: oauth2_client_id,
 							// url of the WordPress.com authorize page for this OAuth2 client
 							// convert to legacy oauth2_redirect format: %s@https://public-api.wordpress.com/oauth2/authorize/...
 							oauth2_redirect: response.oauth2_redirect && '0@' + response.oauth2_redirect,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -237,7 +237,7 @@ export function generateFlows( {
 
 	if ( isEnabled( 'signup/wpcc' ) ) {
 		flows.wpcc = {
-			steps: [ 'oauth2-user' ],
+			steps: [ 'oauth2-passwordless' ],
 			destination: getRedirectDestination,
 			description: 'WordPress.com Connect signup flow',
 			lastModified: '2017-08-24',

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -237,6 +237,14 @@ export function generateFlows( {
 
 	if ( isEnabled( 'signup/wpcc' ) ) {
 		flows.wpcc = {
+			steps: [ 'oauth2' ],
+			destination: getRedirectDestination,
+			description: 'WordPress.com Connect signup flow',
+			lastModified: '2017-08-24',
+			disallowResume: true, // don't allow resume so we don't clear query params when we go back in the history
+		};
+
+		flows[ 'wpcc-simple' ] = {
 			steps: [ 'oauth2-passwordless' ],
 			destination: getRedirectDestination,
 			description: 'WordPress.com Connect signup flow',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -60,6 +60,7 @@ const stepNameToModuleName = {
 	'domains-with-preview': 'domains',
 	'site-title-with-preview': 'site-title',
 	passwordless: 'passwordless',
+	'oauth2-passwordless': 'passwordless',
 };
 
 export async function getStepComponent( stepName ) {

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -542,6 +542,22 @@ export function generateSteps( {
 			providesDependencies: [ 'bearer_token', 'email', 'username' ],
 			unstorableDependencies: [ 'bearer_token' ],
 		},
+
+		'oauth2-passwordless': {
+			stepName: 'oauth2-passwordless',
+			props: {
+				oauth2Signup: true,
+			},
+			providesToken: true,
+			providesDependencies: [
+				'bearer_token',
+				'email',
+				'username',
+				'oauth2_client_id',
+				'oauth2_redirect',
+			],
+			unstorableDependencies: [ 'bearer_token' ],
+		},
 	};
 }
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -387,7 +387,7 @@ class Signup extends React.Component {
 			} );
 		}
 
-		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || dependencies.oauth2_client_id ) ) {
+		if ( ! userIsLoggedIn && config.isEnabled( 'oauth' ) ) {
 			debug( `Handling oauth login` );
 			oauthToken.setToken( dependencies.bearer_token );
 			this.signupFlowController.reset();

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -118,10 +118,7 @@ export class PasswordlessStep extends Component {
 			submitting: true,
 		} );
 
-		verifyPasswordlessUser( this.handleUserVerificationRequest, {
-			email: getFieldValue( this.formStore.get(), 'email' ),
-			code: getFieldValue( this.formStore.get(), 'code' ),
-		} );
+		verifyPasswordlessUser( this.handleUserVerificationRequest, data );
 	};
 
 	handleUserVerificationRequest = ( error, providedDependencies ) => {
@@ -253,13 +250,35 @@ export class PasswordlessStep extends Component {
 			: this.renderSignupForm();
 	}
 
+	getHeaderText() {
+		if (
+			this.props.flowName === 'wpcc-simple' &&
+			this.props.queryObject.oauth2_client_id === '50916'
+		) {
+			return this.props.translate( 'Get started with WooCommerce Payments' );
+		}
+
+		return this.props.headerText;
+	}
+
+	getSubHeaderText() {
+		if (
+			this.props.flowName === 'wpcc-simple' &&
+			this.props.queryObject.oauth2_client_id === '50916'
+		) {
+			return this.props.translate( 'Enter the email address of the primary business owner' );
+		}
+
+		return this.props.translate( 'Create a WordPress.com account' );
+	}
+
 	render() {
 		return (
 			<StepWrapper
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
-				headerText={ this.props.headerText }
-				subHeaderText={ this.props.translate( 'Create a WordPress.com account' ) }
+				headerText={ this.getHeaderText() }
+				subHeaderText={ this.getSubHeaderText() }
 				positionInFlow={ this.props.positionInFlow }
 				stepContent={ this.renderStepContent() }
 			/>

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -101,6 +101,20 @@ export class PasswordlessStep extends Component {
 
 	verifyUser = event => {
 		event.preventDefault();
+<<<<<<< HEAD
+=======
+		const queryArgs = ( this.props.initialContext && this.props.initialContext.query ) || null;
+		const data = {
+			email: getFieldValue( this.formStore.get(), 'email' ),
+			code: getFieldValue( this.formStore.get(), 'code' ),
+		};
+
+		if ( this.props.oauth2Signup && queryArgs ) {
+			data.oauth2_client_id = queryArgs.oauth2_client_id;
+			data.oauth2_redirect = queryArgs.oauth2_redirect;
+		}
+
+>>>>>>> Add WPCC support to the passwordless user step
 		this.setState( {
 			errorMessages: null,
 			submitting: true,

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -101,8 +101,7 @@ export class PasswordlessStep extends Component {
 
 	verifyUser = event => {
 		event.preventDefault();
-<<<<<<< HEAD
-=======
+
 		const queryArgs = ( this.props.initialContext && this.props.initialContext.query ) || null;
 		const data = {
 			email: getFieldValue( this.formStore.get(), 'email' ),
@@ -114,7 +113,6 @@ export class PasswordlessStep extends Component {
 			data.oauth2_redirect = queryArgs.oauth2_redirect;
 		}
 
->>>>>>> Add WPCC support to the passwordless user step
 		this.setState( {
 			errorMessages: null,
 			submitting: true,

--- a/client/state/ui/oauth2-clients/reducer.js
+++ b/client/state/ui/oauth2-clients/reducer.js
@@ -18,7 +18,11 @@ export const currentClientId = createReducer( null, {
 			return query.client_id ? Number( query.client_id ) : state;
 		}
 
-		if ( startsWith( path, '/start/wpcc' ) || startsWith( path, '/start/crowdsignal' ) ) {
+		if (
+			startsWith( path, '/start/wpcc' ) ||
+			startsWith( path, '/start/crowdsignal' ) ||
+			startsWith( path, '/start/wpcc-simple' )
+		) {
 			return query.oauth2_client_id ? Number( query.oauth2_client_id ) : state;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This adds passwordless signup to WordPress.com Connect
* This is just a proof of concept, there's still a lot to do
* Requires D29469-code

TODO:
- setup an A/B test for this change so we can see if it's better
- Add Tracks events to the passwordless step
- Update the verification email to include a log in link
- Calypso seems to swallow the query string, which it doesn't on the current flow
- Add support for two factor accounts (we could just disable it for them)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D29469-code
* Go to a WPCC service, for example vaultpress.com
* Click on WordPress.com Sign In
* Click on `Not on WordPress.com? Create an Account.`
* Change the URL from https://wordpress.com/start/wpcc/...... to http://calypso.localhost:3000/start/wpcc-simple/....
* Go through the passwordless signup flow
* Check that you are are redirected back to vaultpress.com and logged in
