### PR TITLE
FSE: Account for locales with dash

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 0.2
+ * Version: 0.2.1
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -98,7 +98,7 @@ function a8c_fse_on_plugin_activation() {
 	/**
 	 * Can be used to disable Full Site Editing functionality.
 	 *
-	 * @since 0.1
+	 * @since 0.2
 	 *
 	 * @param bool true if Full Site Editing should be disabled, false otherwise.
 	 */

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -40,6 +40,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 
+= 0.2.1 =
+* Bug fix with sub-locales.
+
 = 0.2 =
 * Bug fixes and performance improvements.
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -199,7 +199,7 @@ class Starter_Page_Templates {
 	private function get_iso_639_locale() {
 		$language = strtolower( get_locale() );
 
-		if ( in_array( $language, [ 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn'], true ) ) {
+		if ( in_array( $language, [ 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ], true ) ) {
 			$language = str_replace( '_', '-', $language );
 		} else {
 			$language = preg_replace( '/([-_].*)$/i', '', $language );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -199,10 +199,10 @@ class Starter_Page_Templates {
 	private function get_iso_639_locale() {
 		$language = strtolower( get_locale() );
 
-		if ( in_array( $language, [ 'zh_tw', 'zh_cn' ], true ) ) {
+		if ( in_array( $language, [ 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn'], true ) ) {
 			$language = str_replace( '_', '-', $language );
 		} else {
-			$language = preg_replace( '/(_.*)$/i', '', $language );
+			$language = preg_replace( '/([-_].*)$/i', '', $language );
 		}
 
 		return $language;


### PR DESCRIPTION
Fixes a bug where `en-gb` or `fr-ca`  locales would not be shortened to their parent locale

To test:
* Set your site to a locale with a dash, one of the two mentioned above will do.
* Go to https://horizon.wordpress.com/block-editor/page/ and select a site.
* Make sure the page template selector shows up.