### PR TITLE
Auto-renewal Toggle: Prevent the survey from showing excessively.

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -35,6 +35,7 @@ class AutoRenewDisablingDialog extends Component {
 
 	state = {
 		dialogType: DIALOG.GENERAL,
+		surveyHasShown: false,
 	};
 
 	getVariation() {
@@ -124,6 +125,10 @@ class AutoRenewDisablingDialog extends Component {
 
 	closeAndCleanup = () => {
 		this.props.onClose();
+
+		// It is intentional that we don't reset `surveyHasShown` flag here.
+		// That state is for preventing the survey from showing excessively.
+		// The current behavior is that it won't show up until this component has been unmounted and then remounted.
 		this.setState( {
 			dialogType: DIALOG.GENERAL,
 		} );
@@ -173,8 +178,14 @@ class AutoRenewDisablingDialog extends Component {
 		}
 
 		this.props.onConfirm();
+
+		if ( this.state.surveyHasShown ) {
+			return this.closeAndCleanup();
+		}
+
 		this.setState( {
 			dialogType: DIALOG.SURVEY,
+			surveyHasShown: true,
 		} );
 	};
 

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -26,6 +26,7 @@ const DIALOG = {
 
 class AutoRenewDisablingDialog extends Component {
 	static propTypes = {
+		isVisible: PropTypes.bool,
 		translate: PropTypes.func.isRequired,
 		planName: PropTypes.string.isRequired,
 		siteDomain: PropTypes.string.isRequired,
@@ -33,7 +34,6 @@ class AutoRenewDisablingDialog extends Component {
 	};
 
 	state = {
-		showAtomicFollowUpDialog: false,
 		dialogType: DIALOG.GENERAL,
 	};
 
@@ -122,16 +122,23 @@ class AutoRenewDisablingDialog extends Component {
 		} );
 	};
 
+	closeAndCleanup = () => {
+		this.props.onClose();
+		this.setState( {
+			dialogType: DIALOG.GENERAL,
+		} );
+	};
+
 	renderAtomicFollowUpDialog = () => {
-		const { siteDomain, onClose, translate } = this.props;
+		const { siteDomain, isVisible, translate } = this.props;
 
 		const exportPath = '//' + siteDomain + '/wp-admin/export.php';
 
 		return (
 			<Dialog
-				isVisible={ true }
+				isVisible={ isVisible }
 				additionalClassNames="auto-renew-disabling-dialog atomic-follow-up"
-				onClose={ onClose }
+				onClose={ this.closeAndCleanup }
 			>
 				<p>
 					{ translate(
@@ -172,21 +179,21 @@ class AutoRenewDisablingDialog extends Component {
 	};
 
 	renderGeneralDialog = () => {
-		const { onClose, translate } = this.props;
+		const { isVisible, translate } = this.props;
 		const description = this.getCopy( this.getVariation() );
 
 		return (
 			<Dialog
-				isVisible={ true }
+				isVisible={ isVisible }
 				additionalClassNames="auto-renew-disabling-dialog"
-				onClose={ onClose }
+				onClose={ this.closeAndCleanup }
 			>
 				<h2 className="auto-renew-disabling-dialog__header">{ translate( 'Before you go…' ) }</h2>
 				<p>{ description }</p>
 				<Button onClick={ this.onClickGeneralConfirm }>
 					{ translate( 'Confirm cancellation' ) }
 				</Button>
-				<Button onClick={ onClose } primary>
+				<Button onClick={ this.closeAndCleanup } primary>
 					{ translate( "I'll keep it" ) }
 				</Button>
 			</Dialog>
@@ -194,15 +201,15 @@ class AutoRenewDisablingDialog extends Component {
 	};
 
 	renderSurvey = () => {
-		const { purchase, selectedSite, onClose } = this.props;
+		const { purchase, isVisible, selectedSite } = this.props;
 
 		return (
 			<CancelPurchaseForm
 				purchase={ purchase }
 				selectedSite={ selectedSite }
-				isVisible={ true }
-				onClose={ onClose }
-				onClickFinalConfirm={ onClose }
+				isVisible={ isVisible }
+				onClose={ this.closeAndCleanup }
+				onClickFinalConfirm={ this.closeAndCleanup }
 				flowType={ 'cancel_autorenew_survey_only' }
 			/>
 		);

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -125,15 +125,14 @@ class AutoRenewToggle extends Component {
 					disabled={ this.isUpdatingAutoRenew() }
 					onChange={ this.onToggleAutoRenew }
 				/>
-				{ this.state.showAutoRenewDisablingDialog && (
-					<AutoRenewDisablingDialog
-						planName={ planName }
-						purchase={ purchase }
-						siteDomain={ siteDomain }
-						onClose={ this.onCloseAutoRenewDisablingDialog }
-						onConfirm={ this.toggleAutoRenew }
-					/>
-				) }
+				<AutoRenewDisablingDialog
+					isVisible={ this.state.showAutoRenewDisablingDialog }
+					planName={ planName }
+					purchase={ purchase }
+					siteDomain={ siteDomain }
+					onClose={ this.onCloseAutoRenewDisablingDialog }
+					onConfirm={ this.toggleAutoRenew }
+				/>
 			</>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements a simplified version of the great suggestion from @tbradsha . It prevents the toggling-off survey from showing excessively until navigating away and back. Here is a screencast:

![demo-debounce-survey](https://user-images.githubusercontent.com/1842898/61276088-ed2adc00-a7e1-11e9-9afc-03025883d00f.gif)

As demonstrated above, the survey showed the first time I had toggled the auto-renewal off. After that, re-toggling off wouldn't trigger the survey. It only came back after I had navigated away and back.

#### Testing instructions

1. Go to the purchase management page of a subscription.
1. Toggle off and hit "confirm cancellation", and the survey should show.
1. Complete the survey or skip it.
1. Re-toggling it off shouldn't make the survey show up.
1. Navigating away and back, toggling off should make the survey show up this time.


