### PR TITLE
Explicitly return null from user id reducer

### DIFF
--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -38,7 +38,9 @@ import emailVerification from './email-verification/reducer';
 export const id = createReducer(
 	null,
 	{
-		[ CURRENT_USER_RECEIVE ]: ( state, action ) => action.user.ID,
+		[ CURRENT_USER_RECEIVE ]: ( state, action ) => {
+			return action.user.ID || null;
+		},
 	},
 	idSchema
 );


### PR DESCRIPTION
#### Edit - not sure if this is happening for everyone

Please try to reproduce before merging, I am not 100% sure this is happening for everyone. I have a someone messed up sandbox.

#### Changes proposed in this Pull Request

* Explicitly return null on a falsy user ID value in the user ID reducer. This eliminates the following message: 

> Uncaught (in promise) Error: Given action "CURRENT_USER_RECEIVE", reducer "id" returned undefined. To ignore an action, you must explicitly return the previous state. If you want this reducer to hold no value, you can return null instead of undefined.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On current Calypso master, as a logged-out user (I suspect this only happens if you're logged out)
* Try to access the reader URL or any page that requires authentication checks (probably all of them?)
* You will see the error above ^^
* Try this patch
* Everything should work

<img width="921" alt="calypso-crash-current_user_receive" src="https://user-images.githubusercontent.com/51896/61306162-f182d500-a7a0-11e9-8c32-401cee9b4921.png">

