### PR TITLE
Add brief explanation for Jed configuration data key

### DIFF
--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -56,6 +56,10 @@ class CommunityTranslator extends Component {
 
 	setLanguage() {
 		this.languageJson = i18n.getLocale() || { '': {} };
+		// The '' here is a Jed convention used for storing configuration data
+		// alongside translations in the same dictionary (because '' will never
+		// be a legitimately translatable string)
+		// See https://messageformat.github.io/Jed/
 		const { localeSlug, localeVariant } = this.languageJson[ '' ];
 		this.localeCode = localeVariant || localeSlug;
 		this.currentLocale = find( languages, lang => lang.langSlug === this.localeCode );


### PR DESCRIPTION
This PR adds an explanation for a magic key suggested by @southp in https://github.com/Automattic/wp-calypso/pull/21591/files#r180353663

@southp: Satisfactory?

#### Testing instructions

Comment only, non-semantic change so we just need to check that the comment actually makes sense.

We should also check that we don't increase the size of scripts we ship to browsers, but there's no reason to suppose those processes won't work in this case.
