### PR TITLE
Replace superagent in auth and network-connection.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -123,6 +123,11 @@ module.exports = {
 						importNames: [ 'combineReducers' ],
 						message: "`combineReducers` should be imported from 'state/utils', not 'redux'.",
 					},
+					// Use fetch instead of superagent.
+					{
+						name: 'superagent',
+						message: 'Please use native `fetch` instead.',
+					},
 				],
 			},
 		],
@@ -136,6 +141,11 @@ module.exports = {
 					{
 						name: 'gridicons',
 						message: "Please use 'components/gridicon' instead.",
+					},
+					// Use fetch instead of superagent.
+					{
+						name: 'superagent',
+						message: 'Please use native `fetch` instead.',
 					},
 				],
 			},

--- a/client/auth/auth-code-button.jsx
+++ b/client/auth/auth-code-button.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import request from 'superagent';
 import { identity } from 'lodash';
 
 /**
@@ -14,6 +11,9 @@ import { identity } from 'lodash';
 import Notice from 'components/notice';
 
 const initialState = { status: 'ready', errorLevel: false, errorMessage: false };
+
+// The tests need an absolute URL, so we need to detect if Jest is running.
+const SMS_URL = process.env.JEST_WORKER_ID !== undefined ? 'http://localhost/sms' : '/sms';
 
 export class AuthCodeButton extends React.Component {
 	static defaultProps = {
@@ -40,9 +40,10 @@ export class AuthCodeButton extends React.Component {
 	requestSMSCode = async () => {
 		this.setState( { status: 'requesting' } );
 
-		this.request = request
-			.post( '/sms' )
-			.send( { username: this.props.username, password: this.props.password } );
+		this.request = fetch( SMS_URL, {
+			method: 'POST',
+			body: JSON.stringify( { username: this.props.username, password: this.props.password } ),
+		} ).then( response => response.json() );
 
 		try {
 			this.handleSMSResponse( null, await this.request );
@@ -53,20 +54,20 @@ export class AuthCodeButton extends React.Component {
 		}
 	};
 
-	handleSMSResponse( error, response ) {
+	handleSMSResponse( error, json ) {
 		this.timeout = setTimeout( this.resetSMSCode, 1000 * 30 );
 
 		// if it's 2fa error then we actually successfully requested an sms code
-		if ( response && response.body && response.body.error === 'needs_2fa' ) {
+		if ( json && json.error === 'needs_2fa' ) {
 			this.setState( { status: 'complete' } );
 			return;
 		}
 
 		let errorMessage = null;
 
-		// assign the error message from the response body, otherwise take it from the error object
-		if ( response && response.body && response.body.error_description ) {
-			errorMessage = response.body.error_description;
+		// assign the error message from the response json, otherwise take it from the error object
+		if ( json && json.error_description ) {
+			errorMessage = json.error_description;
 		} else if ( error ) {
 			errorMessage = error.message;
 		}

--- a/client/auth/auth-code-button.jsx
+++ b/client/auth/auth-code-button.jsx
@@ -12,8 +12,7 @@ import Notice from 'components/notice';
 
 const initialState = { status: 'ready', errorLevel: false, errorMessage: false };
 
-// The tests need an absolute URL, so we need to detect if Jest is running.
-const SMS_URL = process.env.JEST_WORKER_ID !== undefined ? 'http://localhost/sms' : '/sms';
+const SMS_URL = '/sms';
 
 export class AuthCodeButton extends React.Component {
 	static defaultProps = {

--- a/client/auth/test/auth-code-button.jsx
+++ b/client/auth/test/auth-code-button.jsx
@@ -1,5 +1,4 @@
 /**
- * @format
  * @jest-environment jsdom
  */
 
@@ -9,6 +8,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import nock from 'nock';
+// Importing `jest-fetch-mock` adds a jest-friendly `fetch` polyfill to the global scope.
+import 'jest-fetch-mock';
 
 /**
  * Internal dependencies
@@ -70,6 +71,6 @@ describe( 'AuthCodeButton', () => {
 		await request;
 		expect( button.state( 'status' ) ).toBe( 'complete' );
 		expect( button.state( 'errorLevel' ) ).toBe( 'is-error' );
-		expect( button.state( 'errorMessage' ) ).toBe( 'Failed' );
+		expect( button.state( 'errorMessage' ) ).toContain( 'Failed' );
 	} );
 } );

--- a/client/auth/test/auth-code-button.jsx
+++ b/client/auth/test/auth-code-button.jsx
@@ -11,6 +11,8 @@ import nock from 'nock';
 // Importing `jest-fetch-mock` adds a jest-friendly `fetch` polyfill to the global scope.
 import 'jest-fetch-mock';
 
+const savedFetch = fetch;
+
 /**
  * Internal dependencies
  */
@@ -18,6 +20,17 @@ import { AuthCodeButton } from '../auth-code-button';
 import Notice from 'components/notice';
 
 describe( 'AuthCodeButton', () => {
+	beforeAll( () => {
+		// Transform relative URLs to absolute URLs with a `http://localhost` base URL.
+		// This is needed since the server-side fetch polyfill only accepts absolute URLs.
+		self.fetch = ( resource, init ) => savedFetch( new URL( resource, 'http://localhost' ), init );
+	} );
+
+	afterAll( () => {
+		// Restore 'fetch'.
+		self.fetch = savedFetch;
+	} );
+
 	test( 'button renders in ready state', () => {
 		const button = shallow( <AuthCodeButton username="usr" password="pwd" /> );
 		const notice = button.find( Notice );

--- a/client/lib/network-connection/index.js
+++ b/client/lib/network-connection/index.js
@@ -1,14 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
-
-const debug = debugFactory( 'calypso:network-connection' );
-import Emitter from 'lib/mixins/emitter';
-import request from 'superagent';
 import i18n from 'i18n-calypso';
 
 /**
@@ -16,16 +9,31 @@ import i18n from 'i18n-calypso';
  */
 import config from 'config';
 import PollerPool from 'lib/data-poller';
-
+import Emitter from 'lib/mixins/emitter';
 import { connectionLost, connectionRestored } from 'state/application/actions';
 
-let STATUS_CHECK_INTERVAL = 20000,
-	connected = true,
-	NetworkConnectionApp;
+const debug = debugFactory( 'calypso:network-connection' );
 
-NetworkConnectionApp = {
+const STATUS_CHECK_INTERVAL = 20000;
+let connected = true;
+
+function fetchWithTimeout( url, init, timeout = 0 ) {
+	if ( ! timeout ) {
+		return fetch( url, init );
+	}
+
+	return Promise.race( [
+		fetch( url, init ),
+		new Promise( ( resolve, reject ) => {
+			setTimeout( () => reject( new Error() ), timeout );
+		} ),
+	] );
+}
+
+const NetworkConnectionApp = {
 	/**
-	 * @returns {boolean}
+	 * Returns whether the network connection is enabled in config.
+	 * @returns {boolean} whether the network connection is enabled in config
 	 */
 	isEnabled: function() {
 		return config.isEnabled( 'network-connection' );
@@ -33,15 +41,14 @@ NetworkConnectionApp = {
 
 	/**
 	 * Bootstraps network connection status change handler.
+	 * @param {Store} reduxStore The Redux store.
 	 */
 	init: function( reduxStore ) {
-		let changeCallback;
-
 		if ( ! this.isEnabled( 'network-connection' ) ) {
 			return;
 		}
 
-		changeCallback = function() {
+		const changeCallback = () => {
 			if ( connected ) {
 				debug( 'Showing notice "Connection restored".' );
 				reduxStore.dispatch( connectionRestored( i18n.translate( 'Connection restored.' ) ) );
@@ -82,18 +89,16 @@ NetworkConnectionApp = {
 	checkNetworkStatus: function() {
 		debug( 'Checking network status.' );
 
-		request
-			.head( '/version?' + new Date().getTime() )
-			.timeout( STATUS_CHECK_INTERVAL / 2 )
-			.end(
-				function( error ) {
-					if ( error ) {
-						this.emitDisconnected();
-					} else {
-						this.emitConnected();
-					}
-				}.bind( this )
-			);
+		fetchWithTimeout(
+			'/version?' + new Date().getTime(),
+			{ method: 'HEAD' },
+			STATUS_CHECK_INTERVAL / 2
+		).then(
+			// Success
+			() => this.emitConnected(),
+			// Failure
+			() => this.emitDisconnected()
+		);
 	},
 
 	/**
@@ -125,7 +130,8 @@ NetworkConnectionApp = {
 	},
 
 	/**
-	 * @returns {boolean}
+	 * Returns whether the connections is currently active.
+	 * @returns {boolean} whether the connections is currently active.
 	 */
 	isConnected: function() {
 		return connected;

--- a/client/lib/oauth-store/actions.js
+++ b/client/lib/oauth-store/actions.js
@@ -1,11 +1,3 @@
-/** @format */
-
-/**
- * External dependencies
- */
-import { replace } from 'lodash';
-import request from 'superagent';
-
 /**
  * Internal dependencies
  */
@@ -13,27 +5,40 @@ import Dispatcher from 'dispatcher';
 import { actions, errors as errorTypes } from './constants';
 import analytics from 'lib/analytics';
 
-export function login( username, password, auth_code ) {
+async function makeRequest( username, password, authCode = '' ) {
+	try {
+		const response = fetch( '/oauth', {
+			method: 'POST',
+			body: JSON.stringify( {
+				username,
+				password,
+				auth_code: authCode.replace( /\s/g, '' ),
+			} ),
+		} );
+
+		return [
+			response.ok ? null : new Error(),
+			{ ok: response.ok, status: response.status, body: await response.json() },
+		];
+	} catch ( error ) {
+		return [ error, null ];
+	}
+}
+
+export function login( username, password, authCode ) {
 	Dispatcher.handleViewAction( {
 		type: actions.AUTH_LOGIN,
 	} );
 
-	request
-		.post( '/oauth' )
-		.send( {
-			username,
-			password,
-			auth_code: replace( auth_code, /\s/g, '' ),
-		} )
-		.end( ( error, data ) => {
-			bumpStats( error, data );
+	makeRequest( username, password, authCode ).then( ( [ error, response ] ) => {
+		bumpStats( error, response );
 
-			Dispatcher.handleServerAction( {
-				type: actions.RECEIVE_AUTH_LOGIN,
-				data,
-				error,
-			} );
+		Dispatcher.handleServerAction( {
+			type: actions.RECEIVE_AUTH_LOGIN,
+			response,
+			error,
 		} );
+	} );
 }
 
 function bumpStats( error, data ) {


### PR DESCRIPTION
Some modules used `superagent`, a 3rd party `npm` package, for network requests, and have here been rewritten to use native `fetch` instead.

This is part of an effort to remove `superagent` from client code altogether, and replace it with native `fetch` functionality. This will eventually lead to being able to drop that dependency from the client-side bundle, thus improving loading performance.

#### Changes proposed in this Pull Request

Replace usage of `superagent` with `fetch` in:
* `auth/auth-code-button`
* `lib/oauth-store`
* `lib/network-connection`

#### Testing instructions

For testing `auth/auth-code-button`: this component already includes network request-level tests, which continue working after the changes (save for a small change in some error messages).

For testing `lib/oauth-store`: I'm unsure what the best way of testing this is. Hopefully some of the folks I added to the review will know.

For testing `lib/network-connection`:
* Start a local server
* When it starts, ensure that the application detects its status as being online
* Terminate local server
* Ensure that the application detects its status as being offline after a while (up to 30s)
