### PR TITLE
Signup: Save the url of the site being imported

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -171,17 +171,15 @@ export function createSiteWithCart(
 		validate: false,
 	};
 
-	const importingFromUrl =
-		'import' === flowName ? normalizeImportUrl( getNuxUrlInputValue( state ) ) : '';
-	const importEngine = 'import' === flowName ? getSelectedImportEngine( state ) : '';
-
 	// flowName isn't always passed in
 	const flowToCheck = flowName || lastKnownFlow;
 
-	if ( importingFromUrl ) {
-		newSiteParams.blog_name = importingFromUrl;
+	if ( 'import' === flowName ) {
+		const importingFromUrl = getNuxUrlInputValue( state );
+		newSiteParams.blog_name = normalizeImportUrl( importingFromUrl );
 		newSiteParams.find_available_url = true;
-		newSiteParams.options.nux_import_engine = importEngine;
+		newSiteParams.options.nux_import_engine = getSelectedImportEngine( state );
+		newSiteParams.options.nux_import_from_url = importingFromUrl;
 	} else if ( ! siteUrl && isDomainStepSkippable( flowToCheck ) ) {
 		newSiteParams.blog_name =
 			get( user.get(), 'username' ) ||


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When completing the import signup flow, save the url of the site being imported with the newly created site.

Needed for D30603-code

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the network tab of the browser and check "Preserve log"
- Visit `/start/import` and complete the signup flow
- Look in the network history for a POST call to `/sites/new` and verify that `options` contains
    - `nux_import_from_url` that matches the url you entered during the flow
    - `nux_import_engine` that matches the engine of the site being imported (currently `godaddy-gocentral` or `wix`)
