### PR TITLE
Removes the block-editor dependency reintroduced on #34146.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -10,7 +10,7 @@ import { get, noop } from 'lodash';
  * WordPress dependencies
  */
 import { parse, createBlock } from '@wordpress/blocks';
-import { BlockEdit } from '@wordpress/block-editor';
+import { BlockEdit } from '@wordpress/editor';
 import { Button, Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { compose, withState } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -31,7 +31,6 @@
 	"dependencies": {
 		"@wordpress/api-fetch": "^3.1.2",
 		"@wordpress/blocks": "^6.2.3",
-		"@wordpress/block-editor": "^2.2.0",
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",
 		"@wordpress/data": "^4.4.0",


### PR DESCRIPTION
The dependency to `@wordpress/block-editor` was reintroduced on #34146, but it was agreed that, for the time being, we'll stick with `@wordpress/editor` instead so the externalized dependencies (`wp.editor`) work with older versions of Gutenberg.

#### Changes proposed in this Pull Request

* imports `BlockEdit` from `@wordpress/editor` instead of `@wordpress/block-editor`.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Edit a Page with a template. Verify that there are no regressions and the Template Parts blocks are loaded correctly.

Context: #34096 