### PR TITLE
Gutenberg: Disable experimental blocks

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -25,6 +25,7 @@
 		"@wordpress/data": "4.4.0",
 		"@wordpress/blocks": "6.0.7",
 		"@wordpress/compose": "3.2.0",
+		"@wordpress/dom-ready": "2.4.0",
 		"@wordpress/editor": "9.2.2",
 		"@wordpress/hooks": "2.0.5",
 		"@wordpress/rich-text": "3.2.2",

--- a/apps/wpcom-block-editor/src/common/index.js
+++ b/apps/wpcom-block-editor/src/common/index.js
@@ -6,3 +6,4 @@ import './rich-text';
 import './switch-to-classic';
 import './style.scss';
 import './track-search';
+import './unregister-experimental-blocks';

--- a/apps/wpcom-block-editor/src/common/unregister-experimental-blocks.js
+++ b/apps/wpcom-block-editor/src/common/unregister-experimental-blocks.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { getBlockType, unregisterBlockType } from '@wordpress/blocks';
+import domReady from '@wordpress/dom-ready';
+
+const experimentalBlocks = [
+	'core/legacy-widget',
+	'core/navigation-menu',
+	'core/navigation-menu-item',
+];
+
+domReady( function() {
+	experimentalBlocks.forEach( blockName => {
+		const block = getBlockType( blockName );
+		if ( block ) {
+			unregisterBlockType( blockName );
+		}
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Disable all the experimental blocks since they don't work on WordPress.com sites.

![download](https://user-images.githubusercontent.com/10121835/60207087-c4cf4380-981a-11e9-9bbe-95a9dc467942.png)

As Gutenberg doesn't expose any way for turning them all off (that's currently a task in progress: WordPress/gutenberg#16318), we're just hardcoding the name of experimental blocks in the meantime. 

These blocks can be identified by those whore are registered behind a `process.env.GUTENBERG_PHASE === 2` check:

https://github.com/WordPress/gutenberg/blob/79d8dd90afa7a975d11a5236ccc9dddf7c58d946/packages/block-library/src/index.js#L107-L111

Note that the `core/navigation-menu` and `core/navigation-menu-item` blocks are not included in Gutenberg 5.8.0 (the version used in Simple sites).

#### Testing instructions

- Apply D29930-code and sandbox `widgets.wp.com`.
- Go to https://wordpress.com/block-editor and select your sandbox site.
- Click the add block button.
- Type "experimental" or "legacy" into the search box.
- Make sure the "Legacy Widget (Experimental)" block doesn't show up.

Fixes #34316
