### PR TITLE
Signup: Hide site preview when showing the loading screen

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -519,24 +519,27 @@ class Signup extends React.Component {
 					{ this.state.shouldShowLoadingScreen ? (
 						<SignupProcessingScreen />
 					) : (
-						<CurrentComponent
-							path={ this.props.path }
-							step={ currentStepProgress }
-							initialContext={ this.props.initialContext }
-							steps={ flow.steps }
-							stepName={ this.props.stepName }
-							meta={ flow.meta || {} }
-							goToNextStep={ this.goToNextStep }
-							goToStep={ this.goToStep }
-							previousFlowName={ this.state.previousFlowName }
-							flowName={ this.props.flowName }
-							signupProgress={ this.props.progress }
-							signupDependencies={ this.props.signupDependencies }
-							stepSectionName={ this.props.stepSectionName }
-							positionInFlow={ this.getPositionInFlow() }
-							hideFreePlan={ hideFreePlan }
-							{ ...propsFromConfig }
-						/>
+						<>
+							<CurrentComponent
+								path={ this.props.path }
+								step={ currentStepProgress }
+								initialContext={ this.props.initialContext }
+								steps={ flow.steps }
+								stepName={ this.props.stepName }
+								meta={ flow.meta || {} }
+								goToNextStep={ this.goToNextStep }
+								goToStep={ this.goToStep }
+								previousFlowName={ this.state.previousFlowName }
+								flowName={ this.props.flowName }
+								signupProgress={ this.props.progress }
+								signupDependencies={ this.props.signupDependencies }
+								stepSectionName={ this.props.stepSectionName }
+								positionInFlow={ this.getPositionInFlow() }
+								hideFreePlan={ hideFreePlan }
+								{ ...propsFromConfig }
+							/>
+							{ this.props.shouldShowMockups && <SiteMockups stepName={ this.props.stepName } /> }
+						</>
 					) }
 				</div>
 			</div>
@@ -598,7 +601,6 @@ class Signup extends React.Component {
 						redirectTo={ this.state.redirectTo }
 					/>
 				) }
-				{ this.props.shouldShowMockups && <SiteMockups stepName={ this.props.stepName } /> }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The site preview during signup was always showing if `showSiteMockups` was true in `steps-pure.js`, even when the loading screen was displaying at the end of the flow.

This worked for the `onboarding` flow because the last step just happened to have no preview. However flows like `premium` end on a step that shows a preview.

This change does change the DOM a little bit (moving the site preview inside the `.signup__step` container) but it doesn't look like it affects any layout. And I think the preview belongs in the same ternary expression that chooses between `<SignupProcessingScreen>` and `<CurrentComponent>`.

**Bug looks like this:**
<img width="1151" alt="image" src="https://user-images.githubusercontent.com/1500769/61427676-31011b00-a973-11e9-948e-09b38bc39677.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to `master`
* Start at `/start/free` and create a site
* Notice that the preview appears on the loading screen
* Switch to this branch
* Start at `/start/free` and create a site
* Note that the preview is no longer on the loading screen
