### PR TITLE
Rewind State: Add alerts & threats to redux state

### DIFF
--- a/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
+++ b/client/state/data-layer/wpcom/sites/rewind/api-transformer.js
@@ -70,6 +70,7 @@ export function transformApi( data ) {
 		data.credentials && { credentials: data.credentials.map( transformCredential ) },
 		data.downloads && { downloads: data.downloads.map( transformDownload ) },
 		data.reason && { reason: data.reason },
-		data.rewind && { rewind: transformRewind( data.rewind ) }
+		data.rewind && { rewind: transformRewind( data.rewind ) },
+		data.alerts && { alerts: data.alerts }
 	);
 }

--- a/client/state/data-layer/wpcom/sites/rewind/schema.js
+++ b/client/state/data-layer/wpcom/sites/rewind/schema.js
@@ -55,6 +55,21 @@ export const rewind = {
 	required: [ 'restore_id', 'rewind_id', 'status' ],
 };
 
+export const threat = {
+	type: 'object',
+	properties: {
+		id: { type: 'integer' },
+		signature: { type: 'string' },
+		description: { type: 'string' },
+		first_detected: { type: 'string' },
+		fixable: { oneOf: [ { type: 'boolean' }, { type: 'object' } ] },
+		status: { type: 'string', enum: [ 'current', 'fixed', 'in_progress' ] },
+		filename: { type: 'string' },
+		context: { type: 'object' },
+		extension: { type: 'object' },
+	},
+};
+
 export const unavailable = stateSchema( 'unavailable', {
 	type: 'object',
 	properties: {
@@ -130,6 +145,12 @@ export const active = stateSchema( 'active', {
 			items: download,
 		},
 		rewind,
+		alerts: {
+			type: 'object',
+			items: {
+				threats: { type: threat },
+			},
+		},
 		last_updated: { oneOf: [ { type: 'integer' }, { type: 'string', format: 'date-time' } ] },
 	},
 	required: [ 'state', 'last_updated' ],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR takes advantage of the addition of alerts/threats contained in the state machine responses in  D30397-code and adds that data to redux state so that it's available in the activity log without an additional network request to `/wpcom/{blog_id}/alerts`.

Now that we have the alerts/threats data in the state machine response, we can use subproperties of this object to manipulate the UI. The `status` property can be manipulated to show a spinner while fixing is in progress. The `fixable` property can be used to determine whether to show the "fix" button or not. Etc, etc.

#### Testing instructions

1. Apply D30397-code to your wpcom sandbox and sandbox the API from your local machine.
2. Boot up this PR and navigate to the activity log of a site with one or more active threats.
3. Head to your browser console and inspect the `state.rewind[blog_id]` object. You should see a list of threats inside the `alerts` property.
4. Ensure nothing backup/restore related is negatively affected.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
