### PR TITLE
Plans: Fix Flows for Non-Administrators

### DIFF
--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -13,12 +11,13 @@ import formatCurrency from '@automattic/format-currency';
 import Banner from 'components/banner';
 import { TYPE_PREMIUM, TERM_ANNUALLY } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
+import canCurrentUser from 'state/selectors/can-current-user';
 import { getSitePlan } from 'state/sites/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSitePlanRawPrice, getPlanDiscountedRawPrice } from 'state/sites/plans/selectors';
 
 export const UpgradeToPremiumNudgePure = props => {
-	const { price, planSlug, translate, userCurrency, isJetpack } = props;
+	const { price, planSlug, translate, userCurrency, canUserUpgrade, isJetpack } = props;
 
 	let featureList;
 	if ( isJetpack ) {
@@ -36,6 +35,10 @@ export const UpgradeToPremiumNudgePure = props => {
 			translate( 'Easy monetization options' ),
 			translate( 'Unlimited premium themes.' ),
 		];
+	}
+	
+	if ( ! canUserUpgrade ) {
+		return null;
 	}
 
 	return (
@@ -67,5 +70,6 @@ export const UpgradeToPremiumNudge = connect( ( state, ownProps ) => {
 	return {
 		planSlug: proposedPlan,
 		price: getDiscountedOrRegularPrice( state, siteId, proposedPlan ),
+		canUserUpgrade: canCurrentUser( state, siteId, 'manage_options' ),
 	};
 } )( UpgradeToPremiumNudgePure );

--- a/client/blocks/post-share/test/nudges.jsx
+++ b/client/blocks/post-share/test/nudges.jsx
@@ -57,12 +57,22 @@ import {
 
 const props = {
 	translate: x => x,
+	canUserUpgrade: true,
 };
 
 describe( 'UpgradeToPremiumNudgePure basic tests', () => {
 	test( 'should not blow up', () => {
 		const comp = shallow( <UpgradeToPremiumNudgePure { ...props } /> );
 		expect( comp.find( 'Banner' ).length ).toBe( 1 );
+	} );
+	
+	test( 'hide when user cannot upgrade', () => {
+		const props = {
+			translate: x => x,
+			canUserUpgrade: false,
+		};
+		const comp = shallow( <UpgradeToPremiumNudgePure { ...props } /> );
+		expect( comp.find( 'Banner' ).length ).toBe( 0 );
 	} );
 } );
 

--- a/client/blocks/upgrade-nudge/index.jsx
+++ b/client/blocks/upgrade-nudge/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -77,59 +75,32 @@ export class UpgradeNudge extends React.Component {
 		onClick();
 	};
 
-	shouldDisplay() {
-		const { feature, jetpack, planHasFeature, shouldDisplay, site, canManageSite } = this.props;
-
-		if ( shouldDisplay === true ) {
-			return true;
-		}
-
-		if ( shouldDisplay ) {
-			return shouldDisplay();
-		}
-
-		if ( ! canManageSite ) {
-			return false;
-		}
-
-		if ( ! site || typeof site !== 'object' || typeof site.jetpack !== 'boolean' ) {
-			return false;
-		}
-
-		if ( feature && planHasFeature ) {
-			return false;
-		}
-
-		if ( ! feature && ! isFreePlan( site.plan ) ) {
-			return false;
-		}
-
-		if ( feature === FEATURE_NO_ADS && site.options.wordads ) {
-			return false;
-		}
-
-		if ( ( ! jetpack && site.jetpack ) || ( jetpack && ! site.jetpack ) ) {
-			return false;
-		}
-
-		return true;
-	}
-
 	render() {
 		const {
+			canManageSite,
 			className,
 			compact,
 			event,
 			plan,
+			planHasFeature,
 			feature,
 			icon,
+			jetpack,
 			message,
 			site,
 			title,
 			translate,
 		} = this.props;
+		
+		const shouldNotDisplay = 
+			  ! canManageSite || 
+			  ( ! site || typeof site !== 'object' || typeof site.jetpack !== 'boolean' ) ||
+			  ( feature && planHasFeature ) ||
+			  ( ! feature && ! isFreePlan( site.plan ) ) ||
+			  ( feature === FEATURE_NO_ADS && site.options.wordads ) ||
+			  ( ( ! jetpack && site.jetpack ) || ( jetpack && ! site.jetpack ) );
 
-		if ( ! this.shouldDisplay() ) {
+		if ( shouldNotDisplay ) {
 			return null;
 		}
 

--- a/client/blocks/upgrade-nudge/test/index.js
+++ b/client/blocks/upgrade-nudge/test/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -26,12 +25,12 @@ describe( 'UpgradeNudge', () => {
 		return merge( {}, defaultProps, overrideProps );
 	};
 
-	describe( '#shouldDisplay()', () => {
+	describe( 'wrapper', () => {
 		test( 'should display with default props', () => {
 			const props = createProps();
 			const wrapper = shallow( <UpgradeNudge { ...props } /> );
 
-			expect( wrapper.instance().shouldDisplay() ).toBe( true );
+			expect( wrapper.find( '.upgrade-nudge' ) ).toHaveLength( 1 );
 		} );
 
 		test( 'should not display without a site', () => {
@@ -39,7 +38,7 @@ describe( 'UpgradeNudge', () => {
 			delete props.site;
 			const wrapper = shallow( <UpgradeNudge { ...props } /> );
 
-			expect( wrapper.instance().shouldDisplay() ).toBe( false );
+			expect( wrapper.find( '.upgrade-nudge' ) ).toHaveLength( 0 );
 		} );
 
 		test( 'should not display for paid plans without feature prop (personal)', () => {
@@ -53,7 +52,7 @@ describe( 'UpgradeNudge', () => {
 			delete props.feature;
 			const wrapper = shallow( <UpgradeNudge { ...props } /> );
 
-			expect( wrapper.instance().shouldDisplay() ).toBe( false );
+			expect( wrapper.find( '.upgrade-nudge' ) ).toHaveLength( 0 );
 		} );
 
 		test( 'should not display for paid plans without feature prop (blogger)', () => {
@@ -67,32 +66,16 @@ describe( 'UpgradeNudge', () => {
 			delete props.feature;
 			const wrapper = shallow( <UpgradeNudge { ...props } /> );
 
-			expect( wrapper.instance().shouldDisplay() ).toBe( false );
+			expect( wrapper.find( '.upgrade-nudge' ) ).toHaveLength( 0 );
 		} );
 
 		test( "should not display when user can't manage site", () => {
 			const props = createProps( { canManageSite: false } );
 			const wrapper = shallow( <UpgradeNudge { ...props } /> );
 
-			expect( wrapper.instance().shouldDisplay() ).toBe( false );
+			expect( wrapper.find( '.upgrade-nudge' ) ).toHaveLength( 0 );
 		} );
-
-		describe( 'with shouldDisplay prop', () => {
-			test( 'should display when shouldDisplay returns true', () => {
-				const props = createProps( { shouldDisplay: () => true } );
-				const wrapper = shallow( <UpgradeNudge { ...props } /> );
-
-				expect( wrapper.instance().shouldDisplay() ).toBe( true );
-			} );
-
-			test( 'should not display when shouldDisplay returns false', () => {
-				const props = createProps( { shouldDisplay: () => false } );
-				const wrapper = shallow( <UpgradeNudge { ...props } /> );
-
-				expect( wrapper.instance().shouldDisplay() ).toBe( false );
-			} );
-		} );
-
+		
 		describe( 'with feature prop', () => {
 			test( 'should not display when plan has feature', () => {
 				const props = createProps( {
@@ -101,7 +84,7 @@ describe( 'UpgradeNudge', () => {
 				} );
 				const wrapper = shallow( <UpgradeNudge { ...props } /> );
 
-				expect( wrapper.instance().shouldDisplay() ).toBe( false );
+				expect( wrapper.find( '.upgrade-nudge' ) ).toHaveLength( 0 );
 			} );
 
 			test( "should display when plan doesn't have feature", () => {
@@ -111,7 +94,7 @@ describe( 'UpgradeNudge', () => {
 				} );
 				const wrapper = shallow( <UpgradeNudge { ...props } /> );
 
-				expect( wrapper.instance().shouldDisplay() ).toBe( true );
+				expect( wrapper.find( '.upgrade-nudge' ) ).toHaveLength( 1 );
 			} );
 		} );
 
@@ -125,7 +108,7 @@ describe( 'UpgradeNudge', () => {
 				} );
 				const wrapper = shallow( <UpgradeNudge { ...props } /> );
 
-				expect( wrapper.instance().shouldDisplay() ).toBe( false );
+				expect( wrapper.find( '.upgrade-nudge' ) ).toHaveLength( 0 );
 			} );
 
 			test( 'should not display when non-jetpack feature for jetpack sites', () => {
@@ -137,7 +120,7 @@ describe( 'UpgradeNudge', () => {
 				} );
 				const wrapper = shallow( <UpgradeNudge { ...props } /> );
 
-				expect( wrapper.instance().shouldDisplay() ).toBe( false );
+				expect( wrapper.find( '.upgrade-nudge' ) ).toHaveLength( 0 );
 			} );
 		} );
 	} );

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -25,7 +23,8 @@ import {
 import { GROUP_JETPACK, GROUP_WPCOM } from 'lib/plans/constants';
 import { addQueryArgs } from 'lib/url';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import Button from 'components/button';
 import Card from 'components/card';
 import DismissibleCard from 'blocks/dismissible-card';
@@ -70,9 +69,9 @@ export class Banner extends Component {
 	};
 
 	getHref() {
-		const { feature, href, plan, siteSlug } = this.props;
+		const { canUserUpgrade, feature, href, plan, siteSlug } = this.props;
 
-		if ( ! href && siteSlug ) {
+		if ( ! href && siteSlug && canUserUpgrade ) {
 			const baseUrl = `/plans/${ siteSlug }`;
 			if ( feature || plan ) {
 				return addQueryArgs(
@@ -264,6 +263,7 @@ export class Banner extends Component {
 
 const mapStateToProps = ( state, ownProps ) => ( {
 	siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
+	canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 } );
 
 export default connect(

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -25,7 +23,8 @@ import {
 import { GROUP_JETPACK, GROUP_WPCOM } from 'lib/plans/constants';
 import { addQueryArgs } from 'lib/url';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import Button from 'components/button';
 import Card from 'components/card';
 import DismissibleCard from 'blocks/dismissible-card';
@@ -145,6 +144,7 @@ export class Banner extends Component {
 			description,
 			event,
 			feature,
+			isAdmin,
 			list,
 			price,
 			title,
@@ -179,7 +179,7 @@ export class Banner extends Component {
 						</ul>
 					) }
 				</div>
-				{ ( callToAction || price ) && (
+				{ isAdmin && ( callToAction || price ) && (
 					<div className="banner__action">
 						{ size( prices ) === 1 && <PlanPrice rawPrice={ prices[ 0 ] } /> }
 						{ size( prices ) === 2 && (
@@ -264,6 +264,7 @@ export class Banner extends Component {
 
 const mapStateToProps = ( state, ownProps ) => ( {
 	siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
+	isAdmin: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 } );
 
 export default connect(

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -23,7 +23,7 @@ import {
 import { GROUP_JETPACK, GROUP_WPCOM } from 'lib/plans/constants';
 import { addQueryArgs } from 'lib/url';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import Button from 'components/button';
 import Card from 'components/card';

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * External dependencies
  */
@@ -23,8 +25,7 @@ import {
 import { GROUP_JETPACK, GROUP_WPCOM } from 'lib/plans/constants';
 import { addQueryArgs } from 'lib/url';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import canCurrentUser from 'state/selectors/can-current-user';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 import Button from 'components/button';
 import Card from 'components/card';
 import DismissibleCard from 'blocks/dismissible-card';
@@ -144,7 +145,6 @@ export class Banner extends Component {
 			description,
 			event,
 			feature,
-			isAdmin,
 			list,
 			price,
 			title,
@@ -179,7 +179,7 @@ export class Banner extends Component {
 						</ul>
 					) }
 				</div>
-				{ isAdmin && ( callToAction || price ) && (
+				{ ( callToAction || price ) && (
 					<div className="banner__action">
 						{ size( prices ) === 1 && <PlanPrice rawPrice={ prices[ 0 ] } /> }
 						{ size( prices ) === 2 && (
@@ -264,7 +264,6 @@ export class Banner extends Component {
 
 const mapStateToProps = ( state, ownProps ) => ( {
 	siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
-	isAdmin: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 } );
 
 export default connect(

--- a/client/components/banner/style.scss
+++ b/client/components/banner/style.scss
@@ -1,11 +1,16 @@
 .banner.card {
 	border-left: 3px solid;
+	cursor: default;
 	display: flex;
 	padding: 12px 6px 12px 12px;
 	line-height: 29px;
 
 	&.is-dismissible {
 		padding-right: 48px;
+	}
+	
+	&[href] {
+		cursor: pointer;
 	}
 
 	@include banner-color( var( --color-primary ) );

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -17,6 +17,8 @@ import QueryPlans from 'components/data/query-plans';
 import TrackComponentView from 'lib/analytics/track-component-view';
 import { preventWidows } from 'lib/formatting';
 import { isJetpackSite } from 'state/sites/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
+import { getSelectedSiteId } from 'state/ui/selectors';
 import FeatureExample from 'components/feature-example';
 import Banner from 'components/banner';
 import { findFirstSimilarPlanKey } from 'lib/plans';
@@ -28,7 +30,7 @@ import { TERM_ANNUALLY, TYPE_BUSINESS } from 'lib/plans/constants';
 import './style.scss';
 import upgradeNudgeImage from './preview-upgrade-nudge.png';
 
-export const SeoPreviewNudge = ( { translate, site, isJetpack = false } ) => {
+export const SeoPreviewNudge = ( { canCurrentUserUpgrade, translate, site, isJetpack = false } ) => {
 	return (
 		<div className="preview-upgrade-nudge">
 			<QueryPlans />
@@ -42,7 +44,9 @@ export const SeoPreviewNudge = ( { translate, site, isJetpack = false } ) => {
 						...( isJetpack ? { term: TERM_ANNUALLY } : {} ),
 					} )
 				}
-				title={ translate( 'Upgrade to a Business Plan to unlock the power of our SEO tools!' ) }
+				title={ canCurrentUserUpgrade ? translate( 'Upgrade to a Business plan to unlock the power of our SEO tools!' ) 
+						: translate ( "Contact your site's administrator to upgrade to a Business plan and unlock the power of our SEO tools!" ) 
+					  }
 				event="site_preview_seo_plan_upgrade"
 				className="preview-upgrade-nudge__banner"
 			/>
@@ -103,6 +107,7 @@ const mapStateToProps = ( state, ownProps ) => {
 
 	return {
 		isJetpack,
+		canCurrentUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 	};
 };
 

--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -45,7 +45,7 @@ export const SeoPreviewNudge = ( { canCurrentUserUpgrade, translate, site, isJet
 					} )
 				}
 				title={ canCurrentUserUpgrade ? translate( 'Upgrade to a Business plan to unlock the power of our SEO tools!' ) 
-						: translate ( "Contact your site's administrator to upgrade to a Business plan and unlock the power of our SEO tools!" ) 
+						: translate ( "Unlock powerful SEO tools! Contact your site's administrator to upgrade to a Business plan." ) 
 					  }
 				event="site_preview_seo_plan_upgrade"
 				className="preview-upgrade-nudge__banner"

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -504,7 +504,6 @@ class SimplePaymentsDialog extends Component {
 							) }
 							feature={ FEATURE_SIMPLE_PAYMENTS }
 							event="editor_simple_payments_modal_nudge"
-							shouldDisplay={ canCurrentUserUpgrade }
 						/>
 					}
 					secondaryAction={

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -494,7 +494,7 @@ class SimplePaymentsDialog extends Component {
 					illustration="/calypso/images/illustrations/type-e-commerce.svg"
 					illustrationWidth={ 300 }
 					title={ translate( 'Want to add a payment button to your site?' ) }
-					line={ ! canCurrentUserUpgrade ? translate ( "Contact your site's administrator to upgrade to the Premium, Business or eCommerce Plan." ) : false }
+					line={ ! canCurrentUserUpgrade ? translate ( "Contact your site's administrator to upgrade to the Premium, Business, or eCommerce Plan." ) : false }
 					action={
 						<UpgradeNudge
 							className="editor-simple-payments-modal__nudge-nudge"

--- a/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
+++ b/client/components/tinymce/plugins/simple-payments/dialog/index.jsx
@@ -444,10 +444,6 @@ class SimplePaymentsDialog extends Component {
 		);
 	}
 
-	returnTrue() {
-		return true;
-	}
-
 	render() {
 		const {
 			showDialog,
@@ -460,6 +456,7 @@ class SimplePaymentsDialog extends Component {
 			planHasSimplePaymentsFeature,
 			shouldQuerySitePlans,
 			canCurrentUserAddButtons,
+			canCurrentUserUpgrade,
 		} = this.props;
 		const { activeTab, initialFormValues, errorMessage } = this.state;
 
@@ -497,6 +494,7 @@ class SimplePaymentsDialog extends Component {
 					illustration="/calypso/images/illustrations/type-e-commerce.svg"
 					illustrationWidth={ 300 }
 					title={ translate( 'Want to add a payment button to your site?' ) }
+					line={ ! canCurrentUserUpgrade ? translate ( "Contact your site's administrator to upgrade to the Premium, Business or eCommerce Plan." ) : false }
 					action={
 						<UpgradeNudge
 							className="editor-simple-payments-modal__nudge-nudge"
@@ -506,7 +504,7 @@ class SimplePaymentsDialog extends Component {
 							) }
 							feature={ FEATURE_SIMPLE_PAYMENTS }
 							event="editor_simple_payments_modal_nudge"
-							shouldDisplay={ this.returnTrue }
+							shouldDisplay={ canCurrentUserUpgrade }
 						/>
 					}
 					secondaryAction={
@@ -617,5 +615,6 @@ export default connect( ( state, { siteId } ) => {
 		currentUserEmail: getCurrentUserEmail( state ),
 		featuredImageId: get( getFormValues( REDUX_FORM_NAME )( state ), 'featuredImageId' ),
 		canCurrentUserAddButtons: canCurrentUser( state, siteId, 'publish_posts' ),
+		canCurrentUserUpgrade: canCurrentUser( state, siteId, 'manage_options' ),
 	};
 } )( localize( SimplePaymentsDialog ) );

--- a/client/components/tinymce/plugins/simple-payments/style.scss
+++ b/client/components/tinymce/plugins/simple-payments/style.scss
@@ -78,6 +78,10 @@
 		flex-shrink: 0;
 		text-align: left;
 	}
+	
+	.empty-content__line {
+		margin: 8px;
+	}
 
 	.empty-content__action {
 		margin-top: 16px;

--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -6,8 +6,6 @@
 
 import { userCan } from 'lib/site/utils';
 import { isBusiness, isPremium, isEcommerce } from 'lib/products-values';
-import canCurrentUser from 'state/selectors/can-current-user';
-import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Returns true if the site has WordAds access
@@ -35,7 +33,7 @@ export function canAccessWordads( site ) {
 
 export function canAccessAds( site ) {
 	return ( canAccessWordads( site ) || canUpgradeToUseWordAds( site ) ) 
-	&& canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' );
+	&& userCan( 'manage_options', site )
 }
 
 export function isWordadsInstantActivationEligible( site ) {

--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -6,6 +6,8 @@
 
 import { userCan } from 'lib/site/utils';
 import { isBusiness, isPremium, isEcommerce } from 'lib/products-values';
+import canCurrentUser from 'state/selectors/can-current-user';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 /**
  * Returns true if the site has WordAds access
@@ -32,7 +34,8 @@ export function canAccessWordads( site ) {
 }
 
 export function canAccessAds( site ) {
-	return canAccessWordads( site ) || canUpgradeToUseWordAds( site );
+	return ( canAccessWordads( site ) || canUpgradeToUseWordAds( site ) ) 
+	&& canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' );
 }
 
 export function isWordadsInstantActivationEligible( site ) {

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -166,7 +166,7 @@ class AdsWrapper extends Component {
 		return (
 			<EmptyContent
 				illustration="/calypso/images/illustrations/illustration-404.svg"
-				title={ this.props.translate( 'You are not authorized to view this page.' ) }
+				title={ this.props.translate( 'You are not authorized to view this page' ) }
 			/>
 		);
 	}

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -20,6 +20,7 @@ import { isPremium, isBusiness, isEcommerce } from 'lib/products-values';
 import FeatureExample from 'components/feature-example';
 import FormButton from 'components/forms/form-button';
 import Card from 'components/card';
+import EmptyContent from 'components/empty-content';
 import { requestWordAdsApproval, dismissWordAdsError } from 'state/wordads/approve/actions';
 import {
 	isRequestingWordAdsApprovalForSite,
@@ -32,7 +33,6 @@ import QueryWordadsStatus from 'components/data/query-wordads-status';
 import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
 import { PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, FEATURE_WORDADS_INSTANT } from 'lib/plans/constants';
 import canCurrentUser from 'state/selectors/can-current-user';
-import { getSiteFragment } from 'lib/route';
 import { isSiteWordadsUnsafe } from 'state/wordads/status/selectors';
 import { wordadsUnsafeValues } from 'state/wordads/status/schema';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -55,25 +55,6 @@ class AdsWrapper extends Component {
 		wordAdsError: PropTypes.string,
 		wordAdsSuccess: PropTypes.bool,
 	};
-
-	componentDidMount() {
-		this.redirectToStats();
-	}
-
-	componentDidUpdate() {
-		this.redirectToStats();
-	}
-
-	redirectToStats() {
-		const { siteSlug, site } = this.props;
-		const siteFragment = getSiteFragment( page.current );
-
-		if ( siteSlug && site && ! canAccessAds( site ) ) {
-			page( '/stats/' + siteSlug );
-		} else if ( ! siteFragment ) {
-			page( '/earn/' );
-		}
-	}
 
 	handleDismissWordAdsError = () => {
 		const { siteId } = this.props;
@@ -181,6 +162,15 @@ class AdsWrapper extends Component {
 		);
 	}
 
+	renderEmptyContent() {
+		return (
+			<EmptyContent
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+				title={ this.props.translate( 'You are not authorized to view this page.' ) }
+			/>
+		);
+	}
+
 	renderUpsell() {
 		const { translate } = this.props;
 		return (
@@ -223,10 +213,6 @@ class AdsWrapper extends Component {
 			site.jetpack &&
 			( isPremium( site.plan ) || isBusiness( site.plan ) || isEcommerce( site.plan ) );
 
-		if ( ! canAccessAds( site ) ) {
-			return null;
-		}
-
 		let component = this.props.children;
 		let notice = null;
 
@@ -238,6 +224,8 @@ class AdsWrapper extends Component {
 			);
 		} else if ( ! site.options.wordads && isWordadsInstantActivationEligible( site ) ) {
 			component = this.renderInstantActivationToggle( component );
+		} else if ( ! canAccessAds( site ) ) {
+			component = this.renderEmptyContent();
 		} else if ( canUpgradeToUseWordAds( site ) && site.jetpack && ! jetpackPremium ) {
 			component = this.renderjetpackUpsell();
 		} else if ( canUpgradeToUseWordAds( site ) ) {

--- a/client/my-sites/earn/ads/wrapper.jsx
+++ b/client/my-sites/earn/ads/wrapper.jsx
@@ -216,7 +216,9 @@ class AdsWrapper extends Component {
 		let component = this.props.children;
 		let notice = null;
 
-		if ( this.props.requestingWordAdsApproval || this.props.wordAdsSuccess ) {
+		if ( ! canAccessAds( site ) ) {
+			component = this.renderEmptyContent();
+		} else if ( this.props.requestingWordAdsApproval || this.props.wordAdsSuccess ) {
 			notice = (
 				<Notice status="is-success" showDismiss={ false }>
 					{ translate( 'You have joined the WordAds program. Please review these settings:' ) }

--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -132,7 +132,7 @@ export default connect( state => {
 	return {
 		showButtons: siteId && canManageOptions && ( ! isJetpack || hasSharedaddy ),
 		showConnections: ! siteId || ! isJetpack || isJetpackModuleActive( state, siteId, 'publicize' ),
-		showTraffic: !! siteId,
+		showTraffic: canManageOptions && !! siteId,
 		siteId,
 		siteSlug: getSiteSlug( state, siteId ),
 	};

--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -13,6 +11,7 @@ import { flowRight, partialRight, pick } from 'lodash';
  * Internal dependencies
  */
 import Main from 'components/main';
+import EmptyContent from 'components/empty-content';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import SeoSettingsMain from 'my-sites/site-settings/seo-settings/main';
@@ -26,6 +25,7 @@ import RelatedPosts from 'my-sites/site-settings/related-posts';
 import Sitemaps from 'my-sites/site-settings/sitemaps';
 import Shortlinks from 'my-sites/site-settings/shortlinks';
 import wrapSettingsForm from 'my-sites/site-settings/wrap-settings-form';
+import canCurrentUser from 'state/selectors/can-current-user';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { isJetpackSite } from 'state/sites/selectors';
 
@@ -39,6 +39,7 @@ const SiteSettingsTraffic = ( {
 	handleAutosavingToggle,
 	handleAutosavingRadio,
 	handleSubmitForm,
+	isAdmin,
 	isJetpack,
 	isRequestingSettings,
 	isSavingSettings,
@@ -49,6 +50,12 @@ const SiteSettingsTraffic = ( {
 	<Main className="settings-traffic site-settings" wideLayout>
     <PageViewTracker path="/marketing/traffic/:site" title="Marketing > Traffic" />
 		<DocumentHead title={ translate( 'Site Settings' ) } />
+		{ ! isAdmin && (
+			<EmptyContent
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+				title={ translate( 'You are not authorized to view this page' ) }
+			/>
+		) }
 		<JetpackDevModeNotice />
 
 		{ isJetpack && (
@@ -59,15 +66,18 @@ const SiteSettingsTraffic = ( {
 				fields={ fields }
 			/>
 		) }
-		<SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } />
-		<SeoSettingsMain />
-		<RelatedPosts
-			onSubmitForm={ handleSubmitForm }
-			handleAutosavingToggle={ handleAutosavingToggle }
-			isSavingSettings={ isSavingSettings }
-			isRequestingSettings={ isRequestingSettings }
-			fields={ fields }
-		/>
+		{ isAdmin && ( <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> ) }
+		{ isAdmin && ( <SeoSettingsMain /> ) }
+		{ isAdmin && ( 
+			<RelatedPosts
+				onSubmitForm={ handleSubmitForm }
+				handleAutosavingToggle={ handleAutosavingToggle }
+				isSavingSettings={ isSavingSettings }
+				isRequestingSettings={ isRequestingSettings }
+				fields={ fields }
+			/>
+		 ) }
+				
 		{ isJetpack && (
 			<JetpackSiteStats
 				handleAutosavingToggle={ handleAutosavingToggle }
@@ -77,7 +87,7 @@ const SiteSettingsTraffic = ( {
 				fields={ fields }
 			/>
 		) }
-		<AnalyticsSettings />
+		{ isAdmin && ( <AnalyticsSettings /> ) }
 		{ isJetpack && (
 			<Shortlinks
 				handleAutosavingRadio={ handleAutosavingRadio }
@@ -88,17 +98,20 @@ const SiteSettingsTraffic = ( {
 				onSubmitForm={ handleSubmitForm }
 			/>
 		) }
-		<Sitemaps
-			isSavingSettings={ isSavingSettings }
-			isRequestingSettings={ isRequestingSettings }
-			fields={ fields }
-		/>
-		<SiteVerification />
+		{ isAdmin && ( 
+			<Sitemaps
+				isSavingSettings={ isSavingSettings }
+				isRequestingSettings={ isRequestingSettings }
+				fields={ fields }
+			/> 
+		) }
+		{ isAdmin && ( <SiteVerification /> ) }
 	</Main>
 );
 
 const connectComponent = connect( state => ( {
 	isJetpack: isJetpackSite( state, getSelectedSiteId( state ) ),
+	isAdmin: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 } ) );
 
 const getFormSettings = partialRight( pick, [

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -112,7 +112,7 @@ class MediaLibraryListPlanPromo extends React.Component {
 	}
 }
 
-export default connect( ( state, { siteId } ) => {
+export default connect( ( state ) => {
 	return {
 		canUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 	};

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -57,7 +57,8 @@ class MediaLibraryListPlanPromo extends React.Component {
 						textOnly: true,
 						context: 'Media upgrade promo',
 					} )
-					: this.props.translate( "If you'd like to upload video files, contact your site administrator and ask them to upgrade their plan." ),
+					: this.props.translate( "Uploading video requires a paid plan." )
+					+ " " + this.props.translate( 'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.' ),
 					2
 				);
 
@@ -68,7 +69,8 @@ class MediaLibraryListPlanPromo extends React.Component {
 						textOnly: true,
 						context: 'Media upgrade promo',
 					} )
-					: this.props.translate( "If you'd like to upload audio files, contact your site administrator and ask them to upgrade their plan." ),
+					: this.props.translate( "Uploading audio requires a paid plan." )
+					+ " " + this.props.translate( 'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.' ),
 					2
 				);
 

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -1,10 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
 
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import page from 'page';
@@ -16,6 +15,8 @@ import { preventWidows } from 'lib/formatting';
  */
 import EmptyContent from 'components/empty-content';
 import Button from 'components/button';
+import canCurrentUser from 'state/selectors/can-current-user';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 class MediaLibraryListPlanPromo extends React.Component {
 	static displayName = 'MediaLibraryListPlanPromo';
@@ -51,19 +52,23 @@ class MediaLibraryListPlanPromo extends React.Component {
 		switch ( this.props.filter ) {
 			case 'videos':
 				return preventWidows(
+					this.props.canUpgrade ?
 					this.props.translate( 'To upload video files to your site, upgrade your plan.', {
 						textOnly: true,
 						context: 'Media upgrade promo',
-					} ),
+					} )
+					: this.props.translate( "If you'd like to upload video files, contact your site administrator and ask them to upgrade their plan." ),
 					2
 				);
 
 			case 'audio':
 				return preventWidows(
+					this.props.canUpgrade ?
 					this.props.translate( 'To upload audio files to your site, upgrade your plan.', {
 						textOnly: true,
 						context: 'Media upgrade promo',
-					} ),
+					} )
+					: this.props.translate( "If you'd like to upload audio files, contact your site administrator and ask them to upgrade their plan." ),
 					2
 				);
 
@@ -107,4 +112,8 @@ class MediaLibraryListPlanPromo extends React.Component {
 	}
 }
 
-export default localize( MediaLibraryListPlanPromo );
+export default connect( ( state, { siteId } ) => {
+	return {
+		canUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
+	};
+} )( localize( MediaLibraryListPlanPromo ) );

--- a/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
+++ b/client/my-sites/media-library/list-plan-upgrade-nudge.jsx
@@ -18,21 +18,21 @@ import ListPlanPromo from './list-plan-promo';
 
 function getTitle( filter, translate ) {
 	if ( filter === 'audio' ) {
-		return translate( 'Upgrade to the Premium Plan and Enable Audio Uploads' );
+		return translate( 'Upgrade to the Premium Plan to Enable Audio Uploads' );
 	}
 
-	return translate( 'Upgrade to a Premium Plan and Enable VideoPress' );
+	return translate( 'Upgrade to the Premium Plan to Enable VideoPress' );
 }
 
 function getSubtitle( filter, translate ) {
 	if ( filter === 'audio' ) {
 		return translate(
-			"By upgrading to the Premium plan you'll enable audio upload support on your site."
+			"By upgrading to the Premium plan, you'll enable audio upload support on your site."
 		);
 	}
 
 	return translate(
-		"By upgrading to a Premium Plan you'll enable VideoPress support on your site."
+		"By upgrading to the Premium plan, you'll enable VideoPress support on your site."
 	);
 }
 

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -252,6 +252,11 @@
 	position: absolute;
 	top: 50px;
 	bottom: 72px;
+	
+	.empty-content__line {
+		margin-right: 20px;
+		margin-left: 20px;
+	}
 }
 
 .empty-content .media-library__videopress-nudge-regular.card.upgrade-nudge {

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -15,7 +15,9 @@ import page from 'page';
  */
 import DocumentHead from 'components/data/document-head';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import Main from 'components/main';
+import EmptyContent from 'components/empty-content';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
@@ -84,7 +86,7 @@ class Plans extends React.Component {
 	};
 
 	render() {
-		const { selectedSite, translate, displayJetpackPlans } = this.props;
+		const { selectedSite, translate, displayJetpackPlans, canAccessPlans } = this.props;
 
 		if ( ! selectedSite || this.isInvalidPlanInterval() ) {
 			return this.renderPlaceholder();
@@ -98,22 +100,29 @@ class Plans extends React.Component {
 				<TrackComponentView eventName="calypso_plans_view" />
 				<Main wideLayout={ true }>
 					<SidebarNavigation />
-
-					<div id="plans" className="plans plans__has-sidebar">
-						<PlansNavigation cart={ this.props.cart } path={ this.props.context.path } />
-						<PlansFeaturesMain
-							displayJetpackPlans={ displayJetpackPlans }
-							hideFreePlan={ true }
-							customerType={ this.props.customerType }
-							intervalType={ this.props.intervalType }
-							selectedFeature={ this.props.selectedFeature }
-							selectedPlan={ this.props.selectedPlan }
-							withDiscount={ this.props.withDiscount }
-							discountEndDate={ this.props.discountEndDate }
-							site={ selectedSite }
-							plansWithScroll={ false }
+					{ ! canAccessPlans && (
+						<EmptyContent
+							illustration="/calypso/images/illustrations/illustration-404.svg"
+							title={ translate( 'You are not authorized to view this page' ) }
 						/>
-					</div>
+					) }
+					{ canAccessPlans && (
+						<div id="plans" className="plans plans__has-sidebar">
+							<PlansNavigation cart={ this.props.cart } path={ this.props.context.path } />
+							<PlansFeaturesMain
+								displayJetpackPlans={ displayJetpackPlans }
+								hideFreePlan={ true }
+								customerType={ this.props.customerType }
+								intervalType={ this.props.intervalType }
+								selectedFeature={ this.props.selectedFeature }
+								selectedPlan={ this.props.selectedPlan }
+								withDiscount={ this.props.withDiscount }
+								discountEndDate={ this.props.discountEndDate }
+								site={ selectedSite }
+								plansWithScroll={ false }
+							/>
+						</div>
+					) }
 				</Main>
 			</div>
 		);
@@ -129,5 +138,6 @@ export default connect( state => {
 	return {
 		selectedSite: getSelectedSite( state ),
 		displayJetpackPlans: ! isSiteAutomatedTransfer && jetpackSite,
+		canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 	};
 } )( localize( Plans ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This addresses all the flows which can get a non-admin stuck into the Cart page, where Calypso then starts to break. 

**Individual Minor Nudges:**

| Admin  | Non-Admin | To note | Flow
| ------------- | ------------- | ------------- | -------------
|  <img width="779" alt="Screenshot 2019-07-14 at 19 58 41" src="https://user-images.githubusercontent.com/43215253/61188072-cc437900-a671-11e9-9078-82eaa78eef43.png"> | <img width="1007" alt="Screenshot 2019-07-14 at 19 59 50" src="https://user-images.githubusercontent.com/43215253/61188084-f72dcd00-a671-11e9-927c-6660409d21e1.png"> | This also updates the copy for the actual nudge - that received approval in #29437. For the Empty Content subtitle, that received wording approval in #24039. | /media/video/site
  | <img width="785" alt="Screenshot 2019-07-14 at 20 03 40" src="https://user-images.githubusercontent.com/43215253/61188117-7e7b4080-a672-11e9-9d72-dfef454bfaed.png"> | <img width="1020" alt="Screenshot 2019-07-14 at 20 04 11" src="https://user-images.githubusercontent.com/43215253/61188124-905ce380-a672-11e9-81a6-08450290f471.png"> | Consistent wording as above | /media/audio/site
| <img width="935" alt="Screenshot 2019-07-14 at 20 06 07" src="https://user-images.githubusercontent.com/43215253/61188143-d7e36f80-a672-11e9-9e95-4043182586e5.png">  | <img width="1113" alt="Screenshot 2019-07-14 at 20 05 08" src="https://user-images.githubusercontent.com/43215253/61188131-b5515680-a672-11e9-957f-5d53f91fad04.png"> | The wording comes from #24041, just accounts for the new eCommerce plan| In the Classic Editor, click "Add" and then "Payment Button" |  <img width="779" alt="Screenshot 2019-07-14 at 19 58 41" src="https://user-images.githubusercontent.com/43215253/61188072-cc437900-a671-11e9-9078-82eaa78eef43.png"> | <img width="1007" alt="Screenshot 2019-07-14 at 19 59 50" src="https://user-images.githubusercontent.com/43215253/61188084-f72dcd00-a671-11e9-927c-6660409d21e1.png"> | This also updates the copy for the actual nudge - that received approval in #29437. For the Empty Content subtitle, that received wording approval in #24039. | /media/video/site
  | <img width="758" alt="Screenshot 2019-07-14 at 12 08 49" src="https://user-images.githubusercontent.com/43215253/61188160-1c6f0b00-a673-11e9-8502-7fd0df4b02bc.png"> | <img width="750" alt="Screenshot 2019-07-14 at 12 08 41" src="https://user-images.githubusercontent.com/43215253/61188159-1c6f0b00-a673-11e9-9322-05228965b661.png"> | Hidden for non-admins, but please see #34638 for a fix for contributors being led down this route | /posts - ellipses menu - Share | | <img width="935" alt="Screenshot 2019-07-14 at 20 06 07" src="https://user-images.githubusercontent.com/43215253/61188143-d7e36f80-a672-11e9-9e95-4043182586e5.png">  | <img width="1113" alt="Screenshot 2019-07-14 at 20 05 08" src="https://user-images.githubusercontent.com/43215253/61188131-b5515680-a672-11e9-957f-5d53f91fad04.png"> | The wording comes from #24041, just accounts for the new eCommerce plan| In the Classic Editor, click "Add" and then "Payment Button" |  <img width="779" alt="Screenshot 2019-07-14 at 19 58 41" src="https://user-images.githubusercontent.com/43215253/61188072-cc437900-a671-11e9-9078-82eaa78eef43.png"> | <img width="1007" alt="Screenshot 2019-07-14 at 19 59 50" src="https://user-images.githubusercontent.com/43215253/61188084-f72dcd00-a671-11e9-927c-6660409d21e1.png"> | This also updates the copy for the actual nudge - that received approval in #29437. For the Empty Content subtitle, that received wording approval in #24039. | /media/video/site
  | <img width="609" alt="Screenshot 2019-07-14 at 20 13 04" src="https://user-images.githubusercontent.com/43215253/61188218-cea6d280-a673-11e9-91b9-21261f00d95f.png"> | <img width="800" alt="Screenshot 2019-07-14 at 20 12 47" src="https://user-images.githubusercontent.com/43215253/61188217-cea6d280-a673-11e9-85b1-12d3c1056678.png"> | Non-admin nudge isn't clickable, admin one is - this PR also ensures a cursor only appears if it is clickable | /view/site - dropdown at top - Search & Social |

**EmptyContent Components:**

These flows will now trigger this error for non-admins:

<img width="1040" alt="Screenshot 2019-07-14 at 12 09 10" src="https://user-images.githubusercontent.com/43215253/61188270-a075c280-a674-11e9-9f45-3fbe1bb64604.png">

- /plans (clicking "Upgrade" immediately starts to break things)
- /earn/ads-earnings & /earn/ads-settings (they currently both display two huge nudges that lead directly to Checkout and display nothing else)
- /marketing/traffic (filled with Business Plan nudges, a Global Error currently appears but this makes things more clear, non-admins shouldn't have access to settings like this anyway)

**Other:**

- Logic currently existed to hide the normal upgrade nudges...but it didn't actually work. I've made it so that such nudges are now actually hidden, which broke the tests (even though they're now fixed!). I got it to pass but it's my first time modifying them, so I'm not certain I used the best approach. That means the nudge in` /stats/insights` is now hidden for non-admins

<img width="1106" alt="Screenshot 2019-07-14 at 20 24 19" src="https://user-images.githubusercontent.com/43215253/61188332-6953e100-a675-11e9-84e5-217589539d55.png">

I'm still not convinced that non-admins should have access to "Marketing Tools" or "Earn", but that's probably for a different PR. 

_More broken flows unrelated to the Cart/Plan:_

- #34638
- #34643 _(this crashes Calypso!)_

#### Testing instructions

- Verify all the flows act correctly as pointed above
- Verify that there are no other flows for non-admins that leads to an item being added to the cart

Fixes #34596 and fixes #20250
