### PR TITLE
Changing site verification toggle copy to match copy sprint

### DIFF
--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -306,7 +306,7 @@ class SiteVerification extends Component {
 							<JetpackModuleToggle
 								siteId={ siteId }
 								moduleSlug="verification-tools"
-								label={ translate( 'Enable Site Verification Services.' ) }
+								label={ translate( 'Verify site ownership with third party services' ) }
 								disabled={ isDisabled }
 							/>
 						</FormFieldset>

--- a/client/my-sites/site-settings/seo-settings/site-verification.jsx
+++ b/client/my-sites/site-settings/seo-settings/site-verification.jsx
@@ -306,7 +306,7 @@ class SiteVerification extends Component {
 							<JetpackModuleToggle
 								siteId={ siteId }
 								moduleSlug="verification-tools"
-								label={ translate( 'Verify site ownership with third party services' ) }
+								label={ translate( 'Verify site ownership with third-party services' ) }
 								disabled={ isDisabled }
 							/>
 						</FormFieldset>


### PR DESCRIPTION

#### Changes proposed in this Pull Request

*Change the toggle label for Enable Site Verification Services to ```Verify site ownership with third-party services```

#### Testing instructions
* Visit marketing/traffic/(site name)
* Scroll down to site verification services

**CURRENT**
<img width="926" alt="Screenshot 2019-06-24 16 20 31" src="https://user-images.githubusercontent.com/49159284/60053425-70528980-969d-11e9-9f23-5b42d1bf4280.png">

**PROPOSED**
<img width="923" alt="Screenshot 2019-06-24 16 22 59" src="https://user-images.githubusercontent.com/49159284/60053441-79435b00-969d-11e9-9ab9-ec2a1e9f707a.png">


Fixes #34226
