### PR TITLE
Checkout: Add `install` param to Jetpack plans checkout.

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -458,7 +458,7 @@ export class Checkout extends React.Component {
 		}
 
 		if ( this.props.isJetpackNotAtomic ) {
-			return `/plans/my-plan/${ selectedSiteSlug }?thank-you`;
+			return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
 		}
 
 		return this.props.selectedFeature && isValidFeatureKey( this.props.selectedFeature )

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -38,6 +38,11 @@ export class ThankYouCard extends Component {
 			translate,
 		} = this.props;
 
+		const dismissUrl =
+			this.props.queryArgs && 'install' in this.props.queryArgs
+				? addQueryArgs( { install: this.props.queryArgs.install }, this.props.currentRoute )
+				: this.props.getCurrentRoute;
+
 		return (
 			<div className="current-plan-thank-you">
 				{ illustration && (
@@ -62,27 +67,13 @@ export class ThankYouCard extends Component {
 					</p>
 				) }
 				{ showContinueButton && (
-					<Button
-						href={ `/plans/my-plan/${ siteSlug }` }
-						onClick={ this.startChecklistTour }
-						primary
-					>
+					<Button href={ dismissUrl } onClick={ this.startChecklistTour } primary>
 						{ translate( 'Continue' ) }
 					</Button>
 				) }
 				{ showHideMessage && (
 					<p>
-						<a
-							href={
-								this.props.queryArgs && 'install' in this.props.queryArgs
-									? addQueryArgs(
-											{ install: this.props.queryArgs.install },
-											this.props.currentRoute
-									  )
-									: this.props.getCurrentRoute
-							}
-							onClick={ this.startChecklistTour }
-						>
+						<a href={ dismissUrl } onClick={ this.startChecklistTour }>
 							{ translate( 'Hide message' ) }
 						</a>
 					</p>

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -13,6 +13,9 @@ import { isDesktop } from 'lib/viewport';
 import { preventWidows } from 'lib/formatting';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import Button from 'components/button';
+import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
+import getCurrentRoute from 'state/selectors/get-current-route';
+import { addQueryArgs } from 'lib/url';
 
 import './style.scss';
 
@@ -69,7 +72,17 @@ export class ThankYouCard extends Component {
 				) }
 				{ showHideMessage && (
 					<p>
-						<a href={ `/plans/my-plan/${ siteSlug }` } onClick={ this.startChecklistTour }>
+						<a
+							href={
+								this.props.queryArgs && 'install' in this.props.queryArgs
+									? addQueryArgs(
+											{ install: this.props.queryArgs.install },
+											this.props.currentRoute
+									  )
+									: this.props.getCurrentRoute
+							}
+							onClick={ this.startChecklistTour }
+						>
 							{ translate( 'Hide message' ) }
 						</a>
 					</p>
@@ -81,6 +94,8 @@ export class ThankYouCard extends Component {
 
 export default connect(
 	state => ( {
+		currentRoute: getCurrentRoute( state ),
+		queryArgs: getCurrentQueryArguments( state ),
 		siteSlug: getSelectedSiteSlug( state ),
 	} ),
 	{ requestGuidedTour }

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -28,6 +28,7 @@ export class ThankYouCard extends Component {
 	render() {
 		const {
 			children,
+			currentRoute,
 			illustration,
 			showCalypsoIntro,
 			showContinueButton,
@@ -38,8 +39,8 @@ export class ThankYouCard extends Component {
 
 		const dismissUrl =
 			this.props.queryArgs && 'install' in this.props.queryArgs
-				? addQueryArgs( { install: this.props.queryArgs.install }, this.props.currentRoute )
-				: this.props.getCurrentRoute;
+				? addQueryArgs( { install: this.props.queryArgs.install }, currentRoute )
+				: currentRoute;
 
 		return (
 			<div className="current-plan-thank-you">

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
 import { localize } from 'i18n-calypso';
 import React, { Component } from 'react';
 
@@ -33,7 +32,6 @@ export class ThankYouCard extends Component {
 			showCalypsoIntro,
 			showContinueButton,
 			showHideMessage,
-			siteSlug,
 			title,
 			translate,
 		} = this.props;
@@ -87,7 +85,6 @@ export default connect(
 	state => ( {
 		currentRoute: getCurrentRoute( state ),
 		queryArgs: getCurrentQueryArguments( state ),
-		siteSlug: getSelectedSiteSlug( state ),
 	} ),
 	{ requestGuidedTour }
 )( localize( ThankYouCard ) );


### PR DESCRIPTION
From #34180

Part of paObgF-fw-p2

- Add `install=all` query parameter to the post-checkout URL.
- Keep `install` query when closing the `thank-you` modal.

This query parameter is currently unused but is part of the full implementation from #34180 that is safe to merge independently.

## Testing
- Purchase any plan for a Jetpack site.
- You should be redirected to `/plans/my-plan/SITE_SLUG?thank-you&install=all` after checkout. Confirm the presence of `thank-you` and `install=all` query params.
- The plugin installer continues to work as before (Akismet and VaultPress are installed and provisioned with keys as required by plan).
- Closing the "Thank You" modal removes the `thank-you` param but keeps the `install=all`.
- Other checkout flows are unaffected.