### PR TITLE
AB Test: Pro-rated credits banner copy

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -143,4 +143,14 @@ export default {
 		},
 		defaultVariation: 'siteType',
 	},
+	proratedCreditsBanner: {
+		//this test is used to dial down the upsell offer
+		datestamp: '20190626',
+		variations: {
+			control: 50,
+			variant: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -213,18 +213,31 @@ export class PlanFeatures extends Component {
 				icon="info-outline"
 				status="is-success"
 			>
-				{ translate(
-					'You have {{b}}%(amountInCurrency)s{{/b}} of pro-rated credits available from your current plan. ' +
-						'Apply those credits towards an upgrade before they expire!',
-					{
-						args: {
-							amountInCurrency: formatCurrency( planCredits, planProperties[ 0 ].currencyCode ),
-						},
-						components: {
-							b: <strong />,
-						},
-					}
-				) }
+				{ 'variant' === abtest( 'proratedCreditsBanner' )
+					? translate(
+							'Need to upgrade? You have {{b}}%(amountInCurrency)s{{/b}} pro-rated credits available from your current plan. ' +
+								'We have applied them to the plan upgrades below.',
+							{
+								args: {
+									amountInCurrency: formatCurrency( planCredits, planProperties[ 0 ].currencyCode ),
+								},
+								components: {
+									b: <strong />,
+								},
+							}
+					  )
+					: translate(
+							'You have {{b}}%(amountInCurrency)s{{/b}} of pro-rated credits available from your current plan. ' +
+								'Apply those credits towards an upgrade before they expire!',
+							{
+								args: {
+									amountInCurrency: formatCurrency( planCredits, planProperties[ 0 ].currencyCode ),
+								},
+								components: {
+									b: <strong />,
+								},
+							}
+					  ) }
 			</Notice>,
 			bannerContainer
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds an AB test to test a different copy in the Credits Banner for the Calypso Plans section. 
 More here: p8Eqe3-FT

#### Testing instructions

* Go to the Plans section within Calypso: https://wordpress.com/plans/[SITE]

* Put yourself in the "variant" group for the `proratedCreditBanner`test:
![image](https://user-images.githubusercontent.com/538790/60191710-0f5db980-9835-11e9-8977-66f954f5c0cd.png)

* Check that the Banner copy looks like the screenshot:
![image](https://user-images.githubusercontent.com/538790/60191750-200e2f80-9835-11e9-8a41-843961a795f0.png)

* Now put yourself in the Control group and check that the Banner copy looks like this:
![image](https://user-images.githubusercontent.com/538790/60191886-52b82800-9835-11e9-8493-0cf6daa10361.png)


