### PR TITLE
Starter Page Templates: Prevent changing selection on template insertion

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -129,7 +129,8 @@ const PageTemplatesPlugin = compose(
 				editorDispatcher.insertBlocks(
 					blocks,
 					0,
-					postContentBlock ? postContentBlock.clientId : ''
+					postContentBlock ? postContentBlock.clientId : '',
+					false
 				);
 			},
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Last week I have noticed that [`insertBlocks` has one more (optional) argument](https://github.com/WordPress/gutenberg/blob/42b27486c11c2dd937b81234e3db27169e53e6e5/packages/block-editor/src/store/actions.js#L360) that controls if selection should change after the insertion.
- I have switched it to **not** change the selection and that prevents opening the keyboard on mobile!

#### Testing instructions

- on a mobile device (or iOS Simulator with the software keyboard enabled)
- try to create a new page - template selector should show up
- select a template
- make sure the keyboard won't spontaneously show up

Fixes #34178
