### PR TITLE
FSE: Use older `editor` package for better Gutenberg compatibility.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
@@ -3,7 +3,7 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { InnerBlocks } from '@wordpress/block-editor';
+import { InnerBlocks } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { PlainText } from '@wordpress/block-editor';
+import { PlainText } from '@wordpress/editor';
 import { withNotices, Button } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
@@ -11,7 +11,7 @@ import edit from './edit';
 import './style.scss';
 
 registerBlockType( 'a8c/site-description', {
-	title: __( 'Site Description2' ),
+	title: __( 'Site Description' ),
 	description: __( 'Site description, also known as the tagline.' ),
 	icon: 'layout',
 	category: 'layout',

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -33,7 +33,6 @@
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^3.1.2",
-		"@wordpress/block-editor": "^2.2.0",
 		"@wordpress/blocks": "^6.2.3",
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Stick with the older `editor` package in case we need to accommodate older versions of Gutenberg. See https://github.com/Automattic/wp-calypso/pull/33720#discussion_r294933460.

#### Testing instructions

* Add a Site Description block and verify it continues to work normally.

