### PR TITLE
Updated External Link Component

### DIFF
--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -52,6 +52,10 @@ class ExternalLink extends Component {
 			}
 		);
 
+		if ( this.props.icon ) {
+			props.target = '_blank';
+		}
+
 		if ( props.target ) {
 			props.rel = props.rel.concat( ' noopener noreferrer' );
 		}


### PR DESCRIPTION
I have added a conditional to set the `target="_blank"` if the icon is displayed.

#### Changes proposed in this Pull Request

The `externalLink` component doesn't currently group icon and target props together. As a result, if the target prop is omitted, links are shown with the external Icon but without the expected behavior.

Given the relationship between the external icon and the expectation of the link opening in a new window/tab, I propose we move this into the component by adding a conditional to check for the icon, then automatically adding a `target="_blank"` to the link. 

Doing so will add consistency for user expectations and lessen the margin of error in the implementation of external links.  

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to https://wordpress.com/following/manage. Click on a link with the external icon as seen below:

![Screen Shot 2019-06-18 at 12 16 48 PM](https://user-images.githubusercontent.com/181733/59725814-fecd9380-91e3-11e9-9175-2c8e1222e71a.png)
 
The external link will open in a new window, even if the target was left undefined. 

Fixes #
#34101 