### PR TITLE
Update signup flows for business, premium, personal, and free to match new onboarding

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -27,37 +27,62 @@ export function generateFlows( {
 		},
 
 		business: {
-			steps: [ 'user', 'about', 'plans-business', 'themes', 'domains' ],
-			destination: getSiteDestination,
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'site-style-with-preview',
+				'domains-with-preview',
+				'plans-business',
+			],
+			destination: getChecklistDestination,
 			description: 'Create an account and a blog and then add the business plan to the users cart.',
-			lastModified: '2019-03-04',
-			meta: {
-				skipBundlingPlan: true,
-			},
+			lastModified: '2019-06-17',
 		},
 
 		premium: {
-			steps: [ 'user', 'about', 'plans-premium', 'themes', 'domains' ],
-			destination: getSiteDestination,
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'site-style-with-preview',
+				'domains-with-preview',
+				'plans-premium',
+			],
+			destination: getChecklistDestination,
 			description: 'Create an account and a blog and then add the premium plan to the users cart.',
-			lastModified: '2019-03-04',
-			meta: {
-				skipBundlingPlan: true,
-			},
+			lastModified: '2019-06-17',
 		},
 
 		personal: {
-			steps: [ 'user', 'about', 'plans-personal', 'themes', 'domains' ],
-			destination: getSiteDestination,
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'site-style-with-preview',
+				'domains-with-preview',
+				'plans-personal',
+			],
+			destination: getChecklistDestination,
 			description: 'Create an account and a blog and then add the personal plan to the users cart.',
-			lastModified: '2019-03-04',
+			lastModified: '2019-06-17',
 		},
 
 		free: {
-			steps: [ 'user', 'about', 'themes', 'domains' ],
-			destination: getSiteDestination,
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'site-style-with-preview',
+				'domains-with-preview',
+			],
+			destination: getChecklistDestination,
 			description: 'Create an account and a blog and default to the free plan.',
-			lastModified: '2018-01-24',
+			lastModified: '2019-06-17',
 		},
 
 		blog: {
@@ -80,10 +105,7 @@ export function generateFlows( {
 				return '/plans/select/business/' + dependencies.siteSlug;
 			},
 			description: 'Create an account for REBRAND cities partnership',
-			lastModified: '2017-07-01',
-			meta: {
-				skipBundlingPlan: true,
-			},
+			lastModified: '2019-06-17',
 		},
 
 		'with-theme': {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Copy the steps from the `onboarding` flow to the flows linked to from the pricing page of WordPress.com: `business`, `premium`, `personal`, `free`. The relevant plans step is moved to the final position in the flow, retaining the pre-selected plan type for checkout.

* This change also removes the meta object with `skipBundlingPlan` since it is no longer used. It looks like the `skipBundlingPlan` check was removed back in https://github.com/Automattic/wp-calypso/pull/5899/files.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check that signing up works and the steps are correct for the flows below (it should pretty much match the steps in `/start/onboarding`, with the exception of the final plans step).
* Make sure that the plan that is added to the cart at the end of the paid flows is the correct plan.

URLs to test:

* http://calypso.localhost:3000/start/business
* http://calypso.localhost:3000/start/premium
* http://calypso.localhost:3000/start/personal
* http://calypso.localhost:3000/start/free
