### PR TITLE
Hide blog preview in all signup flows

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -41,6 +41,14 @@ export function generateFlows( {
 			lastModified: '2019-06-17',
 		},
 
+		'business-blog': {
+			steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains', 'plans-business' ],
+			destination: getChecklistDestination,
+			description:
+				"Create an account and a blog and then add the business plan to the users cart. Doesn't show preview.",
+			lastModified: '2019-06-24',
+		},
+
 		premium: {
 			steps: [
 				'user',
@@ -54,6 +62,14 @@ export function generateFlows( {
 			destination: getChecklistDestination,
 			description: 'Create an account and a blog and then add the premium plan to the users cart.',
 			lastModified: '2019-06-17',
+		},
+
+		'premium-blog': {
+			steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains', 'plans-premium' ],
+			destination: getChecklistDestination,
+			description:
+				"Create an account and a blog and then add the premium plan to the users cart. Doesn't show preview.",
+			lastModified: '2019-06-24',
 		},
 
 		personal: {
@@ -71,6 +87,14 @@ export function generateFlows( {
 			lastModified: '2019-06-17',
 		},
 
+		'personal-blog': {
+			steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains', 'plans-personal' ],
+			destination: getChecklistDestination,
+			description:
+				"Create an account and a blog and then add the personal plan to the users cart. Doesn't show preview.",
+			lastModified: '2019-06-24',
+		},
+
 		free: {
 			steps: [
 				'user',
@@ -83,6 +107,14 @@ export function generateFlows( {
 			destination: getChecklistDestination,
 			description: 'Create an account and a blog and default to the free plan.',
 			lastModified: '2019-06-17',
+		},
+
+		'free-blog': {
+			steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains' ],
+			destination: getChecklistDestination,
+			description:
+				"Create an account and a blog and default to the free plan. Doesn't show preview.",
+			lastModified: '2019-06-24',
 		},
 
 		blog: {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -17,7 +18,14 @@ import { saveSignupStep } from 'state/signup/progress/actions';
 
 const siteTypeToFlowname = {
 	'online-store': 'ecommerce-onboarding',
-	blog: 'onboarding-blog',
+
+	blog: {
+		business: 'business-blog',
+		free: 'free-blog',
+		onboarding: 'onboarding-blog',
+		personal: 'personal-blog',
+		premium: 'premium-blog',
+	},
 };
 
 class SiteType extends Component {
@@ -28,19 +36,28 @@ class SiteType extends Component {
 	submitStep = siteTypeValue => {
 		this.props.submitSiteType( siteTypeValue );
 
-		// TODO Hack to fix the `/start/premium|business|personal` routes
-		if (
-			( this.props.flowName === 'premium' ||
-				this.props.flowName === 'business' ||
-				this.props.flowName === 'personal' ) &&
-			siteTypeValue === 'blog'
-		) {
-			this.props.goToNextStep( this.props.flowName );
-		} else {
-			// Modify the flowname if the site type matches an override.
-			this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
-		}
+		const nextFlow = this.getNextFlow( siteTypeValue );
+
+		this.props.goToNextStep( nextFlow );
 	};
+
+	/**
+	 * Uses the `siteTypeToFlowname` map to choose whether to continue on the
+	 * current flow or switch to a different one. This decision is based on
+	 * the user's site type selection and the current flow.
+	 *
+	 * @param {string} siteTypeValue site type selected by user
+	 * @returns {string} name of the flow to continue with
+	 */
+	getNextFlow( siteTypeValue ) {
+		const currentFlow = this.props.flowName;
+
+		return (
+			get( siteTypeToFlowname, [ siteTypeValue, currentFlow ] ) ||
+			get( siteTypeToFlowname, siteTypeValue ) ||
+			currentFlow
+		);
+	}
 
 	render() {
 		const {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Creates explicit "no preview" versions of each flow where it's possible to choose the blog segment. This replaces some intricate branching in `<SiteType>` and instead moves the user to a different flow depending on their segment choice.

This still has some override code in the `<SiteType>` component which doesn't feel like it belongs in the model layer. Perhaps another PR can move it to redux or the flow controller. But this at least moves us closer to defining everything as a flow which is closer to the mental model we want..

Another approach might have been to remove the `<SiteMockup>` when `site-type` was `'blog'`, but then we would still need a way to skip the `site-style` step (which doesn't make sense if there's no preview), and we wouldn't be able to have a flow like `onboarding-dev` that allows us to test the blog preview before shipping it.

#### Testing instructions

- `/start/onboarding`
- Create a blog
- Notice progress indicator goes down by one, site style step is missing, and site mockups are hidden
- Go back and switch site type to business|professional|online store
- Notice progress indicator goes up by one, site style step is back, and site mockups are back

Then also test with:

- `/start/personal`
- `/start/premium`
- `/start/business`
- `/start/onboarding?site_type=blog`
- `/start/onboarding?vertical=art`

et cetera, et cetera.

This might impact analytics, but I'm not sure. The `calypso_signup_actions_submit_site_style` event won't be recorded if the user chooses a blog site type, but that's already the case in the `onboarding-blog` flow, so I think we're good on that front.

Fixes Automattic/zelda-private#83
