### PR TITLE
Gutenframe: Add the snackbar to the list of link elements that should open in the parent frame.

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -538,7 +538,8 @@ function handleGoToAllPosts( calypsoPort ) {
  */
 function openLinksInParentFrame() {
 	const viewPostLinkSelectors = [
-		'.components-notice-list .is-success .components-notice__action.is-link', // View Post link in success notice
+		'.components-notice-list .is-success .components-notice__action.is-link', // View Post link in success notice, Gutenberg <5.9
+		'.components-notice-list .components-snackbar__content a', // View Post link in success snackbar, Gutenberg >=5.9
 		'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
 		'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
 	].join( ',' );

--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -539,7 +539,7 @@ function handleGoToAllPosts( calypsoPort ) {
 function openLinksInParentFrame() {
 	const viewPostLinkSelectors = [
 		'.components-notice-list .is-success .components-notice__action.is-link', // View Post link in success notice, Gutenberg <5.9
-		'.components-notice-list .components-snackbar__content a', // View Post link in success snackbar, Gutenberg >=5.9
+		'.components-snackbar-list .components-snackbar__content a', // View Post link in success snackbar, Gutenberg >=5.9
 		'.post-publish-panel__postpublish .components-panel__body.is-opened a', // Post title link in publish panel
 		'.components-panel__body.is-opened .post-publish-panel__postpublish-buttons a.components-button', // View Post button in publish panel
 	].join( ',' );


### PR DESCRIPTION
[Gutenberg v5.9](https://make.wordpress.org/core/2019/06/12/whats-new-in-gutenberg-12th-june/) introduced the snackbar, a new way to display notices to users in the block editor.

This PR ensures the View Post anchor of snackbars will open their link in the parent frame, as we already do with the same link in existing Gutenberg admin notices.

<img width="1167" alt="Screen Shot 2019-06-18 at 1 37 02 PM" src="https://user-images.githubusercontent.com/349751/59718140-55c86e00-91ce-11e9-83ce-f6e782af7f79.png">

#### Testing instructions

* Apply this PR's `ci/circleci: build-wpcom-block-editor` build to your dotcom sandbox using the instructions in PCYsg-l4k-p2 (the "Building, Testing, and Deploying" section).
* Sandbox your test site, as well as `widgets.wp.com`.
* Have your sandbox run v5.9.2 of the Gutenberg plugin by applying D29595-code.
* Load your test site in WordPress.com.
* Publish a new post, and when the snackbar pops up, click the View Post link.
* Verify the post loads in the parent frame (not under WordPress.com's `/block-editor` URL).

Fixes #34098
