### PR TITLE
Add support for manually marking phase 2 checklist items as completed

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -110,6 +110,15 @@ class WpcomTaskList {
 		return this.tasks.find( task => task.id === taskId );
 	}
 
+	getIds() {
+		return this.getAll().map( ( { id } ) => id );
+	}
+
+	isCompleted( taskId ) {
+		const task = this.get( taskId );
+		return task ? task.isCompleted : false;
+	}
+
 	has( taskId ) {
 		return !! this.get( taskId );
 	}

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -31,7 +31,8 @@ function getTasks( {
 	const tasks = [];
 	const segmentSlug = getSiteTypePropertyValue( 'id', siteSegment, 'slug' );
 
-	const getTask = taskId => get( taskStatuses, taskId );
+	const getTask = taskId =>
+		taskStatuses ? taskStatuses.filter( task => task.id === taskId )[ 0 ] : undefined;
 	const hasTask = taskId => getTask( taskId ) !== undefined;
 	const isCompleted = taskId => get( getTask( taskId ), 'completed', false );
 	const addTask = ( taskId, completed ) => {

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -34,9 +34,9 @@ function getTasks( {
 	const getTask = taskId =>
 		taskStatuses ? taskStatuses.filter( task => task.id === taskId )[ 0 ] : undefined;
 	const hasTask = taskId => getTask( taskId ) !== undefined;
-	const isCompleted = taskId => get( getTask( taskId ), 'completed', false );
+	const isCompleted = taskId => get( getTask( taskId ), 'isCompleted', false );
 	const addTask = ( taskId, completed ) => {
-		const task = Object.assign( omit( getTask( taskId ), [ 'completed' ] ), {
+		const task = Object.assign( omit( getTask( taskId ), [ 'isCompleted' ] ), {
 			id: taskId,
 			isCompleted: isBoolean( completed ) ? completed : isCompleted( taskId ),
 		} );

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -45,7 +45,7 @@ import withTrackingTool from 'lib/analytics/with-tracking-tool';
  * Style dependencies
  */
 import './style.scss';
-import { getTaskList } from '../../../checklist/wpcom-checklist/wpcom-task-list';
+import { getTaskList } from 'my-sites/checklist/wpcom-checklist/wpcom-task-list';
 
 interface ChecklistTaskState {
 	[taskId: string]: {

--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -45,6 +45,7 @@ import withTrackingTool from 'lib/analytics/with-tracking-tool';
  * Style dependencies
  */
 import './style.scss';
+import { getTaskList } from '../../../checklist/wpcom-checklist/wpcom-task-list';
 
 interface ChecklistTaskState {
 	[taskId: string]: {
@@ -68,7 +69,7 @@ class JetpackChecklist extends PureComponent< Props > {
 	}
 
 	isComplete( taskId: string ): boolean {
-		return get( this.props.taskStatuses, [ taskId, 'completed' ], false );
+		return getTaskList( this.props ).isCompleted( taskId );
 	}
 
 	handleTaskStart = ( { taskId, tourId }: { taskId: string; tourId?: string } ) => () => {
@@ -101,7 +102,9 @@ class JetpackChecklist extends PureComponent< Props > {
 				? // Force render all the tasks from this development-only list
 				  // @todo Remove this branch when API returns performance task statuses
 				  Object.keys( JETPACK_PERFORMANCE_CHECKLIST_TASKS )
-				: Object.keys( this.props.taskStatuses ).filter( taskId => taskId in checklistTasks );
+				: getTaskList( this.props )
+						.getIds()
+						.filter( taskId => taskId in checklistTasks );
 
 		return taskIds.map( taskId => {
 			const task = checklistTasks[ taskId ];
@@ -290,10 +293,13 @@ const connectComponent = connect(
 			isProfessional,
 			isPaidPlan,
 			rewindState,
+			// `phase2: true` is passed to `getTaskList()` in the component and makes it possible to use
+			// the array-based checklist data format
+			phase2: true,
 			productInstallStatus,
 			siteId,
 			siteSlug: getSiteSlug( state, siteId ),
-			taskStatuses: get( getSiteChecklist( state, siteId ), [ 'tasks' ] ),
+			taskStatuses: get( getSiteChecklist( state, siteId ), 'tasks' ),
 			wpAdminUrl,
 		};
 	},

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -35,18 +34,6 @@ const moduleTaskMap = {
 function items( state = {}, action ) {
 	switch ( action.type ) {
 		case SITE_CHECKLIST_RECEIVE:
-			// Legacy, object-based response format
-			if ( ! Array.isArray( action.checklist.tasks ) ) {
-				return {
-					...action.checklist,
-					tasks: map( action.checklist.tasks, ( value, id ) => ( {
-						id,
-						...value,
-					} ) ),
-				};
-			}
-
-			// Phase 2 data format
 			return action.checklist;
 		case SITE_CHECKLIST_TASK_UPDATE:
 			return setChecklistTaskCompletion( state, action.taskId, true );

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { get } from 'lodash';
+import { map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,10 +17,9 @@ import { items as itemSchemas } from './schema';
 
 const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 	...state,
-	tasks: {
-		...state.tasks,
-		[ taskId ]: { ...get( state.tasks, [ taskId ] ), completed },
-	},
+	tasks: state.tasks.map( task =>
+		task.id === taskId ? { ...task, isCompleted: completed } : task
+	),
 } );
 
 const moduleTaskMap = {
@@ -36,6 +35,18 @@ const moduleTaskMap = {
 function items( state = {}, action ) {
 	switch ( action.type ) {
 		case SITE_CHECKLIST_RECEIVE:
+			// Legacy, object-based response format
+			if ( ! Array.isArray( action.checklist.tasks ) ) {
+				return {
+					...action.checklist,
+					tasks: map( action.checklist.tasks, ( value, id ) => ( {
+						id,
+						...value,
+					} ) ),
+				};
+			}
+
+			// Phase 2 data format
 			return action.checklist;
 		case SITE_CHECKLIST_TASK_UPDATE:
 			return setChecklistTaskCompletion( state, action.taskId, true );

--- a/client/state/checklist/schema.js
+++ b/client/state/checklist/schema.js
@@ -4,7 +4,7 @@ export const items = {
 	properties: {
 		designType: { type: 'string' },
 		segment: { type: 'integer' },
-		tasks: { type: 'object' },
+		tasks: { type: 'array' },
 		verticals: { type: 'array' },
 	},
 };

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -43,7 +43,7 @@ export const updateChecklistTask = action =>
 		{
 			path: `/sites/${ action.siteId }/checklist`,
 			method: 'POST',
-			apiNamespace: 'rest/v1',
+			apiNamespace: isEnabled( 'onboarding-checklist/phase2' ) ? 'rest/v1.1' : 'rest/v1',
 			query: {
 				http_envelope: 1,
 			},

--- a/client/state/data-layer/wpcom/checklist/index.js
+++ b/client/state/data-layer/wpcom/checklist/index.js
@@ -29,8 +29,26 @@ export const fetchChecklist = action =>
 		action
 	);
 
-export const receiveChecklistSuccess = ( action, checklist ) =>
-	receiveSiteChecklist( action.siteId, checklist );
+export const receiveChecklistSuccess = ( action, receivedChecklist ) => {
+	let checklist = receivedChecklist;
+
+	// Legacy object-based data format, let's convert it to the new array-based format and ultimately remove it.
+	if ( ! Array.isArray( receivedChecklist.tasks ) ) {
+		checklist = {
+			...receivedChecklist,
+			tasks: Object.keys( receivedChecklist.tasks ).map( taskId => {
+				const { completed, ...rest } = receivedChecklist.tasks[ taskId ];
+				return {
+					id: taskId,
+					isCompleted: completed,
+					...rest,
+				};
+			} ),
+		};
+	}
+
+	return receiveSiteChecklist( action.siteId, checklist );
+};
 
 const dispatchChecklistRequest = dispatchRequest( {
 	fetch: fetchChecklist,


### PR DESCRIPTION
**Changes proposed in this Pull Request**

After updating the checklist data structure for the purposes of Phase 2 checklist updates (paObgF-aE-p2), manually marking tasks as complete broke. This PR updates the redux state structure to only use the new data format, even if the API response is in the old data format.

This was merged and reverted since it didn't address required Jetpack changes such as updating this function here:

https://github.com/Automattic/wp-calypso/blob/5fe221b6cc276f47a5e7d5fdb9076936de58017a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx#L70-L72

**Testing instructions**

* Apply D29524-code
* Signup as a new user on calypso.localhost:3000
* Manually mark all tasks as completed and confirm they remains completed after refreshing the page
* Login as your regular user on calypso.localhost:3000
* Create a new free site, confirm you get the "old" 5+ items checklist
* Manually mark some tasks as completed and confirm they remains completed after refreshing the page
* Create a new Jetpack site, for example using Jurassic Ninja, complete a few tasks, confirm that appropriate items are showing as complete