### PR TITLE
Signup: prevent back button from navigating iframe history

### DIFF
--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -166,7 +166,7 @@ export default class SignupSitePreviewIframe extends Component {
 			this.iframe.current.contentWindow.document.close();
 		} else {
 			revokeObjectURL( this.iframe.current.src );
-			this.iframe.current.src = iframeSrc;
+			this.iframe.current.contentWindow.location.replace( iframeSrc );
 		}
 	};
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

After having searched for a vertical, clicking the back button will sometimes navigates through the iframe window's history:

![Jul-02-2019 13-04-22](https://user-images.githubusercontent.com/6458278/60480050-7105a400-9ccb-11e9-81f2-bd5bdaee777a.gif)

😱 

By replacing the iframe location rather than setting it, we avoid adding an entry to the browser session history state, thereby not capturing the parent window back button. See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Location/replace).

🛑😱**&** 😄 

## Testing instructions

At `/start/onboarding` select **Business** and search for a few verticals. 

Click the browser back button.

You should be navigating the parent window's session history. Not the iframe's.
