### PR TITLE
Add rough basic files for the CoBlocks builder script.

### DIFF
--- a/apps/coblocks-builder/README.md
+++ b/apps/coblocks-builder/README.md
@@ -1,0 +1,23 @@
+# CoBlocks Builder
+
+A prototype custom build script for CoBlocks. Currently it:
+
+- Clones the release branch of CoBlocks that matches the version in ./package.json
+- Copies custom blocks.js, class-coblocks.php, class-coblocks-register-blocks.php files to the source folder to only build and run selected blocks
+- Runs CoBlocks standard grunt build job
+- Copies the CoBlocks build folder that is generated to ./build
+- Removes any unused files and folders from the build folder
+
+To use:
+
+```shell
+npm install
+npm run build
+```
+
+After build has completed the `./build/coblocks-VERSION` folder should be in state to be added to `wp-content/plugins` folder.
+
+## Things to note
+
+- You may need to install grunt globally for build script to run `npm install -g grunt`
+- You currently need WP CLI in your path for the CoBlocks build to run

--- a/apps/coblocks-builder/build.js
+++ b/apps/coblocks-builder/build.js
@@ -1,0 +1,132 @@
+const version = require( './package.json' ).version;
+const exec = require( 'child_process' ).execSync;
+const util = require( 'util' );
+const rimraf = util.promisify( require( 'rimraf' ) );
+const copyFile = require( 'fs' ).copyFileSync;
+const unlink = require( 'fs' ).unlinkSync;
+const mv = util.promisify( require( 'mv' ) );
+const { readdirSync } = require( 'fs' );
+
+const usedBlocks = [
+	'row',
+	'hero',
+	'media-card',
+	'gallery-masonry',
+	'shape-divider',
+	'dynamic-separator',
+	'gallery-stacked',
+	'gallery-carousel',
+	'buttons',
+	'pricing-table',
+	'food-and-drinks',
+	'icon',
+	'features',
+	'click-to-tweet',
+	'highlight',
+];
+
+const filesToRemove = [
+	'includes/class-coblocks-accordion-ie-support.php',
+	'includes/class-coblocks-form.php',
+	'includes/class-coblocks-google-map-block.php',
+	'dist/js/coblocks-accordion-polyfill.min.js',
+	'dist/js/coblocks-google-maps.min.js',
+	'dist/js/coblocks-google-recaptcha.min.js',
+];
+
+const directoriesToRemove = [ 'includes/admin', 'src', 'dist/images/admin' ];
+
+build();
+
+async function build() {
+	await removeDirectory( './coblocks' );
+	await removeDirectory( './build' );
+	cloneRelease( version );
+	removedUnusedBlocks( usedBlocks );
+	copy( './blocks.js', './coblocks/src/blocks.js' );
+	copy( './class-coblocks.php', './coblocks/class-coblocks.php' );
+	runCoBlocksBuild();
+	await moveDirectory( './coblocks/build/coblocks', `./build/coblocks-${ version }` );
+	await removeDirectory( './coblocks' );
+	cleanBuild();
+}
+
+function removedUnusedBlocks( usedBlocks ) {
+	console.log( `Removing unused block src` );
+	const path = './coblocks/src/blocks';
+	readdirSync( path, { withFileTypes: true } )
+		.filter( directoryItem => directoryItem.isDirectory() )
+		.map( directoryItem => directoryItem.name )
+		.forEach( dir => {
+			if ( ! usedBlocks.includes( dir ) ) {
+				removeDirectory( `${ path }/${ dir }` );
+			}
+		} );
+}
+
+function removeDirectory( directory ) {
+	console.log( `Removing directory  ${ directory }` );
+	try {
+		return rimraf( directory );
+	} catch ( error ) {
+		console.log( `There was an error removing ${ directory }: ${ error }` );
+	}
+}
+
+function cloneRelease( version ) {
+	console.log( `Cloning the CoBlocks branch for release ${ version }` );
+	try {
+		exec( `git clone --branch ${ version } https://github.com/godaddy/coblocks.git` );
+	} catch ( error ) {
+		console.log( `There was an error cloning the CoBlocks repo: ${ error }` );
+	}
+}
+
+function copy( source, destination ) {
+	console.log( `Copying ${ source } to ${ destination }` );
+	try {
+		copyFile( source, destination, () => console.log( 'success' ) );
+	} catch ( error ) {
+		console.log( `There was an error copying ${ source } to ${ destination }` );
+	}
+}
+
+function removeFile( file ) {
+	console.log( `Removing ${ file }` );
+	try {
+		unlink( file, () => console.log( 'success' ) );
+	} catch ( error ) {
+		console.log( `There was an error removing ${ file }` );
+	}
+}
+
+function moveDirectory( source, destination ) {
+	console.log( `Moving ${ source } to ${ destination }` );
+	try {
+		return mv( source, destination, { mkdirp: true } );
+	} catch ( error ) {
+		console.log( `There was an error moving ${ source } to ${ destination }` );
+	}
+}
+
+function runCoBlocksBuild() {
+	console.log( 'Running CoBlocks build ...' );
+	try {
+		exec( 'cd coblocks && npm install && grunt build', {
+			maxBuffer: 1024 * 2000,
+		} );
+	} catch ( error ) {
+		console.log( `There was an error running the CoBlocks build: ${ error }` );
+	}
+}
+
+function cleanBuild() {
+	directoriesToRemove.forEach( directory =>
+		removeDirectory( `./build/coblocks-${ version }/${ directory }` )
+	);
+	filesToRemove.forEach( file => removeFile( `./build/coblocks-${ version }/${ file }` ) );
+	copy(
+		'./class-coblocks-register-blocks.php',
+		`./build/coblocks-${ version }/includes/class-coblocks-register-blocks.php`
+	);
+}

--- a/apps/coblocks-builder/package.json
+++ b/apps/coblocks-builder/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@automattic/coblocks-builder",
+	"version": "1.0.0",
+	"description": "Build script to provide a select list of blocks from CoBlocks to WP.com users.",
+	"main": "build.js",
+	"sideEffects": true,
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/Automattic/wp-calypso.git",
+		"directory": "apps/coblocks-builder"
+	},
+	"private": true,
+	"author": "Automattic, Inc.",
+	"license": "GPL-2.0-or-later",
+	"bugs": {
+		"url": "https://github.com/Automattic/wp-calypso/issues"
+	},
+	"homepage": "https://github.com/Automattic/wp-calypso#readme",
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1",
+		"clone": "rimraf coblocks && git clone --branch 1.11.1 https://github.com/godaddy/coblocks.git",
+		"copy": "cp blocks.js ./coblocks/src",
+		"remove-src": "rimraf ./coblocks/build/coblocks/src",
+		"build": "node build.js"
+	}
+}

--- a/package.json
+++ b/package.json
@@ -312,6 +312,7 @@
 		"mixedindentlint": "1.2.0",
 		"mockdate": "2.0.2",
 		"moment-timezone-data-webpack-plugin": "1.1.0",
+		"mv": "2.1.1",
 		"ncp": "2.0.0",
 		"nock": "10.0.6",
 		"npm-merge-driver": "2.3.5",


### PR DESCRIPTION
This PR will add the current [standalone Node CoBlocks builder script](https://github.com/glendaviesnz/coblocks-builder/blob/master/build.js) into the `/apps` section of Calypso. 

The script clones a copy of the CoBlocks repo, strips a pile of unneeded code out, and performs a build with only the blocks that we require. This is all to give us a minimal version that we can load on WordPress.com.

I'm not even sure if this is the best approach –  since no real development is going on within `/apps/coblocks-builder`, should we even add this to Calypso? @ockham or @sirreal  maybe you could give us some guidance here?

