### PR TITLE
Full Site Editing: prevent data duplication on multiple activations

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template-data-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template-data-inserter.php
@@ -9,10 +9,16 @@
  * Class A8C_WP_Template_Data_Inserter
  */
 class A8C_WP_Template_Data_Inserter {
+
+	const OPTION_NAME = 'fse_template_data_version';
 	/**
 	 * This function will be called on plugin activation hook.
 	 */
 	public function insert_default_template_data() {
+		if ( false !== get_option( self::OPTION_NAME ) ) {
+			return;
+		}
+
 		$header_id = wp_insert_post(
 			[
 				'post_title'     => 'Header',
@@ -63,6 +69,9 @@ class A8C_WP_Template_Data_Inserter {
 		}
 
 		wp_set_object_terms( $page_template_id, 'page_template', 'wp_template_type' );
+
+		// store plugin version as value in case of future data migration needs
+		update_option( self::OPTION_NAME, A8C_FSE_VERSION );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Store an option (with plugin version number) after inserting data to ensure it is not inserted multiple times

#### Testing instructions

* Checkout this PR
* Deactivate the plugin
* Re-activate the plugin
* Note under **Templates** in wp-admin how many instances of "Page Template" there currently are
* Once again, deactivate and re-activate the plugin
* There should be the same number of instances of "Page Template" as previously noted.

Fixes #34415
