### PR TITLE
Signup: Try/embed iframe in preview [WIP]

### DIFF
--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -60,6 +60,24 @@ export default class SignupSitePreviewIframe extends Component {
 				debounce( this.setContainerHeight, 50 )
 			);
 		}
+		// TODO: we'll do this right later if it works
+		window.addEventListener( 'message', ( event ) => {
+			let data;
+			if ( 'string' === typeof event.data ) {
+				try {
+					data = JSON.parse( event.data );
+				} catch ( err ) {
+					// The string needs to be a valid serialized JSON: we don't accept arbitrary strings
+					// We'll ignore this message.
+					return;
+				}
+			} else {
+				data = event.data;
+			}
+			console.log( 'From parent:', data );
+
+			this.props.setWrapperHeight( data.height + 25 );
+		} );
 	}
 
 	componentWillUnmount() {
@@ -210,7 +228,7 @@ export default class SignupSitePreviewIframe extends Component {
 
 
 		this.props.setIsLoaded( false );
-		this.iframe.current.src = `https://a8cvm${ siteTypeId }${ verticalId && siteTypeId === 1 ? verticalId : '' }.wordpress.com?hide_masterbar=true`;
+		this.iframe.current.src = `https://a8cvm${ siteTypeId }${ verticalId && siteTypeId === 1 ? verticalId : '' }.wordpress.com?onboarding_preview=true#${ window.location.origin }`;
 	};
 
 	render() {

--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -168,21 +168,22 @@ export default class SignupSitePreviewIframe extends Component {
 	};
 
 	setLoaded = () => {
-		this.setOnPreviewClick();
+/*		this.setOnPreviewClick();
 		this.setIframeIsLoading();
 		this.props.resize && this.setContainerHeight();
 
 		const { params, tagline, title } = this.props.content;
 
 		this.setContentTitle( title, tagline );
-		this.setContentParams( params );
+		this.setContentParams( params );*/
+		this.props.setIsLoaded( true );
 	};
 
-	setIframeSource = ( { content, cssUrl, fontUrl, gutenbergStylesUrl, isRtl, langSlug } ) => {
+	setIframeSource = ( { siteTypeId, verticalId } ) => {
 		if ( ! this.iframe.current ) {
 			return;
 		}
-
+/*
 		const iframeSrc = getIframeSource(
 			content,
 			cssUrl,
@@ -205,7 +206,11 @@ export default class SignupSitePreviewIframe extends Component {
 		const { params, tagline, title } = content;
 
 		this.setContentTitle( title, tagline );
-		this.setContentParams( params );
+		this.setContentParams( params );*/
+
+
+		this.props.setIsLoaded( false );
+		this.iframe.current.src = `https://a8cvm${ siteTypeId }${ verticalId && siteTypeId === 1 ? verticalId : '' }.wordpress.com?hide_masterbar=true`;
 	};
 
 	render() {

--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -61,7 +61,7 @@ export default class SignupSitePreviewIframe extends Component {
 			);
 		}
 		// TODO: we'll do this right later if it works
-		window.addEventListener( 'message', ( event ) => {
+		window.addEventListener( 'message', event => {
 			let data;
 			if ( 'string' === typeof event.data ) {
 				try {
@@ -75,8 +75,9 @@ export default class SignupSitePreviewIframe extends Component {
 				data = event.data;
 			}
 			console.log( 'From parent:', data );
-
-			this.props.setWrapperHeight( data.height + 25 );
+			if ( typeof data.height === 'number' ) {
+				this.props.setWrapperHeight( data.height + 25 );
+			}
 		} );
 	}
 
@@ -96,7 +97,7 @@ export default class SignupSitePreviewIframe extends Component {
 			return false;
 		}
 
-		if (
+		/*if (
 			this.props.content.title !== nextProps.content.title ||
 			this.props.content.tagline !== nextProps.content.tagline
 		) {
@@ -112,7 +113,7 @@ export default class SignupSitePreviewIframe extends Component {
 			! shallowEqual( this.props.content.params, nextProps.content.params )
 		) {
 			this.setContentParams( nextProps.content.params );
-		}
+		}*/
 
 		return false;
 	}
@@ -186,7 +187,7 @@ export default class SignupSitePreviewIframe extends Component {
 	};
 
 	setLoaded = () => {
-/*		this.setOnPreviewClick();
+		/*		this.setOnPreviewClick();
 		this.setIframeIsLoading();
 		this.props.resize && this.setContainerHeight();
 
@@ -201,7 +202,7 @@ export default class SignupSitePreviewIframe extends Component {
 		if ( ! this.iframe.current ) {
 			return;
 		}
-/*
+		/*
 		const iframeSrc = getIframeSource(
 			content,
 			cssUrl,
@@ -226,9 +227,10 @@ export default class SignupSitePreviewIframe extends Component {
 		this.setContentTitle( title, tagline );
 		this.setContentParams( params );*/
 
-
 		this.props.setIsLoaded( false );
-		this.iframe.current.src = `https://a8cvm${ siteTypeId }${ verticalId && siteTypeId === 1 ? verticalId : '' }.wordpress.com?onboarding_preview=true#${ window.location.origin }`;
+		this.iframe.current.src = `https://a8cvm${ siteTypeId }${
+			verticalId && siteTypeId === 1 ? verticalId : ''
+		}.wordpress.com?onboarding_preview=true#${ window.location.origin }`;
 	};
 
 	render() {

--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -34,6 +34,7 @@ export default class SignupSitePreviewIframe extends Component {
 		setIsLoaded: PropTypes.func,
 		setWrapperHeight: PropTypes.func,
 		scrolling: PropTypes.bool,
+		defaultViewportDevice: PropTypes.oneOf( [ 'desktop', 'phone' ] ),
 	};
 
 	static defaultProps = {
@@ -54,12 +55,7 @@ export default class SignupSitePreviewIframe extends Component {
 
 	componentDidMount() {
 		this.setIframeSource( this.props );
-		if ( this.props.resize ) {
-			this.resizeListener = window.addEventListener(
-				'resize',
-				debounce( this.setContainerHeight, 50 )
-			);
-		}
+
 		// TODO: we'll do this right later if it works
 		window.addEventListener( 'message', event => {
 			let data;
@@ -74,24 +70,24 @@ export default class SignupSitePreviewIframe extends Component {
 			} else {
 				data = event.data;
 			}
-			console.log( 'From parent:', data );
-			if ( typeof data.height === 'number' ) {
+			console.log( 'From parent:', event.origin, data );
+			if ( typeof data.height === 'number' && this.props.resize ) {
 				this.props.setWrapperHeight( data.height + 25 );
 			}
+
+			if ( typeof data.loaded === true  ) {
+
+			}
+
 		} );
 	}
 
-	componentWillUnmount() {
-		this.resizeListener && window.removeEventListener( 'resize', this.resizeListener );
-	}
+
 
 	shouldComponentUpdate( nextProps ) {
 		if (
-			this.props.cssUrl !== nextProps.cssUrl ||
-			this.props.fontUrl !== nextProps.fontUrl ||
-			this.props.gutenbergStylesUrl !== nextProps.gutenbergStylesUrl ||
-			this.props.langSlug !== nextProps.langSlug ||
-			this.props.isRtl !== nextProps.isRtl
+			this.props.verticalId !== nextProps.verticalId ||
+			this.props.siteTypeId !== nextProps.siteTypeId
 		) {
 			this.setIframeSource( nextProps );
 			return false;
@@ -228,9 +224,11 @@ export default class SignupSitePreviewIframe extends Component {
 		this.setContentParams( params );*/
 
 		this.props.setIsLoaded( false );
+		// the base site URL could come from the verticals API
+		// added to the annotation during generation?
 		this.iframe.current.src = `https://a8cvm${ siteTypeId }${
 			verticalId && siteTypeId === 1 ? verticalId : ''
-		}.wordpress.com?onboarding_preview=true#${ window.location.origin }`;
+		}.wordpress.com?onboarding_preview=true&size=${ this.props.defaultViewportDevice }#${ window.location.origin }`;
 	};
 
 	render() {

--- a/client/signup/site-mockup/index.jsx
+++ b/client/signup/site-mockup/index.jsx
@@ -21,6 +21,8 @@ import {
 	getSiteVerticalPreview,
 	getSiteVerticalPreviewStyles,
 	getSiteVerticalSlug,
+	getSiteVerticalId,
+	getSiteVerticalParentId,
 } from 'state/signup/steps/site-vertical/selectors';
 import { getSiteStyle } from 'state/signup/steps/site-style/selectors';
 import { getSiteStyleOptions, getThemeCssUri } from 'lib/signup/site-styles';
@@ -145,10 +147,12 @@ class SiteMockups extends Component {
 			shouldShowHelpTip,
 			siteStyle,
 			siteType,
+			siteTypeId,
 			siteVerticalName,
 			title,
 			themeSlug,
 			verticalPreviewContent,
+			verticalId,
 			verticalPreviewStyles,
 		} = this.props;
 
@@ -172,6 +176,8 @@ class SiteMockups extends Component {
 			isRtl,
 			onPreviewClick: this.handlePreviewClick,
 			className: siteStyle,
+			verticalId,
+			siteTypeId,
 		};
 
 		return (
@@ -202,6 +208,7 @@ export default connect(
 		const styleOptions = getSiteStyleOptions( siteType );
 		const style = find( styleOptions, { id: siteStyle || 'modern' } );
 		const titleFallback = getSiteTypePropertyValue( 'slug', siteType, 'siteMockupTitleFallback' );
+		const siteTypeId = getSiteTypePropertyValue( 'slug', siteType, 'id' );
 		const verticalPreviewContent = getSiteVerticalPreview( state );
 		const shouldFetchVerticalData = ! verticalPreviewContent;
 		return {
@@ -218,6 +225,8 @@ export default connect(
 			themeSlug: style.theme,
 			fontUrl: style.fontUrl,
 			shouldFetchVerticalData,
+			siteTypeId,
+			verticalId: getSiteVerticalParentId( state ) || getSiteVerticalId( state ),
 		};
 	},
 	{

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -17,7 +17,6 @@ import { saveSignupStep } from 'state/signup/progress/actions';
 
 const siteTypeToFlowname = {
 	'online-store': 'ecommerce-onboarding',
-	blog: 'onboarding-blog',
 };
 
 class SiteType extends Component {

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -368,6 +368,9 @@ function setUpLoggedOutRoute( req, res, next ) {
 		'X-Frame-Options': 'SAMEORIGIN',
 	} );
 
+	// res.set('X-Frame-Options', 'ALLOW-FROM htps://google.com/');
+
+
 	next();
 }
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

A spike to test embedding site vertical sites in an iframe.

The vertical sites have a plugin (a mu-plugin now for ease of development) that filters the content before it's rendered to make it embedabble-friendly, and also opens up a `postMessage` channel between the two frames.

D30034-code

#### Testing instructions

Apply D30034-code

