### PR TITLE
Marketing: Auto-apply coupon code in site-selected flow.

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -17,6 +17,10 @@ import { generateFlows } from './flows-pure';
 const user = userFactory();
 
 function getCheckoutUrl( dependencies ) {
+	if ( dependencies.couponCode ) {
+		return `/checkout/${ dependencies.siteSlug }?coupon=${ dependencies.couponCode }`;
+	}
+
 	return '/checkout/' + dependencies.siteSlug;
 }
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -109,6 +109,9 @@ export function generateSteps( {
 			stepName: 'plans-site-selected',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
+			props: {
+				provideCouponCode: true,
+			},
 			providesDependencies: [ 'cartItem', 'couponCode' ],
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -109,7 +109,7 @@ export function generateSteps( {
 			stepName: 'plans-site-selected',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
-			providesDependencies: [ 'cartItem' ],
+			providesDependencies: [ 'cartItem', 'couponCode' ],
 		},
 
 		site: {

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -70,9 +70,7 @@ export class PlansStep extends Component {
 	}
 
 	onSelectPlan = cartItem => {
-		const { additionalStepData, stepSectionName, stepName, flowName, queryObject } = this.props;
-		const couponCode =
-			cartItem && flowName === 'site-selected' && get( queryObject, 'discount', '' );
+		const { additionalStepData, stepSectionName, stepName, flowName } = this.props;
 
 		if ( cartItem ) {
 			this.props.recordTracksEvent( 'calypso_signup_plan_select', {
@@ -105,7 +103,13 @@ export class PlansStep extends Component {
 			...additionalStepData,
 		};
 
-		this.props.submitSignupStep( step, { cartItem, couponCode } );
+		if ( this.props.provideCouponCode ) {
+			const couponCode = get( this.props.queryObject, 'discount', '' );
+			this.props.submitSignupStep( step, { cartItem, couponCode } );
+		} else {
+			this.props.submitSignupStep( step, { cartItem } );
+		}
+
 		this.props.goToNextStep();
 	};
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -7,7 +7,7 @@
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { intersection } from 'lodash';
+import { get, intersection } from 'lodash';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { parse as parseQs } from 'qs';
@@ -70,7 +70,9 @@ export class PlansStep extends Component {
 	}
 
 	onSelectPlan = cartItem => {
-		const { additionalStepData, stepSectionName, stepName, flowName } = this.props;
+		const { additionalStepData, stepSectionName, stepName, flowName, queryObject } = this.props;
+		const couponCode =
+			cartItem && flowName === 'site-selected' && get( queryObject, 'discount', '' );
 
 		if ( cartItem ) {
 			this.props.recordTracksEvent( 'calypso_signup_plan_select', {
@@ -103,7 +105,7 @@ export class PlansStep extends Component {
 			...additionalStepData,
 		};
 
-		this.props.submitSignupStep( step, { cartItem } );
+		this.props.submitSignupStep( step, { cartItem, couponCode } );
 		this.props.goToNextStep();
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the `site-selected` signup flow, the `discount` URL param will be auto-applied to the cart.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox the store.
* Open the start page through an URL like `/start/site-selected?siteSlug=YOUR_SITE_SLUG&siteId=YOUR_SITE_ID&discount=TESTING10`.
* The coupon code should be auto-applied to your cart at the end of the signup flow.

![demo2](https://user-images.githubusercontent.com/212034/61364436-cb545680-a8c0-11e9-842b-c10e714ef52e.gif)

