### PR TITLE
Earn section: add a feature flag earn-relayout

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -56,6 +56,7 @@
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/max-characters-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"earn-relayout": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -32,6 +32,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"earn-relayout": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -40,6 +40,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
+		"earn-relayout": true,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds a `earn-relayout` flag to development, wpcalypso and stage configs.

#### Testing instructions

* can be tested adding the following  
```
import config from 'config';
.
.
.
console.log( config( 'earn-relayout' ) );
```

Fixes #34527
