### PR TITLE
Domain only flow breaks due to missing dependency

### DIFF
--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -136,7 +136,7 @@ class SiteOrDomain extends Component {
 		);
 		this.props.submitSignupStep(
 			{ stepName: 'plans-site-selected', wasSkipped: true },
-			{ cartItem: null }
+			{ cartItem: null, couponCode: null }
 		);
 		goToStep( 'user' );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request
* The domain only flow gets stuck at the `Awesome! Give us a minute ... page`. The console shows the following error(props to @ockham for finding the bug):

![61649498-67bc9580-acd3-11e9-96d8-153db5f3a994](https://user-images.githubusercontent.com/1269602/61662950-233df380-aced-11e9-8f63-659909616cff.png)

* This PR sets the couponCode dependency in the domain only flow. This is needed because `couponCode` was defined as a dependency to be provided for the `plans-site-selected` step in #34710. 

#### Testing instructions
* Start at the domain only flow at /start/domain
* Select a domain, and proceed to the next step. When on the `/start/domain/site-or-domain` step, select "Just buy a domain"
* Verify that you are able to complete the purchase.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


