### PR TITLE
Consistent state handling of domain whois data.

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -131,6 +131,7 @@ export class ContactDetailsFormFields extends Component {
 	// This is an attempt limit the redraws to only what we need.
 	shouldComponentUpdate( nextProps, nextState ) {
 		return (
+			( nextProps.isSubmitting === false && this.props.isSubmitting === true ) ||
 			nextState.phoneCountryCode !== this.state.phoneCountryCode ||
 			! isEqual( nextState.form, this.state.form ) ||
 			! isEqual( nextProps.labelTexts, this.props.labelTexts ) ||

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -133,6 +133,7 @@ export class ContactDetailsFormFields extends Component {
 		return (
 			( nextProps.isSubmitting === false && this.props.isSubmitting === true ) ||
 			nextState.phoneCountryCode !== this.state.phoneCountryCode ||
+			! isEqual( nextProps.contactDetails, this.props.contactDetails ) ||
 			! isEqual( nextState.form, this.state.form ) ||
 			! isEqual( nextProps.labelTexts, this.props.labelTexts ) ||
 			! isEqual( nextProps.countriesList, this.props.countriesList ) ||

--- a/client/my-sites/domains/domain-management/components/icann-verification/index.jsx
+++ b/client/my-sites/domains/domain-management/components/icann-verification/index.jsx
@@ -25,6 +25,7 @@ class IcannVerificationCard extends React.Component {
 		explanationContext: PropTypes.string,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
+		whoisData: PropTypes.array,
 	};
 
 	getExplanation() {
@@ -80,8 +81,10 @@ class IcannVerificationCard extends React.Component {
 }
 
 export default connect(
-	( state, ownProps ) => ( {
-		contactDetails: getRegistrantWhois( state, ownProps.selectedDomainName ),
-	} ),
+	( state, ownProps ) => {
+		return {
+			contactDetails: getRegistrantWhois( state, ownProps.selectedDomainName ),
+		};
+	},
 	{ errorNotice }
 )( localize( IcannVerificationCard ) );

--- a/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
@@ -16,14 +16,13 @@ import { PUBLIC_VS_PRIVATE } from 'lib/url/support';
 
 class ContactsPrivacyCard extends React.PureComponent {
 	static propTypes = {
-		contactInformation: PropTypes.object.isRequired,
 		privateDomain: PropTypes.bool.isRequired,
 		selectedDomainName: PropTypes.string.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 	};
 
 	render() {
-		const { contactInformation, privateDomain, translate } = this.props;
+		const { privateDomain, translate, selectedDomainName } = this.props;
 		let privacyText = translate(
 			'{{strong}}Privacy Protection is enabled{{/strong}} so your contact information' +
 				' {{strong}}is not shown{{/strong}}.',
@@ -51,7 +50,7 @@ class ContactsPrivacyCard extends React.PureComponent {
 
 				<CompactCard className="contacts-privacy__card">
 					<p>{ privacyText }</p>
-					<ContactDisplay contactInformation={ contactInformation } />
+					<ContactDisplay selectedDomainName={ selectedDomainName } />
 					<p className="contacts-privacy__settings-explanation">
 						{ translate(
 							'Domain owners are required to provide correct contact information. ' +

--- a/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/card.jsx
@@ -50,7 +50,10 @@ class ContactsPrivacyCard extends React.PureComponent {
 
 				<CompactCard className="contacts-privacy__card">
 					<p>{ privacyText }</p>
-					<ContactDisplay selectedDomainName={ selectedDomainName } />
+					<ContactDisplay
+						selectedDomainName={ selectedDomainName }
+						privateDomain={ privateDomain }
+					/>
 					<p className="contacts-privacy__settings-explanation">
 						{ translate(
 							'Domain owners are required to provide correct contact information. ' +

--- a/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/contact-display.jsx
@@ -10,16 +10,13 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import { getWhoisData } from 'state/domains/management/selectors';
 import { requestWhois } from 'state/domains/management/actions';
-import { find, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
+import { findRegistrantWhois, findPrivacyServiceWhois } from 'lib/domains/whois/utils';
 
 class ContactDisplay extends React.PureComponent {
 	static propTypes = {
 		selectedDomainName: PropTypes.string.isRequired,
 	};
-
-	componentDidUpdate() {
-		this.fetchWhois();
-	}
 
 	fetchWhois = () => {
 		if ( isEmpty( this.props.whoisData ) && ! isEmpty( this.props.selectedDomainName ) ) {
@@ -28,10 +25,14 @@ class ContactDisplay extends React.PureComponent {
 	};
 
 	render() {
-		const { translate, whoisData } = this.props;
-		const registrantWhoisData = find( whoisData, { type: 'registrant' } );
+		const { privateDomain, translate, whoisData } = this.props;
 
-		if ( isEmpty( registrantWhoisData ) ) {
+		const contactInformation = privateDomain
+			? findPrivacyServiceWhois( whoisData )
+			: findRegistrantWhois( whoisData );
+
+		if ( isEmpty( contactInformation ) ) {
+			this.fetchWhois();
 			return null;
 		}
 
@@ -41,20 +42,20 @@ class ContactDisplay extends React.PureComponent {
 
 				<div className="contact-display__content">
 					<p>
-						{ registrantWhoisData.fname } { registrantWhoisData.lname }
+						{ contactInformation.fname } { contactInformation.lname }
 					</p>
-					{ registrantWhoisData.org && <p>{ registrantWhoisData.org }</p> }
-					<p>{ registrantWhoisData.email }</p>
-					<p>{ registrantWhoisData.sa1 }</p>
-					{ registrantWhoisData.sa2 && <p>{ registrantWhoisData.sa2 }</p> }
+					{ contactInformation.org && <p>{ contactInformation.org }</p> }
+					<p>{ contactInformation.email }</p>
+					<p>{ contactInformation.sa1 }</p>
+					{ contactInformation.sa2 && <p>{ contactInformation.sa2 }</p> }
 					<p>
-						{ registrantWhoisData.city }
-						{ registrantWhoisData.sp && <span>, { registrantWhoisData.sp }</span> }
-						<span> { registrantWhoisData.pc }</span>
+						{ contactInformation.city }
+						{ contactInformation.sp && <span>, { contactInformation.sp }</span> }
+						<span> { contactInformation.pc }</span>
 					</p>
-					<p>{ registrantWhoisData.country_code }</p>
-					<p>{ registrantWhoisData.phone }</p>
-					{ registrantWhoisData.fax && <p>{ registrantWhoisData.fax }</p> }
+					<p>{ contactInformation.country_code }</p>
+					<p>{ contactInformation.phone }</p>
+					{ contactInformation.fax && <p>{ contactInformation.fax }</p> }
 				</div>
 			</div>
 		);

--- a/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
+++ b/client/my-sites/domains/domain-management/contacts-privacy/index.jsx
@@ -23,7 +23,6 @@ import {
 	domainManagementManageConsent,
 } from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
-import { findRegistrantWhois, findPrivacyServiceWhois } from 'lib/domains/whois/utils';
 
 /**
  * Style dependencies
@@ -43,14 +42,11 @@ class ContactsPrivacy extends React.PureComponent {
 			return <DomainMainPlaceholder goBack={ this.goToEdit } />;
 		}
 
-		const { translate, whois } = this.props;
+		const { translate } = this.props;
 		const domain = getSelectedDomain( this.props );
 		const { privateDomain, privacyAvailable } = domain;
 		const canManageConsent =
 			config.isEnabled( 'domains/gdpr-consent-page' ) && domain.supportsGdprConsentManagement;
-		const contactInformation = privateDomain
-			? findPrivacyServiceWhois( whois.data )
-			: findRegistrantWhois( whois.data );
 
 		return (
 			<Main className="contacts-privacy">
@@ -60,7 +56,6 @@ class ContactsPrivacy extends React.PureComponent {
 
 				<VerticalNav>
 					<ContactsPrivacyCard
-						contactInformation={ contactInformation }
 						selectedDomainName={ this.props.selectedDomainName }
 						selectedSite={ this.props.selectedSite }
 						privateDomain={ privateDomain }

--- a/client/my-sites/domains/domain-management/contacts-privacy/style.scss
+++ b/client/my-sites/domains/domain-management/contacts-privacy/style.scss
@@ -29,7 +29,7 @@
 			text-align: center;
 		}
 
-		.contact-display-content {
+		.contact-display__content {
 			border: 1px solid var( --color-neutral-0 );
 			color: var( --color-neutral );
 			font-size: 12px;

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -38,7 +38,6 @@ const wpcom = wp.undocumented();
 
 class EditContactInfoFormCard extends React.Component {
 	static propTypes = {
-		contactInformation: PropTypes.object.isRequired,
 		selectedDomain: PropTypes.object.isRequired,
 		selectedSite: PropTypes.oneOfType( [ PropTypes.object, PropTypes.bool ] ).isRequired,
 		currentUser: PropTypes.object.isRequired,
@@ -115,7 +114,7 @@ class EditContactInfoFormCard extends React.Component {
 	};
 
 	requiresConfirmation( newContactDetails ) {
-		const { firstName, lastName, organization, email } = this.props.contactInformation;
+		const { firstName, lastName, organization, email } = this.getContactFormFieldValues();
 		const isWwdDomain = this.props.selectedDomain.registrar === registrarNames.WWD;
 
 		const primaryFieldsChanged = ! (
@@ -164,17 +163,17 @@ class EditContactInfoFormCard extends React.Component {
 	}
 
 	renderBackupEmail() {
-		const currentEmail = this.props.contactInformation.email,
+		const { email } = this.getContactFormFieldValues(),
 			wpcomEmail = this.props.currentUser.email,
 			strong = <strong />;
 
 		return (
 			<p>
 				{ this.props.translate(
-					'If you don’t have access to {{strong}}%(currentEmail)s{{/strong}}, ' +
+					'If you don’t have access to {{strong}}%(email)s{{/strong}}, ' +
 						'we will also email you at {{strong}}%(wpcomEmail)s{{/strong}}, as backup.',
 					{
-						args: { currentEmail, wpcomEmail },
+						args: { email, wpcomEmail },
 						components: { strong },
 					}
 				) }
@@ -198,7 +197,7 @@ class EditContactInfoFormCard extends React.Component {
 				isPrimary: true,
 			},
 		];
-		const currentEmail = this.props.contactInformation.email;
+		const { email } = this.getContactFormFieldValues();
 		const wpcomEmail = this.props.currentUser.email;
 
 		let text;
@@ -208,15 +207,15 @@ class EditContactInfoFormCard extends React.Component {
 				'We’ll email you at {{strong}}%(oldEmail)s{{/strong}} and {{strong}}%(newEmail)s{{/strong}} ' +
 					'with a link to confirm the new details. The change won’t go live until we receive confirmation from both emails.',
 				{
-					args: { oldEmail: currentEmail, newEmail: newContactDetails.email },
+					args: { oldEmail: email, newEmail: newContactDetails.email },
 					components: { strong },
 				}
 			);
 		} else {
 			text = translate(
-				'We’ll email you at {{strong}}%(currentEmail)s{{/strong}} with a link to confirm the new details. ' +
+				'We’ll email you at {{strong}}%(email)s{{/strong}} with a link to confirm the new details. ' +
 					"The change won't go live until we receive confirmation from this email.",
-				{ args: { currentEmail }, components: { strong } }
+				{ args: { email }, components: { strong } }
 			);
 		}
 		return (
@@ -227,18 +226,16 @@ class EditContactInfoFormCard extends React.Component {
 			>
 				<h1>{ translate( 'Confirmation Needed' ) }</h1>
 				<p>{ text }</p>
-				{ currentEmail !== wpcomEmail && this.renderBackupEmail() }
+				{ email !== wpcomEmail && this.renderBackupEmail() }
 			</Dialog>
 		);
 	}
 
 	needsFax() {
 		const NETHERLANDS_TLD = '.nl';
+		const { fax } = this.getContactFormFieldValues();
 
-		return (
-			endsWith( this.props.selectedDomain.name, NETHERLANDS_TLD ) ||
-			!! this.props.contactInformation.fax
-		);
+		return endsWith( this.props.selectedDomain.name, NETHERLANDS_TLD ) || !! fax;
 	}
 
 	onTransferLockOptOutChange = event => this.setState( { transferLock: ! event.target.checked } );
@@ -306,7 +303,7 @@ class EditContactInfoFormCard extends React.Component {
 			return;
 		}
 
-		const currentEmail = this.props.contactInformation.email;
+		const { email } = this.getContactFormFieldValues();
 		const strong = <strong />;
 		const { hasEmailChanged, newContactDetails = {} } = this.state;
 		let message;
@@ -316,7 +313,7 @@ class EditContactInfoFormCard extends React.Component {
 				'Emails have been sent to {{strong}}%(oldEmail)s{{/strong}} and {{strong}}%(newEmail)s{{/strong}}. ' +
 					"Please ensure they're both confirmed to finish this process.",
 				{
-					args: { oldEmail: currentEmail, newEmail: newContactDetails.email },
+					args: { oldEmail: email, newEmail: newContactDetails.email },
 					components: { strong },
 				}
 			);
@@ -325,7 +322,7 @@ class EditContactInfoFormCard extends React.Component {
 				'An email has been sent to {{strong}}%(email)s{{/strong}}. ' +
 					'Please confirm it to finish this process.',
 				{
-					args: { email: currentEmail },
+					args: { email: email },
 					components: { strong },
 				}
 			);

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -64,30 +64,6 @@ class EditContactInfoFormCard extends React.Component {
 		this.contactFormFieldValues = this.getContactFormFieldValues();
 	}
 
-	// shouldComponentUpdate( nextProps, nextState ) {
-	// 	return (
-	// 		! isEqual( this.state, nextState ) ||
-	// 		! isEqual( this.props.whoisData, nextProps.whoisData ) ||
-	// 		! isEqual( this.props.isUpdatingWhois, nextProps.isUpdatingWhois ) ||
-	// 		! isEqual( this.props.whoisSaveSuccess, nextProps.whoisSaveSuccess ) ||
-	// 		! isEqual( this.props.whoisSaveError, nextProps.whoisSaveError ) ||
-	// 		! isEqual( this.props.contactInformation, nextProps.contactInformation )
-	// 	);
-	// }
-
-	// 	getDerivedStateFromProps( nextProps, prevState ) {
-	// console.log( prevState.formSubmitting );
-	// console.log( nextProps.isUpdatingWhois );
-	// console.log( '------------------------------' );
-	//
-	// 		if ( prevState.formSubmitting && ! nextProps.isUpdatingWhois ) {
-	// 			return{
-	// 				formSubmitting: false,
-	// 			};
-	// 		}
-	// 		return {};
-	// 	}
-
 	componentDidUpdate( prevProps ) {
 		if ( this.state.formSubmitting && prevProps.isUpdatingWhois && ! this.props.isUpdatingWhois ) {
 			this.handleFormSubmittingComplete();
@@ -102,12 +78,6 @@ class EditContactInfoFormCard extends React.Component {
 				return;
 			}
 		}
-	}
-
-	UNSAFE_componentWillMount() {
-		this.setState( {
-			transferLock: true,
-		} );
 	}
 
 	getContactFormFieldValues() {
@@ -153,7 +123,6 @@ class EditContactInfoFormCard extends React.Component {
 					<FormCheckbox
 						name="transfer-lock-opt-out"
 						disabled={ this.state.formSubmitting }
-						// disabled={ this.props.isUpdatingWhois }
 						onChange={ this.onTransferLockOptOutChange }
 					/>
 					<span>
@@ -291,7 +260,6 @@ class EditContactInfoFormCard extends React.Component {
 				showNonDaConfirmationDialog: false,
 			},
 			() => {
-				// updateWhois( selectedDomain.name, newContactDetails, transferLock, this.onWhoisUpdate );
 				this.props.saveWhois( selectedDomain.name, newContactDetails, transferLock );
 			}
 		);
@@ -355,69 +323,6 @@ class EditContactInfoFormCard extends React.Component {
 
 		notices.error( message );
 	};
-
-	// onWhoisUpdate = ( error, data ) => {
-	// 	this.setState( {
-	// 		formSubmitting: false,
-	// 	} );
-	//
-	// 	if ( data && data.success ) {
-	// 		this.contactFormFieldValues = this.getContactFormFieldValues();
-	//
-	// 		this.setState( {
-	// 			haveContactDetailsChanged: ! isEqual(
-	// 				this.contactFormFieldValues,
-	// 				this.state.newContactDetails
-	// 			),
-	// 		} );
-	//
-	// 		if ( ! this.state.requiresConfirmation ) {
-	// 			this.props.successNotice(
-	// 				this.props.translate(
-	// 					'The contact info has been updated. ' +
-	// 						'There may be a short delay before the changes show up in the public records.'
-	// 				)
-	// 			);
-	// 			return;
-	// 		}
-	//
-	// 		const currentEmail = this.props.contactInformation.email;
-	// 		const strong = <strong />;
-	// 		const { hasEmailChanged, newContactDetails = {} } = this.state;
-	// 		let message;
-	//
-	// 		if ( hasEmailChanged && newContactDetails.email ) {
-	// 			message = this.props.translate(
-	// 				'Emails have been sent to {{strong}}%(oldEmail)s{{/strong}} and {{strong}}%(newEmail)s{{/strong}}. ' +
-	// 					"Please ensure they're both confirmed to finish this process.",
-	// 				{
-	// 					args: { oldEmail: currentEmail, newEmail: newContactDetails.email },
-	// 					components: { strong },
-	// 				}
-	// 			);
-	// 		} else {
-	// 			message = this.props.translate(
-	// 				'An email has been sent to {{strong}}%(email)s{{/strong}}. ' +
-	// 					'Please confirm it to finish this process.',
-	// 				{
-	// 					args: { email: currentEmail },
-	// 					components: { strong },
-	// 				}
-	// 			);
-	// 		}
-	//
-	// 		this.props.successNotice( message );
-	// 	} else if ( error && error.message ) {
-	// 		notices.error( error.message );
-	// 	} else {
-	// 		notices.error(
-	// 			this.props.translate(
-	// 				'There was a problem updating your contact info. ' +
-	// 					'Please try again later or contact support.'
-	// 			)
-	// 		);
-	// 	}
-	// };
 
 	handleSubmitButtonClick = newContactDetails => {
 		this.setState(

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -333,7 +333,7 @@ class EditContactInfoFormCard extends React.Component {
 
 	onWhoisUpdateError = () => {
 		const message =
-			this.props.whoisSaveError ||
+			get( this.props.whoisSaveError, 'message' ) ||
 			this.props.translate(
 				'There was a problem updating your contact info. ' +
 					'Please try again later or contact support.'

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -5,7 +5,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import page from 'page';
-import { endsWith, find, get, isEmpty, isEqual, includes, snakeCase } from 'lodash';
+import { endsWith, get, isEmpty, isEqual, includes, snakeCase } from 'lodash';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 
@@ -33,6 +33,7 @@ import {
 	getWhoisSaveError,
 	getWhoisSaveSuccess,
 } from 'state/domains/management/selectors';
+import { findRegistrantWhois } from 'lib/domains/whois/utils';
 
 const wpcom = wp.undocumented();
 
@@ -91,7 +92,7 @@ class EditContactInfoFormCard extends React.Component {
 	};
 
 	getContactFormFieldValues() {
-		const registrantWhoisData = find( this.props.whoisData, { type: 'registrant' } );
+		const registrantWhoisData = findRegistrantWhois( this.props.whoisData );
 
 		return {
 			firstName: get( registrantWhoisData, 'fname' ),

--- a/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/form-card.jsx
@@ -62,9 +62,13 @@ class EditContactInfoFormCard extends React.Component {
 		};
 
 		this.contactFormFieldValues = this.getContactFormFieldValues();
+
+		this.fetchWhois();
 	}
 
 	componentDidUpdate( prevProps ) {
+		this.fetchWhois();
+
 		if ( this.state.formSubmitting && prevProps.isUpdatingWhois && ! this.props.isUpdatingWhois ) {
 			this.handleFormSubmittingComplete();
 
@@ -79,6 +83,12 @@ class EditContactInfoFormCard extends React.Component {
 			}
 		}
 	}
+
+	fetchWhois = () => {
+		if ( isEmpty( this.props.whoisData ) && ! isEmpty( this.props.selectedDomain.name ) ) {
+			this.props.requestWhois( this.props.selectedDomain.name );
+		}
+	};
 
 	getContactFormFieldValues() {
 		const registrantWhoisData = find( this.props.whoisData, { type: 'registrant' } );
@@ -375,12 +385,12 @@ class EditContactInfoFormCard extends React.Component {
 	}
 
 	render() {
-		const { selectedDomain, translate, whoisData } = this.props;
+		const { selectedDomain, translate } = this.props;
 		const canUseDesignatedAgent = selectedDomain.transferLockOnWhoisUpdateOptional;
 		const whoisRegistrantData = this.getContactFormFieldValues();
 
-		if ( isEmpty( whoisData ) ) {
-			this.props.requestWhois( selectedDomain.name );
+		if ( Object.values( whoisRegistrantData ).every( value => isEmpty( value ) ) ) {
+			return null;
 		}
 
 		return (

--- a/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
+++ b/client/my-sites/domains/domain-management/edit-contact-info/index.jsx
@@ -21,7 +21,6 @@ import Header from 'my-sites/domains/domain-management/components/header';
 import Main from 'components/main';
 import { domainManagementContactsPrivacy } from 'my-sites/domains/paths';
 import { getSelectedDomain } from 'lib/domains';
-import { findRegistrantWhois } from 'lib/domains/whois/utils';
 import SectionHeader from 'components/section-header';
 
 class EditContactInfo extends React.Component {
@@ -78,7 +77,6 @@ class EditContactInfo extends React.Component {
 			<div>
 				<SectionHeader label={ this.props.translate( 'Edit Contact Info' ) } />
 				<EditContactInfoFormCard
-					contactInformation={ findRegistrantWhois( this.props.whois.data ) }
 					domainRegistrationAgreementUrl={ domain.domainRegistrationAgreementUrl }
 					selectedDomain={ getSelectedDomain( this.props ) }
 					selectedSite={ this.props.selectedSite }

--- a/client/state/domains/management/actions.js
+++ b/client/state/domains/management/actions.js
@@ -125,9 +125,10 @@ export function requestWhois( domain ) {
  *
  * @param   {String}   domain		domain to query
  * @param   {Object}   whoisData	whois details object
+ * @param	{Bool}     transferLock set 60-day transfer lock after update
  * @returns {Function}				Action thunk
  */
-export function saveWhois( domain, whoisData ) {
+export function saveWhois( domain, whoisData, transferLock ) {
 	return dispatch => {
 		dispatch( {
 			type: DOMAIN_MANAGEMENT_WHOIS_SAVE,
@@ -136,12 +137,13 @@ export function saveWhois( domain, whoisData ) {
 
 		return wpcom
 			.undocumented()
-			.updateWhois( domain, whoisData )
-			.then( ( { updated } ) => {
-				dispatch( updateWhois( domain, updated ) );
+			.updateWhois( domain, whoisData, transferLock )
+			.then( data => {
+				dispatch( updateWhois( domain, whoisData ) );
 				dispatch( {
 					type: DOMAIN_MANAGEMENT_WHOIS_SAVE_SUCCESS,
 					domain,
+					data,
 				} );
 			} )
 			.catch( error => {

--- a/client/state/domains/management/reducer.js
+++ b/client/state/domains/management/reducer.js
@@ -25,6 +25,7 @@ import {
 	DOMAIN_MANAGEMENT_WHOIS_SAVE_SUCCESS,
 	DOMAIN_MANAGEMENT_WHOIS_UPDATE,
 } from 'state/action-types';
+import { whoisType } from '../../../lib/domains/whois/constants';
 
 /**
  * Returns the updated requests state after an action has been dispatched. The
@@ -75,6 +76,25 @@ export const isSaving = createReducer(
 	}
 );
 
+function mergeDomainRegistrantContactDetails( domainState, registrantContactDetails ) {
+	return isArray( domainState )
+		? domainState.map( item => {
+				if ( item.type === whoisType.REGISTRANT ) {
+					return {
+						...item,
+						...registrantContactDetails,
+					};
+				}
+				return item;
+		  } )
+		: [
+				{
+					...registrantContactDetails,
+					type: whoisType.REGISTRANT,
+				},
+		  ];
+}
+
 /**
  * Returns the updated items state after an action has been dispatched. The
  * state maps domain to the domain's whoisData object.
@@ -98,7 +118,10 @@ export const items = createReducer(
 			[ domain ]: whoisData,
 		} ),
 		[ DOMAIN_MANAGEMENT_WHOIS_UPDATE ]: ( state, { domain, whoisData } ) => {
-			return merge( {}, state, { [ domain ]: { ...state[ domain ], ...whoisData } } );
+			const domainState = get( state, [ `${ domain }` ], {} );
+			return merge( {}, state, {
+				[ domain ]: mergeDomainRegistrantContactDetails( domainState, whoisData ),
+			} );
 		},
 	},
 	domainWhoisSchema

--- a/client/state/domains/management/selectors.js
+++ b/client/state/domains/management/selectors.js
@@ -1,0 +1,41 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+export function isUpdatingWhois( state, domain ) {
+	return get( state, [ 'domains', 'management', 'isSaving', `${ domain }`, 'saving' ], false );
+}
+
+export function getWhoisData( state, domain ) {
+	return get( state, [ 'domains', 'management', 'items', `${ domain }` ], null );
+}
+
+export function getWhoisSaveError( state, domain ) {
+	const status = get(
+		state,
+		[ 'domains', 'management', 'isSaving', `${ domain }`, 'status' ],
+		null
+	);
+
+	if ( ! isUpdatingWhois( state, domain ) && 'error' === status ) {
+		return get(
+			state,
+			[ 'domains', 'management', 'isSaving', `${ domain }`, 'error' ],
+			'unknown error'
+		);
+	}
+
+	return null;
+}
+
+export function getWhoisSaveSuccess( state, domain ) {
+	const status = get(
+		state,
+		[ 'domains', 'management', 'isSaving', `${ domain }`, 'status' ],
+		null
+	);
+
+	return ! isUpdatingWhois( state, domain ) && 'success' === status;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the contact information for a domain is changed on the Edit Contact Info page, the correct email that the verification has been sent to isn't reflected on the Domain Settings page because the two pages are using different data to display the email address.

#### Testing instructions

- Pick a domain that we manage the emails for.
- Update the email address in the Edit Contact Info page.
- Return to the Domain Settings page.
- Make sure that the ICANN notice at the top of the page shows the newly saved email.
- Make sure that the email is sent to the correct address.
- Make sure that the contact form still works correctly for newly purchased domains as well.
