### PR TITLE
Add support for manually marking phase 2 checklist items as completed

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -31,7 +31,8 @@ function getTasks( {
 	const tasks = [];
 	const segmentSlug = getSiteTypePropertyValue( 'id', siteSegment, 'slug' );
 
-	const getTask = taskId => get( taskStatuses, taskId );
+	const getTask = taskId =>
+		taskStatuses ? taskStatuses.filter( task => task.id === taskId )[ 0 ] : undefined;
 	const hasTask = taskId => getTask( taskId ) !== undefined;
 	const isCompleted = taskId => get( getTask( taskId ), 'completed', false );
 	const addTask = ( taskId, completed ) => {

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,10 +17,9 @@ import { items as itemSchemas } from './schema';
 
 const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 	...state,
-	tasks: {
-		...state.tasks,
-		[ taskId ]: { ...get( state.tasks, [ taskId ] ), completed },
-	},
+	tasks: state.tasks.map( task =>
+		task.id === taskId ? { ...task, isCompleted: completed } : task
+	),
 } );
 
 const moduleTaskMap = {
@@ -36,6 +35,18 @@ const moduleTaskMap = {
 function items( state = {}, action ) {
 	switch ( action.type ) {
 		case SITE_CHECKLIST_RECEIVE:
+			// Legacy, object-based response format
+			if ( ! Array.isArray( action.checklist.tasks ) ) {
+				return {
+					...action.checklist,
+					tasks: map( action.checklist.tasks, ( value, id ) => ( {
+						id,
+						...value,
+					} ) ),
+				};
+			}
+
+			// Phase 2 data format
 			return action.checklist;
 		case SITE_CHECKLIST_TASK_UPDATE:
 			return setChecklistTaskCompletion( state, action.taskId, true );

--- a/client/state/checklist/schema.js
+++ b/client/state/checklist/schema.js
@@ -4,7 +4,7 @@ export const items = {
 	properties: {
 		designType: { type: 'string' },
 		segment: { type: 'integer' },
-		tasks: { type: 'object' },
+		tasks: { type: 'array' },
 		verticals: { type: 'array' },
 	},
 };

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -43,7 +43,7 @@ export const updateChecklistTask = action =>
 		{
 			path: `/sites/${ action.siteId }/checklist`,
 			method: 'POST',
-			apiNamespace: 'rest/v1',
+			apiNamespace: isEnabled( 'onboarding-checklist/phase2' ) ? 'rest/v1.1' : 'rest/v1',
 			query: {
 				http_envelope: 1,
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After updating the checklist data structure for the purposes of Phase 2 checklist updates (paObgF-aE-p2), manually marking tasks as complete broke. This PR updates the redux state structure to only use the new data format, even if the API response is in the old data format.

#### Testing instructions

1. Apply D29524-code
2. Signup as a new user on `calypso.localhost:3000`
3. Manually mark all tasks as completed and confirm they remains completed after refreshing the page
4. Login as your regular user on `calypso.localhost:3000`
5. Create a new free site, confirm you get the "old" 5+ items checklist
6. Manually mark some tasks as completed and confirm they remains completed after refreshing the page
