### PR TITLE
(5P) Starter Page Templates: Fetch assets from template before insertion

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -82,7 +82,7 @@ class PageTemplateModal extends Component {
 		}
 
 		// Make sure all blocks use local assets before inserting.
-		ensureAssets( blocks )
+		this.maybePrefetchAssets( blocks )
 			.then( blocksWithAssets => {
 				// Don't insert anything if the user clicked Cancel/Close
 				// before we loaded everything.
@@ -99,6 +99,10 @@ class PageTemplateModal extends Component {
 					error,
 				} );
 			} );
+	};
+
+	maybePrefetchAssets = blocks => {
+		return this.props.shouldPrefetchAssets ? ensureAssets( blocks ) : Promise.resolve( blocks );
 	};
 
 	handleConfirmation = () => this.setTemplate( this.state.slug, this.state.title );
@@ -236,7 +240,12 @@ if ( tracksUserData ) {
 registerPlugin( 'page-templates', {
 	render: () => {
 		return (
-			<PageTemplatesPlugin templates={ templates } vertical={ vertical } segment={ segment } />
+			<PageTemplatesPlugin
+				shouldPrefetchAssets={ false }
+				templates={ templates }
+				vertical={ vertical }
+				segment={ segment }
+			/>
 		);
 	},
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -296,3 +296,16 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		height: 100%;
 	}
 }
+
+.page-template-modal__loading {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+	transform: translate( -50%, -50% );
+	display: flex;
+    align-items: flex-end;
+}
+
+.page-template-modal__loading .components-spinner {
+	float: none;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

New flow after selecting a template:

- analyze blocks used and look for images in them:
  - if there are none, proceed right away or after a short delay (that would address #34570)
  - if there are any, call API that fetches images from remote URLs into the site and returns their new URLs and attachment ids. Replace old URLs and ids with those local ones
- (optional) loading state
- insert template into the editor and close modal

#### TODO:

- [x] add support for `core/cover`
- [x] `core/gallery` blocks
- [x] `core/media-text` blocks
- [x] document functions, params, return values…
- [x] gracefully handle URLs with resizing arguments (like `?w=640`)
- [x] replace mocked API with real one
- [x] introduce a "loading state" between template selection and showing it inside editor

#### Testing instructions

Install plugin on your WP, following https://github.com/Automattic/wp-calypso/blob/master/apps/full-site-editing/README.md

- Create a new page and use the tempalte selector
- About or Contact templates should be inserted immediately (but the modal itself has a 300ms delay before it closes)
- Other templates using images should fire a request to import images (follow your devtools and look for `POST /wp-json/fse/v1/batch`)
- After the request succeeds, template is inserted into the editor and modal closes 300ms after
- Inspect images inside the block editor - they should all be loaded from the same domain.
- Check media library for new images.

Fixes #34603
Fixes #34570