### PR TITLE
Mobile Back to Sidebar: CSS Migration

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -15,7 +15,6 @@
 @import 'components/info-popover/style';
 @import 'components/locale-suggestions/style';
 @import 'components/main/style';
-@import 'components/mobile-back-to-sidebar/style';
 @import 'components/notice/style';
 @import 'components/popover/style';
 @import 'components/section-nav/style';

--- a/client/components/mobile-back-to-sidebar/index.jsx
+++ b/client/components/mobile-back-to-sidebar/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -11,6 +9,11 @@ import { connect } from 'react-redux';
  * Internal Dependencies
  */
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 class MobileBackToSidebar extends React.Component {
 	toggleSidebar = event => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrates the CSS of the `mobile-back-to-sidebar` component. Should be fairly straightforward.

#### Testing instructions

Resize your screen to mobile on the reader and verify that the styling of "Streams" is identical.

<img width="546" alt="Screenshot 2019-07-06 at 11 43 04" src="https://user-images.githubusercontent.com/43215253/60755245-e4b5f280-9fe4-11e9-8bfb-6e2a0a914878.png">

cc @blowery, @jsnajdr, @flootr 

Fixes #34493
Part of #27515
