### PR TITLE
Signup: Add "Purchase required" badge to "Online store" site type

### DIFF
--- a/assets/stylesheets/shared/_variables.scss
+++ b/assets/stylesheets/shared/_variables.scss
@@ -1,7 +1,20 @@
 
+// =======================
+// Layout
+// =======================
+
 // Sidebar size limits
 $sidebar-width-max: 272px;
 $sidebar-width-min: 228px;
 
+
+// =======================
+// Components
+// =======================
+
 // Accordion
 $accordion-padding: 16px;
+
+// Badge
+$badge-padding-x: 11px;
+$badge-padding-y: 2px;

--- a/client/components/badge/index.jsx
+++ b/client/components/badge/index.jsx
@@ -6,6 +6,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 
 /**
  * Style dependencies
@@ -14,7 +15,7 @@ import './style.scss';
 
 export default class Badge extends React.Component {
 	static propTypes = {
-		type: PropTypes.oneOf( [ 'warning', 'success' ] ).isRequired,
+		type: PropTypes.oneOf( [ 'warning', 'success', 'info' ] ).isRequired,
 	};
 
 	static defaultProps = {
@@ -22,7 +23,11 @@ export default class Badge extends React.Component {
 	};
 
 	render() {
-		const { type } = this.props;
-		return <div className={ `badge badge--${ type }` }>{ this.props.children }</div>;
+		const { className, type } = this.props;
+		return (
+			<div className={ classNames( `badge badge--${ type }`, className ) }>
+				{ this.props.children }
+			</div>
+		);
 	}
 }

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -15,3 +15,8 @@
 	color: var( --color-white );
 	background-color: var( --color-success );
 }
+
+.badge--info {
+	color: var( --color-neutral-800 );
+	background-color: var( --color-neutral-50 );
+}

--- a/client/components/badge/style.scss
+++ b/client/components/badge/style.scss
@@ -1,7 +1,7 @@
 .badge {
 	display: inline-block;
 	border-radius: 1000px; // A number large enough to exceed height of any badge to make it look like a pill
-	padding: 2px 11px;
+	padding: $badge-padding-y $badge-padding-x;
 	font-size: 14px;
 	line-height: 18px;
 }

--- a/client/components/badge/test/index.js
+++ b/client/components/badge/test/index.js
@@ -28,6 +28,11 @@ describe( 'Badge', () => {
 		assert.lengthOf( badge.find( '.badge.badge--success' ), 1 );
 	} );
 
+	test( 'should have proper type class (info)', () => {
+		const badge = shallow( <Badge type="info" /> );
+		assert.lengthOf( badge.find( '.badge.badge--info' ), 1 );
+	} );
+
 	test( 'should have proper type class (default)', () => {
 		const badge = shallow( <Badge /> );
 		assert.lengthOf( badge.find( '.badge.badge--warning' ), 1 );

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -148,6 +148,7 @@ export function getAllSiteTypes() {
 			siteTopicHeader: i18n.translate( 'What type of products do you sell?' ),
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
+			purchaseRequired: true,
 		},
 	];
 }

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import Badge from 'components/badge';
 import Card from 'components/card';
 import { getAllSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -51,6 +52,11 @@ class SiteTypeForm extends Component {
 							<span className="site-type__option-description">
 								{ siteTypeProperties.description }
 							</span>
+							{ siteTypeProperties.purchaseRequired && (
+								<Badge className="site-type__option-badge" type="info">
+									{ this.props.translate( 'Purchase required' ) }
+								</Badge>
+							) }
 						</Card>
 					) ) }
 				</Card>

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -50,6 +50,13 @@
 		color: var( --color-text-subtle );
 	}
 
+	.site-type__option-badge {
+		font-size: 12px;
+		margin-top: 6px;
+		// Offset .badge padding-left
+		margin-left: -11px;
+	}
+
 	.card__link-indicator {
 		@include breakpoint( '>660px' ) {
 			opacity: 0.5;

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -54,7 +54,7 @@
 		font-size: 12px;
 		margin-top: 6px;
 		// Offset .badge padding-left
-		margin-left: -11px;
+		margin-left: -( $badge-padding-x );
 	}
 
 	.card__link-indicator {

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -53,7 +53,7 @@
 	.site-type__option-badge {
 		font-size: 12px;
 		margin-top: 6px;
-		// Offset .badge padding-left
+		// Offset .badge padding-left to vertically align badge text with site type description.
 		margin-left: -( $badge-padding-x );
 	}
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Adds a "Purchase required" badge to the "Online store" option in the list of site types during signup

<img width="488" alt="Screen Shot 2019-06-17 at 17 45 43" src="https://user-images.githubusercontent.com/1699996/59641859-8950bd00-9128-11e9-95a2-8bccf3ee2109.png">

#### Testing instructions

1. Visit `/start`
1. Create a user if you are not logged in
1. In the list of site types, see the `Purchase required` badge below the `Online store` option

Fixes #33544 