### PR TITLE
Potential fix for #34281 - prevent iFrame refreshing if already loaded

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -504,7 +504,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				{ /* eslint-disable-next-line wpcalypso/jsx-classname-namespace */ }
 				<div className="main main-column calypsoify is-iframe" role="main">
 					{ ! isIframeLoaded && <Placeholder /> }
-					{ shouldLoadIframe && (
+					{ ( shouldLoadIframe || isIframeLoaded ) && (
 						/* eslint-disable-next-line jsx-a11y/iframe-has-title */
 						<iframe
 							ref={ this.iframeRef }

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -69,6 +69,7 @@ interface State {
 	editedPost?: any;
 	gallery?: any;
 	isIframeLoaded: boolean;
+	currentIFrameUrl: string;
 	isMediaModalVisible: boolean;
 	isPreviewVisible: boolean;
 	isConversionPromptVisible: boolean;
@@ -102,6 +103,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		isPreviewVisible: false,
 		isConversionPromptVisible: false,
 		previewUrl: 'about:blank',
+		currentIFrameUrl: '',
 	};
 
 	iframeRef: React.RefObject< HTMLIFrameElement > = React.createRef();
@@ -487,6 +489,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			previewUrl,
 			postUrl,
 			editedPost,
+			currentIFrameUrl,
 		} = this.state;
 
 		return (
@@ -510,8 +513,12 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 							ref={ this.iframeRef }
 							/* eslint-disable-next-line wpcalypso/jsx-classname-namespace */
 							className={ isIframeLoaded ? 'is-iframe-loaded' : undefined }
-							src={ iframeUrl }
-							onLoad={ () => this.setState( { isIframeLoaded: true } ) }
+							src={ isIframeLoaded ? currentIFrameUrl : iframeUrl }
+							// Iframe url needs to be kept in state to prevent editor reloading if frame_nonce changes
+							// in Jetpack sites
+							onLoad={ () =>
+								this.setState( { isIframeLoaded: true, currentIFrameUrl: iframeUrl } )
+							}
 						/>
 					) }
 				</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a check to prevent gutenberg editor iFrame reloading if it is already loaded. This is a potential fix for a bug that causes editor content to be lost if user chooses to edit an image from within the media gallery.

#### Testing instructions

- Apply patch
- Add a new post via block-editor/post/
- Add a title, add some text
- Add an Image Block
- Select Media Library
- Click an image
- Select "Edit"
- Select "Edit Image"
- Click "Cancel" or "Done"
- Insert
- Post content should remain and image should be successfully inserted

Fixes #34281

#### Additional notes

#34281 is caused by the fact that when the Image editor modal is launched the `isRequestingSite( state, siteId )` selector returns true (https://github.com/Automattic/wp-calypso/blob/master/client/gutenberg/editor/calypsoify-iframe.tsx#L575) , which sets `shouldLoadIframe` to false. `shouldLoadIframe` is then subsequently set back to true and the editor iFrame is reloaded, but with all previous content gone. 
