### PR TITLE
Gutenberg: update switch to classic menu options selector

### DIFF
--- a/apps/wpcom-block-editor/src/common/switch-to-classic.js
+++ b/apps/wpcom-block-editor/src/common/switch-to-classic.js
@@ -13,8 +13,8 @@ function addSwitchToClassicButton() {
 	$( '#editor' ).on( 'click', '.edit-post-more-menu .components-button', () => {
 		// We need to wait a few ms until the menu content is rendered
 		setTimeout( () => {
-			$( '.edit-post-more-menu__content .components-menu-group:last-child > div[role=menu]' )
-				.append( `
+			//role may be 'menu' or 'group', depending on the Gutenberg version
+			$( '.edit-post-more-menu__content .components-menu-group:last-child > div[role]' ).append( `
 					<a 
 						href="${ wpcomGutenberg.switchToClassic.url }" target="_top" role="menuitem" 
 						aria-label="${ wpcomGutenberg.switchToClassic.label }"


### PR DESCRIPTION
Adds back the switch to classic option in the Block Editor dropdown.

This broke in the v6.1.1 update since markup changed from `role=menu` to `role=group`
<img width="294" alt="Screen Shot 2019-07-15 at 5 31 39 PM" src="https://user-images.githubusercontent.com/1270189/61257584-901e2000-a726-11e9-84df-a311c28c28aa.png">

<img width="309" alt="screen-shot-2019-07-08-at-11 35 10-am" src="https://user-images.githubusercontent.com/1270189/61257609-a88e3a80-a726-11e9-93c8-f30c4a0a030a.png">

### Testing Instructions
- Sandbox, and use the related patch D30460-code
- Verify that the switch to classic option is still present in Simple Sites and Jetpack sites that _do not_ use the Gutenberg plugin
