### PR TITLE
getPostRevisions: sort revisions in descending order by ID when timestams are equal

### DIFF
--- a/client/state/selectors/get-post-revisions.js
+++ b/client/state/selectors/get-post-revisions.js
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import { get, orderBy, values } from 'lodash';
+import { get, orderBy } from 'lodash';
 
 /**
  * Internal dependencies
@@ -13,11 +13,8 @@ import createSelector from 'lib/create-selector';
 
 const getPostRevisions = createSelector(
 	( state, siteId, postId ) => {
-		return orderBy(
-			values( get( state.posts.revisions.diffs, [ siteId, postId, 'revisions' ], {} ) ),
-			'post_modified_gmt',
-			'desc'
-		);
+		const revisions = get( state.posts.revisions.diffs, [ siteId, postId, 'revisions' ] );
+		return orderBy( revisions, [ 'post_modified_gmt', 'id' ], [ 'desc', 'desc' ] );
 	},
 	state => [ state.posts.revisions.diffs ]
 );

--- a/client/state/selectors/test/get-post-revisions.js
+++ b/client/state/selectors/test/get-post-revisions.js
@@ -1,88 +1,33 @@
-/** @format */
-
-/**
- * External dependencies
- */
-import { expect } from 'chai';
-
 /**
  * Internal dependencies
  */
 import getPostRevisions from 'state/selectors/get-post-revisions';
 
 describe( 'getPostRevisions', () => {
-	test( 'should return an empty array if there is no revision in the state for `siteId, postId`', () => {
-		expect(
-			getPostRevisions(
-				{
-					posts: {
-						revisions: {
-							12345678: {
-								10: {
-									revisions: {},
-								},
-							},
+	const SITE_ID = 12345678;
+	const POST_ID = 10;
+
+	const stateWithRevisions = revisions => ( {
+		posts: {
+			revisions: {
+				diffs: {
+					[ SITE_ID ]: {
+						[ POST_ID ]: {
+							revisions,
 						},
 					},
 				},
-				12345678,
-				10
-			)
-		).to.eql( [] );
+			},
+		},
+	} );
+
+	test( 'should return an empty array if there is no revision in the state for `siteId, postId`', () => {
+		expect( getPostRevisions( stateWithRevisions( {} ), SITE_ID, POST_ID ) ).toEqual( [] );
 	} );
 
 	test( 'should return a sorted array of revisions', () => {
-		expect(
-			getPostRevisions(
-				{
-					posts: {
-						revisions: {
-							diffs: {
-								12345678: {
-									10: {
-										revisions: {
-											168: {
-												post_date_gmt: '2017-12-12 18:24:37Z',
-												post_modified_gmt: '2017-12-12 18:24:37Z',
-												post_author: '20416304',
-												id: 168,
-												post_content: 'This is a super cool test!\nOh rly? Ya rly',
-												post_excerpt: '',
-												post_title: 'Yet Another Awesome Test Post!',
-											},
-											169: {
-												post_date_gmt: '2017-12-14 18:24:37Z',
-												post_modified_gmt: '2017-12-14 18:24:37Z',
-												post_author: '20416304',
-												id: 169,
-												post_content: 'This is a super duper cool test!\nOh rly? Ya rly',
-												post_excerpt: '',
-												post_title: 'Yet Another Awesome Test Post!',
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-					users: {
-						items: {},
-					},
-				},
-				12345678,
-				10
-			)
-		).to.eql( [
-			{
-				post_date_gmt: '2017-12-14 18:24:37Z',
-				post_modified_gmt: '2017-12-14 18:24:37Z',
-				post_author: '20416304',
-				id: 169,
-				post_content: 'This is a super duper cool test!\nOh rly? Ya rly',
-				post_excerpt: '',
-				post_title: 'Yet Another Awesome Test Post!',
-			},
-			{
+		const revisions = {
+			168: {
 				post_date_gmt: '2017-12-12 18:24:37Z',
 				post_modified_gmt: '2017-12-12 18:24:37Z',
 				post_author: '20416304',
@@ -91,6 +36,31 @@ describe( 'getPostRevisions', () => {
 				post_excerpt: '',
 				post_title: 'Yet Another Awesome Test Post!',
 			},
-		] );
+			169: {
+				post_date_gmt: '2017-12-14 18:24:37Z',
+				post_modified_gmt: '2017-12-14 18:24:37Z',
+				post_author: '20416304',
+				id: 169,
+				post_content: 'This is a super duper cool test!\nOh rly? Ya rly',
+				post_excerpt: '',
+				post_title: 'Yet Another Awesome Test Post!',
+			},
+			170: {
+				// identical to id:169
+				post_date_gmt: '2017-12-14 18:24:37Z',
+				post_modified_gmt: '2017-12-14 18:24:37Z',
+				post_author: '20416304',
+				id: 170,
+				post_content: 'This is a super duper cool test!\nOh rly? Ya rly',
+				post_excerpt: '',
+				post_title: 'Yet Another Awesome Test Post!',
+			},
+		};
+
+		const sortedRevisions = getPostRevisions( stateWithRevisions( revisions ), SITE_ID, POST_ID );
+		const sortedRevisionIds = sortedRevisions.map( revision => revision.id );
+
+		// revisions with the same `post_modified_gmt` timestamp should be further desc-sorted by ID
+		expect( sortedRevisionIds ).toEqual( [ 170, 169, 168 ] );
 	} );
 } );


### PR DESCRIPTION
Post revisions arrive from server in ascending order by ID, and the `getPostRevisions` selector wants to sort them by descending order by timestamp. There was a bug where two revisions with identical timestamp would be sorted in the opposite direction.

Input:
```
[
  { id: 1, post_modified_gmt: '2019-07-12' },
  { id: 2, post_modified_gmt: '2019-07-11' },
  { id: 3, post_modified_gmt: '2019-07-11' }
]
```

Expected order (after bugfix): `1, 3, 2` (descending by timestamp and ID, too)
Actual order (before bugfix): `1, 2, 3`

Practical example is where the `id:1` revision is autosave (most recently modified content,
but reuses old ID of previous autosave) and the `id:2` and `id:3` are identical revisions. Then the latest revision is the autosave (`id:1`), the second latest is `id:3` and the oldest is `id:2`.

The diffs returned by the REST endpoint are "2 to 3" and "3 to 1", and the revision order
needs to match that (it didn't).

**How to test:**
Verify the unit tests are correct and that they pass. Testing in practice is hard: identical revisions should never happen and I discovered this bug by testing a wpcom patch that incorrectly creates two identical revisions. Edge case 🙂 

Part of fix for #20265.