### PR TITLE
Action Panel: Allow figure to be left aligned

### DIFF
--- a/client/components/action-panel/README.md
+++ b/client/components/action-panel/README.md
@@ -14,29 +14,53 @@ import ActionPanelFooter from 'components/action-panel/footer';
 import Button from 'components/button';
 
 const ActionPanelExample = ( { translate }) => {
-  return (
-      <ActionPanel>
-        <ActionPanelBody>
-          <ActionPanelFigure inlineBodyText={ true }>
-            <img
-              src="/calypso/images/wordpress/logo-stars.svg"
-              width="170"
-              height="143"
-              alt="WordPress logo"
-            />
-          </ActionPanelFigure>
-          <ActionPanelTitle>Action panel title</ActionPanelTitle>
-          <p>
-            This is a description of the action. It gives a bit more detail and explains what we are
-            inviting the user to do.
-          </p>
-        </ActionPanelBody>
-        <ActionPanelFooter>
-          <Button className="action-panel__support-button" href="/help/contact">
-            Call to action!
-          </Button>
-        </ActionPanelFooter>
-      </ActionPanel>
-  );
+	return (
+		<div>
+			<ActionPanel>
+				<ActionPanelBody>
+					<ActionPanelFigure inlineBodyText={ true }>
+						<img
+							src="/calypso/images/wordpress/logo-stars.svg"
+							width="170"
+							height="143"
+							alt="WordPress logo"
+						/>
+					</ActionPanelFigure>
+					<ActionPanelTitle>Action panel title</ActionPanelTitle>
+					<p>
+						This is a description of the action. It gives a bit more detail and explains what we are
+						inviting the user to do.
+					</p>
+				</ActionPanelBody>
+				<ActionPanelFooter>
+					<Button className="action-panel__support-button" href="/help/contact">
+						Call to action!
+					</Button>
+				</ActionPanelFooter>
+			</ActionPanel>
+			<ActionPanel>
+				<ActionPanelBody>
+					<ActionPanelFigure inlineBodyText={ true } align="left">
+						<img
+							src="/calypso/images/wordpress/logo-stars.svg"
+							width="170"
+							height="143"
+							alt="WordPress logo"
+						/>
+					</ActionPanelFigure>
+					<ActionPanelTitle>Action panel with left aligned image</ActionPanelTitle>
+					<p>
+						This is a description of the action. It gives a bit more detail and explains what we are
+						inviting the user to do.
+					</p>
+					<ActionPanelFooter>
+						<Button className="action-panel__support-button" href="/help/contact">
+							Call to action!
+						</Button>
+					</ActionPanelFooter>
+				</ActionPanelBody>
+			</ActionPanel>
+		</div>
+	);
 }
 ```

--- a/client/components/action-panel/README.md
+++ b/client/components/action-panel/README.md
@@ -10,6 +10,7 @@ import ActionPanel from 'components/action-panel';
 import ActionPanelTitle from 'components/action-panel/title';
 import ActionPanelBody from 'components/action-panel/body';
 import ActionPanelFigure from 'components/action-panel/figure';
+import ActionPanelCta from 'components/action-panel/cta';
 import ActionPanelFooter from 'components/action-panel/footer';
 import Button from 'components/button';
 
@@ -53,11 +54,11 @@ const ActionPanelExample = ( { translate }) => {
 						This is a description of the action. It gives a bit more detail and explains what we are
 						inviting the user to do.
 					</p>
-					<ActionPanelFooter>
+					<ActionPanelCta>
 						<Button className="action-panel__support-button" href="/help/contact">
 							Call to action!
 						</Button>
-					</ActionPanelFooter>
+					</ActionPanelCta>
 				</ActionPanelBody>
 			</ActionPanel>
 		</div>

--- a/client/components/action-panel/cta.jsx
+++ b/client/components/action-panel/cta.jsx
@@ -1,0 +1,14 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import React from 'react';
+import classNames from 'classnames';
+
+const ActionPanelCta = ( { children, className } ) => {
+	return <div className={ classNames( 'action-panel__cta', className ) }>{ children }</div>;
+};
+
+export default ActionPanelCta;

--- a/client/components/action-panel/docs/example.jsx
+++ b/client/components/action-panel/docs/example.jsx
@@ -41,6 +41,30 @@ const ActionPanelExample = () => (
 				</ActionPanelFooter>
 			</ActionPanel>
 		</div>
+		<div>
+			<ActionPanel>
+				<ActionPanelBody>
+					<ActionPanelFigure inlineBodyText={ true } align="left">
+						<img
+							src="/calypso/images/wordpress/logo-stars.svg"
+							width="170"
+							height="143"
+							alt="WordPress logo"
+						/>
+					</ActionPanelFigure>
+					<ActionPanelTitle>Action panel with left aligned image</ActionPanelTitle>
+					<p>
+						This is a description of the action. It gives a bit more detail and explains what we are
+						inviting the user to do.
+					</p>
+					<ActionPanelFooter>
+						<Button className="action-panel__support-button" href="/help/contact">
+							Call to action!
+						</Button>
+					</ActionPanelFooter>
+				</ActionPanelBody>
+			</ActionPanel>
+		</div>
 	</div>
 );
 

--- a/client/components/action-panel/docs/example.jsx
+++ b/client/components/action-panel/docs/example.jsx
@@ -12,9 +12,11 @@ import ActionPanel from 'components/action-panel';
 import ActionPanelTitle from 'components/action-panel/title';
 import ActionPanelBody from 'components/action-panel/body';
 import ActionPanelFigure from 'components/action-panel/figure';
+import ActionPanelCta from 'components/action-panel/cta';
 import ActionPanelFooter from 'components/action-panel/footer';
 import Button from 'components/button';
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 const ActionPanelExample = () => (
 	<div className="design-assets__group">
 		<div>
@@ -57,16 +59,17 @@ const ActionPanelExample = () => (
 						This is a description of the action. It gives a bit more detail and explains what we are
 						inviting the user to do.
 					</p>
-					<ActionPanelFooter>
+					<ActionPanelCta>
 						<Button className="action-panel__support-button" href="/help/contact">
 							Call to action!
 						</Button>
-					</ActionPanelFooter>
+					</ActionPanelCta>
 				</ActionPanelBody>
 			</ActionPanel>
 		</div>
 	</div>
 );
+/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 ActionPanelExample.displayName = 'ActionPanel';
 

--- a/client/components/action-panel/figure.jsx
+++ b/client/components/action-panel/figure.jsx
@@ -8,10 +8,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
-const ActionPanelFigure = ( { inlineBodyText, children } ) => {
+const ActionPanelFigure = ( { inlineBodyText, align, children } ) => {
 	const figureClasses = classNames( {
 		'action-panel__figure': true,
 		'is-inline-body-text': inlineBodyText,
+		'is-aligned-left': 'left' === align,
 	} );
 
 	return <div className={ figureClasses }>{ children }</div>;

--- a/client/components/action-panel/figure.jsx
+++ b/client/components/action-panel/figure.jsx
@@ -11,8 +11,8 @@ import classNames from 'classnames';
 const ActionPanelFigure = ( { inlineBodyText, align, children } ) => {
 	const figureClasses = classNames( {
 		'action-panel__figure': true,
+		[ `align-${ 'left' === align ? 'left' : 'right' }` ]: true,
 		'is-inline-body-text': inlineBodyText,
-		'is-aligned-left': 'left' === align,
 	} );
 
 	return <div className={ figureClasses }>{ children }</div>;

--- a/client/components/action-panel/footer.jsx
+++ b/client/components/action-panel/footer.jsx
@@ -3,11 +3,15 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 
+/**
+ * Internal dependencies
+ */
+import ActionPanelCta from './cta';
+
 const ActionPanelFooter = ( { children } ) => {
-	return <div className="action-panel__footer">{ children }</div>;
+	return <ActionPanelCta className="action-panel__footer">{ children }</ActionPanelCta>;
 };
 
 export default ActionPanelFooter;

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -48,7 +48,13 @@ a.action-panel__body-text-link {
 		margin: 0 0 20px 24px;
 
 		&.is-inline-body-text {
-			margin: 40px 0 20px 24px;
+			margin-top: 40px;
+		}
+
+		&.is-aligned-left {
+			float: left;
+			margin-left: 0;
+			margin-right: 24px;
 		}
 	}
 }
@@ -103,7 +109,13 @@ a.action-panel__body-text-link {
 			right: -24px;
 		}
 	}
+
+	.action-panel__body &::before {
+		background-color: transparent;
+	}
+
 }
+
 
 .action-panel__export-button .gridicon,
 .action-panel__support-button .gridicon {

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -51,7 +51,7 @@ a.action-panel__body-text-link {
 			margin-top: 40px;
 		}
 
-		&.is-aligned-left {
+		&.align-left {
 			float: left;
 			margin-left: 0;
 			margin-right: 24px;
@@ -108,10 +108,6 @@ a.action-panel__body-text-link {
 			left: -24px;
 			right: -24px;
 		}
-	}
-
-	.action-panel__body &::before {
-		background-color: transparent;
 	}
 
 }

--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -91,9 +91,12 @@ a.action-panel__body-text-link {
 }
 
 // Footer
+.action-panel__cta {
+	padding-top: 17px;
+}
+
 .action-panel__footer {
 	position: relative;
-	padding-top: 17px;
 
 	&::before {
 		content: '';


### PR DESCRIPTION
As part of the project to overhaul the 'Earn' section, we need a card format that's similar to the action panel, but has the image on the lefthand side.

This change adds a prop to the figure component, that can be set to `left` or `right`, with a default of right to be consistent with the current behaviour.

#### Testing instructions

Using this branch, navigate to http://calypso.localhost:3000/devdocs/design/action-panel 

The example has been updated with two versions of the component, one with an image on the right, and the other using the new functionality to display it on the left.

#### N.B.

The figure is positioned using floats, which can lead to elements wrapping around the image if it's too small. This can't really be helped without updating the component's HTML. There should probably be a follow-up change to rework this after auditing the use of the `AuditPanel`
