### PR TITLE
RewindCredentialsForm: migrate CSS to webpack and improve styling

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -28,7 +28,6 @@
 @import 'components/mobile-back-to-sidebar/style';
 @import 'components/notice/style';
 @import 'components/popover/style';
-@import 'components/rewind-credentials-form/style';
 @import 'components/section-nav/style';
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -41,15 +41,15 @@ export class RewindCredentialsForm extends Component {
 		onComplete: PropTypes.func,
 		siteUrl: PropTypes.string,
 		labels: PropTypes.object,
+		requirePath: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		labels: {},
-		requirePath: PropTypes.bool,
+		requirePath: false,
 	};
 
 	state = {
-		showPrivateKeyField: false,
 		form: {
 			protocol: 'ssh',
 			host: '',

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-/* eslint-disable */
 /**
  * External dependendies
  */
@@ -27,6 +25,11 @@ import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/
 import { getSiteSlug } from 'state/sites/selectors';
 import getJetpackCredentialsUpdateStatus from 'state/selectors/get-jetpack-credentials-update-status';
 import getRewindState from 'state/selectors/get-rewind-state';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export class RewindCredentialsForm extends Component {
 	static propTypes = {

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -19,6 +19,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextArea from 'components/forms/form-textarea';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPasswordInput from 'components/forms/form-password-input';
+import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import Gridicon from 'gridicons';
 import QueryRewindState from 'components/data/query-rewind-state';
 import { deleteCredentials, updateCredentials } from 'state/jetpack/credentials/actions';
@@ -281,9 +282,9 @@ export class RewindCredentialsForm extends Component {
 									disabled={ formIsSubmitting }
 									className="rewind-credentials-form__private-key"
 								/>
-								<p className="form-setting-explanation">
+								<FormSettingExplanation>
 									{ translate( 'Only non-encrypted private keys are supported.' ) }
-								</p>
+								</FormSettingExplanation>
 							</FormFieldset>
 						</div>
 					) }

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -86,7 +86,7 @@ export class RewindCredentialsForm extends Component {
 	};
 
 	handleSubmit = () => {
-		const { requirePath, role, siteId, siteUrl, translate, updateCredentials } = this.props;
+		const { requirePath, role, siteId, siteUrl, translate } = this.props;
 
 		const payload = {
 			role,
@@ -116,7 +116,7 @@ export class RewindCredentialsForm extends Component {
 		);
 
 		return isEmpty( errors )
-			? updateCredentials( siteId, payload )
+			? this.props.updateCredentials( siteId, payload )
 			: this.setState( { formErrors: errors } );
 	};
 

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -307,7 +307,8 @@ export class RewindCredentialsForm extends Component {
 					) }
 					{ this.props.allowDelete && (
 						<Button
-							borderless={ true }
+							borderless
+							scary
 							disabled={ formIsSubmitting }
 							onClick={ this.handleDelete }
 							className="rewind-credentials-form__delete-button"

--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -237,12 +237,14 @@ export class RewindCredentialsForm extends Component {
 				<FormFieldset>
 					{ ! requirePath && (
 						<Button
+							borderless
 							disabled={ formIsSubmitting }
 							onClick={ this.toggleAdvancedSettings }
-							borderless={ true }
-							primary={ true }
-							className="rewind-credentials-form__advanced-button"
+							className={ classNames( 'rewind-credentials-form__advanced-button', {
+								'is-expanded': showAdvancedSettings,
+							} ) }
 						>
+							<Gridicon icon="chevron-down" />
 							{ translate( 'Advanced settings' ) }
 						</Button>
 					) }

--- a/client/components/rewind-credentials-form/style.scss
+++ b/client/components/rewind-credentials-form/style.scss
@@ -36,7 +36,6 @@
 }
 
 .button.is-borderless.rewind-credentials-form__delete-button {
-	color: var( --color-error );
 	float: left;
 }
 

--- a/client/components/rewind-credentials-form/style.scss
+++ b/client/components/rewind-credentials-form/style.scss
@@ -35,14 +35,22 @@
 	margin-right: 15px;
 }
 
-.rewind-credentials-form__delete-button.button.is-borderless {
+.button.is-borderless.rewind-credentials-form__delete-button {
 	color: var( --color-error );
 	float: left;
 }
 
-.rewind-credentials-form__advanced-button.button.button {
+.button.is-borderless.rewind-credentials-form__advanced-button {
 	float: none;
 	margin-top: -8px;
+
+	.gridicon {
+		transition: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 ), color 0.2s ease-in;
+	}
+
+	&.is-expanded .gridicon {
+		transform: rotate( 180deg );
+	}
 }
 
 .rewind-credentials-form__advanced-settings {

--- a/client/signup/steps/rewind-add-creds/index.jsx
+++ b/client/signup/steps/rewind-add-creds/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
@@ -14,6 +14,7 @@ import { get } from 'lodash';
 import StepWrapper from 'signup/step-wrapper';
 import Card from 'components/card';
 import Button from 'components/button';
+import FormattedHeader from 'components/formatted-header';
 import { submitSignupStep } from 'state/signup/progress/actions';
 
 /**
@@ -45,22 +46,22 @@ class RewindAddCreds extends Component {
 		const { translate } = this.props;
 
 		return (
-			<Card className="rewind-add-creds__card rewind-switch__card rewind-switch__content">
-				<h3 className="rewind-add-creds__title rewind-switch__heading">
-					{ translate( 'Add your credentials' ) }
-				</h3>
-				<img src="/calypso/images/illustrations/security.svg" alt="" />
-				<p className="rewind-add-creds__description rewind-switch__description">
-					{ translate(
-						'To activate Jetpack backups and security, please add your site credentials. ' +
-							'WordPress.com will then be able to access your site to perform automatic backups, ' +
-							'and to restore your site in case of an emergency.'
-					) }
-				</p>
-				<Button primary onClick={ this.goToCredsForm }>
-					{ translate( 'Add your credentials' ) }
-				</Button>
-			</Card>
+			<Fragment>
+				<FormattedHeader headerText={ translate( 'Add your credentials' ) } />
+				<Card className="rewind-add-creds__card rewind-switch__card rewind-switch__content">
+					<img src="/calypso/images/illustrations/security.svg" alt="" />
+					<p className="rewind-add-creds__description rewind-switch__description">
+						{ translate(
+							'To activate Jetpack backups and security, please add your site credentials. ' +
+								'WordPress.com will then be able to access your site to perform automatic backups, ' +
+								'and to restore your site in case of an emergency.'
+						) }
+					</p>
+					<Button primary className="rewind-add-creds__add-button" onClick={ this.goToCredsForm }>
+						{ translate( 'Add your credentials' ) }
+					</Button>
+				</Card>
+			</Fragment>
 		);
 	}
 

--- a/client/signup/steps/rewind-add-creds/style.scss
+++ b/client/signup/steps/rewind-add-creds/style.scss
@@ -5,3 +5,8 @@
 		margin: rem( 20px ) auto;
 	}
 }
+
+.rewind-add-creds__add-button {
+	display: block;
+	margin: 0 auto;
+}

--- a/client/signup/steps/rewind-form-creds/style.scss
+++ b/client/signup/steps/rewind-form-creds/style.scss
@@ -15,8 +15,7 @@
 	}
 
 	.rewind-credentials-form {
-		text-align: left;
-		width: 90%;
+		padding: 0 24px;
 
 		.rewind-credentials-form__user-pass {
 			display: block;

--- a/client/signup/steps/rewind-form-creds/style.scss
+++ b/client/signup/steps/rewind-form-creds/style.scss
@@ -29,11 +29,6 @@
 		padding-right: 32px;
 	}
 
-	.button.is-primary.rewind-credentials-form__advanced-button {
-		float: none;
-		padding: 8px 0;
-	}
-
 	.credentials-setup-flow__footer {
 		width: 100%;
 		text-align: left;


### PR DESCRIPTION
Migrates CSS of `RewindCredentialsForm` and fixes several issues in the component (see individual commit messages)

Updates the styling of the `/start/rewind-setup` flow.

**How to test:**
- test the credentials form in `/start/rewind-setup`
- test the credentials form in Jetpack settings at `/settings/security/:jetpack-site`