### PR TITLE
SSR: Log render errors

### DIFF
--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -132,7 +132,8 @@ export function render( element, key = JSON.stringify( element ), req ) {
 						feature: 'calypso_ssr',
 						message: 'Exception thrown on render',
 						extra: {
-							error: ex,
+							message: ex.message,
+							stack: ex.stack,
 						},
 					} )
 				);

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -123,6 +123,16 @@ export function render( element, key = JSON.stringify( element ), req ) {
 
 		return renderedLayout;
 	} catch ( ex ) {
+		// Log 1% of errors
+		if ( Math.random() < 0.01 ) {
+			logToLogstash( {
+				feature: 'calypso_ssr',
+				message: 'Exception thrown on render',
+				extra: {
+					error: ex,
+				},
+			} );
+		}
 		if ( process.env.NODE_ENV === 'development' ) {
 			throw ex;
 		}

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -134,10 +134,11 @@ export function render( element, key = JSON.stringify( element ), req ) {
 						extra: {
 							message: ex.message,
 							stack: ex.stack,
+							userId: req.context?.user?.ID,
 						},
 					} )
 				);
-			} catch ( exception ) {
+			} catch {
 				// Failed to log the error, swallow it so it doesn't break anything. This will serve
 				// a blank page and the client will render on top of it.
 			}

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -123,15 +123,23 @@ export function render( element, key = JSON.stringify( element ), req ) {
 
 		return renderedLayout;
 	} catch ( ex ) {
-		logToLogstash( {
-			feature: 'calypso_ssr',
-			message: 'Exception thrown on render',
-			extra: {
-				error: ex,
-			},
-		} );
 		if ( process.env.NODE_ENV === 'development' ) {
 			throw ex;
+		} else {
+			try {
+				req.context.store.dispatch(
+					logToLogstash( {
+						feature: 'calypso_ssr',
+						message: 'Exception thrown on render',
+						extra: {
+							error: ex,
+						},
+					} )
+				);
+			} catch ( exception ) {
+				// Failed to log the error, swallow it so it doesn't break anything. This will serve
+				// a blank page and the client will render on top of it.
+			}
 		}
 	}
 	//todo: render an error?

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -123,16 +123,13 @@ export function render( element, key = JSON.stringify( element ), req ) {
 
 		return renderedLayout;
 	} catch ( ex ) {
-		// Log 1% of errors
-		if ( Math.random() < 0.01 ) {
-			logToLogstash( {
-				feature: 'calypso_ssr',
-				message: 'Exception thrown on render',
-				extra: {
-					error: ex,
-				},
-			} );
-		}
+		logToLogstash( {
+			feature: 'calypso_ssr',
+			message: 'Exception thrown on render',
+			extra: {
+				error: ex,
+			},
+		} );
 		if ( process.env.NODE_ENV === 'development' ) {
 			throw ex;
 		}

--- a/client/server/render/index.js
+++ b/client/server/render/index.js
@@ -131,10 +131,10 @@ export function render( element, key = JSON.stringify( element ), req ) {
 					logToLogstash( {
 						feature: 'calypso_ssr',
 						message: 'Exception thrown on render',
+						user_id: req.context.user?.ID,
 						extra: {
 							message: ex.message,
 							stack: ex.stack,
-							userId: req.context?.user?.ID,
 						},
 					} )
 				);


### PR DESCRIPTION
Render errors are silently ignored and end up being discovered through secondary methods. Add logging for render errors.

Companion to #34717

#### Testing instructions

* Verify Calypso SSR continues to work as expected.