### PR TITLE
Replace Jed with Tannin.

### DIFF
--- a/client/my-sites/email/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-item.jsx
@@ -85,8 +85,8 @@ class EmailForwardingItem extends React.Component {
 								em: <em />,
 							},
 							args: {
-								email: email || '',
-								forwardTo: destination || '',
+								email: email,
+								forwardTo: destination,
 							},
 						}
 					) }

--- a/client/my-sites/email/email-forwarding/email-forwarding-item.jsx
+++ b/client/my-sites/email/email-forwarding/email-forwarding-item.jsx
@@ -85,8 +85,8 @@ class EmailForwardingItem extends React.Component {
 								em: <em />,
 							},
 							args: {
-								email: email,
-								forwardTo: destination,
+								email: email || '',
+								forwardTo: destination || '',
 							},
 						}
 					) }

--- a/package-lock.json
+++ b/package-lock.json
@@ -272,7 +272,7 @@
 				"@emotion/styled": "10.0.23",
 				"@wordpress/data": "^4.9.2",
 				"emotion-theming": "10.0.19",
-				"i18n-calypso": "^4.0.0",
+				"i18n-calypso": "file:packages/i18n-calypso",
 				"prop-types": "^15.7.2",
 				"react": "^16.8.6",
 				"react-stripe-elements": "^5.1.0"
@@ -284,22 +284,6 @@
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"requires": {
 						"ms": "^2.1.1"
-					}
-				},
-				"i18n-calypso": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/i18n-calypso/-/i18n-calypso-4.0.0.tgz",
-					"integrity": "sha512-L1oMtViG/LtwWqGcLfA6FJN+ililsA6r/fPJswxvND8waJAWRONZEDmmjojs6MKratJ1E6cnFjTifiC75zuHHQ==",
-					"requires": {
-						"debug": "^3.2.6",
-						"events": "^3.0.0",
-						"hash.js": "^1.1.5",
-						"interpolate-components": "^1.1.1",
-						"jed": "^1.1.1",
-						"lodash": "^4.17.11",
-						"lru": "^3.1.0",
-						"moment": "^2.24.0",
-						"react": "^16.8.3"
 					}
 				},
 				"react-stripe-elements": {
@@ -3425,31 +3409,31 @@
 			"dev": true
 		},
 		"@tannin/compile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.3.tgz",
-			"integrity": "sha512-OkPHvaM/hIHdSco3+ZO1hzkOtfEddn5a0veWft2aDLvKnbdj9VusiLKNdEE9by3hCZIIcb9aWF+iBorhfrQOfw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.4.tgz",
+			"integrity": "sha512-RVfzknkrDTgtLhFSEaoGGIjpQsOzS75lzsf6v3IHP+sThoJ4qL2iQDopGo36OYeb6EzJMSKVGhsrTvqE/a1IpQ==",
 			"requires": {
-				"@tannin/evaluate": "^1.1.1",
-				"@tannin/postfix": "^1.0.2"
+				"@tannin/evaluate": "^1.1.2",
+				"@tannin/postfix": "^1.0.3"
 			}
 		},
 		"@tannin/evaluate": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.1.1.tgz",
-			"integrity": "sha512-ALuSZHjrLHGnw0WxsHDHde74FJ2WW0Ck4rg3QBxFBCmxd6Wsac+e0HXfJ++Qion15LIOCmFhyVpWzawMgeBA8Q=="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.1.2.tgz",
+			"integrity": "sha512-ME/CNm9zpCqJwTZa1WUpWp51lY5IpJcsFgsNouPsgApI5D1Vr/sR/zPAQEyS8ruk45YUoFqP82VIGIhQFrhYKQ=="
 		},
 		"@tannin/plural-forms": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.3.tgz",
-			"integrity": "sha512-IUr9+FiCnzCiB9aRio3FVNR8TNL9SmX2zkV6tmfWWwSclX4uTCykoGsDhTGKK+sZnMrdPCTmb/OxbtGNdVyV4g==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.4.tgz",
+			"integrity": "sha512-NSlGvF6q2OLXWWDLgzZRM2+L1uLBxl5wgxfmi9ZZUpZjlg+Z7Ss/QbAJpAJGxgvERuA1jhqpAuTvr/2fNbH+Ag==",
 			"requires": {
-				"@tannin/compile": "^1.0.3"
+				"@tannin/compile": "^1.0.4"
 			}
 		},
 		"@tannin/postfix": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.2.tgz",
-			"integrity": "sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.3.tgz",
+			"integrity": "sha512-80uoGtphTH3vDZlJgE2xJh3qBWMAlCXq8wN8WLOxHJjms0A38vkbXOXiYMIabgnIJVc1vCcZVQa2pHt+X3AF5Q=="
 		},
 		"@tannin/sprintf": {
 			"version": "1.1.0",
@@ -14463,11 +14447,6 @@
 			"requires": {
 				"handlebars": "^4.1.2"
 			}
-		},
-		"jed": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/jed/-/jed-1.1.1.tgz",
-			"integrity": "sha1-elSbvZ/+FYWwzQoZHiAwVb7ldLQ="
 		},
 		"jest": {
 			"version": "24.9.0",
@@ -27335,11 +27314,11 @@
 			}
 		},
 		"tannin": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.1.0.tgz",
-			"integrity": "sha512-LxhcXqpMHEOVeVKmuG5aCPPsTXFlO373vrWkqN7FSJBVLS6lFOAg8ZGzIyGhrOf7Ho3xB4jdGedY1gi/8J1FCA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.1.1.tgz",
+			"integrity": "sha512-e6qNtx1XZnvC3psLnvboUekSY4phq77YDnDDhE/nqghpTVz2MbrsrN0M1dysof/WfkcSvnRVZyR8NYu5KcFtQw==",
 			"requires": {
-				"@tannin/plural-forms": "^1.0.3"
+				"@tannin/plural-forms": "^1.0.4"
 			}
 		},
 		"tapable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13368,20 +13368,7 @@
 			}
 		},
 		"i18n-calypso": {
-			"version": "file:packages/i18n-calypso",
-			"requires": {
-				"@wordpress/compose": "^3.7.2",
-				"debug": "^4.0.0",
-				"events": "^3.0.0",
-				"hash.js": "^1.1.5",
-				"interpolate-components": "^1.1.1",
-				"jed": "^1.1.1",
-				"lodash": "^4.17.11",
-				"lru": "^3.1.0",
-				"moment": "^2.24.0",
-				"react": "^16.8.3",
-				"use-subscription": "^1.2.0"
-			}
+			"version": "file:packages/i18n-calypso"
 		},
 		"i18n-calypso-cli": {
 			"version": "file:packages/i18n-calypso-cli",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3451,6 +3451,11 @@
 			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.2.tgz",
 			"integrity": "sha512-Nggtk7/ljfNPpAX8CjxxLkMKuO6u2gH1ozmTvGclWF2pNcxTf6YGghYNYNWZRKrimXGhQ8yZqvAHep7h80K04g=="
 		},
+		"@tannin/sprintf": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.1.0.tgz",
+			"integrity": "sha512-ZDNn9GHcrvdhQJMSl7fyo2MUZTZrXG7IgNf1g8wRNWP3J48OAl1ZlSC7Tx81fJQHnblm3UIFVZO9XvNV94FW+g=="
+		},
 		"@testing-library/dom": {
 			"version": "6.10.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.10.1.tgz",
@@ -13368,7 +13373,58 @@
 			}
 		},
 		"i18n-calypso": {
-			"version": "file:packages/i18n-calypso"
+			"version": "file:packages/i18n-calypso",
+			"requires": {
+				"@tannin/sprintf": "^1.1.0",
+				"@wordpress/compose": "^3.7.2",
+				"debug": "^4.0.0",
+				"events": "^3.0.0",
+				"hash.js": "^1.1.5",
+				"interpolate-components": "^1.1.1",
+				"lodash": "^4.17.11",
+				"lru": "^3.1.0",
+				"moment": "^2.24.0",
+				"react": "^16.8.3",
+				"tannin": "^1.1.1",
+				"use-subscription": "^1.2.0"
+			},
+			"dependencies": {
+				"@tannin/compile": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.0.4.tgz",
+					"integrity": "sha512-RVfzknkrDTgtLhFSEaoGGIjpQsOzS75lzsf6v3IHP+sThoJ4qL2iQDopGo36OYeb6EzJMSKVGhsrTvqE/a1IpQ==",
+					"requires": {
+						"@tannin/evaluate": "^1.1.2",
+						"@tannin/postfix": "^1.0.3"
+					}
+				},
+				"@tannin/evaluate": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/@tannin/evaluate/-/evaluate-1.1.2.tgz",
+					"integrity": "sha512-ME/CNm9zpCqJwTZa1WUpWp51lY5IpJcsFgsNouPsgApI5D1Vr/sR/zPAQEyS8ruk45YUoFqP82VIGIhQFrhYKQ=="
+				},
+				"@tannin/plural-forms": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/@tannin/plural-forms/-/plural-forms-1.0.4.tgz",
+					"integrity": "sha512-NSlGvF6q2OLXWWDLgzZRM2+L1uLBxl5wgxfmi9ZZUpZjlg+Z7Ss/QbAJpAJGxgvERuA1jhqpAuTvr/2fNbH+Ag==",
+					"requires": {
+						"@tannin/compile": "^1.0.4"
+					}
+				},
+				"@tannin/postfix": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.0.3.tgz",
+					"integrity": "sha512-80uoGtphTH3vDZlJgE2xJh3qBWMAlCXq8wN8WLOxHJjms0A38vkbXOXiYMIabgnIJVc1vCcZVQa2pHt+X3AF5Q=="
+				},
+				"tannin": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/tannin/-/tannin-1.1.1.tgz",
+					"integrity": "sha512-e6qNtx1XZnvC3psLnvboUekSY4phq77YDnDDhE/nqghpTVz2MbrsrN0M1dysof/WfkcSvnRVZyR8NYu5KcFtQw==",
+					"requires": {
+						"@tannin/plural-forms": "^1.0.4"
+					}
+				}
+			}
 		},
 		"i18n-calypso-cli": {
 			"version": "file:packages/i18n-calypso-cli",

--- a/packages/composite-checkout-wpcom/package.json
+++ b/packages/composite-checkout-wpcom/package.json
@@ -42,7 +42,7 @@
 		"@emotion/styled": "10.0.23",
 		"@wordpress/data": "^4.9.2",
 		"emotion-theming": "10.0.19",
-		"i18n-calypso": "^4.0.0",
+		"i18n-calypso": "file:../i18n-calypso",
 		"prop-types": "^15.7.2",
 		"react": "^16.8.6",
 		"react-stripe-elements": "^5.1.0"

--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -2,6 +2,7 @@ next
 -----
 
 * Update debug to v4
+* Switch from Jed to Tannin, for smaller size as well as runtime speedups
 
 4.1.0
 -----

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -391,11 +391,11 @@ export default withRtl( Header );
 
 ## Some Background
 
-I18n accepts a language-specific locale json file that contains the whitelisted translation strings for your JS project, uses that data to instantiate a [Jed](https://messageformat.github.io/Jed/) instance, and exposes a single `translate` method with sugared syntax for interacting with Jed.
+I18n accepts a language-specific locale json file that contains the whitelisted translation strings for your JS project, uses that data to instantiate a [Tannin](https://github.com/aduth/tannin) instance, and exposes a single `translate` method with sugared syntax for interacting with Tannin.
 
 ### Key Hashing
 
-In order to reduce file-size, i18n-calypso allows the usage of hashed keys for lookup. This is a non-standard extension of the Jed standard which is enabled by supplying a header key `key-hash` to specify a hash method (currently only `sha1` is supported), as well as a hash length. For example `sha1-4` uses the first 4 hexadecimal chars of the sha1 hash of the standard Jed lookup string. As a further optimization, variable hash lengths are available, potentially requiring multiple lookups per string: `sha1-3-7` specifies that hash lengths of 3 to 7 are used in the file.
+In order to reduce file-size, i18n-calypso allows the usage of hashed keys for lookup. This is a non-standard extension of the Jed standard (used by Tannin) which is enabled by supplying a header key `key-hash` to specify a hash method (currently only `sha1` is supported), as well as a hash length. For example `sha1-4` uses the first 4 hexadecimal chars of the sha1 hash of the standard Jed lookup string. As a further optimization, variable hash lengths are available, potentially requiring multiple lookups per string: `sha1-3-7` specifies that hash lengths of 3 to 7 are used in the file.
 
 #### Example
 

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -28,6 +28,8 @@
 		"lru": "^3.1.0",
 		"moment": "^2.24.0",
 		"react": "^16.8.3",
+		"sprintf-js": "^1.1.2",
+		"tannin": "^1.1.0",
 		"use-subscription": "^1.2.0"
 	},
 	"scripts": {

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "i18n-calypso",
 	"version": "4.1.0",
-	"description": "i18n JavaScript library on top of Jed originally used in Calypso",
+	"description": "i18n JavaScript library on top of Tannin originally used in Calypso",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",
 	"types": "types/index.d.ts",
@@ -18,18 +18,17 @@
 	},
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/master/packages/i18n-calypso#readme",
 	"dependencies": {
+		"@tannin/sprintf": "^1.1.0",
 		"@wordpress/compose": "^3.7.2",
 		"debug": "^4.0.0",
 		"events": "^3.0.0",
 		"hash.js": "^1.1.5",
 		"interpolate-components": "^1.1.1",
-		"jed": "^1.1.1",
 		"lodash": "^4.17.11",
 		"lru": "^3.1.0",
 		"moment": "^2.24.0",
 		"react": "^16.8.3",
-		"sprintf-js": "^1.1.2",
-		"tannin": "^1.1.0",
+		"tannin": "^1.1.1",
 		"use-subscription": "^1.2.0"
 	},
 	"scripts": {

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -52,9 +52,10 @@ function simpleArguments( args ) {
 }
 
 /**
- * Coerce the possible arguments and normalize to a single object
- * @param  {arguments} args - arguments passed in from `translate()`
- * @return {object}         - a single object describing translation needs
+ * Coerce the possible arguments and normalize to a single object.
+ *
+ * @param   {any} args - arguments passed in from `translate()`
+ * @returns {object}         - a single object describing translation needs
  */
 function normalizeTranslateArguments( args ) {
 	const original = args[ 0 ];
@@ -108,10 +109,11 @@ function normalizeTranslateArguments( args ) {
 }
 
 /**
- * Takes translate options object and coerces to a Tannin request to retrieve translation
- * @param  {object} tannin  - tannin data object
- * @param  {object} options - object describing translation
- * @return {string}         - the returned translation from Tannin
+ * Takes translate options object and coerces to a Tannin request to retrieve translation.
+ *
+ * @param   {object} tannin  - tannin data object
+ * @param   {object} options - object describing translation
+ * @returns {string}         - the returned translation from Tannin
  */
 function getTranslationFromTannin( tannin, options ) {
 	return tannin.dcnpgettext(
@@ -177,10 +179,11 @@ I18N.prototype.emit = function( ...args ) {
 };
 
 /**
- * Formats numbers using locale settings and/or passed options
- * @param  {String|Number|Int}  number to format (required)
- * @param  {Int|object} options  Number of decimal places or options object (optional)
- * @return {string}         Formatted number as string
+ * Formats numbers using locale settings and/or passed options.
+ *
+ * @param   {string|number}  number to format (required)
+ * @param   {number|object}  options  Number of decimal places or options object (optional)
+ * @returns {string}         Formatted number as string
  */
 I18N.prototype.numberFormat = function( number, options = {} ) {
 	const decimals = typeof options === 'number' ? options : options.decimals || 0;
@@ -309,6 +312,7 @@ I18N.prototype.getLocale = function() {
 
 /**
  * Get the current locale slug.
+ *
  * @returns {string} The string representing the currently loaded locale
  **/
 I18N.prototype.getLocaleSlug = function() {
@@ -316,7 +320,8 @@ I18N.prototype.getLocaleSlug = function() {
 };
 
 /**
- * Get the current text direction, left-to-right (LTR) or right-to-left (RTL)
+ * Get the current text direction, left-to-right (LTR) or right-to-left (RTL).
+ *
  * @returns {boolean} `true` in case the current locale has RTL text direction
  */
 I18N.prototype.isRtl = function() {
@@ -324,8 +329,9 @@ I18N.prototype.isRtl = function() {
 };
 
 /**
- * Adds new translations to the locale data, overwriting any existing translations with a matching key
- * @param {Object} localeData Locale data
+ * Adds new translations to the locale data, overwriting any existing translations with a matching key.
+ *
+ * @param {object} localeData Locale data
  */
 I18N.prototype.addTranslations = function( localeData ) {
 	for ( const prop in localeData ) {
@@ -338,12 +344,9 @@ I18N.prototype.addTranslations = function( localeData ) {
 };
 
 /**
- * Checks whether the given original has a translation. Parameters are the same as for translate().
+ * Checks whether the given original has a translation.
  *
- * @param  {string} original  the string to translate
- * @param  {string} plural    the plural string to translate (if applicable), original used as singular
- * @param  {object} options   properties describing translation requirements for given text
- * @return {boolean} whether a translation exists
+ * @returns {boolean} whether a translation exists
  */
 I18N.prototype.hasTranslation = function() {
 	return !! getTranslation( this, normalizeTranslateArguments( arguments ) );
@@ -352,10 +355,8 @@ I18N.prototype.hasTranslation = function() {
 /**
  * Exposes single translation method.
  * See sibling README
- * @param  {string} original  the string to translate
- * @param  {string} plural    the plural string to translate (if applicable), original used as singular
- * @param  {object} options   properties describing translation requirements for given text
- * @return {string|React-components} translated text or an object containing React children that can be inserted into a parent component
+ *
+ * @returns {string|object} translated text or an object containing React children that can be inserted into a parent component
  */
 I18N.prototype.translate = function() {
 	const options = normalizeTranslateArguments( arguments );

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -8,7 +8,7 @@ import LRU from 'lru';
 import moment from 'moment';
 import sha1 from 'hash.js/lib/hash/sha/1';
 import { EventEmitter } from 'events';
-import { sprintf } from 'sprintf-js';
+import sprintf from '@tannin/sprintf';
 
 /**
  * Internal dependencies

--- a/packages/i18n-calypso/src/i18n.js
+++ b/packages/i18n-calypso/src/i18n.js
@@ -300,7 +300,6 @@ I18N.prototype.setLocale = function( localeData ) {
 		this.state.numberFormatSettings.thousands_sep = ',';
 	}
 
-	this.state.translations.clear();
 	this.stateObserver.emit( 'change' );
 };
 
@@ -335,7 +334,6 @@ I18N.prototype.addTranslations = function( localeData ) {
 		}
 	}
 
-	this.state.translations.clear();
 	this.stateObserver.emit( 'change' );
 };
 
@@ -361,26 +359,6 @@ I18N.prototype.hasTranslation = function() {
  */
 I18N.prototype.translate = function() {
 	const options = normalizeTranslateArguments( arguments );
-
-	let optionsString;
-	let cacheable = ! options.components;
-	if ( cacheable ) {
-		// Safe JSON stringification here to catch Circular JSON error
-		// caused by passing a React component into args where only scalars are allowed
-		try {
-			optionsString = JSON.stringify( options );
-		} catch ( e ) {
-			cacheable = false;
-		}
-
-		if ( optionsString ) {
-			const translation = this.state.translations.get( optionsString );
-			// Return the cached translation.
-			if ( translation ) {
-				return translation;
-			}
-		}
-	}
 
 	let translation = getTranslation( this, options );
 	if ( ! translation ) {
@@ -422,10 +400,6 @@ I18N.prototype.translate = function() {
 		translation = hook( translation, options );
 	} );
 
-	if ( cacheable ) {
-		this.state.translations.set( optionsString, translation );
-	}
-
 	return translation;
 };
 
@@ -441,7 +415,6 @@ I18N.prototype.translate = function() {
  */
 I18N.prototype.reRenderTranslations = function() {
 	debug( 'Re-rendering all translations due to external request' );
-	this.state.translations.clear();
 	this.stateObserver.emit( 'change' );
 };
 


### PR DESCRIPTION
`Jed` is both large and slow at runtime. `Tannin` is better in both respects and is relatively straightforward to get working in our current setup.

Big thanks to @aduth for writing `Tannin` in the first place! 🙂 

Loading performance: ~3.7KB less JS in the critical path.
Runtime performance: `I18N.translate` now takes approximately 1/3 of the time it did before this PR while loading Reader.

#### Changes proposed in this Pull Request

* Rewrite `i18n-calypso` to use `Tannin` instead of `Jed`.
* Remove `i18n-calypso` caching layer, as it is no longer necessary.

#### Testing instructions

Visit as many pages as possible in a language other than English, and ensure that translations are correct. Pay particular attention to plurals and translations with context.