### PR TITLE
Improve removeUnneededSteps logic

### DIFF
--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -120,9 +120,9 @@ export function invalidateStep( step, errors ) {
 	};
 }
 
-export function removeUnneededSteps( flowName ) {
-	return {
+export const removeUnneededSteps = flowName => ( dispatch, getState ) =>
+	dispatch( {
 		type: SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
+		currentFlow: getCurrentFlowName( getState() ),
 		flowName,
-	};
-}
+	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Recently, we discovered bugs when moving from one flow to another similar flow (`onboarding` > `onboarding-blog` & `onboarding` > `ecommerce-onboarding`are examples). The behaviour that we would see would be that, on changing the flow, nothing would be rendered where we would expect to see the signup step content, leaving the customer with no way to progress and no hint as to what was wrong.

I traced this down to logic within the render method of `signup/main.jsx` where we render `null` under certain conditions:

https://github.com/Automattic/wp-calypso/blob/e9d99a80f9d1cd1d87c7cbc29f2316bf1f29c124/client/signup/main.jsx#L586-L592

The condition that is troublesome here is the check for progress position and the number of items in the progress state.
As we change from one flow to another we invoke the `signup/progress#removeUnneededSteps` reducer to clean out any steps that don't apply to the new flow, and steps that are generally redundant (the `user` when a user is already signed, for example). This makes sense - not all steps in flow A are necessary or useful for the completion of flow B.

The issue seems to be in the way we compare and filter those steps.
Currently, we're checking each step in the progress state for 2 things - does it exist in the definition of flow B and does it's position in the state array match perfectly with the position in the array of steps in flow B (do the indexes match 1-1). If both conditions match, we keep that step, if not we reject it.

This becomes problematic when we factor in the ability to push extra steps that are not part of a flows definition as we do with the `survey` step, when the `?vertical=x` param is provided:

https://github.com/Automattic/wp-calypso/blob/e9d99a80f9d1cd1d87c7cbc29f2316bf1f29c124/client/lib/signup/step-actions.js#L667-L670

After this step is injected, we might finish the onboarding flow with these steps in the progress state:
```js
'survey', 'user', 'site-type', 'site-topic-with-preview', 'site-title-with-preview', 'site-style-with-preview', 'domains-with-preview', 'plans',
```

So, if we were to switch flows midway through, you can see that our comparison of the step indexes will each be off by one and our filtering logic would then reject every step and return an empty array, causing the render method to return `null`.

I've tweaked the filtering logic somewhat to take these extra steps in to account. The new logic here goes something like this:

- figure out which steps of flow A do not apply to flow B and remove those.
- remove the user step if a user is already signed in.
- sort the steps that match both flow A and flow B to the order found in flow B.
- sort the extra, 'injected' steps to the appear before those matching steps

This way, we maintain the progress of steps such as `survey` while filtering the flow A > flow B discrepancies.

In my own testing, this approach seems to work but I'm not 100% confident with this area of the codebase, and so not 100% sure that this doesn't cause issues elsewhere.
Does the new logic seem robust? Can you see other areas suffering because of this change?

I'd love some feedback from , if this approach looks good enough I'll spend some time adding unit tests to cover this reducer :)

### Reproducing

First, get familiar with the issue by reproducing it:

- On master, start out with http://calypso.localhost:3000/start/onboarding?vertical=art
- Go through the user step
- On the site-type step, select one of the types that has a forked flow, currently I'm reproducing by choosing "Online store", which will switch us to the `ecommerce-onboarding` fork.
- Here, you should notice that nothing is rendered where we would expect to see the next step

A little tip here, you can log out the result of like so, and see how the state looks before an after the filtering:

```js
function removeUnneededSteps( state, { flowName } ) {
	let flowSteps = [];
	const user = userFactory();

	flowSteps = get( flows, [ flowName, 'steps' ], [] );

	if ( user && user.get() ) {
		flowSteps = flowSteps.filter( item => item !== 'user' );
	}

	const result = state.filter(
		( step, index ) =>
			flowSteps.includes( step.stepName ) && index === flowSteps.indexOf( step.stepName )
	);

	console.log( { state, result } );

	return result;
}
```

### Testing

- Set the debugger up in the console with `localStorage.setItem( 'debug', 'calypso:state:signup:progress:reducer' )`
- After patching, start out again at http://calypso.localhost:3000/start/onboarding?vertical=art
- Again, go through the steps and select "Online Store"
- You should now progress to the next step in the flow, as expected.
- If you set the debug option, you'll also be able to compare the various steps of filtering & sorting. In this case, there'll be no difference in any of them.

Fixes: https://github.com/Automattic/zelda-private/issues/58