### PR TITLE
Traffic: Remove Error for Non-Admins

### DIFF
--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -120,12 +120,6 @@ export const traffic = ( context, next ) => {
 	const state = store.getState();
 	const siteId = getSelectedSiteId( state );
 
-	if ( siteId && ! canCurrentUser( state, siteId, 'manage_options' ) ) {
-		notices.error(
-			translate( 'You are not authorized to manage sharing settings for this site.' )
-		);
-	}
-
 	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
 
 	if (


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the notice for non-admins when visiting the Traffic page; it isn't necessary with the already used EmptyContent component. Fixes #33032

<img width="1332" alt="Screenshot 2019-07-20 at 19 30 47" src="https://user-images.githubusercontent.com/43215253/61582653-49189c00-ab25-11e9-8711-3b5910d1d338.png">

#### Testing instructions

Visit `/marketing/traffic/` as a non-admin and verify that the notice error doesn't appear. 