### PR TITLE
Auto-renewal Toggle: Add a "I'll keep it" button to the disabling auto-renewal dialog.

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -171,6 +171,7 @@ class AutoRenewDisablingDialog extends Component {
 				<Button onClick={ this.onClickGeneralConfirm } primary>
 					{ translate( 'Confirm cancellation' ) }
 				</Button>
+				<Button onClick={ onClose }>{ translate( "I'll keep it" ) }</Button>
 			</Dialog>
 		);
 	};

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -168,10 +168,12 @@ class AutoRenewDisablingDialog extends Component {
 			>
 				<h2 className="auto-renew-disabling-dialog__header">{ translate( 'Before you go…' ) }</h2>
 				<p>{ description }</p>
-				<Button onClick={ this.onClickGeneralConfirm } primary>
+				<Button onClick={ this.onClickGeneralConfirm }>
 					{ translate( 'Confirm cancellation' ) }
 				</Button>
-				<Button onClick={ onClose }>{ translate( "I'll keep it" ) }</Button>
+				<Button onClick={ onClose } primary>
+					{ translate( "I'll keep it" ) }
+				</Button>
 			</Dialog>
 		);
 	};

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/style.scss
@@ -2,6 +2,7 @@
 	max-width: 440px;
 
 	.button {
+		margin-right: 10px;
 		margin-bottom: 8px;
 		padding: 8px 10px;
 		text-align: left;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a "I'll keep it" button to the disabling auto-renewal dialog, which closes the dialog without changing the auto-renewal status. Props to @niranjan-uma-shankar .
![image](https://user-images.githubusercontent.com/1842898/60149725-48cc0000-9808-11e9-8b25-24f55a128526.png)

#### Testing instructions

1. Go to the purchase management page, http://calypso.localhost:3000/me/purchases/,  and open a subscription with auto-renewal on.
1. Turn off the auto-renewal through the toggle. You should see the dialog with a "I'll keep it button".
1. Clicking on the button should close the dialog without changing the auto-renewal status.

