### PR TITLE
Checkout: StripeElementsPaymentBox: stop passing component to hook

### DIFF
--- a/client/my-sites/checkout/checkout/stripe-elements-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/stripe-elements-payment-box.jsx
@@ -64,7 +64,7 @@ export function StripeElementsPaymentBox( {
 	cards,
 } ) {
 	// TODO: send the country to useStripeConfiguration
-	const stripeConfiguration = useStripeConfiguration( CreditCardPaymentBox );
+	const stripeConfiguration = useStripeConfiguration();
 	const stripeJs = useStripeJs( stripeConfiguration );
 	return (
 		<StripeProvider stripe={ stripeJs }>


### PR DESCRIPTION
Somehow in #34469 we ended up with a typo where a component would be
passed to a custom `useEffect()` hook in `StripeElementsPaymentBox`
rather than null. I'm not sure exactly what that will do, but it can't
be good. This change removes it.

#### Testing instructions

Sandbox your store connection and try to visit the checkout page. Be sure you can see the Stripe form (see screenshots in #34469).