### PR TITLE
Concierge: handle 2FA authorization

### DIFF
--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -44,8 +44,25 @@ export class ConciergeMain extends Component {
 
 		this.state = {
 			currentStep: 0,
+			reauthRequired: false,
 		};
 	}
+
+	componentDidMount() {
+		twoStepAuthorization.on( 'change', this.checkReauthRequired );
+		this.checkReauthRequired();
+	}
+
+	componentWillUnmount() {
+		twoStepAuthorization.off( 'change', this.checkReauthRequired );
+	}
+
+	checkReauthRequired = () => {
+		const reauthRequired = twoStepAuthorization.isReauthRequired();
+		if ( this.state.reauthRequired !== reauthRequired ) {
+			this.setState( { reauthRequired } );
+		}
+	};
 
 	goToPreviousStep = () => {
 		this.setState( { currentStep: this.state.currentStep - 1 } );
@@ -101,16 +118,18 @@ export class ConciergeMain extends Component {
 	render() {
 		const { analyticsPath, analyticsTitle, site } = this.props;
 		const siteId = site && site.ID;
-
+		const { reauthRequired } = this.state;
 		return (
 			<Main>
 				<PageViewTracker path={ analyticsPath } title={ analyticsTitle } />
-				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				<QueryUserSettings />
-				<QuerySites />
-				{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
-				{ siteId && <QuerySitePlans siteId={ siteId } /> }
-				{ this.getDisplayComponent() }
+				{ reauthRequired && <ReauthRequired twoStepAuthorization={ twoStepAuthorization } /> }
+				{ ! reauthRequired && [
+					<QueryUserSettings />,
+					<QuerySites />,
+					siteId && <QueryConciergeInitial siteId={ siteId } />,
+					siteId && <QuerySitePlans siteId={ siteId } />,
+					this.getDisplayComponent(),
+				] }
 			</Main>
 		);
 	}

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -116,22 +116,17 @@ export class ConciergeMain extends Component {
 	};
 
 	render() {
-		const { analyticsPath, analyticsTitle, site, ignoreReauth } = this.props;
+		const { analyticsPath, analyticsTitle, site } = this.props;
 		const siteId = site && site.ID;
-		const { reauthRequired } = this.state;
 		return (
 			<Main>
 				<PageViewTracker path={ analyticsPath } title={ analyticsTitle } />
-				{ ! ignoreReauth && <ReauthRequired twoStepAuthorization={ twoStepAuthorization } /> }
-				{ ( ignoreReauth || ! reauthRequired ) && (
-					<>
-						<QueryUserSettings />
-						<QuerySites />
-						{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
-						{ siteId && <QuerySitePlans siteId={ siteId } /> }
-						{ this.getDisplayComponent() }
-					</>
-				) }
+				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				<QueryUserSettings />
+				<QuerySites />
+				{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
+				{ siteId && <QuerySitePlans siteId={ siteId } /> }
+				{ this.getDisplayComponent() }
 			</Main>
 		);
 	}

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -37,6 +37,7 @@ import AppointmentInfo from './shared/appointment-info';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
+import { localize } from 'i18n-calypso';
 
 export class ConciergeMain extends Component {
 	constructor( props ) {
@@ -117,15 +118,20 @@ export class ConciergeMain extends Component {
 
 	render() {
 		const { analyticsPath, analyticsTitle, site } = this.props;
+		const { reauthRequired } = this.state;
 		const siteId = site && site.ID;
 		return (
 			<Main>
 				<PageViewTracker path={ analyticsPath } title={ analyticsTitle } />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				<QueryUserSettings />
-				<QuerySites />
-				{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
-				{ siteId && <QuerySitePlans siteId={ siteId } /> }
+				{ reauthRequired && (
+					<>
+						<QueryUserSettings />
+						<QuerySites />
+						{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
+						{ siteId && <QuerySitePlans siteId={ siteId } /> }
+					</>
+				) }
 				{ this.getDisplayComponent() }
 			</Main>
 		);
@@ -138,4 +144,5 @@ export default connect( ( state, props ) => ( {
 	site: getSite( state, props.siteSlug ),
 	scheduleId: getConciergeScheduleId( state ),
 	userSettings: getUserSettings( state ),
+	localize,
 } ) )( ConciergeMain );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -37,7 +37,6 @@ import AppointmentInfo from './shared/appointment-info';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import { localize } from 'i18n-calypso';
 
 export class ConciergeMain extends Component {
 	constructor( props ) {
@@ -124,7 +123,7 @@ export class ConciergeMain extends Component {
 			<Main>
 				<PageViewTracker path={ analyticsPath } title={ analyticsTitle } />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				{ reauthRequired && (
+				{ ! reauthRequired && (
 					<>
 						<QueryUserSettings />
 						<QuerySites />
@@ -144,5 +143,4 @@ export default connect( ( state, props ) => ( {
 	site: getSite( state, props.siteSlug ),
 	scheduleId: getConciergeScheduleId( state ),
 	userSettings: getUserSettings( state ),
-	localize,
 } ) )( ConciergeMain );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -35,6 +35,8 @@ import NoAvailableTimes from './shared/no-available-times';
 import Upsell from './shared/upsell';
 import AppointmentInfo from './shared/appointment-info';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import ReauthRequired from 'me/reauth-required';
+import twoStepAuthorization from 'lib/two-step-authorization';
 
 export class ConciergeMain extends Component {
 	constructor( props ) {
@@ -103,6 +105,7 @@ export class ConciergeMain extends Component {
 		return (
 			<Main>
 				<PageViewTracker path={ analyticsPath } title={ analyticsTitle } />
+				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<QueryUserSettings />
 				<QuerySites />
 				{ siteId && <QueryConciergeInitial siteId={ siteId } /> }

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -37,8 +37,6 @@ import AppointmentInfo from './shared/appointment-info';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
-import { localize } from 'i18n-calypso';
-import { withLocalizedMoment } from 'components/localized-moment';
 
 export class ConciergeMain extends Component {
 	constructor( props ) {
@@ -140,6 +138,4 @@ export default connect( ( state, props ) => ( {
 	site: getSite( state, props.siteSlug ),
 	scheduleId: getConciergeScheduleId( state ),
 	userSettings: getUserSettings( state ),
-	localize,
-	withLocalizedMoment,
 } ) )( ConciergeMain );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -116,14 +116,14 @@ export class ConciergeMain extends Component {
 	};
 
 	render() {
-		const { analyticsPath, analyticsTitle, site } = this.props;
+		const { analyticsPath, analyticsTitle, site, ignoreReauth } = this.props;
 		const siteId = site && site.ID;
 		const { reauthRequired } = this.state;
 		return (
 			<Main>
 				<PageViewTracker path={ analyticsPath } title={ analyticsTitle } />
-				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
-				{ ! reauthRequired && (
+				{ ! ignoreReauth && <ReauthRequired twoStepAuthorization={ twoStepAuthorization } /> }
+				{ ( ignoreReauth || ! reauthRequired ) && (
 					<>
 						<QueryUserSettings />
 						<QuerySites />

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -37,6 +37,8 @@ import AppointmentInfo from './shared/appointment-info';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import ReauthRequired from 'me/reauth-required';
 import twoStepAuthorization from 'lib/two-step-authorization';
+import { localize } from 'i18n-calypso';
+import { withLocalizedMoment } from 'components/localized-moment';
 
 export class ConciergeMain extends Component {
 	constructor( props ) {
@@ -138,4 +140,6 @@ export default connect( ( state, props ) => ( {
 	site: getSite( state, props.siteSlug ),
 	scheduleId: getConciergeScheduleId( state ),
 	userSettings: getUserSettings( state ),
+	localize,
+	withLocalizedMoment,
 } ) )( ConciergeMain );

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -122,14 +122,16 @@ export class ConciergeMain extends Component {
 		return (
 			<Main>
 				<PageViewTracker path={ analyticsPath } title={ analyticsTitle } />
-				{ reauthRequired && <ReauthRequired twoStepAuthorization={ twoStepAuthorization } /> }
-				{ ! reauthRequired && [
-					<QueryUserSettings />,
-					<QuerySites />,
-					siteId && <QueryConciergeInitial siteId={ siteId } />,
-					siteId && <QuerySitePlans siteId={ siteId } />,
-					this.getDisplayComponent(),
-				] }
+				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
+				{ ! reauthRequired && (
+					<>
+						<QueryUserSettings />
+						<QuerySites />
+						{ siteId && <QueryConciergeInitial siteId={ siteId } /> }
+						{ siteId && <QuerySitePlans siteId={ siteId } /> }
+						{ this.getDisplayComponent() }
+					</>
+				) }
 			</Main>
 		);
 	}

--- a/client/me/concierge/test/main.js
+++ b/client/me/concierge/test/main.js
@@ -46,7 +46,6 @@ const props = {
 	},
 	userSettings: {},
 	skeleton: 'Skeleton',
-	ignoreReauth: true,
 };
 
 describe( 'ConciergeMain basic tests', () => {

--- a/client/me/concierge/test/main.js
+++ b/client/me/concierge/test/main.js
@@ -17,6 +17,7 @@ jest.mock( 'i18n-calypso', () => ( {
 		/>
 	),
 	numberFormat: x => x,
+	translate: x => x,
 } ) );
 
 /**

--- a/client/me/concierge/test/main.js
+++ b/client/me/concierge/test/main.js
@@ -46,6 +46,7 @@ const props = {
 	},
 	userSettings: {},
 	skeleton: 'Skeleton',
+	ignoreReauth: true,
 };
 
 describe( 'ConciergeMain basic tests', () => {

--- a/client/me/concierge/test/main.js
+++ b/client/me/concierge/test/main.js
@@ -7,19 +7,6 @@ jest.mock( 'lib/abtest', () => ( {
 jest.mock( '../shared/upsell', () => 'Upsell' );
 jest.mock( '../shared/no-available-times', () => 'NoAvailableTimes' );
 
-jest.mock( 'i18n-calypso', () => ( {
-	localize: Comp => props => (
-		<Comp
-			{ ...props }
-			translate={ function( x ) {
-				return x;
-			} }
-		/>
-	),
-	numberFormat: x => x,
-	translate: x => x,
-} ) );
-
 /**
  * External dependencies
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As detailed in 581-GH-hg, expired 2FA token can prevent the signup form from rendering.
This patch reauthorizes the user before proceeding with Conceirge booking session.

#### Testing instructions

See test instructions in 581-GH-hg.

*

Fixes 581-GH-hg