### PR TITLE
Domains: Wrap up .blog subdomains test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -99,16 +99,6 @@ export default {
 		defaultVariation: 'noOffer',
 		allowExistingUsers: true,
 	},
-	hideDotBlogSubdomainsV2: {
-		datestamp: '20190626',
-		variations: {
-			show: 50,
-			hide: 50,
-		},
-		defaultVariation: 'show',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	popularPlanBy: {
 		datestamp: '20190529',
 		variations: {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -8,7 +8,6 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { defer, endsWith, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import { abtest } from 'lib/abtest';
 
 /**
  * Internal dependencies
@@ -358,11 +357,9 @@ class DomainsStep extends React.Component {
 		// If we detect a 'blog' site type from Signup data
 		return (
 			// All flows where 'about' step is before 'domains' step, user picked only 'share' on the `about` step
-			( ( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 ) ||
-				// Users choose `Blog` as their site type
-				'blog' === get( signupDependencies, 'siteType' ) ) &&
-			// Assign THE A/B test variation at the last moment, so we have a proper dataset split
-			'show' === abtest( 'hideDotBlogSubdomainsV2' )
+			( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 ) ||
+			// Users choose `Blog` as their site type
+			'blog' === get( signupDependencies, 'siteType' )
 		);
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Show the .blog subdomains to users that are in
the 'blog' vertical.

#### Testing instructions

- http://calypso.localhost:3000/start
- Select `blog`
- Get to domains screen
- search
- See a `.blog` subdomain suggestion
