### PR TITLE
Signup: send site information options when creating a new site

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -162,6 +162,9 @@ export function createSiteWithCart(
 			site_style: siteStyle || undefined,
 			site_segment: siteSegment || undefined,
 			site_vertical: siteVerticalId || undefined,
+			site_information: {
+				title: siteTitle,
+			},
 		},
 		public: 1,
 		validate: false,


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR reinstates the `site_information` option that headstart uses to fill in the company name placeholders. 

Headstart is already set up to handle he `site_information` option, so, given a site title of **sdsdasdasd**, instead of this:

<img width="400" alt="60534930-efb11000-9cd0-11e9-9cd6-49b9007f4a99" src="https://user-images.githubusercontent.com/6458278/60701358-de6d3b00-9f3e-11e9-9bda-86b28fba9342.png">

You'll see this:

<img width="400" alt="Screen Shot 2019-07-05 at 3 46 54 pm" src="https://user-images.githubusercontent.com/6458278/60701353-d90ff080-9f3e-11e9-9390-35277daba4e6.png">

🍡 

## Testing instructions

Create a Business site. Make sure to enter a title! Check that your title is reflect in the final site's footer and business details (i.e., wherever there is a `{{CompanyName}}` placeholder.


Fixes https://github.com/Automattic/zelda-private/issues/100
