### PR TITLE
Update copy on masterbar / .com toolbar setting

### DIFF
--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -65,16 +65,6 @@ class SiteSettingsFormWriting extends Component {
 				onSubmit={ handleSubmitForm }
 				className="site-settings__general-settings"
 			>
-				{ isMasterbarSectionVisible && (
-					<div>
-						<SettingsSectionHeader title={ translate( 'WordPress.com toolbar' ) } />
-						<Masterbar
-							isSavingSettings={ isSavingSettings }
-							isRequestingSettings={ isRequestingSettings }
-						/>
-					</div>
-				) }
-
 				{ config.isEnabled( 'manage/site-settings/categories' ) && (
 					<div className="site-settings__taxonomies">
 						<QueryTaxonomies siteId={ siteId } postType="post" />
@@ -184,6 +174,16 @@ class SiteSettingsFormWriting extends Component {
 							title={ translate( 'Press This', { context: 'name of browser bookmarklet tool' } ) }
 						/>
 						<PressThis />
+					</div>
+				) }
+
+				{ isMasterbarSectionVisible && (
+					<div>
+						<SettingsSectionHeader title={ translate( 'WordPress.com toolbar' ) } />
+						<Masterbar
+							isSavingSettings={ isSavingSettings }
+							isRequestingSettings={ isRequestingSettings }
+						/>
 					</div>
 				) }
 			</form>

--- a/client/my-sites/site-settings/masterbar.jsx
+++ b/client/my-sites/site-settings/masterbar.jsx
@@ -46,9 +46,10 @@ const Masterbar = ( {
 						moduleSlug="masterbar"
 						label={ translate( 'Enable the WordPress.com toolbar' ) }
 						description={ translate(
-							'The WordPress.com toolbar replaces the default admin bar and offers quick links to ' +
-								'the Reader, all your sites, your WordPress.com profile, and notifications. ' +
-								'Centralize your WordPress experience with a single global toolbar.'
+							'The WordPress.com toolbar replaces the default WordPress admin toolbar. ' +
+								'It offers one-click access to notifcations, your WordPress.com profile and ' +
+								'your other Jetpack and WordPress.com websites. You can also catch up on the sites ' +
+								'you follow in the Reader.'
 						) }
 						disabled={ isRequestingSettings || isSavingSettings || masterbarModuleUnavailable }
 					/>


### PR DESCRIPTION
Before:

![60031286-59f7fe00-969c-11e9-81aa-e68c3ac2e2a7](https://user-images.githubusercontent.com/411945/60093346-14414100-9741-11e9-86a3-c3307004c17e.png)

After:

![Screenshot 2019-06-25 at 12 02 11](https://user-images.githubusercontent.com/411945/60093354-1905f500-9741-11e9-909f-39077a16104f.png)

The setting has also been moved to the bottom of the page - this matches the location in Jetpcak

Fixes #34225 
