### PR TITLE
AB test to default Jetpack plan to monthly renewal

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -14,6 +14,7 @@ import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { abtest } from 'lib/abtest';
 
 /**
  * Constants
@@ -52,6 +53,10 @@ class JetpackPlansGrid extends Component {
 	}
 
 	render() {
+		const { interval } = this.props;
+		const defaultInterval =
+			abtest( 'defaultMonthlyJetpackPlan' ) === 'monthlyPlan' ? 'monthly' : 'yearly';
+
 		return (
 			<MainWrapper isWide className="jetpack-connect__hide-plan-icons">
 				<div className="jetpack-connect__plans">
@@ -63,7 +68,7 @@ class JetpackPlansGrid extends Component {
 							isLandingPage={ ! this.props.selectedSite }
 							basePlansPath={ this.props.basePlansPath }
 							onUpgradeClick={ this.props.onSelect }
-							intervalType={ this.props.interval }
+							intervalType={ interval ? interval : defaultInterval }
 							hideFreePlan={ this.props.hideFreePlan }
 							displayJetpackPlans={ true }
 						/>

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -140,7 +140,7 @@ export default {
 			monthlyPlan: 50,
 			yearlyPlan: 50,
 		},
-		defaultVariation: 'monthlyPlan',
+		defaultVariation: 'yearlyPlan',
 		allowExistingUsers: true,
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -134,4 +134,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	defaultMonthlyJetpackPlan: {
+		datestamp: '20190722',
+		variations: {
+			monthlyPlan: 50,
+			yearlyPlan: 50,
+		},
+		defaultVariation: 'monthlyPlan',
+		allowExistingUsers: true,
+	},
 };


### PR DESCRIPTION
In working on the G Suite flows, we discovered a significant drop in conversions when displaying yearly prices vs monthly. As with my previous AB test (#34685), I wondered if the same phenomenon might apply to Jetpack plans.

This AB test tests the effect on Jetpack's plans page of:

- default to monthly pricing - 50%
- default to yearly pricing (current setting) - 50%

#### Changes proposed in this Pull Request

* Add AB test for monthly pricing on Jetpack plans

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In the browser's dev console, enable AB test debugging with `localStorage.setItem('debug', 'calypso:abtests');`
* Connect a Jetpack site and proceed to the plans step
* Enable Monthly prices using `localStorage.setItem( 'ABTests', '{"defaultMonthlyJetpackPlan_20190722":"monthlyPlan"}' );`, reload page and observe that page shows monthly prices
* Same for `yearlyPlan`, which should show default yearly prices
