### PR TITLE
Remove `private` and `name` signup flows

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -312,13 +312,6 @@ export function generateFlows( {
 		lastModified: '2017-01-19',
 	};
 
-	flows.private = {
-		steps: [ 'user', 'site' ],
-		destination: getChecklistDestination,
-		description: 'Test private site signup',
-		lastModified: '2018-10-22',
-	};
-
 	flows[ 'launch-site' ] = {
 		steps: [ 'domains-launch', 'plans-launch', 'launch' ],
 		destination: getSiteDestination,
@@ -358,13 +351,6 @@ export function generateFlows( {
 		lastModified: '2018-11-14',
 		disallowResume: true,
 		autoContinue: true,
-	};
-
-	flows.name = {
-		steps: [ 'displayname', 'about', 'domains', 'plans' ],
-		destination: getSiteDestination,
-		description: 'Ask for a display name not a user name',
-		lastModified: '2018-12-12',
 	};
 
 	flows[ 'plan-no-domain' ] = {


### PR DESCRIPTION
I can't find any instances where we're doing things based on either of these flow names, so this change is fairly simple.

#### Changes proposed in this Pull Request

* Remove `private` signup flow
* Remove `name` signup flow

Context: paObgF-hM-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open an Incognito browser window
* Go to: http://calypso.localhost:3000/start/private
* This should redirect to: http://calypso.localhost:3000/start/user
* Go to: http://calypso.localhost:3000/start/name
* This should redirect to: http://calypso.localhost:3000/start/user


