### PR TITLE
Fix site topic step for `/start/premium|business|personal` routes

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -617,8 +617,9 @@ class Signup extends React.Component {
 						redirectTo={ this.state.redirectTo }
 					/>
 				) }
-				{ get( steps[ this.props.stepName ], 'props.showSiteMockups', false ) &&
-					'blog' !== this.props.siteType && <SiteMockups stepName={ this.props.stepName } /> }
+				{ get( steps[ this.props.stepName ], 'props.showSiteMockups', false ) && (
+					<SiteMockups stepName={ this.props.stepName } />
+				) }
 			</div>
 		);
 	}

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -28,8 +28,18 @@ class SiteType extends Component {
 	submitStep = siteTypeValue => {
 		this.props.submitSiteType( siteTypeValue );
 
-		// Modify the flowname if the site type matches an override.
-		this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
+		// TODO Hack to fix the `/start/premium|business|personal` routes
+		if (
+			( this.props.flowName === 'premium' ||
+				this.props.flowName === 'business' ||
+				this.props.flowName === 'personal' ) &&
+			siteTypeValue === 'blog'
+		) {
+			this.props.goToNextStep( this.props.flowName );
+		} else {
+			// Modify the flowname if the site type matches an override.
+			this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
+		}
 	};
 
 	render() {

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -540,6 +540,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await siteTitlePage.submitForm();
 		} );
 
+		step( 'Can see the "Site style" page, and continue with the default style', async function() {
+			const siteTitlePage = await SiteStylePage.Expect( driver );
+			return await siteTitlePage.submitForm();
+		} );
+
 		step(
 			'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results',
 			async function() {
@@ -659,6 +664,11 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step( 'Can see the "Site title" page, and enter the site title', async function() {
 			const siteTitlePage = await SiteTitlePage.Expect( driver );
 			await siteTitlePage.enterSiteTitle( blogName );
+			return await siteTitlePage.submitForm();
+		} );
+
+		step( 'Can see the "Site style" page, and continue with the default style', async function() {
+			const siteTitlePage = await SiteStylePage.Expect( driver );
 			return await siteTitlePage.submitForm();
 		} );
 


### PR DESCRIPTION
#34163 broke these routes. The site topic step displays an empty
screen. This is a hack to get the pages showing.