### PR TITLE
Use describe.skip instead xdescribe

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -20,6 +20,7 @@ Automated end-to-end acceptance tests for the [wp-calypso](https://github.com/Au
     - [To run with different modes](docs/running-tests.md#to-run-with-different-modes)
     - [To run a specific suite of specs](docs/running-tests.md#to-run-a-specific-suite-of-specs)
     - [To run headlessly](docs/running-tests.md#to-run-headlessly)
+  - [How to disable tests](docs/disabling-tests.md)
 - [Writing tests](#)
   - [Gutenberg blocks](docs/gutenberg.md)
 - [Style Guide](docs/style-guide.md)

--- a/test/e2e/docs/disabling-tests.md
+++ b/test/e2e/docs/disabling-tests.md
@@ -1,0 +1,9 @@
+# Disable test
+
+## To disable an individual test
+
+Sometimes you will need to disable specific test, eg. functionality is currently broken and you are waiting for a fix. You can simply do that by adding `.skip` after `describe`:
+
+`describe.skip( 'Sign up for free subdomain site @parallel', function() {`
+
+

--- a/test/e2e/docs/disabling-tests.md
+++ b/test/e2e/docs/disabling-tests.md
@@ -1,4 +1,4 @@
-# Disable test
+# Disable tests and steps
 
 ## To disable an individual test
 
@@ -6,4 +6,12 @@ Sometimes you will need to disable specific test, eg. functionality is currently
 
 `describe.skip( 'Sign up for free subdomain site @parallel', function() {`
 
+## To disable an individual step
 
+Steps could also be disabled by adding `x` before `step`. First `xstep` needs to be imported if it's not already:
+
+`import { xstep } from 'mocha-steps';`
+
+and then:
+
+`xstep( 'Can see the domain search component', async function() {`

--- a/test/e2e/specs/wp-invite-users-spec.js
+++ b/test/e2e/specs/wp-invite-users-spec.js
@@ -329,7 +329,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 		} );
 	} );
 
-	xdescribe( 'Inviting New User as an Contributor, then change them to Author: @parallel @jetpack', function() {
+	describe.skip( 'Inviting New User as an Contributor, then change them to Author: @parallel @jetpack', function() {
 		const newUserName = 'e2eflowtestingcontributor' + new Date().getTime().toString();
 		const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );
 		const reviewPostTitle = dataHelper.randomPhrase();
@@ -469,7 +469,7 @@ describe( `[${ host }] Invites:  (${ screenSize })`, function() {
 	} );
 
 	// Disabled pending wp-calypso issue 26178
-	xdescribe( 'Inviting New User as a Follower: @parallel @jetpack', function() {
+	describe.skip( 'Inviting New User as a Follower: @parallel @jetpack', function() {
 		const newUserName = 'e2eflowtestingfollower' + new Date().getTime().toString();
 		const newInviteEmailAddress = dataHelper.getEmailAddress( newUserName, inviteInboxId );
 		let acceptInviteURL = '';

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -747,7 +747,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 	} );
 
-	xdescribe( 'Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel', function() {
+	describe.skip( 'Sign up for a domain only purchase coming in from wordpress.com/domains in EUR currency @parallel', function() {
 		const siteName = dataHelper.getNewBlogName();
 		const expectedDomainName = `${ siteName }.live`;
 		const emailAddress = dataHelper.getEmailAddress( siteName, signupInboxId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We have two ways how to disable specific test - `xdescribe` and `describe.skip`, and we used both of them in our e2e tests. This PR unifies the way how we disable them, using `describe.skip`. I also added description in docs how to do that. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Make sure that same tests are skipped as before. 


