### PR TITLE
E2E: Add support for horizon testing label

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ If you have any problems running Calypso, [please see most common issues](./docs
 
 ## License
 
-Calypso is licensed under [GNU General Public License v2 (or later)](./LICENSE.md).test
+Calypso is licensed under [GNU General Public License v2 (or later)](./LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -46,4 +46,4 @@ If you have any problems running Calypso, [please see most common issues](./docs
 
 ## License
 
-Calypso is licensed under [GNU General Public License v2 (or later)](./LICENSE.md).
+Calypso is licensed under [GNU General Public License v2 (or later)](./LICENSE.md).test

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -147,12 +147,18 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can log out and request a magic link', async function() {
+			if ( process.env.HORIZON_TESTS === 'true' ) {
+				return this.skip();
+			}
 			await driverManager.ensureNotLoggedIn( driver );
 			const loginPage = await LoginPage.Visit( driver );
 			return await loginPage.requestMagicLink( emailAddress );
 		} );
 
 		step( 'Can see email containing magic link', async function() {
+			if ( process.env.HORIZON_TESTS === 'true' ) {
+				return this.skip();
+			}
 			const emailClient = new EmailClient( signupInboxId );
 			const validator = emails => emails.find( email => email.subject.includes( 'WordPress.com' ) );
 			const emails = await emailClient.pollEmailsByRecipient( emailAddress, validator );
@@ -173,6 +179,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can visit the magic link and we should be logged in', async function() {
+			if ( process.env.HORIZON_TESTS === 'true' ) {
+				return this.skip();
+			}
 			await driver.get( magicLoginLink );
 			const magicLoginPage = await MagicLoginPage.Expect( driver );
 			await magicLoginPage.finishLogin();
@@ -1549,6 +1558,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		const emailAddress = dataHelper.getEmailAddress( userName, signupInboxId );
 
 		before( async function() {
+			if ( process.env.HORIZON_TESTS === 'true' ) {
+				return this.skip();
+			}
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR adds code to skip some tests or steps if a variable is set. This will be used to skip some functionality that won't work on the horizon environment and is meant to go along with https://github.com/Automattic/wp-e2e-tests-gh-bridge/pull/72

#### Testing instructions

* To Test, set `HORIZON_TESTS=true` and then run tests. Ensure that the steps or tests where the check has been added, pass. 
 
* Another option is to re-add the horizon testing label after the PR mentioned above is merged. Ensure that the domains and sign-up tests don't fail. Currently some Gutenberg tests fail but that is because of changes on Horizon where e2e tests haven't been updated yet.
