### PR TITLE
Fix spacing for skip option

### DIFF
--- a/client/components/domains/domain-skip-suggestion/index.jsx
+++ b/client/components/domains/domain-skip-suggestion/index.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import DomainSuggestion from 'components/domains/domain-suggestion';
+import './style.scss';
 
 class DomainSkipSuggestion extends React.Component {
 	static propTypes = {
@@ -34,7 +35,7 @@ class DomainSkipSuggestion extends React.Component {
 				<div className="domain-skip-suggestion__domain-description">
 					<h3>{ this.props.selectedSiteSlug }</h3>
 					<p>
-						{ translate( 'This is your current free site address', {
+						{ translate( 'This is your current free site address.', {
 							comment:
 								"Explains that the domain name shown above this sentence is this site's currently active domain, and it is free of cost.",
 						} ) }

--- a/client/components/domains/domain-skip-suggestion/style.scss
+++ b/client/components/domains/domain-skip-suggestion/style.scss
@@ -14,12 +14,10 @@
 		width: 75%;
 	}
 
-	> p {
+	p {
 		color: var( --color-neutral-700 );
 		font-size: 12px;
-		font-weight: 600;
 		margin-bottom: 0;
-		opacity: 0.7;
 
 		@include breakpoint( '>960px' ) {
 			margin-bottom: 8px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR fixes a spacing issue on the domain screen in the launch flow.

**Before**
![image](https://user-images.githubusercontent.com/6981253/60737931-7280d780-9f2a-11e9-9840-7845ec867c21.png)


**After**
![image](https://user-images.githubusercontent.com/6981253/60737915-64cb5200-9f2a-11e9-97ad-67b51cfb8d80.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site with [this other branch](https://hash-4dc572ae4b332471355c2f527515d0ba498a5747.calypso.live/start).
* When you see the checklist, update your url to this branch
* Expand the Launch task and click "Try it"

cc @jblz 
