### PR TITLE
CSS: Restrict override score to remaining components

### DIFF
--- a/bin/categorize-component-styles.js
+++ b/bin/categorize-component-styles.js
@@ -67,11 +67,14 @@ function overridenByOthers( f, name, componentPath ) {
 		],
 		{ encoding: 'utf8', shell: true }
 	);
-	const matchCount = results.stdout.split( '\n' ).length - 1;
+	const r = results.stdout.split( '\n' );
+	const componentsFullPath = components.map( c => 'client/' + c + '.scss' );
+	const matches = r.filter( p => componentsFullPath.includes( p ) );
+	const matchCount = matches.length;
 	if ( matchCount > 0 ) {
 		return {
 			score: matchCount,
-			name: `styles overriden by ${ matchCount } consumers`,
+			name: `styles overriden by ${ matchCount } consumers:\n\t${ matches.join( '\n\t' ) }`,
 		};
 	}
 	return zero;


### PR DESCRIPTION
Rework the scorer for overrides to only take into account components that remain to be migrated. Should help us order the remaining work.

To test:
`node bin/categorize-component-styles.js`

Scores should be quite a bit lower than on `master`.

Part of #27515