### PR TITLE
Re-enable parallel builds.

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
 		"build-client": "npm run build-client-evergreen",
 		"build-client-fallback": "cross-env-shell BROWSERSLIST_ENV=defaults NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
 		"build-client-evergreen": "cross-env-shell BROWSERSLIST_ENV=evergreen NODE_PATH=$NODE_PATH:server:client:. node $NODE_ARGS ./node_modules/webpack/bin/webpack.js --display errors-only",
-		"build-client-both": "npm run build-client-fallback && npm run build-client-evergreen",
+		"build-client-both": "concurrently -c cyan -n \"fallback ,evergreen\" \"npm run build-client-fallback\" \"npm run build-client-evergreen\"",
 		"build-client-if-prod": "node -e \"process.env.CALYPSO_ENV === 'production' && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client-both",
 		"build-client-if-desktop": "node -e \"(process.env.CALYPSO_ENV === 'desktop' || process.env.CALYPSO_ENV === 'desktop-development') && process.exit(1)\" || cross-env-shell NODE_ARGS=--max_old_space_size=8192 npm run build-client-fallback",
 		"build-packages": "npx lerna run prepare --stream",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -296,6 +296,12 @@ const webpackConfig = {
 		shouldEmitStats && new webpack.ProgressPlugin( createProgressHandler() ),
 		new MomentTimezoneDataPlugin( {
 			startYear: 2000,
+			cacheDir: path.join(
+				__dirname,
+				'build',
+				'.moment-timezone-data-webpack-plugin-cache',
+				extraPath
+			),
 		} ),
 		isCalypsoClient && new InlineConstantExportsPlugin( /\/client\/state\/action-types.js$/ ),
 	] ),


### PR DESCRIPTION
Parallel builds (for evergreen and fallback) had been disabled in #32281 due to a race condition in the `moment-timezone-data-webpack-plugin` WebPack Plugin. This was caused by both builds attempting to access the same temporary directory and occasionally reading data in inconsistent states.

The plugin has now been updated with a new option that allows for specifying the cache directory, and we use that to make sure that the two builds write to different directories.

Re-enabling parallel builds should help reduce build times.

#### Changes proposed in this Pull Request

* Rewrite build rule to run builds in parallel.
* Add directory configuration to WebPack config.

#### Testing instructions

I'm not sure how to go about testing this other than running as many production builds as you can, and analysing whether any of them fails unexpectedly 😕 
