### PR TITLE
Add check for `devdocs/redirect-loggedout-homepage` before redirecting to log-in page

### DIFF
--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -252,8 +252,8 @@ export const setupMiddlewares = ( currentUser, reduxStore ) => {
 	installPerfmonPageHandlers();
 	setupContextMiddleware( reduxStore );
 	oauthTokenMiddleware();
-	loadSectionsMiddleware();
 	loggedOutMiddleware( currentUser );
+	loadSectionsMiddleware();
 	setRouteMiddleware();
 	clearNoticesMiddleware();
 	unsavedFormsMiddleware();

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -66,7 +66,10 @@ function createPageDefinition( path, sectionDefinition ) {
 	const pathRegex = pathToRegExp( path );
 
 	// if the section doesn't support logged-out views, redirect to login if user is not logged in
-	if ( ! sectionDefinition.enableLoggedOut ) {
+	if (
+		! sectionDefinition.enableLoggedOut &&
+		! ( path === '/' && config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) )
+	) {
 		page( pathRegex, controller.redirectLoggedOut );
 	}
 

--- a/client/sections-middleware.js
+++ b/client/sections-middleware.js
@@ -66,10 +66,7 @@ function createPageDefinition( path, sectionDefinition ) {
 	const pathRegex = pathToRegExp( path );
 
 	// if the section doesn't support logged-out views, redirect to login if user is not logged in
-	if (
-		! sectionDefinition.enableLoggedOut &&
-		! ( path === '/' && config.isEnabled( 'devdocs/redirect-loggedout-homepage' ) )
-	) {
+	if ( ! sectionDefinition.enableLoggedOut ) {
 		page( pathRegex, controller.redirectLoggedOut );
 	}
 


### PR DESCRIPTION
This PR changes the order of two middlewares in `setupMiddlewares`.

In environments like `development` where `devdocs` is enabled, the `loggedOutMiddleware` should redirect requests to `/` to `/devdocs/start` so that new developers see a friendly landing page, and are able to walk through the simpler `/start/developer` signup flow. The existing order of middlewares was registering a redirect that would be executed first, sending `/` to `/log-in` instead.

More broadly, this change allows developers to go to http://calypso.localhost:3000/ and use the `/start/developer` flow, linked to from https://wpcalypso.wordpress.com/devdocs/start.

It looks like this landing page was last available from `/` before PR https://github.com/Automattic/wp-calypso/pull/30537 was merged.

#### Changes proposed in this Pull Request

* ~Add check to `createPageDefinition` to confirm that the path for the section isn't `/` when the `devdocs/redirect-loggedout-homepage` flag is set, before performing a redirect to the login page.~
* Update: instead of my original approach, based on: https://github.com/Automattic/wp-calypso/pull/34475#issuecomment-509946854 I've swapped the order of `loggedOutMiddleware` and `loadSectionsMiddleware` calls in `boot/common` to ensure that the `/` logged out redirects are registered before the logged out redirects for all the sections.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Ensure the devdocs landing page is restored
* From a logged out session, go to http://calypso.localhost:3000
* This should redirect you to http://calypso.localhost:3000/devdocs/start
* Clicking on `Register` should take you to the simplified `/start/developer` signup flow

***The landing page should be:***
![image](https://user-images.githubusercontent.com/14988353/60709816-a7098900-9f54-11e9-9420-350dfee7144d.png)

##### Ensure the normal logged out redirects are still working correctly
* From a logged out session, go to http://calypso.localhost:3000/stats
* This should redirect you to: http://calypso.localhost:3000/log-in?redirect_to=%2Fstats

##### Ensure that switching the `devdocs/redirect-loggedout-homepage` flag works
* In `/config/development.json` set the feature `devdocs/redirect-loggedout-homepage` to `false`
* Restart your local development environment (this change doesn't play nicely with hot reload)
* From a logged out session, go to: http://calypso.localhost:3000
* This should redirect you to: http://calypso.localhost:3000/log-in?redirect_to=%2F

***The landing page should be:***
![image](https://user-images.githubusercontent.com/14988353/60709886-cc969280-9f54-11e9-8084-c6fed7b62114.png)
