### PR TITLE
 Related posts block documentation link

### DIFF
--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -60,9 +60,7 @@ const RelatedPosts = ( {
 							}
 							onChange={ handleAutosavingToggle( 'jetpack_relatedposts_show_headline' ) }
 						>
-							{ translate(
-								'Show a "Related" header to more clearly separate the related section from posts'
-							) }
+							{ translate( 'Highlight related content with a heading' ) }
 						</CompactFormToggle>
 
 						<CompactFormToggle

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -81,7 +81,7 @@ const RelatedPosts = ( {
 								components: {
 									a: (
 										<a
-											href="https://en.support.wordpress.com/wordpress-editor/blocks/latest-posts-block/"
+											href="https://jetpack.com/support/jetpack-blocks/related-posts-block/"
 											target="_blank"
 											rel="noopener noreferrer"
 										/>

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -78,7 +78,18 @@ const RelatedPosts = ( {
 
 					<FormSettingExplanation>
 						{ translate(
-							"These settings won't apply to related posts added using the block editor."
+							"These settings won't apply to {{a}}related posts added using the block editor{{/a}}.",
+							{
+								components: {
+									a: (
+										<a
+											href="https://en.support.wordpress.com/wordpress-editor/blocks/latest-posts-block/"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+								},
+							}
 						) }
 					</FormSettingExplanation>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before:

![Screenshot 2019-06-25 at 15 18 16](https://user-images.githubusercontent.com/411945/60106091-7c515080-975c-11e9-8de6-791fe5ab56a6.png)

After:

![Screenshot 2019-06-25 at 15 16 38](https://user-images.githubusercontent.com/411945/60105985-46ac6780-975c-11e9-8fc3-c00082f45e40.png)

Jetpack:

![Screenshot 2019-06-25 at 15 17 45](https://user-images.githubusercontent.com/411945/60106066-6ba0da80-975c-11e9-8ff8-b873e82d834f.png)

Added link and mirror Jetpack setting names

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to: /marketing/traffic/domain.com
* Verify copy changes

Fixes #34219
