### PR TITLE
Signup: Differentiate site types configuration for wpcom and jetpack

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -18,7 +18,6 @@ import PopularTopics from 'components/site-verticals-suggestion-search/popular-t
 import QueryVerticals from 'components/data/query-verticals';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 /**
  * Style dependencies
@@ -214,13 +213,14 @@ export default localize(
 	connect(
 		( state, ownProps ) => {
 			const siteType = getSiteType( state );
-			const defaultVerticalSearchTerm =
-				getSiteTypePropertyValue( 'slug', siteType, 'defaultVertical' ) || '';
 			return {
 				siteType,
-				defaultVerticalSearchTerm,
 				verticals: getVerticals( state, ownProps.searchValue, siteType ) || [],
-				defaultVertical: get( getVerticals( state, defaultVerticalSearchTerm, siteType ), '0', {} ),
+				defaultVertical: get(
+					getVerticals( state, ownProps.defaultVerticalSearchTerm, siteType ),
+					'0',
+					{}
+				),
 			};
 		},
 		null

--- a/client/jetpack-connect/site-topic.js
+++ b/client/jetpack-connect/site-topic.js
@@ -21,6 +21,8 @@ import versionCompare from 'lib/version-compare';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { getSiteOption } from 'state/sites/selectors';
 import { saveSiteVertical } from 'state/jetpack-connect/actions';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
+import { getJetpackSiteTypeProp } from 'lib/signup/site-type';
 
 class JetpackSiteTopic extends Component {
 	goToNextStep = () => {
@@ -46,7 +48,10 @@ class JetpackSiteTopic extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { siteType, translate } = this.props;
+		const defaultVerticalSearchTerm = getJetpackSiteTypeProp( siteType, 'defaultVertical' );
+		const searchInputPlaceholder = getJetpackSiteTypeProp( siteType, 'siteTopicInputPlaceholder' );
+		const searchInputLabel = getJetpackSiteTypeProp( siteType, 'siteTopicLabel' );
 
 		return (
 			<MainWrapper isWide>
@@ -58,7 +63,12 @@ class JetpackSiteTopic extends Component {
 						) }
 					/>
 
-					<SiteTopicForm submitForm={ this.handleSubmit } />
+					<SiteTopicForm
+						defaultVerticalSearchTerm={ defaultVerticalSearchTerm }
+						headerText={ searchInputLabel }
+						placeholder={ searchInputPlaceholder }
+						submitForm={ this.handleSubmit }
+					/>
 
 					<SkipButton
 						onClick={ this.goToNextStep }
@@ -79,6 +89,7 @@ const connectComponent = connect(
 			siteId,
 			siteJetpackVersion: getSiteOption( state, siteId, 'jetpack_version' ),
 			siteSlug: getSelectedSiteSlug( state ),
+			siteType: getSiteType( state ),
 		};
 	},
 	{

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -20,6 +20,7 @@ import WpcomColophon from 'components/wpcom-colophon';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { saveSiteType } from 'state/jetpack-connect/actions';
 import { setSiteType } from 'state/signup/steps/site-type/actions';
+import { getJetpackSiteTypes } from 'lib/signup/site-type';
 
 class JetpackSiteType extends Component {
 	goToNextStep = () => {
@@ -50,7 +51,7 @@ class JetpackSiteType extends Component {
 						) }
 					/>
 
-					<SiteTypeForm submitForm={ this.handleSubmit } />
+					<SiteTypeForm submitForm={ this.handleSubmit } siteTypes={ getJetpackSiteTypes() } />
 
 					<SkipButton
 						onClick={ this.goToNextStep }

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -3,7 +3,7 @@
  * Exernal dependencies
  */
 import i18n from 'i18n-calypso';
-import { find, get } from 'lodash';
+import { find, invert } from 'lodash';
 
 /**
  * Internal dependencies
@@ -11,42 +11,62 @@ import { find, get } from 'lodash';
 
 const CONTEXT_WPCOM = 'CONTEXT_WPCOM';
 const CONTEXT_JETPACK = 'CONTEXT_JETPACK';
+const SITE_TYPE_BUSINESS = 'business';
+const SITE_TYPE_BLOG = 'blog';
+const SITE_TYPE_STORE = 'online-store';
+const SITE_TYPE_PROFESSIONAL = 'professional';
 
-const getSiteTypePropertyDefaults = propertyKey =>
-	get(
-		{
-			// General copy
-			siteMockupHelpTipCopy: i18n.translate(
-				"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."
-			),
-			siteMockupHelpTipCopyBottom: i18n.translate( 'Scroll back up to continue.' ),
-			siteMockupTitleFallback: i18n.translate( 'Your New Website' ),
-			// Site title step
-			siteTitleLabel: i18n.translate( 'Give your site a name' ),
-			siteTitleSubheader: i18n.translate(
-				'This will appear at the top of your site and can be changed at anytime.'
-			),
-			siteTitlePlaceholder: i18n.translate( 'default siteTitlePlaceholder' ),
-			// Site topic step
-			siteTopicHeader: i18n.translate( 'What is your site about?' ),
-			siteTopicLabel: i18n.translate( 'What is your site about?' ),
-			siteTopicSubheader: i18n.translate(
-				"We'll add relevant content to your site to help you get started."
-			),
-			siteTopicInputPlaceholder: i18n.translate( 'Enter a topic or choose one from below.' ),
-			// Domains step
-			domainsStepHeader: i18n.translate( 'Give your site an address' ),
-			domainsStepSubheader: i18n.translate(
-				'Enter a keyword that describes your site to get started.'
-			),
-			// Site styles step
-			siteStyleSubheader: i18n.translate(
-				'This will help you get started with a theme you might like. You can change it later.'
-			),
-		},
-		propertyKey,
-		null
-	);
+// These ids _must_ correspond with their siblings in the /segments API results.
+const siteTypeIds = {
+	[ SITE_TYPE_BUSINESS ]: 1,
+	[ SITE_TYPE_BLOG ]: 2,
+	[ SITE_TYPE_STORE ]: 3,
+	[ SITE_TYPE_PROFESSIONAL ]: 4,
+};
+
+export const getSiteTypeSlug = id => invert( siteTypeIds )[ id ] || null;
+
+export const getSiteTypeId = slug => siteTypeIds[ slug ] || null;
+
+const siteTypePropDefaults = {
+	// Attributes.
+	defaultVertical: 'business',
+	label: '',
+	description: '',
+	theme: 'pub/modern-business',
+	designType: '',
+	customerType: null,
+	purchaseRequired: false,
+	// General copy.
+	siteMockupHelpTipCopy: i18n.translate(
+		"Scroll down to see how your site will look. You can customize it with your own text and photos when we're done with the setup basics."
+	),
+	siteMockupHelpTipCopyBottom: i18n.translate( 'Scroll back up to continue.' ),
+	siteMockupTitleFallback: i18n.translate( 'Your New Website' ),
+	// Site title step.
+	siteTitleLabel: i18n.translate( 'Give your site a name' ),
+	siteTitleSubheader: i18n.translate(
+		'This will appear at the top of your site and can be changed at anytime.'
+	),
+	siteTitlePlaceholder: i18n.translate( 'default siteTitlePlaceholder' ),
+	// Site topic step.
+	siteTopicHeader: i18n.translate( 'What is your site about?' ),
+	siteTopicLabel: i18n.translate( 'What is your site about?' ),
+	siteTopicSubheader: i18n.translate(
+		"We'll add relevant content to your site to help you get started."
+	),
+	siteTopicInputPlaceholder: i18n.translate( 'Enter a topic or choose one from below.' ),
+	// Domains step.
+	domainsStepHeader: i18n.translate( 'Give your site an address' ),
+	domainsStepSubheader: i18n.translate(
+		'Enter a keyword that describes your site to get started.'
+	),
+};
+
+const createSiteType = ( slug, properties ) => {
+	const id = getSiteTypeId( slug );
+	return Object.assign( {}, siteTypePropDefaults, properties, { slug, id } );
+};
 
 /**
  * Returns a current list of site types that are displayed in the signup site-type step
@@ -61,13 +81,10 @@ const getSiteTypePropertyDefaults = propertyKey =>
  */
 function getAllSiteTypes( context ) {
 	return [
-		{
-			id: 2, // This value must correspond with its sibling in the /segments API results
-			slug: 'blog',
+		createSiteType( SITE_TYPE_BLOG, {
 			defaultVertical: 'blogging', // used to conduct a vertical search and grab a default vertical for the segment
 			label: i18n.translate( 'Blog' ),
 			description: i18n.translate( 'Share and discuss ideas, updates, or creations.' ),
-			theme: 'pub/modern-business',
 			designType: 'blog',
 			siteTitleLabel: i18n.translate( "Tell us your blog's name" ),
 			siteTitlePlaceholder: i18n.translate( "E.g., Stevie's blog " ),
@@ -87,14 +104,10 @@ function getAllSiteTypes( context ) {
 			domainsStepSubheader: i18n.translate(
 				"Enter your blog's name or some keywords that describe it to get started."
 			),
-		},
-		{
-			id: 1, // This value must correspond with its sibling in the /segments API results
-			slug: 'business',
-			defaultVertical: 'business',
+		} ),
+		createSiteType( SITE_TYPE_BUSINESS, {
 			label: i18n.translate( 'Business' ),
 			description: i18n.translate( 'Promote products and services.' ),
-			theme: 'pub/modern-business',
 			designType: 'page',
 			siteTitleLabel: i18n.translate( 'Tell us your business’s name' ),
 			siteTitlePlaceholder: i18n.translate( 'E.g., Vail Renovations' ),
@@ -104,14 +117,11 @@ function getAllSiteTypes( context ) {
 				"Enter your business's name or some keywords that describe it to get started."
 			),
 			customerType: 'business',
-		},
-		{
-			id: 4, // This value must correspond with its sibling in the /segments API results
-			slug: 'professional',
+		} ),
+		createSiteType( SITE_TYPE_PROFESSIONAL, {
 			defaultVertical: 'designer',
 			label: i18n.translate( 'Professional' ),
 			description: i18n.translate( 'Showcase your portfolio and work.' ),
-			theme: 'pub/modern-business',
 			designType: 'portfolio',
 			siteTitleLabel: i18n.translate( 'What is your name?' ),
 			siteTitlePlaceholder: i18n.translate( 'E.g., John Appleseed' ),
@@ -121,11 +131,8 @@ function getAllSiteTypes( context ) {
 			domainsStepSubheader: i18n.translate(
 				'Enter your name or some keywords that describe yourself to get started.'
 			),
-		},
-		{
-			id: 3, // This value must correspond with its sibling in the /segments API results
-			slug: 'online-store',
-			defaultVertical: 'business',
+		} ),
+		createSiteType( SITE_TYPE_STORE, {
 			label: i18n.translate( 'Online store' ),
 			description: i18n.translate( 'Sell your collection of products online.' ),
 			theme: 'pub/dara',
@@ -136,7 +143,7 @@ function getAllSiteTypes( context ) {
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
 			purchaseRequired: context === CONTEXT_WPCOM,
-		},
+		} ),
 	];
 }
 
@@ -154,21 +161,13 @@ export const getWpcomSiteTypes = () => getAllSiteTypes( CONTEXT_WPCOM );
  */
 export const getJetpackSiteTypes = () => getAllSiteTypes( CONTEXT_JETPACK );
 
-/**
- * Looks up site types array for item match and returns a property value
- *
- * @example
- * // Find the site type where `id === 2`, and return the value of `slug`
- * const siteTypeValue = getSiteTypePropertyValue( 'id', 2, 'slug' );
- *
- * @param {string} key A property name of a site types item
- * @param {string|number} value The value of `key` with which to filter items
- * @param {string} property The name of the property whose value you wish to return
- * @param {array} siteTypes (optional) A site type collection
- * @return {(string|int)?} value of `property` or `null` if none is found
- */
-export function getSiteTypePropertyValue( key, value, property, siteTypes = getWpcomSiteTypes() ) {
-	const siteTypeProperties = find( siteTypes, { [ key ]: value } );
+const getSiteTypeProp = ( siteTypes, slug, prop ) => {
+	const siteType = find( siteTypes, { slug } ) || {};
+	return siteType[ prop ];
+};
 
-	return get( siteTypeProperties, property ) || getSiteTypePropertyDefaults( property );
-}
+export const getWpcomSiteTypeProp = ( slug, prop ) =>
+	getSiteTypeProp( getWpcomSiteTypes(), slug, prop );
+
+export const getJetpackSiteTypeProp = ( slug, prop ) =>
+	getSiteTypeProp( getJetpackSiteTypes(), slug, prop );

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -135,7 +135,7 @@ function getAllSiteTypes( context ) {
 			siteTopicHeader: i18n.translate( 'What type of products do you sell?' ),
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
-			purchaseRequired: context === CONTEXT_WPCOM ? true : null,
+			purchaseRequired: context === CONTEXT_WPCOM,
 		},
 	];
 }

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -9,6 +9,9 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 
+const CONTEXT_WPCOM = 'CONTEXT_WPCOM';
+const CONTEXT_JETPACK = 'CONTEXT_JETPACK';
+
 const getSiteTypePropertyDefaults = propertyKey =>
 	get(
 		{
@@ -46,25 +49,6 @@ const getSiteTypePropertyDefaults = propertyKey =>
 	);
 
 /**
- * Looks up site types array for item match and returns a property value
- *
- * @example
- * // Find the site type where `id === 2`, and return the value of `slug`
- * const siteTypeValue = getSiteTypePropertyValue( 'id', 2, 'slug' );
- *
- * @param {string} key A property name of a site types item
- * @param {string|number} value The value of `key` with which to filter items
- * @param {string} property The name of the property whose value you wish to return
- * @param {array} siteTypes (optional) A site type collection
- * @return {(string|int)?} value of `property` or `null` if none is found
- */
-export function getSiteTypePropertyValue( key, value, property, siteTypes = getAllSiteTypes() ) {
-	const siteTypeProperties = find( siteTypes, { [ key ]: value } );
-
-	return get( siteTypeProperties, property ) || getSiteTypePropertyDefaults( property );
-}
-
-/**
  * Returns a current list of site types that are displayed in the signup site-type step
  * Some (or all) of these site types will also have landing pages.
  * A user who comes in via a landing page will not see the Site Topic dropdown.
@@ -72,9 +56,10 @@ export function getSiteTypePropertyValue( key, value, property, siteTypes = getA
  *
  * Please don't modify the IDs for now until we can integrate the /segments API into Calypso.
  *
+ * @param {string} context of `CONTEXT_WPCOM` or `CONTEXT_JETPACK`
  * @return {array} current list of site types
  */
-export function getAllSiteTypes() {
+function getAllSiteTypes( context ) {
 	return [
 		{
 			id: 2, // This value must correspond with its sibling in the /segments API results
@@ -150,8 +135,40 @@ export function getAllSiteTypes() {
 			siteTopicHeader: i18n.translate( 'What type of products do you sell?' ),
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
-			// TODO: Re-enable "Purchase required" badge, but hide for Jetpack onboarding.
-			// purchaseRequired: true,
+			purchaseRequired: context === CONTEXT_WPCOM ? true : null,
 		},
 	];
+}
+
+/**
+ * Returns site types configuration used for WordPress.com signup
+ *
+ * @return {array} List of WordPress.com site types
+ */
+export const getWpcomSiteTypes = () => getAllSiteTypes( CONTEXT_WPCOM );
+
+/**
+ * Returns site types configuration used for Jetpack onboarding
+ *
+ * @return {array} List of Jetpack site types
+ */
+export const getJetpackSiteTypes = () => getAllSiteTypes( CONTEXT_JETPACK );
+
+/**
+ * Looks up site types array for item match and returns a property value
+ *
+ * @example
+ * // Find the site type where `id === 2`, and return the value of `slug`
+ * const siteTypeValue = getSiteTypePropertyValue( 'id', 2, 'slug' );
+ *
+ * @param {string} key A property name of a site types item
+ * @param {string|number} value The value of `key` with which to filter items
+ * @param {string} property The name of the property whose value you wish to return
+ * @param {array} siteTypes (optional) A site type collection
+ * @return {(string|int)?} value of `property` or `null` if none is found
+ */
+export function getSiteTypePropertyValue( key, value, property, siteTypes = getWpcomSiteTypes() ) {
+	const siteTypeProperties = find( siteTypes, { [ key ]: value } );
+
+	return get( siteTypeProperties, property ) || getSiteTypePropertyDefaults( property );
 }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -40,7 +40,7 @@ import { getSelectedImportEngine, getNuxUrlInputValue } from 'state/importer-nux
 
 // Current directory dependencies
 import { isValidLandingPageVertical } from './verticals';
-import { getSiteTypePropertyValue } from './site-type';
+import { getSiteTypeId, getWpcomSiteTypeProp } from './site-type';
 import SignupCart from './cart';
 import { promisify } from '../../utils';
 
@@ -148,7 +148,7 @@ export function createSiteWithCart(
 	const siteGoals = getSiteGoals( state ).trim();
 	const siteType = getSiteType( state ).trim();
 	const siteStyle = getSiteStyle( state ).trim();
-	const siteSegment = getSiteTypePropertyValue( 'slug', siteType, 'id' );
+	const siteSegment = getSiteTypeId( siteType );
 
 	const newSiteParams = {
 		blog_title: siteTitle,
@@ -625,14 +625,15 @@ export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) 
 		},
 	} = nextProps;
 
-	const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
+	const siteTypeValue = getWpcomSiteTypeProp( siteType, 'slug' );
 	let fulfilledDependencies = [];
 
 	if ( siteTypeValue ) {
 		debug( 'From query string: site_type = %s', siteType );
 		debug( 'Site type value = %s', siteTypeValue );
 
-		nextProps.submitSiteType( siteType );
+		const themeSlugWithRepo = getWpcomSiteTypeProp( siteTypeValue, 'theme' );
+		nextProps.submitSiteType( siteType, themeSlugWithRepo );
 		recordExcludeStepEvent( stepName, siteType );
 
 		// nextProps.submitSiteType( siteType ) above provides dependencies

--- a/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
+++ b/client/my-sites/checklist/wpcom-checklist/wpcom-task-list.js
@@ -9,7 +9,7 @@ import config from 'config';
 /**
  * Internal dependencies
  */
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getSiteTypeSlug } from 'lib/signup/site-type';
 import { getVerticalTaskList } from './vertical-task-list';
 
 const debug = debugModule( 'calypso:wpcom-task-list' );
@@ -29,7 +29,7 @@ function getTasks( {
 	}
 
 	const tasks = [];
-	const segmentSlug = getSiteTypePropertyValue( 'id', siteSegment, 'slug' );
+	const segmentSlug = getSiteTypeSlug( siteSegment );
 
 	const getTask = taskId =>
 		taskStatuses ? taskStatuses.filter( task => task.id === taskId )[ 0 ] : undefined;

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -24,7 +24,7 @@ import { getSiteStyleOptions, getThemeCssUri } from 'lib/signup/site-styles';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getLocaleSlug, getLanguage } from 'lib/i18n-utils';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getWpcomSiteTypeProp } from 'lib/signup/site-type';
 
 /**
  * Style dependencies
@@ -32,7 +32,7 @@ import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import './style.scss';
 
 function SiteMockupHelpTip( { siteType } ) {
-	const helpTipCopy = getSiteTypePropertyValue( 'slug', siteType, 'siteMockupHelpTipCopy' ) || '';
+	const helpTipCopy = getWpcomSiteTypeProp( siteType, 'siteMockupHelpTipCopy' ) || '';
 
 	return (
 		<div className="site-mockup__help-tip">
@@ -43,8 +43,7 @@ function SiteMockupHelpTip( { siteType } ) {
 }
 
 function SiteMockupHelpTipBottom( { siteType } ) {
-	const helpTipCopy =
-		getSiteTypePropertyValue( 'slug', siteType, 'siteMockupHelpTipCopyBottom' ) || '';
+	const helpTipCopy = getWpcomSiteTypeProp( siteType, 'siteMockupHelpTipCopyBottom' ) || '';
 	return (
 		<div className="site-mockup__help-tip">
 			<Gridicon icon="chevron-up" />
@@ -178,7 +177,7 @@ export default connect(
 		const siteType = getSiteType( state );
 		const styleOptions = getSiteStyleOptions( siteType );
 		const style = find( styleOptions, { id: siteStyle || 'modern' } );
-		const titleFallback = getSiteTypePropertyValue( 'slug', siteType, 'siteMockupTitleFallback' );
+		const titleFallback = getWpcomSiteTypeProp( siteType, 'siteMockupTitleFallback' );
 		return {
 			title: getSiteTitle( state ) || titleFallback,
 			siteStyle,

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -27,7 +27,7 @@ import { getSurveyVertical } from 'state/signup/steps/survey/selectors';
 import { isValidLandingPageVertical } from 'lib/signup/verticals';
 import { DESIGN_TYPE_STORE } from 'signup/constants';
 import { isUserLoggedIn } from 'state/current-user/selectors';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getWpcomSiteTypeProp } from 'lib/signup/site-type';
 import {
 	getSiteVerticalId,
 	getSiteVerticalParentId,
@@ -230,13 +230,12 @@ class AboutStep extends Component {
 
 		//Site Goals
 		if ( shouldHideSiteGoals ) {
-			themeRepo =
-				getSiteTypePropertyValue( 'slug', siteType, 'theme' ) || 'pub/independent-publisher-2';
+			themeRepo = getWpcomSiteTypeProp( siteType, 'theme' ) || 'pub/independent-publisher-2';
 
 			if ( 'ecommerce' === flowName ) {
 				designType = 'page';
 			} else {
-				designType = getSiteTypePropertyValue( 'slug', siteType, 'designType' ) || 'blog';
+				designType = getWpcomSiteTypeProp( siteType, 'designType' ) || 'blog';
 			}
 
 			eventAttributes.site_type = siteType;

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -47,7 +47,7 @@ import { getAvailableProductsList } from 'state/products-list/selectors';
 import { getSuggestionsVendor } from 'lib/domains/suggestions';
 import { getSite } from 'state/sites/selectors';
 import { getVerticalForDomainSuggestions } from 'state/signup/steps/site-vertical/selectors';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getWpcomSiteTypeProp } from 'lib/signup/site-type';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 
 /**
@@ -538,7 +538,7 @@ class DomainsStep extends React.Component {
 		const onboardingSubHeaderCopy =
 			siteType &&
 			includes( [ 'onboarding-for-business', 'onboarding' ], flowName ) &&
-			getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
+			getWpcomSiteTypeProp( siteType, 'domainsStepSubheader' );
 
 		if ( onboardingSubHeaderCopy ) {
 			return onboardingSubHeaderCopy;
@@ -551,7 +551,7 @@ class DomainsStep extends React.Component {
 
 	getHeaderText() {
 		const { headerText, siteType } = this.props;
-		return getSiteTypePropertyValue( 'slug', siteType, 'domainsStepHeader' ) || headerText;
+		return getWpcomSiteTypeProp( siteType, 'domainsStepHeader' ) || headerText;
 	}
 
 	getAnalyticsSection() {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -24,7 +24,7 @@ import { FEATURE_UPLOAD_THEMES_PLUGINS } from '../../../lib/plans/constants';
 import { planHasFeature } from '../../../lib/plans';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getWpcomSiteTypeProp } from 'lib/signup/site-type';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -120,7 +120,7 @@ export class PlansStep extends Component {
 
 		const siteGoals = this.props.siteGoals.split( ',' );
 		let customerType =
-			getSiteTypePropertyValue( 'slug', this.props.siteType, 'customerType' ) ||
+			getWpcomSiteTypeProp( this.props.siteType, 'customerType' ) ||
 			( intersection( siteGoals, [ 'sell', 'promote' ] ).length > 0 ? 'business' : 'personal' );
 
 		// Default to 'business' when the blogger plan is not available.

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -24,7 +24,6 @@ import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getSiteStyleOptions } from 'lib/signup/site-styles';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 
 /**
@@ -130,9 +129,9 @@ export class SiteStyleStep extends Component {
 			translate,
 		} = this.props;
 		const headerText = translate( 'Choose a style' );
-		// for the time being we just want to fall back to the default value.
-		// If we come to add segment specific copy for this item, update the first 2 args.
-		const subHeaderText = getSiteTypePropertyValue( null, null, 'siteStyleSubheader' );
+		const subHeaderText = translate(
+			'This will help you get started with a theme you might like. You can change it later.'
+		);
 
 		return (
 			<div>

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -16,7 +16,7 @@ import Button from 'components/button';
 import FormTextInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
 import QueryVerticals from 'components/data/query-verticals';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getWpcomSiteTypeProp } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { setSiteTitle } from 'state/signup/steps/site-title/actions';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
@@ -68,9 +68,8 @@ class SiteTitleStep extends Component {
 
 	renderSiteTitleStep = () => {
 		const { shouldFetchVerticalData, siteTitle, siteType, siteVerticalName } = this.props;
-		const fieldLabel = getSiteTypePropertyValue( 'slug', siteType, 'siteTitleLabel' ) || '';
-		const fieldPlaceholder =
-			getSiteTypePropertyValue( 'slug', siteType, 'siteTitlePlaceholder' ) || '';
+		const fieldLabel = getWpcomSiteTypeProp( siteType, 'siteTitleLabel' ) || '';
+		const fieldPlaceholder = getWpcomSiteTypeProp( siteType, 'siteTitlePlaceholder' ) || '';
 		return (
 			<div className="site-title__wrapper">
 				{ shouldFetchVerticalData && <QueryVerticals searchTerm={ siteVerticalName } /> }
@@ -106,8 +105,8 @@ class SiteTitleStep extends Component {
 			siteType,
 			stepName,
 		} = this.props;
-		const headerText = getSiteTypePropertyValue( 'slug', siteType, 'siteTitleLabel' );
-		const subHeaderText = getSiteTypePropertyValue( 'slug', siteType, 'siteTitleSubheader' );
+		const headerText = getWpcomSiteTypeProp( siteType, 'siteTitleLabel' );
+		const subHeaderText = getWpcomSiteTypeProp( siteType, 'siteTitleSubheader' );
 
 		return (
 			<div>

--- a/client/signup/steps/site-topic/form.jsx
+++ b/client/signup/steps/site-topic/form.jsx
@@ -26,7 +26,6 @@ import {
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getVerticals } from 'state/signup/verticals/selectors';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 /**
  * Style dependencies
@@ -35,6 +34,8 @@ import './style.scss';
 
 class SiteTopicForm extends Component {
 	static propTypes = {
+		labelText: PropTypes.string,
+		placeholder: PropTypes.string,
 		submitForm: PropTypes.func.isRequired,
 
 		// from localize() HoC
@@ -73,18 +74,23 @@ class SiteTopicForm extends Component {
 	};
 
 	render() {
-		const { isButtonDisabled, siteTopic, siteType } = this.props;
-		const suggestionSearchInputPlaceholder =
-			getSiteTypePropertyValue( 'slug', siteType, 'siteTopicInputPlaceholder' ) || '';
-		const headerText = getSiteTypePropertyValue( 'slug', siteType, 'siteTopicLabel' ) || '';
+		const {
+			defaultVerticalSearchTerm,
+			isButtonDisabled,
+			labelText,
+			placeholder,
+			siteTopic,
+			siteType,
+		} = this.props;
 
 		return (
 			<div className={ classNames( 'site-topic__content', { 'is-empty': ! siteTopic } ) }>
 				<form onSubmit={ this.onSubmit }>
 					<FormFieldset>
 						<SiteVerticalsSuggestionSearch
-							placeholder={ suggestionSearchInputPlaceholder }
-							labelText={ headerText }
+							defaultVerticalSearchTerm={ defaultVerticalSearchTerm }
+							placeholder={ placeholder }
+							labelText={ labelText }
 							onChange={ this.onSiteTopicChange }
 							showPopular={ true }
 							searchValue={ siteTopic }

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -14,7 +14,7 @@ import { localize } from 'i18n-calypso';
 import SiteTopicForm from './form';
 import StepWrapper from 'signup/step-wrapper';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getWpcomSiteTypeProp } from 'lib/signup/site-type';
 import { getSiteVerticalIsUserInput } from 'state/signup/steps/site-vertical/selectors';
 import { submitSiteVertical } from 'state/signup/steps/site-vertical/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
@@ -47,26 +47,41 @@ class SiteTopicStep extends Component {
 	};
 
 	render() {
-		const headerText =
-			getSiteTypePropertyValue( 'slug', this.props.siteType, 'siteTopicHeader' ) || '';
-		const subHeaderText =
-			getSiteTypePropertyValue( 'slug', this.props.siteType, 'siteTopicSubheader' ) || '';
+		const {
+			flowName,
+			positionInFlow,
+			showSiteMockups,
+			signupProgress,
+			siteType,
+			stepName,
+		} = this.props;
+		const headerText = getWpcomSiteTypeProp( siteType, 'siteTopicHeader' ) || '';
+		const subHeaderText = getWpcomSiteTypeProp( siteType, 'siteTopicSubheader' ) || '';
+		const searchInputPlaceholder = getWpcomSiteTypeProp( siteType, 'siteTopicInputPlaceholder' );
+		const searchInputLabel = getWpcomSiteTypeProp( siteType, 'siteTopicLabel' );
+		const defaultVerticalSearchTerm = getWpcomSiteTypeProp( siteType, 'defaultVertical' );
 
 		return (
 			<div>
 				<StepWrapper
-					flowName={ this.props.flowName }
-					stepName={ this.props.stepName }
-					positionInFlow={ this.props.positionInFlow }
+					flowName={ flowName }
+					stepName={ stepName }
+					positionInFlow={ positionInFlow }
 					headerText={ headerText }
 					fallbackHeaderText={ headerText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ subHeaderText }
-					signupProgress={ this.props.signupProgress }
+					signupProgress={ signupProgress }
 					stepContent={
-						<SiteTopicForm submitForm={ this.submitSiteTopic } siteType={ this.props.siteType } />
+						<SiteTopicForm
+							defaultVerticalSearchTerm={ defaultVerticalSearchTerm }
+							labelText={ searchInputLabel }
+							placeholder={ searchInputPlaceholder }
+							submitForm={ this.submitSiteTopic }
+							siteType={ siteType }
+						/>
 					}
-					showSiteMockups={ this.props.showSiteMockups }
+					showSiteMockups={ showSiteMockups }
 				/>
 			</div>
 		);

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -11,7 +11,6 @@ import { localize } from 'i18n-calypso';
  */
 import Badge from 'components/badge';
 import Card from 'components/card';
-import { getAllSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
 
 /**
@@ -21,7 +20,7 @@ import './style.scss';
 
 class SiteTypeForm extends Component {
 	static propTypes = {
-		siteType: PropTypes.string,
+		siteTypes: PropTypes.arrayOf( PropTypes.object ).isRequired,
 		submitForm: PropTypes.func.isRequired,
 
 		// from localize() HoC
@@ -39,7 +38,7 @@ class SiteTypeForm extends Component {
 		return (
 			<Fragment>
 				<Card className="site-type__wrapper">
-					{ getAllSiteTypes().map( siteTypeProperties => (
+					{ this.props.siteTypes.map( siteTypeProperties => (
 						<Card
 							className="site-type__option"
 							key={ siteTypeProperties.id }

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -11,9 +11,9 @@ import { connect } from 'react-redux';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import SiteTypeForm from './form';
 import StepWrapper from 'signup/step-wrapper';
-import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
+import { getWpcomSiteTypes } from 'lib/signup/site-type';
 
 const siteTypeToFlowname = {
 	'online-store': 'ecommerce-onboarding',
@@ -47,7 +47,6 @@ class SiteType extends Component {
 			flowName,
 			positionInFlow,
 			signupProgress,
-			siteType,
 			stepName,
 			translate,
 			hasInitializedSitesBackUrl,
@@ -68,7 +67,9 @@ class SiteType extends Component {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
-				stepContent={ <SiteTypeForm submitForm={ this.submitStep } siteType={ siteType } /> }
+				stepContent={
+					<SiteTypeForm submitForm={ this.submitStep } siteTypes={ getWpcomSiteTypes() } />
+				}
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }
 				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to My Sites' ) : null }
@@ -79,7 +80,6 @@ class SiteType extends Component {
 
 export default connect(
 	state => ( {
-		siteType: getSiteType( state ) || 'blog',
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 	} ),
 	{ saveSignupStep, submitSiteType }

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -13,7 +13,7 @@ import SiteTypeForm from './form';
 import StepWrapper from 'signup/step-wrapper';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
-import { getWpcomSiteTypes } from 'lib/signup/site-type';
+import { getWpcomSiteTypes, getWpcomSiteTypeProp } from 'lib/signup/site-type';
 
 const siteTypeToFlowname = {
 	'online-store': 'ecommerce-onboarding',
@@ -26,7 +26,8 @@ class SiteType extends Component {
 	}
 
 	submitStep = siteTypeValue => {
-		this.props.submitSiteType( siteTypeValue );
+		const themeSlugWithRepo = getWpcomSiteTypeProp( siteTypeValue, 'theme' );
+		this.props.submitSiteType( siteTypeValue, themeSlugWithRepo );
 
 		// TODO Hack to fix the `/start/premium|business|personal` routes
 		if (

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -16,7 +16,7 @@ import { convertToCamelCase } from 'state/data-layer/utils';
 import { errorNotice } from 'state/notices/actions';
 import { setVerticals } from 'state/signup/verticals/actions';
 import { SIGNUP_VERTICALS_REQUEST } from 'state/action-types';
-import { getSiteTypeId } from 'state/signup/steps/site-type/selectors';
+import { getSiteTypeId } from 'lib/signup/site-type';
 
 // Some flows do not choose a site type before requesting verticals. In this
 // case don't send a site_type param to the API.
@@ -58,7 +58,7 @@ registerHandlers( 'state/data-layer/wpcom/signup/verticals', {
 		( store, action ) =>
 			verticalsHandlers( store, {
 				...action,
-				siteTypeId: getSiteTypeId( store.getState(), action.siteType ),
+				siteTypeId: getSiteTypeId( action.siteType ),
 			} ),
 	],
 } );

--- a/client/state/signup/steps/site-type/actions.js
+++ b/client/state/signup/steps/site-type/actions.js
@@ -5,7 +5,6 @@
  */
 
 import { SIGNUP_STEPS_SITE_TYPE_SET } from 'state/action-types';
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { submitSignupStep } from 'state/signup/progress/actions';
 
 export function setSiteType( siteType ) {
@@ -15,13 +14,11 @@ export function setSiteType( siteType ) {
 	};
 }
 
-export function submitSiteType( siteType ) {
+export function submitSiteType( siteType, theme ) {
 	return dispatch => {
+		const themeSlugWithRepo = theme || 'pub/independent-publisher-2';
+
 		dispatch( setSiteType( siteType ) );
-
-		const themeSlugWithRepo =
-			getSiteTypePropertyValue( 'slug', siteType, 'theme' ) || 'pub/independent-publisher-2';
-
 		dispatch( submitSignupStep( { stepName: 'site-type' }, { siteType, themeSlugWithRepo } ) );
 	};
 }

--- a/client/state/signup/steps/site-type/selectors.js
+++ b/client/state/signup/steps/site-type/selectors.js
@@ -6,19 +6,6 @@
 
 import { get } from 'lodash';
 
-/**
- * Internal dependencies
- */
-
-import { getSiteTypePropertyValue } from 'lib/signup/site-type';
-
 export function getSiteType( state ) {
 	return get( state, 'signup.steps.siteType', '' );
-}
-
-export function getSiteTypeId( state, siteType = null ) {
-	if ( ! siteType ) {
-		siteType = getSiteType( state );
-	}
-	return getSiteTypePropertyValue( 'slug', siteType, 'id' );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

WordPress.com and Jetpack onboarding flows share the site type step. However, in at least one case, a "Purchase required" badge for the "Online store" site type, we need the step to present differently, depending on which context the user is in.

This PR updates the site types configuration to be specific to each context, including displaying the Purchase required badge only in WordPress.com flows.

I've taken the approach of trying to keep the differences within the site type configuration, so that the `SiteTypeForm` component stays "dumb", simply responding to the configuration it's given.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**WordPress.com**

* Visit `/start` and proceed to the site type step
* See that "Purchase required" displays under the "Online store" site type

<img width="488" alt="Screen Shot 2019-06-17 at 17 45 43" src="https://user-images.githubusercontent.com/1699996/59641859-8950bd00-9128-11e9-95a2-8bccf3ee2109.png">

**Jetpack**

* Create a site on jurassic.ninja and note the url
* Visit `/jetpack/connect` and enter the site url
* Proceed to the site type step and see that "Purchase required" is not visible

<img width="593" alt="Screen Shot 2019-06-21 at 16 13 29" src="https://user-images.githubusercontent.com/1699996/59951808-9f6bbf80-943f-11e9-80b8-55f83e58ab40.png">

Fixes #33544
