### PR TITLE
Serve Noto Serif from Google Fonts with `font-display: swap` on

### DIFF
--- a/apps/notifications/src/index.ejs
+++ b/apps/notifications/src/index.ejs
@@ -10,7 +10,7 @@
 	<meta name="node-platform" content="<%= htmlWebpackPlugin.options.nodeVersion %>">
 	<meta name="node-version" content="<%= htmlWebpackPlugin.options.nodePlatform %>">
 	<meta name="git-describe" content="<%= htmlWebpackPlugin.options.gitDescribe %>">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese">
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
     <% htmlWebpackPlugin.files.css.forEach( function( style ) { if ( style.includes( 'rtl' ) && htmlWebpackPlugin.options.isRTL ) { %><link rel="stylesheet" href="<%= style %>"><% } else if ( ! ( style.includes( 'rtl' ) || htmlWebpackPlugin.options.isRTL ) ) { %><link rel="stylesheet" href="<%= style %>"><% } } ) %>
 </head>
 

--- a/apps/notifications/src/standalone/root.html
+++ b/apps/notifications/src/standalone/root.html
@@ -10,7 +10,7 @@
 	<meta name="node-platform" content="v10.8.0">
 	<meta name="node-version" content="darwin">
 	<meta name="git-describe" content="desktop/2.4.0-12531-gef8d1a2a9c-dirty">
-	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese">
+	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap">
 <link href="../../../../../../Downloads/ntfs/main.css?a0ff59cf6957666700e1" rel="stylesheet"></head>
 
 <body>

--- a/client/components/head/index.jsx
+++ b/client/components/head/index.jsx
@@ -86,13 +86,13 @@ const Head = ( {
 			) }
 			<link
 				rel="preload"
-				href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"
+				href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap"
 				as="style"
 			/>
 			<noscript>
 				<link
 					rel="stylesheet"
-					href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"
+					href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap"
 				/>
 			</noscript>
 			{ /* eslint-disable react/no-danger */ }
@@ -105,7 +105,7 @@ const Head = ( {
 			(function() {
 				var m = document.createElement( "link" );
 				m.rel = "stylesheet";
-				m.href = "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese";
+				m.href = "https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap";
 				document.head.insertBefore( m, document.head.childNodes[ document.head.childNodes.length - 1 ].nextSibling );
 			})()
 			`,

--- a/client/components/head/test/__snapshots__/index.jsx.snap
+++ b/client/components/head/test/__snapshots__/index.jsx.snap
@@ -141,12 +141,12 @@ exports[`Head should render custom title 1`] = `
   />
   <link
     as="style"
-    href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"
+    href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap"
     rel="preload"
   />
   <noscript>
     <link
-      href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"
+      href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap"
       rel="stylesheet"
     />
   </noscript>
@@ -157,7 +157,7 @@ exports[`Head should render custom title 1`] = `
 			(function() {
 				var m = document.createElement( \\"link\\" );
 				m.rel = \\"stylesheet\\";
-				m.href = \\"https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese\\";
+				m.href = \\"https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap\\";
 				document.head.insertBefore( m, document.head.childNodes[ document.head.childNodes.length - 1 ].nextSibling );
 			})()
 			",
@@ -309,12 +309,12 @@ exports[`Head should render default title 1`] = `
   />
   <link
     as="style"
-    href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"
+    href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap"
     rel="preload"
   />
   <noscript>
     <link
-      href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"
+      href="https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap"
       rel="stylesheet"
     />
   </noscript>
@@ -325,7 +325,7 @@ exports[`Head should render default title 1`] = `
 			(function() {
 				var m = document.createElement( \\"link\\" );
 				m.rel = \\"stylesheet\\";
-				m.href = \\"https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese\\";
+				m.href = \\"https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap\\";
 				document.head.insertBefore( m, document.head.childNodes[ document.head.childNodes.length - 1 ].nextSibling );
 			})()
 			",

--- a/client/components/tinymce/index.jsx
+++ b/client/components/tinymce/index.jsx
@@ -167,7 +167,7 @@ const CONTENT_CSS = [
 	window.app.staticUrls[ 'tinymce/skins/wordpress/wp-content.css' ],
 	'//s1.wp.com/wp-includes/css/dashicons.css?v=20150727',
 	window.app.staticUrls[ 'editor.css' ],
-	'https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese',
+	'https://fonts.googleapis.com/css?family=Noto+Serif:400,400i,700,700i&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese&display=swap',
 ];
 
 export default class extends React.Component {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Following our landing pages, this tiny PR makes sure that our content typeface, Noto Serif, is served from Google Fonts with `font-display: swap` enabled.

`font-display: swap` improves perceived performance by displaying the fallback font immediately (that’s Georgia in our case) instead of showing blocks of invisible text while waiting for the final webfont to load.

[![Comparison graph](https://cdn.glitch.com/be746fa6-6ce9-423d-b9a3-684949adc8d5%2FScreen%20Shot%202017-11-14%20at%202.49.37%20PM.png?1510699808180)](https://font-display.glitch.me)

Due to Calypso’s content loading tricks, the change may not be as noticeable, but all other cases we don’t control as tightly will benefit from it.

`font-display: swap` works in all modern browsers. Google Fonts adds `&display=swap` to all the URLs it generates now.

#### Testing instructions

* Navigate to a dedicated page article from Reader and hard-reload (`⌘⇧R` in Chrome on macOS).
* Make sure Noto Serif has been loaded.