### PR TITLE
Fix/fse template content parsing

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/save.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/save.js
@@ -6,4 +6,4 @@
 import { InnerBlocks } from '@wordpress/editor';
 
 const isTemplatePostType = 'wp_template' === fullSiteEditing.editorPostType;
-export default () => ( isTemplatePostType ? () => null : () => <InnerBlocks.Content /> );
+export default ( isTemplatePostType ? () => null : () => <InnerBlocks.Content /> );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -469,8 +469,21 @@ class Full_Site_Editing {
 
 		$template = new A8C_WP_Template( $post->ID );
 
-		$wrapped_post_content = sprintf( '<!-- wp:a8c/post-content -->%s<!-- /wp:a8c/post-content -->', $post->post_content );
-		$post->post_content   = str_replace( '<!-- wp:a8c/post-content {"align":"full"} /-->', $wrapped_post_content, $template->get_template_content() );
+		$parser = new WP_Block_Parser();
+		$template_content = $template->get_template_content();
+		$template_blocks = $parser->parse( $template_content );
+		$content_attrs = json_encode( $this->get_post_content_block_attrs( $template_blocks ) );
+
+		$wrapped_post_content = sprintf( '<!-- wp:a8c/post-content %s -->%s<!-- /wp:a8c/post-content -->', $content_attrs, $post->post_content );
+		$post->post_content   = str_replace( "<!-- wp:a8c/post-content $content_attrs /-->", $wrapped_post_content, $template_content );
+	}
+
+	private function get_post_content_block_attrs( $blocks ) {
+		foreach ( $blocks as $key => $value ) { 
+            if ( 'a8c/post-content' == $value['blockName'] ) {
+                return $value['attrs'];
+			}
+		}
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -474,7 +474,7 @@ class Full_Site_Editing {
 		$template_blocks  = $parser->parse( $template_content );
 		$content_attrs    = $this->get_post_content_block_attrs( $template_blocks );
 
-		// Bail if the post has no post content block.
+		// Bail if the template has no post content block.
 		if ( is_null( $content_attrs ) ) {
 			return;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -467,16 +467,16 @@ class Full_Site_Editing {
 			return;
 		}
 
-		$template = new A8C_WP_Template( $post->ID );
+		$template         = new A8C_WP_Template( $post->ID );
 		$template_content = $template->get_template_content();
-		
+
 		// Bail if the template has no post content block.
 		if ( ! has_block( 'a8c/post-content', $template_content ) ) {
-    		return;
+			return;
 		}
 
-		$template_blocks  = parse_blocks( $template_content );
-		$content_attrs    = $this->get_post_content_block_attrs( $template_blocks );
+		$template_blocks = parse_blocks( $template_content );
+		$content_attrs   = $this->get_post_content_block_attrs( $template_blocks );
 
 		$wrapped_post_content = sprintf( '<!-- wp:a8c/post-content %s -->%s<!-- /wp:a8c/post-content -->', $content_attrs, $post->post_content );
 		$post->post_content   = str_replace( "<!-- wp:a8c/post-content $content_attrs /-->", $wrapped_post_content, $template_content );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -472,7 +472,7 @@ class Full_Site_Editing {
 		$parser = new WP_Block_Parser();
 		$template_content = $template->get_template_content();
 		$template_blocks = $parser->parse( $template_content );
-		$content_attrs = json_encode( $this->get_post_content_block_attrs( $template_blocks ) );
+		$content_attrs = $this->get_post_content_block_attrs( $template_blocks );
 
 		$wrapped_post_content = sprintf( '<!-- wp:a8c/post-content %s -->%s<!-- /wp:a8c/post-content -->', $content_attrs, $post->post_content );
 		$post->post_content   = str_replace( "<!-- wp:a8c/post-content $content_attrs /-->", $wrapped_post_content, $template_content );
@@ -481,7 +481,7 @@ class Full_Site_Editing {
 	private function get_post_content_block_attrs( $blocks ) {
 		foreach ( $blocks as $key => $value ) { 
             if ( 'a8c/post-content' == $value['blockName'] ) {
-                return $value['attrs'];
+                return sizeof( $value['attrs'] ) > 0 ? json_encode( $value['attrs'] ) : '';
 			}
 		}
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -471,17 +471,28 @@ class Full_Site_Editing {
 
 		$parser = new WP_Block_Parser();
 		$template_content = $template->get_template_content();
-		$template_blocks = $parser->parse( $template_content );
-		$content_attrs = $this->get_post_content_block_attrs( $template_blocks );
+		$template_blocks  = $parser->parse( $template_content );
+		$content_attrs    = $this->get_post_content_block_attrs( $template_blocks );
+
+		// Bail if the post has no post content block.
+		if ( is_null( $content_attrs ) ) {
+			return;
+		}
 
 		$wrapped_post_content = sprintf( '<!-- wp:a8c/post-content %s -->%s<!-- /wp:a8c/post-content -->', $content_attrs, $post->post_content );
 		$post->post_content   = str_replace( "<!-- wp:a8c/post-content $content_attrs /-->", $wrapped_post_content, $template_content );
 	}
 
+	/**
+	 * This will extract the attributes from the post content block
+	 * json encode them.
+	 *
+	 * @param array $blocks    An array of template blocks.
+	 */
 	private function get_post_content_block_attrs( $blocks ) {
-		foreach ( $blocks as $key => $value ) { 
-            if ( 'a8c/post-content' == $value['blockName'] ) {
-                return sizeof( $value['attrs'] ) > 0 ? json_encode( $value['attrs'] ) : '';
+		foreach ( $blocks as $key => $value ) {
+			if ( 'a8c/post-content' === $value['blockName'] ) {
+				return count( $value['attrs'] ) > 0 ? wp_json_encode( $value['attrs'] ) : '';
 			}
 		}
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -468,16 +468,15 @@ class Full_Site_Editing {
 		}
 
 		$template = new A8C_WP_Template( $post->ID );
-
-		$parser = new WP_Block_Parser();
 		$template_content = $template->get_template_content();
-		$template_blocks  = $parser->parse( $template_content );
-		$content_attrs    = $this->get_post_content_block_attrs( $template_blocks );
-
+		
 		// Bail if the template has no post content block.
-		if ( is_null( $content_attrs ) ) {
-			return;
+		if ( ! has_block( 'a8c/post-content', $template_content ) ) {
+    		return;
 		}
+
+		$template_blocks  = parse_blocks( $template_content );
+		$content_attrs    = $this->get_post_content_block_attrs( $template_blocks );
 
 		$wrapped_post_content = sprintf( '<!-- wp:a8c/post-content %s -->%s<!-- /wp:a8c/post-content -->', $content_attrs, $post->post_content );
 		$post->post_content   = str_replace( "<!-- wp:a8c/post-content $content_attrs /-->", $wrapped_post_content, $template_content );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Modify the search and replace syntax to correctly insert post content into template and also apply the post content block attributes correctly. The previous fix #34289 was not applying these attributes to the inserted content block, and was also fragile if the attributes changed.

#### Testing instructions
- Check out branch and Install the FSE plugin, and activate it on local gutenberg dev
- Edit a page
- Note that the header and footer template appears, within the page editor.
- Note that the post content also appears between the header and footer.
- Edit the page again (with a refresh) and check that the post content still appears
<img width="535" alt="Screen Shot 2019-06-26 at 12 14 59 PM" src="https://user-images.githubusercontent.com/3629020/60142014-102e2580-980c-11e9-913b-8796e18022a7.png">

Fixes  #34243
