### PR TITLE
Fix broken task

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -829,6 +829,8 @@ class WpcomChecklistComponent extends PureComponent {
 				{ ...baseProps }
 				preset="update-homepage"
 				title={ translate( 'Update your homepage' ) }
+				completedTitle={ translate( 'You updated your homepage' ) }
+				completedButtonText={ translate( 'Change' ) }
 				description={ translate(
 					`We've created the basics, now it's time for you to update the images and text.`
 				) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a bug for one of our new checklist tasks that doesn't show any title when you complete a task. The fix introduces copy for the completed task and does not appear broken.

**Before**
![before](https://user-images.githubusercontent.com/6981253/59789894-bde58580-929c-11e9-93c6-d8056b071d18.gif)

**After**
![after](https://user-images.githubusercontent.com/6981253/59789888-bcb45880-929c-11e9-862c-c4a01c45dbb8.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start/onboarding`
* pick the business or professional site type
* Mark the `Update your homepage` task complete.

