### PR TITLE
AB test to show single plan

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -43,7 +43,7 @@ class JetpackPlansGrid extends Component {
 
 	renderConnectHeader() {
 		const { isLanding, translate } = this.props;
-		const isPremiumOnly = abtest( 'singleJetpackPlan' ).startsWith( 'premiumOnly' );
+		const isPremiumOnly = abtest( 'singleJetpackPlan' ) === 'premiumOnly';
 
 		// mutable headers
 		let headerText = translate( 'Explore our Jetpack plans' );
@@ -64,12 +64,8 @@ class JetpackPlansGrid extends Component {
 	}
 
 	render() {
-		const { interval } = this.props;
-
 		// single-plan AB test
-		const abTestVariation = abtest( 'singleJetpackPlan' );
-		const isPremiumOnly = abTestVariation.startsWith( 'premiumOnly' );
-		const defaultInterval = abTestVariation.endsWith( 'Monthly' ) ? 'monthly' : 'yearly';
+		const isPremiumOnly = abtest( 'singleJetpackPlan' ) === 'premiumOnly';
 		const planTypes = isPremiumOnly ? [ TYPE_PREMIUM ] : [];
 
 		return (
@@ -83,7 +79,7 @@ class JetpackPlansGrid extends Component {
 							isLandingPage={ ! this.props.selectedSite }
 							basePlansPath={ this.props.basePlansPath }
 							onUpgradeClick={ this.props.onSelect }
-							intervalType={ interval ? interval : defaultInterval }
+							intervalType={ this.props.interval }
 							hideFreePlan={ this.props.hideFreePlan }
 							displayJetpackPlans={ true }
 							planTypes={ planTypes }

--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -14,6 +14,8 @@ import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { abtest } from 'lib/abtest';
+import { TYPE_PREMIUM } from 'lib/plans/constants';
 
 /**
  * Constants
@@ -41,17 +43,35 @@ class JetpackPlansGrid extends Component {
 
 	renderConnectHeader() {
 		const { isLanding, translate } = this.props;
+		const isPremiumOnly = abtest( 'singleJetpackPlan' ).startsWith( 'premiumOnly' );
 
-		const headerText = translate( 'Explore our Jetpack plans' );
+		// mutable headers
+		let headerText = translate( 'Explore our Jetpack plans' );
 		let subheaderText = translate( "Now that you're set up, pick a plan that fits your needs." );
 
 		if ( isLanding ) {
 			subheaderText = translate( 'Pick a plan that fits your needs.' );
 		}
+
+		if ( isPremiumOnly ) {
+			headerText = translate( 'Build like a pro with Jetpack Premium' );
+			subheaderText = translate(
+				'Jetpack Premium automatically protects your site from spam, prevents data loss and enhances SEO'
+			);
+		}
+
 		return <FormattedHeader headerText={ headerText } subHeaderText={ subheaderText } />;
 	}
 
 	render() {
+		const { interval } = this.props;
+
+		// single-plan AB test
+		const abTestVariation = abtest( 'singleJetpackPlan' );
+		const isPremiumOnly = abTestVariation.startsWith( 'premiumOnly' );
+		const defaultInterval = abTestVariation.endsWith( 'Monthly' ) ? 'monthly' : 'yearly';
+		const planTypes = isPremiumOnly ? [ TYPE_PREMIUM ] : [];
+
 		return (
 			<MainWrapper isWide className="jetpack-connect__hide-plan-icons">
 				<div className="jetpack-connect__plans">
@@ -63,9 +83,10 @@ class JetpackPlansGrid extends Component {
 							isLandingPage={ ! this.props.selectedSite }
 							basePlansPath={ this.props.basePlansPath }
 							onUpgradeClick={ this.props.onSelect }
-							intervalType={ this.props.interval }
+							intervalType={ interval ? interval : defaultInterval }
 							hideFreePlan={ this.props.hideFreePlan }
 							displayJetpackPlans={ true }
+							planTypes={ planTypes }
 						/>
 
 						<PlansSkipButton onClick={ this.handleSkipButtonClick } />

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -197,7 +197,7 @@ class Plans extends Component {
 
 		const helpButtonLabel = translate( 'Need help?' );
 
-		const isPremiumOnly = abtest( 'singleJetpackPlan' ).startsWith( 'premiumOnly' );
+		const isPremiumOnly = abtest( 'singleJetpackPlan' ) === 'premiumOnly';
 
 		return (
 			<Fragment>

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -38,6 +38,7 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
+import { abtest } from 'lib/abtest';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
 const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
@@ -196,6 +197,8 @@ class Plans extends Component {
 
 		const helpButtonLabel = translate( 'Need help?' );
 
+		const isPremiumOnly = abtest( 'singleJetpackPlan' ).startsWith( 'premiumOnly' );
+
 		return (
 			<Fragment>
 				<DocumentHead title={ translate( 'Plans' ) } />
@@ -209,7 +212,7 @@ class Plans extends Component {
 					interval={ interval }
 					selectedSite={ selectedSite }
 				>
-					<PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } />
+					{ ! isPremiumOnly && <PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } /> }
 					<LoggedOutFormLinks>
 						<JetpackConnectHappychatButton
 							label={ helpButtonLabel }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -143,7 +143,7 @@ export default {
 			allPlansMonthly: 25,
 			allPlansYearly: 25,
 		},
-		defaultVariation: 'premiumOnlyMonthly',
+		defaultVariation: 'allPlansYearly',
 		allowExistingUsers: true,
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -138,12 +138,10 @@ export default {
 	singleJetpackPlan: {
 		datestamp: '20190715',
 		variations: {
-			premiumOnlyMonthly: 25,
-			premiumOnlyYearly: 25,
-			allPlansMonthly: 25,
-			allPlansYearly: 25,
+			premiumOnly: 20,
+			allPlans: 80,
 		},
-		defaultVariation: 'allPlansYearly',
+		defaultVariation: 'allPlans',
 		allowExistingUsers: true,
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -135,4 +135,15 @@ export default {
 		defaultVariation: 'notSkippable',
 		allowExistingUsers: true,
 	},
+	singleJetpackPlan: {
+		datestamp: '20190715',
+		variations: {
+			premiumOnlyMonthly: 25,
+			premiumOnlyYearly: 25,
+			allPlansMonthly: 25,
+			allPlansYearly: 25,
+		},
+		defaultVariation: 'premiumOnlyMonthly',
+		allowExistingUsers: true,
+	},
 };


### PR DESCRIPTION
In working on the G Suite flows, we discovered a significant drop in conversions when displaying more than one plan. I wondered if the same phenomenon might apply to Jetpack plans.

This AB test tests the effect on Jetpack's plans page of:

- only show Premium plan - 20%
- show all plans (current setting) - 80%

#### Changes proposed in this Pull Request

* Add AB test for Premium-only Jetpack plans
* Change wording to make sense for a single plan (e.g. removing "choose a plan" type phrases)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In the browser's dev console, enable AB test debugging with `localStorage.setItem('debug', 'calypso:abtests');`
* Enable Premium only, Monthly prices using `localStorage.setItem( 'ABTests', '{"singleJetpackPlan_20190715":"premiumOnly"}' );`, reload page and observe that page shows only one plan
* Same for `allPlans`, which should show default 3-panel view

Screenshot of original plans view:

<img width="936" alt="original-plans-view" src="https://user-images.githubusercontent.com/51896/61322160-ebe9b700-a7c1-11e9-8cf0-09e41dc23b9f.png">

Premium-only view:

<img width="651" alt="premium-only-plans-view" src="https://user-images.githubusercontent.com/51896/61322171-f1470180-a7c1-11e9-91f7-7b54a1ea237c.png">


Fixes #
