### PR TITLE
Update canResume to only match against the current flowName

### DIFF
--- a/client/signup/test/fixtures/flows.js
+++ b/client/signup/test/fixtures/flows.js
@@ -19,4 +19,31 @@ export default {
 		steps: [ 'user', 'site' ],
 		destination: '/',
 	},
+
+	onboarding: {
+		steps: [
+			'user',
+			'site-type',
+			'site-topic-with-preview',
+			'site-title-with-preview',
+			'site-style-with-preview',
+			'domains-with-preview',
+			'plans',
+		],
+		destination: '/',
+	},
+
+	'disallow-resume': {
+		steps: [
+			'user',
+			'site-type',
+			'site-topic-with-preview',
+			'site-title-with-preview',
+			'site-style-with-preview',
+			'domains-with-preview',
+			'plans',
+		],
+		destination: '/',
+		disallowResume: true,
+	},
 };

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -13,6 +13,7 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import {
+	canResumeFlow,
 	getValueFromProgressStore,
 	getValidPath,
 	getStepName,
@@ -214,6 +215,36 @@ describe( 'utils', () => {
 		test( 'should return null if the field is not present', () => {
 			delete signupProgress[ 1 ].site;
 			assert.equal( getValueFromProgressStore( config ), null );
+		} );
+	} );
+
+	describe( 'canResumeFlow', () => {
+		test( 'should return true when given flow matches progress state', () => {
+			const signupProgress = [ { stepName: 'site-type', lastKnownFlow: 'onboarding' } ];
+			const canResume = canResumeFlow( 'onboarding', signupProgress );
+
+			expect( canResume ).toBe( true );
+		} );
+
+		test( 'should return false when given flow does not match progress state', () => {
+			const signupProgress = [ { stepName: 'site-type', lastKnownFlow: 'onboarding' } ];
+			const canResume = canResumeFlow( 'other', signupProgress );
+
+			expect( canResume ).toBe( false );
+		} );
+
+		test( 'should return false when flow sets disallowResume', () => {
+			const signupProgress = [ { stepName: 'site-type', lastKnownFlow: 'disallow-resume' } ];
+			const canResume = canResumeFlow( 'disallow-resume', signupProgress );
+
+			expect( canResume ).toBe( false );
+		} );
+
+		test( 'should return false when progress state is empty', () => {
+			const signupProgress = [];
+			const canResume = canResumeFlow( 'onboarding', signupProgress );
+
+			expect( canResume ).toBe( false );
 		} );
 	} );
 } );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -188,7 +188,10 @@ export function getDesignTypeForSiteGoals( siteGoals, flow ) {
 
 export function getFilteredSteps( flowName, progress ) {
 	const flow = flows.getFlow( flowName );
-	return filter( progress, step => includes( flow.steps, step.stepName ) );
+	return filter(
+		progress,
+		step => includes( flow.steps, step.stepName ) && step.lastKnownFlow === flowName
+	);
 }
 
 export function getFirstInvalidStep( flowName, progress ) {


### PR DESCRIPTION
This attempts to make `resumeProgress` less eager to resume the progress. In this change, progress should only resume if we're certain that the user is resuming the same flow that they were last on. Otherwise, they will start from the beginning of the flow again.

~***Note: This is a WIP PR to try out an approach for dealing with issue #34299***~

This PR is now ready for review.

#### Changes proposed in this Pull Request

* In `getFilteredSteps` only match a step if its `lastKnownFlow` matches the current `flowName`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

For these steps, select either the Business or Professional site types.

* Go to http://calypso.localhost:3000/start
* Complete steps up until the `domains-with-preview` step
* Go to http://calypso.localhost:3000/start
* It should resume you back to the `domains-with-preview` step
* Go to http://calypso.localhost:3000/start/premium
* It should take you to the `site-type` step.

