### PR TITLE
PoC: Attach the pre-cancellation survey on toggling off auto-renewal.

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -322,6 +322,7 @@ class CancelPurchaseForm extends React.Component {
 
 	render() {
 		const { translate, showSurvey, surveyStep } = this.props;
+
 		if ( showSurvey ) {
 			if ( surveyStep === steps.INITIAL_STEP ) {
 				return (

--- a/client/me/purchases/index.js
+++ b/client/me/purchases/index.js
@@ -94,6 +94,7 @@ export default function( router ) {
 	router(
 		paths.managePurchase( ':site', ':purchaseId' ),
 		sidebar,
+		siteSelection,
 		controller.managePurchase,
 		makeLayout,
 		clientRender


### PR DESCRIPTION
### Summary

This PR is just a demonstration for how it would look if we show the same precancellation survey on toggling off auto-renewal.

Simple sites:
![demo-toggling-off-with-the-survey](https://user-images.githubusercontent.com/1842898/60092232-17f0ba00-9779-11e9-8738-538991b12c41.gif)

Atomic sites:
![demo-toggling-off-atomic-with-the-survey](https://user-images.githubusercontent.com/1842898/60092235-1a531400-9779-11e9-9d41-ad0769fad402.gif)

@sararosso You should be able to test it on calypso.live. Is this what you expected? Please let me know how do you think and if we should go with this direction.
