### PR TITLE
Replace string refs in FormTextInput.

### DIFF
--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -17,24 +14,28 @@ export default class FormTextInput extends PureComponent {
 		className: PropTypes.string,
 	};
 
-	constructor() {
-		super( ...arguments );
+	currentTextField = undefined;
 
-		this.selectOnFocus = this.selectOnFocus.bind( this );
-	}
+	textFieldRef = element => {
+		if ( element && this.props.inputRef ) {
+			this.props.inputRef.current = element;
+		}
+		this.currentTextField = element;
+	};
 
 	focus() {
-		this.refs.textField.focus();
-	}
-
-	selectOnFocus( event ) {
-		if ( this.props.selectOnFocus ) {
-			event.target.select();
+		if ( this.currentTextField ) {
+			this.currentTextField.focus();
 		}
 	}
 
+	selectOnFocus = event => {
+		if ( this.props.selectOnFocus ) {
+			event.target.select();
+		}
+	};
+
 	render() {
-		const { inputRef } = this.props;
 		const props = omit( this.props, 'isError', 'isValid', 'selectOnFocus', 'inputRef' );
 
 		const classes = classNames( 'form-text-input', this.props.className, {
@@ -46,7 +47,7 @@ export default class FormTextInput extends PureComponent {
 			<input
 				type="text"
 				{ ...props }
-				ref={ inputRef || 'textField' }
+				ref={ this.textFieldRef }
 				className={ classes }
 				onClick={ this.selectOnFocus }
 			/>

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -17,13 +17,14 @@ export default class FormTextInput extends PureComponent {
 	currentTextField = undefined;
 
 	textFieldRef = element => {
-		if ( element && this.props.inputRef ) {
-			if ( typeof this.props.inputRef === 'function' ) {
-				this.props.inputRef( element );
-			} else if ( this.props.inputRef.hasOwnProperty( 'current' ) ) {
-				this.props.inputRef.current = element;
-			}
+		const { inputRef } = this.props;
+
+		if ( inputRef && typeof inputRef === 'function' ) {
+			inputRef( element );
+		} else if ( inputRef && inputRef.hasOwnProperty( 'current' ) ) {
+			inputRef.current = element;
 		}
+
 		this.currentTextField = element;
 	};
 

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -17,15 +17,19 @@ export default class FormTextInput extends PureComponent {
 	currentTextField = undefined;
 
 	textFieldRef = element => {
+		this.currentTextField = element;
+
 		const { inputRef } = this.props;
 
-		if ( inputRef && typeof inputRef === 'function' ) {
-			inputRef( element );
-		} else if ( inputRef && inputRef.hasOwnProperty( 'current' ) ) {
-			inputRef.current = element;
+		if ( ! inputRef ) {
+			return;
 		}
 
-		this.currentTextField = element;
+		if ( typeof inputRef === 'function' ) {
+			inputRef( element );
+		} else {
+			inputRef.current = element;
+		}
 	};
 
 	focus() {

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -18,7 +18,11 @@ export default class FormTextInput extends PureComponent {
 
 	textFieldRef = element => {
 		if ( element && this.props.inputRef ) {
-			this.props.inputRef.current = element;
+			if ( typeof this.props.inputRef === 'function' ) {
+				this.props.inputRef( element );
+			} else if ( this.props.inputRef.hasOwnProperty( 'current' ) ) {
+				this.props.inputRef.current = element;
+			}
 		}
 		this.currentTextField = element;
 	};


### PR DESCRIPTION
String refs are deprecated and can easily be replaced in this component.

#### Changes proposed in this Pull Request

* Replace string refs in FormTextInput.

#### Testing instructions

* Ensure that `FormTextInput` continues working correctly. The "username or email" field in `/log-in` is one example.
