### PR TITLE
Copy refinements

### DIFF
--- a/client/my-sites/site-settings/form-security.jsx
+++ b/client/my-sites/site-settings/form-security.jsx
@@ -92,9 +92,7 @@ class SiteSettingsFormSecurity extends Component {
 					</div>
 				) }
 
-				<SettingsSectionHeader
-					title={ translate( 'WordPress.com log in / single sign-on (SSO)' ) }
-				/>
+				<SettingsSectionHeader title={ translate( 'WordPress.com log in' ) } />
 				<Sso
 					handleAutosavingToggle={ handleAutosavingToggle }
 					isSavingSettings={ isSavingSettings }

--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -307,9 +307,11 @@ export class SeoForm extends React.Component {
 		const generalTabUrl = getGeneralTabUrl( slug );
 
 		const nudgeTitle = siteIsJetpack
-			? translate( 'Boost your search engine ranking with the power SEO tools in Jetpack Premium' )
+			? translate(
+					'Boost your search engine ranking with the powerful SEO tools in Jetpack Premium'
+			  )
 			: translate(
-					'Boost your search engine ranking with the power SEO tools in the Business plan'
+					'Boost your search engine ranking with the powerful SEO tools in the Business plan'
 			  );
 		return (
 			<div>


### PR DESCRIPTION
As part of a [recent copy sprint](https://github.com/Automattic/jetpack/projects/23) on Jetpack, many small changes were made to the settings and interface copy.

This is some refinements to those changes. 

Spelling change on the banner for SEO: s/power/powerful
Update the setting heading for SSO/WordPress.com login