### PR TITLE
CartSynchronizer: handle error rather than throw

### DIFF
--- a/client/lib/cart/store/cart-synchronizer.js
+++ b/client/lib/cart/store/cart-synchronizer.js
@@ -93,7 +93,7 @@ CartSynchronizer.prototype.handleDispatch = function( payload ) {
 	}
 };
 
-CartSynchronizer.prototype.update = function( changeFunction ) {
+CartSynchronizer.prototype.update = function( changeFunction, errorHandler ) {
 	if ( ! this._hasLoadedFromServer ) {
 		// If we haven't loaded any data from the server yet, it's possible that
 		// the local data could completely overwrite the existing data. This would
@@ -114,7 +114,7 @@ CartSynchronizer.prototype.update = function( changeFunction ) {
 	}
 
 	this._latestValue = changeFunction( this._latestValue );
-	this._performRequest( 'update', this._postToServer.bind( this ) );
+	this._performRequest( 'update', this._postToServer.bind( this ), errorHandler );
 	this.emit( 'change' );
 };
 
@@ -187,7 +187,7 @@ CartSynchronizer.prototype._getFromServer = function( callback ) {
 
 let requestCounter = 0;
 
-CartSynchronizer.prototype._performRequest = function( type, requestFunction ) {
+CartSynchronizer.prototype._performRequest = function( type, requestFunction, errorHandler ) {
 	if ( type === 'poll' && this._paused ) {
 		return;
 	}
@@ -214,7 +214,9 @@ CartSynchronizer.prototype._performRequest = function( type, requestFunction ) {
 			}
 
 			if ( error ) {
-				throw error;
+				debug( request.id + ': error ' + request.type, error );
+				errorHandler && errorHandler( error );
+				return;
 			}
 			debug( request.id + ': finishing ' + request.type );
 

--- a/client/lib/cart/store/index.js
+++ b/client/lib/cart/store/index.js
@@ -104,14 +104,14 @@ function emitChange() {
 	CartStore.emit( 'change' );
 }
 
-function update( changeFunction ) {
+function update( changeFunction, errorHandler ) {
 	const wrappedFunction = cart =>
 		fillInAllCartItemAttributes( changeFunction( cart ), productsList.get() );
 
 	const previousCart = CartStore.get();
 	const nextCart = wrappedFunction( previousCart );
 
-	_synchronizer && _synchronizer.update( wrappedFunction );
+	_synchronizer && _synchronizer.update( wrappedFunction, errorHandler );
 	recordEvents( previousCart, nextCart );
 }
 
@@ -212,7 +212,7 @@ CartStore.dispatchToken = Dispatcher.register( payload => {
 						postalCode = null;
 						countryCode = null;
 				}
-				update( setTaxLocation( { postalCode, countryCode } ) );
+				update( setTaxLocation( { postalCode, countryCode } ), action.errorHandler );
 			}
 			break;
 

--- a/client/lib/upgrades/actions/checkout.js
+++ b/client/lib/upgrades/actions/checkout.js
@@ -24,10 +24,11 @@ export function setDomainDetails( domainDetails ) {
 	} );
 }
 
-export function setPayment( payment ) {
+export function setPayment( payment, errorHandler ) {
 	Dispatcher.handleViewAction( {
 		type: TRANSACTION_PAYMENT_SET,
 		payment,
+		errorHandler,
 	} );
 }
 

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -110,12 +110,13 @@ export class SecurePaymentForm extends Component {
 		}
 
 		if ( newPayment ) {
+			const errorHandler = err => displayError( err );
 			// We need to defer this because this is mounted after `setDomainDetails`
 			// is called.
 			// Note: If this defer() is ever able to be removed, the corresponding
 			// defer() in NewCardForm::handleFieldChange() can likely be removed too.
 			defer( function() {
-				setPayment( newPayment );
+				setPayment( newPayment, errorHandler );
 			} );
 		}
 	}


### PR DESCRIPTION
This passes an error handler function down through the chain of calls from the SecurePaymentForm's `componentDidMount` lifecycle method to `CartSynchronizer._performRequest()` and uses it rather than throwing an error.

The error handler uses `displayError()` (already used by this component) to show the message on the screen.

This is really not the best way to do this, since passing a function through a Flux action is an anti-pattern, but it's hard to know how to dispatch an error message action from the `CartSynchronizer` Flux store, which is pre-Redux.

Another problem is that even though this allows the error to be shown, the user may still end up with no available actions since the page will still hang.
