### PR TITLE
Signup: Blog hides preview and site-style step using config option

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -102,6 +102,7 @@ export function getAllSiteTypes() {
 			domainsStepSubheader: i18n.translate(
 				"Enter your blog's name or some keywords that describe it to get started."
 			),
+			hideSiteMockups: true,
 		},
 		{
 			id: 1, // This value must correspond with its sibling in the /segments API results

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -697,6 +697,18 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 	}
 }
 
+export function isSiteStyleFulfilled( stepName, defaultDependencies, nextProps ) {
+	if ( nextProps.siteType === 'blog' ) {
+		flows.excludeStep( stepName );
+	}
+}
+
+export function isSiteStyleUnfulfilled( stepName, defaultDependencies, nextProps ) {
+	if ( nextProps.siteType !== 'blog' ) {
+		flows.includeStep( stepName );
+	}
+}
+
 export function createPasswordlessUser( callback, dependencies, data ) {
 	const { email } = data;
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -698,13 +698,17 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 }
 
 export function isSiteStyleFulfilled( stepName, defaultDependencies, nextProps ) {
-	if ( nextProps.siteType === 'blog' ) {
+	// Switching to a site type where the mockups are hidden means we
+	// don't want to ask what site style they want.
+	if ( getSiteTypePropertyValue( 'slug', nextProps.siteType, 'hideSiteMockups' ) ) {
 		flows.excludeStep( stepName );
 	}
 }
 
 export function isSiteStyleUnfulfilled( stepName, defaultDependencies, nextProps ) {
-	if ( nextProps.siteType !== 'blog' ) {
+	// Switching to a site type where the mockups aren't hidden means we
+	// _will_ want to ask what site style they want.
+	if ( ! getSiteTypePropertyValue( 'slug', nextProps.siteType, 'hideSiteMockups' ) ) {
 		flows.includeStep( stepName );
 	}
 }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -37,6 +37,7 @@ import { getUserExperience } from 'state/signup/steps/user-experience/selectors'
 import { requestSites } from 'state/sites/actions';
 import { getProductsList } from 'state/products-list/selectors';
 import { getSelectedImportEngine, getNuxUrlInputValue } from 'state/importer-nux/temp-selectors';
+import { getSiteStyleOptions } from 'lib/signup/site-styles';
 
 // Current directory dependencies
 import { isValidLandingPageVertical } from './verticals';
@@ -699,8 +700,12 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 
 export function isSiteStyleFulfilled( stepName, defaultDependencies, nextProps ) {
 	// Switching to a site type where the mockups are hidden means we
-	// don't want to ask what site style they want.
+	// don't want to ask what site style they want, we'll pick one for them.
 	if ( getSiteTypePropertyValue( 'slug', nextProps.siteType, 'hideSiteMockups' ) ) {
+		const { siteType } = nextProps;
+		const { id: siteStyle, theme: themeSlugWithRepo } = getSiteStyleOptions( siteType )[ 0 ];
+
+		nextProps.submitSignupStep( { stepName }, { siteStyle, themeSlugWithRepo } );
 		flows.excludeStep( stepName );
 	}
 }

--- a/client/lib/signup/test/mocks/signup/config/flows.js
+++ b/client/lib/signup/test/mocks/signup/config/flows.js
@@ -13,4 +13,6 @@ export default {
 	},
 
 	excludeStep: jest.fn(),
+
+	includeStep: jest.fn(),
 };

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -329,48 +329,48 @@ describe( 'isSiteTopicFulfilled()', () => {
 		expect( setSurvey ).not.toHaveBeenCalled();
 		expect( submitSiteVertical ).not.toHaveBeenCalled();
 	} );
+} );
 
-	describe( 'isSiteStyleFulfilled()', () => {
-		beforeEach( () => {
-			flows.excludeStep.mockClear();
-		} );
-
-		test( 'excludes site style step if site type is a blog', () => {
-			const nextProps = { siteType: 'blog' };
-
-			isSiteStyleFulfilled( 'step-name', undefined, nextProps );
-
-			expect( flows.excludeStep ).toHaveBeenCalledWith( 'step-name' );
-		} );
-
-		test( "don't exclude site style step if site type isn't a blog", () => {
-			const nextProps = { siteType: 'business' };
-
-			isSiteStyleFulfilled( 'step-name', undefined, nextProps );
-
-			expect( flows.excludeStep ).not.toHaveBeenCalled();
-		} );
+describe( 'isSiteStyleFulfilled()', () => {
+	beforeEach( () => {
+		flows.excludeStep.mockClear();
 	} );
 
-	describe( 'isSiteStyleUnfulfilled()', () => {
-		beforeEach( () => {
-			flows.includeStep.mockClear();
-		} );
+	test( 'excludes site style step if site type is a blog', () => {
+		const nextProps = { siteType: 'blog' };
 
-		test( "includes site style step if site type isn't a blog", () => {
-			const nextProps = { siteType: 'business' };
+		isSiteStyleFulfilled( 'step-name', undefined, nextProps );
 
-			isSiteStyleUnfulfilled( 'step-name', undefined, nextProps );
+		expect( flows.excludeStep ).toHaveBeenCalledWith( 'step-name' );
+	} );
 
-			expect( flows.includeStep ).toHaveBeenCalledWith( 'step-name' );
-		} );
+	test( "don't exclude site style step if site type isn't a blog", () => {
+		const nextProps = { siteType: 'business' };
 
-		test( "don't include site style step if site type is a blog", () => {
-			const nextProps = { siteType: 'blog' };
+		isSiteStyleFulfilled( 'step-name', undefined, nextProps );
 
-			isSiteStyleUnfulfilled( 'step-name', undefined, nextProps );
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+	} );
+} );
 
-			expect( flows.includeStep ).not.toHaveBeenCalled();
-		} );
+describe( 'isSiteStyleUnfulfilled()', () => {
+	beforeEach( () => {
+		flows.includeStep.mockClear();
+	} );
+
+	test( "includes site style step if site type isn't a blog", () => {
+		const nextProps = { siteType: 'business' };
+
+		isSiteStyleUnfulfilled( 'step-name', undefined, nextProps );
+
+		expect( flows.includeStep ).toHaveBeenCalledWith( 'step-name' );
+	} );
+
+	test( "don't include site style step if site type is a blog", () => {
+		const nextProps = { siteType: 'blog' };
+
+		isSiteStyleUnfulfilled( 'step-name', undefined, nextProps );
+
+		expect( flows.includeStep ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -14,6 +14,7 @@ import {
 } from '../step-actions';
 import { useNock } from 'test/helpers/use-nock';
 import flows from 'signup/config/flows';
+import { getSiteStyleOptions } from 'lib/signup/site-styles';
 
 // This is necessary since localforage will throw "no local storage method found" promise rejection without this.
 // See how lib/user-settings/test apply the same trick.
@@ -24,6 +25,7 @@ jest.mock( 'signup/config/steps', () => require( './mocks/signup/config/steps' )
 jest.mock( 'signup/config/steps-pure', () => require( './mocks/signup/config/steps-pure' ) );
 jest.mock( 'signup/config/flows', () => require( './mocks/signup/config/flows' ) );
 jest.mock( 'signup/config/flows-pure', () => require( './mocks/signup/config/flows-pure' ) );
+jest.mock( 'lib/signup/site-styles' );
 
 describe( 'createSiteWithCart()', () => {
 	// createSiteWithCart() function is not designed to be easy for test at the moment.
@@ -332,23 +334,32 @@ describe( 'isSiteTopicFulfilled()', () => {
 } );
 
 describe( 'isSiteStyleFulfilled()', () => {
+	const siteStyle = 'styleId';
+	const themeSlugWithRepo = 'themeSlug';
+
 	beforeEach( () => {
 		flows.excludeStep.mockClear();
+		getSiteStyleOptions.mockReturnValue( [ { id: siteStyle, theme: themeSlugWithRepo } ] );
 	} );
 
-	test( 'excludes site style step if site type is a blog', () => {
-		const nextProps = { siteType: 'blog' };
+	test( 'complete site style step if site type is a blog', () => {
+		const nextProps = { siteType: 'blog', submitSignupStep: jest.fn() };
 
 		isSiteStyleFulfilled( 'step-name', undefined, nextProps );
 
+		expect( nextProps.submitSignupStep ).toHaveBeenCalledWith(
+			{ stepName: 'step-name' },
+			{ siteStyle, themeSlugWithRepo }
+		);
 		expect( flows.excludeStep ).toHaveBeenCalledWith( 'step-name' );
 	} );
 
-	test( "don't exclude site style step if site type isn't a blog", () => {
-		const nextProps = { siteType: 'business' };
+	test( "don't complete site style step if site type isn't a blog", () => {
+		const nextProps = { siteType: 'business', submitSignupStep: jest.fn() };
 
 		isSiteStyleFulfilled( 'step-name', undefined, nextProps );
 
+		expect( nextProps.submitSignupStep ).not.toHaveBeenCalled();
 		expect( flows.excludeStep ).not.toHaveBeenCalled();
 	} );
 } );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -9,6 +9,8 @@ import {
 	isPlanFulfilled,
 	isSiteTopicFulfilled,
 	isSiteTypeFulfilled,
+	isSiteStyleFulfilled,
+	isSiteStyleUnfulfilled,
 } from '../step-actions';
 import { useNock } from 'test/helpers/use-nock';
 import flows from 'signup/config/flows';
@@ -326,5 +328,49 @@ describe( 'isSiteTopicFulfilled()', () => {
 
 		expect( setSurvey ).not.toHaveBeenCalled();
 		expect( submitSiteVertical ).not.toHaveBeenCalled();
+	} );
+
+	describe( 'isSiteStyleFulfilled()', () => {
+		beforeEach( () => {
+			flows.excludeStep.mockClear();
+		} );
+
+		test( 'excludes site style step if site type is a blog', () => {
+			const nextProps = { siteType: 'blog' };
+
+			isSiteStyleFulfilled( 'step-name', undefined, nextProps );
+
+			expect( flows.excludeStep ).toHaveBeenCalledWith( 'step-name' );
+		} );
+
+		test( "don't exclude site style step if site type isn't a blog", () => {
+			const nextProps = { siteType: 'business' };
+
+			isSiteStyleFulfilled( 'step-name', undefined, nextProps );
+
+			expect( flows.excludeStep ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'isSiteStyleUnfulfilled()', () => {
+		beforeEach( () => {
+			flows.includeStep.mockClear();
+		} );
+
+		test( "includes site style step if site type isn't a blog", () => {
+			const nextProps = { siteType: 'business' };
+
+			isSiteStyleUnfulfilled( 'step-name', undefined, nextProps );
+
+			expect( flows.includeStep ).toHaveBeenCalledWith( 'step-name' );
+		} );
+
+		test( "don't include site style step if site type is a blog", () => {
+			const nextProps = { siteType: 'blog' };
+
+			isSiteStyleUnfulfilled( 'step-name', undefined, nextProps );
+
+			expect( flows.includeStep ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { assign, get, includes, indexOf, reject } from 'lodash';
+import { assign, get, indexOf, reject } from 'lodash';
 
 /**
  * Internal dependencies
@@ -108,7 +108,7 @@ const Flows = {
 	defaultFlowName: config.isEnabled( 'signup/onboarding-flow' )
 		? abtest( 'improvedOnboarding' )
 		: 'main',
-	excludedSteps: [],
+	excludedSteps: new Set(),
 
 	/**
 	 * Get certain flow from the flows configuration.
@@ -160,7 +160,15 @@ const Flows = {
 	 * @param {String} step Name of the step to be excluded.
 	 */
 	excludeStep( step ) {
-		step && Flows.excludedSteps.push( step );
+		step && Flows.excludedSteps.add( step );
+	},
+
+	/**
+	 * Make `getFlow()` re-include the given step after it's been excluded by `excludeStep()`.
+	 * @param {String} step Name of the step to include
+	 */
+	includeStep( step ) {
+		Flows.excludedSteps.delete( step );
 	},
 
 	filterExcludedSteps( flow ) {
@@ -169,7 +177,7 @@ const Flows = {
 		}
 
 		return assign( {}, flow, {
-			steps: reject( flow.steps, stepName => includes( Flows.excludedSteps, stepName ) ),
+			steps: reject( flow.steps, stepName => Flows.excludedSteps.has( stepName ) ),
 		} );
 	},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -32,6 +32,8 @@ export function generateSteps( {
 	isDomainFulfilled = noop,
 	isSiteTypeFulfilled = noop,
 	isSiteTopicFulfilled = noop,
+	isSiteStyleFulfilled = noop,
+	isSiteStyleUnfulfilled = noop,
 } = {} ) {
 	return {
 		survey: {
@@ -459,6 +461,8 @@ export function generateSteps( {
 		'site-style': {
 			stepName: 'site-style',
 			providesDependencies: [ 'siteStyle', 'themeSlugWithRepo' ],
+			fulfilledStepCallback: isSiteStyleFulfilled,
+			unfulfilledStepCallback: isSiteStyleUnfulfilled,
 		},
 
 		// Steps with preview
@@ -475,6 +479,8 @@ export function generateSteps( {
 		'site-style-with-preview': {
 			stepName: 'site-style-with-preview',
 			providesDependencies: [ 'siteStyle', 'themeSlugWithRepo' ],
+			fulfilledStepCallback: isSiteStyleFulfilled,
+			unfulfilledStepCallback: isSiteStyleUnfulfilled,
 			props: {
 				showSiteMockups: true,
 			},

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -22,6 +22,8 @@ import {
 	isDomainFulfilled,
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
+	isSiteStyleFulfilled,
+	isSiteStyleUnfulfilled,
 } from 'lib/signup/step-actions';
 import { generateSteps } from './steps-pure';
 
@@ -39,4 +41,6 @@ export default generateSteps( {
 	isDomainFulfilled,
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
+	isSiteStyleFulfilled,
+	isSiteStyleUnfulfilled,
 } );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -157,6 +157,7 @@ class Signup extends React.Component {
 		} );
 
 		this.removeFulfilledSteps( this.props );
+		this.addUnfulfilledSteps( this.props );
 
 		this.updateShouldShowLoadingScreen();
 
@@ -183,6 +184,7 @@ class Signup extends React.Component {
 		const { stepName, flowName, progress } = nextProps;
 
 		this.removeFulfilledSteps( nextProps );
+		this.addUnfulfilledSteps( nextProps );
 
 		if ( this.props.stepName !== stepName ) {
 			this.recordStep( stepName, flowName );
@@ -302,6 +304,23 @@ class Signup extends React.Component {
 			this.goToNextStep( flowName );
 		}
 	};
+
+	addUnfulfilledSteps( nextProps ) {
+		const flow = flows.getFlows()[ nextProps.flowName ];
+		if ( ! flow ) {
+			return;
+		}
+
+		for ( const stepName of flows.excludedSteps ) {
+			if ( ! flow.steps.includes( stepName ) ) {
+				continue;
+			}
+
+			const isUnfulfilledCallback = steps[ stepName ].unfulfilledStepCallback;
+			const defaultDependencies = steps[ stepName ].defaultDependencies;
+			isUnfulfilledCallback && isUnfulfilledCallback( stepName, defaultDependencies, nextProps );
+		}
+	}
 
 	preloadNextStep() {
 		const currentStepName = this.props.stepName;

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -46,6 +46,7 @@ import * as oauthToken from 'lib/oauth-token';
 import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
 import SignupFlowController from 'lib/signup/flow-controller';
 import { disableCart, saveCouponQueryArgument } from 'lib/upgrades/actions';
+import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 
 // State actions and selectors
 import { loadTrackingTool } from 'state/analytics/actions';
@@ -648,6 +649,8 @@ export default connect(
 		const signupDependencies = getSignupDependencyStore( state );
 		const siteId = getSiteId( state, signupDependencies.siteSlug );
 		const siteDomains = getDomainsBySiteId( state, siteId );
+		const siteType = getSiteType( state );
+
 		return {
 			domainsWithPlansOnly: getCurrentUser( state )
 				? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
@@ -662,8 +665,10 @@ export default connect(
 			sitePlanSlug: getSitePlanSlug( state, siteId ),
 			siteDomains,
 			siteId,
-			siteType: getSiteType( state ),
-			shouldShowMockups: get( steps[ ownProps.stepName ], 'props.showSiteMockups', false ),
+			siteType,
+			shouldShowMockups:
+				! getSiteTypePropertyValue( 'slug', siteType, 'hideSiteMockups' ) &&
+				get( steps[ ownProps.stepName ], 'props.showSiteMockups', false ),
 		};
 	},
 	{

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -284,7 +284,7 @@ class Signup extends React.Component {
 	};
 
 	processFulfilledSteps = ( stepName, nextProps ) => {
-		if ( includes( flows.excludedSteps, stepName ) ) {
+		if ( flows.excludedSteps.has( stepName ) ) {
 			return;
 		}
 
@@ -298,7 +298,7 @@ class Signup extends React.Component {
 		const flowSteps = flows.getFlow( flowName ).steps;
 		map( flowSteps, flowStepName => this.processFulfilledSteps( flowStepName, nextProps ) );
 
-		if ( includes( flows.excludedSteps, stepName ) ) {
+		if ( flows.excludedSteps.has( stepName ) ) {
 			this.goToNextStep( flowName );
 		}
 	};

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -17,7 +17,6 @@ import { saveSignupStep } from 'state/signup/progress/actions';
 
 const siteTypeToFlowname = {
 	'online-store': 'ecommerce-onboarding',
-	blog: 'onboarding-blog',
 };
 
 class SiteType extends Component {
@@ -28,18 +27,8 @@ class SiteType extends Component {
 	submitStep = siteTypeValue => {
 		this.props.submitSiteType( siteTypeValue );
 
-		// TODO Hack to fix the `/start/premium|business|personal` routes
-		if (
-			( this.props.flowName === 'premium' ||
-				this.props.flowName === 'business' ||
-				this.props.flowName === 'personal' ) &&
-			siteTypeValue === 'blog'
-		) {
-			this.props.goToNextStep( this.props.flowName );
-		} else {
-			// Modify the flowname if the site type matches an override.
-			this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
-		}
+		// Modify the flowname if the site type matches an override.
+		this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
 	};
 
 	render() {

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -58,4 +58,31 @@ describe( 'Signup Flows Configuration', () => {
 			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'user' ] );
 		} );
 	} );
+
+	describe( 'includeSteps', () => {
+		beforeAll( () => {
+			sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
+		} );
+
+		afterAll( () => {
+			flows.getFlows.restore();
+		} );
+
+		test( 'including step that was never excluded has no effect', () => {
+			flows.includeStep( 'site' );
+			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'user', 'site' ] );
+		} );
+
+		test( "including step that doesn't exist has no effect", () => {
+			flows.includeStep( 'fake' );
+			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'user', 'site' ] );
+		} );
+
+		test( 'including step after it was excluded restores the step', () => {
+			flows.excludeStep( 'site' );
+			flows.excludeStep( 'user' );
+			flows.includeStep( 'site' );
+			assert.deepEqual( flows.getFlow( 'main' ).steps, [ 'site' ] );
+		} );
+	} );
 } );

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -540,11 +540,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await siteTitlePage.submitForm();
 		} );
 
-		step( 'Can see the "Site style" page, and continue with the default style', async function() {
-			const siteTitlePage = await SiteStylePage.Expect( driver );
-			return await siteTitlePage.submitForm();
-		} );
-
 		step(
 			'Can then see the domains page and can search for a blog name, can see and select a free WordPress.com blog address in results',
 			async function() {
@@ -664,11 +659,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step( 'Can see the "Site title" page, and enter the site title', async function() {
 			const siteTitlePage = await SiteTitlePage.Expect( driver );
 			await siteTitlePage.enterSiteTitle( blogName );
-			return await siteTitlePage.submitForm();
-		} );
-
-		step( 'Can see the "Site style" page, and continue with the default style', async function() {
-			const siteTitlePage = await SiteStylePage.Expect( driver );
 			return await siteTitlePage.submitForm();
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We don't want site mockups to show when the user opts to create a blog. This affects multiple flows, not just `onboarding`, which has caused us issues. Rather than create special "mockup hidden" variations of each flow, this PR adds the ability to hide mockups based on site type.

Changes:

* Add a `hideSiteMockups` flag to site type config so mockups can be disabled/enabled declaratively
* Add `includeStep()` function that does the opposite of `excludeStep()`. I'm not fussed on the name, I really want something like `unExcludeStep()`. Suggestions welcome 😄 
* Add an optional `unfulfilledStepCallback` property for steps so they can do the opposite of `fulfilledStepCallback`
* We can turn the blog preview on and off again with ease 😉 

I think this will also allow us to remove the special `-with-preview` step variations and the special `onboarding-blog`, but I'll do that in a later PR.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* `/start/onboarding`
* Create a blog
* Notice progress indicator goes down by one, site style step is missing, and site mockups are hidden
* Go back and switch site type to business|professional|online store
* Notice progress indicator goes up by one, site style step is back, and site mockups are back

Then also test with:

* `/start/personal`
* `/start/premium`
* `/start/business`
* `/start/onboarding?site_type=blog`
* `/start/onboarding?vertical=art`

et cetera, et cetera.

This might impact analytics, but I'm not sure. The `calypso_signup_actions_submit_site_style` event won't be recorded if the user chooses a blog site type, but that's already the case in the `onboarding-blog` flow, so I think we're good on that front.

Fixes Automattic/zelda-private#83
