### PR TITLE
Editor: Remove Google Photo Library and Free photo library menu item if user is Contributor

### DIFF
--- a/client/components/tinymce/plugins/insert-menu/menu-items.jsx
+++ b/client/components/tinymce/plugins/insert-menu/menu-items.jsx
@@ -12,6 +12,15 @@ import i18n from 'i18n-calypso';
  */
 import config from 'config';
 import Gridicon from 'components/gridicon';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
+
+const canUserUploadFiles = editor => {
+	const store = editor.getParam( 'redux_store' );
+	const state = store ? store.getState() : null;
+	const siteId = state ? getSelectedSiteId( state ) : null;
+	return state && siteId ? canCurrentUser( state, siteId, 'upload_files' ) : false;
+};
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const GridiconButton = ( { icon, label, e2e } ) => (
@@ -50,6 +59,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 				/>
 			),
 			cmd: 'googleAddMedia',
+			condition: canUserUploadFiles,
 		} );
 	}
 	if ( config.isEnabled( 'external-media/free-photo-library' ) ) {
@@ -63,6 +73,7 @@ if ( config.isEnabled( 'external-media' ) ) {
 				/>
 			),
 			cmd: 'pexelsAddMedia',
+			condition: canUserUploadFiles,
 		} );
 	}
 }

--- a/client/components/tinymce/plugins/insert-menu/plugin.jsx
+++ b/client/components/tinymce/plugins/insert-menu/plugin.jsx
@@ -14,7 +14,13 @@ import { menuItems, GridiconButton } from './menu-items';
 import Gridicon from 'components/gridicon';
 
 function initialize( editor ) {
-	menuItems.forEach( item =>
+	// Conditional menu item support:
+	// Filters out menu item if has optional "condition" function field that returns false.
+	const filteredMenuItems = menuItems.filter(
+		item => ! item.condition || item.condition( editor )
+	);
+
+	filteredMenuItems.forEach( item =>
 		editor.addMenuItem( item.name, {
 			classes: 'wpcom-insert-menu__menu-item',
 			cmd: item.cmd,
@@ -28,7 +34,7 @@ function initialize( editor ) {
 		type: 'menubutton',
 		title: i18n.translate( 'Add content' ),
 		classes: 'btn wpcom-insert-menu insert-menu',
-		menu: menuItems.map( ( { name } ) => editor.menuItems[ name ] ),
+		menu: filteredMenuItems.map( ( { name } ) => editor.menuItems[ name ] ),
 		onPostRender() {
 			const [ insertContentElm ] = this.$el[ 0 ].children;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR hides "Google photo library" and "Free photo library" menu items from Classic Editor's "Add" popup menu if user does not have permission to upload files.

Details:

- Adds conditional TinyMCE menu item support by adding optional `condition` function field to menu item data.
- Adds `canUserUploadFiles` condition to Google and Free photo library menu items.

#### Testing instructions

1. Using Classic Editor, create a post as Contributor.
2. Click on the + Add button and verify that popup menu looks like this:

<img width="245" alt="screenshot_762" src="https://user-images.githubusercontent.com/127594/60744790-52eaae80-9f2c-11e9-9e57-64305d9dfa97.png">

3. Switch to a user with role that allows file upload, like Admin.
2. Click on the + Add button and verify that popup menu looks like this:

<img width="249" alt="screenshot_763" src="https://user-images.githubusercontent.com/127594/60744824-7e6d9900-9f2c-11e9-9ed2-c83d76e17e2a.png">

*

Fixes #22829
