### PR TITLE
Remove unused `store-woo` signup flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -270,13 +270,6 @@ export function generateFlows( {
 			description: 'Signup flow for creating an online store with an Atomic site',
 			lastModified: '2018-11-21',
 		};
-
-		flows[ 'store-woo' ] = {
-			steps: [ 'domains-store', 'plans-store-nux', 'user' ],
-			destination: getSiteDestination,
-			description: 'Short signup flow for creating an online store with an Atomic site',
-			lastModified: '2018-03-15',
-		};
 	}
 
 	if ( config.isEnabled( 'signup/wpcc' ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `store-woo` sign up flow

This sign up flow (`store-woo`) used to be used in the WooCommerce.com onboarding if a user selects that they want hosting. That flow now directs to: https://wordpress.com/start/ecommerce/?aff=6393

paObgF-hM-p2#comment-681

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In an Incognito browser window, go to:
* Go to: http://calypso.localhost:3000/start/store-woo
* This should redirect you to: http://calypso.localhost:3000/start/user (or if you are already logged in: http://calypso.localhost:3000/start/site-type )
