### PR TITLE
Full Site Editing: uses the A8C_WP_Template class to get template content

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -448,15 +448,15 @@ class Full_Site_Editing {
 			return;
 		}
 
-		$template_id = get_post_meta( $post->ID, '_wp_template_id', true );
+		$template = new A8C_WP_Template( $post->ID );
+
 		//bail if the post has no tempalte id assigned
-		if ( ! $template_id ) {
+		if ( ! $template->get_template_id() ) {
 			return;
 		}
 
-		$template = get_post( $template_id );
 		$wrapped_post_content = sprintf( '<!-- wp:a8c/post-content -->%s<!-- /wp:a8c/post-content -->', $post->post_content );
-		$post->post_content = str_replace( '<!-- wp:a8c/post-content /-->', $wrapped_post_content, $template->post_content );
+		$post->post_content = str_replace( '<!-- wp:a8c/post-content /-->', $wrapped_post_content, $template->get_template_content() );
 	}
 
 	/**


### PR DESCRIPTION
This PR uses the `A8C_WP_Template` class to access the page's template content, instead of duplicating that logic.

#### Testing instructions

* Create a _Template Part_. We'll call it `Header`.
* Create a _Template_ that uses `Header` and a _Content Block_. We'll call it `My Template`.
* Assing `My Template` to a page. Refresh the editor to load the template along with the page content.

There should be no regressions there.