### PR TITLE
Themes: fix entities in theme description

### DIFF
--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -189,7 +189,7 @@ export function themeInstalls( state = {}, action ) {
 /**
  * Returns the updated site theme requests error state after an action has been
  * dispatched. The state reflects a mapping of site ID, theme ID pairing to a
- * object describing request error. If there is no error null is storred.
+ * object describing request error. If there is no error null is stored.
  *
  * @param  {Object} state  Current state
  * @param  {Object} action Action payload
@@ -311,7 +311,7 @@ export const queries = ( () => {
 		return Object.assign( {}, theme, { description: decodeEntities( theme.description ) } );
 	}
 
-	// Time after which queries storred in IndexedDb will be invalidated.
+	// Time after which queries stored in IndexedDb will be invalidated.
 	// days * hours_in_day * minutes_in_hour * seconds_in_minute * miliseconds_in_second
 	const MAX_THEMES_AGE = 1 * 24 * 60 * 60 * 1000;
 

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -308,7 +308,7 @@ export const queries = ( () => {
 			return theme;
 		}
 
-		return Object.assign( {}, theme, { description: decodeEntities( theme.description ) } );
+		return { ...theme, description: decodeEntities( theme.description ) };
 	}
 
 	// Time after which queries stored in IndexedDb will be invalidated.

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-
-import { mapValues, omit } from 'lodash';
+import { mapValues, omit, map } from 'lodash';
 
 /**
  * Internal dependencies
@@ -44,6 +43,7 @@ import {
 } from './schema';
 import themesUI from './themes-ui/reducer';
 import uploadTheme from './upload-theme/reducer';
+import { decodeEntities } from 'lib/formatting';
 
 /**
  * Returns the updated active theme state after an action has been
@@ -223,11 +223,13 @@ export const themeRequestErrors = createReducer(
  * @return {Object}        Updated state
  */
 export function queryRequests( state = {}, action ) {
+	let serializedQuery;
+
 	switch ( action.type ) {
 		case THEMES_REQUEST:
 		case THEMES_REQUEST_SUCCESS:
 		case THEMES_REQUEST_FAILURE:
-			const serializedQuery = getSerializedThemesQuery( action.query, action.siteId );
+			serializedQuery = getSerializedThemesQuery( action.query, action.siteId );
 			return Object.assign( {}, state, {
 				[ serializedQuery ]: THEMES_REQUEST === action.type,
 			} );
@@ -301,6 +303,14 @@ export const queries = ( () => {
 		};
 	}
 
+	function fromApi( theme ) {
+		if ( ! theme || ! theme.description ) {
+			return theme;
+		}
+
+		return Object.assign( {}, theme, { description: decodeEntities( theme.description ) } );
+	}
+
 	// Time after which queries storred in IndexedDb will be invalidated.
 	// days * hours_in_day * minutes_in_hour * seconds_in_minute * miliseconds_in_second
 	const MAX_THEMES_AGE = 1 * 24 * 60 * 60 * 1000;
@@ -316,7 +326,7 @@ export const queries = ( () => {
 					siteId,
 					'receive',
 					true,
-					themes,
+					map( themes, fromApi ),
 					{ query, found, patch: true }
 				);
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/issues/34091, it was reported that there was no alt text for theme screenshots. I've made an API change to include theme descriptions in the response, but some of them contain HTML entities.

This PR decodes HTML entities as they are received in the theme description.

#### Testing instructions

Go to http://calypso.localhost:3000/themes and hover over a theme screenshot. Make sure there are no entities in the theme description.

Examples of theme descriptions that previously included undecoded entities are 'Modern Business' and 'Elegant Business'.

Before:

<img width="593" alt="Screen Shot 2019-06-25 at 15 47 31" src="https://user-images.githubusercontent.com/17325/60067924-b3296580-9760-11e9-8dda-0930d719e661.png">

After:

<img width="683" alt="Screen Shot 2019-06-25 at 15 48 25" src="https://user-images.githubusercontent.com/17325/60067928-b9b7dd00-9760-11e9-9286-37b8a22924e0.png">

Fixes #34091.