### PR TITLE
Add context for guided tours Continue button

### DIFF
--- a/client/layout/guided-tours/button-labels.jsx
+++ b/client/layout/guided-tours/button-labels.jsx
@@ -21,9 +21,9 @@ function button( label, icon ) {
 	};
 }
 
-// we use this translate to ensure the strings get picked up by the scripts that
-// scan for translations, and 'useTranslate' above to make sure the strings get
-// the right update hooks for runtime localization
+// we use this translate because the i18n scripts are scanning for
+// translate( string ) calls, but the runtime translation hooks are set up with
+// the 'useTranslate' above
 const translate = ( ...args ) => args;
 
 export const AddContentButton = button( translate( 'Add' ), <Gridicon icon="add-outline" /> );

--- a/client/layout/guided-tours/button-labels.jsx
+++ b/client/layout/guided-tours/button-labels.jsx
@@ -5,22 +5,26 @@
  */
 import React from 'react';
 import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
-import { identity } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
 
 // Returns React component with a localized label and optional icon
 function button( label, icon ) {
-	return localize( ( { translate: tr } ) => (
-		<strong>
-			{ icon }
-			{ icon && '\u00A0' /* NBSP between icon and label */ }
-			{ tr( label ) }
-		</strong>
-	) );
+	return () => {
+		const tr = useTranslate();
+		return (
+			<strong>
+				{ icon }
+				{ icon && '\u00A0' /* NBSP between icon and label */ }
+				{ tr( ...label ) }
+			</strong>
+		);
+	};
 }
 
-// Localized texts need to be wrapped in a `translate` function to be found by the l10n bot
-const translate = identity;
+// we use this translate to ensure the strings get picked up by the scripts that
+// scan for translations, and 'useTranslate' above to make sure the strings get
+// the right update hooks for runtime localization
+const translate = ( ...args ) => args;
 
 export const AddContentButton = button( translate( 'Add' ), <Gridicon icon="add-outline" /> );
 export const AddMediaButton = button( translate( 'Add Media' ) );


### PR DESCRIPTION
This PR adds the context needed to make the Guided tours "Continue" button consistent with the tooltip, as @sixhours identified.

This PR fixes issue #34383 

The pattern is kind of interesting, but if we decide to change it we can do that in a later PR.

# Testing Instructions:

Check that the strings match: Go to http://calypso.localhost:3000/settings/general/ , choose a site, then add 
`?tour=checklistSiteIcon`

![Réglages_du_site_‹_julesauspremiumtest_—_WordPress_com](https://user-images.githubusercontent.com/5952255/61494415-710ae100-a9f9-11e9-9847-2596d4a3860e.jpg)

