### PR TITLE
Signup: Alias anonUserId to WPCOM user id when user is created 

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -781,17 +781,16 @@ const analytics = {
 		},
 	},
 
-	identifyUser: function( user = _user, newUserId = '', newUserName = '' ) {
+	identifyUser: function( user = _user ) {
 		const anonymousUserId = this.tracks.anonymousUserId();
 
 		// Don't identify the user if we don't have one
-		if ( ( user && user.initialized ) || ( newUserId && newUserName ) ) {
+		if ( user && user.initialized ) {
 			if ( anonymousUserId ) {
 				recordAliasInFloodlight();
 			}
 
-			const userId = newUserId || user.get().ID;
-			const userName = newUserName || user.get().username;
+			const { ID: userId, username: userName } = user.get();
 
 			window._tkq.push( [ 'identifyUser', userId, userName ] );
 		}

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -781,16 +781,19 @@ const analytics = {
 		},
 	},
 
-	identifyUser: function() {
+	identifyUser: function( user = _user, newUserId = '', newUserName = '' ) {
 		const anonymousUserId = this.tracks.anonymousUserId();
 
 		// Don't identify the user if we don't have one
-		if ( _user && _user.initialized ) {
+		if ( ( user && user.initialized ) || ( newUserId && newUserName ) ) {
 			if ( anonymousUserId ) {
 				recordAliasInFloodlight();
 			}
 
-			window._tkq.push( [ 'identifyUser', _user.get().ID, _user.get().username ] );
+			const userId = newUserId || user.get().ID;
+			const userName = newUserName || user.get().username;
+
+			window._tkq.push( [ 'identifyUser', userId, userName ] );
 		}
 	},
 

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -122,12 +122,5 @@ describe( 'Analytics', () => {
 			expect( userMock.get ).toBeCalled();
 			expect( window._tkq.push ).toBeCalledWith( [ 'identifyUser', '007', 'james' ] );
 		} );
-
-		test( 'should call window._tkq.push and recordAliasInFloodlight when user info is passed as arguments', () => {
-			analytics.identifyUser( null, '123', 'oneTwoThree' );
-			expect( recordAliasInFloodlight ).toBeCalled();
-			expect( window._tkq.push ).toBeCalledWith( [ 'identifyUser', '123', 'oneTwoThree' ] );
-		} );
 	} );
-
 } );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -257,9 +257,6 @@ export function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
 }
 
 export function fetchUser( userInstance = user ) {
-	userInstance.fetching = false;
-	userInstance.fetch();
-
 	// @TODO: When user fetching is reduxified, let's get rid of this hack.
 	return new Promise( resolve => {
 		const userFetched = setInterval( () => {
@@ -540,6 +537,8 @@ export function createAccount(
 
 				// Fire after a new user registers.
 				analytics.recordRegistration();
+
+				// Try to fetch the user so we can track the newly-created account
 				fetchUser( user ).then( () => {
 					analytics.setUser( user );
 					analytics.identifyUser();

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -166,6 +166,9 @@ User.prototype.fetch = function() {
  * @param {Error} error network response error
  */
 User.prototype.handleFetchFailure = function( error ) {
+	// Release lock from subsequent fetches
+	this.fetching = false;
+
 	if ( ! config.isEnabled( 'wpcom-user-bootstrap' ) && error.error === 'authorization_required' ) {
 		/**
 		 * if the user bootstrap is disabled (in development), we need to rely on a request to


### PR DESCRIPTION
## Changes proposed in this Pull Request

Reworks https://github.com/Automattic/wp-calypso/pull/32850, which we reverted in https://github.com/Automattic/wp-calypso/pull/34471.

> When people visit WordPress.com before they sign up, we associate their Tracks events with an anonymous user id that’s stored in their cookies. In theory once they create an account, we’re supposed to alias/connect their anonymous user id to their actual user id so that we know which events those users fired before signing up.

Background: p3Ex-3vP-p2

## Testing instructions

Open dev tools and in the Network tab, search for “alias”

 Go through the onboarding flow. 

`t.gif` (the pixel we load to alias the user) should load immediately after the user is created and we have a user id available to alias.

<img width="832" alt="Screen Shot 2019-06-22 at 10 41 27 am" src="https://user-images.githubusercontent.com/6458278/59961610-6a607b00-94da-11e9-9fc7-f6e382c0c077.png">

E.g.,

![Jun-22-2019 10-40-42](https://user-images.githubusercontent.com/6458278/59961620-751b1000-94da-11e9-837d-e6aff86f1247.gif)


Fixes https://github.com/Automattic/zelda-private/issues/105
