### PR TITLE
Add types to icon components.

### DIFF
--- a/client/components/gridicon/gridicons.d.ts
+++ b/client/components/gridicon/gridicons.d.ts
@@ -1,0 +1,10 @@
+declare module 'gridicons/dist/util/icons-offset' {
+	const iconsThatNeedOffset: [string];
+	const iconsThatNeedOffsetX: [string];
+	const iconsThatNeedOffsetY: [string];
+}
+
+declare module 'gridicons/svg-sprite/gridicons.svg' {
+	const def: string;
+	export = def;
+}

--- a/client/components/gridicon/gridicons.d.ts
+++ b/client/components/gridicon/gridicons.d.ts
@@ -1,7 +1,7 @@
 declare module 'gridicons/dist/util/icons-offset' {
-	const iconsThatNeedOffset: [string];
-	const iconsThatNeedOffsetX: [string];
-	const iconsThatNeedOffsetY: [string];
+	const iconsThatNeedOffset: string[];
+	const iconsThatNeedOffsetX: string[];
+	const iconsThatNeedOffsetY: string[];
 }
 
 declare module 'gridicons/svg-sprite/gridicons.svg' {

--- a/client/components/gridicon/index.tsx
+++ b/client/components/gridicon/index.tsx
@@ -9,19 +9,21 @@ import {
 	iconsThatNeedOffsetY,
 } from 'gridicons/dist/util/icons-offset';
 import spritePath from 'gridicons/svg-sprite/gridicons.svg';
+import { Assign } from 'utility-types';
 
 function needsOffset( name: string, icons: [string] ) {
 	return icons.indexOf( name ) >= 0;
 }
 
-interface Props extends React.SVGProps< SVGSVGElement > {
+interface Props {
 	icon: string;
 	size?: number;
 	onClick?: React.MouseEventHandler< SVGSVGElement >;
 	className?: string;
 }
+type AllProps = Assign< React.SVGProps< SVGSVGElement >, Props >;
 
-const Gridicon = React.forwardRef< SVGSVGElement, Props >( ( props: Props, ref ) => {
+const Gridicon = React.forwardRef< SVGSVGElement, AllProps >( ( props: AllProps, ref ) => {
 	const { size = 24, icon, onClick, className, ...otherProps } = props;
 	const isModulo18 = size % 18 === 0;
 

--- a/client/components/gridicon/index.tsx
+++ b/client/components/gridicon/index.tsx
@@ -11,7 +11,7 @@ import {
 import spritePath from 'gridicons/svg-sprite/gridicons.svg';
 import { Assign } from 'utility-types';
 
-function needsOffset( name: string, icons: [string] ) {
+function needsOffset( name: string, icons: string[] ) {
 	return icons.indexOf( name ) >= 0;
 }
 

--- a/client/components/gridicon/index.tsx
+++ b/client/components/gridicon/index.tsx
@@ -14,12 +14,11 @@ function needsOffset( name: string, icons: [string] ) {
 	return icons.indexOf( name ) >= 0;
 }
 
-interface Props {
+interface Props extends React.SVGProps< SVGSVGElement > {
 	icon: string;
 	size?: number;
 	onClick?: React.MouseEventHandler< SVGSVGElement >;
 	className?: string;
-	[propName: string]: any;
 }
 
 const Gridicon = React.forwardRef< SVGSVGElement, Props >( ( props: Props, ref ) => {

--- a/client/components/gridicon/index.tsx
+++ b/client/components/gridicon/index.tsx
@@ -18,8 +18,6 @@ function needsOffset( name: string, icons: [string] ) {
 interface Props {
 	icon: string;
 	size?: number;
-	onClick?: React.MouseEventHandler< SVGSVGElement >;
-	className?: string;
 }
 type AllProps = Assign< React.SVGProps< SVGSVGElement >, Props >;
 

--- a/client/components/gridicon/index.tsx
+++ b/client/components/gridicon/index.tsx
@@ -17,7 +17,7 @@ function needsOffset( name: string, icons: [string] ) {
 interface Props {
 	icon: string;
 	size?: number;
-	onClick?: ( event?: React.MouseEvent< SVGSVGElement, MouseEvent > ) => any;
+	onClick?: React.MouseEventHandler< SVGSVGElement >;
 	className?: string;
 	[propName: string]: any;
 }

--- a/client/components/gridicon/index.tsx
+++ b/client/components/gridicon/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {
 	iconsThatNeedOffset,
@@ -11,11 +10,19 @@ import {
 } from 'gridicons/dist/util/icons-offset';
 import spritePath from 'gridicons/svg-sprite/gridicons.svg';
 
-function needsOffset( name, icons ) {
+function needsOffset( name: string, icons: [string] ) {
 	return icons.indexOf( name ) >= 0;
 }
 
-const Gridicon = React.forwardRef( ( props, ref ) => {
+interface Props {
+	icon: string;
+	size?: number;
+	onClick?: ( event?: React.MouseEvent< SVGSVGElement, MouseEvent > ) => any;
+	className?: string;
+	[propName: string]: any;
+}
+
+const Gridicon = React.forwardRef< SVGSVGElement, Props >( ( props: Props, ref ) => {
 	const { size = 24, icon, onClick, className, ...otherProps } = props;
 	const isModulo18 = size % 18 === 0;
 
@@ -45,12 +52,5 @@ const Gridicon = React.forwardRef( ( props, ref ) => {
 		</svg>
 	);
 } );
-
-Gridicon.propTypes = {
-	icon: PropTypes.string.isRequired,
-	size: PropTypes.number,
-	onClick: PropTypes.func,
-	className: PropTypes.string,
-};
 
 export default React.memo( Gridicon );

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React, { Fragment, FunctionComponent, ReactNode } from 'react';
 import { useTranslate } from 'i18n-calypso';
 

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React, { ChangeEvent, Fragment, FunctionComponent, useState } from 'react';
 import { useTranslate } from 'i18n-calypso';
 

--- a/client/components/material-icon/index.tsx
+++ b/client/components/material-icon/index.tsx
@@ -4,9 +4,9 @@
 import classnames from 'classnames';
 import React from 'react';
 import spritePath from '@automattic/material-design-icons/svg-sprite/material-icons.svg';
-import { Omit } from 'utility-types';
+import { Assign } from 'utility-types';
 
-interface Props extends Omit< React.SVGProps< SVGSVGElement >, 'style' > {
+interface Props {
 	icon: string;
 	style?: string;
 	size?: number;
@@ -14,7 +14,7 @@ interface Props extends Omit< React.SVGProps< SVGSVGElement >, 'style' > {
 	className?: string;
 }
 
-function MaterialIcon( props: Props ) {
+function MaterialIcon( props: Assign< React.SVGProps< SVGSVGElement >, Props > ) {
 	const { size = 24, style = 'outline', icon, onClick, className, ...otherProps } = props;
 
 	// Using a missing icon doesn't produce any errors, just a blank icon, which is the exact intended behaviour.

--- a/client/components/material-icon/index.tsx
+++ b/client/components/material-icon/index.tsx
@@ -5,6 +5,8 @@ import classnames from 'classnames';
 import React from 'react';
 import spritePath from '@automattic/material-design-icons/svg-sprite/material-icons.svg';
 
+type Omit< T, K extends keyof any > = Pick< T, Exclude< keyof T, K > >;
+
 interface Props extends Omit< React.SVGProps< SVGSVGElement >, 'style' > {
 	icon: string;
 	style?: string;

--- a/client/components/material-icon/index.tsx
+++ b/client/components/material-icon/index.tsx
@@ -9,7 +9,7 @@ interface Props {
 	icon: string;
 	style?: string;
 	size?: number;
-	onClick?: ( event?: React.MouseEvent< SVGSVGElement, MouseEvent > ) => any;
+	onClick?: React.MouseEventHandler< SVGSVGElement >;
 	className?: string;
 	[propName: string]: any;
 }

--- a/client/components/material-icon/index.tsx
+++ b/client/components/material-icon/index.tsx
@@ -4,8 +4,7 @@
 import classnames from 'classnames';
 import React from 'react';
 import spritePath from '@automattic/material-design-icons/svg-sprite/material-icons.svg';
-
-type Omit< T, K extends keyof any > = Pick< T, Exclude< keyof T, K > >;
+import { Omit } from 'utility-types';
 
 interface Props extends Omit< React.SVGProps< SVGSVGElement >, 'style' > {
 	icon: string;

--- a/client/components/material-icon/index.tsx
+++ b/client/components/material-icon/index.tsx
@@ -10,8 +10,6 @@ interface Props {
 	icon: string;
 	style?: string;
 	size?: number;
-	onClick?: React.MouseEventHandler< SVGSVGElement >;
-	className?: string;
 }
 
 function MaterialIcon( props: Assign< React.SVGProps< SVGSVGElement >, Props > ) {

--- a/client/components/material-icon/index.tsx
+++ b/client/components/material-icon/index.tsx
@@ -3,10 +3,18 @@
  */
 import classnames from 'classnames';
 import React from 'react';
-import PropTypes from 'prop-types';
 import spritePath from '@automattic/material-design-icons/svg-sprite/material-icons.svg';
 
-function MaterialIcon( props ) {
+interface Props {
+	icon: string;
+	style?: string;
+	size?: number;
+	onClick?: ( event?: React.MouseEvent< SVGSVGElement, MouseEvent > ) => any;
+	className?: string;
+	[propName: string]: any;
+}
+
+function MaterialIcon( props: Props ) {
 	const { size = 24, style = 'outline', icon, onClick, className, ...otherProps } = props;
 
 	// Using a missing icon doesn't produce any errors, just a blank icon, which is the exact intended behaviour.
@@ -30,13 +38,5 @@ function MaterialIcon( props ) {
 		</svg>
 	);
 }
-
-MaterialIcon.propTypes = {
-	icon: PropTypes.string.isRequired,
-	style: PropTypes.string,
-	size: PropTypes.number,
-	onClick: PropTypes.func,
-	className: PropTypes.string,
-};
 
 export default React.memo( MaterialIcon );

--- a/client/components/material-icon/index.tsx
+++ b/client/components/material-icon/index.tsx
@@ -5,13 +5,12 @@ import classnames from 'classnames';
 import React from 'react';
 import spritePath from '@automattic/material-design-icons/svg-sprite/material-icons.svg';
 
-interface Props {
+interface Props extends Omit< React.SVGProps< SVGSVGElement >, 'style' > {
 	icon: string;
 	style?: string;
 	size?: number;
 	onClick?: React.MouseEventHandler< SVGSVGElement >;
 	className?: string;
-	[propName: string]: any;
 }
 
 function MaterialIcon( props: Props ) {

--- a/client/components/material-icon/material-design-icons.d.ts
+++ b/client/components/material-icon/material-design-icons.d.ts
@@ -1,0 +1,4 @@
+declare module '@automattic/material-design-icons/svg-sprite/material-icons.svg' {
+	const def: string;
+	export = def;
+}

--- a/client/components/social-logo/index.tsx
+++ b/client/components/social-logo/index.tsx
@@ -5,12 +5,11 @@ import classnames from 'classnames';
 import React from 'react';
 import spritePath from 'social-logos/svg-sprite/social-logos.svg';
 
-interface Props {
+interface Props extends React.SVGProps< SVGSVGElement > {
 	icon: string;
 	size?: number;
 	onClick?: React.MouseEventHandler< SVGSVGElement >;
 	className?: string;
-	[propName: string]: any;
 }
 
 function SocialLogo( props: Props ) {

--- a/client/components/social-logo/index.tsx
+++ b/client/components/social-logo/index.tsx
@@ -9,8 +9,6 @@ import { Assign } from 'utility-types';
 interface Props {
 	icon: string;
 	size?: number;
-	onClick?: React.MouseEventHandler< SVGSVGElement >;
-	className?: string;
 }
 
 function SocialLogo( props: Assign< React.SVGProps< SVGSVGElement >, Props > ) {

--- a/client/components/social-logo/index.tsx
+++ b/client/components/social-logo/index.tsx
@@ -3,10 +3,17 @@
  */
 import classnames from 'classnames';
 import React from 'react';
-import PropTypes from 'prop-types';
 import spritePath from 'social-logos/svg-sprite/social-logos.svg';
 
-function SocialLogo( props ) {
+interface Props {
+	icon: string;
+	size?: number;
+	onClick?: ( event?: React.MouseEvent< SVGSVGElement, MouseEvent > ) => any;
+	className?: string;
+	[propName: string]: any;
+}
+
+function SocialLogo( props: Props ) {
 	const { size = 24, icon, onClick, className, ...otherProps } = props;
 
 	// Using a missing icon doesn't produce any errors, just a blank icon, which is the exact intended behaviour.
@@ -31,12 +38,5 @@ function SocialLogo( props ) {
 		</svg>
 	);
 }
-
-SocialLogo.propTypes = {
-	icon: PropTypes.string.isRequired,
-	size: PropTypes.number,
-	onClick: PropTypes.func,
-	className: PropTypes.string,
-};
 
 export default React.memo( SocialLogo );

--- a/client/components/social-logo/index.tsx
+++ b/client/components/social-logo/index.tsx
@@ -8,7 +8,7 @@ import spritePath from 'social-logos/svg-sprite/social-logos.svg';
 interface Props {
 	icon: string;
 	size?: number;
-	onClick?: ( event?: React.MouseEvent< SVGSVGElement, MouseEvent > ) => any;
+	onClick?: React.MouseEventHandler< SVGSVGElement >;
 	className?: string;
 	[propName: string]: any;
 }

--- a/client/components/social-logo/index.tsx
+++ b/client/components/social-logo/index.tsx
@@ -4,15 +4,16 @@
 import classnames from 'classnames';
 import React from 'react';
 import spritePath from 'social-logos/svg-sprite/social-logos.svg';
+import { Assign } from 'utility-types';
 
-interface Props extends React.SVGProps< SVGSVGElement > {
+interface Props {
 	icon: string;
 	size?: number;
 	onClick?: React.MouseEventHandler< SVGSVGElement >;
 	className?: string;
 }
 
-function SocialLogo( props: Props ) {
+function SocialLogo( props: Assign< React.SVGProps< SVGSVGElement >, Props > ) {
 	const { size = 24, icon, onClick, className, ...otherProps } = props;
 
 	// Using a missing icon doesn't produce any errors, just a blank icon, which is the exact intended behaviour.

--- a/client/components/social-logo/social-logos.d.ts
+++ b/client/components/social-logo/social-logos.d.ts
@@ -1,0 +1,4 @@
+declare module 'social-logos/svg-sprite/social-logos.svg' {
+	const def: string;
+	export = def;
+}

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 import React, { Fragment } from 'react';
 
 /**
@@ -26,7 +26,7 @@ const JETPACK_TOGGLE_SELECTOR = '.plugin-item-jetpack .form-toggle__switch';
 export const JetpackPluginUpdatesTour = makeTour(
 	<Tour
 		{ ...meta }
-		when={ state => {
+		when={ ( state: any ) => {
 			const site = getSelectedSite( state );
 			const res =
 				! PluginsStore.isFetchingSite( site ) && !! PluginsStore.getSitePlugin( site, 'jetpack' );

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -26,7 +26,7 @@ const JETPACK_TOGGLE_SELECTOR = '.plugin-item-jetpack .form-toggle__switch';
 export const JetpackPluginUpdatesTour = makeTour(
 	<Tour
 		{ ...meta }
-		when={ ( state: any ) => {
+		when={ state => {
 			const site = getSelectedSite( state );
 			const res =
 				! PluginsStore.isFetchingSite( site ) && !! PluginsStore.getSitePlugin( site, 'jetpack' );


### PR DESCRIPTION
This change adds types to `Gridicon`, `MaterialIcon`, and `SocialLogo`, since they're all similar in implementation.

Type definition files were also added for the external modules they depend on.

#### Changes proposed in this Pull Request

* Add type definitions to `Gridicon`, `MaterialIcon`, and `SocialLogo`.
* Add type definition files for the `gridicons`, `material-design-icons` and `social-logos` modules.
* In existing `.tsx` files, import `Gridicon` component directly from `components/gridicon`, rather than through webpack alias.

#### Testing instructions

These changes shouldn't need testing, as they deal exclusively with types and import aliases.