### PR TITLE
Calypso build: Use @wordpress webpack plugin

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -39,6 +39,7 @@
 		"tinymce": "4.8.5"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "file:../../packages/calypso-build"
+		"@automattic/calypso-build": "file:../../packages/calypso-build",
+		"@wordpress/dependency-extraction-webpack-plugin": "^1.0.1"
 	}
 }

--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -39,7 +39,6 @@
 		"tinymce": "4.8.5"
 	},
 	"devDependencies": {
-		"@automattic/calypso-build": "file:../../packages/calypso-build",
-		"@wordpress/dependency-extraction-webpack-plugin": "^1.0.1"
+		"@automattic/calypso-build": "file:../../packages/calypso-build"
 	}
 }

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -6,6 +6,7 @@
 /**
  * External dependencies
  */
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
 
@@ -57,6 +58,23 @@ function getWebpackConfig(
 	return {
 		...webpackConfig,
 		devtool: isDevelopment ? 'inline-cheap-source-map' : false,
+		plugins: [
+			...webpackConfig.plugins.filter(
+				plugin => ! ( plugin instanceof DependencyExtractionWebpackPlugin )
+			),
+			new DependencyExtractionWebpackPlugin( {
+				requestToExternal( request ) {
+					if ( request === 'tinymce/tinymce' ) {
+						return 'tinymce';
+					}
+				},
+				requestToHandle( request ) {
+					if ( request === 'tinymce/tinymce' ) {
+						return 'wp-tinymce';
+					}
+				},
+			} ),
+		],
 	};
 }
 

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -60,7 +60,7 @@ function getWebpackConfig(
 		devtool: isDevelopment ? 'inline-cheap-source-map' : false,
 		plugins: [
 			...webpackConfig.plugins.filter(
-				plugin => ! ( plugin instanceof DependencyExtractionWebpackPlugin )
+				plugin => plugin.constructor.name !== 'DependencyExtractionWebpackPlugin'
 			),
 			new DependencyExtractionWebpackPlugin( {
 				requestToExternal( request ) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -21,7 +21,6 @@
 			"dev": true,
 			"requires": {
 				"@automattic/calypso-color-schemes": "file:packages/calypso-color-schemes",
-				"@automattic/wordpress-external-dependencies-plugin": "file:packages/wordpress-external-dependencies-plugin",
 				"@babel/core": "7.5.5",
 				"@babel/plugin-proposal-class-properties": "7.5.5",
 				"@babel/plugin-syntax-dynamic-import": "7.2.0",
@@ -32,6 +31,7 @@
 				"@babel/preset-typescript": "7.3.3",
 				"@wordpress/babel-plugin-import-jsx-pragma": "2.3.0",
 				"@wordpress/browserslist-config": "2.3.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^1.0.1",
 				"autoprefixer": "9.4.4",
 				"babel-loader": "8.0.5",
 				"browserslist": "4.6.6",
@@ -101,14 +101,6 @@
 			"version": "file:packages/webpack-inline-constant-exports-plugin",
 			"dev": true
 		},
-		"@automattic/wordpress-external-dependencies-plugin": {
-			"version": "file:packages/wordpress-external-dependencies-plugin",
-			"dev": true,
-			"requires": {
-				"webpack": "^4.29.6",
-				"webpack-sources": "^1.3.0"
-			}
-		},
 		"@babel/cli": {
 			"version": "7.5.5",
 			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.5.5.tgz",
@@ -126,19 +118,6 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -2965,9 +2944,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "12.6.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-			"integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
+			"version": "12.7.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.1.tgz",
+			"integrity": "sha512-aK9jxMypeSrhiYofWWBf/T7O+KwaiAHzM4sveCdWPn71lzUSMimRnKzhXDKfKwV1kWoBo2P1aGgaIYGLf9/ljw=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -3905,6 +3884,16 @@
 				"@babel/runtime": "^7.4.4",
 				"moment": "^2.22.1",
 				"moment-timezone": "^0.5.16"
+			}
+		},
+		"@wordpress/dependency-extraction-webpack-plugin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-1.1.0.tgz",
+			"integrity": "sha512-tCyxy7hLzDdCHQ1xGPiMlE7fBp/pCuEum89gqzoiz2HQJld6F7BTNMo3XfTzxFO0SHh/C64yOZgBB8FvH+warQ==",
+			"dev": true,
+			"requires": {
+				"webpack": "^4.8.3",
+				"webpack-sources": "^1.3.0"
 			}
 		},
 		"@wordpress/deprecated": {
@@ -6334,21 +6323,25 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 							"optional": true,
 							"requires": {
 								"delegates": "^1.0.0",
@@ -6357,11 +6350,13 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -6369,29 +6364,35 @@
 						},
 						"chownr": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+							"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 							"optional": true
 						},
 						"debug": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 							"optional": true,
 							"requires": {
 								"ms": "^2.1.1"
@@ -6399,22 +6400,26 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -6422,12 +6427,14 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 							"optional": true,
 							"requires": {
 								"aproba": "^1.0.3",
@@ -6442,7 +6449,8 @@
 						},
 						"glob": {
 							"version": "7.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 							"optional": true,
 							"requires": {
 								"fs.realpath": "^1.0.0",
@@ -6455,12 +6463,14 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 							"optional": true,
 							"requires": {
 								"safer-buffer": ">= 2.1.2 < 3"
@@ -6468,7 +6478,8 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 							"optional": true,
 							"requires": {
 								"minimatch": "^3.0.4"
@@ -6476,7 +6487,8 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"optional": true,
 							"requires": {
 								"once": "^1.3.0",
@@ -6485,39 +6497,46 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 						},
 						"ini": {
 							"version": "1.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 						},
 						"minipass": {
 							"version": "2.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -6525,7 +6544,8 @@
 						},
 						"minizlib": {
 							"version": "1.2.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+							"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 							"optional": true,
 							"requires": {
 								"minipass": "^2.2.1"
@@ -6533,19 +6553,22 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"requires": {
 								"minimist": "0.0.8"
 							}
 						},
 						"ms": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 							"optional": true
 						},
 						"needle": {
 							"version": "2.3.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+							"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
 							"optional": true,
 							"requires": {
 								"debug": "^4.1.0",
@@ -6555,7 +6578,8 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.12.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+							"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 							"optional": true,
 							"requires": {
 								"detect-libc": "^1.0.2",
@@ -6572,7 +6596,8 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"optional": true,
 							"requires": {
 								"abbrev": "1",
@@ -6581,12 +6606,14 @@
 						},
 						"npm-bundled": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+							"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+							"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 							"optional": true,
 							"requires": {
 								"ignore-walk": "^3.0.1",
@@ -6595,7 +6622,8 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"optional": true,
 							"requires": {
 								"are-we-there-yet": "~1.1.2",
@@ -6606,33 +6634,39 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"requires": {
 								"wrappy": "1"
 							}
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 							"optional": true,
 							"requires": {
 								"os-homedir": "^1.0.0",
@@ -6641,17 +6675,20 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 							"optional": true,
 							"requires": {
 								"deep-extend": "^0.6.0",
@@ -6662,14 +6699,16 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"optional": true
 								}
 							}
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"optional": true,
 							"requires": {
 								"core-util-is": "~1.0.0",
@@ -6683,7 +6722,8 @@
 						},
 						"rimraf": {
 							"version": "2.6.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+							"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 							"optional": true,
 							"requires": {
 								"glob": "^7.1.3"
@@ -6691,36 +6731,43 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -6729,7 +6776,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"optional": true,
 							"requires": {
 								"safe-buffer": "~5.1.0"
@@ -6737,19 +6785,22 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+							"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 							"optional": true,
 							"requires": {
 								"chownr": "^1.1.1",
@@ -6763,12 +6814,14 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 							"optional": true,
 							"requires": {
 								"string-width": "^1.0.2 || 2"
@@ -6776,11 +6829,13 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 						}
 					}
 				}
@@ -8836,9 +8891,9 @@
 			"integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q=="
 		},
 		"electron-to-chromium": {
-			"version": "1.3.216",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.216.tgz",
-			"integrity": "sha512-G2rJKCdDLTaAP56WKMj0mcr7jtr3LBBL2EaF73DamfFpvcl0PzKUIaUocPP8NLu9s/RbbHLMGkbFOkDRK5PQIQ=="
+			"version": "1.3.220",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.220.tgz",
+			"integrity": "sha512-ZsaFWi+9J9Nsm4OmGM/BvZF3HEeZL4bte1+CcN9vHUcqdkOOVAXP4SeacPZ/W5uCQZEKPYBXg6yUjZx8/jpD0Q=="
 		},
 		"elliptic": {
 			"version": "6.5.0",
@@ -10781,7 +10836,6 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -10870,21 +10924,6 @@
 				"ignore": "^4.0.3",
 				"pify": "^4.0.1",
 				"slash": "^2.0.0"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"globjoin": {
@@ -11832,19 +11871,6 @@
 				"validate-npm-package-name": "^3.0.0"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"semver": {
 					"version": "5.7.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
@@ -12892,24 +12918,28 @@
 					"dependencies": {
 						"abbrev": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+							"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 							"dev": true,
 							"optional": true
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 							"dev": true
 						},
 						"aproba": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+							"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 							"dev": true,
 							"optional": true
 						},
 						"are-we-there-yet": {
 							"version": "1.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+							"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -12919,12 +12949,14 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+							"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 							"dev": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+							"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 							"dev": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
@@ -12933,34 +12965,40 @@
 						},
 						"chownr": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+							"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 							"dev": true,
 							"optional": true
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+							"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 							"dev": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+							"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 							"dev": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+							"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 							"dev": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+							"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 							"dev": true,
 							"optional": true
 						},
 						"debug": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -12969,25 +13007,29 @@
 						},
 						"deep-extend": {
 							"version": "0.6.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+							"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 							"dev": true,
 							"optional": true
 						},
 						"delegates": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+							"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 							"dev": true,
 							"optional": true
 						},
 						"detect-libc": {
 							"version": "1.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+							"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 							"dev": true,
 							"optional": true
 						},
 						"fs-minipass": {
 							"version": "1.2.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+							"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -12996,13 +13038,15 @@
 						},
 						"fs.realpath": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+							"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 							"dev": true,
 							"optional": true
 						},
 						"gauge": {
 							"version": "2.7.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+							"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13018,7 +13062,8 @@
 						},
 						"glob": {
 							"version": "7.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+							"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13032,13 +13077,15 @@
 						},
 						"has-unicode": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+							"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 							"dev": true,
 							"optional": true
 						},
 						"iconv-lite": {
 							"version": "0.4.24",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+							"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13047,7 +13094,8 @@
 						},
 						"ignore-walk": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+							"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13056,7 +13104,8 @@
 						},
 						"inflight": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+							"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13066,18 +13115,21 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+							"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 							"dev": true
 						},
 						"ini": {
 							"version": "1.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+							"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 							"dev": true,
 							"optional": true
 						},
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+							"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 							"dev": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
@@ -13085,13 +13137,15 @@
 						},
 						"isarray": {
 							"version": "1.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+							"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 							"dev": true,
 							"optional": true
 						},
 						"minimatch": {
 							"version": "3.0.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+							"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 							"dev": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
@@ -13099,12 +13153,14 @@
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+							"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 							"dev": true
 						},
 						"minipass": {
 							"version": "2.3.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+							"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 							"dev": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
@@ -13113,7 +13169,8 @@
 						},
 						"minizlib": {
 							"version": "1.2.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+							"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13122,7 +13179,8 @@
 						},
 						"mkdirp": {
 							"version": "0.5.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+							"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 							"dev": true,
 							"requires": {
 								"minimist": "0.0.8"
@@ -13130,13 +13188,15 @@
 						},
 						"ms": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+							"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 							"dev": true,
 							"optional": true
 						},
 						"needle": {
 							"version": "2.3.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+							"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13147,7 +13207,8 @@
 						},
 						"node-pre-gyp": {
 							"version": "0.12.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+							"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13165,7 +13226,8 @@
 						},
 						"nopt": {
 							"version": "4.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+							"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13175,13 +13237,15 @@
 						},
 						"npm-bundled": {
 							"version": "1.0.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+							"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 							"dev": true,
 							"optional": true
 						},
 						"npm-packlist": {
 							"version": "1.4.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+							"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13191,7 +13255,8 @@
 						},
 						"npmlog": {
 							"version": "4.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+							"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13203,18 +13268,21 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+							"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 							"dev": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+							"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 							"dev": true,
 							"optional": true
 						},
 						"once": {
 							"version": "1.4.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+							"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 							"dev": true,
 							"requires": {
 								"wrappy": "1"
@@ -13222,19 +13290,22 @@
 						},
 						"os-homedir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+							"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 							"dev": true,
 							"optional": true
 						},
 						"os-tmpdir": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+							"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 							"dev": true,
 							"optional": true
 						},
 						"osenv": {
 							"version": "0.1.5",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+							"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13244,19 +13315,22 @@
 						},
 						"path-is-absolute": {
 							"version": "1.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+							"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 							"dev": true,
 							"optional": true
 						},
 						"process-nextick-args": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+							"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 							"dev": true,
 							"optional": true
 						},
 						"rc": {
 							"version": "1.2.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+							"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13268,7 +13342,8 @@
 							"dependencies": {
 								"minimist": {
 									"version": "1.2.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+									"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 									"dev": true,
 									"optional": true
 								}
@@ -13276,7 +13351,8 @@
 						},
 						"readable-stream": {
 							"version": "2.3.6",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+							"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13291,7 +13367,8 @@
 						},
 						"rimraf": {
 							"version": "2.6.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+							"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13300,42 +13377,49 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+							"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 							"dev": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+							"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 							"dev": true,
 							"optional": true
 						},
 						"sax": {
 							"version": "1.2.4",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+							"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 							"dev": true,
 							"optional": true
 						},
 						"semver": {
 							"version": "5.7.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 							"dev": true,
 							"optional": true
 						},
 						"set-blocking": {
 							"version": "2.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+							"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 							"dev": true,
 							"optional": true
 						},
 						"signal-exit": {
 							"version": "3.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+							"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 							"dev": true,
 							"optional": true
 						},
 						"string-width": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 							"dev": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
@@ -13345,7 +13429,8 @@
 						},
 						"string_decoder": {
 							"version": "1.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+							"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13354,7 +13439,8 @@
 						},
 						"strip-ansi": {
 							"version": "3.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 							"dev": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
@@ -13362,13 +13448,15 @@
 						},
 						"strip-json-comments": {
 							"version": "2.0.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+							"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 							"dev": true,
 							"optional": true
 						},
 						"tar": {
 							"version": "4.4.8",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+							"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13383,13 +13471,15 @@
 						},
 						"util-deprecate": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+							"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 							"dev": true,
 							"optional": true
 						},
 						"wide-align": {
 							"version": "1.1.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+							"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 							"dev": true,
 							"optional": true,
 							"requires": {
@@ -13398,12 +13488,14 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+							"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 							"dev": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+							"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 							"dev": true
 						}
 					}
@@ -15356,19 +15448,6 @@
 				"which": "1"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -15759,21 +15838,6 @@
 				"object-hash": "^1.3.1",
 				"postcss-scss": "^2.0.0",
 				"resolve": "^1.10.1"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"node-sass-package-importer": {
@@ -15864,17 +15928,20 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true
 				},
 				"cross-spawn": {
 					"version": "5.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
 						"lru-cache": "^4.0.1",
@@ -15884,12 +15951,14 @@
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 					"dev": true
 				},
 				"execa": {
 					"version": "0.7.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+					"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^5.0.1",
@@ -15903,7 +15972,8 @@
 				},
 				"find-up": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
 						"locate-path": "^2.0.0"
@@ -15911,22 +15981,26 @@
 				},
 				"get-caller-file": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+					"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
 					"dev": true
 				},
 				"get-stream": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+					"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 					"dev": true
 				},
 				"invert-kv": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+					"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
@@ -15934,17 +16008,20 @@
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 					"dev": true
 				},
 				"lcid": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+					"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 					"dev": true,
 					"requires": {
 						"invert-kv": "^1.0.0"
@@ -15952,7 +16029,8 @@
 				},
 				"locate-path": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+					"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 					"dev": true,
 					"requires": {
 						"p-locate": "^2.0.0",
@@ -15961,7 +16039,8 @@
 				},
 				"lru-cache": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+					"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
@@ -15970,7 +16049,8 @@
 				},
 				"mem": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+					"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 					"dev": true,
 					"requires": {
 						"mimic-fn": "^1.0.0"
@@ -15978,17 +16058,20 @@
 				},
 				"mimic-fn": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+					"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
 					"dev": true
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"requires": {
 						"minimist": "0.0.8"
@@ -15996,7 +16079,8 @@
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
@@ -16004,12 +16088,14 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true
 				},
 				"os-locale": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
 						"execa": "^0.7.0",
@@ -16019,17 +16105,20 @@
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 					"dev": true
 				},
 				"p-limit": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+					"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
 					"dev": true
 				},
 				"p-locate": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+					"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 					"dev": true,
 					"requires": {
 						"p-limit": "^1.1.0"
@@ -16037,37 +16126,44 @@
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 					"dev": true
 				},
 				"pseudomap": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+					"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
 					"dev": true
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+					"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
 					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
@@ -16075,17 +16171,20 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
@@ -16095,7 +16194,8 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
@@ -16103,12 +16203,14 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 					"dev": true
 				},
 				"which": {
 					"version": "1.3.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+					"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
@@ -16116,12 +16218,14 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+					"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 					"dev": true,
 					"requires": {
 						"string-width": "^1.0.1",
@@ -16130,17 +16234,20 @@
 				},
 				"y18n": {
 					"version": "3.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+					"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
 					"dev": true
 				},
 				"yallist": {
 					"version": "2.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
 					"dev": true
 				},
 				"yargs": {
 					"version": "10.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+					"integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
 					"dev": true,
 					"requires": {
 						"cliui": "^3.2.0",
@@ -16159,12 +16266,14 @@
 					"dependencies": {
 						"ansi-regex": {
 							"version": "3.0.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+							"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
 							"dev": true
 						},
 						"cliui": {
 							"version": "3.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 							"dev": true,
 							"requires": {
 								"string-width": "^1.0.1",
@@ -16174,7 +16283,8 @@
 							"dependencies": {
 								"string-width": {
 									"version": "1.0.2",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+									"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 									"dev": true,
 									"requires": {
 										"code-point-at": "^1.0.0",
@@ -16186,7 +16296,8 @@
 						},
 						"string-width": {
 							"version": "2.1.1",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+							"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 							"dev": true,
 							"requires": {
 								"is-fullwidth-code-point": "^2.0.0",
@@ -16195,12 +16306,14 @@
 							"dependencies": {
 								"is-fullwidth-code-point": {
 									"version": "2.0.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+									"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 									"dev": true
 								},
 								"strip-ansi": {
 									"version": "4.0.0",
-									"bundled": true,
+									"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+									"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 									"dev": true,
 									"requires": {
 										"ansi-regex": "^3.0.0"
@@ -16212,7 +16325,8 @@
 				},
 				"yargs-parser": {
 					"version": "8.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+					"integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
 					"dev": true,
 					"requires": {
 						"camelcase": "^4.1.0"
@@ -16220,7 +16334,8 @@
 					"dependencies": {
 						"camelcase": {
 							"version": "4.1.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+							"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
 							"dev": true
 						}
 					}
@@ -19648,19 +19763,6 @@
 				"slash": "^1.0.0"
 			},
 			"dependencies": {
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -20401,21 +20503,6 @@
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"requires": {
 				"glob": "^7.1.3"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				}
 			}
 		},
 		"ripemd160": {
@@ -22884,9 +22971,9 @@
 			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
 		},
 		"tsutils": {
-			"version": "3.17.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.0.tgz",
-			"integrity": "sha512-fyveWOtAXfumAxIqkcMHuPaaVyLBKjB8Y00ANZkqh+HITBAQscCbQIHwwBTJdvQq7RykLEbOPcUUnJ16X4NA0g==",
+			"version": "3.17.1",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+			"integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"

--- a/package.json
+++ b/package.json
@@ -284,6 +284,7 @@
 		"@typescript-eslint/eslint-plugin": "1.10.2",
 		"@typescript-eslint/parser": "1.10.2",
 		"@wordpress/babel-plugin-makepot": "2.1.3",
+		"@wordpress/dependency-extraction-webpack-plugin": "^1.0.1",
 		"babel-eslint": "10.0.2",
 		"babel-jest": "24.8.0",
 		"babel-plugin-dynamic-import-node": "2.3.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -35,7 +35,6 @@
 	],
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "file:../calypso-color-schemes",
-		"@automattic/wordpress-external-dependencies-plugin": "file:../wordpress-external-dependencies-plugin",
 		"@babel/core": "7.5.5",
 		"@babel/plugin-proposal-class-properties": "7.5.5",
 		"@babel/plugin-syntax-dynamic-import": "7.2.0",
@@ -46,6 +45,7 @@
 		"@babel/preset-typescript": "7.3.3",
 		"@wordpress/babel-plugin-import-jsx-pragma": "2.3.0",
 		"@wordpress/browserslist-config": "2.3.0",
+		"@wordpress/dependency-extraction-webpack-plugin": "^1.0.1",
 		"autoprefixer": "9.4.4",
 		"babel-loader": "8.0.5",
 		"browserslist": "4.6.6",

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -133,7 +133,7 @@ function getWebpackConfig(
 				minify: ! isDevelopment,
 			} ),
 			new DuplicatePackageCheckerPlugin(),
-			...( env.WP ? [ new DependencyExtractionWebpackPlugin() ] : [] ),
+			...( env.WP ? [ new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ) ] : [] ),
 		],
 	};
 

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -15,7 +15,7 @@ const FileConfig = require( './webpack/file-loader' );
 const Minify = require( './webpack/minify' );
 const SassConfig = require( './webpack/sass' );
 const TranspileConfig = require( './webpack/transpile' );
-const WordPressExternalDependenciesPlugin = require( '@automattic/wordpress-external-dependencies-plugin' );
+const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 
 /**
  * Internal dependencies
@@ -133,7 +133,7 @@ function getWebpackConfig(
 				minify: ! isDevelopment,
 			} ),
 			new DuplicatePackageCheckerPlugin(),
-			...( env.WP ? [ new WordPressExternalDependenciesPlugin() ] : [] ),
+			...( env.WP ? [ new DependencyExtractionWebpackPlugin() ] : [] ),
 		],
 	};
 


### PR DESCRIPTION
We should keep an eye on consumers getting the same packages:

https://github.com/Automattic/wp-calypso/blob/e85241257c09ba9838850b834923f06f393dc283/packages/wordpress-external-dependencies-plugin/index.js#L20-L38

Compare with https://github.com/WordPress/gutenberg/blob/master/packages/dependency-extraction-webpack-plugin/README.md:

| Request | Global | Script handle |
| --- | --- | --- |
| `@babel/runtime/regenerator` | `regeneratorRuntime` | `wp-polyfill` |
| `@wordpress/*` | `wp['*']` | `wp-*` |
| `jquery` | `jQuery` | `jquery` |
| `lodash-es` | `lodash` | `lodash` |
| `lodash` | `lodash` | `lodash` |
| `moment` | `moment` | `moment` |
| `react-dom` | `ReactDOM` | `react-dom` |
| `react` | `React` | `react` |

Notably, `tinymce` support is dropped by this change.

