### PR TITLE
Update website signup flow to match onboarding steps

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -93,10 +93,18 @@ export function generateFlows( {
 		},
 
 		website: {
-			steps: [ 'user', 'website-themes', 'domains', 'plans' ],
-			destination: getSiteDestination,
-			description: 'Signup flow starting with website themes',
-			lastModified: '2017-09-01',
+			steps: [
+				'user',
+				'site-type-website',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'site-style-with-preview',
+				'domains-with-preview',
+				'plans',
+			],
+			destination: getChecklistDestination,
+			description: 'Signup flow for a website, hiding blog site type',
+			lastModified: '2019-07-15',
 		},
 
 		'rebrand-cities': {

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -38,6 +38,7 @@ const stepNameToModuleName = {
 	'site-title-without-domains': 'site-title',
 	'site-topic': 'site-topic',
 	'site-type': 'site-type',
+	'site-type-website': 'site-type',
 	survey: 'survey',
 	'survey-user': 'survey-user',
 	test: 'test-step',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -437,6 +437,15 @@ export function generateSteps( {
 			fulfilledStepCallback: isSiteTypeFulfilled,
 		},
 
+		'site-type-website': {
+			stepName: 'site-type-website',
+			providesDependencies: [ 'siteType', 'themeSlugWithRepo' ],
+			fulfilledStepCallback: isSiteTypeFulfilled,
+			props: {
+				hideBlogSiteType: true,
+			},
+		},
+
 		'site-topic': {
 			stepName: 'site-topic',
 			providesDependencies: [ 'siteTopic' ],

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -41,26 +41,29 @@ class SiteTypeForm extends Component {
 		return (
 			<Fragment>
 				<Card className="site-type__wrapper">
-					{ getAllSiteTypes().map( siteTypeProperties => (
-						<Card
-							className="site-type__option"
-							key={ siteTypeProperties.id }
-							tagName="button"
-							displayAsLink
-							data-e2e-title={ siteTypeProperties.slug }
-							onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
-						>
-							<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
-							<span className="site-type__option-description">
-								{ siteTypeProperties.description }
-							</span>
-							{ ! this.props.isJetpack && siteTypeProperties.purchaseRequired && (
-								<Badge className="site-type__option-badge" type="info">
-									{ this.props.translate( 'Purchase required' ) }
-								</Badge>
-							) }
-						</Card>
-					) ) }
+					{ getAllSiteTypes().map(
+						siteTypeProperties =>
+							! ( this.props.hideBlogSiteType && siteTypeProperties.slug === 'blog' ) && (
+								<Card
+									className="site-type__option"
+									key={ siteTypeProperties.id }
+									tagName="button"
+									displayAsLink
+									data-e2e-title={ siteTypeProperties.slug }
+									onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
+								>
+									<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
+									<span className="site-type__option-description">
+										{ siteTypeProperties.description }
+									</span>
+									{ ! this.props.isJetpack && siteTypeProperties.purchaseRequired && (
+										<Badge className="site-type__option-badge" type="info">
+											{ this.props.translate( 'Purchase required' ) }
+										</Badge>
+									) }
+								</Card>
+							)
+					) }
 				</Card>
 			</Fragment>
 		);

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -51,6 +51,7 @@ class SiteType extends Component {
 			stepName,
 			translate,
 			hasInitializedSitesBackUrl,
+			hideBlogSiteType,
 		} = this.props;
 
 		const headerText = translate( 'What kind of site are you building?' );
@@ -68,7 +69,13 @@ class SiteType extends Component {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
-				stepContent={ <SiteTypeForm submitForm={ this.submitStep } siteType={ siteType } /> }
+				stepContent={
+					<SiteTypeForm
+						submitForm={ this.submitStep }
+						siteType={ siteType }
+						hideBlogSiteType={ hideBlogSiteType }
+					/>
+				}
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }
 				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to My Sites' ) : null }


### PR DESCRIPTION
This change also provides a new step called `site-type-website` which is exactly the same as `site-type` except that it passes in a prop to the `siteType` component to conditionally hide the blog site type.

***Note: this is a draft PR because the back button behaviour doesn't seem to play nicely with the different site-type step. This is an existing issue: https://github.com/Automattic/wp-calypso/issues/32506***

Also, this approach doesn't play nicely with switching flows to `onboarding-ecommerce`, as it has a different step for `site-type`, so I may need to rethink the approach for hiding the site type.

Normal `site-type` step

![image](https://user-images.githubusercontent.com/14988353/61204313-33bffe00-a730-11e9-8f43-4ea4c096b43a.png)

New `site-type-website` step

![image](https://user-images.githubusercontent.com/14988353/61204294-273ba580-a730-11e9-8d08-53e5c661ef0d.png)


#### Changes proposed in this Pull Request

* Update the `/start/website` flow to use the onboarding steps, with the exception of the `site-type` step which here uses a custom `site-type-website` step that conditionally hides the blog site type.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/start/website` and after logging in you should see the `site-type` step with the `blog` type hidden. The rest of the signup should be identical to `onboarding`.
* Go to `http://calypso.localhost:3000/start` and the the `site-type` step should display all four site types.
* Check that Jetpack sign up is unaffected

***Note: also check that back button behaviour from the final steps right back to the first step works as expected — this is currently a bit broken***
