### PR TITLE
Revert "People: Fix team list and follower list freezing while scrolling (#33705)"

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -52,11 +52,6 @@ export default class InfiniteList extends React.Component {
 	_isMounted = false;
 	smartSetState = smartSetState;
 
-	namedRefs = {
-		topPlaceholder: React.createRef(),
-		bottomPlaceholder: React.createRef(),
-	};
-
 	componentWillMount() {
 		const url = page.current;
 		let newState, scrollTop;
@@ -159,14 +154,9 @@ export default class InfiniteList extends React.Component {
 		// we may have guessed item heights wrong - now we have real heights
 		if ( ! this.isScrolling ) {
 			this.cancelAnimationFrame();
-			// updateScroll misbehaves when it's called syncronously from componentDidUpdate.
-			// Promise.resolve() is not used here intentionally to avoid the orignal problem which
-			// I suspect is a race condition introduced by changes in React fiber implementation.
-			setTimeout( () => {
-				if ( this._isMounted ) {
-					this.updateScroll( { triggeredByScroll: false } );
-				}
-			}, 0 );
+			this.updateScroll( {
+				triggeredByScroll: false,
+			} );
 		}
 	}
 
@@ -303,9 +293,8 @@ export default class InfiniteList extends React.Component {
 	}
 
 	boundsForRef = ref => {
-		if ( ref in this.namedRefs ) {
-			const node = this.namedRefs[ ref ].current;
-			return node ? node.getBoundingClientRect() : null;
+		if ( ref in this.refs ) {
+			return ReactDom.findDOMNode( this.refs[ ref ] ).getBoundingClientRect();
 		}
 		return null;
 	};
@@ -387,14 +376,14 @@ export default class InfiniteList extends React.Component {
 		return (
 			<div { ...propsToTransfer }>
 				<div
-					ref={ this.namedRefs.topPlaceholder }
+					ref="topPlaceholder"
 					className={ spacerClassName }
 					style={ { height: this.state.topPlaceholderHeight } }
 				/>
 				{ itemsToRender }
 				{ this.props.renderTrailingItems() }
 				<div
-					ref={ this.namedRefs.bottomPlaceholder }
+					ref="bottomPlaceholder"
 					className={ spacerClassName }
 					style={ { height: this.state.bottomPlaceholderHeight } }
 				/>


### PR DESCRIPTION
This reverts commit f5125c54e7b591f00a0a54fd726e81e73ca585c4, which made modifications to the `InfiniteList` component used by the Media modal.

#### Testing instructions

* Load a site on WordPress.com with lots of media.
* In a Classic block, or opted out of Gutenberg, attempt to add an image to a post, and see how the media in the modal keeps reloading.
* Apply this branch to a local dev install.
* Load the same site and attempt to add an image – the media modal will scroll and load media properly, allowing images to be added again.

Fixes #33464
