### PR TITLE
Replace `superagent` in `state/login`.

### DIFF
--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -50,7 +50,7 @@ import {
 	getErrorFromHTTPError,
 	getErrorFromWPCOMError,
 	getSMSMessageFromResponse,
-	HttpError,
+	HTTPError,
 } from './utils';
 import wpcom from 'lib/wp';
 import { localizeUrl } from 'lib/i18n-utils';
@@ -126,7 +126,7 @@ async function postLoginRequest( action, bodyObj ) {
 	if ( response.ok ) {
 		return { body: await response.json() };
 	}
-	throw new HttpError( response, await response.body );
+	throw new HTTPError( response, await response.body );
 }
 
 /**

--- a/client/state/login/actions.js
+++ b/client/state/login/actions.js
@@ -126,7 +126,7 @@ async function postLoginRequest( action, bodyObj ) {
 	if ( response.ok ) {
 		return { body: await response.json() };
 	}
-	throw new HTTPError( response, await response.body );
+	throw new HTTPError( response, await response.text() );
 }
 
 /**

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -100,7 +100,7 @@ async function postMagicLoginRequest( url, bodyObj ) {
 	if ( response.ok ) {
 		return await response.json();
 	}
-	throw new HTTPError( response.status, await response.body );
+	throw new HTTPError( response, await response.text() );
 }
 
 /**

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -9,6 +9,7 @@ import { stringify } from 'qs';
 import config from 'config';
 import wpcom from 'lib/wp';
 import { AUTHENTICATE_URL } from './constants';
+import { HttpError } from '../utils';
 import {
 	LOGIN_REQUEST_SUCCESS,
 	MAGIC_LOGIN_HIDE_REQUEST_FORM,
@@ -88,14 +89,6 @@ export const fetchMagicLoginRequestEmail = ( email, redirectTo ) => dispatch => 
 		} );
 };
 
-class MagicLoginError extends Error {
-	constructor( status ) {
-		super();
-		this.name = 'MagicLoginError';
-		this.status = status;
-	}
-}
-
 async function postMagicLoginRequest( url, bodyObj ) {
 	const response = await fetch( url, {
 		method: 'POST',
@@ -107,7 +100,7 @@ async function postMagicLoginRequest( url, bodyObj ) {
 	if ( response.ok ) {
 		return await response.json();
 	}
-	throw new MagicLoginError( response.status );
+	throw new HttpError( response.status, await response.body );
 }
 
 /**

--- a/client/state/login/magic-login/actions.js
+++ b/client/state/login/magic-login/actions.js
@@ -9,7 +9,7 @@ import { stringify } from 'qs';
 import config from 'config';
 import wpcom from 'lib/wp';
 import { AUTHENTICATE_URL } from './constants';
-import { HttpError } from '../utils';
+import { HTTPError } from '../utils';
 import {
 	LOGIN_REQUEST_SUCCESS,
 	MAGIC_LOGIN_HIDE_REQUEST_FORM,
@@ -100,7 +100,7 @@ async function postMagicLoginRequest( url, bodyObj ) {
 	if ( response.ok ) {
 		return await response.json();
 	}
-	throw new HttpError( response.status, await response.body );
+	throw new HTTPError( response.status, await response.body );
 }
 
 /**

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -30,10 +30,10 @@ const errorFields = {
 	invalid_username: 'usernameOrEmail',
 };
 
-export class HttpError extends Error {
+export class HTTPError extends Error {
 	constructor( response, body ) {
 		super();
-		this.name = 'HttpError';
+		this.name = 'HTTPError';
 		this.status = response.status;
 		try {
 			this.response = { body: JSON.parse( body ) };

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -37,7 +37,7 @@ export class HTTPError extends Error {
 		this.status = response.status;
 		try {
 			this.response = { body: JSON.parse( body ) };
-		} catch ( error ) {
+		} catch {
 			this.response = { body };
 		}
 	}

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -31,6 +29,19 @@ const errorFields = {
 	invalid_two_step_code: 'twoStepCode',
 	invalid_username: 'usernameOrEmail',
 };
+
+export class HttpError extends Error {
+	constructor( response, body ) {
+		super();
+		this.name = 'HttpError';
+		this.status = response.status;
+		try {
+			this.response = { body: JSON.parse( body ) };
+		} catch ( error ) {
+			this.response = { body };
+		}
+	}
+}
 
 /**
  * Retrieves the first error message from the specified HTTP error.


### PR DESCRIPTION
Some modules used `superagent`, a 3rd party `npm` package, for network requests, and have here been rewritten to use native `fetch` instead.

This is part of an effort to remove `superagent` from client code altogether, and replace it with native `fetch` functionality. This will eventually lead to being able to drop that dependency from the client-side bundle, thus improving loading performance.

#### Changes proposed in this Pull Request

* Replace usage of `superagent` in `state/login` with native `fetch`

#### Testing instructions

Ensure that login and magic login continue working correctly. Some things to try:
* Regular login
* Social login
* Magic login
* 2FA

Error conditions (such as providing the wrong password) should be tested too.