### PR TITLE
Retest hiding the Blogger plan

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -143,6 +143,15 @@ export default {
 		},
 		defaultVariation: 'siteType',
 	},
+	hideBloggerPlan2: {
+		datestamp: '20190627',
+		variations: {
+			hide: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		localeTargets: 'any',
+	},
 	proratedCreditsBanner: {
 		//this test is used to dial down the upsell offer
 		datestamp: '20190626',

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -40,6 +40,7 @@ import {
 	getPlan,
 	getPopularPlanSpec,
 	isFreePlan,
+	isBloggerPlan,
 	planMatches,
 	plansLink,
 } from 'lib/plans';
@@ -146,9 +147,20 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getPlansForPlanFeatures() {
-		const { displayJetpackPlans, intervalType, selectedPlan, hideFreePlan } = this.props;
+		const {
+			displayJetpackPlans,
+			intervalType,
+			selectedPlan,
+			hideFreePlan,
+			sitePlanSlug,
+		} = this.props;
 
 		const currentPlan = getPlan( selectedPlan );
+
+		const hideBloggerPlan =
+			! isBloggerPlan( selectedPlan ) &&
+			! isBloggerPlan( sitePlanSlug ) &&
+			abtest( 'hideBloggerPlan2' ) === 'hide';
 
 		let term;
 		if ( intervalType === 'monthly' ) {
@@ -187,12 +199,12 @@ export class PlansFeaturesMain extends Component {
 		} else {
 			plans = [
 				findPlansKeys( { group, type: TYPE_FREE } )[ 0 ],
-				findPlansKeys( { group, term, type: TYPE_BLOGGER } )[ 0 ],
+				hideBloggerPlan ? null : findPlansKeys( { group, term, type: TYPE_BLOGGER } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PERSONAL } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_PREMIUM } )[ 0 ],
 				findPlansKeys( { group, term: businessPlanTerm, type: TYPE_BUSINESS } )[ 0 ],
 				findPlansKeys( { group, term, type: TYPE_ECOMMERCE } )[ 0 ],
-			];
+			].filter( el => el !== null );
 		}
 
 		if ( hideFreePlan ) {
@@ -460,6 +472,7 @@ export default connect(
 			isJetpack: isJetpackSite( state, siteId ),
 			siteId,
 			siteSlug: getSiteSlug( state, get( props.site, [ 'ID' ] ) ),
+			sitePlanSlug: currentPlan && currentPlan.product_slug,
 			siteType,
 		};
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Relaunches the hideBloggerPlan test again. The first re-test was non-English users only and was ended because of a bug in anonids. Given that the same bug affected the original test, we are retesting that this time.

#### Testing instructions

1. Sign up with a new site by using English as your browser language
2. You should be assigned to the new test (confirm the assignment is triggered)
3. Change the variation to see that both variations work fine
4. Go to logged in /plans and make sure both variations work
5. Set your browser language to a language other than English
6. Sign up and make sure you're assigned to a variation as well

*

Fixes #
