### PR TITLE
Stop using deprecated "user facing expiry" field on plans

### DIFF
--- a/client/lib/plans/index.js
+++ b/client/lib/plans/index.js
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-import moment from 'moment';
 import { format as urlFormat, parse as urlParse } from 'url';
 import { difference, get, includes, pick, values } from 'lodash';
 
@@ -105,43 +104,6 @@ export function planHasFeature( plan, feature ) {
 	);
 
 	return includes( allFeatures, feature );
-}
-
-export function getCurrentTrialPeriodInDays( plan ) {
-	const { expiryMoment, subscribedDayMoment, userFacingExpiryMoment } = plan;
-
-	if ( isInGracePeriod( plan ) ) {
-		return expiryMoment.diff( userFacingExpiryMoment, 'days' );
-	}
-
-	return userFacingExpiryMoment.diff( subscribedDayMoment, 'days' );
-}
-
-export function getDayOfTrial( plan ) {
-	const { subscribedDayMoment } = plan;
-
-	// we return the difference plus one day so that the first day is day 1 instead of day 0
-	return (
-		moment()
-			.startOf( 'day' )
-			.diff( subscribedDayMoment, 'days' ) + 1
-	);
-}
-
-export function getDaysUntilUserFacingExpiry( plan ) {
-	const { userFacingExpiryMoment } = plan;
-
-	return userFacingExpiryMoment.diff( moment().startOf( 'day' ), 'days' );
-}
-
-export function getDaysUntilExpiry( plan ) {
-	const { expiryMoment } = plan;
-
-	return expiryMoment.diff( moment().startOf( 'day' ), 'days' );
-}
-
-export function isInGracePeriod( plan ) {
-	return getDaysUntilUserFacingExpiry( plan ) <= 0;
 }
 
 export function shouldFetchSitePlans( sitePlans, selectedSite ) {

--- a/client/my-sites/plans/current-plan/header.jsx
+++ b/client/my-sites/plans/current-plan/header.jsx
@@ -50,19 +50,17 @@ export class CurrentPlanHeader extends Component {
 									args: invoke( currentPlan, 'autoRenewDateMoment.format', 'LL' ),
 							  } )
 							: translate( 'Expires on %s.', {
-									args: invoke( currentPlan, 'userFacingExpiryMoment.format', 'LL' ),
+									args: invoke( currentPlan, 'expiryMoment.format', 'LL' ),
 							  } ) }
 					</span>
 					{ currentPlan.userIsOwner && Boolean( currentPlan.id ) && siteSlug && (
 						<Button compact href={ managePurchase( siteSlug, currentPlan.id ) }>
 							{ hasAutoRenew && translate( 'Manage Payment' ) }
 							{ ! hasAutoRenew &&
-								! shouldAddPaymentSourceInsteadOfRenewingNow(
-									currentPlan.userFacingExpiryMoment
-								) &&
+								! shouldAddPaymentSourceInsteadOfRenewingNow( currentPlan.expiryMoment ) &&
 								translate( 'Renew Now' ) }
 							{ ! hasAutoRenew &&
-								shouldAddPaymentSourceInsteadOfRenewingNow( currentPlan.userFacingExpiryMoment ) &&
+								shouldAddPaymentSourceInsteadOfRenewingNow( currentPlan.expiryMoment ) &&
 								translate( 'Manage Payment' ) }
 						</Button>
 					) }

--- a/client/state/sites/plans/README.md
+++ b/client/state/sites/plans/README.md
@@ -41,9 +41,7 @@ state.sites.plans = {
 			rawDiscount: Number,
 			rawPrice: Number,
 			subscribedDate: String,
-			subscribedDayMoment: Moment,
-			userFacingExpiry: String,
-			userFacingExpiryMoment: Moment
+			subscribedDayMoment: Moment
 		},
 		{ ... }
 	]

--- a/client/state/sites/plans/assembler.js
+++ b/client/state/sites/plans/assembler.js
@@ -36,10 +36,6 @@ export const createSitePlanObject = plan => {
 		rawPrice: plan.raw_price,
 		subscribedDate: plan.subscribed_date,
 		subscribedDayMoment: moment( plan.subscribed_date ).startOf( 'day' ),
-		userFacingExpiry: plan.user_facing_expiry,
-		userFacingExpiryMoment: plan.user_facing_expiry
-			? moment( plan.user_facing_expiry ).startOf( 'day' )
-			: null,
 		userIsOwner: Boolean( plan.user_is_owner ),
 	};
 };

--- a/client/state/sites/plans/selectors.js
+++ b/client/state/sites/plans/selectors.js
@@ -172,7 +172,7 @@ export function isRequestingSitePlans( state, siteId ) {
 
 export function isCurrentPlanExpiring( state, siteId ) {
 	const currentPlan = getCurrentPlan( state, siteId );
-	const expiration = get( currentPlan, 'userFacingExpiryMoment', null );
+	const expiration = get( currentPlan, 'expiryMoment', null );
 	return expiration < moment().add( 30, 'days' );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The site plans endpoint returns a `user_facing_expiry` field that is somewhat broken (the date is off a couple days from the actual expiration) and which is now deprecated in favor of the `expiry` field.

This pull request stops using that field everywhere, and uses `expiry` instead.

In doing so, it removes several obsolete/unused functions which previously cared about the difference between those fields for free trial purposes, but now no longer are necessary and no longer make sense.

#### Testing instructions

This is designed to be used along with D29854-code on the server side.

1. Purchase a plan and turn auto-renew off.
2. Go to https://wordpress.com/me/purchases.
3. Click on the individual subscription there to go to its Manage Purchase page.
4. Then go to https://wordpress.com/plans/my-plan.

Make sure the expiration date shown in all three places is the same, and that all the other functionality on the My Plan page looks the same as before.