### PR TITLE
OAuth: move the checkToken handler to the client/boot/common module

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -5,7 +5,6 @@
  */
 
 import React from 'react';
-import { startsWith } from 'lodash';
 import page from 'page';
 
 /**
@@ -13,7 +12,7 @@ import page from 'page';
  */
 import OAuthLogin from './login';
 import ConnectComponent from './connect';
-import * as OAuthToken from 'lib/oauth-token';
+import { getToken } from 'lib/oauth-token';
 import wpcom from 'lib/wp';
 import config from 'config';
 import store from 'store';
@@ -25,7 +24,7 @@ import PulsingDot from 'components/pulsing-dot';
 export default {
 	oauthLogin: function( context, next ) {
 		if ( config.isEnabled( 'oauth' ) ) {
-			if ( OAuthToken.getToken() ) {
+			if ( getToken() ) {
 				page( '/' );
 			} else {
 				context.primary = <OAuthLogin />;
@@ -33,28 +32,6 @@ export default {
 		} else {
 			page( '/' );
 		}
-		next();
-	},
-
-	checkToken: function( context, next ) {
-		const loggedOutRoutes = [
-				'/oauth-login',
-				'/oauth',
-				'/start',
-				'/authorize',
-				'/api/oauth/token',
-			],
-			isValidSection = loggedOutRoutes.some( route => startsWith( context.path, route ) );
-
-		// Check we have an OAuth token, otherwise redirect to auth/login page
-		if ( OAuthToken.getToken() === false && ! isValidSection ) {
-			if ( config( 'env_id' ) === 'desktop' || config( 'env_id' ) === 'desktop-development' ) {
-				return page( config( 'login_url' ) );
-			}
-
-			return page( '/authorize' );
-		}
-
 		next();
 	},
 


### PR DESCRIPTION
Avoids dragging in the whole `auth` section into the main entrypoint.

**How to test:**
1. Apply this patch (use `git format-patch` and `git apply`) to Calypso submodule in `wp-desktop`
2. Run the dev server with `make dev-server` and `make dev`
3. In the Electron window, ensure you're logged out.
4. Open devtools in the Electron window and type `window.location = '/me'` in console
5. Verify that you're redirected to `/oauth-login`
6. Log in
7. Verify that the same navigation to `/me` doesn't redirect to login this time.
