### PR TITLE
Components : Use Draggable from Gutenberg instead of Calypso Draggable

### DIFF
--- a/client/blocks/image-editor/image-editor-crop.jsx
+++ b/client/blocks/image-editor/image-editor-crop.jsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { isEqual, noop } from 'lodash';
 import classNames from 'classnames';
+// import {Draggable} from '@wordpress/components';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* WIP

* There is a direct overlap between the Draggable component in Calypso and the Draggable component from @wordpress/components. This pull request looks at using the WordPress Draggable component instead of the existing Calypso one.

Related to #27034
