### PR TITLE
FSE: Add transparent background color to site title and description blocks

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
@@ -8,6 +8,7 @@
 			letter-spacing: -0.01em;
 			margin: 0;
 			box-shadow: none;
+			background-color: transparent;
 		}
 	}
 	.site-description__save-button {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
@@ -11,6 +11,7 @@
 			line-height: 1.2;
 			margin: 0;
 			box-shadow: none;
+			background-color: transparent;
 		}
 	}
 	.site-title__save-button {


### PR DESCRIPTION
Since the title and description blocks are text areas, the bg color is white by default. This changes those to transparent to avoid style issues within the editor context.

#### Changes proposed in this Pull Request

Change site title & description block background colors to transparent.

<img width="773" alt="Screen Shot 2019-07-10 at 4 55 58 PM" src="https://user-images.githubusercontent.com/6265975/61012548-ddb81880-a333-11e9-9802-750d205e29b9.png">

**Before** ^

<img width="740" alt="Screen Shot 2019-07-10 at 4 48 49 PM" src="https://user-images.githubusercontent.com/6265975/61012547-ddb81880-a333-11e9-8c0e-b61810394b2e.png">

**After** ^

#### Testing instructions
* Pull branch and run code
* Add a group block around the title and description in the Header template part
* Change the group block background color to a contrast-y color like black.
* Make sure there is no background behind either the text of the site title or site description blocks.

Fixes #34571
