### PR TITLE
Signup: AB test that allows users to skip the domain step

### DIFF
--- a/client/components/domains/example-domain-suggestions/style.scss
+++ b/client/components/domains/example-domain-suggestions/style.scss
@@ -35,7 +35,6 @@
 	width: 300px;
 
 	@include breakpoint( '<660px' ) {
-		padding-top: 24px;
 		position: relative;
 		margin: 0 auto;
 	}

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -136,4 +136,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	skippableDomainStep: {
+		datestamp: '20190702',
+		variations: {
+			skippable: 50,
+			notSkippable: 50,
+		},
+		defaultVariation: 'notSkippable',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -172,11 +172,14 @@ export function createSiteWithCart(
 		'import' === flowName ? normalizeImportUrl( getNuxUrlInputValue( state ) ) : '';
 	const importEngine = 'import' === flowName ? getSelectedImportEngine( state ) : '';
 
+	// flowName isn't always passed in
+	const flowToCheck = flowName || lastKnownFlow;
+
 	if ( importingFromUrl ) {
 		newSiteParams.blog_name = importingFromUrl;
 		newSiteParams.find_available_url = true;
 		newSiteParams.options.nux_import_engine = importEngine;
-	} else if ( ! siteUrl && isDomainStepSkippable( flowName ) ) {
+	} else if ( ! siteUrl && isDomainStepSkippable( flowToCheck ) ) {
 		newSiteParams.blog_name =
 			get( user.get(), 'username', siteTitle ) || siteType || getSiteVertical( state );
 		newSiteParams.find_available_url = true;
@@ -184,8 +187,7 @@ export function createSiteWithCart(
 		newSiteParams.blog_name = siteUrl;
 		newSiteParams.find_available_url = !! isPurchasingItem;
 	}
-	// flowName isn't always passed in
-	const flowToCheck = flowName || lastKnownFlow;
+
 	if ( isEligibleForPageBuilder( siteSegment, flowToCheck ) && shouldEnterPageBuilder() ) {
 		newSiteParams.options.in_page_builder = true;
 	}

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -35,6 +35,7 @@ import getSiteId from 'state/selectors/get-site-id';
 import { getSiteGoals } from 'state/signup/steps/site-goals/selectors';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getUserExperience } from 'state/signup/steps/user-experience/selectors';
+import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { requestSites } from 'state/sites/actions';
 import { getProductsList } from 'state/products-list/selectors';
 import { getSelectedImportEngine, getNuxUrlInputValue } from 'state/importer-nux/temp-selectors';
@@ -181,7 +182,11 @@ export function createSiteWithCart(
 		newSiteParams.options.nux_import_engine = importEngine;
 	} else if ( ! siteUrl && isDomainStepSkippable( flowToCheck ) ) {
 		newSiteParams.blog_name =
-			get( user.get(), 'username', siteTitle ) || siteType || getSiteVertical( state );
+			get( user.get(), 'username' ) ||
+			get( getSignupDependencyStore( state ), 'username' ) ||
+			siteTitle ||
+			siteType ||
+			getSiteVertical( state );
 		newSiteParams.find_available_url = true;
 	} else {
 		newSiteParams.blog_name = siteUrl;

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -47,7 +47,7 @@ import { promisify } from '../../utils';
 
 // Others
 import flows from 'signup/config/flows';
-import steps from 'signup/config/steps';
+import steps, { isDomainStepSkippable } from 'signup/config/steps';
 import { normalizeImportUrl } from 'state/importer-nux/utils';
 import { isEligibleForPageBuilder, shouldEnterPageBuilder } from 'lib/signup/page-builder';
 
@@ -176,6 +176,10 @@ export function createSiteWithCart(
 		newSiteParams.blog_name = importingFromUrl;
 		newSiteParams.find_available_url = true;
 		newSiteParams.options.nux_import_engine = importEngine;
+	} else if ( ! siteUrl && isDomainStepSkippable( flowName ) ) {
+		newSiteParams.blog_name =
+			get( user.get(), 'username', siteTitle ) || siteType || getSiteVertical( state );
+		newSiteParams.find_available_url = true;
 	} else {
 		newSiteParams.blog_name = siteUrl;
 		newSiteParams.find_available_url = !! isPurchasingItem;

--- a/client/lib/signup/test/mocks/signup/config/steps.js
+++ b/client/lib/signup/test/mocks/signup/config/steps.js
@@ -97,3 +97,7 @@ export default {
 		providesDependencies: [ 'siteTopic', 'siteTitle' ],
 	},
 };
+
+export function isDomainStepSkippable() {
+	return false;
+}

--- a/client/lib/signup/test/mocks/signup/config/steps.js
+++ b/client/lib/signup/test/mocks/signup/config/steps.js
@@ -98,6 +98,4 @@ export default {
 	},
 };
 
-export function isDomainStepSkippable() {
-	return false;
-}
+export const isDomainStepSkippable = jest.fn( () => false );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -12,6 +12,7 @@ import {
 } from '../step-actions';
 import { useNock } from 'test/helpers/use-nock';
 import flows from 'signup/config/flows';
+import { isDomainStepSkippable } from 'signup/config/steps';
 
 // This is necessary since localforage will throw "no local storage method found" promise rejection without this.
 // See how lib/user-settings/test apply the same trick.
@@ -38,6 +39,10 @@ describe( 'createSiteWithCart()', () => {
 					requestBody,
 				};
 			} );
+	} );
+
+	beforeEach( () => {
+		isDomainStepSkippable.mockReset();
 	} );
 
 	test( 'should use the vertical field in the survey tree if the site topic one is empty.', () => {
@@ -90,6 +95,40 @@ describe( 'createSiteWithCart()', () => {
 			},
 			[],
 			[],
+			fakeStore
+		);
+	} );
+
+	test( 'should find available url if siteUrl is empty (and in test group)', () => {
+		isDomainStepSkippable.mockReturnValue( true );
+
+		const fakeStore = {
+			getState: () => ( {} ),
+		};
+
+		createSiteWithCart(
+			response => {
+				expect( response.requestBody.find_available_url ).toBe( true );
+			},
+			[],
+			{ siteUrl: undefined },
+			fakeStore
+		);
+	} );
+
+	test( "don't automatically find available url if siteUrl is defined (and in test group)", () => {
+		isDomainStepSkippable.mockReturnValue( true );
+
+		const fakeStore = {
+			getState: () => ( {} ),
+		};
+
+		createSiteWithCart(
+			response => {
+				expect( response.requestBody.find_available_url ).toBeFalsy();
+			},
+			[],
+			{ siteUrl: 'mysite' },
 			fakeStore
 		);
 	} );

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -23,6 +23,7 @@ import {
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
 } from 'lib/signup/step-actions';
+import { abtest } from 'lib/abtest';
 import { generateSteps } from './steps-pure';
 
 export default generateSteps( {
@@ -40,3 +41,10 @@ export default generateSteps( {
 	isSiteTypeFulfilled,
 	isSiteTopicFulfilled,
 } );
+
+export function isDomainStepSkippable( flowName ) {
+	return (
+		( flowName === 'onboarding' || flowName === 'onboarding-blog' ) &&
+		abtest( 'skippableDomainStep' ) === 'skippable'
+	);
+}

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -29,6 +29,7 @@ export class NavigationLink extends Component {
 		direction: PropTypes.oneOf( [ 'back', 'forward' ] ),
 		flowName: PropTypes.string.isRequired,
 		labelText: PropTypes.string,
+		cssClass: PropTypes.string,
 		positionInFlow: PropTypes.number,
 		previousPath: PropTypes.string,
 		signupProgress: PropTypes.array,
@@ -138,7 +139,11 @@ export class NavigationLink extends Component {
 			text = labelText ? labelText : translate( 'Skip for now' );
 		}
 
-		const buttonClasses = classnames( 'navigation-link', this.props.direction );
+		const buttonClasses = classnames(
+			'navigation-link',
+			this.props.direction,
+			this.props.cssClass
+		);
 
 		return (
 			<Button

--- a/client/signup/navigation-link/style.scss
+++ b/client/signup/navigation-link/style.scss
@@ -8,3 +8,9 @@
 		fill: var( --color-white );
 	}
 }
+
+.navigation-link--has-skip-heading {
+	transform: translateY( -3px );
+	//override unessecary super specificity added by another class
+	padding-top: 0 !important;
+}

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -72,6 +72,7 @@ class StepWrapper extends Component {
 						flowName={ this.props.flowName }
 						stepName={ this.props.stepName }
 						labelText={ this.props.skipLabelText }
+						cssClass={ !! this.props.skipHeadingText && ' navigation-link--has-skip-heading ' }
 					/>
 				</>
 			);

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -29,6 +29,10 @@ class StepWrapper extends Component {
 		// Allows to force a back button in the first step for example.
 		// You should only force this when you're passing a backUrl.
 		allowBackFirstStep: PropTypes.bool,
+		skipLabelText: PropTypes.string,
+		skipHeadingText: PropTypes.string,
+		// Displays an <hr> above the skip button and adds more white space
+		isLargeSkipLayout: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -57,14 +61,19 @@ class StepWrapper extends Component {
 	renderSkip() {
 		if ( ! this.props.shouldHideNavButtons && this.props.goToNextStep ) {
 			return (
-				<NavigationLink
-					direction="forward"
-					goToNextStep={ this.props.goToNextStep }
-					defaultDependencies={ this.props.defaultDependencies }
-					flowName={ this.props.flowName }
-					stepName={ this.props.stepName }
-					labelText={ this.props.skipLabelText }
-				/>
+				<>
+					{ !! this.props.skipHeadingText && (
+						<div className="step-wrapper__skip-heading">{ this.props.skipHeadingText }</div>
+					) }
+					<NavigationLink
+						direction="forward"
+						goToNextStep={ this.props.goToNextStep }
+						defaultDependencies={ this.props.defaultDependencies }
+						flowName={ this.props.flowName }
+						stepName={ this.props.stepName }
+						labelText={ this.props.skipLabelText }
+					/>
+				</>
 			);
 		}
 	}
@@ -98,9 +107,18 @@ class StepWrapper extends Component {
 	}
 
 	render() {
-		const { stepContent, headerButton, hideFormattedHeader, hideBack, hideSkip } = this.props;
+		const {
+			stepContent,
+			headerButton,
+			hideFormattedHeader,
+			hideBack,
+			hideSkip,
+			isLargeSkipLayout,
+			isWideLayout,
+		} = this.props;
 		const classes = classNames( 'step-wrapper', this.props.className, {
-			'is-wide-layout': this.props.isWideLayout,
+			'is-wide-layout': isWideLayout,
+			'is-large-skip-layout': isLargeSkipLayout,
 		} );
 
 		return (
@@ -120,7 +138,12 @@ class StepWrapper extends Component {
 
 					<div className="step-wrapper__content">{ stepContent }</div>
 
-					{ ! hideSkip && <div className="step-wrapper__buttons">{ this.renderSkip() }</div> }
+					{ ! hideSkip && (
+						<div className="step-wrapper__buttons">
+							{ isLargeSkipLayout && <hr className="step-wrapper__skip-hr" /> }
+							{ this.renderSkip() }
+						</div>
+					) }
 				</div>
 			</>
 		);

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -6,9 +6,10 @@
 	background: var( --color-primary-light );
 	max-width: 270px;
 	margin-bottom: 50px;
+	margin-top: -20px;
 
 	@include breakpoint( '<660px' ) {
-		margin-bottom: 30px;
+		margin: 30px auto;
 	}
 }
 

--- a/client/signup/step-wrapper/style.scss
+++ b/client/signup/step-wrapper/style.scss
@@ -1,3 +1,25 @@
 .step-wrapper__content .themes-list {
 	padding: 0 20px;
 }
+
+.step-wrapper__skip-hr {
+	background: var( --color-primary-light );
+	max-width: 270px;
+	margin-bottom: 50px;
+
+	@include breakpoint( '<660px' ) {
+		margin-bottom: 30px;
+	}
+}
+
+.step-wrapper__skip-heading {
+	color: var( --color-white );
+}
+
+.is-large-skip-layout .step-wrapper__buttons {
+	margin-bottom: 34px;
+
+	@include breakpoint( '<660px' ) {
+		margin-bottom: 14px;
+	}
+}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -49,6 +49,7 @@ import { getSite } from 'state/sites/selectors';
 import { getVerticalForDomainSuggestions } from 'state/signup/steps/site-vertical/selectors';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
+import { isDomainStepSkippable } from 'signup/config/steps';
 
 /**
  * Style dependencies
@@ -604,7 +605,7 @@ class DomainsStep extends React.Component {
 			return null;
 		}
 
-		const { translate, selectedSite } = this.props;
+		const { flowName, translate, selectedSite } = this.props;
 		let backUrl, backLabelText;
 
 		if ( 'transfer' === this.props.stepSectionName || 'mapping' === this.props.stepSectionName ) {
@@ -644,6 +645,8 @@ class DomainsStep extends React.Component {
 				showSiteMockups={ this.props.showSiteMockups }
 				allowBackFirstStep={ !! selectedSite }
 				backLabelText={ backLabelText }
+				hideSkip={ ! isDomainStepSkippable( flowName ) }
+				goToNextStep={ this.handleSkip }
 			/>
 		);
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -624,6 +624,7 @@ class DomainsStep extends React.Component {
 
 		const headerText = this.getHeaderText();
 		const fallbackSubHeaderText = this.getSubHeaderText();
+		const showSkip = isDomainStepSkippable( flowName );
 
 		return (
 			<StepWrapper
@@ -645,9 +646,11 @@ class DomainsStep extends React.Component {
 				showSiteMockups={ this.props.showSiteMockups }
 				allowBackFirstStep={ !! selectedSite }
 				backLabelText={ backLabelText }
-				hideSkip={ ! isDomainStepSkippable( flowName ) }
+				hideSkip={ ! showSkip }
+				isLargeSkipLayout={ showSkip }
 				goToNextStep={ this.handleSkip }
-				skipLabelText={ translate( 'Not sure yet? Start with a temporary domain' ) }
+				skipHeadingText={ translate( 'Not sure yet?' ) }
+				skipLabelText={ translate( 'Choose a domain later' ) }
 			/>
 		);
 	}

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -647,6 +647,7 @@ class DomainsStep extends React.Component {
 				backLabelText={ backLabelText }
 				hideSkip={ ! isDomainStepSkippable( flowName ) }
 				goToNextStep={ this.handleSkip }
+				skipLabelText={ translate( 'Not sure yet? Start with a temporary domain' ) }
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Choosing a domain can feel like a big commitment! Test to see if adding the ability to skip this step improves dropoff stats.

- Added `skippableDomainStep` test with 50/50 split between `skippable` and `notSkippable`
- Skip button only shown in `onboarding` and `onboarding-blog` flows
- If domain step is skipped then new site is created with the `find_available_url` param
- Domain will be based on the user name, with some fallback cases (way this is choosen comes from Automattic/wp-calypso#29494)

If the user finds themselves in the test group they will see:
![Screen Shot on 2019-07-02 at 15:59:58](https://user-images.githubusercontent.com/1500769/60560056-86013680-9da2-11e9-8703-77ba7a0d2ae4.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Explicitly set your `skippableDomainStep` value to `skippable` using the dev menu
- `/start` and create a blog skipping the domain step
- Blog is created with a domain name based on the username
- Repeat, but don't skip the domain step this time, site should be created with the domain you choose
- Repeat:
  - Start with `/start` and choose **business**, domain step should be skippable
  - Start with `/start` and choose **online store**, domain step ***should not*** be skippable
  - Start with `/start/personal`, which isn't an onboarding flow so domain step ***should not*** be skippable regardless of site type choice
  - Using jetpack, there is no domain step, but site creation shouldn't be broken
- Explicitly set your `skippableDomainStep` value to `notSkippable` and do it all again
- Open private tab and verify that running `JSON.parse(localStorage.getItem('ABTests'))['skippableDomainStep_20190702']` in the console returns `undefined` until you get to the domain step in the `onboarding` or `onboarding-blog` flow.

Fixes Automattic/zelda-private#89
