### PR TITLE
Full Site Editing: save/preview not preserving content.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/save.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/save.js
@@ -6,4 +6,4 @@
 import { InnerBlocks } from '@wordpress/editor';
 
 const isTemplatePostType = 'wp_template' === fullSiteEditing.editorPostType;
-export default () => ( isTemplatePostType ? () => null : () => <InnerBlocks.Content /> );
+export default ( isTemplatePostType ? () => null : () => <InnerBlocks.Content /> );


### PR DESCRIPTION
After #34214, with the introduction of the `save` import for the `a8c/post-content` block, a regression was also introduced, causing the editor to fail when saving the post content.

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/233601/60228683-dbe95200-9869-11e9-969c-37258fe2f117.gif) | ![after](https://user-images.githubusercontent.com/233601/60233819-5c16b400-9878-11e9-9fa7-8ac7661f2fac.gif) |

#### Changes proposed in this Pull Request

* The `save` property for `a8c/post-content` must be a function that returns either a `Component` or `null`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Edit a page.
* Click _Preview_ and verify that the content is displayed correctly.
* Make some modifications on the page.
* Click _Preview_ and verify that the content is displayed correctly.
* Click _Publish_ and verify that the content is saved.