### PR TITLE
Add save button to FSE block to allow saving if Editor Update button not enabled

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
@@ -1,10 +1,16 @@
-.block-editor .wp-block-a8c-site-description {
-	&, &:focus {
-		display: inline;
-		color: #767676;
-		font-size: 1.125em;
-		font-weight: normal;
-		letter-spacing: -0.01em;
-		margin: 0;
+.block-editor {
+	.wp-block-a8c-site-description {
+		&,&:focus {
+			display: inline;
+			color: #767676;
+			font-size: 1.125em;
+			font-weight: normal;
+			letter-spacing: -0.01em;
+			margin: 0;
+		}
+	}
+	.site-description__save-button {
+		margin-left: auto;
+		display: block;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a `Save` button to the Site Description Full Site Editing block to allow saving of the block if the Editor `Update` button is not active.  This is a temporary solution to allow editing of the FSE block content. As the block does not have attribute data, edits to its content do not flag the post content as dirty so the editor Update button does not become active on changes. The save button makes the block usable while a more permanent solution to this issue is explored.

After the initial add and save of the FSE block, additional changes do not affect the Post State (FSE blocks update Site Options) so the Post content is not flagged as dirty to enable the `Update` button again. So far this is the only way we can find to still allow updates without leaving any arbitrary serialised attributes behind in the post content. 

Using this `Save` button approach is similar to the Edit button for Reusable block titles

#### Testing instructions

* Checkout branch
* Make sure you have the wp-calypso/apps/full-site-editing/full-site-editing-plugin compiled plugin plumbed through to your local gutenberg dev setup and activated
* Edit a Page and add the Site Description block
* The Editor Update button should be active so save the change
* Select the Site Description block again and edit the content, and a save button should appear as below. 
* Click the Save button - it should show busy and disabled and then disappear once save complete
* Edit the description again and then edit another block on the page to make `Update` active. Clicking`Update` should also make the description save again and the button disappear.

![add-save-button](https://user-images.githubusercontent.com/3629020/59734287-f4270300-92a4-11e9-940b-a0ef3c1c4329.gif)



