### PR TITLE
FSE on WP.com: Open previous page after closing template part editor

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -521,15 +521,11 @@ function handleInsertClassicBlockMedia( calypsoPort ) {
  *
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
-function handleGoToAllPosts( calypsoPort ) {
-	if ( ! calypsoifyGutenberg.closeUrl ) {
-		return;
-	}
-
+function handleCloseEditor( calypsoPort ) {
 	$( '#editor' ).on( 'click', '.edit-post-fullscreen-mode-close__toolbar a', e => {
 		e.preventDefault();
 		calypsoPort.postMessage( {
-			action: 'goToAllPosts',
+			action: 'closeEditor',
 			payload: {
 				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
 			},
@@ -657,7 +653,7 @@ function initPort( message ) {
 
 		handlePreview( calypsoPort );
 
-		handleGoToAllPosts( calypsoPort );
+		handleCloseEditor( calypsoPort );
 
 		openLinksInParentFrame();
 

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -108,6 +108,7 @@ export const post = ( context, next ) => {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const pressThis = getPressThisData( context.query );
+	const fseParentPageId = parseInt( context.query.fse_parent_post, 10 ) || null;
 
 	// Set postId on state.ui.editor.postId, so components like editor revisions can read from it.
 	context.store.dispatch( { type: EDITOR_START, siteId, postId } );
@@ -118,6 +119,7 @@ export const post = ( context, next ) => {
 			postType={ postType }
 			duplicatePostId={ duplicatePostId }
 			pressThis={ pressThis }
+			fseParentPageId={ fseParentPageId }
 		/>
 	);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Opens the previous edited page after closing the editor of a template part (such as the header or the footer). 

This assumes that the edit button that appears when hovering a template part on the page editor will redirect to a URL containing a `fse_parent_post` parameter (to be done in #34074).

#### Testing instructions

* Since FSE functionality is currently disabled on Atomic sites via filter in wpcomsh, you'll have to deactivate the default version of FSE plugin and upload a custom version that removes `a8c_disable_full_site_editing bails` from the code, to make sure it loads regardless of wpcomsh overrides. You can use [this archive](https://github.com/Automattic/wp-calypso/files/3405020/full-site-editing-plugin.zip) for testing that includes the needed modifications.
* Upload the new build of the `@automattic/wpcom-block-editor` app yo tour sandbox following instructions available at PCYsg-l4k-p2.
* Sandbox the API and `widgets.cdn.com`.
* Apply this branch to your local Calypso dev environment.
* Determine the ID of any template part created on your Atomic test site (I'll refer to this as `templatePartId`).
* Determine the ID of any page created on your Atomic test site (I'll refer to this as `pageId`).
* Go to `http://calypso.localhost:3000/block-editor/edit/wp_template_part/:atomicSiteDomain/:templatePartId?fse_parent_post=:pageId`.
* Click on close button.
* Make sure the page with the ID determined above is opened on the editor (the URL should be `http://calypso.localhost:3000/block-editor/page/:pageId`).

Fixes #34071.
