### PR TITLE
Replace usage of superagent in domain transfer.

### DIFF
--- a/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-out/select-ips-tag.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import request from 'superagent';
 import { find, isEmpty, startsWith, toUpper } from 'lodash';
 import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
@@ -39,10 +36,9 @@ class SelectIpsTag extends Component {
 	};
 
 	componentDidMount() {
-		request
-			.get( SelectIpsTag.ipsTagListUrl )
-			.then( response => {
-				this.receiveIpsTagList( response.body );
+		fetch( SelectIpsTag.ipsTagListUrl )
+			.then( async response => {
+				this.receiveIpsTagList( await response.json() );
 			} )
 			.catch( error => {
 				debug( 'Failed to load IPS tag list! ' + error );


### PR DESCRIPTION
The `SelectIpsTag` component used `superagent`, a 3rd party `npm` package, for network requests, and has here been rewritten to use native `fetch` instead.

This is part of an effort to remove `superagent` from client code altogether, and replace it with native `fetch` functionality. This will eventually lead to being able to drop that dependency from the client-side bundle, thus improving loading performance.

#### Changes proposed in this Pull Request

* Replace usage of `superagent` in the `SelectIpsTag` component

#### Testing instructions

I am not familiar with this functionality, so I can't provide good testing instructions. Please ensure that the `SelectIpsTag` component continues to load the IPS tag list correctly after these changes.

If I added you as a reviewer and you're not familiar with this code, sorry about that, I'm just going by GitHub recommendations! If that's the case, please feel free to remove yourself or ignore the PR. And if you can point me to a better reviewer, please do! 🙂
