### PR TITLE
FSE: Don't translate variables

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -85,7 +85,7 @@ function render_navigation_menu_block( $attributes ) {
 	ob_start();
 	// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText
 	?>
-	<nav class="<?php echo esc_attr( $wrapper_attr['class'] ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
+	<nav class="<?php echo esc_attr( $wrapper_attr['class'] ); ?>" aria-label="<?php echo esc_attr( $wrapper_attr['label'] ); ?>">
 		<?php
 		wp_nav_menu( get_menu_params_by_theme_location( $location ) );
 		?>


### PR DESCRIPTION
```
wpcut__check_translatable_strings()                     => FAIL (1.0989) (

!! Empty translatable string (please only use plain strings):
/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php:88 esc_attr_e( "" )
```
Let's wrap the label strings in i18n functions when they're ready to be translated.