### PR TITLE
Add save button to FSE Site Title Block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -20,11 +20,11 @@ function SiteDescriptionEdit( {
 	shouldUpdateSiteOption,
 	isSelected,
 } ) {
-	const defaultDescription = __( 'Site description loading…' );
+	const inititalDescription = __( 'Site description loading…' );
 
 	const { onSave, siteOptions, setSiteOptions } = useSiteOptions(
 		'description',
-		defaultDescription,
+		inititalDescription,
 		noticeOperations,
 		isSelected,
 		shouldUpdateSiteOption

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -1,121 +1,60 @@
 /**
  * External dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { PlainText } from '@wordpress/editor';
 import { withNotices, Button } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
-import { Component, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-class SiteDescriptionEdit extends Component {
-	state = {
-		description: __( 'Site description loading…' ),
-		initialDescription: '',
-		isDirty: false,
-		isSaving: false,
-	};
+/**
+ * Internal dependencies
+ */
+import useSiteOptions from '../useSiteOptions';
 
-	componentDidMount() {
-		const { noticeOperations } = this.props;
+function SiteDescriptionEdit( {
+	className,
+	noticeUI,
+	noticeOperations,
+	shouldUpdateSiteOption,
+	isSelected,
+} ) {
+	const defaultDescription = __( 'Site description loading…' );
 
-		return apiFetch( { path: '/wp/v2/settings' } )
-			.then( ( { description } ) =>
-				this.setState( { initialDescription: description, description } )
-			)
-			.catch( ( { message } ) => {
-				noticeOperations.createErrorNotice( message );
-			} );
-	}
+	const { onSave, siteOptions, setSiteOptions } = useSiteOptions(
+		'description',
+		defaultDescription,
+		noticeOperations,
+		isSelected,
+		shouldUpdateSiteOption
+	);
 
-	componentDidUpdate( prevProps ) {
-		const { description, initialDescription } = this.state;
-		const { shouldUpdateSiteOption, isSelected } = this.props;
+	const { option, isDirty, isSaving } = siteOptions;
 
-		const descriptionUnchanged = description && description.trim() === initialDescription.trim();
-		const descriptionIsEmpty = ! description || description.trim().length === 0;
-
-		// Reset to initial value if user de-selects the block with an empty value.
-		if ( ! isSelected && prevProps.isSelected && descriptionIsEmpty ) {
-			this.revertDescription();
-		}
-
-		// Don't do anything further if we shouldn't update the site option or the value is unchanged.
-		if ( ! shouldUpdateSiteOption || descriptionUnchanged ) {
-			return;
-		}
-
-		if ( ! prevProps.shouldUpdateSiteOption && shouldUpdateSiteOption ) {
-			this.saveSiteDescription( description );
-		}
-	}
-
-	onSave = () => {
-		const { description, initialDescription } = this.state;
-		const descriptionUnchanged = description && description.trim() === initialDescription.trim();
-
-		if ( descriptionUnchanged ) {
-			this.setState( { isDirty: false } );
-			return;
-		}
-		this.saveSiteDescription( description );
-	};
-
-	saveSiteDescription( description ) {
-		const { noticeOperations } = this.props;
-		this.setState( { isSaving: true } );
-		apiFetch( { path: '/wp/v2/settings', method: 'POST', data: { description } } )
-			.then( () => this.updateInitialDescription() )
-			.catch( ( { message } ) => {
-				noticeOperations.createErrorNotice( message );
-				this.revertDescription();
-			} );
-	}
-
-	revertDescription = () =>
-		this.setState( {
-			description: this.state.initialDescription,
-			isSaving: false,
-		} );
-
-	updateInitialDescription = () => {
-		this.setState( {
-			initialDescription: this.state.description,
-			isDirty: false,
-			isSaving: false,
-		} );
-	};
-
-	render() {
-		const { className, noticeUI } = this.props;
-		const { description, isDirty, isSaving } = this.state;
-
-		return (
-			<Fragment>
-				{ noticeUI }
-				<PlainText
-					className={ className }
-					value={ description }
-					onChange={ value => this.setState( { description: value, isDirty: true } ) }
-					placeholder={ __( 'Site Description' ) }
-					aria-label={ __( 'Site Description' ) }
-				/>
-				{ isDirty && (
-					<Button
-						ref={ this.editButton }
-						isLarge
-						className="site-description__save-button"
-						disabled={ isSaving }
-						isBusy={ isSaving }
-						onClick={ this.onSave }
-					>
-						{ __( 'Save' ) }
-					</Button>
-				) }
-			</Fragment>
-		);
-	}
+	return (
+		<Fragment>
+			{ noticeUI }
+			<PlainText
+				className={ className }
+				value={ option }
+				onChange={ value => setSiteOptions( { ...siteOptions, option: value, isDirty: true } ) }
+				placeholder={ __( 'Site Description' ) }
+				aria-label={ __( 'Site Description' ) }
+			/>
+			{ isDirty && (
+				<Button
+					isLarge
+					className="site-description__save-button"
+					disabled={ isSaving }
+					isBusy={ isSaving }
+					onClick={ onSave }
+				>
+					{ __( 'Save' ) }
+				</Button>
+			) }
+		</Fragment>
+	);
 }
 
 export default compose( [

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
@@ -25,10 +25,10 @@ function SiteTitleEdit( {
 	shouldUpdateSiteOption,
 	isSelected,
 } ) {
-	const defaultTitle = __( 'Site title loading…' );
+	const inititalTitle = __( 'Site title loading…' );
 	const { onSave, siteOptions, setSiteOptions } = useSiteOptions(
 		'title',
-		defaultTitle,
+		inititalTitle,
 		noticeOperations,
 		isSelected,
 		shouldUpdateSiteOption

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
@@ -1,12 +1,19 @@
-.block-editor .wp-block-a8c-site-title {
-	&, &:focus {
-		display: inline;
-        color: #111111;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-		font-size: 1.125em;
-		font-weight: normal;
-        letter-spacing: -0.02em;
-        line-height: 1.2;
-		margin: 0;
+.block-editor {
+	.wp-block-a8c-site-title {
+		&, &:focus {
+			display: inline;
+			color: #111111;
+			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
+				'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+			font-size: 1.125em;
+			font-weight: normal;
+			letter-spacing: -0.02em;
+			line-height: 1.2;
+			margin: 0;
+		}
+	}
+	.site-title__save-button {
+		margin-left: auto;
+		display: block;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/usePrevious.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/usePrevious.js
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+
+export default function usePrevious( value ) {
+	// The ref object is a generic container whose current property is mutable ...
+	// ... and can hold any value, similar to an instance property on a class
+	const ref = useRef();
+
+	// Store current value in ref
+	useEffect( () => {
+		ref.current = value;
+	}, [ value ] ); // Only re-run if value changes
+
+	// Return previous value (happens before update in useEffect above)
+	return ref.current;
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/usePrevious.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/usePrevious.js
@@ -3,16 +3,20 @@
  */
 import { useEffect, useRef } from '@wordpress/element';
 
+/**
+ * Custom hook to provide the previous value of state or props in a functional component
+ *
+ * see https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+ *
+ * @param  {any}  value state or prop value for which previous value is required
+ * @return {any}  previous value of requested state or prop value
+ */
 export default function usePrevious( value ) {
-	// The ref object is a generic container whose current property is mutable ...
-	// ... and can hold any value, similar to an instance property on a class
 	const ref = useRef();
 
-	// Store current value in ref
 	useEffect( () => {
 		ref.current = value;
-	}, [ value ] ); // Only re-run if value changes
+	}, [ value ] );
 
-	// Return previous value (happens before update in useEffect above)
 	return ref.current;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/useSiteOptions.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/useSiteOptions.js
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import usePrevious from './usePrevious';
+
+export default function useSiteOptions(
+	siteOption,
+	defaultOption,
+	noticeOperations,
+	isSelected,
+	shouldUpdateSiteOption
+) {
+	const [ siteOptions, setSiteOptions ] = useState( {
+		option: defaultOption,
+		initialOption: '',
+		loaded: false,
+		isDirty: false,
+		isSaving: false,
+	} );
+
+	const prevIsSelected = usePrevious( isSelected );
+	const prevShouldUpdateSiteOption = usePrevious( shouldUpdateSiteOption );
+
+	useEffect( () => {
+		if ( ! siteOptions.loaded ) {
+			loadSiteOption();
+		} else {
+			updateSiteOption();
+		}
+	} );
+
+	function loadSiteOption() {
+		apiFetch( { path: '/wp/v2/settings' } )
+			.then( result =>
+				setSiteOptions( {
+					...siteOptions,
+					option: result[ siteOption ],
+					intialOption: result[ siteOption ],
+					loaded: true,
+				} )
+			)
+			.catch( ( { message } ) => {
+				noticeOperations.createErrorNotice( message );
+			} );
+	}
+
+	function updateSiteOption() {
+		const { option, initialOption } = siteOptions;
+		const optionUnchanged = option && option.trim() === initialOption.trim();
+		const optionIsEmpty = ! option || option.trim().length === 0;
+
+		// Reset to initial value if user de-selects the block with an empty value.
+		if ( ! isSelected && prevIsSelected && optionIsEmpty ) {
+			revertOption();
+		}
+
+		// Don't do anything further if we shouldn't update the site option or the value is unchanged.
+		if ( ! shouldUpdateSiteOption || optionUnchanged ) {
+			return;
+		}
+
+		if ( ! prevShouldUpdateSiteOption && shouldUpdateSiteOption ) {
+			saveSiteOption( option );
+		}
+	}
+
+	function onSave() {
+		const { option, initialOption } = siteOptions;
+		const optionUnchanged = option && option.trim() === initialOption.trim();
+
+		if ( optionUnchanged ) {
+			setSiteOptions( { ...siteOptions, isDirty: false } );
+			return;
+		}
+		saveSiteOption( option );
+	}
+
+	function saveSiteOption( option ) {
+		setSiteOptions( { ...siteOptions, isSaving: true } );
+		apiFetch( { path: '/wp/v2/settings', method: 'POST', data: { [ siteOption ]: option } } )
+			.then( () => updateInitialOption( option ) )
+			.catch( ( { message } ) => {
+				noticeOperations.createErrorNotice( message );
+				revertOption();
+			} );
+	}
+
+	function revertOption() {
+		setSiteOptions( {
+			...siteOptions,
+			option: siteOptions.initialOption,
+			isSaving: false,
+		} );
+	}
+
+	function updateInitialOption( option ) {
+		setSiteOptions( {
+			...siteOptions,
+			initialOption: option,
+			isDirty: false,
+			isSaving: false,
+		} );
+	}
+
+	return { siteOptions, setSiteOptions, onSave };
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the temporary save button from Site Description to the FSE Site Title Block 

* Share the Site Option loading and updating code between Site Title and Description blocks using a custom hook. The React team are suggesting hooks as the way forward instead of class components and HOCs. Hooks have already landed in Gutenberg core - https://unfoldingneurons.com/2019/fantastic-hooks-and-where-to-use-them - so thought it was worth at least exploring the option of using a custom useSiteOptions hook to share the site options fetch and update logic between the FSE blocks. Happy to revert back to class components and copy and paste of the save button logic to the site title block if we feel it is still too early to abstract this.

#### Testing instructions
* Checkout branch
* Make sure you have the wp-calypso/apps/full-site-editing/full-site-editing-plugin compiled plugin plumbed through to your local gutenberg dev setup and activated
* Edit a Page and add the Site Title block
* The Editor Update button should be active so save the change
* Select the Site Title block again and edit the content, and a save button should appear. 
* Click the Save button - it should show busy and disabled and then disappear once save complete
* Edit the title again and then edit another block on the page to make `Update` active. Clicking`Update` should also make the description save again and the button disappear.
* Repeat the above steps for Site Description block
