### PR TITLE
MobileBackToSidebar: fixup CSS margin

### DIFF
--- a/client/components/mobile-back-to-sidebar/style.scss
+++ b/client/components/mobile-back-to-sidebar/style.scss
@@ -16,7 +16,7 @@
 
 .mobile-back-to-sidebar__icon {
 	fill: var( --color-neutral-light );
-	margin: 0 14px 8px 0;
+	margin: 0 14px 0 8px;
 }
 
 .mobile-back-to-sidebar__content {


### PR DESCRIPTION
Followup to #34538. Only when the PR was already on staging, I noticed the icon's CSS is broken:

Broken:
<img width="337" alt="Screenshot 2019-07-17 at 13 42 08" src="https://user-images.githubusercontent.com/664258/61376606-c7650c00-a8a1-11e9-9da3-ab6af942f97e.png">

Fixed:
<img width="336" alt="Screenshot 2019-07-17 at 13 41 35" src="https://user-images.githubusercontent.com/664258/61376612-ccc25680-a8a1-11e9-9425-4caa8f99d036.png">

**How to test:** You can see this UI in Reader in mobile mode (small screen)