### PR TITLE
Help: Pre-fill the help message form with NPS survey feedback

### DIFF
--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { debounce, isEqual, find, isEmpty, isArray } from 'lodash';
+import { debounce, isEqual, find, isEmpty, isArray, repeat } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -35,6 +35,7 @@ import { bumpStat, recordTracksEvent, composeAnalytics } from 'state/analytics/a
 import { getCurrentUserLocale } from 'state/current-user/selectors';
 import { isShowingQandAInlineHelpContactForm } from 'state/inline-help/selectors';
 import { showQandAOnInlineHelpContactForm } from 'state/inline-help/actions';
+import { getNpsSurveyFeedback } from 'state/nps-survey/selectors';
 import { generateSubjectFromMessage } from './utils';
 
 /**
@@ -78,6 +79,7 @@ export class HelpContactForm extends React.PureComponent {
 			value: PropTypes.any,
 			requestChange: PropTypes.func.isRequired,
 		} ),
+		npsSurveyFeedback: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -94,6 +96,7 @@ export class HelpContactForm extends React.PureComponent {
 		},
 		showingQandAStep: false,
 		showQandAOnInlineHelpContactForm: () => {},
+		npsSurveyFeedback: '',
 	};
 
 	/**
@@ -108,6 +111,17 @@ export class HelpContactForm extends React.PureComponent {
 		sibylClicked: false,
 		qanda: [],
 	};
+
+	componentWillMount() {
+		const { npsSurveyFeedback, translate } = this.props;
+
+		if ( npsSurveyFeedback ) {
+			this.state.message =
+				'\n' +
+				translate( 'The below comment is copied from your survey response:' ) +
+				`\n${ repeat( '-', 20 ) }\n${ npsSurveyFeedback }`;
+		}
+	}
 
 	componentDidMount() {
 		this.debouncedQandA = debounce( this.doQandASearch, 500 );
@@ -465,6 +479,7 @@ const mapStateToProps = state => ( {
 	helpSite: getHelpSelectedSite( state ),
 	helpSiteId: getHelpSelectedSiteId( state ),
 	showingQandAStep: isShowingQandAInlineHelpContactForm( state ),
+	npsSurveyFeedback: getNpsSurveyFeedback( state ),
 } );
 
 const mapDispatchToProps = {

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -6,7 +6,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { debounce, isEqual, find, isEmpty, isArray, repeat } from 'lodash';
+import { debounce, isEqual, find, isEmpty, isArray } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Gridicon from 'gridicons';
@@ -119,7 +119,7 @@ export class HelpContactForm extends React.PureComponent {
 			this.state.message =
 				'\n' +
 				translate( 'The below comment is copied from your survey response:' ) +
-				`\n${ repeat( '-', 20 ) }\n${ npsSurveyFeedback }`;
+				`\n--------------------\n${ npsSurveyFeedback }`;
 		}
 	}
 

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -118,7 +118,7 @@ export class HelpContactForm extends React.PureComponent {
 		if ( npsSurveyFeedback ) {
 			this.state.message =
 				'\n' +
-				translate( 'The below comment is copied from your survey response:' ) +
+				translate( 'The comment below is copied from your survey response:' ) +
 				`\n--------------------\n${ npsSurveyFeedback }`;
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The help message form is pre-filled with the NPS survey feedback when a user comes from the final page in the NPS popup.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/` page as a logged-in user and run `npsSurvey();` in the browser console to show the NPS popup.
* Set the score a number smaller than 7 and put some text down in the feedback form.
* Click on the `over live chat or email` link.
* The help message form should be pre-filled with your survey feedback as below:
![image](https://user-images.githubusercontent.com/212034/61105975-94dc9d00-a4b6-11e9-825e-e78ad8d4bc0d.png)
