### PR TITLE
Signup: Show "Purchase required" for online store site type

### DIFF
--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -150,8 +150,7 @@ export function getAllSiteTypes() {
 			siteTopicHeader: i18n.translate( 'What type of products do you sell?' ),
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
-			// TODO: Re-enable "Purchase required" badge, but hide for Jetpack onboarding.
-			// purchaseRequired: true,
+			purchaseRequired: true,
 		},
 	];
 }

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -54,7 +54,7 @@ class SiteTypeForm extends Component {
 							<span className="site-type__option-description">
 								{ siteTypeProperties.description }
 							</span>
-							{ this.props.notJetpack && siteTypeProperties.purchaseRequired && (
+							{ ! this.props.isJetpack && siteTypeProperties.purchaseRequired && (
 								<Badge className="site-type__option-badge" type="info">
 									{ this.props.translate( 'Purchase required' ) }
 								</Badge>
@@ -68,15 +68,11 @@ class SiteTypeForm extends Component {
 }
 
 export default connect(
-	state => {
-		const siteId = getSelectedSiteId( state );
-
-		return {
-			// TODO: Better handling for Jetpack flows in the site-type lib,
-			// so we don't depend on injecting conditionals into components like this.
-			notJetpack: ! isJetpackSite( state, siteId ),
-		};
-	},
+	state => ( {
+		// TODO: Better handling for Jetpack flows in the site-type lib,
+		// so we don't depend on injecting conditionals into components like this.
+		isJetpack: !! isJetpackSite( state, getSelectedSiteId( state ) ),
+	} ),
 	{
 		recordTracksEvent,
 	}

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -72,6 +72,8 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
+			// TODO: Better handling for Jetpack flows in the site-type lib,
+			// so we don't depend on injecting conditionals into components like this.
 			notJetpack: ! isJetpackSite( state, siteId ),
 		};
 	},

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -13,6 +13,8 @@ import Badge from 'components/badge';
 import Card from 'components/card';
 import { getAllSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 
 /**
  * Style dependencies
@@ -52,7 +54,7 @@ class SiteTypeForm extends Component {
 							<span className="site-type__option-description">
 								{ siteTypeProperties.description }
 							</span>
-							{ siteTypeProperties.purchaseRequired && (
+							{ this.props.notJetpack && siteTypeProperties.purchaseRequired && (
 								<Badge className="site-type__option-badge" type="info">
 									{ this.props.translate( 'Purchase required' ) }
 								</Badge>
@@ -66,7 +68,13 @@ class SiteTypeForm extends Component {
 }
 
 export default connect(
-	null,
+	state => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			notJetpack: ! isJetpackSite( state, siteId ),
+		};
+	},
 	{
 		recordTracksEvent,
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow-up to https://github.com/Automattic/wp-calypso/pull/34054

* Show a "Purchase required" badge for the "Online store" site type
* Show only in WordPress.com flows, hide in Jetpack flows

Similar to #34199, but taking a much simpler approach.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**WordPress.com**

* Visit `/start` and proceed to the site type step
* See that "Purchase required" displays under the "Online store" site type

<img width="488" alt="Screen Shot 2019-06-17 at 17 45 43" src="https://user-images.githubusercontent.com/1699996/59641859-8950bd00-9128-11e9-95a2-8bccf3ee2109.png">

**Jetpack**

* Create a site on jurassic.ninja and note the url
* Visit `/jetpack/connect` and enter the site url
* Proceed to the site type step and see that "Purchase required" is not visible

<img width="593" alt="Screen Shot 2019-06-21 at 16 13 29" src="https://user-images.githubusercontent.com/1699996/59951808-9f6bbf80-943f-11e9-80b8-55f83e58ab40.png">

Fixes #33544
