### PR TITLE
G Suite: Add notice for prorated additional licenses

### DIFF
--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -48,6 +48,7 @@ import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/ac
  * Style dependencies
  */
 import './style.scss';
+import GSuiteNewUser from '../../../components/gsuite/gsuite-new-user-list/new-user';
 
 class GSuiteAddUsers extends React.Component {
 	state = {
@@ -145,6 +146,62 @@ class GSuiteAddUsers extends React.Component {
 		page( emailManagement( this.props.selectedSite.slug, this.props.selectedDomainName ) );
 	};
 
+	renderProratedNotice() {
+		const { translate } = this.props;
+
+		// 1. Retrieve list of unique domains for the mailboxes about to be added
+		// 2. Retrieve extra license product (from productList)
+		// 3. Retrieve extra license product for each domain (with the prorated price)
+		// 4. Display notices only for domains where regular price <> prorated price
+
+		const accounts = [
+			{
+				domain: 'example.com',
+				fullPrice: '$72',
+				proratedPrice: '$22'
+			}
+		];
+
+		if (accounts.length === 0) {
+			return;
+		}
+
+
+		if (accounts.length === 1) {
+			return (
+				<Notice showDismiss={ false } icon="info-outline" status="is-success">
+					{ translate(
+						'You can purchase additional G Suite users at the pro-rated price of {{b}}%(proratedPrice)s{{/b}} per user. All your G Suite users will renew at the regular price of {{b}}%(fullPrice)s{{/b}} per user when your G Suite subscription renews.',
+						{
+							args: accounts[0],
+							components: {
+								b: <strong />
+							}
+						}
+					) }
+				</Notice>
+			);
+		}
+
+		return (
+			<Fragment>
+				{ accounts.map( ( account, index ) => (
+					<Notice key={ index } showDismiss={ false } icon="info-outline" status="is-success">
+						{ translate(
+							'You can purchase additional G Suite users for {{b}}%(domain)s{{/b}} at the pro-rated price of {{b}}%(proratedPrice)s{{/b}} per user. All your G Suite users from this account will renew at the regular price of {{b}}%(fullPrice)s{{/b}} per user when your G Suite subscription renews.',
+							{
+								args: accounts[index],
+								components: {
+									b: <strong />
+								}
+							}
+						) }
+					</Notice>
+				) ) }
+			</Fragment>
+		);
+	}
+
 	renderAddGSuite() {
 		const {
 			domains,
@@ -164,6 +221,8 @@ class GSuiteAddUsers extends React.Component {
 
 		return (
 			<Fragment>
+				{ this.renderProratedNotice() }
+
 				{ domainsWithForwards.length ? (
 					<Notice showDismiss={ false } status="is-warning">
 						{ translate(
@@ -181,8 +240,10 @@ class GSuiteAddUsers extends React.Component {
 				{ selectedDomainInfo.map( domain => {
 					return <QueryEmailForwards key={ domain.domain } domainName={ domain.domain } />;
 				} ) }
+
 				<SectionHeader label={ translate( 'Add G Suite' ) } />
 				{ gsuiteUsers && selectedDomainInfo && ! isRequestingDomains ? (
+
 					<Card>
 						<GSuiteNewUserList
 							extraValidation={ user => validateAgainstExistingUsers( user, gsuiteUsers ) }


### PR DESCRIPTION
This pull request adds a new notice on the `Add G Suite` page in order to explain users that the price of the mailboxes they are about to add is prorated. We indeed now price additional licenses according to the time left until the renewal of their G Suite subscription:

![screenshot](https://user-images.githubusercontent.com/594356/60196590-cd854100-983d-11e9-812e-56f88eb7faab.png)

#### Testing instructions

1. Run `git checkout update/show-gsuite-prorated-notice` and start your server, or open a [live branch](https://calypso.live/?branch=update/show-gsuite-prorated-notice)
2. Log in with a WordPress.com account with a site with G Suite
3. Open the [`Email` page](http://calypso.localhost:3000/email)
4. Click the `Add G Suite User` button
5. Assert that you see the new notice
6. Fill in the form, and click the `Continue` button
7. Notice that the price is indeed prorated in the shopping cart