### PR TITLE
Payments/reword change payment method to add

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -198,7 +198,7 @@ class ManagePurchase extends Component {
 				return null;
 			}
 
-			const textEdit = translate( 'Edit Payment Method' );
+			const textEdit = translate( 'Change Payment Method' );
 			const textAdd = translate( 'Add Credit Card' );
 
 			// With the self-serving auto-renewal toggle enabled, the payment data should be always there.

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -10,7 +10,7 @@ export default {
 	addCreditCard: i18n.translate( 'Add Credit Card' ),
 	cancelPurchase: i18n.translate( 'Cancel Purchase' ),
 	confirmCancelDomain: i18n.translate( 'Cancel Domain' ),
-	editCardDetails: i18n.translate( 'Edit Card Details', { comment: 'Credit card' } ),
+	editCardDetails: i18n.translate( 'Change Card', { comment: 'Credit card' } ),
 	addCardDetails: i18n.translate( 'Add Card Details', { comment: 'Credit card' } ),
 	managePurchase: i18n.translate( 'Manage Purchase' ),
 	purchases: i18n.translate( 'Purchases' ),

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -10,8 +10,8 @@ export default {
 	addCreditCard: i18n.translate( 'Add Credit Card' ),
 	cancelPurchase: i18n.translate( 'Cancel Purchase' ),
 	confirmCancelDomain: i18n.translate( 'Cancel Domain' ),
-	editCardDetails: i18n.translate( 'Change Card', { comment: 'Credit card' } ),
-	addCardDetails: i18n.translate( 'Add Card Details', { comment: 'Credit card' } ),
+	editCardDetails: i18n.translate( 'Change Credit Card', { comment: 'Credit card' } ),
+	addCardDetails: i18n.translate( 'Add Credit Card', { comment: 'Credit card' } ),
 	managePurchase: i18n.translate( 'Manage Purchase' ),
 	purchases: i18n.translate( 'Purchases' ),
 };

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -12,7 +12,7 @@ export default {
 	confirmCancelDomain: i18n.translate( 'Cancel Domain' ),
 	editCardDetails: i18n.translate( 'Edit Card Details', { comment: 'Credit card' } ),
 	addCardDetails: i18n.translate( 'Add Card Details', { comment: 'Credit card' } ),
-	editPaymentMethod: i18n.translate( 'Edit Payment Method' ),
+	editPaymentMethod: i18n.translate( 'Change Payment Method' ),
 	managePurchase: i18n.translate( 'Manage Purchase' ),
 	purchases: i18n.translate( 'Purchases' ),
 };

--- a/client/me/purchases/titles.js
+++ b/client/me/purchases/titles.js
@@ -12,7 +12,6 @@ export default {
 	confirmCancelDomain: i18n.translate( 'Cancel Domain' ),
 	editCardDetails: i18n.translate( 'Edit Card Details', { comment: 'Credit card' } ),
 	addCardDetails: i18n.translate( 'Add Card Details', { comment: 'Credit card' } ),
-	editPaymentMethod: i18n.translate( 'Change Payment Method' ),
 	managePurchase: i18n.translate( 'Manage Purchase' ),
 	purchases: i18n.translate( 'Purchases' ),
 };


### PR DESCRIPTION
This fixes wzFhJSNZ-trello

By the words of @DavidRothstein  

> When you go to Manage Purchases and click on an individual subscription, the "Edit Payment Method" option isn't very clear or accurate. You can't use that option to actually "edit" an existing credit card record, only to replace the credit card record with an entirely new one that you type in from scratch.

### Screenshots

![Zrzut ekranu 2019-06-18 o 14 44 27](https://user-images.githubusercontent.com/3775068/59683671-e310c000-91d8-11e9-81b5-22f849c1d20e.png)

![Zrzut ekranu 2019-06-20 o 11 47 08](https://user-images.githubusercontent.com/3775068/59839612-2aba5780-9351-11e9-8dd6-8a2b67d849ab.png)


### Testiing instructions

1. Go to /me/purchases
2. Find a purchase with a card
3. Click "Change Payment Method"