### PR TITLE
Revert "AB test to show single plan"

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -14,8 +14,6 @@ import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { abtest } from 'lib/abtest';
-import { TYPE_PREMIUM } from 'lib/plans/constants';
 
 /**
  * Constants
@@ -43,31 +41,17 @@ class JetpackPlansGrid extends Component {
 
 	renderConnectHeader() {
 		const { isLanding, translate } = this.props;
-		const isPremiumOnly = abtest( 'singleJetpackPlan' ) === 'premiumOnly';
 
-		// mutable headers
-		let headerText = translate( 'Explore our Jetpack plans' );
+		const headerText = translate( 'Explore our Jetpack plans' );
 		let subheaderText = translate( "Now that you're set up, pick a plan that fits your needs." );
 
 		if ( isLanding ) {
 			subheaderText = translate( 'Pick a plan that fits your needs.' );
 		}
-
-		if ( isPremiumOnly ) {
-			headerText = translate( 'Build like a pro with Jetpack Premium' );
-			subheaderText = translate(
-				'Jetpack Premium automatically protects your site from spam, prevents data loss and enhances SEO'
-			);
-		}
-
 		return <FormattedHeader headerText={ headerText } subHeaderText={ subheaderText } />;
 	}
 
 	render() {
-		// single-plan AB test
-		const isPremiumOnly = abtest( 'singleJetpackPlan' ) === 'premiumOnly';
-		const planTypes = isPremiumOnly ? [ TYPE_PREMIUM ] : [];
-
 		return (
 			<MainWrapper isWide className="jetpack-connect__hide-plan-icons">
 				<div className="jetpack-connect__plans">
@@ -82,7 +66,6 @@ class JetpackPlansGrid extends Component {
 							intervalType={ this.props.interval }
 							hideFreePlan={ this.props.hideFreePlan }
 							displayJetpackPlans={ true }
-							planTypes={ planTypes }
 						/>
 
 						<PlansSkipButton onClick={ this.handleSkipButtonClick } />

--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -38,7 +38,6 @@ import canCurrentUser from 'state/selectors/can-current-user';
 import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import withTrackingTool from 'lib/analytics/with-tracking-tool';
-import { abtest } from 'lib/abtest';
 
 const CALYPSO_PLANS_PAGE = '/plans/';
 const CALYPSO_MY_PLAN_PAGE = '/plans/my-plan/';
@@ -197,8 +196,6 @@ class Plans extends Component {
 
 		const helpButtonLabel = translate( 'Need help?' );
 
-		const isPremiumOnly = abtest( 'singleJetpackPlan' ) === 'premiumOnly';
-
 		return (
 			<Fragment>
 				<DocumentHead title={ translate( 'Plans' ) } />
@@ -212,7 +209,7 @@ class Plans extends Component {
 					interval={ interval }
 					selectedSite={ selectedSite }
 				>
-					{ ! isPremiumOnly && <PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } /> }
+					<PlansExtendedInfo recordTracks={ this.handleInfoButtonClick } />
 					<LoggedOutFormLinks>
 						<JetpackConnectHappychatButton
 							label={ helpButtonLabel }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -135,13 +135,4 @@ export default {
 		defaultVariation: 'notSkippable',
 		allowExistingUsers: true,
 	},
-	singleJetpackPlan: {
-		datestamp: '20190715',
-		variations: {
-			premiumOnly: 20,
-			allPlans: 80,
-		},
-		defaultVariation: 'allPlans',
-		allowExistingUsers: true,
-	},
 };


### PR DESCRIPTION
Reverts Automattic/wp-calypso#34685

Hypothesis had a 99.7% confidence that allPlans was better within 2 days.