### PR TITLE
Revert "Signup: Alias anonUserId to WPCOM user id when user is create…

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -781,18 +781,16 @@ const analytics = {
 		},
 	},
 
-	identifyUser: function( user = _user ) {
+	identifyUser: function() {
 		const anonymousUserId = this.tracks.anonymousUserId();
 
 		// Don't identify the user if we don't have one
-		if ( user && user.initialized ) {
+		if ( _user && _user.initialized ) {
 			if ( anonymousUserId ) {
 				recordAliasInFloodlight();
 			}
 
-			const { ID: userId, username: userName } = user.get();
-
-			window._tkq.push( [ 'identifyUser', userId, userName ] );
+			window._tkq.push( [ 'identifyUser', _user.get().ID, _user.get().username ] );
 		}
 	},
 

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -12,12 +12,10 @@ import url from 'url';
  * Internal dependencies
  */
 import analytics from '../';
-import { recordAliasInFloodlight } from 'lib/analytics/ad-tracking';
 
 jest.mock( 'config', () => require( './mocks/config' ) );
 jest.mock( 'lib/analytics/ad-tracking', () => ( {
 	retarget: () => {},
-	recordAliasInFloodlight: jest.fn(),
 } ) );
 jest.mock( '@automattic/load-script', () => require( './mocks/lib/load-script' ) );
 
@@ -94,33 +92,6 @@ describe( 'Analytics', () => {
 			expect( imagesLoaded[ 0 ].query.go ).toEqual( 'time' );
 			expect( imagesLoaded[ 0 ].query.another ).toEqual( 'one' );
 			expect( imagesLoaded[ 0 ].query.t ).toBeTruthy();
-		} );
-	} );
-
-	describe( 'identifyUser', () => {
-		let userMock;
-		beforeEach( () => {
-			analytics.tracks.anonymousUserId = jest.fn( () => true );
-			userMock = {
-				get: jest.fn( () => ( {
-					ID: '007',
-					username: 'james',
-				} ) ),
-				initialized: true,
-			};
-			window._tkq.push = jest.fn();
-		} );
-		test( 'should not call window._tkq.push or recordAliasInFloodlight when there is no user info', () => {
-			analytics.identifyUser();
-			expect( window._tkq.push ).not.toBeCalled();
-			expect( recordAliasInFloodlight ).not.toBeCalled();
-		} );
-
-		test( 'should call window._tkq.push and recordAliasInFloodlight when user object exists', () => {
-			analytics.identifyUser( userMock );
-			expect( recordAliasInFloodlight ).toBeCalled();
-			expect( userMock.get ).toBeCalled();
-			expect( window._tkq.push ).toBeCalledWith( [ 'identifyUser', '007', 'james' ] );
 		} );
 	} );
 } );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -257,20 +257,6 @@ export function fetchSitesAndUser( siteSlug, onComplete, reduxStore ) {
 	] ).then( onComplete );
 }
 
-export function fetchUser( userInstance = user ) {
-	// @TODO: When user fetching is reduxified, let's get rid of this hack.
-	return new Promise( resolve => {
-		const userFetched = setInterval( () => {
-			const loadedUser = userInstance.get();
-			if ( loadedUser ) {
-				clearInterval( userFetched );
-				resolve( loadedUser );
-				return;
-			}
-		}, 333 );
-	} );
-}
-
 export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
 	if ( isEmpty( themeSlugWithRepo ) ) {
 		defer( callback );
@@ -538,12 +524,6 @@ export function createAccount(
 
 				// Fire after a new user registers.
 				analytics.recordRegistration();
-
-				// Try to fetch the user so we can track the newly-created account
-				fetchUser( user ).then( () => {
-					analytics.setUser( user );
-					analytics.identifyUser();
-				} );
 
 				const username =
 					( response && response.signup_sandbox_username ) ||

--- a/client/lib/user/user.js
+++ b/client/lib/user/user.js
@@ -166,9 +166,6 @@ User.prototype.fetch = function() {
  * @param {Error} error network response error
  */
 User.prototype.handleFetchFailure = function( error ) {
-	// Release lock from subsequent fetches
-	this.fetching = false;
-
 	if ( ! config.isEnabled( 'wpcom-user-bootstrap' ) && error.error === 'authorization_required' ) {
 		/**
 		 * if the user bootstrap is disabled (in development), we need to rely on a request to


### PR DESCRIPTION
…d  (#34648)"

This reverts commit 0bb899ca8805865a70a4620b46f82d915f61e168.

Fixes #34817

**To test:**
- visit calypso.localhost:3000/start/ in an unproxied, incognito window
- submit the user step
- select "online-store" segment
- make sure /domains/ step renders