### PR TITLE
Wrap-up AB Test: Pro-rated credits banner copy

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -116,16 +116,6 @@ export default {
 		defaultVariation: 'control',
 		localeTargets: 'any',
 	},
-	proratedCreditsBanner: {
-		//this test is used to dial down the upsell offer
-		datestamp: '20190626',
-		variations: {
-			control: 50,
-			variant: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 	skippableDomainStep: {
 		datestamp: '20190717',
 		variations: {

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -214,31 +214,18 @@ export class PlanFeatures extends Component {
 				icon="info-outline"
 				status="is-success"
 			>
-				{ 'variant' === abtest( 'proratedCreditsBanner' )
-					? translate(
-							'Need to upgrade? You have {{b}}%(amountInCurrency)s{{/b}} pro-rated credits available from your current plan. ' +
-								'We have applied them to the plan upgrades below.',
-							{
-								args: {
-									amountInCurrency: formatCurrency( planCredits, planProperties[ 0 ].currencyCode ),
-								},
-								components: {
-									b: <strong />,
-								},
-							}
-					  )
-					: translate(
-							'You have {{b}}%(amountInCurrency)s{{/b}} of pro-rated credits available from your current plan. ' +
-								'Apply those credits towards an upgrade before they expire!',
-							{
-								args: {
-									amountInCurrency: formatCurrency( planCredits, planProperties[ 0 ].currencyCode ),
-								},
-								components: {
-									b: <strong />,
-								},
-							}
-					  ) }
+				{ translate(
+					'You have {{b}}%(amountInCurrency)s{{/b}} of pro-rated credits available from your current plan. ' +
+						'Apply those credits towards an upgrade before they expire!',
+					{
+						args: {
+							amountInCurrency: formatCurrency( planCredits, planProperties[ 0 ].currencyCode ),
+						},
+						components: {
+							b: <strong />,
+						},
+					}
+				) }
 			</Notice>,
 			bannerContainer
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes this AB test: https://github.com/Automattic/wp-calypso/pull/34309

#### Testing instructions

* Visiting the Plans section in Calypso, in a paid plan with more than 1 month left (i.e. having pro-rated credits to apply for an upgrade), should show this banner:

![image](https://user-images.githubusercontent.com/538790/60191886-52b82800-9835-11e9-8493-0cf6daa10361.png)
