### PR TITLE
Analytics: replace chai with Jest in unit tests

### DIFF
--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import url from 'url';
 
 /**
@@ -61,9 +60,9 @@ describe( 'Analytics', () => {
 	describe( 'mc', () => {
 		test( 'bumpStat with group and stat', () => {
 			analytics.mc.bumpStat( 'go', 'time' );
-			expect( imagesLoaded[ 0 ].query.v ).to.eql( 'wpcom-no-pv' );
-			expect( imagesLoaded[ 0 ].query.x_go ).to.eql( 'time' );
-			expect( imagesLoaded[ 0 ].query.t ).to.be.ok;
+			expect( imagesLoaded[ 0 ].query.v ).toEqual( 'wpcom-no-pv' );
+			expect( imagesLoaded[ 0 ].query.x_go ).toEqual( 'time' );
+			expect( imagesLoaded[ 0 ].query.t ).toBeTruthy();
 		} );
 
 		test( 'bumpStat with value object', () => {
@@ -71,17 +70,17 @@ describe( 'Analytics', () => {
 				go: 'time',
 				another: 'one',
 			} );
-			expect( imagesLoaded[ 0 ].query.v ).to.eql( 'wpcom-no-pv' );
-			expect( imagesLoaded[ 0 ].query.x_go ).to.eql( 'time' );
-			expect( imagesLoaded[ 0 ].query.x_another ).to.eql( 'one' );
-			expect( imagesLoaded[ 0 ].query.t ).to.be.ok;
+			expect( imagesLoaded[ 0 ].query.v ).toEqual( 'wpcom-no-pv' );
+			expect( imagesLoaded[ 0 ].query.x_go ).toEqual( 'time' );
+			expect( imagesLoaded[ 0 ].query.x_another ).toEqual( 'one' );
+			expect( imagesLoaded[ 0 ].query.t ).toBeTruthy();
 		} );
 
 		test( 'bumpStatWithPageView with group and stat', () => {
 			analytics.mc.bumpStatWithPageView( 'go', 'time' );
-			expect( imagesLoaded[ 0 ].query.v ).to.eql( 'wpcom' );
-			expect( imagesLoaded[ 0 ].query.go ).to.eql( 'time' );
-			expect( imagesLoaded[ 0 ].query.t ).to.be.ok;
+			expect( imagesLoaded[ 0 ].query.v ).toEqual( 'wpcom' );
+			expect( imagesLoaded[ 0 ].query.go ).toEqual( 'time' );
+			expect( imagesLoaded[ 0 ].query.t ).toBeTruthy();
 		} );
 
 		test( 'bumpStatWithPageView with value object', () => {
@@ -89,10 +88,10 @@ describe( 'Analytics', () => {
 				go: 'time',
 				another: 'one',
 			} );
-			expect( imagesLoaded[ 0 ].query.v ).to.eql( 'wpcom' );
-			expect( imagesLoaded[ 0 ].query.go ).to.eql( 'time' );
-			expect( imagesLoaded[ 0 ].query.another ).to.eql( 'one' );
-			expect( imagesLoaded[ 0 ].query.t ).to.be.ok;
+			expect( imagesLoaded[ 0 ].query.v ).toEqual( 'wpcom' );
+			expect( imagesLoaded[ 0 ].query.go ).toEqual( 'time' );
+			expect( imagesLoaded[ 0 ].query.another ).toEqual( 'one' );
+			expect( imagesLoaded[ 0 ].query.t ).toBeTruthy();
 		} );
 	} );
 } );

--- a/client/lib/analytics/test/statsd.js
+++ b/client/lib/analytics/test/statsd.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import { expect } from 'chai';
 import url from 'url';
 
 /**
@@ -15,9 +14,9 @@ describe( 'StatsD Analytics', () => {
 	describe( 'statsdTimingUrl', () => {
 		test( 'returns a URL for recording timing data to statsd', () => {
 			const sdUrl = url.parse( statsdTimingUrl( 'post-mysite.com', 'page-load', 150 ), true, true );
-			expect( sdUrl.query.v ).to.eql( 'calypso' );
-			expect( sdUrl.query.u ).to.eql( 'post_mysite_com' );
-			expect( sdUrl.query.json ).to.eql(
+			expect( sdUrl.query.v ).toEqual( 'calypso' );
+			expect( sdUrl.query.u ).toEqual( 'post_mysite_com' );
+			expect( sdUrl.query.json ).toEqual(
 				JSON.stringify( {
 					beacons: [ 'calypso.development.post_mysite_com.page_load:150|ms' ],
 				} )


### PR DESCRIPTION
## Changes proposed in this Pull Request

A janitorial tidbit to prepare for an alternative solution to https://github.com/Automattic/wp-calypso/pull/32850, which we reverted in https://github.com/Automattic/wp-calypso/pull/34471.

We're removing chai from the unit tests, and replacing expectation methods with Jest.

## Did you know?

"Die Hard", starring Bruce Willis and Alan Rickman is released in the US on this day in 1988

## Testing instructions

`npm run test-client client/lib/analytics`
