### PR TITLE
Update signup canResume's dependencies to only match steps against the same flowName

### DIFF
--- a/client/signup/test/fixtures/flows.js
+++ b/client/signup/test/fixtures/flows.js
@@ -33,6 +33,11 @@ export default {
 		destination: '/',
 	},
 
+	'onboarding-blog': {
+		steps: [ 'user', 'site-type', 'site-topic', 'site-title', 'domains', 'plans' ],
+		destination: '/',
+	},
+
 	'disallow-resume': {
 		steps: [
 			'user',

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -13,6 +13,8 @@ import sinon from 'sinon';
  * Internal dependencies
  */
 import {
+	canResumeFlow,
+	getCompletedSteps,
 	getValueFromProgressStore,
 	getValidPath,
 	getStepName,
@@ -214,6 +216,86 @@ describe( 'utils', () => {
 		test( 'should return null if the field is not present', () => {
 			delete signupProgress[ 1 ].site;
 			assert.equal( getValueFromProgressStore( config ), null );
+		} );
+	} );
+
+	describe( 'getCompletedSteps', () => {
+		const mixedFlowsSignupProgress = [
+			{ stepName: 'user', lastKnownFlow: 'onboarding', status: 'completed' },
+			{ stepName: 'site-type', lastKnownFlow: 'onboarding', status: 'completed' },
+			{ stepName: 'site-topic', lastKnownFlow: 'onboarding-blog', status: 'completed' },
+			{ stepName: 'site-title', lastKnownFlow: 'onboarding-blog', status: 'completed' },
+			{ stepName: 'domains', lastKnownFlow: 'onboarding-blog', status: 'pending' },
+			{ stepName: 'plans', lastKnownFlow: 'onboarding-blog', status: 'pending' },
+		];
+		const singleFlowSignupProgress = [
+			{ stepName: 'user', lastKnownFlow: 'onboarding', status: 'completed' },
+			{ stepName: 'site-type', lastKnownFlow: 'onboarding', status: 'completed' },
+			{ stepName: 'site-topic-with-preview', lastKnownFlow: 'onboarding', status: 'completed' },
+			{ stepName: 'site-title-with-preview', lastKnownFlow: 'onboarding', status: 'completed' },
+			{ stepName: 'site-style-with-preview', lastKnownFlow: 'onboarding', status: 'completed' },
+			{ stepName: 'domains-with-preview', lastKnownFlow: 'onboarding', status: 'pending' },
+			{ stepName: 'plans', lastKnownFlow: 'onboarding', status: 'pending' },
+		];
+
+		test( 'step names should match steps of a particular flow given progress with mixed flows', () => {
+			const completedSteps = getCompletedSteps( 'onboarding-blog', mixedFlowsSignupProgress );
+			const stepNames = completedSteps.map( step => step.stepName );
+
+			expect( stepNames ).toStrictEqual( flows.getFlow( 'onboarding-blog' ).steps );
+		} );
+
+		test( 'should not match steps of a flow given progress with mixed flows and `shouldMatchFlowName` flag', () => {
+			const completedSteps = getCompletedSteps( 'onboarding-blog', mixedFlowsSignupProgress, {
+				shouldMatchFlowName: true,
+			} );
+			const filteredOnboardingBlogSteps = mixedFlowsSignupProgress.filter(
+				step => step.lastKnownFlow === 'onboarding-blog'
+			);
+			const stepNames = completedSteps.map( step => step.stepName );
+
+			expect( stepNames ).not.toStrictEqual( flows.getFlow( 'onboarding-blog' ).steps );
+			expect( completedSteps ).toStrictEqual( filteredOnboardingBlogSteps );
+		} );
+
+		test( 'should match steps of a flow given progress with single flow and `shouldMatchFlowName` flag', () => {
+			const completedSteps = getCompletedSteps( 'onboarding', singleFlowSignupProgress, {
+				shouldMatchFlowName: true,
+			} );
+			const stepNames = completedSteps.map( step => step.stepName );
+
+			expect( stepNames ).toStrictEqual( flows.getFlow( 'onboarding' ).steps );
+			expect( completedSteps ).toStrictEqual( singleFlowSignupProgress );
+		} );
+	} );
+
+	describe( 'canResumeFlow', () => {
+		test( 'should return true when given flow matches progress state', () => {
+			const signupProgress = [ { stepName: 'site-type', lastKnownFlow: 'onboarding' } ];
+			const canResume = canResumeFlow( 'onboarding', signupProgress );
+
+			expect( canResume ).toBe( true );
+		} );
+
+		test( 'should return false when given flow does not match progress state', () => {
+			const signupProgress = [ { stepName: 'site-type', lastKnownFlow: 'onboarding' } ];
+			const canResume = canResumeFlow( 'onboarding-blog', signupProgress );
+
+			expect( canResume ).toBe( false );
+		} );
+
+		test( 'should return false when flow sets disallowResume', () => {
+			const signupProgress = [ { stepName: 'site-type', lastKnownFlow: 'disallow-resume' } ];
+			const canResume = canResumeFlow( 'disallow-resume', signupProgress );
+
+			expect( canResume ).toBe( false );
+		} );
+
+		test( 'should return false when progress state is empty', () => {
+			const signupProgress = [];
+			const canResume = canResumeFlow( 'onboarding', signupProgress );
+
+			expect( canResume ).toBe( false );
 		} );
 	} );
 } );

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -195,12 +195,20 @@ export function getFirstInvalidStep( flowName, progress ) {
 	return find( getFilteredSteps( flowName, progress ), { status: 'invalid' } );
 }
 
-export function getCompletedSteps( flowName, progress ) {
+export function getCompletedSteps( flowName, progress, options = {} ) {
+	if ( options.shouldMatchFlowName ) {
+		return filter(
+			getFilteredSteps( flowName, progress ),
+			step => 'in-progress' !== step.status && step.lastKnownFlow === flowName
+		);
+	}
 	return filter( getFilteredSteps( flowName, progress ), step => 'in-progress' !== step.status );
 }
 
 export function canResumeFlow( flowName, progress ) {
 	const flow = flows.getFlow( flowName );
-	const flowStepsInProgressStore = getCompletedSteps( flowName, progress );
+	const flowStepsInProgressStore = getCompletedSteps( flowName, progress, {
+		shouldMatchFlowName: true,
+	} );
 	return flowStepsInProgressStore.length > 0 && ! flow.disallowResume;
 }

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -196,6 +196,9 @@ export function getFirstInvalidStep( flowName, progress ) {
 }
 
 export function getCompletedSteps( flowName, progress, options = {} ) {
+	// Option to check that the current `flowName` matches the `lastKnownFlow`.
+	// This is to ensure that when resuming progress, we only do so if
+	// the last known flow matches the one that the user is returning to.
 	if ( options.shouldMatchFlowName ) {
 		return filter(
 			getFilteredSteps( flowName, progress ),


### PR DESCRIPTION
This is the second attempt at making `resumeProgress` less eager to resume the progress. In this change, progress should only resume if we're certain that the user is resuming the same flow that they were last on. Otherwise, they will start from the beginning of the flow.

Additionally, `getCompletedSteps`, which gets called by the main Signup's `isEveryStepSubmitted` method should _not_ only match against the same flow. Tests are included to confirm this, and fixes a regression in #34356 where the loading screen would not display after submitting the final step, and instead it would show `user` step before redirecting to the checkout page. That issue was logged in #34403.

#### Changes proposed in this Pull Request

* Update `getCompletedSteps` to accept an `options` object with a `shouldMatchFlowName` key to optionally filter the completed steps by the current `flowName`, matching against the progress state's `lastKnownFlow` value for each step. Thanks for the suggestion @ramonjd!
* Add tests to ensure that `getCompletedSteps` returns the correct results given a similar progress state with mixed flows for completed steps as in the regression flagged in #34403.

Note that ideally we would be directly testing the [`updateShouldShowLoadingScreen`](https://github.com/Automattic/wp-calypso/blob/1d9b571d7160f089bde059b086703cd02ce2021b/client/signup/main.jsx#L268) method of the main Signup class. However, adding tests to that class feels like a much bigger task, so this PR attempts to get at the specific issue by trying to thoroughly test `getCompletedSteps` and `canResume`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### For these steps, select either the Business or Professional site types.

* Go to http://calypso.localhost:3000/start
* Complete steps up until the domains-with-preview step
* Go to http://calypso.localhost:3000/start
* It should resume you back to the domains-with-preview step
* Go to http://calypso.localhost:3000/start/premium
* It should take you to the site-type step.

##### Testing that this resolves the regression in #34403

From an Incognito window:

* Go to http://calypso.localhost:3000/start and _create a new account_ (this can be a sandboxed signup)
* Select the `blog` site type
* Follow all the steps and on the plans stage select the `free` plan
* The loading screen with `Awesome!` and the background animation should display, and you should then be taken to the checklist page. You should _not_ be redirected to the `user` step in sign up. For reference screenshots / video, see issue #34403.

Fixes #34403
