### PR TITLE
Checkout: add popover info for the pan number field

### DIFF
--- a/client/lib/cart-values/index.js
+++ b/client/lib/cart-values/index.js
@@ -321,7 +321,7 @@ export function getEnabledPaymentMethods( cart ) {
 /**
  * Return a string that represents the WPCOM class name for a payment method
  *
- * @param {string} method - payment method
+ * @param {string} method -  payment method
  * @returns {string} the wpcom class name
  */
 export function paymentMethodClassName( method ) {

--- a/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
+++ b/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
@@ -85,16 +85,12 @@ export class CountrySpecificPaymentFields extends Component {
 
 	getPanNumberPopover = () => {
 		const { translate } = this.props;
-		const popoverText = translate(
-			'To pay with %(indiaPaymentMethods)s, we are required to ask for your PAN number. ' +
-				'Entry of the PAN number is not required for payment with credit cards enabled for international payments.',
-			{
-				comment: 'indiaPaymentMethods are local payment methods in India.',
-				args: {
-					indiaPaymentMethods: paymentMethodName( 'netbanking' ),
-				},
-			}
-		);
+		const popoverText = translate( 'Paying with %(indiaPaymentMethods)s requires a PAN number.', {
+			comment: 'indiaPaymentMethods are local payment methods in India.',
+			args: {
+				indiaPaymentMethods: paymentMethodName( 'netbanking' ),
+			},
+		} );
 		return (
 			<InfoPopover position="right" className="checkout__pan-number-popover">
 				{ popoverText }

--- a/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
+++ b/client/my-sites/checkout/checkout/country-specific-payment-fields.jsx
@@ -14,6 +14,8 @@ import { find, isEmpty, includes, get } from 'lodash';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 import { StateSelect, Input, HiddenInput } from 'my-sites/domains/components/form';
 import { PAYMENT_PROCESSOR_COUNTRIES_FIELDS } from 'lib/checkout/constants';
+import InfoPopover from 'components/info-popover';
+import { paymentMethodName } from 'lib/cart-values';
 
 export class CountrySpecificPaymentFields extends Component {
 	static propTypes = {
@@ -81,6 +83,25 @@ export class CountrySpecificPaymentFields extends Component {
 		this.setState( { userSelectedPhoneCountryCode: countryCode } );
 	};
 
+	getPanNumberPopover = () => {
+		const { translate } = this.props;
+		const popoverText = translate(
+			'To pay with %(indiaPaymentMethods)s, we are required to ask for your PAN number. ' +
+				'Entry of the PAN number is not required for payment with credit cards enabled for international payments.',
+			{
+				comment: 'indiaPaymentMethods are local payment methods in India.',
+				args: {
+					indiaPaymentMethods: paymentMethodName( 'netbanking' ),
+				},
+			}
+		);
+		return (
+			<InfoPopover position="right" className="checkout__pan-number-popover">
+				{ popoverText }
+			</InfoPopover>
+		);
+	};
+
 	onFieldChange = event => this.props.handleFieldChange( event.target.name, event.target.value );
 
 	render() {
@@ -113,8 +134,12 @@ export class CountrySpecificPaymentFields extends Component {
 				} ) }
 
 				{ this.createField( 'pan', Input, {
-					label: translate( 'PAN Number', {
+					placeholder: ' ',
+					label: translate( 'PAN Number {{panNumberPopover/}}', {
 						comment: 'India PAN number ',
+						components: {
+							panNumberPopover: this.getPanNumberPopover(),
+						},
 					} ),
 				} ) }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're required to ask our customers for their PAN numbers when paying with local payment methods in India (soon launching, NetBanking).  This adds a tooltip popover to explain the requirement and to let customers know that the PAN number isn't required when paying with a credit card.

<img width="711" alt="Screen Shot 2019-07-01 at 14 59 51" src="https://user-images.githubusercontent.com/844866/60434917-ee201300-9c10-11e9-8021-e4eb617c36f7.png">


#### Testing instructions

To enable "Net Banking", you'll want your backend to have store sandbox enabled. 
Then, visit the checkout form to see the Ne Banking tab available.
