### PR TITLE
css: migrate styles for lib/preferences-helper

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -29,5 +29,4 @@
 @import 'layout/guided-tours/style';
 @import 'layout/community-translator/style';
 @import 'layout/sidebar/style';
-@import 'lib/preferences-helper/style';
 @import 'my-sites/sidebar-navigation/style';

--- a/client/lib/preferences-helper/index.js
+++ b/client/lib/preferences-helper/index.js
@@ -12,6 +12,11 @@ import { Provider } from 'react-redux';
  */
 import PreferenceList from './preference-list';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default function injectPreferenceHelper( element, store ) {
 	ReactDom.render(
 		<Provider store={ store }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate styles for `lib/preferences-helper` to be processed by webpack

#### Testing instructions

* Open [calypso.live](https://calypso.live/?branch=update/css-preferences-helper) or start a local Calypso server
* Hover over the small bug icon on the bottom right
* Make sure the _Preferences_ section looks the same as on current master (dev, not prod) or wpcalypso

<img width="294" alt="Screenshot 2019-06-26 at 09 45 31" src="https://user-images.githubusercontent.com/9202899/60161303-93914c00-97f7-11e9-9e53-4f8eedc0d33b.png">


Fixes #33671 (part of #27515)
