### PR TITLE
 Plans: Add some more test coverage on the plan selection functionality

### DIFF
--- a/client/lib/plans/test/get-popular-plan-spec.js
+++ b/client/lib/plans/test/get-popular-plan-spec.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/lib/plans/test/get-popular-plan-spec.js
+++ b/client/lib/plans/test/get-popular-plan-spec.js
@@ -1,0 +1,29 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { expect } from 'chai';
+
+/**
+ * Internal dependencies
+ */
+import { getPopularPlanSpec } from '..';
+import { TYPE_BUSINESS } from '../constants';
+
+describe( 'getPopularPlanSpec()', () => {
+	test( 'Should return biz for biz customer type', () => {
+		expect(
+			getPopularPlanSpec( {
+				customerType: 'business',
+			} )
+		).to.deep.equal( { type: TYPE_BUSINESS, group: 'GROUP_WPCOM' } );
+	} );
+	test( 'Should return false when isJetpack is true', () => {
+		expect(
+			getPopularPlanSpec( {
+				customerType: 'business',
+				isJetpack: true,
+			} )
+		).to.be.false;
+	} );
+} );

--- a/client/lib/plans/test/get-popular-plan-spec.js
+++ b/client/lib/plans/test/get-popular-plan-spec.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import { noop } from 'lodash';
 
 /**
@@ -14,7 +13,7 @@ const abtest = noop;
 
 describe( 'getPopularPlanSpec()', () => {
 	test( 'Should return biz for empty customer type', () => {
-		expect( getPopularPlanSpec( {} ) ).to.deep.equal( {
+		expect( getPopularPlanSpec( {} ) ).toEqual( {
 			type: TYPE_BUSINESS,
 			group: GROUP_WPCOM,
 		} );
@@ -25,7 +24,7 @@ describe( 'getPopularPlanSpec()', () => {
 			getPopularPlanSpec( {
 				customerType: 'personal',
 			} )
-		).to.deep.equal( {
+		).toEqual( {
 			type: TYPE_PREMIUM,
 			group: GROUP_WPCOM,
 		} );
@@ -37,7 +36,7 @@ describe( 'getPopularPlanSpec()', () => {
 				siteType: 'blog',
 				abtest,
 			} )
-		).to.deep.equal( {
+		).toEqual( {
 			type: TYPE_PERSONAL,
 			group: GROUP_WPCOM,
 		} );
@@ -49,7 +48,7 @@ describe( 'getPopularPlanSpec()', () => {
 				siteType: 'professional',
 				abtest,
 			} )
-		).to.deep.equal( {
+		).toEqual( {
 			type: TYPE_PREMIUM,
 			group: GROUP_WPCOM,
 		} );
@@ -60,7 +59,7 @@ describe( 'getPopularPlanSpec()', () => {
 			getPopularPlanSpec( {
 				customerType: 'business',
 			} )
-		).to.deep.equal( { type: TYPE_BUSINESS, group: GROUP_WPCOM } );
+		).toEqual( { type: TYPE_BUSINESS, group: GROUP_WPCOM } );
 	} );
 
 	test( 'Should return false when isJetpack is true', () => {
@@ -69,6 +68,6 @@ describe( 'getPopularPlanSpec()', () => {
 				customerType: 'business',
 				isJetpack: true,
 			} )
-		).to.be.false;
+		).toBe( false );
 	} );
 } );

--- a/client/lib/plans/test/get-popular-plan-spec.js
+++ b/client/lib/plans/test/get-popular-plan-spec.js
@@ -3,21 +3,67 @@
  * External dependencies
  */
 import { expect } from 'chai';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { getPopularPlanSpec } from '..';
-import { TYPE_BUSINESS } from '../constants';
+import { GROUP_WPCOM, TYPE_BUSINESS, TYPE_PERSONAL, TYPE_PREMIUM } from '../constants';
+
+const abtest = noop;
 
 describe( 'getPopularPlanSpec()', () => {
+	test( 'Should return biz for empty customer type', () => {
+		expect( getPopularPlanSpec( {} ) ).to.deep.equal( {
+			type: TYPE_BUSINESS,
+			group: GROUP_WPCOM,
+		} );
+	} );
+
+	test( 'Should return premium for personal customer type', () => {
+		expect(
+			getPopularPlanSpec( {
+				customerType: 'personal',
+			} )
+		).to.deep.equal( {
+			type: TYPE_PREMIUM,
+			group: GROUP_WPCOM,
+		} );
+	} );
+
+	test( 'Should return personal for blog site type', () => {
+		expect(
+			getPopularPlanSpec( {
+				siteType: 'blog',
+				abtest,
+			} )
+		).to.deep.equal( {
+			type: TYPE_PERSONAL,
+			group: GROUP_WPCOM,
+		} );
+	} );
+
+	test( 'Should return premium for professional site type', () => {
+		expect(
+			getPopularPlanSpec( {
+				siteType: 'professional',
+				abtest,
+			} )
+		).to.deep.equal( {
+			type: TYPE_PREMIUM,
+			group: GROUP_WPCOM,
+		} );
+	} );
+
 	test( 'Should return biz for biz customer type', () => {
 		expect(
 			getPopularPlanSpec( {
 				customerType: 'business',
 			} )
-		).to.deep.equal( { type: TYPE_BUSINESS, group: 'GROUP_WPCOM' } );
+		).to.deep.equal( { type: TYPE_BUSINESS, group: GROUP_WPCOM } );
 	} );
+
 	test( 'Should return false when isJetpack is true', () => {
 		expect(
 			getPopularPlanSpec( {

--- a/client/lib/plans/test/get-popular-plan-type.js
+++ b/client/lib/plans/test/get-popular-plan-type.js
@@ -1,9 +1,3 @@
-/** @format */
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-
 /**
  * Internal dependencies
  */
@@ -12,14 +6,14 @@ import { TYPE_BUSINESS, TYPE_PERSONAL, TYPE_PREMIUM } from '../constants';
 
 describe( 'getPopularPlanType()', () => {
 	test( 'Should return TYPE_PERSONAL for personal site type', () => {
-		expect( getPopularPlanType( 'blog' ) ).to.equal( TYPE_PERSONAL );
+		expect( getPopularPlanType( 'blog' ) ).toEqual( TYPE_PERSONAL );
 	} );
 
 	test( 'Should return TYPE_PREMIUM for business site type', () => {
-		expect( getPopularPlanType( 'professional' ) ).to.equal( TYPE_PREMIUM );
+		expect( getPopularPlanType( 'professional' ) ).toEqual( TYPE_PREMIUM );
 	} );
 
 	test( 'Should return TYPE_BUSINESS for business site type', () => {
-		expect( getPopularPlanType( 'business' ) ).to.equal( TYPE_BUSINESS );
+		expect( getPopularPlanType( 'business' ) ).toEqual( TYPE_BUSINESS );
 	} );
 } );

--- a/client/lib/plans/test/get-popular-plan-type.js
+++ b/client/lib/plans/test/get-popular-plan-type.js
@@ -6,14 +6,14 @@ import { TYPE_BUSINESS, TYPE_PERSONAL, TYPE_PREMIUM } from '../constants';
 
 describe( 'getPopularPlanType()', () => {
 	test( 'Should return TYPE_PERSONAL for personal site type', () => {
-		expect( getPopularPlanType( 'blog' ) ).toEqual( TYPE_PERSONAL );
+		expect( getPopularPlanType( 'blog' ) ).toBe( TYPE_PERSONAL );
 	} );
 
 	test( 'Should return TYPE_PREMIUM for business site type', () => {
-		expect( getPopularPlanType( 'professional' ) ).toEqual( TYPE_PREMIUM );
+		expect( getPopularPlanType( 'professional' ) ).toBe( TYPE_PREMIUM );
 	} );
 
 	test( 'Should return TYPE_BUSINESS for business site type', () => {
-		expect( getPopularPlanType( 'business' ) ).toEqual( TYPE_BUSINESS );
+		expect( getPopularPlanType( 'business' ) ).toBe( TYPE_BUSINESS );
 	} );
 } );

--- a/test/e2e/lib/driver-helper.js
+++ b/test/e2e/lib/driver-helper.js
@@ -218,6 +218,11 @@ export function clickIfPresent( driver, selector, attempts ) {
 	}
 }
 
+export async function getElementCount( driver, selector ) {
+	const elements = await driver.findElements( selector );
+	return elements.length || 0;
+}
+
 export async function isElementPresent( driver, selector ) {
 	const elements = await driver.findElements( selector );
 	return !! elements.length;

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -41,16 +41,33 @@ export default class PlansPage extends AsyncBaseContainer {
 	}
 
 	async onePrimaryButtonShown() {
+		const isMobile = currentScreenSize() === 'mobile';
+
 		if ( host === 'WPCOM' ) {
-			const selector =
-				currentScreenSize() === 'mobile'
-					? '.plan-features__mobile .plan-features__actions-button.is-primary'
-					: '.plan-features__table-item.is-top-buttons button.plan-features__actions-button.is-primary';
+			const selector = isMobile
+				? '.plan-features__mobile .plan-features__actions-button.is-primary'
+				: '.plan-features__table-item.is-top-buttons button.plan-features__actions-button.is-primary';
 			const count = await driverHelper.getElementCount( this.driver, by.css( selector ) );
 			return count === 1;
 		}
 
 		// Jetpack non-atomic (inside wp-admin)
+		if ( isMobile ) {
+			const isShowingMobileNotice = await driverHelper.isEventuallyPresentAndDisplayed(
+				this.driver,
+				by.css( '.plans-mobile-notice.dops-card' ),
+				500
+			);
+
+			const isShowingPlanFeaturesContent = await driverHelper.isEventuallyPresentAndDisplayed(
+				this.driver,
+				by.css( 'plan-features__content' ),
+				500
+			);
+
+			return isShowingMobileNotice && ! isShowingPlanFeaturesContent;
+		}
+
 		const selector = '.plan-features__table-item.is-top-buttons a.dops-button.is-primary';
 		const count = await driverHelper.getElementCount( this.driver, by.css( selector ) );
 		return count === 1;

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -41,12 +41,18 @@ export default class PlansPage extends AsyncBaseContainer {
 	}
 
 	async onePrimaryButtonShown() {
-		const selector =
-			currentScreenSize() === 'mobile'
-				? '.plan-features__mobile .plan-features__actions-button.is-primary'
-				: '.plan-features__table-item.is-top-buttons button.plan-features__actions-button.is-primary';
-		const count = await driverHelper.getElementCount( this.driver, by.css( selector ) );
+		if ( host === 'WPCOM' ) {
+			const selector =
+				currentScreenSize() === 'mobile'
+					? '.plan-features__mobile .plan-features__actions-button.is-primary'
+					: '.plan-features__table-item.is-top-buttons button.plan-features__actions-button.is-primary';
+			const count = await driverHelper.getElementCount( this.driver, by.css( selector ) );
+			return count === 1;
+		}
 
+		// Jetpack non-atomic (inside wp-admin)
+		const selector = '.plan-features__table-item.is-top-buttons a.dops-button.is-primary';
+		const count = await driverHelper.getElementCount( this.driver, by.css( selector ) );
 		return count === 1;
 	}
 

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -41,34 +41,10 @@ export default class PlansPage extends AsyncBaseContainer {
 	}
 
 	async onePrimaryButtonShown() {
-		const isMobile = currentScreenSize() === 'mobile';
-
-		if ( host === 'WPCOM' ) {
-			const selector = isMobile
+		const selector =
+			currentScreenSize() === 'mobile'
 				? '.plan-features__mobile .plan-features__actions-button.is-primary'
 				: '.plan-features__table-item.is-top-buttons button.plan-features__actions-button.is-primary';
-			const count = await driverHelper.getElementCount( this.driver, by.css( selector ) );
-			return count === 1;
-		}
-
-		// Jetpack non-atomic (inside wp-admin)
-		if ( isMobile ) {
-			const isShowingMobileNotice = await driverHelper.isEventuallyPresentAndDisplayed(
-				this.driver,
-				by.css( '.plans-mobile-notice.dops-card' ),
-				500
-			);
-
-			const isShowingPlanFeaturesContent = await driverHelper.isEventuallyPresentAndDisplayed(
-				this.driver,
-				by.css( 'plan-features__content' ),
-				500
-			);
-
-			return isShowingMobileNotice && ! isShowingPlanFeaturesContent;
-		}
-
-		const selector = '.plan-features__table-item.is-top-buttons a.dops-button.is-primary';
 		const count = await driverHelper.getElementCount( this.driver, by.css( selector ) );
 		return count === 1;
 	}

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -40,6 +40,26 @@ export default class PlansPage extends AsyncBaseContainer {
 		return await driverHelper.clickWhenClickable( this.driver, by.css( '.header-cake__back' ) );
 	}
 
+	async onePrimaryButtonShown() {
+		const count = await driverHelper.getElementCount(
+			this.driver,
+			by.css(
+				'.plan-features__table-item.is-top-buttons button.plan-features__actions-button.is-primary'
+			)
+		);
+
+		return count === 1;
+	}
+
+	async onePrimaryButtonShownForMobile() {
+		const count = await driverHelper.getElementCount(
+			this.driver,
+			by.css( '.plan-features__mobile .plan-features__actions-button.is-primary' )
+		);
+
+		return count === 1;
+	}
+
 	async confirmCurrentPlan( planName ) {
 		let selector = by.css( `.is-current.is-${ planName }-plan` );
 		if ( host !== 'WPCOM' ) {

--- a/test/e2e/lib/pages/plans-page.js
+++ b/test/e2e/lib/pages/plans-page.js
@@ -41,21 +41,11 @@ export default class PlansPage extends AsyncBaseContainer {
 	}
 
 	async onePrimaryButtonShown() {
-		const count = await driverHelper.getElementCount(
-			this.driver,
-			by.css(
-				'.plan-features__table-item.is-top-buttons button.plan-features__actions-button.is-primary'
-			)
-		);
-
-		return count === 1;
-	}
-
-	async onePrimaryButtonShownForMobile() {
-		const count = await driverHelper.getElementCount(
-			this.driver,
-			by.css( '.plan-features__mobile .plan-features__actions-button.is-primary' )
-		);
+		const selector =
+			currentScreenSize() === 'mobile'
+				? '.plan-features__mobile .plan-features__actions-button.is-primary'
+				: '.plan-features__table-item.is-top-buttons button.plan-features__actions-button.is-primary';
+		const count = await driverHelper.getElementCount( this.driver, by.css( selector ) );
 
 		return count === 1;
 	}

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -56,20 +56,20 @@ describe( `[${ host }] Plans: (${ screenSize }) @parallel @jetpack`, function() 
 			return await plansPage.waitForComparison();
 		} );
 
-		step( 'Can See Exactly One Primary CTA Button', async function() {
-			const plansPage = await PlansPage.Expect( driver );
-			return assert(
-				await plansPage.onePrimaryButtonShown(),
-				'Incorrect number of primary buttons'
-			);
-		} );
-
 		if ( host === 'WPCOM' ) {
 			step( 'Can Verify Current Plan', async function() {
 				const planName = 'premium';
 				const plansPage = await PlansPage.Expect( driver );
 				const present = await plansPage.confirmCurrentPlan( planName );
 				return assert( present, `Failed to detect correct plan (${ planName })` );
+			} );
+
+			step( 'Can See Exactly One Primary CTA Button', async function() {
+				const plansPage = await PlansPage.Expect( driver );
+				return assert(
+					await plansPage.onePrimaryButtonShown(),
+					'Incorrect number of primary buttons'
+				);
 			} );
 		} else {
 			step( 'Can Verify Current Plan', async function() {

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -56,6 +56,22 @@ describe( `[${ host }] Plans: (${ screenSize }) @parallel @jetpack`, function() 
 			return await plansPage.waitForComparison();
 		} );
 
+		step( 'Can See Exactly One Primary CTA Button', async function() {
+			const plansPage = await PlansPage.Expect( driver );
+			return assert(
+				await plansPage.onePrimaryButtonShown(),
+				'Incorrect number of primary buttons'
+			);
+		} );
+
+		step( 'Can See Exactly One Primary CTA Button for Mobile', async function() {
+			const plansPage = await PlansPage.Expect( driver );
+			return assert(
+				await plansPage.onePrimaryButtonShownForMobile(),
+				'Incorrect number of primary buttons'
+			);
+		} );
+
 		if ( host === 'WPCOM' ) {
 			step( 'Can Verify Current Plan', async function() {
 				const planName = 'premium';

--- a/test/e2e/specs/wp-plan-purchase-spec.js
+++ b/test/e2e/specs/wp-plan-purchase-spec.js
@@ -64,14 +64,6 @@ describe( `[${ host }] Plans: (${ screenSize }) @parallel @jetpack`, function() 
 			);
 		} );
 
-		step( 'Can See Exactly One Primary CTA Button for Mobile', async function() {
-			const plansPage = await PlansPage.Expect( driver );
-			return assert(
-				await plansPage.onePrimaryButtonShownForMobile(),
-				'Incorrect number of primary buttons'
-			);
-		} );
-
 		if ( host === 'WPCOM' ) {
 			step( 'Can Verify Current Plan', async function() {
 				const planName = 'premium';


### PR DESCRIPTION
Prevent something like #34312 from happening again :)

#### Changes proposed in this Pull Request

* e2e tests that make sure exactly one plan is displayed w/ a "primary" CTA button (on desktop & mobile resolutions)
* new driverHelper function `getElementCount` to help w/ the above
* unit tests for `getPopularPlanSpec` to:
  * prevent calling a plan 'popular' in jetpack
  * cover the rest of the code paths

#### Testing instructions

* Tests should be reasonable
* e2e test should pass
  * `./node_modules/.bin/mocha specs/wp-plan-purchase-spec.js`
* unit tests should pass
  * `npm run test-client client/lib/plans`