### PR TITLE
FSE: Update the default content for the full site editor plugin header

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template-data-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template-data-inserter.php
@@ -72,9 +72,14 @@ class A8C_WP_Template_Data_Inserter {
 	 */
 	public function get_header_content() {
 		// TODO: replace with header blocks once they are ready.
-		return '<!-- wp:a8c/site-title /-->' .
+		return '<!-- wp:group {"className":"site-header site-branding"} -->' .
+				'<div class="wp-block-group site-header site-branding">' .
+				'<div class="wp-block-group__inner-container">' .
 				'<!-- wp:a8c/site-description /-->' .
-				'<!-- wp:a8c/navigation-menu /-->';
+				'<!-- wp:a8c/site-title /-->' .
+				'<!-- wp:a8c/navigation-menu /-->' .
+				'</div></div>' .
+				'<!-- /wp:group -->';
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the default content for the header template part in full site editor plugin. This adds a group block to provide the correct css classes to the business modern theme and support the styles being added in https://github.com/Automattic/wp-calypso/issues/34387

#### Testing instructions

Activate the FSE plugin and confirm that inside of the header template part you see a group block that contains the site title, site description, and site navigation blocks.

If you want to test this with the correct styles, you can also install the modern business theme from this branch: https://github.com/Automattic/themes/compare/add/modern-business-fse-header-support

If you do not install the theme branch, then confirming the blocks are present is enough until the modern business theme changes are merged.

With both installed then the header should look like this in the editor:

<img width="1293" alt="Screen Shot 2019-07-09 at 3 05 34 PM" src="https://user-images.githubusercontent.com/1464705/60927708-b263f980-a25f-11e9-93d8-daec5a7400e6.png">

and like this on the front end of the site:

<img width="854" alt="Screen Shot 2019-07-09 at 3 39 37 PM" src="https://user-images.githubusercontent.com/1464705/60927742-c60f6000-a25f-11e9-8968-fab93dadd4d9.png">
