### PR TITLE
translatableStringChecker: Accept localized Translate components

### DIFF
--- a/client/components/translatable/proptype.js
+++ b/client/components/translatable/proptype.js
@@ -18,7 +18,9 @@ function translatableStringChecker( props, propName, componentName ) {
 		if (
 			'object' === typeof value &&
 			'function' === typeof value.type &&
-			'Translatable' === value.type.name
+			( 'Translatable' === value.type.name ||
+				// Accept HOC wrappings (e.g. `localize( Translatable )`)
+				String( value.type.displayName ).match( /\(Translatable\)/ ) )
 		) {
 			return null;
 		}

--- a/client/components/translatable/test/proptype.js
+++ b/client/components/translatable/test/proptype.js
@@ -7,6 +7,7 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 /**
  * Internal dependencies
@@ -23,22 +24,7 @@ function assertFails( validator, { props }, propName = 'translatableString' ) {
 }
 
 const Translatable = () => <span />;
-
-function testHOC( ComposedComponent ) {
-	const componentName = ComposedComponent.displayName || ComposedComponent.name || '';
-
-	return class extends React.Component {
-		static displayName = 'Localized(' + componentName + ')';
-
-		render() {
-			const props = {
-				...this.props,
-			};
-			return <ComposedComponent { ...props } />;
-		}
-	};
-}
-const WrappedTranslatable = testHOC( Translatable );
+const LocalizedTranslatable = localize( Translatable );
 
 describe( 'translatable proptype', () => {
 	test( 'should pass when no propType Name declared', () => {
@@ -83,9 +69,9 @@ describe( 'translatable proptype', () => {
 
 	it( 'should fail when required', () => assertFails( translatableString.isRequired, <legend /> ) );
 
-	it( 'should pass with <Translatable> component wrapped in a HOC', () =>
+	it( 'should pass with <Translatable> component run through i18n-calypso.localize()', () =>
 		assertPasses(
 			translatableString.isRequired,
-			<legend translatableString={ <WrappedTranslatable /> } />
+			<legend translatableString={ <LocalizedTranslatable /> } />
 		) );
 } );

--- a/client/components/translatable/test/proptype.js
+++ b/client/components/translatable/test/proptype.js
@@ -24,6 +24,22 @@ function assertFails( validator, { props }, propName = 'translatableString' ) {
 
 const Translatable = () => <span />;
 
+function testHOC( ComposedComponent ) {
+	const componentName = ComposedComponent.displayName || ComposedComponent.name || '';
+
+	return class extends React.Component {
+		static displayName = 'Localized(' + componentName + ')';
+
+		render() {
+			const props = {
+				...this.props,
+			};
+			return <ComposedComponent { ...props } />;
+		}
+	};
+}
+const WrappedTranslatable = testHOC( Translatable );
+
 describe( 'translatable proptype', () => {
 	test( 'should pass when no propType Name declared', () => {
 		assertPasses( translatableString, <legend />, '' );
@@ -66,4 +82,10 @@ describe( 'translatable proptype', () => {
 	} );
 
 	it( 'should fail when required', () => assertFails( translatableString.isRequired, <legend /> ) );
+
+	it( 'should pass with <Translatable> component wrapped in a HOC', () =>
+		assertPasses(
+			translatableString.isRequired,
+			<legend translatableString={ <WrappedTranslatable /> } />
+		) );
 } );


### PR DESCRIPTION
This PR updates the type-check on the TranslatableString proptype to allow the localized Translatable components used in the new iteration of the Community Translator.

We can see what's going wrong here:

![Réglages_de_compte_—_WordPress_com_and___a8c_wp-calypso_client_components_forms_form-radio-with-thumbnail_index_jsx_—_wp-calypso](https://user-images.githubusercontent.com/5952255/61337035-0467d900-a877-11e9-87d7-70fa7cf7ace2.jpg)

We can see that the component that we're complaining about did receive a Translatable component, it's just that we're localizing it. The check is looking for the type.name === 'Translatable', which is not true any more.

We don't have any general conventions for higher order components, but we really don't have enough HOCs one anyway, so matching against the display-name like this is a bit of a hack (because we're relying on implementation details of i18n-calypso.localize()), but it's appropriate for now.

#### Testing instructions

enable the translator and set a non-english interface locale in https://wordpress.com/me/account

- Before applying the patch
 - lload the new translator using `ENABLE_FEATURES=i18n/community-translator npm start`
open the console
 - click around the site and Note a few type errors that read `Please pass a translate() call.`.  These will all be false positives, because plain strings are accepted as a valid `TranslatableString`.
- Apply the patch
 - Verify that the errors you noticed are resolved.


FYI: While we're looking for type warnings, you may well see one of the legitimate failures where we still need to change a `PropTypes.string` to `Translatable`. These are of the form ``Warning: Failed prop type: Invalid prop `message` of type `object` supplied to `StatsError`, expected `string`.``. Fixing these is not part of this PR, but feel free to report them here and I'll fix them in a followup.
