### PR TITLE
Credits Purchases: tell truth about auto renew

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -314,6 +314,10 @@ function hasCreditCardData( purchase ) {
 	return Boolean( purchase.payment.creditCard.expiryMoment );
 }
 
+function shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) {
+	return isPaidWithCredits( purchase ) && purchase.expiryMoment > moment().add( 90, 'days' );
+}
+
 /**
  * Checks whether the purchase is capable of being renewed by intentional
  * action (eg, a button press by user). Some purchases (eg, .fr domains)
@@ -438,4 +442,5 @@ export {
 	cardProcessorSupportsUpdates,
 	showCreditCardExpiringWarning,
 	subscribedWithinPastWeek,
+	shouldAddPaymentSourceInsteadOfRenewingNow,
 };

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -315,7 +315,7 @@ function hasCreditCardData( purchase ) {
 }
 
 function shouldAddPaymentSourceInsteadOfRenewingNow( expiryMoment ) {
-	return expiryMoment > moment().add( 90, 'days' );
+	return expiryMoment > moment().add( 3, 'months' );
 }
 
 /**

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -314,8 +314,8 @@ function hasCreditCardData( purchase ) {
 	return Boolean( purchase.payment.creditCard.expiryMoment );
 }
 
-function shouldAddPaymentSourceInsteadOfRenewingNow( purchase ) {
-	return isPaidWithCredits( purchase ) && purchase.expiryMoment > moment().add( 90, 'days' );
+function shouldAddPaymentSourceInsteadOfRenewingNow( expiryMoment ) {
+	return expiryMoment > moment().add( 90, 'days' );
 }
 
 /**

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -119,7 +119,8 @@ class PurchaseNotice extends Component {
 
 		if (
 			! canExplicitRenew( purchase ) ||
-			shouldAddPaymentSourceInsteadOfRenewingNow( purchase )
+			( isPaidWithCredits( purchase ) &&
+				shouldAddPaymentSourceInsteadOfRenewingNow( purchase.expiryMoment ) )
 		) {
 			return (
 				<NoticeAction href={ editCardDetailsPath }>

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -27,6 +27,7 @@ import {
 	showCreditCardExpiringWarning,
 	isPaidWithCredits,
 	subscribedWithinPastWeek,
+	shouldAddPaymentSourceInsteadOfRenewingNow,
 } from 'lib/purchases';
 import { isDomainTransfer, isConciergeSession } from 'lib/products-values';
 import Notice from 'components/notice';
@@ -116,7 +117,10 @@ class PurchaseNotice extends Component {
 			return null;
 		}
 
-		if ( ! canExplicitRenew( purchase ) ) {
+		if (
+			! canExplicitRenew( purchase ) ||
+			shouldAddPaymentSourceInsteadOfRenewingNow( purchase )
+		) {
 			return (
 				<NoticeAction href={ editCardDetailsPath }>
 					{ translate( 'Enable Auto Renew' ) }

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -122,7 +122,7 @@ class PurchaseNotice extends Component {
 			shouldAddPaymentSourceInsteadOfRenewingNow( purchase.expiryMoment )
 		) {
 			return (
-				<NoticeAction href={ editCardDetailsPath }>{ translate( 'Manage Payment' ) }</NoticeAction>
+				<NoticeAction href={ editCardDetailsPath }>{ translate( 'Add Credit Card' ) }</NoticeAction>
 			);
 		}
 

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -119,13 +119,10 @@ class PurchaseNotice extends Component {
 
 		if (
 			! canExplicitRenew( purchase ) ||
-			( isPaidWithCredits( purchase ) &&
-				shouldAddPaymentSourceInsteadOfRenewingNow( purchase.expiryMoment ) )
+			shouldAddPaymentSourceInsteadOfRenewingNow( purchase.expiryMoment )
 		) {
 			return (
-				<NoticeAction href={ editCardDetailsPath }>
-					{ translate( 'Enable Auto Renew' ) }
-				</NoticeAction>
+				<NoticeAction href={ editCardDetailsPath }>{ translate( 'Manage Payment' ) }</NoticeAction>
 			);
 		}
 

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -16,6 +16,7 @@ import Card from 'components/card';
 import PlanIcon from 'components/plans/plan-icon';
 import { isFreeJetpackPlan } from 'lib/products-values';
 import { managePurchase } from 'me/purchases/paths';
+import { shouldAddPaymentSourceInsteadOfRenewingNow } from 'lib/purchases';
 
 export class CurrentPlanHeader extends Component {
 	static propTypes = {
@@ -54,7 +55,15 @@ export class CurrentPlanHeader extends Component {
 					</span>
 					{ currentPlan.userIsOwner && Boolean( currentPlan.id ) && siteSlug && (
 						<Button compact href={ managePurchase( siteSlug, currentPlan.id ) }>
-							{ hasAutoRenew ? translate( 'Manage Payment' ) : translate( 'Renew Now' ) }
+							{ hasAutoRenew && translate( 'Manage Payment' ) }
+							{ ! hasAutoRenew &&
+								! shouldAddPaymentSourceInsteadOfRenewingNow(
+									currentPlan.userFacingExpiryMoment
+								) &&
+								translate( 'Renew Now' ) }
+							{ ! hasAutoRenew &&
+								shouldAddPaymentSourceInsteadOfRenewingNow( currentPlan.userFacingExpiryMoment ) &&
+								translate( 'Enable Auto Renew' ) }
 						</Button>
 					) }
 				</div>

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -63,7 +63,7 @@ export class CurrentPlanHeader extends Component {
 								translate( 'Renew Now' ) }
 							{ ! hasAutoRenew &&
 								shouldAddPaymentSourceInsteadOfRenewingNow( currentPlan.userFacingExpiryMoment ) &&
-								translate( 'Enable Auto Renew' ) }
+								translate( 'Manage Payment' ) }
 						</Button>
 					) }
 				</div>

--- a/client/my-sites/plans/current-plan/test/header.jsx
+++ b/client/my-sites/plans/current-plan/test/header.jsx
@@ -10,7 +10,7 @@ jest.mock( 'components/popover', () => 'Popover' );
 jest.mock( 'my-sites/checkout/cart/cart-item', () => 'CartItem' );
 jest.mock( 'my-sites/checkout/cart/cart-coupon', () => 'CartCoupon' );
 jest.mock( 'my-sites/checkout/checkout-thank-you/google-voucher', () => 'GoogleVoucher' );
-jest.mock( 'lib/user', () => ( {} ) );
+jest.mock( 'lib/user', () => () => ( {} ) );
 jest.mock( 'lib/cart/store/cart-analytics', () => ( {} ) );
 jest.mock( 'lib/mixins/analytics', () => () => {} );
 


### PR DESCRIPTION
This fixes #26360

There were multiple issues
a) Endpoints ( both /me/purchases and /plans ) did claim that auto renew is possible for credit purchases. I fixed this with D29558-code
b) I made a change that until 90 days before renewal it's "Enable Auto Renew" and after that - "Renew Now"

### Screenshots

![Zrzut ekranu 2019-06-18 o 13 53 12](https://user-images.githubusercontent.com/3775068/59680112-df793b00-91d0-11e9-91d3-bd5670e27caa.png)

![Zrzut ekranu 2019-06-18 o 13 53 24](https://user-images.githubusercontent.com/3775068/59680118-e4d68580-91d0-11e9-8987-7ffe9cdb195a.png)


### Testing instructions
1. purchase plan with credits
2. go to your plan page.