### PR TITLE
Updates to force 2col layout on small viewports.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -74,8 +74,14 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	.template-selector-control__options {
 		display: grid;
 		// stylelint-disable-next-line unit-whitelist
-		grid-template-columns: repeat( auto-fit, minmax( 200px, 1fr ) );
-		grid-gap: 1.5em;
+		grid-template-columns: 1fr 1fr; // force 2 col on small screens to ensure blank isn't the only option visible on load
+		grid-gap: 0.5em;
+
+		@media screen and ( min-width: 660px ) {
+			// stylelint-disable-next-line unit-whitelist
+			grid-template-columns: repeat( auto-fit, minmax( 200px, 1fr ) ); // allow grid to take over number of cols on large screens
+			grid-gap: 1.5em;
+		}
 	}
 
 	.template-selector-control__label {
@@ -83,12 +89,16 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		width: 100%;
 		text-align: center;
 		border: 1px solid transparent;
-		padding: 2em;
 		border-radius: 4px;
 		cursor: pointer;
 		background: none;
 		appearance: none;
+		padding: 1em;
 
+		@media screen and ( min-width: 660px ) {
+			padding: 2em;
+		}
+		
 		&:hover {
 			background: #f3f4f5;
 		}
@@ -99,6 +109,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			outline: 2px solid transparent;
 			outline-offset: -2px;
 		}
+
 	}
 
 	.template-selector-control__media-wrap {


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/34174

#### Changes proposed in this Pull Request

* Update to force 2 col layout of Templates on small viewports
* Retain grid gap for a11y reasons as click targets should have sufficient (non clickable) gap to ensure users with motor impairments can avoid selecting the wrong item

#### Testing instructions

* On a small viewport - add new Page and see the Template layout in 2cols with reasonable space between each
* On larger viewport - confirm layout is as previously with the CSS Grid algorithm being allowed to make the decision about when to change to a 3 col layout.

