### PR TITLE
Gutenframe: Open FSE links to the customizer in parent frame

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -1,4 +1,4 @@
-/* global calypsoifyGutenberg */
+/* global calypsoifyGutenberg, wpcomGutenberg */
 
 /**
  * External dependencies
@@ -8,7 +8,7 @@ import { filter, find, forEach, get, map, partialRight } from 'lodash';
 import { dispatch, select, subscribe } from '@wordpress/data';
 import { createBlock, parse, rawHandler } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
-import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { addQueryArgs, getQueryArg, removeQueryArgs } from '@wordpress/url';
 import { Component } from 'react';
 import tinymce from 'tinymce/tinymce';
 
@@ -556,6 +556,18 @@ function openLinksInParentFrame() {
 		$( '#editor' ).on( 'click', manageReusableBlocksLinkSelectors, e => {
 			e.preventDefault();
 			window.open( calypsoifyGutenberg.manageReusableBlocksUrl, '_top' );
+		} );
+	}
+
+	if ( wpcomGutenberg.blockEditorUrl ) {
+		const customizerLinkSelector = 'a.components-button[href*="customize.php"]'; // Link in the FSE blocks edit buttons
+		$( '#editor' ).on( 'click', customizerLinkSelector, e => {
+			e.preventDefault();
+			let url = removeQueryArgs( e.currentTarget.href, 'return' );
+			url = addQueryArgs( url, {
+				return: wpcomGutenberg.blockEditorUrl,
+			} );
+			window.open( url, '_top' );
 		} );
 	}
 }

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -17,6 +17,7 @@ import MediaStore from 'lib/media/store';
 import EditorMediaModal from 'post-editor/editor-media-modal';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import {
+	getCustomizerUrl,
 	getSiteOption,
 	getSiteAdminUrl,
 	isRequestingSites,
@@ -87,6 +88,7 @@ enum EditorActions {
 	SetDraftId = 'draftIdSet',
 	TrashPost = 'trashPost',
 	ConversionRequest = 'triggerConversionRequest',
+	OpenCustomizer = 'openCustomizer',
 }
 
 class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedFormProps, State > {
@@ -239,6 +241,11 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			const { postUrl } = payload;
 			this.openPreviewModal( postUrl, ports[ 0 ] );
 		}
+
+		if ( EditorActions.OpenCustomizer === action ) {
+			const { autofocus = null, unsavedChanges = false } = payload;
+			this.openCustomizer( autofocus, unsavedChanges );
+		}
 	};
 
 	loadRevision = ( {
@@ -365,6 +372,25 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	};
 
 	closePreviewModal = () => this.setState( { isPreviewVisible: false } );
+
+	openCustomizer = ( autofocus: object, unsavedChanges: boolean ) => {
+		let { customizerUrl } = this.props;
+		if ( autofocus ) {
+			const [ key, value ] = Object.entries( autofocus )[ 0 ];
+			customizerUrl = addQueryArgs(
+				{
+					[ `autofocus[${ key }]` ]: value,
+				},
+				customizerUrl
+			);
+		}
+		if ( unsavedChanges ) {
+			this.props.markChanged();
+		} else {
+			this.props.markSaved();
+		}
+		this.props.navigate( customizerUrl );
+	};
 
 	handleConversionResponse = ( confirmed: boolean ) => {
 		this.setState( { isConversionPromptVisible: false } );
@@ -517,6 +543,7 @@ const mapStateToProps = ( state, { postId, postType, duplicatePostId }: Props ) 
 		shouldLoadIframe,
 		siteAdminUrl,
 		siteId,
+		customizerUrl: getCustomizerUrl( state, siteId ),
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously, the links to the customizer of the FSE blocks' edit buttons were opened in the child frame of the WordPress.com block editor, causing a sad-browser error because the customizer is not allowed to be embed in an iframe.

Furthermore, those links were pointing to the WP Admin customizer, but we should use the Calypso Customizer (`https://wordpress.com/customize/:domain`) on WP.com sites.

This PR ensures that we open the Calypso Customizer when the edit links of the FSE blocks are clicked by sending a message to the client side that caused a navigation to the Customizer within Calypso.

#### Testing instructions

- Update the `wpcom-block-editor` build of your sandbox following instructions available at PCYsg-l4k-p2#building-and-testing-changes.
- Make sure the Full Site Editing plugin is available in your sandbox by following instructions available at PCYsg-ly5-p2#activating-the-plugin-on-wordpress-com.
- Go to http://calypso.localhost:3000/block-editor and select your sandbox site.
- Insert any FSE block that contains an edit link to the customizer (i.e. 'Navigation Menu' or 'Site Logo').
- Click on the edit button of the block (the one with the pencil icon).
- Make sure the Customizer is opened on the parent frame and you get the Calypso Customizer (`http://calypso.localhost:3000/customize/:domain`) instead of the  WP Admin Customizer (`:domain/wp-admin/customize.php`).

Fixes #34005
