### PR TITLE
Import: Show permissions requirement for non-admin users

### DIFF
--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -32,12 +32,15 @@ import {
 	SQUARESPACE,
 } from 'state/imports/constants';
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
-import { getSelectedSite, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
 import { getSelectedImportEngine, getImporterSiteUrl } from 'state/importer-nux/temp-selectors';
 import Main from 'components/main';
 import FormattedHeader from 'components/formatted-header';
 import JetpackImporter from 'my-sites/importer/jetpack-importer';
 import ExternalLink from 'components/external-link';
+import canCurrentUser from 'state/selectors/can-current-user';
+import SidebarNavigation from 'my-sites/sidebar-navigation';
+import EmptyContent from 'components/empty-content';
 
 /**
  * Style dependencies
@@ -267,7 +270,20 @@ class SectionImport extends Component {
 	}
 
 	render() {
-		const { site, translate } = this.props;
+		const { site, translate, canImport } = this.props;
+
+		if ( ! canImport ) {
+			return (
+				<Main>
+					<SidebarNavigation />
+					<EmptyContent
+						title={ this.props.translate( 'You are not authorized to view this page' ) }
+						illustration={ '/calypso/images/illustrations/illustration-404.svg' }
+					/>
+				</Main>
+			);
+		}
+
 		const { jetpack: isJetpack } = site;
 		const headerText = translate( 'Import your content' );
 		const subHeaderText = translate(
@@ -302,6 +318,7 @@ export default flow(
 		fromSite: getImporterSiteUrl( state ),
 		site: getSelectedSite( state ),
 		siteSlug: getSelectedSiteSlug( state ),
+		canImport: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 	} ) ),
 	localize
 )( SectionImport );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Checks and shows permissions requirement if user do not have permission to import.

#### Testing instructions

1. Select a test site with non-Admin test user.

2. Navigate to https://wordpress.com/import/{site_slug}.
3. You should see:

**BEFORE**
<img width="1074" alt="screenshot_765" src="https://user-images.githubusercontent.com/127594/60828180-a3e5e700-a166-11e9-9fdb-7ece87085a0d.png">

4. Navigate to http://calypso.localhost:3000/import/{site_slug}
5. You should see:

**AFTER**
<img width="1070" alt="screenshot_764" src="https://user-images.githubusercontent.com/127594/60828210-ba8c3e00-a166-11e9-9a6d-6172af8374df.png">

*

Fixes #33030
