### PR TITLE
Signup Form: Fix password field not validating after first blur

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -324,20 +324,32 @@ class SignupForm extends Component {
 	};
 
 	handleBlur = event => {
-		const data = this.getUserData();
 		const fieldId = event.target.id;
 		// Ensure that username and password field validation does not trigger prematurely
 		if ( fieldId === 'password' ) {
-			this.setState( { focusPassword: true } );
+			this.setState( { focusPassword: true }, () => {
+				this.validateAndSaveForm();
+			} );
+			return;
 		}
 		if ( fieldId === 'username' ) {
-			this.setState( { focusUsername: true } );
+			this.setState( { focusUsername: true }, () => {
+				this.validateAndSaveForm();
+			} );
+			return;
 		}
+
+		this.validateAndSaveForm();
+	};
+
+	validateAndSaveForm = () => {
+		const data = this.getUserData();
 		// When a user moves away from the signup form without having entered
 		// anything do not show error messages, think going to click log in.
 		if ( data.username.length === 0 && data.password.length === 0 && data.email.length === 0 ) {
 			return;
 		}
+
 		this.formStateController.sanitize();
 		this.formStateController.validate();
 		this.props.save && this.props.save( this.state.form );


### PR DESCRIPTION
I believe #31149 caused a wee bug where the password field doesn't validate after the first time it `blur`s. We noticed this on the Crowdsignal signup form, but it also has the same behavior on the wp.com signup form. This is because we set the state to track if some fields have been focused and then immediately validate the fields, but in some cases this could fail because [setting the state is asynchronous](https://reactjs.org/docs/state-and-lifecycle.html). 

This makes it look like the password field was valid, when it should show an error message:
![false-validation](https://user-images.githubusercontent.com/789137/60048240-9289de80-9680-11e9-802d-1346de4541aa.gif)

#### Changes proposed in this Pull Request

* If we `blur` the username or password field and set the `focus` state boolean for them, we wait until the set has completed before we validate the fields.

#### Testing instructions

Visit `/start` in an incognito window, and enter an invalid password, then press `tab` to blur the field or click outside of it. You should see an error message straight away! Entering valid data should still allow the registration as expected.


