### PR TITLE
Reader: improve rendering of Gutenberg galleries

### DIFF
--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -231,19 +231,13 @@
 		margin-bottom: 1em;
 	}
 
-	ul.wp-block-gallery {
-		list-style-type: none;
+	.wp-block-gallery {
 		margin-left: 0;
 		margin-bottom: 1em;
-
-		&.columns-3 .blocks-gallery-item {
-			column-count: 3;
-			column-gap: 8px;
-			// max-width: 32%;
-			// float: left;
-			// margin-right: 8px;
-		}
 	}
+
+	// Import Gutenberg gallery styles
+	@import 'gutenberg-gallery.scss';
 
 	.wp-block-embed .embed-vimeo {
 		padding-top: 0;

--- a/client/blocks/reader-full-post/_content.scss
+++ b/client/blocks/reader-full-post/_content.scss
@@ -235,6 +235,14 @@
 		list-style-type: none;
 		margin-left: 0;
 		margin-bottom: 1em;
+
+		&.columns-3 .blocks-gallery-item {
+			column-count: 3;
+			column-gap: 8px;
+			// max-width: 32%;
+			// float: left;
+			// margin-right: 8px;
+		}
 	}
 
 	.wp-block-embed .embed-vimeo {

--- a/client/blocks/reader-full-post/gutenberg-gallery.scss
+++ b/client/blocks/reader-full-post/gutenberg-gallery.scss
@@ -1,0 +1,168 @@
+$grid-size-large: 16px;
+$default-font-size: 13px;
+$content-width: 610px;
+$break-small: 600px;
+$black: #000;
+$white: #fff;
+
+@mixin break-small() {
+	@media ( min-width: #{ ( $break-small ) } ) {
+		@content;
+	}
+}
+
+.wp-block-gallery {
+	display: flex;
+	flex-wrap: wrap;
+	list-style-type: none;
+	padding: 0;
+
+	.blocks-gallery-image,
+	.blocks-gallery-item {
+		// Add space between thumbnails, and unset right most thumbnails later.
+		margin: 0 $grid-size-large $grid-size-large 0;
+		display: flex;
+		flex-grow: 1;
+		flex-direction: column;
+		justify-content: center;
+		position: relative;
+
+		figure {
+			margin: 0;
+			height: 100%;
+
+			// IE doesn't support flex so omit that.
+			@supports ( position: sticky ) {
+				display: flex;
+				align-items: flex-end;
+				justify-content: flex-start;
+			}
+		}
+
+		img {
+			display: block;
+			max-width: 100%;
+			height: auto;
+		}
+
+		// IE doesn't handle cropping, so we need an explicit width here.
+		img {
+			width: 100%;
+
+			// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
+			@supports ( position: sticky ) {
+				width: auto;
+			}
+		}
+
+		figcaption {
+			position: absolute;
+			bottom: 0;
+			width: 100%;
+			max-height: 100%;
+			overflow: auto;
+			padding: 40px 10px 9px;
+			color: $white;
+			text-align: center;
+			font-size: $default-font-size;
+			background: linear-gradient(
+				0deg,
+				rgba( $color: $black, $alpha: 0.7 ) 0,
+				rgba( $color: $black, $alpha: 0.3 ) 70%,
+				transparent
+			);
+
+			img {
+				display: inline;
+			}
+		}
+	}
+
+	// Cropped
+	&.is-cropped .blocks-gallery-image,
+	&.is-cropped .blocks-gallery-item {
+		a,
+		img {
+			// IE11 doesn't support object-fit, so just make sure images aren't skewed.
+			// The following rules are for all browsers.
+			width: 100%;
+
+			// IE11 doesn't read rules inside this query. They are applied only to modern browsers.
+			@supports ( position: sticky ) {
+				height: 100%;
+				flex: 1;
+				object-fit: cover;
+			}
+		}
+	}
+
+	// On mobile and responsive viewports, we allow only 1 or 2 columns at the most.
+	& .blocks-gallery-image,
+	& .blocks-gallery-item {
+		width: calc( ( 100% - #{$grid-size-large} ) / 2 );
+
+		&:nth-of-type( even ) {
+			margin-right: 0;
+		}
+	}
+
+	&.columns-1 .blocks-gallery-image,
+	&.columns-1 .blocks-gallery-item {
+		width: 100%;
+		margin-right: 0;
+	}
+
+	// Beyond mobile viewports, we allow up to 8 columns.
+	@include break-small {
+		@for $i from 3 through 8 {
+			&.columns-#{ $i } .blocks-gallery-image,
+			&.columns-#{ $i } .blocks-gallery-item {
+				width: calc( ( 100% - #{$grid-size-large} * #{$i - 1} ) / #{$i} );
+				margin-right: 16px;
+
+				// Rules inside this query are only run by Microsoft Edge.
+				// Edge miscalculates `calc`, so we have to add some buffer.
+				// See also https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/15637241/
+				@supports ( -ms-ime-align: auto ) {
+					width: calc( ( 100% - #{$grid-size-large} * #{$i - 1} ) / #{$i} - 1px );
+				}
+			}
+		}
+
+		// Unset the right margin on every rightmost gallery item to ensure center balance.
+		@for $column-count from 1 through 8 {
+			&.columns-#{ $column-count } .blocks-gallery-image:nth-of-type( #{ $column-count }n ),
+			&.columns-#{ $column-count } .blocks-gallery-item:nth-of-type( #{ $column-count }n ) {
+				margin-right: 0;
+			}
+		}
+	}
+
+	// Last item always needs margins reset.
+	.blocks-gallery-image:last-child,
+	.blocks-gallery-item:last-child {
+		margin-right: 0;
+	}
+
+	// Apply max-width to floated items that have no intrinsic width.
+	&.alignleft,
+	&.alignright {
+		max-width: $content-width / 2;
+		width: 100%;
+	}
+
+	// Keep the display property consistent when alignments are applied
+	// to preserve columns
+	&.alignleft,
+	&.aligncenter,
+	&.alignright {
+		display: flex;
+	}
+
+	// If the gallery is centered, center the content inside as well.
+	&.aligncenter {
+		.blocks-gallery-item figure {
+			justify-content: center;
+		}
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In a recent blog post, I included ~50 images in a three column gallery. When viewed in the Reader, all of the images were shown full width instead which made the post extremely long.

I think Reader should honour the column layout chosen in the block (which offers 1 to 8 columns).

#### Testing instructions

If you're an internal user, you can check out the post p11AhY-6vt-p2 for a good example. Check that the post displays nicely in 3 columns on 600px+ viewports, and 2 columns on mobile.

Otherwise, you can try creating a Gutenberg gallery with images of varying sizes and view the post in Reader.

Before (giant images):

<img width="766" alt="Screen Shot 2019-06-18 at 14 48 16" src="https://user-images.githubusercontent.com/17325/59649859-3afaf700-91d8-11e9-8d9f-066f6620ae38.png">

After (3 columns on desktop):

<img width="764" alt="Screen Shot 2019-06-18 at 14 47 42" src="https://user-images.githubusercontent.com/17325/59649869-42220500-91d8-11e9-8855-d860d3dace11.png">

Also after (2 columns on mobile):

<img width="492" alt="Screen Shot 2019-06-18 at 14 48 43" src="https://user-images.githubusercontent.com/17325/59649884-4cdc9a00-91d8-11e9-856d-0179e2798263.png">

