### PR TITLE
Enable file download stats panel on wpcalypso

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -59,6 +59,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/stats": true,
+		"manage/stats/file-downloads": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -82,6 +82,7 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/stats": true,
+		"manage/stats/file-downloads": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Turn on the new file download stats panel on wpcalypso for easier testing.

<img width="390" alt="Screen Shot 2019-07-02 at 14 32 52" src="https://user-images.githubusercontent.com/17325/60516758-4cfb9000-9cd6-11e9-96c8-f0d00ff17db4.png">
