### PR TITLE
Update domain refund window mentioned in Calypso to 96 hours

### DIFF
--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -220,7 +220,7 @@ function maybeWithinRefundPeriod( purchase ) {
 /**
  * Checks if a purchase can be canceled and refunded via the WordPress.com API.
  * Purchases usually can be refunded up to 30 days after purchase.
- * Domains and domain mappings can be refunded up to 48 hours.
+ * Domains and domain mappings can be refunded up to 96 hours.
  * Purchases included with plan can't be refunded.
  *
  * If this function returns false but you want to see if the subscription may

--- a/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-refund-policy.jsx
@@ -24,7 +24,7 @@ class DomainRegistrationRefundPolicy extends React.Component {
 
 	renderPolicy = () => {
 		let message = this.props.translate(
-			'You understand that {{refundsSupportPage}}domain name refunds{{/refundsSupportPage}} are limited to 48 hours after registration.',
+			'You understand that {{refundsSupportPage}}domain name refunds{{/refundsSupportPage}} are limited to 96 hours after registration.',
 			{
 				components: {
 					refundsSupportPage: (
@@ -41,7 +41,7 @@ class DomainRegistrationRefundPolicy extends React.Component {
 
 		if ( hasDomainBeingUsedForPlan( this.props.cart ) ) {
 			message = this.props.translate(
-				'You understand that {{refundsSupportPage}}domain name refunds{{/refundsSupportPage}} are limited to 48 hours after registration. Refunds of paid plans will deduct the standard cost of any domain name registered within a plan.',
+				'You understand that {{refundsSupportPage}}domain name refunds{{/refundsSupportPage}} are limited to 96 hours after registration. Refunds of paid plans will deduct the standard cost of any domain name registered within a plan.',
 				{
 					components: {
 						refundsSupportPage: (

--- a/client/my-sites/feature-upsell/refund-asterisk.jsx
+++ b/client/my-sites/feature-upsell/refund-asterisk.jsx
@@ -17,8 +17,8 @@ const RefundAsterisk = () => (
 		<div className="feature-upsell__refund-asterisk">
 			<p>Purchases made on WordPress.com can be cancelled and refunded during the refund period.</p>
 			<p>
-				For new domain registrations, you must cancel within 48 hours of purchase to receive a
-				refund. There are no refunds, pro-rated or otherwise, after 48 hours.
+				For new domain registrations, you must cancel within 96 hours of purchase to receive a
+				refund. There are no refunds, pro-rated or otherwise, after 96 hours.
 			</p>
 			<p>
 				For plans and all other purchases, you must cancel within 30 days of purchase to receive a


### PR DESCRIPTION
Domain refunds used to be allowed in a 48 hour window after purchase.  However the window is now 96 hours (see for example https://en.support.wordpress.com/manage-purchases/#refund-policy).

This pull request updates locations in Calypso that had 48 hours hardcoded for display so that they show 96 hours instead.

The most prominent place is on the checkout form, when purchasing a domain.  This screenshot shows one example of the new text in that case:
![Screenshot from 2019-07-08 17-35-31](https://user-images.githubusercontent.com/235183/60844933-d6183880-a1a8-11e9-892a-884acbb0a3bd.png)

p7DVsv-6Rv-p2