### PR TITLE
Community Translator Launcher: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -24,5 +24,4 @@
 @import 'components/sites-popover/style';
 @import 'components/tooltip/style';
 @import 'layout/guided-tours/style';
-@import 'layout/community-translator/style';
 @import 'layout/sidebar/style';

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -6,9 +6,10 @@
 
 import PropTypes from 'prop-types';
 import i18n, { localize } from 'i18n-calypso';
-import React from 'react';
+import React, { Fragment } from 'react';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -95,56 +96,61 @@ class TranslatorLauncher extends React.Component {
 		this.setState( { isActive: nextIsActive } );
 	};
 
-	render() {
-		let launcherClasses = 'community-translator';
-		let toggleString;
-
-		if ( this.state.isActive ) {
-			toggleString = this.props.translate( 'Disable Translator' );
-			launcherClasses += ' is-active';
-		} else {
-			toggleString = this.props.translate( 'Enable Translator' );
-		}
-
-		const infoDialogButtons = [ { action: 'cancel', label: this.props.translate( 'Ok' ) } ];
+	renderConfirmationModal() {
+		const { translate } = this.props;
+		const infoDialogButtons = [ { action: 'cancel', label: translate( 'OK' ) } ];
 
 		return (
-			<div>
+			<Dialog
+				isVisible
+				buttons={ infoDialogButtons }
+				onClose={ this.infoDialogClose }
+				additionalClassNames="community-translator__modal"
+			>
+				<h1>{ translate( 'Community Translator' ) }</h1>
+				<p>
+					{ translate(
+						'You have now enabled the translator. Right click the text to translate it.'
+					) }
+				</p>
+				<p>
+					<label htmlFor="toggle">
+						<input type="checkbox" id="toggle" onClick={ this.toggleInfoCheckbox } />
+						<span>{ translate( "Don't show again" ) }</span>
+					</label>
+				</p>
+			</Dialog>
+		);
+	}
+
+	render() {
+		const { translate } = this.props;
+		const { isEnabled, isActive, infoDialogVisible } = this.state;
+
+		const launcherClasses = classNames( 'community-translator', { 'is-active': isActive } );
+		const toggleString = isActive
+			? translate( 'Disable Translator' )
+			: translate( 'Enable Translator' );
+
+		return (
+			<Fragment>
 				<QueryUserSettings />
-				{ this.state.isEnabled && (
-					<Dialog
-						isVisible={ this.state.infoDialogVisible }
-						buttons={ infoDialogButtons }
-						onClose={ this.infoDialogClose }
-						additionalClassNames="community-translator__modal"
-					>
-						<h1>{ this.props.translate( 'Community Translator' ) }</h1>
-						<p>
-							{ this.props.translate(
-								'You have now enabled the translator. Right click the text to translate it.'
-							) }
-						</p>
-						<p>
-							<label htmlFor="toggle">
-								<input type="checkbox" id="toggle" onClick={ this.toggleInfoCheckbox } />
-								<span>{ this.props.translate( "Don't show again" ) }</span>
-							</label>
-						</p>
-					</Dialog>
+				{ isEnabled && (
+					<Fragment>
+						<div className={ launcherClasses }>
+							<button
+								className="community-translator__button"
+								onClick={ this.toggle }
+								title={ translate( 'Community Translator' ) }
+							>
+								<Gridicon icon="globe" />
+								<div className="community-translator__text">{ toggleString }</div>
+							</button>
+						</div>
+						{ infoDialogVisible && this.renderConfirmationModal() }
+					</Fragment>
 				) }
-				{ this.state.isEnabled && (
-					<div className={ launcherClasses }>
-						<button
-							className="community-translator__button"
-							onClick={ this.toggle }
-							title={ this.props.translate( 'Community Translator' ) }
-						>
-							<Gridicon icon="globe" />
-							<div className="community-translator__text">{ toggleString }</div>
-						</button>
-					</div>
-				) }
-			</div>
+			</Fragment>
 		);
 	}
 }

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -28,9 +28,7 @@ import QueryUserSettings from 'components/data/query-user-settings';
  */
 import './style.scss';
 
-class TranslatorLauncher extends React.PureComponent {
-	static displayName = 'TranslatorLauncher';
-
+class TranslatorLauncher extends React.Component {
 	static propTypes = {
 		translate: PropTypes.func,
 	};

--- a/client/layout/community-translator/launcher.jsx
+++ b/client/layout/community-translator/launcher.jsx
@@ -23,6 +23,11 @@ import getUserSettings from 'state/selectors/get-user-settings';
 import getOriginalUserSetting from 'state/selectors/get-original-user-setting';
 import QueryUserSettings from 'components/data/query-user-settings';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class TranslatorLauncher extends React.PureComponent {
 	static displayName = 'TranslatorLauncher';
 


### PR DESCRIPTION
Migrates the community translator styles to webpack, including the styling of jQuery based UI loaded from `widgets.wp.com`. I also reorganized the launcher's JSX markup a bit to replace redundant `div` elements with fragments and to avoid rendering the `Dialog` markup when not needed.

**How to test:**
- switch your locale to non-English language
- the community translator globe icon should appear above the help icon. Check that is has correct styling both in enabled and disabled state.

<img width="219" alt="Screenshot 2019-07-16 at 09 39 08" src="https://user-images.githubusercontent.com/664258/61275496-64467d00-a7ae-11e9-9348-e968744e2fee.png">

- a confirmation dialog should appear after enabling the translator:

<img width="675" alt="Screenshot 2019-07-16 at 09 39 31" src="https://user-images.githubusercontent.com/664258/61275561-83450f00-a7ae-11e9-9351-cadf88cf8eba.png">

- after right-click on a highlighted translation, you should see the jQuery based popup. Verify that the popup, its title and the arrow has the custom styling defined by the `.webui-*` classes:

<img width="462" alt="Screenshot 2019-07-16 at 09 41 57" src="https://user-images.githubusercontent.com/664258/61275626-a53e9180-a7ae-11e9-867d-cb0aaaa61509.png">
