### PR TITLE
Stop treating subscriptions with expiring credit cards as if they have auto-renew turned off

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -135,10 +135,7 @@ function isExpired( purchase ) {
 }
 
 function isExpiring( purchase ) {
-	return includes(
-		[ 'cardExpired', 'cardExpiring', 'manualRenew', 'expiring' ],
-		purchase.expiryStatus
-	);
+	return includes( [ 'manualRenew', 'expiring' ], purchase.expiryStatus );
 }
 
 function isIncludedWithPlan( purchase ) {

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -16,7 +16,6 @@ import { times } from 'lodash';
 import config from 'config';
 import {
 	getName,
-	creditCardExpiresBeforeSubscription,
 	isExpired,
 	isExpiring,
 	isIncludedWithPlan,
@@ -110,7 +109,7 @@ class PurchaseMeta extends Component {
 	renderRenewsOrExpiresOnLabel() {
 		const { purchase, translate } = this.props;
 
-		if ( isExpiring( purchase ) || creditCardExpiresBeforeSubscription( purchase ) ) {
+		if ( isExpiring( purchase ) ) {
 			if ( isDomainRegistration( purchase ) ) {
 				return translate( 'Domain expires on' );
 			}
@@ -170,11 +169,7 @@ class PurchaseMeta extends Component {
 			);
 		}
 
-		if (
-			isExpiring( purchase ) ||
-			isExpired( purchase ) ||
-			creditCardExpiresBeforeSubscription( purchase )
-		) {
+		if ( isExpiring( purchase ) || isExpired( purchase ) ) {
 			return moment( purchase.expiryDate ).format( 'LL' );
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently when a subscription's credit card expires before the subscription does, Calypso will treat the subscription as if auto-renew is off.

This doesn't make sense, since auto-renew is still on, and auto-renewals will still be attempted.

This is mostly fixed via changes in the WordPress.com REST API (D29852-code) but requires some small Calypso changes also, basically to stop looking for obsolete expiration statuses that the API will no longer return, and to change some behavior where Calypso hardcodes showing the subscription expiration date (rather than the auto-renewal date) for an auto-renewing subscription whose payment method expires before the subscription does.

#### Testing instructions

This requires D29852-code to test also.

Buy a subscription using a test credit card with an expiration date earlier than the subscription's expiration.

Click around Calypso and note that on all pages (Manage Purchases, etc.) the subscription is displayed as auto-renewing (along with a message at the top of the subscription's Manage Purchase page which notes the expiring credit card). 

Below are screenshots of the main change.

Before:

![card-expires-before-plan-BEFORE](https://user-images.githubusercontent.com/235183/60212256-cacf1f80-982e-11e9-892a-c289a69c7c9f.png)

After:

![card-expires-before-plan-AFTER](https://user-images.githubusercontent.com/235183/60212257-cacf1f80-982e-11e9-9471-a1bd84cce572.png)