### PR TITLE
FSE: Remove the edit option from the navigation block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -8,7 +8,6 @@
  */
 import { ServerSideRender } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/edit.js
@@ -6,9 +6,7 @@
 /**
  * WordPress dependencies
  */
-import { IconButton, ServerSideRender, Toolbar } from '@wordpress/components';
-import { BlockControls } from '@wordpress/editor';
-import { addQueryArgs } from '@wordpress/url';
+import { ServerSideRender } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -17,23 +15,8 @@ import { __ } from '@wordpress/i18n';
  */
 
 const NavigationMenuEdit = ( { attributes } ) => {
-	const url = addQueryArgs( 'customize.php', {
-		'autofocus[panel]': 'nav_menus',
-		return: window.location.href,
-	} );
-
 	return (
 		<Fragment>
-			<BlockControls>
-				<Toolbar className="wp-block-a8c-navigation-menu-toolbar">
-					<IconButton
-						icon="edit"
-						label={ __( 'Edit Menu' ) }
-						href={ url }
-						className="components-toolbar__control"
-					/>
-				</Toolbar>
-			</BlockControls>
 			<ServerSideRender attributes={ attributes } block="a8c/navigation-menu" />
 		</Fragment>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove the edit option from the navigation block, for the reasons mentioned in https://github.com/Automattic/wp-calypso/issues/34755

#### Testing instructions

* Install the full site editing plugin, and use the modern business theme
* Confirm on the navigation block in the header that you do not see the edit icon in the menu as shown in https://github.com/Automattic/wp-calypso/issues/34755

Fixes #34755
