### PR TITLE
css: migrate components/locale-suggestions styles

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -13,7 +13,6 @@
 @import 'components/date-picker/style';
 @import 'components/dialog/style';
 @import 'components/info-popover/style';
-@import 'components/locale-suggestions/style';
 @import 'components/main/style';
 @import 'components/notice/style';
 @import 'components/popover/style';

--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -19,6 +19,11 @@ import Notice from 'components/notice';
 import getLocaleSuggestions from 'state/selectors/get-locale-suggestions';
 import { setLocale } from 'state/ui/language/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export class LocaleSuggestions extends Component {
 	static propTypes = {
 		locale: PropTypes.string,

--- a/client/components/locale-suggestions/list-item.jsx
+++ b/client/components/locale-suggestions/list-item.jsx
@@ -14,6 +14,11 @@ import { getLocaleSlug } from 'i18n-calypso';
  */
 import { getLanguage } from 'lib/i18n-utils';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class LocaleSuggestionsListItem extends Component {
 	static propTypes = {
 		locale: PropTypes.object.isRequired,

--- a/client/components/locale-suggestions/list-item.jsx
+++ b/client/components/locale-suggestions/list-item.jsx
@@ -14,11 +14,6 @@ import { getLocaleSlug } from 'i18n-calypso';
  */
 import { getLanguage } from 'lib/i18n-utils';
 
-/**
- * Style dependencies
- */
-import './style.scss';
-
 class LocaleSuggestionsListItem extends Component {
 	static propTypes = {
 		locale: PropTypes.object.isRequired,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate styles of `components/locale-suggestions` to be processed by webpack

#### Testing instructions

The `.locale-suggestions` class selector is being used in two other places to change its `margin-top`:

https://github.com/Automattic/wp-calypso/blob/4966300954b3478f07a1be712d948c4c3e3d8dff/client/my-sites/invites/invite-accept/style.scss#L1-L3

https://github.com/Automattic/wp-calypso/blob/4966300954b3478f07a1be712d948c4c3e3d8dff/client/layout/masterbar/oauth-client.scss#L84-L88

Both use selectors with higher specificity and continue working as expected.

##### InviteAccept

![Screen shot of LocaleSuggestions as seen in InviteAccept component](https://cld.wthms.co/moJLFT+)

1. Send an invite from account A to account B.
2. Copy the link sent to account B's email and replace https://wordpress.com by https://calypso.localhost:3000.
3. Comment these lines to show the `LocaleSuggestions` component: https://github.com/Automattic/wp-calypso/blob/4966300954b3478f07a1be712d948c4c3e3d8dff/client/my-sites/invites/invite-accept/index.jsx#L111-L113

##### Layout

![Screen shot of LocaleSuggestions as seen in DOPS layout](https://cld.wthms.co/9SfLVY+)

1. Go to `/log-in/es` (or a different language code if `es` is your default).
2. Run on console: `document.querySelector('.layout').classList.add('dops')`

Fixes #34670 (part of #27515)
