### PR TITLE
Adds tracking lib skeleton for Block Editor

### DIFF
--- a/apps/wpcom-block-editor/src/common/index.js
+++ b/apps/wpcom-block-editor/src/common/index.js
@@ -5,5 +5,5 @@ import './disable-nux-tour';
 import './rich-text';
 import './switch-to-classic';
 import './style.scss';
-import './track-search';
 import './unregister-experimental-blocks';
+import './tracking';

--- a/apps/wpcom-block-editor/src/common/tracking.js
+++ b/apps/wpcom-block-editor/src/common/tracking.js
@@ -1,0 +1,154 @@
+/**
+ * External dependencies
+ */
+import { use, select } from '@wordpress/data';
+import { registerPlugin } from '@wordpress/plugins';
+import { castArray } from 'lodash';
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './tracking/track-record-event';
+import delegateEventTracking from './tracking/delegate-event-tracking';
+
+// Debugger.
+const debug = debugFactory( 'wpcom-block-editor:tracking' );
+
+/**
+ * Looks up the block name based on its id.
+ *
+ * @param {string} blockId Blog identifier.
+ * @return {string|null} Blg name if it exists. Otherwise, `null`.
+ */
+const getTypeForBlockId = blockId => {
+	const block = select( 'core/block-editor' ).getBlock( blockId );
+	return block ? block.name : null;
+};
+
+/**
+ * A lot of actions accept either string (block id)
+ * or an array of multiple string when operating with multiple blocks selected.
+ * This is a convenience method that processes the first argument of the action (blocks)
+ * and calls your tracking for each of the blocks involved in the action.
+ *
+ * @param {string} eventName event name
+ * @return {function} track handler
+ */
+const getBlocksTracker = eventName => blockIds => {
+	// track separately for each block
+	castArray( blockIds ).forEach( blockId => {
+		tracksRecordEvent( eventName, { block_name: getTypeForBlockId( blockId ) } );
+	} );
+};
+
+/**
+ * Track block insertion.
+ *
+ * @param {object|array} blocks block instance object or an array of such objects
+ * @return {void}
+ */
+const trackBlockInsertion = blocks => {
+	castArray( blocks ).forEach( block => {
+		tracksRecordEvent( 'wpcom_block_inserted', {
+			block_name: block.name,
+			blocks_replaced: false,
+		} );
+	} );
+};
+
+/**
+ * Track block replacement.
+ *
+ * @param {array} originalBlockIds ids or blocks that are being replaced
+ * @param {object|array} blocks block instance object or an array of such objects
+ * @return {void}
+ */
+const trackBlockReplacement = ( originalBlockIds, blocks ) => {
+	castArray( blocks ).forEach( block => {
+		tracksRecordEvent( 'wpcom_block_picker_block_inserted', {
+			block_name: block.name,
+			blocks_replaced: true,
+		} );
+	} );
+};
+
+/**
+ * Tracker can be
+ * - string - which means it is an event name and should be tracked as such automatically
+ * - function - in case you need to load additional properties from the action.
+ *
+ * @type {object}
+ */
+const REDUX_TRACKING = {
+	'core/editor': {
+		undo: 'wpcom_block_editor_undo_performed',
+		redo: 'wpcom_block_editor_redo_performed',
+	},
+	'core/block-editor': {
+		moveBlocksUp: getBlocksTracker( 'wpcom_block_moved_up' ),
+		moveBlocksDown: getBlocksTracker( 'wpcom_block_moved_down' ),
+		removeBlocks: getBlocksTracker( 'wpcom_block_deleted' ),
+		removeBlock: getBlocksTracker( 'wpcom_block_deleted' ),
+		moveBlockToPosition: getBlocksTracker( 'wpcom_block_moved_via_dragging' ),
+		deleteBlock: getBlocksTracker( 'wpcom_block_deleted' ),
+		insertBlock: trackBlockInsertion,
+		insertBlocks: trackBlockInsertion,
+		replaceBlock: trackBlockReplacement,
+		replaceBlocks: trackBlockReplacement,
+	},
+};
+
+/**
+ * Mapping of Events by DOM selector.
+ * Events are matched by selector and their handlers called.
+ * @type {Array}
+ */
+const EVENT_TYPES = [ 'keyup', 'click' ];
+
+// Registering tracking handlers.
+if (
+	undefined === window ||
+	undefined === window._currentSiteId ||
+	undefined === window._currentSiteType
+) {
+	debug( 'Skip: No data available.' );
+} else {
+	debug( 'registering tracking handlers.' );
+	// Intercept dispatch function and add tracking for actions that need it.
+	use( registry => ( {
+		dispatch: namespace => {
+			const actions = { ...registry.dispatch( namespace ) };
+			const trackers = REDUX_TRACKING[ namespace ];
+
+			if ( trackers ) {
+				Object.keys( trackers ).forEach( actionName => {
+					const originalAction = actions[ actionName ];
+					const tracker = trackers[ actionName ];
+					actions[ actionName ] = ( ...args ) => {
+						debug( 'action "%s" called with %o arguments', actionName, [ ...args ] );
+						if ( typeof tracker === 'string' ) {
+							// Simple track - just based on the event name.
+							tracksRecordEvent( tracker );
+						} else if ( typeof tracker === 'function' ) {
+							// Advanced tracking - call function.
+							tracker( ...args );
+						}
+						return originalAction( ...args );
+					};
+				} );
+			}
+			return actions;
+		},
+	} ) );
+
+	// Registers Plugin.
+	registerPlugin( 'wpcom-block-editor-tracking', {
+		render: () => {
+			EVENT_TYPES.forEach( eventType =>
+				document.addEventListener( eventType, delegateEventTracking )
+			);
+			return null;
+		},
+	} );
+}

--- a/apps/wpcom-block-editor/src/common/tracking/delegate-event-tracking.js
+++ b/apps/wpcom-block-editor/src/common/tracking/delegate-event-tracking.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+/**
+ * Internal dependencies
+ */
+import wpcomBlockPickerSearchTerm from './wpcom-block-picker-search-term-handler';
+import wpcomBlockEditorCloseClick from './wpcom-block-editor-close-click';
+
+// Debugger.
+const debug = debugFactory( 'wpcom-block-editor:tracking' );
+
+/**
+ * Mapping of Events by DOM selector.
+ * Events are matched by selector and their handlers called.
+ *
+ * @type {Array}
+ */
+const EVENTS_MAPPING = [ wpcomBlockEditorCloseClick(), wpcomBlockPickerSearchTerm() ];
+
+/**
+ * Checks the event for a selector which matches
+ * the desired target element. Accounts for event
+ * bubbling.
+ * @param  {DOMEvent} event          the DOM event
+ * @param  {String} targetSelector the CSS selector for the target element
+ * @return {Node}                the target element if found
+ */
+const getMatchingEventTarget = ( event, targetSelector ) => {
+	return event.target.matches( targetSelector )
+		? event.target
+		: event.target.closest( targetSelector );
+};
+
+/**
+ * Handles delegation of click tracking events.
+ * Matches an event against list of known events
+ * and for each match fires an appropriate handler function.
+ *
+ * @param  {Object} event DOM event for the click event.
+ * @return {void}
+ */
+export default event => {
+	const matchingEvents = EVENTS_MAPPING.reduce( ( acc, mapping ) => {
+		const target = getMatchingEventTarget( event, mapping.selector );
+
+		// Set `click` as default of mapping event type.
+		const mappingEventType = mapping.type || 'click';
+
+		if ( target && event.type && event.type === mappingEventType ) {
+			acc.push( { mapping, event, target } );
+		}
+		return acc;
+	}, [] );
+
+	if ( ! matchingEvents.length ) {
+		return;
+	}
+
+	matchingEvents.forEach( match => {
+		debug( 'triggering "%s". target: "%s"', match.event, match.target );
+		match.mapping.handler( match.event, match.target );
+	} );
+};

--- a/apps/wpcom-block-editor/src/common/tracking/track-record-event.js
+++ b/apps/wpcom-block-editor/src/common/tracking/track-record-event.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { registerPlugin } from '@wordpress/plugins';
 import { isObjectLike, isUndefined, omit } from 'lodash';
 import debug from 'debug';
+
 const tracksDebug = debug( 'wpcom-block-editor:analytics:tracks' );
 
-// In case Tracks hasn't loaded
+// In case Tracks hasn't loaded.
 if ( typeof window !== 'undefined' ) {
 	window._tkq = window._tkq || [];
 }
@@ -14,7 +14,12 @@ if ( typeof window !== 'undefined' ) {
 // Adapted from the analytics lib :(
 // Because this is happening outside of the Calypso app we can't reuse the same lib
 // This means we don't have any extra props like user
-const tracksRecordEvent = function( eventName, eventProperties ) {
+
+export default ( eventName, eventProperties ) => {
+	// Required by Tracks when added manually
+	const blog_id = window._currentSiteId;
+	const site_type = window._currentSiteType;
+
 	eventProperties = eventProperties || {};
 
 	if ( process.env.NODE_ENV !== 'production' && typeof console !== 'undefined' ) {
@@ -43,44 +48,11 @@ const tracksRecordEvent = function( eventName, eventProperties ) {
 	// This allows a caller to easily remove properties from the recorded set by setting them to undefined
 	eventProperties = omit( eventProperties, isUndefined );
 
+	// Populate custom properties.
+	eventProperties = { ...eventProperties, blog_id, site_type };
+
 	tracksDebug( 'Recording event "%s" with actual props %o', eventName, eventProperties );
 
-	if ( 'undefined' !== typeof window ) {
-		window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
-	}
+	// window._tkq.push( [ 'identifyUser', userId, userUsername ] );
+	window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 };
-
-const trackGutenbergSearch = event => {
-	const searchTerm = event.target.value;
-	const hasResults =
-		document.getElementsByClassName( 'block-editor-inserter__no-results' ).length === 0;
-
-	if ( searchTerm.length < 3 ) {
-		return;
-	}
-
-	tracksRecordEvent( 'wpcom_block_picker_search_term', {
-		search_term: searchTerm,
-	} );
-
-	if ( hasResults ) {
-		return;
-	}
-
-	// Create a separate event for search with no results to make it easier to filter by them
-	tracksRecordEvent( 'wpcom_block_picker_no_results', {
-		search_term: searchTerm,
-	} );
-};
-
-registerPlugin( 'track-no-search-results', {
-	render: () => {
-		document.onkeyup = event => {
-			if ( event.target.id.indexOf( 'block-editor-inserter__search' ) === 0 ) {
-				trackGutenbergSearch( event );
-			}
-		};
-
-		return null;
-	},
-} );

--- a/apps/wpcom-block-editor/src/common/tracking/wpcom-block-editor-close-click.js
+++ b/apps/wpcom-block-editor/src/common/tracking/wpcom-block-editor-close-click.js
@@ -1,0 +1,15 @@
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_block_editor_close_click`.
+ *
+ * @return {{handler: function, selector: string, type: string}} event object definition.
+ */
+export default () => ( {
+	selector: '.edit-post-fullscreen-mode-close__toolbar',
+	type: 'click',
+	handler: () => tracksRecordEvent( 'wpcom_block_editor_close_click' ),
+} );

--- a/apps/wpcom-block-editor/src/common/tracking/wpcom-block-picker-search-term-handler.js
+++ b/apps/wpcom-block-editor/src/common/tracking/wpcom-block-picker-search-term-handler.js
@@ -1,0 +1,32 @@
+/**
+ * Internal dependencies
+ */
+import tracksRecordEvent from './track-record-event';
+
+/**
+ * Return the event definition object to track `wpcom_block_picker_no_results`.
+ * Also, it tracks `wpcom_block_picker_no_results` is the searcher doesn't return any result.
+ *
+ * @return {{handler: function, selector: string, type: string}} event object definition.
+ */
+export default () => ( {
+	selector: '.block-editor-inserter__search',
+	type: 'keyup',
+	handler: ( event, target ) => {
+		const search_term = target.value;
+		if ( search_term.length < 3 ) {
+			return;
+		}
+
+		tracksRecordEvent( 'wpcom_block_picker_search_term', { search_term } );
+
+		// Create a separate event for search with no results to make it easier to filter by them
+		const hasResults =
+			document.querySelectorAll( '.block-editor-inserter__no-results' ).length === 0;
+		if ( hasResults ) {
+			return;
+		}
+
+		tracksRecordEvent( 'wpcom_block_picker_no_results', { search_term } );
+	},
+} );


### PR DESCRIPTION
At the moment the Block Editor within WPCom is something of a black hole for events and stats. This PR aims to provide a basic skeleton for tracking events based on event delegation and DOM interrogation.

This is as discussed in `paYJgx-5g-p2`.

## Changes proposed in this Pull Request

* Add centralized "library" `tracking.js` to enable easy addition of events to be tracked.
* Removes bespoke `tracking-search.js` and moves tracking into main `tracking.js` lib.
* Tracks a set of events (described below)
* Passes Blog ID with tracking

## Set of events to track

- [x] gutenberg_headerbar_selected_back / `wpcom_block_editor_close_click`
- [x] gutenberg_headerbar_performed_undo / `wpcom_block_editor_undo_performed`
- [x]  gutenberg_headerbar_performed_redo / `wpcom_block_editor_redo_performed`
- [x] gutenberg_blockpicker_selected_block / `wpcom_block_inserted`
- [x] gutenberg_blockoptions_deleted_block / `wpcom_block_deleted`
- [x] gutenberg_blockarrangement_moved_block_up / `wpcom_block_moved_up`
- [x] gutenberg_blockarrangement_moved_block_down / `wpcom_block_moved_down`
- [x] gutenberg_blockarrangement_dragged_block / `wpcom_block_moved_via_dragging`

## How to test

Follow the instructions in PCYsg-l4k-p2 to pull the changes in this PR onto your sandbox.
Sandbox `widgets.wp.com` and a test site, and go to create a new post.
In your devtool's console, run the command `localStorage.debug = '*'`.
Reload the editor.
If you're testing from wordpress.com, set the debug scope in your devtool's console to your test site (default is "top").
Start inserting and moving blocks.
Then, you will be able to see logs as the following image shows:

![image](https://user-images.githubusercontent.com/77539/61416049-dad79d80-a8c8-11e9-8bb6-ef71c3c4bfcd.png)

Some notes: When the event to track is detected via event delegation, it shows the `triggering "<event-type>"` in the logline. If it's via redux, shows `action "<action-name>"` (light orange squares).


## Questions

- Should we throttle the events so repeated clicks/resize/keyboard events don't fire tracks events too often? A good case in point is the block picker search event which fires on each key stroke. That's a tonne of events!
- How best to add the `blog_id` property?

## Development

To work with this code you will need to build the app (tip: use `--watch` to run on change) as per [instructions](https://github.com/Automattic/wp-calypso/tree/master/apps/wpcom-block-editor) _into_ your sandbox:

You should set the output directory to target the `widgets.wp.com/wpcom-block-editor` directory which is part of the WPCom codebase. You then need to sandbox `widgets.wp.com` which is where the code is served from.

Fixes: #34656.
