### PR TITLE
Signup: Fix preview not shown when site topic pre-selected with query parameter

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -118,6 +118,7 @@ class Signup extends React.Component {
 		pageTitle: PropTypes.string,
 		siteType: PropTypes.string,
 		stepSectionName: PropTypes.string,
+		shouldShowMockup: PropTypes.bool,
 	};
 
 	constructor( props, context ) {
@@ -617,16 +618,14 @@ class Signup extends React.Component {
 						redirectTo={ this.state.redirectTo }
 					/>
 				) }
-				{ get( steps[ this.props.stepName ], 'props.showSiteMockups', false ) && (
-					<SiteMockups stepName={ this.props.stepName } />
-				) }
+				{ this.props.shouldShowMockup && <SiteMockups stepName={ this.props.stepName } /> }
 			</div>
 		);
 	}
 }
 
 export default connect(
-	state => {
+	( state, ownProps ) => {
 		const signupDependencies = getSignupDependencyStore( state );
 		const siteId = getSiteId( state, signupDependencies.siteSlug );
 		const siteDomains = getDomainsBySiteId( state, siteId );
@@ -645,6 +644,7 @@ export default connect(
 			siteDomains,
 			siteId,
 			siteType: getSiteType( state ),
+			shouldShowMockup: get( steps[ ownProps.stepName ], 'props.showSiteMockups', false ),
 		};
 	},
 	{

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -118,7 +118,7 @@ class Signup extends React.Component {
 		pageTitle: PropTypes.string,
 		siteType: PropTypes.string,
 		stepSectionName: PropTypes.string,
-		shouldShowMockup: PropTypes.bool,
+		shouldShowMockups: PropTypes.bool,
 	};
 
 	constructor( props, context ) {
@@ -618,7 +618,7 @@ class Signup extends React.Component {
 						redirectTo={ this.state.redirectTo }
 					/>
 				) }
-				{ this.props.shouldShowMockup && <SiteMockups stepName={ this.props.stepName } /> }
+				{ this.props.shouldShowMockups && <SiteMockups stepName={ this.props.stepName } /> }
 			</div>
 		);
 	}
@@ -644,7 +644,7 @@ export default connect(
 			siteDomains,
 			siteId,
 			siteType: getSiteType( state ),
-			shouldShowMockup: get( steps[ ownProps.stepName ], 'props.showSiteMockups', false ),
+			shouldShowMockups: get( steps[ ownProps.stepName ], 'props.showSiteMockups', false ),
 		};
 	},
 	{

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -73,7 +73,9 @@ class SiteTitleStep extends Component {
 			getSiteTypePropertyValue( 'slug', siteType, 'siteTitlePlaceholder' ) || '';
 		return (
 			<div className="site-title__wrapper">
-				{ shouldFetchVerticalData && <QueryVerticals searchTerm={ siteVerticalName } /> }
+				{ shouldFetchVerticalData && (
+					<QueryVerticals searchTerm={ siteVerticalName } siteType={ siteType } />
+				) }
 				<form>
 					<div className="site-title__field-control site-title__title">
 						<FormFieldset>
@@ -132,7 +134,9 @@ export default connect(
 	( state, ownProps ) => {
 		const siteType = getSiteType( state );
 		const shouldFetchVerticalData =
-			ownProps.showSiteMockups && siteType === 'business' && getSiteVerticalPreview( state ) === '';
+			ownProps.showSiteMockups &&
+			ownProps.flowName === 'onboarding' &&
+			getSiteVerticalPreview( state ) === '';
 		return {
 			siteTitle: getSiteTitle( state ),
 			siteVerticalName: getSiteVerticalName( state ),


### PR DESCRIPTION
## Changes proposed in this Pull Request

Behold! A vertical-specific landing page: https://wordpress.com/websites/create/restaurant/

When thou doth clicketh the CTA, the site preview appeareth not! 

All this, while the lonely query parameter declares a `'business'` segment should be chosen, yet it performs no more service than a stewed prune would at a Roman feast!

_(This PR passes passing a site type to `<QueryVerticals />`. We need this prop since we changed the vertical results state to use segment key in https://github.com/Automattic/wp-calypso/pull/33209. We're also moving the should show site mockups check to the connect function.)_

## Testing instructions

1. http://calypso.localhost:3000/start/onboarding?vertical=Restaurants&site_type=business&ref=restaurants-vertical-landing
2. Log in if necessary

The site preview should render itself unto thee! Away you bug! You rank compound!

<img width="1013" alt="Screen Shot 2019-06-26 at 10 12 28 pm" src="https://user-images.githubusercontent.com/6458278/60179291-b6a41600-9860-11e9-8969-97d3c0b2f32c.png">

Fixes https://github.com/Automattic/zelda-private/issues/87
