### PR TITLE
FSE: Document `identity` to clarify usage

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/tracking.js
@@ -3,6 +3,10 @@ window._tkq = window._tkq || [];
 
 let tracksIdentity = null;
 
+/**
+ * Populate `identity` on WPCOM and ATOMIC to enable tracking.
+ * Always disabled for regular self-hosted installations.
+ */
 export const initializeWithIdentity = identity => {
 	tracksIdentity = identity;
 	window._tkq.push( [ 'identifyUser', identity.userid, identity.username ] );


### PR DESCRIPTION
Makes it clear that it is never enabled for self-hosted installs.
