### PR TITLE
Signup: Hides free plan option in signup for domain only sites

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -67,6 +67,7 @@ import { submitSiteVertical } from 'state/signup/steps/site-vertical/actions';
 import getSiteId from 'state/selectors/get-site-id';
 import { isCurrentPlanPaid, getSitePlanSlug } from 'state/sites/selectors';
 import { getDomainsBySiteId } from 'state/sites/domains/selectors';
+import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 
 // Current directory dependencies
 import steps from './config/steps';
@@ -521,12 +522,12 @@ class Signup extends React.Component {
 		const propsFromConfig = assign( {}, this.props, steps[ this.props.stepName ].props );
 		const stepKey = this.state.shouldShowLoadingScreen ? 'processing' : this.props.stepName;
 		const flow = flows.getFlow( this.props.flowName );
-		const hideFreePlan = !! (
+		const planWithDomain =
+			this.props.domainsWithPlansOnly &&
 			( isDomainRegistration( domainItem ) ||
 				isDomainTransfer( domainItem ) ||
-				isDomainMapping( domainItem ) ) &&
-			this.props.domainsWithPlansOnly
-		);
+				isDomainMapping( domainItem ) );
+		const hideFreePlan = planWithDomain || this.props.isDomainOnlySite;
 		const shouldRenderLocaleSuggestions = 0 === this.getPositionInFlow() && ! this.props.isLoggedIn;
 
 		return (
@@ -634,6 +635,7 @@ export default connect(
 			domainsWithPlansOnly: getCurrentUser( state )
 				? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
 				: true,
+			isDomainOnlySite: isDomainOnlySite( state, siteId ),
 			progress: getSignupProgress( state ),
 			signupDependencies,
 			isLoggedIn: isUserLoggedIn( state ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hides the free plan option in signup flows for domain only sites. Fixes a regression introduced in #33763.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Domain only site

1. Visit `/start/domain`.
1. Purchase a domain with the "Just buy a domain" option.
1. After the signup flow is complete, go to the WordPress.com dashboard for the domain you just purchased and click the "Create Site" button.
1. When you get to the plan step, you should not see a free plan option.

##### Check for regressions

**`site-selected` signup flow**

- Logged in and with an existing site without a domain, visit `/start/site-selected?siteSlug={your-site-slug}&siteId={your-site-id}` using the slug and id of an existing site.
- Proceed to the 2nd step of this flow `/site-selected/plans-site-selected`.
- You should see "Not sure yet? Start with a free site" above the plans.

**`domain` signup flow with a site**

- Logged in, visit `/start/domain`.
- `/start/domain/domain-only`: selected an available domain to purchase.
- `/domain/site-or-domain`: choose "New site" or "Existing WordPress.com site".
- Proceed to `/start/domain/plans-site-selected`.
- See that the free plan is hidden from the plans display (because you must purchase a plan when purchasing a domain with a site).

**Main flow with a domain**

- Visit `/start` and proceed until the domains step.
- Select a free domain and proceed to the plans step.
- You should see "Not sure yet? Start with a free site" above the plans.
- Go back and selected a paid domain option and proceed to the plans step
- You should not see the free plan option.

Fixes #34001
