### PR TITLE
wpcom-undocumented: Clarify function documentation

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1096,6 +1096,7 @@ Undocumented.prototype.updateConnection = function( siteId, connectionId, data, 
  * @param {string} [method] The request method
  * @param {object} [data] The REQUEST data
  * @param {Function} fn The callback function
+ * @returns {Promise} A promise that resolves when the request completes
  * @api public
  *
  * The post data format is: {

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1101,9 +1101,10 @@ Undocumented.prototype.updateConnection = function( siteId, connectionId, data, 
  * The post data format is: {
  *		payment_method: {string} The payment gateway,
  *		payment_key: {string} Either the cc token from the gateway, or the mp_ref from /me/stored_cards,
- *		products: {array} An array of products from the card,
- *		coupon: {string} A coupon code,
- *		currency: {string} The three letter currency code,
+ *		payment: {object} Payment details, including payment_method and payment_key,
+ *		cart: {object>shopping_cart} A Shopping cart object
+ *		domain_details: {object>contact_information} Optional set of domain contact information
+ *		locale: {string} Locale for translating strings in response data,
  * }
  */
 Undocumented.prototype.transactions = function( method, data, fn ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The `wpcom.undocumented.transactions()` function documentation did not correctly list the arguments required by the current version of the endpoint. This corrects the documentation to match the endpoint documentation. It also clarifies that the function can return a Promise.

#### Testing instructions

None. This is just a documentation change.
