### PR TITLE
Update label as requested

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -520,7 +520,7 @@ export class PlanFeatures extends Component {
 				buttonText = null;
 
 			if ( disableBloggerPlanWithNonBlogDomain || this.props.nonDotBlogDomains.length > 0 ) {
-				if ( planMatches( planName, { type: TYPE_BLOGGER } ) ) {
+				if ( planMatches( planName, { type: TYPE_BLOGGER } ) && availableForPurchase ) {
 					availableForPurchase = false;
 					forceDisplayButton = true;
 					buttonText = translate( 'Only with .blog domains' );


### PR DESCRIPTION
Update copy to make a button more clear. Hide it when it doesn't need to be visible.

#### Changes proposed in this Pull Request

Owners of non-.blog domains are not allowed to upgrade to the Blogger plan but we still display it

#### Testing instructions

1. Add a domain to your site either by SA or by buying a plan+domain and canceling the plan
2. Make sure you're in control for hideBloggerPlan2
3. Go to plans

<img width="346" alt="Screenshot 2019-07-17 at 13 26 51" src="https://user-images.githubusercontent.com/82778/61368455-8e736a00-a896-11e9-8da9-f6bebb498c18.png">

4. Get a domain + Business plan. The button should now be completely hidden.

See #34683