### PR TITLE
Fix wp-admin link appearing below the fold on Chrome

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -624,7 +624,7 @@ form.sidebar__button input {
 	.sidebar__menu-wrapper {
 		display: flex;
 		flex-direction: column;
-		height: 100%;
+		flex: 1;
 
 		> li:last-child {
 			margin-bottom: 20px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

p1561092326225900-slack-calypso

The wp-admin link is only appearing after scrolling on Chrome.

![Jun-21-2019 17-35-00](https://user-images.githubusercontent.com/1500769/59900009-edd28b80-944a-11e9-8076-8ecde86d2e40.gif)

The .sidebar__menu-wrapper (which contains the wp-admin link)
was 100% of its parent height. However its parent also contains the
current site info, so the bottom of .sidebar__menu-wrapper was pushed
off screen.

Using flex so that we use up all remaining space in the parent, not 100%
of it.

Issue wasn't present on Firefox, but I think using `flex: 1` makes more
sense here IMO so it doesn't feel like a hack to make Chrome work.

#### Testing instructions

I've only tested Chrome and FF on Mac. Pretty sure `flex: 1` is fine on IE 11 but haven't tried it out.

Also need to check this out in mobile view.
