### PR TITLE
Launch Apple Pay to 100% of eligible users

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -115,16 +115,6 @@ export default {
 		defaultVariation: 'noOffer',
 		allowExistingUsers: true,
 	},
-	showApplePay: {
-		datestamp: '20190529',
-		variations: {
-			hide: 50,
-			show: 50,
-		},
-		defaultVariation: 'hide',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	hideDotBlogSubdomainsV2: {
 		datestamp: '20190626',
 		variations: {

--- a/client/lib/web-payment/index.js
+++ b/client/lib/web-payment/index.js
@@ -6,11 +6,6 @@
 import config from 'config';
 
 /**
- * Internal dependencies
- */
-import { abtest } from 'lib/abtest';
-
-/**
  * Web Payment method identifiers.
  */
 export const WEB_PAYMENT_BASIC_CARD_METHOD = 'basic-card';
@@ -59,7 +54,7 @@ export function isApplePayAvailable() {
  *                         if none can be detected.
  */
 export function detectWebPaymentMethod() {
-	if ( isApplePayAvailable() && abtest( 'showApplePay' ) === 'show' ) {
+	if ( isApplePayAvailable() ) {
 		return WEB_PAYMENT_APPLE_PAY_METHOD;
 	}
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -87,6 +87,7 @@ import { getProductsList, isProductsListFetching } from 'state/products-list/sel
 import QueryProducts from 'components/data/query-products-list';
 import { isRequestingSitePlans } from 'state/sites/plans/selectors';
 import { isRequestingPlans } from 'state/plans/selectors';
+import { isApplePayAvailable } from 'lib/web-payment';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import config from 'config';
@@ -192,6 +193,7 @@ export class Checkout extends React.Component {
 		analytics.tracks.recordEvent( 'calypso_checkout_page_view', {
 			saved_cards: props.cards.length,
 			is_renewal: hasRenewalItem( props.cart ),
+			apple_pay_available: isApplePayAvailable(),
 		} );
 
 		recordViewCheckout( props.cart );


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/33370 Apple Pay was enabled on production with a 50/50 A/B test.  We're now ready to end the A/B test and enable Apple Pay as a payment method for 100% of eligible users.

Because the A/B test is over, we no longer have a good way to identify (for analytics purposes) a population of users who see Apple Pay as a payment method.  As a result, this pull request also adds a new `apple_pay_available` property to the `calypso_checkout_page_view` tracks event, so we can distinguish users who view the checkout page and see Apple Pay as an available payment option there.