### PR TITLE
Signup: Disable the skippableDomainStep AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -127,10 +127,10 @@ export default {
 		allowExistingUsers: true,
 	},
 	skippableDomainStep: {
-		datestamp: '20190702',
+		datestamp: '20190717',
 		variations: {
-			skippable: 50,
-			notSkippable: 50,
+			skippable: 0,
+			notSkippable: 100,
 		},
 		defaultVariation: 'notSkippable',
 		allowExistingUsers: true,


### PR DESCRIPTION
Preparing a PR so we're ready to suspend this test when the time comes.
p8Eqe3-GX-p2#comment-1829

Adding "DO NOT MERGE" label until then, but should be good to review.

#### Changes proposed in this Pull Request

Leaves the code in place but sends 100% of traffic to the control group.

Datestamp adjusted so that new users aren't added to either variant and we can just analyse results from within the test period.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout `master`
* Find or create a user account that's been assigned to the `skippable` test group
* Go to `/start` and create a blog, the domain step should be skippable.
* Checkout this branch
* Using the same user go to `/start` and create a blog: **the domain step shouldn't be skippable**.