### PR TITLE
Added skip button to WP.com checklist

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -262,6 +262,10 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 		white-space: nowrap;
 	}
 
+	.checklist__task-skip {
+		margin-left: 8px;
+	}
+
 	&.warning {
 		.gridicons-notice-outline {
 			display: block;

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -199,11 +199,11 @@ class Task extends PureComponent {
 									>
 										{ taskActionButtonText }
 									</Button>
-									{ ! completed && showSkip ? (
+									{ ! completed && showSkip && (
 										<Button className="checklist__task-skip" onClick={ onDismiss }>
-											Skip
+											{ translate( 'Skip' ) }
 										</Button>
-									) : null }
+									) }
 								</div>
 							</div>
 						</div>

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -37,6 +37,7 @@ class Task extends PureComponent {
 		title: PropTypes.node.isRequired,
 		translate: PropTypes.func.isRequired,
 		trackTaskDisplay: PropTypes.func,
+		showSkip: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -137,6 +138,8 @@ class Task extends PureComponent {
 			target,
 			title,
 			translate,
+			onDismiss,
+			showSkip,
 		} = this.props;
 
 		// A task that's being automatically completed ("in progress") cannot be expanded.
@@ -196,6 +199,11 @@ class Task extends PureComponent {
 									>
 										{ taskActionButtonText }
 									</Button>
+									{ ! completed && showSkip ? (
+										<Button className="checklist__task-skip" onClick={ onDismiss }>
+											Skip
+										</Button>
+									) : null }
 								</div>
 							</div>
 						</div>

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -425,6 +425,7 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Give your site a name' ) }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -449,6 +450,7 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Upload a site icon' ) }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -473,6 +475,7 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Create a tagline' ) }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -497,6 +500,7 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Upload your profile picture' ) }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -521,6 +525,7 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Personalize your Contact page' ) }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -543,6 +548,7 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Publish your first blog post' ) }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -567,6 +573,7 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Register a custom domain' ) }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -591,6 +598,7 @@ class WpcomChecklistComponent extends PureComponent {
 				} ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Get the WordPress app' ) }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -637,6 +645,7 @@ class WpcomChecklistComponent extends PureComponent {
 					'Subscribe to G Suite to get a dedicated inbox with a personalized email address using your domain and collaborate in real-time on documents, spreadsheets, and slides.'
 				) }
 				duration={ translate( '%d minute', '%d minutes', { count: 5, args: [ 5 ] } ) }
+				showSkip={ true }
 				{ ...clickProps }
 			/>
 		);
@@ -671,6 +680,7 @@ class WpcomChecklistComponent extends PureComponent {
 					page( emailManagement( siteSlug ) );
 				} }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -778,6 +788,7 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -817,6 +828,7 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -844,6 +856,7 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -880,6 +893,7 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -914,6 +928,7 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -957,6 +972,7 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }
+				showSkip={ true }
 			/>
 		);
 	};
@@ -991,6 +1007,7 @@ class WpcomChecklistComponent extends PureComponent {
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				backToChecklist={ this.backToChecklist }
 				nextInlineHelp={ this.nextInlineHelp }
+				showSkip={ true }
 			/>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR introduces a skip button to the WP.com checklist. The Jetpack checklist currently doesn't offer a way to skip tasks so I added it in such a way that it should not impact Woo or Jetpack.

For the time being, we will have two ways to skip a task. I will be replace the circle next to the title with an icon in another PR in the future. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/60537103-c181ff00-9cd5-11e9-95a8-e631e4cc5305.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/60537094-b929c400-9cd5-11e9-8871-4637b6d4eaa6.png)


**Jetpack**
![image](https://user-images.githubusercontent.com/6981253/60537085-b3cc7980-9cd5-11e9-9990-32f3df818172.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site on WP.com
* Visit `/checklist/[url]`
* Click on the skip button and confirm that it is marked complete

Something to note, tasks don't automatically collapse when you mark them complete. Since this is the existing behaviour, and it's a little beyond my expertise, I'd suggest we tackle that in a separate PR. 

cc @Automattic/zelda @simison, @jeffgolenski

Fixes # https://github.com/Automattic/zelda-private/issues/56
