### PR TITLE
Add localization

### DIFF
--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -44,7 +44,6 @@ class ExternalLink extends Component {
 				'has-icon': !! this.props.icon,
 			}
 		);
-
 		const props = assign(
 			{},
 			omit( this.props, 'icon', 'iconSize', 'showIconFirst', 'iconClassName' ),
@@ -53,8 +52,6 @@ class ExternalLink extends Component {
 				rel: 'external',
 			}
 		);
-
-		const { translate } = this.props;
 
 		if ( this.props.icon ) {
 			props.target = '_blank';
@@ -81,7 +78,7 @@ class ExternalLink extends Component {
 					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 					<span className="screen-reader-text">
 						{ /* translators: accessibility text */
-						translate( '(opens in a new tab)' ) }
+						this.props.translate( '(opens in a new tab)' ) }
 					</span>
 				) }
 			</a>

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { assign, omit } from 'lodash';
 import Gridicon from 'gridicons';
-import { localize } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 
 /**
  * Style dependencies
@@ -31,7 +31,6 @@ class ExternalLink extends Component {
 		target: PropTypes.string,
 		showIconFirst: PropTypes.bool,
 		iconClassName: PropTypes.string,
-		translate: PropTypes.func,
 	};
 
 	render() {
@@ -79,11 +78,11 @@ class ExternalLink extends Component {
 					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 					<span className="screen-reader-text">
 						{ /* translators: accessibility text */
-						this.props.translate( '(opens in a new tab)' ) }
+						translate( '(opens in a new tab)' ) }
 					</span>
 				) }
 			</a>
 		);
 	}
 }
-export default localize( ExternalLink );
+export default ExternalLink;

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -31,6 +31,7 @@ class ExternalLink extends Component {
 		target: PropTypes.string,
 		showIconFirst: PropTypes.bool,
 		iconClassName: PropTypes.string,
+		translate: PropTypes.func,
 	};
 
 	render() {

--- a/client/components/external-link/index.jsx
+++ b/client/components/external-link/index.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { assign, omit } from 'lodash';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Style dependencies
@@ -43,6 +44,7 @@ class ExternalLink extends Component {
 				'has-icon': !! this.props.icon,
 			}
 		);
+
 		const props = assign(
 			{},
 			omit( this.props, 'icon', 'iconSize', 'showIconFirst', 'iconClassName' ),
@@ -51,6 +53,8 @@ class ExternalLink extends Component {
 				rel: 'external',
 			}
 		);
+
+		const { translate } = this.props;
 
 		if ( this.props.icon ) {
 			props.target = '_blank';
@@ -76,14 +80,12 @@ class ExternalLink extends Component {
 				{ this.props.icon && (
 					// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 					<span className="screen-reader-text">
-						{
-							/* translators: accessibility text */
-							'(opens in a new tab)'
-						}
+						{ /* translators: accessibility text */
+						translate( '(opens in a new tab)' ) }
 					</span>
 				) }
 			</a>
 		);
 	}
 }
-export default ExternalLink;
+export default localize( ExternalLink );

--- a/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
@@ -27,13 +27,9 @@ exports[`GSuiteUserItem renders user item with manage correctly 1`] = `
   <a
     className="external-link gsuite-user-item has-icon"
     href="https://accounts.google.com/AccountChooser?Email=foo@bar.buzz&service=CPanel&continue=https://admin.google.com/a/bar.buzz"
-    locale="en"
-    moment={[Function]}
-    numberFormat={[Function]}
     onClick={[Function]}
     rel="external noopener noreferrer"
     target="_blank"
-    translate={[Function]}
   >
     Manage
     <svg

--- a/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
+++ b/client/my-sites/email/email-management/gsuite-user-item/test/__snapshots__/index.js.snap
@@ -27,9 +27,13 @@ exports[`GSuiteUserItem renders user item with manage correctly 1`] = `
   <a
     className="external-link gsuite-user-item has-icon"
     href="https://accounts.google.com/AccountChooser?Email=foo@bar.buzz&service=CPanel&continue=https://admin.google.com/a/bar.buzz"
+    locale="en"
+    moment={[Function]}
+    numberFormat={[Function]}
     onClick={[Function]}
     rel="external noopener noreferrer"
     target="_blank"
+    translate={[Function]}
   >
     Manage
     <svg


### PR DESCRIPTION
Wrapped accessibility text in translate

#### Changes proposed in this Pull Request

Wrapped ExternalLink screen reader text in `translate`.
Updated gsuite-user-item snapshot

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Switch to add-translate-callout branch.
2. Navigate to http://calypso.localhost:3000/following/manage
3. Verify external links work as expected. 

Fixes #34586 