### PR TITLE
Add GA event: `calypso_domain_registration`

### DIFF
--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -277,6 +277,8 @@ export class SecurePaymentForm extends Component {
 			success = parameters.success;
 
 		getDomainRegistrations( cart ).forEach( function( cartItem ) {
+			analytics.ga.recordEvent( 'Checkout', 'calypso_domain_registration', cartItem.meta );
+
 			analytics.tracks.recordEvent( 'calypso_domain_registration', {
 				domain_name: cartItem.meta,
 				domain_tld: getTld( cartItem.meta ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add GA event: `calypso_domain_registration` (pau2Xa-j3-p2)

#### Testing instructions

- Enable analytics by running the following in your browser console, then reload the page: `document.cookie='flags=google-analytics,ad-tracking; path=/'`

- Register a domain name in Calypso and filter console by `calypso_domain_registration` to confirm that a GA event fires with category set to `Checkout` and action set to `calypso_domain_registration`, with the label set to the domain name.