### PR TITLE
Community Translator v2: Update Icons

### DIFF
--- a/client/components/community-translator/style.scss
+++ b/client/components/community-translator/style.scss
@@ -74,8 +74,9 @@
 	}
 }
 
-.community-translator__nav-link {
+.community-translator__nav-link, .community-translator__close-icon {
 	display: inline-block;
 	margin-left: 7px;
+	cursor: pointer;
 }
 

--- a/client/components/community-translator/style.scss
+++ b/client/components/community-translator/style.scss
@@ -74,7 +74,9 @@
 	}
 }
 
-.community-translator__nav-link, .community-translator__close-icon {
+.community-translator__nav-link,
+.community-translator__close-icon,
+.community-translator__settings-link {
 	display: inline-block;
 	margin-left: 7px;
 	cursor: pointer;

--- a/client/components/community-translator/translatable.jsx
+++ b/client/components/community-translator/translatable.jsx
@@ -216,6 +216,13 @@ export class Translatable extends Component {
 								<Gridicon icon="external" size={ 12 } />
 							</a>
 						) }
+						<a
+							title={ translate( 'Settings' ) }
+							href={ '/me/account' }
+							className="community-translator__settings-link"
+						>
+							<Gridicon icon="cog" size={ 12 } onClick={ this.closeDialog } />
+						</a>
 						<Gridicon icon="help" className="community-translator__nav-link" size={ 12 } />
 						<Gridicon
 							icon="cross-circle"

--- a/client/components/community-translator/translatable.jsx
+++ b/client/components/community-translator/translatable.jsx
@@ -217,6 +217,12 @@ export class Translatable extends Component {
 							</a>
 						) }
 						<Gridicon icon="help" className="community-translator__nav-link" size={ 12 } />
+						<Gridicon
+							icon="cross-circle"
+							className="community-translator__close-icon"
+							size={ 12 }
+							onClick={ this.closeDialog }
+						/>
 					</nav>
 				</header>
 				<section className="community-translator__dialog-body">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a settings icon (to turn it off) a close icon (for improved UX) to the the v2 community translator to improve UX.

Currently this change is entirely behind the `i18n/community-translator` feature flag.

The close icon is a little bit redundant with the big "Close" button, but the dialog is modal and potentially confusing, so the "X" is potentially very comforting (especially if I'mH^H^H^ a user is weak enough in the language that they don't immediately recognize the "Close" text).

The settings icon/link is to help users turn off the translator altogether as it would be very easy to forget how/where it was enabled.

![Paramètres_du_compte_—_WordPress_com](https://user-images.githubusercontent.com/5952255/61029968-b3339180-a3ff-11e9-9e5e-70e87728f6d8.jpg)
(We should point that help button somewhere too, soon.)

#### Testing instructions
1. Enable the v2 community translator `ENABLE_FEATURES=i18n/community-translator npm start`
2. Turn it on: http://calypso.localhost:3000/me/account (Account Settings) -> Interface Language -> Community translator
![Paramètres_du_compte_—_WordPress_com](https://user-images.githubusercontent.com/5952255/61027504-b4fa5680-a3f9-11e9-829c-c1a9801b0e6c.jpg)
3. Find a few translatable strings to right-click on and click on the (x) to close the dialog for each.
4a. Try the settings link from `/me/account`
4b. Try the settings link from anywhere else.

![community translator v2 close icon](https://user-images.githubusercontent.com/5952255/61030225-466cc700-a400-11e9-84ee-484296b97ba1.gif)

