### PR TITLE
Update link to renewal

### DIFF
--- a/test/e2e/lib/pages/manage-purchase-page.js
+++ b/test/e2e/lib/pages/manage-purchase-page.js
@@ -10,7 +10,6 @@ import { By as by } from 'selenium-webdriver';
  */
 import * as driverHelper from '../driver-helper.js';
 import AsyncBaseContainer from '../async-base-container';
-import NoticesComponent from '../components/notices-component';
 
 export default class ManagePurchasePage extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -33,7 +32,9 @@ export default class ManagePurchasePage extends AsyncBaseContainer {
 	}
 
 	async chooseRenewNow() {
-		const noticesComponent = await NoticesComponent.Expect( this.driver );
-		return await noticesComponent.isNoticeDisplayed( true );
+		return await driverHelper.clickWhenClickable(
+			this.driver,
+			by.css( '.manage-purchase button.is-card-link' )
+		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We we using a link from a notice to renew now. This was changed in https://github.com/Automattic/wp-calypso/pull/34076

#### Testing instructions
* Ensure that Plan renewal test passes in CI
