### PR TITLE
Exporter: Add DocumentHead Title & SidebarNavigation

### DIFF
--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -12,6 +12,7 @@ import EmptyContent from 'components/empty-content';
 import ExporterContainer from 'my-sites/exporter/container';
 import Main from 'components/main';
 import DocumentHead from 'components/data/document-head';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import FormattedHeader from 'components/formatted-header';
@@ -24,6 +25,7 @@ import './style.scss';
 const SectionExport = ( { isJetpack, site, translate } ) => (
 	<Main>
 		<DocumentHead title={ translate( 'Export' ) } />
+		<SidebarNavigation />
 		<FormattedHeader
 			className="exporter__section-header"
 			headerText={ translate( 'Export your content' ) }

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 import React from 'react';
 import { connect } from 'react-redux';

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -11,6 +11,7 @@ import { localize } from 'i18n-calypso';
 import EmptyContent from 'components/empty-content';
 import ExporterContainer from 'my-sites/exporter/container';
 import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 import FormattedHeader from 'components/formatted-header';
@@ -22,6 +23,7 @@ import './style.scss';
 
 const SectionExport = ( { isJetpack, site, translate } ) => (
 	<Main>
+		<DocumentHead title={ translate( 'Export' ) } />
 		<FormattedHeader
 			className="exporter__section-header"
 			headerText={ translate( 'Export your content' ) }

--- a/client/my-sites/exporter/section-export.jsx
+++ b/client/my-sites/exporter/section-export.jsx
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * External dependencies.
  */
 import React from 'react';
 import { connect } from 'react-redux';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I noticed that the Exporter lacks a title after the change in #33181.

#### Testing instructions

Visit `/export/site` and verify that the browser displays "Export" in the heading, followed by the site. Previously, it'd just display whatever previous page you were on or just your site name.

<img width="383" alt="Screenshot 2019-07-06 at 11 57 40" src="https://user-images.githubusercontent.com/43215253/60755306-cbfa0c80-9fe5-11e9-9e60-6d2b12b1d945.png">

cc @creativecoder, @jonathansadowski, @jsnajdr 