### PR TITLE
Editor/Media: Handle contributor upload gracefully

### DIFF
--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
 import Gridicon from 'gridicons';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -16,9 +17,8 @@ import analytics from 'lib/analytics';
 import DropZone from 'components/drop-zone';
 import MediaActions from 'lib/media/actions';
 import { userCan } from 'lib/site/utils';
-import { translate } from 'i18n-calypso';
 
-export default class extends React.Component {
+class MediaLibraryDropZone extends React.Component {
 	static displayName = 'MediaLibraryDropZone';
 
 	static propTypes = {
@@ -72,7 +72,8 @@ export default class extends React.Component {
 	};
 
 	render() {
-		const canUploadFiles = userCan( 'upload_files', this.props.site );
+		const { site, fullScreen, translate } = this.props;
+		const canUploadFiles = userCan( 'upload_files', site );
 		const textLabel = ! canUploadFiles
 			? translate( 'You are not authorized to upload files to this site' )
 			: null;
@@ -83,7 +84,7 @@ export default class extends React.Component {
 		);
 		return (
 			<DropZone
-				fullScreen={ this.props.fullScreen }
+				fullScreen={ fullScreen }
 				onVerifyValidTransfer={ this.isValidTransfer }
 				onFilesDrop={ this.uploadFiles }
 				textLabel={ textLabel }
@@ -92,3 +93,5 @@ export default class extends React.Component {
 		);
 	}
 }
+
+export default localize( MediaLibraryDropZone );

--- a/client/my-sites/media-library/drop-zone.jsx
+++ b/client/my-sites/media-library/drop-zone.jsx
@@ -7,6 +7,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { noop } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -15,6 +16,7 @@ import analytics from 'lib/analytics';
 import DropZone from 'components/drop-zone';
 import MediaActions from 'lib/media/actions';
 import { userCan } from 'lib/site/utils';
+import { translate } from 'i18n-calypso';
 
 export default class extends React.Component {
 	static displayName = 'MediaLibraryDropZone';
@@ -33,7 +35,7 @@ export default class extends React.Component {
 	};
 
 	uploadFiles = files => {
-		if ( ! this.props.site ) {
+		if ( ! this.props.site || ! userCan( 'upload_files', this.props.site ) ) {
 			return;
 		}
 
@@ -70,15 +72,22 @@ export default class extends React.Component {
 	};
 
 	render() {
-		if ( ! userCan( 'upload_files', this.props.site ) ) {
-			return null;
-		}
-
+		const canUploadFiles = userCan( 'upload_files', this.props.site );
+		const textLabel = ! canUploadFiles
+			? translate( 'You are not authorized to upload files to this site' )
+			: null;
+		const icon = ! canUploadFiles ? (
+			<Gridicon icon="cross" size={ 48 } />
+		) : (
+			<Gridicon icon="cloud-upload" size={ 48 } />
+		);
 		return (
 			<DropZone
 				fullScreen={ this.props.fullScreen }
 				onVerifyValidTransfer={ this.isValidTransfer }
 				onFilesDrop={ this.uploadFiles }
+				textLabel={ textLabel }
+				icon={ icon }
 			/>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Contributors cannot upload files but MediaLibraryDropZone component, used by both Media Library and Classic Editor, currently just return null if user does not have permission to upload files. This has the side effect of other drop zones, like featured image side-widget, highlighting.

When user does not have file upload permission, this PR overrides DropZone to:

1. Display an error message along with appropriate icon when user drags a file over.
2. Ignore if files are actually dropped.

#### Testing instructions

1. Using **Classic Editor**, create a post as **Contributor**.
2. Drag a file over content being edited.

**Before**: 
> No drop zone over content will appear.

**After**: 
> <img width="894" alt="screenshot_782" src="https://user-images.githubusercontent.com/127594/61162690-9316d780-a4be-11e9-85b8-6e677a54aa8e.png">

3. Dropping the file should not do anything.

4. Click on **Media** menu item from the **+ Add** popup menu.
5. Drag a file over **Media Library modal** when it appears.

**Before**: 
> No drop zone over modal will appear.

**After**: 
> <img width="902" alt="screenshot_781" src="https://user-images.githubusercontent.com/127594/61162733-ed179d00-a4be-11e9-89d0-2d1f6728b3f2.png">

6. Dropping the file should not do anything.

Fixes #33533
