### PR TITLE
Update/preview hover

### DIFF
--- a/client/components/signup-site-preview/style.scss
+++ b/client/components/signup-site-preview/style.scss
@@ -135,6 +135,7 @@
 		width: 70%;
 		background: var( --color-neutral-0 );
 		border-radius: 3px;
+		cursor: default;
 
 		// At small screen sizes "hide" the label
 		// text as its mostly redundant.
@@ -160,5 +161,6 @@
 		width: 50%;
 		background: var( --color-neutral-0 );
 		border-radius: 16px;
+		cursor: default;
 	}
 }

--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -65,6 +65,10 @@ export function getIframeSource(
 					padding-bottom: 25px;
 				}
 
+				*, *:hover {
+					cursor: default;
+				}
+
 				.no-scrolling {
 					overflow: hidden;
 				}

--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -65,7 +65,7 @@ export function getIframeSource(
 					padding-bottom: 25px;
 				}
 
-				*, *:hover {
+				* {
 					cursor: default;
 				}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In a number of usability studies we heard people say they thought the preview was editable. I noticed someone say it after they hovered over it and saw the cursor change. This PR changes the appearance of the cursor when it hovers over text in the preview. Instead of showing a [text cursor](https://www.google.com/search?q=text+cursor&tbm=isch&source=iu&ictx=1&fir=Gb_YuZ5vzdmTsM%253A%252Cr9msV3my-8qA9M%252C_&vet=1&usg=AI4_-kTmiF5EUmKF93XTulJTb1jMrBlAcw&sa=X&ved=2ahUKEwi6ovWHw_TiAhVEcq0KHW9tADoQ9QEwCXoECAAQBA#imgrc=Gb_YuZ5vzdmTsM:) it shows [an arrow](https://www.google.com/search?q=arrow+cursor&source=lnms&tbm=isch&sa=X&ved=0ahUKEwjogtXqw_TiAhVG-qwKHW9dDMUQ_AUIECgB&biw=1680&bih=948&dpr=2#imgrc=Dy4Um9HGtEd_NM:). 

**Before**
![before](https://user-images.githubusercontent.com/6981253/59733322-84206a80-921b-11e9-85f7-ef383313ed51.gif)

**After**
![after](https://user-images.githubusercontent.com/6981253/59733323-8682c480-921b-11e9-8272-1860f2923c12.gif)

#### Testing instructions

* Visit `/start/onboarding`
* Pick `blog`, `professional`, or `business`
* Pick a vertical and hover over the preview when it appears.