### PR TITLE
Better support for @wordpress/element Fragment JSX

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -30,7 +30,7 @@
 				"@babel/preset-env": "7.5.5",
 				"@babel/preset-react": "7.0.0",
 				"@babel/preset-typescript": "7.3.3",
-				"@wordpress/babel-plugin-import-jsx-pragma": "2.1.0",
+				"@wordpress/babel-plugin-import-jsx-pragma": "2.3.0",
 				"@wordpress/browserslist-config": "2.3.0",
 				"autoprefixer": "9.4.4",
 				"babel-loader": "8.0.5",
@@ -41,7 +41,7 @@
 				"enzyme": "3.10.0",
 				"enzyme-adapter-react-16": "1.14.0",
 				"file-loader": "3.0.1",
-				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
+				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
 				"node-sass": "4.11.0",
 				"postcss-custom-properties": "8.0.9",
 				"postcss-loader": "3.0.0",
@@ -54,42 +54,6 @@
 				"webpack-cli": "3.3.0",
 				"webpack-filter-warnings-plugin": "1.2.1",
 				"webpack-rtl-plugin": "1.8.0"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "4.6.6",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-					"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
-					"dev": true,
-					"requires": {
-						"caniuse-lite": "^1.0.30000984",
-						"electron-to-chromium": "^1.3.191",
-						"node-releases": "^1.1.25"
-					},
-					"dependencies": {
-						"caniuse-lite": {
-							"version": "1.0.30000988",
-							"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz",
-							"integrity": "sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ==",
-							"dev": true
-						},
-						"electron-to-chromium": {
-							"version": "1.3.211",
-							"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.211.tgz",
-							"integrity": "sha512-GZAiK3oHrs0K+LwH+HD+bdjZ17v40oQQdXbbd3dgrwgbENvazrGpcuIADSAREWnxzo9gADB1evuizrbXsnoU2Q==",
-							"dev": true
-						},
-						"node-releases": {
-							"version": "1.1.26",
-							"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-							"integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-							"dev": true,
-							"requires": {
-								"semver": "^5.3.0"
-							}
-						}
-					}
-				}
 			}
 		},
 		"@automattic/calypso-color-schemes": {
@@ -131,14 +95,6 @@
 			"dev": true,
 			"requires": {
 				"semver": "^6.1.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
-					"dev": true
-				}
 			}
 		},
 		"@automattic/webpack-inline-constant-exports-plugin": {
@@ -243,6 +199,12 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				},
 				"source-map": {
@@ -958,6 +920,14 @@
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
@@ -1094,6 +1064,14 @@
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
 				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/preset-react": {
@@ -1250,6 +1228,11 @@
 					"requires": {
 						"pump": "^3.0.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -1316,28 +1299,6 @@
 				"which": "^1.3.1"
 			},
 			"dependencies": {
-				"cacache": {
-					"version": "12.0.2",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz",
-					"integrity": "sha512-ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==",
-					"requires": {
-						"bluebird": "^3.5.5",
-						"chownr": "^1.1.1",
-						"figgy-pudding": "^3.5.1",
-						"glob": "^7.1.4",
-						"graceful-fs": "^4.1.15",
-						"infer-owner": "^1.0.3",
-						"lru-cache": "^5.1.1",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"move-concurrently": "^1.0.1",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.3",
-						"ssri": "^6.0.1",
-						"unique-filename": "^1.1.1",
-						"y18n": "^4.0.0"
-					}
-				},
 				"get-stream": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -1372,10 +1333,10 @@
 					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
 					"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
 				},
-				"y18n": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				},
 				"yallist": {
 					"version": "3.0.3",
@@ -1623,13 +1584,6 @@
 				"npm-package-arg": "^6.1.0",
 				"p-map": "^2.1.0",
 				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@lerna/batch-packages": {
@@ -1670,13 +1624,6 @@
 				"p-waterfall": "^1.0.0",
 				"read-package-tree": "^5.1.6",
 				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@lerna/changed": {
@@ -1744,6 +1691,11 @@
 					"requires": {
 						"pump": "^3.0.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -1888,6 +1840,11 @@
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
 				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				},
 				"yargs": {
 					"version": "12.0.5",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
@@ -1991,6 +1948,11 @@
 					"requires": {
 						"pump": "^3.0.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -2012,16 +1974,6 @@
 				"semver": "^6.2.0"
 			},
 			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
 				"get-stream": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
@@ -2029,16 +1981,6 @@
 					"requires": {
 						"pump": "^3.0.0"
 					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -2071,26 +2013,6 @@
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-				},
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 				}
 			}
 		},
@@ -2102,23 +2024,6 @@
 				"@zkochan/cmd-shim": "^3.1.0",
 				"fs-extra": "^8.1.0",
 				"npmlog": "^4.1.2"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				}
 			}
 		},
 		"@lerna/describe-ref": {
@@ -2190,23 +2095,6 @@
 				"fs-extra": "^8.1.0",
 				"ssri": "^6.0.1",
 				"tar": "^4.4.8"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				}
 			}
 		},
 		"@lerna/github-client": {
@@ -2250,13 +2138,6 @@
 			"requires": {
 				"@lerna/child-process": "3.14.2",
 				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@lerna/import": {
@@ -2272,23 +2153,6 @@
 				"dedent": "^0.7.0",
 				"fs-extra": "^8.1.0",
 				"p-map-series": "^1.0.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				}
 			}
 		},
 		"@lerna/init": {
@@ -2301,23 +2165,6 @@
 				"fs-extra": "^8.1.0",
 				"p-map": "^2.1.0",
 				"write-json-file": "^3.2.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				}
 			}
 		},
 		"@lerna/link": {
@@ -2397,23 +2244,6 @@
 				"npmlog": "^4.1.2",
 				"signal-exit": "^3.0.2",
 				"write-pkg": "^3.1.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				}
 			}
 		},
 		"@lerna/npm-publish": {
@@ -2430,23 +2260,6 @@
 				"npmlog": "^4.1.2",
 				"pify": "^4.0.1",
 				"read-package-json": "^2.0.13"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				}
 			}
 		},
 		"@lerna/npm-run-script": {
@@ -2499,25 +2312,6 @@
 				"load-json-file": "^5.3.0",
 				"npm-package-arg": "^6.1.0",
 				"write-pkg": "^3.1.0"
-			},
-			"dependencies": {
-				"load-json-file": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
-					"integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
-					"requires": {
-						"graceful-fs": "^4.1.15",
-						"parse-json": "^4.0.0",
-						"pify": "^4.0.1",
-						"strip-bom": "^3.0.0",
-						"type-fest": "^0.3.0"
-					}
-				},
-				"type-fest": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
-				}
 			}
 		},
 		"@lerna/package-graph": {
@@ -2530,13 +2324,6 @@
 				"npm-package-arg": "^6.1.0",
 				"npmlog": "^4.1.2",
 				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@lerna/prerelease-id-from-version": {
@@ -2545,13 +2332,6 @@
 			"integrity": "sha512-qZyeUyrE59uOK8rKdGn7jQz+9uOpAaF/3hbslJVFL1NqF9ELDTqjCPXivuejMX/lN4OgD6BugTO4cR7UTq/sZA==",
 			"requires": {
 				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@lerna/project": {
@@ -2580,23 +2360,6 @@
 					"requires": {
 						"is-glob": "^4.0.1"
 					}
-				},
-				"load-json-file": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
-					"integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
-					"requires": {
-						"graceful-fs": "^4.1.15",
-						"parse-json": "^4.0.0",
-						"pify": "^4.0.1",
-						"strip-bom": "^3.0.0",
-						"type-fest": "^0.3.0"
-					}
-				},
-				"type-fest": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-					"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
 				}
 			}
 		},
@@ -2644,28 +2407,6 @@
 				"p-map": "^2.1.0",
 				"p-pipe": "^1.2.0",
 				"semver": "^6.2.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@lerna/pulse-till-done": {
@@ -2693,23 +2434,6 @@
 				"fs-extra": "^8.1.0",
 				"npmlog": "^4.1.2",
 				"read-cmd-shim": "^1.0.1"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				}
 			}
 		},
 		"@lerna/rimraf-dir": {
@@ -2777,23 +2501,6 @@
 				"@lerna/package": "3.16.0",
 				"fs-extra": "^8.1.0",
 				"p-map": "^2.1.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				}
 			}
 		},
 		"@lerna/symlink-dependencies": {
@@ -2808,23 +2515,6 @@
 				"p-finally": "^1.0.0",
 				"p-map": "^2.1.0",
 				"p-map-series": "^1.0.0"
-			},
-			"dependencies": {
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-					"integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
-				}
 			}
 		},
 		"@lerna/timer": {
@@ -2869,13 +2559,6 @@
 				"semver": "^6.2.0",
 				"slash": "^2.0.0",
 				"temp-write": "^3.4.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@lerna/write-log-file": {
@@ -2938,9 +2621,9 @@
 			"integrity": "sha512-3wF5eueS5OHQYuAEudkpN+xVeUsg8vYEMMenEzLphUZ7PRZ8OJtDcsreL3ad9zxXmBbaFWzLmFcdob5CLyZftA=="
 		},
 		"@octokit/request": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.0.1.tgz",
-			"integrity": "sha512-SHOk/APYpfrzV1RNf7Ux8SZi+vZXhMIB2dBr4TQR6ExMX8R4jcy/0gHw26HLe1dWV7Wxe9WzYyDSEC0XwnoCSQ==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.0.2.tgz",
+			"integrity": "sha512-z1BQr43g4kOL4ZrIVBMHwi68Yg9VbkRUyuAgqCp1rU3vbYa69+2gIld/+gHclw15bJWQnhqqyEb7h5a5EqgZ0A==",
 			"requires": {
 				"@octokit/endpoint": "^5.1.0",
 				"@octokit/request-error": "^1.0.1",
@@ -2981,9 +2664,9 @@
 			}
 		},
 		"@octokit/rest": {
-			"version": "16.28.6",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.28.6.tgz",
-			"integrity": "sha512-ERfzS6g6ZNPJkEUclxLenr+UEncbymCe//IBrWWdp59nslYDeJboq07Ue9brX05Uv0+SY3kwA33cdiVBVPAOMQ==",
+			"version": "16.28.7",
+			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.28.7.tgz",
+			"integrity": "sha512-cznFSLEhh22XD3XeqJw51OLSfyL2fcFKUO+v2Ep9MTAFfFLS1cK1Zwd1yEgQJmJoDnj4/vv3+fGGZweG+xsbIA==",
 			"requires": {
 				"@octokit/request": "^5.0.0",
 				"@octokit/request-error": "^1.0.2",
@@ -3107,9 +2790,9 @@
 			}
 		},
 		"@sinonjs/samsam": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
-			"integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.2.tgz",
+			"integrity": "sha512-ILO/rR8LfAb60Y1Yfp9vxfYAASK43NFC2mLzpvLUbCQY/Qu8YwReboseu8aheCEkyElZF2L2T9mHcR2bgdvZyA==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.0.2",
@@ -3183,9 +2866,9 @@
 			}
 		},
 		"@types/babel__traverse": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
-			"integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+			"version": "7.0.7",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.7.tgz",
+			"integrity": "sha512-CeBpmX1J8kWLcDEnI3Cl2Eo6RfbGvzUctA+CjZUhOKDFbLfcr7fc4usEqLNWetrlJd7RhAkyYe2czXop4fICpw==",
 			"dev": true,
 			"requires": {
 				"@babel/types": "^7.3.0"
@@ -3282,9 +2965,9 @@
 			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.5.tgz",
-			"integrity": "sha512-CFLSALoE+93+Hcb5pFjp0J1uMrrbLRe+L1+gFwerJ776R3TACSF0kTVRQ7AvRa7aFx70nqYHAc7wQPlt9kY2Mg=="
+			"version": "12.6.9",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
+			"integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.0",
@@ -3600,12 +3283,12 @@
 			}
 		},
 		"@wordpress/a11y": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.3.0.tgz",
-			"integrity": "sha512-+V/LBz9lQx+jjKk3Do4rSx8vkBS2J8FQTLD8DgPKH/sXo6C6/tTFpNENPKo/O9ZB/NktrIJffQJd4rTbUJesvg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.5.0.tgz",
+			"integrity": "sha512-KY+Z0NFQUH6cNbFnP9P58fTCLS93zBz+SIEDA633yG46u1NHOBfWDS4lIrx52fihFdaakSTS0f2OH6yeRb41HQ==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/dom-ready": "^2.3.0"
+				"@wordpress/dom-ready": "^2.5.0"
 			}
 		},
 		"@wordpress/api-fetch": {
@@ -3620,17 +3303,17 @@
 			}
 		},
 		"@wordpress/autop": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-2.3.0.tgz",
-			"integrity": "sha512-j6vm65yragfH7iDLwEdhSP++69ntOabkyPiuYURMILRmPmystZ29R8T7tHrt7SgnE/YOwRqFH45DRq74u9ciDg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-2.4.0.tgz",
+			"integrity": "sha512-QapmHuXN3daJpfBDVmKLAVIy97xmqoeBbAKT4sfhZGwR3NIv9fmiKrM8XKWSDAGAqNF1lYN2KkrFieXM7lDU4Q==",
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/babel-plugin-import-jsx-pragma": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.1.0.tgz",
-			"integrity": "sha512-EuEX/wyR+26Z2GTcaK9kMbBBmN1oIgGj5Q2zjp4O5lWFCKNJS0pHEstRI9nlzTjsr+RCUOYKg6Sge9b0DETr7w==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-2.3.0.tgz",
+			"integrity": "sha512-b45c4x1+OvQm1f6egrBruO8eVF4bRVRZ8ojM1ttDcMi+K/qXfun3J6O8xXpSnA5eeNCZaJL3DhIk/aoNBbpwzw==",
 			"dev": true
 		},
 		"@wordpress/babel-plugin-makepot": {
@@ -3645,93 +3328,84 @@
 			}
 		},
 		"@wordpress/blob": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.4.0.tgz",
-			"integrity": "sha512-VUHUTABAR7xgZtP1qRYDNTZqeRlrpSqjAAczk80YkpKQOq2LD+HhxBpktBQ06YchV+OTwXh0l853IRDOUsGwWw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.5.0.tgz",
+			"integrity": "sha512-Eze4O8XivI8Xw4ol3l2TIPUk+K/FVT3GDOuYnwykNXKf19AwOrc51rfX7bqKqonsoGpEQ3TZTIsMfj6+l4k95g==",
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/block-editor": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-2.0.3.tgz",
-			"integrity": "sha512-ZPNIf9P9xkguWI3fWqn3ViN+9/gcZ5Rhc7mU0wc1SfHlnDx4VWGaqkBYk9rWqE7mP+yivhr8zWWr5UUYfkyjdg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-3.0.0.tgz",
+			"integrity": "sha512-ooEBV8kf1mnShUNLYSAZNiAZNFDoy9Eg9wihtfSDzc89431iFeClIw49dYEy3GFn84MNOHiCqXWHD7Ew2RR8iQ==",
 			"requires": {
-				"@babel/runtime": "^7.0.0",
-				"@wordpress/a11y": "^2.2.0",
-				"@wordpress/blob": "^2.3.0",
-				"@wordpress/blocks": "^6.2.5",
-				"@wordpress/components": "^7.3.2",
-				"@wordpress/compose": "^3.2.0",
-				"@wordpress/core-data": "^2.2.2",
-				"@wordpress/data": "^4.4.0",
-				"@wordpress/dom": "^2.2.5",
-				"@wordpress/element": "^2.3.0",
-				"@wordpress/hooks": "^2.2.0",
-				"@wordpress/html-entities": "^2.2.0",
-				"@wordpress/i18n": "^3.3.0",
-				"@wordpress/is-shallow-equal": "^1.2.0",
-				"@wordpress/keycodes": "^2.2.0",
-				"@wordpress/rich-text": "^3.2.3",
-				"@wordpress/token-list": "^1.2.0",
-				"@wordpress/url": "^2.5.0",
-				"@wordpress/viewport": "^2.3.0",
-				"@wordpress/wordcount": "^2.2.0",
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/a11y": "^2.5.0",
+				"@wordpress/blob": "^2.5.0",
+				"@wordpress/blocks": "^6.5.0",
+				"@wordpress/components": "^8.1.0",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/dom": "^2.4.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/hooks": "^2.5.0",
+				"@wordpress/html-entities": "^2.5.0",
+				"@wordpress/i18n": "^3.6.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/keycodes": "^2.5.0",
+				"@wordpress/rich-text": "^3.5.0",
+				"@wordpress/token-list": "^1.5.0",
+				"@wordpress/url": "^2.7.0",
+				"@wordpress/viewport": "^2.6.0",
+				"@wordpress/wordcount": "^2.5.0",
 				"classnames": "^2.2.5",
 				"dom-scroll-into-view": "^1.2.1",
 				"lodash": "^4.17.10",
+				"react-spring": "^8.0.19",
 				"redux-multi": "^0.1.12",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1"
 			},
 			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.2.0.tgz",
-					"integrity": "sha512-JWnV8HPQLmEDK8H1T1ucYqmYgdSFy5FRC7Gk/+r02W+irF1igiXz1YVPDdBgDuLrs3fvs7SmEHHp9PON/ONG+g==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/url": "^2.6.0"
-					}
-				},
 				"@wordpress/block-serialization-default-parser": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.2.0.tgz",
-					"integrity": "sha512-2e079+2TIAD+H+HX3LZB8SZqzfVD4VcqYnH1/pTdppPcgtcI+4o1Fyrwqm/23JPOhDN/++QCHjrDTBySWvVX9w==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.3.0.tgz",
+					"integrity": "sha512-fTUS/LEvvwyMcy1VvPl4I8c49GrmtFz5/5h9peaRJdk+jCFD0OsXhpXN1bdHC+0CAoJRz5j8Nf0k8FdFqj6uMg==",
 					"requires": {
 						"@babel/runtime": "^7.4.4"
 					}
 				},
 				"@wordpress/block-serialization-spec-parser": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-3.1.0.tgz",
-					"integrity": "sha512-OSMLDj+FvHWSJYXkNSXLeovaiuNKrkXjVKLKWW9MQjI4sxaVFypEG9WeTpYmjDMXmTj+om9WL/1Uj0aUv1i5TA==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-3.2.0.tgz",
+					"integrity": "sha512-Qce6P7hBI4PBb1nqzJHcyQ4IMa5i0weBDmfGrDNE1EHoJJZ4zfBnzkUqVVnYNDH5al896y6OzLcQoEKk6SDW9Q==",
 					"requires": {
 						"pegjs": "^0.10.0"
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.3.0.tgz",
-					"integrity": "sha512-eoMwdIbeAgqu8A/zy80m4jkgFJ4ceuk88lzZSb1+FLZiX+IA+UWUEY91OFuvUiWVzv/UthoJnZdN6ngA6V474A==",
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.5.0.tgz",
+					"integrity": "sha512-0luBvWl8IvQwBkbKLuKg6enBvumxwVexR7gIQ6M9CaptUuVNmTheJIdg1EUUft/srRGyEwsQICDk/D9Pmx6nNw==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/autop": "^2.3.0",
-						"@wordpress/blob": "^2.4.0",
-						"@wordpress/block-serialization-default-parser": "^3.2.0",
-						"@wordpress/block-serialization-spec-parser": "^3.1.0",
-						"@wordpress/data": "^4.5.0",
-						"@wordpress/dom": "^2.3.0",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/hooks": "^2.3.0",
-						"@wordpress/html-entities": "^2.3.0",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"@wordpress/shortcode": "^2.3.0",
+						"@wordpress/autop": "^2.4.0",
+						"@wordpress/blob": "^2.5.0",
+						"@wordpress/block-serialization-default-parser": "^3.3.0",
+						"@wordpress/block-serialization-spec-parser": "^3.2.0",
+						"@wordpress/data": "^4.7.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/html-entities": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/shortcode": "^2.4.0",
 						"hpq": "^1.3.0",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"rememo": "^3.0.0",
 						"showdown": "^1.8.6",
 						"simple-html-tokenizer": "^0.5.7",
@@ -3740,164 +3414,163 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
-					"integrity": "sha512-riVey0Z5835YdPZLWFSAs/4Hzo0nr7WA/393mRXwGuUtkqdk7ia++5emKfhyaCLYbinVBd6366xFFfiFxxcsCA==",
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.1.0.tgz",
+					"integrity": "sha512-V35ZyDIVadVQQhKB6IyGULdMfi+44KLL6K0FL2gVihLxHq1P0g3sC6kE26DmYNcYXYfhyGMZT440nkUi1jEo3A==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/a11y": "^2.3.0",
-						"@wordpress/api-fetch": "^3.2.0",
-						"@wordpress/compose": "^3.3.0",
-						"@wordpress/dom": "^2.3.0",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/hooks": "^2.3.0",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"@wordpress/keycodes": "^2.3.0",
-						"@wordpress/rich-text": "^3.3.0",
-						"@wordpress/url": "^2.6.0",
+						"@wordpress/a11y": "^2.5.0",
+						"@wordpress/compose": "^3.5.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/keycodes": "^2.5.0",
+						"@wordpress/rich-text": "^3.5.0",
+						"@wordpress/url": "^2.7.0",
 						"classnames": "^2.2.5",
 						"clipboard": "^2.0.1",
 						"diff": "^3.5.0",
 						"dom-scroll-into-view": "^1.2.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"moment": "^2.22.1",
 						"mousetrap": "^1.6.2",
-						"re-resizable": "^4.7.1",
+						"re-resizable": "^5.0.1",
 						"react-click-outside": "^3.0.0",
 						"react-dates": "^17.1.1",
+						"react-spring": "^8.0.20",
 						"rememo": "^3.0.0",
 						"tinycolor2": "^1.4.1",
 						"uuid": "^3.3.2"
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.3.0.tgz",
-					"integrity": "sha512-535cdgFiOKNfdNriyvA6CoFNYJWsL7V5EX1ZB9hqe9BR2m5a2EM+nlr64L3LI/gE9X3+KnZUjX4FRqSHJWxfew==",
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"lodash": "^4.17.11"
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.4.0.tgz",
-					"integrity": "sha512-6DRJ35MY+DJIlPKz8MEEr6V40w1zAcA4r7Ge0HYx9xJRxaFHwtYURqZbJmO0TidfFhv6fZg5/qVtf8LrnFnDLA==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.3.0",
-						"lodash": "^4.17.11",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
 						"react": "^16.8.4",
 						"react-dom": "^16.8.4"
 					}
 				},
 				"@wordpress/i18n": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.4.0.tgz",
-					"integrity": "sha512-58rgcUA9PGQsTzvp6jJxQ+uzTKk7wzzfLmA/jz7MKglrWi1AANaae5NExe+63/AC9/e2srV7baKNUWmak/UGAQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"sprintf-js": "^1.1.1",
-						"tannin": "^1.0.1"
+						"tannin": "^1.1.0"
 					}
 				},
 				"@wordpress/url": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.6.0.tgz",
-					"integrity": "sha512-QlC/T6VsIMhArKdYvO1sVEUZYuky+5UojHU1vfZgLNZtt2Tj1dOgP4teMaDhMZtc6FqDkHNiA8r03CvXtbNDQA==",
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+					"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"qs": "^6.5.2"
 					}
 				},
+				"re-resizable": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
+					"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+					"requires": {
+						"fast-memoize": "^2.5.1"
+					}
+				},
 				"simple-html-tokenizer": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.7.tgz",
-					"integrity": "sha512-APW9iYbkJ5cijjX4Ljhf3VG8SwYPUJT5gZrwci/wieMabQxWFiV5VwsrP5c6GMRvXKEQMGkAB1d9dvW66dTqpg=="
+					"version": "0.5.8",
+					"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.8.tgz",
+					"integrity": "sha512-0Sq4FvLlQEQODVA6PH2MIrc7tzYO0KT2HzzwvaVLYClWgIsuvaNUOrhrAvTi1pZHrcq7GDB4WiI3ukjqBMxcGQ=="
 				}
 			}
 		},
 		"@wordpress/block-library": {
-			"version": "2.4.6",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.4.6.tgz",
-			"integrity": "sha512-qDFltzuIUo6Rh8fRc/vYx5aPtohm+7c5fDiGtVAXxF4CB/7ZdScjL0m/2My0lNg42yXv+rSn4nSFryeSVUhW5A==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-library/-/block-library-2.7.0.tgz",
+			"integrity": "sha512-roArvZV4IN7URvI+dHUsNyLWy7WUSmuwndGxVqev15hdv7aOGct4DINv+S6l4LM/PgYsbSOHgDujT4vie9zfmA==",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
-				"@wordpress/autop": "^2.2.0",
-				"@wordpress/blob": "^2.3.0",
-				"@wordpress/block-editor": "^2.0.3",
-				"@wordpress/blocks": "^6.2.5",
-				"@wordpress/components": "^7.3.2",
-				"@wordpress/compose": "^3.2.0",
-				"@wordpress/core-data": "^2.2.2",
-				"@wordpress/data": "^4.4.0",
-				"@wordpress/deprecated": "^2.2.0",
-				"@wordpress/editor": "^9.2.6",
-				"@wordpress/element": "^2.3.0",
-				"@wordpress/html-entities": "^2.2.0",
-				"@wordpress/i18n": "^3.3.0",
-				"@wordpress/keycodes": "^2.2.0",
-				"@wordpress/viewport": "^2.3.0",
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/autop": "^2.4.0",
+				"@wordpress/blob": "^2.5.0",
+				"@wordpress/block-editor": "^3.0.0",
+				"@wordpress/blocks": "^6.5.0",
+				"@wordpress/components": "^8.1.0",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/core-data": "^2.5.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/editor": "^9.5.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/html-entities": "^2.5.0",
+				"@wordpress/i18n": "^3.6.0",
+				"@wordpress/keycodes": "^2.5.0",
+				"@wordpress/server-side-render": "^1.1.0",
+				"@wordpress/viewport": "^2.6.0",
 				"classnames": "^2.2.5",
 				"fast-average-color": "4.3.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"memize": "^1.0.5",
 				"url": "^0.11.0"
 			},
 			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.2.0.tgz",
-					"integrity": "sha512-JWnV8HPQLmEDK8H1T1ucYqmYgdSFy5FRC7Gk/+r02W+irF1igiXz1YVPDdBgDuLrs3fvs7SmEHHp9PON/ONG+g==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/url": "^2.6.0"
-					}
-				},
 				"@wordpress/block-serialization-default-parser": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.2.0.tgz",
-					"integrity": "sha512-2e079+2TIAD+H+HX3LZB8SZqzfVD4VcqYnH1/pTdppPcgtcI+4o1Fyrwqm/23JPOhDN/++QCHjrDTBySWvVX9w==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.3.0.tgz",
+					"integrity": "sha512-fTUS/LEvvwyMcy1VvPl4I8c49GrmtFz5/5h9peaRJdk+jCFD0OsXhpXN1bdHC+0CAoJRz5j8Nf0k8FdFqj6uMg==",
 					"requires": {
 						"@babel/runtime": "^7.4.4"
 					}
 				},
 				"@wordpress/block-serialization-spec-parser": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-3.1.0.tgz",
-					"integrity": "sha512-OSMLDj+FvHWSJYXkNSXLeovaiuNKrkXjVKLKWW9MQjI4sxaVFypEG9WeTpYmjDMXmTj+om9WL/1Uj0aUv1i5TA==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-3.2.0.tgz",
+					"integrity": "sha512-Qce6P7hBI4PBb1nqzJHcyQ4IMa5i0weBDmfGrDNE1EHoJJZ4zfBnzkUqVVnYNDH5al896y6OzLcQoEKk6SDW9Q==",
 					"requires": {
 						"pegjs": "^0.10.0"
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.3.0.tgz",
-					"integrity": "sha512-eoMwdIbeAgqu8A/zy80m4jkgFJ4ceuk88lzZSb1+FLZiX+IA+UWUEY91OFuvUiWVzv/UthoJnZdN6ngA6V474A==",
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.5.0.tgz",
+					"integrity": "sha512-0luBvWl8IvQwBkbKLuKg6enBvumxwVexR7gIQ6M9CaptUuVNmTheJIdg1EUUft/srRGyEwsQICDk/D9Pmx6nNw==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/autop": "^2.3.0",
-						"@wordpress/blob": "^2.4.0",
-						"@wordpress/block-serialization-default-parser": "^3.2.0",
-						"@wordpress/block-serialization-spec-parser": "^3.1.0",
-						"@wordpress/data": "^4.5.0",
-						"@wordpress/dom": "^2.3.0",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/hooks": "^2.3.0",
-						"@wordpress/html-entities": "^2.3.0",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"@wordpress/shortcode": "^2.3.0",
+						"@wordpress/autop": "^2.4.0",
+						"@wordpress/blob": "^2.5.0",
+						"@wordpress/block-serialization-default-parser": "^3.3.0",
+						"@wordpress/block-serialization-spec-parser": "^3.2.0",
+						"@wordpress/data": "^4.7.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/html-entities": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/shortcode": "^2.4.0",
 						"hpq": "^1.3.0",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"rememo": "^3.0.0",
 						"showdown": "^1.8.6",
 						"simple-html-tokenizer": "^0.5.7",
@@ -3906,87 +3579,95 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
-					"integrity": "sha512-riVey0Z5835YdPZLWFSAs/4Hzo0nr7WA/393mRXwGuUtkqdk7ia++5emKfhyaCLYbinVBd6366xFFfiFxxcsCA==",
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.1.0.tgz",
+					"integrity": "sha512-V35ZyDIVadVQQhKB6IyGULdMfi+44KLL6K0FL2gVihLxHq1P0g3sC6kE26DmYNcYXYfhyGMZT440nkUi1jEo3A==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/a11y": "^2.3.0",
-						"@wordpress/api-fetch": "^3.2.0",
-						"@wordpress/compose": "^3.3.0",
-						"@wordpress/dom": "^2.3.0",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/hooks": "^2.3.0",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"@wordpress/keycodes": "^2.3.0",
-						"@wordpress/rich-text": "^3.3.0",
-						"@wordpress/url": "^2.6.0",
+						"@wordpress/a11y": "^2.5.0",
+						"@wordpress/compose": "^3.5.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/keycodes": "^2.5.0",
+						"@wordpress/rich-text": "^3.5.0",
+						"@wordpress/url": "^2.7.0",
 						"classnames": "^2.2.5",
 						"clipboard": "^2.0.1",
 						"diff": "^3.5.0",
 						"dom-scroll-into-view": "^1.2.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"moment": "^2.22.1",
 						"mousetrap": "^1.6.2",
-						"re-resizable": "^4.7.1",
+						"re-resizable": "^5.0.1",
 						"react-click-outside": "^3.0.0",
 						"react-dates": "^17.1.1",
+						"react-spring": "^8.0.20",
 						"rememo": "^3.0.0",
 						"tinycolor2": "^1.4.1",
 						"uuid": "^3.3.2"
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.3.0.tgz",
-					"integrity": "sha512-535cdgFiOKNfdNriyvA6CoFNYJWsL7V5EX1ZB9hqe9BR2m5a2EM+nlr64L3LI/gE9X3+KnZUjX4FRqSHJWxfew==",
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"lodash": "^4.17.11"
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.4.0.tgz",
-					"integrity": "sha512-6DRJ35MY+DJIlPKz8MEEr6V40w1zAcA4r7Ge0HYx9xJRxaFHwtYURqZbJmO0TidfFhv6fZg5/qVtf8LrnFnDLA==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.3.0",
-						"lodash": "^4.17.11",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
 						"react": "^16.8.4",
 						"react-dom": "^16.8.4"
 					}
 				},
 				"@wordpress/i18n": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.4.0.tgz",
-					"integrity": "sha512-58rgcUA9PGQsTzvp6jJxQ+uzTKk7wzzfLmA/jz7MKglrWi1AANaae5NExe+63/AC9/e2srV7baKNUWmak/UGAQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"sprintf-js": "^1.1.1",
-						"tannin": "^1.0.1"
+						"tannin": "^1.1.0"
 					}
 				},
 				"@wordpress/url": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.6.0.tgz",
-					"integrity": "sha512-QlC/T6VsIMhArKdYvO1sVEUZYuky+5UojHU1vfZgLNZtt2Tj1dOgP4teMaDhMZtc6FqDkHNiA8r03CvXtbNDQA==",
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+					"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"qs": "^6.5.2"
 					}
 				},
+				"re-resizable": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
+					"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+					"requires": {
+						"fast-memoize": "^2.5.1"
+					}
+				},
 				"simple-html-tokenizer": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.7.tgz",
-					"integrity": "sha512-APW9iYbkJ5cijjX4Ljhf3VG8SwYPUJT5gZrwci/wieMabQxWFiV5VwsrP5c6GMRvXKEQMGkAB1d9dvW66dTqpg=="
+					"version": "0.5.8",
+					"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.8.tgz",
+					"integrity": "sha512-0Sq4FvLlQEQODVA6PH2MIrc7tzYO0KT2HzzwvaVLYClWgIsuvaNUOrhrAvTi1pZHrcq7GDB4WiI3ukjqBMxcGQ=="
 				}
 			}
 		},
@@ -4081,47 +3762,47 @@
 			}
 		},
 		"@wordpress/core-data": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-2.3.0.tgz",
-			"integrity": "sha512-Bg3J4EqAfsIfQXhO0CZ5XCl9OSiIF0XtCWKcl7Ne56e1aeV9rilAoOZKcBeBTiiRt4PSyD9UQdnxYlPcZAfx3Q==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-2.5.0.tgz",
+			"integrity": "sha512-v29VwTOvMvpiebkMDu6r57LHPvIL9mcWKxyrxQUTglXd8Nv9irAoyRxAFRS64DGu8ZbksC5Bl4piiuya2UwUDQ==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/api-fetch": "^3.2.0",
-				"@wordpress/data": "^4.5.0",
-				"@wordpress/deprecated": "^2.3.0",
-				"@wordpress/url": "^2.6.0",
+				"@wordpress/api-fetch": "^3.4.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/url": "^2.7.0",
 				"equivalent-key-map": "^0.2.2",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"rememo": "^3.0.0"
 			},
 			"dependencies": {
 				"@wordpress/api-fetch": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.2.0.tgz",
-					"integrity": "sha512-JWnV8HPQLmEDK8H1T1ucYqmYgdSFy5FRC7Gk/+r02W+irF1igiXz1YVPDdBgDuLrs3fvs7SmEHHp9PON/ONG+g==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.4.0.tgz",
+					"integrity": "sha512-aNLVIXlnn7RIEzbDcVFhyQfV60O0ggLQOCkHhMCW1Ya86Jlohp658TXe8wIjFhC2ugY239WeZIl1tgoRjqIr0A==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/url": "^2.6.0"
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/url": "^2.7.0"
 					}
 				},
 				"@wordpress/i18n": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.4.0.tgz",
-					"integrity": "sha512-58rgcUA9PGQsTzvp6jJxQ+uzTKk7wzzfLmA/jz7MKglrWi1AANaae5NExe+63/AC9/e2srV7baKNUWmak/UGAQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"sprintf-js": "^1.1.1",
-						"tannin": "^1.0.1"
+						"tannin": "^1.1.0"
 					}
 				},
 				"@wordpress/url": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.6.0.tgz",
-					"integrity": "sha512-QlC/T6VsIMhArKdYvO1sVEUZYuky+5UojHU1vfZgLNZtt2Tj1dOgP4teMaDhMZtc6FqDkHNiA8r03CvXtbNDQA==",
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+					"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"qs": "^6.5.2"
@@ -4130,53 +3811,96 @@
 			}
 		},
 		"@wordpress/data": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.5.0.tgz",
-			"integrity": "sha512-ATfN1P4LPKqeA0jkJlZd81y9vdZH3PVL+mYNKTsK3/+RPOpZDtfRn1UwSxTYR4LsAbhZVykbLl1WiWd+7eIAVg==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.7.0.tgz",
+			"integrity": "sha512-6ytvrcvg6otalvFNA26gnHv0GQkQT0h9/a780IKl0wyUqAYdKbn1J52CcJWopyfZ53HDq816NCZng1a4tWxHjQ==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.3.0",
-				"@wordpress/deprecated": "^2.3.0",
-				"@wordpress/element": "^2.4.0",
-				"@wordpress/is-shallow-equal": "^1.3.0",
-				"@wordpress/priority-queue": "^1.2.0",
-				"@wordpress/redux-routine": "^3.3.0",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/priority-queue": "^1.3.0",
+				"@wordpress/redux-routine": "^3.5.0",
 				"equivalent-key-map": "^0.2.2",
 				"is-promise": "^2.1.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"redux": "^4.0.0",
 				"turbo-combine-reducers": "^1.0.2"
 			},
 			"dependencies": {
 				"@wordpress/compose": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.3.0.tgz",
-					"integrity": "sha512-535cdgFiOKNfdNriyvA6CoFNYJWsL7V5EX1ZB9hqe9BR2m5a2EM+nlr64L3LI/gE9X3+KnZUjX4FRqSHJWxfew==",
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"lodash": "^4.17.11"
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.4.0.tgz",
-					"integrity": "sha512-6DRJ35MY+DJIlPKz8MEEr6V40w1zAcA4r7Ge0HYx9xJRxaFHwtYURqZbJmO0TidfFhv6fZg5/qVtf8LrnFnDLA==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.3.0",
-						"lodash": "^4.17.11",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
 						"react": "^16.8.4",
 						"react-dom": "^16.8.4"
 					}
 				}
 			}
 		},
+		"@wordpress/data-controls": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data-controls/-/data-controls-1.1.0.tgz",
+			"integrity": "sha512-uJSrOKdBBYJjLwES4AsfPRyh/GWVFZhf0e/znkx+4yB2T9M1UW156vMq7wuX7xkPiEwdu1j9hZItii9aVrnCmQ==",
+			"requires": {
+				"@wordpress/api-fetch": "^3.4.0",
+				"@wordpress/data": "^4.7.0"
+			},
+			"dependencies": {
+				"@wordpress/api-fetch": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.4.0.tgz",
+					"integrity": "sha512-aNLVIXlnn7RIEzbDcVFhyQfV60O0ggLQOCkHhMCW1Ya86Jlohp658TXe8wIjFhC2ugY239WeZIl1tgoRjqIr0A==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/url": "^2.7.0"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.14",
+						"memize": "^1.0.5",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.1.0"
+					}
+				},
+				"@wordpress/url": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+					"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"qs": "^6.5.2"
+					}
+				}
+			}
+		},
 		"@wordpress/date": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.3.0.tgz",
-			"integrity": "sha512-xv7vXXPWyFzUUl/MPZnsbEwrNlDBM6TZCeH/66u7x9TcylVujpaI/ePhowXcnNUvYDHxAkGoBtmKQyfjFRf0rg==",
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-3.4.0.tgz",
+			"integrity": "sha512-3rhgSs3KGdGy3m8LIuWe65bkU9zEnbZ2jT0GBtLXqP1yP4STkAcDuedOApbMONgMP7R8bo9KYrQQcOi6eZi5NA==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"moment": "^2.22.1",
@@ -4184,27 +3908,27 @@
 			}
 		},
 		"@wordpress/deprecated": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.3.0.tgz",
-			"integrity": "sha512-8ZbWPwZo/X6Hen6S1HpDPVneWMnRFesRQmSonbJklAcoz0BrJG/gUGUgfwFNGhe659z9ZbP5xAXEpinG0vsHWA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.5.0.tgz",
+			"integrity": "sha512-bryhXZZ9dZ8DlMQ2liDAV3CQV7wEiftJ9UAOB7X32X4MPZoPqvk3IGiKgHFs3/pEr4Ums0CCckgUlnY7AI+hxQ==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/hooks": "^2.3.0"
+				"@wordpress/hooks": "^2.5.0"
 			}
 		},
 		"@wordpress/dom": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.3.0.tgz",
-			"integrity": "sha512-cy/AD7gcbQmYJd8hSsuOVhdvkdFARsP1UBirZ1nwQZtQyjwAqWQzMdLUml5PzeczhEZQlo9vzJGo8fGwQvpxEw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.4.0.tgz",
+			"integrity": "sha512-8hcHi5iHgi1Z/1G6ti04bgsiYBDNlR05X7MiosjwP8U/iTmcRwKrmtA1X6qzsMlOgvJ3MetoLqGZb3lCjLtXmw==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/dom-ready": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.3.0.tgz",
-			"integrity": "sha512-Wu+UOL+U3PlvdrWDLS2WHys/utzchtkBVJvSPFj8G+5wdGIayEiaj7nmGV02+Vidow6v+4Rc1+UOVuQcoH6vzA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.5.0.tgz",
+			"integrity": "sha512-1CXRTZcQ0yn9Aj5x3e0xwYJeRv81NyuwoQUD2ZvDXRXCvaNq33fm79MDvpW5E2uYoo0t9jPHTCwadVXt7bzhwQ==",
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
@@ -4239,37 +3963,38 @@
 			}
 		},
 		"@wordpress/editor": {
-			"version": "9.2.6",
-			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.2.6.tgz",
-			"integrity": "sha512-qlbGq9TrKA+E000CENuPfnAQh5ZYzVJDThJ3iX2i0kvXQPwmjzfxMXLy6XlCx/kLvtsaJbE4NeEcbODSq4AnCg==",
+			"version": "9.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-9.5.0.tgz",
+			"integrity": "sha512-9TrRwfmPaqUOyLcTYnl/qqOkYesfFGN2OSLEqbLJIyA961xkRLDz5975MAvGZakHDWwkSv3bxS2ogSoJcr8FOg==",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
-				"@wordpress/api-fetch": "^3.1.2",
-				"@wordpress/blob": "^2.3.0",
-				"@wordpress/block-editor": "^2.0.3",
-				"@wordpress/blocks": "^6.2.5",
-				"@wordpress/components": "^7.3.2",
-				"@wordpress/compose": "^3.2.0",
-				"@wordpress/core-data": "^2.2.2",
-				"@wordpress/data": "^4.4.0",
-				"@wordpress/date": "^3.2.0",
-				"@wordpress/deprecated": "^2.2.0",
-				"@wordpress/element": "^2.3.0",
-				"@wordpress/hooks": "^2.2.0",
-				"@wordpress/html-entities": "^2.2.0",
-				"@wordpress/i18n": "^3.3.0",
-				"@wordpress/keycodes": "^2.2.0",
-				"@wordpress/notices": "^1.3.0",
-				"@wordpress/nux": "^3.2.5",
-				"@wordpress/url": "^2.5.0",
-				"@wordpress/viewport": "^2.3.0",
-				"@wordpress/wordcount": "^2.2.0",
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/api-fetch": "^3.4.0",
+				"@wordpress/blob": "^2.5.0",
+				"@wordpress/block-editor": "^3.0.0",
+				"@wordpress/blocks": "^6.5.0",
+				"@wordpress/components": "^8.1.0",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/core-data": "^2.5.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/data-controls": "^1.1.0",
+				"@wordpress/date": "^3.4.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/hooks": "^2.5.0",
+				"@wordpress/html-entities": "^2.5.0",
+				"@wordpress/i18n": "^3.6.0",
+				"@wordpress/keycodes": "^2.5.0",
+				"@wordpress/media-utils": "^1.0.0",
+				"@wordpress/notices": "^1.6.0",
+				"@wordpress/nux": "^3.5.0",
+				"@wordpress/url": "^2.7.0",
+				"@wordpress/viewport": "^2.6.0",
+				"@wordpress/wordcount": "^2.5.0",
 				"classnames": "^2.2.5",
 				"inherits": "^2.0.3",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.14",
 				"memize": "^1.0.5",
 				"react-autosize-textarea": "^3.0.2",
-				"redux-multi": "^0.1.12",
 				"redux-optimist": "^1.0.0",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0",
@@ -4277,51 +4002,51 @@
 			},
 			"dependencies": {
 				"@wordpress/api-fetch": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.2.0.tgz",
-					"integrity": "sha512-JWnV8HPQLmEDK8H1T1ucYqmYgdSFy5FRC7Gk/+r02W+irF1igiXz1YVPDdBgDuLrs3fvs7SmEHHp9PON/ONG+g==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.4.0.tgz",
+					"integrity": "sha512-aNLVIXlnn7RIEzbDcVFhyQfV60O0ggLQOCkHhMCW1Ya86Jlohp658TXe8wIjFhC2ugY239WeZIl1tgoRjqIr0A==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/url": "^2.6.0"
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/url": "^2.7.0"
 					}
 				},
 				"@wordpress/block-serialization-default-parser": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.2.0.tgz",
-					"integrity": "sha512-2e079+2TIAD+H+HX3LZB8SZqzfVD4VcqYnH1/pTdppPcgtcI+4o1Fyrwqm/23JPOhDN/++QCHjrDTBySWvVX9w==",
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.3.0.tgz",
+					"integrity": "sha512-fTUS/LEvvwyMcy1VvPl4I8c49GrmtFz5/5h9peaRJdk+jCFD0OsXhpXN1bdHC+0CAoJRz5j8Nf0k8FdFqj6uMg==",
 					"requires": {
 						"@babel/runtime": "^7.4.4"
 					}
 				},
 				"@wordpress/block-serialization-spec-parser": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-3.1.0.tgz",
-					"integrity": "sha512-OSMLDj+FvHWSJYXkNSXLeovaiuNKrkXjVKLKWW9MQjI4sxaVFypEG9WeTpYmjDMXmTj+om9WL/1Uj0aUv1i5TA==",
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-3.2.0.tgz",
+					"integrity": "sha512-Qce6P7hBI4PBb1nqzJHcyQ4IMa5i0weBDmfGrDNE1EHoJJZ4zfBnzkUqVVnYNDH5al896y6OzLcQoEKk6SDW9Q==",
 					"requires": {
 						"pegjs": "^0.10.0"
 					}
 				},
 				"@wordpress/blocks": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.3.0.tgz",
-					"integrity": "sha512-eoMwdIbeAgqu8A/zy80m4jkgFJ4ceuk88lzZSb1+FLZiX+IA+UWUEY91OFuvUiWVzv/UthoJnZdN6ngA6V474A==",
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.5.0.tgz",
+					"integrity": "sha512-0luBvWl8IvQwBkbKLuKg6enBvumxwVexR7gIQ6M9CaptUuVNmTheJIdg1EUUft/srRGyEwsQICDk/D9Pmx6nNw==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/autop": "^2.3.0",
-						"@wordpress/blob": "^2.4.0",
-						"@wordpress/block-serialization-default-parser": "^3.2.0",
-						"@wordpress/block-serialization-spec-parser": "^3.1.0",
-						"@wordpress/data": "^4.5.0",
-						"@wordpress/dom": "^2.3.0",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/hooks": "^2.3.0",
-						"@wordpress/html-entities": "^2.3.0",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"@wordpress/shortcode": "^2.3.0",
+						"@wordpress/autop": "^2.4.0",
+						"@wordpress/blob": "^2.5.0",
+						"@wordpress/block-serialization-default-parser": "^3.3.0",
+						"@wordpress/block-serialization-spec-parser": "^3.2.0",
+						"@wordpress/data": "^4.7.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/html-entities": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/shortcode": "^2.4.0",
 						"hpq": "^1.3.0",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"rememo": "^3.0.0",
 						"showdown": "^1.8.6",
 						"simple-html-tokenizer": "^0.5.7",
@@ -4330,87 +4055,95 @@
 					}
 				},
 				"@wordpress/components": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
-					"integrity": "sha512-riVey0Z5835YdPZLWFSAs/4Hzo0nr7WA/393mRXwGuUtkqdk7ia++5emKfhyaCLYbinVBd6366xFFfiFxxcsCA==",
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.1.0.tgz",
+					"integrity": "sha512-V35ZyDIVadVQQhKB6IyGULdMfi+44KLL6K0FL2gVihLxHq1P0g3sC6kE26DmYNcYXYfhyGMZT440nkUi1jEo3A==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/a11y": "^2.3.0",
-						"@wordpress/api-fetch": "^3.2.0",
-						"@wordpress/compose": "^3.3.0",
-						"@wordpress/dom": "^2.3.0",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/hooks": "^2.3.0",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"@wordpress/keycodes": "^2.3.0",
-						"@wordpress/rich-text": "^3.3.0",
-						"@wordpress/url": "^2.6.0",
+						"@wordpress/a11y": "^2.5.0",
+						"@wordpress/compose": "^3.5.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/keycodes": "^2.5.0",
+						"@wordpress/rich-text": "^3.5.0",
+						"@wordpress/url": "^2.7.0",
 						"classnames": "^2.2.5",
 						"clipboard": "^2.0.1",
 						"diff": "^3.5.0",
 						"dom-scroll-into-view": "^1.2.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"moment": "^2.22.1",
 						"mousetrap": "^1.6.2",
-						"re-resizable": "^4.7.1",
+						"re-resizable": "^5.0.1",
 						"react-click-outside": "^3.0.0",
 						"react-dates": "^17.1.1",
+						"react-spring": "^8.0.20",
 						"rememo": "^3.0.0",
 						"tinycolor2": "^1.4.1",
 						"uuid": "^3.3.2"
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.3.0.tgz",
-					"integrity": "sha512-535cdgFiOKNfdNriyvA6CoFNYJWsL7V5EX1ZB9hqe9BR2m5a2EM+nlr64L3LI/gE9X3+KnZUjX4FRqSHJWxfew==",
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"lodash": "^4.17.11"
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.4.0.tgz",
-					"integrity": "sha512-6DRJ35MY+DJIlPKz8MEEr6V40w1zAcA4r7Ge0HYx9xJRxaFHwtYURqZbJmO0TidfFhv6fZg5/qVtf8LrnFnDLA==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.3.0",
-						"lodash": "^4.17.11",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
 						"react": "^16.8.4",
 						"react-dom": "^16.8.4"
 					}
 				},
 				"@wordpress/i18n": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.4.0.tgz",
-					"integrity": "sha512-58rgcUA9PGQsTzvp6jJxQ+uzTKk7wzzfLmA/jz7MKglrWi1AANaae5NExe+63/AC9/e2srV7baKNUWmak/UGAQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"sprintf-js": "^1.1.1",
-						"tannin": "^1.0.1"
+						"tannin": "^1.1.0"
 					}
 				},
 				"@wordpress/url": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.6.0.tgz",
-					"integrity": "sha512-QlC/T6VsIMhArKdYvO1sVEUZYuky+5UojHU1vfZgLNZtt2Tj1dOgP4teMaDhMZtc6FqDkHNiA8r03CvXtbNDQA==",
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+					"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"qs": "^6.5.2"
 					}
 				},
+				"re-resizable": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
+					"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+					"requires": {
+						"fast-memoize": "^2.5.1"
+					}
+				},
 				"simple-html-tokenizer": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.7.tgz",
-					"integrity": "sha512-APW9iYbkJ5cijjX4Ljhf3VG8SwYPUJT5gZrwci/wieMabQxWFiV5VwsrP5c6GMRvXKEQMGkAB1d9dvW66dTqpg=="
+					"version": "0.5.8",
+					"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.8.tgz",
+					"integrity": "sha512-0Sq4FvLlQEQODVA6PH2MIrc7tzYO0KT2HzzwvaVLYClWgIsuvaNUOrhrAvTi1pZHrcq7GDB4WiI3ukjqBMxcGQ=="
 				}
 			}
 		},
@@ -4427,131 +4160,130 @@
 			}
 		},
 		"@wordpress/escape-html": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.3.0.tgz",
-			"integrity": "sha512-4iYVMAwREg9/jXJE80wJAreamwljLmLlA5stXMQ6UIoaW5tPPdyjyjjhCgw7jhEzJAKc+re3UXKf6Up4RXwQ8A==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.5.0.tgz",
+			"integrity": "sha512-9jGwPbpdJ309EP4Acf6/zwHWeuYi0Bi5RAZx9q+BIYC7bjxLs3oFDS5QkEAi2mzrVAhIz+BbEWBGRg70U1RLlA==",
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/format-library": {
-			"version": "1.4.6",
-			"resolved": "https://registry.npmjs.org/@wordpress/format-library/-/format-library-1.4.6.tgz",
-			"integrity": "sha512-wpe3KBcI23tun3aY6en/BjmJP1YKdlWFryWzpUQ0M89wOATjdrEJ3rWFLpIi68i9zKsLZJVcap0jjqen0ABAOA==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/format-library/-/format-library-1.7.0.tgz",
+			"integrity": "sha512-zb1XgM4Pk4YHjDMU0DYuGnvb07oZvhIsUO8QYWkkM0WQGsd7FCgAtvCRq87oufRDhgJf/IIOm0hXhJXetNc7VA==",
 			"requires": {
-				"@babel/runtime": "^7.3.1",
-				"@wordpress/block-editor": "^2.0.3",
-				"@wordpress/components": "^7.3.2",
-				"@wordpress/editor": "^9.2.6",
-				"@wordpress/element": "^2.3.0",
-				"@wordpress/i18n": "^3.3.0",
-				"@wordpress/keycodes": "^2.2.0",
-				"@wordpress/rich-text": "^3.2.3",
-				"@wordpress/url": "^2.5.0"
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/block-editor": "^3.0.0",
+				"@wordpress/components": "^8.1.0",
+				"@wordpress/editor": "^9.5.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/html-entities": "^2.5.0",
+				"@wordpress/i18n": "^3.6.0",
+				"@wordpress/keycodes": "^2.5.0",
+				"@wordpress/rich-text": "^3.5.0",
+				"@wordpress/url": "^2.7.0"
 			},
 			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.2.0.tgz",
-					"integrity": "sha512-JWnV8HPQLmEDK8H1T1ucYqmYgdSFy5FRC7Gk/+r02W+irF1igiXz1YVPDdBgDuLrs3fvs7SmEHHp9PON/ONG+g==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/url": "^2.6.0"
-					}
-				},
 				"@wordpress/components": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
-					"integrity": "sha512-riVey0Z5835YdPZLWFSAs/4Hzo0nr7WA/393mRXwGuUtkqdk7ia++5emKfhyaCLYbinVBd6366xFFfiFxxcsCA==",
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.1.0.tgz",
+					"integrity": "sha512-V35ZyDIVadVQQhKB6IyGULdMfi+44KLL6K0FL2gVihLxHq1P0g3sC6kE26DmYNcYXYfhyGMZT440nkUi1jEo3A==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/a11y": "^2.3.0",
-						"@wordpress/api-fetch": "^3.2.0",
-						"@wordpress/compose": "^3.3.0",
-						"@wordpress/dom": "^2.3.0",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/hooks": "^2.3.0",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"@wordpress/keycodes": "^2.3.0",
-						"@wordpress/rich-text": "^3.3.0",
-						"@wordpress/url": "^2.6.0",
+						"@wordpress/a11y": "^2.5.0",
+						"@wordpress/compose": "^3.5.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/keycodes": "^2.5.0",
+						"@wordpress/rich-text": "^3.5.0",
+						"@wordpress/url": "^2.7.0",
 						"classnames": "^2.2.5",
 						"clipboard": "^2.0.1",
 						"diff": "^3.5.0",
 						"dom-scroll-into-view": "^1.2.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"moment": "^2.22.1",
 						"mousetrap": "^1.6.2",
-						"re-resizable": "^4.7.1",
+						"re-resizable": "^5.0.1",
 						"react-click-outside": "^3.0.0",
 						"react-dates": "^17.1.1",
+						"react-spring": "^8.0.20",
 						"rememo": "^3.0.0",
 						"tinycolor2": "^1.4.1",
 						"uuid": "^3.3.2"
 					}
 				},
 				"@wordpress/compose": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.3.0.tgz",
-					"integrity": "sha512-535cdgFiOKNfdNriyvA6CoFNYJWsL7V5EX1ZB9hqe9BR2m5a2EM+nlr64L3LI/gE9X3+KnZUjX4FRqSHJWxfew==",
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"lodash": "^4.17.11"
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.4.0.tgz",
-					"integrity": "sha512-6DRJ35MY+DJIlPKz8MEEr6V40w1zAcA4r7Ge0HYx9xJRxaFHwtYURqZbJmO0TidfFhv6fZg5/qVtf8LrnFnDLA==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.3.0",
-						"lodash": "^4.17.11",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
 						"react": "^16.8.4",
 						"react-dom": "^16.8.4"
 					}
 				},
 				"@wordpress/i18n": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.4.0.tgz",
-					"integrity": "sha512-58rgcUA9PGQsTzvp6jJxQ+uzTKk7wzzfLmA/jz7MKglrWi1AANaae5NExe+63/AC9/e2srV7baKNUWmak/UGAQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"sprintf-js": "^1.1.1",
-						"tannin": "^1.0.1"
+						"tannin": "^1.1.0"
 					}
 				},
 				"@wordpress/url": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.6.0.tgz",
-					"integrity": "sha512-QlC/T6VsIMhArKdYvO1sVEUZYuky+5UojHU1vfZgLNZtt2Tj1dOgP4teMaDhMZtc6FqDkHNiA8r03CvXtbNDQA==",
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+					"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"qs": "^6.5.2"
+					}
+				},
+				"re-resizable": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
+					"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+					"requires": {
+						"fast-memoize": "^2.5.1"
 					}
 				}
 			}
 		},
 		"@wordpress/hooks": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.3.0.tgz",
-			"integrity": "sha512-N7ijZUcBbcTO6AsITS66On3X14fkT3+e3rNbx/w4AANnUDmP4Nqkl+OiMWqM3gjr936hReAqIqprKKTQ98DBYQ==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.5.0.tgz",
+			"integrity": "sha512-+nsYv5AdX7Oj9gVHvtDIQSE9gntrJwA5FpXSEVlZ2u2E5lhjGQS+a+IrRhxZL/7f2eKby5zvQV6vYCrqMtKxYg==",
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/html-entities": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.3.0.tgz",
-			"integrity": "sha512-pVK1IMOvErrhWXJcsrT970H/tV9GZX4KdGjTYTNVDYFxayCXPYq6HLcWWFn2r+QqNkhCpR+fuH6oee6BZx0JEg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.5.0.tgz",
+			"integrity": "sha512-7TKaJKkOX2Tas0OyXNPz1kA2my1Z804weBf2RsPLiNXm593JDsf6Em8z1TA4mXtn7FO2ZAKTj/3yRemKK4PhnA==",
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
@@ -4570,147 +4302,90 @@
 			}
 		},
 		"@wordpress/is-shallow-equal": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.3.0.tgz",
-			"integrity": "sha512-NVMeS7mP/7VCZQmq0L88BrPJ5OlzcImhyGp+zk4nCeD3LhO2VNGyAmnFQtbR500C0xjBugF7wTscoTJM6Z7ZCg==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.5.0.tgz",
+			"integrity": "sha512-6GjIDZlwcgLmnt1uexUgnIj3zbzCPCtqe5vTqmsQeexC4zCIzgFJgzilOuuW/4kdwF/XB3jex91L9EImc5HTcw==",
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/keycodes": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.3.0.tgz",
-			"integrity": "sha512-iutKSqHcvhxEvkV/QjgOXlWi/FLaOTtRumQtGxXd7eb8fDqs+8LmhExNn4dw6QJ+vvY+sjUnJh8121eTzCmPjw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.5.0.tgz",
+			"integrity": "sha512-4SMN3pmJnNBexpd3/6JB6gJw+wcahBaVZaeMcHyF+Uw7bKcG6hDkzEAN6dWFJuifpdxmvilDE4H5JS/Ex9C6sA==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/i18n": "^3.4.0",
-				"lodash": "^4.17.11"
+				"@wordpress/i18n": "^3.6.0",
+				"lodash": "^4.17.14"
 			},
 			"dependencies": {
 				"@wordpress/i18n": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.4.0.tgz",
-					"integrity": "sha512-58rgcUA9PGQsTzvp6jJxQ+uzTKk7wzzfLmA/jz7MKglrWi1AANaae5NExe+63/AC9/e2srV7baKNUWmak/UGAQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"sprintf-js": "^1.1.1",
-						"tannin": "^1.0.1"
+						"tannin": "^1.1.0"
 					}
 				}
 			}
 		},
-		"@wordpress/notices": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-1.4.0.tgz",
-			"integrity": "sha512-v88VsEPtcktZriCKr6YW90xYxFgELF6mDMGrXgRviZwRm8Yfubto1Q0DnWFgYV1U8GXgZio95+A1HjZ+/TG32g==",
+		"@wordpress/media-utils": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-1.0.0.tgz",
+			"integrity": "sha512-HjleyNFc+toqeznm8KnR/JhAfDki08FhxZj3/3uksxA4HSJ3Qq6cNc46GlxCCNy7cGhSAsmYrATEsbq3s4IhAA==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/a11y": "^2.3.0",
-				"@wordpress/data": "^4.5.0",
-				"lodash": "^4.17.11"
-			}
-		},
-		"@wordpress/nux": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-3.3.0.tgz",
-			"integrity": "sha512-zvFt54+cZ1xq+RqpXyJ5OLAkR7948NjpmF6heT5XTnm27FnagRqF5JMOliOM2ALUGIvTubmnMjaY0CGNGTjUbA==",
-			"requires": {
-				"@babel/runtime": "^7.4.4",
-				"@wordpress/components": "^7.4.0",
-				"@wordpress/compose": "^3.3.0",
-				"@wordpress/data": "^4.5.0",
-				"@wordpress/element": "^2.4.0",
-				"@wordpress/i18n": "^3.4.0",
-				"lodash": "^4.17.11",
-				"rememo": "^3.0.0"
+				"@wordpress/api-fetch": "^3.4.0",
+				"@wordpress/blob": "^2.5.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/i18n": "^3.6.0",
+				"lodash": "^4.17.14"
 			},
 			"dependencies": {
 				"@wordpress/api-fetch": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.2.0.tgz",
-					"integrity": "sha512-JWnV8HPQLmEDK8H1T1ucYqmYgdSFy5FRC7Gk/+r02W+irF1igiXz1YVPDdBgDuLrs3fvs7SmEHHp9PON/ONG+g==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.4.0.tgz",
+					"integrity": "sha512-aNLVIXlnn7RIEzbDcVFhyQfV60O0ggLQOCkHhMCW1Ya86Jlohp658TXe8wIjFhC2ugY239WeZIl1tgoRjqIr0A==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/url": "^2.6.0"
-					}
-				},
-				"@wordpress/components": {
-					"version": "7.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-7.4.0.tgz",
-					"integrity": "sha512-riVey0Z5835YdPZLWFSAs/4Hzo0nr7WA/393mRXwGuUtkqdk7ia++5emKfhyaCLYbinVBd6366xFFfiFxxcsCA==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/a11y": "^2.3.0",
-						"@wordpress/api-fetch": "^3.2.0",
-						"@wordpress/compose": "^3.3.0",
-						"@wordpress/dom": "^2.3.0",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/hooks": "^2.3.0",
-						"@wordpress/i18n": "^3.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"@wordpress/keycodes": "^2.3.0",
-						"@wordpress/rich-text": "^3.3.0",
-						"@wordpress/url": "^2.6.0",
-						"classnames": "^2.2.5",
-						"clipboard": "^2.0.1",
-						"diff": "^3.5.0",
-						"dom-scroll-into-view": "^1.2.1",
-						"lodash": "^4.17.11",
-						"memize": "^1.0.5",
-						"moment": "^2.22.1",
-						"mousetrap": "^1.6.2",
-						"re-resizable": "^4.7.1",
-						"react-click-outside": "^3.0.0",
-						"react-dates": "^17.1.1",
-						"rememo": "^3.0.0",
-						"tinycolor2": "^1.4.1",
-						"uuid": "^3.3.2"
-					}
-				},
-				"@wordpress/compose": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.3.0.tgz",
-					"integrity": "sha512-535cdgFiOKNfdNriyvA6CoFNYJWsL7V5EX1ZB9hqe9BR2m5a2EM+nlr64L3LI/gE9X3+KnZUjX4FRqSHJWxfew==",
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"lodash": "^4.17.11"
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/url": "^2.7.0"
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.4.0.tgz",
-					"integrity": "sha512-6DRJ35MY+DJIlPKz8MEEr6V40w1zAcA4r7Ge0HYx9xJRxaFHwtYURqZbJmO0TidfFhv6fZg5/qVtf8LrnFnDLA==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.3.0",
-						"lodash": "^4.17.11",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
 						"react": "^16.8.4",
 						"react-dom": "^16.8.4"
 					}
 				},
 				"@wordpress/i18n": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.4.0.tgz",
-					"integrity": "sha512-58rgcUA9PGQsTzvp6jJxQ+uzTKk7wzzfLmA/jz7MKglrWi1AANaae5NExe+63/AC9/e2srV7baKNUWmak/UGAQ==",
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"sprintf-js": "^1.1.1",
-						"tannin": "^1.0.1"
+						"tannin": "^1.1.0"
 					}
 				},
 				"@wordpress/url": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.6.0.tgz",
-					"integrity": "sha512-QlC/T6VsIMhArKdYvO1sVEUZYuky+5UojHU1vfZgLNZtt2Tj1dOgP4teMaDhMZtc6FqDkHNiA8r03CvXtbNDQA==",
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+					"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
 						"qs": "^6.5.2"
@@ -4718,37 +4393,151 @@
 				}
 			}
 		},
-		"@wordpress/plugins": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-2.3.0.tgz",
-			"integrity": "sha512-37teeXdcPQt2yEwV+i3pTI2ePm4b0earVJoojuaKGxwy3ya6EOyx6sNvbxkJbnx6+5bmIHWxzZw2SPoNfXbfaA==",
+		"@wordpress/notices": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-1.6.0.tgz",
+			"integrity": "sha512-CXJUHye/qGJo3MF3YC/AwKrFz8X5zEuaD6I1pOoOVVxpLZNMDgA2QqEbxb7X66bedBrh9akFYoNdGwS11KSsKg==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.3.0",
-				"@wordpress/element": "^2.4.0",
-				"@wordpress/hooks": "^2.3.0",
-				"lodash": "^4.17.11"
+				"@wordpress/a11y": "^2.5.0",
+				"@wordpress/data": "^4.7.0",
+				"lodash": "^4.17.14"
+			}
+		},
+		"@wordpress/nux": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/nux/-/nux-3.5.0.tgz",
+			"integrity": "sha512-PJJweT8/cNQvaFlrf8+jgntHouSu3Gf/OH8ZlICuF73W5Om9M+1Or4eaCS5wGjV1G014dxQBR/S2ydEio37NOw==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/components": "^8.1.0",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/i18n": "^3.6.0",
+				"lodash": "^4.17.14",
+				"rememo": "^3.0.0"
 			},
 			"dependencies": {
-				"@wordpress/compose": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.3.0.tgz",
-					"integrity": "sha512-535cdgFiOKNfdNriyvA6CoFNYJWsL7V5EX1ZB9hqe9BR2m5a2EM+nlr64L3LI/gE9X3+KnZUjX4FRqSHJWxfew==",
+				"@wordpress/components": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.1.0.tgz",
+					"integrity": "sha512-V35ZyDIVadVQQhKB6IyGULdMfi+44KLL6K0FL2gVihLxHq1P0g3sC6kE26DmYNcYXYfhyGMZT440nkUi1jEo3A==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"lodash": "^4.17.11"
+						"@wordpress/a11y": "^2.5.0",
+						"@wordpress/compose": "^3.5.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/keycodes": "^2.5.0",
+						"@wordpress/rich-text": "^3.5.0",
+						"@wordpress/url": "^2.7.0",
+						"classnames": "^2.2.5",
+						"clipboard": "^2.0.1",
+						"diff": "^3.5.0",
+						"dom-scroll-into-view": "^1.2.1",
+						"lodash": "^4.17.14",
+						"memize": "^1.0.5",
+						"moment": "^2.22.1",
+						"mousetrap": "^1.6.2",
+						"re-resizable": "^5.0.1",
+						"react-click-outside": "^3.0.0",
+						"react-dates": "^17.1.1",
+						"react-spring": "^8.0.20",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.1",
+						"uuid": "^3.3.2"
+					}
+				},
+				"@wordpress/compose": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.4.0.tgz",
-					"integrity": "sha512-6DRJ35MY+DJIlPKz8MEEr6V40w1zAcA4r7Ge0HYx9xJRxaFHwtYURqZbJmO0TidfFhv6fZg5/qVtf8LrnFnDLA==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.3.0",
-						"lodash": "^4.17.11",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
+						"react": "^16.8.4",
+						"react-dom": "^16.8.4"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.14",
+						"memize": "^1.0.5",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.1.0"
+					}
+				},
+				"@wordpress/url": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+					"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"qs": "^6.5.2"
+					}
+				},
+				"re-resizable": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
+					"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+					"requires": {
+						"fast-memoize": "^2.5.1"
+					}
+				}
+			}
+		},
+		"@wordpress/plugins": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-2.5.0.tgz",
+			"integrity": "sha512-RnILA/bl7w3joov61/sliyODN1MFJIGYgfwv20hkmjirmM/q531T4Mzp7FOPiEBn6mqt+gGo4CuGAe8o+oP/Vw==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/hooks": "^2.5.0",
+				"lodash": "^4.17.14"
+			},
+			"dependencies": {
+				"@wordpress/compose": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
 						"react": "^16.8.4",
 						"react-dom": "^16.8.4"
 					}
@@ -4756,17 +4545,17 @@
 			}
 		},
 		"@wordpress/priority-queue": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.2.0.tgz",
-			"integrity": "sha512-po70nJhWK3oBhc9D/rBv2RFsX9do7fIABdUSVNAFQ+vRnatxlZTxJ6z8A2rtY71tiV244qgy3In6H7n1i6QO7A==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.3.0.tgz",
+			"integrity": "sha512-HlhHZUCnKW56b2KFg2cZcn6fnGdi6mrmfOn2lE3cBOibjQLYfOY3pe3TCd+AxS4GdfkgXFA7BHfAinaWCBpAyg==",
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/redux-routine": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.3.0.tgz",
-			"integrity": "sha512-/6QUXBqVAgI9ew9Oec6c6/6MA9MTqMV89Tn6B6ZIDUuXavINSaeBDMMX8a/FBPvzbODOVfwTyhlOCz3lNiG22g==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.5.0.tgz",
+			"integrity": "sha512-fssGjVcXlNFbAIjv6VhCWZYgsv51sugxxCgxAqgSIexsDVnOphDODo5V5bhcgwiZeL3/n5rzqvFQ7Dv4agvc/A==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
 				"is-promise": "^2.1.0",
@@ -4774,61 +4563,181 @@
 			}
 		},
 		"@wordpress/rich-text": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.3.0.tgz",
-			"integrity": "sha512-vEBBgTHUTKVoYhNuXP1rF7GKOgZY6S4U7G8+sBBltJKPOO4OSfUynDCrJfvPKuXdXkGjeuxEZjGYs6Cu03ZCzg==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.5.0.tgz",
+			"integrity": "sha512-2Pi56SGcao0M0OjZtpwdIyYIXganIDg054InPpdE7zeJRUxf8gKvTGSXA2bYLdDJC0RgCLTtWp+45ItV6byZDg==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.3.0",
-				"@wordpress/data": "^4.5.0",
-				"@wordpress/escape-html": "^1.3.0",
-				"@wordpress/hooks": "^2.3.0",
-				"lodash": "^4.17.11",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/dom": "^2.4.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/escape-html": "^1.5.0",
+				"@wordpress/hooks": "^2.5.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/keycodes": "^2.5.0",
+				"classnames": "^2.2.5",
+				"lodash": "^4.17.14",
+				"memize": "^1.0.5",
 				"rememo": "^3.0.0"
 			},
 			"dependencies": {
 				"@wordpress/compose": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.3.0.tgz",
-					"integrity": "sha512-535cdgFiOKNfdNriyvA6CoFNYJWsL7V5EX1ZB9hqe9BR2m5a2EM+nlr64L3LI/gE9X3+KnZUjX4FRqSHJWxfew==",
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"lodash": "^4.17.11"
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.4.0.tgz",
-					"integrity": "sha512-6DRJ35MY+DJIlPKz8MEEr6V40w1zAcA4r7Ge0HYx9xJRxaFHwtYURqZbJmO0TidfFhv6fZg5/qVtf8LrnFnDLA==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.3.0",
-						"lodash": "^4.17.11",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
 						"react": "^16.8.4",
 						"react-dom": "^16.8.4"
 					}
 				}
 			}
 		},
-		"@wordpress/shortcode": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-2.3.0.tgz",
-			"integrity": "sha512-JVsykCMc1pvEnqM9Q+xOj1qTUCCtY0c5yOtXWMAEpyeDni99p/eROH2AIUW6hKzqSWTlAJSBLIoDR9Ih4YbcxQ==",
+		"@wordpress/server-side-render": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-1.1.0.tgz",
+			"integrity": "sha512-bSRHXfJozVzZSbkDSmhfBO/EuwebSLNvuBi/S0XrPA7lIJgqysZVPjSd7Z21qMnlKasF1N21lL7Dn1z2W/sMVQ==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.11",
+				"@wordpress/api-fetch": "^3.4.0",
+				"@wordpress/components": "^8.1.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/i18n": "^3.6.0",
+				"@wordpress/url": "^2.7.0",
+				"lodash": "^4.17.14"
+			},
+			"dependencies": {
+				"@wordpress/api-fetch": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-3.4.0.tgz",
+					"integrity": "sha512-aNLVIXlnn7RIEzbDcVFhyQfV60O0ggLQOCkHhMCW1Ya86Jlohp658TXe8wIjFhC2ugY239WeZIl1tgoRjqIr0A==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/url": "^2.7.0"
+					}
+				},
+				"@wordpress/components": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.1.0.tgz",
+					"integrity": "sha512-V35ZyDIVadVQQhKB6IyGULdMfi+44KLL6K0FL2gVihLxHq1P0g3sC6kE26DmYNcYXYfhyGMZT440nkUi1jEo3A==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/a11y": "^2.5.0",
+						"@wordpress/compose": "^3.5.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/keycodes": "^2.5.0",
+						"@wordpress/rich-text": "^3.5.0",
+						"@wordpress/url": "^2.7.0",
+						"classnames": "^2.2.5",
+						"clipboard": "^2.0.1",
+						"diff": "^3.5.0",
+						"dom-scroll-into-view": "^1.2.1",
+						"lodash": "^4.17.14",
+						"memize": "^1.0.5",
+						"moment": "^2.22.1",
+						"mousetrap": "^1.6.2",
+						"re-resizable": "^5.0.1",
+						"react-click-outside": "^3.0.0",
+						"react-dates": "^17.1.1",
+						"react-spring": "^8.0.20",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.1",
+						"uuid": "^3.3.2"
+					}
+				},
+				"@wordpress/compose": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
+						"react": "^16.8.4",
+						"react-dom": "^16.8.4"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.14",
+						"memize": "^1.0.5",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.1.0"
+					}
+				},
+				"@wordpress/url": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+					"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"qs": "^6.5.2"
+					}
+				},
+				"re-resizable": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
+					"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+					"requires": {
+						"fast-memoize": "^2.5.1"
+					}
+				}
+			}
+		},
+		"@wordpress/shortcode": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-2.4.0.tgz",
+			"integrity": "sha512-v9x7KPD39dxmnz9rn9LatrfP3SjWYBPnNVrEmLACXTGOe4XCmx1jfKdE4NlplJ5POq5tvCxcqG07bsKYfj4Dyw==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"lodash": "^4.17.14",
 				"memize": "^1.0.5"
 			}
 		},
 		"@wordpress/token-list": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-1.3.0.tgz",
-			"integrity": "sha512-/fN9cOuQbyQE4ULvIFFwGMZ5gO70EbEZQKCRQInGMAIlMXdEYU2qG5+yByEC2u/HR0SXQ6mJquckyx6SDlk6ow==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-1.5.0.tgz",
+			"integrity": "sha512-JamANQZLdv2WgmPd0ZumjzmzPoPjbZTWef2W2kuvNHvoLNO9yVulR754qdR/wGPBYEf5sDC3E2D3Vb/zgVEw7A==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/url": {
@@ -4841,36 +4750,36 @@
 			}
 		},
 		"@wordpress/viewport": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.4.0.tgz",
-			"integrity": "sha512-PTWvCJrpAy2Avs3GhkwRvj+aebv83rAb4gsnZOl0VU0YMdLOOgwc/l+p6ieFVUNuncfES6lLT6pP3UNgOJzpRQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.6.0.tgz",
+			"integrity": "sha512-mnUu/SbwrW949AgOODDFLcbLUM/Qhlbi0qZ4JN5c/nOEukru5NRuktvyPPzcd9wWAeNVlqTSpq6E8ES+65ureg==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/compose": "^3.3.0",
-				"@wordpress/data": "^4.5.0",
-				"@wordpress/element": "^2.4.0",
-				"lodash": "^4.17.11"
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/element": "^2.6.0",
+				"lodash": "^4.17.14"
 			},
 			"dependencies": {
 				"@wordpress/compose": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.3.0.tgz",
-					"integrity": "sha512-535cdgFiOKNfdNriyvA6CoFNYJWsL7V5EX1ZB9hqe9BR2m5a2EM+nlr64L3LI/gE9X3+KnZUjX4FRqSHJWxfew==",
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.4.0",
-						"@wordpress/is-shallow-equal": "^1.3.0",
-						"lodash": "^4.17.11"
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
 					}
 				},
 				"@wordpress/element": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.4.0.tgz",
-					"integrity": "sha512-6DRJ35MY+DJIlPKz8MEEr6V40w1zAcA4r7Ge0HYx9xJRxaFHwtYURqZbJmO0TidfFhv6fZg5/qVtf8LrnFnDLA==",
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.3.0",
-						"lodash": "^4.17.11",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
 						"react": "^16.8.4",
 						"react-dom": "^16.8.4"
 					}
@@ -4878,12 +4787,12 @@
 			}
 		},
 		"@wordpress/wordcount": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-2.3.0.tgz",
-			"integrity": "sha512-ztXw7/4a51OJ/nZUCJDagvpKOf7BnLxVzfNfDaRXv6rvCI/bEVXWRMfQqjXWkbPxUSSVYcxyTUdru3B6YGxyHA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-2.5.0.tgz",
+			"integrity": "sha512-Du/O50ZBpl5Pq/MevUZHQg0FBpT6v/SRhSV8lF5ByjZfXelUcQGN+gQ6RmNdasQ33KVPmspdCQHnQ+sThm4/iA==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@xtuc/ieee754": {
@@ -4948,9 +4857,9 @@
 			"integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw=="
 		},
 		"acorn-globals": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
-			"integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
+			"integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
 			"dev": true,
 			"requires": {
 				"acorn": "^6.0.1",
@@ -4963,9 +4872,9 @@
 			"integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
 		},
 		"acorn-walk": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-			"integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw=="
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
 		},
 		"after": {
 			"version": "0.8.2",
@@ -4989,12 +4898,12 @@
 			}
 		},
 		"airbnb-prop-types": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.13.2.tgz",
-			"integrity": "sha512-2FN6DlHr6JCSxPPi25EnqGaXC4OC3/B3k1lCd6MMYrZ51/Gf/1qDfaR+JElzWa+Tl7cY2aYOlsYJGFeQyVHIeQ==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.14.0.tgz",
+			"integrity": "sha512-Yb09vUkr3KP9r9NqfRuYtDYZG76wt8mhTUi2Vfzsghk+qkg01/gOc9NU8n63ZcMCLzpAdMEXyKjCHlxV62yN1A==",
 			"requires": {
-				"array.prototype.find": "^2.0.4",
-				"function.prototype.name": "^1.1.0",
+				"array.prototype.find": "^2.1.0",
+				"function.prototype.name": "^1.1.1",
 				"has": "^1.0.3",
 				"is-regex": "^1.0.4",
 				"object-is": "^1.0.1",
@@ -5006,9 +4915,9 @@
 			}
 		},
 		"ajv": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-			"integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+			"version": "6.10.2",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+			"integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
 			"requires": {
 				"fast-deep-equal": "^2.0.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -5023,9 +4932,9 @@
 			"dev": true
 		},
 		"ajv-keywords": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-			"integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+			"integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
 			"dev": true
 		},
 		"alphanum-sort": {
@@ -5148,10 +5057,9 @@
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
 		},
 		"array-differ": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
-			"dev": true
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz",
+			"integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w=="
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -5342,12 +5250,12 @@
 			"dev": true
 		},
 		"async": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
-			"integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+			"integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"async-each": {
@@ -5362,9 +5270,9 @@
 			"dev": true
 		},
 		"async-limiter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
 		},
 		"asynckit": {
 			"version": "0.4.0",
@@ -5518,11 +5426,12 @@
 			}
 		},
 		"babel-plugin-istanbul": {
-			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
-			"integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+			"integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
 			"dev": true,
 			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
 				"find-up": "^3.0.0",
 				"istanbul-lib-instrument": "^3.3.0",
 				"test-exclude": "^5.2.3"
@@ -5680,9 +5589,9 @@
 			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
 		},
 		"base64-js": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-			"integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
 			"dev": true
 		},
 		"base64id": {
@@ -5971,22 +5880,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz",
-			"integrity": "sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==",
-			"dev": true,
+			"version": "4.6.6",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+			"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
 			"requires": {
-				"caniuse-lite": "^1.0.30000974",
-				"electron-to-chromium": "^1.3.150",
-				"node-releases": "^1.1.23"
-			},
-			"dependencies": {
-				"electron-to-chromium": {
-					"version": "1.3.155",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.155.tgz",
-					"integrity": "sha512-/ci/XgZG8jkLYOgOe3mpJY1onxPPTDY17y7scldhnSjjZqV6VvREG/LvwhRuV7BJbnENFfuDWZkSqlTh4x9ZjQ==",
-					"dev": true
-				}
+				"caniuse-lite": "^1.0.30000984",
+				"electron-to-chromium": "^1.3.191",
+				"node-releases": "^1.1.25"
 			}
 		},
 		"browserslist-useragent": {
@@ -5997,54 +5897,12 @@
 				"browserslist": "^4.6.6",
 				"semver": "^6.3.0",
 				"useragent": "^2.3.0"
-			},
-			"dependencies": {
-				"browserslist": {
-					"version": "4.6.6",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
-					"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
-					"requires": {
-						"caniuse-lite": "^1.0.30000984",
-						"electron-to-chromium": "^1.3.191",
-						"node-releases": "^1.1.25"
-					}
-				},
-				"caniuse-lite": {
-					"version": "1.0.30000988",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz",
-					"integrity": "sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ=="
-				},
-				"electron-to-chromium": {
-					"version": "1.3.211",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.211.tgz",
-					"integrity": "sha512-GZAiK3oHrs0K+LwH+HD+bdjZ17v40oQQdXbbd3dgrwgbENvazrGpcuIADSAREWnxzo9gADB1evuizrbXsnoU2Q=="
-				},
-				"node-releases": {
-					"version": "1.1.26",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
-					"integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
-					"requires": {
-						"semver": "^5.3.0"
-					},
-					"dependencies": {
-						"semver": {
-							"version": "5.7.0",
-							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
-						}
-					}
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"bser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.0.tgz",
+			"integrity": "sha512-8zsjWrQkkBoLK6uxASk1nJ2SKv97ltiGDo6A3wA0/yRPz+CwmEyDo0hUrhIuukG2JHpAl3bvFIixw2/3Hi0DOg==",
 			"dev": true,
 			"requires": {
 				"node-int64": "^0.4.0"
@@ -6056,17 +5914,17 @@
 			"integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc="
 		},
 		"buble": {
-			"version": "0.19.7",
-			"resolved": "https://registry.npmjs.org/buble/-/buble-0.19.7.tgz",
-			"integrity": "sha512-YLgWxX/l+NnfotydBlxqCMPR4FREE4ubuHphALz0FxQ7u2hp3BzxTKQ4nKpapOaRJfEm1gukC68KnT2OymRK0g==",
+			"version": "0.19.8",
+			"resolved": "https://registry.npmjs.org/buble/-/buble-0.19.8.tgz",
+			"integrity": "sha512-IoGZzrUTY5fKXVkgGHw3QeXFMUNBFv+9l8a4QJKG1JhG3nCMHTdEX1DCOg8568E2Q9qvAQIiSokv6Jsgx8p2cA==",
 			"requires": {
 				"acorn": "^6.1.1",
 				"acorn-dynamic-import": "^4.0.0",
 				"acorn-jsx": "^5.0.1",
 				"chalk": "^2.4.2",
-				"magic-string": "^0.25.2",
+				"magic-string": "^0.25.3",
 				"minimist": "^1.2.0",
-				"os-homedir": "^1.0.1",
+				"os-homedir": "^2.0.0",
 				"regexpu-core": "^4.5.4"
 			},
 			"dependencies": {
@@ -6074,6 +5932,11 @@
 					"version": "1.2.0",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+				},
+				"os-homedir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-2.0.0.tgz",
+					"integrity": "sha512-saRNz0DSC5C/I++gFIaJTXoFJMRwiP5zHar5vV3xQ2TkgEw6hDCcU5F272JjUylpiVgBrZNQHnfjkLabTfb92Q=="
 				}
 			}
 		},
@@ -6125,22 +5988,22 @@
 			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
 		},
 		"cacache": {
-			"version": "11.3.2",
-			"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-			"integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
-			"dev": true,
+			"version": "12.0.2",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz",
+			"integrity": "sha512-ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==",
 			"requires": {
-				"bluebird": "^3.5.3",
+				"bluebird": "^3.5.5",
 				"chownr": "^1.1.1",
 				"figgy-pudding": "^3.5.1",
-				"glob": "^7.1.3",
+				"glob": "^7.1.4",
 				"graceful-fs": "^4.1.15",
+				"infer-owner": "^1.0.3",
 				"lru-cache": "^5.1.1",
 				"mississippi": "^3.0.0",
 				"mkdirp": "^0.5.1",
 				"move-concurrently": "^1.0.1",
 				"promise-inflight": "^1.0.1",
-				"rimraf": "^2.6.2",
+				"rimraf": "^2.6.3",
 				"ssri": "^6.0.1",
 				"unique-filename": "^1.1.1",
 				"y18n": "^4.0.0"
@@ -6150,7 +6013,6 @@
 					"version": "7.1.4",
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
 					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"dev": true,
 					"requires": {
 						"fs.realpath": "^1.0.0",
 						"inflight": "^1.0.4",
@@ -6164,7 +6026,6 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-					"dev": true,
 					"requires": {
 						"yallist": "^3.0.2"
 					}
@@ -6172,14 +6033,12 @@
 				"y18n": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-					"dev": true
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-					"dev": true
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
 				}
 			}
 		},
@@ -6404,6 +6263,12 @@
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -6424,6 +6289,18 @@
 				"htmlparser2": "^3.9.1",
 				"lodash": "^4.15.0",
 				"parse5": "^3.0.1"
+			},
+			"dependencies": {
+				"dom-serializer": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+					"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^1.3.0",
+						"entities": "^1.1.1"
+					}
+				}
 			}
 		},
 		"chokidar": {
@@ -6462,8 +6339,7 @@
 						},
 						"ansi-regex": {
 							"version": "2.1.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -6481,13 +6357,11 @@
 						},
 						"balanced-match": {
 							"version": "1.0.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -6500,18 +6374,15 @@
 						},
 						"code-point-at": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -6614,8 +6485,7 @@
 						},
 						"inherits": {
 							"version": "2.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -6625,7 +6495,6 @@
 						"is-fullwidth-code-point": {
 							"version": "1.0.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -6638,20 +6507,17 @@
 						"minimatch": {
 							"version": "3.0.4",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
 						},
 						"minimist": {
 							"version": "0.0.8",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -6668,7 +6534,6 @@
 						"mkdirp": {
 							"version": "0.5.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -6741,8 +6606,7 @@
 						},
 						"number-is-nan": {
 							"version": "1.0.1",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -6752,7 +6616,6 @@
 						"once": {
 							"version": "1.4.0",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -6828,8 +6691,7 @@
 						},
 						"safe-buffer": {
 							"version": "5.1.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -6859,7 +6721,6 @@
 						"string-width": {
 							"version": "1.0.2",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -6877,7 +6738,6 @@
 						"strip-ansi": {
 							"version": "3.0.1",
 							"bundled": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -6916,22 +6776,20 @@
 						},
 						"wrappy": {
 							"version": "1.0.2",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						},
 						"yallist": {
 							"version": "3.0.3",
-							"bundled": true,
-							"optional": true
+							"bundled": true
 						}
 					}
 				}
 			}
 		},
 		"chownr": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+			"integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A=="
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -7474,6 +7332,12 @@
 						"pify": "^3.0.0"
 					}
 				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				},
 				"supports-color": {
 					"version": "4.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -7584,17 +7448,17 @@
 			}
 		},
 		"conventional-changelog-core": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.2.2.tgz",
-			"integrity": "sha512-cssjAKajxaOX5LNAJLB+UOcoWjAIBvXtDMedv/58G+YEmAXMNfC16mmPl0JDOuVJVfIqM0nqQiZ8UCm8IXbE0g==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.2.3.tgz",
+			"integrity": "sha512-LMMX1JlxPIq/Ez5aYAYS5CpuwbOk6QFp8O4HLAcZxe3vxoCtABkhfjetk8IYdRB9CDQGwJFLR3Dr55Za6XKgUQ==",
 			"requires": {
-				"conventional-changelog-writer": "^4.0.5",
-				"conventional-commits-parser": "^3.0.2",
+				"conventional-changelog-writer": "^4.0.6",
+				"conventional-commits-parser": "^3.0.3",
 				"dateformat": "^3.0.0",
 				"get-pkg-repo": "^1.0.0",
 				"git-raw-commits": "2.0.0",
 				"git-remote-origin-url": "^2.0.0",
-				"git-semver-tags": "^2.0.2",
+				"git-semver-tags": "^2.0.3",
 				"lodash": "^4.2.1",
 				"normalize-package-data": "^2.3.5",
 				"q": "^1.5.1",
@@ -7614,19 +7478,19 @@
 			}
 		},
 		"conventional-changelog-preset-loader": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.1.1.tgz",
-			"integrity": "sha512-K4avzGMLm5Xw0Ek/6eE3vdOXkqnpf9ydb68XYmCc16cJ99XMMbc2oaNMuPwAsxVK6CC1yA4/I90EhmWNj0Q6HA=="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.2.0.tgz",
+			"integrity": "sha512-zXB+5vF7D5Y3Cb/rJfSyCCvFphCVmF8mFqOdncX3BmjZwAtGAPfYrBcT225udilCKvBbHgyzgxqz2GWDB5xShQ=="
 		},
 		"conventional-changelog-writer": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.6.tgz",
-			"integrity": "sha512-ou/sbrplJMM6KQpR5rKFYNVQYesFjN7WpNGdudQSWNi6X+RgyFUcSv871YBYkrUYV9EX8ijMohYVzn9RUb+4ag==",
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.7.tgz",
+			"integrity": "sha512-p/wzs9eYaxhFbrmX/mCJNwJuvvHR+j4Fd0SQa2xyAhYed6KBiZ780LvoqUUvsayP4R1DtC27czalGUhKV2oabw==",
 			"requires": {
 				"compare-func": "^1.3.1",
 				"conventional-commits-filter": "^2.0.2",
 				"dateformat": "^3.0.0",
-				"handlebars": "^4.1.0",
+				"handlebars": "^4.1.2",
 				"json-stringify-safe": "^5.0.1",
 				"lodash": "^4.2.1",
 				"meow": "^4.0.0",
@@ -7635,11 +7499,6 @@
 				"through2": "^3.0.0"
 			},
 			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
 				"through2": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
@@ -7684,16 +7543,16 @@
 			}
 		},
 		"conventional-recommended-bump": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-5.0.0.tgz",
-			"integrity": "sha512-CsfdICpbUe0pmM4MTG90GPUqnFgB1SWIR2HAh+vS+JhhJdPWvc0brs8oadWoYGhFOQpQwe57JnvzWEWU0m2OSg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-5.0.1.tgz",
+			"integrity": "sha512-RVdt0elRcCxL90IrNP0fYCpq1uGt2MALko0eyeQ+zQuDVWtMGAy9ng6yYn3kax42lCj9+XBxQ8ZN6S9bdKxDhQ==",
 			"requires": {
 				"concat-stream": "^2.0.0",
 				"conventional-changelog-preset-loader": "^2.1.1",
 				"conventional-commits-filter": "^2.0.2",
-				"conventional-commits-parser": "^3.0.2",
+				"conventional-commits-parser": "^3.0.3",
 				"git-raw-commits": "2.0.0",
-				"git-semver-tags": "^2.0.2",
+				"git-semver-tags": "^2.0.3",
 				"meow": "^4.0.0",
 				"q": "^1.5.1"
 			},
@@ -7777,28 +7636,20 @@
 			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
 		},
 		"core-js-compat": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.3.tgz",
-			"integrity": "sha512-EP018pVhgwsKHz3YoN1hTq49aRe+h017Kjz0NQz3nXV0cCRMvH3fLQl+vEPGr4r4J5sk4sU3tUC7U1aqTCeJeA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.1.4.tgz",
+			"integrity": "sha512-Z5zbO9f1d0YrJdoaQhphVAnKPimX92D6z8lCGphH89MNRxlL1prI9ExJPqVwP0/kgkQCv8c4GJGT8X16yUncOg==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.6.0",
-				"core-js-pure": "3.1.3",
-				"semver": "^6.1.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
-					"dev": true
-				}
+				"browserslist": "^4.6.2",
+				"core-js-pure": "3.1.4",
+				"semver": "^6.1.1"
 			}
 		},
 		"core-js-pure": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.3.tgz",
-			"integrity": "sha512-k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.1.4.tgz",
+			"integrity": "sha512-uJ4Z7iPNwiu1foygbcZYJsJs1jiXrTTCvxfLDXNhI/I+NHbSIEyr548y4fcsCEyWY0XgfAG/qqaunJ1SThHenA==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -7924,6 +7775,11 @@
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -8123,12 +7979,12 @@
 			}
 		},
 		"css-tree": {
-			"version": "1.0.0-alpha.28",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
-			"integrity": "sha512-joNNW1gCp3qFFzj4St6zk+Wh/NBv0vM5YbEreZk0SD4S23S+1xBKb6cLDg2uj4P4k/GUMlIm6cKIDqIG+vdt0w==",
+			"version": "1.0.0-alpha.33",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
+			"integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
 			"dev": true,
 			"requires": {
-				"mdn-data": "~1.1.0",
+				"mdn-data": "2.0.4",
 				"source-map": "^0.5.3"
 			},
 			"dependencies": {
@@ -8144,12 +8000,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
 			"integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
-			"dev": true
-		},
-		"css-url-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
-			"integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w=",
 			"dev": true
 		},
 		"css-what": {
@@ -8343,6 +8193,12 @@
 						"source-map": "^0.5.3"
 					}
 				},
+				"mdn-data": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
+					"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+					"dev": true
+				},
 				"source-map": {
 					"version": "0.5.7",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -8352,24 +8208,24 @@
 			}
 		},
 		"cssom": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-			"integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
 			"dev": true
 		},
 		"cssstyle": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
-			"integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
+			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
 			"dev": true,
 			"requires": {
 				"cssom": "0.3.x"
 			}
 		},
 		"csstype": {
-			"version": "2.6.5",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.5.tgz",
-			"integrity": "sha512-JsTaiksRsel5n7XwqPAfB0l3TFKdpjW/kgAELf9vrb5adGA7UCPLajKK5s3nFrcFm3Rkyp/Qkgl73ENc1UY3cA==",
+			"version": "2.6.6",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
+			"integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==",
 			"dev": true
 		},
 		"currently-unhandled": {
@@ -8396,9 +8252,9 @@
 			"integrity": "sha512-ejINPfPSNdGFKEOAtnBtdkpr24c4d4jsei6Lg98mxf424ivoDP2956/5HDpIAtmHo85lqT4pruy+zEgvRUBqaQ=="
 		},
 		"d3-color": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.2.3.tgz",
-			"integrity": "sha512-x37qq3ChOTLd26hnps36lexMRhNXEtVxZ4B25rL0DVdDsGQIJGB18S7y9XDwlDD6MD/ZBzITCf4JjGMM10TZkw=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.3.0.tgz",
+			"integrity": "sha512-NHODMBlj59xPAwl2BDiO2Mog6V+PrGRtBfWKqKRrs9MCqlSkIEb0Z/SfY7jW29ReHTDC/j+vwXhnZcXI3+3fbg=="
 		},
 		"d3-format": {
 			"version": "1.3.2",
@@ -8414,9 +8270,9 @@
 			}
 		},
 		"d3-path": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.7.tgz",
-			"integrity": "sha512-q0cW1RpvA5c5ma2rch62mX8AYaiLX0+bdaSM2wxSU9tXjU4DNvkx9qiUvjkuWCj3p22UO/hlPivujqMiR9PDzA=="
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.8.tgz",
+			"integrity": "sha512-J6EfUNwcMQ+aM5YPOB8ZbgAZu6wc82f/0WFxrxwV6Ll8wBwLaHLKCqQ5Imub02JriCVVdPjgI+6P3a4EWJCxAg=="
 		},
 		"d3-scale": {
 			"version": "3.0.0",
@@ -8829,12 +8685,24 @@
 			"integrity": "sha1-6PNnMt0ImwIBqI14Fdw/iObWbH4="
 		},
 		"dom-serializer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
-			"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
+			"integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
 			"requires": {
-				"domelementtype": "^1.3.0",
-				"entities": "^1.1.1"
+				"domelementtype": "^2.0.1",
+				"entities": "^2.0.0"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+					"integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+				},
+				"entities": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+					"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+				}
 			}
 		},
 		"domain-browser": {
@@ -8938,6 +8806,14 @@
 				"find-root": "^1.0.0",
 				"lodash": "^4.17.4",
 				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"ecc-jsbn": {
@@ -8959,10 +8835,15 @@
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
 			"integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q=="
 		},
+		"electron-to-chromium": {
+			"version": "1.3.216",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.216.tgz",
+			"integrity": "sha512-G2rJKCdDLTaAP56WKMj0mcr7jtr3LBBL2EaF73DamfFpvcl0PzKUIaUocPP8NLu9s/RbbHLMGkbFOkDRK5PQIQ=="
+		},
 		"elliptic": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-			"integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+			"integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.4.0",
@@ -9169,6 +9050,14 @@
 				"react-is": "^16.8.6",
 				"react-test-renderer": "^16.0.0-0",
 				"semver": "^5.7.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"enzyme-adapter-utils": {
@@ -9183,6 +9072,14 @@
 				"object.fromentries": "^2.0.0",
 				"prop-types": "^15.7.2",
 				"semver": "^5.6.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"enzyme-to-json": {
@@ -9379,14 +9276,20 @@
 					}
 				},
 				"import-fresh": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-					"integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+					"integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
 					"dev": true,
 					"requires": {
 						"parent-module": "^1.0.0",
 						"resolve-from": "^4.0.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -9442,9 +9345,9 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
-			"integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
+			"integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
 			"dev": true,
 			"requires": {
 				"debug": "^2.6.8",
@@ -9465,6 +9368,15 @@
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 					"dev": true
+				},
+				"pkg-dir": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+					"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+					"dev": true,
+					"requires": {
+						"find-up": "^2.1.0"
+					}
 				}
 			}
 		},
@@ -9592,18 +9504,6 @@
 				"emoji-regex": "^7.0.2",
 				"has": "^1.0.3",
 				"jsx-ast-utils": "^2.2.1"
-			},
-			"dependencies": {
-				"jsx-ast-utils": {
-					"version": "2.2.1",
-					"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
-					"integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
-					"dev": true,
-					"requires": {
-						"array-includes": "^3.0.3",
-						"object.assign": "^4.1.0"
-					}
-				}
 			}
 		},
 		"eslint-plugin-react": {
@@ -9633,9 +9533,9 @@
 			}
 		},
 		"eslint-plugin-react-hooks": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.0.tgz",
-			"integrity": "sha512-lHBVRIaz5ibnIgNG07JNiAuBUeKhEf8l4etNx5vfAEwqQ5tcuK3jV9yjmopPgQDagQb7HwIuQVsE3IVcGrRnag==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.6.1.tgz",
+			"integrity": "sha512-wHhmGJyVuijnYIJXZJHDUF2WM+rJYTjulUTqF9k61d3BTk8etydz+M4dXUVH7M76ZRS85rqBTCx0Es/lLsrjnA==",
 			"dev": true
 		},
 		"eslint-plugin-wpcalypso": {
@@ -9653,10 +9553,13 @@
 			}
 		},
 		"eslint-utils": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-			"integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-			"dev": true
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
+			"integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+			"dev": true,
+			"requires": {
+				"eslint-visitor-keys": "^1.0.0"
+			}
 		},
 		"eslint-visitor-keys": {
 			"version": "1.0.0",
@@ -9710,9 +9613,9 @@
 			"integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig=="
 		},
 		"esutils": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-			"integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -9963,9 +9866,9 @@
 			}
 		},
 		"external-editor": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-			"integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
 			"requires": {
 				"chardet": "^0.7.0",
 				"iconv-lite": "^0.4.24",
@@ -10074,6 +9977,11 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/fast-luhn/-/fast-luhn-1.0.4.tgz",
 			"integrity": "sha512-TukISTtdVBSykwFKdXWHNRQWaezelkjpyx+pDkTOKM9r5vnYUlcblYpsA5GLfNpqSj9gXEOVNA43OwqPDK/7Og=="
+		},
+		"fast-memoize": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.1.tgz",
+			"integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g=="
 		},
 		"fastparse": {
 			"version": "1.1.2",
@@ -10221,25 +10129,6 @@
 				"pkg-dir": "^3.0.0"
 			},
 			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
 				"make-dir": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -10250,38 +10139,11 @@
 						"semver": "^5.6.0"
 					}
 				},
-				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-					"dev": true,
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
 				}
 			}
 		},
@@ -10343,9 +10205,9 @@
 			}
 		},
 		"flatted": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-			"integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+			"integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
 			"dev": true
 		},
 		"flatten": {
@@ -10439,11 +10301,11 @@
 			}
 		},
 		"fs-extra": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-			"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+			"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
 			"requires": {
-				"graceful-fs": "^4.1.2",
+				"graceful-fs": "^4.2.0",
 				"jsonfile": "^4.0.0",
 				"universalify": "^0.1.0"
 			}
@@ -10501,13 +10363,14 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"function.prototype.name": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
-			"integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.1.tgz",
+			"integrity": "sha512-e1NzkiJuw6xqVH7YSdiW/qDHebcmMhPNe6w+4ZYYEg0VA+LaLzx37RimbPLuonHhYGFGPx1ME2nSi74JiaCr/Q==",
 			"requires": {
-				"define-properties": "^1.1.2",
+				"define-properties": "^1.1.3",
 				"function-bind": "^1.1.1",
-				"is-callable": "^1.1.3"
+				"functions-have-names": "^1.1.1",
+				"is-callable": "^1.1.4"
 			}
 		},
 		"functional-red-black-tree": {
@@ -10515,6 +10378,11 @@
 			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
+		},
+		"functions-have-names": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.1.1.tgz",
+			"integrity": "sha512-U0kNHUoxwPNPWOJaMG7Z00d4a/qZVrFtzWJRaK8V9goaVOCXBSQSJpt3MYGNtkScKEBKovxLjnNdC9MlXwo5Pw=="
 		},
 		"fuse.js": {
 			"version": "3.4.4",
@@ -10876,12 +10744,12 @@
 			}
 		},
 		"git-semver-tags": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.2.tgz",
-			"integrity": "sha512-34lMF7Yo1xEmsK2EkbArdoU79umpvm0MfzaDkSNYSJqtM5QLAVTPWgpiXSVI5o/O9EvZPSrP4Zvnec/CqhSd5w==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.3.tgz",
+			"integrity": "sha512-tj4FD4ww2RX2ae//jSrXZzrocla9db5h0V7ikPl1P/WwoZar9epdUhwR7XHXSgc+ZkNq72BEEerqQuicoEQfzA==",
 			"requires": {
 				"meow": "^4.0.0",
-				"semver": "^5.5.0"
+				"semver": "^6.0.0"
 			}
 		},
 		"git-up": {
@@ -10913,6 +10781,7 @@
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -11061,9 +10930,9 @@
 			}
 		},
 		"graceful-fs": {
-			"version": "4.1.15",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-			"integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.1.tgz",
+			"integrity": "sha512-b9usnbDGnD928gJB3LrCmxoibr3VE4U2SMo5PBuBnokWyDADTqDPXg4YpwKF1trpH+UbGp7QLicO3+aWEy0+mw=="
 		},
 		"gridicons": {
 			"version": "3.3.1",
@@ -11283,9 +11152,27 @@
 			"integrity": "sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ=="
 		},
 		"hosted-git-info": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-			"integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.2.tgz",
+			"integrity": "sha512-CyjlXII6LMsPMyUzxpTt8fzh5QwzGqPmQXgY/Jyf4Zfp27t/FvfhwoE/8laaMUcMy816CkWF20I7NeQhwwY88w==",
+			"requires": {
+				"lru-cache": "^5.1.1"
+			},
+			"dependencies": {
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+				}
+			}
 		},
 		"hpq": {
 			"version": "1.3.0",
@@ -11555,12 +11442,6 @@
 				"slash": "^3.0.0"
 			},
 			"dependencies": {
-				"ci-info": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-					"dev": true
-				},
 				"cross-spawn": {
 					"version": "6.0.5",
 					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -11614,15 +11495,6 @@
 						"pump": "^3.0.0"
 					}
 				},
-				"is-ci": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-					"dev": true,
-					"requires": {
-						"ci-info": "^2.0.0"
-					}
-				},
 				"locate-path": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -11656,6 +11528,18 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
+				"parse-json": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
 				"path-exists": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -11672,21 +11556,33 @@
 					}
 				},
 				"read-pkg": {
-					"version": "5.1.1",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.1.1.tgz",
-					"integrity": "sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+					"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
 					"dev": true,
 					"requires": {
 						"@types/normalize-package-data": "^2.4.0",
 						"normalize-package-data": "^2.5.0",
-						"parse-json": "^4.0.0",
-						"type-fest": "^0.4.1"
+						"parse-json": "^5.0.0",
+						"type-fest": "^0.6.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				},
 				"slash": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+					"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
 					"dev": true
 				}
 			}
@@ -11852,54 +11748,6 @@
 			"requires": {
 				"pkg-dir": "^3.0.0",
 				"resolve-cwd": "^2.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-limit": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-					"requires": {
-						"p-try": "^2.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"p-try": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
-				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"requires": {
-						"find-up": "^3.0.0"
-					}
-				}
 			}
 		},
 		"imports-loader": {
@@ -11982,12 +11830,32 @@
 				"semver": "2.x || 3.x || 4 || 5",
 				"validate-npm-package-license": "^3.0.1",
 				"validate-npm-package-name": "^3.0.0"
+			},
+			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"inquirer": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
-			"integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.0.tgz",
+			"integrity": "sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==",
 			"requires": {
 				"ansi-escapes": "^3.2.0",
 				"chalk": "^2.4.2",
@@ -11995,7 +11863,7 @@
 				"cli-width": "^2.0.0",
 				"external-editor": "^3.0.3",
 				"figures": "^2.0.0",
-				"lodash": "^4.17.11",
+				"lodash": "^4.17.12",
 				"mute-stream": "0.0.7",
 				"run-async": "^2.2.0",
 				"rxjs": "^6.4.0",
@@ -12535,14 +12403,6 @@
 				"@babel/types": "^7.4.0",
 				"istanbul-lib-coverage": "^2.0.5",
 				"semver": "^6.0.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
-					"dev": true
-				}
 			}
 		},
 		"istanbul-lib-report": {
@@ -12565,6 +12425,12 @@
 						"pify": "^4.0.1",
 						"semver": "^5.6.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				},
 				"supports-color": {
 					"version": "6.1.0",
@@ -12609,6 +12475,12 @@
 						"semver": "^5.6.0"
 					}
 				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -12645,12 +12517,6 @@
 					"version": "5.3.1",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
 					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-					"dev": true
-				},
-				"ci-info": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
 					"dev": true
 				},
 				"cross-spawn": {
@@ -12699,30 +12565,11 @@
 						"pump": "^3.0.0"
 					}
 				},
-				"import-local": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-					"dev": true,
-					"requires": {
-						"pkg-dir": "^3.0.0",
-						"resolve-cwd": "^2.0.0"
-					}
-				},
 				"invert-kv": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
 					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
 					"dev": true
-				},
-				"is-ci": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-					"dev": true,
-					"requires": {
-						"ci-info": "^2.0.0"
-					}
 				},
 				"jest-cli": {
 					"version": "24.8.0",
@@ -12816,14 +12663,11 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -12904,6 +12748,12 @@
 					"requires": {
 						"pump": "^3.0.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -13010,9 +12860,9 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "24.8.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
-			"integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
+			"version": "24.8.1",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.1.tgz",
+			"integrity": "sha512-SwaxMGVdAZk3ernAx2Uv2sorA7jm3Kx+lR0grp6rMmnY06Kn/urtKx1LPN2mGTea4fCT38impYT28FfcLUhX0g==",
 			"dev": true,
 			"requires": {
 				"@jest/types": "^24.8.0",
@@ -13049,8 +12899,7 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -13071,14 +12920,12 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -13093,20 +12940,17 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -13223,8 +13067,7 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -13236,7 +13079,6 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -13251,7 +13093,6 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -13259,14 +13100,12 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -13285,7 +13124,6 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -13366,8 +13204,7 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -13379,7 +13216,6 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -13465,8 +13301,7 @@
 						"safe-buffer": {
 							"version": "5.1.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -13502,7 +13337,6 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -13522,7 +13356,6 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
-							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -13566,14 +13399,12 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						},
 						"yallist": {
 							"version": "3.0.3",
 							"bundled": true,
-							"dev": true,
-							"optional": true
+							"dev": true
 						}
 					}
 				}
@@ -13884,6 +13715,12 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				},
 				"yargs": {
 					"version": "12.0.5",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
@@ -13940,6 +13777,14 @@
 				"natural-compare": "^1.4.0",
 				"pretty-format": "^24.8.0",
 				"semver": "^5.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"jest-util": {
@@ -13967,21 +13812,6 @@
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 					"dev": true
-				},
-				"ci-info": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-					"integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-					"dev": true
-				},
-				"is-ci": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
-					"integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-					"dev": true,
-					"requires": {
-						"ci-info": "^2.0.0"
-					}
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -14249,12 +14079,13 @@
 			}
 		},
 		"jsx-ast-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.1.0.tgz",
-			"integrity": "sha512-yDGDG2DS4JcqhA6blsuYbtsT09xL8AoLuUR2Gb5exrw7UEM19sBcOTq+YBBhrNbl0PUC4R4LnFu+dHg2HKeVvA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
+			"integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
 			"dev": true,
 			"requires": {
-				"array-includes": "^3.0.3"
+				"array-includes": "^3.0.3",
+				"object.assign": "^4.1.0"
 			}
 		},
 		"junk": {
@@ -14353,22 +14184,22 @@
 				"computed-style": "~0.1.3"
 			}
 		},
+		"lines-and-columns": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+			"dev": true
+		},
 		"load-json-file": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+			"integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
 			"requires": {
-				"graceful-fs": "^4.1.2",
+				"graceful-fs": "^4.1.15",
 				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
-				"strip-bom": "^3.0.0"
-			},
-			"dependencies": {
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				}
+				"pify": "^4.0.1",
+				"strip-bom": "^3.0.0",
+				"type-fest": "^0.3.0"
 			}
 		},
 		"loader-runner": {
@@ -14592,9 +14423,9 @@
 			}
 		},
 		"lolex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.1.0.tgz",
-			"integrity": "sha512-BYxIEXiVq5lGIXeVHnsFzqa1TxN5acnKnPCdlZSpzm8viNEOhiigupA4vTQ9HEFQ6nLTQ9wQOgBknJgzUYQ9Aw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+			"integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
 			"dev": true
 		},
 		"longest-streak": {
@@ -14661,9 +14492,9 @@
 			"integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
 		},
 		"magic-string": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
-			"integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.3.tgz",
+			"integrity": "sha512-6QK0OpF/phMz0Q2AxILkX2mFhi7m+WMwTRg0LQKq/WBB0cDP4rYH3Wp4/d3OTXlrPLVJT/RFqj8tFeAR4nk8AA==",
 			"requires": {
 				"sourcemap-codec": "^1.4.4"
 			}
@@ -14701,41 +14532,6 @@
 				"ssri": "^6.0.0"
 			},
 			"dependencies": {
-				"cacache": {
-					"version": "12.0.2",
-					"resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz",
-					"integrity": "sha512-ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==",
-					"requires": {
-						"bluebird": "^3.5.5",
-						"chownr": "^1.1.1",
-						"figgy-pudding": "^3.5.1",
-						"glob": "^7.1.4",
-						"graceful-fs": "^4.1.15",
-						"infer-owner": "^1.0.3",
-						"lru-cache": "^5.1.1",
-						"mississippi": "^3.0.0",
-						"mkdirp": "^0.5.1",
-						"move-concurrently": "^1.0.1",
-						"promise-inflight": "^1.0.1",
-						"rimraf": "^2.6.3",
-						"ssri": "^6.0.1",
-						"unique-filename": "^1.1.1",
-						"y18n": "^4.0.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
 				"lru-cache": {
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -14743,11 +14539,6 @@
 					"requires": {
 						"yallist": "^3.0.2"
 					}
-				},
-				"y18n": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
 				},
 				"yallist": {
 					"version": "3.0.3",
@@ -14836,6 +14627,14 @@
 				"array-union": "^1.0.1",
 				"arrify": "^1.0.0",
 				"minimatch": "^3.0.0"
+			},
+			"dependencies": {
+				"array-differ": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+					"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+					"dev": true
+				}
 			}
 		},
 		"md5-file": {
@@ -14865,9 +14664,9 @@
 			}
 		},
 		"mdn-data": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
-			"integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
+			"integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
 			"dev": true
 		},
 		"media-typer": {
@@ -14940,9 +14739,9 @@
 			}
 		},
 		"merge2": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.3.tgz",
-			"integrity": "sha512-gdUU1Fwj5ep4kplwcmftruWofEFt6lfpkkr3h860CXbAB9c3hGb55EOL2ali0Td5oebvW0E1+3Sr+Ur7XfKpRA=="
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.2.4.tgz",
+			"integrity": "sha512-FYE8xI+6pjFOhokZu0We3S5NKCirLbCzSh2Usf3qEyr4X8U+0jNg9P8RZ4qz+V2UoECLVwSyzU3LxXBaLGtD3A=="
 		},
 		"methods": {
 			"version": "1.1.2",
@@ -15124,9 +14923,9 @@
 			}
 		},
 		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"requires": {
 				"for-in": "^1.0.2",
 				"is-extendable": "^1.0.1"
@@ -15287,12 +15086,6 @@
 					"requires": {
 						"find-up": "^4.0.0"
 					}
-				},
-				"semver": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
-					"integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
-					"dev": true
 				}
 			}
 		},
@@ -15361,13 +15154,6 @@
 				"array-union": "^1.0.2",
 				"arrify": "^1.0.1",
 				"minimatch": "^3.0.4"
-			},
-			"dependencies": {
-				"array-differ": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz",
-					"integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w=="
-				}
 			}
 		},
 		"mute-stream": {
@@ -15421,9 +15207,9 @@
 			"dev": true
 		},
 		"nearley": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.16.0.tgz",
-			"integrity": "sha512-Tr9XD3Vt/EujXbZBv6UAHYoLUSMQAxSsTnm9K3koXzjzNWY195NqALeyrzLZBKzAkL3gl92BcSogqrHjD8QuUg==",
+			"version": "2.18.0",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.18.0.tgz",
+			"integrity": "sha512-/zQOMCeJcioI0xJtd5RpBiWw2WP7wLe6vq8/3Yu0rEwgus/G/+pViX80oA87JdVgjRt2895mZSv2VfZmy4W1uw==",
 			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
@@ -15431,6 +15217,14 @@
 				"railroad-diagrams": "^1.0.0",
 				"randexp": "0.4.6",
 				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"negotiator": {
@@ -15449,12 +15243,12 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
 		},
 		"nise": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/nise/-/nise-1.5.0.tgz",
-			"integrity": "sha512-Z3sfYEkLFzFmL8KY6xnSJLRxwQwYBjOXi/24lb62ZnZiGA0JUzGGTI6TBIgfCSMIDl9Jlu8SRmHNACLTemDHww==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.5.1.tgz",
+			"integrity": "sha512-edFWm0fsFG2n318rfEnKlTZTkjlbVOFF9XIA+fj+Ed+Qz1laYW2lobwavWoMzGrYDHH1EpiNJgDfvGnkZztR/g==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/formatio": "^3.1.0",
+				"@sinonjs/formatio": "^3.2.1",
 				"@sinonjs/text-encoding": "^0.7.1",
 				"just-extend": "^4.0.2",
 				"lolex": "^4.1.0",
@@ -15511,6 +15305,12 @@
 					"requires": {
 						"ms": "^2.1.1"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -15556,6 +15356,19 @@
 				"which": "1"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"semver": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -15570,9 +15383,9 @@
 			"dev": true
 		},
 		"node-libs-browser": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
-			"integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+			"integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
 			"dev": true,
 			"requires": {
 				"assert": "^1.1.1",
@@ -15585,7 +15398,7 @@
 				"events": "^3.0.0",
 				"https-browserify": "^1.0.0",
 				"os-browserify": "^0.3.0",
-				"path-browserify": "0.0.0",
+				"path-browserify": "0.0.1",
 				"process": "^0.11.10",
 				"punycode": "^1.2.4",
 				"querystring-es3": "^0.2.0",
@@ -15597,13 +15410,13 @@
 				"tty-browserify": "0.0.0",
 				"url": "^0.11.0",
 				"util": "^0.11.0",
-				"vm-browserify": "0.0.4"
+				"vm-browserify": "^1.0.1"
 			},
 			"dependencies": {
 				"path-browserify": {
-					"version": "0.0.0",
-					"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-					"integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+					"integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
 					"dev": true
 				}
 			}
@@ -15615,9 +15428,9 @@
 			"dev": true
 		},
 		"node-notifier": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
-			"integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.1.tgz",
+			"integrity": "sha512-p52B+onAEHKW1OF9MGO/S7k/ahGEHfhP5/tvwYzog/5XLYOd8ZuD6vdNZdUuWMONRnKPneXV43v3s6Snx1wsCQ==",
 			"dev": true,
 			"requires": {
 				"growly": "^1.3.0",
@@ -15625,15 +15438,29 @@
 				"semver": "^5.5.0",
 				"shellwords": "^0.1.1",
 				"which": "^1.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				}
 			}
 		},
 		"node-releases": {
-			"version": "1.1.23",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
-			"integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
-			"dev": true,
+			"version": "1.1.26",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
+			"integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
 			"requires": {
 				"semver": "^5.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"node-sass": {
@@ -15974,6 +15801,13 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"normalize-path": {
@@ -16402,6 +16236,13 @@
 				"osenv": "^0.1.5",
 				"semver": "^5.5.0",
 				"validate-npm-package-name": "^3.0.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"npm-packlist": {
@@ -16421,6 +16262,13 @@
 				"figgy-pudding": "^3.5.1",
 				"npm-package-arg": "^6.0.0",
 				"semver": "^5.4.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+				}
 			}
 		},
 		"npm-run-all": {
@@ -16450,6 +16298,11 @@
 						"shebang-command": "^1.2.0",
 						"which": "^1.2.9"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -17192,12 +17045,51 @@
 			}
 		},
 		"pkg-dir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-			"dev": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "^3.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+				}
 			}
 		},
 		"please-upgrade-node": {
@@ -17352,6 +17244,16 @@
 						"locate-path": "^3.0.0"
 					}
 				},
+				"fs-extra": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+					"integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
 				"get-stdin": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -17442,6 +17344,11 @@
 						"source-map": "^0.6.1",
 						"supports-color": "^6.1.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				},
 				"source-map": {
 					"version": "0.6.1",
@@ -17761,9 +17668,9 @@
 			}
 		},
 		"postcss-jsx": {
-			"version": "0.36.1",
-			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.1.tgz",
-			"integrity": "sha512-xaZpy01YR7ijsFUtu5rViYCFHurFIPHir+faiOQp8g/NfTfWqZCKDhKrydQZ4d8WlSAmVdXGwLjpFbsNUI26Sw==",
+			"version": "0.36.3",
+			"resolved": "https://registry.npmjs.org/postcss-jsx/-/postcss-jsx-0.36.3.tgz",
+			"integrity": "sha512-yV8Ndo6KzU8eho5mCn7LoLUGPkXrRXRjhMpX4AaYJ9wLJPv099xbtpbRQ8FrPnzVxb/cuMebbPR7LweSt+hTfA==",
 			"dev": true,
 			"requires": {
 				"@babel/core": ">=7.2.2"
@@ -17807,25 +17714,12 @@
 			}
 		},
 		"postcss-load-config": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
-			"integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
+			"integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
 			"requires": {
-				"cosmiconfig": "^4.0.0",
+				"cosmiconfig": "^5.0.0",
 				"import-cwd": "^2.0.0"
-			},
-			"dependencies": {
-				"cosmiconfig": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-					"integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
-					"requires": {
-						"is-directory": "^0.3.1",
-						"js-yaml": "^3.9.0",
-						"parse-json": "^4.0.0",
-						"require-from-string": "^2.0.1"
-					}
-				}
 			}
 		},
 		"postcss-loader": {
@@ -19098,9 +18992,9 @@
 			"dev": true
 		},
 		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -19142,13 +19036,13 @@
 			}
 		},
 		"prompts": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.1.0.tgz",
-			"integrity": "sha512-+x5TozgqYdOwWsQFZizE/Tra3fKvAoy037kOyU6cgz84n8f6zxngLOV4O32kTwt9FcLCxAqw0P/c8rOr9y+Gfg==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.2.1.tgz",
+			"integrity": "sha512-VObPvJiWPhpZI6C5m60XOzTfnYg/xc/an+r9VYymj9WJW3B/DIH+REzjpAACPf8brwPeP+7vz3bIim3S+AaMjw==",
 			"dev": true,
 			"requires": {
-				"kleur": "^3.0.2",
-				"sisteransi": "^1.0.0"
+				"kleur": "^3.0.3",
+				"sisteransi": "^1.0.3"
 			}
 		},
 		"promzard": {
@@ -19223,9 +19117,9 @@
 			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
-			"version": "1.1.32",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-			"integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g=="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.3.0.tgz",
+			"integrity": "sha512-avHdspHO+9rQTLbv1RO+MPYeP/SzsCoxofjVnHanETfQhTJrmB0HlDoW+EiN/R+C0BZ+gERab9NY0lPN2TxNag=="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -19565,13 +19459,13 @@
 			}
 		},
 		"react-outside-click-handler": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.3.tgz",
-			"integrity": "sha512-4orkx59ais0mM/j1Ekc5ewyRu5xNLX4a6pMs7RT8U7JkbPOlRsucE+190kXzYUUHsGfZvyAmsdQkL7lpqzMGBg==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/react-outside-click-handler/-/react-outside-click-handler-1.2.4.tgz",
+			"integrity": "sha512-FwLnTllTa65O/HjIyDgIrlAKcgPeXQnRUE+iR1EV4NY5opzN37S87+AtO1FF0rAa8qBDKj2QuNp4VfkjmkiB7g==",
 			"requires": {
-				"airbnb-prop-types": "^2.12.0",
+				"airbnb-prop-types": "^2.13.2",
 				"consolidated-events": "^1.1.1 || ^2.0.0",
-				"document.contains": "^1.0.0",
+				"document.contains": "^1.0.1",
 				"object.values": "^1.1.0",
 				"prop-types": "^15.7.2"
 			}
@@ -19611,6 +19505,15 @@
 						"react-is": "^16.7.0"
 					}
 				}
+			}
+		},
+		"react-spring": {
+			"version": "8.0.27",
+			"resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.27.tgz",
+			"integrity": "sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"prop-types": "^15.5.8"
 			}
 		},
 		"react-stripe-elements": {
@@ -19673,14 +19576,24 @@
 			}
 		},
 		"react-with-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.1.tgz",
-			"integrity": "sha512-L+x/EDgrKkqV6pTfDtLMShf7Xs+bVQ+HAT5rByX88QYX+ft9t5Gn4PWMmg36Ur21IVEBMGjjQQIJGJpBrzbsyg==",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/react-with-styles/-/react-with-styles-3.2.3.tgz",
+			"integrity": "sha512-MTI1UOvMHABRLj5M4WpODfwnveHaip6X7QUMI2x6zovinJiBXxzhA9AJP7MZNaKqg1JRFtHPXZdroUC8KcXwlQ==",
 			"requires": {
-				"deepmerge": "^1.5.2",
-				"hoist-non-react-statics": "^2.5.0",
-				"prop-types": "^15.6.1",
+				"hoist-non-react-statics": "^3.2.1",
+				"object.assign": "^4.1.0",
+				"prop-types": "^15.6.2",
 				"react-with-direction": "^1.3.0"
+			},
+			"dependencies": {
+				"hoist-non-react-statics": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+					"integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+					"requires": {
+						"react-is": "^16.7.0"
+					}
+				}
 			}
 		},
 		"react-with-styles-interface-css": {
@@ -19735,6 +19648,19 @@
 				"slash": "^1.0.0"
 			},
 			"dependencies": {
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
 				"slash": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -19760,6 +19686,24 @@
 				"load-json-file": "^4.0.0",
 				"normalize-package-data": "^2.3.2",
 				"path-type": "^3.0.0"
+			},
+			"dependencies": {
+				"load-json-file": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+					"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+					"requires": {
+						"graceful-fs": "^4.1.2",
+						"parse-json": "^4.0.0",
+						"pify": "^3.0.0",
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"pify": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				}
 			}
 		},
 		"read-pkg-up": {
@@ -19943,14 +19887,14 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.2",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-			"integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+			"version": "0.13.3",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 		},
 		"regenerator-transform": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.0.tgz",
-			"integrity": "sha512-rtOelq4Cawlbmq9xuMR5gdFmv7ku/sFoB7sRiywx7aq53bc52b4j6zvH7Te1Vt/X2YveDKnCGUbioieU7FEL3w==",
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
+			"integrity": "sha512-flVuee02C3FKRISbxhXl9mGzdbWUVHubl1SMaknjxkFB1/iqpJhArQUvRxOOPEc/9tAiX0BaQ28FJH10E4isSQ==",
 			"dev": true,
 			"requires": {
 				"private": "^0.1.6"
@@ -19966,9 +19910,9 @@
 			}
 		},
 		"regexp-tree": {
-			"version": "0.1.10",
-			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.10.tgz",
-			"integrity": "sha512-K1qVSbcedffwuIslMwpe6vGlj+ZXRnGkvjAtFHfDZZZuEdA/h0dxljAPu9vhUo6Rrx2U2AwJ+nSQ6hK+lrP5MQ==",
+			"version": "0.1.11",
+			"resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.11.tgz",
+			"integrity": "sha512-7/l/DgapVVDzZobwMCCgMlqiqyLFJ0cduo/j+3BcDJIB+yJdsYCfKuI3l/04NV+H/rfNRdPIDbXNZHM9XvQatg==",
 			"dev": true
 		},
 		"regexpp": {
@@ -20265,6 +20209,12 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
+				},
 				"yargs": {
 					"version": "12.0.5",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
@@ -20362,11 +20312,6 @@
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
 		},
-		"require-from-string": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
-		},
 		"require-main-filename": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -20378,9 +20323,9 @@
 			"integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
 		},
 		"resolve": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-			"integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -20629,6 +20574,12 @@
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 					"dev": true
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -20850,6 +20801,12 @@
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
 					"dev": true
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				}
 			}
 		},
@@ -20916,9 +20873,9 @@
 			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
 		},
 		"semver": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
 		},
 		"semver-compare": {
 			"version": "1.0.0",
@@ -20998,9 +20955,9 @@
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"requires": {
 				"extend-shallow": "^2.0.1",
 				"is-extendable": "^0.1.1",
@@ -21165,9 +21122,9 @@
 			"dev": true
 		},
 		"sisteransi": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
-			"integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.3.tgz",
+			"integrity": "sha512-SbEG75TzH8G7eVXFSN5f9EExILKfly7SUvVY5DhhYLvfhKqhDFY0OzevWa/zwak0RLRfWS5AvfMWpd9gJvr5Yg==",
 			"dev": true
 		},
 		"slash": {
@@ -21515,9 +21472,9 @@
 			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
 		},
 		"sourcemap-codec": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
-			"integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg=="
+			"version": "1.4.6",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
+			"integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg=="
 		},
 		"spawn-command": {
 			"version": "0.0.2-1",
@@ -21549,9 +21506,9 @@
 			}
 		},
 		"spdx-license-ids": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-			"integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA=="
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
 		},
 		"specificity": {
 			"version": "0.4.1",
@@ -22199,17 +22156,16 @@
 			"integrity": "sha1-W9n23vwTOFmgRGRtR0P6vCjbfi0="
 		},
 		"svgo": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.2.2.tgz",
-			"integrity": "sha512-rAfulcwp2D9jjdGu+0CuqlrAUin6bBWrpoqXWwKDZZZJfXcUXQSxLJOFJCQCSA0x0pP2U0TxSlJu2ROq5Bq6qA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.0.tgz",
+			"integrity": "sha512-MLfUA6O+qauLDbym+mMZgtXCGRfIxyQoeH6IKVcFslyODEe/ElJNwr0FohQ3xG4C6HK6bk3KYPPXwHVJk3V5NQ==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"coa": "^2.0.2",
 				"css-select": "^2.0.0",
 				"css-select-base-adapter": "^0.1.1",
-				"css-tree": "1.0.0-alpha.28",
-				"css-url-regex": "^1.1.0",
+				"css-tree": "1.0.0-alpha.33",
 				"csso": "^3.5.1",
 				"js-yaml": "^3.13.1",
 				"mkdirp": "~0.5.1",
@@ -22267,6 +22223,16 @@
 						"lodash.reject": "^4.4.0",
 						"lodash.some": "^4.4.0"
 					}
+				},
+				"dom-serializer": {
+					"version": "0.1.1",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+					"integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^1.3.0",
+						"entities": "^1.1.1"
+					}
 				}
 			}
 		},
@@ -22313,19 +22279,19 @@
 			"integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
 		},
 		"symbol-tree": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-			"integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true
 		},
 		"table": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/table/-/table-5.4.0.tgz",
-			"integrity": "sha512-nHFDrxmbrkU7JAFKqKbDJXfzrX2UBsWmrieXFTGxiI5e4ncg3VqsZeI4EzNmX0ncp4XNGVeoxIWJXfCIXwrsvw==",
+			"version": "5.4.5",
+			"resolved": "https://registry.npmjs.org/table/-/table-5.4.5.tgz",
+			"integrity": "sha512-oGa2Hl7CQjfoaogtrOHEJroOcYILTx7BZWLGsJIlzoWmB2zmguhNfPJZsWPKYek/MgCxfco54gEi31d1uN2hFA==",
 			"dev": true,
 			"requires": {
-				"ajv": "^6.9.1",
-				"lodash": "^4.17.11",
+				"ajv": "^6.10.2",
+				"lodash": "^4.17.14",
 				"slice-ansi": "^2.1.0",
 				"string-width": "^3.0.0"
 			},
@@ -22452,10 +22418,67 @@
 				"worker-farm": "^1.5.2"
 			},
 			"dependencies": {
+				"cacache": {
+					"version": "11.3.3",
+					"resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+					"integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
+					"dev": true,
+					"requires": {
+						"bluebird": "^3.5.5",
+						"chownr": "^1.1.1",
+						"figgy-pudding": "^3.5.1",
+						"glob": "^7.1.4",
+						"graceful-fs": "^4.1.15",
+						"lru-cache": "^5.1.1",
+						"mississippi": "^3.0.0",
+						"mkdirp": "^0.5.1",
+						"move-concurrently": "^1.0.1",
+						"promise-inflight": "^1.0.1",
+						"rimraf": "^2.6.3",
+						"ssri": "^6.0.1",
+						"unique-filename": "^1.1.1",
+						"y18n": "^4.0.0"
+					}
+				},
+				"glob": {
+					"version": "7.1.4",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+					"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"lru-cache": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+					"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+					"dev": true,
+					"requires": {
+						"yallist": "^3.0.2"
+					}
+				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
+				},
+				"y18n": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+					"dev": true
+				},
+				"yallist": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 					"dev": true
 				}
 			}
@@ -22856,14 +22879,14 @@
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
 		},
 		"tslib": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-			"integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
 		},
 		"tsutils": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.14.0.tgz",
-			"integrity": "sha512-SmzGbB0l+8I0QwsPgjooFRaRvHLBLNYM8SeQ0k6rtNDru5sCGeLJcZdwilNndN+GysuFjF5EIYgN8GfFG6UeUw==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.0.tgz",
+			"integrity": "sha512-fyveWOtAXfumAxIqkcMHuPaaVyLBKjB8Y00ANZkqh+HITBAQscCbQIHwwBTJdvQq7RykLEbOPcUUnJ16X4NA0g==",
 			"dev": true,
 			"requires": {
 				"tslib": "^1.8.1"
@@ -22914,10 +22937,9 @@
 			"dev": true
 		},
 		"type-fest": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
-			"integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
-			"dev": true
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+			"integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
 		},
 		"type-is": {
 			"version": "1.6.18",
@@ -23036,35 +23058,14 @@
 			}
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"uniq": {
@@ -23088,9 +23089,9 @@
 			}
 		},
 		"unique-slug": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-			"integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
 			"requires": {
 				"imurmurhash": "^0.1.4"
 			}
@@ -23336,9 +23337,9 @@
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
 		},
 		"v8-compile-cache": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.3.tgz",
-			"integrity": "sha512-CNmdbwQMBjwr9Gsmohvm0pbL954tJrNzf6gWL3K+QMQf00PF7ERGrEiLgjuU3mKreLC2MeGhUsNV9ybTbLgd3w==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+			"integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
 			"dev": true
 		},
 		"valid-url": {
@@ -23420,13 +23421,10 @@
 			}
 		},
 		"vm-browserify": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-			"dev": true,
-			"requires": {
-				"indexof": "0.0.1"
-			}
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+			"integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+			"dev": true
 		},
 		"w3c-hr-time": {
 			"version": "1.0.1",
@@ -23620,16 +23618,6 @@
 						"pump": "^3.0.0"
 					}
 				},
-				"import-local": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
-					"integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-					"dev": true,
-					"requires": {
-						"pkg-dir": "^3.0.0",
-						"resolve-cwd": "^2.0.0"
-					}
-				},
 				"invert-kv": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
@@ -23716,14 +23704,11 @@
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
-				"pkg-dir": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-					"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-					"dev": true,
-					"requires": {
-						"find-up": "^3.0.0"
-					}
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+					"dev": true
 				},
 				"yargs": {
 					"version": "12.0.5",
@@ -23839,9 +23824,9 @@
 			}
 		},
 		"webpack-sources": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-			"integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+			"integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
 			"dev": true,
 			"requires": {
 				"source-list-map": "^2.0.0",
@@ -23965,6 +23950,11 @@
 					"requires": {
 						"pump": "^3.0.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -24121,6 +24111,11 @@
 						"pify": "^4.0.1",
 						"semver": "^5.6.0"
 					}
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				}
 			}
 		},
@@ -24195,9 +24190,9 @@
 			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
 		},
 		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "3.2.1",
@@ -24361,6 +24356,11 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+				},
+				"semver": {
+					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 				},
 				"string-width": {
 					"version": "3.1.0",

--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [Unreleased]
 
+- Update `@wordpress/babel-plugin-import-jsx-pragma` dependency and correctly handle `<></>` via `@wordpress/element`.
 - Update Jest config to be able to handle `import`s otherwise handled by Webpack's `file-loader` and `sass-loader`.
 - Update Jest setup to properly initialize Enzyme's adapter.
 - Fix typo that prevented the `output-library-target` argument from being passed to Webpack.

--- a/packages/calypso-build/babel/wordpress-element.js
+++ b/packages/calypso-build/babel/wordpress-element.js
@@ -4,6 +4,7 @@ module.exports = () => ( {
 			'@wordpress/babel-plugin-import-jsx-pragma',
 			{
 				scopeVariable: 'createElement',
+				scopeVariableFrag: 'Fragment',
 				source: '@wordpress/element',
 				isDefault: false,
 			},
@@ -12,6 +13,7 @@ module.exports = () => ( {
 			'@babel/transform-react-jsx',
 			{
 				pragma: 'createElement',
+				pragmaFrag: 'Fragment',
 			},
 		],
 	],

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -44,7 +44,7 @@
 		"@babel/preset-env": "7.5.5",
 		"@babel/preset-react": "7.0.0",
 		"@babel/preset-typescript": "7.3.3",
-		"@wordpress/babel-plugin-import-jsx-pragma": "2.1.0",
+		"@wordpress/babel-plugin-import-jsx-pragma": "2.3.0",
 		"@wordpress/browserslist-config": "2.3.0",
 		"autoprefixer": "9.4.4",
 		"babel-loader": "8.0.5",

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -121,6 +121,9 @@ function getWebpackConfig(
 		plugins: [
 			new webpack.DefinePlugin( {
 				'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV ),
+				'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
+					!! process.env.FORCE_REDUCED_MOTION || false
+				),
 				global: 'window',
 			} ),
 			new webpack.IgnorePlugin( /^\.\/locale$/, /moment$/ ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -255,6 +255,9 @@ const webpackConfig = {
 	plugins: _.compact( [
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
+			'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
+				!! process.env.FORCE_REDUCED_MOTION || false
+			),
 			global: 'window',
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/15120

Matches Gutenberg babel preset for JSX:
https://github.com/WordPress/gutenberg/blob/af6e5ecd8b398e08127ad1b3c784ce97899de100/packages/babel-preset-default/index.js#L58-L70

Provides better `calypso-build` support for `<></>`.

#### Testing instructions

* Extensions and apps built with `calypso-build` should continue to work as before.

Provided that `<></>` syntax was basically unsupported by the previous setup, this should introduce few or no changes for consumers.

It will allow `<Fragment></Fragment>` to be replaced by `<></>`, leveraging the correct `@wordpress/element` Fragment.