### PR TITLE
Update copy on downtime monitoring setting

### DIFF
--- a/client/my-sites/site-settings/form-jetpack-monitor.jsx
+++ b/client/my-sites/site-settings/form-jetpack-monitor.jsx
@@ -138,14 +138,18 @@ class SiteSettingsFormJetpackMonitor extends Component {
 
 				<Card className="jetpack-monitor-settings">
 					<SupportInfo
-						text={ translate( "Notifies you when there's an issue with your site." ) }
+						text={ translate(
+							'Jetpack will continuously monitor your site, and alert you the moment downtime is detected.'
+						) }
 						link="https://jetpack.com/support/monitor/"
 					/>
 
 					<JetpackModuleToggle
 						siteId={ siteId }
 						moduleSlug="monitor"
-						label={ translate( "Monitor your site's downtime" ) }
+						label={ translate(
+							'Get alerts if your site goes offline. We’ll let you know when it’s back up, too.'
+						) }
 						disabled={ this.disableForm() }
 					/>
 


### PR DESCRIPTION
Before:

![Screenshot 2019-06-25 at 12 20 18](https://user-images.githubusercontent.com/411945/60094433-f6c1a680-9743-11e9-995d-d1069f898e21.png)

After:

![Screenshot 2019-06-25 at 12 21 16](https://user-images.githubusercontent.com/411945/60094440-fd501e00-9743-11e9-9ac1-795e6024b651.png)

![Screenshot 2019-06-25 at 12 22 09](https://user-images.githubusercontent.com/411945/60094448-00e3a500-9744-11e9-9b7a-2b7b8097b8de.png)

Jetpack:

![Screenshot 2019-06-25 at 12 22 16](https://user-images.githubusercontent.com/411945/60094456-080ab300-9744-11e9-9fda-b7b2198f2710.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify copy is in sync with Jetpack setting for downtime monitoring

Fixes #34220 
