### PR TITLE
Plans: Redirects 2yearly plans to yearly plans for Jetpack sites

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -42,7 +42,7 @@ class Plans extends React.Component {
 	};
 
 	componentDidMount() {
-		this.redirectIfNonJetpackMonthly();
+		this.redirectIfInvalidPlanInterval();
 
 		// Scroll to the top
 		if ( typeof window !== 'undefined' ) {
@@ -51,18 +51,21 @@ class Plans extends React.Component {
 	}
 
 	componentDidUpdate() {
-		this.redirectIfNonJetpackMonthly();
+		this.redirectIfInvalidPlanInterval();
 	}
 
-	isNonJetpackMonthly() {
+	isInvalidPlanInterval() {
 		const { displayJetpackPlans, intervalType, selectedSite } = this.props;
-		return selectedSite && ! displayJetpackPlans && intervalType === 'monthly';
+		const isJetpack2Yearly = displayJetpackPlans && intervalType === '2yearly';
+		const isWpcomMonthly = ! displayJetpackPlans && intervalType === 'monthly';
+
+		return selectedSite && ( isJetpack2Yearly || isWpcomMonthly );
 	}
 
-	redirectIfNonJetpackMonthly() {
+	redirectIfInvalidPlanInterval() {
 		const { selectedSite } = this.props;
 
-		if ( this.isNonJetpackMonthly() ) {
+		if ( this.isInvalidPlanInterval() ) {
 			page.redirect( '/plans/yearly/' + selectedSite.slug );
 		}
 	}
@@ -83,7 +86,7 @@ class Plans extends React.Component {
 	render() {
 		const { selectedSite, translate, displayJetpackPlans } = this.props;
 
-		if ( ! selectedSite || this.isNonJetpackMonthly() ) {
+		if ( ! selectedSite || this.isInvalidPlanInterval() ) {
 			return this.renderPlaceholder();
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, visiting `/plans/2yearly/{jetpack-site}` triggers an error because Jetpack doesn't offer plans that are billed every 2 years. This change adds a redirect to `/plans/yearly/{jetpack-site}` to avoid the error.

This particularly affects site switching when viewing the plans page: switching from a wpcom site with a 2yearly plan to a Jetpack site results in an error.

Before

<img width="775" alt="Screen Shot 2019-06-24 at 14 43 13" src="https://user-images.githubusercontent.com/1699996/60047151-9d4b7000-968e-11e9-80c4-f70699ab510e.png">

After

<img width="890" alt="Screen Shot 2019-06-24 at 14 43 24" src="https://user-images.githubusercontent.com/1699996/60047161-a4727e00-968e-11e9-921b-dd06e1a8de12.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Log in to an account with a connected Jetpack site.
* Visit `/plans/2yearly/{site}`.
* You should be redirected to `/plans/yearly/{site}`

Found while reviewing #34151
