### PR TITLE
Updating Upgrade nudge copy on SEO/Google Analytics to bring into sync w wpadmin

### DIFF
--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -126,8 +126,12 @@ export class GoogleAnalyticsForm extends Component {
 		const wooCommerceActive = wooCommercePlugin ? wooCommercePlugin.active : false;
 
 		const nudgeTitle = siteIsJetpack
-			? translate( 'Enable Google Analytics by upgrading to Jetpack Premium' )
-			: translate( 'Enable Google Analytics by upgrading to the Business plan' );
+			? translate(
+					'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional'
+			  )
+			: translate(
+					'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional'
+			  );
 
 		return (
 			<form id="analytics" onSubmit={ handleSubmitForm }>

--- a/client/my-sites/site-settings/form-analytics.jsx
+++ b/client/my-sites/site-settings/form-analytics.jsx
@@ -129,9 +129,7 @@ export class GoogleAnalyticsForm extends Component {
 			? translate(
 					'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional'
 			  )
-			: translate(
-					'Connect your site to Google Analytics in seconds with Jetpack Premium or Professional'
-			  );
+			: translate( 'Connect your site to Google Analytics in seconds with the Business plan' );
 
 		return (
 			<form id="analytics" onSubmit={ handleSubmitForm }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*Update verbiage on Google analytics upgrade prompt from:

```Enable Google Analytics by upgrading to the Business plan
Add your unique tracking ID to monitor your site's performance in Google Analytics.

```
to 
```
Connect your site to Google Analytics in seconds with Jetpack Premium or Professional
Add your unique tracking ID to monitor your site's performance in Google Analytics.
```
#### Testing instructions
Testing instructions:
*Go to wp-admin/admin.php?page=jetpack#/traffic
*Verify call to action on the free plan

**CURRENT**
<img width="918" alt="Screenshot 2019-06-25 12 36 15" src="https://user-images.githubusercontent.com/49159284/60120161-d561ba00-9745-11e9-95dd-ce5c8ac764ec.png">

**PROPOSED**
<img width="901" alt="Screenshot 2019-06-25 12 23 03" src="https://user-images.githubusercontent.com/49159284/60120198-ea3e4d80-9745-11e9-8498-e32a4472e262.png">


Fixes https://github.com/Automattic/wp-calypso/issues/34228
