### PR TITLE
Auth Section: fix a11y issues and migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -8,7 +8,6 @@
 
 @import 'layout/style';
 
-@import 'auth/style';
 @import 'blocks/nps-survey/style';
 @import 'blocks/login/style';
 @import 'blocks/post-item/style';

--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -21,17 +21,19 @@ import userFactory from 'lib/user';
 import Main from 'components/main';
 import PulsingDot from 'components/pulsing-dot';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default {
 	oauthLogin: function( context, next ) {
-		if ( config.isEnabled( 'oauth' ) ) {
-			if ( getToken() ) {
-				page( '/' );
-			} else {
-				context.primary = <OAuthLogin />;
-			}
-		} else {
+		if ( ! config.isEnabled( 'oauth' ) || getToken() ) {
 			page( '/' );
+			return;
 		}
+
+		context.primary = <OAuthLogin />;
 		next();
 	},
 
@@ -57,9 +59,7 @@ export default {
 			authUrl = wpoauth.urlToConnect( { scope: 'global', blog_id: 0 } );
 		}
 
-		context.primary = React.createElement( ConnectComponent, {
-			authUrl: authUrl,
-		} );
+		context.primary = <ConnectComponent authUrl={ authUrl } />;
 		next();
 	},
 
@@ -82,7 +82,7 @@ export default {
 			</Main>
 		);
 
-		// Fetch user and redirect to /sites on success.
+		// Fetch user and redirect to / on success.
 		const user = userFactory();
 		user.fetching = false;
 		user.fetch();

--- a/client/auth/login.jsx
+++ b/client/auth/login.jsx
@@ -174,9 +174,9 @@ export class Auth extends Component {
 						<Gridicon icon="help" />
 					</a>
 					<div className="auth__links">
-						<a href="#" onClick={ this.toggleSelfHostedInstructions }>
+						<button onClick={ this.toggleSelfHostedInstructions }>
 							{ translate( 'Add self-hosted site' ) }
-						</a>
+						</button>
 						<a href={ config( 'signup_url' ) }>{ translate( 'Create account' ) }</a>
 					</div>
 					{ showInstructions && (

--- a/client/auth/lost-password.jsx
+++ b/client/auth/lost-password.jsx
@@ -1,19 +1,18 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
  */
 import { localizeUrl } from 'lib/i18n-utils';
 
-const LostPassword = ( { translate } ) => {
+export default function LostPassword() {
+	const translate = useTranslate();
 	const url = localizeUrl( 'https://wordpress.com/wp-login.php?action=lostpassword' );
+
 	return (
 		<p className="auth__lost-password">
 			<a href={ url } target="_blank" rel="noopener noreferrer">
@@ -21,6 +20,4 @@ const LostPassword = ( { translate } ) => {
 			</a>
 		</p>
 	);
-};
-
-export default localize( LostPassword );
+}

--- a/client/auth/self-hosted-instructions.jsx
+++ b/client/auth/self-hosted-instructions.jsx
@@ -5,45 +5,47 @@
  */
 
 import React from 'react';
-import { localize } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 
-const SelfHostedInstructions = ( { onClickClose, translate } ) => (
-	<div className="auth__self-hosted-instructions">
-		<button onClick={ onClickClose } className="auth__self-hosted-instructions-close">
-			<Gridicon icon="cross" size={ 24 } />
-		</button>
+export default function SelfHostedInstructions( { onClickClose } ) {
+	const translate = useTranslate();
 
-		<h2>{ translate( 'Add self-hosted site' ) }</h2>
-		<p>
-			{ translate(
-				'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com'
-			) }
-		</p>
-		<p>
-			{ translate(
-				"If you'd like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:"
-			) }
-		</p>
+	return (
+		<div className="auth__self-hosted-instructions">
+			<button onClick={ onClickClose } className="auth__self-hosted-instructions-close">
+				<Gridicon icon="cross" size={ 24 } />
+			</button>
 
-		<ol>
-			<li>
-				<strong>{ translate( 'Install the Jetpack plugin.' ) }</strong>
-				<br />
-				<a href="http://jetpack.me/install/">
-					{ translate( 'Please follow these instructions to install Jetpack' ) }
-				</a>
-				.
-			</li>
-			<li>{ translate( 'Connect Jetpack to WordPress.com.' ) }</li>
-			<li>
+			<h2>{ translate( 'Add self-hosted site' ) }</h2>
+			<p>
 				{ translate(
-					'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, ' +
-						'and you can find your self-hosted site under the "My Sites" section.'
+					'By default when you sign into the WordPress.com app, you can edit blogs and sites hosted at WordPress.com'
 				) }
-			</li>
-		</ol>
-	</div>
-);
+			</p>
+			<p>
+				{ translate(
+					"If you'd like to edit your self-hosted WordPress blog or site, you can do that by following these instructions:"
+				) }
+			</p>
 
-export default localize( SelfHostedInstructions );
+			<ol>
+				<li>
+					<strong>{ translate( 'Install the Jetpack plugin.' ) }</strong>
+					<br />
+					<a href="http://jetpack.me/install/">
+						{ translate( 'Please follow these instructions to install Jetpack' ) }
+					</a>
+					.
+				</li>
+				<li>{ translate( 'Connect Jetpack to WordPress.com.' ) }</li>
+				<li>
+					{ translate(
+						'Now you can sign in to the app using the WordPress.com account Jetpack is connected to, ' +
+							'and you can find your self-hosted site under the "My Sites" section.'
+					) }
+				</li>
+			</ol>
+		</div>
+	);
+}

--- a/client/auth/self-hosted-instructions.jsx
+++ b/client/auth/self-hosted-instructions.jsx
@@ -10,9 +10,9 @@ import Gridicon from 'gridicons';
 
 const SelfHostedInstructions = ( { onClickClose, translate } ) => (
 	<div className="auth__self-hosted-instructions">
-		<a href="#" onClick={ onClickClose } className="auth__self-hosted-instructions-close">
+		<button onClick={ onClickClose } className="auth__self-hosted-instructions-close">
 			<Gridicon icon="cross" size={ 24 } />
-		</a>
+		</button>
 
 		<h2>{ translate( 'Add self-hosted site' ) }</h2>
 		<p>

--- a/client/auth/style.scss
+++ b/client/auth/style.scss
@@ -65,7 +65,7 @@
 	width: 320px;
 	margin: 0 auto;
 
-		.form-fieldset input {
+	.form-fieldset input {
 		position: relative;
 		z-index: z-index( 'root', '.auth__form .form-fieldset input' );
 	}
@@ -156,18 +156,21 @@
 	bottom: 40px;
 	left: 0;
 	right: 0;
-}
 
-.auth__links a {
-	text-decoration: none;
-	color: var( --color-white );
-	margin: 0 16px;
-	padding: 10px 0;
-}
+	a,
+	button {
+		text-decoration: none;
+		color: var( --color-white );
+		margin: 0 16px;
+		padding: 10px 0;
+		cursor: pointer;
+		font-size: inherit;
 
-.auth__links a:hover,
-.auth__links a:focus {
-	color: var( --color-neutral-0 );
+		&:hover,
+		&:focus {
+			color: var( --color-neutral-0 );
+		}
+	}
 }
 
 .auth__self-hosted-instructions {
@@ -244,13 +247,13 @@
 		right: 10px;
 		top: 10px;
 		text-decoration: none;
+		cursor: pointer;
 		color: var( --color-white );
 	}
 
 	.auth__self-hosted-instructions-close:hover {
 		color: var( --color-primary-light );
 	}
-
 }
 
 .auth__welcome {


### PR DESCRIPTION
Stacked on top of OAuth handler refactor in #34123.

Solves a few a11y issues by converting `<a href="#" onClick>` links to buttons.

Rewrites a few simple components to hooked (`useTranslate`) functional ones.

Migrates the CSS of the Auth section.

**How to test:**
The section is used only in the Desktop app:
1. Checkout this branch in your `wp-desktop/calypso` submodule.
2. Run `make dev-server` and `make dev` to start the Electron window
3. Verify the OAuth login page:

<img width="455" alt="Screenshot 2019-06-19 at 12 51 02" src="https://user-images.githubusercontent.com/664258/59760916-ad7cdd00-9293-11e9-9cde-cf49ad7aa273.png">

Is everything correctly styled? Are the "self-hosted" and "create account" links styled the same way (one is a `button`, the other an `a`)? Is the "self-hosted" popup styled properly (especially the modified close button)?
