### PR TITLE
Force GdprBanner not to render in SSR.

### DIFF
--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -27,6 +27,8 @@ import './style.scss';
 
 const SIX_MONTHS = 6 * 30 * 24 * 60 * 60;
 
+const hasDocument = typeof document !== 'undefined';
+
 class GdprBanner extends Component {
 	static propTypes = {
 		recordCookieBannerOk: PropTypes.func,
@@ -54,6 +56,10 @@ class GdprBanner extends Component {
 	};
 
 	shouldShowBanner() {
+		// Don't render banner in SSR.
+		if ( ! hasDocument ) {
+			return false;
+		}
 		const cookies = cookie.parse( document.cookie );
 		if ( cookies.sensitive_pixel_option === 'yes' || cookies.sensitive_pixel_option === 'no' ) {
 			return false;


### PR DESCRIPTION
`GdprBanner` tries to access certain client-side-only properties, such as `document`  and `navigator.userAgent`.

This caused SSR to fail when the component was added to the logged-out layout, which greatly affected the speed index of the login page.

It doesn't make sense to render the GDPR banner on the server anyway (since we don't have enough information to determine whether it should be shown), so this change effectively disables it by rendering nothing whenever the `document` object isn't present.

#### Changes proposed in this Pull Request

* Skip rendering `GdprBanner` if the `document` object isn't present.

#### Testing instructions

* Disable JavaScript on your browser
* Visit `/log-in` (without any URL parameters)
* Ensure that the login form is server-side rendered

Note that testing is complicated by the fact that not all environments have GDPR prompts enabled. Be sure that `gdpr-banner` is enabled in the environment you're testing with.