### PR TITLE
FSE: Open WP.com block editor when editing template parts

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -561,7 +561,7 @@ function openLinksInParentFrame() {
 }
 
 /**
- * Ensures the Calypso Customizer is opened when clicking on the the FSE blocks' edit buttons.
+ * Ensures the Calypso Customizer is opened when clicking on the FSE blocks' edit buttons.
  *
  * @param {MessagePort} calypsoPort Port used for communication with parent frame.
  */
@@ -575,6 +575,26 @@ function openCustomizer( calypsoPort ) {
 			payload: {
 				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
 				autofocus: getQueryArg( e.currentTarget.href, 'autofocus' ),
+			},
+		} );
+	} );
+}
+
+/**
+ * Ensures the Calypso block editor is opened when editing a template part.
+ *
+ * @param {MessagePort} calypsoPort Port used for communication with parent frame.
+ */
+function openTemplatePartEditor( calypsoPort ) {
+	const editTemplatePartLinkSelector = '.template-block__overlay a';
+	$( '#editor' ).on( 'click', editTemplatePartLinkSelector, e => {
+		e.preventDefault();
+
+		calypsoPort.postMessage( {
+			action: 'openTemplatePartEditor',
+			payload: {
+				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
+				templatePartId: getQueryArg( e.currentTarget.href, 'post' ),
 			},
 		} );
 	} );
@@ -658,6 +678,8 @@ function initPort( message ) {
 		openLinksInParentFrame();
 
 		openCustomizer( calypsoPort );
+
+		openTemplatePartEditor( calypsoPort );
 	}
 
 	window.removeEventListener( 'message', initPort, false );

--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -624,22 +624,8 @@ async function openTemplatePartEditor( calypsoPort ) {
 	const editTemplatePartLinks = await getTemplatePartLinks();
 
 	editTemplatePartLinks.forEach( link => {
-		const templatePartId = getQueryArg( link.getAttribute( 'href' ), 'post' );
+		const templatePartId = parseInt( getQueryArg( link.getAttribute( 'href' ), 'post' ), 10 );
 
-		// Delegates the navigation to Calypso in order to avoid a full load page.
-		link.addEventListener( 'click', e => {
-			e.preventDefault();
-
-			calypsoPort.postMessage( {
-				action: 'openTemplatePartEditor',
-				payload: {
-					unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
-					templatePartId,
-				},
-			} );
-		} );
-
-		// But overrides the link just in case the user treats the link as a link.
 		const { port1, port2 } = new MessageChannel();
 		calypsoPort.postMessage(
 			{
@@ -651,7 +637,6 @@ async function openTemplatePartEditor( calypsoPort ) {
 		port1.onmessage = ( { data } ) => {
 			link.setAttribute( 'target', '_parent' );
 			link.setAttribute( 'href', data );
-			port1.close();
 		};
 	} );
 }

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -93,6 +93,7 @@ enum EditorActions {
 	ConversionRequest = 'triggerConversionRequest',
 	OpenCustomizer = 'openCustomizer',
 	OpenTemplatePartEditor = 'openTemplatePartEditor',
+	GetTemplatePartEditorUrl = 'getTemplatePartEditorUrl',
 }
 
 class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedFormProps, State > {
@@ -254,6 +255,11 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		if ( EditorActions.OpenTemplatePartEditor === action ) {
 			const { templatePartId = null, unsavedChanges = false } = payload;
 			this.openTemplatePartEditor( templatePartId, unsavedChanges );
+		}
+
+		if ( EditorActions.GetTemplatePartEditorUrl === action ) {
+			const { templatePartId = null } = payload;
+			this.getTemplatePartEditorUrl( templatePartId, ports[ 0 ] );
 		}
 	};
 
@@ -425,6 +431,21 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		}
 
 		goTo( templatePartEditorUrl );
+	};
+
+	getTemplatePartEditorUrl = ( templatePartId: object, port: MessagePort ) => {
+		const { getTemplatePartEditorUrl, editedPostId } = this.props;
+
+		let templatePartEditorUrl = getTemplatePartEditorUrl( templatePartId );
+		if ( editedPostId ) {
+			templatePartEditorUrl = addQueryArgs(
+				{ fse_parent_post: editedPostId },
+				templatePartEditorUrl
+			);
+		}
+
+		port.postMessage( `${ window.location.origin }${ templatePartEditorUrl }` );
+		port.close();
 	};
 
 	handleConversionResponse = ( confirmed: boolean ) => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Ensures the WordPress.com block editor is opened after clicking on the Edit buttons of the template parts displayed when editing a full site page.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update your sandbox with the latest changes of the FSE plugin and Modern Business theme following instructions at D30622.
* Generate a new build of the `wpcom-block-editor` app and upload it your sandbox site following instructions at PCYsg-l4k-p2.
* Sandbox the API and `widgets.cdn.com`.
* Open an existing page (`/block-editor/page/:sandboxSite/:pageId`).
* You should see the FSE header and footer on the block editor.
* Try editing either the header or the footer template part.
* Make sure the template part is opened on the block editor (the URL should be `/block-editor/edit/wp_template_part/:sandboxSite/:templatePartId?fse_parent_post=:pageId`).
* Click on the close button.
* Make sure the block editor loads the previous page.
* Start creating now a new page (`/block-editor/page/:site/`).
* Try editing either the header or the footer template part without saving any change.
* Make sure the template part is opened on the block editor (the URL should be `/block-editor/edit/wp_template_part/:site/:templatePartId`).
* Click on the close button.
* Make sure the block editor loads a new page.
* Try editing either the header or the footer template part after adding and saving some changes.
* Make sure the template part is opened on the block editor (the URL should be `/block-editor/edit/wp_template_part/:site/:templatePartId?fse_parent_post=:pageId`)
* Click on the close button.
* Make sure the block editor loads the previously created page.

Fixes #34074
