### PR TITLE
E2E: Enables import signup test, now that import system is working

### DIFF
--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1513,8 +1513,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	describe.skip( 'Import a site while signing up @parallel', function() {
-		// Temporarily skip https://github.com/Automattic/wp-calypso/pull/34021#issuecomment-502487953
+	describe( 'Import a site while signing up @parallel', function() {
 		// Currently must use a Wix site to be importable through this flow.
 		const siteURL = 'https://hi6822.wixsite.com/eat-here-its-good';
 		const userName = dataHelper.getNewBlogName();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Enables import signup test, now that import system is working

(See https://github.com/Automattic/wp-calypso/pull/34021#pullrequestreview-250247798 for context)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

`Import a site while signing up @parallel` test should pass in CI.
