### PR TITLE
FSE: ensure that page templates stay valid on wpcom

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/template-validity-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/template-validity-override/index.js
@@ -3,8 +3,7 @@
 /**
  * External dependencies
  */
-import domReady from '@wordpress/dom-ready';
-import { dispatch } from '@wordpress/data';
+import { select, dispatch, subscribe } from '@wordpress/data';
 
 /**
  * Forces the template validity.
@@ -14,12 +13,13 @@ import { dispatch } from '@wordpress/data';
  *
  * @see https://github.com/WordPress/gutenberg/issues/11681
  */
-function resetTemplateValidity() {
+const unsubscribe = subscribe( () => {
 	if ( 'page' !== fullSiteEditing.editorPostType ) {
-		return;
+		return unsubscribe();
 	}
-
-	dispatch( 'core/editor' ).setTemplateValidity( true );
-}
-
-domReady( () => resetTemplateValidity() );
+	if ( select( 'core/editor' ).isValidTemplate() === false ) {
+		dispatch( 'core/editor' ).setTemplateValidity( true );
+		// should only need to do this once
+		unsubscribe();
+	}
+} );


### PR DESCRIPTION
Previously, we had a hack which helped us maintain template validity in the editor. Matt and I are guessing that this worked fine for local development, but that on the sandbox, things move slowly enough that this function is called at a time when the change doesn't stick, or something isn't available.

**This is what the bug looked like. It should no longer appear.**
<img width="583" alt="Screenshot 2019-07-19 at 16 32 51" src="https://user-images.githubusercontent.com/1182160/61544248-4f374b80-aa45-11e9-878c-1308ee5817f8.png">

### Changes proposed in this Pull Request
* Instead of maintaining validity via `domReady`, use a wp.data subscriber to maintain validity once everything is online.

_You can skip setup if you already have the sync stuff working_
### FSE Sandbox Setup:
1) You'll need to test this on your sandbox, so you'll want to make sure you have this setup ready to go: PCYsg-ly5-p2 (developing-against-wp-com-sandbox) I added a force option to my unison config which makes my own machine the source of truth and disregards any changes on the remote. This makes sure that the sandbox plugin stuff === what's in this PR.
2) You'll also need to make sure that you add the fse sticker (PCYsg-ly5-p2 activating-the-plugin-on-wordpress-com) to your sandbox site so that it activates the changes properly,

### Testing
_Make sure you can sync this PR to your sandbox before continuing ^^_
1) Create a new page in wp admin. You should be able to see FSE header/footer. Save it.
2) Now, go out of the page back to wp admin. Then, go back into the page. Previously, the error above would have appeared at the top. If you do not see the error, then this PR is working!
3) Also try editing an existing page on your sandbox from calypso. The error should not show there either.

Now, when I go back into the page editor for these existing page, it is not loading the FSE editor. (i.e. the post content is not inside a post content block and the header/footer don't show up). I believe that is unrelated and possibly just an issue with my setup.

Fixes #34784