### PR TITLE
WIP: Fix Translatable String PropTypes

### DIFF
--- a/client/components/translatable/proptype.js
+++ b/client/components/translatable/proptype.js
@@ -18,7 +18,9 @@ function translatableStringChecker( props, propName, componentName ) {
 		if (
 			'object' === typeof value &&
 			'function' === typeof value.type &&
-			'Translatable' === value.type.name
+			( 'Translatable' === value.type.name ||
+				// Accept HOC wrappings (e.g. `localize( Translatable )`)
+				String( value.type.displayName ).match( /\(Translatable\)/ ) )
 		) {
 			return null;
 		}

--- a/client/components/translatable/test/proptype.js
+++ b/client/components/translatable/test/proptype.js
@@ -24,6 +24,22 @@ function assertFails( validator, { props }, propName = 'translatableString' ) {
 
 const Translatable = () => <span />;
 
+function testHOC( ComposedComponent ) {
+	const componentName = ComposedComponent.displayName || ComposedComponent.name || '';
+
+	return class extends React.Component {
+		static displayName = 'Localized(' + componentName + ')';
+
+		render() {
+			const props = {
+				...this.props,
+			};
+			return <ComposedComponent { ...props } />;
+		}
+	};
+}
+const WrappedTranslatable = testHOC( Translatable );
+
 describe( 'translatable proptype', () => {
 	test( 'should pass when no propType Name declared', () => {
 		assertPasses( translatableString, <legend />, '' );
@@ -66,4 +82,10 @@ describe( 'translatable proptype', () => {
 	} );
 
 	it( 'should fail when required', () => assertFails( translatableString.isRequired, <legend /> ) );
+
+	it( 'should pass with <Translatable> component wrapped in a HOC', () =>
+		assertPasses(
+			translatableString.isRequired,
+			<legend translatableString={ <WrappedTranslatable /> } />
+		) );
 } );

--- a/client/my-sites/stats/stats-list/legend.jsx
+++ b/client/my-sites/stats/stats-list/legend.jsx
@@ -10,12 +10,13 @@ import React from 'react';
 /**
  * Internal dependencies
  */
+import TranslatableString from 'components/translatable/proptype';
 
 export default class extends React.PureComponent {
 	static displayName = 'StatsListLegend';
 
 	static propTypes = {
-		value: PropTypes.string,
+		value: TranslatableString,
 		label: PropTypes.string,
 	};
 


### PR DESCRIPTION
This PR fixes the PropType check on some translatable strings by replacing `PropTypes.string` with `components/translatable/proptype` we pass as props. When activated, the community translator wraps these strings in order to add more information, leading to type errors.

#### Testing instructions

Enable the Community translator, open the console,  and click around calypso looking for type warnings.

Here are some specific places to check where warnings came from:
