### PR TITLE
Tracks: Rename track events to match wp-admin and include dynamic factors as properties.

### DIFF
--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -45,18 +45,19 @@ class JetpackModuleToggle extends Component {
 
 	handleChange = () => {
 		if ( ! this.props.checked ) {
-			this.recordTracksEvent( 'calypso_jetpack_module_toggle_activated' );
+			this.recordTracksEvent( 'calypso_jetpack_module_toggle', 'on' );
 			this.props.activateModule( this.props.siteId, this.props.moduleSlug );
 		} else {
-			this.recordTracksEvent( 'calypso_jetpack_module_toggle_deactivated' );
+			this.recordTracksEvent( 'calypso_jetpack_module_toggle', 'off' );
 			this.props.deactivateModule( this.props.siteId, this.props.moduleSlug );
 		}
 	};
 
-	recordTracksEvent = name => {
+	recordTracksEvent = ( name, status ) => {
 		const tracksProps = {
 			module: this.props.moduleSlug,
 			path: this.props.path,
+			toggled: status,
 		};
 
 		this.props.recordTracksEvent( name, tracksProps );


### PR DESCRIPTION
This is part of an effort to reduce naming space of tracks events, and include dynamic data as part of properties.

This change unifies the naming and convention with the events fired for equivalent events within the wp-admin.

#### Changes proposed in this Pull Request

* Change `calypso_jetpack_module_toggle_activated` to `calypso_jetpack_module_toggle`, adding property `toggled` indicating the state of activation.

#### Testing instructions
Toggle any settings that activate/deactivate Jetpack modules and verify that the name of the event corresponds with the above, e.g. `sso` under `settings/security/` .