### PR TITLE
Site Selector: CSS Migration

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -21,7 +21,6 @@
 @import 'components/section-nav/style';
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
-@import 'components/site-selector/style';
 @import 'components/sites-popover/style';
 @import 'components/tooltip/style';
 @import 'layout/guided-tours/style';

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -30,6 +29,11 @@ import SitePlaceholder from 'blocks/site/placeholder';
 import Search from 'components/search';
 import SiteSelectorAddSite from './add-site';
 import searchSites from 'components/search-sites';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 const ALL_SITES = 'ALL_SITES';
 
@@ -135,7 +139,7 @@ class SiteSelector extends Component {
 			highlightedSiteId = this.props.highlightedSiteId || this.lastMouseHover;
 			highlightedIndex = this.visibleSites.indexOf( highlightedSiteId );
 		} else {
-			debug( 'reseting highlight as mouse left site selector' );
+			debug( 'resetting highlight as mouse left site selector' );
 			highlightedSiteId = null;
 			highlightedIndex = -1;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Simply migrates the Site Selector styling

#### Testing instructions

Click "Switch Site" near the top left to verify that everything is identical in the `my-sites` sidebar, but also verify that when visiting a route such as `/media`, the styling is also identical.

<img width="471" alt="Screenshot 2019-07-06 at 15 41 20" src="https://user-images.githubusercontent.com/43215253/60757677-7d5c6a80-a005-11e9-8974-4d3e6e655e85.png">

cc @jsnajdr, @blowery, @flootr 

Closes #34497
Part of #27515
