### PR TITLE
Media Modal: Improve Search Box Shadow

### DIFF
--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -42,11 +42,6 @@
 	}
 }
 
-// Make sure focus ring on search bar is not hidden
-.editor-media-modal .dialog__content {
-	overflow: inherit;
-}
-
 .media-library__filter-bar {
 	display: flex;
 	flex-flow: row nowrap;

--- a/client/post-editor/media-modal/dialog.scss
+++ b/client/post-editor/media-modal/dialog.scss
@@ -27,12 +27,25 @@
 	color: var( --color-neutral-700 );
 	height: 100%;
 	padding: 0;
+	overflow: inherit;
 }
 
 .editor-media-modal .section-nav {
 	z-index: z-index( '.dialog__backdrop', '.editor-media-modal .section-nav' );
 	@include breakpoint( '>480px' ) {
 		margin-bottom: 16px;
+	}
+	
+	.search {
+		&.is-expanded-to-container {
+			height: 100%;
+		}
+		
+		&.has-focus {
+			@include breakpoint( '<660px' ) {
+				margin-right: 4px;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves the original CSS override out of the Media Library file into the Media Modal file 
* Fixes the lack of a right border on smaller screens
* Fixes the height of the border not being great enough on smaller screens

#### Testing instructions

Open the Media Modal when writing a post and search at the top. 

Resize to 320px. Verify that the box shadow now appears on the right.

**Current:**
<img width="359" alt="Screenshot 2019-06-14 at 17 44 30" src="https://user-images.githubusercontent.com/43215253/59524754-95404300-8ecc-11e9-96de-40125c9b805c.png">

**Proposed:**
<img width="429" alt="Screenshot 2019-06-14 at 17 43 32" src="https://user-images.githubusercontent.com/43215253/59524770-9f624180-8ecc-11e9-837f-b36b5b86d51a.png">

Resize to 560px. Verify that the box shadow is now inline.

**Current:**
<img width="529" alt="Screenshot 2019-06-14 at 17 44 14" src="https://user-images.githubusercontent.com/43215253/59524828-bc971000-8ecc-11e9-86ff-55d365668478.png">

**Proposed:**
<img width="529" alt="Screenshot 2019-06-14 at 17 43 59" src="https://user-images.githubusercontent.com/43215253/59524840-c587e180-8ecc-11e9-9f61-26a2befc85e1.png">

Resize to anything and verify that the overflow override is still taking effect.

cc @drw158, @MichaelArestad, @alaczek

Fixes [#33925 (comment)](https://github.com/Automattic/wp-calypso/pull/33925#issuecomment-501915833_)
