### PR TITLE
Signup: Link import from main signup flow by using `import` site type

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -637,17 +637,16 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 }
 
 export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) {
-	if ( isEmpty( nextProps.initialContext && nextProps.initialContext.query ) ) {
-		return;
+	// debugger;
+	let siteType, siteTypeValue;
+
+	if ( nextProps.flowName === 'import' ) {
+		siteType = siteTypeValue = 'import';
+	} else {
+		siteType = get( nextProps, [ 'initialContext', 'query', 'site_type' ], null );
+		siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
 	}
 
-	const {
-		initialContext: {
-			query: { site_type: siteType },
-		},
-	} = nextProps;
-
-	const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
 	let fulfilledDependencies = [];
 
 	if ( siteTypeValue ) {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -637,7 +637,6 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 }
 
 export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) {
-	// debugger;
 	let siteType, siteTypeValue;
 
 	if ( nextProps.flowName === 'import' ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -281,7 +281,7 @@ export function generateFlows( {
 	};
 
 	flows.import = {
-		steps: [ 'from-url', 'user', 'domains' ],
+		steps: [ 'user', 'site-type', 'from-url', 'domains' ],
 		destination: ( { importEngine, importSiteUrl, siteSlug } ) =>
 			addQueryArgs(
 				{

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Badge from 'components/badge';
+import Button from 'components/button';
 import Card from 'components/card';
 import { getAllSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -62,6 +63,11 @@ class SiteTypeForm extends Component {
 						</Card>
 					) ) }
 				</Card>
+				<div className="site-type__import-button">
+					<Button borderless onClick={ this.handleSubmit.bind( this, 'import' ) }>
+						{ this.props.translate( 'Already have a website?' ) }
+					</Button>
+				</div>
 			</Fragment>
 		);
 	}

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -16,6 +16,7 @@ import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
 
 const siteTypeToFlowname = {
+	import: 'import',
 	'online-store': 'ecommerce-onboarding',
 };
 

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -84,3 +84,20 @@
 		transform: translateX( 0 );
 	}
 }
+
+.site-type__import-button {
+	text-align: center;
+	margin-top: 20px;
+
+	.button.is-borderless {
+		padding: 0;
+		color: var( --color-white );
+		font-size: 14px;
+		font-weight: 500;
+		text-decoration: underline;
+
+		svg {
+			fill: var( --color-white );
+		}
+	}
+}


### PR DESCRIPTION
**Option 3** for linking to import flow from main signup flow

- Adds the site-type step to the import flow
- Use `import` for the site type value
- Automatically submits the site type step within the import flow

**Problems**
1. When entering import signup flow by clicking on "Already have a website?", both the browser back button and the "Back" link in the next step (/start/import/from-url) has unexpected behavior.
    - If creating a new user in the signup flow, both the browser back button and the "Back" link take you to `/start/user` with the user form already filled out. Continuing from there skips the site type step and goes directly to `/start/site-topic-with-preview`.
    - If already logged in, the browser back button takes you to `/start/site-topic-with-preview`, rather than back to the site type step (because site type has already been fulfilled).
1. We don't actually capture a real site type in the import flow this way (but it prevents the step from showing up again at the end of the flow)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Main flow

- Visit `/start` logged out
- Create a new user and proceed to the site type step
- Click "Already have a website?" to be redirected to the import flow

Import flow

- Visit `/start/import`
- You should not see the site type step, but the site type should to `import`
