### PR TITLE
Use new Key Systems API name in contact verification landing page

### DIFF
--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -186,7 +186,7 @@ class RegistrantVerificationPage extends Component {
 				errorState = this.getExpiredState();
 				break;
 
-			case 'Key_Systems_error':
+			case 'KS_RAM_error':
 				errorState = this.getKeySystemsErrorState( error.message );
 				break;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We updated the name of the API on the back end, but didn't make the same update in the error code on the front end. It looks like the only place where we rely on this string is in the contact verification landing page.

#### Testing instructions

Trigger a contact verification email in a relevant domain. After verifying the new contact using the email you receive, try to click on the button in the same email again.  You should see a message saying that you've already verified this email.