### PR TITLE
FSE: Correct the default theme menu location for the navigation block.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
@@ -29,7 +29,7 @@ registerBlockType( 'a8c/navigation-menu', {
 	attributes: {
 		themeLocation: {
 			type: 'string',
-			default: 'main-1',
+			default: 'menu-1',
 		},
 	},
 	edit,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The navigation menu block has a default theme location of `main-1`, which is an invalid menu location for Twenty Nineteen. The [correct value](https://core.trac.wordpress.org/browser/trunk/src/wp-content/themes/twentynineteen/functions.php#L59) is `menu-1`.

#### Testing instructions

* Apply this branch to your FSE testing environment.
* Create a custom menu and apply it to the "Primary" theme location.
* Add a navigation menu block to a page.
* Verify it displays the correct menu, both in the editor and on the front-end.
