### PR TITLE
Domains: Add domain maintenance notices for the landing pages

### DIFF
--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -12,6 +12,7 @@ import DomainsLandingHeader from '../header';
 import DomainsLandingContentCard from '../content-card';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import wp from 'lib/wp';
+import { getMaintenanceMessageFromError } from '../utils';
 
 const wpcom = wp.undocumented();
 
@@ -174,6 +175,17 @@ class RegistrantVerificationPage extends Component {
 		};
 	};
 
+	getRunningMaintenanceErrorState = error => {
+		const { translate } = this.props;
+
+		const message = getMaintenanceMessageFromError( error, translate );
+
+		return {
+			title: translate( 'Domain maintenance in progress' ),
+			message: message,
+		};
+	};
+
 	setErrorState = error => {
 		let errorState;
 
@@ -192,6 +204,11 @@ class RegistrantVerificationPage extends Component {
 
 			case 'resend_email_failed':
 				errorState = this.getResendEmailErrorState();
+				break;
+
+			case 'domain_registration_unavailable':
+			case 'tld-in-maintenance':
+				errorState = this.getRunningMaintenanceErrorState( error );
 				break;
 		}
 

--- a/client/landing/domains/transfer-away-confirmation/index.jsx
+++ b/client/landing/domains/transfer-away-confirmation/index.jsx
@@ -12,6 +12,7 @@ import DomainsLandingHeader from '../header';
 import DomainsLandingContentCard from '../content-card';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import wp from 'lib/wp';
+import { getMaintenanceMessageFromError } from '../utils';
 
 const wpcom = wp.undocumented();
 
@@ -196,6 +197,17 @@ class TransferAwayConfirmationPage extends Component {
 		};
 	};
 
+	getRunningMaintenanceErrorState = error => {
+		const { translate } = this.props;
+
+		const message = getMaintenanceMessageFromError( error, translate );
+
+		return {
+			title: translate( 'Domain maintenance in progress' ),
+			message: message,
+		};
+	};
+
 	getDefaultErrorState = () => {
 		const { translate } = this.props;
 		const defaultErrorFooter = translate(
@@ -240,6 +252,11 @@ class TransferAwayConfirmationPage extends Component {
 
 			case 'no_pending_transfer':
 				errorState = this.getNotPendingTransferErrorState();
+				break;
+
+			case 'domain_registration_unavailable':
+			case 'tld-in-maintenance':
+				errorState = this.getRunningMaintenanceErrorState( error );
 				break;
 		}
 

--- a/client/landing/domains/utils.js
+++ b/client/landing/domains/utils.js
@@ -9,7 +9,7 @@ export function getMaintenanceMessageFromError( error, translate ) {
 
 	if ( maintenanceEndTime ) {
 		return translate(
-			"There is an active domain maintenance and we can't serve your request at this moment. Please try again %(when)s.",
+			"Our domain management system is currently undergoing maintenance and we can't process your request right now. Please try again %(when)s.",
 			{
 				args: {
 					when: moment.unix( maintenanceEndTime ).fromNow(),
@@ -21,6 +21,6 @@ export function getMaintenanceMessageFromError( error, translate ) {
 	}
 
 	return translate(
-		"There is an active domain maintenance and we can't serve your request at this moment. Please try again later."
+		"Our domain management system is currently undergoing maintenance and we can't process your request right now. Please try again later."
 	);
 }

--- a/client/landing/domains/utils.js
+++ b/client/landing/domains/utils.js
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+import { moment } from 'i18n-calypso';
+
+export function getMaintenanceMessageFromError( error, translate ) {
+	const maintenanceEndTime = get( error, [ 'data', 'maintenance_end_time' ], null );
+
+	if ( maintenanceEndTime ) {
+		return translate(
+			"There is an active domain maintenance and we can't serve your request at this moment. Please try again %(when)s.",
+			{
+				args: {
+					when: moment.unix( maintenanceEndTime ).fromNow(),
+				},
+				comment:
+					'Where `when` is human readable time interval generated from moment.fromNow - something like "in an hour" or "in 30 minutes" and etc.',
+			}
+		);
+	}
+
+	return translate(
+		"There is an active domain maintenance and we can't serve your request at this moment. Please try again later."
+	);
+}


### PR DESCRIPTION
Since we'll soon start to use those for all domain we need to support domain maintenance notices. So if a registrar or registry is in maintenance we'll show a proper message with expected end time.

#### Changes proposed in this Pull Request

* Add domain maintenance notices for the transfer away confirmation page and the registrant verification page.

#### Testing instructions

* Generate a transfer away confirmation url or registrant verification url
* Apply D30371-code on your sandbox
* Follow the instructions in D30371-code to put domains in maintenance
* Check if you see the domain maintenance notice when you visit the above urls
