### PR TITLE
FSE: Update the FSE navigation block to support a page menu fallback

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.js
@@ -26,12 +26,6 @@ registerBlockType( 'a8c/navigation-menu', {
 		html: false,
 		reusable: false,
 	},
-	attributes: {
-		themeLocation: {
-			type: 'string',
-			default: 'menu-1',
-		},
-	},
 	edit,
 	save: () => null,
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -4,94 +4,49 @@
  *
  * @package full-site-editing
  */
-
-/**
- * Determines necessary wp_nav_menu() parameters by given theme location.
- *
- * @param string $location Theme location.
- * @return array
- */
-function get_menu_params_by_theme_location( $location ) {
-	switch ( $location ) {
-		case 'footer':
-			$params = [
-				'theme_location' => 'footer',
-				'menu_class'     => 'footer-menu',
-				'depth'          => 1,
-			];
-			break;
-		case 'social':
-			$params = [
-				'theme_location' => 'social',
-				'menu_class'     => 'social-links-menu',
-				'link_before'    => '<span class="screen-reader-text">',
-				'link_after'     => '</span>' . twentynineteen_get_icon_svg( 'link' ),
-				'depth'          => 1,
-			];
-			break;
-		case 'main-1':
-		default:
-			$params = [
-				'theme_location' => 'menu-1',
-				'menu_class'     => 'main-menu',
-				'items_wrap'     => '<ul id="%1$s" class="%2$s">%3$s</ul>',
-				'depth'          => 1,
-			];
-			break;
-	}
-	return $params;
-}
-
-/**
- * Determines necessary attributes for the wrapping `nav` element.
- *
- * @param string $location Theme location.
- * @return array
- */
-function get_wrapper_attributes_by_theme_location( $location ) {
-	switch ( $location ) {
-		case 'footer':
-			$attributes = [
-				'class' => 'footer-navigation',
-				'label' => 'Footer Menu',
-			];
-			break;
-		case 'social':
-			$attributes = [
-				'class' => 'social-navigation',
-				'label' => 'Social Links Menu',
-			];
-			break;
-		case 'main-1':
-		default:
-			$attributes = [
-				'class' => 'main-navigation',
-				'label' => 'Top Menu',
-			];
-			break;
-	}
-	return $attributes;
-}
-
-/**
- * Renders post content.
- *
- * @param array $attributes Block attributes.
- * @return string
- */
-function render_navigation_menu_block( $attributes ) {
-	$location     = ! empty( $attributes['themeLocation'] ) ? $attributes['themeLocation'] : null;
-	$wrapper_attr = get_wrapper_attributes_by_theme_location( $location );
-	$class_name   = ! empty( $attributes['className'] ) ? ' ' . $attributes['className'] : '';
+function a8c_fse_render_navigation_menu_block( $attributes ) {
 	ob_start();
 	// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText
 	?>
-	<nav class="<?php echo esc_attr( $wrapper_attr['class'] . ' wp-block-a8c-navigation-menu' . $class_name ); ?>" aria-label="<?php esc_attr_e( $wrapper_attr['label'], 'twentynineteen' ); ?>">
-		<?php
-			wp_nav_menu( get_menu_params_by_theme_location( $location ) );
-		?>
+	<nav class="main-navigation wp-block-a8c-navigation-menu">
+		<div class="menu-nav-container">
+			<?php
+			echo wp_nav_menu([
+				'theme_location' => 'menu-1',
+				'menu_class'     => 'main-menu',
+				'fallback_cb' => 'a8c_fse_get_fallback_navigation_menu'
+			]);
+			?>
+		</div>
 	</nav>
 	<!-- #site-navigation -->
 	<?php
 	return ob_get_clean();
+}
+
+/**
+ * Render a list of all site pages as a fallback
+ * for when a menu does not exist.
+ *
+ * @package full-site-editing
+ */
+function a8c_fse_get_fallback_navigation_menu() {
+	$menu = wp_page_menu([
+		'echo' => 0,
+		'sort_column' => 'post_date',
+		'container' => 'ul',
+		'menu_class' => 'main-menu default-menu',
+		'before' => false,
+		'after' => false
+	]);
+
+	/**
+	 * Filter the fallback page menu to use the same
+	 * CSS class structure as a regularly built menu
+	 * so we don't have to duplicate CSS selectors everywhere.
+	 */
+	$original_classes = [ 'children', 'page_item_has_sub-menu' ];
+	$replacement_classes = [ 'sub-menu', 'menu-item-has-children' ];
+
+	return str_replace( $original_classes, $replacement_classes, $menu );
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -323,16 +323,12 @@ class Full_Site_Editing {
 			'a8c/navigation-menu',
 			array(
 				'attributes'      => [
-					'themeLocation' => [
-						'default' => 'main-1',
-						'type'    => 'string',
-					],
 					'className'     => [
 						'default' => '',
 						'type'    => 'string',
 					],
 				],
-				'render_callback' => 'render_navigation_menu_block',
+				'render_callback' => 'a8c_fse_render_navigation_menu_block',
 			)
 		);
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Update the navigation block to provide a page navigation rendering function that can be used as the default. This means that all users that do not set up a page menu in the customizer will still get a functional page menu rendered.

#### Testing instructions

* Activate modern business with the following updates:  https://github.com/Automattic/themes/pull/1105
* Delete all menus from your site.
* Confirm that the navigation menu works, and displays the pages on your site in the order they were created.
* Confirm that sub pages work and display correctly. Reference graphic:

<img width="1030" alt="Screen Shot 2019-07-19 at 8 42 55 PM" src="https://user-images.githubusercontent.com/1464705/61573567-f2985880-aa65-11e9-8fcb-da85faa8a902.png">

* Add a new menu, and assign it to the primary theme location.
* Confirm the block adjusts to show this menu you have created.

Fixes https://github.com/Automattic/wp-calypso/issues/34429, #34608, #34793
