### PR TITLE
Importer: Add Mobile Sidebar Navigation

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * External dependencies.
  */
 
 import PropTypes from 'prop-types';

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -1,5 +1,5 @@
 /**
- * External dependencies.
+ * External dependencies
  */
 
 import PropTypes from 'prop-types';

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -13,6 +13,7 @@ import { filter, find, flow, get, isEmpty, memoize, once } from 'lodash';
  */
 import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ImporterStore, { getState as getImporterState } from 'lib/importer/store';
 import Interval, { EVERY_FIVE_SECONDS } from 'lib/interval';
 import WordPressImporter from 'my-sites/importer/importer-wordpress';
@@ -283,6 +284,7 @@ class SectionImport extends Component {
 		return (
 			<Main>
 				<DocumentHead title={ translate( 'Import' ) } />
+				<SidebarNavigation />
 				<FormattedHeader
 					className="importer__section-header"
 					headerText={ headerText }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Noticed whilst creating #34494, the importer is currently lacking sidebar navigation on mobile. The exporter also is too, but that's a separate PR in #34495 as that's dependant on the DocumentHead title being included as well.

#### Testing instructions

Visit the importer and resize your screen down, note that you can now navigate back to the sidebar.

<img width="535" alt="Screenshot 2019-07-06 at 12 12 09" src="https://user-images.githubusercontent.com/43215253/60755428-7de60880-9fe7-11e9-8359-b2c5fc8e4d8e.png">

cc @creativecoder, @jonathansadowski, @jsnajdr