### PR TITLE
Roll back Gutenberg CSS to v5.8.0 in site preview

### DIFF
--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -57,7 +57,7 @@ export function getIframeSource(
 			<link rel="dns-prefetch" href="//s0.wp.com">
 			<link rel="dns-prefetch" href="//fonts.googleapis.com">
 			<title>${ content.title } – ${ content.tagline }</title>
-			<link type="text/css" media="all" rel="stylesheet" href="https://s0.wp.com/wp-content/plugins/gutenberg-core/v5.9.2/build/block-library/style.css" />
+			<link type="text/css" media="all" rel="stylesheet" href="https://s0.wp.com/wp-content/plugins/gutenberg-core/v5.8.0/build/block-library/style.css" />
 			${ getCSSLinkHtml( cssUrl ) }
 			${ getCSSLinkHtml( fontUrl ) }
 			<style type="text/css">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Revert Gutenberg `style.css` in the site preview back to v5.8.0 due to changes in D29802-code.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an Incognito browser, navigate to http://calypso.localhost:3000/start/ and select the Professional site type. The site preview should look like the After image below.

#### Before

![image](https://user-images.githubusercontent.com/14988353/60149077-c8f96200-9816-11e9-9275-f397b9e0647f.png)

#### After

![image](https://user-images.githubusercontent.com/14988353/60149120-fd6d1e00-9816-11e9-8901-e077a44a997b.png)
