### PR TITLE
Marketing: Auto-apply coupon code on /plans page.

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -859,7 +859,6 @@ export default connect(
 								}
 
 								const args = {};
-
 								// Auto-apply the coupon code to the cart for WPCOM sites
 								if ( ! displayJetpackPlans && withDiscount ) {
 									args.coupon = withDiscount;

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -32,6 +32,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 import { retargetViewPlans } from 'lib/analytics/ad-tracking';
 import canUpgradeToPlan from 'state/selectors/can-upgrade-to-plan';
 import { getDiscountByName } from 'lib/discounts';
+import { addQueryArgs } from 'lib/url';
 import {
 	planMatches,
 	applyTestFiltersToPlansList,
@@ -763,6 +764,7 @@ export default connect(
 			displayJetpackPlans,
 			visiblePlans,
 			popularPlanSpec,
+			withDiscount,
 		} = ownProps;
 		const selectedSiteId = siteId;
 		const selectedSiteSlug = getSiteSlug( state, selectedSiteId );
@@ -856,7 +858,19 @@ export default connect(
 									return;
 								}
 
-								page( `/checkout/${ selectedSiteSlug }/${ getPlanPath( plan ) || '' }` );
+								const args = {};
+
+								// Auto-apply the coupon code to the cart for WPCOM sites
+								if ( ! displayJetpackPlans && withDiscount ) {
+									args.coupon = withDiscount;
+								}
+
+								page(
+									addQueryArgs(
+										args,
+										`/checkout/${ selectedSiteSlug }/${ getPlanPath( plan ) || '' }`
+									)
+								);
 						  },
 					planConstantObj,
 					planName: plan,

--- a/client/my-sites/plans-features-main/index.jsx
+++ b/client/my-sites/plans-features-main/index.jsx
@@ -274,12 +274,14 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	constructPath( plansUrl, intervalType, customerType = '' ) {
-		const { selectedFeature, selectedPlan, siteSlug } = this.props;
+		const { selectedFeature, selectedPlan, siteSlug, withDiscount } = this.props;
+
 		return addQueryArgs(
 			{
 				customerType,
 				feature: selectedFeature,
 				plan: selectedPlan,
+				discount: withDiscount,
 			},
 			plansLink( plansUrl, siteSlug, intervalType, true )
 		);
@@ -315,21 +317,24 @@ export class PlansFeaturesMain extends Component {
 	}
 
 	getCustomerTypeToggle() {
-		const { customerType, translate } = this.props;
+		const { customerType, translate, withDiscount } = this.props;
 		const segmentClasses = classNames( 'plan-features__interval-type', 'is-customer-type-toggle' );
+		const queryArgs = {
+			discount: withDiscount,
+		};
 
 		return (
 			<SegmentedControl className={ segmentClasses } primary={ true }>
 				<SegmentedControlItem
 					selected={ customerType === 'personal' }
-					path={ '?customerType=personal' }
+					path={ addQueryArgs( { ...queryArgs, customerType: 'personal' }, '' ) }
 				>
 					{ translate( 'Blogs and Personal Sites' ) }
 				</SegmentedControlItem>
 
 				<SegmentedControlItem
 					selected={ customerType === 'business' }
-					path={ '?customerType=business' }
+					path={ addQueryArgs( { ...queryArgs, customerType: 'business' }, '' ) }
 				>
 					{ translate( 'Business Sites and Online Stores' ) }
 				</SegmentedControlItem>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When a user picks a paid plan In `/plans` page loaded with `discount` param, the coupon code will be auto-applied to the cart.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox store. (Cookie method would be working)
* Open `/plans` page of your free plan website with `discount` param like `/plans/YOUR_SITE_SLUG/?discount=TESTING10`.
* Pick a paid plan.
* The coupon should be applied to the cart.
