### PR TITLE
Hook up the rewind fixers on the AL UI

### DIFF
--- a/client/my-sites/activity/activity-log/rewind-alerts.jsx
+++ b/client/my-sites/activity/activity-log/rewind-alerts.jsx
@@ -18,16 +18,29 @@ import { requestSiteAlerts } from 'state/data-getters';
  */
 import './rewind-alerts.scss';
 
-const refreshList = () => {
-	//TODO: REFRESH LIST HERE!
-};
-
 export class RewindAlerts extends Component {
+	refreshList() {
+		//console.log("refreshing!");
+		//console.log("this.state BEFORE:", this.state);
+
+		this.setState( {} );
+	}
+
 	render() {
-		const { siteId, alerts, translate } = this.props;
+		//console.log("RENDERING LIST!!!");
+		//console.log("this.state", this.state);
+
+		const { siteId, translate, alerts } = this.props;
+
+		//console.log("siteId", siteId);
+		//console.log("alerts:", alerts);
+
 		if ( ! alerts || ! alerts.threats || alerts.threats.length === 0 ) {
+			//console.log("A1");
 			return null;
 		}
+
+		//console.log("B1");
 
 		return (
 			<Card className="activity-log__threats" highlight="error">
@@ -35,12 +48,7 @@ export class RewindAlerts extends Component {
 					{ translate( 'These items require your immediate attention' ) }
 				</div>
 				{ alerts.threats.map( threat => (
-					<ThreatAlert
-						siteId={ siteId }
-						key={ threat.id }
-						threat={ threat }
-						refreshList={ refreshList }
-					/>
+					<ThreatAlert siteId={ siteId } key={ threat.id } threat={ threat } parentList={ this } />
 				) ) }
 			</Card>
 		);

--- a/client/my-sites/activity/activity-log/rewind-alerts.jsx
+++ b/client/my-sites/activity/activity-log/rewind-alerts.jsx
@@ -2,9 +2,9 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { useTranslate } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -18,27 +18,37 @@ import { requestSiteAlerts } from 'state/data-getters';
  */
 import './rewind-alerts.scss';
 
-function RewindAlerts( { alerts } ) {
-	const translate = useTranslate();
+const refreshList = () => {
+	//TODO: REFRESH LIST HERE!
+};
 
-	if ( ! alerts || ! alerts.threats || alerts.threats.length === 0 ) {
-		return null;
+export class RewindAlerts extends Component {
+	render() {
+		const { siteId, alerts, translate } = this.props;
+		if ( ! alerts || ! alerts.threats || alerts.threats.length === 0 ) {
+			return null;
+		}
+
+		return (
+			<Card className="activity-log__threats" highlight="error">
+				<div className="activity-log__threats-heading">
+					{ translate( 'These items require your immediate attention' ) }
+				</div>
+				{ alerts.threats.map( threat => (
+					<ThreatAlert
+						siteId={ siteId }
+						key={ threat.id }
+						threat={ threat }
+						refreshList={ refreshList }
+					/>
+				) ) }
+			</Card>
+		);
 	}
-
-	return (
-		<Card className="activity-log__threats" highlight="error">
-			<div className="activity-log__threats-heading">
-				{ translate( 'These items require your immediate attention' ) }
-			</div>
-			{ alerts.threats.map( threat => (
-				<ThreatAlert key={ threat.id } threat={ threat } />
-			) ) }
-		</Card>
-	);
 }
 
 const mapStateToProps = ( state, { siteId } ) => ( {
 	alerts: requestSiteAlerts( siteId ).data,
 } );
 
-export default connect( mapStateToProps )( RewindAlerts );
+export default connect( mapStateToProps )( localize( RewindAlerts ) );

--- a/client/my-sites/activity/activity-log/rewind-alerts.jsx
+++ b/client/my-sites/activity/activity-log/rewind-alerts.jsx
@@ -18,29 +18,20 @@ import { requestSiteAlerts } from 'state/data-getters';
  */
 import './rewind-alerts.scss';
 
+let refreshFlag = false;
+
 export class RewindAlerts extends Component {
 	refreshList() {
-		//console.log("refreshing!");
-		//console.log("this.state BEFORE:", this.state);
-
+		refreshFlag = true;
 		this.setState( {} );
 	}
 
 	render() {
-		//console.log("RENDERING LIST!!!");
-		//console.log("this.state", this.state);
-
 		const { siteId, translate, alerts } = this.props;
 
-		//console.log("siteId", siteId);
-		//console.log("alerts:", alerts);
-
 		if ( ! alerts || ! alerts.threats || alerts.threats.length === 0 ) {
-			//console.log("A1");
 			return null;
 		}
-
-		//console.log("B1");
 
 		return (
 			<Card className="activity-log__threats" highlight="error">
@@ -55,8 +46,14 @@ export class RewindAlerts extends Component {
 	}
 }
 
+const requestStuff = siteId => {
+	const output = requestSiteAlerts( siteId, refreshFlag ).data;
+	refreshFlag = false;
+	return output;
+};
+
 const mapStateToProps = ( state, { siteId } ) => ( {
-	alerts: requestSiteAlerts( siteId ).data,
+	alerts: requestStuff( siteId ),
 } );
 
 export default connect( mapStateToProps )( localize( RewindAlerts ) );

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -192,7 +192,7 @@ export class ThreatAlert extends Component {
 	};
 
 	checkFixStatus = () => {
-		const { threat, siteId, refreshList } = this.props;
+		const { threat, siteId, parentList } = this.props;
 		const self = this;
 
 		if ( ! self.timerId ) {
@@ -216,9 +216,8 @@ export class ThreatAlert extends Component {
 						return;
 					}
 					if ( 'fixed' === data.status || 'not_started' === data.status ) {
-						this.enableButton( threat.id, true );
 						clearInterval( self.timerId );
-						refreshList();
+						parentList.refreshList();
 					} else {
 						//status in_progress
 					}

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -184,6 +184,11 @@ export class ThreatAlert extends Component {
 						//TODO: error handling?
 						return;
 					}
+
+					if ( ! fix ) {
+						//TODO: replace this with a Calypso notice
+						//console.log( 'The issue was ignored!' );
+					}
 					this.checkFixStatus();
 				},
 				freshness: -Infinity,
@@ -218,6 +223,10 @@ export class ThreatAlert extends Component {
 					if ( 'fixed' === data.status || 'not_started' === data.status ) {
 						clearInterval( self.timerId );
 						parentList.refreshList();
+						if ( 'fixed' === data.status ) {
+							//TODO: replace this with a Calypso notice
+							//console.log( 'The issue was fixed!' );
+						}
 					} else {
 						//status in_progress
 					}

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -101,8 +101,9 @@ export const requestGeoLocation = () =>
 		{ fromApi: () => ( { body: { country_short } } ) => [ [ 'geo', country_short ] ] }
 	);
 
-export const requestSiteAlerts = siteId => {
+export const requestSiteAlerts = ( siteId, force ) => {
 	const id = `site-alerts-${ siteId }`;
+	const freshness = force ? -Infinity : 5 * 60 * 1000;
 
 	return requestHttpData(
 		id,
@@ -111,11 +112,13 @@ export const requestSiteAlerts = siteId => {
 				method: 'GET',
 				path: `/sites/${ siteId }/alerts`,
 				apiNamespace: 'wpcom/v2',
+				apiVersion: '2',
+				body: {}, // have to have an empty body to make wpcom-http happy
 			},
 			{}
 		),
 		{
-			freshness: 5 * 60 * 1000,
+			freshness: freshness,
 			fromApi: () => ( { suggestions, threats, warnings, updates } ) => [
 				[
 					id,

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -126,6 +126,7 @@ export const requestSiteAlerts = siteId => {
 							signature: threat.signature,
 							description: threat.description,
 							firstDetected: Date.parse( threat.first_detected ),
+							...( threat.actions ? { actions: threat.actions } : {} ),
 							...( threat.context ? { filename: threat.filename, context: threat.context } : {} ),
 							...( threat.diff ? { filename: threat.filename, diff: threat.diff } : {} ),
 							...( threat.extension


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hook up the rewind fixers to the UI, so that we can display the threats found by the Rewind security scanner in the Activity Log and let the user take actions, such as fix or ignore them. Right now the backend part is done and the frontend (Calypso) is partially completed.

#### Testing instructions

There are different use cases that will be supported as this PR progresses, so this description will be updated accordingly. **Only fixable alerts are supported at the moment.**

#### a) Vulnerable extensions alerts
1) Upload a known vulnerable plugin. I'm using the infamous facebook_for_woocommerce Version 1.9.12, get it from .org. There seems to be some (automated?) cleanup process in Atomic V2 that would eliminate any vulnerable plugin as soon as it's uploaded, so I've tested it on my own Pressable test site.
2) Trigger a backup. I've been using the cli jetpack_backups/bin/backup.js program, like: 

> node backup.js -b {your blog ID} --config local-transport

you should receive a security alert on your email, mobile app and Calypso ActivityLog. That is good. If you don't see any alert, it means that the scanner didn't pick it up, so try with a different plugin and repeat.
3) Make sure you're in DEV, so fire up your local Calypso, go to Activity, you should see the threat alert(s) at the top. Example URL: 

> http://calypso.localhost:3000/activity-log/{your_site_hostname}

4) Click on the pink **Fix** button at the right of the alert. A spinner will be displayed and the button will be disabled, indicating a process has been triggered.
You can also **Ignore** a threat by clicking that option in the dropdown box.
5) When the fix is completed, the list of alerts will be re-rendered and the fixed alert should be gone. It is rare, but this process could fail at the server side, which is outside the scope of this PR. Failure or error handling is not properly implemented yet, but you should see the error message in the console of your browser's Developer Tools.