### PR TITLE
Full Site Editing: Add custom class name support to the navigation menu block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -82,10 +82,11 @@ function get_wrapper_attributes_by_theme_location( $location ) {
 function render_navigation_menu_block( $attributes ) {
 	$location     = ! empty( $attributes['themeLocation'] ) ? $attributes['themeLocation'] : null;
 	$wrapper_attr = get_wrapper_attributes_by_theme_location( $location );
+	$class_name   = ! empty( $attributes['className'] ) ? ' ' . $attributes['className'] : '';
 	ob_start();
 	// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText
 	?>
-	<nav class="<?php echo esc_attr( $wrapper_attr['class'] . ' wp-block-a8c-navigation-menu' ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
+	<nav class="<?php echo esc_attr( $wrapper_attr['class'] . ' wp-block-a8c-navigation-menu' . $class_name ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
 		<?php
 			wp_nav_menu( get_menu_params_by_theme_location( $location ) );
 		?>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -328,6 +328,10 @@ class Full_Site_Editing {
 						'default' => 'main-1',
 						'type'    => 'string',
 					],
+					'className'     => [
+						'default' => '',
+						'type'    => 'string',
+					],
 				],
 				'render_callback' => 'render_navigation_menu_block',
 			)
@@ -587,7 +591,7 @@ class Full_Site_Editing {
 			foreach ( $template_blocks as $block ) {
 				$template[] = fse_map_block_to_editor_template_setting( $block );
 			}
-			$editor_settings['template'] = $template;
+			$editor_settings['template']     = $template;
 			$editor_settings['templateLock'] = 'all';
 		}
 		return $editor_settings;


### PR DESCRIPTION
### Motivation
Currently, when trying to add a custom class name to the navigation menu in the header template part editor, you get a nasty error on the block:
<img width="1486" alt="Screen Shot 2019-07-16 at 5 33 37 PM" src="https://user-images.githubusercontent.com/6265975/61338774-e7d48e00-a7ef-11e9-9370-cc309350c22d.png">

Now, you can add the class!
<img width="1097" alt="Screen Shot 2019-07-16 at 5 30 21 PM" src="https://user-images.githubusercontent.com/6265975/61338820-1a7e8680-a7f0-11e9-8c4b-e245b5097096.png">

#### Changes proposed in this Pull Request
- Adds className as a valid attribute for the navigation menu.
- If className exists on the attribute dictionary, add it to the html class attribute for the nav menu block.

#### Testing instructions
* Have FSE active with this change.
* Test that adding a class name adds it to the `nav` in the block editor.
* Test that adding a class name in the editor adds it to the `nav` on a front end page which supports the FSE template.
* Test that everything still works fine when you do not have a custom class name set.

_Note: we had discussed removing this option altogether, but it was easy enough to just add support that I went that route instead._

Fixes #34563