### PR TITLE
FSE: Add the site title and description to the default template header.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template-data-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template-data-inserter.php
@@ -72,9 +72,9 @@ class A8C_WP_Template_Data_Inserter {
 	 */
 	public function get_header_content() {
 		// TODO: replace with header blocks once they are ready.
-		return '<!-- wp:heading -->' .
-				'<h2>Test Header Content</h2>' .
-				'<!-- /wp:heading -->';
+		return '<!-- wp:a8c/site-title /-->' .
+				'<!-- wp:a8c/site-description /-->' .
+				'<!-- wp:a8c/navigation-menu /-->';
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template-data-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template-data-inserter.php
@@ -73,8 +73,7 @@ class A8C_WP_Template_Data_Inserter {
 	public function get_header_content() {
 		// TODO: replace with header blocks once they are ready.
 		return '<!-- wp:a8c/site-title /-->' .
-				'<!-- wp:a8c/site-description /-->' .
-				'<!-- wp:a8c/navigation-menu /-->';
+				'<!-- wp:a8c/site-description /-->';
 	}
 
 	/**


### PR DESCRIPTION
With the site title and site description blocks now merged, this PR adds them to the default header template part.

#### Testing instructions

* In your FSE test environment, switch to this branch.
* Delete everything under Templates and Template Parts (not technically needed, but makes testing easier in the next steps).
* De-activate then re-activate the FSE plugin.
* Verify the site title and site description show up in the `header` template part.
* Create a page, and apply the default template to it.
* Publish and view the page on the front-end.

Fixes #34013 