### PR TITLE
Sharing: Differentiate between the Edit and More button clicks in Tracks

### DIFF
--- a/client/my-sites/marketing/buttons/preview.jsx
+++ b/client/my-sites/marketing/buttons/preview.jsx
@@ -75,8 +75,13 @@ class SharingButtonsPreview extends React.Component {
 			buttonsTrayVisibility: visibility,
 		} );
 
-		analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_buttons_click', { path } );
-		analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Buttons Links', visibility );
+		if ( 'hidden' === visibility ) {
+			analytics.tracks.recordEvent( 'calypso_sharing_buttons_more_button_click', { path } );
+			analytics.ga.recordEvent( 'Sharing', 'Clicked More Button Link', visibility );
+		} else {
+			analytics.tracks.recordEvent( 'calypso_sharing_buttons_edit_button_click', { path } );
+			analytics.ga.recordEvent( 'Sharing', 'Clicked Edit Button Link', visibility );
+		}
 	};
 
 	hideButtonsTray = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We currently log the "Edit sharing buttons" and "Add “More” button" as a single click event in Tracks, but it would be helpful to know if people are using one but not the other. This PR checks the `visibility` property of the button component to determine which button is being clicked.

<img width="369" alt="Screen Shot 2019-06-25 at 5 10 19 PM" src="https://user-images.githubusercontent.com/2124984/60133802-2389b400-976c-11e9-8366-4b8e621ea17c.png">

#### Testing instructions

* Switch to this PR
* Navigate to `/marketing/sharing-buttons/`
* Open the browser inspector and copy and paste the following into your browser console so you can see Tracks events fire in real time: `localStorage.setItem( 'debug', 'calypso:analytics*' );`. Hit Enter, then refresh the page.
* Click on the "Edit sharing buttons" button and check the console; you should see an event fire named `calypso_sharing_buttons_edit_button_click`
* Close the panel and click on the "Add "More" button" button and check the console; you should see an event fire named `calypso_sharing_buttons_more_button_click`

Fixes #32226