### PR TITLE
Update post by email input label to match Jetpack

### DIFF
--- a/client/my-sites/site-settings/publishing-tools/index.jsx
+++ b/client/my-sites/site-settings/publishing-tools/index.jsx
@@ -89,7 +89,9 @@ class PublishingTools extends Component {
 
 		return (
 			<div className="publishing-tools__module-settings site-settings__child-settings">
-				<FormLabel className={ labelClassName }>{ translate( 'Email Address' ) }</FormLabel>
+				<FormLabel className={ labelClassName }>
+					{ translate( 'Send your new posts to this email address:' ) }
+				</FormLabel>
 				<ClipboardButtonInput
 					className="publishing-tools__email-address"
 					disabled={


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Before:

![Screenshot 2019-06-25 at 16 26 35](https://user-images.githubusercontent.com/411945/60111529-0520ba00-9766-11e9-913d-fb2fafb0ec94.png)

After:

![Screenshot 2019-06-25 at 16 25 22](https://user-images.githubusercontent.com/411945/60111483-ecb09f80-9765-11e9-9283-4eb1d876f4a3.png)

Jetpack:

![Screenshot 2019-06-25 at 16 12 18](https://user-images.githubusercontent.com/411945/60111503-f508da80-9765-11e9-826d-988e5c493592.png)

There are still some differences here due to the different setting group in Calypso.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Goto: /settings/writing/domain.com
* Verify updated copy on the post by email input 
Fixes #
