### PR TITLE
Updating SEO settings upgrade nudge to align with Copy Sprint work

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -308,7 +308,9 @@ export class SeoForm extends React.Component {
 
 		const nudgeTitle = siteIsJetpack
 			? translate( 'Boost your search engine ranking with the power SEO tools in Jetpack Premium' )
-			: translate( 'Boost your search engine ranking with the power SEO tools in Jetpack Premium' );
+			: translate(
+					'Boost your search engine ranking with the power SEO tools in the Business plan'
+			  );
 		return (
 			<div>
 				<QuerySiteSettings siteId={ siteId } />

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -307,8 +307,8 @@ export class SeoForm extends React.Component {
 		const generalTabUrl = getGeneralTabUrl( slug );
 
 		const nudgeTitle = siteIsJetpack
-			? translate( 'Enable SEO Tools by upgrading to Jetpack Premium' )
-			: translate( 'Enable SEO Tools by upgrading to the Business plan' );
+			? translate( 'Boost your search engine ranking with the power SEO tools in Jetpack Premium' )
+			: translate( 'Boost your search engine ranking with the power SEO tools in Jetpack Premium' );
 		return (
 			<div>
 				<QuerySiteSettings siteId={ siteId } />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*Copy change on seo settings upgrade prompt

#### Testing instructions
* As a non-upgraded user go to =/marketing/traffic/(site name)
* Scroll down to SEO settings
**CURRENT**
<img width="914" alt="Screenshot 2019-06-25 13 41 48" src="https://user-images.githubusercontent.com/49159284/60124353-01356d80-974f-11e9-88a7-aa7f1c4070f9.png">


**PROPOSED**
<img width="911" alt="Screenshot 2019-06-25 13 45 03" src="https://user-images.githubusercontent.com/49159284/60124557-7acd5b80-974f-11e9-8c6e-395e921af1bd.png">




Fixes #34234


