### PR TITLE
Full Site Editing: make Edit Template Part link work on Gutenframe.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -15,7 +15,7 @@ import { withSelect } from '@wordpress/data';
 import { BlockControls } from '@wordpress/editor';
 import { Fragment, RawHTML } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-
+import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
@@ -48,6 +48,11 @@ const TemplateEdit = compose(
 	const showPlaceholder = isEditing || ! templateId;
 	const showContent = ! isEditing && !! templateId;
 	const isTemplate = 'wp_template' === fullSiteEditing.editorPostType;
+
+	const editTemplatePartUrl = addQueryArgs( fullSiteEditing.editTemplatePartBaseUrl, {
+		post: templateId,
+		fse_parent_post: currentPostId,
+	} );
 
 	return (
 		<Fragment>
@@ -83,7 +88,7 @@ const TemplateEdit = compose(
 								postType="wp_template_part"
 							/>
 							{ !! template && (
-								<a href={ `?post=${ templateId }&action=edit&fse_parent_post=${ currentPostId }` }>
+								<a href={ editTemplatePartUrl }>
 									{ sprintf( __( 'Edit "%s"' ), get( template, [ 'title', 'rendered' ], '' ) ) }
 								</a>
 							) }
@@ -102,10 +107,7 @@ const TemplateEdit = compose(
 									'This block is part of your site template and may appear on multiple pages.'
 								) }
 							>
-								<Button
-									href={ `?post=${ templateId }&action=edit&fse_parent_post=${ currentPostId }` }
-									isDefault
-								>
+								<Button href={ editTemplatePartUrl } isDefault>
 									{ sprintf( __( 'Edit %s' ), get( template, [ 'title', 'rendered' ], '' ) ) }
 								</Button>
 							</Placeholder>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -307,8 +307,8 @@ class Full_Site_Editing {
 			array(
 				'editorPostType' => get_current_screen()->post_type,
 				'featureFlags'   => $feature_flags->get_flags(),
-				'closeButtonUrl' => $this->get_close_button_url(),
-				'editTemplatePartBaseUrl' => $this->get_edit_template_part_base_url(),
+				'closeButtonUrl' => esc_url( $this->get_close_button_url() ),
+				'editTemplatePartBaseUrl' => esc_url( $this->get_edit_template_part_base_url() ),
 			)
 		);
 
@@ -446,7 +446,7 @@ class Full_Site_Editing {
 	 * @return string edit link without post ID
 	 */
 	public function get_edit_template_part_base_url() {
-		$edit_post_link = esc_url( remove_query_arg( 'post', get_edit_post_link( 0, 'edit' ) ) );
+		$edit_post_link = remove_query_arg( 'post', get_edit_post_link( 0, 'edit' ) );
 
 		/**
 		 * Filter the Gutenberg's edit template part button base URL

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -308,6 +308,7 @@ class Full_Site_Editing {
 				'editorPostType' => get_current_screen()->post_type,
 				'featureFlags'   => $feature_flags->get_flags(),
 				'closeButtonUrl' => $this->get_close_button_url(),
+				'editTemplatePartBaseUrl' => $this->get_edit_template_part_base_url(),
 			)
 		);
 
@@ -434,9 +435,28 @@ class Full_Site_Editing {
 		 *
 		 * @param string Current close button URL.
 		 */
-		$close_button_url = apply_filters( 'a8c_fse_close_button_link', $close_button_url );
+		return apply_filters( 'a8c_fse_close_button_link', $close_button_url );
+	}
 
-		return $close_button_url;
+	/**
+	 * Returns the base URL for the Edit Template Part button. The URL does not contain neither
+	 * the post ID nor the template part ID. Those query arguments should be provided by
+	 * the Template Part on the Block.
+	 *
+	 * @return string edit link without post ID
+	 */
+	public function get_edit_template_part_base_url() {
+		$edit_post_link = esc_url( remove_query_arg( 'post', get_edit_post_link( 0, 'edit' ) ) );
+
+		/**
+		 * Filter the Gutenberg's edit template part button base URL
+		 * when editing pages or posts.
+		 *
+		 * @since 0.2
+		 *
+		 * @param string Current edit button URL.
+		 */
+		return apply_filters( 'a8c_fse_edit_template_part_base_url', $edit_post_link );
 	}
 
 	/** This will merge the post content with the post template, modifiying the


### PR DESCRIPTION
In order to add all the extra querystring arguments needed to run the editor on Gutenframe, we need to provide a way for the WordPress.com backend to calculate the URL of the edit button.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/233601/59960337-81cd4300-949d-11e9-93ea-dd704aeadef1.gif) | ![after](https://user-images.githubusercontent.com/233601/59960287-ce644e80-949c-11e9-8537-748366cccda0.gif) |

#### Changes proposed in this Pull Request

* Use `fullSiteEditing` to store the base URL for the Edit button. Post ID and Template ID are added by the _Template Part_.
* A value for the base URL is calculated on the `Full_Site_Editing` class.
* A filter is provided to add extra query string arguments when running on WordPress.com

Using the backend to create the URL is enough for the `frame_nonce` argument to be added to the button URL. This PR does not add any extra parameters (like support token). That should be resolved using the `a8c_fse_edit_template_part_base_url` filter on the plugin loader on WordPress.com.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build the Full Site Editing files following the instructions from PCYsg-ly5-p2 and upload them to your WordPress.com sandbox.
* Sandbox a WordPress.com site and the `public-api`.
* on Calypso, edit a page with a template assigned to it. If you don't have a template, assign one.
* Click on the Edit Template Part link when you hover a Template Part.
* Verify that the editor reloads with the Template Part contents.
* Verify that there are no regressions on the standalone plugin.

Fixes #34074 
