### PR TITLE
Sidebar: show Plugins item and its target destination correctly

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -44,6 +44,7 @@ import {
 	canCurrentUserUseAds,
 	canCurrentUserUseStore,
 } from 'state/sites/selectors';
+import canCurrentUserManagePlugins from 'state/selectors/can-current-user-manage-plugins';
 import { getStatsPathForTab } from 'lib/route';
 import { itemLinkMatches } from './utils';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
@@ -103,9 +104,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	tools() {
-		const { canUserManageOptions } = this.props;
-
-		if ( ! canUserManageOptions ) {
+		if ( ! this.props.canUserManageOptions && ! this.props.canUserManagePlugins ) {
 			return null;
 		}
 
@@ -724,6 +723,7 @@ function mapStateToProps( state ) {
 		canUserManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
 		canUserPublishPosts: canCurrentUser( state, siteId, 'publish_posts' ),
 		canUserViewStats: canCurrentUser( state, siteId, 'view_stats' ),
+		canUserManagePlugins: canCurrentUserManagePlugins( state ),
 		canUserUseStore: canCurrentUserUseStore( state, siteId ),
 		canUserUseAds: canCurrentUserUseAds( state, siteId ),
 		canUserUpgradeSite: canCurrentUserUpgradeSite( state, siteId ),

--- a/client/my-sites/sidebar/tools-menu.jsx
+++ b/client/my-sites/sidebar/tools-menu.jsx
@@ -44,17 +44,16 @@ class ToolsMenu extends PureComponent {
 			name: 'plugins',
 			label: translate( 'Plugins' ),
 			capability: 'manage_options',
-			queryable: ! isAtomicSite,
+			queryable: ! config.isEnabled( 'calypsoify/plugins' ) || ! isAtomicSite,
 			config: 'manage/plugins',
 			link: '/plugins',
 			paths: [ '/extensions', '/plugins' ],
 			wpAdminLink: 'plugin-install.php?calypsoify=1',
 			showOnAllMySites: canManagePlugins,
-			forceInternalLink: isAtomicSite,
 		};
 	}
 
-	getImportItem = () => {
+	getImportItem() {
 		const { isJetpack, translate } = this.props;
 
 		return {
@@ -65,12 +64,10 @@ class ToolsMenu extends PureComponent {
 			link: '/import',
 			paths: [ '/import' ],
 			wpAdminLink: 'import.php',
-			showOnAllMySites: false,
-			forceInternalLink: ! isJetpack,
 		};
-	};
+	}
 
-	getExportItem = () => {
+	getExportItem() {
 		const { isJetpack, translate } = this.props;
 
 		return {
@@ -81,10 +78,8 @@ class ToolsMenu extends PureComponent {
 			link: '/export',
 			paths: [ '/export' ],
 			wpAdminLink: 'export.php',
-			showOnAllMySites: false,
-			forceInternalLink: ! isJetpack,
 		};
-	};
+	}
 
 	onNavigate = postType => () => {
 		if ( ! includes( [ 'post', 'page' ], postType ) ) {
@@ -128,22 +123,13 @@ class ToolsMenu extends PureComponent {
 				onNavigate={ this.onNavigate( menuItem.name ) }
 				postType={ menuItem.name === 'plugins' ? null : menuItem.name }
 				tipTarget={ `side-menu-${ menuItem.name }` }
-				forceInternalLink={ menuItem.forceInternalLink }
 				expandSection={ this.expandToolsSection }
 			/>
 		);
 	}
 
 	render() {
-		const menuItems = [];
-
-		if ( config.isEnabled( 'calypsoify/plugins' ) ) {
-			menuItems.push( this.getPluginItem() );
-		}
-
-		menuItems.push( this.getImportItem() );
-
-		menuItems.push( this.getExportItem() );
+		const menuItems = [ this.getPluginItem(), this.getImportItem(), this.getExportItem() ];
 
 		return <ul>{ menuItems.map( this.renderMenuItem, this ) }</ul>;
 	}


### PR DESCRIPTION
The New Sidebar project introduced a few bugs in how the "Plugins" item is
displayed and where it navigates to.

**Correct behavior:**
- the "All Sites" view shows "Plugins" if and only if user has the `manage_options` capability for
  at least one site. It shows overview of plugins on all sites. The "All Sites" UI is always in Calypso,
  never redirects to wp-admin. Before this patch, the item wasn't displayed in "All Sites" at all.
- for Simple and Jetpack sites, sidebar shows "Plugins" for user who can `manage_options` and always
  points to Calypso.
- for Atomic sites, the "Plugins" item navigates to wp-admin's Calypsoified URL. Except for the desktop
  environment (where the `calypsoify/plugins` flag is false), where it navigates to Calypso UI, too.

Fixes Automattic/wp-desktop#636