### PR TITLE
Remove `require-await` eslint rule.

### DIFF
--- a/packages/eslint-config-wpcalypso/CHANGELOG.md
+++ b/packages/eslint-config-wpcalypso/CHANGELOG.md
@@ -1,6 +1,3 @@
-### next (…)
-- Added: [`require-await`](https://eslint.org/docs/rules/require-await) as error
-
 ### v4.0.1 (2018-09-13)
 - Allow usage of eslint v5 (159e240)
 

--- a/packages/eslint-config-wpcalypso/index.js
+++ b/packages/eslint-config-wpcalypso/index.js
@@ -85,7 +85,6 @@ module.exports = {
 		'prefer-const': 2,
 		'quote-props': [ 2, 'as-needed' ],
 		quotes: [ 2, 'single', 'avoid-escape' ],
-		'require-await': 2,
 		semi: 2,
 		'semi-spacing': 2,
 		'space-before-blocks': [ 2, 'always' ],


### PR DESCRIPTION
This rule was originally added in #30697 to help catch incorrect usage of async functions. It validates that an async function has at least one usage of `await` in its body.

While this helps catch basic errors such as forgetting to remove the `async` keyword when refactoring an async function to sync, it also prevents some useful, terse syntax, where you want return values to be auto-promisified.

@jsnajdr summarised it best in his comment in #33948:

> I think we found a reasonable use case where the ESLint rule is an obstacle: implementing an interface that specifies async functions (i.e., Promise return values), but not doing anything async inside the implementation:
>
>```js
> class StorageWithLocalStorage extends Storage {
>  async set( key, value ) {
>    localStorage.setItem( key, value );
>  }
>  async get( key ) {
>    return localStorage.getItem( key );
>  }
>}
>```

#### Changes proposed in this Pull Request

* Remove usage of `require-await` eslint rule.

#### Testing instructions

There should be no testing needed, as we're simply removing a lint rule.
