### PR TITLE
Add `once` method to memoizeLast.

### DIFF
--- a/client/lib/memoize-last/index.ts
+++ b/client/lib/memoize-last/index.ts
@@ -37,7 +37,7 @@ export default function memoizeLast< T extends ( ...args: any[] ) => any >( fn: 
  */
 export function once< T extends () => any >( fn: T ) {
 	// Runtime validation. Useful when static validation is unavailable.
-	if ( fn.length !== 0 ) {
+	if ( process.env.NODE_ENV !== 'production' && fn.length !== 0 ) {
 		throw new Error( 'memoize-last: The `once` method expects a function with no arguments.' );
 	}
 	return memoizeLast( fn );

--- a/client/lib/memoize-last/index.ts
+++ b/client/lib/memoize-last/index.ts
@@ -24,3 +24,21 @@ export default function memoizeLast< T extends ( ...args: any[] ) => any >( fn: 
 		return lastResult;
 	} ) as T;
 }
+
+/**
+ * A stricter-typed alias of `memoizeLast`, for functions without arguments.
+ * Since it only accepts functions without arguments, it effectively guarantees
+ * that the provided function will only be run once, as the check for whether
+ * the arguments have not changed will always pass.
+ *
+ * @param fn The function to be wrapped.
+ *
+ * @returns The wrapped function.
+ */
+export function once< T extends () => any >( fn: T ) {
+	// Runtime validation. Useful when static validation is unavailable.
+	if ( fn.length !== 0 ) {
+		throw new Error( 'memoize-last: The `once` method expects a function with no arguments.' );
+	}
+	return memoizeLast( fn );
+}

--- a/client/lib/memoize-last/test/index.js
+++ b/client/lib/memoize-last/test/index.js
@@ -6,7 +6,7 @@
 /**
  * Internal dependencies
  */
-import memoizeLast from '../';
+import memoizeLast, { once } from '../';
 
 describe( 'memoizeLast', () => {
 	let mockFunction;
@@ -43,5 +43,36 @@ describe( 'memoizeLast', () => {
 		expect( result1 ).toEqual( { result: 6 } );
 		expect( result2 ).toEqual( { result: 6 } );
 		expect( result2 ).not.toBe( result1 );
+	} );
+} );
+
+describe( 'once', () => {
+	let mockFunction;
+	let memoizedFunction;
+
+	beforeEach( () => {
+		mockFunction = jest.fn( () => ( { foo: 'bar' } ) );
+		memoizedFunction = once( mockFunction );
+	} );
+
+	test( 'it should throw an exception if called with a function with arguments', () => {
+		expect( () => {
+			once( ( a, b, c ) => a + b + c );
+		} ).toThrow();
+	} );
+
+	test( 'it should call the function if it has not been called yet', () => {
+		const result = memoizedFunction();
+		expect( mockFunction ).toHaveBeenCalledTimes( 1 );
+		expect( mockFunction ).toHaveBeenCalledWith();
+		expect( result ).toEqual( { foo: 'bar' } );
+	} );
+
+	test( 'it should not call the function if it was already called ', () => {
+		const result1 = memoizedFunction();
+		const result2 = memoizedFunction();
+		expect( mockFunction ).toHaveBeenCalledTimes( 1 );
+		expect( mockFunction ).toHaveBeenCalledWith();
+		expect( result2 ).toBe( result1 );
 	} );
 } );


### PR DESCRIPTION
This is effectively an alias of `memoizeLast`, albeit with stricter typing, which ensures that the function to be wrapped doesn't have any arguments. There's a runtime check too, for non-typed scenarios.

This guarantees that the provided method will only be run once (through the wrapper), and we can thus take advantage of the special semantics with some clearer naming.

This method provides a much lighter alternative to `lodash`'s `once`, since it lives in a self-contained module and doesn't depend on a large portion of the `lodash` library, unlike `_.once`.

#### Changes proposed in this Pull Request

* Add `once` method to `lib/memoize-last`.

#### Testing instructions

The new unit tests should ensure that the functionality is correct. There are no changes to existing functionality, as this is a new utility method inside of the `lib/memoize-last` library.
