### PR TITLE
Update {{CompanyName}} placeholders when user types

### DIFF
--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -62,7 +62,8 @@ export default class SignupSitePreviewIframe extends Component {
 		if (
 			this.props.cssUrl !== nextProps.cssUrl ||
 			this.props.fontUrl !== nextProps.fontUrl ||
-			this.props.langSlug !== nextProps.langSlug
+			this.props.langSlug !== nextProps.langSlug ||
+			this.props.isRtl !== nextProps.isRtl
 		) {
 			this.setIframeSource( nextProps );
 			return false;
@@ -70,12 +71,10 @@ export default class SignupSitePreviewIframe extends Component {
 
 		if ( this.props.content.title !== nextProps.content.title ) {
 			this.setIframeElementContent( '.signup-site-preview__title', nextProps.content.title );
-			return false;
 		}
 
 		if ( this.props.content.body !== nextProps.content.body ) {
 			this.setIframeBodyContent( nextProps.content );
-			return false;
 		}
 
 		return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the business preview, the site title (company name) appears in the site preview in the contact information and the copyright notice. This wasn't being updated because sCU bailed too soon before everything that was affected by the site title had been updated.

I also updated the check that re-renders the whole iframe while I was there. A change to the `isRtl` prop now refreshes the entire preview. Seems like it should be treated the same way as `laungSlug`.

![Jun-21-2019 10-30-04](https://user-images.githubusercontent.com/1500769/59885502-9531cd00-940f-11e9-9d28-15c51fe8cdef.gif)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/start/site-type`
* Make a business
* Set the business name, the preview should update as you type
* Check server rendering of the placeholders hasn't broken by refreshing
* Check that live site title update hasn't broken in the other segments

@ramonjd just want to double check there isn't an optimisation you were doing here that I'm breaking.

Fixes #33969
