### PR TITLE
Auto-renewal Toggle: Bring the "Renew Now" button back to the purchase management page.

### DIFF
--- a/client/me/purchases/manage-purchase/index.jsx
+++ b/client/me/purchases/manage-purchase/index.jsx
@@ -28,7 +28,6 @@ import {
 	hasPaymentMethod,
 	isCancelable,
 	isExpired,
-	isExpiring,
 	isOneTimePurchase,
 	isPaidWithCreditCard,
 	isRefundable,
@@ -140,14 +139,7 @@ class ManagePurchase extends Component {
 			return null;
 		}
 
-		// This is hidden for expired and expiring subscriptions because they
-		// will get a PurchaseNotice will a renewal call-to-action instead.
-		if (
-			! isRenewable( purchase ) ||
-			isExpired( purchase ) ||
-			isExpiring( purchase ) ||
-			! this.props.site
-		) {
+		if ( ! isRenewable( purchase ) || ! this.props.site ) {
 			return null;
 		}
 
@@ -165,9 +157,6 @@ class ManagePurchase extends Component {
 			return null;
 		}
 
-		// Unlike renderRenewButton(), this shows the link even for expired or
-		// expiring subscriptions (as long as they are renewable), which keeps
-		// the nav items consistent.
 		if ( ! isRenewable( purchase ) || ! this.props.site ) {
 			return null;
 		}

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -110,7 +110,7 @@ class PurchaseNotice extends Component {
 		} );
 	}
 
-	renderRenewNoticeAction() {
+	renderRenewNoticeAction( onClick ) {
 		const { editCardDetailsPath, purchase, translate } = this.props;
 
 		if ( ! config.isEnabled( 'upgrades/checkout' ) || ! this.props.selectedSite ) {
@@ -127,7 +127,12 @@ class PurchaseNotice extends Component {
 			);
 		}
 
-		return null;
+		// In case of `manualRenew`, the text encouraging users to enable auto-renewal through the toggle will be presented.
+		return (
+			purchase.expiryStatus !== 'manualRenew' && (
+				<NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>
+			)
+		);
 	}
 
 	trackImpression( warning ) {
@@ -145,6 +150,13 @@ class PurchaseNotice extends Component {
 			eventProperties( warning )
 		);
 	}
+
+	handleExpiringNoticeRenewal = () => {
+		this.trackClick( 'purchase-expiring' );
+		if ( this.props.handleRenew ) {
+			this.props.handleRenew();
+		}
+	};
 
 	renderPurchaseExpiringNotice() {
 		const { moment, purchase } = this.props;
@@ -167,7 +179,7 @@ class PurchaseNotice extends Component {
 				status={ noticeStatus }
 				text={ this.getExpiringText( purchase ) }
 			>
-				{ this.renderRenewNoticeAction() }
+				{ this.renderRenewNoticeAction( this.handleExpiringNoticeRenewal ) }
 				{ this.trackImpression( 'purchase-expiring' ) }
 			</Notice>
 		);
@@ -224,6 +236,13 @@ class PurchaseNotice extends Component {
 		}
 	}
 
+	handleExpiredNoticeRenewal = () => {
+		this.trackClick( 'purchase-expired' );
+		if ( this.props.handleRenew ) {
+			this.props.handleRenew();
+		}
+	};
+
 	renderExpiredRenewNotice() {
 		const { purchase, translate } = this.props;
 
@@ -241,7 +260,7 @@ class PurchaseNotice extends Component {
 				status="is-error"
 				text={ translate( 'This purchase has expired and is no longer in use.' ) }
 			>
-				{ this.renderRenewNoticeAction() }
+				{ this.renderRenewNoticeAction( this.handleExpiredNoticeRenewal ) }
 				{ this.trackImpression( 'purchase-expired' ) }
 			</Notice>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As indicated by @DavidRothstein in #34338, the changes I've introduced for the auto-renewal toggle has been too aggressive by removing the notification button altogether. This PR brings back the "Renew Now" button to the expiring & expired notifications while keeping the newly-introduced auto-renewal enabling message.

This should also resolve #34338 since it will become [an expected behavior](https://github.com/Automattic/wp-calypso/blob/master/client/me/purchases/manage-purchase/index.jsx#L143) once again.

#### Testing instructions

1. Disable the auto-renewal through the toggle on a subscription expiring in more than 3 months, and the nudge for enabling auto-renewal should show:
<img width="788" alt="螢幕快照 2019-07-19 下午3 52 26" src="https://user-images.githubusercontent.com/1842898/61519537-b7366380-aa3e-11e9-919e-8ba7bb60d87c.png">

2. Disable the auto-renewal through the toggle on a subscription expiring within 3 months, and the nudge should contain the "Renew Now" button:
<img width="805" alt="螢幕快照 2019-07-19 下午3 50 57" src="https://user-images.githubusercontent.com/1842898/61519577-d1704180-aa3e-11e9-9017-e2e12216dc77.png">

3. For an expired subscription, the "Renew Now" button should be there:
<img width="783" alt="螢幕快照 2019-07-19 下午3 51 47" src="https://user-images.githubusercontent.com/1842898/61520233-57d95300-aa40-11e9-8a57-f814f00a953e.png">

