### PR TITLE
Simplify the reducer helper function `removeMissingPurchasesByPredicate`

### DIFF
--- a/client/state/purchases/reducer.js
+++ b/client/state/purchases/reducer.js
@@ -61,20 +61,9 @@ function overwriteExistingPurchases( existingPurchases, newPurchases ) {
  * @return {array} An array of purchases
  */
 function removeMissingPurchasesByPredicate( existingPurchases, newPurchases, predicate ) {
-	return existingPurchases.filter( purchase => {
-		if ( matches( predicate )( purchase ) && find( newPurchases, { ID: purchase.ID } ) ) {
-			// this purchase is present in the new array
-			return true;
-		}
-
-		if ( ! matches( predicate )( purchase ) ) {
-			// only overwrite remove purchases that match the predicate
-			return true;
-		}
-
-		// the purchase doesn't match the predicate or is missing from the array of new purchases
-		return false;
-	} );
+	return existingPurchases.filter(
+		purchase => ! matches( predicate )( purchase ) || find( newPurchases, { ID: purchase.ID } )
+	);
 }
 
 function updatePurchases( existingPurchases, action ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is a janitorial PR that simplifies `removeMissingPurchasesByPredicate()`. No functionality change should be introduced. 

We can show that the logic will be the same after simplification by a truth table:

Given `matches( predicate )( purchase )` as A, `find( purchases, { ID: purchase.ID} )` as B. `current` as the return value of the filter function, `simplified` as the one after simplification.

|    A/B  | current | simplified |
|-------|-------- |-----------|
|   T/T    |       T     |    T            |
|   T/F    |        F    |    F            |
|   F/T    | T           | T               |
|   F/F    |T            |T                 |

#### Testing instructions

`npm test-client state/purchases` should pass.
