### PR TITLE
Fix Subscription Length Picker With Coupons

### DIFF
--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -45,8 +45,7 @@ export class SubscriptionLengthPicker extends React.Component {
 	render() {
 		const { productsWithPrices, translate, shouldShowTax } = this.props;
 		const hasDiscount = productsWithPrices.some(
-			( { priceFullBeforeDiscount, priceMinusCredits } ) =>
-				priceMinusCredits !== priceFullBeforeDiscount
+			( { priceFullBeforeDiscount, priceFinal } ) => priceFinal !== priceFullBeforeDiscount
 		);
 
 		return (
@@ -73,10 +72,10 @@ export class SubscriptionLengthPicker extends React.Component {
 							planSlug,
 							priceFull,
 							priceFullBeforeDiscount,
-							priceMinusCredits,
+							priceFinal,
 							priceMonthly,
 						} ) => {
-							const price = ! priceMinusCredits ? priceFull : priceMinusCredits;
+							const price = ! priceFinal ? priceFull : priceFinal;
 							return (
 								<div className="subscription-length-picker__option-container" key={ planSlug }>
 									<SubscriptionLengthOption

--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -122,10 +122,15 @@ export function myFormatCurrency( price, code, options = {} ) {
 
 export const mapStateToProps = ( state, { plans, cart } ) => {
 	const selectedSiteId = getSelectedSiteId( state );
-	const credits = cart.credits;
 	return {
 		currencyCode: getCurrentUserCurrencyCode( state ),
-		productsWithPrices: computeProductsWithPrices( state, selectedSiteId, plans, credits ),
+		productsWithPrices: computeProductsWithPrices(
+			state,
+			selectedSiteId,
+			plans,
+			cart.credits || 0,
+			cart.coupon_discounts || {}
+		),
 	};
 };
 

--- a/client/blocks/subscription-length-picker/index.jsx
+++ b/client/blocks/subscription-length-picker/index.jsx
@@ -75,7 +75,7 @@ export class SubscriptionLengthPicker extends React.Component {
 							priceFinal,
 							priceMonthly,
 						} ) => {
-							const price = ! priceFinal ? priceFull : priceFinal;
+							const price = priceFinal || priceFull;
 							return (
 								<div className="subscription-length-picker__option-container" key={ planSlug }>
 									<SubscriptionLengthOption

--- a/client/blocks/subscription-length-picker/test/index.js
+++ b/client/blocks/subscription-length-picker/test/index.js
@@ -26,14 +26,14 @@ describe( 'SubscriptionLengthPicker basic tests', () => {
 			planSlug: PLAN_BUSINESS,
 			plan: getPlan( PLAN_BUSINESS ),
 			priceFull: 1200,
-			priceMinusCredits: 1200,
+			priceFinal: 1200,
 			priceMonthly: 100,
 		},
 		{
 			planSlug: PLAN_BUSINESS_2_YEARS,
 			plan: getPlan( PLAN_BUSINESS_2_YEARS ),
 			priceFull: 1800,
-			priceMinusCredits: 1800,
+			priceFinal: 1800,
 			priceMonthly: 150,
 		},
 	];

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -100,14 +100,28 @@ export const planSlugToPlanProduct = ( products, planSlug ) => {
  * @param {Number} siteId Site ID to consider
  * @param {Object} planObject Plan object returned by getPlan() from lib/plans
  * @param {Number} credits The number of free credits in cart
+ * @param {Object} couponDiscounts Absolute values of any discounts coming from a discount coupon
  * @return {Object} Object with a full and monthly price
  */
-export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject, credits ) => ( {
-	priceFullBeforeDiscount: getPlanRawPrice( state, planObject.getProductId(), false ),
-	priceFull: getPlanPrice( state, siteId, planObject, false ),
-	priceMinusCredits: max( [ getPlanPrice( state, siteId, planObject, false ) - credits, 0 ] ),
-	priceMonthly: getPlanPrice( state, siteId, planObject, true ),
-} );
+export const computeFullAndMonthlyPricesForPlan = (
+	state,
+	siteId,
+	planObject,
+	credits,
+	couponDiscounts
+) => {
+	const couponDiscount = couponDiscounts[ planObject.getProductId() ] || 0;
+
+	return {
+		priceFullBeforeDiscount: getPlanRawPrice( state, planObject.getProductId(), false ),
+		priceFull: getPlanPrice( state, siteId, planObject, false ),
+		priceMinusCredits: max( [
+			getPlanPrice( state, siteId, planObject, false ) - credits - couponDiscount,
+			0,
+		] ),
+		priceMonthly: getPlanPrice( state, siteId, planObject, true ),
+	};
+};
 
 /**
  * Turns a list of plan slugs into a list of plan objects, corresponding
@@ -117,9 +131,10 @@ export const computeFullAndMonthlyPricesForPlan = ( state, siteId, planObject, c
  * @param {Number} siteId Site ID to consider
  * @param {String[]} planSlugs Plans constants
  * @param {Number} credits The number of free credits in cart
+ * @param {Object} couponDiscounts Absolute values of any discounts coming from a discount coupon
  * @return {Array} A list of objects as described above
  */
-export const computeProductsWithPrices = ( state, siteId, planSlugs, credits ) => {
+export const computeProductsWithPrices = ( state, siteId, planSlugs, credits, couponDiscounts ) => {
 	const products = getProductsList( state );
 
 	return planSlugs
@@ -127,7 +142,13 @@ export const computeProductsWithPrices = ( state, siteId, planSlugs, credits ) =
 		.filter( planProduct => planProduct.plan && get( planProduct, [ 'product', 'available' ] ) )
 		.map( availablePlanProduct => ( {
 			...availablePlanProduct,
-			...computeFullAndMonthlyPricesForPlan( state, siteId, availablePlanProduct.plan, credits ),
+			...computeFullAndMonthlyPricesForPlan(
+				state,
+				siteId,
+				availablePlanProduct.plan,
+				credits,
+				couponDiscounts
+			),
 		} ) )
 		.filter( availablePlanProduct => availablePlanProduct.priceFull )
 		.sort( ( a, b ) => getTermDuration( a.plan.term ) - getTermDuration( b.plan.term ) );

--- a/client/state/products-list/selectors.js
+++ b/client/state/products-list/selectors.js
@@ -115,7 +115,7 @@ export const computeFullAndMonthlyPricesForPlan = (
 	return {
 		priceFullBeforeDiscount: getPlanRawPrice( state, planObject.getProductId(), false ),
 		priceFull: getPlanPrice( state, siteId, planObject, false ),
-		priceMinusCredits: max( [
+		priceFinal: max( [
 			getPlanPrice( state, siteId, planObject, false ) - credits - couponDiscount,
 			0,
 		] ),

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -142,7 +142,7 @@ describe( 'selectors', () => {
 			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0 ) ).toEqual( {
 				priceFullBeforeDiscount: 150,
 				priceFull: 120,
-				priceMinusCredits: 120,
+				priceFinal: 120,
 				priceMonthly: 10,
 			} );
 		} );
@@ -195,7 +195,7 @@ describe( 'selectors', () => {
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
-					priceMinusCredits: 120,
+					priceFinal: 120,
 					priceMonthly: 10,
 				},
 				{
@@ -204,7 +204,7 @@ describe( 'selectors', () => {
 					product: state.productsList.items.plan2,
 					priceFullBeforeDiscount: 150,
 					priceFull: 240,
-					priceMinusCredits: 240,
+					priceFinal: 240,
 					priceMonthly: 20,
 				},
 			] );
@@ -226,7 +226,7 @@ describe( 'selectors', () => {
 					plan: testPlans.plan1,
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
-					priceMinusCredits: 120,
+					priceFinal: 120,
 					priceFull: 120,
 					priceMonthly: 10,
 				},
@@ -249,7 +249,7 @@ describe( 'selectors', () => {
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
-					priceMinusCredits: 120,
+					priceFinal: 120,
 					priceMonthly: 10,
 				},
 			] );
@@ -283,7 +283,7 @@ describe( 'selectors', () => {
 					product: state.productsList.items.plan1,
 					priceFullBeforeDiscount: 150,
 					priceFull: 120,
-					priceMinusCredits: 120,
+					priceFinal: 120,
 					priceMonthly: 10,
 				},
 			] );

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -139,7 +139,7 @@ describe( 'selectors', () => {
 			getPlanRawPrice.mockImplementation( () => 150 );
 
 			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
-			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0 ) ).toEqual( {
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, {} ) ).toEqual( {
 				priceFullBeforeDiscount: 150,
 				priceFull: 120,
 				priceFinal: 120,
@@ -188,7 +188,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, {} ) ).toEqual( [
 				{
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
@@ -220,7 +220,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, {} ) ).toEqual( [
 				{
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
@@ -242,7 +242,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, {} ) ).toEqual( [
 				{
 					planSlug: 'plan1',
 					plan: testPlans.plan1,
@@ -276,7 +276,7 @@ describe( 'selectors', () => {
 				},
 			};
 
-			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0 ) ).toEqual( [
+			expect( computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, {} ) ).toEqual( [
 				{
 					planSlug: 'plan1',
 					plan: testPlans.plan1,

--- a/client/state/products-list/test/selectors.js
+++ b/client/state/products-list/test/selectors.js
@@ -146,6 +146,16 @@ describe( 'selectors', () => {
 				priceMonthly: 10,
 			} );
 		} );
+
+		test( 'Should return proper priceFinal if couponDiscounts are provided', () => {
+			const plan = { getStoreSlug: () => 'abc', getProductId: () => 'def' };
+			expect( computeFullAndMonthlyPricesForPlan( {}, 1, plan, 0, { def: 60 } ) ).toEqual( {
+				priceFullBeforeDiscount: 150,
+				priceFull: 120,
+				priceFinal: 60,
+				priceMonthly: 10, // The monthly price is without discounts applied
+			} );
+		} );
 	} );
 
 	describe( '#computeProductsWithPrices()', () => {
@@ -205,6 +215,40 @@ describe( 'selectors', () => {
 					priceFullBeforeDiscount: 150,
 					priceFull: 240,
 					priceFinal: 240,
+					priceMonthly: 20,
+				},
+			] );
+		} );
+
+		test( 'couponDiscount should discount priceFinal', () => {
+			const state = {
+				productsList: {
+					items: {
+						plan1: { available: true },
+						plan2: { available: true },
+					},
+				},
+			};
+
+			expect(
+				computeProductsWithPrices( state, 10, [ 'plan1', 'plan2' ], 0, { def: 60, mno: 120 } )
+			).toEqual( [
+				{
+					planSlug: 'plan1',
+					plan: testPlans.plan1,
+					product: state.productsList.items.plan1,
+					priceFullBeforeDiscount: 150,
+					priceFull: 120,
+					priceFinal: 60,
+					priceMonthly: 10,
+				},
+				{
+					planSlug: 'plan2',
+					plan: testPlans.plan2,
+					product: state.productsList.items.plan2,
+					priceFullBeforeDiscount: 150,
+					priceFull: 240,
+					priceFinal: 120,
 					priceMonthly: 20,
 				},
 			] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The SubscriptionLengthPicker doesn't correctly display combinations of discounts. This PR attempts to fix the cases when we have coupon only or coupon + upgrade discount from one plan to another. It doesn't attempt to fix coupon + free credit which seems to be broken on the server (or not supported).

#### Testing instructions

1. On a site without any existing plans, add a plan to the cart and go to the checkout
2. SubscriptionLengthPicker should display the same price as the shopping cart and the pay button
3. Add a coupon
4. SubscriptionLengthPicker should display the same price as the shopping cart and the pay button

5. On a site WITH a lower-tier plan (like Blogger or Personal), add a higher tier plan (like Premium or Business) and go to the checkout
6. SubscriptionLengthPicker should display the same price as the shopping cart and the pay button
7. Add a coupon
8. SubscriptionLengthPicker should display the same price as the shopping cart and the pay button

*

Fixes #
