### PR TITLE
(1P) Posts List Block - check for perms before displaying Edit Link

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/post-item.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/post-item.php
@@ -32,9 +32,9 @@
 			<?php the_author_posts_link(); ?>
 		</span>
 		<?php if ( current_user_can( 'edit_posts' ) ) : ?>	
-		<span class="a8c-posts-list-item__edit-link">
-			<a href="<?php echo esc_attr( get_edit_post_link() ); ?>"><?php esc_html_e( 'Edit', 'full-site-editing' ); ?></a>
-		</span>
+			<span class="a8c-posts-list-item__edit-link">
+				<a href="<?php echo esc_attr( get_edit_post_link() ); ?>"><?php esc_html_e( 'Edit', 'full-site-editing' ); ?></a>
+			</span>
 		<?php endif ?>
 	</div>
 

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/post-item.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/post-item.php
@@ -31,9 +31,11 @@
 		<span class="a8c-posts-list-item__author"><?php echo esc_html_x( 'by', 'designating the post author (eg: by John Doe', 'full-site-editing' ); ?>
 			<?php the_author_posts_link(); ?>
 		</span>
+		<?php if ( current_user_can( 'edit_posts' ) ) : ?>	
 		<span class="a8c-posts-list-item__edit-link">
 			<a href="<?php echo esc_attr( get_edit_post_link() ); ?>"><?php esc_html_e( 'Edit', 'full-site-editing' ); ?></a>
 		</span>
+		<?php endif ?>
 	</div>
 
 	<div class="a8c-posts-list-item__excerpt">


### PR DESCRIPTION
Previously each article displayed the “Edit” link unconditionally. Here we're adding a test for permissions first to ensure this only shows for those with _appropriate_ perms.

See also `p1561128533033800-slack-gutengroup-wpcomhappy`

#### Changes proposed in this Pull Request

* Restrict display of Edit link on front of site to users with correct permissions.

#### Testing instructions

This assumes you're running a local env and the Plugin is symlinked into `plugins` and activated.

* Build the FSE Plugin (see README)
* Create Page
* Add `Posts List` Block
* Publish Page
* View Page on front of site
* See `Edit` link next to each article in listing
* Create user with **_no_** `edit-posts` permissions - https://wordpress.org/support/article/roles-and-capabilities/#subscriber
* Switch to that user 
* View Page on front of site
* See there is no edit link
* Switch to browser in which you are not logged into site (eg: Incognito mode or whatever).
* View Page on front of site
* See there is no edit link

Fixes https://github.com/Automattic/wp-calypso/issues/34200
