### PR TITLE
Add context to this label

### DIFF
--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -105,7 +105,7 @@ export class SiteNotice extends React.Component {
 		return (
 			<SidebarBanner
 				ctaName="free-to-paid-sidebar"
-				ctaText={ translate( 'Upgrade' ) }
+				ctaText={ translate( 'Upgrade', { context: 'Upgrade from one plan to another' } ) }
 				href={ '/plans/' + site.slug }
 				icon="info-outline"
 				text={ translate( 'Free domain with a plan' ) }


### PR DESCRIPTION
The word Upgrade in Bulgarian and perhaps in other languages have different translations for different meanings.

"Upgrade" is translated as Update the software to a newer version and the word is similar to "software update" while the meaning here is "go to a higher tier plan". The overall impression in Bulgarian left by this label is that something with my site is broken and I need to download a fix.

<img width="342" alt="Screenshot 2019-06-28 at 15 27 50" src="https://user-images.githubusercontent.com/82778/60342158-612f4c80-99b9-11e9-8c8a-504303de9d86.png">

#### Changes proposed in this Pull Request

Add context to a string

#### Testing instructions

Log in with a free site, make sure the text is there.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
