### PR TITLE
Signup: update suggested verticals for blog and professional segments

### DIFF
--- a/client/components/site-verticals-suggestion-search/popular-topics.jsx
+++ b/client/components/site-verticals-suggestion-search/popular-topics.jsx
@@ -56,14 +56,16 @@ class PopularTopics extends PureComponent {
 		onSelect: PropTypes.func.isRequired,
 	};
 
-	onClick = event => {
+	onClick = index => event => {
 		event.preventDefault();
 		event.stopPropagation();
 		this.props.onSelect( event.currentTarget.value );
 		this.props.recordTracksEvent( 'calypso_signup_common_site_vertical_clicked', {
 			value: event.currentTarget.value,
+			position_in_list: index,
 		} );
 	};
+
 	render() {
 		const { popularTopics } = this.props;
 
@@ -82,7 +84,7 @@ class PopularTopics extends PureComponent {
 						key={ index }
 						value={ topic }
 						className="site-verticals-suggestion-search__topic-list-item"
-						onClick={ this.onClick }
+						onClick={ this.onClick( index ) }
 						tabIndex="0"
 					>
 						{ topic }

--- a/client/components/site-verticals-suggestion-search/popular-topics.jsx
+++ b/client/components/site-verticals-suggestion-search/popular-topics.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import { translate } from 'i18n-calypso';
+import { shuffle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -30,22 +31,22 @@ const POPULAR_TOPICS = {
 		translate( 'Restaurants' ),
 	],
 	blog: [
-		translate( 'Food' ),
-		translate( 'Travel' ),
-		translate( 'Film' ),
-		translate( 'Photography' ),
-		translate( 'Local' ),
 		translate( 'People' ),
-		translate( 'Sport' ),
+		translate( 'Dating' ),
+		translate( 'Travel' ),
+		translate( 'Food' ),
+		translate( 'Local' ),
+		translate( 'Blogging' ),
+		translate( 'Photography' ),
 	],
 	professional: [
 		translate( 'Photographer' ),
-		translate( 'Web Designer' ),
 		translate( 'Writer' ),
-		translate( 'Programmer' ),
-		translate( 'Tutor' ),
-		translate( 'Architect' ),
+		translate( 'Web Designer' ),
 		translate( 'Engineer' ),
+		translate( 'Tutor' ),
+		translate( 'Graphic Designer' ),
+		translate( 'Architect' ),
 	],
 };
 
@@ -70,10 +71,12 @@ class PopularTopics extends PureComponent {
 			return null;
 		}
 
+		const shuffledTopics = shuffle( popularTopics );
+
 		return (
 			<div className="site-verticals-suggestion-search__common-topics">
 				<div className="site-verticals-suggestion-search__heading">{ translate( 'Popular' ) }</div>
-				{ popularTopics.map( ( topic, index ) => (
+				{ shuffledTopics.map( ( topic, index ) => (
 					<button
 						type="button"
 						key={ index }


### PR DESCRIPTION
In #33381, we introduce segment-specific "popular" vertical suggestions. This PR updates the lists to reflect our most popular verticals for those segments in the time since introduction. It additionally randomizes those popular suggestions to account for weighting in the data.

paWIov-6l-p2#comment-107

**To test:**
- visit /start/
- select either "blog" or "professional" segments
- verify that the popular suggestions are randomized in the site-topic step