### PR TITLE
Site Indicator: Align scary button to the baseline

### DIFF
--- a/client/my-sites/site-indicator/style.scss
+++ b/client/my-sites/site-indicator/style.scss
@@ -125,4 +125,13 @@
 		margin-left: 0.5em;
 		position: static;
 	}
+
+	> span {
+		display: flex;
+		flex-direction: column;
+
+		.button.is-borderless.is-scary {
+			align-self: baseline;
+		}
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Set the parent `span` to flex and the direction to column
* Align the `.button` to the baseline

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With a broken connection of a Jetpack site (e.g. https://jurassic.ninja/create?shortlived and wait until it's gone)
* Check the message to remove site in the sidebar (you might need to resize your browser)
* The button should be aligned at the bottom

__Before:__

![Screenshot 2019-07-05 at 12 10 05](https://user-images.githubusercontent.com/177929/60718895-ebc5fd80-9f1d-11e9-8fb5-6b7c00dd2493.png)

__After:__

![Screenshot 2019-07-05 at 12 10 41](https://user-images.githubusercontent.com/177929/60718906-f2ed0b80-9f1d-11e9-9f53-7cedb6c2df71.png)

Fixes #32644 
