### PR TITLE
Ensure lodash-es usage through a WebPack plugin.

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -20,20 +20,7 @@ const config = {
 		],
 		'@automattic/calypso-build/babel/default',
 	],
-	plugins: [
-		[ '@automattic/transform-wpcalypso-async', { async: isBrowser && codeSplit } ],
-		isBrowser
-			? [
-					'module-resolver',
-					{
-						alias: {
-							lodash: 'lodash-es',
-							'lodash/': ( [ , name ] ) => `lodash-es/${ name }`,
-						},
-					},
-			  ]
-			: {},
-	],
+	plugins: [ [ '@automattic/transform-wpcalypso-async', { async: isBrowser && codeSplit } ] ],
 	env: {
 		build_pot: {
 			plugins: [
@@ -51,19 +38,7 @@ const config = {
 		},
 		test: {
 			presets: [ [ '@babel/env', { targets: { node: 'current' } } ] ],
-			plugins: [
-				'add-module-exports',
-				'babel-plugin-dynamic-import-node',
-				[
-					'module-resolver',
-					{
-						alias: {
-							'lodash-es': 'lodash',
-							'lodash-es/': ( [ , name ] ) => `lodash/${ name }`,
-						},
-					},
-				],
-			],
+			plugins: [ 'add-module-exports', 'babel-plugin-dynamic-import-node' ],
 		},
 	},
 };

--- a/babel.dependencies.config.js
+++ b/babel.dependencies.config.js
@@ -1,6 +1,3 @@
-/** @format */
-const isBrowser = process.env.BROWSERSLIST_ENV !== 'server';
-
 const config = {
 	// see https://github.com/webpack/webpack/issues/4039#issuecomment-419284940
 	sourceType: 'unambiguous',
@@ -18,15 +15,6 @@ const config = {
 	],
 	plugins: [
 		'@babel/plugin-syntax-dynamic-import',
-		isBrowser && [
-			'module-resolver',
-			{
-				alias: {
-					lodash: 'lodash-es',
-					'lodash/': ( [ , name ] ) => `lodash-es/${ name }`,
-				},
-			},
-		],
 		[
 			'@babel/transform-runtime',
 			{

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -5268,19 +5268,6 @@
 				"@types/babel__traverse": "^7.0.6"
 			}
 		},
-		"babel-plugin-module-resolver": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
-			"integrity": "sha512-tjR0GvSndzPew/Iayf4uICWZqjBwnlMWjSx6brryfQ81F9rxBVqwDJtFCV8oOs0+vJeefK9TmdZtkIFdFe1UnA==",
-			"dev": true,
-			"requires": {
-				"find-babel-config": "^1.1.0",
-				"glob": "^7.1.2",
-				"pkg-up": "^2.0.0",
-				"reselect": "^3.0.1",
-				"resolve": "^1.4.0"
-			}
-		},
 		"babel-preset-jest": {
 			"version": "24.6.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
@@ -9852,24 +9839,6 @@
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
 					"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-				}
-			}
-		},
-		"find-babel-config": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-1.2.0.tgz",
-			"integrity": "sha512-jB2CHJeqy6a820ssiqwrKMeyC6nNdmrcgkKWJWmpoxpE8RKciYJXCcXRq1h2AzCo5I5BJeN2tkGEO3hLTuePRA==",
-			"dev": true,
-			"requires": {
-				"json5": "^0.5.1",
-				"path-exists": "^3.0.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-					"dev": true
 				}
 			}
 		},
@@ -16765,15 +16734,6 @@
 				"find-up": "^2.1.0"
 			}
 		},
-		"pkg-up": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
-			"integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
-			"dev": true,
-			"requires": {
-				"find-up": "^2.1.0"
-			}
-		},
 		"please-upgrade-node": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.1.1.tgz",
@@ -19952,12 +19912,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
 			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-		},
-		"reselect": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-			"integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc=",
-			"dev": true
 		},
 		"resize-observer-polyfill": {
 			"version": "1.5.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -103,6 +103,22 @@
 		"@automattic/tree-select": {
 			"version": "file:packages/tree-select"
 		},
+		"@automattic/webpack-extensive-lodash-replacement-plugin": {
+			"version": "file:packages/webpack-extensive-lodash-replacement-plugin",
+			"dev": true,
+			"requires": {
+				"find-package-json": "^1.2.0",
+				"semver": "^6.1.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.1.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
+					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
+					"dev": true
+				}
+			}
+		},
 		"@automattic/webpack-inline-constant-exports-plugin": {
 			"version": "file:packages/webpack-inline-constant-exports-plugin",
 			"dev": true
@@ -9916,6 +9932,12 @@
 					}
 				}
 			}
+		},
+		"find-package-json": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz",
+			"integrity": "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==",
+			"dev": true
 		},
 		"find-root": {
 			"version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -286,7 +286,6 @@
 		"babel-eslint": "10.0.1",
 		"babel-jest": "24.8.0",
 		"babel-plugin-dynamic-import-node": "2.3.0",
-		"babel-plugin-module-resolver": "3.2.0",
 		"chai": "4.2.0",
 		"chai-enzyme": "1.0.0-beta.1",
 		"check-node-version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -273,6 +273,7 @@
 		"@automattic/babel-plugin-transform-wpcalypso-async": "file:./packages/babel-plugin-transform-wpcalypso-async",
 		"@automattic/calypso-build": "file:./packages/calypso-build",
 		"@automattic/calypso-color-schemes": "file:./packages/calypso-color-schemes",
+		"@automattic/webpack-extensive-lodash-replacement-plugin": "file:./packages/webpack-extensive-lodash-replacement-plugin",
 		"@automattic/webpack-inline-constant-exports-plugin": "file:./packages/webpack-inline-constant-exports-plugin",
 		"@types/classnames": "2.2.7",
 		"@types/debug": "4.1.4",

--- a/packages/webpack-extensive-lodash-replacement-plugin/README.md
+++ b/packages/webpack-extensive-lodash-replacement-plugin/README.md
@@ -1,0 +1,41 @@
+# webpack-extensive-lodash-replacement-plugin
+
+Replaces most usage of `lodash` with `lodash-es`:
+
+```js
+import { map } from 'lodash';
+// becomes
+import { map } from 'lodash-es';
+
+import map from 'lodash/map';
+// becomes
+import map from 'lodash-es/map';
+
+import camelCase from 'lodash.camelcase';
+// becomes
+import camelCase from 'lodash-es/camelCase';
+```
+
+This applies transitively to the whole codebase. However, requested versions are
+compared against the root's `lodash-es` version to ensure that they can be replaced.
+
+**Note:**: The `lodash-es` version in the root `package.json` must be defined as a single version
+string (e.g. "4.17.11"), not a range.
+
+## Usage
+
+_webpack.config.js_
+```js
+const ExtensiveLodashReplacementPlugin =
+  require( '@automattic/webpack-extensive-lodash-replacement-plugin' );
+
+module.exports = {
+  ...,
+  plugins: [
+    new ExtensiveLodashReplacementPlugin( './package.json' ),
+    ...
+  ]
+};
+```
+
+The optional constructor argument is the location of the `package.json` file for the project.

--- a/packages/webpack-extensive-lodash-replacement-plugin/index.js
+++ b/packages/webpack-extensive-lodash-replacement-plugin/index.js
@@ -1,0 +1,461 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/no-nodejs-modules */
+const path = require( 'path' );
+const findPackageJson = require( 'find-package-json' );
+const fs = require( 'fs' );
+const semver = require( 'semver' );
+
+// List of all known lodash module names.
+// Used for normalizing names to avoid code duplication.
+// Note: this list should be kept up-to-date with new lodash versions.
+const LODASH_MODULE_NAMES = [
+	'add',
+	'after',
+	'ary',
+	'assign',
+	'assignIn',
+	'assignInWith',
+	'assignWith',
+	'at',
+	'attempt',
+	'before',
+	'bind',
+	'bindAll',
+	'bindKey',
+	'camelCase',
+	'capitalize',
+	'castArray',
+	'ceil',
+	'chain',
+	'chunk',
+	'clamp',
+	'clone',
+	'cloneDeep',
+	'cloneDeepWith',
+	'cloneWith',
+	'commit',
+	'compact',
+	'concat',
+	'cond',
+	'conforms',
+	'conformsTo',
+	'constant',
+	'countBy',
+	'create',
+	'curry',
+	'curryRight',
+	'debounce',
+	'deburr',
+	'defaultTo',
+	'defaults',
+	'defaultsDeep',
+	'defer',
+	'delay',
+	'difference',
+	'differenceBy',
+	'differenceWith',
+	'divide',
+	'drop',
+	'dropRight',
+	'dropRightWhile',
+	'dropWhile',
+	'each',
+	'eachRight',
+	'endsWith',
+	'entries',
+	'entriesIn',
+	'eq',
+	'escape',
+	'escapeRegExp',
+	'every',
+	'extend',
+	'extendWith',
+	'fill',
+	'filter',
+	'find',
+	'findIndex',
+	'findKey',
+	'findLast',
+	'findLastIndex',
+	'findLastKey',
+	'first',
+	'flatMap',
+	'flatMapDeep',
+	'flatMapDepth',
+	'flatten',
+	'flattenDeep',
+	'flattenDepth',
+	'flip',
+	'floor',
+	'flow',
+	'flowRight',
+	'forEach',
+	'forEachRight',
+	'forIn',
+	'forInRight',
+	'forOwn',
+	'forOwnRight',
+	'fromPairs',
+	'functions',
+	'functionsIn',
+	'get',
+	'groupBy',
+	'gt',
+	'gte',
+	'has',
+	'hasIn',
+	'head',
+	'identity',
+	'inRange',
+	'includes',
+	'indexOf',
+	'initial',
+	'intersection',
+	'intersectionBy',
+	'intersectionWith',
+	'invert',
+	'invertBy',
+	'invoke',
+	'invokeMap',
+	'isArguments',
+	'isArray',
+	'isArrayBuffer',
+	'isArrayLike',
+	'isArrayLikeObject',
+	'isBoolean',
+	'isBuffer',
+	'isDate',
+	'isElement',
+	'isEmpty',
+	'isEqual',
+	'isEqualWith',
+	'isError',
+	'isFinite',
+	'isFunction',
+	'isInteger',
+	'isLength',
+	'isMap',
+	'isMatch',
+	'isMatchWith',
+	'isNaN',
+	'isNative',
+	'isNil',
+	'isNull',
+	'isNumber',
+	'isObject',
+	'isObjectLike',
+	'isPlainObject',
+	'isRegExp',
+	'isSafeInteger',
+	'isSet',
+	'isString',
+	'isSymbol',
+	'isTypedArray',
+	'isUndefined',
+	'isWeakMap',
+	'isWeakSet',
+	'iteratee',
+	'join',
+	'kebabCase',
+	'keyBy',
+	'keys',
+	'keysIn',
+	'last',
+	'lastIndexOf',
+	'lodash',
+	'lowerCase',
+	'lowerFirst',
+	'lt',
+	'lte',
+	'map',
+	'mapKeys',
+	'mapValues',
+	'matches',
+	'matchesProperty',
+	'max',
+	'maxBy',
+	'mean',
+	'meanBy',
+	'memoize',
+	'merge',
+	'mergeWith',
+	'method',
+	'methodOf',
+	'min',
+	'minBy',
+	'mixin',
+	'multiply',
+	'negate',
+	'next',
+	'noop',
+	'now',
+	'nth',
+	'nthArg',
+	'omit',
+	'omitBy',
+	'once',
+	'orderBy',
+	'over',
+	'overArgs',
+	'overEvery',
+	'overSome',
+	'pad',
+	'padEnd',
+	'padStart',
+	'parseInt',
+	'partial',
+	'partialRight',
+	'partition',
+	'pick',
+	'pickBy',
+	'plant',
+	'property',
+	'propertyOf',
+	'pull',
+	'pullAll',
+	'pullAllBy',
+	'pullAllWith',
+	'pullAt',
+	'random',
+	'range',
+	'rangeRight',
+	'rearg',
+	'reduce',
+	'reduceRight',
+	'reject',
+	'remove',
+	'repeat',
+	'replace',
+	'rest',
+	'result',
+	'reverse',
+	'round',
+	'sample',
+	'sampleSize',
+	'set',
+	'setWith',
+	'shuffle',
+	'size',
+	'slice',
+	'snakeCase',
+	'some',
+	'sortBy',
+	'sortedIndex',
+	'sortedIndexBy',
+	'sortedIndexOf',
+	'sortedLastIndex',
+	'sortedLastIndexBy',
+	'sortedLastIndexOf',
+	'sortedUniq',
+	'sortedUniqBy',
+	'split',
+	'spread',
+	'startCase',
+	'startsWith',
+	'stubArray',
+	'stubFalse',
+	'stubObject',
+	'stubString',
+	'stubTrue',
+	'subtract',
+	'sum',
+	'sumBy',
+	'tail',
+	'take',
+	'takeRight',
+	'takeRightWhile',
+	'takeWhile',
+	'tap',
+	'template',
+	'templateSettings',
+	'throttle',
+	'thru',
+	'times',
+	'toArray',
+	'toFinite',
+	'toInteger',
+	'toIterator',
+	'toJSON',
+	'toLength',
+	'toLower',
+	'toNumber',
+	'toPairs',
+	'toPairsIn',
+	'toPath',
+	'toPlainObject',
+	'toSafeInteger',
+	'toString',
+	'toUpper',
+	'transform',
+	'trim',
+	'trimEnd',
+	'trimStart',
+	'truncate',
+	'unary',
+	'unescape',
+	'union',
+	'unionBy',
+	'unionWith',
+	'uniq',
+	'uniqBy',
+	'uniqWith',
+	'uniqueId',
+	'unset',
+	'unzip',
+	'unzipWith',
+	'update',
+	'updateWith',
+	'upperCase',
+	'upperFirst',
+	'value',
+	'valueOf',
+	'values',
+	'valuesIn',
+	'without',
+	'words',
+	'wrap',
+	'wrapperAt',
+	'wrapperChain',
+	'wrapperCommit',
+	'wrapperLodash',
+	'wrapperNext',
+	'wrapperPlant',
+	'wrapperReverse',
+	'wrapperToIterator',
+	'wrapperValue',
+	'xor',
+	'xorBy',
+	'xorWith',
+	'zip',
+	'zipObject',
+	'zipObjectDeep',
+	'zipWith',
+];
+
+function throwError( message, error = null ) {
+	throw new Error(
+		`[ExtensiveLodashReplacementPlugin] ${ message }${ error ? ' Error: ' : '' }${ error }`
+	);
+}
+
+class ExtensiveLodashReplacementPlugin {
+	constructor( baseFile = './package.json' ) {
+		this.baseFile = path.resolve( baseFile );
+		let data;
+
+		try {
+			data = fs.readFileSync( this.baseFile );
+		} catch ( error ) {
+			throwError( 'Could not read root package.json.', error );
+		}
+
+		try {
+			const packageJson = JSON.parse( data );
+			this.lodashVersion =
+				packageJson && packageJson.dependencies && packageJson.dependencies[ 'lodash-es' ];
+		} catch ( error ) {
+			throwError( 'Could not parse root package.json.', error );
+		}
+
+		if ( ! this.lodashVersion ) {
+			throwError( 'No lodash-es dependency in root package.json.' );
+		}
+
+		if ( ! semver.valid( this.lodashVersion ) ) {
+			throwError( `Invalid root package.json lodash-es version: ${ this.lodashVersion }.` );
+		}
+	}
+
+	// Figure out the requested Lodash version range for a given import.
+	// It looks at the file with the import and traverses upwards, until it finds a package.json file
+	// with the requested dependency. It returns this range.
+	findRequestedLodashRange( file, packageName ) {
+		const finder = findPackageJson( path.dirname( file ) );
+		let version;
+
+		try {
+			while ( ! version ) {
+				const found = finder.next();
+
+				if ( found.filename === this.baseFile ) {
+					return this.lodashVersion;
+				}
+
+				const contents = found && found.value;
+				version = contents && contents.dependencies && contents.dependencies[ packageName ];
+			}
+		} catch ( error ) {
+			throwError( `Could not find requested range for import on ${ file }.`, error );
+		}
+
+		return version;
+	}
+
+	// Figure out if the requested Lodash import can be replaced with global lodash-es.
+	// It takes the importer's lodash version range and the global lodash-es version into account.
+	canBeReplaced( file, packageName ) {
+		const requestedVersion = this.findRequestedLodashRange( file, packageName );
+		return requestedVersion && semver.satisfies( this.lodashVersion, requestedVersion );
+	}
+
+	// Get the modified request
+	getModifiedRequest( result ) {
+		const { request } = result;
+
+		if ( ! result.contextInfo || ! result.contextInfo.issuer ) {
+			return request;
+		}
+
+		// Replace plain 'lodash' with 'lodash-es'.
+		if ( /^lodash$/.test( request ) ) {
+			if ( this.canBeReplaced( result.contextInfo.issuer, 'lodash' ) ) {
+				return 'lodash-es';
+			}
+		}
+
+		// Replace 'lodash/foo' with 'lodash-es/foo'.
+		if ( /^lodash\/(.*)$/.test( request ) ) {
+			if ( this.canBeReplaced( result.contextInfo.issuer, 'lodash' ) ) {
+				return request.replace( 'lodash/', 'lodash-es/' );
+			}
+		}
+
+		// Replace 'lodash.foo' with 'lodash-es/foo'.
+		if ( /^lodash\.(.*)$/.test( request ) ) {
+			if ( this.canBeReplaced( result.contextInfo.issuer, request ) ) {
+				const match = /^lodash\.(.*)$/.exec( request );
+				let subModule = match[ 1 ];
+
+				// Normalize module names.
+				// This avoids code duplication due to module name case differences
+				// (e.g. 'camelcase' vs 'camelCase').
+				LODASH_MODULE_NAMES.forEach( casedModule => {
+					if ( subModule === casedModule.toLowerCase() ) {
+						subModule = casedModule;
+					}
+				} );
+
+				return `lodash-es/${ subModule }`;
+			}
+		}
+
+		return request;
+	}
+
+	apply( compiler ) {
+		compiler.hooks.normalModuleFactory.tap( 'LodashReplacementPlugin', nmf => {
+			nmf.hooks.beforeResolve.tap( 'LodashReplacementPlugin', result => {
+				if ( ! result ) return;
+				result.request = this.getModifiedRequest( result );
+				return result;
+			} );
+			nmf.hooks.afterResolve.tap( 'LodashReplacementPlugin', result => {
+				if ( ! result ) return;
+				result.request = this.getModifiedRequest( result );
+				return result;
+			} );
+		} );
+	}
+}
+
+module.exports = ExtensiveLodashReplacementPlugin;

--- a/packages/webpack-extensive-lodash-replacement-plugin/package.json
+++ b/packages/webpack-extensive-lodash-replacement-plugin/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "@automattic/webpack-extensive-lodash-replacement-plugin",
+	"private": true,
+	"version": "0.0.1",
+	"description": "Webpack plugin to replace lodash, lodash/foo and lodash.foo imports with lodash-es",
+	"keywords": [
+		"Webpack",
+		"lodash"
+	],
+	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/webpack-extensive-lodash-replacement-plugin",
+	"license": "GPL-2.0-or-later",
+	"publishConfig": {
+		"access": "public"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/webpack-extensive-lodash-replacement-plugin"
+	},
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"scripts": {},
+	"peerDependencies": {
+		"webpack": "^4.29.6"
+	},
+	"dependencies": {
+		"find-package-json": "^1.2.0",
+		"semver": "^6.1.1"
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ const Minify = require( '@automattic/calypso-build/webpack/minify' );
 const SassConfig = require( '@automattic/calypso-build/webpack/sass' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
 const { cssNameFromFilename } = require( '@automattic/calypso-build/webpack/util' );
+const ExtensiveLodashReplacementPlugin = require( '@automattic/webpack-extensive-lodash-replacement-plugin' );
 
 /**
  * Internal dependencies
@@ -324,34 +325,7 @@ if ( ! config.isEnabled( 'desktop' ) ) {
 
 // Replace `lodash` with `lodash-es`.
 if ( isCalypsoClient ) {
-	webpackConfig.plugins.push(
-		// Replace plain 'lodash' with 'lodash-es'.
-		new webpack.NormalModuleReplacementPlugin( /^lodash$/, 'lodash-es' ),
-		// Replace 'lodash/foo' with 'lodash-es/foo'.
-		new webpack.NormalModuleReplacementPlugin( /^lodash\/(.*)$/, resource => {
-			resource.request = resource.request.replace( 'lodash/', 'lodash-es/' );
-		} ),
-		// Replace 'lodash.foo' with 'lodash-es/foo'.
-		new webpack.NormalModuleReplacementPlugin( /^lodash\.(.*)$/, resource => {
-			const request = resource.request;
-			const match = /^lodash\.(.*)$/.exec( request );
-			let subModule = match[ 1 ];
-
-			// Fix module casing, ensuring `lodash.foobar` becomes `lodash-es/fooBar`.
-			// `lodash.foobar` modules get published in lowercase, but `lodash-es` submodules use camelcase.
-			// Ensuring the right case avoids code duplication and other potential problems in case-sensitive filesystems.
-			// If you come across any `There are multiple modules with names that only differ in casing` warnings on build,
-			// be sure to add the offending module to the list below.
-			const casedModules = [ 'camelCase', 'isEqual' ];
-			casedModules.forEach( casedModule => {
-				if ( subModule === casedModule.toLowerCase() ) {
-					subModule = casedModule;
-				}
-			} );
-
-			resource.request = `lodash-es/${ subModule }`;
-		} )
-	);
+	webpackConfig.plugins.push( new ExtensiveLodashReplacementPlugin() );
 }
 
 // List of polyfills that we skip including in the evergreen bundle.


### PR DESCRIPTION
We were using a Babel plugin before, which forced us to transpile code that didn't need it just for the sake of using `lodash-es` instead.

The WebPack plugin works at the compiler level, replacing `lodash` usage with `lodash-es` regardless of the module format or ES version.

#### Changes proposed in this Pull Request

* Stop transpiling `@wordpress/` modules.
* Stop using Babel plugin to transform `lodash` imports into `lodash-es` imports.
* Create new `ExtensiveLodashReplacementPlugin` instead to do the same.

#### Testing instructions

Lodash is used pretty extensively throughout Calypso, so ensuring most of it keeps working should be enough for the functional side of things. The E2E tests should help there.

For the performance side of things, icfy should help us see if there are any unexpected changes in chunk sizes.