### PR TITLE
Post Item: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -8,7 +8,6 @@
 
 @import 'layout/style';
 
-@import 'blocks/post-item/style';
 @import 'components/button/style';
 @import 'components/card/style';
 @import 'components/date-picker/style';

--- a/client/blocks/post-item/index.jsx
+++ b/client/blocks/post-item/index.jsx
@@ -41,6 +41,11 @@ import PostTypeSiteInfo from 'my-sites/post-type-list/post-type-site-info';
 import PostTypePostAuthor from 'my-sites/post-type-list/post-type-post-author';
 import { preload } from 'sections-helper';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 function preloadEditor() {
 	preload( 'post-editor' );
 }


### PR DESCRIPTION
Migrates the `PostItem` component in the post list, very straightforward.

**How to test:**
Check the styling of site's post list (beware that it's very different from page list):

<img width="726" alt="Screenshot 2019-06-28 at 09 04 37" src="https://user-images.githubusercontent.com/664258/60324014-e3048300-9983-11e9-8e34-e1313eebf9a7.png">

Also check that when the item has expanded "Share" section, the spacing around it is OK.
