### PR TITLE
Expand affiliate/coupon tracking coverage.

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -10,7 +10,6 @@ import page from 'page';
 import { connect } from 'react-redux';
 import { flowRight, get, includes, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
-import urlUtils from 'url';
 
 /**
  * Internal dependencies
@@ -77,7 +76,6 @@ import {
 	isSiteBlacklistedError as isSiteBlacklistedSelector,
 } from 'state/jetpack-connect/selectors';
 import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
-import { affiliateReferral } from 'state/refer/actions';
 
 /**
  * Constants
@@ -169,30 +167,6 @@ export class JetpackAuthorize extends Component {
 			const attempts = this.props.authAttempts || 0;
 			this.retryingAuth = true;
 			return retryAuth( site, attempts + 1, nextProps.authQuery.from );
-		}
-	}
-
-	componentDidMount() {
-		this.trackAffiliate();
-	}
-
-	/**
-	 * Track affiliate code based on the aff and cid URL params.
-	 */
-	trackAffiliate() {
-		const urlPath = location.href;
-		const parsedUrl = urlUtils.parse( urlPath, true );
-		const affiliateId = parsedUrl.query.aff;
-		const campaignId = parsedUrl.query.cid;
-		const subId = parsedUrl.query.sid;
-
-		if ( affiliateId && ! isNaN( affiliateId ) ) {
-			const hostPath = `${ parsedUrl.host }${ parsedUrl.pathname }`;
-			this.props.recordTracksEvent( 'calypso_jpc_refer_visit', {
-				flow: this.props.flowName,
-				page: hostPath,
-			} );
-			this.props.trackAffiliateReferral( { affiliateId, campaignId, subId, hostPath } );
 		}
 	}
 
@@ -729,7 +703,6 @@ const connectComponent = connect(
 		authorize: authorizeAction,
 		recordTracksEvent: recordTracksEventAction,
 		retryAuth: retryAuthAction,
-		trackAffiliateReferral: affiliateReferral,
 	}
 );
 

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -29,9 +29,11 @@ import {
 	isPiiUrl,
 	shouldReportOmitBlogId,
 	costToUSD,
+	urlParseAmpCompatible,
+	saveCouponQueryArgument,
 } from 'lib/analytics/utils';
 import {
-	retarget,
+	retarget as retargetAdTrackers,
 	recordAliasInFloodlight,
 	recordSignupCompletionInFloodlight,
 	recordSignupStartInFloodlight,
@@ -49,12 +51,16 @@ import { updateQueryParamsTracking } from 'lib/analytics/sem';
 import { statsdTimingUrl } from 'lib/analytics/statsd';
 import { isE2ETest } from 'lib/e2e';
 import { getGoogleAnalyticsDefaultConfig } from './ad-tracking';
+import { affiliateReferral as trackAffiliateReferral } from 'state/refer/actions';
+import { reduxDispatch } from 'lib/redux-bridge';
 
 /**
  * Module variables
  */
+const pvDebug = debug( 'calypso:analytics:pv' );
 const mcDebug = debug( 'calypso:analytics:mc' );
 const gaDebug = debug( 'calypso:analytics:ga' );
+const referDebug = debug( 'calypso:analytics:refer' );
 const queueDebug = debug( 'calypso:analytics:queue' );
 const hotjarDebug = debug( 'calypso:analytics:hotjar' );
 const tracksDebug = debug( 'calypso:analytics:tracks' );
@@ -260,13 +266,17 @@ const analytics = {
 					mostRecentUrlPath + '(' + pathCounter.toString() + ')';
 				params.this_pageview_path_with_count = urlPath + '(' + ( pathCounter + 1 ).toString() + ')';
 
-				// Tracks & Google Analytics.
+				pvDebug( 'Recording pageview.', urlPath, pageTitle, params );
+
+				// Tracks, Google Analytics, Refer platform.
 				analytics.tracks.recordPageView( urlPath, params );
 				analytics.ga.recordPageView( urlPath, pageTitle );
+				analytics.refer.recordPageView();
 
-				// SEM & Ad Tracking.
+				// Retargeting.
+				saveCouponQueryArgument();
 				updateQueryParamsTracking();
-				retarget( urlPath ); // Retargeting pixels.
+				retargetAdTrackers( urlPath );
 
 				// Event emitter.
 				analytics.emit( 'page-view', urlPath, pageTitle );
@@ -708,6 +718,30 @@ const analytics = {
 
 			fireGoogleAnalyticsTiming( eventType, duration, urlPath, triggerName );
 		} ),
+	},
+
+	// Refer platform tracking.
+	refer: {
+		recordPageView: function() {
+			if ( ! window || ! window.location ) {
+				return; // Not possible.
+			}
+
+			const referrer = window.location.href;
+			const parsedUrl = urlParseAmpCompatible( referrer );
+			const affiliateId = parsedUrl.query.aff || parsedUrl.query.affiliate;
+			const campaignId = parsedUrl.query.cid;
+			const subId = parsedUrl.query.sid;
+
+			if ( affiliateId && ! isNaN( affiliateId ) ) {
+				analytics.tracks.recordEvent( 'calypso_refer_visit', {
+					page: parsedUrl.host + parsedUrl.pathname,
+				} );
+
+				referDebug( 'Recording affiliate referral.', { affiliateId, campaignId, subId, referrer } );
+				reduxDispatch( trackAffiliateReferral( { affiliateId, campaignId, subId, referrer } ) );
+			}
+		},
 	},
 
 	// HotJar tracking

--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -29,11 +29,6 @@ import {
 } from './constants';
 import { PLANS_LIST } from './plans-list';
 
-/**
- * Module vars
- */
-const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
-
 export function getPlans() {
 	return PLANS_LIST;
 }
@@ -160,6 +155,7 @@ export function filterPlansBySiteAndProps(
 	intervalType,
 	showJetpackFreePlan
 ) {
+	const isPersonalPlanEnabled = isEnabled( 'plans/personal-plan' );
 	const hasPersonalPlan = site && site.plan.product_slug === PLAN_PERSONAL;
 
 	return plans.filter( function( plan ) {

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -25,7 +25,7 @@ import {
 } from 'lib/upgrades/action-types';
 import Dispatcher from 'dispatcher';
 import { domainRegistration } from 'lib/cart-values/cart-items';
-import { urlParseAmpCompatible } from 'lib/analytics/utils';
+import { MARKETING_COUPONS_KEY } from 'lib/analytics/utils';
 
 // We need to load the CartStore to make sure the store is registered with the
 // dispatcher even though it's not used directly here
@@ -35,7 +35,6 @@ import 'lib/cart/store';
  * Constants
  */
 const debug = debugModule( 'calypso:signup:cart' );
-const MARKETING_COUPONS_KEY = 'marketing-coupons';
 
 export function disableCart() {
 	Dispatcher.handleViewAction( { type: CART_DISABLE } );
@@ -144,35 +143,6 @@ export function removeCoupon() {
 	Dispatcher.handleViewAction( {
 		type: CART_COUPON_REMOVE,
 	} );
-}
-
-export function saveCouponQueryArgument() {
-	// read coupon query argument, return early if there is none
-	const parsedUrl = urlParseAmpCompatible( location.href );
-	const couponCode = parsedUrl.query.coupon;
-	if ( ! couponCode ) {
-		return;
-	}
-
-	// read coupon list from localStorage, create new if it's not there yet, refresh existing
-	const couponsJson = localStorage.getItem( MARKETING_COUPONS_KEY );
-	const coupons = JSON.parse( couponsJson ) || {};
-	const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
-	const now = Date.now();
-	debug( 'Found coupons in localStorage: ', coupons );
-
-	coupons[ couponCode ] = now;
-
-	// delete coupons if they're older than a week
-	Object.keys( coupons ).forEach( key => {
-		if ( now > coupons[ key ] + ONE_WEEK_MILLISECONDS ) {
-			delete coupons[ key ];
-		}
-	} );
-
-	// write remembered coupons back to localStorage
-	debug( 'Storing coupons in localStorage: ', coupons );
-	localStorage.setItem( MARKETING_COUPONS_KEY, JSON.stringify( coupons ) );
 }
 
 export function getRememberedCoupon() {

--- a/client/lib/upgrades/actions/index.js
+++ b/client/lib/upgrades/actions/index.js
@@ -21,7 +21,6 @@ export {
 	removePrivacyFromAllDomains,
 	replaceCartWithItems,
 	replaceItem,
-	saveCouponQueryArgument,
 	showCartOnMobile,
 } from './cart';
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -128,7 +128,8 @@ export default {
 
 		analytics.pageView.record(
 			basePath,
-			basePageTitle + ' > Start > ' + flowName + ' > ' + stepName
+			basePageTitle + ' > Start > ' + flowName + ' > ' + stepName,
+			{ flow: flowName }
 		);
 
 		context.store.dispatch( setLayoutFocus( 'content' ) );

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -26,7 +26,6 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import config from 'config';
-import { urlParseAmpCompatible } from 'lib/analytics/utils';
 
 /**
  * Style dependencies
@@ -45,7 +44,7 @@ import analytics from 'lib/analytics';
 import * as oauthToken from 'lib/oauth-token';
 import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
 import SignupFlowController from 'lib/signup/flow-controller';
-import { disableCart, saveCouponQueryArgument } from 'lib/upgrades/actions';
+import { disableCart } from 'lib/upgrades/actions';
 
 // State actions and selectors
 import { loadTrackingTool } from 'state/analytics/actions';
@@ -57,7 +56,6 @@ import {
 	getCurrentUserSiteCount,
 } from 'state/current-user/selectors';
 import isUserRegistrationDaysWithinRange from 'state/selectors/is-user-registration-days-within-range';
-import { affiliateReferral } from 'state/refer/actions';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
 import { removeUnneededSteps, submitSignupStep } from 'state/signup/progress/actions';
@@ -112,7 +110,6 @@ class Signup extends React.Component {
 		signupDependencies: PropTypes.object,
 		siteDomains: PropTypes.array,
 		isPaidPlan: PropTypes.bool,
-		trackAffiliateReferral: PropTypes.func.isRequired,
 		flowName: PropTypes.string,
 		stepName: PropTypes.string,
 		pageTitle: PropTypes.string,
@@ -207,7 +204,6 @@ class Signup extends React.Component {
 
 	componentDidMount() {
 		debug( 'Signup component mounted' );
-		saveCouponQueryArgument();
 		this.startTrackingForBusinessSite();
 		this.recordSignupStart();
 		this.preloadNextStep();
@@ -244,25 +240,6 @@ class Signup extends React.Component {
 			flow: this.props.flowName,
 			ref: this.props.refParameter,
 		} );
-		this.recordReferralVisit();
-	}
-
-	recordReferralVisit() {
-		const urlPath = location.href;
-		const parsedUrl = urlParseAmpCompatible( urlPath );
-		const affiliateId = parsedUrl.query.aff;
-		const campaignId = parsedUrl.query.cid;
-		const subId = parsedUrl.query.sid;
-
-		if ( affiliateId && ! isNaN( affiliateId ) ) {
-			// Record the referral in Tracks
-			analytics.tracks.recordEvent( 'calypso_refer_visit', {
-				flow: this.props.flowName,
-				// The current page without any query params
-				page: `${ parsedUrl.host }${ parsedUrl.pathname }`,
-			} );
-			this.props.trackAffiliateReferral( { affiliateId, campaignId, subId, urlPath } );
-		}
 	}
 
 	updateShouldShowLoadingScreen = ( progress = this.props.progress ) => {
@@ -656,7 +633,6 @@ export default connect(
 		submitSiteVertical,
 		submitSignupStep,
 		loadTrackingTool,
-		trackAffiliateReferral: affiliateReferral,
 		removeUnneededSteps,
 	}
 )( Signup );

--- a/client/state/data-layer/third-party/refer/index.js
+++ b/client/state/data-layer/third-party/refer/index.js
@@ -4,6 +4,7 @@
  * External dependencies
  */
 import { pick } from 'lodash';
+import debug from 'debug';
 
 /**
  * Internal dependencies
@@ -13,6 +14,8 @@ import { AFFILIATE_REFERRAL } from 'state/action-types';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { registerHandlers } from 'state/data-layer/handler-registry';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
+
+const referDebug = debug( 'calypso:analytics:refer' );
 
 const whitelistedEventProps = [
 	'status',
@@ -28,35 +31,40 @@ const whitelistedEventProps = [
 ];
 
 const fetch = action => {
-	const { affiliateId, campaignId, subId, urlPath } = action;
+	const { affiliateId, campaignId, subId, referrer } = action;
 
 	if ( ! affiliateId || isNaN( affiliateId ) ) {
 		return null;
 	}
 
+	const requestBody = {
+		affiliate_id: affiliateId,
+		campaign_id: campaignId || '',
+		sub_id: subId || '',
+		referrer: referrer || '',
+	};
+
+	referDebug( 'Fetching Refer platform response.', action, requestBody );
 	return http(
 		{
 			method: 'POST',
 			url: 'https://refer.wordpress.com/clicks/67402',
-			headers: [ [ 'content-type', 'application/x-www-form-urlencoded; charset=UTF-8' ] ],
-			body: {
-				affiliate_id: affiliateId,
-				campaign_id: campaignId || '',
-				sub_id: subId || '',
-				referrer: urlPath,
-			},
-			// Needed to check and set the 'wp-affiliate-tracker' cookie
-			withCredentials: true,
+			headers: [ [ 'Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8' ] ],
+			body: requestBody,
+			withCredentials: true, // Needed to check and set the 'wp-affiliate-tracker' cookie.
 		},
 		action
 	);
 };
 
 const onSuccess = ( action, eventProps ) => {
+	referDebug( 'Recording Refer platform success response.', eventProps );
 	return recordTracksEvent( 'calypso_refer_visit_response', eventProps );
 };
 
 const onError = ( action, error ) => {
+	referDebug( 'Recording Refer platform error response.', error );
+
 	if ( ! ( error && error.response && 'string' === typeof error.response.text ) ) {
 		return;
 	}

--- a/client/state/refer/actions.js
+++ b/client/state/refer/actions.js
@@ -6,6 +6,6 @@
 import { AFFILIATE_REFERRAL } from 'state/action-types';
 import 'state/data-layer/third-party/refer';
 
-export function affiliateReferral( { affiliateId, campaignId, subId, urlPath } ) {
-	return { type: AFFILIATE_REFERRAL, affiliateId, campaignId, subId, urlPath };
+export function affiliateReferral( { affiliateId, campaignId, subId, referrer } ) {
+	return { type: AFFILIATE_REFERRAL, affiliateId, campaignId, subId, referrer };
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Track `?affiliate` the same as `?aff`, because `?affiliate` is still used in the wild by some affiliates.
* Track `?affiliate` or `?aff` on pageview, instead of in signup and Jetpack connect only. This enables affiliate tracking for themes and in other areas of Calypso, instead of confining affiliate tracking to just the signup flows.
* Track `?coupon` on pageview as well, allowing for a coupon code to be passed in to any location in Calypso that tracks a pageview, instead of only tracking coupons in signup.
* Bug fix. `content-type` should be `Content-Type` so that form data is processed properly.

#### Testing instructions

Open an incognito window:
http://calypso.localhost:3000/start/user?aff=3343&cid=594611&sid=foo&coupon=FBSAVE15_X56456

Enable ad tracking, Google Analytics, and debugging by entering the following into your JS console before testing. Once you've run these scripts, please refresh the page.

```
document.cookie = 'flags=gdpr-banner,google-analytics,ad-tracking; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
document.cookie = 'sensitive_pixel_option=yes; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
localStorage.setItem( 'debug', 'calypso:analytics:*' );
```

---

Upon refreshing the page, filter Console tab by `calypso:analytics:refer` and confirm the following.
http://calypso.localhost:3000/start/user?aff=3343&cid=594611&sid=foo&coupon=FBSAVE15_X56456

<img width="1346" alt="Screen Shot 2019-07-02 at 23 41 44" src="https://user-images.githubusercontent.com/1563559/60561822-ff594480-9d22-11e9-8e8e-b4158d5965b0.png">

Also filter Console tab by `calypso_page_view` and confirm.

<img width="1231" alt="Screen Shot 2019-07-02 at 23 42 29" src="https://user-images.githubusercontent.com/1563559/60561850-15ff9b80-9d23-11e9-9ded-b15ba3c47212.png">

Also filter Console tab by `coupon` and confirm.

<img width="936" alt="Screen Shot 2019-07-02 at 23 43 21" src="https://user-images.githubusercontent.com/1563559/60561879-34659700-9d23-11e9-950c-664fdef84662.png">

Also filter Network tab by `67402` and confirm.

![Screen Shot 2019-07-02 at 23 49 33](https://user-images.githubusercontent.com/1563559/60562091-206e6500-9d24-11e9-93ec-d5ba6b43e4e1.png)


---

Run the same checks, but this time with `?affiliate` instead of `?aff`.
http://calypso.localhost:3000/themes?affiliate=3343&cid=594611&sid=foo&coupon=FBSAVE15_X56456

---

Run the same checks, but this time with `/themes`.
http://calypso.localhost:3000/themes?aff=3343&cid=594611&sid=foo&coupon=FBSAVE15_X56456

---

Run the same checks, but this time with `/jetpack/connect`.
http://calypso.localhost:3000/jetpack/connect?aff=3343&cid=594611&sid=foo&coupon=FBSAVE15_X56456

---

Register and complete signup, starting from:
http://calypso.localhost:3000/start/user?aff=3343&cid=594611&sid=foo&coupon=FBSAVE15_X56456

Add any paid plan and complete a test purchase. Upon entering checkout, confirm that coupon code `FBSAVE15_X56456` is applied automatically at checkout.

---

Run the same check, but this time with `/jetpack/connect`.
http://calypso.localhost:3000/jetpack/connect?aff=3343&cid=594611&sid=foo&coupon=FBSAVE15_X56456

---

Confirm no JS console errors.

---

@micbosi In each test, also filter by `ad-tracking` and confirm that all ad trackers are still firing as expected on signup start, signup complete, all the way through a test purchase.