### PR TITLE
When redirecting a foreign site link to login or site selection, offer visiting the site

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -156,26 +156,24 @@ class Login extends Component {
 			fromSite,
 		} = this.props;
 
-		let headerText = translate( 'Log in to your account.' );
+		let headerText = translate( 'Log in to your account' );
 		let preHeader = null;
 		let postHeader = null;
 
 		if ( isManualRenewalImmediateLoginAttempt ) {
-			headerText = translate(
-				'Log in to update your payment details and renew your subscription.'
-			);
+			headerText = translate( 'Log in to update your payment details and renew your subscription' );
 		}
 
 		if ( twoStepNonce ) {
 			headerText = translate( 'Two-Step Authentication' );
 		} else if ( socialConnect ) {
-			headerText = translate( 'Connect your %(service)s account.', {
+			headerText = translate( 'Connect your %(service)s account', {
 				args: {
 					service: capitalize( linkingSocialService ),
 				},
 			} );
 		} else if ( privateSite ) {
-			headerText = translate( 'This is a private WordPress.com site.' );
+			headerText = translate( 'This is a private WordPress.com site' );
 		} else if ( oauth2Client ) {
 			headerText = translate( 'Howdy! Log in to %(clientTitle)s with your WordPress.com account.', {
 				args: {
@@ -240,7 +238,7 @@ class Login extends Component {
 				</p>
 			);
 		} else if ( isJetpack ) {
-			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack.' );
+			headerText = translate( 'Log in to your WordPress.com account to set up Jetpack' );
 			preHeader = (
 				<div className="login__jetpack-logo">
 					<AsyncLoad

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -38,6 +38,7 @@ import Notice from 'components/notice';
 import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
 import userFactory from 'lib/user';
 import AsyncLoad from 'components/async-load';
+import VisitSite from 'blocks/visit-site';
 
 /**
  * Style dependencies
@@ -152,6 +153,7 @@ class Login extends Component {
 			socialConnect,
 			translate,
 			twoStepNonce,
+			fromSite,
 		} = this.props;
 
 		let headerText = translate( 'Log in to your account.' );
@@ -249,6 +251,9 @@ class Login extends Component {
 					/>
 				</div>
 			);
+		} else if ( fromSite ) {
+			// if redirected from Calypso URL with a site slug, offer a link to that site's frontend
+			postHeader = <VisitSite siteSlug={ fromSite } />;
 		}
 
 		return (

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -173,7 +173,7 @@ class Login extends Component {
 				},
 			} );
 		} else if ( privateSite ) {
-			headerText = translate( 'This is a private WordPress.com site' );
+			headerText = translate( 'This is a private WordPress.com site.' );
 		} else if ( oauth2Client ) {
 			headerText = translate( 'Howdy! Log in to %(clientTitle)s with your WordPress.com account.', {
 				args: {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -134,7 +134,7 @@
 	}
 
 	.visit-site {
-		margin-bottom: 24px;
+		margin: -12px 0 24px;
 	}
 }
 

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -132,6 +132,10 @@
 	.gridicon {
 		color: var( --color-primary );
 	}
+
+	.visit-site {
+		margin-bottom: 24px;
+	}
 }
 
 .login__form-header {

--- a/client/blocks/visit-site/index.jsx
+++ b/client/blocks/visit-site/index.jsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import React, { useState, useEffect } from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import wpcom from 'lib/wp';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+function useSite( siteSlug ) {
+	const [ site, setSite ] = useState( null );
+
+	useEffect( () => {
+		wpcom
+			.site( siteSlug )
+			.get( { apiVersion: '1.2' } )
+			.then( setSite );
+	}, [ siteSlug ] );
+
+	return site;
+}
+
+export default function VisitSite( { siteSlug } ) {
+	const translate = useTranslate();
+	const site = useSite( siteSlug );
+
+	if ( ! site ) {
+		return null;
+	}
+
+	const siteLink = <a href={ site.URL }>{ site.name.trim() }</a>;
+
+	return (
+		<div className="visit-site">
+			{ translate( 'or visit {{siteLink/}}', { components: { siteLink } } ) }
+		</div>
+	);
+}

--- a/client/blocks/visit-site/style.scss
+++ b/client/blocks/visit-site/style.scss
@@ -1,0 +1,4 @@
+.visit-site {
+	color: var( --color-text-subtle );
+	font-size: 14px;
+}

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -19,6 +19,7 @@ import { login } from 'lib/paths';
 import { makeLayoutMiddleware } from './shared.js';
 import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getImmediateLoginEmail, getImmediateLoginLocale } from 'state/immediate-login/selectors';
+import { getSiteFragment } from 'lib/route';
 
 /**
  * Re-export
@@ -78,9 +79,12 @@ export function redirectLoggedOut( context, next ) {
 	const userLoggedOut = ! isUserLoggedIn( state );
 
 	if ( userLoggedOut ) {
+		const siteFragment = context.params.site || getSiteFragment( context.path );
+
 		const loginParameters = {
 			isNative: config.isEnabled( 'login/native-login-links' ),
 			redirectTo: context.path,
+			site: siteFragment,
 		};
 
 		// Pass along "login_email" and "login_locale" parameters from the

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -19,6 +19,7 @@ export function login( {
 	emailAddress,
 	socialService,
 	oauth2ClientId,
+	site,
 } = {} ) {
 	let url = config( 'login_url' );
 
@@ -42,6 +43,10 @@ export function login( {
 		} else {
 			url = localizeUrl( url, locale );
 		}
+	}
+
+	if ( site ) {
+		url = addQueryArgs( { site }, url );
 	}
 
 	if ( redirectTo ) {

--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -37,6 +37,7 @@ const enhanceContextWithLogin = context => {
 			socialConnect={ flow === 'social-connect' }
 			privateSite={ flow === 'private-site' }
 			domain={ ( query && query.domain ) || null }
+			fromSite={ ( query && query.site ) || null }
 		/>
 	);
 };

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -195,6 +195,7 @@ export class Login extends React.Component {
 			twoFactorAuthType,
 			socialService,
 			socialServiceResponse,
+			fromSite,
 		} = this.props;
 
 		if ( privateSite && isLoggedIn ) {
@@ -212,6 +213,7 @@ export class Login extends React.Component {
 				socialService={ socialService }
 				socialServiceResponse={ socialServiceResponse }
 				domain={ domain }
+				fromSite={ fromSite }
 			/>
 		);
 	}

--- a/client/login/wp-login/private-site.jsx
+++ b/client/login/wp-login/private-site.jsx
@@ -4,9 +4,8 @@
  * External dependencies
  */
 
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { localize } from 'i18n-calypso';
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -14,37 +13,29 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Card from 'components/card';
 
-class PrivateSite extends Component {
-	static propTypes = {
-		translate: PropTypes.func.isRequired,
-	};
+export default function PrivateSite() {
+	const translate = useTranslate();
 
-	render() {
-		const { translate } = this.props;
+	return (
+		<Card className="wp-login__private-site">
+			<div className="wp-login__private-site-image">
+				<img src="/calypso/images/private/private.svg" alt="" />
+			</div>
 
-		return (
-			<Card className="wp-login__private-site">
-				<div className="wp-login__private-site-image">
-					<img src="/calypso/images/private/private.svg" />
-				</div>
+			<h2 className="wp-login__private-site-header">
+				{ translate( 'This is a private WordPress.com site' ) }
+			</h2>
 
-				<h2 className="wp-login__private-site-header">
-					{ translate( 'This is a private WordPress.com site.' ) }
-				</h2>
+			<p>
+				{ translate(
+					"Request an invitation to view it and we'll " +
+						'send your username to the site owner for their approval.'
+				) }
+			</p>
 
-				<p>
-					{ translate(
-						"Request an invitation to view it and we'll " +
-							'send your username to the site owner for their approval.'
-					) }
-				</p>
-
-				<Button primary className="wp-login__private-site-button">
-					{ translate( 'Request Invitation' ) }
-				</Button>
-			</Card>
-		);
-	}
+			<Button primary className="wp-login__private-site-button">
+				{ translate( 'Request Invitation' ) }
+			</Button>
+		</Card>
+	);
 }
-
-export default localize( PrivateSite );

--- a/client/login/wp-login/private-site.jsx
+++ b/client/login/wp-login/private-site.jsx
@@ -23,7 +23,7 @@ export default function PrivateSite() {
 			</div>
 
 			<h2 className="wp-login__private-site-header">
-				{ translate( 'This is a private WordPress.com site' ) }
+				{ translate( 'This is a private WordPress.com site.' ) }
 			</h2>
 
 			<p>

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -136,6 +136,7 @@ $image-height: 47px;
 .wp-login__private-site-header {
 	font-weight: bold;
 	margin-bottom: 10px;
+	text-align: center;
 }
 
 .wp-login__private-site-button {

--- a/client/me/concierge/controller.js
+++ b/client/me/concierge/controller.js
@@ -70,7 +70,7 @@ const siteSelector = ( context, next ) => {
 	context.store.dispatch( recordTracksEvent( 'calypso_concierge_site_selection_step' ) );
 
 	context.getSiteSelectionHeaderText = () =>
-		i18n.translate( 'Please select a site for your {{strong}}Support Session{{/strong}}', {
+		i18n.translate( 'Select a site for your {{strong}}Support Session{{/strong}}', {
 			components: { strong: <strong /> },
 		} );
 	next();

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -23,7 +23,7 @@ import { setSelectedSiteId, setSection, setAllSitesSelected } from 'state/ui/act
 import { savePreference } from 'state/preferences/actions';
 import { hasReceivedRemotePreferences, getPreference } from 'state/preferences/selectors';
 import NavigationComponent from 'my-sites/navigation';
-import { getSiteFragment, sectionify } from 'lib/route';
+import { addQueryArgs, getSiteFragment, sectionify } from 'lib/route';
 import notices from 'notices';
 import config from 'config';
 import analytics from 'lib/analytics';
@@ -264,6 +264,7 @@ function createSitesComponent( context ) {
 		<SitesComponent
 			siteBasePath={ basePath }
 			getSiteSelectionHeaderText={ context.getSiteSelectionHeaderText }
+			fromSite={ context.query.site }
 		/>
 	);
 }
@@ -308,7 +309,6 @@ export function siteSelection( context, next ) {
 	const basePath = sectionify( context.path, siteFragment );
 	const currentUser = getCurrentUser( getState() );
 	const hasOneSite = currentUser && currentUser.visible_site_count === 1;
-	const allSitesPath = sectionify( context.path, siteFragment );
 
 	// The user doesn't have any sites: render `NoSitesMessage`
 	if ( currentUser && currentUser.site_count === 0 ) {
@@ -396,6 +396,10 @@ export function siteSelection( context, next ) {
 				}
 			} else {
 				// If the site has loaded but siteId is still invalid then redirect to allSitesPath.
+				const allSitesPath = addQueryArgs(
+					{ site: siteFragment },
+					sectionify( context.path, siteFragment )
+				);
 				page.redirect( allSitesPath );
 			}
 		} );

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -92,7 +92,7 @@ class Sites extends Component {
 				break;
 		}
 
-		return translate( 'Please select a site to open {{strong}}%(path)s{{/strong}}', {
+		return translate( 'Select a site to open {{strong}}%(path)s{{/strong}}', {
 			args: { path },
 			components: {
 				strong: <strong />,

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
 import Card from 'components/card';
 import Main from 'components/main';
 import SiteSelector from 'components/site-selector';
+import VisitSite from 'blocks/visit-site';
 
 /**
  * Style dependencies
@@ -102,7 +103,10 @@ class Sites extends Component {
 	render() {
 		return (
 			<Main className="sites">
-				<h2 className="sites__select-heading">{ this.getHeaderText() }</h2>
+				<div className="sites__select-header">
+					<h2 className="sites__select-heading">{ this.getHeaderText() }</h2>
+					{ this.props.fromSite && <VisitSite siteSlug={ this.props.fromSite } /> }
+				</div>
 				<Card className="sites__select-wrapper">
 					<SiteSelector
 						filter={ this.filterSites }

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -1,10 +1,16 @@
+.sites__select-header {
+	text-align: center;
+
+	.visit-site {
+		margin-bottom: 24px;
+	}
+}
+
 .sites__select-heading {
-	clear: both;
-	color: var( --color-neutral-600 );
-	display: block;
-	font-family: $sans;
-	font-size: 20px;
-	margin: 24px 0;
+	font-size: 22px;
+	margin-top: 16px;
+	margin-bottom: 24px;
+
 	strong {
 		text-transform: capitalize;
 	}

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -2,7 +2,7 @@
 	text-align: center;
 
 	.visit-site {
-		margin-bottom: 24px;
+		margin: -12px 0 24px;
 	}
 }
 


### PR DESCRIPTION
Proof of concept to fix #4657.

1. After navigating to `https://wordpress.com/customize/simpledream.wordpress.com`, i.e., Customizer for a site that I'm not member of, offer visiting the foreign site on top of the existing site selector that displays only my sites:

<img width="696" alt="Screenshot 2019-07-09 at 10 49 14" src="https://user-images.githubusercontent.com/664258/60873886-6309d300-a237-11e9-88ae-dcafce31e040.png">

2. After navigating to the same URL, but logged out, offer visiting the foreign site on top of the existing login page:

<img width="695" alt="Screenshot 2019-07-09 at 10 52 57" src="https://user-images.githubusercontent.com/664258/60874081-bb40d500-a237-11e9-867f-50f33ef76c7e.png">

Note that the site slug (`simpledream.wordpress.com` or `281665`) has a very loose relation to the actual site's URL (`http://sensible.blog`). Fortunately for us, the `/rest/v1.2/sites/:site` REST endpoint supports also public logged-out requests and returns all the info we need to make the link work: site's real URL, and also its name and icon.