### PR TITLE
Docs: Use absolute URLs so that e2e links are valid on the wpcalypso environment.

### DIFF
--- a/docs/testing/testing-overview.md
+++ b/docs/testing/testing-overview.md
@@ -72,7 +72,7 @@ They run daily on continuous integration (CircleCI), because they can use networ
 
 ### End-to-end tests
 
-All those tests now live in the [test/e2e](/test/e2e) directory. For details on how to run them, see the [e2e documentation](/test/e2e/README.md).
+All those tests now live in the [test/e2e](https://github.com/Automattic/wp-calypso/blob/master/test/e2e) directory. For details on how to run them, see the [e2e documentation](https://github.com/Automattic/wp-calypso/blob/master/test/e2e/README.md).
 
 ## FAQ
 


### PR DESCRIPTION
Use absolute URLs so that e2e links are valid on the wpcalypso environment. Otherwise, they 404.

#### Testing instructions

* Load the calypso.live branch below and go to `/devdocs/docs/testing/testing-overview.md`.
* Verify the links for `test/e2e` and `e2e documentation` go to the proper Calypso repo pages.
