### PR TITLE
Site Settings: Preserve backslashes in custom date/time formats

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -340,6 +340,14 @@ Undocumented.prototype.createInviteValidation = function( siteId, usernamesOrEma
 	);
 };
 
+// Used to preserve backslash in some known settings fields like custom time and date formats.
+function encode_backslash( value ) {
+	if ( typeof value !== 'string' || value.indexOf( '\\' ) === -1 ) {
+		return value;
+	}
+	return value.replace( /\\/g, '\\\\' );
+}
+
 /**
  * GET/POST site settings
  *
@@ -364,6 +372,14 @@ Undocumented.prototype.settings = function( siteId, method = 'get', data = {}, f
 
 	if ( 'get' === method ) {
 		return this.wpcom.req.get( path, { apiVersion }, fn );
+	}
+
+	// special treatment to preserve backslash in date_format
+	if ( body.date_format ) {
+		body.date_format = encode_backslash( body.date_format );
+	}
+	if ( body.time_format ) {
+		body.time_format = encode_backslash( body.time_format );
 	}
 
 	return this.wpcom.req.post( { path }, { apiVersion }, body, fn );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Custom date and time formats can have backslashes which needs to be escaped to be preserved across JSON marshaling. This is already done on the WordPress side when settings values are retrieved.

This PR does the same for Calypso side when `date_format` or `time_format` contains backslash.

#### Testing instructions

1. Navigate to "**My Site** > **Manage** > **Settings** > **Writing**" in Calypso.
2. Expand **Date and Time Format** panel.
3. Select **Custom** date format and enter "j \d\e F Y" like this:

<img width="371" alt="screenshot_777" src="https://user-images.githubusercontent.com/127594/61094260-4621fb00-a403-11e9-8063-6d4d6fb4d0a2.png">

4. Click on **Save Settings** then **Reload** to read back the saved date format.

**Before:**
<img width="274" alt="screenshot_778" src="https://user-images.githubusercontent.com/127594/61094315-8b462d00-a403-11e9-872d-234b2d8dc288.png">

**After:**
<img width="260" alt="screenshot_779" src="https://user-images.githubusercontent.com/127594/61094333-9d27d000-a403-11e9-9680-cd98c1a22870.png">

5. For bonus points, try the same with **Time Format**.
6. For extra bonus points, try the test steps using wp-admin in #32820

*

Fixes #32820
