### PR TITLE
Add graphic for stats banner

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -830,6 +830,7 @@ class WpcomChecklistComponent extends PureComponent {
 				preset="update-homepage"
 				title={ translate( 'Update your homepage' ) }
 				completedTitle={ translate( 'You updated your homepage' ) }
+				bannerImageSrc="/calypso/images/stats/tasks/personalize-your-site.svg"
 				completedButtonText={ translate( 'Change' ) }
 				description={ translate(
 					`We've created the basics, now it's time for you to update the images and text.`


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a banner graphic for the new task on the stats page.

**Before**
![image](https://user-images.githubusercontent.com/6981253/59863202-3c502f00-9352-11e9-8df3-2ec7d01e39fc.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/59863122-17f45280-9352-11e9-90ec-ef1adf2857ef.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site by visiting `/start/onboarding`
* Visit the stats screen for your new site. The "Update your Homepage" task should have a graphic.


