### PR TITLE
Update copy on plans for launch flow

### DIFF
--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -343,8 +343,13 @@ export class PlansFeaturesMain extends Component {
 	};
 
 	renderFreePlanBanner() {
-		const { hideFreePlan, translate } = this.props;
+		const { hideFreePlan, translate, flowName, isInSignup } = this.props;
 		const className = 'is-free-plan';
+		const callToAction =
+			isInSignup && flowName === 'launch-site'
+				? translate( 'Continue with your free site' )
+				: translate( 'Start with a free site' );
+
 		if ( hideFreePlan ) {
 			return null;
 		}
@@ -354,7 +359,7 @@ export class PlansFeaturesMain extends Component {
 				<div className="plans-features-main__banner-content">
 					{ translate( 'Not sure yet?' ) }
 					<Button className={ className } onClick={ this.handleFreePlanButtonClick } borderless>
-						{ translate( 'Start with a free site' ) }
+						{ callToAction }
 					</Button>
 				</div>
 			</div>
@@ -415,6 +420,7 @@ PlansFeaturesMain.propTypes = {
 	displayJetpackPlans: PropTypes.bool.isRequired,
 	hideFreePlan: PropTypes.bool,
 	customerType: PropTypes.string,
+	flowName: PropTypes.string,
 	intervalType: PropTypes.string,
 	isChatAvailable: PropTypes.bool,
 	isInSignup: PropTypes.bool,

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -142,6 +142,7 @@ export class PlansStep extends Component {
 			isLaunchPage,
 			selectedSite,
 			planTypes,
+			flowName,
 		} = this.props;
 
 		return (
@@ -161,6 +162,7 @@ export class PlansStep extends Component {
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain }
 					plansWithScroll={ true }
 					planTypes={ planTypes }
+					flowName={ flowName }
 				/>
 			</div>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds some more contextual copy on the plans screen in the launch flow.

**Before**
<img width="1720" alt="Screen Shot 2019-07-05 at 2 09 10 PM" src="https://user-images.githubusercontent.com/6981253/60739979-ea063500-9f31-11e9-97be-249b2fd42a21.png">

**After**
<img width="1723" alt="Screen Shot 2019-07-05 at 2 32 12 PM" src="https://user-images.githubusercontent.com/6981253/60739982-ef637f80-9f31-11e9-8531-5891b3e4dbb5.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site with [this other branch](https://hash-4dc572ae4b332471355c2f527515d0ba498a5747.calypso.live/start).
* When you see the checklist, update your url to this branch
* Expand the Launch task and click "Try it"

cc @jblz 
