### PR TITLE
Full Site Editing: render child blocks using BlockEdit

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -4,20 +4,21 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { get } from 'lodash';
+import { get, noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { Button, IconButton, Placeholder, Toolbar } from '@wordpress/components';
-import { compose, withState } from '@wordpress/compose';
 import { parse, createBlock } from '@wordpress/blocks';
 import { BlockEdit } from '@wordpress/block-editor';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { Button, IconButton, Placeholder, Toolbar, Spinner, Disabled } from '@wordpress/components';
+import { compose, withState } from '@wordpress/compose';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { BlockControls } from '@wordpress/editor';
 import { Fragment, useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
+
 /**
  * Internal dependencies
  */
@@ -25,41 +26,75 @@ import PostAutocomplete from '../../components/post-autocomplete';
 import './style.scss';
 
 const TemplateEdit = compose(
-	withSelect( ( select, { attributes } ) => {
+	withState( { isEditing: false, templateClientId: null } ),
+	withSelect( ( select, { attributes, templateClientId } ) => {
 		const { getEntityRecord } = select( 'core' );
 		const { getCurrentPostId } = select( 'core/editor' );
+		const { getBlock } = select( 'core/block-editor' );
 
 		const { templateId } = attributes;
-
 		const template = templateId && getEntityRecord( 'postType', 'wp_template_part', templateId );
-		const parsedBlocks = parse( get( template, [ 'content', 'raw' ] ) );
-		const parsedBlock =
-			parsedBlocks.length === 1
-				? parsedBlocks[ 0 ]
-				: createBlock( 'core/template', {}, parsedBlocks );
 
 		return {
 			currentPostId: getCurrentPostId(),
 			template,
-			parsedBlock,
+			templateBlock: getBlock( templateClientId ),
 		};
 	} ),
-	withDispatch( dispatch => ( {
-		receiveBlocks: dispatch( 'core/block-editor' ).receiveBlocks,
-	} ) ),
-	withState( { isEditing: false } )
+	withDispatch( ( dispatch, ownProps ) => {
+		const { receiveBlocks } = dispatch( 'core/block-editor' );
+		const { template, templateClientId, setState } = ownProps;
+
+		return {
+			receiveTemplateBlocks: () => {
+				if ( ! template || templateClientId ) {
+					return;
+				}
+
+				const templateBlocks = parse( get( template, [ 'content', 'raw' ], '' ) );
+				const templateBlock =
+					templateBlocks.length === 1
+						? templateBlocks[ 0 ]
+						: createBlock( 'core/template', {}, templateBlocks );
+
+				receiveBlocks( [ templateBlock ] );
+				setState( { templateClientId: templateBlock.clientId } );
+			},
+		};
+	} )
 )(
 	( {
 		attributes,
 		currentPostId,
 		isEditing,
-		parsedBlock,
-		receiveBlocks,
+		receiveTemplateBlocks,
 		setAttributes,
 		setState,
 		template,
+		templateBlock,
 	} ) => {
+		const isTemplate = 'wp_template' === fullSiteEditing.editorPostType;
 		const { align, templateId } = attributes;
+		const showToggleButton = ! isEditing || !! templateId;
+		const showPlaceholder = isEditing || ! templateId;
+		const showContent = ! isEditing && !! templateId && template;
+
+		const editTemplatePartUrl = addQueryArgs( fullSiteEditing.editTemplatePartBaseUrl, {
+			post: templateId,
+			fse_parent_post: currentPostId,
+		} );
+
+		if ( ! isTemplate && templateId && ! template ) {
+			return (
+				<Placeholder>
+					<Spinner />
+				</Placeholder>
+			);
+		}
+
+		useEffect( () => {
+			receiveTemplateBlocks();
+		} );
 
 		const toggleEditing = () => setState( { isEditing: ! isEditing } );
 
@@ -68,64 +103,21 @@ const TemplateEdit = compose(
 			setAttributes( { templateId: id } );
 		};
 
-		const showToggleButton = ! isEditing || !! templateId;
-		const showPlaceholder = isEditing || ! templateId;
-		const showContent = ! isEditing && !! templateId;
-		const isTemplate = 'wp_template' === fullSiteEditing.editorPostType;
-
-		useEffect( () => {
-			if ( ! parsedBlock ) {
-				return;
-			}
-
-			receiveBlocks( [ parsedBlock ] );
-		} );
-
-	const editTemplatePartUrl = addQueryArgs( fullSiteEditing.editTemplatePartBaseUrl, {
-		post: templateId,
-		fse_parent_post: currentPostId,
-	} );
-
-	return (
-		<Fragment>
-			{ showToggleButton && isTemplate && (
-				<BlockControls>
-					<Toolbar>
-						<IconButton
-							className={ classNames( 'components-icon-button components-toolbar__control', {
-								'is-active': isEditing,
-							} ) }
-							label={ __( 'Change Template Part' ) }
-							onClick={ toggleEditing }
-							icon="edit"
-						/>
-					</Toolbar>
-				</BlockControls>
-			) }
-			<div
-				className={ classNames( 'template-block', {
-					[ `align${ align }` ]: align,
-				} ) }
-			>
-				{ showPlaceholder && (
-					<Placeholder
-						icon="layout"
-						label={ __( 'Template Part' ) }
-						instructions={ __( 'Select a template part to display' ) }
-					>
-						<div className="template-block__selector">
-							<PostAutocomplete
-								initialValue={ get( template, [ 'title', 'rendered' ] ) }
-								onSelectPost={ onSelectTemplate }
-								postType="wp_template_part"
+		return (
+			<Fragment>
+				{ showToggleButton && isTemplate && (
+					<BlockControls>
+						<Toolbar>
+							<IconButton
+								className={ classNames( 'components-icon-button components-toolbar__control', {
+									'is-active': isEditing,
+								} ) }
+								label={ __( 'Change Template Part' ) }
+								onClick={ toggleEditing }
+								icon="edit"
 							/>
-							{ !! template && (
-								<a href={ editTemplatePartUrl }>
-									{ sprintf( __( 'Edit "%s"' ), get( template, [ 'title', 'rendered' ], '' ) ) }
-								</a>
-							) }
-						</div>
-					</Placeholder>
+						</Toolbar>
+					</BlockControls>
 				) }
 				<div
 					className={ classNames( 'template-block', {
@@ -145,23 +137,45 @@ const TemplateEdit = compose(
 									postType="wp_template_part"
 								/>
 								{ !! template && (
-									<a
-										href={ `?post=${ templateId }&action=edit&fse_parent_post=${ currentPostId }` }
-									>
+									<a href={ editTemplatePartUrl }>
 										{ sprintf( __( 'Edit "%s"' ), get( template, [ 'title', 'rendered' ], '' ) ) }
 									</a>
 								) }
-							>
-								<Button href={ editTemplatePartUrl } isDefault>
-									{ sprintf( __( 'Edit %s' ), get( template, [ 'title', 'rendered' ], '' ) ) }
-								</Button>
-							</Placeholder>
-						) }
-					</Fragment>
-				) }
-			</div>
-		</Fragment>
-	);
-} );
+							</div>
+						</Placeholder>
+					) }
+					{ showContent && (
+						<Fragment>
+							{ templateBlock && (
+								<Disabled>
+									<BlockEdit
+										attributes={ templateBlock.attributes }
+										block={ templateBlock }
+										clientId={ templateBlock.clientId }
+										isSelected={ false }
+										name={ templateBlock.name }
+										setAttributes={ noop }
+									/>
+								</Disabled>
+							) }
+							{ ! isTemplate && (
+								<Placeholder
+									className="template-block__overlay"
+									instructions={ __(
+										'This block is part of your site template and may appear on multiple pages.'
+									) }
+								>
+									<Button href={ editTemplatePartUrl } isDefault>
+										{ sprintf( __( 'Edit %s' ), get( template, [ 'title', 'rendered' ], '' ) ) }
+									</Button>
+								</Placeholder>
+							) }
+						</Fragment>
+					) }
+				</div>
+			</Fragment>
+		);
+	}
+);
 
 export default TemplateEdit;

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -31,6 +31,7 @@
 	"dependencies": {
 		"@wordpress/api-fetch": "^3.1.2",
 		"@wordpress/blocks": "^6.2.3",
+		"@wordpress/block-editor": "^2.2.0",
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",
 		"@wordpress/data": "^4.4.0",


### PR DESCRIPTION
Uses the `<BlockEdit />` component instead of `<RawHTML />` to render the child blocks of the template part.

#### The Problem

When we edit a block and set a property like _overlay_ or _text colour_ using the _Block Sidebar_, some CSS classes (like `has-background-dim-##` or `has-*-background-color`) are appended to the block. Those CSS classes are not loaded with the _Editor Styles_, so, to compensate for their absence some inline styles are added to the `edit` instance of the block. By design, those inline styles are not persisted when saving the HTML representation of the block.

When we load the raw content of the template part for preview, it could potentially show broken.

| Edit | Preview |
| - | - |
| ![Screen Shot 2019-07-04 at 14 47 52](https://user-images.githubusercontent.com/233601/60682795-1145ff00-9e6b-11e9-8f20-682b6e8256f2.png) | ![Screen Shot 2019-07-04 at 14 49 03](https://user-images.githubusercontent.com/233601/60682803-1905a380-9e6b-11e9-862e-3c6d083f570a.png) |

#### Changes proposed in this Pull Request

Instead of loading the raw content, we need to parse the template blocks and add them to the editor state.

- Show a `<Spinner />` while loading the template post.
- Parse the template block from the post raw content.
- Create a `core/template` block if the template has multiple blocks. This is because we need to store the clientId on the state for later use.
- Add the received blocks to the editor state using `receiveBlocks` and preserve the clientId of the template top-most component in the state.
- If the template block has been added to the state, render it using the `<BlockEdit />` component.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/233601/60691930-7ae4fe00-9ea9-11e9-9601-d9669a052d68.gif) | ![after](https://user-images.githubusercontent.com/233601/60691962-a49e2500-9ea9-11e9-813a-c567cb9818ad.gif) |

#### Alternative Approaches that almost worked

##### Adding the missing classes to the _Editor Styles_

The _Editor Styles_ are loaded when the editor is initialized (`wp.editPost.initializeEditor`) and stored in the state on the `core/editor` store. Settings can be changed by dispatching a `updateEditorSettings` action with the extra styles. The problem with this approach was that the mechanisms to detect the need to add extra CSS declarations depends on knowing the allowed themes and all the class variants. This could be viable now but could be difficult to maintain.
There is also a problem of timing because the editor is initialized on `domReady`. We need to delay the execution of our code with the potential of making the content _flash_.

##### Using `<InnerBlocks />` or `<BlockList />`

Instead of using `receiveBlocks` to add the template blocks to the editor state and render them manually, we could use `replaceInnerBlocks` to add them as children to the template part block when we load them. Then we could delegate the rendering to `<InnerBlocks />` (or `<BlockList />`).
This works fine, but it has a couple of undesirable side effect. The focus of the editor is set to the last block added, making the page jump to the footer. And the _appender_ is shown unless we override the template lock.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Edit a Template part. Add a paragraph with Color, or a Cover with an Overlay.
- Verify that all the blocks inside the template part render correctly.
- Verify that there are no regressions when editing a template.

Fixes #34102 