### PR TITLE
FSE: Add the navigation menu block to the header and footer.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template-data-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template-data-inserter.php
@@ -73,7 +73,8 @@ class A8C_WP_Template_Data_Inserter {
 	public function get_header_content() {
 		// TODO: replace with header blocks once they are ready.
 		return '<!-- wp:a8c/site-title /-->' .
-				'<!-- wp:a8c/site-description /-->';
+				'<!-- wp:a8c/site-description /-->' .
+				'<!-- wp:a8c/navigation-menu /-->';
 	}
 
 	/**
@@ -82,10 +83,7 @@ class A8C_WP_Template_Data_Inserter {
 	 * @return string
 	 */
 	public function get_footer_content() {
-		// TODO: replace with footer blocks once they are ready.
-		return '<!-- wp:heading -->' .
-				'<h2>Test Footer Content</h2>' .
-				'<!-- /wp:heading -->';
+		return '<!-- wp:a8c/navigation-menu {\"themeLocation\":"footer"} /-->';
 	}
 
 	/**


### PR DESCRIPTION
_Do not merge; this will need rebasing after #34142 gets merged._

This PR adds the `a8c/navigation-menu` block to the header and footer. Note that the block outputs the main (`menu-1`) menu by default, which is why the header instance does not specify a `themeLocation`.

#### Testing instructions

* Apply this branch and load your FSE test environment.
* Trash all templates and template parts.
* Deactivate and then reactivate the FSE plugin.
* Create a page and assign the `Page Template` page template to it.
* Publish the page.
* Verify the correct menus show up in the editor and the front-end.

Fixes #34014.
