### PR TITLE
FSE: Allow multiple Navigation Menu blocks on the same page.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
@@ -24,7 +24,6 @@ registerBlockType( 'a8c/navigation-menu', {
 	category: 'layout',
 	supports: {
 		html: false,
-		multiple: false,
 		reusable: false,
 	},
 	attributes: {


### PR DESCRIPTION
Allow multiple Navigation Menu blocks. It's possible to need menus for primary navigation, social menus, etc on the same page.

#### Testing instructions

* Apply this branch to your local FSE testing environment.
* Verify you can add multiple Navigation Menu blocks to the same editor instance.
* Verify they all display properly on the front-end.
