### PR TITLE
App Promo: Update a couple of the desktop app promo messages 

### DIFF
--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -31,7 +31,7 @@ const getRandomPromo = () => {
 		},
 		{
 			promoCode: 'a0002',
-			message: 'Get WordPress.com app for your desktop.',
+			message: 'Get the WordPress.com app for your desktop.',
 			type: 'desktop',
 		},
 		{
@@ -41,7 +41,7 @@ const getRandomPromo = () => {
 		},
 		{
 			promoCode: 'a0005',
-			message: 'WordPress.com at your fingertips — download app for desktop.',
+			message: 'Fast, distraction-free WordPress.com — download the desktop app.',
 			type: 'desktop',
 		},
 		{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Similar to #33913, this lightens up a couple of the desktop notices to sound more human. 
* Also removes references to the desktop app putting WordPress "at your fingertips" since this applies more to mobile. Uses copy by @benhuberman instead.

**Before**

<img width="265" alt="Screen Shot 2019-06-26 at 3 54 18 PM" src="https://user-images.githubusercontent.com/2124984/60210459-eafcdf80-982a-11e9-904f-b1c705ce7f0a.png">

<img width="269" alt="Screen Shot 2019-06-26 at 3 58 38 PM" src="https://user-images.githubusercontent.com/2124984/60210620-47f89580-982b-11e9-882d-2b9ea3951fb7.png">

**After**

<img width="267" alt="Screen Shot 2019-06-26 at 3 54 25 PM" src="https://user-images.githubusercontent.com/2124984/60210467-ef28fd00-982a-11e9-96d6-f4ff3200c88f.png">

<img width="267" alt="Screen Shot 2019-06-26 at 3 53 34 PM" src="https://user-images.githubusercontent.com/2124984/60210481-f8b26500-982a-11e9-8788-faac89a35931.png">

#### Testing instructions

* Switch to this PR and view the Reader
* App promo notices appear in the bottom left area of the sidebar nav. You may need to log in with an incognito window if you've dismissed them before.
* Refresh a few times to see the different messages; they're random.

Fixes #34053
