### PR TITLE
Community Translator V2: Load user waiting translations

### DIFF
--- a/client/components/community-translator/community-translator.jsx
+++ b/client/components/community-translator/community-translator.jsx
@@ -1,0 +1,227 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import i18n, { localize, reRenderTranslations } from 'i18n-calypso';
+import debugModule from 'debug';
+import { find, isEmpty, isMatch } from 'lodash';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import Translatable from './translatable';
+import { languages } from 'languages';
+import { canDisplayCommunityTranslator } from 'components/community-translator/utils';
+import { loadUndeployedTranslations } from 'lib/i18n-utils/switch-locale';
+import { getCurrentUserName } from 'state/current-user/selectors';
+import getUserSetting from 'state/selectors/get-user-setting';
+import { ENABLE_TRANSLATOR_KEY } from 'lib/i18n-utils/constants';
+import QueryUserSettings from 'components/data/query-user-settings';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
+ * Local variables
+ */
+const debug = debugModule( 'calypso:community-translator' );
+
+/**
+ * @returns {Object} of shape { localeSlug, localeVariant, localeCode } (all strings)
+ */
+function getLocaleSlugsFromLoadedTranslations() {
+	const { localeSlug, localeVariant } = i18n.getLocale()[ '' ];
+	return {
+		localeSlug,
+		localeVariant,
+		localeCode: localeVariant || localeSlug,
+	};
+}
+
+class CommunityTranslator extends Component {
+	currentLocale = { localeSlug: 'en' };
+
+	componentDidMount() {
+		// wrap translations from i18n
+		debug( 'registering wrapTranslation()' );
+		i18n.registerTranslateHook( ( translation, options ) =>
+			this.wrapTranslation( options.original, translation, options )
+		);
+
+		this.componentDidMountOrUpdate();
+	}
+
+	componentDidUpdate( prevprops ) {
+		this.componentDidMountOrUpdate( prevprops );
+	}
+
+	componentDidMountOrUpdate( prevprops = {} ) {
+		const { username, translatorEnabled } = this.props;
+		if ( ! this.props.translatorEnabled ) {
+			if ( prevprops.translatorEnabled ) {
+				reRenderTranslations();
+			}
+			return;
+		}
+
+		// This is a bit weird because we get forcedUpdates from i18n where
+		// our props haven't changed in addition to normal props-driven updates
+		const { localeCode: newLocaleCode } = getLocaleSlugsFromLoadedTranslations();
+
+		const languageChanged = this.setLanguageIfNecessary();
+
+		// ignore additional props from i18n-calypso
+		const relevantProps = { username, translatorEnabled };
+		if ( languageChanged || ! isMatch( prevprops, relevantProps ) ) {
+			debug( "fetching user's waiting translations", username, newLocaleCode );
+			loadUndeployedTranslations( {
+				username,
+				project: 'test', // TMP TESTING
+				locale: newLocaleCode,
+				translationStatus: 'waiting',
+			} );
+		}
+
+		// We need to force a rerender if the translator has just been enabled
+		// i18n will force a rerender if the language has changed, so we
+		// shouldn't cause another.
+		if ( ! languageChanged && ! prevprops.translatorEnabled ) {
+			reRenderTranslations();
+		}
+	}
+
+	/**
+	 * @return {bool} returns true if the current language actually changed.
+	 */
+	setLanguageIfNecessary() {
+		// The '' here is a Jed convention used for storing configuration data
+		// alongside translations in the same dictionary (because '' will never
+		// be a legitimately translatable string)
+		// See https://messageformat.github.io/Jed/
+		const { localeSlug, localeVariant } = i18n.getLocale()[ '' ];
+		const { username } = this.props;
+		const newLocaleCode = localeVariant || localeSlug;
+
+		if ( newLocaleCode === this.currentLocale.langSlug ) {
+			return;
+		}
+
+		debug( 'Changing locale to ' + newLocaleCode );
+		this.currentLocale = find( languages, lang => lang.langSlug === newLocaleCode );
+
+		if ( ! canDisplayCommunityTranslator( localeSlug, localeVariant ) ) {
+			debug(
+				`community translator not activated for ${ newLocaleCode } (${ localeSlug }/${ localeVariant })`
+			);
+			return;
+		}
+
+		debug(
+			`community translator activated for ${ newLocaleCode } (${ localeSlug }/${ localeVariant })`
+		);
+		debug( "fetching user's waiting translations", username, newLocaleCode );
+		loadUndeployedTranslations( { username, locale: newLocaleCode, translationStatus: 'waiting' } );
+		return true;
+	}
+
+	/**
+	 * Wraps translation in a DOM object and attaches `toString()` method in case in can't be rendered
+	 * @param { String } originalFromPage - original string
+	 * @param { String } displayedTranslationFromPage - translated string
+	 * @param  { Object } optionsFromPage - i18n.translate options
+	 * @returns {Object} DOM object
+	 */
+	wrapTranslation( originalFromPage, displayedTranslationFromPage, optionsFromPage ) {
+		if ( ! this.props.translatorEnabled ) {
+			return displayedTranslationFromPage;
+		}
+
+		// This checks the currently loaded translations rather than user
+		// settings or the last one we saw.
+		// This means when a user changes locale, it will still show
+		// the old translations until the new translations are loaded, but:
+		// - it won't try to show translations when it can't
+		// - it will change all the translations over when i18n-calypso
+		//   triggers a rerender (it can't "miss" part of the rerender due to
+		//   the order of callbacks triggered by the change)
+		const currentlyLoadedTranslationsSlug = getLocaleSlugsFromLoadedTranslations().localeCode;
+		if ( ! canDisplayCommunityTranslator( currentlyLoadedTranslationsSlug ) ) {
+			return displayedTranslationFromPage;
+		}
+
+		if ( 'object' !== typeof optionsFromPage ) {
+			optionsFromPage = {};
+		}
+
+		if ( 'string' !== typeof originalFromPage ) {
+			debug( 'unknown original format' );
+			return displayedTranslationFromPage;
+		}
+
+		if ( optionsFromPage.textOnly ) {
+			debug( `respecting textOnly for string "${ originalFromPage }"` );
+			return displayedTranslationFromPage;
+		}
+
+		const props = {
+			singular: originalFromPage,
+			locale: this.currentLocale,
+		};
+
+		let key = originalFromPage;
+
+		// Has Context
+		if ( 'string' === typeof optionsFromPage.context ) {
+			props.context = optionsFromPage.context;
+
+			// see how Jed defines \u0004 as the delimiter here: https://messageformat.github.io/Jed/
+			key = `${ optionsFromPage.context }\u0004${ originalFromPage }`;
+		}
+
+		// Has Plural
+		if ( 'string' === typeof optionsFromPage.plural ) {
+			props.plural = optionsFromPage.plural;
+		}
+
+		// Has no translation in current locale
+		// Must be a string to be a valid DOM attribute value
+		if ( isEmpty( i18n.getLocale()[ key ] ) ) {
+			props.untranslated = 'true';
+		}
+
+		// <Translatable> returns a frozen object, therefore we make a copy so that we can modify it below
+		const translatableElement = Object.assign(
+			{},
+			<Translatable { ...props }>{ displayedTranslationFromPage }</Translatable>
+		);
+
+		// now we can override the toString function which would otherwise return [object Object]
+		translatableElement.toString = () => {
+			// here we can store the strings that cannot be rendered to the page
+			return displayedTranslationFromPage;
+		};
+
+		// freeze the object again to certify the same behavior as the original ReactElement object
+		Object.freeze( translatableElement );
+
+		return translatableElement;
+	}
+
+	render() {
+		return <QueryUserSettings />;
+	}
+}
+
+const mapState = state => ( {
+	username: getCurrentUserName( state ),
+	translatorEnabled: getUserSetting( state, ENABLE_TRANSLATOR_KEY ),
+} );
+
+// The i18n-calypso localize() HOC will force an update when i18n changes
+// (see boundForceUpdate()), so we use it to react to those changes even though
+// we actually don't use translate() directly.
+export default connect( mapState )( localize( CommunityTranslator ) );

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -37,12 +37,12 @@ function getLocaleSlugsFromLoadedTranslations() {
 	return {
 		localeSlug,
 		localeVariant,
-		localeCode: localeVariant || localeSlug
+		localeCode: localeVariant || localeSlug,
 	};
 }
 
 class CommunityTranslator extends Component {
-	currentLocale = ( { localeSlug: 'en' } )
+	currentLocale = { localeSlug: 'en' };
 
 	componentDidMount() {
 		// wrap translations from i18n
@@ -51,8 +51,7 @@ class CommunityTranslator extends Component {
 			this.wrapTranslation( options.original, translation, options )
 		);
 
-		this.componentDidMountOrUpdate()
-
+		this.componentDidMountOrUpdate();
 	}
 
 	componentDidUpdate( prevprops ) {
@@ -70,11 +69,7 @@ class CommunityTranslator extends Component {
 
 		// This is a bit weird because we get forcedUpdates from i18n where
 		// our props haven't changed in addition to normal props-driven updates
-		const {
-			localeSlug,
-			localeVariant,
-			localeCode: newLocaleCode,
-		} = getLocaleSlugsFromLoadedTranslations();
+		const { localeCode: newLocaleCode } = getLocaleSlugsFromLoadedTranslations();
 
 		const languageChanged = this.setLanguageIfNecessary();
 
@@ -82,7 +77,11 @@ class CommunityTranslator extends Component {
 		const relevantProps = { username, translatorEnabled };
 		if ( languageChanged || ! isMatch( prevprops, relevantProps ) ) {
 			debug( "fetching user's waiting translations", username, newLocaleCode );
-			loadUndeployedTranslations( { username, locale: newLocaleCode, translationStatus: 'waiting' } );
+			loadUndeployedTranslations( {
+				username,
+				locale: newLocaleCode,
+				translationStatus: 'waiting',
+			} );
 		}
 
 		// We need to force a rerender if the translator has just been enabled
@@ -105,7 +104,7 @@ class CommunityTranslator extends Component {
 		const { username } = this.props;
 		const newLocaleCode = localeVariant || localeSlug;
 
-		if( newLocaleCode === this.currentLocale.langSlug ) {
+		if ( newLocaleCode === this.currentLocale.langSlug ) {
 			return;
 		}
 
@@ -147,8 +146,7 @@ class CommunityTranslator extends Component {
 		// - it will change all the translations over when i18n-calypso
 		//   triggers a rerender (it can't "miss" part of the rerender due to
 		//   the order of callbacks triggered by the change)
-		const currentlyLoadedTranslationsSlug =
-			getLocaleSlugsFromLoadedTranslations().localeCode;
+		const currentlyLoadedTranslationsSlug = getLocaleSlugsFromLoadedTranslations().localeCode;
 		if ( ! canDisplayCommunityTranslator( currentlyLoadedTranslationsSlug ) ) {
 			return displayedTranslationFromPage;
 		}

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -42,8 +42,6 @@ function getLocaleSlugsFromLoadedTranslations() {
 }
 
 class CommunityTranslator extends Component {
-	// The i18n-calypso localize() HOC will force an update when i18n changes
-	// (see boundForceUpdate()), so we need to track what we've set
 	currentLocale = ( { localeSlug: 'en' } )
 
 	componentDidMount() {
@@ -84,6 +82,7 @@ class CommunityTranslator extends Component {
 			loadUndeployedTranslations( { username, locale: newLocaleCode, translationStatus: 'waiting' } );
 		}
 
+		// We need to force a rerender if the translator has just been enabled
 		// i18n will force a rerender if the language has changed, so we
 		// shouldn't cause another.
 		if ( ! languageChanged && ! prevprops.translatorEnabled ) {
@@ -219,4 +218,7 @@ const mapState = state => ( {
 	translatorEnabled: getUserSetting( state, ENABLE_TRANSLATOR_KEY ),
 } );
 
+// The i18n-calypso localize() HOC will force an update when i18n changes
+// (see boundForceUpdate()), so we use it to react to those changes even though
+// we actually don't use translate() directly.
 export default connect( mapState )( localize( CommunityTranslator ) );

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import i18n, { localize, reRenderTranslations } from 'i18n-calypso';
 import debugModule from 'debug';
 import { find, isEmpty, isMatch } from 'lodash';
@@ -41,7 +41,7 @@ function getLocaleSlugsFromLoadedTranslations() {
 	};
 }
 
-class CommunityTranslator extends PureComponent {
+class CommunityTranslator extends Component {
 	// The i18n-calypso localize() HOC will force an update when i18n changes
 	// (see boundForceUpdate()), so we need to track what we've set
 	currentLocale = ( { localeSlug: 'en' } )

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -62,6 +62,9 @@ class CommunityTranslator extends Component {
 	componentDidMountOrUpdate( prevprops = {} ) {
 		const { username, translatorEnabled } = this.props;
 		if ( ! this.props.translatorEnabled ) {
+			if ( prevprops.translatorEnabled ) {
+				reRenderTranslations();
+			}
 			return;
 		}
 

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -6,6 +6,8 @@ import React, { Component } from 'react';
 import i18n, { localize } from 'i18n-calypso';
 import debugModule from 'debug';
 import { find, isEmpty } from 'lodash';
+import { connect } from 'react-redux';
+
 /**
  * Internal dependencies
  */
@@ -14,6 +16,10 @@ import { languages } from 'languages';
 import User from 'lib/user';
 import userSettings from 'lib/user-settings';
 import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
+import getCurrentLocaleSlug from 'state/selectors/get-current-locale-slug';
+import getCurrentLocaleVariant from 'state/selectors/get-current-locale-variant';
+import { loadUndeployedTranslations } from 'lib/i18n-utils/switch-locale';
+import { getCurrentUserName, getCurrentUserLocale } from 'state/current-user/selectors';
 
 /**
  * Style dependencies
@@ -47,6 +53,14 @@ class CommunityTranslator extends Component {
 		userSettings.on( 'change', this.refresh );
 	}
 
+	shouldComponentUpdate( nextProps ) {
+		// TODO
+	}
+
+	componentDidUpdate( prevProps ) {
+		this.refresh();
+	}
+
 	componentWillUnmount() {
 		i18n.off( 'change', this.refresh );
 		user.removeListener( 'change', this.refresh );
@@ -60,8 +74,11 @@ class CommunityTranslator extends Component {
 		// be a legitimately translatable string)
 		// See https://messageformat.github.io/Jed/
 		const { localeSlug, localeVariant } = this.languageJson[ '' ];
+		const { username } = this.props;
+
 		this.localeCode = localeVariant || localeSlug;
 		this.currentLocale = find( languages, lang => lang.langSlug === this.localeCode );
+		loadUndeployedTranslations( { username, locale: this.localeCode, translationStatus: 'waiting' } )
 	}
 
 	refresh = () => {
@@ -165,4 +182,10 @@ class CommunityTranslator extends Component {
 	}
 }
 
-export default localize( CommunityTranslator );
+const mapState = state => ( {
+	localeSlug: getCurrentLocaleSlug( state ),
+	localeVariant: getCurrentLocaleVariant( state ),
+	username: getCurrentUserName( state ),
+} );
+
+export default connect( mapState )( localize( CommunityTranslator ) );

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -15,7 +15,7 @@ import Translatable from './translatable';
 import { canDisplayCommunityTranslator } from 'components/community-translator/utils';
 import { loadUndeployedTranslations } from 'lib/i18n-utils/switch-locale';
 import { getCurrentUserName } from 'state/current-user/selectors';
-import getUserSetting from 'state/selectors/get-user-setting.js';
+import getUserSetting from 'state/selectors/get-user-setting';
 import { ENABLE_TRANSLATOR_KEY } from 'lib/i18n-utils/constants';
 import QueryUserSettings from 'components/data/query-user-settings';
 
@@ -85,15 +85,12 @@ class CommunityTranslator extends PureComponent {
 		// See https://messageformat.github.io/Jed/
 		const { localeSlug, localeVariant } = i18n.getLocale()[ '' ];
 		const { username } = this.props;
-
-		if ( ! canDisplayCommunityTranslator( localeSlug, localeVariant ) ) {
-			return;
-		}
-
 		const newLocaleCode = localeVariant || localeSlug;
 
 		if ( ! canDisplayCommunityTranslator( localeSlug, localeVariant ) ) {
-			debug( 'community translator not activated for ', newLocaleCode );
+			debug(
+				`community translator not activated for ${ newLocaleCode } (${ localeSlug }/${ localeVariant })`
+			);
 			return;
 		}
 

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
  * Internal dependencies
  */
 import Translatable from './translatable';
+import { languages } from 'languages';
 import { canDisplayCommunityTranslator } from 'components/community-translator/utils';
 import { loadUndeployedTranslations } from 'lib/i18n-utils/switch-locale';
 import { getCurrentUserName } from 'state/current-user/selectors';

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import React, { PureComponent } from 'react';
-import i18n, { localize } from 'i18n-calypso';
+import i18n, { localize, reRenderTranslations } from 'i18n-calypso';
 import debugModule from 'debug';
 import { find, isEmpty, isMatch } from 'lodash';
 import { connect } from 'react-redux';
@@ -87,7 +87,7 @@ class CommunityTranslator extends PureComponent {
 		// i18n will force a rerender if the language has changed, so we
 		// shouldn't cause another.
 		if ( ! languageChanged && ! prevprops.translatorEnabled ) {
-			i18n.rerenderTranslations();
+			reRenderTranslations();
 		}
 	}
 

--- a/client/components/community-translator/index.jsx
+++ b/client/components/community-translator/index.jsx
@@ -2,225 +2,32 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
-import i18n, { localize, reRenderTranslations } from 'i18n-calypso';
-import debugModule from 'debug';
-import { find, isEmpty, isMatch } from 'lodash';
+import React from 'react';
 import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
  */
-import Translatable from './translatable';
-import { languages } from 'languages';
-import { canDisplayCommunityTranslator } from 'components/community-translator/utils';
-import { loadUndeployedTranslations } from 'lib/i18n-utils/switch-locale';
-import { getCurrentUserName } from 'state/current-user/selectors';
+import AsyncLoad from 'components/async-load';
+import config from 'config';
+import QueryUserSettings from 'components/data/query-user-settings';
 import getUserSetting from 'state/selectors/get-user-setting';
 import { ENABLE_TRANSLATOR_KEY } from 'lib/i18n-utils/constants';
-import QueryUserSettings from 'components/data/query-user-settings';
 
-/**
- * Style dependencies
- */
-import './style.scss';
+export const CommunityTranslatorComponent = ( { communityTranslatorEnabled } ) =>
+	config.isEnabled( 'i18n/community-translator' ) ? (
+		<>
+			<QueryUserSettings />
+			{ communityTranslatorEnabled && (
+				<AsyncLoad require="components/community-translator/community-translator" />
+			) }
+		</>
+	) : (
+		<AsyncLoad require="layout/community-translator/launcher" placeholder={ null } />
+	);
 
-/**
- * Local variables
- */
-const debug = debugModule( 'calypso:community-translator' );
-
-/**
- * @returns {Object} of shape { localeSlug, localeVariant, localeCode } (all strings)
- */
-function getLocaleSlugsFromLoadedTranslations() {
-	const { localeSlug, localeVariant } = i18n.getLocale()[ '' ];
-	return {
-		localeSlug,
-		localeVariant,
-		localeCode: localeVariant || localeSlug,
-	};
-}
-
-class CommunityTranslator extends Component {
-	currentLocale = { localeSlug: 'en' };
-
-	componentDidMount() {
-		// wrap translations from i18n
-		debug( 'registering wrapTranslation()' );
-		i18n.registerTranslateHook( ( translation, options ) =>
-			this.wrapTranslation( options.original, translation, options )
-		);
-
-		this.componentDidMountOrUpdate();
-	}
-
-	componentDidUpdate( prevprops ) {
-		this.componentDidMountOrUpdate( prevprops );
-	}
-
-	componentDidMountOrUpdate( prevprops = {} ) {
-		const { username, translatorEnabled } = this.props;
-		if ( ! this.props.translatorEnabled ) {
-			if ( prevprops.translatorEnabled ) {
-				reRenderTranslations();
-			}
-			return;
-		}
-
-		// This is a bit weird because we get forcedUpdates from i18n where
-		// our props haven't changed in addition to normal props-driven updates
-		const { localeCode: newLocaleCode } = getLocaleSlugsFromLoadedTranslations();
-
-		const languageChanged = this.setLanguageIfNecessary();
-
-		// ignore additional props from i18n-calypso
-		const relevantProps = { username, translatorEnabled };
-		if ( languageChanged || ! isMatch( prevprops, relevantProps ) ) {
-			debug( "fetching user's waiting translations", username, newLocaleCode );
-			loadUndeployedTranslations( {
-				username,
-				locale: newLocaleCode,
-				translationStatus: 'waiting',
-			} );
-		}
-
-		// We need to force a rerender if the translator has just been enabled
-		// i18n will force a rerender if the language has changed, so we
-		// shouldn't cause another.
-		if ( ! languageChanged && ! prevprops.translatorEnabled ) {
-			reRenderTranslations();
-		}
-	}
-
-	/**
-	 * @return {bool} returns true if the current language actually changed.
-	 */
-	setLanguageIfNecessary() {
-		// The '' here is a Jed convention used for storing configuration data
-		// alongside translations in the same dictionary (because '' will never
-		// be a legitimately translatable string)
-		// See https://messageformat.github.io/Jed/
-		const { localeSlug, localeVariant } = i18n.getLocale()[ '' ];
-		const { username } = this.props;
-		const newLocaleCode = localeVariant || localeSlug;
-
-		if ( newLocaleCode === this.currentLocale.langSlug ) {
-			return;
-		}
-
-		debug( 'Changing locale to ' + newLocaleCode );
-		this.currentLocale = find( languages, lang => lang.langSlug === newLocaleCode );
-
-		if ( ! canDisplayCommunityTranslator( localeSlug, localeVariant ) ) {
-			debug(
-				`community translator not activated for ${ newLocaleCode } (${ localeSlug }/${ localeVariant })`
-			);
-			return;
-		}
-
-		debug(
-			`community translator activated for ${ newLocaleCode } (${ localeSlug }/${ localeVariant })`
-		);
-		debug( "fetching user's waiting translations", username, newLocaleCode );
-		loadUndeployedTranslations( { username, locale: newLocaleCode, translationStatus: 'waiting' } );
-		return true;
-	}
-
-	/**
-	 * Wraps translation in a DOM object and attaches `toString()` method in case in can't be rendered
-	 * @param { String } originalFromPage - original string
-	 * @param { String } displayedTranslationFromPage - translated string
-	 * @param  { Object } optionsFromPage - i18n.translate options
-	 * @returns {Object} DOM object
-	 */
-	wrapTranslation( originalFromPage, displayedTranslationFromPage, optionsFromPage ) {
-		if ( ! this.props.translatorEnabled ) {
-			return displayedTranslationFromPage;
-		}
-
-		// This checks the currently loaded translations rather than user
-		// settings or the last one we saw.
-		// This means when a user changes locale, it will still show
-		// the old translations until the new translations are loaded, but:
-		// - it won't try to show translations when it can't
-		// - it will change all the translations over when i18n-calypso
-		//   triggers a rerender (it can't "miss" part of the rerender due to
-		//   the order of callbacks triggered by the change)
-		const currentlyLoadedTranslationsSlug = getLocaleSlugsFromLoadedTranslations().localeCode;
-		if ( ! canDisplayCommunityTranslator( currentlyLoadedTranslationsSlug ) ) {
-			return displayedTranslationFromPage;
-		}
-
-		if ( 'object' !== typeof optionsFromPage ) {
-			optionsFromPage = {};
-		}
-
-		if ( 'string' !== typeof originalFromPage ) {
-			debug( 'unknown original format' );
-			return displayedTranslationFromPage;
-		}
-
-		if ( optionsFromPage.textOnly ) {
-			debug( `respecting textOnly for string "${ originalFromPage }"` );
-			return displayedTranslationFromPage;
-		}
-
-		const props = {
-			singular: originalFromPage,
-			locale: this.currentLocale,
-		};
-
-		let key = originalFromPage;
-
-		// Has Context
-		if ( 'string' === typeof optionsFromPage.context ) {
-			props.context = optionsFromPage.context;
-
-			// see how Jed defines \u0004 as the delimiter here: https://messageformat.github.io/Jed/
-			key = `${ optionsFromPage.context }\u0004${ originalFromPage }`;
-		}
-
-		// Has Plural
-		if ( 'string' === typeof optionsFromPage.plural ) {
-			props.plural = optionsFromPage.plural;
-		}
-
-		// Has no translation in current locale
-		// Must be a string to be a valid DOM attribute value
-		if ( isEmpty( i18n.getLocale()[ key ] ) ) {
-			props.untranslated = 'true';
-		}
-
-		// <Translatable> returns a frozen object, therefore we make a copy so that we can modify it below
-		const translatableElement = Object.assign(
-			{},
-			<Translatable { ...props }>{ displayedTranslationFromPage }</Translatable>
-		);
-
-		// now we can override the toString function which would otherwise return [object Object]
-		translatableElement.toString = () => {
-			// here we can store the strings that cannot be rendered to the page
-			return displayedTranslationFromPage;
-		};
-
-		// freeze the object again to certify the same behavior as the original ReactElement object
-		Object.freeze( translatableElement );
-
-		return translatableElement;
-	}
-
-	render() {
-		return <QueryUserSettings />;
-	}
-}
-
-const mapState = state => ( {
-	username: getCurrentUserName( state ),
-	translatorEnabled: getUserSetting( state, ENABLE_TRANSLATOR_KEY ),
-} );
-
-// The i18n-calypso localize() HOC will force an update when i18n changes
-// (see boundForceUpdate()), so we use it to react to those changes even though
-// we actually don't use translate() directly.
-export default connect( mapState )( localize( CommunityTranslator ) );
+export default connect( state => ( {
+	communityTranslatorEnabled:
+		config.isEnabled( 'i18n/community-translator' ) &&
+		getUserSetting( state, ENABLE_TRANSLATOR_KEY ),
+} ) )( CommunityTranslatorComponent );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -22,7 +22,6 @@ import OfflineStatus from 'layout/offline-status';
 import QueryPreferences from 'components/data/query-preferences';
 import QuerySites from 'components/data/query-sites';
 import QuerySiteSelectedEditor from 'components/data/query-site-selected-editor';
-import QueryUserSettings from 'components/data/query-user-settings';
 import { isOffline } from 'state/application/selectors';
 import {
 	getSelectedSiteId,
@@ -44,7 +43,6 @@ import DocumentHead from 'components/data/document-head';
 import AppBanner from 'blocks/app-banner';
 import GdprBanner from 'blocks/gdpr-banner';
 import { getPreference } from 'state/preferences/selectors';
-import getUserSetting from 'state/selectors/get-user-setting';
 import JITM from 'blocks/jitm';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
 import SupportUser from 'support/support-user';
@@ -54,7 +52,7 @@ import { retrieveMobileRedirect } from 'jetpack-connect/persistence-utils';
 import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import LayoutLoader from './loader';
-import { ENABLE_TRANSLATOR_KEY } from 'lib/i18n-utils/constants';
+import CommunityTranslator from 'components/community-translator';
 
 /**
  * Style dependencies
@@ -138,7 +136,6 @@ class Layout extends Component {
 				{ this.props.shouldQueryAllSites && <QuerySites allSites /> }
 				<QueryPreferences />
 				<QuerySiteSelectedEditor siteId={ this.props.siteId } />
-				{ config.isEnabled( 'i18n/community-translator' ) && <QueryUserSettings /> }
 				<AsyncLoad require="layout/guided-tours" placeholder={ null } />
 				{ ! isE2ETest() && <AsyncLoad require="layout/nps-survey-notice" placeholder={ null } /> }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
@@ -159,13 +156,7 @@ class Layout extends Component {
 						{ this.props.primary }
 					</div>
 				</div>
-				{ config.isEnabled( 'i18n/community-translator' ) ? (
-					this.props.communityTranslatorEnabled && (
-						<AsyncLoad require="components/community-translator" />
-					)
-				) : (
-					<AsyncLoad require="layout/community-translator/launcher" placeholder={ null } />
-				) }
+				<CommunityTranslator />
 				{ this.props.sectionGroup === 'sites' && <SitePreview /> }
 				{ config.isEnabled( 'happychat' ) && this.props.chatIsOpen && (
 					<AsyncLoad require="components/happychat" />
@@ -229,8 +220,5 @@ export default connect( state => {
 		authorization, it would remove the newly connected site that has been fetched separately.
 		See https://github.com/Automattic/wp-calypso/pull/31277 for more details. */
 		shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
-		communityTranslatorEnabled:
-			config.isEnabled( 'i18n/community-translator' ) &&
-			getUserSetting( state, ENABLE_TRANSLATOR_KEY ),
 	};
 } )( Layout );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -22,6 +22,7 @@ import OfflineStatus from 'layout/offline-status';
 import QueryPreferences from 'components/data/query-preferences';
 import QuerySites from 'components/data/query-sites';
 import QuerySiteSelectedEditor from 'components/data/query-site-selected-editor';
+import QueryUserSettings from 'components/data/query-user-settings';
 import { isOffline } from 'state/application/selectors';
 import {
 	getSelectedSiteId,
@@ -43,16 +44,17 @@ import DocumentHead from 'components/data/document-head';
 import AppBanner from 'blocks/app-banner';
 import GdprBanner from 'blocks/gdpr-banner';
 import { getPreference } from 'state/preferences/selectors';
+import getUserSetting from 'state/selectors/get-user-setting';
 import JITM from 'blocks/jitm';
 import KeyboardShortcutsMenu from 'lib/keyboard-shortcuts/menu';
 import SupportUser from 'support/support-user';
-import { isCommunityTranslatorEnabled } from 'components/community-translator/utils';
 import { isE2ETest } from 'lib/e2e';
 import BodySectionCssClass from './body-section-css-class';
 import { retrieveMobileRedirect } from 'jetpack-connect/persistence-utils';
 import { isWooOAuth2Client } from 'lib/oauth2-clients';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import LayoutLoader from './loader';
+import { ENABLE_TRANSLATOR_KEY } from 'lib/i18n-utils/constants';
 
 /**
  * Style dependencies
@@ -136,6 +138,7 @@ class Layout extends Component {
 				{ this.props.shouldQueryAllSites && <QuerySites allSites /> }
 				<QueryPreferences />
 				<QuerySiteSelectedEditor siteId={ this.props.siteId } />
+				{ config.isEnabled( 'i18n/community-translator' ) && <QueryUserSettings /> }
 				<AsyncLoad require="layout/guided-tours" placeholder={ null } />
 				{ ! isE2ETest() && <AsyncLoad require="layout/nps-survey-notice" placeholder={ null } /> }
 				{ config.isEnabled( 'keyboard-shortcuts' ) ? <KeyboardShortcutsMenu /> : null }
@@ -157,7 +160,9 @@ class Layout extends Component {
 					</div>
 				</div>
 				{ config.isEnabled( 'i18n/community-translator' ) ? (
-					isCommunityTranslatorEnabled() && <AsyncLoad require="components/community-translator" />
+					this.props.communityTranslatorEnabled && (
+						<AsyncLoad require="components/community-translator" />
+					)
 				) : (
 					<AsyncLoad require="layout/community-translator/launcher" placeholder={ null } />
 				) }
@@ -224,5 +229,8 @@ export default connect( state => {
 		authorization, it would remove the newly connected site that has been fetched separately.
 		See https://github.com/Automattic/wp-calypso/pull/31277 for more details. */
 		shouldQueryAllSites: currentRoute && currentRoute !== '/jetpack/connect/authorize',
+		communityTranslatorEnabled:
+			config.isEnabled( 'i18n/community-translator' ) &&
+			getUserSetting( state, ENABLE_TRANSLATOR_KEY ),
 	};
 } )( Layout );

--- a/client/lib/i18n-utils/glotpress.js
+++ b/client/lib/i18n-utils/glotpress.js
@@ -19,10 +19,15 @@ const debug = debugFactory( 'calypso:i18n-utils:glotpress' );
 export async function postRequest( glotPressUrl, postFormData ) {
 	let response;
 
+	// TODO: make sure this works for recordOriginals as well
 	try {
 		response = await fetch( glotPressUrl, {
 			method: 'POST',
 			credentials: 'include',
+			mode: 'cors',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
 			body: postFormData,
 		} );
 		if ( response.ok ) {

--- a/client/lib/i18n-utils/glotpress.js
+++ b/client/lib/i18n-utils/glotpress.js
@@ -19,7 +19,6 @@ const debug = debugFactory( 'calypso:i18n-utils:glotpress' );
 export async function postRequest( glotPressUrl, postFormData ) {
 	let response;
 
-	// TODO: make sure this works for recordOriginals as well
 	try {
 		response = await fetch( glotPressUrl, {
 			method: 'POST',

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import request from 'superagent';
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
 import { includes, map, pick } from 'lodash';
@@ -145,7 +144,7 @@ export default function switchLocale( localeSlug ) {
 					`Encountered an error loading locale file for ${ localeSlug }. Falling back to English.`
 				);
 			}
-		} );
+		);
 	}
 }
 

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -193,8 +193,7 @@ export function loadUndeployedTranslations( {
 	}
 
 	if ( 'waiting' === translationStatus ) {
-		// TODO only allow loading your own waiting translations. Disallow loading them for now.
-		// return;
+		// TODO only allow loading your own waiting translations.
 	}
 
 	debug(

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -158,19 +158,41 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 		locale = currentLocaleSlug,
 	} = parsedURL.query;
 
-	if ( ! username ) {
+	const translationParams = {
+		username,
+		project,
+		translationSet,
+		translationStatus,
+		locale,
+	};
+
+	return loadUndeployedTranslations( translationParams );
+}
+
+export function loadUndeployedTranslations( {
+	username,
+	locale,
+	project = 'wpcom',
+	translationSet = 'default',
+	translationStatus = 'current',
+} ) {
+	if ( ! username || ! locale ) {
+		username || debug( 'unable to load undeployed translations, username missing.' );
+		locale || debug( 'unable to load undeployed translations, username missing.' );
 		return;
 	}
 
-	if ( ! includes( [ 'current', 'waiting' ], translationStatus ) ) {
+	if ( ! includes( [ 'current', 'waiting', 'current-or-waiting' ], translationStatus ) ) {
+		debug( 'unrecognized translationStatus', translationStatus );
 		return;
 	}
 
 	if ( 'waiting' === translationStatus ) {
 		// TODO only allow loading your own waiting translations. Disallow loading them for now.
-		return;
+		// return;
 	}
 
+	debug( `loading undeployed translations for ${ username } from ${ project }/${ translationSet }` );
 	const pathname = [
 		'api',
 		'projects',

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -225,6 +225,7 @@ export function loadUndeployedTranslations( {
 	return fetch( requestUrl, {
 		headers: { Accept: 'application/json' },
 		credentials: 'include',
+		mode: 'cors',
 	} )
 		.then( res => res.json() )
 		.then( translations => i18n.addTranslations( translations ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR loads and displays current and waiting translations from the user, so if they go to the trouble of submitting a translation, they don't have to keep looking at the old ones.

Still TODO:

- [x] Move the visibility logic out of `layout`

#### Testing instructions

All the changes in this PR are behind the `i18n/community-translator` feature flag, so you'll want to start up calypso with `ENABLE_FEATURES=i18n/community-translator npm start`

For testing, we should set the GP project to 'test' (in `loadUndeployedTranslations()` in `client/lib/i18n-utils/switch-locale.js`) and add translations there, but it's ok to submit a few strings for testing - just remember to reject them later.

Once you've got some strings under your username, turn on the community translator, and check that they're picked up:

![Mon_profil_—_WordPress_com_and_Translations___French__Canada____WordPress_com___GlotPress_-_julesaus_dev_dfw_wordpress_com](https://user-images.githubusercontent.com/5952255/61206924-1e9a9d80-a737-11e9-9a32-5cd6bb5bdac1.jpg)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
