### PR TITLE
Update `blog` flow to use new onboarding steps, and skip site-type step

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -618,7 +618,10 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 }
 
 export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) {
-	if ( isEmpty( nextProps.initialContext && nextProps.initialContext.query ) ) {
+	if (
+		isEmpty( nextProps.initialContext && nextProps.initialContext.query ) &&
+		nextProps.flowName !== 'blog'
+	) {
 		return;
 	}
 
@@ -626,6 +629,7 @@ export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) 
 		initialContext: {
 			query: { site_type: siteType },
 		},
+		flowName,
 	} = nextProps;
 
 	const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
@@ -637,6 +641,12 @@ export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) 
 
 		nextProps.submitSiteType( siteType );
 		recordExcludeStepEvent( stepName, siteType );
+
+		// nextProps.submitSiteType( siteType ) above provides dependencies
+		fulfilledDependencies = fulfilledDependencies.concat( [ 'siteType', 'themeSlugWithRepo' ] );
+	} else if ( flowName === 'blog' ) {
+		nextProps.submitSiteType( 'blog' );
+		recordExcludeStepEvent( stepName, 'blog' );
 
 		// nextProps.submitSiteType( siteType ) above provides dependencies
 		fulfilledDependencies = fulfilledDependencies.concat( [ 'siteType', 'themeSlugWithRepo' ] );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -205,6 +205,20 @@ describe( 'isSiteTypeFulfilled()', () => {
 		submitSiteType.mockClear();
 	} );
 
+	test( 'should exclude step if `flowName` is blog', () => {
+		const stepName = 'site-type';
+		const initialContext = { query: {} };
+		const nextProps = { initialContext, submitSiteType, flowName: 'blog' };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+		expect( submitSiteType ).not.toHaveBeenCalled();
+
+		isSiteTypeFulfilled( stepName, undefined, nextProps );
+
+		expect( submitSiteType ).toHaveBeenCalledWith( 'blog' );
+		expect( flows.excludeStep ).toHaveBeenCalledWith( 'site-type' );
+	} );
+
 	test( 'should remove a fulfilled step', () => {
 		const stepName = 'site-type';
 		const initialContext = { query: { site_type: 'blog' } };
@@ -235,6 +249,19 @@ describe( 'isSiteTypeFulfilled()', () => {
 		const stepName = 'site-type';
 		const initialContext = { query: { site_type: 'an-invalid-site-type-slug' } };
 		const nextProps = { initialContext, submitSiteType };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+
+		isSiteTypeFulfilled( stepName, undefined, nextProps );
+
+		expect( submitSiteType ).not.toHaveBeenCalled();
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should not remove step if `flowName` is main', () => {
+		const stepName = 'site-type';
+		const initialContext = {};
+		const nextProps = { initialContext, submitSiteType, flowName: 'main' };
 
 		expect( flows.excludeStep ).not.toHaveBeenCalled();
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -86,19 +86,11 @@ export function generateFlows( {
 		},
 
 		blog: {
-			steps: [
-				'user',
-				'site-type',
-				'site-topic-with-preview',
-				'site-title-with-preview',
-				'site-style-with-preview',
-				'domains-with-preview',
-				'plans',
-			],
+			steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains', 'plans' ],
 			destination: getChecklistDestination,
 			disallowResume: true,
 			description: 'Signup flow starting with blog site type.',
-			lastModified: '2019-06-26',
+			lastModified: '2019-07-02',
 		},
 
 		website: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -86,10 +86,19 @@ export function generateFlows( {
 		},
 
 		blog: {
-			steps: [ 'user', 'blog-themes', 'domains', 'plans' ],
-			destination: getSiteDestination,
-			description: 'Signup flow starting with blog themes',
-			lastModified: '2017-09-01',
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'site-style-with-preview',
+				'domains-with-preview',
+				'plans',
+			],
+			destination: getChecklistDestination,
+			disallowResume: true,
+			description: 'Signup flow starting with blog site type.',
+			lastModified: '2019-06-26',
 		},
 
 		website: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -88,7 +88,6 @@ export function generateFlows( {
 		blog: {
 			steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains', 'plans' ],
 			destination: getChecklistDestination,
-			disallowResume: true,
 			description: 'Signup flow starting with blog site type.',
 			lastModified: '2019-07-02',
 		},


### PR DESCRIPTION
This change excludes the `site-type` step when the `flowName` is `blog`, so that the `siteType` is already set, without the user having to select it.

#### Changes proposed in this Pull Request

* Update the `blog` flow to use the same steps as the new onboarding flow.
* Exclude the `site-type` step and submit the site type of `blog` when the `flowName` is `blog.
* To attempt to deal with the `resumeProgress` issue below, I've switched this flow to `disallowResume: true`, but more work needs to be done.

***Note:*** This PR currently has a couple of issues that need to be addressed before it's ready to merge. TL;DR — blog site preview should be active, and `resumeProgress` / progress state issues need to be resolved.

1. This PR uses the steps assuming that there will be a site preview for blogs. Because this change uses the `isSiteTypeFulfilled` function to add the site type, instead of the `submitStep` in the `siteType` component, the flow remains on the _current_ flow instead of switching to `onboarding-blog`. Rather than change this flow to match `onboarding-blog`, I'm making an assumption that it would be better to try to get the site preview back, and then merge this with the steps dependent on site preview intact?

2. Skipping over the `siteType` step causes an issue if you get halfway through creating a blog, and then go to a different flow to create a site. This will "resume" your progress, say at the domains step for example, but if you click the `back` button, you will go to the previous steps in the blog flow, where there is no `site-type` step. Effectively, if you start the blog flow in this PR and get half way through, you won't be able to reach the `site-type` step from the other flows.

This issue should be resolved before merging this PR. I'll open a separate issue for it. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Testing the `blog` flow

* Go to http://calypso.localhost:3000/start/blog
* This should redirect you to: http://calypso.localhost:3000/start/blog/site-topic-with-preview with 5 steps visible in the flow
* You should be able to complete the flow and create a site

##### Testing how this change can break the experience for other flows

* Go to http://calypso.localhost:3000/start/blog
* Proceed to the domains step
* Go to http://calypso.localhost:3000/start/
* Attempt to click Back to reach the `site-type` step. You currently can't get there, as the `NavigationLink` will take you back to the blog flow.