### PR TITLE
Remove superagent usage in devdocs.

### DIFF
--- a/client/components/readme-viewer/index.jsx
+++ b/client/components/readme-viewer/index.jsx
@@ -44,6 +44,12 @@ export default class ReadmeViewer extends Component {
 		this.makeRequest();
 	}
 
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.readmeFilePath !== this.props.readmeFilePath ) {
+			this.makeRequest();
+		}
+	}
+
 	render() {
 		const { readmeFilePath, showEditLink } = this.props;
 		const editLink = (

--- a/client/components/readme-viewer/index.jsx
+++ b/client/components/readme-viewer/index.jsx
@@ -1,13 +1,9 @@
-/** @format */
-
 /**
  * External Dependencies
  */
-
 import React, { Component } from 'react';
 import { Parser } from 'html-to-react';
 import PropTypes from 'prop-types';
-import request from 'superagent';
 
 /**
  * Style Dependencies
@@ -16,7 +12,7 @@ import './style.scss';
 
 const htmlToReactParser = new Parser();
 
-class ReadmeViewer extends Component {
+export default class ReadmeViewer extends Component {
 	static propTypes = {
 		readmeFilePath: PropTypes.string,
 		showEditLink: PropTypes.bool,
@@ -30,16 +26,22 @@ class ReadmeViewer extends Component {
 		readme: null,
 	};
 
-	componentDidMount() {
+	makeRequest = async () => {
 		const { readmeFilePath } = this.props;
-		request
-			.get( '/devdocs/service/content' )
-			.query( { path: readmeFilePath } )
-			.then( ( { text } ) => {
-				this.setState( {
-					readme: htmlToReactParser.parse( text ),
-				} );
-			} );
+
+		try {
+			const res = await fetch( `/devdocs/service/content?path=${ readmeFilePath }` );
+			if ( res.ok ) {
+				const text = await res.text();
+				this.setState( { readme: htmlToReactParser.parse( text ) } );
+			}
+		} catch ( err ) {
+			// Do nothing.
+		}
+	};
+
+	componentDidMount() {
+		this.makeRequest();
 	}
 
 	render() {
@@ -63,5 +65,3 @@ class ReadmeViewer extends Component {
 		) : null;
 	}
 }
-
-export default ReadmeViewer;

--- a/client/devdocs/docs-selectors/search.jsx
+++ b/client/devdocs/docs-selectors/search.jsx
@@ -1,14 +1,11 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import request from 'superagent';
 import page from 'page';
 import { map } from 'lodash';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -25,23 +22,28 @@ export default class DocsSelectorsSearch extends Component {
 
 	state = {};
 
-	componentWillMount() {
+	componentDidMount() {
 		this.request( this.props.search );
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.search !== this.props.search ) {
-			this.request( nextProps.search );
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.search !== this.props.search ) {
+			this.request( this.props.search );
 		}
 	}
 
-	request = search => {
-		request
-			.get( '/devdocs/service/selectors' )
-			.query( { search } )
-			.then( ( { body: results } ) => {
+	request = async search => {
+		const query = stringify( { search } );
+
+		try {
+			const res = await fetch( `/devdocs/service/selectors?${ query }` );
+			if ( res.ok ) {
+				const results = await res.json();
 				this.setState( { results } );
-			} );
+			}
+		} catch ( error ) {
+			// Do nothing.
+		}
 	};
 
 	onSearch( search ) {
@@ -55,6 +57,7 @@ export default class DocsSelectorsSearch extends Component {
 		return (
 			<div>
 				<SearchCard
+					// eslint-disable-next-line jsx-a11y/no-autofocus
 					autoFocus
 					placeholder="Search selectors…"
 					analyticsGroup="Docs"

--- a/client/devdocs/docs-selectors/single.jsx
+++ b/client/devdocs/docs-selectors/single.jsx
@@ -1,14 +1,11 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import page from 'page';
-import request from 'superagent';
 import { find } from 'lodash';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -25,24 +22,29 @@ export default class DocsSelectorsSingle extends Component {
 
 	state = {};
 
-	componentWillMount() {
+	componentDidMount() {
 		this.request( this.props.selector );
 	}
 
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.selector !== this.props.selector ) {
-			this.request( nextProps.selector );
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.selector !== this.props.selector ) {
+			this.request( this.props.selector );
 		}
 	}
 
-	request = selector => {
-		request
-			.get( '/devdocs/service/selectors' )
-			.query( { search: selector } )
-			.then( ( { body } ) => {
-				const result = find( body, { name: selector } );
+	request = async selector => {
+		const query = stringify( { search: selector } );
+
+		try {
+			const res = await fetch( `/devdocs/service/selectors?${ query }` );
+			if ( res.ok ) {
+				const results = await res.json();
+				const result = find( results, { name: selector } );
 				this.setState( { result } );
-			} );
+			}
+		} catch ( error ) {
+			// Do nothing.
+		}
 	};
 
 	onReturnToSearch = () => {

--- a/client/devdocs/service.js
+++ b/client/devdocs/service.js
@@ -1,22 +1,24 @@
-/** @format */
-
 /**
  * External dependencies
  */
+import { stringify } from 'qs';
 
-import request from 'superagent';
+async function fetchDocsEndpoint( endpoint, params, callback ) {
+	const queryParams = stringify( params );
+	const query = queryParams === '' ? '' : `?${ queryParams }`;
 
-function fetchDocsEndpoint( endpoint, params, callback ) {
-	request
-		.get( '/devdocs/service/' + endpoint )
-		.query( params )
-		.end( function( error, res ) {
-			if ( res.ok ) {
-				callback( null, res.body || res.text ); // this conditional is to capture both JSON and text/html responses
-			} else {
-				callback( 'Error invoking /devdocs/' + endpoint + ': ' + res.text, null );
-			}
-		} );
+	const res = await fetch( `/devdocs/service/${ endpoint }${ query }` );
+	if ( ! res.ok ) {
+		callback( `Error invoking /devdocs/${ endpoint }: ${ await res.text() }`, null );
+		return;
+	}
+
+	const contentType = res.headers.get( 'content-type' );
+	if ( contentType && contentType.includes( 'application/json' ) ) {
+		callback( null, await res.json() );
+	} else {
+		callback( null, await res.text() );
+	}
 }
 
 /**


### PR DESCRIPTION
Several modules used `superagent`, a 3rd party npm package, for network requests, and have here been rewritten to use native `fetch` instead.

This is part of an effort to remove `superagent` from client code altogether, and replace it with native `fetch` functionality. This will eventually lead to being able to drop that dependency from the client-side bundle, thus improving loading performance.

#### Changes proposed in this Pull Request

* Rewrite several devdocs modules using `fetch` instead of `superagent`
* Replace deprecated React lifecycle method usage.

#### Testing instructions

* Use devdocs design (`/devdocs/design`) search, ensure that readmes are retrieved correctly.
* Open a component with a readme (e.g. `ActionCard`), and ensure the readme is retrieved correctly.
* Search for selectors (`/devdocs/selectors`) and ensure results are retrieved correctly.
* Open an individual selector (e.g. `/devdocs/selectors/countPostLikes`) and ensure that documentation is retrieved correctly.
