### PR TITLE
FSE: Handle post content block with no attributes when merging post with template

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -478,25 +478,7 @@ class Full_Site_Editing {
 			return;
 		}
 
-		$template_blocks = parse_blocks( $template_content );
-		$content_attrs   = $this->get_post_content_block_attrs( $template_blocks );
-
-		$wrapped_post_content = sprintf( '<!-- wp:a8c/post-content %s -->%s<!-- /wp:a8c/post-content -->', $content_attrs, $post->post_content );
-		$post->post_content   = str_replace( "<!-- wp:a8c/post-content $content_attrs /-->", $wrapped_post_content, $template_content );
-	}
-
-	/**
-	 * This will extract the attributes from the post content block
-	 * json encode them.
-	 *
-	 * @param array $blocks    An array of template blocks.
-	 */
-	private function get_post_content_block_attrs( $blocks ) {
-		foreach ( $blocks as $key => $value ) {
-			if ( 'a8c/post-content' === $value['blockName'] ) {
-				return count( $value['attrs'] ) > 0 ? wp_json_encode( $value['attrs'] ) : '';
-			}
-		}
+		$post->post_content = preg_replace( '@(<!-- wp:a8c/post-content)(.*?)(/-->)@', "$1$2-->$post->post_content<!-- /wp:a8c/post-content -->", $template_content );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In order to display the template on the editor, the FSE plugin merges the content with the template during the `the_post` action ([#](https://github.com/Automattic/wp-calypso/blob/d05a79ff74bac431ff30a2e74dab54746cc39475/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php#L35)). 

Previously, the plugin was assuming that any post content block present in the template will have attributes ([#](https://github.com/Automattic/wp-calypso/blob/d05a79ff74bac431ff30a2e74dab54746cc39475/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php#L481-L485)), but that won't be true after https://github.com/Automattic/themes/pull/1103, making the `str_replace` call to don't wrap the inner blocks in a post content block, since the expected pattern was not found.

This PR tries to make that merge more abstract by just copying the same markup present in the template. If there are no attributes, the wrapped post content block won't have them.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update your sandbox with the latest changes of the FSE plugin (D30622).
* Update your sandbox with the changes to the Modern Business theme available at https://github.com/Automattic/themes/pull/1103.
* Switch to the Modern Business theme. If that was already the active theme of your site, you'll need to delete the existing template parts and templates and then deactivate Modern Business. To make sure that when you reactivate modern business that it repopulates everything, you'll need to comment out the line in `inc/fse-template-data.php` where it bails to prevent multiple insertions. (line 29).
* Start creating a new page.
* Add some content save it.
* Reload the editor.
* Make sure the content previously added is present on the editor after the reload.

Fixes #34431
