### PR TITLE
Fix gutenberg notice issues

### DIFF
--- a/test/e2e/lib/gutenberg/blocks/contact-form-block-component.js
+++ b/test/e2e/lib/gutenberg/blocks/contact-form-block-component.js
@@ -17,7 +17,9 @@ export class ContactFormBlockComponent extends GutenbergBlockComponent {
 	}
 
 	async insertEmail( email ) {
-		const emailSelector = By.css( '#inspector-text-control-0' );
+		const emailSelector = By.css(
+			'.jetpack-contact-form .components-base-control:nth-child(2) .components-text-control__input'
+		);
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, emailSelector );
 
 		const emailTextfield = await this.driver.findElement( emailSelector );
@@ -25,7 +27,9 @@ export class ContactFormBlockComponent extends GutenbergBlockComponent {
 	}
 
 	async insertSubject( subject ) {
-		const subjectSelector = By.css( '#inspector-text-control-1' );
+		const subjectSelector = By.css(
+			'.jetpack-contact-form .components-base-control:nth-child(4) .components-text-control__input'
+		);
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, subjectSelector );
 
 		const subjectTextfiled = await this.driver.findElement( subjectSelector );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -304,7 +304,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async viewPublishedPostOrPage() {
-		const viewPostSelector = By.css( '.components-notice__content a' );
+		const viewPostSelector = By.css( '.components-snackbar__content a' );
 		await driverHelper.clickWhenClickable( this.driver, viewPostSelector );
 	}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -84,7 +84,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( visit ) {
 			return await driverHelper.clickWhenClickable(
 				this.driver,
-				By.css( '.components-snackbar a' )
+				By.css( '.components-snackbar__content a' )
 			);
 		}
 	}
@@ -270,10 +270,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 
 	async dismissSuccessNotice() {
 		await this.waitForSuccessViewPostNotice();
-		return await driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.components-notice__dismiss' )
-		);
+		return await driverHelper.clickWhenClickable( this.driver, By.css( '.components-snackbar' ) );
 	}
 
 	async launchPreview() {

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -82,6 +82,8 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		);
 
 		if ( visit ) {
+			await this.waitForSuccessViewPostNotice();
+			await this.driver.sleep( 1000 );
 			return await driverHelper.clickWhenClickable(
 				this.driver,
 				By.css( '.components-snackbar__content a' )

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -84,7 +84,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 		if ( visit ) {
 			return await driverHelper.clickWhenClickable(
 				this.driver,
-				By.css( '.components-notice.is-success a' )
+				By.css( '.components-snackbar a' )
 			);
 		}
 	}
@@ -264,7 +264,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	async waitForSuccessViewPostNotice() {
 		return await driverHelper.waitTillPresentAndDisplayed(
 			this.driver,
-			By.css( '.components-notice.is-success' )
+			By.css( '.components-snackbar' )
 		);
 	}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -90,7 +90,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async enterTitle( title ) {
-		const titleFieldSelector = By.css( '#post-title-0' );
+		const titleFieldSelector = By.css( '.editor-post-title__input' );
 		await driverHelper.clearTextArea( this.driver, titleFieldSelector );
 		return await this.driver.findElement( titleFieldSelector ).sendKeys( title );
 	}
@@ -192,7 +192,7 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 	}
 
 	async titleShown() {
-		const titleSelector = By.css( '#post-title-0' );
+		const titleSelector = By.css( '.editor-post-title__input' );
 		await driverHelper.waitTillPresentAndDisplayed( this.driver, titleSelector );
 		const element = await this.driver.findElement( titleSelector );
 		return await element.getAttribute( 'value' );


### PR DESCRIPTION
### DO NOT MERGE until > 5.9.x is available on WordPress.com

Requires to update the Gutenberg plugin to v6.1 on simple sites.

#### Changes proposed in this Pull Request

With Gutenberg v5.9.2 the success component was updated to the snackbar. This PR updates the CSS selector to match this.

![snackbars](https://user-images.githubusercontent.com/1270189/59707456-84871a00-91b7-11e9-827f-957a6f5a5194.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Follow instructions in https://github.com/Automattic/wp-calypso/blob/master/test/e2e/docs/running-tests.md 
* Run `/node_modules/.bin/mocha specs/wp-calypso-gutenberg-page-editor-spec.js`
* Run `/node_modules/.bin/mocha specs/wp-calypso-gutenberg-post-editor-spec.js`

Fixes #
