### PR TITLE
Full Site Editing: Adds a better background color to the edit overlay

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -35,4 +35,5 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
+	background: rgba( #8b8b96, 0.8 );
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -35,5 +35,5 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-	background: rgba( #8b8b96, 0.8 );
+	background: rgba( #8b8b96, 0.95 );
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -35,5 +35,9 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
-	background: rgba( #8b8b96, 0.95 );
+	background: rgba( #000000, 0.75 );
+
+	.components-placeholder__instructions {
+		color: white;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes a small change in the background of the `<Placeholder />` that acts as an overlay of the _Template Part_ block when editing a page.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/233601/59827170-58ca7800-930e-11e9-8ad5-7f859dbf3b96.png) | ![FireShot Capture 023 - Edit Page ‹ Gutenberg Dev — WordPress - localhost](https://user-images.githubusercontent.com/233601/59951615-de097600-944f-11e9-94df-5dc1015021a0.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Edit a Page and verify that the overlay text and buttons are visible. Edit the _Template Part_ with different blocks (images, covers, different text combinations) to verify that the overlay is readable.

Fixes #34073 
