### PR TITLE
Jetpack Backups: Make partial restore settings available to users

### DIFF
--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import ActivityIcon from '../activity-log-item/activity-icon';
 import Button from 'components/button';
 import Card from 'components/card';
@@ -47,46 +46,44 @@ const ActivityLogConfirmDialog = ( {
 
 			<div className="activity-log-confirm-dialog__highlight">{ children }</div>
 
-			{ config.isEnabled( 'rewind/partial-restores' ) && (
-				<Card className="activity-log-confirm-dialog__partial-restore-settings">
-					<p>
-						<strong>
-							{ notice
-								? translate( 'Partial Restore Settings (A8C Only)' )
-								: translate( 'Partial Download Settings (A8C Only)' ) }
-						</strong>
-					</p>
-					<p>
+			<Card className="activity-log-confirm-dialog__partial-restore-settings">
+				<p>
+					<strong>
 						{ notice
-							? translate( 'Include the following things in this restore:' )
-							: translate( 'Include the following things in this download:' ) }
-					</p>
-					<FormLabel>
-						<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'WordPress Themes' ) }
-					</FormLabel>
-					<FormLabel>
-						<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'WordPress Plugins' ) }
-					</FormLabel>
-					<FormLabel>
-						<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'Media Uploads' ) }
-					</FormLabel>
-					<FormLabel>
-						<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'WordPress Root (includes wp-config.php and any non-WordPress files)' ) }
-					</FormLabel>
-					<FormLabel>
-						<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'WP-Content Directory (excluding themes, plugins, and uploads)' ) }
-					</FormLabel>
-					<FormLabel>
-						<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'Site Database (SQL)' ) }
-					</FormLabel>
-				</Card>
-			) }
+							? translate( 'Partial Restore Settings' )
+							: translate( 'Partial Download Settings' ) }
+					</strong>
+				</p>
+				<p>
+					{ notice
+						? translate( 'Include the following things in this restore:' )
+						: translate( 'Include the following things in this download:' ) }
+				</p>
+				<FormLabel>
+					<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'WordPress Themes' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'WordPress Plugins' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox name="uploads" onChange={ onSettingsChange } />
+					{ translate( 'Media Uploads' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'WordPress Root (includes wp-config.php and any non-WordPress files)' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'WP-Content Directory (excluding themes, plugins, and uploads)' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'Site Database (SQL)' ) }
+				</FormLabel>
+			</Card>
 
 			{ notice && (
 				<div className="activity-log-confirm-dialog__notice">

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -36,6 +36,7 @@ const ActivityLogConfirmDialog = ( {
 	title,
 	translate,
 	happychatEvent,
+	partial,
 } ) => (
 	<div className="activity-log-item activity-log-item__restore-confirm">
 		<div className="activity-log-item__type">
@@ -46,44 +47,39 @@ const ActivityLogConfirmDialog = ( {
 
 			<div className="activity-log-confirm-dialog__highlight">{ children }</div>
 
-			<Card className="activity-log-confirm-dialog__partial-restore-settings">
-				<p>
-					<strong>
+			{ partial && (
+				<div className="activity-log-confirm-dialog__partial-restore-settings">
+					<p>
 						{ notice
-							? translate( 'Partial Restore Settings' )
-							: translate( 'Partial Download Settings' ) }
-					</strong>
-				</p>
-				<p>
-					{ notice
-						? translate( 'Include the following things in this restore:' )
-						: translate( 'Include the following things in this download:' ) }
-				</p>
-				<FormLabel>
-					<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'WordPress Themes' ) }
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'WordPress Plugins' ) }
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'Media Uploads' ) }
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'WordPress Root (includes wp-config.php and any non-WordPress files)' ) }
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'WP-Content Directory (excluding themes, plugins, and uploads)' ) }
-				</FormLabel>
-				<FormLabel>
-					<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
-					{ translate( 'Site Database (SQL)' ) }
-				</FormLabel>
-			</Card>
+							? translate( 'Choose the items you wish to rewind:' )
+							: translate( 'Choose the items you wish to include in the download:' ) }
+					</p>
+					<FormLabel>
+						<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'WordPress Themes' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'WordPress Plugins' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'Media Uploads' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'WordPress Root (includes wp-config.php and any non-WordPress files)' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'WP-Content Directory (excluding themes, plugins, and uploads)' ) }
+					</FormLabel>
+					<FormLabel>
+						<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
+						{ translate( 'Site Database (SQL)' ) }
+					</FormLabel>
+				</div>
+			) }
 
 			{ notice && (
 				<div className="activity-log-confirm-dialog__notice">

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -68,7 +68,7 @@ const ActivityLogConfirmDialog = ( {
 					{ translate( 'WordPress Plugins' ) }
 				</FormLabel>
 				<FormLabel>
-					<FormCheckbox name="uploads" onChange={ onSettingsChange } />
+					<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
 					{ translate( 'Media Uploads' ) }
 				</FormLabel>
 				<FormLabel>

--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -37,6 +37,7 @@ const ActivityLogConfirmDialog = ( {
 	translate,
 	happychatEvent,
 	partial,
+	disableButton,
 } ) => (
 	<div className="activity-log-item activity-log-item__restore-confirm">
 		<div className="activity-log-item__type">
@@ -91,7 +92,7 @@ const ActivityLogConfirmDialog = ( {
 			<div className="activity-log-confirm-dialog__button-wrap">
 				<div className="activity-log-confirm-dialog__primary-actions">
 					<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
-					<Button primary onClick={ onConfirm }>
+					<Button primary disabled={ disableButton } onClick={ onConfirm }>
 						{ confirmTitle }
 					</Button>
 				</div>

--- a/client/my-sites/activity/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/activity/activity-log-confirm-dialog/style.scss
@@ -185,5 +185,4 @@
 
 .activity-log-confirm-dialog__partial-restore-settings .form-checkbox {
 	margin-right: 0.5rem;
-	margin-left: 1.5rem;
 }

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -423,6 +423,7 @@ const mapDispatchToProps = ( dispatch, { activity: { activityId }, siteId } ) =>
 				recordTracksEvent( 'calypso_activitylog_restore_confirm', {
 					action_id: rewindId,
 					activity_name: activityName,
+					restore_types: restoreArgs.join( ',' ),
 				} ),
 				rewindRestore( siteId, rewindId, restoreArgs )
 			)

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -199,7 +199,18 @@ class ActivityLogItem extends Component {
 	};
 
 	createFullRewind = () => {
-		this.setState( { partialSelected: false } );
+		this.setState( {
+			restoreArgs: {
+				themes: true,
+				plugins: true,
+				uploads: true,
+				sqls: true,
+				roots: true,
+				contents: true,
+			},
+			partialSelected: false,
+		} );
+
 		this.props.createRewind();
 	};
 
@@ -447,7 +458,7 @@ const mapDispatchToProps = ( dispatch, { activity: { activityId }, siteId } ) =>
 				recordTracksEvent( 'calypso_activitylog_restore_confirm', {
 					action_id: rewindId,
 					activity_name: activityName,
-					restore_types: restoreArgs.join( ',' ),
+					restore_types: JSON.stringify( restoreArgs ),
 				} ),
 				rewindRestore( siteId, rewindId, restoreArgs )
 			)

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -77,6 +77,7 @@ class ActivityLogItem extends Component {
 			roots: true,
 			contents: true,
 		},
+		partialSelected: false,
 	};
 
 	confirmBackup = () =>
@@ -192,10 +193,19 @@ class ActivityLogItem extends Component {
 
 	performCloneAction = () => this.props.cloneOnClick( this.props.activity.activityTs );
 
+	createPartialRewind = () => {
+		this.setState( { partialSelected: true } );
+		this.props.createRewind();
+	};
+
+	createFullRewind = () => {
+		this.setState( { partialSelected: false } );
+		this.props.createRewind();
+	};
+
 	renderRewindAction() {
 		const {
 			createBackup,
-			createRewind,
 			disableRestore,
 			disableBackup,
 			hideRestore,
@@ -210,8 +220,20 @@ class ActivityLogItem extends Component {
 		return (
 			<div className="activity-log-item__action">
 				<EllipsisMenu>
-					<PopoverMenuItem disabled={ disableRestore } icon="history" onClick={ createRewind }>
+					<PopoverMenuItem
+						disabled={ disableRestore }
+						icon="history"
+						onClick={ this.createFullRewind }
+					>
 						{ translate( 'Rewind to this point' ) }
+					</PopoverMenuItem>
+
+					<PopoverMenuItem
+						disabled={ disableRestore }
+						icon="history"
+						onClick={ this.createPartialRewind }
+					>
+						{ translate( 'Partial rewind' ) }
 					</PopoverMenuItem>
 
 					<PopoverMenuSeparator />
@@ -299,13 +321,14 @@ class ActivityLogItem extends Component {
 						key="activity-rewind-dialog"
 						confirmTitle={ translate( 'Confirm Rewind' ) }
 						notice={ translate(
-							'This will remove all content and options created or changed since then.'
+							'This will override and remove all content created after this point.'
 						) }
 						onClose={ dismissRewind }
 						onConfirm={ this.confirmRewind }
 						onSettingsChange={ this.restoreSettingsChange }
 						supportLink="https://jetpack.com/support/how-to-rewind"
 						title={ translate( 'Rewind Site' ) }
+						partial={ this.state.partialSelected }
 					>
 						{ translate(
 							'This is the selected point for your site Rewind. ' +
@@ -329,6 +352,7 @@ class ActivityLogItem extends Component {
 						title={ translate( 'Create downloadable backup' ) }
 						type={ 'backup' }
 						icon={ 'cloud-download' }
+						partial={ true }
 					>
 						{ translate(
 							'We will build a downloadable backup of your site at {{time/}}. ' +

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -78,6 +78,8 @@ class ActivityLogItem extends Component {
 			contents: true,
 		},
 		partialSelected: false,
+		disableRestoreButton: false,
+		disableDownloadButton: false,
 	};
 
 	confirmBackup = () =>
@@ -90,15 +92,31 @@ class ActivityLogItem extends Component {
 			this.state.restoreArgs
 		);
 
-	restoreSettingsChange = ( { target: { name, checked } } ) =>
+	restoreSettingsChange = ( { target: { name, checked } } ) => {
 		this.setState( {
 			restoreArgs: Object.assign( this.state.restoreArgs, { [ name ]: checked } ),
 		} );
 
-	downloadSettingsChange = ( { target: { name, checked } } ) =>
+		this.setState( {
+			disableRestoreButton: Object.keys( this.state.restoreArgs ).every(
+				k => ! this.state.restoreArgs[ k ]
+			),
+			disableDownloadButton: false,
+		} );
+	};
+
+	downloadSettingsChange = ( { target: { name, checked } } ) => {
 		this.setState( {
 			downloadArgs: Object.assign( this.state.downloadArgs, { [ name ]: checked } ),
 		} );
+
+		this.setState( {
+			disableDownloadButton: Object.keys( this.state.downloadArgs ).every(
+				k => ! this.state.downloadArgs[ k ]
+			),
+			disableRestoreButton: false,
+		} );
+	};
 
 	sizeChanged = () => {
 		this.forceUpdate();
@@ -331,15 +349,18 @@ class ActivityLogItem extends Component {
 					<ActivityLogConfirmDialog
 						key="activity-rewind-dialog"
 						confirmTitle={ translate( 'Confirm Rewind' ) }
-						notice={ translate(
-							'This will override and remove all content created after this point.'
-						) }
+						notice={
+							this.state.disableRestoreButton
+								? translate( 'Please select at least one item to rewind.' )
+								: translate( 'This will override and remove all content created after this point.' )
+						}
 						onClose={ dismissRewind }
 						onConfirm={ this.confirmRewind }
 						onSettingsChange={ this.restoreSettingsChange }
 						supportLink="https://jetpack.com/support/how-to-rewind"
 						title={ translate( 'Rewind Site' ) }
 						partial={ this.state.partialSelected }
+						disableButton={ this.state.disableRestoreButton }
 					>
 						{ translate(
 							'This is the selected point for your site Rewind. ' +
@@ -364,6 +385,7 @@ class ActivityLogItem extends Component {
 						type={ 'backup' }
 						icon={ 'cloud-download' }
 						partial={ true }
+						disableButton={ this.state.disableDownloadButton }
 					>
 						{ translate(
 							'We will build a downloadable backup of your site at {{time/}}. ' +

--- a/config/development.json
+++ b/config/development.json
@@ -158,7 +158,6 @@
 		"republicize": true,
 		"rewind-alerts": true,
 		"rewind/clone-site": true,
-		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -95,7 +95,6 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rewind/clone-site": true,
-		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -109,7 +109,6 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rewind/clone-site": true,
-		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -130,7 +130,6 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rewind/clone-site": true,
-		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR makes partial restores available to users.
* It also removes the "A8C Only" text
* Removes config specific logic and feature flags, and makes partial restore settings available in all environments.
* Unchecks the media checkbox by default, so that users are less inclined to restore media redundantly.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test a full restore, make sure everything is restored.
* Test any combination that you want of plugins/themes/uploads/sqls/roots. They should all restore the specified types.
