### PR TITLE
Store Services: Remove red text in dropdown options

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
+++ b/client/extensions/woocommerce/woocommerce-services/views/shipping-label/label-purchase-modal/style.scss
@@ -73,6 +73,10 @@
 
 	select {
 		width: 100%;
+
+		option, optgroup {
+			color: initial;
+		}
 	}
 
 	.foldable-card__header {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a `<select>` dropdown is in an invalid state, the text color is set to red, which in Firefox is inherited by the options in the menu. This is not intended, and this change is to override the inherited color.

Closed (master and this branch):
<img width="491" alt="branch-closed" src="https://user-images.githubusercontent.com/1867547/61380511-7f30f400-a877-11e9-840a-20059b1d4b09.png">

Open – master:
<img width="479" alt="master-open" src="https://user-images.githubusercontent.com/1867547/61380527-86580200-a877-11e9-9721-148c175ccee5.png">

Open – this branch:
<img width="493" alt="branch-open" src="https://user-images.githubusercontent.com/1867547/61380551-8eb03d00-a877-11e9-9e4e-d9b33ed94ebd.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using Firefox, go to Store
* Open an order in a processing state, and open the label purchase dialog
* In the rates (or packages) step, select the empty value in the dropdown ("Select one…")
* Verify that the dropdown options appear in a neutral color
