### PR TITLE
Temporarily skip gutenberg specs

### DIFF
--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -37,7 +37,7 @@ before( async function() {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, function() {
+describe.skip( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Public Pages: @parallel', function() {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -45,7 +45,7 @@ before( async function() {
 	driver = await driverManager.startBrowser();
 } );
 
-describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function() {
+describe.skip( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {

--- a/test/e2e/specs/wp-comments-spec.js
+++ b/test/e2e/specs/wp-comments-spec.js
@@ -84,7 +84,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 		} );
 	} );
 
-	describe( 'Commenting and replying to newly created post in Gutenberg Editor: @parallel', function() {
+	describe.skip( 'Commenting and replying to newly created post in Gutenberg Editor: @parallel', function() {
 		step( 'Can login and create a new post', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
 			await this.loginFlow.loginAndStartNewPost( null, true );


### PR DESCRIPTION
Temporarily skips related Gutenberg suites from the v6.1.1 update.