### PR TITLE
Remove superagent usage in a few places.

### DIFF
--- a/client/state/components-usage-stats/actions.js
+++ b/client/state/components-usage-stats/actions.js
@@ -1,11 +1,7 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { COMPONENTS_USAGE_STATS_REQUEST, COMPONENTS_USAGE_STATS_RECEIVE } from 'state/action-types';
-import request from 'superagent';
 
 /**
  * Return an action object to signaling that the "usage stats" have been requested
@@ -36,11 +32,15 @@ export function receiveComponentsUsageStats( componentsUsageStats ) {
 export default function fetchComponentsUsageStats() {
 	return dispatch => {
 		dispatch( requestComponentsUsageStats() );
-		return request.get( '/devdocs/service/components-usage-stats' ).end( ( error, res ) => {
-			if ( ! res.ok ) {
-				return;
-			}
-			dispatch( receiveComponentsUsageStats( res.body ) );
-		} );
+		return fetch( '/devdocs/service/components-usage-stats' )
+			.then( async response => {
+				if ( ! response.ok ) {
+					return;
+				}
+				dispatch( receiveComponentsUsageStats( await response.json() ) );
+			} )
+			.catch( () => {
+				// Do nothing.
+			} );
 	};
 }

--- a/client/state/reader/thumbnails/test/actions.js
+++ b/client/state/reader/thumbnails/test/actions.js
@@ -1,10 +1,11 @@
-/** @format */
 /**
  * External dependencies
  */
 import { assert, expect } from 'chai';
 import deepFreeze from 'deep-freeze';
 import sinon from 'sinon';
+// Importing `jest-fetch-mock` adds a jest-friendly `fetch` polyfill to the global scope.
+import 'jest-fetch-mock';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
These files used `superagent`, a 3rd party `npm` package, for network requests, and have here been rewritten to use native `fetch` instead.

This is part of an effort to remove `superagent` from client code altogether, and replace it with native `fetch` functionality. This will eventually lead to being able to drop that dependency from the client-side bundle, thus improving loading performance.

#### Changes proposed in this Pull Request

* Remove `superagent` usage in `client/state/components-usage-stats`
* Remove `superagent` usage in `client/state/reader/thumbnails`

#### Testing instructions

For `client/state/reader/thumbnails/actions.js`: this code already includes network request-level tests, which continue working after the changes.

For `client/state/components-usage-stats`: Unclear. I'm not very familiar with this code, so I can't provide good testing instructions. Please ensure that the usage stats continue being loaded correctly after these changes.

If I added you as a reviewer and you're not familiar with this code, sorry about that, I'm just going by GitHub recommendations! If that's the case, please feel free to remove yourself or ignore the PR. And if you can point me to a better reviewer, please do!
