### PR TITLE
Full Site Editing: override close button for template parts on Gtutenframe.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
@@ -16,9 +16,16 @@ domReady( () => {
 		return;
 	}
 
-	const closeButton = document.querySelector( '.edit-post-fullscreen-mode-close__toolbar a' );
+	const editPostHeaderInception = setInterval( () => {
+		const closeButton = document.querySelector( '.edit-post-fullscreen-mode-close__toolbar a' );
 
-	if ( closeButton ) {
-		closeButton.href = fullSiteEditing.closeButtonUrl;
-	}
+		if ( ! closeButton ) {
+			return;
+		}
+		clearInterval( editPostHeaderInception );
+
+		if ( fullSiteEditing.closeButtonUrl ) {
+			closeButton.href = fullSiteEditing.closeButtonUrl;
+		}
+	} );
 } );

--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -522,6 +522,10 @@ function handleInsertClassicBlockMedia( calypsoPort ) {
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
 function handleGoToAllPosts( calypsoPort ) {
+	if ( ! calypsoifyGutenberg.closeUrl ) {
+		return;
+	}
+
 	$( '#editor' ).on( 'click', '.edit-post-fullscreen-mode-close__toolbar a', e => {
 		e.preventDefault();
 		calypsoPort.postMessage( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the close button override on the Full Site Editing plugin to handle the close button not being ready for manipulation inside Gutenframe. This is the same approach `mods-gutenberg.js` uses.
* Updates the `handleGoToAllPosts` function on the iframe bridge so the click handler can be cancelled if the `closeUrl` property is `null` or missing on `calypsoifyGutenberg`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To test this PR, you'll need to sandbox a WordPress.com site, `public-api` and `widgets.wp.com`.
* ~~Get #34203 and merge it with this PR.~~
* Build the Full Site Editing plugin following  PCYsg-ly5-p2.
* Build the iFrame Bridge following the instructions on its readme.
* Upload the new Full Site Editing plugin and the iFrame bridge to your sandbox.
* Apply D29742 to your sandbox.
* on Calypso, edit a page with a template assigned to it. If you don't have a template, assign one.
* Click on the Edit Template Part link when you hover a Template Part.
* Verify that the editor reloads with the Template Part contents.
* Make changes to your template part and publish them.
* Click the close button.
* Verify that it takes you back to the original post.
* Verify that there are no regressions on the standalone plugin.


Depends on ~~#34203~~ and D29742-code.
Fixes #34071 
