### PR TITLE
Billing History: Let long text overflow with an ellipsis on medium-sized screens

### DIFF
--- a/client/layout/guided-tours/button-labels.jsx
+++ b/client/layout/guided-tours/button-labels.jsx
@@ -26,7 +26,7 @@ export const AddContentButton = button( translate( 'Add' ), <Gridicon icon="add-
 export const AddMediaButton = button( translate( 'Add Media' ) );
 export const AddNewButton = button( translate( 'Add New' ), <Gridicon icon="add-image" /> );
 export const AllThemesButton = button( translate( 'All Themes' ) );
-export const ChangeButton = button( translate( 'Change' ) );
+export const ChangeButton = button( translate( 'Change', { context: 'verb' } ) );
 export const ContinueButton = button( translate( 'Continue' ) );
 export const DoneButton = button( translate( 'Done' ) );
 export const EditButton = button( translate( 'Edit' ) );

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -356,6 +356,19 @@ textarea.billing-history__billing-details-editable {
 	margin: 0;
 }
 
+.billing-history__receipts.card .card.is-compact:nth-of-type( 2 ) {
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.billing-history__receipts.card .pagination__list-item.pagination__arrow.is-left {
+	padding-left: 8px;
+}
+
+.billing-history__receipts.card .pagination__list-item.pagination__arrow.is-right {
+	padding-right: 8px;
+}
+
 .billing-history__receipt-card.is-placeholder {
 	.billing-history__app-overview {
 		display: flex;

--- a/client/me/billing-history/style.scss
+++ b/client/me/billing-history/style.scss
@@ -123,6 +123,12 @@
 		display: block;
 		font-size: 12px;
 		font-style: italic;
+
+		@include breakpoint( '660px-800px' ) {
+			max-width: 220px;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
 	}
 }
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Fixes the edge case where, if the site URL in this table is quite long, the rest of the table overflows the container on medium-sized screens 660-800px. 
* Set a max width and add overflow rules to hide part of longer site URLs.

**Before**

<img width="718" alt="Screen Shot 2019-07-02 at 1 12 02 PM" src="https://user-images.githubusercontent.com/2124984/60532514-6f3be080-9ccb-11e9-84a8-90f051c895d5.png">


**After**

<img width="714" alt="Screen Shot 2019-07-02 at 1 10 49 PM" src="https://user-images.githubusercontent.com/2124984/60532504-69de9600-9ccb-11e9-9d12-e305e360cd22.png">


#### Testing instructions

* Switch to this PR
* Check out the Billing History under Me -> Manage Purchases
* Values in the table should not overflow even if a site URL is very long. Test with values of different lengths, look at different pages, test with different screen widths to ensure these changes haven't inadvertently broken something else.

Fixes #33690
