### PR TITLE
Fix Guided Transfer Card Unavailable Info Icon style

### DIFF
--- a/client/my-sites/exporter/guided-transfer-card/style.scss
+++ b/client/my-sites/exporter/guided-transfer-card/style.scss
@@ -117,6 +117,6 @@
 }
 
 .guided-transfer-card__unavailable-info-icon.info-popover .gridicon:hover,
-.guided-transfer-card__unavailable-info-icon.info-popover.is_active .gridicon {
+.guided-transfer-card__unavailable-info-icon.info-popover.is-active .gridicon {
 	color: var( --color-neutral-0 );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix Guided Transfer Card Unavailable Info Icon style

#### Testing instructions

1. Go to `/export`
2. Update this snippet to show the `UnavailableInfo` component: https://github.com/Automattic/wp-calypso/blob/4612c223c8224d832687fb0cc3f51b9e0682bd78/client/my-sites/exporter/guided-transfer-card/index.jsx#L75-L87

<details><summary>Before</summary>

![With wrong icon color](https://cld.wthms.co/fBB0fp+)
</details>

<details><summary>After</summary>

![With right icon color](https://cld.wthms.co/t7G0xw+)
</details>
