### PR TITLE
NPS: Improve tracks event

### DIFF
--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -59,10 +59,13 @@ export class NpsSurvey extends PureComponent {
 	};
 
 	componentDidUpdate( _, prevState ) {
+		const { hasAvailableConciergeSession, onChangeForm } = this.props;
+
 		if ( prevState.currentForm !== this.state.currentForm ) {
-			this.props.onChangeForm && this.props.onChangeForm( this.state.currentForm );
+			onChangeForm && onChangeForm( this.state.currentForm );
 			this.props.recordTracksEvent( 'calypso_nps_survey_page_displayed', {
 				name: this.state.currentForm,
+				hasAvailableConciergeSession,
 			} );
 		}
 	}
@@ -111,6 +114,7 @@ export class NpsSurvey extends PureComponent {
 	handleLinkClick = event => {
 		this.props.recordTracksEvent( 'calypso_nps_survey_link_clicked', {
 			url: event.target.href,
+			type: event.target.dataset.type,
 		} );
 		this.onClose( noop );
 	};
@@ -236,8 +240,20 @@ export class NpsSurvey extends PureComponent {
 								'{{booking}}Reserve a 1:1 Support Session{{/booking}} now or connect with a Happiness Engineer {{contact}}over live chat or email{{/contact}}.',
 								{
 									components: {
-										booking: <a href="/me/concierge" onClick={ this.handleLinkClick } />,
-										contact: <a href={ CALYPSO_CONTACT } onClick={ this.handleLinkClick } />,
+										booking: (
+											<a
+												href="/me/concierge"
+												onClick={ this.handleLinkClick }
+												data-type="booking"
+											/>
+										),
+										contact: (
+											<a
+												href={ CALYPSO_CONTACT }
+												onClick={ this.handleLinkClick }
+												data-type="contact"
+											/>
+										),
 									},
 								}
 							) }
@@ -250,7 +266,13 @@ export class NpsSurvey extends PureComponent {
 							'If you would like help with your site, our WordPress.com Happiness Engineers are ready {{contact}}over live chat or email{{/contact}} now.',
 							{
 								components: {
-									contact: <a href={ CALYPSO_CONTACT } onClick={ this.handleLinkClick } />,
+									contact: (
+										<a
+											href={ CALYPSO_CONTACT }
+											onClick={ this.handleLinkClick }
+											data-type="contact"
+										/>
+									),
 								},
 							}
 						) }

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -65,7 +65,7 @@ export class NpsSurvey extends PureComponent {
 			onChangeForm && onChangeForm( this.state.currentForm );
 			this.props.recordTracksEvent( 'calypso_nps_survey_page_displayed', {
 				name: this.state.currentForm,
-				hasAvailableConciergeSession,
+				has_available_concierge_sessions: hasAvailableConciergeSession,
 			} );
 		}
 	}

--- a/client/blocks/nps-survey/test/index.jsx
+++ b/client/blocks/nps-survey/test/index.jsx
@@ -1,10 +1,14 @@
-/** @format */
+/**
+ * @format
+ * @jest-environment jsdom
+ */
 
 /**
  * External dependencies
  */
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import React from 'react';
+import { translate } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -13,11 +17,6 @@ import { NpsSurvey } from '../';
 
 jest.mock( 'react-redux', () => ( {
 	connect: () => () => {},
-} ) );
-
-jest.mock( 'i18n-calypso', () => ( {
-	localize: component => component,
-	getLocaleSlug: () => 'en',
 } ) );
 
 jest.mock( 'state/nps-survey/actions' );
@@ -37,7 +36,7 @@ describe( 'NpsSurvey', () => {
 		sendNpsSurveyFeedback: jest.fn(),
 		successNotice: jest.fn(),
 		recordTracksEvent: jest.fn(),
-		translate: str => str,
+		translate,
 	};
 
 	beforeEach( () => {
@@ -59,14 +58,100 @@ describe( 'NpsSurvey', () => {
 		expect( wrapper.state( 'currentForm' ) ).toBe( 'feedback' );
 		expect( mockedProps.recordTracksEvent ).toHaveBeenLastCalledWith(
 			'calypso_nps_survey_page_displayed',
-			{ name: 'feedback' }
+			{
+				name: 'feedback',
+				hasAvailableConciergeSession: true,
+			}
 		);
 		wrapper.find( '.nps-survey__finish-button' ).simulate( 'click' );
 
 		expect( wrapper.state( 'currentForm' ) ).toBe( 'promotion' );
 		expect( mockedProps.recordTracksEvent ).toHaveBeenLastCalledWith(
 			'calypso_nps_survey_page_displayed',
-			{ name: 'promotion' }
+			{
+				name: 'promotion',
+				hasAvailableConciergeSession: true,
+			}
+		);
+	} );
+
+	test( 'should track the concierge session availability too', () => {
+		const wrapper = shallow(
+			<NpsSurvey { ...mockedProps } hasAvailableConciergeSession={ false } />
+		);
+
+		wrapper.setState( {
+			score: 6,
+			feedback: 'feedback',
+		} );
+
+		expect( wrapper.state( 'currentForm' ) ).toBe( 'score' );
+		wrapper.find( '.nps-survey__finish-button' ).simulate( 'click' );
+		// we don't track the first page.
+
+		expect( wrapper.state( 'currentForm' ) ).toBe( 'feedback' );
+		expect( mockedProps.recordTracksEvent ).toHaveBeenLastCalledWith(
+			'calypso_nps_survey_page_displayed',
+			{
+				name: 'feedback',
+				hasAvailableConciergeSession: false,
+			}
+		);
+		wrapper.find( '.nps-survey__finish-button' ).simulate( 'click' );
+
+		expect( wrapper.state( 'currentForm' ) ).toBe( 'promotion' );
+		expect( mockedProps.recordTracksEvent ).toHaveBeenLastCalledWith(
+			'calypso_nps_survey_page_displayed',
+			{
+				name: 'promotion',
+				hasAvailableConciergeSession: false,
+			}
+		);
+	} );
+
+	test( 'should track when any link in the promotion page is clicked', () => {
+		const wrapper = mount( <NpsSurvey { ...mockedProps } /> );
+
+		wrapper.setState( {
+			score: 6,
+			feedback: 'feedback',
+			currentForm: 'promotion',
+		} );
+
+		expect( wrapper.state( 'currentForm' ) ).toBe( 'promotion' );
+		expect( wrapper.find( 'a[data-type]' ) ).toHaveLength( 2 );
+
+		wrapper.find( 'a[data-type="booking"]' ).simulate( 'click' );
+		expect( mockedProps.recordTracksEvent ).toHaveBeenLastCalledWith(
+			'calypso_nps_survey_link_clicked',
+			{
+				url: 'https://example.com/me/concierge',
+				type: 'booking',
+			}
+		);
+
+		wrapper.find( 'a[data-type="contact"]' ).simulate( 'click' );
+		expect( mockedProps.recordTracksEvent ).toHaveBeenLastCalledWith(
+			'calypso_nps_survey_link_clicked',
+			{
+				url: 'https://example.com/help/contact',
+				type: 'contact',
+			}
+		);
+
+		// When the user used up concierge sessions
+		wrapper.setProps( { ...mockedProps, hasAvailableConciergeSession: false } );
+
+		// There will be only one contact link
+		expect( wrapper.find( 'a[data-type]' ) ).toHaveLength( 1 );
+
+		wrapper.find( 'a[data-type="contact"]' ).simulate( 'click' );
+		expect( mockedProps.recordTracksEvent ).toHaveBeenLastCalledWith(
+			'calypso_nps_survey_link_clicked',
+			{
+				url: 'https://example.com/help/contact',
+				type: 'contact',
+			}
 		);
 	} );
 } );

--- a/client/blocks/nps-survey/test/index.jsx
+++ b/client/blocks/nps-survey/test/index.jsx
@@ -60,7 +60,7 @@ describe( 'NpsSurvey', () => {
 			'calypso_nps_survey_page_displayed',
 			{
 				name: 'feedback',
-				hasAvailableConciergeSession: true,
+				has_available_concierge_sessions: true,
 			}
 		);
 		wrapper.find( '.nps-survey__finish-button' ).simulate( 'click' );
@@ -70,7 +70,7 @@ describe( 'NpsSurvey', () => {
 			'calypso_nps_survey_page_displayed',
 			{
 				name: 'promotion',
-				hasAvailableConciergeSession: true,
+				has_available_concierge_sessions: true,
 			}
 		);
 	} );
@@ -94,7 +94,7 @@ describe( 'NpsSurvey', () => {
 			'calypso_nps_survey_page_displayed',
 			{
 				name: 'feedback',
-				hasAvailableConciergeSession: false,
+				has_available_concierge_sessions: false,
 			}
 		);
 		wrapper.find( '.nps-survey__finish-button' ).simulate( 'click' );
@@ -104,7 +104,7 @@ describe( 'NpsSurvey', () => {
 			'calypso_nps_survey_page_displayed',
 			{
 				name: 'promotion',
-				hasAvailableConciergeSession: false,
+				has_available_concierge_sessions: false,
 			}
 		);
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `hasAvailableConciergeSession` prop to `calypso_nps_survey_page_displayed` tracks event. It can be used to divide involved users into two groups based on their availability for concierge sessions.
* Add `type` prop to `calypso_nps_survey_link_clicked` tracks event. The event originally has `url` prop but the new prop would be better to use.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `npm run test-client client/blocks/nps-survey/test` and all test should be passed.
