### PR TITLE
Fix: Do not show "Add a Credit Card" if a payment method has been added already.

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -118,8 +118,9 @@ class PurchaseNotice extends Component {
 		}
 
 		if (
-			! canExplicitRenew( purchase ) ||
-			shouldAddPaymentSourceInsteadOfRenewingNow( purchase.expiryMoment )
+			! hasPaymentMethod( purchase ) &&
+			( ! canExplicitRenew( purchase ) ||
+				shouldAddPaymentSourceInsteadOfRenewingNow( purchase.expiryMoment ) )
 		) {
 			return (
 				<NoticeAction href={ editCardDetailsPath }>{ translate( 'Add Credit Card' ) }</NoticeAction>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently, an "Add a Credit Card" notice action is shown no matter a payment method is there or not, as long as the purchase expiry date is more than 3 months from now:
![image](https://user-images.githubusercontent.com/1842898/60151221-7d42ba80-980e-11e9-8155-bea448de9a71.png)

This PR removes it if a payment method has been added already to remove the confusion:
![image](https://user-images.githubusercontent.com/1842898/60151060-e37b0d80-980d-11e9-94cf-f7903cc797ea.png)

#### Testing instructions

1. Find a purchase that has a payment method attached and its expiry date is more than 3 months from now.
1. Go to its purchase management page(`/me/purchases/{site domain}/{purchase id}`), and turn off its auto-renewal. You can do it via the auto-renewal toggle from calypso running on the local development environment or from the SA.
1. Make sure that there is no "Add a Credit Card" notice action.
