### PR TITLE
New layout: action panel as header plus two columns of cards

### DIFF
--- a/client/components/layout-header-two-col/index.tsx
+++ b/client/components/layout-header-two-col/index.tsx
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import React, { Fragment, FunctionComponent, ReactNode } from 'react';
+import { map } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import Button from 'components/button';
+import Card from 'components/card';
+import ActionPanel from 'components/action-panel';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
+import PageViewTracker from 'lib/analytics/page-view-tracker';
+
+/**
+ * Types
+ */
+import * as T from 'types';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+interface Props {
+	selectedSiteSlug: T.SiteSlug | null;
+	viewTrackerPath: string; // /marketing/tools/:site
+	viewTrackerTitle: string; // Marketing > Tools
+	header: ReactNode;
+	headerClick: null | Function;
+	cards: ReactNode[];
+}
+
+const renderCards: ( card: ReactNode ) => ReactNode = function( card: ReactNode ): ReactNode {
+	return (
+		<Card title={ card.title } description={ card.description } imagePath={ card.icon }>
+			<Button compact onClick={ card.buttonClick } href={ card.buttonHref } target="_blank">
+				{ card.buttonLabel }
+			</Button>
+		</Card>
+	);
+};
+
+export const LayoutHeaderTwoCol: FunctionComponent< Props > = ( {
+	selectedSiteSlug,
+	viewTrackerPath,
+	viewTrackerTitle,
+	header,
+	headerClick,
+	cards,
+} ) => {
+	return (
+		<Fragment>
+			<PageViewTracker path={ viewTrackerPath } title={ viewTrackerTitle } />
+			<ActionPanel>
+				<div>{ header }</div>
+				<div>{ headerClick }</div>
+				<div>{ selectedSiteSlug }</div>
+			</ActionPanel>
+			<div className="layout-header-two-col__list">{ map( cards, renderCards ) }</div>
+		</Fragment>
+	);
+};
+
+export default connect( state => ( {
+	selectedSiteSlug: getSelectedSiteSlug( state ),
+} ) )( LayoutHeaderTwoCol );

--- a/client/components/layout-header-two-col/index.tsx
+++ b/client/components/layout-header-two-col/index.tsx
@@ -11,6 +11,10 @@ import { map } from 'lodash';
 import Button from 'components/button';
 import Card from 'components/card';
 import ActionPanel from 'components/action-panel';
+import ActionPanelTitle from 'components/action-panel/title';
+import ActionPanelBody from 'components/action-panel/body';
+import ActionPanelFigure from 'components/action-panel/figure';
+import ActionPanelCta from 'components/action-panel/cta';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 
@@ -28,8 +32,16 @@ interface Props {
 	selectedSiteSlug: T.SiteSlug | null;
 	viewTrackerPath: string; // /marketing/tools/:site
 	viewTrackerTitle: string; // Marketing > Tools
-	header: ReactNode;
-	headerClick: null | Function;
+	header: {
+		title: string;
+		desc: string;
+		iconSrc: string;
+		iconWidth: '170' | string;
+		iconHeight: '143' | string;
+		alt: string;
+		buttonLabel: string;
+		buttonHref: string;
+	};
 	cards: ReactNode[];
 }
 
@@ -48,16 +60,32 @@ export const LayoutHeaderTwoCol: FunctionComponent< Props > = ( {
 	viewTrackerPath,
 	viewTrackerTitle,
 	header,
-	headerClick,
 	cards,
 } ) => {
 	return (
 		<Fragment>
 			<PageViewTracker path={ viewTrackerPath } title={ viewTrackerTitle } />
 			<ActionPanel>
-				<div>{ header }</div>
-				<div>{ headerClick }</div>
-				<div>{ selectedSiteSlug }</div>
+				<ActionPanelBody>
+					<ActionPanelFigure inlineBodyText={ true } align="left">
+						<img
+							src={ header.iconSrc }
+							width={ header.iconWidth }
+							height={ header.iconHeight }
+							alt={ header.alt }
+						/>
+					</ActionPanelFigure>
+					<ActionPanelTitle>{ header.title }</ActionPanelTitle>
+					<p>
+						{ header.description }
+						{ `remove this ${ selectedSiteSlug }` }
+					</p>
+					<ActionPanelCta>
+						<Button className="layout-header-two-col__header-button" href={ header.buttonHref }>
+							{ header.buttonLabel }
+						</Button>
+					</ActionPanelCta>
+				</ActionPanelBody>
 			</ActionPanel>
 			<div className="layout-header-two-col__list">{ map( cards, renderCards ) }</div>
 		</Fragment>

--- a/client/components/layout-header-two-col/style.scss
+++ b/client/components/layout-header-two-col/style.scss
@@ -1,0 +1,56 @@
+.layout-header-two-col__list {
+	position: relative;
+	left: calc( -0.5em );
+	display: flex;
+	flex-wrap: wrap;
+	// margins of the items will "hang off the side" invisibly
+	width: calc( 100% + 1em );
+}
+
+.layout-header-two-col__list-item {
+	display: flex;
+	flex-direction: column;
+	margin: 0.5em;
+	width: calc( 100% - 1em );
+
+	@include breakpoint( '>1040px' ) {
+		width: calc( 50% - 1em );
+	}
+}
+
+.layout-header-two-col__list-item-disclaimer {
+	color: var( --color-text-subtle );
+	font-style: italic;
+}
+
+.layout-header-two-col__list-item-body {
+	align-items: flex-start;
+	display: flex; // grow this, leave buttons on the bottom of the card
+	flex: 1 0 auto;
+}
+
+.layout-header-two-col__list-item-body-text {
+	width: 100%;
+
+	> p {
+		margin-bottom: 0;
+	}
+
+	@include breakpoint( '>1040px' ) {
+		width: 75%;
+	}
+}
+
+.layout-header-two-col__list-item-body-image {
+	margin: 10px 20px 0 0;
+	max-width: 150px;
+	width: 15%;
+
+	@include breakpoint( '>1040px' ) {
+		display: flex;
+	}
+
+	@include breakpoint( '<480px' ) {
+		display: none;
+	}
+}


### PR DESCRIPTION
This PR introduces a new component that renders a layout consisting a full width actionable card as header, plus two columns of feature cards, each one with an icon, title, description, and an optional action button.

#### Changes proposed in this Pull Request

* introduce new layout with full width card header and two columns of feature cards

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* use calypso live and make sure things look good

Fixes #34530
