### PR TITLE
Signup: cleaning up the flows config

### DIFF
--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -12,7 +12,7 @@ import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
 import { abtest } from 'lib/abtest';
-import { generateFlows } from './flows-pure';
+import { generateFlows } from 'signup/config/flows-pure';
 
 const user = userFactory();
 
@@ -74,29 +74,6 @@ function removeUserStepFromFlow( flow ) {
 	} );
 }
 
-/**
- * Properly filter the current flow.
- *
- * Called by `getFlowName` in 'signup/utils.js' to allow conditional filtering of the current
- * flow for AB tests.
- *
- * @example
- * function filterFlowName( flowName ) {
- *   const defaultFlows = [ 'main', 'website' ];
- *   if ( ! user.get() && includes( defaultFlows, flowName ) ) {
- *     return 'filtered-flow-name';
- *   }
- *   return flowName;
- * }
- * // If user is logged out and the current flow is 'main' or 'website' switch to 'filtered-flow-name' flow.
- *
- * @param  {string} flowName Current flow name.
- * @return {string}          New flow name.
- */
-function filterFlowName( flowName ) {
-	return flowName;
-}
-
 function filterDestination( destination, dependencies ) {
 	if ( dependenciesContainCartItem( dependencies ) ) {
 		return getCheckoutUrl( dependencies );
@@ -106,7 +83,6 @@ function filterDestination( destination, dependencies ) {
 }
 
 const Flows = {
-	filterFlowName,
 	filterDestination,
 
 	defaultFlowName: config.isEnabled( 'signup/onboarding-flow' )
@@ -179,19 +155,6 @@ const Flows = {
 
 	getFlows() {
 		return flows;
-	},
-
-	isValidFlow( flowName ) {
-		return Boolean( Flows.getFlows()[ flowName ] );
-	},
-
-	removeStepFromFlow( stepName, flow ) {
-		return {
-			...flow,
-			steps: flow.steps.filter( step => {
-				return step !== stepName;
-			} ),
-		};
 	},
 };
 

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -5,9 +5,6 @@
 /**
  * External dependencies
  */
-import assert from 'assert'; // eslint-disable-line import/no-nodejs-modules
-import debugModule from 'debug';
-import sinon from 'sinon';
 
 /**
  * Internal dependencies
@@ -21,7 +18,6 @@ import {
 	getLocale,
 	getFlowName,
 } from '../utils';
-import mockedFlows from './fixtures/flows';
 import flows from 'signup/config/flows';
 
 jest.mock( 'lib/abtest', () => ( {
@@ -31,173 +27,123 @@ jest.mock( 'lib/user', () => () => ( {
 	get: () => {},
 } ) );
 
-/**
- * Module variables
- */
-const debug = debugModule( 'calypso:client:signup:controller-utils:test' );
-
-debug( 'start utils test' );
+jest.mock( 'signup/config/flows-pure', () => ( {
+	generateFlows: () => require( './fixtures/flows' ),
+} ) );
 
 describe( 'utils', () => {
-	beforeAll( () => {
-		sinon.stub( flows, 'getFlows' ).returns( mockedFlows );
-	} );
-
 	describe( 'getLocale', () => {
 		test( 'should find the locale anywhere in the params', () => {
-			assert.equal( getLocale( { lang: 'fr' } ), 'fr' );
-			assert.equal( getLocale( { stepName: 'fr' } ), 'fr' );
-			assert.equal( getLocale( { flowName: 'fr' } ), 'fr' );
+			expect( getLocale( { lang: 'fr' } ) ).toBe( 'fr' );
+			expect( getLocale( { stepName: 'fr' } ) ).toBe( 'fr' );
+			expect( getLocale( { flowName: 'fr' } ) ).toBe( 'fr' );
 		} );
 
 		test( 'should return undefined if no locale is present in the params', () => {
-			assert.equal(
+			expect(
 				getLocale( {
 					stepName: 'theme-selection',
 					flowName: 'flow-one',
-				} ),
-				undefined
-			);
+				} )
+			).toBeUndefined();
 		} );
 	} );
 
 	describe( 'getStepName', () => {
 		test( 'should find the step name in either the stepName or flowName fragment', () => {
-			assert.equal( getStepName( { stepName: 'user' } ), 'user' );
-			assert.equal( getStepName( { flowName: 'user' } ), 'user' );
+			expect( getStepName( { stepName: 'user' } ) ).toBe( 'user' );
+			expect( getStepName( { flowName: 'user' } ) ).toBe( 'user' );
 		} );
 
 		test( 'should return undefined if no step name is found', () => {
-			assert.equal( getStepName( { flowName: 'account' } ), undefined );
+			expect( getStepName( { flowName: 'account' } ) ).toBeUndefined();
 		} );
 	} );
 
 	describe( 'getFlowName', () => {
-		afterEach( () => {
-			flows.filterFlowName = null;
-		} );
-
 		test( 'should find the flow name in the flowName fragment if present', () => {
-			assert.equal( getFlowName( { flowName: 'other' } ), 'other' );
+			expect( getFlowName( { flowName: 'other' } ) ).toBe( 'other' );
 		} );
 
 		test( 'should return the default flow if the flow is missing', () => {
-			assert.equal( getFlowName( {} ), 'main' );
-		} );
-
-		test( 'should return the result of filterFlowName if it is a function and the flow is missing', () => {
-			flows.filterFlowName = sinon.stub().returns( 'filtered' );
-			assert.equal( getFlowName( {} ), 'filtered' );
-		} );
-
-		test( 'should return the result of filterFlowName if it is a function and the flow is not valid', () => {
-			flows.filterFlowName = sinon.stub().returns( 'filtered' );
-			assert.equal( getFlowName( { flowName: 'invalid' } ), 'filtered' );
-		} );
-
-		test( 'should return the result of filterFlowName if it is a function and the requested flow is present', () => {
-			flows.filterFlowName = sinon.stub().returns( 'filtered' );
-			assert.equal( getFlowName( { flowName: 'other' } ), 'filtered' );
-		} );
-
-		test( 'should return the passed flow if the result of filterFlowName is not valid', () => {
-			flows.filterFlowName = sinon.stub().returns( 'foobar' );
-			assert.equal( getFlowName( { flowName: 'other' } ), 'other' );
-		} );
-
-		test( 'should call filterFlowName with the default flow if it is a function and the flow is not valid', () => {
-			flows.filterFlowName = sinon.stub().returns( 'filtered' );
-			getFlowName( { flowName: 'invalid' } );
-			assert( flows.filterFlowName.calledWith( 'main' ) );
-		} );
-
-		test( 'should call filterFlowName with the requested flow if it is a function and the flow is valid', () => {
-			flows.filterFlowName = sinon.stub().returns( 'filtered' );
-			getFlowName( { flowName: 'other' } );
-			assert( flows.filterFlowName.calledWith( 'other' ) );
+			expect( getFlowName( {} ) ).toBe( 'main' );
 		} );
 	} );
 
 	describe( 'getValidPath', () => {
 		test( 'should redirect to the default if no flow is present', () => {
-			assert.equal( getValidPath( {} ), '/start/user' );
+			expect( getValidPath( {} ) ).toBe( '/start/user' );
 		} );
 
 		test( 'should redirect to the current flow default if no step is present', () => {
-			assert.equal( getValidPath( { flowName: 'account' } ), '/start/account/user' );
+			expect( getValidPath( { flowName: 'account' } ) ).toBe( '/start/account/user' );
 		} );
 
 		test( 'should redirect to the default flow if the flow is the default', () => {
-			assert.equal( getValidPath( { flowName: 'main' } ), '/start/user' );
+			expect( getValidPath( { flowName: 'main' } ) ).toBe( '/start/user' );
 		} );
 
 		test( 'should redirect invalid steps to the default flow if no flow is present', () => {
-			assert.equal(
+			expect(
 				getValidPath( {
 					stepName: 'fr',
 					stepSectionName: 'fr',
-				} ),
-				'/start/user/fr'
-			);
+				} )
+			).toBe( '/start/user/fr' );
 		} );
 
 		test( 'should preserve a valid locale to the default flow if one is specified', () => {
-			assert.equal(
+			expect(
 				getValidPath( {
 					stepName: 'fr',
 					stepSectionName: 'abc',
-				} ),
-				'/start/user/abc/fr'
-			);
+				} )
+			).toBe( '/start/user/abc/fr' );
 		} );
 
 		test( 'should redirect invalid steps to the current flow default', () => {
-			assert.equal(
+			expect(
 				getValidPath( {
 					flowName: 'account',
 					stepName: 'fr',
 					stepSectionName: 'fr',
-				} ),
-				'/start/account/user/fr'
-			);
+				} )
+			).toBe( '/start/account/user/fr' );
 		} );
 
 		test( 'should preserve a valid locale if one is specified', () => {
-			assert.equal(
+			expect(
 				getValidPath( {
 					flowName: 'account',
 					stepName: 'fr',
 					stepSectionName: 'abc',
-				} ),
-				'/start/account/user/abc/fr'
-			);
+				} )
+			).toBe( '/start/account/user/abc/fr' );
 		} );
 
 		test( 'should handle arbitrary step section names', () => {
 			const randomStepSectionName = 'random-step-section-' + Math.random();
 
-			assert.equal(
+			expect(
 				getValidPath( {
 					flowName: 'account',
 					stepName: 'user',
 					stepSectionName: randomStepSectionName,
 					lang: 'fr',
-				} ),
-				'/start/account/user/' + randomStepSectionName + '/fr'
-			);
+				} )
+			).toBe( `/start/account/user/${ randomStepSectionName }/fr` );
 		} );
 
 		test( 'should handle arbitrary step section names in the default flow', () => {
 			const randomStepSectionName = 'random-step-section-' + Math.random();
 
-			assert.equal(
+			expect(
 				getValidPath( {
 					stepName: 'user',
 					stepSectionName: randomStepSectionName,
 					lang: 'fr',
-				} ),
-				'/start/user/' + randomStepSectionName + '/fr'
-			);
+				} )
+			).toBe( `/start/user/${ randomStepSectionName }/fr` );
 		} );
 	} );
 
@@ -210,12 +156,12 @@ describe( 'utils', () => {
 		};
 
 		test( 'should return the value of the field if it exists', () => {
-			assert.equal( getValueFromProgressStore( config ), 'calypso' );
+			expect( getValueFromProgressStore( config ) ).toBe( 'calypso' );
 		} );
 
 		test( 'should return null if the field is not present', () => {
 			delete signupProgress[ 1 ].site;
-			assert.equal( getValueFromProgressStore( config ), null );
+			expect( getValueFromProgressStore( config ) ).toBeUndefined();
 		} );
 	} );
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Sung to the tune of [Bohemian Rhapsody](https://www.youtube.com/watch?v=fJ9rUzIMcZQ) by Queen

> Is this our flows code?
> Is this just fantasy?
> Methods we don't use,
> no escape from code legacy.
> 
> We must excise,
> bundle size guaranteeeeeeed,
> I'm just a poor dev,
> I need no `sinon` here,
> Because we're TDD... apparently,
> Make it rhyme with lemon tea.
> 
> Run the unit tests to check,
> shouldn't really break anythiiiing,
> anything...

🎹 

#### Testing instructions

`npm run test-client client/signup/test/utils.js`