### PR TITLE
Enable the auto-renewal toggle on wpcalypso and horizon.

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -17,6 +17,7 @@
 	"features": {
 		"async-payments": false,
 		"ad-tracking": false,
+		"autorenewal-toggle": true,
 		"automated-transfer": true,
 		"blogger-plan": false,
 		"calypsoify/gutenberg": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -19,6 +19,7 @@
 	"features": {
 		"async-payments": false,
 		"ad-tracking": false,
+		"autorenewal-toggle": true,
 		"automated-transfer": true,
 		"blogger-plan": false,
 		"comments/management/threaded-view": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR enables the auto-renewal toggle on `wpcalypso` and `horizon` environment for soliciting test feedbacks.

#### Testing instructions

N/A
