### PR TITLE
Correct DOM order for back button in signup flow

### DIFF
--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -106,6 +106,8 @@ class StepWrapper extends Component {
 		return (
 			<>
 				<div className={ classes }>
+					{ ! hideBack && this.renderBack() }
+
 					{ ! hideFormattedHeader && (
 						<FormattedHeader
 							id={ 'step-header' }
@@ -118,10 +120,7 @@ class StepWrapper extends Component {
 
 					<div className="step-wrapper__content">{ stepContent }</div>
 
-					<div className="step-wrapper__buttons">
-						{ ! hideBack && this.renderBack() }
-						{ ! hideSkip && this.renderSkip() }
-					</div>
+					{ ! hideSkip && <div className="step-wrapper__buttons">{ this.renderSkip() }</div> }
 				</div>
 			</>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Reordering the Back button in `<StepWrapper>` so that you shift-tab to
it from the onboarding controls, which is what you'd expect from the
visual order.

[Matching visual order and DOM order is a good a11y technique](https://www.w3.org/TR/WCAG20-TECHS/C27.html) 

The back button can be safetly moved out of the `step-wrapper__button`
because that container is only doing centering and the back button is
absolutely positioned.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* http://calypso.localhost:3000/start/site-type
* Make a blog (or any other site type)
* Your cursor is in the site topic field, shift-tab will take you to the back button
* Likewise for the other steps. The site style page has no text field so focus will start is at the top of the document

There's also a skip button that might appear on some steps but I couldn't find a flow where it wasn't hidden. I enabled it in code to test layout was good and tab order matches the visual order.