### PR TITLE
Gauge: Use SVG to draw component

### DIFF
--- a/client/components/gauge/README.md
+++ b/client/components/gauge/README.md
@@ -1,7 +1,6 @@
-Gauge
-======
+# Gauge
 
-This component renders a simple gauge using a `<canvas/>` element that shows a percentage visually.
+This component renders a simple gauge to show a percentage visually.
 
 #### How to use:
 
@@ -17,15 +16,15 @@ render() {
 
 #### Required Props
 
-* `percentage`: a numeric percentage between 0-100.
+- `percentage`: a numeric percentage between 0-100.
 
 #### Optional Props
 
-The following props may also be used.  Default values are shown inside [].
+The following props may be used to override defaults.
 
-* `width`: [ 100 ] numeric width of canvas
-* `height`: [ 100 ] numeric height of canvas
-* `lineWidth`: [ 14 ] numeric width of arc stroke in the canvas
-* `labelSize`: [ 20 ] numeric size used for `px` of the label
-* `colors`: [ '#c8d7e1', '#004069' ] array of colors used for the arcs. First value is the background color, second value is used to show percentage
-* `metric`: text label for the numerical value above it
+- `size`: Size (width and height) of element in pixels
+- `lineWidth`: Width of arc stroke in pixels
+- `labelSize`: Font size of label in pixels
+- `colorBg`: Background color
+- `colorFg`: Foreground color. The percentage bar displayed over the background.
+- `metric`: Text label for the percentage.

--- a/client/components/gauge/index.jsx
+++ b/client/components/gauge/index.jsx
@@ -31,13 +31,14 @@ export default class extends React.PureComponent {
 
 	// See https://stackoverflow.com/a/18473154/1432801
 	// Renders 2d-canvas like circle segment arcs as svg path
-	partialCircle = ( color, percent ) => {
+	getPathDefinition = percent => {
+		const { lineWidth, size } = this.props;
 		const start = 0.8 * Math.PI;
 		const end = ( 0.8 + 1.4 * ( percent / 100 ) ) * Math.PI;
 		const length = end - start;
 
-		const center = this.props.size / 2;
-		const radius = center - this.props.lineWidth / 2;
+		const center = size / 2;
+		const radius = center - lineWidth / 2;
 
 		const fromX = radius * Math.cos( start ) + center;
 		const fromY = radius * Math.sin( start ) + center;
@@ -46,42 +47,38 @@ export default class extends React.PureComponent {
 		const large = Math.abs( length ) <= Math.PI ? '0' : '1';
 		const sweep = length < 0 ? '0' : '1';
 
-		return (
-			<path
-				d={ `M ${ fromX } ${ fromY } A ${ radius } ${ radius } 0 ${ large } ${ sweep } ${ toX } ${ toY }` }
-				fill="none"
-				stroke={ color }
-				stroke-width={ this.props.lineWidth }
-				stroke-linecap="round"
-			/>
-		);
+		return `M ${ fromX } ${ fromY } A ${ radius } ${ radius } 0 ${ large } ${ sweep } ${ toX } ${ toY }`;
 	};
 
 	render() {
-		const { size } = this.props;
-		const wrapperStyles = {
-			width: this.props.size,
-			height: this.props.size,
-		};
+		const { colorBg, colorFg, labelSize, lineWidth, metric, percentage, size } = this.props;
 		const labelStyles = {
-			color: this.props.colorFg,
-			fontSize: this.props.labelSize + 'px',
+			fontSize: labelSize + 'px',
+			top: `-${ size / 2 + labelSize }px`,
 		};
-		const label = this.props.percentage + '%';
-
-		const labelTop = this.props.size / 2 + this.props.labelSize;
-		labelStyles.top = '-' + labelTop + 'px';
 
 		return (
 			<>
-				<div className="gauge" style={ wrapperStyles }>
+				<div className="gauge" style={ { height: size, width: size } }>
 					<svg width={ size } height={ size } viewBox={ `0 0 ${ size } ${ size }` }>
-						{ this.partialCircle( this.props.colorBg, 100 ) }
-						{ this.partialCircle( this.props.colorFg, this.props.percentage ) }
+						<path
+							d={ this.getPathDefinition( 100 ) }
+							fill="none"
+							stroke={ colorBg }
+							stroke-width={ lineWidth }
+							stroke-linecap="round"
+						/>
+						<path
+							d={ this.getPathDefinition( percentage ) }
+							fill="none"
+							stroke={ colorFg }
+							stroke-width={ lineWidth }
+							stroke-linecap="round"
+						/>
 					</svg>
 					<span className="gauge__label" style={ labelStyles }>
-						<span className="gauge__number">{ label }</span>
-						<span className="gauge__metric">{ this.props.metric }</span>
+						<span className="gauge__number">{ percentage }%</span>
+						<span className="gauge__metric">{ metric }</span>
 					</span>
 				</div>
 			</>

--- a/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-banner/index.jsx
@@ -64,12 +64,12 @@ export class ChecklistBanner extends Component {
 				<div className="checklist-banner__gauge animate__fade-in">
 					<span className="checklist-banner__gauge-additional-text">{ translate( 'setup' ) }</span>
 					<Gauge
-						width={ 152 }
-						height={ 152 }
+						size={ 152 }
 						lineWidth={ 18 }
 						percentage={ percentage }
 						metric={ translate( 'completed' ) }
-						colors={ [ '#ffffff', '#008a00' ] }
+						colorBg="#ffffff"
+						colorFg="#008a00"
 					/>
 				</div>
 				<div className="checklist-banner__progress">

--- a/client/my-sites/checklist/wpcom-checklist/checklist-banner/style.scss
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-banner/style.scss
@@ -1,4 +1,3 @@
-
 .checklist-banner {
 	display: flex;
 	flex-direction: row;
@@ -14,8 +13,6 @@
 	position: relative;
 
 	.gauge__label {
-		color: var( --color-success ) !important; /* important overrides inline style with CSS var */
-
 		/* this has to nest under .gauge__label to override the specificity for the stock styles */
 		.gauge__metric {
 			text-transform: none;


### PR DESCRIPTION
Fixes #33735

- Replace `width` + `height` props with `size`. This component doesn't work properly if width and height are different.
- Replace `colors` array prop with 2 distinct properties `colorBg` and `colorFg`.
- Replace canvas with SVG. Visually this should be nearly identical (fixes the retina issue from #33735)

## Screens

### Before

<img width="579" alt="before" src="https://user-images.githubusercontent.com/841763/60116052-94829900-9777-11e9-8b53-8673e9fac538.png">

<img width="196" alt="before-detail" src="https://user-images.githubusercontent.com/841763/60116048-93ea0280-9777-11e9-8ac5-ce8e1c43dee3.png">

<img width="196" alt="before-0" src="https://user-images.githubusercontent.com/841763/60116045-93516c00-9777-11e9-9eb2-9edba2e662e3.png">

<img width="196" alt="before-42" src="https://user-images.githubusercontent.com/841763/60116044-93516c00-9777-11e9-81d4-4b50773dcfe7.png">

### After
<img width="579" alt="after" src="https://user-images.githubusercontent.com/841763/60116051-94829900-9777-11e9-8949-873c520e69be.png">

<img width="196" alt="after-detail" src="https://user-images.githubusercontent.com/841763/60116049-93ea0280-9777-11e9-85a7-d09849eaa7c5.png">

<img width="196" alt="after-0" src="https://user-images.githubusercontent.com/841763/60116047-93ea0280-9777-11e9-9174-363591bcc728.png">

<img width="196" alt="after-42" src="https://user-images.githubusercontent.com/841763/60116046-93516c00-9777-11e9-8c88-cc902c5b031a.png">

## Testing

- Compare in the checklist banner shown above. This is the only production usage I saw with a quick search. Test a few different browsers if possible, especially older safari (on mobile?) or ie11
  - https://calypso.live/stats/day/SIMPLE_SITE_SLUG?branch=update/component-gauge-svg
  - https://wordpress.com/stats/day/SIMPLE_SITE_SLUG
- Compare in devdocs
  - https://calypso.live/devdocs/design/gauge?branch=update/component-gauge-svg
  - https://wpcalypso.wordpress.com/devdocs/design/gauge
- Play in the devdocs playground. Does it work as expected?
  - https://calypso.live/devdocs/playground?branch=update/component-gauge-svg
  - https://wpcalypso.wordpress.com/devdocs/playground

```jsx
<Main>
<Gauge percentage={25}/>
<Gauge size={200} colors={['red','green']} colorBg="red" colorFg="green" metric="Awesomeness" width={200} height={200} percentage={45} lineWidth={5} labelSize={60}/>
<Gauge size={200} percentage={25}  lineWidth={1} />
<Gauge size={200} percentage={50}  lineWidth={10} />
<Gauge size={200} percentage={75} lineWidth={20} colorBg="red" colorFg="blue" metric="Awesomeness" />
<Gauge size={200} percentage={100} lineWidth={50} />
</Main>
```

