### PR TITLE
Replace FSE block save buttons with temporary fake setAttribute call

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { PlainText } from '@wordpress/editor';
-import { withNotices, Button } from '@wordpress/components';
+import { withNotices } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
@@ -19,18 +19,20 @@ function SiteDescriptionEdit( {
 	noticeOperations,
 	shouldUpdateSiteOption,
 	isSelected,
+	setAttributes,
 } ) {
 	const inititalDescription = __( 'Site description loading…' );
 
-	const { onSave, siteOptions, setSiteOptions } = useSiteOptions(
+	const { siteOptions, handleChange } = useSiteOptions(
 		'description',
 		inititalDescription,
 		noticeOperations,
 		isSelected,
-		shouldUpdateSiteOption
+		shouldUpdateSiteOption,
+		setAttributes
 	);
 
-	const { option, isDirty, isSaving } = siteOptions;
+	const { option } = siteOptions;
 
 	return (
 		<Fragment>
@@ -38,21 +40,10 @@ function SiteDescriptionEdit( {
 			<PlainText
 				className={ className }
 				value={ option }
-				onChange={ value => setSiteOptions( { ...siteOptions, option: value, isDirty: true } ) }
+				onChange={ value => handleChange( value ) }
 				placeholder={ __( 'Site Description' ) }
 				aria-label={ __( 'Site Description' ) }
 			/>
-			{ isDirty && (
-				<Button
-					isLarge
-					className="site-description__save-button"
-					disabled={ isSaving }
-					isBusy={ isSaving }
-					onClick={ onSave }
-				>
-					{ __( 'Save' ) }
-				</Button>
-			) }
 		</Fragment>
 	);
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
@@ -7,7 +7,7 @@ import classNames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withNotices, Button } from '@wordpress/components';
+import { withNotices } from '@wordpress/components';
 import { PlainText } from '@wordpress/editor';
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
@@ -24,17 +24,19 @@ function SiteTitleEdit( {
 	noticeOperations,
 	shouldUpdateSiteOption,
 	isSelected,
+	setAttributes,
 } ) {
 	const inititalTitle = __( 'Site title loading…' );
-	const { onSave, siteOptions, setSiteOptions } = useSiteOptions(
+	const { siteOptions, handleChange } = useSiteOptions(
 		'title',
 		inititalTitle,
 		noticeOperations,
 		isSelected,
-		shouldUpdateSiteOption
+		shouldUpdateSiteOption,
+		setAttributes
 	);
 
-	const { option, isDirty, isSaving } = siteOptions;
+	const { option } = siteOptions;
 
 	return (
 		<Fragment>
@@ -42,21 +44,10 @@ function SiteTitleEdit( {
 			<PlainText
 				className={ classNames( 'site-title', className ) }
 				value={ option }
-				onChange={ value => setSiteOptions( { ...siteOptions, option: value, isDirty: true } ) }
+				onChange={ value => handleChange( value ) }
 				placeholder={ __( 'Site Title' ) }
 				aria-label={ __( 'Site Title' ) }
 			/>
-			{ isDirty && (
-				<Button
-					isLarge
-					className="site-title__save-button"
-					disabled={ isSaving }
-					isBusy={ isSaving }
-					onClick={ onSave }
-				>
-					{ __( 'Save' ) }
-				</Button>
-			) }
 		</Fragment>
 	);
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/useSiteOptions.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/useSiteOptions.js
@@ -14,14 +14,13 @@ export default function useSiteOptions(
 	inititalOption,
 	noticeOperations,
 	isSelected,
-	shouldUpdateSiteOption
+	shouldUpdateSiteOption,
+	setAttributes
 ) {
 	const [ siteOptions, setSiteOptions ] = useState( {
 		option: inititalOption,
 		previousOption: '',
 		loaded: false,
-		isDirty: false,
-		isSaving: false,
 		error: false,
 	} );
 
@@ -76,17 +75,6 @@ export default function useSiteOptions(
 		}
 	}
 
-	function onSave() {
-		const { option, previousOption } = siteOptions;
-		const optionUnchanged = option && option.trim() === previousOption.trim();
-
-		if ( optionUnchanged ) {
-			setSiteOptions( { ...siteOptions, isDirty: false } );
-			return;
-		}
-		saveSiteOption( option );
-	}
-
 	function saveSiteOption( option ) {
 		setSiteOptions( { ...siteOptions, isSaving: true } );
 		apiFetch( { path: '/wp/v2/settings', method: 'POST', data: { [ siteOption ]: option } } )
@@ -114,5 +102,13 @@ export default function useSiteOptions(
 		} );
 	}
 
-	return { siteOptions, setSiteOptions, onSave };
+	function handleChange( value ) {
+		// The following is a temporary fix. Setting this fake attribute is used to flag
+		// the content as dirty to editor and enable Update/Publish button. This should be
+		// removed once updating of site options handled in core editor
+		setAttributes( { updated: Date.now() } );
+		setSiteOptions( { ...siteOptions, option: value } );
+	}
+
+	return { siteOptions, handleChange };
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the Site Description and Site Title FSE block save buttons and add a temporary setAttributes call to flag dirty state to editor to enable Update button to save changes

#### Testing instructions

* Load this branch in your FSE testing environment.
* Add a Site Description and Site Title block to a post
* Publish/Update the post
* Edit the Site Description block - check that the Update button becomes active again, then save
* Edit the Site Title block - check that the Update button becomes active again
![attributeUpdate](https://user-images.githubusercontent.com/3629020/60308478-0ab41500-999d-11e9-8c34-dd84ed62967e.gif)

Fixes #34287