### PR TITLE
Mobile Back to Sidebar: improve a11y, use Gridicon and flex layout

### DIFF
--- a/client/components/mobile-back-to-sidebar/index.jsx
+++ b/client/components/mobile-back-to-sidebar/index.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
+import Gridicon from 'gridicons';
 
 /**
  * Internal Dependencies
@@ -15,33 +16,16 @@ import { setLayoutFocus } from 'state/ui/layout-focus/actions';
  */
 import './style.scss';
 
-class MobileBackToSidebar extends React.Component {
-	toggleSidebar = event => {
-		event.preventDefault();
-		this.props.setLayoutFocus( 'sidebar' );
-	};
-
-	render() {
-		return (
-			<div className="mobile-back-to-sidebar" onClick={ this.toggleSidebar }>
-				<svg
-					className="gridicon gridicon-back-arrow mobile-back-to-sidebar__icon"
-					height="24"
-					width="24"
-					xmlns="http://www.w3.org/2000/svg"
-					viewBox="0 0 24 24"
-				>
-					<g>
-						<path d="M8.886 4L7 5.886 13.114 12 7 18.114 8.886 20l8-8" />
-					</g>
-				</svg>
-				<span className="mobile-back-to-sidebar__content">{ this.props.children }</span>
-			</div>
-		);
-	}
+function MobileBackToSidebar( { children, toggleSidebar } ) {
+	return (
+		<button className="mobile-back-to-sidebar" onClick={ toggleSidebar }>
+			<Gridicon icon="chevron-left" className="mobile-back-to-sidebar__icon" />
+			<span className="mobile-back-to-sidebar__content">{ children }</span>
+		</button>
+	);
 }
 
 export default connect(
 	null,
-	{ setLayoutFocus }
+	{ toggleSidebar: () => setLayoutFocus( 'sidebar' ) }
 )( MobileBackToSidebar );

--- a/client/components/mobile-back-to-sidebar/style.scss
+++ b/client/components/mobile-back-to-sidebar/style.scss
@@ -1,9 +1,11 @@
 // Mobile Back to Sidebar
 .mobile-back-to-sidebar {
+	display: flex;
+	width: 100%;
+	align-items: center;
 	margin: 0 0 8px;
-	padding: 15px 0 15px 36px;
-	position: relative;
-	background: var( --color-white );
+	padding: 14px 0;
+	background: var( --color-surface );
 	border-bottom: 1px solid var( --color-neutral-100 );
 	cursor: pointer;
 
@@ -13,16 +15,10 @@
 }
 
 .mobile-back-to-sidebar__icon {
-	position: absolute;
-		top: 16px;
-		left: 10px;
 	fill: var( --color-neutral-light );
-	height: 20px;
-	width: 20px;
-	transform: rotate( 180deg );
+	margin: 0 14px 8px 0;
 }
 
 .mobile-back-to-sidebar__content {
-	font-size: 15px;
 	color: var( --color-neutral-700 );
 }


### PR DESCRIPTION
Modernization of the `MobileBackToSidebar`, followup to #34494 by @Aurorum:
- use `button` element instead of clickable `div` (a11y!)
- simplify the React code, convert to functional component
- use the standard `chevron-left` gridicon instead of custom SVG
- use modern Flex layout instead of `position: absolute`
- align the styles (padding, font size) with other similar components (`SidebarNavigation` or "Switch Site")

**Before:**
<img width="503" alt="Screenshot 2019-07-09 at 08 44 27" src="https://user-images.githubusercontent.com/664258/60865542-88daac00-a226-11e9-8dd8-49eb3a4fac42.png">

**After:**
<img width="502" alt="Screenshot 2019-07-09 at 08 41 22" src="https://user-images.githubusercontent.com/664258/60865550-8b3d0600-a226-11e9-9445-23671b40fad9.png">
