### PR TITLE
Replace usage of superagent in i18n-utils.

### DIFF
--- a/client/lib/i18n-utils/glotpress.js
+++ b/client/lib/i18n-utils/glotpress.js
@@ -26,7 +26,7 @@ export async function postRequest( glotPressUrl, postFormData ) {
 			body: postFormData,
 		} );
 		if ( response.ok ) {
-			return await response.body;
+			return await response.json();
 		}
 	} catch ( err ) {
 		throw err;

--- a/client/lib/i18n-utils/glotpress.js
+++ b/client/lib/i18n-utils/glotpress.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-import request from 'superagent';
 import debugFactory from 'debug';
 
 /**
@@ -19,15 +16,24 @@ const debug = debugFactory( 'calypso:i18n-utils:glotpress' );
  * @param {String} postFormData post data url param string
  * @returns {Object} request object
  */
-export function postRequest( glotPressUrl, postFormData ) {
-	return request
-		.post( glotPressUrl )
-		.withCredentials()
-		.send( postFormData )
-		.then( response => response.body )
-		.catch( error => {
-			throw error; // pass on the error so the call sites can handle it accordingly.
+export async function postRequest( glotPressUrl, postFormData ) {
+	let response;
+
+	try {
+		response = await fetch( glotPressUrl, {
+			method: 'POST',
+			credentials: 'include',
+			body: postFormData,
 		} );
+		if ( response.ok ) {
+			return await response.body;
+		}
+	} catch ( err ) {
+		throw err;
+	}
+
+	// Invalid response.
+	throw new Error( await response.body );
 }
 
 export function encodeOriginalKey( { original, context } ) {

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-import request from 'superagent';
 import i18n from 'i18n-calypso';
 import debugFactory from 'debug';
 import { map, includes } from 'lodash';
@@ -63,6 +60,18 @@ function setLocaleInDOM( localeSlug, isRTL ) {
 	switchWebpackCSS( isRTL );
 }
 
+async function getLanguageFile( targetLocaleSlug ) {
+	const url = getLanguageFileUrl( targetLocaleSlug );
+
+	const response = await fetch( url );
+	if ( response.ok ) {
+		return await response.body;
+	}
+
+	// Invalid response.
+	throw new Error();
+}
+
 let lastRequestedLocale = null;
 export default function switchLocale( localeSlug ) {
 	// check if the language exists in config.languages
@@ -89,28 +98,28 @@ export default function switchLocale( localeSlug ) {
 		i18n.configure( { defaultLocaleSlug: targetLocaleSlug } );
 		setLocaleInDOM( domLocaleSlug, !! language.rtl );
 	} else {
-		request.get( getLanguageFileUrl( targetLocaleSlug ) ).end( function( error, response ) {
-			if ( error ) {
+		getLanguageFile( targetLocaleSlug ).then(
+			// Success.
+			body => {
+				// Handle race condition when we're requested to switch to a different
+				// locale while we're in the middle of request, we should abandon result
+				if ( targetLocaleSlug !== lastRequestedLocale ) {
+					return;
+				}
+
+				i18n.setLocale( body );
+
+				setLocaleInDOM( domLocaleSlug, !! language.rtl );
+
+				loadUserUndeployedTranslations( targetLocaleSlug );
+			},
+			// Failure.
+			() => {
 				debug(
-					'Encountered an error loading locale file for ' +
-						localeSlug +
-						'. Falling back to English.'
+					`Encountered an error loading locale file for ${ localeSlug }. Falling back to English.`
 				);
-				return;
 			}
-
-			// Handle race condition when we're requested to switch to a different
-			// locale while we're in the middle of request, we should abondon result
-			if ( targetLocaleSlug !== lastRequestedLocale ) {
-				return;
-			}
-
-			i18n.setLocale( response.body );
-
-			setLocaleInDOM( domLocaleSlug, !! language.rtl );
-
-			loadUserUndeployedTranslations( targetLocaleSlug );
-		} );
+		);
 	}
 }
 
@@ -164,14 +173,12 @@ export function loadUserUndeployedTranslations( currentLocaleSlug ) {
 		query,
 	} );
 
-	return request
-		.get( requestUrl )
-		.set( 'Accept', 'application/json' )
-		.withCredentials()
-		.then( res => {
-			const translations = JSON.parse( res.text );
-			i18n.addTranslations( translations );
-		} );
+	return fetch( requestUrl, {
+		headers: { Accept: 'application/json' },
+		credentials: 'include',
+	} )
+		.then( res => res.json() )
+		.then( translations => i18n.addTranslations( translations ) );
 }
 
 const bundles = {};

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -65,7 +65,7 @@ async function getLanguageFile( targetLocaleSlug ) {
 
 	const response = await fetch( url );
 	if ( response.ok ) {
-		return await response.body;
+		return await response.json();
 	}
 
 	// Invalid response.


### PR DESCRIPTION
Some functions used `superagent`, a 3rd party `npm` package, for network requests, and have here been rewritten to use native `fetch` instead.

This is part of an effort to remove `superagent` from client code altogether, and replace it with native `fetch` functionality. This will eventually lead to being able to drop that dependency from the client-side bundle, thus improving loading performance.

#### Changes proposed in this Pull Request

* Rewrite several `i18n-utils` functions using `fetch` instead of `superagent`

#### Testing instructions

I am not familiar with this functionality, so I can't provide good testing instructions. Please ensure that `glotpress` and locale switching functionality continue to work correctly with these changes.

If I added you as a reviewer and you're not familiar with this code, sorry about that, I'm just going by GitHub recommendations! If that's the case, please feel free to remove yourself or ignore the PR. And if you can point me to a better reviewer, please do! 🙂 