### PR TITLE
Editor/Media: Hide menu items requiring upload from Contributors

### DIFF
--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -29,10 +29,12 @@ export class MediaLibraryDataSource extends Component {
 		source: PropTypes.string.isRequired,
 		onSourceChange: PropTypes.func.isRequired,
 		disabledSources: PropTypes.array,
+		ignorePermissions: PropTypes.bool,
 	};
 
 	static defaultProps = {
 		disabledSources: [],
+		ignorePermissions: false,
 	};
 
 	state = { popover: false };
@@ -50,7 +52,8 @@ export class MediaLibraryDataSource extends Component {
 	};
 
 	getSources = () => {
-		const { disabledSources, translate, canUserUploadFiles } = this.props;
+		const { disabledSources, translate, ignorePermissions, canUserUploadFiles } = this.props;
+		const includeExternalMedia = ignorePermissions || canUserUploadFiles;
 		const sources = [
 			{
 				value: '',
@@ -58,14 +61,14 @@ export class MediaLibraryDataSource extends Component {
 				icon: <Gridicon icon="image" size={ 24 } />,
 			},
 		];
-		if ( config.isEnabled( 'external-media/google-photos' ) && canUserUploadFiles ) {
+		if ( config.isEnabled( 'external-media/google-photos' ) && includeExternalMedia ) {
 			sources.push( {
 				value: 'google_photos',
 				label: translate( 'Google Photos library' ),
 				icon: <GooglePhotosIcon />,
 			} );
 		}
-		if ( config.isEnabled( 'external-media/free-photo-library' ) && canUserUploadFiles ) {
+		if ( config.isEnabled( 'external-media/free-photo-library' ) && includeExternalMedia ) {
 			sources.push( {
 				value: 'pexels',
 				label: translate( 'Free photo library' ),

--- a/client/my-sites/media-library/data-source.jsx
+++ b/client/my-sites/media-library/data-source.jsx
@@ -5,6 +5,7 @@
  */
 
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
 import { find, includes } from 'lodash';
@@ -20,6 +21,8 @@ import PopoverMenu from 'components/popover/menu';
 import PopoverMenuItem from 'components/popover/menu-item';
 import GooglePhotosIcon from './google-photos-icon';
 import config from 'config';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 
 export class MediaLibraryDataSource extends Component {
 	static propTypes = {
@@ -47,20 +50,22 @@ export class MediaLibraryDataSource extends Component {
 	};
 
 	getSources = () => {
-		const { disabledSources, translate } = this.props;
+		const { disabledSources, translate, canUserUploadFiles } = this.props;
 		const sources = [
 			{
 				value: '',
 				label: translate( 'WordPress library' ),
 				icon: <Gridicon icon="image" size={ 24 } />,
 			},
-			{
+		];
+		if ( config.isEnabled( 'external-media/google-photos' ) && canUserUploadFiles ) {
+			sources.push( {
 				value: 'google_photos',
 				label: translate( 'Google Photos library' ),
 				icon: <GooglePhotosIcon />,
-			},
-		];
-		if ( config.isEnabled( 'external-media/free-photo-library' ) ) {
+			} );
+		}
+		if ( config.isEnabled( 'external-media/free-photo-library' ) && canUserUploadFiles ) {
 			sources.push( {
 				value: 'pexels',
 				label: translate( 'Free photo library' ),
@@ -127,4 +132,8 @@ export class MediaLibraryDataSource extends Component {
 	}
 }
 
-export default localize( MediaLibraryDataSource );
+const mapStateToProps = state => ( {
+	canUserUploadFiles: canCurrentUser( state, getSelectedSiteId( state ), 'upload_files' ),
+} );
+
+export default connect( mapStateToProps )( localize( MediaLibraryDataSource ) );

--- a/client/my-sites/media-library/test/data-source.jsx
+++ b/client/my-sites/media-library/test/data-source.jsx
@@ -37,7 +37,11 @@ describe( 'MediaLibraryDataSource', () => {
 			const store = createReduxStore();
 			const wrapper = mount(
 				<ReduxProvider store={ store }>
-					<MediaLibraryDataSource source={ '' } onSourceChange={ noop } />
+					<MediaLibraryDataSource
+						source={ '' }
+						onSourceChange={ noop }
+						ignorePermissions={ true }
+					/>
 				</ReduxProvider>
 			);
 			expect( wrapper.find( 'button[data-source="google_photos"]' ) ).to.have.length( 1 );
@@ -52,6 +56,7 @@ describe( 'MediaLibraryDataSource', () => {
 						source={ '' }
 						onSourceChange={ noop }
 						disabledSources={ [ 'pexels' ] }
+						ignorePermissions={ true }
 					/>
 				</ReduxProvider>
 			);

--- a/client/post-editor/editor-html-toolbar/index.jsx
+++ b/client/post-editor/editor-html-toolbar/index.jsx
@@ -24,7 +24,8 @@ import { getMimePrefix } from 'lib/media/utils';
 import MediaValidationStore from 'lib/media/validation-store';
 import { isWithinBreakpoint } from 'lib/viewport';
 import markup from 'post-editor/media-modal/markup';
-import { getSelectedSite } from 'state/ui/selectors';
+import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import {
 	fieldAdd,
 	fieldRemove,
@@ -506,7 +507,7 @@ export class EditorHtmlToolbar extends Component {
 	isTagOpen = tag => -1 !== this.state.openTags.indexOf( tag );
 
 	renderAddEverythingDropdown = () => {
-		const { translate } = this.props;
+		const { translate, canUserUploadFiles } = this.props;
 
 		const insertContentClasses = classNames( 'editor-html-toolbar__insert-content-dropdown', {
 			'is-visible': this.state.showInsertContentMenu,
@@ -522,7 +523,7 @@ export class EditorHtmlToolbar extends Component {
 					<span data-e2e-insert-type="media">{ translate( 'Media' ) }</span>
 				</button>
 
-				{ config.isEnabled( 'external-media/google-photos' ) && (
+				{ config.isEnabled( 'external-media/google-photos' ) && canUserUploadFiles && (
 					<button
 						className="editor-html-toolbar__insert-content-dropdown-item"
 						onClick={ this.openGoogleModal }
@@ -534,7 +535,7 @@ export class EditorHtmlToolbar extends Component {
 					</button>
 				) }
 
-				{ config.isEnabled( 'external-media/free-photo-library' ) && (
+				{ config.isEnabled( 'external-media/free-photo-library' ) && canUserUploadFiles && (
 					<button
 						className="editor-html-toolbar__insert-content-dropdown-item"
 						onClick={ this.openPexelsModal }
@@ -712,6 +713,7 @@ const mapStateToProps = state => ( {
 	contactForm: get( state, 'ui.editor.contactForm', {} ),
 	isDropZoneVisible: isDropZoneVisible( state ),
 	site: getSelectedSite( state ),
+	canUserUploadFiles: canCurrentUser( state, getSelectedSiteId( state ), 'upload_files' ),
 } );
 
 const mapDispatchToProps = {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Hides Media related menu items requiring upload permission from Contributors in:

- Classic HTML Editor's "Add" popup menu.
- Media Library's has its own Media Data Source popup.

#### Testing instructions

1. Using **Classic Editor**, create a post **as Contributor**.

2. Switch to **HTML editor tab**.
3. Click on the **+ Add** button:

**Before:**
<img width="249" alt="60744824-7e6d9900-9f2c-11e9-9ed2-c83d76e17e2a" src="https://user-images.githubusercontent.com/127594/61075948-ec540d80-a3cf-11e9-9507-6207127f3196.png">

**After:**
<img width="245" alt="60744790-52eaae80-9f2c-11e9-9e57-64305d9dfa97" src="https://user-images.githubusercontent.com/127594/61075957-f118c180-a3cf-11e9-9206-dbc6ef9e9137.png">

4. Click on **Media** menu item from the **+ Add** popup menu.
5. When **Media Library modal** appears, Look at its **top-left corner**.

**Before:**
<img width="249" alt="screenshot_773" src="https://user-images.githubusercontent.com/127594/61076258-a5b2e300-a3d0-11e9-9abf-7e9fe2720dbf.png">
<img width="241" alt="screenshot_772" src="https://user-images.githubusercontent.com/127594/61076350-e01c8000-a3d0-11e9-9e95-f7fe7fb81804.png">

With changes in this PR,
- It should no longer display down arrow and clicking on it should not do anything.
- Add New popdown button should not be displayed.

**After:**
<img width="234" alt="screenshot_774" src="https://user-images.githubusercontent.com/127594/61076405-02160280-a3d1-11e9-9f68-c4c54c40f0b1.png">

*

Fixes #34600
