### PR TITLE
Janitorial: Deprecate the `upgrades/removal-survey` feature flag

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -48,6 +48,10 @@ class CancelPurchaseForm extends React.Component {
 		translate: PropTypes.func,
 	};
 
+	static defaultProps = {
+		showSurvey: true,
+	};
+
 	constructor( props ) {
 		super( props );
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -12,7 +12,6 @@ import { getCurrencyDefaults } from '@automattic/format-currency';
 /**
  * Internal Dependencies
  */
-import config from 'config';
 import Button from 'components/button';
 import { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from 'lib/upgrades/actions';
 import { clearPurchases } from 'state/purchases/actions';
@@ -160,9 +159,7 @@ class CancelPurchaseButton extends Component {
 		};
 
 		let buttonsArr;
-		if ( ! config.isEnabled( 'upgrades/removal-survey' ) ) {
-			buttonsArr = [ buttons.close, buttons.cancel ];
-		} else if ( this.state.surveyStep === FINAL_STEP ) {
+		if ( this.state.surveyStep === FINAL_STEP ) {
 			buttonsArr = [ buttons.close, buttons.prev, buttons.cancel ];
 		} else {
 			buttonsArr =
@@ -184,7 +181,6 @@ class CancelPurchaseButton extends Component {
 					onInputChange={ this.onSurveyChange }
 					purchase={ purchase }
 					selectedSite={ selectedSite }
-					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
 					surveyStep={ this.state.surveyStep }
 				/>
 			</Dialog>
@@ -280,26 +276,24 @@ class CancelPurchaseButton extends Component {
 			submitting: true,
 		} );
 
-		if ( config.isEnabled( 'upgrades/removal-survey' ) ) {
-			const surveyData = {
-				'why-cancel': {
-					response: this.state.survey.questionOneRadio,
-					text: this.state.survey.questionOneText,
-				},
-				'next-adventure': {
-					response: this.state.survey.questionTwoRadio,
-					text: this.state.survey.questionTwoText,
-				},
-				'what-better': { text: this.state.survey.questionThreeText },
-				type: refundable ? 'refund' : 'cancel-autorenew',
-			};
+		const surveyData = {
+			'why-cancel': {
+				response: this.state.survey.questionOneRadio,
+				text: this.state.survey.questionOneText,
+			},
+			'next-adventure': {
+				response: this.state.survey.questionTwoRadio,
+				text: this.state.survey.questionTwoText,
+			},
+			'what-better': { text: this.state.survey.questionThreeText },
+			type: refundable ? 'refund' : 'cancel-autorenew',
+		};
 
-			submitSurvey(
-				'calypso-remove-purchase',
-				this.props.selectedSite.ID,
-				enrichedSurveyData( surveyData, moment(), selectedSite, purchase )
-			);
-		}
+		submitSurvey(
+			'calypso-remove-purchase',
+			this.props.selectedSite.ID,
+			enrichedSurveyData( surveyData, moment(), selectedSite, purchase )
+		);
 
 		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -165,11 +165,7 @@ class RemovePurchase extends Component {
 
 		const { isDomainOnlySite, purchase, site, translate } = this.props;
 
-		if (
-			! isDomainRegistration( purchase ) &&
-			! isGoogleApps( purchase ) &&
-			config.isEnabled( 'upgrades/removal-survey' )
-		) {
+		if ( ! isDomainRegistration( purchase ) && ! isGoogleApps( purchase ) ) {
 			const survey = wpcom
 				.marketing()
 				.survey( 'calypso-remove-purchase', this.props.purchase.siteId );
@@ -308,9 +304,7 @@ class RemovePurchase extends Component {
 		};
 
 		let buttonsArr;
-		if ( ! config.isEnabled( 'upgrades/removal-survey' ) ) {
-			buttonsArr = [ buttons.cancel, buttons.remove ];
-		} else if ( this.state.surveyStep === FINAL_STEP ) {
+		if ( this.state.surveyStep === FINAL_STEP ) {
 			buttonsArr = [ buttons.cancel, buttons.prev, buttons.remove ];
 		} else {
 			buttonsArr =
@@ -339,7 +333,6 @@ class RemovePurchase extends Component {
 					onInputChange={ this.onSurveyChange }
 					purchase={ purchase }
 					selectedSite={ site }
-					showSurvey={ config.isEnabled( 'upgrades/removal-survey' ) }
 					surveyStep={ this.state.surveyStep }
 				/>
 			</Dialog>

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -149,7 +149,6 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -99,7 +99,6 @@
 		"upgrades/premium-themes": true,
 		"upgrades/presale-chat": true,
 		"upgrades/wpcom-monthly-plans": true,
-		"upgrades/removal-survey": true,
 		"woocommerce/extension-dashboard": false,
 		"woocommerce/extension-orders": false,
 		"woocommerce/extension-orders-create": false,

--- a/config/development.json
+++ b/config/development.json
@@ -181,7 +181,6 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -114,7 +114,6 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -122,7 +122,6 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -129,7 +129,6 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -148,7 +148,6 @@
 		"upgrades/in-app-purchase": false,
 		"upgrades/redirect-payments": true,
 		"upgrades/premium-themes": true,
-		"upgrades/removal-survey": true,
 		"upgrades/precancellation-chat": true,
 		"upgrades/presale-chat": true,
 		"upgrades/wpcom-monthly-plans": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the `upgrades/removal-survey` feature flag, as it has been enabled for all the environments already. There shouldn't be any functional-wise change with this PR.

#### Testing instructions

1. Go to the purchase management page, http://calypso.localhost:3000/me/purchases/, and click on any plan subscription.
1. Click on the "Cancel subscription" and go through the subscription cancelling process. The survey should be there and works as expected.

