### PR TITLE
Remove translator comment from built bundle

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -30,6 +30,7 @@ const config = {
 					'content-type': 'text/plain; charset=UTF-8',
 					'x-generator': 'calypso',
 				},
+				writePot: process.env.NODE_ENV === 'build_pot',
 			},
 		],
 		isBrowser

--- a/babel.config.js
+++ b/babel.config.js
@@ -22,6 +22,16 @@ const config = {
 	],
 	plugins: [
 		[ '@automattic/transform-wpcalypso-async', { async: isBrowser && codeSplit } ],
+		[
+			'@automattic/babel-plugin-i18n-calypso',
+			{
+				dir: 'build/i18n-calypso/',
+				headers: {
+					'content-type': 'text/plain; charset=UTF-8',
+					'x-generator': 'calypso',
+				},
+			},
+		],
 		isBrowser
 			? [
 					'module-resolver',
@@ -35,20 +45,6 @@ const config = {
 			: {},
 	],
 	env: {
-		build_pot: {
-			plugins: [
-				[
-					'@automattic/babel-plugin-i18n-calypso',
-					{
-						dir: 'build/i18n-calypso/',
-						headers: {
-							'content-type': 'text/plain; charset=UTF-8',
-							'x-generator': 'calypso',
-						},
-					},
-				],
-			],
-		},
 		test: {
 			presets: [ [ '@babel/env', { targets: { node: 'current' } } ] ],
 			plugins: [

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -144,7 +144,7 @@ module.exports = function() {
 									translation.comments.extracted =
 										path.node.arguments[ i ].properties[ j ].value.value;
 									// Remove the comment from the transpiled code.
-									delete path.node.arguments[ i ].properties[ j ];
+									path.node.arguments[ i ].properties.splice( j, 1 );
 									break;
 							}
 						}

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -114,37 +114,6 @@ module.exports = function() {
 					return;
 				}
 
-				// At this point we assume we'll save data, so initialize if
-				// we haven't already
-				if ( ! baseData ) {
-					baseData = {
-						charset: 'utf-8',
-						headers: state.opts.headers || DEFAULT_HEADERS,
-						translations: {
-							'': {
-								'': {
-									msgid: '',
-									msgstr: [],
-								},
-							},
-						},
-					};
-
-					for ( const key in baseData.headers ) {
-						baseData.translations[ '' ][ '' ].msgstr.push(
-							`${ key }: ${ baseData.headers[ key ] };\n`
-						);
-					}
-
-					// Attempt to exract nplurals from header
-					const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match(
-						/nplurals\s*=\s*(\d+);/
-					);
-					if ( pluralsMatch ) {
-						nplurals = pluralsMatch[ 1 ];
-					}
-				}
-
 				if ( path.node.arguments.length > i ) {
 					const msgid_plural = getNodeAsString( path.node.arguments[ i ] );
 					if ( msgid_plural.length ) {
@@ -174,9 +143,46 @@ module.exports = function() {
 								case 'comment':
 									translation.comments.extracted =
 										path.node.arguments[ i ].properties[ j ].value.value;
+									// Remove the comment from the transpiled code.
+									delete path.node.arguments[ i ].properties[ j ];
 									break;
 							}
 						}
+					}
+				}
+
+				if ( process.env.NODE_ENV !== 'build_pot' ) {
+					return;
+				}
+
+				// At this point we assume we'll save data, so initialize if
+				// we haven't already
+				if ( ! baseData ) {
+					baseData = {
+						charset: 'utf-8',
+						headers: state.opts.headers || DEFAULT_HEADERS,
+						translations: {
+							'': {
+								'': {
+									msgid: '',
+									msgstr: [],
+								},
+							},
+						},
+					};
+
+					for ( const key in baseData.headers ) {
+						baseData.translations[ '' ][ '' ].msgstr.push(
+							`${ key }: ${ baseData.headers[ key ] };\n`
+						);
+					}
+
+					// Attempt to exract nplurals from header
+					const pluralsMatch = ( baseData.headers[ 'plural-forms' ] || '' ).match(
+						/nplurals\s*=\s*(\d+);/
+					);
+					if ( pluralsMatch ) {
+						nplurals = pluralsMatch[ 1 ];
 					}
 				}
 

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -156,7 +156,7 @@ module.exports = function() {
 					}
 				}
 
-				if ( process.env.NODE_ENV !== 'build_pot' ) {
+				if ( ! state.opts.writePot ) {
 					return;
 				}
 

--- a/packages/babel-plugin-i18n-calypso/src/index.js
+++ b/packages/babel-plugin-i18n-calypso/src/index.js
@@ -134,6 +134,7 @@ module.exports = function() {
 					path.node.arguments.length > i &&
 					'ObjectExpression' === path.node.arguments[ i ].type
 				) {
+					let removeProperty = false;
 					for ( const j in path.node.arguments[ i ].properties ) {
 						if ( 'ObjectProperty' === path.node.arguments[ i ].properties[ j ].type ) {
 							switch ( path.node.arguments[ i ].properties[ j ].key.name ) {
@@ -143,11 +144,15 @@ module.exports = function() {
 								case 'comment':
 									translation.comments.extracted =
 										path.node.arguments[ i ].properties[ j ].value.value;
-									// Remove the comment from the transpiled code.
-									path.node.arguments[ i ].properties.splice( j, 1 );
+									removeProperty = j;
 									break;
 							}
 						}
+					}
+
+					// Remove the comment from the transpiled code.
+					if ( false !== removeProperty ) {
+						path.node.arguments[ i ].properties.splice( removeProperty, 1 );
 					}
 				}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `comment:` from `translate()` parameters object in the bundle.

Reasoning: We don't use this for lookup, so we don't actually need it at runtime. To make this work we use the `babel-plugin-i18n-calypso`. Actually this is only activated when running in the `build_pot` environment. We turn this around by always activating it but stop it from collecting strings and writing POT files when not in that node environment.

#### Testing instructions

* Nothing should change, just the bundle size shrink (4kb uncompressed)

See #34025