### PR TITLE
Signup: load vertical data if necessary

### DIFF
--- a/client/components/data/query-verticals/index.jsx
+++ b/client/components/data/query-verticals/index.jsx
@@ -44,12 +44,12 @@ export class QueryVerticals extends Component {
 	};
 
 	componentDidMount() {
-		const { searchTerm = '', siteType, limit } = this.props;
+		const { searchTerm = '', siteType, limit, isFetched } = this.props;
 		const trimmedSearchTerm = searchTerm.trim();
 
 		this.debouncedRequest = this.bindDebouncedRequest();
 
-		if ( trimmedSearchTerm ) {
+		if ( ! isFetched && trimmedSearchTerm ) {
 			this.debouncedRequest( trimmedSearchTerm, siteType, limit );
 		}
 	}

--- a/client/components/data/query-verticals/test/index.js
+++ b/client/components/data/query-verticals/test/index.js
@@ -34,7 +34,15 @@ describe( 'QueryVerticals', () => {
 		expect( requestVerticals ).not.toHaveBeenCalled();
 	} );
 
-	test( 'should call request on update if isFetched is false.', () => {
+	test( 'should not call request on mount if a matching fetched result is found in state.', () => {
+		const requestVerticals = jest.fn();
+
+		shallow( <QueryVerticals requestVerticals={ requestVerticals } isFetched={ true } /> );
+
+		expect( requestVerticals ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should call request on update if no matching fetched result is found in state.', () => {
 		const requestVerticals = jest.fn();
 
 		const wrapped = shallow( <QueryVerticals requestVerticals={ requestVerticals } /> );
@@ -55,7 +63,7 @@ describe( 'QueryVerticals', () => {
 		);
 	} );
 
-	test( 'should not call request on update if isFetched is true.', () => {
+	test( 'should not call request on update if a matching fetched result is found in state.', () => {
 		const requestVerticals = jest.fn();
 
 		const wrapped = shallow( <QueryVerticals requestVerticals={ requestVerticals } /> );

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -16,6 +16,7 @@ import { translate } from 'i18n-calypso';
 import SignupSitePreview from 'components/signup-site-preview';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import {
+	getSiteVerticalName,
 	getSiteVerticalPreview,
 	getSiteVerticalPreviewStyles,
 	getSiteVerticalSlug,
@@ -26,6 +27,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { getLocaleSlug, getLanguage } from 'lib/i18n-utils';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import QueryVerticals from 'components/data/query-verticals';
 
 /**
  * Style dependencies
@@ -129,9 +131,11 @@ class SiteMockups extends Component {
 	render() {
 		const {
 			fontUrl,
+			shouldFetchVerticalData,
 			shouldShowHelpTip,
 			siteStyle,
 			siteType,
+			siteVerticalName,
 			title,
 			themeSlug,
 			verticalPreviewContent,
@@ -172,6 +176,9 @@ class SiteMockups extends Component {
 					<SignupSitePreview defaultViewportDevice="phone" { ...otherProps } />
 				</div>
 				{ shouldShowHelpTip && <SiteMockupHelpTipBottom siteType={ siteType } /> }
+				{ shouldFetchVerticalData && (
+					<QueryVerticals searchTerm={ siteVerticalName } siteType={ siteType } />
+				) }
 			</div>
 		);
 	}
@@ -184,18 +191,22 @@ export default connect(
 		const styleOptions = getSiteStyleOptions( siteType );
 		const style = find( styleOptions, { id: siteStyle || 'modern' } );
 		const titleFallback = getSiteTypePropertyValue( 'slug', siteType, 'siteMockupTitleFallback' );
+		const verticalPreviewContent = getSiteVerticalPreview( state );
+		const shouldFetchVerticalData = ! verticalPreviewContent;
 		return {
 			title: getSiteTitle( state ) || titleFallback,
 			siteStyle,
 			siteType,
-			verticalPreviewContent: getSiteVerticalPreview( state ),
+			verticalPreviewContent,
 			verticalPreviewStyles: getSiteVerticalPreviewStyles( state ),
+			siteVerticalName: getSiteVerticalName( state ),
 			verticalSlug: getSiteVerticalSlug( state ),
 			shouldShowHelpTip:
 				'site-topic-with-preview' === ownProps.stepName ||
 				'site-title-with-preview' === ownProps.stepName,
 			themeSlug: style.theme,
 			fontUrl: style.fontUrl,
+			shouldFetchVerticalData,
 		};
 	},
 	{

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -15,16 +15,11 @@ import StepWrapper from 'signup/step-wrapper';
 import Button from 'components/button';
 import FormTextInput from 'components/forms/form-text-input';
 import FormFieldset from 'components/forms/form-fieldset';
-import QueryVerticals from 'components/data/query-verticals';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { setSiteTitle } from 'state/signup/steps/site-title/actions';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
-import {
-	getSiteVerticalName,
-	getSiteVerticalPreview,
-} from 'state/signup/steps/site-vertical/selectors';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 
 /**
@@ -67,15 +62,12 @@ class SiteTitleStep extends Component {
 	};
 
 	renderSiteTitleStep = () => {
-		const { shouldFetchVerticalData, siteTitle, siteType, siteVerticalName } = this.props;
+		const { siteTitle, siteType } = this.props;
 		const fieldLabel = getSiteTypePropertyValue( 'slug', siteType, 'siteTitleLabel' ) || '';
 		const fieldPlaceholder =
 			getSiteTypePropertyValue( 'slug', siteType, 'siteTitlePlaceholder' ) || '';
 		return (
 			<div className="site-title__wrapper">
-				{ shouldFetchVerticalData && (
-					<QueryVerticals searchTerm={ siteVerticalName } siteType={ siteType } />
-				) }
 				<form>
 					<div className="site-title__field-control site-title__title">
 						<FormFieldset>
@@ -131,19 +123,10 @@ class SiteTitleStep extends Component {
 }
 
 export default connect(
-	( state, ownProps ) => {
-		const siteType = getSiteType( state );
-		const shouldFetchVerticalData =
-			ownProps.showSiteMockups &&
-			ownProps.flowName === 'onboarding' &&
-			getSiteVerticalPreview( state ) === '';
-		return {
-			siteTitle: getSiteTitle( state ),
-			siteVerticalName: getSiteVerticalName( state ),
-			shouldFetchVerticalData,
-			siteType,
-		};
-	},
+	state => ( {
+		siteTitle: getSiteTitle( state ),
+		siteType: getSiteType( state ),
+	} ),
 	{
 		recordTracksEvent,
 		setSiteTitle,


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR does two things. It:

1. shifts the burden of loading vertical preview data on page reload to `<SiteMockup />`. Previously we were doing this only in `<SiteTitleStep />`. The grounds for performing the check in `<SiteMockup />` is that it removes the need to test for a compatible flow and presence of a `showSiteMockups` props. 
2. ensures that `<QueryVerticals />` doesn't trigger a vertical search on `componentDidMount` if we've already fetched the results elsewhere.

## Testing instructions

1. Visit http://calypso.localhost:3000/start/onboarding
2. For any site type (Blog/Business/Professional) continue on a flow until you reach the site title step.  Notice that `/vertical` has been requested in the network tab of dev tools.
3. Return to the site topic step. `/vertical` should not be called again until you search for a new vertical.
4. Now select a site type of Business or Professional (the two that show the site preview for now)
5. Carry on to the site style or domains with preview step. Either is fine. You decide. Really, it's up to you.
6. Enter http://calypso.localhost:3000/start in your address bar and go! When returning to the previously-unfinished step, the site mockup should load with your chosen vertical.
