### PR TITLE
Signup: update site mockup font weights

### DIFF
--- a/client/lib/signup/site-styles.js
+++ b/client/lib/signup/site-styles.js
@@ -17,7 +17,7 @@ export const siteStyleOptions = {
 			id: 'modern',
 			label: 'Modern',
 			theme: 'pub/modern-business',
-			fontUrl: 'https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,700',
+			fontUrl: 'https://fonts.googleapis.com/css?family=IBM+Plex+Sans:300,500,700',
 			buttonSvg: (
 				<svg width="62" height="32" xmlns="http://www.w3.org/2000/svg">
 					<g fill="none" fillRule="evenodd">
@@ -37,7 +37,7 @@ export const siteStyleOptions = {
 			id: 'professional',
 			label: 'Professional',
 			theme: 'pub/professional-business',
-			fontUrl: 'https://fonts.googleapis.com/css?family=Crimson+Text:400,700',
+			fontUrl: 'https://fonts.googleapis.com/css?family=Crimson+Text:400,600,700',
 			buttonSvg: (
 				<svg xmlns="http://www.w3.org/2000/svg" width="130" height="32">
 					<g fill="none" fillRule="evenodd">
@@ -57,7 +57,7 @@ export const siteStyleOptions = {
 			id: 'sophisticated',
 			label: 'Sophisticated',
 			theme: 'pub/sophisticated-business',
-			fontUrl: 'https://fonts.googleapis.com/css?family=Poppins:400,700',
+			fontUrl: 'https://fonts.googleapis.com/css?family=Poppins:400,600,700',
 			buttonSvg: (
 				<svg width="93" height="32" xmlns="http://www.w3.org/2000/svg">
 					<g fill="#FFF" fillRule="evenodd">


### PR DESCRIPTION
This enqueues the proper font-weights for each of the site styles to help them better match the end themes. Fixes #34055, #34056, #34057 

**Testing instructions:**

* visit /start/onboarding
* select "business"
* select a vertical
* on the site style step, make sure that the correct font weights are displayed in the preview cover image and headers for Modern (400), Professional (600), and Sophisticated (600) 