### PR TITLE
Remove overlay background color (obsolete due to  Gutenberg PR 15974)

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -13,7 +13,6 @@
 
 // Modal Overlay
 .page-template-modal-screen-overlay {
-	background-color: hsla( 0, 0%, 0%, 0.7 );
 	animation: none;
 }
 


### PR DESCRIPTION

> BLOCKED: We need to wait for the Gutenberg change to be available on WPCOM 

#### Changes proposed in this Pull Request

* This PR removes the custom background color on the modal overlay. This custom background color became obsolete thanks to the Gutenberg PR https://github.com/WordPress/gutenberg/pull/15974
* For more details see the corresponding issue https://github.com/Automattic/wp-calypso/issues/34306

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new page with the block editor
* The background-color of the overlay should use the Gutenberg default. No custom override should be present.

Fixes https://github.com/Automattic/wp-calypso/issues/34306
