### PR TITLE
Signup: Replacing deleted business flow name with blog flow name

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -537,7 +537,7 @@ class DomainsStep extends React.Component {
 		const { flowName, siteType, translate } = this.props;
 		const onboardingSubHeaderCopy =
 			siteType &&
-			includes( [ 'onboarding-for-business', 'onboarding' ], flowName ) &&
+			includes( [ 'onboarding-blog', 'onboarding' ], flowName ) &&
 			getSiteTypePropertyValue( 'slug', siteType, 'domainsStepSubheader' );
 
 		if ( onboardingSubHeaderCopy ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request

We no longer have `onboarding-for-business`. Replacing with `onboarding-blog` so that we can grab the right copy.

**Before** 
<img width="1063" alt="Screen Shot 2019-07-05 at 12 03 54 pm" src="https://user-images.githubusercontent.com/6458278/60693265-06e43d80-9f1d-11e9-8c8a-d73278da96e0.png">

**After**
![Screen Shot 2019-07-05 at 12](https://user-images.githubusercontent.com/6458278/60693485-d05af280-9f1d-11e9-8890-d13e1190668a.jpg)

## Testing instructions

When selecting Blog as your site type the domains step subheader should be `"Enter your blog's name or some keywords that describe it to get started."`

