### PR TITLE
Refactor: Eliminate the duplicated Tracks events among `<CancelPurchaseButton>` and `<RemovePurchase>`

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -51,7 +51,6 @@ import './style.scss';
 
 class CancelPurchaseForm extends React.Component {
 	static propTypes = {
-		chatInitiated: PropTypes.func.isRequired,
 		defaultContent: PropTypes.node.isRequired,
 		disableButtons: PropTypes.bool,
 		purchase: PropTypes.object.isRequired,
@@ -59,7 +58,6 @@ class CancelPurchaseForm extends React.Component {
 		isVisible: PropTypes.bool,
 		onInputChange: PropTypes.func.isRequired,
 		onClose: PropTypes.func.isRequired,
-		onStepChange: PropTypes.func.isRequired,
 		onClickFinalConfirm: PropTypes.func.isRequired,
 		flowType: PropTypes.string.isRequired,
 		showSurvey: PropTypes.bool.isRequired,
@@ -395,8 +393,13 @@ class CancelPurchaseForm extends React.Component {
 		);
 	};
 
+	onChatInitiated = () => {
+		this.recordEvent( 'calypso_purchases_cancel_form_chat_initiated' );
+		this.closeDialog();
+	};
+
 	renderLiveChat = () => {
-		const { chatInitiated, purchase, translate } = this.props;
+		const { purchase, translate } = this.props;
 		const productName = getName( purchase );
 		return (
 			<FormFieldset>
@@ -410,7 +413,7 @@ class CancelPurchaseForm extends React.Component {
 						}
 					) }
 				</p>
-				<HappychatButton primary borderless={ false } onClick={ chatInitiated }>
+				<HappychatButton primary borderless={ false } onClick={ this.onChatInitiated }>
 					{ translate( 'Start a Live chat' ) }
 				</HappychatButton>
 			</FormFieldset>
@@ -501,7 +504,6 @@ class CancelPurchaseForm extends React.Component {
 		);
 		const newStep = stepFunction( this.state.surveyStep, allSteps );
 
-		this.props.onStepChange( newStep );
 		this.setState( { surveyStep: newStep } );
 
 		this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: newStep } );

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -99,8 +99,15 @@ class CancelPurchaseForm extends React.Component {
 		};
 	}
 
+	recordClickRadioEvent = ( option, value ) =>
+		this.props.recordTracksEvent( 'calypso_purchases_cancel_form_select_radio_option', {
+			option,
+			value,
+		} );
+
 	onRadioOneChange = event => {
-		this.props.clickRadio( 'radio_1', event.currentTarget.value );
+		this.recordClickRadioEvent( 'radio_1', event.currentTarget.value );
+
 		const newState = {
 			...this.state,
 			questionOneRadio: event.currentTarget.value,
@@ -120,7 +127,8 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	onRadioTwoChange = event => {
-		this.props.clickRadio( 'radio_2', event.currentTarget.value );
+		this.recordClickRadioEvent( 'radio_2', event.currentTarget.value );
+
 		const newState = {
 			...this.state,
 			questionTwoRadio: event.currentTarget.value,
@@ -341,11 +349,15 @@ class CancelPurchaseForm extends React.Component {
 		);
 	};
 
+	recordClickConciergeEvent = () =>
+		this.props.recordTracksEvent( 'calypso_purchases_cancel_form_concierge_click' );
+
 	openConcierge = () => {
 		if ( ! this.props.selectedSite ) {
 			return;
 		}
-		this.props.clickConcierge();
+		this.recordClickConciergeEvent();
+
 		return window.open( `/me/concierge/${ this.props.selectedSite.slug }/book` );
 	};
 
@@ -559,15 +571,7 @@ export default connect(
 		isChatActive: hasActiveHappychatSession( state ),
 		precancellationChatAvailable: isPrecancellationChatAvailable( state ),
 	} ),
-	dispatch => ( {
-		clickRadio: ( option, value ) =>
-			dispatch(
-				recordTracksEvent( 'calypso_purchases_cancel_form_select_radio_option', {
-					option: option,
-					value: value,
-				} )
-			),
-		clickConcierge: () =>
-			dispatch( recordTracksEvent( 'calypso_purchases_cancel_form_concierge_click' ) ),
-	} )
+	{
+		recordTracksEvent,
+	}
 )( localize( CancelPurchaseForm ) );

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -7,7 +7,6 @@ import page from 'page';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 import { getCurrencyDefaults } from '@automattic/format-currency';
 
 /**
@@ -53,25 +52,10 @@ class CancelPurchaseButton extends Component {
 		return isRefundable( this.props.purchase ) ? 'cancel_with_refund' : 'cancel_autorenew';
 	};
 
-	recordEvent = ( name, properties = {} ) => {
-		const { purchase } = this.props;
-		const product_slug = get( purchase, 'productSlug' );
-
-		this.props.recordTracksEvent(
-			name,
-			Object.assign(
-				{ cancellation_flow: this.getCancellationFlowType(), product_slug },
-				properties
-			)
-		);
-	};
-
 	handleCancelPurchaseClick = () => {
 		if ( isDomainRegistration( this.props.purchase ) ) {
 			return this.goToCancelConfirmation();
 		}
-
-		this.recordEvent( 'calypso_purchases_cancel_form_start' );
 
 		this.setState( {
 			showDialog: true,
@@ -79,8 +63,6 @@ class CancelPurchaseButton extends Component {
 	};
 
 	closeDialog = () => {
-		this.recordEvent( 'calypso_purchases_cancel_form_close' );
-
 		this.setState( {
 			showDialog: false,
 		} );
@@ -89,10 +71,6 @@ class CancelPurchaseButton extends Component {
 	chatInitiated = () => {
 		this.recordEvent( 'calypso_purchases_cancel_form_chat_initiated' );
 		this.closeDialog();
-	};
-
-	onStepChange = newStep => {
-		this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: newStep } );
 	};
 
 	onSurveyChange = update => {
@@ -212,8 +190,6 @@ class CancelPurchaseButton extends Component {
 	submitCancelAndRefundPurchase = () => {
 		const refundable = isRefundable( this.props.purchase );
 
-		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
-
 		if ( refundable ) {
 			this.cancelAndRefund();
 		} else {
@@ -297,7 +273,6 @@ class CancelPurchaseButton extends Component {
 					selectedSite={ selectedSite }
 					isVisible={ this.state.showDialog }
 					onClose={ this.closeDialog }
-					onStepChange={ this.onStepChange }
 					onClickFinalConfirm={ this.submitCancelAndRefundPurchase }
 					flowType={ this.getCancellationFlowType() }
 				/>

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -15,8 +15,6 @@ import { getCurrencyDefaults } from '@automattic/format-currency';
 import Button from 'components/button';
 import { cancelAndRefundPurchase, cancelPurchase } from 'lib/upgrades/actions';
 import { clearPurchases } from 'state/purchases/actions';
-import hasActiveHappychatSession from 'state/happychat/selectors/has-active-happychat-session';
-import isHappychatAvailable from 'state/happychat/selectors/is-happychat-available';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
 import {
 	getName,
@@ -29,9 +27,7 @@ import { isDomainRegistration } from 'lib/products-values';
 import notices from 'notices';
 import { confirmCancelDomain, purchasesRoot } from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
-import { recordTracksEvent } from 'state/analytics/actions';
 import { cancellationEffectDetail, cancellationEffectHeadline } from './cancellation-effect';
-import isPrecancellationChatAvailable from 'state/happychat/selectors/is-precancellation-chat-available';
 
 class CancelPurchaseButton extends Component {
 	static propTypes = {
@@ -66,11 +62,6 @@ class CancelPurchaseButton extends Component {
 		this.setState( {
 			showDialog: false,
 		} );
-	};
-
-	chatInitiated = () => {
-		this.recordEvent( 'calypso_purchases_cancel_form_chat_initiated' );
-		this.closeDialog();
 	};
 
 	onSurveyChange = update => {
@@ -265,7 +256,6 @@ class CancelPurchaseButton extends Component {
 					{ text }
 				</Button>
 				<CancelPurchaseForm
-					chatInitiated={ this.chatInitiated }
 					disableButtons={ disableButtons }
 					defaultContent={ this.renderCancellationEffect() }
 					onInputChange={ this.onSurveyChange }
@@ -282,14 +272,9 @@ class CancelPurchaseButton extends Component {
 }
 
 export default connect(
-	state => ( {
-		isChatAvailable: isHappychatAvailable( state ),
-		isChatActive: hasActiveHappychatSession( state ),
-		precancellationChatAvailable: isPrecancellationChatAvailable( state ),
-	} ),
+	null,
 	{
 		clearPurchases,
-		recordTracksEvent,
 		refreshSitePlans,
 	}
 )( localize( CancelPurchaseButton ) );

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Gridicon from 'gridicons';
 import { localize } from 'i18n-calypso';
-import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -71,18 +70,7 @@ class RemovePurchase extends Component {
 		} );
 	}
 
-	recordEvent = ( name, properties = {} ) => {
-		const product_slug = get( this.props, [ 'purchase', 'productSlug' ] );
-		const cancellation_flow = 'remove';
-		const is_atomic = this.props.isAtomicSite;
-		this.props.recordTracksEvent(
-			name,
-			Object.assign( { cancellation_flow, product_slug, is_atomic }, properties )
-		);
-	};
-
 	closeDialog = () => {
-		this.recordEvent( 'calypso_purchases_cancel_form_close' );
 		this.setState( {
 			isDialogVisible: false,
 		} );
@@ -94,7 +82,6 @@ class RemovePurchase extends Component {
 	};
 
 	openDialog = event => {
-		this.recordEvent( 'calypso_purchases_cancel_form_start' );
 		event.preventDefault();
 
 		this.setState( { isDialogVisible: true } );
@@ -107,10 +94,6 @@ class RemovePurchase extends Component {
 		this.setState( { isDialogVisible: false } );
 	};
 
-	onStepChange = newStep => {
-		this.recordEvent( 'calypso_purchases_cancel_survey_step', { new_step: newStep } );
-	};
-
 	onSurveyChange = update => {
 		this.setState( {
 			survey: update,
@@ -121,8 +104,6 @@ class RemovePurchase extends Component {
 		this.setState( { isRemoving: true } );
 
 		const { isDomainOnlySite, purchase, translate } = this.props;
-
-		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
 
 		this.props.removePurchase( purchase.id, this.props.userId ).then( () => {
 			const productName = getName( purchase );
@@ -218,7 +199,6 @@ class RemovePurchase extends Component {
 				selectedSite={ site }
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }
-				onStepChange={ this.onStepChange }
 				onClickFinalConfirm={ this.removePurchase }
 				extraPrependedButtons={ prependedChatButton }
 				flowType="remove"

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -76,11 +76,6 @@ class RemovePurchase extends Component {
 		} );
 	};
 
-	chatInitiated = () => {
-		this.recordEvent( 'calypso_purchases_cancel_form_chat_initiated' );
-		this.closeDialog();
-	};
-
 	openDialog = event => {
 		event.preventDefault();
 
@@ -191,7 +186,6 @@ class RemovePurchase extends Component {
 
 		return (
 			<CancelPurchaseForm
-				chatInitiated={ this.chatInitiated }
 				disableButtons={ this.state.isRemoving }
 				defaultContent={ this.renderPlanDialogText() }
 				onInputChange={ this.onSurveyChange }


### PR DESCRIPTION
_This PR is part of a broader attempt of making more reusable by eliminating code duplication._

#### Changes proposed in this Pull Request

This PR attempts to eliminate the duplicated Tracks events code by consolidating them into `<CancelPurchaseForm>`.

#### Dependency

https://github.com/Automattic/wp-calypso/pull/34459


#### Testing instructions

There shouldn't be any functional-wise changes. In general, go through the precancellation survey from both the canceling flow and the removal flow, and make sure all the Tracks events are sent as expected:

1. Open the console and run `localStorage.setItem("debug", "calypso:analytics:tracks" );` to see 
1. Go to the purchase management page, http://calypso.localhost:3000/me/purchases/, and click on any plan subscription.
1. Click on the "Cancel subscription" and go through the subscription cancelling process. All the survey-wise Tracks events should be sent as expected.
1. Go to the same subscription management page and this time there should be a "Remove Subscription" button. Click on it and go through the removing process. All the survey-wise Tracks events should be sent as expected.