### PR TITLE
Signup: update heigh calculation for preview iframe

### DIFF
--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -160,10 +160,18 @@ export default class SignupSitePreviewIframe extends Component {
 			return;
 		}
 
-		const element = this.iframe.current.contentWindow.document.querySelector( '#page' );
+		const body = this.iframe.current.contentWindow.document.body;
+		const html = this.iframe.current.contentWindow.document.documentElement;
 
-		if ( element ) {
-			this.props.setWrapperHeight( element.scrollHeight + 25 );
+		if ( body && html ) {
+			const height = Math.max(
+				body.scrollHeight,
+				body.offsetHeight,
+				html.clientHeight,
+				html.scrollHeight,
+				html.offsetHeight
+			);
+			this.props.setWrapperHeight( height + 25 );
 		}
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Checking the scrollHeight alone often does not return a reliable content height. It's especially obvious when the preview loads for the first time.

![Jul-04-2019 11-38-35](https://user-images.githubusercontent.com/6458278/60633936-4b55d780-9e50-11e9-9410-f91d2b742d29.gif)

In this PR we're getting largest of the html and body offset and scroll heights.


## Testing instructions

Check Business and Professional vertical previews. Does the desktop view resize correctly to fit the entire content height?
