### PR TITLE
Disables the `popularPlanBy` a/b test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -138,8 +138,8 @@ export default {
 	popularPlanBy: {
 		datestamp: '20190529',
 		variations: {
-			siteType: 50,
-			customerType: 50,
+			siteType: 0,
+			customerType: 100,
 		},
 		defaultVariation: 'siteType',
 	},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disables the `popularPlanBy` a/b test which is developed in #33291. Not ready to run this yet, see: p8Eqe3-Cr-p2#comment-1628

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open private tab
* Make your way to `http://calypso.localhost:3000/start/plans`
* In console: `JSON.parse(localStorage.getItem('ABTests'))['popularPlanBy_20190529']`
* It should say `"customerType"`, 100% of the time.


Fixes Automattic/zelda-private#26