### PR TITLE
FSE: Fix template part update button render loop

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/button.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/button.js
@@ -23,37 +23,29 @@ const initialState = {
 class TemplateUpdateConfirmationButton extends Component {
 	constructor( props ) {
 		super( props );
-		this.onResize = debounce( this.onResize, 100 );
+		this.onSetButtonStyles = debounce( this.onSetButtonStyles, 100 );
 		this.state = initialState;
-		this.onResize();
-	}
-
-	componentDidUpdate( props, prevProps ) {
-		if ( props.isFullScreen !== prevProps.isFullScreen ) {
-			// this ensures the button is repositioned properly when toggling fullscreen mode
-			setTimeout( () => this.onResize(), 1 );
-		}
+		this.onSetButtonStyles();
 	}
 
 	getOriginalButton() {
 		return document.querySelector( '.edit-post-header .editor-post-publish-button' );
 	}
 
-	onResize() {
+	onSetButtonStyles() {
 		const originalButton = this.getOriginalButton();
 		let { buttonStyle } = initialState;
 		if ( isNil( originalButton ) || ! ( 'getBoundingClientRect' in originalButton ) ) {
 			// if it's not there, might need a timeout to await it?
 			return this.setState( { buttonStyle } );
 		}
-		const rect = originalButton.getBoundingClientRect();
+
 		buttonStyle = {
 			// height doesn't line up perfectly with default styles
 			height: '33px',
-			position: 'fixed',
-			zIndex: '10001',
-			top: rect.top,
-			left: rect.x,
+			position: 'absolute',
+			right: '96px',
+			top: '12px',
 		};
 		if ( ! window.matchMedia( '(min-width: 600px)' ).matches ) {
 			buttonStyle.paddingLeft = '5px';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/index.js
@@ -16,6 +16,7 @@ domReady( () => {
 	}
 	const element = document.createElement( 'div' );
 	element.id = 'template-update-confirmation';
-	document.getElementById( 'wpcontent' ).appendChild( element );
+	const settingsElement = document.querySelector( '.edit-post-header .edit-post-header__settings' );
+	settingsElement.appendChild( element );
 	render( <TemplateUpdateConfirmationButton />, element );
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/panel.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/panel.js
@@ -6,6 +6,11 @@ import { Component } from '@wordpress/element';
 import { Button, IconButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 export default class Panel extends Component {
 	render() {
 		const { onSave, onClose, isBusy, disabled } = this.props;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-confirmation/style.scss
@@ -1,0 +1,6 @@
+@media ( min-width: 782px ) {
+	body.is-fullscreen-mode .edit-post-layout .editor-post-publish-panel {
+		top: 0;
+		height: 100vh;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Render the FSE template part update button into the editor toolbar to prevent the need to listen for changes in full page editing mode  which was causing a re-render loop

#### Testing instructions

* Check out branch follow instructions in https://github.com/Automattic/wp-calypso/tree/master/apps/full-site-editing#build-system. Install the FSE plugin, and activate it on local gutenberg dev

* Edit a footer or header template part and check that the Update button causes update warning panel to appear in both normal and full screen edit. Also check everything works correctly till in different screen sizes

Fixes #34705
