### PR TITLE
Checkout: TransactionFlow: return Promise from _submitWithPayment

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -181,27 +181,37 @@ TransactionFlow.prototype._submitWithPayment = function( payment ) {
 	};
 
 	this._pushStep( { name: SUBMITTING_WPCOM_REQUEST } );
-	wpcom.transactions( 'POST', transaction, ( error, data ) => {
-		if ( error ) {
-			return this._pushStep( {
+	return new Promise( resolve => {
+		wpcom.transactions( 'POST', transaction, ( error, data ) => {
+			if ( error ) {
+				this._pushStep( {
+					name: RECEIVED_WPCOM_RESPONSE,
+					error,
+					last: true,
+				} );
+				// This should probably reject but since the error is already
+				// reported just above, that might risk double-reporting or
+				// changing the step to the wrong one, so this just resolves
+				// without data instead.
+				resolve();
+				return;
+			}
+
+			if ( data.redirect_url ) {
+				return this._pushStep( {
+					name: REDIRECTING_FOR_AUTHORIZATION,
+					data: data,
+					last: true,
+				} );
+			}
+
+			this._pushStep( {
 				name: RECEIVED_WPCOM_RESPONSE,
-				error,
+				data,
 				last: true,
 			} );
-		}
 
-		if ( data.redirect_url ) {
-			return this._pushStep( {
-				name: REDIRECTING_FOR_AUTHORIZATION,
-				data: data,
-				last: true,
-			} );
-		}
-
-		this._pushStep( {
-			name: RECEIVED_WPCOM_RESPONSE,
-			data,
-			last: true,
+			resolve( data );
 		} );
 	} );
 };

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -198,11 +198,13 @@ TransactionFlow.prototype._submitWithPayment = function( payment ) {
 			}
 
 			if ( data.redirect_url ) {
-				return this._pushStep( {
+				this._pushStep( {
 					name: REDIRECTING_FOR_AUTHORIZATION,
 					data: data,
 					last: true,
 				} );
+				resolve( data );
+				return;
 			}
 
 			this._pushStep( {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This alters the `TransactionFlow.prototype._submitWithPayment()` method such that it returns a Promise which will allow it to be chained to additional function calls in the future (see #34469). Currently there is no way to get at the data returned by the submission other than to query the current step, but more importantly there is no way to know when the submission is complete. This diff should not have any functional changes to existing flows since nothing uses this Promise yet.

#### Testing instructions

Make a purchase and be sure that it goes through.

