### PR TITLE
Refactor: Make the state of <CancelPurchaseForm> self-contained.

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -438,51 +438,46 @@ class CancelPurchaseForm extends React.Component {
 
 	getStepButtons = () => {
 		const { translate } = this.props;
-		const buttons = {
-			close: {
+		const close = {
 				action: 'close',
 				label: translate( "I'll Keep It" ),
 			},
-			next: {
+			next = {
 				action: 'next',
 				disabled: ! isSurveyFilledIn( this.state ),
 				label: translate( 'Next Step' ),
 				onClick: this.clickNext,
 			},
-			prev: {
+			prev = {
 				action: 'prev',
 				label: translate( 'Previous Step' ),
 				onClick: this.clickPrevious,
 			},
-			cancel: {
+			cancel = {
 				action: 'cancel',
 				label: translate( 'Cancel Now' ),
 				isPrimary: true,
-				// disabled: this.state.submitting,
-				// onClick: this.submitCancelAndRefundPurchase,
 				onClick: this.props.onClickFinalConfirm,
 			},
-			remove: {
+			remove = {
 				action: 'remove',
 				disabled: this.state.isRemoving,
 				isPrimary: true,
 				label: translate( 'Remove Now' ),
 				onClick: this.props.onClickFinalConfirm,
-			},
-		};
+			};
 
-		// TODO:
-		// Add the chat button back
+		const firstButtons = [ ...this.props.extraPrependedButtons, close ];
 
 		if ( this.state.surveyStep === steps.FINAL_STEP ) {
-			return this.props.flowType === 'remove'
-				? [ buttons.close, buttons.prev, buttons.remove ]
-				: [ buttons.close, buttons.prev, buttons.cancel ];
+			return firstButtons.concat(
+				this.props.flowType === 'remove' ? [ prev, remove ] : [ prev, cancel ]
+			);
 		}
 
-		return this.state.surveyStep === steps.INITIAL_STEP
-			? [ buttons.close, buttons.next ]
-			: [ buttons.close, buttons.prev, buttons.next ];
+		return firstButtons.concat(
+			this.state.surveyStep === steps.INITIAL_STEP ? [ next ] : [ prev, next ]
+		);
 	};
 
 	render() {

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -463,14 +463,13 @@ class CancelPurchaseForm extends React.Component {
 
 	changeSurveyStep = stepFunction => {
 		const { purchase, isChatAvailable, isChatActive, precancellationChatAvailable } = this.props;
-		const { surveyStep, survey } = this.state;
 		const allSteps = stepsForProductAndSurvey(
-			survey,
+			this.state,
 			purchase,
 			isChatAvailable || isChatActive,
 			precancellationChatAvailable
 		);
-		const newStep = stepFunction( surveyStep, allSteps );
+		const newStep = stepFunction( this.state.surveyStep, allSteps );
 
 		this.props.onStepChange( newStep );
 		this.setState( { surveyStep: newStep } );

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -52,6 +52,7 @@ class CancelPurchaseForm extends React.Component {
 	static propTypes = {
 		chatInitiated: PropTypes.func.isRequired,
 		defaultContent: PropTypes.node.isRequired,
+		disableButtons: PropTypes.bool,
 		purchase: PropTypes.object.isRequired,
 		selectedSite: PropTypes.shape( { slug: PropTypes.string.isRequired } ),
 		isVisible: PropTypes.bool,
@@ -160,7 +161,7 @@ class CancelPurchaseForm extends React.Component {
 
 		if ( ! isDomainRegistration( purchase ) && ! isGoogleApps( purchase ) ) {
 			this.setState( {
-				submitting: true,
+				isSubmitting: true,
 			} );
 
 			const surveyData = {
@@ -182,7 +183,7 @@ class CancelPurchaseForm extends React.Component {
 				enrichedSurveyData( surveyData, moment(), selectedSite, purchase )
 			).then( () => {
 				this.setState( {
-					submitting: false,
+					isSubmitting: false,
 				} );
 			} );
 		}
@@ -490,32 +491,36 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	getStepButtons = () => {
-		const { translate } = this.props;
+		const { translate, disableButtons } = this.props;
+		const disabled = disableButtons || this.state.isSubmitting;
+
 		const close = {
 				action: 'close',
+				disabled,
 				label: translate( "I'll Keep It" ),
 			},
 			next = {
 				action: 'next',
-				disabled: ! isSurveyFilledIn( this.state ),
+				disabled: disabled || ! isSurveyFilledIn( this.state ),
 				label: translate( 'Next Step' ),
 				onClick: this.clickNext,
 			},
 			prev = {
 				action: 'prev',
+				disabled,
 				label: translate( 'Previous Step' ),
 				onClick: this.clickPrevious,
 			},
 			cancel = {
 				action: 'cancel',
-				disabled: this.state.isSubmitting,
+				disabled,
 				label: translate( 'Cancel Now' ),
 				onClick: this.onSubmit,
 				isPrimary: true,
 			},
 			remove = {
 				action: 'remove',
-				disabled: this.state.isSubmitting,
+				disabled,
 				label: translate( 'Remove Now' ),
 				onClick: this.onSubmit,
 				isPrimary: true,

--- a/client/lib/upgrades/actions/purchases.js
+++ b/client/lib/upgrades/actions/purchases.js
@@ -32,7 +32,7 @@ export function submitSurvey( surveyName, siteID, surveyData ) {
 	survey.addResponses( surveyData );
 
 	debug( 'Survey responses', survey );
-	survey
+	return survey
 		.submit()
 		.then( res => {
 			debug( 'Survey submit response', res );

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { getCurrencyDefaults } from '@automattic/format-currency';
 
@@ -14,12 +14,11 @@ import { getCurrencyDefaults } from '@automattic/format-currency';
  * Internal Dependencies
  */
 import Button from 'components/button';
-import { cancelAndRefundPurchase, cancelPurchase, submitSurvey } from 'lib/upgrades/actions';
+import { cancelAndRefundPurchase, cancelPurchase } from 'lib/upgrades/actions';
 import { clearPurchases } from 'state/purchases/actions';
 import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
-import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import {
 	getName,
 	getSubscriptionEndDate,
@@ -47,7 +46,6 @@ class CancelPurchaseButton extends Component {
 	state = {
 		disabled: false,
 		showDialog: false,
-		isRemoving: false,
 		survey: {},
 	};
 
@@ -185,31 +183,9 @@ class CancelPurchaseButton extends Component {
 	};
 
 	submitCancelAndRefundPurchase = () => {
-		const { purchase, selectedSite } = this.props;
+		const { purchase } = this.props;
 		const refundable = isRefundable( purchase );
 		const cancelBundledDomain = this.props.cancelBundledDomain;
-		this.setState( {
-			submitting: true,
-		} );
-
-		const surveyData = {
-			'why-cancel': {
-				response: this.state.survey.questionOneRadio,
-				text: this.state.survey.questionOneText,
-			},
-			'next-adventure': {
-				response: this.state.survey.questionTwoRadio,
-				text: this.state.survey.questionTwoText,
-			},
-			'what-better': { text: this.state.survey.questionThreeText },
-			type: refundable ? 'refund' : 'cancel-autorenew',
-		};
-
-		submitSurvey(
-			'calypso-remove-purchase',
-			this.props.selectedSite.ID,
-			enrichedSurveyData( surveyData, moment(), selectedSite, purchase )
-		);
 
 		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -7,19 +7,17 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Gridicon from 'gridicons';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
-import wpcom from 'lib/wp';
 import config from 'config';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
-import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import GSuiteCancellationPurchaseDialog from 'components/marketing-survey/gsuite-cancel-purchase-dialog';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { isDataLoading } from '../utils';
@@ -45,12 +43,6 @@ import RemoveDomainDialog from './remove-domain-dialog';
  * Style dependencies
  */
 import './style.scss';
-
-/**
- * Module dependencies
- */
-import debugFactory from 'debug';
-const debug = debugFactory( 'calypso:purchases:survey' );
 
 class RemovePurchase extends Component {
 	static propTypes = {
@@ -130,38 +122,7 @@ class RemovePurchase extends Component {
 	removePurchase = closeDialog => {
 		this.setState( { isRemoving: true } );
 
-		const { isDomainOnlySite, purchase, site, translate } = this.props;
-
-		if ( ! isDomainRegistration( purchase ) && ! isGoogleApps( purchase ) ) {
-			const survey = wpcom
-				.marketing()
-				.survey( 'calypso-remove-purchase', this.props.purchase.siteId );
-			const surveyData = {
-				'why-cancel': {
-					response: this.state.survey.questionOneRadio,
-					text: this.state.survey.questionOneText,
-				},
-				'next-adventure': {
-					response: this.state.survey.questionTwoRadio,
-					text: this.state.survey.questionTwoText,
-				},
-				'what-better': { text: this.state.survey.questionThreeText },
-				type: 'remove',
-			};
-
-			survey.addResponses( enrichedSurveyData( surveyData, moment(), site, purchase ) );
-
-			debug( 'Survey responses', survey );
-			survey
-				.submit()
-				.then( res => {
-					debug( 'Survey submit response', res );
-					if ( ! res.success ) {
-						notices.error( res.err );
-					}
-				} )
-				.catch( err => debug( err ) ); // shouldn't get here
-		}
+		const { isDomainOnlySite, purchase, translate } = this.props;
 
 		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -26,7 +26,6 @@ import notices from 'notices';
 import { purchasesRoot } from '../paths';
 import { getPurchasesError } from 'state/purchases/selectors';
 import { removePurchase } from 'state/purchases/actions';
-import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
 import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import isDomainOnly from 'state/selectors/is-domain-only-site';
@@ -35,7 +34,6 @@ import { receiveDeletedSite } from 'state/sites/actions';
 import { setAllSitesSelected } from 'state/ui/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import HappychatButton from 'components/happychat/button';
-import isPrecancellationChatAvailable from 'state/happychat/selectors/is-precancellation-chat-available';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import RemoveDomainDialog from './remove-domain-dialog';
 
@@ -268,7 +266,7 @@ class RemovePurchase extends Component {
 
 	renderAtomicDialog( purchase ) {
 		const { translate } = this.props;
-		const supportButton = this.state.isChatAvailable
+		const supportButton = this.props.isChatAvailable
 			? this.getChatButton()
 			: this.getContactUsButton();
 
@@ -365,10 +363,8 @@ export default connect(
 			isDomainOnlySite: purchase && isDomainOnly( state, purchase.siteId ),
 			isAtomicSite: isSiteAutomatedTransfer( state, purchase.siteId ),
 			isChatAvailable: isHappychatAvailable( state ),
-			isChatActive: hasActiveHappychatSession( state ),
 			isJetpack,
 			purchasesError: getPurchasesError( state ),
-			precancellationChatAvailable: isPrecancellationChatAvailable( state ),
 			userId: getCurrentUserId( state ),
 		};
 	},

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -110,7 +110,7 @@ class RemovePurchase extends Component {
 		this.setState( { isDialogVisible: true } );
 	};
 
-	chatButtonClicked = event => {
+	onClickChatButton = event => {
 		this.recordChatEvent( 'calypso_precancellation_chat_click' );
 		event.preventDefault();
 
@@ -203,12 +203,9 @@ class RemovePurchase extends Component {
 		} );
 	};
 
-	// TODO:
-	// Extract this button out as a reusable component, sharing it with <CancelPurchaseForm/>,
-	// and add the chat button back to non-happychat steps.
 	getChatButton = () => {
 		return (
-			<HappychatButton className="remove-purchase__chat-button" onClick={ this.chatButtonClicked }>
+			<HappychatButton className="remove-purchase__chat-button" onClick={ this.onClickChatButton }>
 				{ this.props.translate( 'Need help? Chat with us' ) }
 			</HappychatButton>
 		);
@@ -240,6 +237,31 @@ class RemovePurchase extends Component {
 				closeDialog={ this.closeDialog }
 				chatButton={ chatButton }
 				purchase={ this.props.purchase }
+			/>
+		);
+	}
+
+	renderPlanDialog() {
+		const { purchase, site } = this.props;
+		const prependedChatButton =
+			config.isEnabled( 'upgrades/precancellation-chat' ) &&
+			this.state.surveyStep !== 'happychat_step'
+				? [ this.getChatButton() ]
+				: [];
+
+		return (
+			<CancelPurchaseForm
+				chatInitiated={ this.chatInitiated }
+				defaultContent={ this.renderPlanDialogText() }
+				onInputChange={ this.onSurveyChange }
+				purchase={ purchase }
+				selectedSite={ site }
+				isVisible={ this.state.isDialogVisible }
+				onClose={ this.closeDialog }
+				onStepChange={ this.onStepChange }
+				onClickFinalConfirm={ this.removePurchase }
+				extraPrependedButtons={ prependedChatButton }
+				flowType="remove"
 			/>
 		);
 	}
@@ -321,7 +343,9 @@ class RemovePurchase extends Component {
 		);
 	}
 
-	renderDialog( purchase ) {
+	renderDialog() {
+		const { purchase } = this.props;
+
 		if ( this.props.isAtomicSite ) {
 			return this.renderAtomicDialog( purchase );
 		}
@@ -367,18 +391,7 @@ class RemovePurchase extends Component {
 					<Gridicon icon="trash" />
 					{ translate( 'Remove %(productName)s', { args: { productName } } ) }
 				</CompactCard>
-				<CancelPurchaseForm
-					chatInitiated={ this.chatInitiated }
-					defaultContent={ this.renderPlanDialogText() }
-					onInputChange={ this.onSurveyChange }
-					purchase={ purchase }
-					selectedSite={ this.props.site }
-					isVisible={ this.state.isDialogVisible }
-					onClose={ this.closeDialog }
-					onStepChange={ this.onStepChange }
-					onClickFinalConfirm={ this.removePurchase }
-					flowType="remove"
-				/>
+				{ this.renderDialog() }
 			</>
 		);
 	}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -211,6 +211,7 @@ class RemovePurchase extends Component {
 		return (
 			<CancelPurchaseForm
 				chatInitiated={ this.chatInitiated }
+				disableButtons={ this.state.isRemoving }
 				defaultContent={ this.renderPlanDialogText() }
 				onInputChange={ this.onSurveyChange }
 				purchase={ purchase }


### PR DESCRIPTION
_This PR is part of a broader attempt of making <CancelPurchaseForm> more reusable by eliminating code duplication._

#### Changes proposed in this Pull Request

This PR attempts to move the state of `<CancelPurchaseForm/>` survey self-contained, removing the duplicated code spread in `cancel-purchase/buttons.jsx` and `remove-purchase/index.jsx`.

In general, it consists of:

* `<CancelPurchaseForm/>` should know which survey step it is at.
* The functions for moving survey forward should be only called in `<CancelPurchaseForm/>`
* A new `flowType` prop for varying buttons and the submitted survey data.
* A new `extraPrependedButtons` so `<RemovePurchase/>` component can prepend a Happychat button to the survey button array.
* `<CancelPurchaseForm/>` should be responsible of the survey data submission via `submitSurvey()` action.

#### Testing instructions

There shouldn't be any functional-wise changes. In general, go through the plan cancelling process and the plan removal process to make sure the survey works as expected:

1. Go to the purchase management page, http://calypso.localhost:3000/me/purchases/, and click on any plan subscription.
1. Click on the "Cancel subscription" and go through the subscription cancelling process. The survey should be there and works as expected.
1. Go to the same subscription management page and this time there should be a "Remove Subscription" button. Click on it and go through the removing process. The survey should work as expected.

A few more finer details worth checking as well:

1. Open the Network inspector before hitting the last "Cancel" or "Remove" CTA button. After clicking, make sure this is a `POST` request to the `survey` endpoint with the expected values.
1. Run `localStorage.setItem( 'debug', 'calypso:analytics:*' );` from the console, go through the survey and see if each step submits the expected Tracks events.

