### PR TITLE
Fix/dot org references on wpcom

### DIFF
--- a/client/my-sites/site-settings/date-time-format/time-format-option.jsx
+++ b/client/my-sites/site-settings/date-time-format/time-format-option.jsx
@@ -70,7 +70,7 @@ export const TimeFormatOption = ( {
 			</span>
 			<FormSettingExplanation>
 				<ExternalLink
-					href="https://codex.wordpress.org/Formatting_Date_and_Time"
+					href="https://support.wordpress.com/settings/time-settings/"
 					icon
 					target="_blank"
 				>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -219,7 +219,7 @@ export class SiteSettingsFormGeneral extends Component {
 		const errors = {
 			error_cap: {
 				text: translate( 'The Site Language setting is disabled due to insufficient permissions.' ),
-				link: 'https://codex.wordpress.org/Roles_and_Capabilities',
+				link: 'https://support.wordpress.com/user-roles/',
 				linkText: translate( 'More info' ),
 			},
 			error_const: {
@@ -228,6 +228,7 @@ export class SiteSettingsFormGeneral extends Component {
 				),
 				link:
 					'https://codex.wordpress.org/Installing_WordPress_in_Your_Language#Setting_the_language_for_your_site',
+				//don't know if this will ever trigger on a .com site?
 				linkText: translate( 'More info' ),
 			},
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes support references in Calypso directing users to dotorg support (codex.wordpress.org -> support.wordpress.com)

#### Testing instructions

**Datetime:**
- Head to https://wordpress.com/settings/writing/
- Expand "Date and Time Format"
- The link is _"Learn more about date and time formatting"_
- Should link to https://support.wordpress.com/settings/time-settings/ instead of https://codex.wordpress.org/Formatting_Date_and_Time - our docs accurately reflect this help link. 

**Language:**
- This one was odd. [In the code](https://github.com/Automattic/wp-calypso/blob/e4862897aec6ccd7e3ef7120df19f20df216a07a/client/my-sites/site-settings/form-general.jsx#L221) it seems like it would trigger if a user tried to update the site's language without a proper user role for the site, but a non-administrator on the site can't pull up a site's https://wordpress.com/settings/general/ to trigger this. I changed the reference to refer to dotcom user roles just in case. Couldn't replicate it in a test. Ultimately though it should link to https://support.wordpress.com/user-roles/ instead of https://codex.wordpress.org/Roles_and_Capabilities

- Did not modify WPLANG constant dotorg reference in same file. Doesn't seem like it would apply on dotcom.

**Other references to codex.wordpress.org in calypso:**
```
client/state/selectors/can-current-user.js
15: * @see https://codex.wordpress.org/Function_Reference/current_user_can

client/extensions/wp-super-cache/components/advanced/accepted-filenames.jsx
111: href=“http://codex.wordpress.org/Conditional_Tags”

client/extensions/wp-super-cache/components/advanced/caching.jsx
61: href=“https://codex.wordpress.org/Changing_File_Permissions”

client/my-sites/site-settings/form-general.jsx
230: ‘https://codex.wordpress.org/Installing_WordPress_in_Your_Language#Setting_the_language_for_your_site’,

client/components/gallery-shortcode/README.md
45:More information about the gallery shortcode can be found [at the WordPress Codex](https://codex.wordpress.org/Gallery_Shortcode).

client/lib/shortcode/README.md
4:Utility functions for working with WordPress shortcodes. These functions largely mirror those made available in the core WordPress `wp.shortcode` JavaScript class. More information about shortcodes is available [at the WordPress Codex](https://codex.wordpress.org/Shortcode_API).
32:See: https://codex.wordpress.org/Shortcode_API#Names
38:See: https://codex.wordpress.org/Shortcode_API#Enclosing_vs_self-closing_shortcodes
```
All of these seem like dev documentation or non-user facing references, so I didn't modify these. 

Fixes #31998 (task 1) 
