### PR TITLE
Post Actions: Sharing - Hide for Contributors

### DIFF
--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/share.jsx
@@ -17,6 +17,8 @@ import { bumpStatGenerator } from './utils';
 import { getPost } from 'state/posts/selectors';
 import { toggleSharePanel } from 'state/ui/post-type-list/actions';
 import isPublicizeEnabled from 'state/selectors/is-publicize-enabled';
+import canCurrentUser from 'state/selectors/can-current-user';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 class PostActionsEllipsisMenuShare extends Component {
 	static propTypes = {
@@ -42,8 +44,8 @@ class PostActionsEllipsisMenuShare extends Component {
 	}
 
 	render() {
-		const { translate, status, type, isPublicizeEnabled: isPublicizeEnabledForSite } = this.props;
-		if ( 'publish' !== status || ! isPublicizeEnabledForSite || 'post' !== type ) {
+		const { canShare, translate, status, type, isPublicizeEnabled: isPublicizeEnabledForSite } = this.props;
+		if ( 'publish' !== status || ! isPublicizeEnabledForSite || 'post' !== type || ! canShare ) {
 			return null;
 		}
 
@@ -65,6 +67,7 @@ const mapStateToProps = ( state, { globalId } ) => {
 		status: post.status,
 		type: post.type,
 		isPublicizeEnabled: isPublicizeEnabled( state, post.site_ID, post.type ),
+		canShare: canCurrentUser( state, getSelectedSiteId( state ), 'publish_posts' ),
 	};
 };
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Noticed whilst working on #34597, contributors can't set up Publicize: https://en.support.wordpress.com/publicize/

> If you’re a Contributor for a blog, you cannot use Publicize.

Clicking the "Publicize" link takes contributors to the Marketing page where an error appears and the flow breaks.

<img width="717" alt="Screenshot 2019-07-12 at 23 13 03" src="https://user-images.githubusercontent.com/43215253/61161185-acd61000-a4fa-11e9-80f6-af50cd25dbf8.png">

So this just hides that for contributors.

#### Testing instructions

1. Visit the posts page of a site as both a contributor and not
2. Click the ellipses menu next to a published post
<img width="245" alt="Screenshot 2019-07-12 at 23 14 50" src="https://user-images.githubusercontent.com/43215253/61161227-dd1dae80-a4fa-11e9-8be1-1cd6b8194c9e.png">

3. Verify "Sharing" doesn't appear as a contributor

**Author and above:**

<img width="233" alt="Screenshot 2019-07-12 at 23 11 13" src="https://user-images.githubusercontent.com/43215253/61161247-ee66bb00-a4fa-11e9-84cf-a73b869af8df.png">

**Contributor:**

<img width="265" alt="Screenshot 2019-07-12 at 23 10 58" src="https://user-images.githubusercontent.com/43215253/61161253-f7578c80-a4fa-11e9-9d90-07992209f60a.png">
