### PR TITLE
Passes the current env to the Gutenframe iframe

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -40,6 +40,7 @@ import { getEditorPostId } from 'state/ui/editor/selectors';
 import { protectForm, ProtectedFormProps } from 'lib/protect-form';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ConvertToBlocksDialog from 'components/convert-to-blocks';
+import config from 'config';
 
 /**
  * Types
@@ -490,6 +491,7 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) 
 		'frame-nonce': getSiteOption( state, siteId, siteOption ) || '',
 		'jetpack-copy': duplicatePostId,
 		origin: window.location.origin,
+		environment_id: config( 'env_id' ),
 	} );
 
 	// needed for loading the editor in SU sessions

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -437,6 +437,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 					showDialog={ isConversionPromptVisible }
 					handleResponse={ this.handleConversionResponse }
 				/>
+				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<div className="main main-column calypsoify is-iframe" role="main">
 					{ ! isIframeLoaded && <Placeholder /> }
 					{ shouldLoadIframe && (
@@ -491,7 +492,7 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) 
 		'frame-nonce': getSiteOption( state, siteId, siteOption ) || '',
 		'jetpack-copy': duplicatePostId,
 		origin: window.location.origin,
-		environment_id: config( 'env_id' ),
+		'environment-id': config( 'env_id' ),
 	} );
 
 	// needed for loading the editor in SU sessions


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Passes the current Calypso env to the Gutenframe `iframe` - this can then be used to selectively enable features on WPCom

#### Questions

* Are there any security implications here?
* This parameter could be manually amended via devtools. Is this considered a problem?
* I had to `--no-verify` this commit because of BEM notices around the use of classes on the `iframe`. Is this ok or not? I'm loath to tamper with these classes unless @gwwar feels otherwise.


#### Testing instructions

* Load Calypso
* Create new Page
* Inspect `iframe` 
* Verify that `environment_id` query arg is on the`iframe` and that it matches your env (likely `development`)
