### PR TITLE
Fix regression that prevented "Add Credit Card" from appearing in place of "Renew Now" when auto-renew is off and the subscription doesn't expire soon

### DIFF
--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -118,7 +118,7 @@ class PurchaseNotice extends Component {
 		}
 
 		if (
-			! hasPaymentMethod( purchase ) &&
+			( ! config.isEnabled( 'autorenewal-toggle' ) || ! hasPaymentMethod( purchase ) ) &&
 			( ! canExplicitRenew( purchase ) ||
 				shouldAddPaymentSourceInsteadOfRenewingNow( purchase.expiryMoment ) )
 		) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fixes a regression caused by https://github.com/Automattic/wp-calypso/pull/34294 which inadvertently undid some of the changes from https://github.com/Automattic/wp-calypso/pull/34076.

If a subscription has auto-renew off and isn't expiring soon, we want the message that tells them to add a credit card to just link to the "Add Credit Card" form, not "Renew Now".  But currently it has gone back to linking to "Renew Now":
![60483946-aaa3c400-9c65-11e9-84c1-3e74b41e4e5f](https://user-images.githubusercontent.com/235183/60918675-eb04d280-a261-11e9-9621-b1e772cf2824.png)

The new behavior will work itself out once the auto-renew toggle feature is enabled in production, but that hasn't happened yet so it's worth making this small fix now.

#### Testing instructions

Purchase a subscription and turn auto-renewal off, then visit the Manage Purchase page for the subscription.

In the Calypso development environment (where the auto-renew toggle feature is already on) this pull request makes no changes in behavior.

In the production environment (which can be simulated by building Calypso with the `autorenewal-toggle` feature flag set to `false`) the link will remain "Renew Now" if the subscription expires in the next few months, but it will be "Add Credit Card" if the subscription expires later.