### PR TITLE
Fix/fse nav menu rendering

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -82,16 +82,22 @@ function get_wrapper_attributes_by_theme_location( $location ) {
 function render_navigation_menu_block( $attributes ) {
 	$location     = ! empty( $attributes['themeLocation'] ) ? $attributes['themeLocation'] : null;
 	$wrapper_attr = get_wrapper_attributes_by_theme_location( $location );
-	$class_name   = ! empty( $attributes['className'] ) ? ' ' . $attributes['className'] : '';
+
+	$params = get_menu_params_by_theme_location( $location );
+	if ( ! array_key_exists( $params['theme_location'], get_nav_menu_locations() ) ) {
+		return ' ';
+	}
 	ob_start();
-	// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText
-	?>
-	<nav class="<?php echo esc_attr( $wrapper_attr['class'] . ' wp-block-a8c-navigation-menu' . $class_name ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
-		<?php
-			wp_nav_menu( get_menu_params_by_theme_location( $location ) );
+	if ( array_key_exists( $params['theme_location'], get_nav_menu_locations() ) ) {
+		// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText
 		?>
-	</nav>
-	<!-- #site-navigation -->
-	<?php
+		<nav class="<?php echo esc_attr( $wrapper_attr['class'] . ' wp-block-a8c-navigation-menu' ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
+			<?php
+				wp_nav_menu( $params );
+			?>
+		</nav>
+		<!-- #site-navigation -->
+		<?php
+	}
 	return ob_get_clean();
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -66,33 +66,11 @@ function get_wrapper_attributes_by_theme_location( $location ) {
 		default:
 			$attributes = [
 				'class' => 'main-navigation',
-				'label' => 'Top Menu',
+				'label' => 'Primary Menu',
 			];
 			break;
 	}
 	return $attributes;
-}
-
-/**
- * Determines the message to display if a menu is not set for the given location.
- *
- * @param string $location Theme location.
- * @return string
- */
-function get_add_menu_message( $location ) {
-	switch ( $location ) {
-		case 'footer':
-			$message = __( 'Add a menu to the Footer Menu display location', 'full-site-editing' );
-			break;
-		case 'social':
-			$message = __( 'Add a menu to the Social Links Menu display location', 'full-site-editing' );
-			break;
-		case 'main-1':
-		default:
-			$message = __( 'Add a menu to the Primary display location', 'full-site-editing' );
-			break;
-	}
-	return $message;
 }
 
 /**
@@ -108,7 +86,8 @@ function render_navigation_menu_block( $attributes ) {
 	$params       = get_menu_params_by_theme_location( $location );
 
 	if ( ! array_key_exists( $params['theme_location'], get_nav_menu_locations() ) ) {
-		return get_add_menu_message( $location );
+		// translators: message to indicate to the user that they need to add a menu in a specific location.
+		return sprintf( __( 'Add a menu to the %1$s display location', 'full-site-editing' ), $wrapper_attr['label'] );
 	} else {
 		ob_start();
 		// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -74,6 +74,28 @@ function get_wrapper_attributes_by_theme_location( $location ) {
 }
 
 /**
+ * Determines the message to display if a menu is not set for the given location.
+ *
+ * @param string $location Theme location.
+ * @return string
+ */
+function get_add_menu_message( $location ) {
+	switch ( $location ) {
+		case 'footer':
+			$message = __( 'Add a menu to the Footer Menu display location', 'full-site-editing' );
+			break;
+		case 'social':
+			$message = __( 'Add a menu to the Social Links Menu display location', 'full-site-editing' );
+			break;
+		case 'main-1':
+		default:
+			$message = __( 'Add a menu to the Primary display location', 'full-site-editing' );
+			break;
+	}
+	return $message;
+}
+
+/**
  * Renders post content.
  *
  * @param array $attributes Block attributes.
@@ -82,22 +104,22 @@ function get_wrapper_attributes_by_theme_location( $location ) {
 function render_navigation_menu_block( $attributes ) {
 	$location     = ! empty( $attributes['themeLocation'] ) ? $attributes['themeLocation'] : null;
 	$wrapper_attr = get_wrapper_attributes_by_theme_location( $location );
+	$class_name   = ! empty( $attributes['className'] ) ? ' ' . $attributes['className'] : '';
+	$params       = get_menu_params_by_theme_location( $location );
 
-	$params = get_menu_params_by_theme_location( $location );
 	if ( ! array_key_exists( $params['theme_location'], get_nav_menu_locations() ) ) {
-		return ' ';
-	}
-	ob_start();
-	if ( array_key_exists( $params['theme_location'], get_nav_menu_locations() ) ) {
+		return get_add_menu_message( $location );
+	} else {
+		ob_start();
 		// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText
 		?>
-		<nav class="<?php echo esc_attr( $wrapper_attr['class'] . ' wp-block-a8c-navigation-menu' ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
+		<nav class="<?php echo esc_attr( $wrapper_attr['class'] . ' wp-block-a8c-navigation-menu' . $class_name ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
 			<?php
 				wp_nav_menu( $params );
 			?>
 		</nav>
 		<!-- #site-navigation -->
 		<?php
+		return ob_get_clean();
 	}
-	return ob_get_clean();
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Check for the existence of a nav menu in the correct location before rendering the menu in the nav menu block, and display message indicating which menu needs to be added if one doesn't exist.

#### Testing instructions

* Check out branch and follow instructions in https://github.com/Automattic/wp-calypso/tree/master/apps/full-site-editing#build-system. Install the FSE plugin, and activate it on local gutenberg dev
* Check that your site does not have a nav menu in Primary location
* Edit the Header template part, and check that you see message indicating that you need to add a menu to Primary location
* Add menu back to Primary location and check that the menu now displays in the Header template part
* Repeat process for Footer template part

Below is how the Header nav menu displays with broken styles if there is no nav menu in Primary location:

<img width="628" alt="broken-menu" src="https://user-images.githubusercontent.com/3629020/61492421-59d1f080-aa05-11e9-9624-a1b62ca0a00a.png">

And with patch in place a message indicating to add the menu displays instead:

<img width="645" alt="missing-menu-message" src="https://user-images.githubusercontent.com/3629020/61492462-72420b00-aa05-11e9-8811-4584c12f8480.png">

Fixes #34429
