### PR TITLE
Signup: reset signup state before navigation to destination outside Calypso

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -374,9 +374,12 @@ class Signup extends React.Component {
 			const { bearer_token: bearerToken, username } = dependencies;
 
 			if ( this.state.bearerToken !== bearerToken && this.state.username !== username ) {
+				this.signupFlowController.reset();
+				// This setState will trigger a render if WpcomLoginForm that submits the login
+				// form on mount and navigates away from signup.
 				this.setState( {
-					bearerToken: dependencies.bearer_token,
-					username: dependencies.username,
+					bearerToken,
+					username,
 					redirectTo: this.loginRedirectTo( destination ),
 				} );
 			}

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {
 	assign,
-	defer,
 	find,
 	get,
 	includes,
@@ -356,17 +355,9 @@ class Signup extends React.Component {
 		}
 
 		if ( userIsLoggedIn ) {
-			// don't use page.js for external URLs (eg redirect to new site after signup)
-			if ( /^https?:\/\//.test( destination ) ) {
-				return ( window.location.href = destination );
-			}
-
-			// deferred in case the user is logged in and the redirect triggers a dispatch
-			defer( () => {
-				debug( `Redirecting you to "${ destination }"` );
-				this.signupFlowController.reset();
-				window.location.href = destination;
-			} );
+			debug( `Redirecting you to "${ destination }"` );
+			this.signupFlowController.reset();
+			window.location.href = destination;
 		}
 
 		if ( ! userIsLoggedIn && ( config.isEnabled( 'oauth' ) || dependencies.oauth2_client_id ) ) {


### PR DESCRIPTION
The code path that handled navigation outside Calypso (typically site frontend by virtue of the `getSiteDestination` function) didn't call `signupFlowController.reset()`, leaving the signup state in Redux (and in IndexedDB) and causing weird behavior should we return to `/start` again shortly after.

This patch also unifies the code paths that handle inside- and outside-Calypso destinations, as there is no longer any difference between them. The inside- one used to use `page( ... )` to navigate, but that's no longer true.

Also removes the `defer` call that was needed for Flux, but is not needed in Redux-only code.

**How to test:**
Go through a flow that has `getSiteDestination` as destination and doesn't add any cart items that would cause a "layover" at the Calypso checkout page, but goes there directly. One example is the `/start/blog` flow where you select a free domain and the free plan.

After arriving at the destination site frontend, press the Back button. The flow should start again rather than freezing in a weird state (typically the "Awesome" page with big WP logo).
