### PR TITLE
DevDocs: Add Margin to Small Screens

### DIFF
--- a/client/devdocs/style.scss
+++ b/client/devdocs/style.scss
@@ -342,10 +342,14 @@ $devdocs-max-width: 720px;
 // Documentation — Copy-heavy things like Contributing and Typography
 .devdocs__doc-content {
 	max-width: $devdocs-max-width;
-	margin: 32px auto;
+	margin: 32px 20px;
 	font-size: 16px;
 	font-family: $serif;
-
+	
+	@include breakpoint( '>660px' ) {
+		margin: 32px auto;
+	}
+	
 	a {
 		text-decoration: underline;
 	}
@@ -474,10 +478,13 @@ $devdocs-max-width: 720px;
 	max-width: 150px;
 }
 
-// At the end of documentation and reademe's
+// At the top of documentation and readme's
 a.devdocs__doc-edit-link {
 	text-align: center;
 	text-decoration: underline;
 	float: right;
-	position: relative;
+	
+	@include breakpoint( '<660px' ) {
+		margin-right: 12px;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a margin to DevDocs to increase legibility on smaller screens (20px, I got that value from the Reader)

#### Testing instructions

Visit DevDocs on any page on both a mobile and desktop device. Verify that in all cases, there is no situation where the content looks out of place.

**Desktop:**

<img width="1756" alt="Screenshot 2019-06-19 at 18 05 04" src="https://user-images.githubusercontent.com/43215253/59786182-91426580-92be-11e9-9315-37e88f0b1310.png">

**Mobile:**

<img width="596" alt="Screenshot 2019-06-19 at 18 04 28" src="https://user-images.githubusercontent.com/43215253/59786189-97384680-92be-11e9-971e-e8b5d4300c51.png">

cc @simison, @lancewillett 

Fixes #27331
