### PR TITLE
Signup: show GDPR banner in signup

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -520,7 +520,6 @@ class SignupForm extends Component {
 					autoCapitalize="off"
 					autoCorrect="off"
 					className="signup-form__input"
-					autofocus="true"
 					disabled={
 						this.state.submitting || !! this.props.disabled || !! this.props.disableEmailInput
 					}

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -24,6 +24,7 @@ import { getCurrentRoute } from 'state/selectors/get-current-route';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import { getSection, masterbarIsVisible } from 'state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
+import GdprBanner from 'blocks/gdpr-banner';
 
 // Returns true if given section should display sidebar for logged out users.
 const hasSidebar = section => {
@@ -98,6 +99,7 @@ const LayoutLoggedOut = ( {
 					{ secondary }
 				</div>
 			</div>
+			{ config.isEnabled( 'gdpr-banner' ) && <GdprBanner /> }
 		</div>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* remove the `autoFocus` prop from the `SignupForm` component as it violates one of our accessibility rules
* add `GdprBanner` to `LayoutLoggedOut` so it shows during signup

#### Testing instructions

* checkout branch locally and activate `gdpr-banner` in `config/development.json`
* in an incognito window and from a GDPR country, open `http://calypso.localhost:3000/start/user`
* ensure that the GDPR banner is showing during signup

Huge props to @MicBosi for finding this issue! 🙌 