### PR TITLE
Async load the ResumeEditing component in Masterbar

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -17,7 +17,6 @@ import Notifications from './notifications';
 import Gravatar from 'components/gravatar';
 import config from 'config';
 import { preload } from 'sections-helper';
-import ResumeEditing from 'my-sites/resume-editing';
 import { getCurrentUserSiteCount, getCurrentUser } from 'state/current-user/selectors';
 import { isSupportSession } from 'state/support/selectors';
 import AsyncLoad from 'components/async-load';
@@ -187,7 +186,7 @@ class MasterbarLoggedIn extends React.Component {
 				{ ( this.props.isSupportSession || config.isEnabled( 'quick-language-switcher' ) ) && (
 					<AsyncLoad require="./quick-language-switcher" placeholder={ null } />
 				) }
-				{ config.isEnabled( 'resume-editing' ) && <ResumeEditing /> }
+				<AsyncLoad require="my-sites/resume-editing" />
 				{ ! domainOnlySite && ! isMigrationInProgress && (
 					<Publish
 						isActive={ this.isActive( 'post' ) }

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -116,7 +116,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -86,7 +86,6 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/user-mention-suggestions": false,
-		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"settings/security/monitor": true,

--- a/config/development.json
+++ b/config/development.json
@@ -151,7 +151,6 @@
 		"reader/full-errors": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,
-		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"safari-idb-mitigation": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -101,7 +101,6 @@
 		"privacy-policy": true,
 		"reader": true,
 		"reader/user-mention-suggestions": true,
-		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"safari-idb-mitigation": true,

--- a/config/production.json
+++ b/config/production.json
@@ -110,7 +110,6 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/user-mention-suggestions": false,
-		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"safari-idb-mitigation": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -116,7 +116,6 @@
 		"reader": true,
 		"reader/full-errors": false,
 		"reader/user-mention-suggestions": true,
-		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"safari-idb-mitigation": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -127,7 +127,6 @@
 		"reader/full-errors": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,
-		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,
 		"safari-idb-mitigation": true,


### PR DESCRIPTION
Avoids bundling a lot of `state/posts` code in the `entry-main` chunk. Also removes the always-true `resume-editing` feature flag.
