### PR TITLE
Revert "Skip the transfer page if the user has already selected a domain (#32803)"

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -333,13 +333,6 @@ class RegisterDomainStep extends React.Component {
 		}
 	}
 
-	clearLastDomainState() {
-		this.setState( {
-			lastDomainStatus: null,
-			lastDomainIsTransferrable: false,
-		} );
-	}
-
 	getNewRailcarId() {
 		return `${ uuid().replace( /-/g, '' ) }-domain-suggestion`;
 	}
@@ -718,12 +711,11 @@ class RegisterDomainStep extends React.Component {
 				/^([a-z0-9]([a-z0-9-]*[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]*[a-z0-9])?\.[a-z]{2,63}$/i
 			)
 		) {
-			this.clearLastDomainState();
+			this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
 			return;
 		}
-
 		if ( this.props.isSignupStep && domain.match( /\.wordpress\.com$/ ) ) {
-			this.clearLastDomainState();
+			this.setState( { lastDomainStatus: null, lastDomainIsTransferrable: false } );
 			return;
 		}
 
@@ -1244,10 +1236,7 @@ class RegisterDomainStep extends React.Component {
 		if ( this.props.useYourDomainUrl ) {
 			useYourDomainUrl = this.props.useYourDomainUrl;
 		} else {
-			const query = stringify( {
-				initialQuery: this.state.lastQuery.trim(),
-				isDomainTransferrable: this.state.lastDomainIsTransferrable,
-			} );
+			const query = stringify( { initialQuery: this.state.lastQuery.trim() } );
 			useYourDomainUrl = `${ this.props.basePath }/use-your-domain`;
 			if ( this.props.selectedSite ) {
 				useYourDomainUrl += `/${ this.props.selectedSite.slug }?${ query }`;

--- a/client/components/domains/use-your-domain-step/index.jsx
+++ b/client/components/domains/use-your-domain-step/index.jsx
@@ -52,7 +52,6 @@ class UseYourDomainStep extends React.Component {
 		domainsWithPlansOnly: PropTypes.bool,
 		goBack: PropTypes.func,
 		initialQuery: PropTypes.string,
-		isDomainTransferrable: PropTypes.bool,
 		isSignupStep: PropTypes.bool,
 		mapDomainUrl: PropTypes.string,
 		transferDomainUrl: PropTypes.string,
@@ -128,10 +127,7 @@ class UseYourDomainStep extends React.Component {
 		buildTransferDomainUrl = `${ basePathForTransfer }/transfer`;
 
 		if ( selectedSite ) {
-			const query = stringify( {
-				initialQuery: this.state.searchQuery.trim(),
-				isDomainTransferrable: this.props.isDomainTransferrable,
-			} );
+			const query = stringify( { initialQuery: this.state.searchQuery.trim() } );
 			buildTransferDomainUrl += `/${ selectedSite.slug }?${ query }`;
 		}
 

--- a/client/my-sites/domains/controller.jsx
+++ b/client/my-sites/domains/controller.jsx
@@ -118,7 +118,6 @@ const transferDomain = ( context, next ) => {
 				<TransferDomain
 					basePath={ sectionify( context.path ) }
 					initialQuery={ context.query.initialQuery }
-					isDomainTransferrable={ context.query.isDomainTransferrable === 'true' }
 				/>
 			</CartData>
 		</Main>
@@ -146,7 +145,6 @@ const useYourDomain = ( context, next ) => {
 				<UseYourDomainStep
 					basePath={ sectionify( context.path ) }
 					initialQuery={ context.query.initialQuery }
-					isDomainTransferrable={ context.query.isDomainTransferrable === 'true' }
 					goBack={ handleGoBack }
 				/>
 			</CartData>
@@ -163,7 +161,6 @@ const transferDomainPrecheck = ( context, next ) => {
 	const handleGoBack = () => {
 		page( domainManagementTransferIn( siteSlug, domain ) );
 	};
-
 	context.primary = (
 		<Main>
 			<PageViewTracker
@@ -225,17 +222,19 @@ const redirectIfNoSite = redirectTo => {
 	};
 };
 
-const redirectToUseYourDomainIfVipSite = ( context, next ) => {
-	const state = context.store.getState();
-	const selectedSite = getSelectedSite( state );
+const redirectToUseYourDomainIfVipSite = () => {
+	return ( context, next ) => {
+		const state = context.store.getState();
+		const selectedSite = getSelectedSite( state );
 
-	if ( selectedSite && selectedSite.is_vip ) {
-		return page.redirect(
-			domainUseYourDomain( selectedSite.slug, get( context, 'params.suggestion', '' ) )
-		);
-	}
+		if ( selectedSite && selectedSite.is_vip ) {
+			return page.redirect(
+				domainUseYourDomain( selectedSite.slug, get( context, 'params.suggestion', '' ) )
+			);
+		}
 
-	next();
+		next();
+	};
 };
 
 const jetpackNoDomainsWarning = ( context, next ) => {

--- a/client/my-sites/domains/index.js
+++ b/client/my-sites/domains/index.js
@@ -190,7 +190,7 @@ export default function() {
 			'/domains/add',
 			siteSelection,
 			domainsController.domainsAddHeader,
-			domainsController.redirectToUseYourDomainIfVipSite,
+			domainsController.redirectToUseYourDomainIfVipSite(),
 			domainsController.jetpackNoDomainsWarning,
 			sites,
 			makeLayout,
@@ -232,7 +232,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.redirectToUseYourDomainIfVipSite,
+			domainsController.redirectToUseYourDomainIfVipSite(),
 			domainsController.jetpackNoDomainsWarning,
 			domainsController.domainSearch,
 			makeLayout,
@@ -244,7 +244,7 @@ export default function() {
 			siteSelection,
 			navigation,
 			domainsController.redirectIfNoSite( '/domains/add' ),
-			domainsController.redirectToUseYourDomainIfVipSite,
+			domainsController.redirectToUseYourDomainIfVipSite(),
 			domainsController.jetpackNoDomainsWarning,
 			domainsController.redirectToDomainSearchSuggestion
 		);

--- a/client/my-sites/domains/transfer-domain/index.jsx
+++ b/client/my-sites/domains/transfer-domain/index.jsx
@@ -33,7 +33,6 @@ export class TransferDomain extends Component {
 		query: PropTypes.string,
 		cart: PropTypes.object.isRequired,
 		domainsWithPlansOnly: PropTypes.bool.isRequired,
-		isDomainTransferrable: PropTypes.bool,
 		isSiteUpgradeable: PropTypes.bool,
 		productsList: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object,
@@ -170,7 +169,6 @@ export class TransferDomain extends Component {
 					onRegisterDomain={ this.handleRegisterDomain }
 					onTransferDomain={ this.handleTransferDomain }
 					analyticsSection="domains"
-					forcePrecheck={ this.props.isDomainTransferrable }
 				/>
 			</span>
 		);


### PR DESCRIPTION
This reverts commit 8b0c47bfca1b7c3a91963ef27ab912ea457fa0cb.

#### Changes proposed in this Pull Request

It turns out that this PR was causing issues when starting an inbound transfer from the transfer domain step because the `pending_start` status is never set.  After discussing with @klimeryk, we decided that it would be most prudent to simply revert this for now and research a fix in the future when when we have more time to work on it.

See p2MSmN-7gW-p2 for more information.

#### Testing instructions

Attempt to start an inbound transfer.

Make sure that you don't get the message about not being able to start the inbound transfer.
