### PR TITLE
Show error message from back end, if one is returned.

### DIFF
--- a/client/my-sites/domains/domain-management/components/email-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/email-verification/index.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
+import { get } from 'lodash';
 import { connect } from 'react-redux';
 
 /**
@@ -60,7 +61,8 @@ class EmailVerificationCard extends React.Component {
 
 		resendVerification( selectedDomainName, error => {
 			if ( error ) {
-				this.props.errorNotice( errorMessage );
+				const message = get( error, 'message', errorMessage );
+				this.props.errorNotice( message );
 			} else {
 				this.timer = setTimeout( this.revertToWaitingState, 5000 );
 				this.setState( { emailSent: true } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If we get an error message from the endpoint to  request a new contact verification email, we should show that message instead of the default one.

There are certain circumstances where the new back end provider will not always allow a new email to be sent while an old request is still pending. 

#### Testing instructions

Depends on D30122-code

Build this branch, apply the backend patch and try to request multiple verification email in quick succession as mentioned on the backend patch. Make sure that a meaningful error notice is shown.
