### PR TITLE
Boot: abort the Calypso boot early if `/me` response is invalid

### DIFF
--- a/client/lib/cart/store/test/index.js
+++ b/client/lib/cart/store/test/index.js
@@ -40,7 +40,7 @@ jest.mock( 'lib/products-list', () => () => ( { get: () => [] } ) );
 jest.mock( 'lib/wp', () => ( {
 	undocumented: () => ( {} ),
 	me: () => ( {
-		get: () => ( {} ),
+		get: async () => ( {} ),
 	} ),
 } ) );
 

--- a/client/lib/user-settings/test/mocks/wp.js
+++ b/client/lib/user-settings/test/mocks/wp.js
@@ -1,7 +1,6 @@
-/** @format */
 const me = function() {
 	return {
-		get() {},
+		get: async () => ( {} ),
 		settings() {
 			return {
 				get( callback ) {

--- a/client/lib/user/shared-utils.js
+++ b/client/lib/user/shared-utils.js
@@ -1,11 +1,3 @@
-/** @format */
-
-/**
- * External dependencies
- */
-
-import { assign, includes } from 'lodash';
-
 /**
  * Internal dependencies
  */
@@ -18,40 +10,51 @@ function getSiteSlug( url ) {
 	return slug.replace( /\//g, '::' );
 }
 
+const allowedKeys = [
+	'ID',
+	'display_name',
+	'username',
+	'avatar_URL',
+	'site_count',
+	'visible_site_count',
+	'date',
+	'has_unseen_notes',
+	'newest_note_type',
+	'phone_account',
+	'email',
+	'email_verified',
+	'is_valid_google_apps_country',
+	'user_ip_country_code',
+	'logout_URL',
+	'primary_blog',
+	'primary_blog_is_jetpack',
+	'primary_blog_url',
+	'meta',
+	'is_new_reader',
+	'social_login_connections',
+	'abtests',
+];
+const requiredKeys = [ 'ID' ];
+const decodedKeys = [ 'display_name', 'description', 'user_URL' ];
+
 export function filterUserObject( obj ) {
+	if ( typeof obj !== 'object' ) {
+		throw new Error( 'the /me response is not an object' );
+	}
+
+	for ( const key of requiredKeys ) {
+		if ( ! obj.hasOwnProperty( key ) ) {
+			throw new Error( `the /me response misses a required field '${ key }'` );
+		}
+	}
+
 	const user = {};
-	const allowedKeys = [
-		'ID',
-		'display_name',
-		'username',
-		'avatar_URL',
-		'site_count',
-		'visible_site_count',
-		'date',
-		'has_unseen_notes',
-		'newest_note_type',
-		'phone_account',
-		'email',
-		'email_verified',
-		'is_valid_google_apps_country',
-		'user_ip_country_code',
-		'logout_URL',
-		'primary_blog',
-		'primary_blog_is_jetpack',
-		'primary_blog_url',
-		'meta',
-		'is_new_reader',
-		'social_login_connections',
-		'abtests',
-	];
-	const decodeWhitelist = [ 'display_name', 'description', 'user_URL' ];
+	for ( const key of allowedKeys ) {
+		const value = obj[ key ];
+		user[ key ] = value && decodedKeys.includes( key ) ? decodeEntities( value ) : value;
+	}
 
-	allowedKeys.forEach( function( key ) {
-		user[ key ] =
-			obj[ key ] && includes( decodeWhitelist, key ) ? decodeEntities( obj[ key ] ) : obj[ key ];
-	} );
-
-	return assign( user, getComputedAttributes( obj ) );
+	return Object.assign( user, getComputedAttributes( obj ) );
 }
 
 export function getComputedAttributes( attributes ) {

--- a/client/lib/user/test/utils.js
+++ b/client/lib/user/test/utils.js
@@ -18,14 +18,15 @@ import configMock from 'config';
 jest.mock( 'config', () => {
 	const { stub } = require( 'sinon' );
 
-	const configMock = stub();
-	configMock.isEnabled = stub();
+	const mock = stub();
+	mock.isEnabled = stub();
 
-	return configMock;
+	return mock;
 } );
+
 jest.mock( 'lib/wp', () => ( {
 	me: () => ( {
-		get: () => {},
+		get: async () => ( {} ),
 	} ),
 } ) );
 

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -144,19 +144,15 @@ User.prototype.fetch = function() {
 	this.fetching = true;
 	debug( 'Getting user from api' );
 
-	me.get(
-		{ meta: 'flags', abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ) },
-		( error, data ) => {
-			if ( error ) {
-				this.handleFetchFailure( error );
-				return;
-			}
-
+	me.get( { meta: 'flags', abtests: getActiveTestNames( { appendDatestamp: true, asCSV: true } ) } )
+		.then( data => {
 			const userData = filterUserObject( data );
 			this.handleFetchSuccess( userData );
 			debug( 'User successfully retrieved' );
-		}
-	);
+		} )
+		.catch( error => {
+			this.handleFetchFailure( error );
+		} );
 };
 
 /**
@@ -176,7 +172,8 @@ User.prototype.handleFetchFailure = function( error ) {
 		this.initialized = true;
 		this.emit( 'change' );
 	} else {
-		debug( 'Something went wrong trying to get the user.' );
+		// eslint-disable-next-line no-console
+		console.error( 'Failed to fetch the user from /me endpoint:', error );
 	}
 };
 

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -35,80 +35,66 @@ const debug = debugFactory( 'calypso:bootstrap' ),
  *
  * @returns {Promise<object>} A promise for a user object.
  */
-module.exports = function( request ) {
+module.exports = async function( request ) {
 	const authCookieValue = request.cookies[ AUTH_COOKIE_NAME ];
 	const geoCountry = request.get( 'x-geoip-country-code' ) || '';
 	const supportSession = request.get( 'x-support-session' );
 
-	return new Promise( ( resolve, reject ) => {
-		if ( ! authCookieValue ) {
-			reject( new Error( 'Cannot bootstrap without an auth cookie' ) );
-			return;
+	if ( ! authCookieValue ) {
+		throw new Error( 'Cannot bootstrap without an auth cookie' );
+	}
+
+	const decodedAuthCookieValue = decodeURIComponent( authCookieValue );
+
+	// create HTTP Request object
+	const req = superagent.get( url );
+	req.set( 'User-Agent', 'WordPress.com Calypso' );
+	req.set( 'X-Forwarded-GeoIP-Country-Code', geoCountry );
+	req.set( 'Cookie', AUTH_COOKIE_NAME + '=' + decodedAuthCookieValue );
+
+	if ( supportSession ) {
+		if ( typeof SUPPORT_SESSION_API_KEY !== 'string' ) {
+			throw new Error(
+				'Unable to boostrap user because of invalid SUPPORT SESSION API key in secrets.json'
+			);
 		}
 
-		const decodedAuthCookieValue = decodeURIComponent( authCookieValue );
+		const hmac = crypto.createHmac( 'md5', SUPPORT_SESSION_API_KEY );
+		hmac.update( supportSession );
+		const hash = hmac.digest( 'hex' );
 
-		// create HTTP Request object
-		const req = superagent.get( url );
-		req.set( 'User-Agent', 'WordPress.com Calypso' );
-		req.set( 'X-Forwarded-GeoIP-Country-Code', geoCountry );
-		req.set( 'Cookie', AUTH_COOKIE_NAME + '=' + decodedAuthCookieValue );
-
-		if ( supportSession ) {
-			if ( typeof SUPPORT_SESSION_API_KEY !== 'string' ) {
-				reject(
-					new Error(
-						'Unable to boostrap user because of invalid SUPPORT SESSION API key in secrets.json'
-					)
-				);
-				return;
-			}
-
-			const hmac = crypto.createHmac( 'md5', SUPPORT_SESSION_API_KEY );
-			hmac.update( supportSession );
-			const hash = hmac.digest( 'hex' );
-			req.set( 'Authorization', `X-WPCALYPSO-SUPPORT-SESSION ${ hash }` );
-
-			req.set( 'x-support-session', supportSession );
-		} else {
-			if ( typeof API_KEY !== 'string' ) {
-				reject( new Error( 'Unable to boostrap user because of invalid API key in secrets.json' ) );
-				return;
-			}
-
-			const hmac = crypto.createHmac( 'md5', API_KEY );
-			hmac.update( decodedAuthCookieValue );
-			const hash = hmac.digest( 'hex' );
-
-			req.set( 'Authorization', 'X-WPCALYPSO ' + hash );
+		req.set( 'Authorization', `X-WPCALYPSO-SUPPORT-SESSION ${ hash }` );
+		req.set( 'x-support-session', supportSession );
+	} else {
+		if ( typeof API_KEY !== 'string' ) {
+			throw new Error( 'Unable to boostrap user because of invalid API key in secrets.json' );
 		}
 
-		// start the request
-		req.end( function( err, res ) {
-			let error, key;
+		const hmac = crypto.createHmac( 'md5', API_KEY );
+		hmac.update( decodedAuthCookieValue );
+		const hash = hmac.digest( 'hex' );
 
-			if ( err && ! res ) {
-				return reject( err );
-			}
+		req.set( 'Authorization', 'X-WPCALYPSO ' + hash );
+	}
 
-			const body = res.body;
-			const statusCode = res.status;
+	// start the request
+	try {
+		const res = await req;
+		debug( '%o -> %o status code', url, res.status );
+		return filterUserObject( res.body );
+	} catch ( err ) {
+		if ( ! err.response ) {
+			throw err;
+		}
 
-			debug( '%o -> %o status code', url, statusCode );
+		const { body, status } = err.response;
+		debug( '%o -> %o status code', url, status );
+		const error = new Error();
+		error.statusCode = status;
+		for ( const key in body ) {
+			error[ key ] = body[ key ];
+		}
 
-			if ( err ) {
-				error = new Error();
-				error.statusCode = statusCode;
-				for ( key in body ) {
-					error[ key ] = body[ key ];
-				}
-
-				return reject( error );
-			}
-
-			const user = filterUserObject( body );
-
-			resolve( user );
-		} );
-	} );
+		throw error;
+	}
 };

--- a/server/user-bootstrap/index.js
+++ b/server/user-bootstrap/index.js
@@ -46,46 +46,41 @@ module.exports = function( request ) {
 			return;
 		}
 
+		const decodedAuthCookieValue = decodeURIComponent( authCookieValue );
+
 		// create HTTP Request object
 		const req = superagent.get( url );
 		req.set( 'User-Agent', 'WordPress.com Calypso' );
 		req.set( 'X-Forwarded-GeoIP-Country-Code', geoCountry );
+		req.set( 'Cookie', AUTH_COOKIE_NAME + '=' + decodedAuthCookieValue );
 
-		if ( authCookieValue ) {
-			const decodedAuthCookieValue = decodeURIComponent( authCookieValue );
-
-			req.set( 'Cookie', AUTH_COOKIE_NAME + '=' + decodedAuthCookieValue );
-
-			if ( supportSession ) {
-				if ( typeof SUPPORT_SESSION_API_KEY !== 'string' ) {
-					reject(
-						new Error(
-							'Unable to boostrap user because of invalid SUPPORT SESSION API key in secrets.json'
-						)
-					);
-					return;
-				}
-
-				const hmac = crypto.createHmac( 'md5', SUPPORT_SESSION_API_KEY );
-				hmac.update( supportSession );
-				const hash = hmac.digest( 'hex' );
-				req.set( 'Authorization', `X-WPCALYPSO-SUPPORT-SESSION ${ hash }` );
-
-				req.set( 'x-support-session', supportSession );
-			} else {
-				if ( typeof API_KEY !== 'string' ) {
-					reject(
-						new Error( 'Unable to boostrap user because of invalid API key in secrets.json' )
-					);
-					return;
-				}
-
-				const hmac = crypto.createHmac( 'md5', API_KEY );
-				hmac.update( decodedAuthCookieValue );
-				const hash = hmac.digest( 'hex' );
-
-				req.set( 'Authorization', 'X-WPCALYPSO ' + hash );
+		if ( supportSession ) {
+			if ( typeof SUPPORT_SESSION_API_KEY !== 'string' ) {
+				reject(
+					new Error(
+						'Unable to boostrap user because of invalid SUPPORT SESSION API key in secrets.json'
+					)
+				);
+				return;
 			}
+
+			const hmac = crypto.createHmac( 'md5', SUPPORT_SESSION_API_KEY );
+			hmac.update( supportSession );
+			const hash = hmac.digest( 'hex' );
+			req.set( 'Authorization', `X-WPCALYPSO-SUPPORT-SESSION ${ hash }` );
+
+			req.set( 'x-support-session', supportSession );
+		} else {
+			if ( typeof API_KEY !== 'string' ) {
+				reject( new Error( 'Unable to boostrap user because of invalid API key in secrets.json' ) );
+				return;
+			}
+
+			const hmac = crypto.createHmac( 'md5', API_KEY );
+			hmac.update( decodedAuthCookieValue );
+			const hash = hmac.digest( 'hex' );
+
+			req.set( 'Authorization', 'X-WPCALYPSO ' + hash );
 		}
 
 		// start the request


### PR DESCRIPTION
The first thing that Calypso does on boot is to figure out who the user is. The `user` object is either sent by the server user-bootstrap code in the HTML response, or retrieved from the `/me` endpoint.

This PR checks that the `/me` response is valid object with required fields (I check just for `ID` here) and if it isn't, aborts the boot process early.

Before this patch, a malformed `user` object would propagate to Redux reducers and cause chaos 🙂 

**How to test:**
Break PHP code on your WP sandbox by, e.g., putting some text outside `<?php` in a plugin file. Then that text will be prepended to every REST response and make it into an invalid JSON.

Check that Calypso refused to boot. It should show an error in console:
```
Failed to fetch the user from /me endpoint: the /me response is not an object
```

Check server-side user bootstrapping, too: the server should return 500 response if it's unable to get a valid `/me` response.