### PR TITLE
Remove unused `onboarding-dev` signup flow

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -720,7 +720,7 @@ class SignupForm extends Component {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href={ logInUrl }>
-					{ [ 'onboarding' ].includes( flowName )
+					{ flowName === 'onboarding'
 						? translate( 'Log in to create a site for your existing account.' )
 						: translate( 'Already have a WordPress.com account?' ) }
 				</LoggedOutFormLinkItem>

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -720,7 +720,7 @@ class SignupForm extends Component {
 		return (
 			<LoggedOutFormLinks>
 				<LoggedOutFormLinkItem href={ logInUrl }>
-					{ [ 'onboarding', 'onboarding-dev' ].includes( flowName )
+					{ [ 'onboarding' ].includes( flowName )
 						? translate( 'Log in to create a site for your existing account.' )
 						: translate( 'Already have a WordPress.com account?' ) }
 				</LoggedOutFormLinkItem>

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -145,21 +145,6 @@ export function generateFlows( {
 			lastModified: '2019-04-30',
 		},
 
-		'onboarding-dev': {
-			steps: [
-				'user',
-				'site-type',
-				'site-topic-with-preview',
-				'site-title-with-preview',
-				'site-style-with-preview',
-				'domains-with-preview',
-				'plans',
-			],
-			destination: getChecklistDestination,
-			description: 'A temporary flow for holding under-development steps',
-			lastModified: '2019-04-30',
-		},
-
 		'delta-discover': {
 			steps: [ 'user' ],
 			destination: '/',

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -177,12 +177,7 @@ export class PlansStep extends Component {
 			siteSlug,
 		} = this.props;
 
-		let headerText = this.props.headerText || translate( "Pick a plan that's right for you." );
-
-		//Temporary header for onboarding-dev flow
-		if ( 'onboarding-dev' === flowName ) {
-			headerText = translate( 'Pick your plan' );
-		}
+		const headerText = this.props.headerText || translate( "Pick a plan that's right for you." );
 
 		const fallbackHeaderText = this.props.fallbackHeaderText || headerText;
 		const subHeaderText = this.props.subHeaderText;

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -141,7 +141,7 @@ export class UserStep extends Component {
 			subHeaderText = translate( 'Welcome to the WordPress.com community.' );
 		}
 
-		if ( positionInFlow === 0 && [ 'onboarding' ].includes( flowName ) ) {
+		if ( positionInFlow === 0 && flowName === 'onboarding' ) {
 			subHeaderText = translate( 'First, create your WordPress.com account.' );
 		}
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -139,12 +139,9 @@ export class UserStep extends Component {
 		} else if ( 1 === getFlowSteps( flowName ).length ) {
 			// Displays specific sub header if users only want to create an account, without a site
 			subHeaderText = translate( 'Welcome to the WordPress.com community.' );
-		} else if ( 'onboarding-dev' === flowName ) {
-			// Displays no sub header for onboarding-dev flow
-			subHeaderText = '';
 		}
 
-		if ( positionInFlow === 0 && [ 'onboarding', 'onboarding-dev' ].includes( flowName ) ) {
+		if ( positionInFlow === 0 && [ 'onboarding' ].includes( flowName ) ) {
 			subHeaderText = translate( 'First, create your WordPress.com account.' );
 		}
 
@@ -239,10 +236,6 @@ export class UserStep extends Component {
 				comment:
 					"'clientTitle' is the name of the app that uses WordPress.com Connect (e.g. 'Akismet' or 'VaultPress')",
 			} );
-		}
-
-		if ( 'onboarding-dev' === flowName ) {
-			return translate( 'Make something great' );
 		}
 
 		return headerText;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the `onboarding-dev` flow from signup as it is no longer used.

Further context: paObgF-hM-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to: http://calypso.localhost:3000/start/onboarding-dev
* You should be redirected to: http://calypso.localhost:3000/start/site-type
