### PR TITLE
Fix InfoPopover event propagation

### DIFF
--- a/client/components/info-popover/index.jsx
+++ b/client/components/info-popover/index.jsx
@@ -52,6 +52,7 @@ export default class InfoPopover extends Component {
 
 	handleClick = e => {
 		e.preventDefault();
+		e.stopPropagation();
 		this.setState( { showPopover: ! this.state.showPopover }, this.recordStats );
 	};
 


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/32805 the handleClick method for the InfoPopover has changed and it seems that changed how the component works inside clickable content. It seems we need to also stopPropagation for the event because otherwise you can't click on the InfoPopover component if it is inside another component that has onClick event handler (for example in domain search we have an HSTS InfoPopover icon and it can't be clicked without adding the domain in your cart).

#### Changes proposed in this Pull Request

* add `stopPropagation` when `InfoPopover` component is clicked

#### Testing instructions

* Go to domain search and search for randomdomain232323.dev. There will be an info icon next to the .dev domain. Try to click it - without this patch the domain will be added to your cart and you won't be able to read the tooltip. With this patch - the tooltip is shown but the domain is not added to your cart.

