### PR TITLE
Update hover state for checklist task

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -223,7 +223,8 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
 		&:hover {
 			cursor: pointer;
-
+			color: var( --color-primary );
+			
 			.checklist__toggle-icon {
 				fill: var( --color-primary );
 			}
@@ -336,11 +337,6 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		.checklist__task-title-button {
 			font-weight: 400;
 			padding-bottom: 16px;
-
-			&:hover {
-				color: var( --color-primary );
-				background: var( --color-primary-50 );
-			}
 		}
 
 		&.is-completed .checklist__task-title-button {

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -132,7 +132,6 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		bottom: 0;
 		left: 34px;
 		border-left: 1px solid var( --color-neutral-100 );
-		z-index: 1;
 	}
 
 	.checklist__task-icon {
@@ -146,7 +145,6 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		border-radius: 16px;
 		background: var( --color-white );
 		cursor: pointer;
-		z-index: 2;
 
 		.gridicons-checkmark {
 			display: none;
@@ -214,7 +212,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		font-weight: 600;
 		font-size: 16px;
 		border-radius: 0;
-		z-index: 0;
+		border-left: 4px solid transparent;
 
 		.checklist__toggle-icon {
 			position: absolute;
@@ -342,7 +340,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 			padding-bottom: 16px;
 
 			&:hover {
-				background: var( --color-neutral-0 );
+				border-left: 4px solid var( --color-primary );
 			}
 		}
 

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -132,6 +132,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		bottom: 0;
 		left: 34px;
 		border-left: 1px solid var( --color-neutral-100 );
+		z-index: 1;
 	}
 
 	.checklist__task-icon {
@@ -145,6 +146,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		border-radius: 16px;
 		background: var( --color-white );
 		cursor: pointer;
+		z-index: 2;
 
 		.gridicons-checkmark {
 			display: none;
@@ -212,7 +214,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		font-weight: 600;
 		font-size: 16px;
 		border-radius: 0;
-		border-left: 4px solid transparent;
+		z-index: 0;
 
 		.checklist__toggle-icon {
 			position: absolute;
@@ -272,7 +274,6 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 
 	&.is-completed {
 		order: 0;
-		background: var( --color-neutral-0 );
 
 		.checklist__task-icon {
 			top: 8px;
@@ -334,13 +335,17 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 			display: none;
 		}
 
+		&.is-completed {
+			background: var( --color-neutral-0 );
+		}
+
 		&.is-completed .checklist__task-title-button,
 		.checklist__task-title-button {
 			font-weight: 400;
 			padding-bottom: 16px;
 
 			&:hover {
-				border-left: 4px solid var( --color-primary );
+				background: var( --color-neutral-50 );
 			}
 		}
 

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -132,6 +132,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		bottom: 0;
 		left: 34px;
 		border-left: 1px solid var( --color-neutral-100 );
+		z-index: 1;
 	}
 
 	.checklist__task-icon {
@@ -145,6 +146,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		border-radius: 16px;
 		background: var( --color-white );
 		cursor: pointer;
+		z-index: 2;
 
 		.gridicons-checkmark {
 			display: none;
@@ -212,6 +214,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		font-weight: 600;
 		font-size: 16px;
 		border-radius: 0;
+		z-index: 0;
 
 		.checklist__toggle-icon {
 			position: absolute;
@@ -224,7 +227,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		&:hover {
 			cursor: pointer;
 			color: var( --color-primary );
-			
+
 			.checklist__toggle-icon {
 				fill: var( --color-primary );
 			}
@@ -337,6 +340,10 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		.checklist__task-title-button {
 			font-weight: 400;
 			padding-bottom: 16px;
+
+			&:hover {
+				background: var( --color-neutral-0 );
+			}
 		}
 
 		&.is-completed .checklist__task-title-button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR makes some subtle design updates to the hover state of the checklist. I was previously using a background colour based on the main navigation, which has now changed, and it felt a bit heavy handed. Plus there were some contrast issues with the background colour and there were also some weird z-index issues. The change moves to a more subtle colour update of the copy and removes the background colour. 

**Before**
![before](https://user-images.githubusercontent.com/6981253/59775341-0aba6380-927f-11e9-80d6-448a389280db.gif)

**After**
![after](https://user-images.githubusercontent.com/6981253/59775331-08f0a000-927f-11e9-84eb-c16056851fc0.gif)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site and visit the checklist.
* Hover over each task.

cc @shaunandrews 
