### PR TITLE
Move the isRefundable() check for the purchase Remove button inside isRemovable()

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -241,6 +241,10 @@ function isRefundable( purchase ) {
  * @return {boolean} true if the purchase can be removed, false otherwise
  */
 function isRemovable( purchase ) {
+	if ( isRefundable( purchase ) ) {
+		return false;
+	}
+
 	if ( isIncludedWithPlan( purchase ) ) {
 		return false;
 	}
@@ -253,9 +257,7 @@ function isRemovable( purchase ) {
 		isJetpackPlan( purchase ) ||
 		isExpiring( purchase ) ||
 		isExpired( purchase ) ||
-		( isDomainTransfer( purchase ) &&
-			! isRefundable( purchase ) &&
-			isPurchaseCancelable( purchase ) )
+		( isDomainTransfer( purchase ) && isPurchaseCancelable( purchase ) )
 	);
 }
 

--- a/client/lib/purchases/test/data/index.js
+++ b/client/lib/purchases/test/data/index.js
@@ -24,6 +24,7 @@ const DOMAIN_PURCHASE_EXPIRED = Object.assign( {}, DOMAIN_PURCHASE, {
 	expiryStatus: 'expired',
 	id: 10002,
 	isCancelable: false,
+	isRefundable: false,
 } );
 
 const DOMAIN_PURCHASE_INCLUDED_IN_PLAN = Object.assign( {}, DOMAIN_PURCHASE, {

--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -206,9 +206,6 @@ class ManagePurchase extends Component {
 	}
 
 	renderRemovePurchaseNavItem() {
-		if ( isRefundable( this.props.purchase ) ) {
-			return null;
-		}
 		return (
 			<RemovePurchase
 				hasLoadedSites={ this.props.hasLoadedSites }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a quick followup to https://github.com/Automattic/wp-calypso/pull/33797.  Since the `RemovePurchase` component already checks an existing `isRemovable()` function to determine whether to display itself, I think we should move the new check added in the above PR inside that function rather than keeping it separate.

#### Testing instructions

Same as https://github.com/Automattic/wp-calypso/pull/33797.