### PR TITLE
Signup: Hides "Purchase required" badge for site type step

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -150,7 +150,8 @@ export function getAllSiteTypes() {
 			siteTopicHeader: i18n.translate( 'What type of products do you sell?' ),
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
-			purchaseRequired: true,
+			// TODO: Re-enable "Purchase required" badge, but hide for Jetpack onboarding.
+			// purchaseRequired: true,
 		},
 	];
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hides the "Purchase required" badge for the Online store site type in signup, recently added in #34054 . This should not show for Jetpack flows, so I'm disabling it, for now.

#### Testing instructions

* Visit `/start`
* Proceed to the site-type step
* Verify that "Purchase required" does not show for the "Online store" site type.
