### PR TITLE
Revert: Signup: Alias anonUserId to WPCOM user id when user is created

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -781,19 +781,16 @@ const analytics = {
 		},
 	},
 
-	identifyUser: function( newUserId = '', newUserName = '' ) {
+	identifyUser: function() {
 		const anonymousUserId = this.tracks.anonymousUserId();
 
 		// Don't identify the user if we don't have one
-		if ( ( _user && _user.initialized ) || ( newUserId && newUserName ) ) {
+		if ( _user && _user.initialized ) {
 			if ( anonymousUserId ) {
 				recordAliasInFloodlight();
 			}
 
-			const userId = newUserId || _user.get().ID;
-			const userName = newUserName || _user.get().username;
-
-			window._tkq.push( [ 'identifyUser', userId, userName ] );
+			window._tkq.push( [ 'identifyUser', _user.get().ID, _user.get().username ] );
 		}
 	},
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -22,7 +22,6 @@ import {
 	supportsPrivacyProtectionPurchase,
 	planItem as getCartItemForPlan,
 } from 'lib/cart-values/cart-items';
-import log from 'lib/catch-js-errors/log';
 
 // State actions and selectors
 import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
@@ -513,36 +512,6 @@ export function createAccount(
 
 				// Fire after a new user registers.
 				analytics.recordRegistration();
-				/**
-				 * Auto login the user when it has been created.
-				 */
-				user.clear();
-				user.fetching = false;
-
-				user.on( 'change', () => {
-					const newLoggedUser = user.get();
-
-					if ( newLoggedUser && newLoggedUser.ID ) {
-						analytics.identifyUser( newLoggedUser.ID, newLoggedUser.username );
-					} else {
-						/**
-						 * The user fetching is a bit fragile and sometimes it requires to do a double-fetch.
-						 */
-						log(
-							'Signup new user account creation: performing a new fetch of user if previous fetch fails',
-							{
-								newLoggedUser: newLoggedUser && newLoggedUser.ID ? newLoggedUser.ID : undefined,
-								userFetching: user.fetching,
-							}
-						);
-						user.clear();
-						user.fetching = false;
-						user.fetch();
-					}
-				} );
-
-				// Force fetch the user details
-				user.fetch();
 
 				const username =
 					( response && response.signup_sandbox_username ) ||


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This reverts commit 1864958a10f038aac116341f993b7a690f89a0ca.

This PR reverts #32850 due to failing canaries. Manual testing works fine. No idea.

`Sign up for a site on a premium paid plan through main flow in USD currency @parallel @canary'`

in test/e2e/specs/wp-signup-spec.js

## Testing instructions

None.
