### PR TITLE
Make `GdprBanner` SSR safer.

### DIFF
--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -69,6 +69,10 @@ function GdprBanner( props ) {
 		setRenderBanner( true );
 	}, [] );
 
+	useEffect( () => {
+		! hideBanner && renderBanner && recordCookieBannerView();
+	}, [ hideBanner, renderBanner, recordCookieBannerView ] );
+
 	if ( ! renderBanner || ! shouldShowBanner() ) {
 		return null;
 	}
@@ -82,14 +86,8 @@ function GdprBanner( props ) {
 			},
 		}
 	);
-	const classes = {
-		'is-compact': true,
-		'gdpr-banner': true,
-		'gdpr-banner__hiding': hideBanner,
-	};
-	recordCookieBannerView();
 	return (
-		<Card className={ classNames( classes ) }>
+		<Card compact className={ classNames( 'gdpr-banner', { 'gdpr-banner__hiding': hideBanner } ) }>
 			<div className="gdpr-banner__text-content">{ preventWidows( decodeEntities( copy ) ) }</div>
 			<div className="gdpr-banner__buttons">
 				<Button className="gdpr-banner__acknowledge-button" onClick={ acknowledgeClicked }>

--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import cookie from 'cookie';
 import { noop } from 'lodash';
 import { useTranslate } from 'i18n-calypso';
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -59,14 +59,14 @@ function GdprBanner( props ) {
 
 	const { recordCookieBannerOk, recordCookieBannerView } = props;
 
-	const acknowledgeClicked = useCallback( () => {
+	const acknowledgeClicked = () => {
 		document.cookie = cookie.serialize( 'sensitive_pixel_option', 'yes', {
 			path: '/',
 			maxAge: SIX_MONTHS,
 		} );
 		recordCookieBannerOk();
 		setBannerStatus( STATUS.RENDERED_BUT_HIDDEN );
-	}, [ recordCookieBannerOk ] );
+	};
 
 	// We want to ensure that the first render is always empty, to match the server.
 	// This avoids potential hydration issues.

--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -3,9 +3,9 @@
  */
 import classNames from 'classnames';
 import cookie from 'cookie';
-import { identity, noop } from 'lodash';
-import { localize } from 'i18n-calypso';
-import React, { Component } from 'react';
+import { noop } from 'lodash';
+import { useTranslate } from 'i18n-calypso';
+import React, { useState, useCallback, useEffect } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -29,82 +29,86 @@ const SIX_MONTHS = 6 * 30 * 24 * 60 * 60;
 
 const hasDocument = typeof document !== 'undefined';
 
-class GdprBanner extends Component {
-	static propTypes = {
-		recordCookieBannerOk: PropTypes.func,
-		recordCookieBannerView: PropTypes.func,
-		translate: PropTypes.func,
-	};
+function shouldShowBanner() {
+	// Don't render banner in SSR.
+	if ( ! hasDocument ) {
+		return false;
+	}
+	const cookies = cookie.parse( document.cookie );
+	if ( cookies.sensitive_pixel_option === 'yes' || cookies.sensitive_pixel_option === 'no' ) {
+		return false;
+	}
+	if ( isWpMobileApp() ) {
+		return false;
+	}
+	if ( isCurrentUserMaybeInGdprZone() ) {
+		return true;
+	}
+	return false;
+}
 
-	static defaultProps = {
-		recordCookieBannerOk: noop,
-		recordCookieBannerView: noop,
-		translate: identity,
-	};
+function GdprBanner( props ) {
+	const [ hideBanner, setHideBanner ] = useState( false );
+	const [ renderBanner, setRenderBanner ] = useState( false );
+	const translate = useTranslate();
 
-	state = {
-		showBanner: true,
-	};
+	const { recordCookieBannerOk, recordCookieBannerView } = props;
 
-	acknowledgeClicked = () => {
+	const acknowledgeClicked = useCallback( () => {
 		document.cookie = cookie.serialize( 'sensitive_pixel_option', 'yes', {
 			path: '/',
 			maxAge: SIX_MONTHS,
 		} );
-		this.props.recordCookieBannerOk();
-		this.setState( { showBanner: false } );
+		recordCookieBannerOk();
+		setHideBanner( true );
+	}, [ recordCookieBannerOk ] );
+
+	// We want to ensure that the first render is always empty, to match the server.
+	// This avoids potential hydration issues.
+	useEffect( () => {
+		setRenderBanner( true );
+	}, [] );
+
+	if ( ! renderBanner || ! shouldShowBanner() ) {
+		return null;
+	}
+
+	const copy = translate(
+		'Our websites and dashboards use cookies. By continuing, you agree to their use. ' +
+			'{{a}}Learn more{{/a}}, including how to control cookies.',
+		{
+			components: {
+				a: <a href={ localizeUrl( 'https://automattic.com/cookies' ) } />,
+			},
+		}
+	);
+	const classes = {
+		'is-compact': true,
+		'gdpr-banner': true,
+		'gdpr-banner__hiding': hideBanner,
 	};
-
-	shouldShowBanner() {
-		// Don't render banner in SSR.
-		if ( ! hasDocument ) {
-			return false;
-		}
-		const cookies = cookie.parse( document.cookie );
-		if ( cookies.sensitive_pixel_option === 'yes' || cookies.sensitive_pixel_option === 'no' ) {
-			return false;
-		}
-		if ( isWpMobileApp() ) {
-			return false;
-		}
-		if ( isCurrentUserMaybeInGdprZone() ) {
-			return true;
-		}
-		return false;
-	}
-
-	render() {
-		if ( ! this.shouldShowBanner() ) {
-			return null;
-		}
-		const { translate } = this.props;
-		const copy = translate(
-			'Our websites and dashboards use cookies. By continuing, you agree to their use. ' +
-				'{{a}}Learn more{{/a}}, including how to control cookies.',
-			{
-				components: {
-					a: <a href={ localizeUrl( 'https://automattic.com/cookies' ) } />,
-				},
-			}
-		);
-		const classes = {
-			'is-compact': true,
-			'gdpr-banner': true,
-			'gdpr-banner__hiding': ! this.state.showBanner,
-		};
-		this.props.recordCookieBannerView();
-		return (
-			<Card className={ classNames( classes ) }>
-				<div className="gdpr-banner__text-content">{ preventWidows( decodeEntities( copy ) ) }</div>
-				<div className="gdpr-banner__buttons">
-					<Button className="gdpr-banner__acknowledge-button" onClick={ this.acknowledgeClicked }>
-						{ translate( 'Got it!' ) }
-					</Button>
-				</div>
-			</Card>
-		);
-	}
+	recordCookieBannerView();
+	return (
+		<Card className={ classNames( classes ) }>
+			<div className="gdpr-banner__text-content">{ preventWidows( decodeEntities( copy ) ) }</div>
+			<div className="gdpr-banner__buttons">
+				<Button className="gdpr-banner__acknowledge-button" onClick={ acknowledgeClicked }>
+					{ translate( 'Got it!' ) }
+				</Button>
+			</div>
+		</Card>
+	);
 }
+
+GdprBanner.propTypes = {
+	recordCookieBannerOk: PropTypes.func,
+	recordCookieBannerView: PropTypes.func,
+};
+
+GdprBanner.defaultProps = {
+	recordCookieBannerOk: noop,
+	recordCookieBannerView: noop,
+};
 
 const mapDispatchToProps = {
 	recordCookieBannerOk: () => recordTracksEvent( 'a8c_cookie_banner_ok', { site: 'Calypso' } ),
@@ -118,4 +122,4 @@ const mapDispatchToProps = {
 export default connect(
 	null,
 	mapDispatchToProps
-)( localize( GdprBanner ) );
+)( GdprBanner );


### PR DESCRIPTION
The first CSR render is now always null, to match the SSR.
This helps avoid potential renconciliation issues during hydration.

Also reimplements `GdprBanner` as a functional component.

#### Changes proposed in this Pull Request

* Ensure the first CSR of `GdprBanner` is always null
* Reimplement `GdprBanner` as a functional component

#### Testing instructions

* Enable `gdpr-banner` in your chosen testing environment.
* Ensure that SSR is working (e.g. by disabling Javascript)
* Ensure that there are no hydration error messages
