### PR TITLE
Prevent empty first and last names when creating G Suite users

### DIFF
--- a/client/lib/gsuite/new-users.ts
+++ b/client/lib/gsuite/new-users.ts
@@ -39,7 +39,7 @@ const removePreviousErrors = ( { value }: GSuiteNewUserField ): GSuiteNewUserFie
 const requiredField = ( { value, error }: GSuiteNewUserField ): GSuiteNewUserField => ( {
 	value,
 	error:
-		! error && ( ! value || '' === value ) ? i18n.translate( 'This field is required.' ) : error,
+		! error && ( ! value || '' === value.trim() ) ? i18n.translate( 'This field is required.' ) : error,
 } );
 
 const sixtyCharacterField = ( { value, error }: GSuiteNewUserField ): GSuiteNewUserField => ( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Input values are trimmed during validation to ensure blank values for names don't pass

Fixes #

- Corrects the issue where G Suite provisioning fails due to blank first and/or last names.

