### PR TITLE
Signup: Have signup previews use Gutenberg styles from the API. (take 2)

### DIFF
--- a/client/components/signup-site-preview/component.jsx
+++ b/client/components/signup-site-preview/component.jsx
@@ -55,6 +55,7 @@ export class SignupSitePreview extends Component {
 		// The viewport device to show initially
 		defaultViewportDevice: PropTypes.oneOf( [ 'desktop', 'phone' ] ),
 		fontUrl: PropTypes.string,
+		gutenbergStylesUrl: PropTypes.string,
 		isRtl: PropTypes.bool,
 		langSlug: PropTypes.string,
 		// Iframe body content

--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -19,6 +19,7 @@ export default class SignupSitePreviewIframe extends Component {
 		// Iframe body content
 		content: PropTypes.object,
 		fontUrl: PropTypes.string,
+		gutenbergStylesUrl: PropTypes.string,
 		isRtl: PropTypes.bool,
 		langSlug: PropTypes.string,
 		onPreviewClick: PropTypes.func,
@@ -62,6 +63,7 @@ export default class SignupSitePreviewIframe extends Component {
 		if (
 			this.props.cssUrl !== nextProps.cssUrl ||
 			this.props.fontUrl !== nextProps.fontUrl ||
+			this.props.gutenbergStylesUrl !== nextProps.gutenbergStylesUrl ||
 			this.props.langSlug !== nextProps.langSlug ||
 			this.props.isRtl !== nextProps.isRtl
 		) {
@@ -143,7 +145,7 @@ export default class SignupSitePreviewIframe extends Component {
 		this.props.resize && this.setContainerHeight();
 	};
 
-	setIframeSource = ( { content, cssUrl, fontUrl, isRtl, langSlug } ) => {
+	setIframeSource = ( { content, cssUrl, fontUrl, gutenbergStylesUrl, isRtl, langSlug } ) => {
 		if ( ! this.iframe.current ) {
 			return;
 		}
@@ -152,6 +154,7 @@ export default class SignupSitePreviewIframe extends Component {
 			content,
 			cssUrl,
 			fontUrl,
+			gutenbergStylesUrl,
 			isRtl,
 			langSlug,
 			this.props.scrolling

--- a/client/components/signup-site-preview/utils.js
+++ b/client/components/signup-site-preview/utils.js
@@ -33,18 +33,20 @@ export function revokeObjectURL( objectUrl ) {
 /**
  * Returns a WordPress page shell HTML
  *
- * @param  {Object}  content   Object containing `title`, `tagline` and `body` strings
- * @param  {String}  cssUrl    A URL to the theme CSS file
- * @param  {String}  fontUrl   A URL to the font CSS file
- * @param  {Boolean} isRtl     If the current locale is a right-to-left language
- * @param  {String}  langSlug  The slug of the current locale
- * @param  {Boolean} scrolling Whether to allow scrolling on the body
- * @return {String}            The HTML source.
+ * @param  {Object}  content            Object containing `title`, `tagline` and `body` strings
+ * @param  {String}  cssUrl             A URL to the theme CSS file
+ * @param  {String}  fontUrl            A URL to the font CSS file
+ * @param  {String}  gutenbergStylesUrl A URL to the active Gutenberg plugin's main CSS file.
+ * @param  {Boolean} isRtl              If the current locale is a right-to-left language
+ * @param  {String}  langSlug           The slug of the current locale
+ * @param  {Boolean} scrolling          Whether to allow scrolling on the body
+ * @return {String}                     The HTML source.
  */
 export function getIframeSource(
 	content,
 	cssUrl,
 	fontUrl,
+	gutenbergStylesUrl,
 	isRtl = false,
 	langSlug = 'en',
 	scrolling = true
@@ -57,7 +59,7 @@ export function getIframeSource(
 			<link rel="dns-prefetch" href="//s0.wp.com">
 			<link rel="dns-prefetch" href="//fonts.googleapis.com">
 			<title>${ content.title } – ${ content.tagline }</title>
-			<link type="text/css" media="all" rel="stylesheet" href="https://s0.wp.com/wp-content/plugins/gutenberg-core/v5.8.0/build/block-library/style.css" />
+			${ getCSSLinkHtml( gutenbergStylesUrl ) }
 			${ getCSSLinkHtml( cssUrl ) }
 			${ getCSSLinkHtml( fontUrl ) }
 			<style type="text/css">

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -17,6 +17,7 @@ import SignupSitePreview from 'components/signup-site-preview';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import {
 	getSiteVerticalPreview,
+	getSiteVerticalPreviewStyles,
 	getSiteVerticalSlug,
 } from 'state/signup/steps/site-vertical/selectors';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
@@ -61,6 +62,7 @@ class SiteMockups extends Component {
 		title: PropTypes.string,
 		vertical: PropTypes.string,
 		verticalPreviewContent: PropTypes.string,
+		verticalPreviewStyles: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -70,6 +72,7 @@ class SiteMockups extends Component {
 		title: '',
 		vertical: '',
 		verticalPreviewContent: '',
+		verticalPreviewStyles: '',
 	};
 
 	shouldComponentUpdate( nextProps ) {
@@ -132,6 +135,7 @@ class SiteMockups extends Component {
 			title,
 			themeSlug,
 			verticalPreviewContent,
+			verticalPreviewStyles,
 		} = this.props;
 
 		const siteMockupClasses = classNames( 'site-mockup__wrap', {
@@ -148,6 +152,7 @@ class SiteMockups extends Component {
 				tagline: translate( 'You’ll be able to customize this to your needs.' ),
 				body: this.getContent( verticalPreviewContent ),
 			},
+			gutenbergStylesUrl: verticalPreviewStyles,
 			langSlug,
 			isRtl,
 			onPreviewClick: this.handlePreviewClick,
@@ -184,6 +189,7 @@ export default connect(
 			siteStyle,
 			siteType,
 			verticalPreviewContent: getSiteVerticalPreview( state ),
+			verticalPreviewStyles: getSiteVerticalPreviewStyles( state ),
 			verticalSlug: getSiteVerticalSlug( state ),
 			shouldShowHelpTip:
 				'site-topic-with-preview' === ownProps.stepName ||

--- a/client/state/signup/steps/site-vertical/selectors.js
+++ b/client/state/signup/steps/site-vertical/selectors.js
@@ -35,6 +35,7 @@ export function getSiteVerticalData( state ) {
 		isUserInputVertical: true,
 		parent: '',
 		preview: '',
+		previewStylesUrl: '',
 		siteType,
 		verticalId: '',
 		verticalName,
@@ -44,6 +45,10 @@ export function getSiteVerticalData( state ) {
 
 export function getSiteVerticalPreview( state ) {
 	return get( getSiteVerticalData( state ), 'preview', '' );
+}
+
+export function getSiteVerticalPreviewStyles( state ) {
+	return get( getSiteVerticalData( state ), 'previewStylesUrl', '' );
 }
 
 // TODO: All the following selectors will be updated to use getSiteVerticalData like getSiteVerticalPreview() does.

--- a/client/state/signup/steps/site-vertical/test/selectors.js
+++ b/client/state/signup/steps/site-vertical/test/selectors.js
@@ -118,6 +118,7 @@ describe( 'selectors', () => {
 			isUserInputVertical: true,
 			parent: '',
 			preview: '',
+			previewStylesUrl: '',
 			siteType: '',
 			verticalId: '',
 			verticalName: '',


### PR DESCRIPTION
_Take 2 of #34349, which I reverted as a precaution when I noticed "insecure content" errors on staging. That issue was fixed server-side in D29956-code. From the original PR:_

To avoid having to update client-side code every time the Gutenberg plugin gets updated on WordPress.com, this PR has the signup preview link to whatever preview styles URL is passed along with the verticals API call.

See: paAmJe-vu-p2

#### Testing instructions

* Apply this PR locally and start creating a new site at `http://calypso.localhost:3000/start/onboarding`.
* Select any site type other than "Blog" to have the site preview appear.
* In the preview iframe's `head`, verify a link tag to the current active Gutenberg plugin's styles (eg. `https://s0.wp.com/wp-content/plugins/gutenberg-core/v5.8.0/build/block-library/style.css`).
