### PR TITLE
The plan cancellation survey shouldn't show on cancelling non-plan products.

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -32,7 +32,7 @@ import initialSurveyState from './initial-survey-state';
 import BusinessATStep from './step-components/business-at-step';
 import UpgradeATStep from './step-components/upgrade-at-step';
 import { getName } from 'lib/purchases';
-import { isDomainRegistration, isGoogleApps } from 'lib/products-values';
+import { isGoogleApps } from 'lib/products-values';
 import { radioOption } from './radio-option';
 import {
 	cancellationOptionsForPurchase,
@@ -74,6 +74,26 @@ class CancelPurchaseForm extends React.Component {
 		extraPrependedButtons: [],
 	};
 
+	getAllSurveySteps = () => {
+		const { purchase, isChatAvailable, isChatActive, precancellationChatAvailable } = this.props;
+
+		return stepsForProductAndSurvey(
+			this.state,
+			purchase,
+			isChatAvailable || isChatActive,
+			precancellationChatAvailable
+		);
+	};
+
+	initSurveyState() {
+		const [ firstStep ] = this.getAllSurveySteps();
+
+		this.setState( {
+			surveyStep: firstStep,
+			...initialSurveyState(),
+		} );
+	}
+
 	constructor( props ) {
 		super( props );
 
@@ -88,15 +108,12 @@ class CancelPurchaseForm extends React.Component {
 		}
 
 		this.state = {
-			questionOneRadio: null,
 			questionOneText: '',
 			questionOneOrder: questionOneOrder,
-			questionTwoRadio: null,
 			questionTwoText: '',
 			questionTwoOrder: questionTwoOrder,
 			questionThreeText: '',
 
-			surveyStep: steps.INITIAL_STEP,
 			isSubmitting: false,
 		};
 	}
@@ -191,7 +208,7 @@ class CancelPurchaseForm extends React.Component {
 	onSubmit = () => {
 		const { purchase, selectedSite } = this.props;
 
-		if ( ! isDomainRegistration( purchase ) && ! isGoogleApps( purchase ) ) {
+		if ( ! isGoogleApps( purchase ) ) {
 			this.setState( {
 				isSubmitting: true,
 			} );
@@ -498,23 +515,13 @@ class CancelPurchaseForm extends React.Component {
 
 	closeDialog = () => {
 		this.props.onClose();
-
-		this.setState( {
-			surveyStep: steps.INITIAL_STEP,
-			...initialSurveyState(),
-		} );
+		this.initSurveyState();
 
 		this.recordEvent( 'calypso_purchases_cancel_form_close' );
 	};
 
 	changeSurveyStep = stepFunction => {
-		const { purchase, isChatAvailable, isChatActive, precancellationChatAvailable } = this.props;
-		const allSteps = stepsForProductAndSurvey(
-			this.state,
-			purchase,
-			isChatAvailable || isChatActive,
-			precancellationChatAvailable
-		);
+		const allSteps = this.getAllSurveySteps();
 		const newStep = stepFunction( this.state.surveyStep, allSteps );
 
 		this.setState( { surveyStep: newStep } );
@@ -585,13 +592,16 @@ class CancelPurchaseForm extends React.Component {
 		const firstButtons = [ ...this.props.extraPrependedButtons, close ];
 
 		if ( this.state.surveyStep === steps.FINAL_STEP ) {
+			const stepsCount = this.getAllSurveySteps().length;
+			const prevButton = stepsCount > 1 ? [ prev ] : [];
+
 			switch ( flowType ) {
 				case CANCEL_FLOW_TYPE.REMOVE:
-					return firstButtons.concat( [ prev, remove ] );
+					return firstButtons.concat( [ ...prevButton, remove ] );
 				case CANCEL_FLOW_TYPE.CANCEL_AUTORENEW_SURVEY_ONLY:
-					return firstButtons.concat( [ prev, submit ] );
+					return firstButtons.concat( [ ...prevButton, submit ] );
 				default:
-					return firstButtons.concat( [ prev, cancel ] );
+					return firstButtons.concat( [ ...prevButton, cancel ] );
 			}
 		}
 
@@ -608,6 +618,10 @@ class CancelPurchaseForm extends React.Component {
 		) {
 			this.recordEvent( 'calypso_purchases_cancel_form_start' );
 		}
+	}
+
+	componentDidMount() {
+		this.initSurveyState();
 	}
 
 	render() {

--- a/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
@@ -12,7 +12,7 @@ import {
 	TYPE_BUSINESS,
 } from 'lib/plans/constants';
 import { findPlansKeys } from 'lib/plans';
-import { includesProduct } from 'lib/products-values';
+import { isPlan, includesProduct } from 'lib/products-values';
 import { abtest } from 'lib/abtest';
 import * as steps from './steps';
 
@@ -58,5 +58,9 @@ export default function stepsForProductAndSurvey(
 		return steps.DEFAULT_STEPS_WITH_HAPPYCHAT;
 	}
 
-	return [ steps.INITIAL_STEP, steps.FINAL_STEP ];
+	if ( isPlan( product ) ) {
+		return [ steps.INITIAL_STEP, steps.FINAL_STEP ];
+	}
+
+	return [ steps.FINAL_STEP ];
 }

--- a/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
@@ -58,7 +58,7 @@ export default function stepsForProductAndSurvey(
 		return steps.DEFAULT_STEPS_WITH_HAPPYCHAT;
 	}
 
-	if ( isPlan( product ) ) {
+	if ( product && isPlan( product ) ) {
 		return [ steps.INITIAL_STEP, steps.FINAL_STEP ];
 	}
 

--- a/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/test/steps-for-product-and-survey.js
@@ -13,7 +13,7 @@ import { abtest } from 'lib/abtest';
 import * as plans from 'lib/plans/constants';
 jest.mock( 'lib/abtest', () => ( { abtest: require( 'sinon' ).stub() } ) );
 
-const DEFAULT_STEPS = [ steps.INITIAL_STEP, steps.FINAL_STEP ];
+const PLAN_SURVEY_STEPS = [ steps.INITIAL_STEP, steps.FINAL_STEP ];
 const DEFAULT_STEPS_WITH_UPGRADE_AT_STEP = [
 	steps.INITIAL_STEP,
 	steps.UPGRADE_AT_STEP,
@@ -24,10 +24,18 @@ const DEFAULT_STEPS_WITH_BUSINESS_AT_STEP = [
 	steps.BUSINESS_AT_STEP,
 	steps.FINAL_STEP,
 ];
+const DEFAULT_STEPS = [ steps.FINAL_STEP ];
 
 describe( 'stepsForProductAndSurvey', () => {
 	test( 'should return default steps if no state or product', () => {
 		expect( stepsForProductAndSurvey() ).to.deep.equal( DEFAULT_STEPS );
+	} );
+
+	test( 'should return default steps if non-plan product', () => {
+		// we use a dotblog domain registration here, but it should work for all other non-plan products.
+		expect(
+			stepsForProductAndSurvey( {}, { product_slug: 'dotblog_domain' }, false, false )
+		).to.deep.equal( DEFAULT_STEPS );
 	} );
 
 	describe( 'question one answer is not "could not install" and precancellation chat turned "On"', () => {
@@ -52,14 +60,14 @@ describe( 'stepsForProductAndSurvey', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is personal plan but happychat is not available (2y)', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 
 		test( 'should include happychat step if product is premium plan and happychat is available', () => {
@@ -80,14 +88,14 @@ describe( 'stepsForProductAndSurvey', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is premium plan but happychat is not available (2y)', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 
 		test( 'should include happychat step if product is business plan and happychat is available', () => {
@@ -108,14 +116,14 @@ describe( 'stepsForProductAndSurvey', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 
 		test( 'should include happychat step if product is business plan but happychat is not available (2y)', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, false, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 	} );
 
@@ -127,42 +135,42 @@ describe( 'stepsForProductAndSurvey', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is personal plan and happychat is available (2y)', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is premium plan and happychat is available', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is premium plan and happychat is available (2y)', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is business plan and happychat is available', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 
 		test( 'should not include happychat step if product is business plan and happychat is available (2y)', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			expect(
 				stepsForProductAndSurvey( survey, product, true, precancellationChatToggle )
-			).to.deep.equal( DEFAULT_STEPS );
+			).to.deep.equal( PLAN_SURVEY_STEPS );
 		} );
 	} );
 
@@ -188,13 +196,17 @@ describe( 'stepsForProductAndSurvey', () => {
 		test( 'should not include AT upgrade step if product is personal plan and abtest variant is hide', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+				PLAN_SURVEY_STEPS
+			);
 		} );
 
 		test( 'should not include AT upgrade step if product is personal plan and abtest variant is hide (2y)', () => {
 			const product = { product_slug: plans.PLAN_PERSONAL_2_YEARS };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+				PLAN_SURVEY_STEPS
+			);
 		} );
 
 		test( 'should include AT upgrade step if product is premium plan and abtest variant is show', () => {
@@ -216,13 +228,17 @@ describe( 'stepsForProductAndSurvey', () => {
 		test( 'should not include AT upgrade step if product is premium plan and abtest variant is hide', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+				PLAN_SURVEY_STEPS
+			);
 		} );
 
 		test( 'should not include AT upgrade step if product is premium plan and abtest variant is hide (2y)', () => {
 			const product = { product_slug: plans.PLAN_PREMIUM_2_YEARS };
 			abtest.withArgs( 'ATUpgradeOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+				PLAN_SURVEY_STEPS
+			);
 		} );
 
 		test( 'should include business AT step if product is personal plan and abtest variant is show', () => {
@@ -244,13 +260,17 @@ describe( 'stepsForProductAndSurvey', () => {
 		test( 'should not include business AT step if product is business plan and abtest variant is hide', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS };
 			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+				PLAN_SURVEY_STEPS
+			);
 		} );
 
 		test( 'should not include business AT step if product is business plan and abtest variant is hide (2y)', () => {
 			const product = { product_slug: plans.PLAN_BUSINESS_2_YEARS };
 			abtest.withArgs( 'ATPromptOnCancel' ).returns( 'hide' );
-			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal( DEFAULT_STEPS );
+			expect( stepsForProductAndSurvey( survey, product, true ) ).to.deep.equal(
+				PLAN_SURVEY_STEPS
+			);
 		} );
 	} );
 } );

--- a/client/me/purchases/cancel-purchase/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/cancellation-effect.jsx
@@ -10,7 +10,14 @@ import React from 'react';
  * Internal Dependencies
  */
 import { getName, getSubscriptionEndDate, isRefundable } from 'lib/purchases';
-import { isDomainMapping, isGoogleApps, isJetpackPlan, isTheme } from 'lib/products-values';
+import {
+	isDomainMapping,
+	isGoogleApps,
+	isJetpackPlan,
+	isDotComPlan,
+	isPlan,
+	isTheme,
+} from 'lib/products-values';
 
 export function cancellationEffectHeadline( purchase, translate ) {
 	const { domain } = purchase;
@@ -83,14 +90,22 @@ function refundableCancellationEffectDetail( purchase, translate, overrides ) {
 		);
 	}
 
-	return translate(
-		'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.',
-		{
-			args: {
-				cost: refundText,
-			},
-		}
-	);
+	if ( isDotComPlan( purchase ) ) {
+		return translate(
+			'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.',
+			{
+				args: {
+					cost: refundText,
+				},
+			}
+		);
+	}
+
+	return translate( 'You will be refunded %(cost)s.', {
+		args: {
+			cost: refundText,
+		},
+	} );
 }
 
 function nonrefundableCancellationEffectDetail( purchase, translate ) {
@@ -118,14 +133,18 @@ function nonrefundableCancellationEffectDetail( purchase, translate ) {
 		);
 	}
 
-	return translate(
-		"Your plan's features remain active until your subscription expires on %(subscriptionEndDate)s.",
-		{
-			args: {
-				subscriptionEndDate,
-			},
-		}
-	);
+	if ( isPlan( purchase ) ) {
+		return translate(
+			"Your plan's features remain active until your subscription expires on %(subscriptionEndDate)s.",
+			{
+				args: {
+					subscriptionEndDate,
+				},
+			}
+		);
+	}
+
+	return '';
 }
 
 export function cancellationEffectDetail( purchase, translate, overrides = {} ) {

--- a/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
+++ b/client/me/purchases/cancel-purchase/test/cancellation-effect.jsx
@@ -90,10 +90,20 @@ describe( 'cancellation-effect', () => {
 				productsValues.isTheme = () => false;
 				productsValues.isGoogleApps = () => false;
 				productsValues.isJetpackPlan = () => false;
+				productsValues.isDotComPlan = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
 				expect( headline.text ).to.equal(
 					'All plan features and custom changes will be removed from your site and you will be refunded %(cost)s.'
 				);
+			} );
+
+			test( 'should return the default when all the product specific conditions are false', () => {
+				productsValues.isTheme = () => false;
+				productsValues.isGoogleApps = () => false;
+				productsValues.isJetpackPlan = () => false;
+				productsValues.isDotComPlan = () => false;
+				const headline = cancellationEffectDetail( purchase, translate );
+				expect( headline.text ).to.equal( 'You will be refunded %(cost)s.' );
 			} );
 		} );
 
@@ -123,10 +133,19 @@ describe( 'cancellation-effect', () => {
 			test( 'should return translation of plan message when product is not g suite or a domain mapping', () => {
 				productsValues.isGoogleApps = () => false;
 				productsValues.isDomainMapping = () => false;
+				productsValues.isPlan = () => true;
 				const headline = cancellationEffectDetail( purchase, translate );
 				expect( headline.text ).to.equal(
 					"Your plan's features remain active until your subscription expires on %(subscriptionEndDate)s."
 				);
+			} );
+
+			test( 'should return an empty message when all the above product specific conditions are false.', () => {
+				productsValues.isGoogleApps = () => false;
+				productsValues.isDomainMapping = () => false;
+				productsValues.isPlan = () => false;
+				const headline = cancellationEffectDetail( purchase, translate );
+				expect( headline ).to.equal( '' );
 			} );
 		} );
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is the first step towards https://github.com/Automattic/wp-calypso/issues/34621. 

The survey for cancelling a plan subscriptions is currently presenting for not only plans, but also domain registrations and support sessions. i.e. This form:
![image](https://user-images.githubusercontent.com/1842898/61434353-44f34f80-a968-11e9-96d3-6f12e463027c.png)

While the ideal solution is to have product specific surveys, the PR aims at resolving customer confusion first, by preventing the plan cancellation survey.

With this PR, only the last open-ended question is presented for domain registrations and support sessions:
![image](https://user-images.githubusercontent.com/1842898/61434639-1033c800-a969-11e9-9e14-7106be761533.png)

Lastly, the blocking condition that prevents the survey data from submitting for domain registrations is also removed, since we are now presenting the survey form on turning off the auto-renewal there.

#### Testing instructions

1. Go to the purchase management page of a plan subscription.
1. Turning off the auto-renewal, cancelling the purchase and removing the product should show the same survey as expected.
1. Go to the purchase management page of a domain registration
1. Turning off the auto-renewal, the updated survey with only one question should show.
1. Go to the purchase management page of a support session
1. Cancelling it, the updated survey with only one question should show.
