### PR TITLE
Remove unused delta signup flows

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -145,33 +145,6 @@ export function generateFlows( {
 			lastModified: '2019-04-30',
 		},
 
-		'delta-discover': {
-			steps: [ 'user' ],
-			destination: '/',
-			description:
-				'A copy of the `account` flow for the Delta email campaigns. Half of users who ' +
-				'go through this flow receive a reader-specific drip email series.',
-			lastModified: '2016-05-03',
-		},
-
-		'delta-blog': {
-			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
-			destination: getSiteDestination,
-			description:
-				'A copy of the `blog` flow for the Delta email campaigns. Half of users who go ' +
-				'through this flow receive a blogging-specific drip email series.',
-			lastModified: '2018-01-24',
-		},
-
-		'delta-site': {
-			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
-			destination: getSiteDestination,
-			description:
-				'A copy of the `website` flow for the Delta email campaigns. Half of users who go ' +
-				'through this flow receive a website-specific drip email series.',
-			lastModified: '2018-01-24',
-		},
-
 		desktop: {
 			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 			destination: getChecklistDestination,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -38,9 +38,7 @@ export function generateSteps( {
 			stepName: 'survey',
 			props: {
 				surveySiteType:
-					currentPage && currentPage.toString().match( /\/start\/(blog|delta-blog)/ )
-						? 'blog'
-						: 'site',
+					currentPage && currentPage.toString().match( /\/start\/blog/ ) ? 'blog' : 'site',
 			},
 			providesDependencies: [ 'surveySiteType', 'surveyQuestion' ],
 		},


### PR DESCRIPTION
Remove `delta-blog`, `delta-discover`, and `delta-site` signup flows. These were once used for email campaigns, but have since been redirected from landing pages to point to `/start`.

paObgF-hM-p2#comment-745

#### Changes proposed in this Pull Request

* Remove `delta-blog`, `delta-discover`, and `delta-site` signup flows.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In an Incognito browser window, go to:

1. Go to: http://calypso.localhost:3000/start/delta-blog
2. This should redirect you to: http://calypso.localhost:3000/start/user (or if you are already logged in: http://calypso.localhost:3000/start/site-type )
3. Repeat steps 1 and 2 for the following URLs:
  - Go to: http://calypso.localhost:3000/start/delta-discover 
  - Go to: http://calypso.localhost:3000/start/delta-site 
