### PR TITLE
Signup: remove unused code for inserting flow steps based on AB test variation

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -417,12 +417,9 @@ class Signup extends React.Component {
 		return firstInProgressStepName || nextStepName || last( currentSteps );
 	};
 
-	resumeProgress = () => {
-		// Update the Flows object to know that the signup flow is being resumed.
-		flows.resumingFlow = true;
-
-		const firstUnsubmittedStep = this.firstUnsubmittedStepName(),
-			stepSectionName = firstUnsubmittedStep.stepSectionName;
+	resumeProgress() {
+		const firstUnsubmittedStep = this.firstUnsubmittedStepName();
+		const stepSectionName = firstUnsubmittedStep.stepSectionName;
 
 		// set `resumingStep` so we don't render/animate anything until we have mounted this step
 		this.setState( { firstUnsubmittedStep } );
@@ -430,7 +427,7 @@ class Signup extends React.Component {
 		return page.redirect(
 			getStepUrl( this.props.flowName, firstUnsubmittedStep, stepSectionName, this.props.locale )
 		);
-	};
+	}
 
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
@@ -466,7 +463,7 @@ class Signup extends React.Component {
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToNextStep = ( nextFlowName = this.props.flowName ) => {
-		const flowSteps = flows.getFlow( nextFlowName, this.props.stepName ).steps,
+		const flowSteps = flows.getFlow( nextFlowName ).steps,
 			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
 			nextStepName = flowSteps[ currentStepIndex + 1 ],
 			nextProgressItem = this.props.progress[ currentStepIndex + 1 ],

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -13,14 +13,9 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import mockedFlows from './fixtures/flows';
-import abtest from 'lib/abtest';
 import flows from 'signup/config/flows';
 import userFactory from 'lib/user';
 
-jest.mock( 'lib/abtest', () => ( {
-	abtest: () => {},
-	getABTestVariation: () => null,
-} ) );
 jest.mock( 'lib/user', () => require( './mocks/lib/user' ) );
 
 describe( 'Signup Flows Configuration', () => {
@@ -31,14 +26,10 @@ describe( 'Signup Flows Configuration', () => {
 			user = userFactory();
 
 			sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
-			sinon.stub( flows, 'getABTestFilteredFlow' ).callsFake( ( flowName, flow ) => {
-				return flow;
-			} );
 		} );
 
 		afterAll( () => {
 			flows.getFlows.restore();
-			flows.getABTestFilteredFlow.restore();
 		} );
 
 		test( 'should return the full flow when the user is not logged in', () => {
@@ -65,86 +56,6 @@ describe( 'Signup Flows Configuration', () => {
 		test( 'should exclude site step from getFlow', () => {
 			flows.excludeStep( 'site' );
 			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'user' ] );
-		} );
-	} );
-
-	describe( 'getABTestFilteredFlow', () => {
-		const getABTestVariationSpy = sinon.stub( abtest, 'getABTestVariation' );
-
-		getABTestVariationSpy.onCall( 0 ).returns( 'notSiteTitle' );
-		getABTestVariationSpy.onCall( 1 ).returns( 'notSiteTitle' );
-		getABTestVariationSpy.onCall( 2 ).returns( 'showSiteTitleStep' );
-		getABTestVariationSpy.onCall( 3 ).returns( 'showSiteTitleStep' );
-
-		beforeAll( () => {
-			sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
-			sinon.stub( flows, 'insertStepIntoFlow' ).callsFake( ( stepName, flow ) => {
-				return flow;
-			} );
-			sinon.stub( flows, 'removeStepFromFlow' ).callsFake( ( stepName, flow ) => {
-				return flow;
-			} );
-		} );
-
-		afterAll( () => {
-			flows.getFlows.restore();
-			flows.insertStepIntoFlow.restore();
-			flows.removeStepFromFlow.restore();
-		} );
-
-		test( 'should return flow unmodified if not in main flow', () => {
-			assert.equal( flows.getABTestFilteredFlow( 'test', 'testflow' ), 'testflow' );
-			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
-			assert.equal( flows.removeStepFromFlow.callCount, 0 );
-		} );
-
-		test( 'should check AB variation in main flow', () => {
-			assert.equal( flows.getABTestFilteredFlow( 'main', 'testflow' ), 'testflow' );
-			assert.equal( getABTestVariationSpy.callCount, 0 );
-			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
-		} );
-
-		test( 'should return flow unmodified if variation is not valid', () => {
-			const myFlow = {
-				name: 'test flow name',
-				steps: [ 1, 2, 3 ],
-			};
-
-			assert.equal( flows.getABTestFilteredFlow( 'main', myFlow ), myFlow );
-			assert.equal( getABTestVariationSpy.callCount, 0 );
-			assert.equal( flows.insertStepIntoFlow.callCount, 0 );
-		} );
-	} );
-
-	describe( 'insertStepIntoFlow', () => {
-		const myFlow = {
-			name: 'test flow name',
-			steps: [ 'step1', 'step2', 'step3', 'step4' ],
-		};
-
-		Object.freeze( myFlow );
-
-		test( 'should return flow unmodified if afterStep is not found', () => {
-			const result = flows.insertStepIntoFlow( 'mystep', myFlow, 'test-step' );
-
-			assert.equal( myFlow, result );
-			assert.equal( myFlow.steps, result.steps );
-		} );
-
-		test( 'should add step at the beginning of flow if afterStep is empty', () => {
-			const result = flows.insertStepIntoFlow( 'mystep', myFlow );
-
-			assert.notStrictEqual( myFlow, result );
-			assert.notStrictEqual( myFlow.steps, result.steps );
-			assert.deepEqual( [ 'mystep', 'step1', 'step2', 'step3', 'step4' ], result.steps );
-		} );
-
-		test( 'should insert step after afterStep', () => {
-			const result = flows.insertStepIntoFlow( 'mystep', myFlow, 'step2' );
-
-			assert.notStrictEqual( myFlow, result );
-			assert.notStrictEqual( myFlow.steps, result.steps );
-			assert.deepEqual( [ 'step1', 'step2', 'mystep', 'step3', 'step4' ], result.steps );
 		} );
 	} );
 } );

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -39,10 +39,6 @@ debug( 'start utils test' );
 describe( 'utils', () => {
 	beforeAll( () => {
 		sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
-		sinon.stub( flows, 'preloadABTestVariationsForStep' ).callsFake( () => {} );
-		sinon.stub( flows, 'getABTestFilteredFlow' ).callsFake( ( flowName, flow ) => {
-			return flow;
-		} );
 	} );
 
 	describe( 'getLocale', () => {


### PR DESCRIPTION
Originally added 3 years ago in #8280 by @bisko, this code is no longer used. We can also remove the `Flows` object's `resumingFlow` flag and the second parameter of `getFlow`.

Another incremental step to make our Signup more minimalistic.
