### PR TITLE
Plans: Don't highlight plans as popular for Jetpack

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -478,9 +478,14 @@ export const getPopularPlanType = siteType => {
 };
 
 export const getPopularPlanSpec = ( { customerType, isJetpack, siteType, abtest } ) => {
+	// Jetpack doesn't currently highlight "Popular" plans
+	if ( isJetpack ) {
+		return false;
+	}
+
 	const spec = {
 		type: TYPE_BUSINESS,
-		group: isJetpack ? GROUP_JETPACK : GROUP_WPCOM,
+		group: GROUP_WPCOM,
 	};
 
 	// Not sure why, but things break if the abtest lib is imported in this file


### PR DESCRIPTION
As reported in Slack, more than one plan is showing as the "primary" call to action in the Jetpack plans list:

<img width="1021" alt="Screen Shot 2019-06-26 at 1 46 59 PM" src="https://user-images.githubusercontent.com/1587282/60202604-e8918a00-9818-11e9-8d79-b5cf2b790e93.png">

Plan "popularity" for Jetpack was inadvertently introduced in #33291 & the mechanism which determines which button is "primary" [hits](https://github.com/Automattic/wp-calypso/blob/94ef2624f932ba0afca91483ba73fa2b43a13132/client/my-sites/plan-features/index.jsx#L855-L860) when a plan is popular.

#### Changes proposed in this Pull Request

* Remove the notion of a "popular" plan in Jetpack

#### Testing instructions

* Run this branch
* Browse to `/jetpack/connect/plans/yourjetpacksitedomian.blog`
* You should see only one plan highlighted as the primary CTA