### PR TITLE
Starter Page Templates: Momentum scrolling in template list

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -51,6 +51,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	justify-content: center;
 }
 
+.page-template-modal .components-modal__content {
+	overflow-y: scroll;
+	-webkit-overflow-scrolling: touch;
+}
+
 .page-template-modal__inner {
 	max-width: 700px;
 	margin: 0 auto;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* enable momentum scrolling for the modal window of Starter Page Templates

#### Testing instructions

* create a new page from an iOS device, observe scrolling in the template list

#### Video

| Old | New |
| - | - |
| ![1](https://user-images.githubusercontent.com/156676/59915571-3b380400-941d-11e9-9d84-9993d7d7f1c2.gif) | ![2](https://user-images.githubusercontent.com/156676/59915585-43903f00-941d-11e9-9c61-c3c2f8b9aaa2.gif)

Fixes #34177
