### PR TITLE
Change checklist button copy

### DIFF
--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -147,7 +147,7 @@ class Task extends PureComponent {
 		const isExpandable = ! inProgress && ( ! completed || completedButtonText );
 		const taskActionButtonText = completed
 			? completedButtonText
-			: buttonText || translate( 'Do it!' );
+			: buttonText || translate( 'Try it' );
 
 		return (
 			<CompactCard


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes the call to action for checklist tasks from `Do it!` to `Try it`. I have gotten feedback that the existing copy feels aggressive and looked to replace it with something a bit more friendly.

**Before**
![image](https://user-images.githubusercontent.com/6981253/59860519-fe044100-934c-11e9-8936-e3b5048c16b1.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/59860496-f3e24280-934c-11e9-91c4-dd90ccfbc018.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site and visit the checklist by going to `/checklist/[url]`

cc @shaunandrews @ranh @Automattic/zelda 
