### PR TITLE
Exclude subs paid with credits from showing the auto-renewal toggle.

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -21,6 +21,7 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isPaidWithCreditCard,
+	isPaidWithCredits,
 	cardProcessorSupportsUpdates,
 	isPaidWithPayPalDirect,
 	isRenewing,
@@ -192,7 +193,7 @@ class PurchaseMeta extends Component {
 		if ( hasPaymentMethod( purchase ) ) {
 			let paymentInfo = null;
 
-			if ( purchase.payment.type === 'credits' ) {
+			if ( isPaidWithCredits( purchase ) ) {
 				return translate( 'Credits' );
 			}
 
@@ -308,6 +309,7 @@ class PurchaseMeta extends Component {
 			config.isEnabled( 'autorenewal-toggle' ) &&
 			( isDomainRegistration( purchase ) || isPlan( purchase ) ) &&
 			hasPaymentMethod( purchase ) &&
+			! isPaidWithCredits( purchase ) &&
 			! isExpired( purchase )
 		) {
 			const dateSpan = <span className="manage-purchase__detail-date-span" />;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements the change that prevents the toggle from showing for the subs paid with dotcom credits. It is an non-legit action to perform, so we shouldn't even show it.

Current:
![image](https://user-images.githubusercontent.com/1842898/61264691-028f0e80-a7c0-11e9-88a4-3a825592bc34.png)

After:
![image](https://user-images.githubusercontent.com/1842898/61264699-07ec5900-a7c0-11e9-90ec-b85141211074.png)

#### Testing instructions

Go to the purchase manage page for a subscription paid with credits, and the auto-renewal toggle shouldn't be there.
