### PR TITLE
Checkout: Remove unsafe lifecycle from CreditCardPaymentBox

### DIFF
--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -94,15 +94,15 @@ export class CreditCardPaymentBox extends React.Component {
 		this.timer = null;
 	}
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
+	componentDidUpdate( prevProps ) {
 		if (
-			! isFormSubmitting( this.props.transactionStep ) &&
-			isFormSubmitting( nextProps.transactionStep )
+			! isFormSubmitting( prevProps.transactionStep ) &&
+			isFormSubmitting( this.props.transactionStep )
 		) {
 			this.timer = setInterval( this.tick, 100 );
 		}
 
-		if ( nextProps.transactionStep.error ) {
+		if ( this.props.transactionStep.error ) {
 			this.clearTickInterval();
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This replaces the `UNSAFE_componentWillReceiveProps` method with the supported `componentDidUpdate` in `CreditCardPaymentBox`.

The method is used to start and stop an interval timer which moves the progress bar along to simulate loading. The loading timer should only be started or stopped when the props change such that the progress bar is shown or has an error, so it requires access to both the current transactionStep data and the previous one. `componentDidUpdate` has both, just like `UNSAFE_componentWillReceiveProps`.

This depends on #34694 to simplify the function which determines if the timer should start.

#### Testing instructions

Make a purchase and be sure that the progress bar moves along after pressing the "Pay" button.