### PR TITLE
[FSE] Update template part publish panel message 

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/panel.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/panel.js
@@ -38,6 +38,7 @@ export default ( { onSave, onClose, isBusy, disabled } ) => {
 						<strong>{ __( 'Are you ready to publish?' ) }</strong>
 					</p>
 					<div className="warning">
+						{ /* TODO:  if we want to keep the icon it should be added to @automattic/material-design-icons */ }
 						<Icon
 							icon={
 								<svg

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/panel.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/panel.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { Button, IconButton, Icon } from '@wordpress/components';
+import { Button, IconButton, Notice } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
@@ -37,25 +37,9 @@ export default ( { onSave, onClose, isBusy, disabled } ) => {
 					<p>
 						<strong>{ __( 'Are you ready to publish?' ) }</strong>
 					</p>
-					<div className="warning">
-						{ /* TODO:  if we want to keep the icon it should be added to @automattic/material-design-icons */ }
-						<Icon
-							icon={
-								<svg
-									className="icon"
-									xmlns="http://www.w3.org/2000/svg"
-									width="24"
-									height="24"
-									viewBox="0 0 24 24"
-								>
-									<path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
-								</svg>
-							}
-						/>
-						<div className="message">
-							{ sprintf( __( 'Changes published will update all pages using this %s.' ), title ) }
-						</div>
-					</div>
+					<Notice status="warning" isDismissible={ false }>
+						{ sprintf( __( 'Changes published will update all pages using this %s.' ), title ) }
+					</Notice>
 				</div>
 			</div>
 		</div>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/panel.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/panel.js
@@ -2,39 +2,61 @@
 /**
  * External dependencies
  */
-import { Component } from '@wordpress/element';
-import { Button, IconButton } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { Button, IconButton, Icon } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
-export default class Panel extends Component {
-	render() {
-		const { onSave, onClose, isBusy, disabled } = this.props;
-		return (
-			<div className="edit-post-layout">
-				<div className="editor-post-publish-panel">
-					<div className="editor-post-publish-panel__header">
-						<div className="editor-post-publish-panel__header-publish-button">
-							<Button isPrimary isLarge isBusy={ isBusy } onClick={ onSave } disabled={ disabled }>
-								{ __( 'Publish' ) }
-							</Button>
-							<span className="editor-post-publish-panel__spacer" />
-						</div>
+/**
+ * Internal dependencies
+ */
+import './style.scss';
 
-						<IconButton
-							aria-expanded={ true }
-							onClick={ onClose }
-							icon="no-alt"
-							label={ __( 'Close panel' ) }
-						/>
+export default ( { onSave, onClose, isBusy, disabled } ) => {
+	const { title } = useSelect( select => {
+		return select( 'core/editor' ).getCurrentPost();
+	} );
+	return (
+		<div className="edit-post-layout">
+			<div className="editor-post-publish-panel">
+				<div className="editor-post-publish-panel__header">
+					<div className="editor-post-publish-panel__header-publish-button">
+						<Button isPrimary isLarge isBusy={ isBusy } onClick={ onSave } disabled={ disabled }>
+							{ __( 'Publish' ) }
+						</Button>
+						<span className="editor-post-publish-panel__spacer" />
 					</div>
-					<div className="editor-post-publish-panel__prepublish">
-						<p>
-							<strong>{ __( 'Are you ready to publish?' ) }</strong>
-						</p>
-						<p>{ __( 'Changes you publish will update all pages with this template part.' ) }</p>
+
+					<IconButton
+						aria-expanded={ true }
+						onClick={ onClose }
+						icon="no-alt"
+						label={ __( 'Close panel' ) }
+					/>
+				</div>
+				<div className="editor-post-publish-panel__prepublish">
+					<p>
+						<strong>{ __( 'Are you ready to publish?' ) }</strong>
+					</p>
+					<div className="warning">
+						<Icon
+							icon={
+								<svg
+									className="icon"
+									xmlns="http://www.w3.org/2000/svg"
+									width="24"
+									height="24"
+									viewBox="0 0 24 24"
+								>
+									<path d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z" />
+								</svg>
+							}
+						/>
+						<div className="message">
+							{ sprintf( __( 'Changes published will update all pages using this %s.' ), title ) }
+						</div>
 					</div>
 				</div>
 			</div>
-		);
-	}
-}
+		</div>
+	);
+};

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/style.scss
@@ -1,12 +1,7 @@
 .editor-post-publish-panel__prepublish {
-	.warning {
-		display: flex;
-		.icon {
-			width: 32px;
-			height: 32px;
-		}
-		.message {
-			margin-left: 4px;
+	.components-notice.is-warning {
+		.components-notice__content {
+			margin: 1em 0;
 		}
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/style.scss
@@ -1,0 +1,12 @@
+.editor-post-publish-panel__prepublish {
+	.warning {
+		display: flex;
+		.icon {
+			width: 32px;
+			height: 32px;
+		}
+		.message {
+			margin-left: 4px;
+		}
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the warning to users on the FSE editor publish panel when editing a template part to give more indication of the impact of the change.

#### Testing instructions

* Check out branch follow instructions in https://github.com/Automattic/wp-calypso/tree/master/apps/full-site-editing#build-system. Install the FSE plugin, and activate it on local gutenberg dev
* Edit a template part, eg. Header or Footer and click the Update button, and check that that panel message shows as below:

<img width="328" alt="publish-warning" src="https://user-images.githubusercontent.com/3629020/61340686-810aaf80-a897-11e9-8940-8872a85e5b9c.png">

Fixes #34343
