### PR TITLE
Build: Speed up the hot reloader by memoizing webpack stats 🔥

### DIFF
--- a/server/bundler/hot-reloader.js
+++ b/server/bundler/hot-reloader.js
@@ -9,7 +9,6 @@
 const socketio = require( 'socket.io' );
 const debug = require( 'debug' )( 'calypso:bundler:hot-reloader' );
 const { memoize } = require( 'lodash' );
-memoize.Cache = WeakMap; // play better with the GC over time
 
 /**
  * Internal dependencies
@@ -26,6 +25,7 @@ function invalidPlugin() {
 }
 
 const getStats = memoize( stats => stats.toJson() );
+getStats.cache = new WeakMap(); // play a bit nicer with the GC than the default lodash cache
 
 function sendStats( socket, stats, force ) {
 	function emitted( asset ) {


### PR DESCRIPTION
Profiling found that emitting the JSON webpack stats consumed a substantial amount of time for each new connection to the dev server. While this is mostly inconsequential for local development, when running the e2e tests against a local instance it would cause the node process to use up a substantial amount of CPU time.

Memoizing the toJson call substantially reduces the CPU time required when many clients are connecting and disconnecting from the dev server.

#### Testing instructions

* Spin up the dev server. Should work just like before
* Try running the full e2e suite against the dev server. It should respond quite a bit faster than before.

cc @bsessions85 
