### PR TITLE
Remove box shadow from FSE block title and description

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
@@ -7,6 +7,7 @@
 			font-weight: normal;
 			letter-spacing: -0.01em;
 			margin: 0;
+			box-shadow: none;
 		}
 	}
 	.site-description__save-button {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
@@ -10,6 +10,7 @@
 			letter-spacing: -0.02em;
 			line-height: 1.2;
 			margin: 0;
+			box-shadow: none;
 		}
 	}
 	.site-title__save-button {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the box shadow from the site title and description block so they look like paragraph blocks when focused. Change suggested in feedback at  https://github.com/Automattic/wp-calypso/issues/34141#issuecomment-503909860

>  I don't feel an actual input field is necessary — it isn't for the Paragraph block.

#### Testing instructions

* Load this branch in your FSE testing environment.
* Add a Site Description and Site Title block to a post.
* Verify that when each block is selected there is no blue text box border display as below
![no-box](https://user-images.githubusercontent.com/3629020/60063298-8ec58d00-9750-11e9-9cd9-70f41e287027.gif)

