### PR TITLE
Activity Log: display DB table threats

### DIFF
--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -28,6 +28,11 @@ import './threat-alert.scss';
 const debug = debugFactory( 'calypso:activity-log' );
 
 const detailType = threat => {
+
+	if ( threat.hasOwnProperty( 'table' ) ) {
+		return 'table';
+	}
+
 	if ( threat.hasOwnProperty( 'diff' ) ) {
 		return 'core';
 	}
@@ -49,6 +54,19 @@ const headerTitle = ( translate, threat ) => {
 	const basename = s => s.replace( /.*\//, '' );
 
 	switch ( detailType( threat ) ) {
+		case 'table':
+			return translate(
+				'The table {{table/}} contains a suspicious link.',
+				'The table {{table/}} contains suspicious links.',
+				{
+					components: {
+						table: (
+							<code className="activity-log__threat-alert-table">{threat.table}</code>
+						),
+					},
+					count: threat.rows.length,
+				});
+
 		case 'core':
 			return translate( 'The file {{filename/}} has been modified from its original.', {
 				components: {

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -28,6 +28,7 @@ import './threat-alert.scss';
 const debug = debugFactory( 'calypso:activity-log' );
 
 const detailType = threat => {
+	console.log( threat );
 
 	if ( threat.hasOwnProperty( 'table' ) ) {
 		return 'table';
@@ -123,6 +124,7 @@ const headerSubtitle = ( translate, threat ) => {
 			return translate( 'Vulnerability found in WordPress' );
 
 		case 'file':
+		case 'table':
 			return translate( 'Threat found ({{signature/}})', {
 				components: {
 					signature: (
@@ -144,6 +146,55 @@ const headerSubtitle = ( translate, threat ) => {
 };
 
 export class ThreatAlert extends Component {
+
+	formatTableRows = ( rows ) => {
+		let l;
+
+		rows.forEach( ( row, i ) => {
+			l = (
+				<p>{ row.url }</p>
+			);
+		} );
+	};
+
+	mainDescription() {
+		const { threat } = this.props;
+
+		if ( threat.filename ) {
+			return (
+				<Fragment>
+					<p>
+						{ translate( 'Threat {{threatSignature/}} found in file:', {
+							comment:
+								'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
+							components: {
+								threatSignature: (
+									<span className="activity-log__threat-alert-signature">
+										{ threat.signature }
+									</span>
+								),
+							},
+						} ) }
+					</p>
+					<pre className="activity-log__threat-alert-filename">{ threat.filename }</pre>
+				</Fragment>
+			);
+		}
+
+		if ( threat.table ) {
+			return (
+
+				<Fragment>
+					<p>This is a table threat</p>
+				</Fragment>
+			);
+		}
+
+		return (
+			<p className="activity-log__threat-alert-signature">{ threat.signature }</p>
+		);
+	}
+
 	render() {
 		const { threat, translate } = this.props;
 
@@ -207,26 +258,7 @@ export class ThreatAlert extends Component {
 				>
 					<Fragment>
 						<p className="activity-log__threat-alert-description">{ threat.description }</p>
-						{ threat.filename ? (
-							<Fragment>
-								<p>
-									{ translate( 'Threat {{threatSignature/}} found in file:', {
-										comment:
-											'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
-										components: {
-											threatSignature: (
-												<span className="activity-log__threat-alert-signature">
-													{ threat.signature }
-												</span>
-											),
-										},
-									} ) }
-								</p>
-								<pre className="activity-log__threat-alert-filename">{ threat.filename }</pre>
-							</Fragment>
-						) : (
-							<p className="activity-log__threat-alert-signature">{ threat.signature }</p>
-						) }
+						{ this.mainDescription() }
 						{ threat.context && <MarkedLines context={ threat.context } /> }
 						{ threat.diff && <DiffViewer diff={ threat.diff } /> }
 					</Fragment>

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -28,8 +28,6 @@ import './threat-alert.scss';
 const debug = debugFactory( 'calypso:activity-log' );
 
 const detailType = threat => {
-	console.log( threat );
-
 	if ( threat.hasOwnProperty( 'table' ) ) {
 		return 'table';
 	}
@@ -61,12 +59,11 @@ const headerTitle = ( translate, threat ) => {
 				'The table {{table/}} contains suspicious links.',
 				{
 					components: {
-						table: (
-							<code className="activity-log__threat-alert-table">{threat.table}</code>
-						),
+						table: <code className="activity-log__threat-alert-table">{ threat.table }</code>,
 					},
 					count: threat.rows.length,
-				});
+				}
+			);
 
 		case 'core':
 			return translate( 'The file {{filename/}} has been modified from its original.', {
@@ -146,32 +143,18 @@ const headerSubtitle = ( translate, threat ) => {
 };
 
 export class ThreatAlert extends Component {
-
-	formatTableRows = ( rows ) => {
-		let l;
-
-		rows.forEach( ( row, i ) => {
-			l = (
-				<p>{ row.url }</p>
-			);
-		} );
-	};
-
 	mainDescription() {
-		const { threat } = this.props;
+		const { threat, translate } = this.props;
 
 		if ( threat.filename ) {
 			return (
 				<Fragment>
 					<p>
 						{ translate( 'Threat {{threatSignature/}} found in file:', {
-							comment:
-								'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
+							comment: 'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
 							components: {
 								threatSignature: (
-									<span className="activity-log__threat-alert-signature">
-										{ threat.signature }
-									</span>
+									<span className="activity-log__threat-alert-signature">{ threat.signature }</span>
 								),
 							},
 						} ) }
@@ -183,16 +166,20 @@ export class ThreatAlert extends Component {
 
 		if ( threat.table ) {
 			return (
-
 				<Fragment>
-					<p>This is a table threat</p>
+					{ Object.values( threat.rows ).map( row => (
+						<div key={ row.id }>
+							<p>{ row.description }</p>
+							<p>{ threat.objectType }</p>
+							<p>{ row.id }</p>
+							<p>{ row.url }</p>
+						</div>
+					) ) }
 				</Fragment>
 			);
 		}
 
-		return (
-			<p className="activity-log__threat-alert-signature">{ threat.signature }</p>
-		);
+		return <p className="activity-log__threat-alert-signature">{ threat.signature }</p>;
 	}
 
 	render() {

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -5,6 +5,7 @@
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import MarkedLines from 'components/marked-lines';
 import TimeSince from 'components/time-since';
 import PopoverMenuItem from 'components/popover/menu-item';
 import SplitButton from 'components/split-button';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 /**
  * Style dependencies
@@ -144,7 +146,7 @@ const headerSubtitle = ( translate, threat ) => {
 
 export class ThreatAlert extends Component {
 	mainDescription() {
-		const { threat, translate } = this.props;
+		const { siteSlug, threat, translate } = this.props;
 
 		if ( threat.filename ) {
 			return (
@@ -169,10 +171,16 @@ export class ThreatAlert extends Component {
 				<Fragment>
 					{ Object.values( threat.rows ).map( row => (
 						<div key={ row.id }>
-							<p>{ row.description }</p>
-							<p>{ threat.objectType }</p>
-							<p>{ row.id }</p>
-							<p>{ row.url }</p>
+							<pre className="activity-log__threat-alert-row-description">
+								{ threat.objectType } id { row.id } ( { row.description } ) contains the malicious
+								link { row.url }
+							</pre>
+							<a
+								className="activity-log__threat-alert-row-link"
+								href={ `/post/${ siteSlug }/${ row.id }` }
+							>
+								Edit post
+							</a>
 						</div>
 					) ) }
 				</Fragment>
@@ -255,4 +263,8 @@ export class ThreatAlert extends Component {
 	}
 }
 
-export default localize( ThreatAlert );
+const mapStateToProps = state => ( {
+	siteSlug: getSelectedSiteSlug( state ),
+} );
+
+export default connect( mapStateToProps )( localize( ThreatAlert ) );

--- a/client/my-sites/activity/activity-log/threat-alert.scss
+++ b/client/my-sites/activity/activity-log/threat-alert.scss
@@ -105,3 +105,8 @@
 		content: '\00b7\2004';
 	}
 }
+
+pre.activity-log__threat-alert-row-description {
+	margin-top: 1rem;
+	margin-bottom: 0;
+}

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -187,7 +187,9 @@ export const requestSiteAlerts = siteId => {
 										},
 								  }
 								: {} ),
-							...( threat.table ? { table: threat.table, rows: threat.rows } : {} ),
+							...( threat.table
+								? { table: threat.table, rows: threat.rows, objectType: threat.objectType }
+								: {} ),
 						} ) ),
 						warnings,
 						updates: {

--- a/client/state/data-getters/index.js
+++ b/client/state/data-getters/index.js
@@ -187,6 +187,7 @@ export const requestSiteAlerts = siteId => {
 										},
 								  }
 								: {} ),
+							...( threat.table ? { table: threat.table, rows: threat.rows } : {} ),
 						} ) ),
 						warnings,
 						updates: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change adds a persistent threat notice to the top of the Activity Log for threats found while scanning the site database pa0RFL-ld-p2.

Default state:
<img width="954" alt="Screenshot 2019-07-24 at 15 16 42" src="https://user-images.githubusercontent.com/7767559/61801437-ad3da780-ae26-11e9-8d7b-f13eb7e44d2d.png">

Expanded state (expanded by clicking on the card):
<img width="955" alt="Screenshot 2019-07-24 at 15 16 54" src="https://user-images.githubusercontent.com/7767559/61801443-b0389800-ae26-11e9-9e6c-20ac3c3ac832.png">

**Note that the `post id ( )` part should contain post id and post title, but this bug is preventing that for some sites: 913-gh-jetpack-backups.**

Current information we can show for one link is:
* post id
* post title
* link text
* a link to the post editor

#### Testing instructions

Complicated right now. Instructions will follow after the merge of another PR.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
