### PR TITLE
Revert "Add support for manually marking phase 2 checklist items as completed"

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -31,8 +31,7 @@ function getTasks( {
 	const tasks = [];
 	const segmentSlug = getSiteTypePropertyValue( 'id', siteSegment, 'slug' );
 
-	const getTask = taskId =>
-		taskStatuses ? taskStatuses.filter( task => task.id === taskId )[ 0 ] : undefined;
+	const getTask = taskId => get( taskStatuses, taskId );
 	const hasTask = taskId => getTask( taskId ) !== undefined;
 	const isCompleted = taskId => get( getTask( taskId ), 'completed', false );
 	const addTask = ( taskId, completed ) => {

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,9 +17,10 @@ import { items as itemSchemas } from './schema';
 
 const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 	...state,
-	tasks: state.tasks.map( task =>
-		task.id === taskId ? { ...task, isCompleted: completed } : task
-	),
+	tasks: {
+		...state.tasks,
+		[ taskId ]: { ...get( state.tasks, [ taskId ] ), completed },
+	},
 } );
 
 const moduleTaskMap = {
@@ -35,18 +36,6 @@ const moduleTaskMap = {
 function items( state = {}, action ) {
 	switch ( action.type ) {
 		case SITE_CHECKLIST_RECEIVE:
-			// Legacy, object-based response format
-			if ( ! Array.isArray( action.checklist.tasks ) ) {
-				return {
-					...action.checklist,
-					tasks: map( action.checklist.tasks, ( value, id ) => ( {
-						id,
-						...value,
-					} ) ),
-				};
-			}
-
-			// Phase 2 data format
 			return action.checklist;
 		case SITE_CHECKLIST_TASK_UPDATE:
 			return setChecklistTaskCompletion( state, action.taskId, true );

--- a/client/state/checklist/schema.js
+++ b/client/state/checklist/schema.js
@@ -4,7 +4,7 @@ export const items = {
 	properties: {
 		designType: { type: 'string' },
 		segment: { type: 'integer' },
-		tasks: { type: 'array' },
+		tasks: { type: 'object' },
 		verticals: { type: 'array' },
 	},
 };

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -43,7 +43,7 @@ export const updateChecklistTask = action =>
 		{
 			path: `/sites/${ action.siteId }/checklist`,
 			method: 'POST',
-			apiNamespace: isEnabled( 'onboarding-checklist/phase2' ) ? 'rest/v1.1' : 'rest/v1',
+			apiNamespace: 'rest/v1',
 			query: {
 				http_envelope: 1,
 			},


### PR DESCRIPTION
Reverts Automattic/wp-calypso#34031 which didn't fully take Jetpack into consideration and caused completed tasks to not show as completed.