### PR TITLE
FSE: Update the Site Description block icon.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.js
@@ -13,7 +13,12 @@ import './style.scss';
 registerBlockType( 'a8c/site-description', {
 	title: __( 'Site Description' ),
 	description: __( 'Site description, also known as the tagline.' ),
-	icon: 'layout',
+	icon: (
+		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
+			<path fill="none" d="M0 0h24v24H0z" />
+			<path d="M4 9h16v2H4V9zm0 4h10v2H4v-2z" />
+		</svg>
+	),
 	category: 'layout',
 	supports: {
 		html: false,


### PR DESCRIPTION
This PR updates the Site Description block's icon to [Material's](https://material.io/tools/icons/?search=text&icon=short_text&style=outline) `short_text` ([#](https://github.com/Automattic/wp-calypso/issues/34141#issuecomment-503909860)), instead of Gutenberg's `layout` icon.

<img width="415" alt="Screen Shot 2019-06-24 at 12 06 21 PM" src="https://user-images.githubusercontent.com/349751/60045657-3c19a180-967a-11e9-8cb8-160f36cf58c7.png">

**Testing Instructions**

* Load this branch in your FSE testing environment.
* Add a Site Description block to a post.
* Verify the icon above appears, instead of the layout icon.

Part of #34141 .