### PR TITLE
FSE: Append new blocks inside post content block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/edit.js
@@ -68,7 +68,7 @@ class PostContentEdit extends Component {
 					} ) }
 				>
 					<PostTitle />
-					{ showInnerBlocks && <InnerBlocks /> }
+					{ showInnerBlocks && <InnerBlocks templateLock={ false } /> }
 					{ showPlaceholder && (
 						<Placeholder
 							icon="layout"

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -588,7 +588,7 @@ class Full_Site_Editing {
 				$template[] = fse_map_block_to_editor_template_setting( $block );
 			}
 			$editor_settings['template'] = $template;
-			$editor_settings['templateLock'] = 'insert';
+			$editor_settings['templateLock'] = 'all';
 		}
 		return $editor_settings;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -588,6 +588,7 @@ class Full_Site_Editing {
 				$template[] = fse_map_block_to_editor_template_setting( $block );
 			}
 			$editor_settings['template'] = $template;
+			$editor_settings['templateLock'] = 'insert';
 		}
 		return $editor_settings;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/block-inserter/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/block-inserter/index.js
@@ -1,0 +1,47 @@
+/* global fullSiteEditing */
+
+/**
+ * External dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { render } from '@wordpress/element';
+import { Inserter } from '@wordpress/editor';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+
+const PostContentBlockAppender = compose(
+	withSelect( select => {
+		const { getBlocks, getEditorSettings } = select( 'core/editor' );
+		const { getEditorMode } = select( 'core/edit-post' );
+
+		const postContentBlock = getBlocks().find( block => block.name === 'a8c/post-content' );
+
+		return {
+			rootClientId: postContentBlock ? postContentBlock.clientId : '',
+			showInserter: getEditorMode() === 'visual' && getEditorSettings().richEditingEnabled,
+		};
+	} )
+)( ( { rootClientId, showInserter } ) => {
+	return (
+		<Inserter rootClientId={ rootClientId } disabled={ ! showInserter } position="bottom right" />
+	);
+} );
+
+/**
+ * Renders a custom block inserter that will append new blocks inside the post content block.
+ */
+function renderPostContentBlockInserter() {
+	if ( 'page' !== fullSiteEditing.editorPostType ) {
+		return;
+	}
+
+	const headerToolbar = document.querySelector( '.edit-post-header-toolbar' );
+	const blockInserterContainer = document.createElement( 'div' );
+	blockInserterContainer.classList.add( 'fse-post-content-block-inserter' );
+
+	headerToolbar.insertBefore( blockInserterContainer, headerToolbar.firstChild );
+
+	render( <PostContentBlockAppender />, blockInserterContainer );
+}
+
+domReady( () => renderPostContentBlockInserter() );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/block-inserter/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/block-inserter/index.js
@@ -5,27 +5,11 @@
  */
 import domReady from '@wordpress/dom-ready';
 import { render } from '@wordpress/element';
-import { Inserter } from '@wordpress/editor';
-import { compose } from '@wordpress/compose';
-import { withSelect } from '@wordpress/data';
 
-const PostContentBlockAppender = compose(
-	withSelect( select => {
-		const { getBlocks, getEditorSettings } = select( 'core/editor' );
-		const { getEditorMode } = select( 'core/edit-post' );
-
-		const postContentBlock = getBlocks().find( block => block.name === 'a8c/post-content' );
-
-		return {
-			rootClientId: postContentBlock ? postContentBlock.clientId : '',
-			showInserter: getEditorMode() === 'visual' && getEditorSettings().richEditingEnabled,
-		};
-	} )
-)( ( { rootClientId, showInserter } ) => {
-	return (
-		<Inserter rootClientId={ rootClientId } disabled={ ! showInserter } position="bottom right" />
-	);
-} );
+/**
+ * Internal dependencies
+ */
+import PostContentBlockAppender from './post-content-block-appender';
 
 /**
  * Renders a custom block inserter that will append new blocks inside the post content block.
@@ -35,13 +19,21 @@ function renderPostContentBlockInserter() {
 		return;
 	}
 
-	const headerToolbar = document.querySelector( '.edit-post-header-toolbar' );
-	const blockInserterContainer = document.createElement( 'div' );
-	blockInserterContainer.classList.add( 'fse-post-content-block-inserter' );
+	const editPostHeaderToolbarInception = setInterval( () => {
+		const headerToolbar = document.querySelector( '.edit-post-header-toolbar' );
 
-	headerToolbar.insertBefore( blockInserterContainer, headerToolbar.firstChild );
+		if ( ! headerToolbar ) {
+			return;
+		}
+		clearInterval( editPostHeaderToolbarInception );
 
-	render( <PostContentBlockAppender />, blockInserterContainer );
+		const blockInserterContainer = document.createElement( 'div' );
+		blockInserterContainer.classList.add( 'fse-post-content-block-inserter' );
+
+		headerToolbar.insertBefore( blockInserterContainer, headerToolbar.firstChild );
+
+		render( <PostContentBlockAppender />, blockInserterContainer );
+	} );
 }
 
 domReady( () => renderPostContentBlockInserter() );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/block-inserter/post-content-block-appender.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/block-inserter/post-content-block-appender.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { Inserter } from '@wordpress/editor';
+import { compose } from '@wordpress/compose';
+import { withSelect } from '@wordpress/data';
+
+const PostContentBlockAppender = compose(
+	withSelect( select => {
+		const { getBlocks, getEditorSettings } = select( 'core/editor' );
+		const { getEditorMode } = select( 'core/edit-post' );
+
+		const postContentBlock = getBlocks().find( block => block.name === 'a8c/post-content' );
+
+		return {
+			rootClientId: postContentBlock ? postContentBlock.clientId : '',
+			showInserter: getEditorMode() === 'visual' && getEditorSettings().richEditingEnabled,
+		};
+	} )
+)( ( { rootClientId, showInserter } ) => {
+	return (
+		<Inserter rootClientId={ rootClientId } disabled={ ! showInserter } position="bottom right" />
+	);
+} );
+
+export default PostContentBlockAppender;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js
@@ -2,3 +2,4 @@
  * Internal dependencies
  */
 import './block-inserter';
+import './template-validity-override';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js
@@ -1,0 +1,4 @@
+/**
+ * Internal dependencies
+ */
+import './block-inserter';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/template-validity-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/template-validity-override/index.js
@@ -1,0 +1,25 @@
+/* global fullSiteEditing */
+
+/**
+ * External dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { dispatch } from '@wordpress/data';
+
+/**
+ * Forces the template validity.
+ *
+ * This is a work-around for the existing core issue that is showing a template mismatch warning when there is a parent
+ * block with a locked template containing a nested InnerBlocks with an unlocked template.
+ *
+ * @see https://github.com/WordPress/gutenberg/issues/11681
+ */
+function resetTemplateValidity() {
+	if ( 'page' !== fullSiteEditing.editorPostType ) {
+		return;
+	}
+
+	dispatch( 'core/editor' ).setTemplateValidity( true );
+}
+
+domReady( () => resetTemplateValidity() );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
@@ -10,3 +10,4 @@ import './blocks/site-logo';
 import './plugins/template-selector-sidebar';
 import './plugins/close-button-override';
 import './plugins/template-update-confirmation';
+import './editor';

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -111,6 +111,9 @@ class PageTemplateModal extends Component {
 const PageTemplatesPlugin = compose(
 	withSelect( select => ( {
 		getMeta: () => select( 'core/editor' ).getEditedPostAttribute( 'meta' ),
+		postContentBlock: select( 'core/editor' )
+			.getBlocks()
+			.find( block => block.name === 'a8c/post-content' ),
 	} ) ),
 	withDispatch( ( dispatch, ownProps ) => {
 		// Disable tips right away as the collide with the modal window.
@@ -135,8 +138,13 @@ const PageTemplatesPlugin = compose(
 				} );
 
 				// Insert blocks.
+				const postContentBlock = ownProps.postContentBlock;
 				const blocks = parseBlocks( template.content );
-				editorDispatcher.insertBlocks( blocks );
+				editorDispatcher.insertBlocks(
+					blocks,
+					0,
+					postContentBlock ? postContentBlock.clientId : ''
+				);
 			},
 		};
 	} )


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR replaces the block inserter in the header toolbar with a custom one that ensures that new blocks are appended inside the post content block.

![Jul-03-2019 09-56-12](https://user-images.githubusercontent.com/1233880/60556676-5e4ba780-9d7d-11e9-8720-7eb90aa08883.gif)

Since the default inserter in the header toolbar rendered by Gutenberg doesn't set any `rootClientId` ([#](https://github.com/WordPress/gutenberg/blob/672bd9e06de74fec0fcddb81d083e792f800d42e/packages/edit-post/src/components/header/header-toolbar/index.js#L34)), we cannot define which block should contain any new inserted block.

This PR aims to solve that by rendering a replica of the same header inserter but using the client id of the post content block as `rootClientId`. The same client id is also used now when inserting a starter page template to avoid that content being appended after the footer (https://github.com/Automattic/wp-calypso/issues/34330).

In order to don't display the default header inserter, we lock the template making impossible to insert new blocks in the root (thus the header doesn't show the default block inserter). But this also prevents the user from removing existing blocks, which solves the issue of having the post content block removable (https://github.com/Automattic/wp-calypso/issues/34331).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch to your FSE dev environment.
* Make sure the FSE plugin is activated.
* Create a new page.
* Select the blank template.
* Insert a block.
* Check the block has been inserted inside the post content block.
* Make sure you cannot insert any block in the root document.
* Verify root blocks (template parts and post content) cannot be moved.
* Create a new page again.
* Select a starter page template such as Portfolio or Services.
* Confirm the template content has been inserted inside the post content block.
* Go to Templates (`/wp-admin/edit.php?post_type=wp_template`).
* Trash all the templates (you also need to delete them permanently due to https://github.com/Automattic/wp-calypso/issues/34424).
* Create one more page.
* Select any template.
* Make sure blocks are inserted in the root document now.

Fixes #34327.
Fixes #34330.
Fixes #34331.
