### PR TITLE
File Download stats: adapt to the correct API response format

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -130,11 +130,11 @@ class StatsSite extends Component {
 		const { period, endOf } = this.props.period;
 		const moduleStrings = statsStrings();
 		let videoList;
-		let podcastList;
+		let fileDownloadList;
 
 		const query = memoizedQuery( period, endOf );
 
-		// Video plays, and tags and categories are not supported in JetPack Stats
+		// Video plays and file downloads are not yet supported in Jetpack Stats
 		if ( ! isJetpack ) {
 			videoList = (
 				<StatsModule
@@ -146,18 +146,19 @@ class StatsSite extends Component {
 					showSummaryLink
 				/>
 			);
-		}
-		if ( config.isEnabled( 'manage/stats/file-downloads' ) ) {
-			podcastList = (
-				<StatsModule
-					path="filedownloads"
-					moduleStrings={ moduleStrings.filedownloads }
-					period={ this.props.period }
-					query={ query }
-					statType="statsFileDownloads"
-					showSummaryLink
-				/>
-			);
+
+			if ( config.isEnabled( 'manage/stats/file-downloads' ) ) {
+				fileDownloadList = (
+					<StatsModule
+						path="filedownloads"
+						moduleStrings={ moduleStrings.filedownloads }
+						period={ this.props.period }
+						query={ query }
+						statType="statsFileDownloads"
+						showSummaryLink
+					/>
+				);
+			}
 		}
 
 		return (
@@ -260,7 +261,7 @@ class StatsSite extends Component {
 								className="stats__author-views"
 								showSummaryLink
 							/>
-							{ podcastList }
+							{ fileDownloadList }
 						</div>
 					</div>
 				</div>

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1820,11 +1820,9 @@ describe( 'utils', () => {
 							date: '2017-01-12',
 							days: {
 								'2017-01-12': {
-									downloads: [
+									files: [
 										{
-											url: 'http://en.blog.wordpress.com/awesome',
-											post_id: 10,
-											title: 'My awesome podcast',
+											filename: '/2019/01/awesome.mov',
 											downloads: 3939,
 										},
 									],
@@ -1840,17 +1838,11 @@ describe( 'utils', () => {
 							slug: 'en.blog.wordpress.com',
 						}
 					)
-				).toEqual( [
+				).toMatchObject( [
 					{
-						actions: [
-							{
-								data: 'http://en.blog.wordpress.com/awesome',
-								type: 'link',
-							},
-						],
-						label: 'My awesome podcast',
-						page: '/stats/day/filedownloads/en.blog.wordpress.com?post=10',
 						value: 3939,
+						label: '/2019/01/awesome.mov',
+						labelIcon: 'external',
 					},
 				] );
 			} );

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { moment } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
@@ -18,6 +19,7 @@ import {
 	parseOrdersChartData,
 	parseStoreStatsReferrers,
 	rangeOfPeriod,
+	getWpcomFilesBaseUrl,
 } from '../utils';
 
 describe( 'utils', () => {
@@ -167,6 +169,30 @@ describe( 'utils', () => {
 
 		test( 'should return correctly year format for short (new) formats', () => {
 			expect( getPeriodFormat( 'year', '2017' ) ).toBe( 'YYYY' );
+		} );
+	} );
+
+	describe( 'getWpcomFilesBaseUrl', () => {
+		test( 'should return null with an empty site object', () => {
+			expect( getWpcomFilesBaseUrl( null ) ).toEqual( false );
+		} );
+
+		test( 'should return the correct files URL for a mapped domain', () => {
+			expect(
+				getWpcomFilesBaseUrl( { wpcom_url: 'discover.wordpress.com', URL: 'http://example.com' } )
+			).toEqual( 'https://discover.files.wordpress.com' );
+		} );
+
+		test( 'should return the correct files URL for a wpcom domain', () => {
+			expect(
+				getWpcomFilesBaseUrl( { wpcom_url: null, URL: 'http://discover.wordpress.com' } )
+			).toEqual( 'https://discover.files.wordpress.com' );
+		} );
+
+		test( 'should return null if URL contains a non-wpcom domain and wpcom_url is empty', () => {
+			expect( getWpcomFilesBaseUrl( { wpcom_url: null, URL: 'http://example.com' } ) ).toEqual(
+				false
+			);
 		} );
 	} );
 

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -977,22 +977,15 @@ export const normalizers = {
 		}
 
 		const { startOf } = rangeOfPeriod( query.period, query.date );
-		const statsData = get( data, [ 'days', startOf, 'downloads' ], [] );
+		const statsData = get( data, [ 'days', startOf, 'files' ], [] );
 
 		return statsData.map( item => {
-			const detailPage = site
-				? '/stats/' + query.period + '/filedownloads/' + site.slug + '?post=' + item.post_id
-				: null;
 			return {
-				label: item.title,
-				page: detailPage,
+				label: item.filename,
+				page: null,
 				value: item.downloads,
-				actions: [
-					{
-						type: 'link',
-						data: item.url,
-					},
-				],
+				link: site.URL + item.filename, // need the site files location, not necessarily the main URL
+				labelIcon: 'external',
 			};
 		} );
 	},

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -984,7 +984,11 @@ export const normalizers = {
 				label: item.filename,
 				page: null,
 				value: item.downloads,
-				link: site.URL + item.filename, // need the site files location, not necessarily the main URL
+				link:
+					site.wpcom_url &&
+					'https://' +
+						site.wpcom_url.replace( '.wordpress.com', '.files.wordpress.com' ) +
+						item.filename,
 				labelIcon: 'external',
 			};
 		} );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -14,8 +14,10 @@ import {
 	map,
 	concat,
 	flatten,
+	endsWith,
 } from 'lodash';
 import { moment, translate } from 'i18n-calypso';
+import { withoutHttp } from 'lib/url';
 
 /**
  * Internal dependencies
@@ -43,6 +45,25 @@ export function getPeriodFormat( period, date ) {
 		default:
 			return 'YYYY-MM-DD';
 	}
+}
+
+/**
+ * Returns the base URL for downloadable files on *.wordpress.com sites.
+ *
+ * @param  {Object} site Site object
+ * @return {String} URL
+ */
+export function getWpcomFilesBaseUrl( site ) {
+	if ( ! site ) {
+		return false;
+	}
+
+	// For mapped domains, wpcom_url will contain the *.wordpress.com domain
+	// Otherwise, use the site.URL without protocol
+	const wpcomUrl =
+		site.wpcom_url || ( endsWith( site.URL, '.wordpress.com' ) && withoutHttp( site.URL ) );
+
+	return wpcomUrl && 'https://' + wpcomUrl.replace( '.wordpress.com', '.files.wordpress.com' );
 }
 
 /**
@@ -980,15 +1001,12 @@ export const normalizers = {
 		const statsData = get( data, [ 'days', startOf, 'files' ], [] );
 
 		return statsData.map( item => {
+			const wpcomFilesBaseUrl = getWpcomFilesBaseUrl( site );
 			return {
 				label: item.filename,
 				page: null,
 				value: item.downloads,
-				link:
-					site.wpcom_url &&
-					'https://' +
-						site.wpcom_url.replace( '.wordpress.com', '.files.wordpress.com' ) +
-						item.filename,
+				link: wpcomFilesBaseUrl + item.filename,
 				labelIcon: 'external',
 			};
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR makes changes to consume the response from the file download stats endpoint correctly.

You'll need patch D29817-code applied to see results from the API.

#### Testing instructions

Head to http://calypso.localhost:3000/stats/day on a site that's had recent file downloads. Ensure that the download information is shown.

Try switching between monthly/daily/yearly views. (There will only be data for the last few days.)

<img width="366" alt="Screen Shot 2019-07-02 at 15 00 06" src="https://user-images.githubusercontent.com/17325/60518935-6acaf400-9cda-11e9-8b6a-e784b3945d92.png">
