### PR TITLE
Rewind credentials: Hint to LastPass not to autocomplete

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -213,6 +213,8 @@ export class RewindCredentialsForm extends Component {
 							onChange={ this.handleFieldChange }
 							disabled={ formIsSubmitting }
 							isError={ !! formErrors.user }
+							// Hint to LastPass not to attempt autofill
+							data-lpignore="true"
 						/>
 						{ formErrors.user && <FormInputValidation isError={ true } text={ formErrors.user } /> }
 					</FormFieldset>
@@ -229,6 +231,8 @@ export class RewindCredentialsForm extends Component {
 							onChange={ this.handleFieldChange }
 							disabled={ formIsSubmitting }
 							isError={ !! formErrors.pass }
+							// Hint to LastPass not to attempt autofill
+							data-lpignore="true"
 						/>
 						{ formErrors.pass && <FormInputValidation isError={ true } text={ formErrors.pass } /> }
 					</FormFieldset>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

**Before** (note the LastPass icon in username/password inputs)

<img width="1000" alt="Screenshot 2019-07-01 at 12 27 48" src="https://user-images.githubusercontent.com/7767559/60433134-f4f05b00-9bfb-11e9-8412-7fadcae96fd6.png">

**After**

<img width="1015" alt="Screenshot 2019-07-01 at 12 29 49" src="https://user-images.githubusercontent.com/7767559/60433138-f7eb4b80-9bfb-11e9-821e-4d60e3ca0182.png">

Fixes https://github.com/Automattic/jetpack/issues/12893, preventing LastPass from attempting to autocomplete Rewind server credentials using unrelated WordPress.com login info.

Using `data-lpignore="true"` instead of `autocomplete="new-password"`, which needs an option set in LastPass to prevent autocomplete.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install LastPass browser extension
* Log into WordPress.com and allow LastPass to save the login
* On this branch, go to http://calypso.localhost:3000/start/rewind-setup/rewind-form-creds
* Ensure LastPass does not attempt to autofill the server username and password



