### PR TITLE
Framework: switch how we load the redux dev tools extension

### DIFF
--- a/client/state/index.js
+++ b/client/state/index.js
@@ -80,7 +80,7 @@ export function createReduxStore( initialState, reducer = initialReducer ) {
 		httpDataEnhancer,
 		applyMiddleware( ...middlewares ),
 		isBrowser && window.app && window.app.isDebug && actionLogger,
-		isBrowser && window.devToolsExtension && window.devToolsExtension(),
+		isBrowser && window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
 	].filter( Boolean );
 
 	return createStore( reducer, initialState, compose( ...enhancers ) );


### PR DESCRIPTION
Noticed the following warning in the browser console:

> `window.devToolsExtension` is deprecated in favor of `window.__REDUX_DEVTOOLS_EXTENSION__`, and will be removed in next version of Redux DevTools: https://git.io/fpEJZ


#### Changes proposed in this Pull Request

* Switch how we load the redux dev tools extension. This change enables support for future versions of the extensions.


#### Testing instructions

* Load calypso in a browser with a current version of the [redux dev tools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en), and make sure it works and that no warning is displayed.

Previously #25509

