### PR TITLE
Account security: don't pre-fill new password -field

### DIFF
--- a/client/me/security/main.jsx
+++ b/client/me/security/main.jsx
@@ -65,8 +65,11 @@ class Security extends React.Component {
 					</p>
 
 					<AccountPassword
-						userSettings={ this.props.userSettings }
 						accountPasswordData={ this.props.accountPasswordData }
+						autocomplete="new-password"
+						// Hint to LastPass not to attempt autofill
+						data-lpignore="true"
+						userSettings={ this.props.userSettings }
 					/>
 				</Card>
 			</Main>


### PR DESCRIPTION
Similarl to https://github.com/Automattic/wp-calypso/pull/34376

#### Changes proposed in this Pull Request

* Add attributes that stop browsers and LastPass prefilling "new password" field in `/me/security`

#### Before
<img width="747" alt="Screenshot 2019-07-05 at 09 31 34" src="https://user-images.githubusercontent.com/87168/60702732-671cb480-9f08-11e9-8fcc-2690396ed31d.png">

#### After
<img width="737" alt="image" src="https://user-images.githubusercontent.com/87168/60706683-ab14b700-9f12-11e9-9a30-b54114b83afe.png">


#### Testing instructions

Open `/me/security` and observe the difference in the password field
