### PR TITLE
[e2e] Fix broken `Renew a plan` test

### DIFF
--- a/test/e2e/lib/pages/purchases-page.js
+++ b/test/e2e/lib/pages/purchases-page.js
@@ -15,7 +15,7 @@ const by = webdriver.By;
 
 export default class PurchasesPage extends AsyncBaseContainer {
 	constructor( driver ) {
-		super( driver, by.css( 'a[href="/me/purchases"][aria-selected="true"]' ) );
+		super( driver, by.css( 'a[href="/me/purchases"][aria-current="true"]' ) );
 	}
 
 	async _postInit() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Selector has changed with https://github.com/Automattic/wp-calypso/pull/34339 which caused `Renew a plan` test to fail - this PR updates it and test should pass now. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make sure that test `Renew a plan` passes.


