### PR TITLE
Add catching around getting the post ID in the FSE Template helper

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template.php
@@ -33,7 +33,13 @@ class A8C_WP_Template {
 	 */
 	public function __construct( $post_id = null ) {
 		if ( null === $post_id ) {
-			$post_id = get_post()->ID;
+			$post = get_post();
+
+			if ( !$post ) {
+				return;
+			}
+
+			$post_id = $post->ID;
 		}
 
 		$this->current_post_id = $post_id;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-a8c-wp-template.php
@@ -35,7 +35,7 @@ class A8C_WP_Template {
 		if ( null === $post_id ) {
 			$post = get_post();
 
-			if ( !$post ) {
+			if ( ! $post ) {
 				return;
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

There was a bug in which errors happened when trying to access a page/post that didn't exist on a site with the FSE plugin activated. ([Screenshots here](https://github.com/Automattic/wp-calypso/issues/34663)) It was occurring because the class for templates in the FSE plugin tried to get the post ID on initializing without any fallback. I fixed that in this PR by ensuring that the post was retrieved in the constructor for WP_Template prior to getting the ID.

#### Testing instructions

* Start up a testing environment with the FSE plugin installed.
* Go to a page that triggers a "page not found error", such as `[site]/?page_id=100/`
* Ensure that no PHP errors are being echoed and that the site works as it should.

Fixes #34663
