### PR TITLE
FSE: Render dynamic blocks on page areas replaced by template parts

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/replace-template-parts.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/replace-template-parts.php
@@ -80,11 +80,7 @@ function a8c_fse_replace_template_parts( $html ) {
 			$node_to_replace->removeChild( $node_to_replace->firstChild );
 		}
 
-		// Rather than appending the FSE content node, we add its child nodes so the extra wrapping div added above is not rendered.
-		for ( $i = 0; $i < $fse_node->childNodes->length; $i++ ) {
-			$fse_child_node = $fse_node->childNodes->item( $i );
-			$node_to_replace->appendChild( $fse_child_node );
-		}
+		$node_to_replace->parentNode->replaceChild( $fse_node, $node_to_replace );
 	}
 
 	return do_blocks( $doc->saveHTML() );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/replace-template-parts.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/replace-template-parts.php
@@ -25,12 +25,12 @@ function a8c_fse_replace_template_parts( $html ) {
 		'header' => [
 			// Query the first <header> element that contains the 'site-header' class.
 			// Note that this is not always the direct descendant of <body> since it's sometimes wrapped in a <div>.
-			'xpath_query' => "(/html/body//header[@class='site-header'])[1]",
+			'xpath_query' => "(//header[@class='site-header'])[1]",
 			'fse_content' => $page_template->get_header_content(),
 		],
 		'footer' => [
 			// Query the first <footer> element that contains the 'site-footer' class.
-			'xpath_query' => "(/html/body//footer[@class='site-footer'])[1]",
+			'xpath_query' => "(//footer[@class='site-footer'])[1]",
 			'fse_content' => $page_template->get_footer_content(),
 		],
 	];
@@ -39,7 +39,14 @@ function a8c_fse_replace_template_parts( $html ) {
 	// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	$doc->preserveWhiteSpace = false;
 	// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
-	@$doc->loadHTML( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ) );
+
+	$encoded_html = mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' );
+
+	// We wrap the given html in a div, since LibXML requires a root node.
+	$wrapped_html = '<div>' . $encoded_html . '</div>';
+
+	// LIBXML_HTML_NOIMPLIED keeps the HTML intact, without removing the blocks comments markup.
+	@$doc->loadHTML( $wrapped_html, LIBXML_HTML_NOIMPLIED );
 
 	$temp_doc                     = new DOMDocument();
 	$temp_doc->preserveWhiteSpace = false;
@@ -58,11 +65,27 @@ function a8c_fse_replace_template_parts( $html ) {
 
 		$node_to_replace = $candidate_nodes[0];
 
-		@$temp_doc->loadHTML( mb_convert_encoding( $replacement['fse_content'], 'HTML-ENTITIES', 'UTF-8' ) );
+		$encoded_fse_content = mb_convert_encoding( $replacement['fse_content'], 'HTML-ENTITIES', 'UTF-8' );
+
+		// We wrap the FSE html content in a div, since LibXML requires a root node.
+		$wrapped_fse_content = '<div>' . $encoded_fse_content . '</div>';
+
+		// LIBXML_HTML_NOIMPLIED keeps the HTML intact, without adding html, body or other unnecessary tags in a single node.
+		@$temp_doc->loadHTML( $wrapped_fse_content, LIBXML_HTML_NOIMPLIED );
 
 		$fse_node = $doc->importNode( $temp_doc->documentElement, true );
-		$node_to_replace->parentNode->replaceChild( $fse_node, $node_to_replace );
+
+		// Remove all the children of the element to be replaced in order to keep using the same container for the FSE content.
+		while ( $node_to_replace->hasChildNodes() ) {
+			$node_to_replace->removeChild( $node_to_replace->firstChild );
+		}
+
+		// Rather than appending the FSE content node, we add its child nodes so the extra wrapping div added above is not rendered.
+		for ( $i = 0; $i < $fse_node->childNodes->length; $i++ ) {
+			$fse_child_node = $fse_node->childNodes->item( $i );
+			$node_to_replace->appendChild( $fse_child_node );
+		}
 	}
 
-	return $doc->saveHTML();
+	return do_blocks( $doc->saveHTML() );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to render a dynamic block, WordPress uses [`do_blocks`](https://developer.wordpress.org/reference/functions/do_blocks/) to parse and replace it with the actual HTML code.

The post content is [automatically filtered by that function](https://github.com/WordPress/WordPress/blob/225de4e6eb6ef4ae0de4a6945aab6556433acad9/wp-includes/default-filters.php#L172), so any other block included in a different area like the site header or footer is not parsed by default.

Since the FSE Template Parts can be inserted out of the post content, we need to ensure that the dynamic blocks are parsed when we replace the page areas with a template part.

To do so, on this PR we're including a call to `do_blocks` before returning the replaced HTML.

I included other small changes that should improve the replacement logic:
- In order to keep intact the HTML loaded by `DOMDocument::loadHTML`, we use now the [`LIBXML_HTML_NOIMPLIED` option](https://www.php.net/manual/en/libxml.constants.php#constant.libxml-html-noimplied) which turns off an automatic clean process that was removing blocks comments markup (i.e. `<!-- a8c:site-logo /-->`) or adding extra `html`/`body` elements wrapping the template parts content.
- The above required to wrap any HTML loaded by `DOMDocument::loadHTML` in an element, since LibXML requires a root node and a template part could contain more than one node.
- Instead of replacing the `.site-header`/`.site-footer` elements with the template parts content, we keep maintaining the container, remove all the child nodes and the template part is appended as a new child:

| HTML before replacement | HTML after replacement (currently in master) | HTML after replacement (on this PR) |
|---|---|---|
| `<header class="site-header"><div class="site-branding-container">...</div></header>` | `<h2>Test Content Header</h2>` | `<header class="site-header"><h2>Test Content Header</h2></header>` |

#### Testing instructions

* Set up a local dev environment by following instructions available at PCYsg-ly5-p2.
* Create a new Template Part and insert a dynamic block (i.e. Site Logo) into it. Save it with "Header" as title.
* Create other new Template Part and insert a dynamic block (i.e. Recent Post) and a static block (i.e. Paragraph) into it. Save it with "Footer" as title.
* Create a new Template CPT with "Default Template" as title and add the following blocks into it:
  * Template Part (select "Header" from previous step).
  * Content Slot.
  * Template Part (select "Footer" from previous step).
* Create a test page and assign the previously created "Default Template" to it.

<img width="287" alt="Screenshot 2019-06-07 at 03 19 23" src="https://user-images.githubusercontent.com/1182160/59075838-1303bd80-88d3-11e9-968f-20a566b3211f.png">

* Publish the page and verify on the published view that the header and footer have been replaced with previously created template parts and the expected blocks are rendered.

Fixes https://github.com/Automattic/wp-calypso/issues/34166