### PR TITLE
Signup: update the preview title default depending on site type

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -17,6 +17,7 @@ const getSiteTypePropertyDefaults = propertyKey =>
 				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."
 			),
 			siteMockupHelpTipCopyBottom: i18n.translate( 'Scroll back up to continue.' ),
+			siteMockupTitleFallback: i18n.translate( 'Your New Website' ),
 			// Site title step
 			siteTitleLabel: i18n.translate( 'Give your site a name' ),
 			siteTitleSubheader: i18n.translate(
@@ -96,6 +97,7 @@ export function getAllSiteTypes() {
 			siteMockupHelpTipCopy: i18n.translate(
 				'Scroll down to see your blog. Once you complete setup you’ll be able to customize it further.'
 			),
+			siteMockupTitleFallback: i18n.translate( 'Your New Blog' ),
 			domainsStepHeader: i18n.translate( 'Give your blog an address' ),
 			domainsStepSubheader: i18n.translate(
 				"Enter your blog's name or some keywords that describe it to get started."

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -178,8 +178,9 @@ export default connect(
 		const siteType = getSiteType( state );
 		const styleOptions = getSiteStyleOptions( siteType );
 		const style = find( styleOptions, { id: siteStyle || 'modern' } );
+		const titleFallback = getSiteTypePropertyValue( 'slug', siteType, 'siteMockupTitleFallback' );
 		return {
-			title: getSiteTitle( state ) || translate( 'Your New Website' ),
+			title: getSiteTitle( state ) || titleFallback,
 			siteStyle,
 			siteType,
 			verticalPreviewContent: getSiteVerticalPreview( state ),


### PR DESCRIPTION
This updates the title placeholder copy in the site preview to read "Your New Blog" for the blog segment, and "Your New Website" for the other segments.

Blog Preview | Business Preview
------------ | -------------
<img width="1516" alt="Screen Shot 2019-06-18 at 10 53 20 PM" src="https://user-images.githubusercontent.com/942359/59733883-605e2400-921d-11e9-83d8-2ef207002a27.png"> | <img width="1516" alt="Screen Shot 2019-06-18 at 10 53 30 PM" src="https://user-images.githubusercontent.com/942359/59733899-6ce27c80-921d-11e9-9d80-03ec5fe06284.png">


Fixes https://github.com/Automattic/zelda-private/issues/80.

**To test:**
- navigate to `/start/`
- select "blog" segment
- select a vertical to have the preview display
- verify that the title says "Your New Blog"
- navigate back to the site type step
- select "business" or "professional" segments
- select a vertical to have the preview display
- verify that the title says "Your New Website"