### PR TITLE
Whitelist Facebook coupon code.

### DIFF
--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -217,7 +217,9 @@ export function getRememberedCoupon() {
 	localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
 	if (
 		COUPON_CODE_WHITELIST.includes(
-			mostRecentCouponCode.substring( 0, mostRecentCouponCode.indexOf( '_' ) )
+			-1 !== mostRecentCouponCode.indexOf( '_' )
+				? mostRecentCouponCode.substring( 0, mostRecentCouponCode.indexOf( '_' ) )
+				: mostRecentCouponCode
 		)
 	) {
 		debug( 'returning coupon code:', mostRecentCouponCode );

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -194,6 +194,7 @@ export function getRememberedCoupon() {
 		'SAFE',
 		'SBDC',
 		'TXAM',
+		'FBSAVE15',
 	];
 	const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
 	const now = Date.now();

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -30,7 +30,7 @@ class CheckoutContainer extends React.Component {
 	};
 
 	render() {
-		const { product, purchaseId, feature, code, plan, selectedSite, reduxStore } = this.props;
+		const { product, purchaseId, feature, couponCode, plan, selectedSite, reduxStore } = this.props;
 
 		return (
 			<>
@@ -41,7 +41,7 @@ class CheckoutContainer extends React.Component {
 							product={ product }
 							purchaseId={ purchaseId }
 							selectedFeature={ feature }
-							couponCode={ code }
+							couponCode={ couponCode }
 							plan={ plan }
 							setHeaderText={ this.setHeaderText }
 							reduxStore={ reduxStore }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -43,7 +43,8 @@ export function checkout( context, next ) {
 			product={ product }
 			purchaseId={ purchaseId }
 			selectedFeature={ feature }
-			couponCode={ context.query.code || getRememberedCoupon() }
+			// NOTE: `context.query.code` is deprecated in favor of `context.query.coupon`.
+			couponCode={ context.query.coupon || context.query.code || getRememberedCoupon() }
 			plan={ plan }
 			selectedSite={ selectedSite }
 			reduxStore={ context.store }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Whitelist `FBSAVE15` coupon code.
- Whitelist now checks for both an exact match and also an underscored suffix.
- Bug fix. `code` should be `couponCode` to get coupon to auto-apply at checkout.
- Deprecate the use of `?code=` at checkout in favor of `?coupon=`.

#### Testing instructions

- Test in Calypso live using the URL below.
- Visit any URL in signup flow; i.e., `/start` with `?coupon=FBSAVE15_*`
  See: pau2Xa-mO-p2#comment-1631 for the actual coupon code to test with.
- Enter checkout flow and confirm coupon code is auto-applied.

#### Regression Testing

- Test with a suffixed coupon, such as the one seen here.
  https://wordpress.com/sbdc/

- Test checkout with a coupon in query string, using both `?code=` and `?coupon=` to confirm both are working. `?code=` is now deprecated in favor of `?coupon=` to avoid ambiguity.