### PR TITLE
Email: Select Tab in Sidebar

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -299,7 +299,7 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				label={ translate( 'Domains' ) }
-				selected={ itemLinkMatches( [ '/domains' ], path ) }
+				selected={ itemLinkMatches( [ '/domains', '/email' ], path ) }
 				link={ domainsLink }
 				onNavigate={ this.trackDomainsClick }
 				icon="domains"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When in the `/email` route, have the "Domains" tab be selected in the Sidebar 

#### Testing instructions

Visit `/email/site` and compare.

**Before:**
<img width="1039" alt="Screenshot 2019-07-18 at 14 52 50" src="https://user-images.githubusercontent.com/43215253/61463240-e7610200-a96b-11e9-8811-ba096a33b957.png">

**After:**
<img width="1618" alt="Screenshot 2019-07-18 at 14 52 15" src="https://user-images.githubusercontent.com/43215253/61463248-ecbe4c80-a96b-11e9-872b-81a510e3a899.png">

Fixes #34744
