### PR TITLE
Signup: update `cartItem` tracking value

### DIFF
--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { includes, isEmpty, reduce, snakeCase } from 'lodash';
+import { includes, isEmpty, reduce, snakeCase, toPairs } from 'lodash';
 
 /**
  * Internal dependencies
@@ -45,9 +45,13 @@ function recordSubmitStep( stepName, providedDependencies ) {
 			}
 
 			// Ensure we don't capture identifiable user data we don't need.
-			if ( includes( [ 'email', 'address', 'phone' ], propName ) ) {
+			if ( includes( [ 'email' ], propName ) ) {
 				propName = `user_entered_${ propName }`;
 				propValue = !! propValue;
+			}
+
+			if ( propName === 'cart_item' && typeof propValue !== 'string' ) {
+				propValue = toPairs( propValue ).join( ';' );
 			}
 
 			return {

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -51,7 +51,9 @@ function recordSubmitStep( stepName, providedDependencies ) {
 			}
 
 			if ( propName === 'cart_item' && typeof propValue !== 'string' ) {
-				propValue = toPairs( propValue ).join( ';' );
+				propValue = toPairs( propValue )
+					.map( pair => pair.join( ':' ) )
+					.join( ',' );
 			}
 
 			return {


### PR DESCRIPTION
## Changes proposed in this Pull Request

A few of our signup steps provide `cartItem` as a dependency. Since it's an object, tracks dishes up a helpful complaint. 

<img width="1099" alt="Screen Shot 2019-07-17 at 11 59 59 am" src="https://user-images.githubusercontent.com/6458278/61341700-c2489280-a88a-11e9-81e7-184ed23f2b29.png">

The results analytics values on the other hand are not so helpful:

`null,[object Object],undefined`

In this PR, we flatten the `cart_item` prop value for analytics to avoid an undefined or `[object, Object]` value. 

We separate new key/values entries by a comma, and pairs by `;`

We've opted for `_.toPairs` over `entries` in order to guard against unknown values. Open to debate on this.

Also, as a bonus, we're removing `address` and `phone` (introduced in https://github.com/Automattic/wp-calypso/pull/29902) from the user info checks we no longer harvest address and phone values in the step dependencies.

`email` is still a dependency of the `passwordless` step, which is used by the `simple` flow.

#### Testing instructions

1. Fire up the branch
2. Open your network console
3. Filter by `calypso_signup_actions_submit_step`
4. Head to http://calypso.localhost:3000/start/business (no need to login)
5. Ignore that I've used underscores in my branch name. 

The query parameter `cart_item` should have a value of `cart_item: product_slug:business-bundle,free_trial:false`
