### PR TITLE
Tool tip update- Related Posts Copy Sprint sync

### DIFF
--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -39,7 +39,7 @@ const RelatedPosts = ( {
 				<FormFieldset>
 					<SupportInfo
 						text={ translate(
-							'Automatically displays similar content (related posts) at the end of each post.'
+							'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.'
 						) }
 						link="https://jetpack.com/support/related-posts/"
 					/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change copy in the tool tip (next to related posts) to match Copy sprint. Change to : ```The feature helps visitors find more of your content by displaying related posts at the bottom of each post. Learn more```

#### Testing instructions
* visit /marketing/traffic/(site name)
* scroll down to Related Posts and hover over the tool tip
**Current**
<img width="904" alt="Screenshot 2019-06-24 15 47 20" src="https://user-images.githubusercontent.com/49159284/60051018-a7be3780-9697-11e9-86b3-2cead6cadfb5.png">

**Proposed**
<img width="914" alt="Screenshot 2019-06-24 15 46 31" src="https://user-images.githubusercontent.com/49159284/60051034-aee54580-9697-11e9-8558-ae49f1a2daf4.png">


Fixes #34229
