### PR TITLE
Magic links: First pass at adding magic link button to get-apps.

### DIFF
--- a/client/blocks/get-apps/mobile-download-card.jsx
+++ b/client/blocks/get-apps/mobile-download-card.jsx
@@ -29,6 +29,7 @@ import {
 import getUserSettings from 'state/selectors/get-user-settings';
 import hasUserSettings from 'state/selectors/has-user-settings';
 import { http } from 'state/data-layer/wpcom-http/actions';
+import wpcom from 'lib/wp';
 import phoneValidation from 'lib/phone-validation';
 import userAgent from 'lib/user-agent';
 import twoStepAuthorization from 'lib/two-step-authorization';
@@ -56,13 +57,11 @@ function sendSMS( phone ) {
 }
 
 function sendMagicLink( email ) {
-
-	var duration = { duration: 4000 }
-	dispatch( infoNotice( i18n.translate( 'Sending email' ), duration ) );
-
 	//Actions must be plain objects. Use custom middleware for async actions.
 	// https://stackoverflow.com/questions/46765896/react-redux-actions-must-be-plain-objects-use-custom-middleware-for-async-acti
 	return function( dispatch ) {
+		const duration = { duration: 4000 }
+		dispatch( infoNotice( i18n.translate( 'Sending email' ), duration ) );
 
 		return wpcom
 			.undocumented()
@@ -326,7 +325,7 @@ class MobileDownloadCard extends React.Component {
 
 	onSubmitLink = () => {
 		this.props.recordTracksEvent( 'calypso_get_apps_magic_link_button_click' );
-		var email = this.props.userSettings.user_email;
+		const email = this.props.userSettings.user_email;
 		this.props.sendMagicLink( email )
 	}
 }

--- a/client/blocks/get-apps/mobile-download-card.jsx
+++ b/client/blocks/get-apps/mobile-download-card.jsx
@@ -19,7 +19,7 @@ import Button from 'components/button';
 import QuerySmsCountries from 'components/data/query-countries/sms';
 import FormPhoneInput from 'components/forms/form-phone-input';
 import getCountries from 'state/selectors/get-countries';
-import { successNotice, errorNotice } from 'state/notices/actions';
+import { infoNotice, successNotice, errorNotice } from 'state/notices/actions';
 import { fetchUserSettings } from 'state/user-settings/actions';
 import { accountRecoverySettingsFetch } from 'state/account-recovery/settings/actions';
 import {
@@ -32,6 +32,7 @@ import { http } from 'state/data-layer/wpcom-http/actions';
 import phoneValidation from 'lib/phone-validation';
 import userAgent from 'lib/user-agent';
 import twoStepAuthorization from 'lib/two-step-authorization';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 function sendSMS( phone ) {
 	function onSuccess( dispatch ) {
@@ -52,6 +53,36 @@ function sendSMS( phone ) {
 		onSuccess,
 		onFailure,
 	} );
+}
+
+function sendMagicLink( email ) {
+
+	var duration = { duration: 4000 }
+	dispatch( infoNotice( i18n.translate( 'Sending email' ), duration ) );
+
+	//Actions must be plain objects. Use custom middleware for async actions.
+	// https://stackoverflow.com/questions/46765896/react-redux-actions-must-be-plain-objects-use-custom-middleware-for-async-acti
+	return function( dispatch ) {
+
+		return wpcom
+			.undocumented()
+			.requestMagicLoginEmail( {
+				email,
+				'infer': true,
+				'scheme': 'wordpress',
+			} )
+			.then( () => {
+				dispatch(
+					successNotice( i18n.translate( 'Email Sent. Check your mail app!' ), duration )
+				);
+			} )
+			.catch( error => {
+				dispatch(
+					errorNotice( i18n.translate( 'Sorry, we couldn’t send the email.' ), duration )
+				);
+				return Promise.reject( error );
+			} );
+	}
 }
 
 class MobileDownloadCard extends React.Component {
@@ -248,6 +279,24 @@ class MobileDownloadCard extends React.Component {
 						</div>
 					</div>
 				) }
+
+				<div className="get-apps__magic-link-subpanel">
+					<div className="get-apps__card-text">
+						<p>
+							<strong>{ translate( 'Instantly log in to the mobile app' ) }</strong>
+							<br />
+							{ translate( 'Send yourself links to download the app and instantly log in on your mobile device.' ) }
+						</p>
+					</div>
+					<div className="get-apps__link-button-wrapper">
+						<Button
+							className="get-apps__magic-link-button"
+							onClick={ this.onSubmitLink }
+						>
+							{ translate( 'Email me a log in link' ) }
+						</Button>
+					</div>
+				</div>
 			</Card>
 		);
 	}
@@ -274,6 +323,12 @@ class MobileDownloadCard extends React.Component {
 		const phoneNumber = this.getPreferredNumber().numberFull;
 		this.props.sendSMS( phoneNumber );
 	};
+
+	onSubmitLink = () => {
+		this.props.recordTracksEvent( 'calypso_get_apps_magic_link_button_click' );
+		var email = this.props.userSettings.user_email;
+		this.props.sendMagicLink( email )
+	}
 }
 
 export default connect(
@@ -284,5 +339,5 @@ export default connect(
 		userSettings: getUserSettings( state ),
 		hasUserSettings: hasUserSettings( state ),
 	} ),
-	{ sendSMS, fetchUserSettings, accountRecoverySettingsFetch }
+	{ sendSMS, sendMagicLink, fetchUserSettings, accountRecoverySettingsFetch, recordTracksEvent }
 )( localize( MobileDownloadCard ) );

--- a/client/blocks/get-apps/style.scss
+++ b/client/blocks/get-apps/style.scss
@@ -67,6 +67,29 @@
 		}
 	}
 
+	.get-apps__magic-link-subpanel {
+
+		margin-top: 64px;
+
+		.get-apps__link-button-wrapper {
+
+			@include breakpoint('>480px') {
+				display: flex;
+				flex-direction: row;
+				justify-content: flex-end;
+				align-items: center;
+			}
+
+			@include breakpoint('<480px') {
+
+				.get-apps__magic-link-button {
+					width: 100%;
+				}
+			}
+		}
+
+	}
+
 	.get-apps__sms-subpanel {
 
 		// This is a hack to allow us to use a feature flag to hide this subpanel


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a button to me/get-apps allowing a user to request a magic link to log in to one of the mobile apps.  The email sent includes a link that will detect the user's mobile platform and redirect them to the appropriate app store.  See the thread at p9OQAC-cl-p2 for more information. 

Requires changes in D30681-code

#### Testing instructions

- Apply the patch. 
- Tap the button. Confirm you receive the magic link email. 
- Resize the screen.  Confirm that the UI resizes as expected. 
- Confirm that the new analytic is logged. 


![calypso-magic-link-demo](https://user-images.githubusercontent.com/1435271/61671686-501ee600-acae-11e9-9fa0-ad5f6e247d07.gif)


