### PR TITLE
SSR: Add stat for render errors

### DIFF
--- a/server/render/index.js
+++ b/server/render/index.js
@@ -120,6 +120,7 @@ export function render( element, key = JSON.stringify( element ), req ) {
 
 		return renderedLayout;
 	} catch ( ex ) {
+		bumpStat( 'calypso-ssr', 'render-exception' );
 		if ( process.env.NODE_ENV === 'development' ) {
 			throw ex;
 		}


### PR DESCRIPTION
Render errors are silently ignored. We end up discovering them through secondary methods. Add a stat so it's clear when there's an increase in errors.

#### Testing instructions

* Make sure Calypso continues to work and SSR as expected.