### PR TITLE
Analytics: Remove `identifyAnonUser` call with OAuth client ID.

### DIFF
--- a/client/lib/analytics/sem.js
+++ b/client/lib/analytics/sem.js
@@ -104,11 +104,6 @@ export function updateQueryParamsTracking() {
 		}
 	} );
 
-	// Cross domain tracking for Tracks
-	if ( query.client_id ) {
-		window._tkq.push( [ 'identifyAnonUser', query.client_id ] );
-	}
-
 	// Drop SEM cookie update if either of these is missing
 	if ( ! sanitized_query.utm_source || ! sanitized_query.utm_campaign ) {
 		debug( 'Missing utm_source or utm_campaign.' );


### PR DESCRIPTION
see: https://nosaraproject.wordpress.com/2019/06/17/recycled-or-invalid-anonids/#comment-10310

Just a WIP to get the ball rolling to revert a Tracks aliasing issue introduced by #32078