### PR TITLE
Checkout: CreditCardPaymentBox: move isFormSubmitting to separate function

### DIFF
--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -32,6 +32,9 @@ import RecentRenewals from './recent-renewals';
 import CheckoutTerms from './checkout-terms';
 
 function isFormSubmitting( transactionStep ) {
+	if ( ! transactionStep ) {
+		return false;
+	}
 	switch ( transactionStep.name ) {
 		case BEFORE_SUBMIT:
 			return false;
@@ -159,15 +162,6 @@ export class CreditCardPaymentBox extends React.Component {
 		);
 	};
 
-	paymentBoxActions = () => {
-		let content = this.paymentButtons();
-		if ( this.props.transactionStep && isFormSubmitting( this.props.transactionStep ) ) {
-			content = this.progressBar();
-		}
-
-		return <div className="checkout__payment-box-actions">{ content }</div>;
-	};
-
 	submit = event => {
 		event.preventDefault();
 		this.setState( {
@@ -195,7 +189,11 @@ export class CreditCardPaymentBox extends React.Component {
 
 					<CheckoutTerms cart={ cart } />
 
-					{ this.paymentBoxActions() }
+					<div className="checkout__payment-box-actions">
+						{ isFormSubmitting( this.props.transactionStep )
+							? this.progressBar()
+							: this.paymentButtons() }
+					</div>
 				</form>
 				<CartCoupon cart={ cart } />
 				<CartToggle />

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -31,7 +31,7 @@ import CartToggle from './cart-toggle';
 import RecentRenewals from './recent-renewals';
 import CheckoutTerms from './checkout-terms';
 
-function isFormSubmitting( transactionStep, props ) {
+function isFormSubmitting( transactionStep ) {
 	switch ( transactionStep.name ) {
 		case BEFORE_SUBMIT:
 			return false;
@@ -43,7 +43,7 @@ function isFormSubmitting( transactionStep, props ) {
 			return true;
 
 		case RECEIVED_PAYMENT_KEY_RESPONSE:
-			if ( props.transactionStep.error ) {
+			if ( transactionStep.error ) {
 				return false;
 			}
 			return true;
@@ -93,8 +93,8 @@ export class CreditCardPaymentBox extends React.Component {
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if (
-			! isFormSubmitting( this.props.transactionStep, this.props ) &&
-			isFormSubmitting( nextProps.transactionStep, this.props )
+			! isFormSubmitting( this.props.transactionStep ) &&
+			isFormSubmitting( nextProps.transactionStep )
 		) {
 			this.timer = setInterval( this.tick, 100 );
 		}
@@ -161,10 +161,7 @@ export class CreditCardPaymentBox extends React.Component {
 
 	paymentBoxActions = () => {
 		let content = this.paymentButtons();
-		if (
-			this.props.transactionStep &&
-			isFormSubmitting( this.props.transactionStep, this.props )
-		) {
+		if ( this.props.transactionStep && isFormSubmitting( this.props.transactionStep ) ) {
 			content = this.progressBar();
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This moves the method `CreditCardPaymentBox.prototype.submitting()` into a pure function outside of the class and renames it `isFormSubmitting()` to be more clear. This is the first step in removing the `UNSAFE_componentWillReceiveProps()`
method in this class, since that function uses `submitting()` several times. (The actual removal is in #34697).

`submitting()` makes its decision mostly based on the object (a transaction step) passed in as an argument, but it also queries `this.props.transactionStep.error` if the step is `RECEIVED_PAYMENT_KEY_RESPONSE`. This reliance on implicit state introduces complexity since the function is used to compare the current transaction step to the next transaction step in `componentWillReceiveProps()`; sometimes it may be looking for errors on the current step when examining the next step, and sometimes it might be looking for errors on the current step when examining the current step.

I think that this usage is actually accidental and a bug. It seems to me that we should always be looking for errors on the step in question, not the current step. Moving the function away from the component makes its dependencies clear and reveals this issue. Furthermore, if there is no need for implicit state in the function, there's no need for it to be a method on the class because it risks creating bugs just like this one in the future.

#### Testing instructions

Make a purchase and be sure that the progress bar moves after pressing the "Pay" button.
