### PR TITLE
FSE: Toggle hierarchical to 'false' for taxonomies

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -197,7 +197,7 @@ class Full_Site_Editing {
 				'rest_base'          => 'template_types',
 				'show_tagcloud'      => false,
 				'show_admin_column'  => true,
-				'hierarchical'       => true,
+				'hierarchical'       => false,
 				'rewrite'            => false,
 				'capabilities'       => array(
 					'manage_terms' => 'edit_theme_options',
@@ -237,7 +237,7 @@ class Full_Site_Editing {
 				'rest_base'          => 'template_part_types',
 				'show_tagcloud'      => false,
 				'show_admin_column'  => true,
-				'hierarchical'       => true,
+				'hierarchical'       => false,
 				'rewrite'            => false,
 				'capabilities'       => array(
 					'manage_terms' => 'edit_theme_options',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Implemented based on Headstart's current inability to handle hierarchical taxonomies.

#### Testing instructions

This should not change any functionality, besides being able to assign `wp_template_type` taxonomies to a parent-child relationship.

Part of #33515