### PR TITLE
Add Error for Duplicate New G Suite Users

### DIFF
--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -10,13 +10,7 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import GSuiteNewUser from './new-user';
-import {
-	clearPreviousErrors,
-	newUser,
-	GSuiteNewUser as NewUser,
-	validateNewUsersAreUnique,
-	validateUser,
-} from 'lib/gsuite/new-users';
+import { newUser, GSuiteNewUser as NewUser, validateUsers } from 'lib/gsuite/new-users';
 
 /**
  * Style dependencies
@@ -43,15 +37,10 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 	const translate = useTranslate();
 
 	const onUserValueChange = ( index: number ) => ( field: string, value: string ) => {
-		const uniqueCheckedUsers = validateNewUsersAreUnique( clearPreviousErrors( users ) );
+		const modifiedUserList = users;
+		modifiedUserList[ index ] = { ...users[ index ], [ field ]: { value, error: null } };
 
-		const modifiedUser = extraValidation(
-			validateUser( { ...uniqueCheckedUsers[ index ], [ field ]: { value, error: null } } )
-		);
-
-		onUsersChange(
-			users.map( ( user, userIndex ) => ( userIndex === index ? modifiedUser : user ) )
-		);
+		onUsersChange( validateUsers( modifiedUserList, extraValidation ) );
 	};
 
 	const onUserAdd = () => {

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -10,7 +10,13 @@ import { useTranslate } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import GSuiteNewUser from './new-user';
-import { newUser, GSuiteNewUser as NewUser, validateUser } from 'lib/gsuite/new-users';
+import {
+	clearPreviousErrors,
+	newUser,
+	GSuiteNewUser as NewUser,
+	validateNewUsersAreUnique,
+	validateUser,
+} from 'lib/gsuite/new-users';
 
 /**
  * Style dependencies
@@ -37,8 +43,10 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 	const translate = useTranslate();
 
 	const onUserValueChange = ( index: number ) => ( field: string, value: string ) => {
+		const uniqueCheckedUsers = validateNewUsersAreUnique( clearPreviousErrors( users ) );
+
 		const modifiedUser = extraValidation(
-			validateUser( { ...users[ index ], [ field ]: { value, error: null } } )
+			validateUser( { ...uniqueCheckedUsers[ index ], [ field ]: { value, error: null } } )
 		);
 
 		onUsersChange(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add Error for Duplicate New G Suite Users in new user list
<img width="893" alt="Screen Shot 2019-06-24 at 3 44 20 PM" src="https://user-images.githubusercontent.com/2810519/60056955-c1f81580-9697-11e9-9013-97e6e8a42721.png">


Note: Because each new user component controls when to validate, the error will appear in each component with the same mailbox as you navigate/ give input to it. This quirk is ok because the correct error will appear 

#### Testing instructions
1. Navigate to `/devdocs/design/g-suite-examples`
2. Add two users, give both the same mailbox
3. Confirm that the error message appears on both