### PR TITLE
Remove redundant hack used to fix some flows

### DIFF
--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -27,18 +27,8 @@ class SiteType extends Component {
 	submitStep = siteTypeValue => {
 		this.props.submitSiteType( siteTypeValue );
 
-		// TODO Hack to fix the `/start/premium|business|personal` routes
-		if (
-			( this.props.flowName === 'premium' ||
-				this.props.flowName === 'business' ||
-				this.props.flowName === 'personal' ) &&
-			siteTypeValue === 'blog'
-		) {
-			this.props.goToNextStep( this.props.flowName );
-		} else {
-			// Modify the flowname if the site type matches an override.
-			this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
-		}
+		// Modify the flowname if the site type matches an override.
+		this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
 	};
 
 	render() {


### PR DESCRIPTION
The `premium`, `business`, and `personal` flows were broken when choosing the blog site type would switch the user to the `onboarding-blog` flow. This carefully crafted hack prevented the flow from being switched when the user choose blog.

Now that the `onboarding-blog` flow is no more we can remove this hack.

Was introduced in #34173

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/start` and create a site, everything should work as expected
- Go to `/start/personal` and choose blog, everything works as expected

**Note:** you might notice that choosing "Online Store" while going through the `premium`, `business`, or `personal` flows is broken. This appears to be an existing bug, not sure how long it's been around.