### PR TITLE
Starter Page Templates: Add segment tracking

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -169,7 +169,7 @@ class Starter_Page_Templates {
 	 */
 	public function fetch_vertical_data() {
 		$vertical_id        = get_option( 'site_vertical', 'default' );
-		$transient_key      = implode( '_', [ 'starter_page_templates', $vertical_id, get_locale() ] );
+		$transient_key      = implode( '_', [ 'starter_page_templates', 'v2', $vertical_id, get_locale() ] );
 		$vertical_templates = get_transient( $transient_key );
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -110,10 +110,11 @@ class Starter_Page_Templates {
 			return;
 		}
 		$vertical           = $vertical_data['vertical'];
+		$segment            = $vertical_data['segment'];
 		$vertical_templates = $vertical_data['templates'];
 
 		// Bail early if we have no templates to offer.
-		if ( empty( $vertical_templates ) || empty( $vertical ) ) {
+		if ( empty( $vertical_templates ) || empty( $vertical ) || empty( $segment ) ) {
 			$this->pass_error_to_frontend( __( 'No templates available. Skipped showing modal window with template selection.', 'full-site-editing' ) );
 			return;
 		}
@@ -143,6 +144,7 @@ class Starter_Page_Templates {
 				'siteInformation' => array_merge( $default_info, $site_info ),
 				'templates'       => array_merge( $default_templates, $vertical_templates ),
 				'vertical'        => $vertical,
+				'segment'         => $segment,
 			]
 		);
 		wp_localize_script( 'starter-page-templates', 'starterPageTemplatesConfig', $config );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -30,13 +30,13 @@ class PageTemplateModal extends Component {
 
 	componentDidMount() {
 		if ( this.state.isOpen ) {
-			trackView( this.props.vertical.id );
+			trackView( this.props.segment.id, this.props.vertical.id );
 		}
 	}
 
 	selectTemplate = newTemplate => {
 		this.setState( { isOpen: false } );
-		trackSelection( this.props.vertical.id, newTemplate );
+		trackSelection( this.props.segment.id, this.props.vertical.id, newTemplate );
 
 		const template = this.props.templates[ newTemplate ];
 
@@ -56,7 +56,7 @@ class PageTemplateModal extends Component {
 
 	closeModal = () => {
 		this.setState( { isOpen: false } );
-		trackDismiss( this.props.vertical.id );
+		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 
 	render() {
@@ -137,6 +137,7 @@ const {
 	siteInformation = {},
 	templates = [],
 	vertical,
+	segment,
 	tracksUserData,
 } = window.starterPageTemplatesConfig;
 
@@ -150,6 +151,7 @@ registerPlugin( 'page-templates', {
 			<PageTemplatesPlugin
 				templates={ keyBy( templates, 'slug' ) }
 				vertical={ vertical }
+				segment={ segment }
 				siteInformation={ siteInformation }
 			/>
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
@@ -8,7 +8,7 @@ export const initializeWithIdentity = identity => {
 	window._tkq.push( [ 'identifyUser', identity.userid, identity.username ] );
 };
 
-export const trackView = vertical_id => {
+export const trackView = ( segment_id, vertical_id ) => {
 	if ( ! tracksIdentity ) {
 		return;
 	}
@@ -17,12 +17,13 @@ export const trackView = vertical_id => {
 		'a8c_test_full_site_editing_template_selector_view',
 		{
 			blog_id: tracksIdentity.blogid,
+			segment_id,
 			vertical_id,
 		},
 	] );
 };
 
-export const trackDismiss = vertical_id => {
+export const trackDismiss = ( segment_id, vertical_id ) => {
 	if ( ! tracksIdentity ) {
 		return;
 	}
@@ -31,12 +32,13 @@ export const trackDismiss = vertical_id => {
 		'a8c_test_full_site_editing_template_selector_dismiss',
 		{
 			blog_id: tracksIdentity.blogid,
+			segment_id,
 			vertical_id,
 		},
 	] );
 };
 
-export const trackSelection = ( vertical_id, template ) => {
+export const trackSelection = ( segment_id, vertical_id, template ) => {
 	if ( ! tracksIdentity ) {
 		return;
 	}
@@ -45,6 +47,7 @@ export const trackSelection = ( vertical_id, template ) => {
 		'a8c_test_full_site_editing_template_selector_template_selected',
 		{
 			blog_id: tracksIdentity.blogid,
+			segment_id,
 			vertical_id,
 			template,
 		},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Pass `segment` from API into frontend
* Use the segment in tracking calls

#### Testing instructions

* test ideally on wpcom
* sandbox your *.wordpress.com site
* build FSE plugin and sync it onto your sandbox
* create a new page and confirm `t.gif` requests contain `segment_id` param

