### PR TITLE
Update signup site preview to use Gutenberg v5.9.2 CSS

### DIFF
--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -57,7 +57,7 @@ export function getIframeSource(
 			<link rel="dns-prefetch" href="//s0.wp.com">
 			<link rel="dns-prefetch" href="//fonts.googleapis.com">
 			<title>${ content.title } – ${ content.tagline }</title>
-			<link type="text/css" media="all" rel="stylesheet" href="https://s0.wp.com/wp-content/plugins/gutenberg-core/v5.9.0/build/block-library/style.css" />
+			<link type="text/css" media="all" rel="stylesheet" href="https://s0.wp.com/wp-content/plugins/gutenberg-core/v5.9.2/build/block-library/style.css" />
 			${ getCSSLinkHtml( cssUrl ) }
 			${ getCSSLinkHtml( fontUrl ) }
 			<style type="text/css">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update site preview iframe to use Gutenberg v5.9.2 CSS
* This should fix the 404 issue with the site currently unable to load the v5.9.0 CSS file

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to create a new site at: http://calypso.localhost:3000/start/
* Check that the site preview looks correct for Business and Professional plans

#### Before

Screenshot of issue where the CSS file wasn't being loaded: https://cld.wthms.co/w6wdrh

#### After

![image](https://user-images.githubusercontent.com/14988353/59649242-4abd1000-91c5-11e9-9b11-6dfb5e034375.png)

