### PR TITLE
Stats: Ensure "View Post" Icon Appears Exclusively on Hover

### DIFF
--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -504,10 +504,12 @@ ul.module-content-list-item-action-submenu {
 		@extend %mobile-interface-element;
 		text-align: center;
 		margin: 0;
+		opacity: 0;
 		line-height: inherit;
 
 		@include breakpoint( '<480px' ) {
 			min-width: 24px;
+			opacity: 1;
 			padding: 0 12px;
 
 			&.toggle {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#33961 made it that the "View Posts" link was always visible, not just on hover. This seems unintentional and was not what was originally unintended in #33080. Let me know if it was intentional though - there's still a bit of code to clean up if it is!

#### Testing instructions

Visit the Stats page and verify the view icon only appears on hover (or by using the tab button).

<img width="472" alt="Screenshot 2019-06-21 at 19 43 22" src="https://user-images.githubusercontent.com/43215253/59944765-9853aa00-945d-11e9-99cf-c330306b36e4.png">

But confirm that when narrowing the screen, when the tooltip appears, the "View Post" label is still there.

<img width="364" alt="Screenshot 2019-06-21 at 19 43 17" src="https://user-images.githubusercontent.com/43215253/59944793-a86b8980-945d-11e9-86ee-1e918293ad39.png">

cc @jancavan, @sixhours, @alaczek