### PR TITLE
Remove `superagent` usage from lib/wporg.

### DIFF
--- a/client/lib/plugins/wporg-data/actions.js
+++ b/client/lib/plugins/wporg-data/actions.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 
 /**
@@ -11,7 +8,7 @@ import debugFactory from 'debug';
  */
 import Dispatcher from 'dispatcher';
 import wpcom from 'lib/wp';
-import wporg from 'lib/wporg';
+import { fetchPluginsList as fetchWporgPluginsList } from 'lib/wporg';
 import { normalizePluginsList } from 'lib/plugins/utils';
 import impureLodash from 'lib/impure-lodash';
 
@@ -67,7 +64,7 @@ const PluginsDataActions = {
 			return;
 		}
 
-		wporg.fetchPluginsList(
+		fetchWporgPluginsList(
 			{
 				pageSize: _LIST_DEFAULT_SIZE,
 				page: page,

--- a/client/lib/plugins/wporg-data/test/actions.js
+++ b/client/lib/plugins/wporg-data/test/actions.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -9,7 +8,7 @@ import { spy } from 'sinon';
  * Internal dependencies
  */
 import WPorgActions from 'lib/plugins/wporg-data/actions';
-import mockedWporg from 'lib/wporg';
+import * as mockedWporg from 'lib/wporg';
 jest.mock( 'lib/wporg', () => require( './mocks/wporg' ) );
 jest.mock( 'lib/impure-lodash', () => ( {
 	debounce: cb => cb,
@@ -38,7 +37,7 @@ describe( 'WPorg Data Actions', () => {
 	} );
 
 	test( "when fetching a plugin list, it shouldn't do the wporg request if there's a previous one still not finished for the same category", () => {
-		mockedWporg.deactivatedCallbacks = true;
+		mockedWporg.setInternalState( { deactivatedCallbacks: true } );
 		WPorgActions.fetchPluginsList( 'new', 1 );
 		WPorgActions.fetchPluginsList( 'new', 1 );
 		assert.equal( mockedWporg.getActivity().fetchPluginsList, 1 );
@@ -68,7 +67,7 @@ describe( 'WPorg Data Actions', () => {
 	} );
 
 	test( 'when fetching for the next page, it should not do any request if the next page is over the number of total pages', () => {
-		mockedWporg.mockedNumberOfReturnedPages = 1;
+		mockedWporg.setInternalState( { mockedNumberOfReturnedPages: 1 } );
 		WPorgActions.fetchPluginsList( 'new', 1 );
 		WPorgActions.fetchNextCategoryPage( 'new' );
 		assert.equal( mockedWporg.getActivity().fetchPluginsList, 1 );

--- a/client/lib/plugins/wporg-data/test/mocks/wporg.js
+++ b/client/lib/plugins/wporg-data/test/mocks/wporg.js
@@ -1,30 +1,40 @@
-/** @format */
-let fetchPluginsListCalls = 0,
-	lastRequestParams = null;
+let fetchPluginsListCalls = 0;
+let lastRequestParams = null;
 
-export default {
-	deactivatedCallbacks: false,
-	mockedNumberOfReturnedPages: 10,
-	reset: function() {
-		fetchPluginsListCalls = 0;
-		this.mockedNumberOfReturnedPages = 10;
-		this.deactivatedCallbacks = false;
-		lastRequestParams = null;
-	},
-	getActivity: function() {
-		return {
-			fetchPluginsList: fetchPluginsListCalls,
-			lastRequestParams: lastRequestParams,
-		};
-	},
-	fetchPluginsList: function( options, callback ) {
-		fetchPluginsListCalls++;
-		lastRequestParams = options;
-		if ( ! this.deactivatedCallbacks ) {
-			callback( null, {
-				plugins: [],
-				info: { pages: this.mockedNumberOfReturnedPages },
-			} );
-		}
-	},
-};
+let deactivatedCallbacks = false;
+let mockedNumberOfReturnedPages = 10;
+
+export function setInternalState( state ) {
+	if ( state.mockedNumberOfReturnedPages !== undefined ) {
+		mockedNumberOfReturnedPages = state.mockedNumberOfReturnedPages;
+	}
+
+	if ( state.deactivatedCallbacks !== undefined ) {
+		deactivatedCallbacks = state.deactivatedCallbacks;
+	}
+}
+
+export function reset() {
+	fetchPluginsListCalls = 0;
+	mockedNumberOfReturnedPages = 10;
+	deactivatedCallbacks = false;
+	lastRequestParams = null;
+}
+
+export function getActivity() {
+	return {
+		fetchPluginsList: fetchPluginsListCalls,
+		lastRequestParams: lastRequestParams,
+	};
+}
+
+export function fetchPluginsList( options, callback ) {
+	fetchPluginsListCalls++;
+	lastRequestParams = options;
+	if ( ! deactivatedCallbacks ) {
+		callback( null, {
+			plugins: [],
+			info: { pages: mockedNumberOfReturnedPages },
+		} );
+	}
+}

--- a/client/lib/wporg/index.js
+++ b/client/lib/wporg/index.js
@@ -1,13 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import i18n from 'i18n-calypso';
-import superagent from 'superagent';
 import { find } from 'lodash';
+import { stringify as stringifyQs } from 'qs';
 
 /**
  * Internal dependencies
@@ -38,117 +35,137 @@ function getWporgLocaleCode() {
 	return wpOrgLocaleCode;
 }
 
-export default {
-	/**
-	 * Fetches details for a particular plugin.
-	 * @param {string} pluginSlug The plugin identifier.
-	 * @returns {Promise} Promise with the plugins details.
-	 */
-	fetchPluginInformation: function( pluginSlug ) {
-		const query = {
-			fields: 'icons,banners,compatibility,ratings,-contributors',
-			locale: getWporgLocaleCode(),
-		};
-
-		pluginSlug = pluginSlug.replace( new RegExp( '.php$' ), '' );
-
-		const baseUrl = 'https://api.wordpress.org/plugins/info/1.0/' + pluginSlug + '.jsonp';
-
-		return new Promise( ( resolve, reject ) => {
-			jsonp( baseUrl, query, function( error, data ) {
-				if ( error ) {
-					debug( 'error downloading plugin details from .org: %s', error );
-					reject( error );
-					return;
-				}
-
-				if ( ! data || ! data.slug ) {
-					debug( 'unrecognized format fetching plugin details from .org: %s', data );
-					reject( new Error( 'Unrecognized response format' ) );
-					return;
-				}
-
-				resolve( data );
-			} );
+async function pluginRequest( url, body ) {
+	try {
+		const response = await fetch( url, {
+			method: 'POST',
+			headers: { Accept: 'application/json', 'Content-Type': 'application/x-www-form-urlencoded' },
+			body,
 		} );
-	},
-	fetchPluginsList: function( options, callback ) {
-		let payload;
-		// default variables;
-		const page = options.page || DEFAULT_FIRST_PAGE;
-		const pageSize = options.pageSize || DEFAULT_PAGE_SIZE;
-		const category = options.category || DEFAULT_CATEGORY;
-		const search = options.search;
 
-		payload =
-			'request[page]=' +
-			page +
-			'&request[per_page]=' +
-			pageSize +
-			'&request[fields][icons]=1&request[fields][banners]=1' +
-			'&request[fields][compatibility]=1&request[fields][tested]=0' +
-			'&request[fields][requires]=0&request[fields][sections]=0';
-
-		if ( search ) {
-			payload += '&request[search]=' + search;
-		} else {
-			payload += '&request[browse]=' + category;
+		if ( response.ok ) {
+			return [ null, await response.json() ];
 		}
-		superagent
-			.post( WPORG_PLUGINS_LIST )
-			.set( 'Accept', 'application/json' )
-			.send( encodeURI( payload ) )
-			.end( function( err, data ) {
-				callback( err, data.body );
-			} );
-	},
-	/**
-	 * Get information about a given theme from the WordPress.org API.
-	 * If provided with a callback, will call that on succes with an object with theme details.
-	 * Otherwise, will return a promise.
-	 *
-	 * @param {string}     themeId  The theme identifier.
-	 * @returns {Promise.<Object>}  A promise that returns a `theme` object
-	 */
-	fetchThemeInformation: function( themeId ) {
-		const query = {
-			action: 'theme_information',
-			// Return an `author` object containing `user_nicename` and `display_name` attrs.
-			// This is for consistency with WP.com, which always returns the display name as `author`.
-			'request[fields][extended_author]': true,
-			'request[slug]': themeId,
-		};
-		return superagent
-			.get( WPORG_THEMES_ENDPOINT )
-			.set( 'Accept', 'application/json' )
-			.query( query )
-			.then( ( { body } ) => body );
-	},
-	/**
-	 * Get information about a given theme from the WordPress.org API.
-	 *
-	 * @param  {Object}        options         Theme query
-	 * @param  {String}        options.search  Search string
-	 * @param  {Number}        options.number  How many themes to return per page
-	 * @param  {Number}        options.page    Which page of matching themes to return
-	 * @returns {Promise.<Object>}             A promise that returns an object containing a `themes` array and an `info` object
-	 */
-	fetchThemesList: function( options = {} ) {
-		const { search, page, number } = options;
-		const query = {
-			action: 'query_themes',
-			// Return an `author` object containing `user_nicename` and `display_name` attrs.
-			// This is for consistency with WP.com, which always returns the display name as `author`.
-			'request[fields][extended_author]': true,
-			'request[search]': search,
-			'request[page]': page,
-			'request[per_page]:': number,
-		};
+		return [ new Error( await response.body ), null ];
+	} catch ( error ) {
+		return [ error, null ];
+	}
+}
 
-		return superagent
-			.get( WPORG_THEMES_ENDPOINT )
-			.set( 'Accept', 'application/json' )
-			.query( query )
-			.then( ( { body } ) => body );
-	},
-};
+async function themeRequest( url, query ) {
+	const response = await fetch( `${ url }?${ stringifyQs( query ) }`, {
+		method: 'GET',
+		headers: { Accept: 'application/json' },
+	} );
+
+	if ( response.ok ) {
+		return await response.json();
+	}
+	throw new Error( await response.body );
+}
+
+/**
+ * Fetches details for a particular plugin.
+ * @param {string} pluginSlug The plugin identifier.
+ * @returns {Promise} Promise with the plugins details.
+ */
+export function fetchPluginInformation( pluginSlug ) {
+	const query = {
+		fields: 'icons,banners,compatibility,ratings,-contributors',
+		locale: getWporgLocaleCode(),
+	};
+
+	pluginSlug = pluginSlug.replace( new RegExp( '.php$' ), '' );
+
+	const baseUrl = 'https://api.wordpress.org/plugins/info/1.0/' + pluginSlug + '.jsonp';
+
+	return new Promise( ( resolve, reject ) => {
+		jsonp( baseUrl, query, function( error, data ) {
+			if ( error ) {
+				debug( 'error downloading plugin details from .org: %s', error );
+				reject( error );
+				return;
+			}
+
+			if ( ! data || ! data.slug ) {
+				debug( 'unrecognized format fetching plugin details from .org: %s', data );
+				reject( new Error( 'Unrecognized response format' ) );
+				return;
+			}
+
+			resolve( data );
+		} );
+	} );
+}
+
+export function fetchPluginsList( options, callback ) {
+	let payload;
+	// default variables;
+	const page = options.page || DEFAULT_FIRST_PAGE;
+	const pageSize = options.pageSize || DEFAULT_PAGE_SIZE;
+	const category = options.category || DEFAULT_CATEGORY;
+	const search = options.search;
+
+	payload =
+		'request[page]=' +
+		page +
+		'&request[per_page]=' +
+		pageSize +
+		'&request[fields][icons]=1&request[fields][banners]=1' +
+		'&request[fields][compatibility]=1&request[fields][tested]=0' +
+		'&request[fields][requires]=0&request[fields][sections]=0';
+
+	if ( search ) {
+		payload += '&request[search]=' + search;
+	} else {
+		payload += '&request[browse]=' + category;
+	}
+
+	pluginRequest( WPORG_PLUGINS_LIST, encodeURI( payload ) ).then( ( [ err, data ] ) => {
+		callback( err, data );
+	} );
+}
+
+/**
+ * Get information about a given theme from the WordPress.org API.
+ * If provided with a callback, will call that on succes with an object with theme details.
+ * Otherwise, will return a promise.
+ *
+ * @param {string}     themeId  The theme identifier.
+ * @returns {Promise.<Object>}  A promise that returns a `theme` object
+ */
+export function fetchThemeInformation( themeId ) {
+	const query = {
+		action: 'theme_information',
+		// Return an `author` object containing `user_nicename` and `display_name` attrs.
+		// This is for consistency with WP.com, which always returns the display name as `author`.
+		'request[fields][extended_author]': true,
+		'request[slug]': themeId,
+	};
+
+	return themeRequest( WPORG_THEMES_ENDPOINT, query );
+}
+
+/**
+ * Get information about a given theme from the WordPress.org API.
+ *
+ * @param  {Object}        options         Theme query
+ * @param  {String}        options.search  Search string
+ * @param  {Number}        options.number  How many themes to return per page
+ * @param  {Number}        options.page    Which page of matching themes to return
+ * @returns {Promise.<Object>}             A promise that returns an object containing a `themes` array and an `info` object
+ */
+export function fetchThemesList( options = {} ) {
+	const { search, page, number } = options;
+	const query = {
+		action: 'query_themes',
+		// Return an `author` object containing `user_nicename` and `display_name` attrs.
+		// This is for consistency with WP.com, which always returns the display name as `author`.
+		'request[fields][extended_author]': true,
+		'request[search]': search,
+		'request[page]': page,
+		'request[per_page]:': number,
+	};
+
+	return themeRequest( WPORG_THEMES_ENDPOINT, query );
+}

--- a/client/state/plugins/wporg/actions.js
+++ b/client/state/plugins/wporg/actions.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -9,7 +8,7 @@ const debug = debugFactory( 'calypso:wporg-data:actions' );
 /**
  * Internal dependencies
  */
-import wporg from 'lib/wporg';
+import { fetchPluginInformation } from 'lib/wporg';
 import { normalizePluginData } from 'lib/plugins/utils';
 import { WPORG_PLUGIN_DATA_RECEIVE, FETCH_WPORG_PLUGIN_DATA } from 'state/action-types';
 
@@ -30,7 +29,7 @@ export function fetchPluginData( pluginSlug ) {
 		} );
 
 		try {
-			const data = await wporg.fetchPluginInformation( pluginSlug );
+			const data = await fetchPluginInformation( pluginSlug );
 
 			debug( 'plugin details fetched from .org', pluginSlug, data );
 			dispatch( {

--- a/client/state/plugins/wporg/test/actions.js
+++ b/client/state/plugins/wporg/test/actions.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -11,7 +10,7 @@ import thunk from 'redux-thunk';
 import { fetchPluginData } from '../actions';
 import wporgReducer from '../reducer';
 import { combineReducers } from 'state/utils';
-import wporg from 'lib/wporg';
+import * as wporg from 'lib/wporg';
 
 jest.mock( 'lib/wporg', () => ( {
 	fetchPluginInformation: jest.fn( slug => Promise.resolve( { slug } ) ),

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { filter, map, property, delay, endsWith } from 'lodash';
 import debugFactory from 'debug';
 import page from 'page';
@@ -13,7 +10,10 @@ import page from 'page';
  */
 import { isExternal } from 'lib/url';
 import wpcom from 'lib/wp';
-import wporg from 'lib/wporg';
+import {
+	fetchThemesList as fetchWporgThemesList,
+	fetchThemeInformation as fetchWporgThemeInformation,
+} from 'lib/wporg';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -165,7 +165,7 @@ export function requestThemes( siteId, query = {} ) {
 		let request;
 
 		if ( siteId === 'wporg' ) {
-			request = () => wporg.fetchThemesList( query );
+			request = () => fetchWporgThemesList( query );
 		} else if ( siteId === 'wpcom' ) {
 			request = () => wpcom.undocumented().themes( null, { ...query, apiVersion: '1.2' } );
 		} else {
@@ -240,8 +240,7 @@ export function requestTheme( themeId, siteId ) {
 		} );
 
 		if ( siteId === 'wporg' ) {
-			return wporg
-				.fetchThemeInformation( themeId )
+			return fetchWporgThemeInformation( themeId )
 				.then( theme => {
 					// Apparently, the WP.org REST API endpoint doesn't 404 but instead returns false
 					// if a theme can't be found.
@@ -651,7 +650,7 @@ export function clearThemeUpload( siteId ) {
  * @returns {Promise} for testing purposes only
  */
 export function initiateThemeTransfer( siteId, file, plugin ) {
-	const context = !! plugin ? 'plugins' : 'themes';
+	const context = plugin ? 'plugins' : 'themes';
 	return dispatch => {
 		const themeInitiateRequest = {
 			type: THEME_TRANSFER_INITIATE_REQUEST,
@@ -723,7 +722,7 @@ function transferStatusFailure( siteId, transferId, error ) {
 
 // receive a transfer initiation failure
 function transferInitiateFailure( siteId, error, plugin ) {
-	const context = !! plugin ? 'plugin' : 'theme';
+	const context = plugin ? 'plugin' : 'theme';
 	return dispatch => {
 		const themeInitiateFailureAction = {
 			type: THEME_TRANSFER_INITIATE_FAILURE,
@@ -768,7 +767,7 @@ export function pollThemeTransferStatus( siteId, transferId, interval = 3000, ti
 					dispatch( transferStatus( siteId, transferId, status, message, uploaded_theme_slug ) );
 					if ( status === 'complete' ) {
 						// finished, stop polling
-						const context = !! uploaded_theme_slug ? 'themes' : 'plugins';
+						const context = uploaded_theme_slug ? 'themes' : 'plugins';
 						dispatch(
 							recordTracksEvent( 'calypso_automated_transfer_complete', {
 								transfer_id: transferId,

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -1,9 +1,10 @@
-/** @format */
 /**
  * External dependencies
  */
 import { expect } from 'chai';
 import sinon from 'sinon';
+// Importing `jest-fetch-mock` adds a jest-friendly `fetch` polyfill to the global scope.
+import 'jest-fetch-mock';
 
 /**
  * Internal dependencies
@@ -365,7 +366,7 @@ describe( 'actions', () => {
 						'/themes/info/1.1/?action=theme_information&request%5Bfields%5D%5Bextended_author%5D=true' +
 							'&request%5Bslug%5D=twentyumpteen'
 					)
-					.reply( 200, false );
+					.reply( 200, 'false' );
 			} );
 
 			test( 'should dispatch request action when thunk triggered', () => {


### PR DESCRIPTION
`lib/wporg` used `superagent`, a 3rd party `npm` package, for network requests, and has here been rewritten to use native `fetch` instead.

In addition, this change modifies `lib/wporg` to export multiple functions, rather than exporting a single composite default object.

#### Changes proposed in this Pull Request

* Replace `superagent` with native `fetch` in `lib/wporg`
* Rewrite `lib/wporg` as a series of exports, rather than a composite default export
* Modify consumers of `lib/wporg` to accept new interface
* Fix themes actions test to mock correct API response

#### Testing instructions

To test plugins:
* Go to `/plugins`
* Ensure that search works correctly, both for empty and non-empty result lists

To test themes:
I haven't found a good manual mechanism for testing the theme-related `wporg` API calls. However, the unit tests for this are pretty extensive, mocking actual API responses for all kinds of scenarios. Apart from a response that was incorrectly mocked (`false` instead of `'false'`), all of the tests work without any changes.
