### PR TITLE
Display error when G Suite password reset failed

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
+++ b/client/my-sites/domains/components/domain-warnings/pending-gsuite-tos-notice-dialog.jsx
@@ -11,9 +11,11 @@ import { useTranslate } from 'i18n-calypso';
  * Internal Dependencies
  */
 import Button from 'components/button';
+import { CALYPSO_CONTACT } from 'lib/url/support';
 import ClipboardButton from 'components/forms/clipboard-button';
 import { composeAnalytics, recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
 import Dialog from 'components/dialog';
+import { errorNotice } from 'state/notices/actions';
 import { getLoginUrlWithTOSRedirect } from 'lib/gsuite';
 import VerticalNav from 'components/vertical-nav';
 import VerticalNavItem from 'components/vertical-nav/item';
@@ -41,6 +43,7 @@ function PendingGSuiteTosNoticeDialog( props ) {
 			`Opened G Suite "ToS Dialog" via ${ props.section }`,
 			'calypso_domain_management_gsuite_pending_account_open_dialog'
 		);
+
 		setOpenTracked( true );
 	}
 
@@ -49,25 +52,46 @@ function PendingGSuiteTosNoticeDialog( props ) {
 			`Clicked "Close ToS Dialog" link in G Suite pending ToS dialog via ${ props.section }`,
 			'calypso_domain_management_gsuite_pending_account_close_dialog_click'
 		);
+
 		setOpenTracked( false );
 		props.onClose();
 	};
 
 	const onCopyAction = () => {
 		setIsCopied( true );
+
 		trackEvent(
 			`Clicked "Copy Password" link in G Suite pending ToS dialog via ${ props.section }`,
 			'calypso_domain_management_gsuite_pending_account_copy_password_click'
 		);
 	};
 
-	const onPasswordClick = e => {
-		e.preventDefault();
+	const onPasswordClick = event => {
+		event.preventDefault();
+
 		const wpcom = wp.undocumented();
 		const mailbox = props.user.split( '@' )[ 0 ];
-		wpcom.resetPasswordForMailbox( props.domainName, mailbox ).then( data => {
-			setPassword( data.password );
-		} );
+
+		wpcom.resetPasswordForMailbox( props.domainName, mailbox ).then(
+			data => {
+				setPassword( data.password );
+			},
+			() => {
+				props.errorNotice( translate( 'There was a problem resetting the password for %(gsuiteEmail)s. Please {{link}}contact support{{/link}}.', {
+						args: {
+							gsuiteEmail: props.user,
+						},
+						components: {
+							link: <a href={ CALYPSO_CONTACT } />,
+						},
+					}
+				) );
+
+				setOpenTracked( false );
+				props.onClose();
+			}
+		);
+
 		trackEvent(
 			`Clicked "Get Password" link in G Suite pending ToS dialog via ${ props.section }`,
 			'calypso_domain_management_gsuite_pending_account_get_password_click'
@@ -115,6 +139,7 @@ function PendingGSuiteTosNoticeDialog( props ) {
 			</header>
 
 			<p>{ password ? renderPasswordResetCopy() : renderEntryCopy() }</p>
+
 			{ password && (
 				<Fragment>
 					<p>
@@ -129,6 +154,7 @@ function PendingGSuiteTosNoticeDialog( props ) {
 							{ isCopied ? translate( 'Copied!' ) : translate( 'Copy' ) }
 						</ClipboardButton>
 					</p>
+
 					<Button
 						href={ getLoginUrlWithTOSRedirect( props.user, props.domainName ) }
 						onClick={ onResetPasswordLogInClick }
@@ -140,6 +166,7 @@ function PendingGSuiteTosNoticeDialog( props ) {
 					</Button>
 				</Fragment>
 			) }
+
 			{ ! password && (
 				<VerticalNav>
 					<VerticalNavItem onClick={ onPasswordClick } key="0" path={ '#' }>
@@ -147,6 +174,7 @@ function PendingGSuiteTosNoticeDialog( props ) {
 							components: { strong: <strong /> },
 						} ) }
 					</VerticalNavItem>
+
 					<VerticalNavItem
 						onClick={ onLogInClick }
 						path={ getLoginUrlWithTOSRedirect( props.user, props.domainName ) }
@@ -163,6 +191,7 @@ function PendingGSuiteTosNoticeDialog( props ) {
 
 PendingGSuiteTosNoticeDialog.propTypes = {
 	domainName: PropTypes.string.isRequired,
+	errorNotice: PropTypes.func.isRequired,
 	onClose: PropTypes.func.isRequired,
 	section: PropTypes.string.isRequired,
 	siteSlug: PropTypes.string.isRequired,
@@ -184,6 +213,7 @@ const trackEvent = ( { domainName, message, section, siteSlug, tracksEvent, user
 export default connect(
 	null,
 	{
+		errorNotice,
 		trackEvent,
 	}
 )( PendingGSuiteTosNoticeDialog );


### PR DESCRIPTION
This pull request updates the G Suite ToS dialog to close and display an error message when the password couldn't be reset:
 
![screenshot22](https://user-images.githubusercontent.com/594356/61589532-5b3d1d80-abab-11e9-9838-28e2427cb9b4.png)

Adding this missing visual feedback should address a surge of failing API requests caused by users who keep clicking on the `I don't have the password` link with the hope that something will happen (see p2MSmN-7hI-p2).

#### Testing instructions
 
1. Run `git checkout fix/missing-error-in-gsuite-tos-notice-dialog` and start your server, or open a [live branch](https://calypso.live/?branch=fix/missing-error-in-gsuite-tos-notice-dialog)
2. Purchase a brand new G Suite account, but do not log in to the G Suite user account
3. Open the [`Email` page](http://calypso.localhost:3000/email)
4. Click any `Finish Setup` button that will appear once provisioning is over
5. Click the `I don't have the password` link
6. Assert that the dialog closes, and that an error is displayed