### PR TITLE
Analytics: switch Floodlight to use USD

### DIFF
--- a/client/lib/analytics/ad-tracking.js
+++ b/client/lib/analytics/ad-tracking.js
@@ -618,6 +618,7 @@ function splitWpcomJetpackCartInfo( cart ) {
 		wpcomCost: wpcomCost,
 		jetpackCostUSD: costToUSD( jetpackCost, cart.currency ),
 		wpcomCostUSD: costToUSD( wpcomCost, cart.currency ),
+		totalCostUSD: costToUSD( cart.total_cost, cart.currency ),
 	};
 }
 
@@ -1195,11 +1196,11 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 
 	debug( 'recordOrderInFloodlight:' );
 	recordParamsInFloodlightGtag( {
-		value: cart.total_cost,
+		value: wpcomJetpackCartInfo.totalCostUSD,
 		transaction_id: orderId,
-		u1: cart.total_cost,
+		u1: wpcomJetpackCartInfo.totalCostUSD,
 		u2: cart.products.map( product => product.product_name ).join( ', ' ),
-		u3: cart.currency,
+		u3: 'USD',
 		send_to: 'DC-6355556/wpsal0/wpsale+transactions',
 	} );
 
@@ -1207,11 +1208,11 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 	if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
 		debug( 'recordOrderInFloodlight: WPCom' );
 		recordParamsInFloodlightGtag( {
-			value: wpcomJetpackCartInfo.wpcomCost,
+			value: wpcomJetpackCartInfo.wpcomCostUSD,
 			transaction_id: orderId,
-			u1: wpcomJetpackCartInfo.wpcomCost,
+			u1: wpcomJetpackCartInfo.wpcomCostUSD,
 			u2: wpcomJetpackCartInfo.wpcomProducts.map( product => product.product_name ).join( ', ' ),
-			u3: cart.currency,
+			u3: 'USD',
 			send_to: 'DC-6355556/wpsal0/purch0+transactions',
 		} );
 	}
@@ -1220,11 +1221,11 @@ function recordOrderInFloodlight( cart, orderId, wpcomJetpackCartInfo ) {
 	if ( wpcomJetpackCartInfo.containsJetpackProducts ) {
 		debug( 'recordOrderInFloodlight: Jetpack' );
 		recordParamsInFloodlightGtag( {
-			value: wpcomJetpackCartInfo.jetpackCost,
+			value: wpcomJetpackCartInfo.jetpackCostUSD,
 			transaction_id: orderId,
-			u1: wpcomJetpackCartInfo.jetpackCost,
+			u1: wpcomJetpackCartInfo.jetpackCostUSD,
 			u2: wpcomJetpackCartInfo.jetpackProducts.map( product => product.product_name ).join( ', ' ),
-			u3: cart.currency,
+			u3: 'USD',
 			send_to: 'DC-6355556/wpsal0/purch00+transactions',
 		} );
 	}


### PR DESCRIPTION
#### Changes

Floodlight assumes all values to be in USD and ignores the currency `u3` param therefore we are switching to passing USD-converted amounts all the time.

#### Testing 

Enable tracking & logging:
```
document.cookie = 'flags=gdpr-banner,google-analytics,ad-tracking; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
document.cookie = 'sensitive_pixel_option=yes; path=/; domain=.' + document.location.hostname.split( '.' ).slice( -2 ).join( '.' );
localStorage.setItem( 'debug', 'calypso:analytics:*' );
```

Reload and make sure your JS console logs show `isAdTrackingAllowed: true`.

Purchase anything and you should see USD amounts in the JS console like so;

![image](https://user-images.githubusercontent.com/10284338/61807998-7cfc0600-ae32-11e9-9be8-adbcf017b289.png)

Everything else should keep working as usual.