### PR TITLE
Classic Editor: remove Jetpack version check when doing post autosave

### DIFF
--- a/client/state/ui/editor/actions.js
+++ b/client/state/ui/editor/actions.js
@@ -10,7 +10,6 @@ import { defaults, filter, get } from 'lodash';
  * Internal dependencies
  */
 import wpcom from 'lib/wp';
-import versionCompare from 'lib/version-compare';
 import {
 	EDITOR_AUTOSAVE,
 	EDITOR_AUTOSAVE_RESET,
@@ -31,7 +30,6 @@ import { setMediaModalView } from 'state/ui/media-modal/actions';
 import { withAnalytics, bumpStat, recordTracksEvent } from 'state/analytics/actions';
 import { savePreference } from 'state/preferences/actions';
 import { getPreference } from 'state/preferences/selectors';
-import { getSelectedSite } from 'state/ui/selectors';
 import { editPost } from 'state/posts/actions';
 
 /**
@@ -172,14 +170,8 @@ export const editorAutosaveFailure = error => ( {
 	error,
 } );
 
-export const editorAutosave = post => ( dispatch, getState ) => {
-	const site = getSelectedSite( getState() );
-
-	if (
-		! post.ID ||
-		! site ||
-		( site.jetpack && versionCompare( site.options.jetpack_version, '3.7.0-dev', '<' ) )
-	) {
+export const editorAutosave = post => dispatch => {
+	if ( ! post.ID ) {
 		return Promise.reject( new Error( 'NO_AUTOSAVE' ) );
 	}
 


### PR DESCRIPTION
There was a check if Jetpack has new enough version to support the autosave
REST endpoint. We don't do these checks any more and remove them from the codebase.

**How to test:**
Edit a published post on a Jetpack site with Calypso Classic Editor. Check that the autosave endpoint:
```
/rest/v1.1/sites/:site/posts/:post/autosave
```
is called regularly and that it succeeds.
