### PR TITLE
Starter Page Templates: Remove extra list padding

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -64,9 +64,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 .page-template-modal__list {
-	padding: 1.5em 0;
-
-
 	.components-base-control__label {
 		@include screen-reader-text();
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* lower the padding in templates list so the intro text looks well aligned

#### Testing instructions

* create a new page and check out the intro text. it should be aligned a little better than in master

#### Screenshots

| Before | After | 
| - | - |
| Bigger gap below the intro text | Roughly equal gap above and below intro text |
| <img width="799" alt="Screenshot 2019-06-21 at 13 13 29" src="https://user-images.githubusercontent.com/156676/59918960-7ab71e00-9426-11e9-8220-d9005ba0a939.png"> | <img width="800" alt="Screenshot 2019-06-21 at 13 13 43" src="https://user-images.githubusercontent.com/156676/59919009-96babf80-9426-11e9-81cd-69c829830551.png">

Fixes #34175