### PR TITLE
Add unit tests for signup step actions

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -583,7 +583,10 @@ export function isDomainFulfilled( stepName, defaultDependencies, nextProps ) {
 	if ( siteDomains && siteDomains.length > 1 ) {
 		const domainItem = undefined;
 		submitSignupStep( { stepName, domainItem }, { domainItem } );
-		recordExcludeStepEvent( stepName, siteDomains );
+		recordExcludeStepEvent(
+			stepName,
+			siteDomains.map( siteDomain => siteDomain.domain ).join( ', ' )
+		);
 
 		fulfilledDependencies = [ 'domainItem' ];
 	}

--- a/client/lib/signup/test/mocks/signup/config/steps.js
+++ b/client/lib/signup/test/mocks/signup/config/steps.js
@@ -70,6 +70,18 @@ export default {
 		},
 	},
 
+	'domains-launch': {
+		stepName: 'domains-launch',
+		dependencies: [ 'siteSlug' ],
+		providesDependencies: [ 'domainItem' ],
+	},
+
+	plans: {
+		stepName: 'plans',
+		dependencies: [ 'siteSlug' ],
+		providesDependencies: [ 'cartItem' ],
+	},
+
 	'site-type': {
 		stepName: 'site-type',
 		providesDependencies: [ 'siteType', 'themeSlugWithRepo' ],

--- a/client/lib/signup/test/mocks/signup/config/steps.js
+++ b/client/lib/signup/test/mocks/signup/config/steps.js
@@ -70,6 +70,11 @@ export default {
 		},
 	},
 
+	'site-type': {
+		stepName: 'site-type',
+		providesDependencies: [ 'siteType', 'themeSlugWithRepo' ],
+	},
+
 	'site-topic': {
 		stepName: 'site-topic',
 		providesDependencies: [ 'siteTopic' ],

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { createSiteWithCart, isSiteTopicFulfilled } from '../step-actions';
+import { createSiteWithCart, isSiteTopicFulfilled, isSiteTypeFulfilled } from '../step-actions';
 import { useNock } from 'test/helpers/use-nock';
 import flows from 'signup/config/flows';
 
@@ -86,6 +86,54 @@ describe( 'createSiteWithCart()', () => {
 			[],
 			fakeStore
 		);
+	} );
+} );
+
+describe( 'isSiteTypeFulfilled()', () => {
+	const submitSiteType = jest.fn();
+
+	beforeEach( () => {
+		flows.excludeStep.mockClear();
+		submitSiteType.mockClear();
+	} );
+
+	test( 'should remove a fulfilled step', () => {
+		const stepName = 'site-type';
+		const initialContext = { query: { site_type: 'blog' } };
+		const nextProps = { initialContext, submitSiteType };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+		expect( submitSiteType ).not.toHaveBeenCalled();
+
+		isSiteTypeFulfilled( stepName, undefined, nextProps );
+
+		expect( submitSiteType ).toHaveBeenCalledWith( 'blog' );
+		expect( flows.excludeStep ).toHaveBeenCalledWith( 'site-type' );
+	} );
+
+	test( 'should not remove unfulfilled step', () => {
+		const stepName = 'site-type';
+		const initialContext = {};
+		const nextProps = { initialContext, submitSiteType };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+
+		isSiteTypeFulfilled( stepName, undefined, nextProps );
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should not remove step given an invalid site type', () => {
+		const stepName = 'site-type';
+		const initialContext = { query: { site_type: 'an-invalid-site-type-slug' } };
+		const nextProps = { initialContext, submitSiteType };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+
+		isSiteTypeFulfilled( stepName, undefined, nextProps );
+
+		expect( submitSiteType ).not.toHaveBeenCalled();
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
 	} );
 } );
 

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -97,20 +97,18 @@ describe( 'createSiteWithCart()', () => {
 
 describe( 'isDomainFulfilled', () => {
 	const submitSignupStep = jest.fn();
+	const oneDomain = [ { domain: 'example.wordpress.com' } ];
+	const twoDomains = [ { domain: 'example.wordpress.com' }, { domain: 'example.com' } ];
 
 	beforeEach( () => {
 		flows.excludeStep.mockClear();
 		submitSignupStep.mockClear();
 	} );
 
-	test( 'should remove a step when there is greater than one domain', () => {
+	test( 'should call `submitSignupStep` with empty domainItem', () => {
 		const stepName = 'domains-launch';
-		const nextProps = {
-			siteDomains: [ { domain: 'example.wordpress.com' }, { domain: 'example.com' } ],
-			submitSignupStep,
-		};
+		const nextProps = { siteDomains: twoDomains, submitSignupStep };
 
-		expect( flows.excludeStep ).not.toHaveBeenCalled();
 		expect( submitSignupStep ).not.toHaveBeenCalled();
 
 		isDomainFulfilled( stepName, undefined, nextProps );
@@ -119,15 +117,22 @@ describe( 'isDomainFulfilled', () => {
 			{ stepName, domainItem: undefined },
 			{ domainItem: undefined }
 		);
+	} );
+
+	test( 'should call `flows.excludeStep` with the stepName', () => {
+		const stepName = 'domains-launch';
+		const nextProps = { siteDomains: twoDomains, submitSignupStep };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+
+		isDomainFulfilled( stepName, undefined, nextProps );
+
 		expect( flows.excludeStep ).toHaveBeenCalledWith( stepName );
 	} );
 
 	test( 'should not remove unfulfilled step', () => {
 		const stepName = 'domains-launch';
-		const nextProps = {
-			siteDomains: [ { domain: 'example.wordpress.com' } ],
-			submitSignupStep,
-		};
+		const nextProps = { siteDomains: oneDomain, submitSignupStep };
 
 		expect( flows.excludeStep ).not.toHaveBeenCalled();
 		expect( submitSignupStep ).not.toHaveBeenCalled();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add unit tests for the following signup step actions functions:

* `isDomainFulfilled`
* `isPlanFulfilled`
* `isSiteTypeFulfilled`

* Also fixes a tiny bug where the Tracks event called via `recordExcludeStepEvent` in `isDomainFulfilled` was failing due to the `siteDomains` variable being an array. Tracks doesn't support nested values, so this approach is to concatenate all the site's domains into one string, with the values comma separated.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From a terminal run `npm run test-client client/lib/signup/test/step-actions.js` to run these tests.

* To confirm that the Tracks event is no longer throwing an error in the console, go to `http://calypso.localhost:3000/start/launch-site/?siteSlug=[insert-your-site-slug-here]` for a site that has a domain. The `domains-launch` step should be skipped, and there shouldn't be an error in the console related to the Tracks event `calypso_signup_actions_exclude_step` failing due to nested values.

Note that if you attempt this on a site that has already been launched, Calypso will go into a loop on the `launch` step. This is an issue outside of the scope of this PR, and is mitigated by the fact that users aren't currently directed to this flow on launched sites.
