### PR TITLE
Auto-renewal Toggle: Add the precancellation survey on toggling off

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/constants.js
+++ b/client/components/marketing-survey/cancel-purchase-form/constants.js
@@ -1,0 +1,19 @@
+export const CANCEL_FLOW_TYPE = {
+	REMOVE: 'remove',
+	CANCEL_WITH_REFUND: 'cancel_with_refund',
+
+	// In the end the following two might be merged into one.
+	// Before that happens, we still need to distinguish the two.
+
+	// When users effectively cancelling the auto-renewal by
+	// cancelling a subscription out of the refund window
+	CANCEL_AUTORENEW: 'cancel_autorenew',
+
+	// When users turns off the auto-renewal through a control
+	// that is specifically for enabling / disabling auto-renewal.
+	// At the moment of writing this, it is a toggle in the purchase management page.
+	// It is called 'survey only' because when the survey pops up the auto-renewal
+	// will be turned off already for the legal compliance reason, instead of
+	// needing users to do any final confirm.
+	CANCEL_AUTORENEW_SURVEY_ONLY: 'cancel_autorenew_survey_only',
+};

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -66,6 +66,8 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	static defaultProps = {
+		defaultContent: '',
+		onInputChange: () => {},
 		showSurvey: true,
 		isVisible: false,
 		extraPrependedButtons: [],

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -524,13 +524,16 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	getStepButtons = () => {
-		const { translate, disableButtons } = this.props;
+		const { flowType, translate, disableButtons } = this.props;
 		const disabled = disableButtons || this.state.isSubmitting;
 
 		const close = {
 				action: 'close',
 				disabled,
-				label: translate( "I'll Keep It" ),
+				label:
+					flowType === 'cancel_autorenew_survey_only'
+						? translate( 'Skip' )
+						: translate( "I'll Keep It" ),
 			},
 			next = {
 				action: 'next',
@@ -557,14 +560,26 @@ class CancelPurchaseForm extends React.Component {
 				label: translate( 'Remove Now' ),
 				onClick: this.onSubmit,
 				isPrimary: true,
+			},
+			submit = {
+				action: 'submit',
+				disabled: this.state.isSubmitting,
+				label: translate( 'Submit' ),
+				onClick: this.onSubmit,
+				isPrimary: true,
 			};
 
 		const firstButtons = [ ...this.props.extraPrependedButtons, close ];
 
 		if ( this.state.surveyStep === steps.FINAL_STEP ) {
-			return firstButtons.concat(
-				this.props.flowType === 'remove' ? [ prev, remove ] : [ prev, cancel ]
-			);
+			switch ( flowType ) {
+				case 'remove':
+					return firstButtons.concat( [ prev, remove ] );
+				case 'cancel_autorenew_survey_only':
+					return firstButtons.concat( [ prev, submit ] );
+				default:
+					return firstButtons.concat( [ prev, cancel ] );
+			}
 		}
 
 		return firstButtons.concat(

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -16,6 +16,7 @@ import Button from 'components/button';
 import { cancelAndRefundPurchase, cancelPurchase } from 'lib/upgrades/actions';
 import { clearPurchases } from 'state/purchases/actions';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
+import { CANCEL_FLOW_TYPE } from 'components/marketing-survey/cancel-purchase-form/constants';
 import {
 	getName,
 	getSubscriptionEndDate,
@@ -45,7 +46,9 @@ class CancelPurchaseButton extends Component {
 	};
 
 	getCancellationFlowType = () => {
-		return isRefundable( this.props.purchase ) ? 'cancel_with_refund' : 'cancel_autorenew';
+		return isRefundable( this.props.purchase )
+			? CANCEL_FLOW_TYPE.CANCEL_WITH_REFUND
+			: CANCEL_FLOW_TYPE.CANCEL_AUTORENEW;
 	};
 
 	handleCancelPurchaseClick = () => {

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -198,8 +198,6 @@ class AutoRenewDisablingDialog extends Component {
 
 		return (
 			<CancelPurchaseForm
-				defaultContent={ '' }
-				onInputChange={ () => {} }
 				purchase={ purchase }
 				selectedSite={ selectedSite }
 				isVisible={ true }

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -116,7 +116,6 @@ class AutoRenewDisablingDialog extends Component {
 	}
 
 	onClickAtomicFollowUpConfirm = () => {
-		// this.props.onConfirm() || this.props.onClose();
 		this.props.onConfirm();
 		this.setState( {
 			dialogType: DIALOG.SURVEY,
@@ -166,7 +165,6 @@ class AutoRenewDisablingDialog extends Component {
 			return;
 		}
 
-		// this.props.onConfirm() || this.props.onClose();
 		this.props.onConfirm();
 		this.setState( {
 			dialogType: DIALOG.SURVEY,

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -17,6 +17,7 @@ import config from 'config';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
+import { CANCEL_FLOW_TYPE } from 'components/marketing-survey/cancel-purchase-form/constants';
 import GSuiteCancellationPurchaseDialog from 'components/marketing-survey/gsuite-cancel-purchase-dialog';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
 import { isDataLoading } from '../utils';
@@ -195,7 +196,7 @@ class RemovePurchase extends Component {
 				onClose={ this.closeDialog }
 				onClickFinalConfirm={ this.removePurchase }
 				extraPrependedButtons={ prependedChatButton }
-				flowType="remove"
+				flowType={ CANCEL_FLOW_TYPE.REMOVE }
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR adds the precancellation survey on toggling off auto-renewal:
![demo-auto-renewal-toggle](https://user-images.githubusercontent.com/1842898/60750431-c3e89f80-9fda-11e9-9591-7382f675cc0b.gif)

#### Dependency
#34393, #34459, #34477 

#### Testing instructions

1. Go to the purchase management page of a subscription(`/me/purchase/{site slug}/{purchase id}`)
1. Toggling off the auto-renewal, the survey should pop up. Note that the toggle should be off already at this moment for the legal compliance reason.
1. Make sure the survey can be submitted as expected.

