### PR TITLE
Theme: remove nested anchor in theme sheet

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -228,6 +228,21 @@ class ThemeSheet extends React.Component {
 		return demo_uri && ! retired;
 	}
 
+	// Render "Open Live Demo" pseudo-button for mobiles.
+	// This is a legacy hack that shows the button under the preview screenshot for mobiles
+	// but not for desktop (becomes hidden behind the screenshot).
+	renderPreviewButton() {
+		return (
+			<div className="theme__sheet-preview-link" data-tip-target="theme-sheet-preview">
+				<span className="theme__sheet-preview-link-text">
+					{ i18n.translate( 'Open Live Demo', {
+						context: 'Individual theme live preview button',
+					} ) }
+				</span>
+			</div>
+		);
+	}
+
 	renderScreenshot() {
 		const { isWpcomTheme, name: themeName } = this.props;
 		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
@@ -253,6 +268,7 @@ class ThemeSheet extends React.Component {
 					onClick={ this.previewAction }
 					rel="noopener noreferrer"
 				>
+					{ this.shouldRenderPreviewButton() && this.renderPreviewButton() }
 					{ img }
 				</a>
 			);

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -228,24 +228,6 @@ class ThemeSheet extends React.Component {
 		return demo_uri && ! retired;
 	}
 
-	renderPreviewButton() {
-		return (
-			<a
-				className="theme__sheet-preview-link"
-				onClick={ this.previewAction }
-				data-tip-target="theme-sheet-preview"
-				href={ this.props.demo_uri }
-				rel="noopener noreferrer"
-			>
-				<span className="theme__sheet-preview-link-text">
-					{ i18n.translate( 'Open Live Demo', {
-						context: 'Individual theme live preview button',
-					} ) }
-				</span>
-			</a>
-		);
-	}
-
 	renderScreenshot() {
 		const { isWpcomTheme, name: themeName } = this.props;
 		const screenshotFull = isWpcomTheme ? this.getFullLengthScreenshot() : this.props.screenshot;
@@ -271,7 +253,6 @@ class ThemeSheet extends React.Component {
 					onClick={ this.previewAction }
 					rel="noopener noreferrer"
 				>
-					{ this.shouldRenderPreviewButton() && this.renderPreviewButton() }
 					{ img }
 				</a>
 			);

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -137,7 +137,7 @@
 			height: 30%;
 			background: linear-gradient(
 				to bottom,
-				rgba( var( --color-neutral-0-rgb ), 1 ) 0%,
+				transparent 0,
 				rgba( var( --color-neutral-0-rgb ), 0.5 ) 40%,
 				var( --color-neutral-0 ) 93%
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes unnecessary 'Open Live Demo' anchor nested inside preview anchor in theme sheet page at `/theme/{theme_slug}` path.

Nested anchor was not visible and is no longer necessary because 'Open Live Demo' button is already displayed in the Nav Bar.

<img width="738" alt="screenshot_790" src="https://user-images.githubusercontent.com/127594/61337347-e0aa8180-a7e9-11e9-89f7-af4cf83ae3bf.png">

#### Testing instructions

1. Using Chrome, navigate to `/theme/photo-blog` or `/theme/photo-blog/{site_slug}`.
2. Open DevTools > Console and verify that following warnings are no longer emitted.

<img width="732" alt="screenshot_789" src="https://user-images.githubusercontent.com/127594/61337458-426aeb80-a7ea-11e9-9708-c158fa658de2.png">

*

Fixes #34609
