### PR TITLE
Roll `get-video-id` back to 3.1.2.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10413,9 +10413,9 @@
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
 		},
 		"get-video-id": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-3.1.3.tgz",
-			"integrity": "sha512-22ktjKAn2Toz8JXvqn16PFGF3aV72l2uUFSaIe6ebtMrf6x6DxgH9Ks7a+HZN5a5QYgfR1E/C2HDwcsh12M8OQ==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/get-video-id/-/get-video-id-3.1.2.tgz",
+			"integrity": "sha512-cz8/LJ6HHRkxUdOCDgdGoJCTGbaCEq0GsGFkxkabL6oy5OWfdsn3TizQtaOerbeX4JhiRmPQlCM/XZ9SSbed5Q==",
 			"requires": {
 				"get-src": "^1.0.1"
 			}

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
 		"flux": "3.1.3",
 		"fontfaceobserver": "2.1.0",
 		"fuse.js": "3.4.4",
-		"get-video-id": "3.1.3",
+		"get-video-id": "3.1.2",
 		"gfm-code-blocks": "1.0.0",
 		"globby": "9.2.0",
 		"gridicons": "3.3.1",


### PR DESCRIPTION
3.1.3 ships with ES6 syntax, which ends up in the fallback build and breaks Calypso in older browsers.

A pull request with a permanent fix has been created on the dependency's repo, but this should fix Calypso in the meantime.

#### Changes proposed in this Pull Request

* Roll back `get-video-id` to 3.1.2.

#### Testing instructions

* In a browser without ES6 syntax support (e.g. Safari 9) open the live branch and visit the login page. It should work correctly, without producing console errors regarding use of the `const` keyword.
