### PR TITLE
Signup: Alias anonUserId to WPCOM user id when user is created 

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -197,7 +197,7 @@ const analytics = {
 	initialize: function( user, superProps ) {
 		analytics.setUser( user );
 		analytics.setSuperProps( superProps );
-		analytics.identifyUser();
+		analytics.identifyUser( user.get().username, user.get().ID );
 	},
 
 	setUser: function( user ) {
@@ -781,19 +781,15 @@ const analytics = {
 		},
 	},
 
-	identifyUser: function( { user = _user, newUserId = '', newUserName = '' } = {} ) {
+	identifyUser: function( newUserName = '', newUserId = '' ) {
 		const anonymousUserId = this.tracks.anonymousUserId();
 
 		// Don't identify the user if we don't have one
-		if ( ( user && user.initialized ) || ( newUserId && newUserName ) ) {
+		if ( newUserId && newUserName ) {
 			if ( anonymousUserId ) {
 				recordAliasInFloodlight();
 			}
-
-			const userId = newUserId || user.get().ID;
-			const userName = newUserName || user.get().username;
-
-			window._tkq.push( [ 'identifyUser', userId, userName ] );
+			window._tkq.push( [ 'identifyUser', newUserId, newUserName ] );
 		}
 	},
 

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -782,7 +782,7 @@ const analytics = {
 		},
 	},
 
-	identifyUser: function( newUserName = '', newUserId = '' ) {
+	identifyUser: function( newUserName, newUserId ) {
 		const anonymousUserId = this.tracks.anonymousUserId();
 
 		// Don't identify the user if we don't have one

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -781,16 +781,19 @@ const analytics = {
 		},
 	},
 
-	identifyUser: function() {
+	identifyUser: function( { user = _user, newUserId = '', newUserName = '' } = {} ) {
 		const anonymousUserId = this.tracks.anonymousUserId();
 
 		// Don't identify the user if we don't have one
-		if ( _user && _user.initialized ) {
+		if ( ( user && user.initialized ) || ( newUserId && newUserName ) ) {
 			if ( anonymousUserId ) {
 				recordAliasInFloodlight();
 			}
 
-			window._tkq.push( [ 'identifyUser', _user.get().ID, _user.get().username ] );
+			const userId = newUserId || user.get().ID;
+			const userName = newUserName || user.get().username;
+
+			window._tkq.push( [ 'identifyUser', userId, userName ] );
 		}
 	},
 

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -197,7 +197,8 @@ const analytics = {
 	initialize: function( user, superProps ) {
 		analytics.setUser( user );
 		analytics.setSuperProps( superProps );
-		analytics.identifyUser( user.get().username, user.get().ID );
+		const userData = user.get();
+		analytics.identifyUser( userData.username, userData.ID );
 	},
 
 	setUser: function( user ) {

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -7,6 +7,7 @@
  * External dependencies
  */
 import url from 'url';
+import cookie from 'cookie';
 
 /**
  * Internal dependencies
@@ -20,6 +21,9 @@ jest.mock( 'lib/analytics/ad-tracking', () => ( {
 	recordAliasInFloodlight: jest.fn(),
 } ) );
 jest.mock( '@automattic/load-script', () => require( './mocks/lib/load-script' ) );
+jest.mock( 'cookie', () => ( {
+	parse: jest.fn(),
+} ) );
 
 function logImageLoads() {
 	const imagesLoaded = [];
@@ -98,35 +102,43 @@ describe( 'Analytics', () => {
 	} );
 
 	describe( 'identifyUser', () => {
-		let userMock;
 		beforeEach( () => {
-			analytics.tracks.anonymousUserId = jest.fn( () => true );
-			userMock = {
-				get: jest.fn( () => ( {
-					ID: '007',
-					username: 'james',
-				} ) ),
-				initialized: true,
-			};
 			window._tkq.push = jest.fn();
+			cookie.parse.mockImplementation( () => ( { tk_ai: true } ) );
 		} );
+
+		afterEach( () => {
+			recordAliasInFloodlight.mockReset();
+		} );
+
 		test( 'should not call window._tkq.push or recordAliasInFloodlight when there is no user info', () => {
 			analytics.identifyUser();
 			expect( window._tkq.push ).not.toBeCalled();
 			expect( recordAliasInFloodlight ).not.toBeCalled();
 		} );
 
-		test( 'should call window._tkq.push and recordAliasInFloodlight when user object exists', () => {
-			analytics.identifyUser( { user: userMock } );
-			expect( recordAliasInFloodlight ).toBeCalled();
-			expect( userMock.get ).toBeCalled();
-			expect( window._tkq.push ).toBeCalledWith( [ 'identifyUser', '007', 'james' ] );
+		test( 'should not call window._tkq.push and recordAliasInFloodlight when username does not exist', () => {
+			analytics.identifyUser( undefined, '8' );
+			expect( window._tkq.push ).not.toBeCalled();
+			expect( recordAliasInFloodlight ).not.toBeCalled();
+		} );
+
+		test( 'should not call window._tkq.push and recordAliasInFloodlight when user id does not exist', () => {
+			analytics.identifyUser( 'eight', undefined );
+			expect( window._tkq.push ).not.toBeCalled();
+			expect( recordAliasInFloodlight ).not.toBeCalled();
 		} );
 
 		test( 'should call window._tkq.push and recordAliasInFloodlight when username and id exists', () => {
-			analytics.identifyUser( { newUserId: '8', newUserName: 'eight' } );
+			analytics.identifyUser( 'eight', '8' );
 			expect( recordAliasInFloodlight ).toBeCalled();
-			expect( userMock.get ).not.toBeCalled();
+			expect( window._tkq.push ).toBeCalledWith( [ 'identifyUser', '8', 'eight' ] );
+		} );
+
+		test( 'should not call recordAliasInFloodlight when anonymousUserId does not exist', () => {
+			cookie.parse.mockImplementationOnce( () => ( {} ) );
+			analytics.identifyUser( 'eight', '8' );
+			expect( recordAliasInFloodlight ).not.toBeCalled();
 			expect( window._tkq.push ).toBeCalledWith( [ 'identifyUser', '8', 'eight' ] );
 		} );
 	} );

--- a/client/lib/analytics/test/index.js
+++ b/client/lib/analytics/test/index.js
@@ -12,10 +12,12 @@ import url from 'url';
  * Internal dependencies
  */
 import analytics from '../';
+import { recordAliasInFloodlight } from 'lib/analytics/ad-tracking';
 
 jest.mock( 'config', () => require( './mocks/config' ) );
 jest.mock( 'lib/analytics/ad-tracking', () => ( {
 	retarget: () => {},
+	recordAliasInFloodlight: jest.fn(),
 } ) );
 jest.mock( '@automattic/load-script', () => require( './mocks/lib/load-script' ) );
 
@@ -92,6 +94,40 @@ describe( 'Analytics', () => {
 			expect( imagesLoaded[ 0 ].query.go ).toEqual( 'time' );
 			expect( imagesLoaded[ 0 ].query.another ).toEqual( 'one' );
 			expect( imagesLoaded[ 0 ].query.t ).toBeTruthy();
+		} );
+	} );
+
+	describe( 'identifyUser', () => {
+		let userMock;
+		beforeEach( () => {
+			analytics.tracks.anonymousUserId = jest.fn( () => true );
+			userMock = {
+				get: jest.fn( () => ( {
+					ID: '007',
+					username: 'james',
+				} ) ),
+				initialized: true,
+			};
+			window._tkq.push = jest.fn();
+		} );
+		test( 'should not call window._tkq.push or recordAliasInFloodlight when there is no user info', () => {
+			analytics.identifyUser();
+			expect( window._tkq.push ).not.toBeCalled();
+			expect( recordAliasInFloodlight ).not.toBeCalled();
+		} );
+
+		test( 'should call window._tkq.push and recordAliasInFloodlight when user object exists', () => {
+			analytics.identifyUser( { user: userMock } );
+			expect( recordAliasInFloodlight ).toBeCalled();
+			expect( userMock.get ).toBeCalled();
+			expect( window._tkq.push ).toBeCalledWith( [ 'identifyUser', '007', 'james' ] );
+		} );
+
+		test( 'should call window._tkq.push and recordAliasInFloodlight when username and id exists', () => {
+			analytics.identifyUser( { newUserId: '8', newUserName: 'eight' } );
+			expect( recordAliasInFloodlight ).toBeCalled();
+			expect( userMock.get ).not.toBeCalled();
+			expect( window._tkq.push ).toBeCalledWith( [ 'identifyUser', '8', 'eight' ] );
 		} );
 	} );
 } );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -534,10 +534,7 @@ export function createAccount(
 
 				// Fire after a new user registers.
 				analytics.recordRegistration();
-				analytics.identifyUser( {
-					newUserName: username,
-					newUserId: userId,
-				} );
+				analytics.identifyUser( username, userId );
 
 				const providedDependencies = assign( { username }, bearerToken );
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -522,13 +522,23 @@ export function createAccount(
 					);
 				}
 
-				// Fire after a new user registers.
-				analytics.recordRegistration();
-
 				const username =
 					( response && response.signup_sandbox_username ) ||
 					( response && response.username ) ||
 					userData.username;
+
+				const userId =
+					( response && response.signup_sandbox_user_id ) ||
+					( response && response.user_id ) ||
+					userData.ID;
+
+				// Fire after a new user registers.
+				analytics.recordRegistration();
+				analytics.identifyUser( {
+					newUserName: username,
+					newUserId: userId,
+				} );
+
 				const providedDependencies = assign( { username }, bearerToken );
 
 				if ( oauth2Signup ) {


### PR DESCRIPTION
Reworks #34648, which we reverted in#34825, which reworked #32850, which we reverted in #34471.

> When people visit WordPress.com before they sign up, we associate their Tracks events with an anonymous user id that’s stored in their cookies. In theory once they create an account, we’re supposed to alias/connect their anonymous user id to their actual user id so that we know which events those users fired before signing up.

We need to match a user's anonymous id with the newly-created account id for tracking purposes.

Here we're accepting a user_id and parameter in the response from the server.

Background: p3Ex-3vP-p2

## Testing instructions

Apply D30699-code

Open dev tools and in the Network tab, search for “alias”

 Go through the onboarding flow. 

`t.gif` (the pixel we load to alias the user) should load immediately after the user is created and we have a user id available to alias.

<img width="832" alt="Screen Shot 2019-06-22 at 10 41 27 am" src="https://user-images.githubusercontent.com/6458278/59961610-6a607b00-94da-11e9-9fc7-f6e382c0c077.png">

E.g.,

![Jun-22-2019 10-40-42](https://user-images.githubusercontent.com/6458278/59961620-751b1000-94da-11e9-837d-e6aff86f1247.gif)

Fixes https://github.com/Automattic/zelda-private/issues/105
