### PR TITLE
Fix/fse post content styles

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -34,11 +34,7 @@ const NavigationMenuEdit = ( { attributes } ) => {
 					/>
 				</Toolbar>
 			</BlockControls>
-			<ServerSideRender
-				attributes={ attributes }
-				block="a8c/navigation-menu"
-				className="wp-block-a8c-navigation-menu"
-			/>
+			<ServerSideRender attributes={ attributes } block="a8c/navigation-menu" />
 		</Fragment>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -86,13 +86,11 @@ function render_navigation_menu_block( $attributes ) {
 	ob_start();
 	// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText
 	?>
-	<div class="wp-block-a8c-navigation-menu">
-	    <nav class="<?php echo esc_attr( $wrapper_attr['class'] ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
-		    <?php
-		        wp_nav_menu( get_menu_params_by_theme_location( $location ) );
-		    ?>
-	    </nav>
-    </div>
+	<nav class="wp-block-a8c-navigation-menu <?php echo esc_attr( $wrapper_attr['class'] ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
+		<?php
+		    wp_nav_menu( get_menu_params_by_theme_location( $location ) );
+		?>
+	</nav>
 	<!-- #site-navigation -->
 	<?php
 	return ob_get_clean();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -85,9 +85,9 @@ function render_navigation_menu_block( $attributes ) {
 	ob_start();
 	// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText
 	?>
-	<nav class="wp-block-a8c-navigation-menu <?php echo esc_attr( $wrapper_attr['class'] ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
+	<nav class="<?php echo esc_attr( $wrapper_attr['class'] . ' wp-block-a8c-navigation-menu' ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
 		<?php
-		    wp_nav_menu( get_menu_params_by_theme_location( $location ) );
+			wp_nav_menu( get_menu_params_by_theme_location( $location ) );
 		?>
 	</nav>
 	<!-- #site-navigation -->

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -34,7 +34,6 @@ function get_menu_params_by_theme_location( $location ) {
 			$params = [
 				'theme_location' => 'menu-1',
 				'menu_class'     => 'main-menu',
-				'container'       => 'ul',
 				'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
 				'depth'          => 1,
 			];

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -34,6 +34,7 @@ function get_menu_params_by_theme_location( $location ) {
 			$params = [
 				'theme_location' => 'menu-1',
 				'menu_class'     => 'main-menu',
+				'container'       => 'ul',
 				'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
 				'depth'          => 1,
 			];
@@ -85,11 +86,14 @@ function render_navigation_menu_block( $attributes ) {
 	ob_start();
 	// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText
 	?>
-	<nav class="<?php echo esc_attr( $wrapper_attr['class'] ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
-		<?php
-		wp_nav_menu( get_menu_params_by_theme_location( $location ) );
-		?>
-	</nav><!-- #site-navigation -->
+	<div class="wp-block-a8c-navigation-menu">
+	    <nav class="<?php echo esc_attr( $wrapper_attr['class'] ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
+		    <?php
+		        wp_nav_menu( get_menu_params_by_theme_location( $location ) );
+		    ?>
+	    </nav>
+    </div>
+	<!-- #site-navigation -->
 	<?php
 	return ob_get_clean();
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/style.scss
@@ -1,4 +1,4 @@
-.wp-block-a8c-navigation-menu .main-navigation {
+.wp-block-a8c-navigation-menu.main-navigation {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
     font-size: 1.125em;
     font-weight: 700;
@@ -8,61 +8,61 @@
     -webkit-font-smoothing: antialiased;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation .main-menu {
+.wp-block-a8c-navigation-menu.main-navigation .main-menu {
     display: inline-block;
     margin: 0;
     padding: 0;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation .main-menu > li {
+.wp-block-a8c-navigation-menu.main-navigation .main-menu > li {
     color: #0073aa;
     display: inline;
     position: relative;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation .main-menu > li > a {
+.wp-block-a8c-navigation-menu.main-navigation .main-menu > li > a {
     font-weight: 700;
     color: #0073aa;
     margin-right: 0.5rem;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation .main-menu > li:last-child > a, .main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
+.wp-block-a8c-navigation-menu.main-navigation .main-menu > li:last-child > a, .main-navigation .main-menu > li:last-child.menu-item-has-children .submenu-expand {
     margin-right: 0;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation .main-menu > li.menu-item-has-children > a {
+.wp-block-a8c-navigation-menu.main-navigation .main-menu > li.menu-item-has-children > a {
     margin-right: 0.125rem;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation .main-menu > li.menu-item-has-children {
+.wp-block-a8c-navigation-menu.main-navigation .main-menu > li.menu-item-has-children {
     display: inline-block;
     position: inherit;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation .main-menu > li.menu-item-has-children .submenu-expand {
+.wp-block-a8c-navigation-menu.main-navigation .main-menu > li.menu-item-has-children .submenu-expand {
     display: inline-block;
     margin-right: 0.25rem;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
+.wp-block-a8c-navigation-menu.main-navigation .main-menu > li.menu-item-has-children .submenu-expand svg {
     position: relative;
     top: 0.3rem;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation .main-menu > li > a:hover, .main-navigation .main-menu > li > a:hover + svg {
+.wp-block-a8c-navigation-menu.main-navigation .main-menu > li > a:hover, .main-navigation .main-menu > li > a:hover + svg {
     color: #005177;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation svg {
+.wp-block-a8c-navigation-menu.main-navigation svg {
     transition: fill 120ms ease-in-out;
     fill: currentColor;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation a {
+.wp-block-a8c-navigation-menu.main-navigation a {
     text-decoration: none;
 }
 
-.wp-block-a8c-navigation-menu .main-navigation button {
+.wp-block-a8c-navigation-menu.main-navigation button {
     display: inline-block;
     border: none;
     padding: 0;
@@ -81,55 +81,55 @@
     -moz-appearance: none;
 }
 
-.wp-block-a8c-navigation-menu .main-menu-more {
+.wp-block-a8c-navigation-menu.main-menu-more {
 	display: none;
 }
 
-.wp-block-a8c-navigation-menu .social-navigation {
+.wp-block-a8c-navigation-menu.social-navigation {
     line-height: 1.25;
     margin-top: calc( 1rem / 2 );
     text-align: left;
 }
 
-.wp-block-a8c-navigation-menu .social-navigation ul.social-links-menu {
+.wp-block-a8c-navigation-menu.social-navigation ul.social-links-menu {
     content: '';
     display: inline-block;
     margin: 0;
     padding: 0;
 }
 
-.wp-block-a8c-navigation-menu .social-navigation ul.social-links-menu li {
+.wp-block-a8c-navigation-menu.social-navigation ul.social-links-menu li {
     display: inline-block;
     vertical-align: bottom;
     vertical-align: -webkit-baseline-middle;
     list-style: none;
 }
 
-.wp-block-a8c-navigation-menu .social-navigation ul.social-links-menu li a svg {
+.wp-block-a8c-navigation-menu.social-navigation ul.social-links-menu li a svg {
     display: block;
     width: 32px;
     height: 32px;
     transform: translateZ( 0 );
 }
 
-.wp-block-a8c-navigation-menu .footer-navigation .footer-menu {
+.wp-block-a8c-navigation-menu.footer-navigation .footer-menu {
     display: inline;
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
     font-size: 0.71111em;
     padding-left: 0;
 }
 
-.wp-block-a8c-navigation-menu .footer-navigation .footer-menu li {
+.wp-block-a8c-navigation-menu.footer-navigation .footer-menu li {
     display: inline;
     margin-right: 1rem;
 }
 
-.wp-block-a8c-navigation-menu .footer-navigation .footer-menu a {
+.wp-block-a8c-navigation-menu.footer-navigation .footer-menu a {
     text-decoration: none;
     color: #767676;
 }
 
-.wp-block-a8c-navigation-menu .footer-navigation .footer-menu a:hover {
+.wp-block-a8c-navigation-menu.footer-navigation .footer-menu a:hover {
     text-decoration: none;
     color: #0073aa;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/style.scss
@@ -53,6 +53,10 @@
     color: #005177;
 }
 
+.wp-block-a8c-navigation-menu.main-navigation .main-menu-more {
+    display: none;
+}
+
 .wp-block-a8c-navigation-menu.main-navigation svg {
     transition: fill 120ms ease-in-out;
     fill: currentColor;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
@@ -14,4 +14,8 @@
 		margin-left: auto;
 		display: block;
 	}
+	.site-title:not( :empty ) + .site-description:not( :empty )::before {
+		content: '\2014';
+		margin: 0 0.2em;
+	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
@@ -17,4 +17,10 @@
 		margin-left: auto;
 		display: block;
 	}
+	.site-title a:link,
+	.site-title a:visited {
+		color: #111;
+		text-decoration: none;
+		font-weight: 400;
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds additional styles to FSE blocks to better match post edit view of header blocks to published page
* Modify navigation menu wrappers so styles get applied properly

#### Testing instructions

* Check out branch follow instructions in https://github.com/Automattic/wp-calypso/tree/master/apps/full-site-editing#build-system. Install the FSE plugin, and activate it on local gutenberg dev
* Edit a page
* Compare the header content in the edit view with the published page view
* The site title, description and navigation menu should display roughly the same 

<img width="968" alt="Screen Shot 2019-07-02 at 4 11 22 PM" src="https://user-images.githubusercontent.com/3629020/60482034-13318600-9ce4-11e9-8e4e-0f264fb1b84e.png">


Related to  #34279
