### PR TITLE
NpsSurvey: migrate CSS to webpack and remove always-true feature flag

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -8,7 +8,6 @@
 
 @import 'layout/style';
 
-@import 'blocks/nps-survey/style';
 @import 'blocks/login/style';
 @import 'blocks/post-item/style';
 @import 'components/button/style';

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -31,6 +31,11 @@ import { CALYPSO_CONTACT } from 'lib/url/support';
 import analytics from 'lib/analytics';
 import RecommendationSelect from './recommendation-select';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class NpsSurvey extends PureComponent {
 	static propTypes = {
 		onChangeForm: PropTypes.func,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -138,9 +138,7 @@ class Layout extends Component {
 				<QueryPreferences />
 				<QuerySiteSelectedEditor siteId={ this.props.siteId } />
 				<AsyncLoad require="layout/guided-tours" placeholder={ null } />
-				{ config.isEnabled( 'nps-survey/notice' ) && ! isE2ETest() && (
-					<AsyncLoad require="layout/nps-survey-notice" placeholder={ null } />
-				) }
+				{ ! isE2ETest() && <AsyncLoad require="layout/nps-survey-notice" placeholder={ null } /> }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
 				<MasterbarLoggedIn
 					section={ this.props.sectionGroup }

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -99,7 +99,6 @@
 		"me/trophies": false,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
-		"nps-survey/notice": true,
 		"paladin": true,
 		"network-connection": true,
 		"oauth": true,

--- a/config/development.json
+++ b/config/development.json
@@ -125,7 +125,6 @@
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
-		"nps-survey/notice": true,
 		"network-connection": true,
 		"oauth": false,
 		"onboarding-checklist": true,

--- a/config/production.json
+++ b/config/production.json
@@ -84,7 +84,6 @@
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
-		"nps-survey/notice": true,
 		"onboarding-checklist": true,
 		"onboarding-checklist/email-setup": true,
 		"onboarding-checklist/phase2": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -86,7 +86,6 @@
 		"my-sites/checkout/web-payment/basic-card": false,
 		"nps-survey/devdocs": false,
 		"nps-survey/dev-trigger": false,
-		"nps-survey/notice": true,
 		"onboarding-checklist": true,
 		"onboarding-checklist/email-setup": true,
 		"onboarding-checklist/phase2": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -101,7 +101,6 @@
 		"network-connection": true,
 		"nps-survey/devdocs": true,
 		"nps-survey/dev-trigger": true,
-		"nps-survey/notice": true,
 		"onboarding-checklist": true,
 		"onboarding-checklist/email-setup": true,
 		"onboarding-checklist/phase2": true,


### PR DESCRIPTION
How to test:
- go to Calypso with `?flags=nps-survey/dev-trigger` query string
- type `npsSurvey()` in console
- verify that the dialog styling is OK