### PR TITLE
Gutenberg: re-enable test suites and close sidebar on new post or page creation

### DIFF
--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -10,6 +10,7 @@ import ReaderPage from '../pages/reader-page.js';
 import StatsPage from '../pages/stats-page.js';
 import StoreDashboardPage from '../pages/woocommerce/store-dashboard-page';
 import PluginsBrowserPage from '../pages/plugins-browser-page';
+import GutenbergEditorComponent from '../gutenberg/gutenberg-editor-component';
 
 import SidebarComponent from '../components/sidebar-component.js';
 import NavBarComponent from '../components/nav-bar-component.js';
@@ -111,6 +112,11 @@ export default class LoginFlow {
 		const navbarComponent = await NavBarComponent.Expect( this.driver );
 		await navbarComponent.clickCreateNewPost( { siteURL: siteURL } );
 
+		if ( usingGutenberg ) {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+			await gEditorComponent.closeSidebar();
+		}
+
 		if ( ! usingGutenberg ) {
 			this.editorPage = await EditorPage.Expect( this.driver );
 
@@ -135,6 +141,11 @@ export default class LoginFlow {
 
 		const pagesPage = await PagesPage.Expect( this.driver );
 		await pagesPage.selectAddNewPage();
+
+		if ( usingGutenberg ) {
+			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+			await gEditorComponent.closeSidebar();
+		}
 
 		if ( ! usingGutenberg ) {
 			this.editorPage = await EditorPage.Expect( this.driver );

--- a/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-sidebar-component.js
@@ -12,6 +12,7 @@ import * as driverHelper from '../driver-helper.js';
 import AsyncBaseContainer from '../async-base-container';
 import * as driverManager from '../driver-manager';
 import * as SlackNotifier from '../slack-notifier';
+import GutenbergEditorComponent from './gutenberg-editor-component';
 
 export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer {
 	constructor( driver ) {
@@ -189,6 +190,8 @@ export default class GutenbergEditorSidebarComponent extends AsyncBaseContainer 
 	}
 
 	async chooseDocumentSettings() {
+		const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+		await gEditorComponent.openSidebar();
 		return await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( '[aria-label^="Document settings"], [data-label^="Document"]' )

--- a/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-page-editor-spec.js
@@ -37,7 +37,7 @@ before( async function() {
 	driver = await driverManager.startBrowser();
 } );
 
-describe.skip( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, function() {
+describe( `[${ host }] Calypso Gutenberg Editor: Pages (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Public Pages: @parallel', function() {

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -264,6 +264,7 @@ describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, funct
 
 			step( 'Can enter post title and text content', async function() {
 				const gEditorComponent = await GutenbergEditorComponent.Expect( driver );
+				await gEditorComponent.closeSidebar();
 				await gEditorComponent.enterTitle( blogPostTitle );
 				await gEditorComponent.enterText( blogPostQuote );
 

--- a/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
+++ b/test/e2e/specs/wp-calypso-gutenberg-post-editor-spec.js
@@ -45,7 +45,7 @@ before( async function() {
 	driver = await driverManager.startBrowser();
 } );
 
-describe.skip( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function() {
+describe( `[${ host }] Calypso Gutenberg Editor: Posts (${ screenSize })`, function() {
 	this.timeout( mochaTimeOut );
 
 	describe( 'Public Posts: Preview and Publish a Public Post @parallel', function() {

--- a/test/e2e/specs/wp-comments-spec.js
+++ b/test/e2e/specs/wp-comments-spec.js
@@ -84,7 +84,7 @@ describe( `[${ host }] Comments: (${ screenSize })`, function() {
 		} );
 	} );
 
-	describe.skip( 'Commenting and replying to newly created post in Gutenberg Editor: @parallel', function() {
+	describe( 'Commenting and replying to newly created post in Gutenberg Editor: @parallel', function() {
 		step( 'Can login and create a new post', async function() {
 			this.loginFlow = new LoginFlow( driver, 'gutenbergSimpleSiteUser' );
 			await this.loginFlow.loginAndStartNewPost( null, true );


### PR DESCRIPTION
## Background

Gutenberg v6.1.1 appears to have broken related E2E tests. We disabled these temporarily, since @Stojdza debugged that tests were failing due to the sidebar being open in the block editor.

The sidebar being open in the Block Editor is a sticky user preference. Because we use the same test user, we need to be careful to reset state. Right now we assume the sidebar is always closed, but this might not be the case if a suite run is interrupted.

https://github.com/WordPress/gutenberg/blob/4fa8431aaf148c9417e20804ee48874b8e271e12/packages/edit-post/src/store/reducer.js#L58