### PR TITLE
Jetpack checklist: enable performance checklist in all environments

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -50,6 +50,7 @@
 		"help": true,
 		"help/courses": true,
 		"jetpack/api-cache": true,
+		"jetpack/checklist/performance": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -38,6 +38,7 @@
 		"gutenberg/opt-in": true,
 		"help": true,
 		"help/courses": true,
+		"jetpack/checklist/performance": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/personalPlan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -43,6 +43,7 @@
 		"help/courses": true,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": true,
+		"jetpack/checklist/performance": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,

--- a/config/production.json
+++ b/config/production.json
@@ -42,6 +42,7 @@
 		"help/courses": true,
 		"i18n/translation-scanner": true,
 		"jetpack/api-cache": false,
+		"jetpack/checklist/performance": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,7 +44,7 @@
 		"help/courses": true,
 		"jetpack/api-cache": true,
 		"jetpack/blocks/beta": true,
-		"jetpack/checklist/performance": false,
+		"jetpack/checklist/performance": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,

--- a/config/test.json
+++ b/config/test.json
@@ -44,6 +44,7 @@
 		"google-my-business": false,
 		"gutenberg/opt-in": true,
 		"help": true,
+		"jetpack/checklist/performance": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/happychat": true,


### PR DESCRIPTION
Pending merging https://github.com/Automattic/wp-calypso/pull/34041 and https://github.com/Automattic/wp-calypso/pull/34052

#### Changes proposed in this Pull Request

* Enable Jetpack performance checklist on all environments

#### Testing instructions
- Have a Jetpack connected site
- Open `/plans/my-plan/:site`
- See that the checklist has performance tasks such as "Site Accelerator", "Lazy Load Images" and that no "feature cards" for those same features under "plan features" title