### PR TITLE
Recurring Payments: Add a link to see users transactions in Stripe

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -35,6 +35,8 @@ import QueryMembershipProducts from 'components/data/query-memberships';
 import CompactCard from 'components/card/compact';
 import Gridicon from 'components/gridicon';
 import { userCan } from 'lib/site/utils';
+import EllipsisMenu from 'components/ellipsis-menu';
+import PopoverMenuItem from 'components/popover/menu-item';
 
 /**
  * Style dependencies
@@ -250,10 +252,26 @@ class MembershipsSection extends Component {
 			} );
 		}
 	}
-
+	renderSubscriberActions( subscriber ) {
+		return (
+			<EllipsisMenu position="bottom left" className="memberships__subscriber-actions">
+				<PopoverMenuItem
+					target="_blank"
+					rel="noopener norefferer"
+					href={ `https://dashboard.stripe.com/test/search?query=metadata%3A${
+						subscriber.user.ID
+					}` }
+				>
+					<Gridicon size={ 18 } icon={ 'external' } />
+					{ this.props.translate( 'See transactions in Stripe Dashboard' ) }
+				</PopoverMenuItem>
+			</EllipsisMenu>
+		);
+	}
 	renderSubscriber( subscriber ) {
 		return (
 			<Card className="memberships__subscriber-profile is-compact" key={ subscriber.id }>
+				{ this.renderSubscriberActions( subscriber ) }
 				<div className="memberships__subscriber-gravatar">
 					<Gravatar user={ subscriber.user } size={ 72 } />
 				</div>

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -202,3 +202,6 @@
 .memberships__earnings-breakdown-notes em {
 	font-weight: bold;
 }
+.memberships__subscriber-actions {
+	float: right;
+}


### PR DESCRIPTION

![Zrzut ekranu 2019-06-26 o 12 35 01](https://user-images.githubusercontent.com/3775068/60173512-343f3600-980f-11e9-8c57-0f52802083d4.png)

#### Changes proposed in this Pull Request

We have a following problem:
We don't pass the user name or email to site owner's Stripe account, for various reasons. We plan to work on that, but in the meantime users have no way of finding transactions relating to a specific user on their stripe dashboard.

That means, that when they want to refund, it is an issue, since they cannot find the transaction.

This adds a link that is a custom search showing Stripe transactions relating to that specific user.

#### Testing instructions

1. Set up recurring payments [ https://en.support.wordpress.com/recurring-payments-button/#adding-a-recurring-payments-button ]
2. go to your members page http://calypso.localhost:3000/earn/payments/
3. Click on the elipsis menu, clcik the link

You should be transported to your stripe dashboard and you should see the list of transactions that this user has made on your site.


