### PR TITLE
Fix a broken my-plan after cancelation

### DIFF
--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -14,7 +14,7 @@ import { invoke } from 'lodash';
 import Button from 'components/button';
 import Card from 'components/card';
 import PlanIcon from 'components/plans/plan-icon';
-import { isFreeJetpackPlan } from 'lib/products-values';
+import { isFreeJetpackPlan, isFreePlan } from 'lib/products-values';
 import { managePurchase } from 'me/purchases/paths';
 import { shouldAddPaymentSourceInsteadOfRenewingNow } from 'lib/purchases';
 
@@ -32,7 +32,7 @@ export class CurrentPlanHeader extends Component {
 	renderPurchaseInfo() {
 		const { currentPlan, siteSlug, isExpiring, translate } = this.props;
 
-		if ( ! currentPlan || isFreeJetpackPlan( currentPlan ) ) {
+		if ( ! currentPlan || isFreeJetpackPlan( currentPlan ) || isFreePlan( currentPlan ) ) {
 			return null;
 		}
 
@@ -77,6 +77,7 @@ export class CurrentPlanHeader extends Component {
 		const headerClasses = classNames( 'current-plan__header', {
 			'is-jetpack-free': currentPlan && isFreeJetpackPlan( currentPlan ),
 		} );
+		const isFree = ! currentPlan || isFreePlan( currentPlan ) || isFreeJetpackPlan( currentPlan );
 
 		return (
 			<div className={ headerClasses }>
@@ -104,7 +105,7 @@ export class CurrentPlanHeader extends Component {
 						</div>
 					</div>
 					{ this.renderPurchaseInfo() }
-					{ currentPlan && isFreeJetpackPlan( currentPlan ) && siteSlug && (
+					{ currentPlan && isFree && siteSlug && (
 						<div className="current-plan__compare-plans">
 							<Button href={ `/plans/${ siteSlug }` }>{ translate( 'Compare Plans' ) }</Button>
 						</div>


### PR DESCRIPTION
This page can't be loaded while I'm on the Free plan - it would redirect to plans. It, however, can be loaded while I'm on a paid plan and cancel and it looks very broken. Our team's current work on the auto-renew toggle and the future on downgrades means seeing this screen over and over.

<img width="1337" alt="Screenshot 2019-07-17 at 11 37 49" src="https://user-images.githubusercontent.com/82778/61362788-721e0000-a88b-11e9-8e38-63ec0b7bf7ab.png">

There were two ways to fix it. To force a redirect, like when you were previously on a Free plan, or to extend a few ifs and use the display for the Jetpack Free. I propose the second as it's an easy fix and won't surprise any user.

#### Changes proposed in this Pull Request

This change makes the broken string disappear and displays a button that will head to /plans.

#### Testing instructions

1. Buy a plan
2. Cancel it
3. Click on my plan
