### PR TITLE
Don't offer mapping subs for unregistered domains

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -80,6 +80,7 @@ class DomainSearchResults extends React.Component {
 			MAPPABLE,
 			MAPPED,
 			TLD_NOT_SUPPORTED,
+			TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE,
 			TLD_NOT_SUPPORTED_TEMPORARILY,
 			TRANSFERRABLE,
 			UNKNOWN,
@@ -98,6 +99,7 @@ class DomainSearchResults extends React.Component {
 					MAPPABLE,
 					MAPPED,
 					TLD_NOT_SUPPORTED,
+					TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE,
 					TLD_NOT_SUPPORTED_TEMPORARILY,
 					UNKNOWN,
 				],
@@ -108,21 +110,24 @@ class DomainSearchResults extends React.Component {
 			// eslint-disable-next-line jsx-a11y/anchor-is-valid
 			const components = { a: <a href="#" onClick={ this.handleAddMapping } />, small: <small /> };
 
-			if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
-				offer = translate(
-					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}',
-					{ args: { domain }, components }
-				);
-			} else if ( ! domainsWithPlansOnly ) {
-				offer = translate(
-					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}',
-					{ args: { domain, cost: this.props.products.domain_map.cost_display }, components }
-				);
-			} else {
-				offer = translate(
-					'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} with WordPress.com Premium.{{/small}}',
-					{ args: { domain }, components }
-				);
+			// If the domain is available we shouldn't offer to let people purchase mappings for it.
+			if ( TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE === lastDomainStatus ) {
+				if ( isDomainMappingFree( selectedSite ) || isNextDomainFree( this.props.cart ) ) {
+					offer = translate(
+						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for free.{{/small}}',
+						{ args: { domain }, components }
+					);
+				} else if ( ! domainsWithPlansOnly ) {
+					offer = translate(
+						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} for %(cost)s.{{/small}}',
+						{ args: { domain, cost: this.props.products.domain_map.cost_display }, components }
+					);
+				} else {
+					offer = translate(
+						'{{small}}If you purchased %(domain)s elsewhere, you can {{a}}map it{{/a}} with WordPress.com Premium.{{/small}}',
+						{ args: { domain }, components }
+					);
+				}
 			}
 
 			// Domain Mapping not supported for Store NUX yet.

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -52,6 +52,7 @@ export const domainAvailability = {
 	REGISTERED_SAME_SITE: 'registered_on_same_site',
 	RESTRICTED: 'restricted_domain',
 	TLD_NOT_SUPPORTED: 'tld_not_supported',
+	TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE: 'tld_not_supported_and_domain_not_available',
 	TLD_NOT_SUPPORTED_TEMPORARILY: 'tld_not_supported_temporarily',
 	TRANSFER_PENDING: 'transfer_pending',
 	TRANSFER_PENDING_SAME_USER: 'transfer_pending_same_user',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-case-declarations */
+
 /** @format */
 
 /**
@@ -196,6 +198,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 		case domainAvailability.MAPPABLE:
 		case domainAvailability.AVAILABLE:
 		case domainAvailability.TLD_NOT_SUPPORTED:
+		case domainAvailability.TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE:
 		case domainAvailability.TLD_NOT_SUPPORTED_TEMPORARILY:
 		case domainAvailability.UNKNOWN:
 			// unavailable domains are displayed in the search results, not as a notice OR


### PR DESCRIPTION
Currently the domain search results offers users to get a free or paid mapping subscription, even if the name is unregistered. This diff prevents showing the mapping offer in this case.

See D30376-code for the backend change and links to more context.

#### Changes proposed in this Pull Request

* Add a new domain status constant `TLD_NOT_SUPPORTED_AND_NAME_NOT_AVAILABLE`, distinguished from the existing `TLD_NOT_SUPPORTED` (which now indicates that the name is available)
* Handle this constant in `availability-messages.js`
* Use this constant in the domain search results to decide whether or not to offer domain mapping

#### Testing instructions

* See D30376-code for testing instructions.
