### PR TITLE
Checkout: SecurePaymentForm: make event optional in submitTransaction

### DIFF
--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -159,7 +159,7 @@ export class SecurePaymentForm extends Component {
 	};
 
 	submitTransaction( event ) {
-		event.preventDefault();
+		event && event.preventDefault();
 
 		const params = pick( this.props, [ 'cart', 'transaction' ] );
 		const origin = getLocationOrigin( window.location );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The only thing that `event` is used for here is to call
`preventDefault()`, and if we are using async synthetic React events,
then `preventDefault()` may already have been called, making it
challenging to pass the un-cancelled event to this function. With this
change, the argument becomes optional.

#### Testing instructions

Make a purchase and be sure that the "Pay" button works as expected.
