### PR TITLE
Signup: Adds privacy protection to domain products for cart after signup

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -22,7 +22,6 @@ import {
 	supportsPrivacyProtectionPurchase,
 	planItem as getCartItemForPlan,
 } from 'lib/cart-values/cart-items';
-import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
 
 // State actions and selectors
 import { getDesignType } from 'state/signup/steps/design-type/selectors';

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -22,6 +22,7 @@ import {
 	supportsPrivacyProtectionPurchase,
 	planItem as getCartItemForPlan,
 } from 'lib/cart-values/cart-items';
+import { isDomainRegistration, isDomainTransfer } from 'lib/products-values';
 
 // State actions and selectors
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
@@ -50,7 +51,6 @@ import { promisify } from '../../utils';
 import flows from 'signup/config/flows';
 import steps, { isDomainStepSkippable } from 'signup/config/steps';
 import { isEligibleForPageBuilder, shouldEnterPageBuilder } from 'lib/signup/page-builder';
-import { isDomainRegistration, isDomainTransfer } from '../products-values';
 
 /**
  * Constants


### PR DESCRIPTION
### Changes proposed in this Pull Request

Automatically adds privacy protection to domain registrations and domain transfers that support it.

**Before: Checkout with domain defaults to public registration**

<img width="921" alt="Screen Shot 2019-06-24 at 18 04 53" src="https://user-images.githubusercontent.com/1699996/60066002-634c8f00-96cb-11e9-8c2e-c0558af4899f.png">

**After: Checkout with domain defaults to private registration**

<img width="926" alt="Screen Shot 2019-06-24 at 18 04 41" src="https://user-images.githubusercontent.com/1699996/60066036-8d05b600-96cb-11e9-9d3f-226f44606025.png">

**See PR comments for notes and caveats**

Domain transfers do _not_ default to private registration because their product items do not indicate that they support private registration.

### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start` and complete a flow that includes a domain registration.
* On the checkout page, see that the domain information defaults to private registration.
* Check other flows, like `/start/domain` and verify the same behavior.

