### PR TITLE
SiteAddressChanger: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -13,7 +13,6 @@
 @import 'blocks/nps-survey/style';
 @import 'blocks/login/style';
 @import 'blocks/post-item/style';
-@import 'blocks/site-address-changer/style';
 @import 'blocks/term-tree-selector/style';
 @import 'blocks/upload-image/style';
 @import 'components/button/style';

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -30,6 +30,11 @@ import getSiteAddressValidationError from 'state/selectors/get-site-address-vali
 import isRequestingSiteAddressChange from 'state/selectors/is-requesting-site-address-change';
 import { getSelectedSiteId } from 'state/ui/selectors';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const SUBDOMAIN_LENGTH_MINIMUM = 4;
 const SUBDOMAIN_LENGTH_MAXIMUM = 50;
 const ADDRESS_CHANGE_SUPPORT_URL = 'https://support.wordpress.com/changing-blog-address/';

--- a/client/blocks/site-address-changer/index.jsx
+++ b/client/blocks/site-address-changer/index.jsx
@@ -42,7 +42,7 @@ export class SiteAddressChanger extends Component {
 
 		// `connect`ed
 		isSiteAddressChangeRequesting: PropTypes.bool,
-		selectedSiteId: PropTypes.number,
+		siteId: PropTypes.number,
 	};
 
 	static defaultProps = {
@@ -62,12 +62,12 @@ export class SiteAddressChanger extends Component {
 
 	onConfirm = () => {
 		const { domainFieldValue, newDomainSuffix } = this.state;
-		const { currentDomain, currentDomainSuffix, selectedSiteId } = this.props;
+		const { currentDomain, currentDomainSuffix, siteId } = this.props;
 		const oldDomain = get( currentDomain, 'name', null );
 		const type = '.wordpress.com' === currentDomainSuffix ? 'blog' : 'dotblog';
 
 		this.props.requestSiteAddressChange(
-			selectedSiteId,
+			siteId,
 			domainFieldValue,
 			newDomainSuffix.substr( 1 ),
 			oldDomain,
@@ -365,7 +365,6 @@ export default flow(
 
 			return {
 				siteId,
-				selectedSiteId: siteId,
 				isAvailable,
 				isSiteAddressChangeRequesting: isRequestingSiteAddressChange( state, siteId ),
 				isAvailabilityPending: getSiteAddressAvailabilityPending( state, siteId ),


### PR DESCRIPTION
Migrates the UI to change a `*.wordpress.com` site address:

<img width="728" alt="Screenshot 2019-06-17 at 17 48 39" src="https://user-images.githubusercontent.com/664258/59618947-a043df00-9129-11e9-96d6-8f2721b98c82.png">

and the confirmation dialog displayed after pressing the "Change" button:

<img width="456" alt="Screenshot 2019-06-17 at 17 48 58" src="https://user-images.githubusercontent.com/664258/59618962-adf96480-9129-11e9-9780-bd85ab9891ed.png">

