### PR TITLE
Notice: Make sure Gridicon is centred when the notice text is long

### DIFF
--- a/client/components/notice/style.scss
+++ b/client/components/notice/style.scss
@@ -82,20 +82,12 @@
 	background: var( --color-text-subtle );
 	color: var( --color-white );
 	display: flex;
-	align-items: baseline;
+	align-items: center;
 	width: 47px;
 	justify-content: center;
 	border-radius: 3px 0 0 3px;
 	flex-shrink: 0;
 	align-self: stretch;
-
-	.gridicon {
-		margin-top: 10px;
-
-		@include breakpoint( '>480px' ) {
-			margin-top: 12px;
-		}
-	}
 }
 
 .notice__content {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Switch the wrapper alignment from baseline to center
* Remove Gridicon's margin-top

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Find any place on Calypso where a notice is shown (easiest option is to visit the https://wordpress.com/plans page on a paid site)
* Reduce the browser width
* As the width gets lesser, the notice text gets wrapped in two lines and the Gridicon will be vertically aligned.

__Before:__

![Screenshot 2019-04-08 at 20 20 45](https://user-images.githubusercontent.com/18581859/55733815-1813d000-5a3c-11e9-932b-a4ba053d22de.png)

__After:__

![Screenshot 2019-04-08 at 20 21 08](https://user-images.githubusercontent.com/18581859/55733817-18ac6680-5a3c-11e9-9c4e-1bff3e3c588d.png)

#### Note

This PR will also make the alignment consistent with the Banner component:

![Screenshot 2019-06-20 at 10 03 19](https://user-images.githubusercontent.com/177929/59836079-d019ff00-9342-11e9-95f5-19fe264df835.png)

Fixes #32113