### PR TITLE
Fix Broken G Suite E2e Tests

### DIFF
--- a/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
@@ -112,9 +112,16 @@ const GSuiteUpsellCard = ( {
 					users={ users }
 				>
 					<div className="gsuite-upsell-card__buttons">
-						<Button onClick={ handleSkipClick }>{ translate( 'Skip' ) }</Button>
+						<Button className="gsuite-upsell-card__skip-button" onClick={ handleSkipClick }>
+							{ translate( 'Skip' ) }
+						</Button>
 
-						<Button primary disabled={ ! canContinue } onClick={ handleAddEmailClick }>
+						<Button
+							className="gsuite-upsell-card__add-email-button"
+							primary
+							disabled={ ! canContinue }
+							onClick={ handleAddEmailClick }
+						>
 							{ renderAddEmailButtonText() }
 						</Button>
 					</div>

--- a/test/e2e/lib/components/find-a-domain-component.js
+++ b/test/e2e/lib/components/find-a-domain-component.js
@@ -15,7 +15,7 @@ import * as driverHelper from '../driver-helper.js';
 export default class FindADomainComponent extends AsyncBaseContainer {
 	constructor( driver ) {
 		super( driver, By.css( '.register-domain-step' ) );
-		this.declineGoogleAppsLinkSelector = By.className( 'gsuite-upsell-card__checkout-button' );
+		this.declineGoogleAppsLinkSelector = By.className( 'gsuite-upsell-card__skip-button' );
 	}
 
 	async waitForResults() {
@@ -110,27 +110,6 @@ export default class FindADomainComponent extends AsyncBaseContainer {
 			//Sometimes the first click doesn't work. Clicking again
 			await driverHelper.clickWhenClickable( this.driver, this.declineGoogleAppsLinkSelector );
 		}
-	}
-
-	selectAddEmailForGoogleApps() {
-		const googleAppsFieldsSelector = By.css( 'fieldset.gsuite-upsell-card__user-fields' );
-		this.waitForGoogleApps();
-		driverHelper.clickWhenClickable(
-			this.driver,
-			By.css( '.gsuite-upsell-card__continue-button' ),
-			this.explicitWaitMS
-		);
-		this.driver.wait(
-			until.elementLocated( googleAppsFieldsSelector ),
-			this.explicitWaitMS,
-			'Could not locate the google apps information fieldset'
-		);
-		const googleAppsFieldsElement = this.driver.findElement( googleAppsFieldsSelector );
-		return this.driver.wait(
-			until.elementIsVisible( googleAppsFieldsElement ),
-			this.explicitWaitMS,
-			'Could not see the google apps information fieldset displayed, check it is visible'
-		);
 	}
 
 	selectPreviousStep() {

--- a/test/e2e/lib/pages/gsuite-upsell-page.js
+++ b/test/e2e/lib/pages/gsuite-upsell-page.js
@@ -13,13 +13,13 @@ import AsyncBaseContainer from '../async-base-container';
 
 export default class GSuiteUpsellPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, By.css( '.gsuite-upsell-card__checkout-button' ) );
+		super( driver, By.css( '.gsuite-upsell-card__skip-button' ) );
 	}
 
 	async declineEmail() {
 		return await driverHelper.clickWhenClickable(
 			this.driver,
-			By.css( '.gsuite-upsell-card__checkout-button' )
+			By.css( '.gsuite-upsell-card__skip-button' )
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add classes to G Suite Upsell Card Buttons
* Fix E2E test selectors that needed selectors for those buttons ( broken by #34133 )
* Remove unused `selectAddEmailForGoogleApps ` method

#### Testing instructions

* Confirm E2E tests pass