### PR TITLE
Fix an overlap of two pills that can be displayed at the same time

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -46,6 +46,7 @@ export class PlanFeaturesHeader extends Component {
 		const { newPlan, bestValue, planType, popular, selectedPlan, title, translate } = this.props;
 
 		const headerClasses = classNames( 'plan-features__header', getPlanClass( planType ) );
+		const isCurrent = this.isPlanCurrent();
 
 		return (
 			<header className={ headerClasses }>
@@ -57,13 +58,17 @@ export class PlanFeaturesHeader extends Component {
 					{ this.getPlanFeaturesPrices() }
 					{ this.getBillingTimeframe() }
 				</div>
-				{ planLevelsMatch( selectedPlan, planType ) && (
+				{ isCurrent && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
+				{ planLevelsMatch( selectedPlan, planType ) && ! isCurrent && (
 					<PlanPill>{ translate( 'Suggested' ) }</PlanPill>
 				) }
-				{ popular && ! selectedPlan && <PlanPill>{ translate( 'Popular' ) }</PlanPill> }
-				{ newPlan && ! selectedPlan && <PlanPill>{ translate( 'New' ) }</PlanPill> }
-				{ bestValue && ! selectedPlan && <PlanPill>{ translate( 'Best Value' ) }</PlanPill> }
-				{ this.isPlanCurrent() && <PlanPill>{ translate( 'Your Plan' ) }</PlanPill> }
+				{ popular && ! selectedPlan && ! isCurrent && (
+					<PlanPill>{ translate( 'Popular' ) }</PlanPill>
+				) }
+				{ newPlan && ! selectedPlan && ! isCurrent && <PlanPill>{ translate( 'New' ) }</PlanPill> }
+				{ bestValue && ! selectedPlan && ! isCurrent && (
+					<PlanPill>{ translate( 'Best Value' ) }</PlanPill>
+				) }
 			</header>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I purchased a Personal plan while trying to test another PR and was surprised to see this:

<img width="335" alt="Screenshot 2019-07-15 at 16 01 29" src="https://user-images.githubusercontent.com/82778/61219345-b212a500-a71c-11e9-93d8-0cad35d8f4e3.png">

Well, the number 1 was actually not 1 but a cut letter from the word "Популярни" - an incorrect translation of Popular in Bulgarian. The pills overlap each other and could potentially look very ugly in certain languages.

#### Testing instructions

1. Buy a plan
2. Check /plans. Make sure only one pill is ever displayed and there are no two pills in dev tools.

