### PR TITLE
Replace some usage of string refs in stats.

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -413,8 +413,6 @@ class SiteSelector extends Component {
 				onMouseLeave={ this.onMouseLeave }
 			>
 				<Search
-					// eslint-disable-next-line react/no-string-refs
-					ref="siteSearch"
 					onSearch={ this.onSearch }
 					delaySearch={ true }
 					// eslint-disable-next-line jsx-a11y/no-autofocus

--- a/client/my-sites/stats/geochart/index.jsx
+++ b/client/my-sites/stats/geochart/index.jsx
@@ -1,12 +1,6 @@
-/** @format */
-
-/* @TODO resolve linting issues */
-/* eslint-disable react/no-string-refs, wpcalypso/jsx-classname-namespace */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
@@ -41,6 +35,7 @@ class StatsGeochart extends Component {
 
 	visualizationsLoaded = false;
 	visualization = null;
+	chartRef = React.createRef();
 
 	componentDidMount() {
 		if ( ! window.google || ! window.google.charts ) {
@@ -81,9 +76,9 @@ class StatsGeochart extends Component {
 	};
 
 	drawRegionsMap = () => {
-		if ( this.refs && this.refs.chart ) {
+		if ( this.chartRef.current ) {
 			this.visualizationsLoaded = true;
-			this.visualization = new window.google.visualization.GeoChart( this.refs.chart );
+			this.visualization = new window.google.visualization.GeoChart( this.chartRef.current );
 			window.google.visualization.events.addListener(
 				this.visualization,
 				'regionClick',
@@ -121,7 +116,7 @@ class StatsGeochart extends Component {
 		chartData.addColumn( 'string', translate( 'Country' ).toString() );
 		chartData.addColumn( 'number', translate( 'Views' ).toString() );
 		chartData.addRows( mapData );
-		const node = this.refs.chart;
+		const node = this.chartRef.current;
 		const width = node.clientWidth;
 
 		// Note that using raw hex values here is an exception due to
@@ -185,8 +180,9 @@ class StatsGeochart extends Component {
 
 		return (
 			<div>
-				<div ref="chart" className={ classes } />
+				<div ref={ this.chartRef } className={ classes } />
 				{ siteId && <QuerySiteStats statType={ statType } siteId={ siteId } query={ query } /> }
+				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<StatsModulePlaceholder className="is-block" isLoading={ isLoading } />
 			</div>
 		);

--- a/client/my-sites/stats/post-trends/day.jsx
+++ b/client/my-sites/stats/post-trends/day.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
 import React from 'react';
@@ -15,8 +12,6 @@ import classNames from 'classnames';
 import Tooltip from 'components/tooltip';
 
 class PostTrendsDay extends React.PureComponent {
-	static displayName = 'PostTrendsDay';
-
 	static propTypes = {
 		label: PropTypes.string,
 		className: PropTypes.string,
@@ -28,6 +23,7 @@ class PostTrendsDay extends React.PureComponent {
 	};
 
 	state = { showPopover: false };
+	dayRef = React.createRef();
 
 	mouseEnter = () => {
 		this.setState( { showPopover: true } );
@@ -37,6 +33,7 @@ class PostTrendsDay extends React.PureComponent {
 		this.setState( { showPopover: false } );
 	};
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	buildTooltipData = () => {
 		const { label, postCount } = this.props;
 		const content = this.props.translate( '%(posts)d post', '%(posts)d posts', {
@@ -66,13 +63,13 @@ class PostTrendsDay extends React.PureComponent {
 				className={ classNames( 'post-trends__day', hoveredClass, className ) }
 				onMouseEnter={ postCount > 0 ? this.mouseEnter : null }
 				onMouseLeave={ postCount > 0 ? this.mouseLeave : null }
-				ref="day"
+				ref={ this.dayRef }
 			>
 				{ postCount > 0 && (
 					<Tooltip
 						className="chart__tooltip is-streak"
 						id="popover__chart-bar"
-						context={ this.refs && this.refs.day }
+						context={ this.dayRef.current }
 						isVisible={ this.state.showPopover }
 						position="top"
 					>
@@ -82,6 +79,8 @@ class PostTrendsDay extends React.PureComponent {
 			</div>
 		);
 	}
+
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }
 
 export default localize( PostTrendsDay );

--- a/client/my-sites/stats/stats-views/months.jsx
+++ b/client/my-sites/stats/stats-views/months.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { map, range, flatten, max, keys, zipObject, times, size, concat, merge } from 'lodash';
@@ -30,6 +27,8 @@ class Month extends PureComponent {
 		showPopover: false,
 	};
 
+	monthRef = React.createRef();
+
 	static defaultProps = {
 		position: 'top',
 	};
@@ -55,7 +54,7 @@ class Month extends PureComponent {
 			tagName,
 			{
 				className: className,
-				ref: 'month',
+				ref: this.monthRef,
 				onClick: this.openPopover,
 			},
 			concat(
@@ -65,7 +64,7 @@ class Month extends PureComponent {
 					onClose={ this.closePopover }
 					position={ position }
 					key="popover"
-					context={ this.refs && this.refs.month }
+					context={ this.monthRef.current }
 				>
 					<div style={ { padding: '10px' } }>{ value }</div>
 				</Popover>


### PR DESCRIPTION
This change reimplements some string ref usage in stats and the site selector using the modern `React.createRef()`.

String refs are deprecated and may be dropped by future versions of `React`. They will also need to be replaced if we ever decide to switch to `Preact`, either partially or completely.

#### Changes proposed in this Pull Request

* Remove unused string ref in the site selector
* Replace string ref usage with `React.createRef()` in several stats components

#### Testing instructions

Ensure that the following still work correctly in the live branch:
* Site selector (no unexpected errors).
* The geo chart in stats (e.g. in `stats/day/countryviews`) still renders correctly.
* The post trends in stats still works correctly. Namely, when hovering over an active day in the calendar in `stats/insights`, does the tooltip show?
* The "All Time Views" component still works correctly in `stats/insights`. Namely, clicking a month header or a year header should show a popup with the period's totals.
