### PR TITLE
Checkout: Show inline Stripe form validation errors

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -75,17 +75,20 @@ StripeElementErrors.propTypes = {
 };
 
 function CreditCardNumberField( { translate, stripe, createField, getErrorMessage } ) {
+	const cardNumberLabel = translate( 'Card Number', {
+		comment: 'Card number label on credit card form',
+	} );
+
 	if ( stripe ) {
 		const elementClasses = {
 			base: 'credit-card-form-fields__element',
 			invalid: 'is-error',
 			focus: 'has-focus',
 		};
-
 		return (
 			<div className="credit-card-form-fields__field number">
 				<label className="credit-card-form-fields__label form-label">
-					{ translate( 'Card Number' ) }
+					{ cardNumberLabel }
 					<CardNumberElement classes={ elementClasses } />
 					<StripeElementErrors getErrorMessage={ getErrorMessage } fieldName="card_number" />
 				</label>
@@ -95,9 +98,7 @@ function CreditCardNumberField( { translate, stripe, createField, getErrorMessag
 
 	return createField( 'number', CreditCardNumberInput, {
 		inputMode: 'numeric',
-		label: translate( 'Card Number', {
-			comment: 'Card number label on credit card form',
-		} ),
+		label: cardNumberLabel,
 		placeholder: '•••• •••• •••• ••••',
 	} );
 }

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -19,6 +19,7 @@ import { Input } from 'my-sites/domains/components/form';
 import InfoPopover from 'components/info-popover';
 import { maskField, unmaskField, getCreditCardType } from 'lib/checkout';
 import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
+import FormInputValidation from 'components/forms/form-input-validation';
 
 /**
  * Style dependencies
@@ -59,7 +60,21 @@ CvvPopover.propTypes = {
 	card: PropTypes.object.isRequired,
 };
 
-function CreditCardNumberField( { translate, stripe, createField } ) {
+function StripeElementErrors( { getErrorMessage, fieldName } ) {
+	const errorMessages = getErrorMessage( fieldName ) || [];
+	if ( ! errorMessages.length ) {
+		return null;
+	}
+	const id = `validation-field-${ fieldName }`;
+	return <FormInputValidation id={ id } isError text={ errorMessages[ 0 ] } />;
+}
+
+StripeElementErrors.propTypes = {
+	getErrorMessage: PropTypes.func.isRequired,
+	fieldName: PropTypes.string.isRequired,
+};
+
+function CreditCardNumberField( { translate, stripe, createField, getErrorMessage } ) {
 	if ( stripe ) {
 		const elementClasses = {
 			base: 'credit-card-form-fields__element',
@@ -72,6 +87,7 @@ function CreditCardNumberField( { translate, stripe, createField } ) {
 				<label className="credit-card-form-fields__label form-label">
 					{ translate( 'Card Number' ) }
 					<CardNumberElement classes={ elementClasses } />
+					<StripeElementErrors getErrorMessage={ getErrorMessage } fieldName="card_number" />
 				</label>
 			</div>
 		);
@@ -89,10 +105,11 @@ function CreditCardNumberField( { translate, stripe, createField } ) {
 CreditCardNumberField.propTypes = {
 	translate: PropTypes.func.isRequired,
 	createField: PropTypes.func.isRequired,
+	getErrorMessage: PropTypes.func.isRequired,
 	stripe: PropTypes.object,
 };
 
-function CreditCardExpiryAndCvvFields( { translate, stripe, createField, card } ) {
+function CreditCardExpiryAndCvvFields( { translate, stripe, createField, getErrorMessage, card } ) {
 	const cvcLabel = translate( 'Security Code {{span}}("CVC" or "CVV"){{/span}}', {
 		components: {
 			span: <span className="credit-card-form-fields__explainer" />,
@@ -116,12 +133,14 @@ function CreditCardExpiryAndCvvFields( { translate, stripe, createField, card } 
 					<label className="credit-card-form-fields__label form-label">
 						{ expiryLabel }
 						<CardExpiryElement classes={ elementClasses } />
+						<StripeElementErrors getErrorMessage={ getErrorMessage } fieldName="card_expiry" />
 					</label>
 				</div>
 				<div className="credit-card-form-fields__field cvv">
 					<label className="credit-card-form-fields__label form-label">
 						{ cvcLabel }
 						<CardCVCElement classes={ elementClasses } />
+						<StripeElementErrors getErrorMessage={ getErrorMessage } fieldName="card_cvc" />
 					</label>
 				</div>
 			</React.Fragment>
@@ -155,6 +174,7 @@ function CreditCardExpiryAndCvvFields( { translate, stripe, createField, card } 
 CreditCardExpiryAndCvvFields.propTypes = {
 	translate: PropTypes.func.isRequired,
 	createField: PropTypes.func.isRequired,
+	getErrorMessage: PropTypes.func.isRequired,
 	card: PropTypes.object.isRequired,
 	stripe: PropTypes.object,
 };
@@ -266,6 +286,7 @@ export class CreditCardFormFields extends React.Component {
 						translate={ this.props.translate }
 						stripe={ this.props.stripe }
 						createField={ this.createField }
+						getErrorMessage={ this.props.getErrorMessage }
 					/>
 				</div>
 
@@ -274,6 +295,7 @@ export class CreditCardFormFields extends React.Component {
 						translate={ this.props.translate }
 						stripe={ this.props.stripe }
 						createField={ this.createField }
+						getErrorMessage={ this.props.getErrorMessage }
 						card={ this.props.card }
 					/>
 					{ this.createField( 'country', PaymentCountrySelect, {

--- a/client/components/forms/form-input-validation/style.scss
+++ b/client/components/forms/form-input-validation/style.scss
@@ -6,6 +6,7 @@
 	box-sizing: border-box;
 	font-size: 14px;
 	animation: appear 0.3s ease-in-out;
+	font-weight: normal;
 
 	&.is-error {
 		color: var( --color-error );

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -287,7 +287,14 @@ validators.validStreetNumber = {
 
 /**
  * Runs payment fields through the relevant validation rules
- * use these validation rules, for example, in <CreditCardForm />, <PayPalPaymentBox /> and <RedirectPaymentBox />
+ *
+ * Use these validation rules, for example, in <CreditCardForm />,
+ * <PayPalPaymentBox /> and <RedirectPaymentBox />
+ *
+ * Returns an object with one property: `errors`. That object is another object
+ * with keys that are the field names of those errors.  The value of each
+ * property of that object is an array of error strings.
+ *
  * @param {object} paymentDetails object containing fieldname/value keypairs
  * @param {string} paymentType credit-card(default)|paypal|ideal|p24|tef|token|stripe
  * @returns {object} validation errors, if any

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -49,9 +49,20 @@ export function submit( params, onStep ) {
 	return new TransactionFlow( params, onStep );
 }
 
-function ValidationError( code, message ) {
+/**
+ * An error for display by the payment form
+ *
+ * TODO: This sets `message` to an object, which is a non-standard way to use
+ * an Error since `Error.message` should be a string. We should set the
+ * messagesByField to a separate property and use that instead. See
+ * `StripeValidationError` for a better pattern.
+ *
+ * @param {string} code - The error code
+ * @param {object} messagesByField - An object whose keys are input field names and whose values are arrays of error strings for that field
+ */
+function ValidationError( code, messagesByField ) {
 	this.code = code;
-	this.message = message;
+	this.message = messagesByField;
 }
 inherits( ValidationError, Error );
 

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -182,7 +182,7 @@ class CreditCardPaymentBox extends React.Component {
 
 		// setStripeObject uses Flux Dispatcher so they are deferred. This
 		// defers the submit so it will occur after they take effect.
-		setTimeout( () => this.props.onSubmit( event ), 0 );
+		setTimeout( () => this.props.onSubmit(), 0 );
 	};
 
 	render = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #34469 we added Stripe Elements form fields to the checkout form in some cases. These fields are rendered, controlled, and validated by Stripe or the local Stripe library and so we cannot run our standard validation system on their values. When we currently receive a validation error for one of these fields, it is treated as an unknown processing error and is displayed in the global notices.

This change looks for specific validation errors and displays them inline next to the Stripe form fields instead, matching the behavior of the non-Stripe fields as much as possible.

Note that it will only show an error for one field at a time, because that's what is returned from the Stripe library. So if three fields are invalid, they will all turn red (that's part of the Stripe library) but only one message will be displayed, on the first invalid field.

Before:
<img width="298" alt="global-card-incomplete" src="https://user-images.githubusercontent.com/2036909/61493401-7e848480-a981-11e9-96b3-c79445d32acc.png">

After:
![inline-card-incomplete](https://user-images.githubusercontent.com/2036909/61493395-775d7680-a981-11e9-865e-7733d41b96d0.png)

#### Testing instructions

1. Sandbox the store.
2. Visit the checkout form for a product (be sure that you see placeholder _numbers_, not dots, in the credit card field; see screenshot above).
3. Fill in the cardholder name, country, and postal code fields, leaving the card number, expiry, and cvc fields blank.
4. Click the "Pay" button.
5. Verify that you see a validation error immediately beneath the invalid form fields.
6. Repeat steps 3-5 with some fields empty and others filled.
7. Repeat steps 3-5 with some fields containing invalid data and others containing valid data (rather than just being empty).