### PR TITLE
Refactor: move <Dialog> into <CancelPurchaseForm>

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import Dialog from 'components/dialog';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLegend from 'components/forms/form-legend';
 import FormLabel from 'components/forms/form-label';
@@ -324,7 +325,7 @@ class CancelPurchaseForm extends React.Component {
 		);
 	};
 
-	render() {
+	surveyContent() {
 		const { translate, showSurvey, surveyStep } = this.props;
 		if ( showSurvey ) {
 			if ( surveyStep === steps.INITIAL_STEP ) {
@@ -383,6 +384,19 @@ class CancelPurchaseForm extends React.Component {
 
 		// just return the default if we don't want to show the survey
 		return <div>{ this.props.defaultContent }</div>;
+	}
+
+	render() {
+		return (
+			<Dialog
+				isVisible={ this.props.isVisible }
+				onClose={ this.props.onClose }
+				buttons={ this.props.buttons }
+				className="cancel-purchase__button-warning-dialog remove-purchase__dialog"
+			>
+				{ this.surveyContent() }
+			</Dialog>
+		);
 	}
 }
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -392,7 +392,7 @@ class CancelPurchaseForm extends React.Component {
 				isVisible={ this.props.isVisible }
 				onClose={ this.props.onClose }
 				buttons={ this.props.buttons }
-				className="cancel-purchase__button-warning-dialog remove-purchase__dialog"
+				className="cancel-purchase-form__dialog"
 			>
 				{ this.surveyContent() }
 			</Dialog>

--- a/client/components/marketing-survey/cancel-purchase-form/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/style.scss
@@ -2,3 +2,8 @@
 	margin: 4px 0 0 24px;
 	width: calc( 100% - 24px );
 }
+
+.cancel-purchase-form__dialog {
+	max-width: 472px;
+}
+

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -18,7 +18,6 @@ import { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from 'lib/upgra
 import { clearPurchases } from 'state/purchases/actions';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import initialSurveyState from 'components/marketing-survey/cancel-purchase-form/initial-survey-state';
@@ -169,21 +168,17 @@ class CancelPurchaseButton extends Component {
 		}
 
 		return (
-			<Dialog
+			<CancelPurchaseForm
+				chatInitiated={ this.chatInitiated }
+				defaultContent={ this.renderCancellationEffect() }
+				onInputChange={ this.onSurveyChange }
+				purchase={ purchase }
+				selectedSite={ selectedSite }
+				surveyStep={ this.state.surveyStep }
 				isVisible={ this.state.showDialog }
 				buttons={ buttonsArr }
 				onClose={ this.closeDialog }
-				className="cancel-purchase__button-warning-dialog"
-			>
-				<CancelPurchaseForm
-					chatInitiated={ this.chatInitiated }
-					defaultContent={ this.renderCancellationEffect() }
-					onInputChange={ this.onSurveyChange }
-					purchase={ purchase }
-					selectedSite={ selectedSite }
-					surveyStep={ this.state.surveyStep }
-				/>
-			</Dialog>
+			/>
 		);
 	};
 

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -2,6 +2,7 @@
 /**
  * External dependencies
  */
+import { connect } from 'react-redux';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -17,7 +18,6 @@ import { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from 'lib/upgra
 import { clearPurchases } from 'state/purchases/actions';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
-import { connect } from 'react-redux';
 import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enriched-survey-data';

--- a/client/me/purchases/cancel-purchase/style.scss
+++ b/client/me/purchases/cancel-purchase/style.scss
@@ -112,7 +112,3 @@
 	margin-bottom: 10px;
 	width: 50%;
 }
-
-.cancel-purchase__button-warning-dialog {
-	max-width: 472px;
-}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -13,11 +13,11 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
+import Dialog from 'components/dialog';
 import wpcom from 'lib/wp';
 import config from 'config';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
-import Dialog from 'components/dialog';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import GSuiteCancellationPurchaseDialog from 'components/marketing-survey/gsuite-cancel-purchase-dialog';
@@ -321,21 +321,17 @@ class RemovePurchase extends Component {
 		}
 
 		return (
-			<Dialog
-				buttons={ buttonsArr }
-				className="remove-purchase__dialog"
+			<CancelPurchaseForm
+				chatInitiated={ this.chatInitiated }
+				defaultContent={ this.renderPlanDialogText() }
+				onInputChange={ this.onSurveyChange }
+				purchase={ purchase }
+				selectedSite={ site }
+				surveyStep={ this.state.surveyStep }
 				isVisible={ this.state.isDialogVisible }
+				buttons={ buttonsArr }
 				onClose={ this.closeDialog }
-			>
-				<CancelPurchaseForm
-					chatInitiated={ this.chatInitiated }
-					defaultContent={ this.renderPlanDialogText() }
-					onInputChange={ this.onSurveyChange }
-					purchase={ purchase }
-					selectedSite={ site }
-					surveyStep={ this.state.surveyStep }
-				/>
-			</Dialog>
+			/>
 		);
 	}
 

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -1,8 +1,3 @@
-
-.remove-purchase__dialog {
-	max-width: 500px;
-}
-
 .remove-purchase__card {
 	color: var( --color-primary );
 	text-align: left;


### PR DESCRIPTION
_This PR is part of a broader attempt of making `<CancelPurchaseForm>` more reusable by eliminating code duplication._

#### Changes proposed in this Pull Request

This PR moves `<Dialog>` into `<CancelPurchaseForm>` so it is not duplicated both in `cancel-purchase/button.jsx` and `remove-purchase/index.jsx`.


#### Testing instructions
1. Go to the purchase management page, http://calypso.localhost:3000/me/purchases/, and click on any plan subscription.
1. Click on the "Cancel subscription" and go through the subscription cancelling process. The survey should be there and works as expected.
1. Go to the same subscription management page and this time there should be a "Remove Subscription" button. Click on it and go through the removing process. The survey should work as expected.


