### PR TITLE
Signup: remove code that resets signup state after user is logged in

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -77,7 +77,6 @@ function SignupFlowController( options ) {
 	);
 
 	this._resetStoresIfProcessing(); // reset the stores if the cached progress contained a processing step
-	this._resetStoresIfUserHasLoggedIn(); // reset the stores if user has newly authenticated
 
 	if ( this._flow.providesDependenciesInQuery ) {
 		this._assertFlowProvidedDependenciesFromConfig( options.providedDependencies );
@@ -94,15 +93,6 @@ function SignupFlowController( options ) {
 assign( SignupFlowController.prototype, {
 	_resetStoresIfProcessing: function() {
 		if ( find( getSignupProgress( this._reduxStore.getState() ), { status: 'processing' } ) ) {
-			this.reset();
-		}
-	},
-
-	_resetStoresIfUserHasLoggedIn: function() {
-		if (
-			isUserLoggedIn( this._reduxStore.getState() ) &&
-			find( getSignupProgress( this._reduxStore.getState() ), { stepName: 'user' } )
-		) {
 			this.reset();
 		}
 	},


### PR DESCRIPTION
When mounting the `Signup` UI, there is a check whether the user is logged in and yet
there are data from the `user` step in the progress store. That condition can never
happen in the Reduxified Signup, because logged-out and logged-in Redux state is stored
in different IndexedDB keys. Logged-in session will never read the persisted signup state
that the logged-out session has written.

Nice incremental step to simplify the very complex Signup controller code.