### PR TITLE
Plans: use named exports from controller

### DIFF
--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -1,20 +1,16 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 import React from 'react';
-
 import { get } from 'lodash';
 
 /**
  * Internal Dependencies
  */
-import { isValidFeatureKey } from 'lib/plans/features-list';
-import Plans from './plans';
 import CheckoutData from 'components/data/checkout';
+import Plans from './plans';
+import { isValidFeatureKey } from 'lib/plans/features-list';
 
 export default {
 	plans( context, next ) {

--- a/client/my-sites/plans/controller.jsx
+++ b/client/my-sites/plans/controller.jsx
@@ -12,49 +12,47 @@ import CheckoutData from 'components/data/checkout';
 import Plans from './plans';
 import { isValidFeatureKey } from 'lib/plans/features-list';
 
-export default {
-	plans( context, next ) {
-		context.primary = (
-			<CheckoutData>
-				<Plans
-					context={ context }
-					intervalType={ context.params.intervalType }
-					customerType={ context.query.customerType }
-					selectedFeature={ context.query.feature }
-					selectedPlan={ context.query.plan }
-					withDiscount={ context.query.discount }
-					discountEndDate={ context.query.ts }
-				/>
-			</CheckoutData>
-		);
-		next();
-	},
+export function plans( context, next ) {
+	context.primary = (
+		<CheckoutData>
+			<Plans
+				context={ context }
+				intervalType={ context.params.intervalType }
+				customerType={ context.query.customerType }
+				selectedFeature={ context.query.feature }
+				selectedPlan={ context.query.plan }
+				withDiscount={ context.query.discount }
+				discountEndDate={ context.query.ts }
+			/>
+		</CheckoutData>
+	);
+	next();
+}
 
-	features( context ) {
-		const domain = context.params.domain;
-		const feature = get( context, 'params.feature' );
-		let comparePath = domain ? `/plans/${ domain }` : '/plans/';
+export function features( context ) {
+	const domain = context.params.domain;
+	const feature = get( context, 'params.feature' );
+	let comparePath = domain ? `/plans/${ domain }` : '/plans/';
 
-		if ( isValidFeatureKey( feature ) ) {
-			comparePath += '?feature=' + feature;
-		}
+	if ( isValidFeatureKey( feature ) ) {
+		comparePath += '?feature=' + feature;
+	}
 
-		// otherwise redirect to the compare page if not found
-		page.redirect( comparePath );
-	},
+	// otherwise redirect to the compare page if not found
+	page.redirect( comparePath );
+}
 
-	redirectToCheckout( context ) {
-		// this route is deprecated, use `/checkout/:site/:plan` to link to plan checkout
-		page.redirect( `/checkout/${ context.params.domain }/${ context.params.plan }` );
-	},
+export function redirectToCheckout( context ) {
+	// this route is deprecated, use `/checkout/:site/:plan` to link to plan checkout
+	page.redirect( `/checkout/${ context.params.domain }/${ context.params.plan }` );
+}
 
-	redirectToPlans( context ) {
-		const siteDomain = context.params.domain;
+export function redirectToPlans( context ) {
+	const siteDomain = context.params.domain;
 
-		if ( siteDomain ) {
-			return page.redirect( `/plans/${ siteDomain }` );
-		}
+	if ( siteDomain ) {
+		return page.redirect( `/plans/${ siteDomain }` );
+	}
 
-		return page.redirect( '/plans' );
-	},
-};
+	return page.redirect( '/plans' );
+}

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/my-sites/plans/index.js
+++ b/client/my-sites/plans/index.js
@@ -6,63 +6,42 @@ import page from 'page';
 /**
  * Internal dependencies
  */
-import plansController from './controller';
+import { features, plans, redirectToCheckout, redirectToPlans } from './controller';
 import { currentPlan } from './current-plan/controller';
 import { makeLayout, render as clientRender } from 'controller';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 
 export default function() {
 	page( '/plans', siteSelection, sites, makeLayout, clientRender );
-	page(
-		'/plans/compare',
-		siteSelection,
-		navigation,
-		plansController.redirectToPlans,
-		makeLayout,
-		clientRender
-	);
+	page( '/plans/compare', siteSelection, navigation, redirectToPlans, makeLayout, clientRender );
 	page(
 		'/plans/compare/:domain',
 		siteSelection,
 		navigation,
-		plansController.redirectToPlans,
+		redirectToPlans,
 		makeLayout,
 		clientRender
 	);
-	page(
-		'/plans/features',
-		siteSelection,
-		navigation,
-		plansController.redirectToPlans,
-		makeLayout,
-		clientRender
-	);
+	page( '/plans/features', siteSelection, navigation, redirectToPlans, makeLayout, clientRender );
 	page(
 		'/plans/features/:domain',
 		siteSelection,
 		navigation,
-		plansController.redirectToPlans,
+		redirectToPlans,
 		makeLayout,
 		clientRender
 	);
-	page( '/plans/features/:feature/:domain', plansController.features, makeLayout, clientRender );
+	page( '/plans/features/:feature/:domain', features, makeLayout, clientRender );
 	page( '/plans/my-plan', siteSelection, sites, navigation, currentPlan, makeLayout, clientRender );
 	page( '/plans/my-plan/:site', siteSelection, navigation, currentPlan, makeLayout, clientRender );
 	page(
 		'/plans/select/:plan/:domain',
 		siteSelection,
-		plansController.redirectToCheckout,
+		redirectToCheckout,
 		makeLayout,
 		clientRender
 	);
 
 	// This route renders the plans page for both WPcom and Jetpack sites.
-	page(
-		'/plans/:intervalType?/:site',
-		siteSelection,
-		navigation,
-		plansController.plans,
-		makeLayout,
-		clientRender
-	);
+	page( '/plans/:intervalType?/:site', siteSelection, navigation, plans, makeLayout, clientRender );
 }


### PR DESCRIPTION
Plans controller was exporting an object with route handlers as properties. The object really represents the exported functionality of the module, replace the default object literal with named exports.

#### Testing instructions

* The plans routes should continue to work as before. No funcitonal changes.
