### PR TITLE
Server webpack config: remove externing of react and redux

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -23348,6 +23348,12 @@
 				"uuid": "^3.3.2"
 			}
 		},
+		"webpack-node-externals": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz",
+			"integrity": "sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==",
+			"dev": true
+		},
 		"webpack-rtl-plugin": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/webpack-rtl-plugin/-/webpack-rtl-plugin-1.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -328,6 +328,7 @@
 		"supertest": "3.4.2",
 		"svgstore-cli": "1.3.1",
 		"webpack-hot-middleware": "2.25.0",
+		"webpack-node-externals": "1.7.2",
 		"whybundled": "1.4.2"
 	},
 	"optionalDependencies": {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -22,6 +22,7 @@ const config = require( 'config' );
 const bundleEnv = config( 'env' );
 const { workerCount } = require( './webpack.common' );
 const TranspileConfig = require( '@automattic/calypso-build/webpack/transpile' );
+const nodeExternals = require( 'webpack-node-externals' );
 
 /**
  * Internal variables
@@ -34,35 +35,26 @@ const commitSha = process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMI
  * This lists modules that must use commonJS `require()`s
  * All modules listed here need to be ES5.
  *
- * @returns { object } list of externals
+ * @returns {Array} list of externals
  */
 function getExternals() {
-	const externals = {};
-
-	// Don't bundle any node_modules, both to avoid a massive bundle, and problems
-	// with modules that are incompatible with webpack bundling.
-	fs.readdirSync( 'node_modules' )
-		.filter( function( module ) {
-			return [ '.bin' ].indexOf( module ) === -1;
-		} )
-		.forEach( function( module ) {
-			externals[ module ] = 'commonjs ' + module;
-		} );
-
-	// Don't bundle webpack.config, as it depends on absolute paths (__dirname)
-	externals[ 'webpack.config' ] = 'commonjs webpack.config';
-	// Exclude hot-reloader, as webpack will try and resolve this in production builds,
-	// and error.
-	externals[ 'bundler/hot-reloader' ] = 'commonjs bundler/hot-reloader';
-	// Exclude the devdocs search-index, as it's huge.
-	externals[ 'devdocs/search-index' ] = 'commonjs devdocs/search-index';
-	// Exclude the devdocs components usage stats data
-	externals[ 'devdocs/components-usage-stats.json' ] =
-		'commonjs devdocs/components-usage-stats.json';
-	// Exclude server/bundler/assets, since the files it requires don't exist until the bundler has run
-	externals[ 'bundler/assets' ] = 'commonjs bundler/assets';
-
-	return externals;
+	return [
+		// Don't bundle any node_modules, both to avoid a massive bundle, and problems
+		// with modules that are incompatible with webpack bundling.
+		nodeExternals(),
+		// Don't bundle webpack.config, as it depends on absolute paths (__dirname)
+		'webpack.config',
+		// Exclude hot-reloader, as webpack will try and resolve this in production builds,
+		// and error.
+		'bundler/hot-reloader',
+		// Exclude the devdocs search-index, as it's huge.
+		'devdocs/search-index',
+		// Exclude the devdocs components usage stats data
+		'devdocs/components-usage-stats.json',
+		'devdocs/components-usage-stats.json',
+		// Exclude server/bundler/assets, since the files it requires don't exist until the bundler has run
+		'bundler/assets',
+	];
 }
 
 const webpackConfig = {
@@ -133,6 +125,7 @@ const webpackConfig = {
 			raw: true,
 			entryOnly: false,
 		} ),
+		new webpack.ExternalsPlugin( 'commonjs', getExternals() ),
 		new webpack.DefinePlugin( {
 			BUILD_TIMESTAMP: JSON.stringify( new Date().toISOString() ),
 			COMMIT_SHA: JSON.stringify( commitSha ),
@@ -150,7 +143,6 @@ const webpackConfig = {
 			'components/empty-component'
 		), // Depends on BOM
 	] ),
-	externals: getExternals(),
 };
 
 if ( ! config.isEnabled( 'desktop' ) ) {

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -41,7 +41,10 @@ function getExternals() {
 	return [
 		// Don't bundle any node_modules, both to avoid a massive bundle, and problems
 		// with modules that are incompatible with webpack bundling.
-		nodeExternals(),
+		//
+		// `@automattic/calypso-ui` is forced to be webpack-ed because it has SCSS and other
+		// non-JS asset imports that couldn't be processed by Node.js at runtime.
+		nodeExternals( { whitelist: [ '@automattic/calypso-ui' ] } ),
 		// Don't bundle webpack.config, as it depends on absolute paths (__dirname)
 		'webpack.config',
 		// Exclude hot-reloader, as webpack will try and resolve this in production builds,

--- a/webpack.config.node.js
+++ b/webpack.config.node.js
@@ -61,11 +61,6 @@ function getExternals() {
 		'commonjs devdocs/components-usage-stats.json';
 	// Exclude server/bundler/assets, since the files it requires don't exist until the bundler has run
 	externals[ 'bundler/assets' ] = 'commonjs bundler/assets';
-	// Map React and redux to the minimized version in production
-	if ( config( 'env' ) === 'production' ) {
-		externals.react = 'commonjs react/umd/react.production.min.js';
-		externals.redux = 'commonjs redux/dist/redux.min';
-	}
 
 	return externals;
 }


### PR DESCRIPTION
Removes outdated trick added in #10693 that causes SSR errors today: two versions of React (`react/umd/...` and `react/cjs/...`) are loaded by the server bundle, and that causes trouble.

How did that happen? The webpack config for the server build specifies all modules in `node_modules` as externals. That means only the Calypso app files will be bundled, and the 3rd party modules are kept as `require( module )` in the resulting bundle -- these modules will be imported by Node at runtime.

Also, `react` was declared as external that resolves to `react/umd/react.production.min.js`. But that applies only to `require` calls processed by webpack. Runtime `require` calls resolve normally, to `react/cjs/react.production.min.js`.

Therefore, React import from Calypso sources and from inside `node_modules` (e.g., `i18n-calypso`) resolve to different files. This has been going on for 2.5 years and started to be a visible problem only after hooks were introduced. Hooks are apparently sensitive to React module instance duplication.