### PR TITLE
Contact Form: only apply Calypso styling for Simple and Atomic sites

### DIFF
--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -27,6 +27,7 @@ import {
 	isJetpackSite,
 	isSingleUserSite,
 } from 'state/sites/selectors';
+import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
 import areAllSitesSingleUser from 'state/selectors/are-all-sites-single-user';
 import { canCurrentUser as canCurrentUserStateSelector } from 'state/selectors/can-current-user';
 import { itemLinkMatches } from './utils';
@@ -44,6 +45,7 @@ class SiteMenu extends PureComponent {
 		allSingleSites: PropTypes.bool,
 		canCurrentUser: PropTypes.func,
 		isJetpack: PropTypes.bool,
+		isSiteAtomic: PropTypes.bool,
 		isSingleUser: PropTypes.bool,
 		postTypes: PropTypes.object,
 		siteAdminUrl: PropTypes.string,
@@ -211,7 +213,7 @@ class SiteMenu extends PureComponent {
 	}
 
 	getCustomMenuItems() {
-		const { isVip } = this.props;
+		const { isVip, isJetpack, isSiteAtomic } = this.props;
 		//reusable blocks are not shown in the sidebar on wp-admin either
 		const customPostTypes = omit( this.props.postTypes, [ 'post', 'page', 'wp_block' ] );
 		return reduce(
@@ -240,10 +242,11 @@ class SiteMenu extends PureComponent {
 						// Required to build the menu item class name. Must be discernible from other
 						// items' paths in the same section for item highlighting to work properly.
 						link: '/types/' + postType.name,
-						// don't calypsoify for VIP
-						wpAdminLink: isVip
-							? 'edit.php?post_type=feedback'
-							: 'edit.php?post_type=feedback&calypsoify=1',
+						// don't calypsoify for VIP or Jetpack
+						wpAdminLink:
+							isVip || ( isJetpack && ! isSiteAtomic )
+								? 'edit.php?post_type=feedback&calypsoify=0'
+								: 'edit.php?post_type=feedback&calypsoify=1',
 						showOnAllMySites: false,
 					} );
 				}
@@ -287,6 +290,7 @@ export default connect(
 		// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 		canCurrentUser: partial( canCurrentUserStateSelector, state, siteId ),
 		isJetpack: isJetpackSite( state, siteId ),
+		isSiteAtomic: isSiteWpcomAtomic( state, siteId ),
 		isSingleUser: isSingleUserSite( state, siteId ),
 		postTypes: getPostTypes( state, siteId ),
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),


### PR DESCRIPTION
This updates the feedback link on the Calypso sidebar to also account for Jetpack sites. We should see a calypsoified styled view for Simple and Atomic sites only.

<img width="272" alt="Screen Shot 2019-06-22 at 11 02 08 AM" src="https://user-images.githubusercontent.com/1270189/59967329-3cc90100-94dd-11e9-9a68-678182890565.png">

### Testing Instructions:
- Switch to a Simple Site and click on Feedback we see the Calypsoifed wp-admin feedback screen

<img width="1097" alt="Screen Shot 2019-06-22 at 10 58 15 AM" src="https://user-images.githubusercontent.com/1270189/59967272-a98fcb80-94dc-11e9-8d74-7f8ecbb6cac6.png">
- Switch to self-hosted Jetpack site and click on Feedback we see:

<img width="1090" alt="Screen Shot 2019-06-22 at 10 57 18 AM" src="https://user-images.githubusercontent.com/1270189/59967300-ee1b6700-94dc-11e9-9372-36501e8d586f.png">

- Switch to an Atomic site and click on Feedback, we see the Calypsoifed wp-admin screen
- Switch to a vip test site on wpcom and click on Feedback. We see the plain wp-admin feedback screen

Note that Atomic sites will be seeing the incorrect plugin menu until Jetpack 7.5 is released (https://github.com/Automattic/jetpack/pull/12691)

Fixes #34204