### PR TITLE
Jetpack connect: disable site questions

### DIFF
--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -47,7 +47,7 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
-		"jetpack/connect/site-questions": true,
+		"jetpack/connect/site-questions": false,
 		"jetpack/connection-rebranding": true,
 		"jetpack/happychat": true,
 		"jetpack/onboarding": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -38,7 +38,7 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
 		"jetpack/personalPlan": true,
-		"jetpack/connect/site-questions": true,
+		"jetpack/connect/site-questions": false,
 		"jitms": false,
 		"login/magic-login": false,
 		"login/native-login-links": false,

--- a/config/development.json
+++ b/config/development.json
@@ -71,7 +71,7 @@
 		"jetpack/connect/remote-install": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/woocommerce": true,
-		"jetpack/connect/site-questions": true,
+		"jetpack/connect/site-questions": false,
 		"jetpack/happychat": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -42,7 +42,7 @@
 		"jetpack/api-cache": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
-		"jetpack/connect/site-questions": true,
+		"jetpack/connect/site-questions": false,
 		"jetpack/happychat": true,
 		"jitms": true,
 		"keyboard-shortcuts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -43,7 +43,7 @@
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
-		"jetpack/connect/site-questions": true,
+		"jetpack/connect/site-questions": false,
 		"jetpack/connect/woocommerce": false,
 		"jetpack/happychat": true,
 		"jitms": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -45,7 +45,7 @@
 		"jetpack/connect-redirect-pressable-credential-approval": true,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
-		"jetpack/connect/site-questions": true,
+		"jetpack/connect/site-questions": false,
 		"jetpack/connect/woocommerce": false,
 		"jetpack/happychat": true,
 		"jitms": true,

--- a/config/test.json
+++ b/config/test.json
@@ -40,7 +40,7 @@
 		"help": true,
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/remote-install": true,
-		"jetpack/connect/site-questions": true,
+		"jetpack/connect/site-questions": false,
 		"jetpack/happychat": true,
 		"jitms": true,
 		"login/native-login-links": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -53,7 +53,7 @@
 		"jetpack/concierge-sessions": false,
 		"jetpack/connect/mobile-app-flow": true,
 		"jetpack/connect/remote-install": true,
-		"jetpack/connect/site-questions": true,
+		"jetpack/connect/site-questions": false,
 		"jetpack/connect/woocommerce": false,
 		"jetpack/happychat": true,
 		"jitms": true,

--- a/test/e2e/lib/flows/jetpack-connect-flow.js
+++ b/test/e2e/lib/flows/jetpack-connect-flow.js
@@ -19,9 +19,10 @@ import * as driverManager from '../driver-manager';
 import * as driverHelper from '../driver-helper';
 import * as dataHelper from '../data-helper';
 import JetpackConnectPage from '../pages/jetpack/jetpack-connect-page';
-import JetpackConnectSiteTypePage from '../pages/jetpack/jetpack-connect-site-type-page';
-import JetpackConnectSiteTopicPage from '../pages/jetpack/jetpack-connect-site-topic-page';
-import JetpackConnectUserTypePage from '../pages/jetpack/jetpack-connect-user-type-page';
+// These flows are disabled via `jetpack/connect/site-questions` feature flag in Calypso:
+// import JetpackConnectSiteTypePage from '../pages/jetpack/jetpack-connect-site-type-page';
+// import JetpackConnectSiteTopicPage from '../pages/jetpack/jetpack-connect-site-topic-page';
+// import JetpackConnectUserTypePage from '../pages/jetpack/jetpack-connect-user-type-page';
 import NoticesComponent from '../components/notices-component';
 
 export default class JetpackConnectFlow {
@@ -60,6 +61,8 @@ export default class JetpackConnectFlow {
 		const jetpackAuthorizePage = await JetpackAuthorizePage.Expect( this.driver );
 		await jetpackAuthorizePage.waitToDisappear();
 
+		/* These flows are disabled via `jetpack/connect/site-questions` feature flag in Calypso */
+		/*
 		const siteTypePage = await JetpackConnectSiteTypePage.Expect( this.driver );
 		await siteTypePage.selectSiteType( 'blog' );
 
@@ -68,6 +71,7 @@ export default class JetpackConnectFlow {
 
 		const userTypePage = await JetpackConnectUserTypePage.Expect( this.driver );
 		await userTypePage.selectUserType( 'creator' );
+		*/
 
 		const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 		return await pickAPlanPage.selectFreePlanJetpack();
@@ -88,6 +92,8 @@ export default class JetpackConnectFlow {
 		await jetpackAuthorizePage.approveConnection();
 		await jetpackAuthorizePage.waitToDisappear();
 
+		/* These flows are disabled via `jetpack/connect/site-questions` feature flag in Calypso */
+		/*
 		const siteTypePage = await JetpackConnectSiteTypePage.Expect( this.driver );
 		await siteTypePage.selectSiteType( 'blog' );
 
@@ -96,6 +102,7 @@ export default class JetpackConnectFlow {
 
 		const userTypePage = await JetpackConnectUserTypePage.Expect( this.driver );
 		await userTypePage.selectUserType( 'creator' );
+		*/
 
 		const pickAPlanPage = await PickAPlanPage.Expect( this.driver );
 		return await pickAPlanPage.selectFreePlanJetpack();

--- a/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
+++ b/test/e2e/specs-jetpack-calypso/wp-jetpack-connect-spec.js
@@ -1,8 +1,9 @@
 /**
  * External dependencies
  */
-import config from 'config';
+import { xstep } from 'mocha-steps';
 import assert from 'assert';
+import config from 'config';
 
 /**
  * Internal dependencies
@@ -109,17 +110,20 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 			return await jetpackAuthorizePage.waitToDisappear();
 		} );
 
-		step( 'Can select a site type', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a site type', async function() {
 			const siteTypePage = await JetpackConnectSiteTypePage.Expect( driver );
 			return await siteTypePage.selectSiteType( 'blog' );
 		} );
 
-		step( 'Can select a site topic', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a site topic', async function() {
 			const siteTopicPage = await JetpackConnectSiteTopicPage.Expect( driver );
 			return await siteTopicPage.selectSiteTopic( 'test site' );
 		} );
 
-		step( 'Can select a user type', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a user type', async function() {
 			const userTypePage = await JetpackConnectUserTypePage.Expect( driver );
 			return await userTypePage.selectUserType( 'creator' );
 		} );
@@ -173,17 +177,20 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 			return await jetpackAuthorizePage.approveConnection();
 		} );
 
-		step( 'Can select a site type', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a site type', async function() {
 			const siteTypePage = await JetpackConnectSiteTypePage.Expect( driver );
 			return await siteTypePage.selectSiteType( 'blog' );
 		} );
 
-		step( 'Can select a site topic', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a site topic', async function() {
 			const siteTopicPage = await JetpackConnectSiteTopicPage.Expect( driver );
 			return await siteTopicPage.selectSiteTopic( 'test site' );
 		} );
 
-		step( 'Can select a user type', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a user type', async function() {
 			const userTypePage = await JetpackConnectUserTypePage.Expect( driver );
 			return await userTypePage.selectUserType( 'creator' );
 		} );
@@ -334,17 +341,20 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 			return await jetpackAuthorizePage.waitToDisappear();
 		} );
 
-		step( 'Can select a site type', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a site type', async function() {
 			const siteTypePage = await JetpackConnectSiteTypePage.Expect( driver );
 			return await siteTypePage.selectSiteType( 'blog' );
 		} );
 
-		step( 'Can select a site topic', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a site topic', async function() {
 			const siteTopicPage = await JetpackConnectSiteTopicPage.Expect( driver );
 			return await siteTopicPage.selectSiteTopic( 'test site' );
 		} );
 
-		step( 'Can select a user type', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a user type', async function() {
 			const userTypePage = await JetpackConnectUserTypePage.Expect( driver );
 			return await userTypePage.selectUserType( 'creator' );
 		} );
@@ -449,17 +459,20 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 			return await jetpackAuthorizePage.approveConnection();
 		} );
 
-		step( 'Can select a site type', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a site type', async function() {
 			const siteTypePage = await JetpackConnectSiteTypePage.Expect( driver );
 			return await siteTypePage.selectSiteType( 'blog' );
 		} );
 
-		step( 'Can select a site topic', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a site topic', async function() {
 			const siteTopicPage = await JetpackConnectSiteTopicPage.Expect( driver );
 			return await siteTopicPage.selectSiteTopic( 'test site' );
 		} );
 
-		step( 'Can select a user type', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a user type', async function() {
 			const userTypePage = await JetpackConnectUserTypePage.Expect( driver );
 			return await userTypePage.selectUserType( 'creator' );
 		} );
@@ -522,17 +535,20 @@ describe( `Jetpack Connect: (${ screenSize })`, function() {
 			return await jetpackAuthorizePage.waitToDisappear();
 		} );
 
-		step( 'Can select a site type', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a site type', async function() {
 			const siteTypePage = await JetpackConnectSiteTypePage.Expect( driver );
 			return await siteTypePage.selectSiteType( 'blog' );
 		} );
 
-		step( 'Can select a site topic', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a site topic', async function() {
 			const siteTopicPage = await JetpackConnectSiteTopicPage.Expect( driver );
 			return await siteTopicPage.selectSiteTopic( 'test site' );
 		} );
 
-		step( 'Can select a user type', async function() {
+		// This step is controlled by `jetpack/connect/site-questions` feature flag in Calypso
+		xstep( 'Can select a user type', async function() {
 			const userTypePage = await JetpackConnectUserTypePage.Expect( driver );
 			return await userTypePage.selectUserType( 'creator' );
 		} );


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/34506

The previous PR added the flag — this PR actually disable the flow.

Context paObgF-k1-p2

<img src="https://user-images.githubusercontent.com/87168/60793477-743bdc80-a170-11e9-8882-21b8b3c3573b.png" alt="Jetpack connect steps" width="450" />

#### Changes proposed in this Pull Request

* Disable `jetpack/connect/site-questions` feature flag in all environments
* Disable E2E tests related to these steps

#### Testing instructions

- Create a new Jetpack site and connect it to .com using localhost.
- All three questions are gone?