### PR TITLE
Jetpack Checklist: Fix Target for Completed Video Hosting Task

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-checklist/index.tsx
@@ -213,7 +213,7 @@ class JetpackChecklist extends PureComponent< Props > {
 							duration={ getJetpackChecklistTaskDuration( 3 ) }
 							href={
 								this.isComplete( 'jetpack_video_hosting' )
-									? `/media/${ siteSlug }`
+									? `/media/videos/${ siteSlug }`
 									: `/settings/performance/${ siteSlug }`
 							}
 							onClick={ this.handleTaskStart( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Jetpack Checklist: Fix Target for Completed Video Hosting Task

Per @jeffgolenski's https://github.com/Automattic/wp-calypso/pull/33737#issuecomment-502705937:

> **Video hosting:** Current when video hosting is activated, the action link in the completed task list item says "upload videos" - it takes the customer to `https://wpcalypso.wordpress.com/media/URL`. It should take them to `https://wpcalypso.wordpress.com/media/videos/URL`

#### Testing instructions

- Start Calypso locally, using this branch
- Create a new jurassic.ninja site
- Locate the 'Connect to WP.com' button in wp-admin, copy its link target, and append `&calypso_env=development` to it. Navigate to that URL.
- Select a the Professinal plan
- On the 'Thank You' page, locate the checklist
- Locate the 'Video Hosting' task, and click the 'Do it!' button next to it
- You're taken to the performance settings page.
- Enable the Video Hosting toggle, as explained by the Guided Tour
- At the end of the tour, choose "Yes, let's do it" to return to the checklist
- Verify that the Video Hosting task is now marked as complete (reload if it isn't)
- Click the 'Upload videos' link next to it
- Verify that it takes you to `calypso.localhost:3000/media/videos/:site`