### PR TITLE
Remove test prefixes from Tracks events

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
@@ -14,7 +14,7 @@ export const trackView = ( segment_id, vertical_id ) => {
 	}
 	window._tkq.push( [
 		'recordEvent',
-		'a8c_test_full_site_editing_template_selector_view',
+		'a8c_full_site_editing_template_selector_view',
 		{
 			blog_id: tracksIdentity.blogid,
 			segment_id,
@@ -29,7 +29,7 @@ export const trackDismiss = ( segment_id, vertical_id ) => {
 	}
 	window._tkq.push( [
 		'recordEvent',
-		'a8c_test_full_site_editing_template_selector_dismiss',
+		'a8c_full_site_editing_template_selector_dismiss',
 		{
 			blog_id: tracksIdentity.blogid,
 			segment_id,
@@ -44,7 +44,7 @@ export const trackSelection = ( segment_id, vertical_id, template ) => {
 	}
 	window._tkq.push( [
 		'recordEvent',
-		'a8c_test_full_site_editing_template_selector_template_selected',
+		'a8c_full_site_editing_template_selector_template_selected',
 		{
 			blog_id: tracksIdentity.blogid,
 			segment_id,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* as our event properties stabilized, we can remove `test_` prefixes we were sending throught

#### Testing instructions

* Test the basic plugin usage and observe `t.gif` network requests. The should no longer contain `test_` in their name
