### PR TITLE
Add updated `HeaderButton` to cart area

### DIFF
--- a/client/components/header-button/index.jsx
+++ b/client/components/header-button/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Gridicon from 'components/gridicon';
 
@@ -16,12 +16,18 @@ import Button from 'components/button';
  */
 import './style.scss';
 
-const HeaderButton = ( { icon, label, ...rest } ) => (
-	<Button className="header-button" { ...rest }>
-		{ icon && <Gridicon icon={ icon } size={ 18 } /> }
-		<span className="header-button__text">{ label }</span>
-	</Button>
-);
+class HeaderButton extends Component {
+	render() {
+		const { icon, label, ...rest } = this.props;
+
+		return (
+			<Button className="header-button" { ...rest }>
+				{ icon && <Gridicon icon={ icon } size={ 18 } /> }
+				<span className="header-button__text">{ label }</span>
+			</Button>
+		);
+	}
+}
 
 HeaderButton.propTypes = {
 	icon: PropTypes.string,

--- a/client/components/section-nav/style.scss
+++ b/client/components/section-nav/style.scss
@@ -5,7 +5,8 @@
 	margin: 0 0 17px;
 	background: var( --color-surface );
 	box-sizing: border-box;
-	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ), 0 1px 2px var( --color-neutral-0 );
+	box-shadow: 0 0 0 1px rgba( var( --color-neutral-10-rgb ), 0.5 ),
+		0 1px 2px var( --color-neutral-0 );
 
 	&.is-empty .section-nav__panel {
 		visibility: hidden;
@@ -59,7 +60,7 @@
 	}
 
 	.section-nav.has-pinned-items & {
-		padding-right: 50px;
+		padding-right: 85px;
 
 		&::after {
 			margin-left: 8px;
@@ -96,7 +97,11 @@
 		.section-nav.is-open & {
 			padding-bottom: 15px;
 			border-top: solid 1px var( --color-neutral-10 );
-			background: linear-gradient( to bottom, var( --color-neutral-0 ) 0%, var( --color-surface ) 4px );
+			background: linear-gradient(
+				to bottom,
+				var( --color-neutral-0 ) 0%,
+				var( --color-surface ) 4px
+			);
 		}
 	}
 

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -94,18 +94,10 @@ class PopoverCart extends React.Component {
 			<div>
 				<CartMessages cart={ cart } selectedSite={ selectedSite } />
 				<div className={ classes }>
-<<<<<<< HEAD
-					<HeaderButton icon="cart" label="Cart" onClick={ this.onToggle } />
-
-					<button
-						className="cart-toggle-button"
-						ref={ this.toggleButtonRef }
-=======
 					<HeaderButton
 						icon="cart"
 						label={ translate( 'Cart' ) }
 						ref={ this.toggleButton }
->>>>>>> Replaces button element w/ HeaderButton component
 						onClick={ this.onToggle }
 					/>
 					{ countBadge }

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -9,7 +9,6 @@ import React from 'react';
 import { reject } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -95,17 +94,21 @@ class PopoverCart extends React.Component {
 			<div>
 				<CartMessages cart={ cart } selectedSite={ selectedSite } />
 				<div className={ classes }>
+<<<<<<< HEAD
 					<HeaderButton icon="cart" label="Cart" onClick={ this.onToggle } />
 
 					<button
 						className="cart-toggle-button"
 						ref={ this.toggleButtonRef }
+=======
+					<HeaderButton
+						icon="cart"
+						label="Cart"
+						ref={ this.toggleButton }
+>>>>>>> Replaces button element w/ HeaderButton component
 						onClick={ this.onToggle }
-					>
-						<div className="popover-cart__label">{ this.props.translate( 'Cart' ) }</div>
-						<Gridicon icon="cart" size={ 24 } />
-						{ countBadge }
-					</button>
+					/>
+					{ countBadge }
 				</div>
 
 				{ this.renderCartContent() }

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -97,7 +97,7 @@ class PopoverCart extends React.Component {
 					<HeaderButton
 						icon="cart"
 						label={ translate( 'Cart' ) }
-						ref={ this.toggleButton }
+						ref={ this.toggleButtonRef }
 						onClick={ this.onToggle }
 					/>
 					{ countBadge }

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -17,6 +17,7 @@ import Gridicon from 'components/gridicon';
 import CartBody from './cart-body';
 import CartBodyLoadingPlaceholder from './cart-body/loading-placeholder';
 import CartMessages from './cart-messages';
+import HeaderButton from 'components/header-button';
 import CartButtons from './cart-buttons';
 import Count from 'components/count';
 import Popover from 'components/popover';
@@ -94,6 +95,8 @@ class PopoverCart extends React.Component {
 			<div>
 				<CartMessages cart={ cart } selectedSite={ selectedSite } />
 				<div className={ classes }>
+					<HeaderButton icon="cart" label="Cart" onClick={ this.onToggle } />
+
 					<button
 						className="cart-toggle-button"
 						ref={ this.toggleButtonRef }

--- a/client/my-sites/checkout/cart/popover-cart.jsx
+++ b/client/my-sites/checkout/cart/popover-cart.jsx
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { reject } from 'lodash';
 import classNames from 'classnames';
-import { localize } from 'i18n-calypso';
+import { localize, translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -103,7 +103,7 @@ class PopoverCart extends React.Component {
 =======
 					<HeaderButton
 						icon="cart"
-						label="Cart"
+						label={ translate( 'Cart' ) }
 						ref={ this.toggleButton }
 >>>>>>> Replaces button element w/ HeaderButton component
 						onClick={ this.onToggle }

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -261,6 +261,16 @@
 	}
 }
 
+.popover-cart {
+	position: relative;
+	display: inline-block;
+
+	button {
+		min-width: auto;
+		padding: 0 16px 0 10px;
+	}
+}
+
 .popover-cart.pinned {
 	position: absolute;
 	right: 0;
@@ -413,7 +423,6 @@ div.popover-cart__popover {
 	}
 }
 
-
 .secondary-cart {
 	background: var( --color-surface );
 
@@ -431,9 +440,7 @@ div.popover-cart__popover {
 	.jetpack-logo {
 		margin: 32px 0;
 	}
-
 }
-
 
 @include breakpoint( '<660px' ) {
 	.secondary-cart__hidden {

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -267,7 +267,11 @@
 
 	button {
 		min-width: auto;
-		padding: 0 25px 0 10px;
+		padding: 0 25px 0 5px;
+
+		@include breakpoint( '>480px' ) {
+			min-height: 50px;
+		}
 	}
 }
 

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -266,11 +266,12 @@
 	display: inline-block;
 
 	button {
+		box-sizing: border-box;
 		min-width: auto;
-		padding: 0 25px 0 5px;
+		padding: 0 15px 0 10px;
 
 		@include breakpoint( '>480px' ) {
-			min-height: 50px;
+			padding: 14px 20px 12px;
 		}
 	}
 }
@@ -287,9 +288,14 @@
 
 .cart__count-badge .count {
 	position: absolute;
-	top: 5px;
-	right: 5px;
+	top: 2px;
+	right: 2px;
 	animation: pulsing-badge 2s infinite;
+
+	@include breakpoint( '>480px' ) {
+		top: 5px;
+		right: 5px;
+	}
 }
 
 .cart__count-badge:hover .count {

--- a/client/my-sites/checkout/cart/style.scss
+++ b/client/my-sites/checkout/cart/style.scss
@@ -267,7 +267,7 @@
 
 	button {
 		min-width: auto;
-		padding: 0 16px 0 10px;
+		padding: 0 25px 0 10px;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replaces button element w/ `HeaderButton` component.
* Refactors (slightly) `HeaderButton` functional component to a class component so that it can accept refs.
*  Adjusts section nav button down caret to avoid overlap with wider cart button.
* Adjusts positioning of the cart count to account for markup adjustments.
* Reduces right padding of cart button to keep width between icon and dropdown caret the same, as well as keep some spacing when focus state is active and background is slightly darker.

#### Testing instructions

* Apply this PR.
* Visit the /plans page on your local site and confirm that the cart is using the `HeaderButton` component (should have the text "Cart" next to it).
* Add something to the cart and verify that the pulsing blue cart-count appears in top right corner of cart button.
* View at mobile viewport width and reload so that the `has-pinned-items` class is applied to the parent navigation.
* Confirm that the dropdown caret for Plans still appears next to the cart icon.
* Navigate to /domains and re-verify previous test items.

Fixes #32531
