### PR TITLE
Checkout: Use black text instead of white on yellow

### DIFF
--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -156,7 +156,7 @@
 
 .purchase-detail__required-notice {
 	background-color: var( --color-warning );
-	color: var( --color-white );
+	color: var( --color-text );
 	font-size: 14px;
 	padding: 8px;
 	text-align: center;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the text color to black from white on the GSuite email warning message to meet WCAG AA color contrast standards.

**Before**

<img width="723" alt="Screen Shot 2019-06-26 at 3 05 07 PM" src="https://user-images.githubusercontent.com/2124984/60208169-a0c52f80-9825-11e9-8498-a4f636879727.png">

**After**

<img width="714" alt="Screen Shot 2019-06-26 at 3 16 21 PM" src="https://user-images.githubusercontent.com/2124984/60208174-a589e380-9825-11e9-8220-49cf3adbe5e4.png">

#### Testing instructions

* Switch to this PR 
* Purchase a .blog domain with GSuite (don't forget to cancel it afterwards!)
* Note the email confirmation message at checkout -- it should have black text on a yellow background instead of white text on a yellow background.

Fixes #32015
