### PR TITLE
Removes the Upwork AB test on the /help page

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -88,14 +88,6 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
-	builderReferralHelpBanner: {
-		datestamp: '20190304',
-		variations: {
-			builderReferralBanner: 25,
-			original: 75,
-		},
-		defaultVariation: 'original',
-	},
 	pageBuilderMVP: {
 		datestamp: '20190419',
 		variations: {

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -12,7 +12,6 @@ import { some } from 'lodash';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
@@ -31,7 +30,6 @@ import { localizeUrl } from 'lib/i18n-utils';
 import { getUserPurchases, isFetchingUserPurchases } from 'state/purchases/selectors';
 import { planHasFeature } from 'lib/plans';
 import { FEATURE_BUSINESS_ONBOARDING } from 'lib/plans/constants';
-import UpworkBanner from 'blocks/upwork-banner';
 
 /**
  * Style dependencies
@@ -245,9 +243,6 @@ class Help extends React.PureComponent {
 
 		return (
 			<Main className="help">
-				{ abtest( 'builderReferralHelpBanner' ) === 'builderReferralBanner' && (
-					<UpworkBanner location={ 'help-home' } />
-				) }
 				<PageViewTracker path="/help" title="Help" />
 				<MeSidebarNavigation />
 				<HelpSearch />


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* #33665 Remove /help page ab test

#### Testing instructions

* Follow the "Help Banner Testing instructions" testing instructions on https://github.com/Automattic/wp-calypso/pull/31195
* Banner should appear
