### PR TITLE
Guided Tours: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -19,5 +19,4 @@
 @import 'components/segmented-control/style';
 @import 'components/select-dropdown/style';
 @import 'components/tooltip/style';
-@import 'layout/guided-tours/style';
 @import 'layout/sidebar/style';

--- a/client/layout/guided-tours/all-tours.js
+++ b/client/layout/guided-tours/all-tours.js
@@ -4,34 +4,34 @@
  * Internal dependencies
  */
 
-import { ActivityLogJetpackIntroTour } from 'layout/guided-tours/tours/activity-log-jetpack-intro-tour';
-import { ActivityLogWpcomIntroTour } from 'layout/guided-tours/tours/activity-log-wpcom-intro-tour';
-import { ChecklistAboutPageTour } from 'layout/guided-tours/tours/checklist-about-page-tour';
-import { ChecklistContactPageTour } from 'layout/guided-tours/tours/checklist-contact-page-tour';
-import { ChecklistDomainRegisterTour } from 'layout/guided-tours/tours/checklist-domain-register-tour';
-import { ChecklistPublishPostTour } from 'layout/guided-tours/tours/checklist-publish-post-tour';
-import { ChecklistSiteIconTour } from 'layout/guided-tours/tours/checklist-site-icon-tour';
-import { ChecklistSiteTaglineTour } from 'layout/guided-tours/tours/checklist-site-tagline-tour';
-import { ChecklistSiteTitleTour } from 'layout/guided-tours/tours/checklist-site-title-tour';
-import { ChecklistUserAvatarTour } from 'layout/guided-tours/tours/checklist-user-avatar-tour';
-import { ChecklistUserEmailTour } from 'layout/guided-tours/tours/checklist-user-email-tour';
-import { EditorBasicsTour } from 'layout/guided-tours/tours/editor-basics-tour';
-import { GDocsIntegrationTour } from 'layout/guided-tours/tours/gdocs-integration-tour';
-import { JetpackBackupsRewindTour } from 'layout/guided-tours/tours/jetpack-backups-rewind-tour';
-import { JetpackChecklistTour } from 'layout/guided-tours/tours/jetpack-checklist-tour';
-import { JetpackLazyImagesTour } from 'layout/guided-tours/tours/jetpack-lazy-images-tour';
-import { JetpackMonitoringTour } from 'layout/guided-tours/tours/jetpack-monitoring-tour';
-import { JetpackPluginUpdatesTour } from 'layout/guided-tours/tours/jetpack-plugin-updates-tour';
-import { JetpackSearchTour } from 'layout/guided-tours/tours/jetpack-search-tour';
-import { JetpackSignInTour } from 'layout/guided-tours/tours/jetpack-sign-in-tour';
-import { JetpackSiteAcceleratorTour } from 'layout/guided-tours/tours/jetpack-site-accelerator-tour';
-import { JetpackVideoHostingTour } from 'layout/guided-tours/tours/jetpack-video-hosting-tour';
-import { MainTour } from 'layout/guided-tours/tours/main-tour';
-import { MediaBasicsTour } from 'layout/guided-tours/tours/media-basics-tour';
-import { SimplePaymentsEmailTour } from 'layout/guided-tours/tours/simple-payments-email-tour';
-import { SimplePaymentsTour } from 'layout/guided-tours/tours/simple-payments-tour';
-import { TutorialSitePreviewTour } from 'layout/guided-tours/tours/tutorial-site-preview-tour';
-import combineTours from 'layout/guided-tours/config-elements/combine-tours';
+import { ActivityLogJetpackIntroTour } from './tours/activity-log-jetpack-intro-tour';
+import { ActivityLogWpcomIntroTour } from './tours/activity-log-wpcom-intro-tour';
+import { ChecklistAboutPageTour } from './tours/checklist-about-page-tour';
+import { ChecklistContactPageTour } from './tours/checklist-contact-page-tour';
+import { ChecklistDomainRegisterTour } from './tours/checklist-domain-register-tour';
+import { ChecklistPublishPostTour } from './tours/checklist-publish-post-tour';
+import { ChecklistSiteIconTour } from './tours/checklist-site-icon-tour';
+import { ChecklistSiteTaglineTour } from './tours/checklist-site-tagline-tour';
+import { ChecklistSiteTitleTour } from './tours/checklist-site-title-tour';
+import { ChecklistUserAvatarTour } from './tours/checklist-user-avatar-tour';
+import { ChecklistUserEmailTour } from './tours/checklist-user-email-tour';
+import { EditorBasicsTour } from './tours/editor-basics-tour';
+import { GDocsIntegrationTour } from './tours/gdocs-integration-tour';
+import { JetpackBackupsRewindTour } from './tours/jetpack-backups-rewind-tour';
+import { JetpackChecklistTour } from './tours/jetpack-checklist-tour';
+import { JetpackLazyImagesTour } from './tours/jetpack-lazy-images-tour';
+import { JetpackMonitoringTour } from './tours/jetpack-monitoring-tour';
+import { JetpackPluginUpdatesTour } from './tours/jetpack-plugin-updates-tour';
+import { JetpackSearchTour } from './tours/jetpack-search-tour';
+import { JetpackSignInTour } from './tours/jetpack-sign-in-tour';
+import { JetpackSiteAcceleratorTour } from './tours/jetpack-site-accelerator-tour';
+import { JetpackVideoHostingTour } from './tours/jetpack-video-hosting-tour';
+import { MainTour } from './tours/main-tour';
+import { MediaBasicsTour } from './tours/media-basics-tour';
+import { SimplePaymentsEmailTour } from './tours/simple-payments-email-tour';
+import { SimplePaymentsTour } from './tours/simple-payments-tour';
+import { TutorialSitePreviewTour } from './tours/tutorial-site-preview-tour';
+import combineTours from './config-elements/combine-tours';
 
 export default combineTours( {
 	activityLogJetpackIntroTour: ActivityLogJetpackIntroTour,

--- a/client/layout/guided-tours/component.jsx
+++ b/client/layout/guided-tours/component.jsx
@@ -26,6 +26,11 @@ import {
 	resetGuidedToursHistory,
 } from 'state/ui/guided-tours/actions';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class GuidedToursComponent extends Component {
 	shouldComponentUpdate( nextProps ) {
 		return this.props.tourState !== nextProps.tourState;

--- a/client/layout/guided-tours/component.jsx
+++ b/client/layout/guided-tours/component.jsx
@@ -6,7 +6,6 @@
 
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
 import { defer } from 'lodash';
 
 /**
@@ -139,4 +138,4 @@ export default connect(
 		quitGuidedTour,
 		resetGuidedToursHistory,
 	}
-)( localize( GuidedToursComponent ) );
+)( GuidedToursComponent );

--- a/client/layout/guided-tours/component.jsx
+++ b/client/layout/guided-tours/component.jsx
@@ -12,7 +12,7 @@ import { defer } from 'lodash';
  * Internal dependencies
  */
 import { tracks } from 'lib/analytics';
-import AllTours from 'layout/guided-tours/all-tours';
+import AllTours from './all-tours';
 import QueryPreferences from 'components/data/query-preferences';
 import RootChild from 'components/root-child';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';

--- a/client/layout/guided-tours/config-elements/combine-tours.js
+++ b/client/layout/guided-tours/config-elements/combine-tours.js
@@ -1,22 +1,15 @@
-/** @format */
-
 /**
  * External dependencies
  */
+import React from 'react';
 
-import React, { Component } from 'react';
-import { omit } from 'lodash';
-import debugFactory from 'debug';
-
-const debug = debugFactory( 'calypso:guided-tours' );
-
-const combineTours = tours =>
-	class AllTours extends Component {
-		render() {
-			debug( 'AllTours#render' );
-			const MyTour = tours[ this.props.tourName ];
-			return MyTour ? <MyTour { ...omit( this.props, 'tourName' ) } /> : null;
+export default function combineTours( tours ) {
+	return function AllTours( { tourName, ...props } ) {
+		const MyTour = tours[ tourName ];
+		if ( ! MyTour ) {
+			return null;
 		}
-	};
 
-export default combineTours;
+		return <MyTour { ...props } />;
+	};
+}

--- a/client/layout/guided-tours/index.js
+++ b/client/layout/guided-tours/index.js
@@ -13,14 +13,12 @@ import { connect } from 'react-redux';
 import AsyncLoad from 'components/async-load';
 import { getGuidedTourState } from 'state/ui/guided-tours/selectors';
 
-function GuidedTours( props ) {
-	const { shouldShow, ...ownProps } = props;
-
+function GuidedTours( { shouldShow } ) {
 	if ( ! shouldShow ) {
 		return null;
 	}
 
-	return <AsyncLoad require="layout/guided-tours/component" { ...ownProps } />;
+	return <AsyncLoad require="layout/guided-tours/component" />;
 }
 
 export default connect( state => {


### PR DESCRIPTION
Migrates guided tours CSS to webpack and does a few more cleanups (see the individual commits):
- unneeded use of `localize` HOC
- `AllTours` can be a functional component
- `<GuidedTours />` doesn't have any outside props, no need to pass them down
- convert full import paths to relative

**How to test:**
Trigger a guided tour, e.g., navigate to `/media/:site?tour=mediaBasicsTour` and verify the tour styling:

<img width="463" alt="Screenshot 2019-07-22 at 17 57 43" src="https://user-images.githubusercontent.com/664258/61665896-7fe1e400-acd6-11e9-988c-48e66fdcc4d4.png">
