### PR TITLE
Update shortlinks setting copy to match Jetpack

### DIFF
--- a/client/my-sites/site-settings/shortlinks.jsx
+++ b/client/my-sites/site-settings/shortlinks.jsx
@@ -61,7 +61,7 @@ class Shortlinks extends Component {
 						<JetpackModuleToggle
 							siteId={ selectedSiteId }
 							moduleSlug="shortlinks"
-							label={ translate( 'Create short and simple links for all posts and pages' ) }
+							label={ translate( 'Generate shortened URLs for simpler sharing.' ) }
 							disabled={ formPending }
 						/>
 					</FormFieldset>


### PR DESCRIPTION
Before:

![Screenshot 2019-06-25 at 11 33 26](https://user-images.githubusercontent.com/411945/60091711-24efb800-973d-11e9-861a-7da5088d0142.png)

After:

![Screenshot 2019-06-25 at 11 33 40](https://user-images.githubusercontent.com/411945/60091718-291bd580-973d-11e9-876d-63b33075c2a6.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /marketing/traffic/domain.com
* Verify copy change

Fixes #34223
