### PR TITLE
.com checklist: switching the site hides the checklist

### DIFF
--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -187,7 +187,7 @@ class ChecklistMain extends PureComponent {
 				<DocumentHead title={ translatedTitle } />
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 				{ this.renderHeader() }
-				<WpcomChecklist updateCompletion={ this.handleCompletionUpdate } />
+				<WpcomChecklist updateCompletion={ this.handleCompletionUpdate } viewMode="checklist" />
 			</Main>
 		);
 	}


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR specifies a view for the checklist main page so that `/checklist/{yoursite.wordpress.com}` will pass the [shouldRender](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checklist/wpcom-checklist/index.jsx#L74) check and display a checklist.

The bug stems from the fact that some older sites are failing [this check](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checklist/wpcom-checklist/index.jsx#L74) because `viewMode` is empty and in `isEligibleForDotcomChecklist()`, I'm half-certain, the site has a creation date that is earlier than the one in [this check](https://github.com/Automattic/wp-calypso/blob/master/client/state/selectors/is-eligible-for-dotcom-checklist.js#L36).

The date restriction was introduced in https://github.com/Automattic/wp-calypso/pull/28415 

Because of this check, older sites will not display links to the checklist in the inline help bubble or the stats banner. 

However if users do somehow land on the checklist, this PR ensure they see something, even though we can't guarantee that the checklist items will be appropriate to their site.

## Testing instructions

It's tricky to test as you need an older site. 

One way to test is to assign an older date, e.g., `2017-08-28T22:25:48+00:00`, to [createdAt](https://github.com/Automattic/wp-calypso/blob/master/client/state/selectors/is-eligible-for-dotcom-checklist.js#L34)

Fixes #34028
