### PR TITLE
Fix simple scss lint warnings

### DIFF
--- a/client/components/happychat/title.scss
+++ b/client/components/happychat/title.scss
@@ -18,5 +18,5 @@
 
 	svg {
 		display: block;
-	} 
+	}
 }

--- a/client/components/language-picker/modal.scss
+++ b/client/components/language-picker/modal.scss
@@ -43,11 +43,11 @@
 		flex: none;
 		margin-bottom: 0;
 		z-index: 10;
-		
+
 		@include breakpoint( '<660px' ) {
 			.search.has-focus {
 				margin: 0 4px;
-				width: calc(100% - 8px);
+				width: calc( 100% - 8px );
 			}
 		}
 	}


### PR DESCRIPTION
`npm run lint` now shows even more issues because the css lint (which runs first) is no longer hiding them.
