### PR TITLE
WIP: Try i18n-calypso thunk.translate()

### DIFF
--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -37,6 +37,7 @@
 		"clean": "npx rimraf dist",
 		"prepublish": "npm run clean",
 		"prepare": "transpile",
-		"test": "pwd | ( cd ../../; npm run test-packages $(cat -))"
+		"test": "pwd | ( cd ../../; npm run test-packages $(cat -))",
+		"test:watch": "pwd | ( cd ../../; npm run test-packages:watch $(cat -))"
 	}
 }

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -36,6 +36,7 @@
 	"scripts": {
 		"clean": "npx rimraf dist",
 		"prepublish": "npm run clean",
-		"prepare": "transpile"
+		"prepare": "transpile",
+		"test": "pwd | ( cd ../../; npm run test-packages $(cat -))"
 	}
 }

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -39,5 +39,8 @@
 		"prepare": "transpile",
 		"test": "pwd | ( cd ../../; npm run test-packages $(cat -))",
 		"test:watch": "pwd | ( cd ../../; npm run test-packages:watch $(cat -))"
+	},
+	"devDependencies": {
+		"react-dom": "^16.8.6"
 	}
 }

--- a/packages/i18n-calypso/src/index.js
+++ b/packages/i18n-calypso/src/index.js
@@ -6,6 +6,7 @@
 import I18N from './i18n';
 import localizeFactory from './localize';
 import useTranslateFactory from './use-translate';
+import thunkFactory from './thunk-translate';
 
 const i18n = new I18N();
 export { I18N };
@@ -28,3 +29,4 @@ export const off = i18n.off.bind( i18n );
 export const emit = i18n.emit.bind( i18n );
 export const localize = localizeFactory( i18n );
 export const useTranslate = useTranslateFactory( i18n );
+export const thunk = { translate: thunkFactory( i18n ) };

--- a/packages/i18n-calypso/src/thunk-translate.js
+++ b/packages/i18n-calypso/src/thunk-translate.js
@@ -1,0 +1,64 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect } from 'react';
+
+/*
+ * The idea here is that we offer a function for developers that want to list
+ * off a bunch of localized stings in a decalarative format (i.e. outside of a
+ * react components)
+ *
+ * This function would return a react component ready to be rendered as though
+ * it were just a string, but with the hooks in place to rerender when i18n
+ * changes.
+ *
+ * ```
+ * const myStrings = [
+ *  thunk.translate( 'String1', { comment: 'other i18n options go here' } ),
+ *  thunk.translate( 'String2' ),
+ *  thunk.translate( 'String3' ),
+ *
+ * render() {
+ *   const String0 = myStrings[0];
+ *   return <div><String0 /></div>;
+ * }
+ *
+ * This may also let React avoid re-rendering the parent in some cases.
+ *
+ * It's possible to iterate too. This seems pretty niche, but we can add
+ * syntacic sugar if it's something we actually want to do:
+ * `createElement( Fragment, null, ...( myStrings.map( createElement ) )`
+ *
+ * In the somewhat unusual event that your arguments depend on the i18n module
+ * itself, you can thunk the arguments to translate as well:
+ * Translation thunk.translate(
+ *   'The current locale is $(lang)s',
+ *   { args: { lang: i18n.getLocaleSlug() } }
+ * );
+ *
+ *
+ */
+const resolve = f => ( typeof f === 'function' ? f() : f );
+
+export default i18n => ( ...translationArgs ) => () => {
+	const [ translation, setTranslation ] = useState(
+		// eslint-disable-next-line wpcalypso/i18n-no-variables
+		i18n.translate( ...translationArgs.map( resolve ) )
+	);
+
+	useEffect( () => {
+		const onChange = () => {
+			setTranslation(
+				// eslint-disable-next-line wpcalypso/i18n-no-variables
+				i18n.translate( ...translationArgs.map( resolve ) )
+				// 'bob'
+			);
+		};
+		i18n.on( 'change', onChange );
+		return () => {
+			i18n.off( 'change', onChange );
+		};
+	}, [] );
+
+	return translation;
+};

--- a/packages/i18n-calypso/test/thunk-translate.js
+++ b/packages/i18n-calypso/test/thunk-translate.js
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment jsdom
+ */
+/**
+ * External dependencies
+ */
+import React, { createElement, Fragment } from 'react';
+import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
+
+/**
+ * Internal dependencies
+ */
+import i18n, { thunk } from '../src';
+
+describe( 'thunk.translate()', () => {
+	let container;
+
+	beforeEach( () => {
+		// reset to default locale
+		i18n.setLocale();
+
+		// create container
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
+	afterEach( () => {
+		// tear down the container
+		ReactDOM.unmountComponentAtNode( container );
+		document.body.removeChild( container );
+		container = null;
+	} );
+
+	test( 'renders a translated string', () => {
+		// set some locale data
+		i18n.setLocale( {
+			'': { localeSlug: 'cs' },
+			'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
+		} );
+
+		const Translation = thunk.translate( 'hook (%(lang)s)', {
+			args: { lang: i18n.getLocaleSlug() },
+		} );
+
+		// render the translation
+		act( () => {
+			ReactDOM.render( <Translation />, container );
+		} );
+
+		// check that it's translated
+		expect( container.textContent ).toBe( 'háček (cs)' );
+	} );
+
+	test( 'rerenders after locale change', () => {
+		// render with the default locale
+		const Translation = thunk.translate( 'hook (%(lang)s)', { args: { lang: 'static example' } } );
+
+		act( () => {
+			ReactDOM.render(
+				<div>
+					<Translation />
+				</div>,
+				container
+			);
+		} );
+
+		expect( container.textContent ).toBe( 'hook (static example)' );
+
+		// change locale and ensure that React UI is rerendered
+		act( () => {
+			i18n.setLocale( {
+				'': { localeSlug: 'cs' },
+				'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
+			} );
+		} );
+
+		expect( container.textContent ).toBe( 'háček (static example)' );
+	} );
+
+	test( 'recalculates thunked arguments after locale change', () => {
+		// render with the default locale
+		const Translation = thunk.translate( 'hook (%(lang)s)', () => ( {
+			args: { lang: i18n.getLocaleSlug() },
+		} ) );
+
+		act( () => {
+			ReactDOM.render( <Translation />, container );
+		} );
+
+		expect( container.textContent ).toBe( 'hook (en)' );
+
+		// change locale and ensure that React UI is rerendered
+		act( () => {
+			i18n.setLocale( {
+				'': { localeSlug: 'dynamic' },
+				'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
+			} );
+		} );
+
+		expect( container.textContent ).toBe( 'háček (dynamic)' );
+	} );
+
+	test( 'rerenders after update of current locale translations', () => {
+		// set some locale data
+		i18n.setLocale( {
+			'': { localeSlug: 'cs' },
+			'hook (%(lang)s)': [ 'háček (%(lang)s)' ],
+		} );
+
+		const HookTranslation = thunk.translate( 'hook (%(lang)s)', () => ( {
+			args: { lang: i18n.getLocaleSlug() },
+		} ) );
+
+		// render the translation
+		act( () => {
+			ReactDOM.render( <HookTranslation />, container );
+		} );
+
+		// check that it's translated
+		expect( container.textContent ).toBe( 'háček (cs)' );
+
+		// update the translations for the current locale
+		act( () => {
+			i18n.setLocale( {
+				'': { localeSlug: 'cs' },
+				'hook (%(lang)s)': [ 'hák (%(lang)s)' ],
+			} );
+		} );
+
+		// check that the rendered translation is updated
+		expect( container.textContent ).toBe( 'hák (cs)' );
+	} );
+
+	test( 'rerenders iteratively', () => {
+		// set some locale data
+		i18n.setLocale( {
+			'': { localeSlug: 'cs' },
+			String0: [ 'řada0' ],
+			String1: [ 'řada1' ],
+			String2: [ 'řada2' ],
+		} );
+
+		const myStrings = [
+			thunk.translate( 'String0', { comment: 'other i18n options go here' } ),
+			thunk.translate( 'String1' ),
+			thunk.translate( 'String2' ),
+		];
+
+		// render the translation
+		act( () => {
+			// Syntax needs a lot of work :p
+			ReactDOM.render(
+				createElement( Fragment, null, ...myStrings.map( createElement ) ),
+				container
+			);
+		} );
+
+		// check that it's translated
+		expect( container.textContent ).toBe( 'řada0řada1řada2' );
+
+		// update the translations for the current locale
+		act( () => {
+			i18n.setLocale( {
+				'': { localeSlug: 'cs' },
+				String0: [ '+řada0' ],
+				String1: [ '+řada1' ],
+				String2: [ '+řada2' ],
+			} );
+		} );
+
+		// check that the rendered translation is updated
+		expect( container.textContent ).toBe( '+řada0+řada1+řada2' );
+	} );
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The PR explores using react hooks to create minimal components to contain localized strings.

#### Background
For a long time developers wanting to write concise & reusable code have wanted to define localized strings separately from their final usage but have run up against limitations imposed by our i18n tooling that need to be able to identify localized strings through static analysis (most notably scanning for `translate( 'Original String' )` function calls.

The runtime requirements for localized strings are twofold:
1. Finding the right translation to render
2. Updating in responses to changes in localization data (usually changing locale)

The tooling requirements are that we can find the original string using static analysis, mainly meaning we can't use the values of variables or functions.

#### Discussion

I don't think this is quite right yet, but it seems promising, so I wanted to see if the right answer was obvious from here.

The test cases show a few uses.

The `resolve` detail is a bit of an aside. I only thought of that because I started with the test cases from `test/use-translate`, and one of those was pulling information out of i18n and failing. I was already thinking about thunks. Resolving the first argument is wrong, but our lint rules will complain anyway.

I ran into some odd warnings around using react hooks not at the top level when I was trying to package it up more conveniently. I'm not sure if this is about my misunderstanding the mechanism or some quirk of the implementation, or if I was just plain getting it wrong.

e.g. #34455 is what got me thinking about this, and this _nearly_  lets us pull the translate concern out of the mini component:

```
function button( Label, icon ) {
    return // localize( ( { translate: tr } ) =>    // This is covered by the thunk 
        ( <strong>
            { icon }
            // [...]
            <Label />                               // instead of `tr( label )`
            </strong>
        ) //);
}

export const AddContentButton = button( thunk.translate( 'Add' ), <Gridicon icon="add-outline" /> );
```