### PR TITLE
Fix/concierge reschedule

### DIFF
--- a/client/me/concierge/book/confirmation-step.js
+++ b/client/me/concierge/book/confirmation-step.js
@@ -24,9 +24,7 @@ class ConfirmationStep extends Component {
 
 		return (
 			<Confirmation
-				description={ translate(
-					'We will send you a calendar invitation and an email with information on how to prepare.'
-				) }
+				description={ translate( 'We will send you an email with information on how to prepare.' ) }
 				title={ translate( 'Your session is booked!' ) }
 			>
 				<Button

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -33,6 +33,7 @@ const book = ( context, next ) => {
 			skeleton={ BookSkeleton }
 			siteSlug={ context.params.siteSlug }
 			steps={ [ BookInfoStep, BookCalendarStep, BookConfirmationStep ] }
+			rescheduling={ false }
 		/>
 	);
 	next();
@@ -59,6 +60,7 @@ const reschedule = ( context, next ) => {
 			skeleton={ RescheduleSkeleton }
 			siteSlug={ context.params.siteSlug }
 			steps={ [ RescheduleCalendarStep, RescheduleConfirmationStep ] }
+			rescheduling={ true }
 		/>
 	);
 	next();

--- a/client/me/concierge/main.js
+++ b/client/me/concierge/main.js
@@ -62,6 +62,7 @@ export class ConciergeMain extends Component {
 			scheduleId,
 			userSettings,
 			nextAppointment,
+			rescheduling,
 		} = this.props;
 
 		const CurrentStep = steps[ this.state.currentStep ];
@@ -76,7 +77,7 @@ export class ConciergeMain extends Component {
 			return <Upsell site={ site } />;
 		}
 
-		if ( nextAppointment ) {
+		if ( nextAppointment && ! rescheduling ) {
 			return <AppointmentInfo appointment={ nextAppointment } />;
 		}
 

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -24,9 +24,7 @@ class ConfirmationStep extends Component {
 
 		return (
 			<Confirmation
-				description={ translate(
-					'We will send you a calendar invitation and an email with information on how to prepare.'
-				) }
+				description={ translate( 'We will send you an email with information on how to prepare.' ) }
 				title={ translate( 'Your session has been rescheduled!' ) }
 			>
 				<Button


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Re-enables Concierge reschedule flow.

#### Testing instructions

1. Book a Concierge session. http://calypso.localhost:3000/me/concierge/book
2. Try rescheduling session. URL to reschedule should be in session schedule notice email.
3. Cancel session using the URL in the rescheduled notice email.

Without this patch, all you should see is appointment info.
With this patch, you should see a calendar page to set new session time.

*

Fixes 35-GH-concierge-admin
