### PR TITLE
Enable implicit submissions of G Suite `Add New User` using the Return key

### DIFF
--- a/client/components/gsuite/docs/new-user-list.tsx
+++ b/client/components/gsuite/docs/new-user-list.tsx
@@ -58,6 +58,7 @@ const GSuiteNewUserListExample = () => {
 				selectedDomainName={ domainOne.name }
 				onUsersChange={ changedUsers => setUsers( changedUsers ) }
 				users={ users }
+				onReturnKeyPress={ () => void 0 }
 			>
 				{ areAllUsersValid( users ) ? (
 					<span>

--- a/client/components/gsuite/gsuite-new-user-list/index.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/index.tsx
@@ -23,6 +23,7 @@ interface Props {
 	extraValidation: ( user: NewUser ) => NewUser;
 	selectedDomainName: string;
 	onUsersChange: ( users: NewUser[] ) => void;
+	onReturnKeyPress: ( event: Event ) => void;
 	users: NewUser[];
 }
 
@@ -33,6 +34,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 	selectedDomainName,
 	onUsersChange,
 	users,
+	onReturnKeyPress,
 } ) => {
 	const translate = useTranslate();
 
@@ -64,6 +66,7 @@ const GSuiteNewUserList: FunctionComponent< Props > = ( {
 						user={ user }
 						onUserValueChange={ onUserValueChange( index ) }
 						onUserRemove={ onUserRemove( index ) }
+						onReturnKeyPress={ onReturnKeyPress }
 					/>
 					<hr className="gsuite-new-user-list__user-divider" />
 				</Fragment>

--- a/client/components/gsuite/gsuite-new-user-list/new-user.tsx
+++ b/client/components/gsuite/gsuite-new-user-list/new-user.tsx
@@ -20,6 +20,7 @@ interface Props {
 	domains: any[];
 	onUserRemove: () => void;
 	onUserValueChange: ( field: string, value: string ) => void;
+	onReturnKeyPress: ( event: Event ) => void;
 	user: NewUser;
 }
 
@@ -27,6 +28,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 	domains,
 	onUserRemove,
 	onUserValueChange,
+	onReturnKeyPress,
 	user: {
 		firstName: { value: firstName, error: firstNameError },
 		lastName: { value: lastName, error: lastNameError },
@@ -67,6 +69,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 				onBlur={ () => {
 					setMailBoxFieldTouched( wasValidated );
 				} }
+				onKeyUp={ onReturnKeyPress }
 				suffix={ `@${ domain }` }
 			/>
 		);
@@ -85,6 +88,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 					onBlur={ () => {
 						setMailBoxFieldTouched( wasValidated );
 					} }
+					onKeyUp={ onReturnKeyPress }
 				/>
 				<GSuiteDomainsSelect
 					domains={ domains }
@@ -120,6 +124,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 							onBlur={ () => {
 								setFirstNameFieldTouched( wasValidated );
 							} }
+							onKeyUp={ onReturnKeyPress }
 						/>
 						{ hasFirstNameError && <FormInputValidation text={ firstNameError } isError /> }
 					</div>
@@ -135,6 +140,7 @@ const GSuiteNewUser: FunctionComponent< Props > = ( {
 							onBlur={ () => {
 								setLastNameFieldTouched( wasValidated );
 							} }
+							onKeyUp={ onReturnKeyPress }
 						/>
 						{ hasLastNameError && <FormInputValidation text={ lastNameError } isError /> }
 					</div>

--- a/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
+++ b/client/components/upgrades/gsuite/gsuite-upsell-card/index.jsx
@@ -71,6 +71,13 @@ const GSuiteUpsellCard = ( {
 		onSkipClick();
 	};
 
+	const handleReturnKeyPress = event => {
+		// Simulate an implicit submission for the add user form :)
+		if ( event.key === 'Enter' ) {
+			handleAddEmailClick();
+		}
+	};
+
 	const handleUsersChange = changedUsers => {
 		recordUsersChangedEvent( users, changedUsers );
 		setUsers( changedUsers );
@@ -110,6 +117,7 @@ const GSuiteUpsellCard = ( {
 					selectedDomainName={ domain }
 					onUsersChange={ handleUsersChange }
 					users={ users }
+					onReturnKeyPress={ handleReturnKeyPress }
 				>
 					<div className="gsuite-upsell-card__buttons">
 						<Button className="gsuite-upsell-card__skip-button" onClick={ handleSkipClick }>

--- a/client/my-sites/email/gsuite-add-users/index.jsx
+++ b/client/my-sites/email/gsuite-add-users/index.jsx
@@ -89,6 +89,13 @@ class GSuiteAddUsers extends React.Component {
 		this.goToEmail();
 	};
 
+	handleReturnKeyPress = event => {
+		// Simulate an implicit submission for the add user form :)
+		if ( event.key === 'Enter' ) {
+			this.handleContinue();
+		}
+	};
+
 	handleUsersChange = changedUsers => {
 		const { users: previousUsers } = this.state;
 
@@ -190,6 +197,7 @@ class GSuiteAddUsers extends React.Component {
 							onUsersChange={ this.handleUsersChange }
 							selectedDomainName={ getEligibleGSuiteDomain( selectedDomainName, domains ) }
 							users={ users }
+							onReturnKeyPress={ this.handleReturnKeyPress }
 						>
 							<div className="gsuite-add-users__buttons">
 								<Button onClick={ this.handleCancel }>{ translate( 'Cancel' ) }</Button>


### PR DESCRIPTION
This is small change to enable form submissions using the <kbd>Enter</kbd> key in two situations:

* When a user purchases a new domain and is nudged to purchase G Suite
* When a user wants to buy additional email users to existing G Suite enabled domains

#### Changes proposed in this Pull Request

* The submission is enabled by leveraging the onKeyUp event handler
* The handler calls the `handleContinue` function that the `Continue` button uses in the click handler
* The handler checks that the form is valid

#### Testing instructions

Load calypso locally ( i.e. calypso.localhost ) and sandbox the API.

##### Adding a new domain
* Navigate to [ My Sites ] ->* [ Manage ] -> [ Domains ] -> [ Add Domain ] 
* Select an appropriate available domain name to purchase
* Fill the form to add a new user and use the <kbd>Enter</kbd> key
* Observe the form get submitted on using the <kbd>Enter</kbd> key

##### Adding additional users to an existing domain
* Navigate to [ My Sites ] ->* [ Manage ] -> [ Domains ] -> [ Email ] -> [ Add New User ]
* Fill the form to add a new user and use the <kbd>Enter</kbd> key
* Observe the form get submitted on using the <kbd>Enter</kbd> key

##### Screenshots

<img width="735" alt="Screenshot 2019-07-05 at 6 12 16 PM" src="https://user-images.githubusercontent.com/277661/60736915-9b1bc800-9f50-11e9-96f7-ce8b557cfbfc.png">
