### PR TITLE
Add helper text for external links

### DIFF
--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -86,5 +86,4 @@ class ExternalLink extends Component {
 		);
 	}
 }
-
 export default ExternalLink;

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -73,6 +73,15 @@ class ExternalLink extends Component {
 				{ this.props.icon && this.props.showIconFirst && iconComponent }
 				{ this.props.children }
 				{ this.props.icon && ! this.props.showIconFirst && iconComponent }
+				{ this.props.icon && (
+					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+					<span className="screen-reader-text">
+						{
+							/* translators: accessibility text */
+							'(opens in a new tab)'
+						}
+					</span>
+				) }
 			</a>
 		);
 	}

--- a/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
@@ -45,6 +45,11 @@ exports[`GSuiteUserItem renders user item with manage correctly 1`] = `
         />
       </g>
     </svg>
+    <span
+      className="screen-reader-text"
+    >
+      (opens in a new tab)
+    </span>
   </a>
 </li>
 `;

--- a/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
@@ -45,12 +45,6 @@ exports[`GSuiteUserItem renders user item with manage correctly 1`] = `
         />
       </g>
     </svg>
-	<span className="screen-reader-text">
-		{
-			/* translators: accessibility text */
-			'(opens in a new tab)'
-		}
-	</span>
   </a>
 </li>
 `;

--- a/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
@@ -45,6 +45,12 @@ exports[`GSuiteUserItem renders user item with manage correctly 1`] = `
         />
       </g>
     </svg>
+	<span className="screen-reader-text">
+		{
+			/* translators: accessibility text */
+			'(opens in a new tab)'
+		}
+	</span>
   </a>
 </li>
 `;


### PR DESCRIPTION
Adds helper text for screen readers only if external link icon is displayed.

#### Changes proposed in this Pull Request

If the external link icon is shown, add helper text for screen readers. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Switch to this PR.
2. Visit https://wordpress.com/following/manage
3. Inspect any link with icon. You will see the helper text present but not visible. 
4. Go to https://wordpress.com/read/feeds/25823/posts/2317223963
5. Inspect the article title. The helper text is not shown.

Fixes #
