### PR TITLE
Ensure that tracks events are sent on /me/get-apps

### DIFF
--- a/client/blocks/get-apps/apps-badge.jsx
+++ b/client/blocks/get-apps/apps-badge.jsx
@@ -14,7 +14,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { getLocaleSlug } from 'lib/i18n-utils';
-import { recordTracksEvent } from 'state/analytics/actions';
+import analytics from 'lib/analytics';
 import TranslatableString from 'components/translatable/proptype';
 
 // the locale slugs for each stores' image paths follow different rules
@@ -97,7 +97,7 @@ export class AppsBadge extends PureComponent {
 
 	onLinkClick = () => {
 		const { storeName } = this.props;
-		recordTracksEvent( APP_STORE_BADGE_URLS[ storeName ].tracksEvent );
+		analytics.tracks.recordEvent( APP_STORE_BADGE_URLS[ storeName ].tracksEvent, {} );
 	};
 
 	render() {
@@ -111,7 +111,12 @@ export class AppsBadge extends PureComponent {
 
 		return (
 			<figure className={ figureClassNames }>
-				<a href={ storeLink } onClick={ this.onLinkClick }>
+				<a
+					href={ storeLink }
+					onClick={ this.onLinkClick }
+					target="_blank"
+					rel="noopener noreferrer"
+				>
 					<img src={ imageSrc } title={ titleText } alt={ altText } />
 				</a>
 			</figure>

--- a/client/blocks/get-apps/apps-badge.jsx
+++ b/client/blocks/get-apps/apps-badge.jsx
@@ -6,6 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
 import { identity, startsWith } from 'lodash';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
@@ -14,7 +15,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import { getLocaleSlug } from 'lib/i18n-utils';
-import analytics from 'lib/analytics';
+import { recordTracksEvent } from 'state/analytics/actions';
 import TranslatableString from 'components/translatable/proptype';
 
 // the locale slugs for each stores' image paths follow different rules
@@ -97,7 +98,7 @@ export class AppsBadge extends PureComponent {
 
 	onLinkClick = () => {
 		const { storeName } = this.props;
-		analytics.tracks.recordEvent( APP_STORE_BADGE_URLS[ storeName ].tracksEvent, {} );
+		this.props.recordTracksEvent( APP_STORE_BADGE_URLS[ storeName ].tracksEvent );
 	};
 
 	render() {
@@ -124,4 +125,9 @@ export class AppsBadge extends PureComponent {
 	}
 }
 
-export default localize( AppsBadge );
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+	}
+)( localize( AppsBadge ) );

--- a/client/blocks/get-apps/test/__snapshots__/apps-badge.js.snap
+++ b/client/blocks/get-apps/test/__snapshots__/apps-badge.js.snap
@@ -7,6 +7,8 @@ exports[`AppsBadge should render 1`] = `
   <a
     href="https://wordpress.com"
     onClick={[Function]}
+    rel="noopener noreferrer"
+    target="_blank"
   >
     <img
       alt="titleText"


### PR DESCRIPTION
This PR fixes an issue where tracks events weren’t being sent.

#### Changes proposed in this Pull Request

1) When the link is clicked, the browser will tear down the page, whether or not the tracks event is complete. I’ve worked around this by causing the relevant store to open in a new tab. This has the benefit of leaving the page intact for the user back when they’re done setting up the app.
2) The `recordTracksEvent` import on this page doesn’t work – I’ve resolved this by using an alternate one I copied from elsewhere. In some cases,`recordTracksEvent` was passed as a prop, but I didn’t want to have to rework any UI code if it could be avoided.

#### Testing instructions

* Checkout this PR
* Run Calypso locally
* Click on the App Store icon in `/me/get-apps`. 
* Look for the `calypso_app_download_ios_click` event in tracks.