### PR TITLE
Wizard: migrate CSS to webpack, useTranslate hook

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -35,7 +35,6 @@
 @import 'components/site-selector/style';
 @import 'components/sites-popover/style';
 @import 'components/tooltip/style';
-@import 'components/wizard/style';
 @import 'layout/guided-tours/style';
 @import 'layout/community-translator/style';
 @import 'layout/sidebar/style';

--- a/client/components/wizard/index.jsx
+++ b/client/components/wizard/index.jsx
@@ -6,13 +6,18 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { compact, get, indexOf, omit } from 'lodash';
+import { compact, get, indexOf } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import NavigationLink from './navigation-link';
-import ProgressIndicator from 'components/wizard/progress-indicator';
+import ProgressIndicator from './progress-indicator';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class Wizard extends Component {
 	static propTypes = {
@@ -78,6 +83,7 @@ class Wizard extends Component {
 		const {
 			backText,
 			basePath,
+			baseSuffix,
 			components,
 			forwardText,
 			hideBackLink,
@@ -106,7 +112,7 @@ class Wizard extends Component {
 					getBackUrl: this.getBackUrl,
 					getForwardUrl: this.getForwardUrl,
 					steps,
-					...omit( otherProps, [ 'basePath', 'baseSuffix' ] ),
+					...otherProps,
 				} ) }
 
 				{ ! hideNavigation && totalSteps > 1 && (

--- a/client/components/wizard/navigation-link.jsx
+++ b/client/components/wizard/navigation-link.jsx
@@ -1,56 +1,46 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
-import { noop } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import Button from 'components/button';
 
-class NavigationLink extends Component {
-	static propTypes = {
-		direction: PropTypes.oneOf( [ 'back', 'forward' ] ).isRequired,
-		href: PropTypes.string,
-		onClick: PropTypes.func,
-		text: PropTypes.string,
-		translate: PropTypes.func.isRequired,
-	};
+/**
+ * Style dependencies
+ */
+import './navigation-link.scss';
 
-	static defaultProps = {
-		onClick: noop,
-	};
+function NavigationLink( { direction, text, href, onClick } ) {
+	const translate = useTranslate();
+	const linkText =
+		text || ( direction === 'back' ? translate( 'Back' ) : translate( 'Skip for now' ) );
 
-	getText = () => {
-		const { direction, text, translate } = this.props;
-
-		return text || ( direction === 'back' ? translate( 'Back' ) : translate( 'Skip for now' ) );
-	};
-
-	render() {
-		const { direction, href, onClick } = this.props;
-
-		return (
-			<Button
-				compact
-				borderless
-				className="wizard__navigation-link"
-				href={ href }
-				onClick={ onClick }
-			>
-				{ direction === 'back' && <Gridicon icon="arrow-left" size={ 18 } /> }
-				{ this.getText() }
-				{ direction === 'forward' && <Gridicon icon="arrow-right" size={ 18 } /> }
-			</Button>
-		);
-	}
+	return (
+		<Button
+			compact
+			borderless
+			className="wizard__navigation-link"
+			href={ href }
+			onClick={ onClick }
+		>
+			{ direction === 'back' && <Gridicon icon="arrow-left" size={ 18 } /> }
+			{ linkText }
+			{ direction === 'forward' && <Gridicon icon="arrow-right" size={ 18 } /> }
+		</Button>
+	);
 }
 
-export default localize( NavigationLink );
+NavigationLink.propTypes = {
+	direction: PropTypes.oneOf( [ 'back', 'forward' ] ).isRequired,
+	text: PropTypes.string,
+	href: PropTypes.string,
+	onClick: PropTypes.func,
+};
+
+export default NavigationLink;

--- a/client/components/wizard/navigation-link.scss
+++ b/client/components/wizard/navigation-link.scss
@@ -1,0 +1,5 @@
+.wizard__navigation-link {
+	display: inline-block;
+	margin: 24px 12px;
+	text-align: center;
+}

--- a/client/components/wizard/progress-indicator.jsx
+++ b/client/components/wizard/progress-indicator.jsx
@@ -1,31 +1,37 @@
-/** @format */
-
 /**
  * External dependencies
  */
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
-const ProgressIndicator = ( { stepNumber, totalSteps, translate } ) => (
-	<div
-		className="wizard__progress-indicator"
-		data-e2e-type={ 'step-indicator-' + ( stepNumber + 1 ) }
-	>
-		{ translate( 'Step %(stepNumber)d of %(stepTotal)d', {
-			args: {
-				stepNumber: stepNumber + 1,
-				stepTotal: totalSteps,
-			},
-		} ) }
-	</div>
-);
+/**
+ * Style dependencies
+ */
+import './progress-indicator.scss';
+
+const ProgressIndicator = ( { stepNumber, totalSteps } ) => {
+	const translate = useTranslate();
+
+	return (
+		<div
+			className="wizard__progress-indicator"
+			data-e2e-type={ 'step-indicator-' + ( stepNumber + 1 ) }
+		>
+			{ translate( 'Step %(stepNumber)d of %(stepTotal)d', {
+				args: {
+					stepNumber: stepNumber + 1,
+					stepTotal: totalSteps,
+				},
+			} ) }
+		</div>
+	);
+};
 
 ProgressIndicator.propTypes = {
 	stepNumber: PropTypes.number.isRequired,
 	totalSteps: PropTypes.number.isRequired,
-	translate: PropTypes.func.isRequired,
 };
 
-export default localize( ProgressIndicator );
+export default ProgressIndicator;

--- a/client/components/wizard/progress-indicator.scss
+++ b/client/components/wizard/progress-indicator.scss
@@ -1,0 +1,13 @@
+.wizard__progress-indicator {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var( --color-text-subtle );
+	font-size: 12px;
+	margin-bottom: 8px;
+	text-align: center;
+
+	@include breakpoint( '<660px' ) {
+		padding-top: 8px;
+	}
+}

--- a/client/components/wizard/style.scss
+++ b/client/components/wizard/style.scss
@@ -1,35 +1,3 @@
-/* Progress Indicator */
-
-.wizard__progress-indicator {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	color: var( --color-text-subtle );
-	font-size: 12px;
-	margin-bottom: 8px;
-	text-align: center;
-
-	@include breakpoint( '<660px' ) {
-		padding-top: 8px;
-	}
-}
-
-/* Navigation */
 .wizard__navigation-links {
-	text-align: center;
-}
-
-.wizard__navigation-links .button.is-borderless {
-	color: var( --color-neutral-500 );
-
-	&:hover {
-		color: var( --color-neutral-700 );
-	}
-}
-
-.wizard__navigation-link {
-	cursor: pointer;
-	display: inline-block;
-	margin: 24px 12px;
 	text-align: center;
 }


### PR DESCRIPTION
Migrates CSS of the `Wizard` component. Also transforms a few components into functional ones using the `useTranslate` hook.

**How to test:**
- check out the devdocs for the component at `/devdocs/design/wizard`
- the navigation links (Back and Skip) are used when disconnecting a Jetpack site and asking the user about their reasons for leaving.
- the `Wizard` is used in the onboarding flow at `/jetpack/start/:site` but that flows seems legacy (@tyxla?)
