### PR TITLE
Avoid a GDPR banner pop up when hidden.

### DIFF
--- a/client/blocks/gdpr-banner/index.jsx
+++ b/client/blocks/gdpr-banner/index.jsx
@@ -71,7 +71,7 @@ function GdprBanner( props ) {
 	// We want to ensure that the first render is always empty, to match the server.
 	// This avoids potential hydration issues.
 	useEffect( () => {
-		setBannerStatus( shouldShowBanner() ? STATUS.RENDERED : STATUS.RENDERED_BUT_HIDDEN );
+		shouldShowBanner() && setBannerStatus( STATUS.RENDERED );
 	}, [] );
 
 	useEffect( () => {


### PR DESCRIPTION
The hiding animation was being triggered on page load.

#### Changes proposed in this Pull Request

* Avoid GDPR banner pop up on page load when hidden.

#### Testing instructions

* Open an environment with GDPR banners enabled
* In an incognito window, navigate to `/log-in`
* Ensure the banner renders
* Dismiss it
* Reload the page
* Ensure the banner doesn't render
