### PR TITLE
Add Muriel TextControl to calypso-ui

### DIFF
--- a/client/components/progress-bar/index.js
+++ b/client/components/progress-bar/index.js
@@ -1,1 +1,5 @@
-export { ProgressBar as default } from '@automattic/calypso-ui';
+/**
+ * Internal dependencies
+ */
+import { default as ProgressBar } from '@automattic/calypso-ui/dist/esm/progress-bar';
+export default ProgressBar;

--- a/client/components/screen-reader-text/index.js
+++ b/client/components/screen-reader-text/index.js
@@ -1,1 +1,5 @@
-export { ScreenReaderText as default } from '@automattic/calypso-ui';
+/**
+ * Internal dependencies
+ */
+import { default as ScreenReaderText } from '@automattic/calypso-ui/dist/esm/screen-reader-text';
+export default ScreenReaderText;

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -81,6 +81,7 @@ export { default as SpinnerLine } from 'components/spinner-line/docs/example';
 export { default as SplitButton } from 'components/split-button/docs/example';
 export { default as Suggestions } from 'components/suggestions/docs/example';
 export { default as TextareaAutosize } from 'components/textarea-autosize/docs/example';
+export { default as TextControl } from '@automattic/calypso-ui/src/text-control/docs/example';
 export { default as TextDiff } from 'components/text-diff/docs/example';
 export { default as TileGrid } from 'components/tile-grid/docs/example';
 export { default as TimeSince } from 'components/time-since/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -111,6 +111,7 @@ import Suggestions from 'components/suggestions/docs/example';
 import SuggestionSearchExample from 'components/suggestion-search/docs/example';
 import SupportInfoExample from 'components/support-info/docs/example';
 import TextareaAutosize from 'components/textarea-autosize/docs/example';
+import TextControl from '@automattic/calypso-ui/src/text-control/docs/example';
 import TextDiff from 'components/text-diff/docs/example';
 import TileGrid from 'components/tile-grid/docs/example';
 import TimeSince from 'components/time-since/docs/example';
@@ -270,6 +271,7 @@ class DesignAssets extends React.Component {
 					<SuggestionSearchExample />
 					<SupportInfoExample />
 					<TextareaAutosize readmeFilePath="textarea-autosize" />
+					<TextControl readmeFilePath="text-control" />
 					<TextDiff readmeFilePath="text-diff" />
 					<TileGrid readmeFilePath="tile-grid" />
 					<TimeSince readmeFilePath="time-since" />

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -75,9 +75,207 @@
 		"@automattic/calypso-ui": {
 			"version": "file:packages/calypso-ui",
 			"requires": {
+				"@wordpress/components": "^8.0.0",
 				"classnames": "2.2.6",
 				"prop-types": "^15.7.2",
 				"react": "^16.8.3"
+			},
+			"dependencies": {
+				"@wordpress/components": {
+					"version": "8.0.0",
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/a11y": "^2.4.0",
+						"@wordpress/compose": "^3.4.0",
+						"@wordpress/dom": "^2.3.0",
+						"@wordpress/element": "^2.5.0",
+						"@wordpress/hooks": "^2.4.0",
+						"@wordpress/i18n": "^3.5.0",
+						"@wordpress/is-shallow-equal": "^1.4.0",
+						"@wordpress/keycodes": "^2.4.0",
+						"@wordpress/rich-text": "^3.4.0",
+						"@wordpress/url": "^2.6.0",
+						"classnames": "^2.2.5",
+						"clipboard": "^2.0.1",
+						"diff": "^3.5.0",
+						"dom-scroll-into-view": "^1.2.1",
+						"lodash": "^4.17.11",
+						"memize": "^1.0.5",
+						"moment": "^2.22.1",
+						"mousetrap": "^1.6.2",
+						"re-resizable": "^4.7.1",
+						"react-click-outside": "^3.0.0",
+						"react-dates": "^17.1.1",
+						"react-spring": "^8.0.20",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.1",
+						"uuid": "^3.3.2"
+					},
+					"dependencies": {
+						"@wordpress/a11y": {
+							"version": "2.4.0",
+							"bundled": true,
+							"requires": {
+								"@babel/runtime": "^7.4.4",
+								"@wordpress/dom-ready": "^2.4.0"
+							}
+						},
+						"@wordpress/hooks": {
+							"version": "2.4.0",
+							"bundled": true,
+							"requires": {
+								"@babel/runtime": "^7.4.4"
+							}
+						},
+						"@wordpress/is-shallow-equal": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"@babel/runtime": "^7.4.4"
+							}
+						},
+						"@wordpress/keycodes": {
+							"version": "2.4.0",
+							"bundled": true,
+							"requires": {
+								"@babel/runtime": "^7.4.4",
+								"@wordpress/i18n": "^3.5.0",
+								"lodash": "^4.17.11"
+							}
+						},
+						"@wordpress/rich-text": {
+							"version": "3.4.0",
+							"bundled": true,
+							"requires": {
+								"@babel/runtime": "^7.4.4",
+								"@wordpress/compose": "^3.4.0",
+								"@wordpress/data": "^4.6.0",
+								"@wordpress/escape-html": "^1.4.0",
+								"@wordpress/hooks": "^2.4.0",
+								"lodash": "^4.17.11",
+								"rememo": "^3.0.0"
+							}
+						}
+					}
+				},
+				"@wordpress/compose": {
+					"version": "3.4.0",
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/element": "^2.5.0",
+						"@wordpress/is-shallow-equal": "^1.4.0",
+						"lodash": "^4.17.11"
+					},
+					"dependencies": {
+						"@wordpress/is-shallow-equal": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"@babel/runtime": "^7.4.4"
+							}
+						}
+					}
+				},
+				"@wordpress/data": {
+					"version": "4.6.0",
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/compose": "^3.4.0",
+						"@wordpress/deprecated": "^2.4.0",
+						"@wordpress/element": "^2.5.0",
+						"@wordpress/is-shallow-equal": "^1.4.0",
+						"@wordpress/priority-queue": "^1.2.0",
+						"@wordpress/redux-routine": "^3.4.0",
+						"equivalent-key-map": "^0.2.2",
+						"is-promise": "^2.1.0",
+						"lodash": "^4.17.11",
+						"redux": "^4.0.0",
+						"turbo-combine-reducers": "^1.0.2"
+					},
+					"dependencies": {
+						"@wordpress/is-shallow-equal": {
+							"version": "1.4.0",
+							"bundled": true,
+							"requires": {
+								"@babel/runtime": "^7.4.4"
+							}
+						}
+					}
+				},
+				"@wordpress/deprecated": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/hooks": "^2.4.0"
+					},
+					"dependencies": {
+						"@wordpress/hooks": {
+							"version": "2.4.0",
+							"bundled": true,
+							"requires": {
+								"@babel/runtime": "^7.4.4"
+							}
+						}
+					}
+				},
+				"@wordpress/dom-ready": {
+					"version": "2.4.0",
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.4.4"
+					}
+				},
+				"@wordpress/element": {
+					"version": "2.5.0",
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/escape-html": "^1.4.0",
+						"lodash": "^4.17.11",
+						"react": "^16.8.4",
+						"react-dom": "^16.8.4"
+					}
+				},
+				"@wordpress/escape-html": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.4.4"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.5.0",
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.11",
+						"memize": "^1.0.5",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.0.1"
+					}
+				},
+				"@wordpress/redux-routine": {
+					"version": "3.4.0",
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"is-promise": "^2.1.0",
+						"rungen": "^0.3.2"
+					}
+				},
+				"@wordpress/url": {
+					"version": "2.6.0",
+					"bundled": true,
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"qs": "^6.5.2"
+					}
+				}
 			}
 		},
 		"@automattic/format-currency": {
@@ -19146,6 +19344,15 @@
 						"react-is": "^16.7.0"
 					}
 				}
+			}
+		},
+		"react-spring": {
+			"version": "8.0.25",
+			"resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.25.tgz",
+			"integrity": "sha512-KLSLI9ccpoxvxzCbtTqSOHNHhndxAeEcHsgFZoyybP3GpGh0axmtauUAH8c3XkozIW8r9gScvrCWw3F1EPIcBw==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"prop-types": "^15.5.8"
 			}
 		},
 		"react-test-renderer": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -75,207 +75,9 @@
 		"@automattic/calypso-ui": {
 			"version": "file:packages/calypso-ui",
 			"requires": {
-				"@wordpress/components": "^8.0.0",
 				"classnames": "2.2.6",
 				"prop-types": "^15.7.2",
 				"react": "^16.8.3"
-			},
-			"dependencies": {
-				"@wordpress/components": {
-					"version": "8.0.0",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/a11y": "^2.4.0",
-						"@wordpress/compose": "^3.4.0",
-						"@wordpress/dom": "^2.3.0",
-						"@wordpress/element": "^2.5.0",
-						"@wordpress/hooks": "^2.4.0",
-						"@wordpress/i18n": "^3.5.0",
-						"@wordpress/is-shallow-equal": "^1.4.0",
-						"@wordpress/keycodes": "^2.4.0",
-						"@wordpress/rich-text": "^3.4.0",
-						"@wordpress/url": "^2.6.0",
-						"classnames": "^2.2.5",
-						"clipboard": "^2.0.1",
-						"diff": "^3.5.0",
-						"dom-scroll-into-view": "^1.2.1",
-						"lodash": "^4.17.11",
-						"memize": "^1.0.5",
-						"moment": "^2.22.1",
-						"mousetrap": "^1.6.2",
-						"re-resizable": "^4.7.1",
-						"react-click-outside": "^3.0.0",
-						"react-dates": "^17.1.1",
-						"react-spring": "^8.0.20",
-						"rememo": "^3.0.0",
-						"tinycolor2": "^1.4.1",
-						"uuid": "^3.3.2"
-					},
-					"dependencies": {
-						"@wordpress/a11y": {
-							"version": "2.4.0",
-							"bundled": true,
-							"requires": {
-								"@babel/runtime": "^7.4.4",
-								"@wordpress/dom-ready": "^2.4.0"
-							}
-						},
-						"@wordpress/hooks": {
-							"version": "2.4.0",
-							"bundled": true,
-							"requires": {
-								"@babel/runtime": "^7.4.4"
-							}
-						},
-						"@wordpress/is-shallow-equal": {
-							"version": "1.4.0",
-							"bundled": true,
-							"requires": {
-								"@babel/runtime": "^7.4.4"
-							}
-						},
-						"@wordpress/keycodes": {
-							"version": "2.4.0",
-							"bundled": true,
-							"requires": {
-								"@babel/runtime": "^7.4.4",
-								"@wordpress/i18n": "^3.5.0",
-								"lodash": "^4.17.11"
-							}
-						},
-						"@wordpress/rich-text": {
-							"version": "3.4.0",
-							"bundled": true,
-							"requires": {
-								"@babel/runtime": "^7.4.4",
-								"@wordpress/compose": "^3.4.0",
-								"@wordpress/data": "^4.6.0",
-								"@wordpress/escape-html": "^1.4.0",
-								"@wordpress/hooks": "^2.4.0",
-								"lodash": "^4.17.11",
-								"rememo": "^3.0.0"
-							}
-						}
-					}
-				},
-				"@wordpress/compose": {
-					"version": "3.4.0",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/element": "^2.5.0",
-						"@wordpress/is-shallow-equal": "^1.4.0",
-						"lodash": "^4.17.11"
-					},
-					"dependencies": {
-						"@wordpress/is-shallow-equal": {
-							"version": "1.4.0",
-							"bundled": true,
-							"requires": {
-								"@babel/runtime": "^7.4.4"
-							}
-						}
-					}
-				},
-				"@wordpress/data": {
-					"version": "4.6.0",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/compose": "^3.4.0",
-						"@wordpress/deprecated": "^2.4.0",
-						"@wordpress/element": "^2.5.0",
-						"@wordpress/is-shallow-equal": "^1.4.0",
-						"@wordpress/priority-queue": "^1.2.0",
-						"@wordpress/redux-routine": "^3.4.0",
-						"equivalent-key-map": "^0.2.2",
-						"is-promise": "^2.1.0",
-						"lodash": "^4.17.11",
-						"redux": "^4.0.0",
-						"turbo-combine-reducers": "^1.0.2"
-					},
-					"dependencies": {
-						"@wordpress/is-shallow-equal": {
-							"version": "1.4.0",
-							"bundled": true,
-							"requires": {
-								"@babel/runtime": "^7.4.4"
-							}
-						}
-					}
-				},
-				"@wordpress/deprecated": {
-					"version": "2.4.0",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/hooks": "^2.4.0"
-					},
-					"dependencies": {
-						"@wordpress/hooks": {
-							"version": "2.4.0",
-							"bundled": true,
-							"requires": {
-								"@babel/runtime": "^7.4.4"
-							}
-						}
-					}
-				},
-				"@wordpress/dom-ready": {
-					"version": "2.4.0",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"@wordpress/element": {
-					"version": "2.5.0",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"@wordpress/escape-html": "^1.4.0",
-						"lodash": "^4.17.11",
-						"react": "^16.8.4",
-						"react-dom": "^16.8.4"
-					}
-				},
-				"@wordpress/escape-html": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "3.5.0",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.11",
-						"memize": "^1.0.5",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.0.1"
-					}
-				},
-				"@wordpress/redux-routine": {
-					"version": "3.4.0",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"is-promise": "^2.1.0",
-						"rungen": "^0.3.2"
-					}
-				},
-				"@wordpress/url": {
-					"version": "2.6.0",
-					"bundled": true,
-					"requires": {
-						"@babel/runtime": "^7.4.4",
-						"qs": "^6.5.2"
-					}
-				}
 			}
 		},
 		"@automattic/format-currency": {
@@ -11828,7 +11630,7 @@
 			"requires": {
 				"react": "^0.14.3 || ^15.1.0 || ^16.0.0",
 				"react-addons-create-fragment": "^0.14.3 || ^15.1.0",
-				"react-dom": "^0.14.3 || ^15.1.0 || ^16.0.0"
+				"react-dom": "^0.14.3 || ^15.1.0 || ^16.0.0"
 			}
 		},
 		"interpret": {
@@ -19344,15 +19146,6 @@
 						"react-is": "^16.7.0"
 					}
 				}
-			}
-		},
-		"react-spring": {
-			"version": "8.0.25",
-			"resolved": "https://registry.npmjs.org/react-spring/-/react-spring-8.0.25.tgz",
-			"integrity": "sha512-KLSLI9ccpoxvxzCbtTqSOHNHhndxAeEcHsgFZoyybP3GpGh0axmtauUAH8c3XkozIW8r9gScvrCWw3F1EPIcBw==",
-			"requires": {
-				"@babel/runtime": "^7.3.1",
-				"prop-types": "^15.5.8"
 			}
 		},
 		"react-test-renderer": {

--- a/packages/calypso-ui/package.json
+++ b/packages/calypso-ui/package.json
@@ -29,7 +29,8 @@
 	"dependencies": {
 		"classnames": "2.2.6",
 		"react": "^16.8.3",
-		"prop-types": "^15.7.2"
+		"prop-types": "^15.7.2",
+		"@wordpress/components": "^8.0.0"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",

--- a/packages/calypso-ui/package.json
+++ b/packages/calypso-ui/package.json
@@ -27,7 +27,6 @@
 		"src"
 	],
 	"dependencies": {
-		"@automattic/calypso-ui": "file:./",
 		"classnames": "2.2.6",
 		"react": "^16.8.3",
 		"prop-types": "^15.7.2",

--- a/packages/calypso-ui/package.json
+++ b/packages/calypso-ui/package.json
@@ -27,10 +27,11 @@
 		"src"
 	],
 	"dependencies": {
+		"@automattic/calypso-ui": "file:./",
 		"classnames": "2.2.6",
 		"react": "^16.8.3",
 		"prop-types": "^15.7.2",
-		"@wordpress/components": "^8.0.0"
+		"@wordpress/components": "7.0.8"
 	},
 	"scripts": {
 		"clean": "npx rimraf dist",

--- a/packages/calypso-ui/src/index.js
+++ b/packages/calypso-ui/src/index.js
@@ -1,2 +1,3 @@
 export { default as ProgressBar } from './progress-bar';
 export { default as ScreenReaderText } from './screen-reader-text';
+export { default as TextControl } from './text-control';

--- a/packages/calypso-ui/src/text-control/README.md
+++ b/packages/calypso-ui/src/text-control/README.md
@@ -1,0 +1,12 @@
+TextControl (JSX)
+====================
+
+Description
+
+-------
+
+#### How to use:
+
+```js
+
+```

--- a/packages/calypso-ui/src/text-control/README.md
+++ b/packages/calypso-ui/src/text-control/README.md
@@ -1,12 +1,37 @@
-TextControl (JSX)
-====================
+TextControl
+==============
 
-Description
-
--------
+This component is used to let users enter and edit text. It is best used for free text entry.
+Because TextControls are single-line fields, they are not suitable for collecting long responses. For those, use a text area instead.
 
 #### How to use:
 
 ```js
+import { TextControl } from '@automattic/calypso-ui';
+
+export default class extends PureComponent {
+	static displayName = 'TextControl';
+
+	state = {
+		inputTextValue1: 'Input value',
+	};
+
+	render() {
+		const { inputTextValue } = this.state;
+		return (
+			<div>
+				<TextControl
+					label={ 'Text input with value' }
+					value={ inputTextValue }
+					onChange={ value => this.setState( { inputTextValue: value } ) }
+				/>
+			</div>
+		);
+	}
+}
 
 ```
+
+#### Props
+
+https://developer.wordpress.org/block-editor/components/text-control/#props

--- a/packages/calypso-ui/src/text-control/docs/example.jsx
+++ b/packages/calypso-ui/src/text-control/docs/example.jsx
@@ -1,0 +1,46 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { TextControl } from '@automattic/calypso-ui';
+
+export default class extends PureComponent {
+	static displayName = 'TextControl';
+
+	state = {
+		inputTextValue1: 'Input value',
+		inputTextValue2: '',
+		inputNumValue: 0,
+	};
+
+	render() {
+		const { inputTextValue1, inputTextValue2, inputNumValue } = this.state;
+		return (
+			<div>
+				<TextControl
+					label={ 'Text input with value' }
+					value={ inputTextValue1 }
+					onChange={ value => this.setState( { inputTextValue1: value } ) }
+				/>
+				<TextControl
+					label={ 'Text Input empty' }
+					value={ inputTextValue2 }
+					onChange={ value => this.setState( { inputTextValue2: value } ) }
+				/>
+				<TextControl
+					type="number"
+					label={ 'Number Input' }
+					value={ inputNumValue }
+					onChange={ value => this.setState( { inputNumValue: value } ) }
+				/>
+				<TextControl label={ 'Text Input disabled' } disabled />
+			</div>
+		);
+	}
+}

--- a/packages/calypso-ui/src/text-control/docs/example.jsx
+++ b/packages/calypso-ui/src/text-control/docs/example.jsx
@@ -8,7 +8,7 @@ import React, { PureComponent } from 'react';
 /**
  * Internal dependencies
  */
-import { TextControl } from '@automattic/calypso-ui';
+import TextControl from '../';
 
 export default class extends PureComponent {
 	static displayName = 'TextControl';

--- a/packages/calypso-ui/src/text-control/docs/example.jsx
+++ b/packages/calypso-ui/src/text-control/docs/example.jsx
@@ -16,11 +16,10 @@ export default class extends PureComponent {
 	state = {
 		inputTextValue1: 'Input value',
 		inputTextValue2: '',
-		inputNumValue: 0,
 	};
 
 	render() {
-		const { inputTextValue1, inputTextValue2, inputNumValue } = this.state;
+		const { inputTextValue1, inputTextValue2 } = this.state;
 		return (
 			<div>
 				<TextControl
@@ -32,12 +31,6 @@ export default class extends PureComponent {
 					label={ 'Text Input empty' }
 					value={ inputTextValue2 }
 					onChange={ value => this.setState( { inputTextValue2: value } ) }
-				/>
-				<TextControl
-					type="number"
-					label={ 'Number Input' }
-					value={ inputNumValue }
-					onChange={ value => this.setState( { inputNumValue: value } ) }
 				/>
 				<TextControl label={ 'Text Input disabled' } disabled />
 			</div>

--- a/packages/calypso-ui/src/text-control/index.js
+++ b/packages/calypso-ui/src/text-control/index.js
@@ -1,0 +1,73 @@
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import { TextControl as BaseComponent, withFocusOutside } from '@wordpress/components';
+import classNames from 'classnames';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class TextControl extends PureComponent {
+	constructor( props ) {
+		super( props );
+		this.state = {
+			isFocused: false,
+		};
+	}
+
+	/**
+	 * A `withFocusOutside`'s default function, handler for the focus outside the component event.
+	 */
+	handleFocusOutside() {
+		this.setState( { isFocused: false } );
+	}
+
+	handleOnClick( onClick ) {
+		this.setState( { isFocused: true } );
+		if ( typeof onClick === 'function' ) {
+			onClick();
+		}
+	}
+
+	getClassName( disabled, isEmpty, isActive ) {
+		let className = 'with-value';
+		if ( disabled ) {
+			className = 'disabled';
+		} else if ( isEmpty ) {
+			className = 'empty';
+		} else if ( isActive ) {
+			className = 'active';
+		}
+
+		return className;
+	}
+
+	render() {
+		const { isFocused } = this.state;
+		const { className, onClick, ...otherProps } = this.props;
+		const { label, value, disabled } = otherProps;
+		const isEmpty = ! value;
+		const isActive = isFocused && ! disabled;
+
+		const classes = classNames(
+			'muriel-component',
+			'muriel-input-text',
+			className,
+			this.getClassName( disabled, isEmpty, isActive )
+		);
+
+		return (
+			<BaseComponent
+				className={ classes }
+				placeholder={ label }
+				onClick={ () => this.handleOnClick( onClick ) }
+				{ ...otherProps }
+			/>
+		);
+	}
+}
+
+export default withFocusOutside( TextControl );

--- a/packages/calypso-ui/src/text-control/index.js
+++ b/packages/calypso-ui/src/text-control/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import { TextControl as BaseComponent, withFocusOutside } from '@wordpress/components';
 import classNames from 'classnames';
 
@@ -10,13 +10,10 @@ import classNames from 'classnames';
  */
 import './style.scss';
 
-class TextControl extends PureComponent {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			isFocused: false,
-		};
-	}
+class TextControl extends Component {
+	state = {
+		isFocused: false,
+	};
 
 	handleFocusOutside() {
 		this.setState( { isFocused: false } );

--- a/packages/calypso-ui/src/text-control/index.js
+++ b/packages/calypso-ui/src/text-control/index.js
@@ -51,11 +51,15 @@ class TextControl extends Component {
 		const isEmpty = ! value;
 		const isActive = isFocused && ! disabled;
 
-		const classes = classNames( className, this.getStatusClassName( disabled, isEmpty ), {
-			active: isActive,
-			'muriel-component': true,
-			'muriel-input-text': true,
-		} );
+		const classes = classNames(
+			'muriel-component',
+			'muriel-input-text',
+			className,
+			this.getStatusClassName( disabled, isEmpty ),
+			{
+				active: isActive,
+			}
+		);
 
 		return (
 			<BaseComponent

--- a/packages/calypso-ui/src/text-control/index.js
+++ b/packages/calypso-ui/src/text-control/index.js
@@ -32,14 +32,24 @@ class TextControl extends PureComponent {
 		}
 	}
 
+	handleOnFocus( onFocus ) {
+		this.setState( { isFocused: true } );
+		if ( typeof onFocus === 'function' ) {
+			onFocus();
+		}
+	}
+
+	// @todo refactor
 	getClassName( disabled, isEmpty, isActive ) {
 		let className = 'with-value';
-		if ( disabled ) {
-			className = 'disabled';
-		} else if ( isEmpty ) {
+		if ( isEmpty ) {
 			className = 'empty';
-		} else if ( isActive ) {
-			className = 'active';
+		} else if ( disabled ) {
+			className = 'disabled';
+		}
+
+		if ( isActive ) {
+			className += ' active';
 		}
 
 		return className;
@@ -47,7 +57,7 @@ class TextControl extends PureComponent {
 
 	render() {
 		const { isFocused } = this.state;
-		const { className, onClick, ...otherProps } = this.props;
+		const { className, onClick, onFocus, ...otherProps } = this.props;
 		const { label, value, disabled } = otherProps;
 		const isEmpty = ! value;
 		const isActive = isFocused && ! disabled;
@@ -64,6 +74,7 @@ class TextControl extends PureComponent {
 				className={ classes }
 				placeholder={ label }
 				onClick={ () => this.handleOnClick( onClick ) }
+				onFocus={ () => this.handleOnFocus( onFocus ) }
 				{ ...otherProps }
 			/>
 		);

--- a/packages/calypso-ui/src/text-control/index.js
+++ b/packages/calypso-ui/src/text-control/index.js
@@ -18,38 +18,30 @@ class TextControl extends PureComponent {
 		};
 	}
 
-	/**
-	 * A `withFocusOutside`'s default function, handler for the focus outside the component event.
-	 */
 	handleFocusOutside() {
 		this.setState( { isFocused: false } );
 	}
 
 	handleOnClick( onClick ) {
 		this.setState( { isFocused: true } );
-		if ( typeof onClick === 'function' ) {
+		if ( 'function' === typeof onClick ) {
 			onClick();
 		}
 	}
 
 	handleOnFocus( onFocus ) {
 		this.setState( { isFocused: true } );
-		if ( typeof onFocus === 'function' ) {
+		if ( 'function' === typeof onFocus ) {
 			onFocus();
 		}
 	}
 
-	// @todo refactor
-	getClassName( disabled, isEmpty, isActive ) {
+	getStatusClassName( disabled, isEmpty ) {
 		let className = 'with-value';
 		if ( isEmpty ) {
 			className = 'empty';
 		} else if ( disabled ) {
 			className = 'disabled';
-		}
-
-		if ( isActive ) {
-			className += ' active';
 		}
 
 		return className;
@@ -62,12 +54,11 @@ class TextControl extends PureComponent {
 		const isEmpty = ! value;
 		const isActive = isFocused && ! disabled;
 
-		const classes = classNames(
-			'muriel-component',
-			'muriel-input-text',
-			className,
-			this.getClassName( disabled, isEmpty, isActive )
-		);
+		const classes = classNames( className, this.getStatusClassName( disabled, isEmpty ), {
+			active: isActive,
+			'muriel-component': true,
+			'muriel-input-text': true,
+		} );
 
 		return (
 			<BaseComponent

--- a/packages/calypso-ui/src/text-control/style.scss
+++ b/packages/calypso-ui/src/text-control/style.scss
@@ -1,0 +1,1 @@
+// @todo carry over styles

--- a/packages/calypso-ui/src/text-control/style.scss
+++ b/packages/calypso-ui/src/text-control/style.scss
@@ -1,22 +1,15 @@
-.muriel-component {
-	margin-top: 14px;
-	margin-bottom: 14px;
-	&.is-centered {
-		margin-left: auto;
-		margin-right: auto;
-	}
-}
-
 .muriel-input-text {
 	position: relative;
 	width: 100%;
 	height: 56px;
+	margin-top: 14px;
+	margin-bottom: 14px;
 
-	border: 1px solid $muriel-gray-200;
+	border: 1px solid var( --color-primary-200 );
 	box-shadow: none;
 	box-sizing: border-box;
 	border-radius: 3px;
-	background: $muriel-white;
+	background: var( --color-white );
 
 	label {
 		position: absolute;
@@ -29,10 +22,10 @@
 
 		font-size: 12px;
 		line-height: 16px;
-		color: $muriel-gray-500;
+		color: var( --color-text );
 	}
  
-	input[type='text'], input[type='number'] {
+	input[type='text'] {
 		position: absolute;
 		width: calc( 100% - 18px - 20px );
 		height: 24px;
@@ -53,14 +46,18 @@
 	}
 
 	&.active {
-		box-shadow: 0 0 0 2px $muriel-hot-purple-600;
+		box-shadow: 0 0 0 2px var( --color-accent );
 		border-color: transparent;
+
+		label {
+			color: var( --color-accent );
+		}
 	}
  
 	&.with-value {
-		input[type='text'], input[type='number'] {
+		input[type='text'] {
 			top: 25px;
-			color: $muriel-gray-800;
+			color: var( --color-text );
 		}
 	 }
  
@@ -70,7 +67,7 @@
 		}
 		input[type='text'] {
 			top: 15px;
-			color: $muriel-gray-500;
+			color: var( --color-primary-500 );
 		}
 	}
 
@@ -80,9 +77,9 @@
 		}
 		input[type='text'] {
 			top: 17px;
-			color: $muriel-gray-200;
+			color: var( --color-primary-200 );
 			&::placeholder {
-				color: $muriel-gray-200;
+				color: var( --color-primary-200 );
 				opacity: 1;
 			}
 		}

--- a/packages/calypso-ui/src/text-control/style.scss
+++ b/packages/calypso-ui/src/text-control/style.scss
@@ -1,1 +1,90 @@
-// @todo carry over styles
+.muriel-component {
+	margin-top: 14px;
+	margin-bottom: 14px;
+	&.is-centered {
+		margin-left: auto;
+		margin-right: auto;
+	}
+}
+
+.muriel-input-text {
+	position: relative;
+	width: 100%;
+	height: 56px;
+
+	border: 1px solid $muriel-gray-200;
+	box-shadow: none;
+	box-sizing: border-box;
+	border-radius: 3px;
+	background: $muriel-white;
+
+	label {
+		position: absolute;
+		width: auto;
+		height: 21px;
+		top: 9px;
+		right: auto;
+		left: 16px;
+		display: initial;
+
+		font-size: 12px;
+		line-height: 16px;
+		color: $muriel-gray-500;
+	}
+ 
+	input[type='text'], input[type='number'] {
+		position: absolute;
+		width: calc( 100% - 18px - 20px );
+		height: 24px;
+		right: 20px;
+		left: 18px;
+
+		border: 0;
+		box-shadow: none;
+		padding: 0;
+
+		font-size: 16px;
+		line-height: 24px;
+	}
+
+	input[type='text']:focus {
+		box-shadow: none;
+		border: 0;
+	}
+
+	&.active {
+		box-shadow: 0 0 0 2px $muriel-hot-purple-600;
+		border-color: transparent;
+	}
+ 
+	&.with-value {
+		input[type='text'], input[type='number'] {
+			top: 25px;
+			color: $muriel-gray-800;
+		}
+	 }
+ 
+	&.empty {
+		.components-base-control__label {
+			display: none;
+		}
+		input[type='text'] {
+			top: 15px;
+			color: $muriel-gray-500;
+		}
+	}
+
+	&.disabled {
+		label {
+			display: none;
+		}
+		input[type='text'] {
+			top: 17px;
+			color: $muriel-gray-200;
+			&::placeholder {
+				color: $muriel-gray-200;
+				opacity: 1;
+			}
+		}
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@
  **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 /* eslint-disable import/no-nodejs-modules */
+/* eslint-disable import/no-extraneous-dependencies */
 
 /**
  * External dependencies
@@ -254,6 +255,7 @@ const webpackConfig = {
 	plugins: _.compact( [
 		new webpack.DefinePlugin( {
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
+			'process.env.FORCE_REDUCED_MOTION': JSON.stringify( process.env.FORCE_REDUCED_MOTION ),
 			global: 'window',
 		} ),
 		new webpack.NormalModuleReplacementPlugin( /^path$/, 'path-browserify' ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,6 @@
  **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 /* eslint-disable import/no-nodejs-modules */
-/* eslint-disable import/no-extraneous-dependencies */
 
 /**
  * External dependencies


### PR DESCRIPTION
This PR introduces a Muriel styled `TextControl` component to the `calypso-ui` package. The styles are implemented on top of `@wordpress/components`. This component has been lifted from https://github.com/Automattic/newspack-plugin. This PR also fixes the issues outlined in https://github.com/Automattic/newspack-plugin/issues/75.

This will be used in WooCommerce onboarding, and it's related connection piece in Calypso, so that these styles match inputs on both sides of the flow.

**Please note**: if you look at the Muriel components Figma, not all of the various modes for the Muriel inputs have been implemented. Only the "contained" style that both Newspack and wc-admin are currently using. This is meant to be a start, that can be immediately consumed by these packages, and we can continue adding the alternatives in the future.

#### Screenshots

<img width="895" alt="Screen Shot 2019-06-25 at 1 01 49 PM" src="https://user-images.githubusercontent.com/689165/60118268-faf0c280-9749-11e9-80d7-7bd6956eb692.png">

#### Testing instructions

* `npm run distclean && npm ci`
* `npm start`
* Visit `http://calypso.localhost:3000/devdocs/design/text-control` and look at / test the TextControl component.
