### PR TITLE
Settings: remove unused code related to legacy /settings redirects

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -328,11 +328,6 @@ export function siteSelection( context, next ) {
 		);
 	}
 
-	// Ignore the user account settings page
-	if ( /^\/settings\/account/.test( context.path ) ) {
-		return next();
-	}
-
 	/*
 	 * If the user has only one site, redirect to the single site context instead of
 	 * rendering the all-site views.

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -104,7 +104,7 @@ export function manageConnection( context, next ) {
 }
 
 export function legacyRedirects( context, next ) {
-	const section = context.params.section;
+	const { section } = context.params;
 	const redirectMap = {
 		account: '/me/account',
 		password: '/me/security',
@@ -116,12 +116,11 @@ export function legacyRedirects( context, next ) {
 		'billing-history-v2': billingHistory,
 		'connected-apps': '/me/security/connected-applications',
 	};
-	if ( ! context ) {
-		return page( '/me/public-profile' );
-	}
+
 	if ( redirectMap[ section ] ) {
 		return page.redirect( redirectMap[ section ] );
 	}
+
 	next();
 }
 


### PR DESCRIPTION
The generic `siteSelection` handler should not have any section-specific knowledge, like handling `/settings/account` specially. This PR removes a legacy bit of code that does exactly that. It doesn't have any effect anyway: the `/settings/:section` handler will call `legacyRedirects` and successfully redirect to `/me` before `siteSelection` has a chance to be called (it won't be called at all in case of successful redirect).

Also removes an unneeded check for null `context` in the settings controller's `legacyRedirects` handler: it's used only as a `page()` handler that always gets a valid context.

**How to test:**
Verify that `/settings/account` still redirects to `/me/account`. Also verify that edge case routes like `/settings/accountant` or `/settings/account/site.blog` behave the same (i.e., render nothing) both before and after.
