### PR TITLE
Fix the search and replace to correctly insert post content into template content

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -473,7 +473,7 @@ class Full_Site_Editing {
 		}
 
 		$wrapped_post_content = sprintf( '<!-- wp:a8c/post-content -->%s<!-- /wp:a8c/post-content -->', $post->post_content );
-		$post->post_content   = str_replace( '<!-- wp:a8c/post-content /-->', $wrapped_post_content, $template->get_template_content() );
+		$post->post_content   = str_replace( '<!-- wp:a8c/post-content {"align":"full"} /-->', $wrapped_post_content, $template->get_template_content() );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Modify the search and replace syntax to correctly insert post content into template

#### Testing instructions
- Check out branch and Install the FSE plugin, and activate it on local gutenberg dev
- Edit a page
- Note that the header and footer template appears, within the page editor.
- Note that the post content also appears between the header and footer.
- Edit the page again (with a refresh) and check that the post content still appears
<img width="535" alt="Screen Shot 2019-06-26 at 12 14 59 PM" src="https://user-images.githubusercontent.com/3629020/60142014-102e2580-980c-11e9-913b-8796e18022a7.png">

Related to  #34243 - this is the initial fix, which will be followed by a more robust approach
