### PR TITLE
Bringing Wp SSO heading into alignment with Wp-admin copy sprint changes

### DIFF
--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -92,7 +92,9 @@ class SiteSettingsFormSecurity extends Component {
 					</div>
 				) }
 
-				<SettingsSectionHeader title={ translate( 'WordPress.com sign in' ) } />
+				<SettingsSectionHeader
+					title={ translate( 'WordPress.com log in / single sign-on (SSO)' ) }
+				/>
 				<Sso
 					handleAutosavingToggle={ handleAutosavingToggle }
 					isSavingSettings={ isSavingSettings }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -307,8 +307,8 @@ export class SeoForm extends React.Component {
 		const generalTabUrl = getGeneralTabUrl( slug );
 
 		const nudgeTitle = siteIsJetpack
-			? translate( 'Enable SEO Tools by upgrading to Jetpack Premium' )
-			: translate( 'Enable SEO Tools by upgrading to the Business plan' );
+			? translate( 'Boost your search engine ranking with the power SEO tools in Jetpack Premium' )
+			: translate( 'oost your search engine ranking with the power SEO tools in Jetpack Premium' );
 		return (
 			<div>
 				<QuerySiteSettings siteId={ siteId } />

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -308,7 +308,9 @@ export class SeoForm extends React.Component {
 
 		const nudgeTitle = siteIsJetpack
 			? translate( 'Boost your search engine ranking with the power SEO tools in Jetpack Premium' )
-			: translate( 'oost your search engine ranking with the power SEO tools in Jetpack Premium' );
+			: translate(
+					'Boost your search engine ranking with the power SEO tools in the Business plan'
+			  );
 		return (
 			<div>
 				<QuerySiteSettings siteId={ siteId } />

--- a/client/my-sites/site-settings/sso.jsx
+++ b/client/my-sites/site-settings/sso.jsx
@@ -49,7 +49,7 @@ const Sso = ( {
 					<JetpackModuleToggle
 						siteId={ selectedSiteId }
 						moduleSlug="sso"
-						label={ translate( 'Allow sign in using WordPress.com accounts' ) }
+						label={ translate( 'Allow users to log in to this site using WordPress.com accounts' ) }
 						description="Use WordPress.com's secure authentication"
 						disabled={ isRequestingSettings || isSavingSettings || ssoModuleUnavailable }
 					/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change SEO heading to match wp-admin from:
```
WordPress.com sign in
```
TO:
```
WordPress.com log in / single sign-on (SSO)
```
**CURRENT**
<img width="675" alt="Screenshot 2019-06-25 13 21 15" src="https://user-images.githubusercontent.com/49159284/60124088-81a79e80-974e-11e9-95af-4f69fe1dbcaf.png">

**PROPOSED**
<img width="760" alt="Screenshot 2019-06-25 13 35 20" src="https://user-images.githubusercontent.com/49159284/60124057-718fbf00-974e-11e9-96dd-96a14d01e23a.png">

#### Testing instructions
*As a non-upgraded user go to settings/security/(site name)
* scroll down to SSO sectin


Fixes #34222

