### PR TITLE
Change "Site" to "Content"

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -634,7 +634,7 @@ export class MySitesSidebar extends Component {
 				<ExpandableSidebarMenu
 					onClick={ this.toggleSection( SIDEBAR_SECTION_SITE ) }
 					expanded={ this.props.isSiteSectionOpen }
-					title={ this.props.translate( 'Site' ) }
+					title={ this.props.translate( 'Content' ) }
 					materialIcon="edit"
 				>
 					{ this.site() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

I'd like to propose changing the "Site" parent category section title:

![site](https://user-images.githubusercontent.com/5634774/61733552-0be32280-ad4e-11e9-9dc6-709e23f373dd.png)

to instead be "Content":

![Screen Shot 2019-07-23 at 12 59 41 PM-1](https://user-images.githubusercontent.com/5634774/61733576-1a313e80-ad4e-11e9-82ab-74ea17f923cf.png)

My reasoning for this change is two-fold:

1) "Content" seems to make more sense when considering ALL of our users. Only ~20% of our customers are trying to build a business "Site". All of our customers however, whether they're trying to build a site, or simply start a blog have the need to edit "Content".

2) Taking into account the links that are embedded within this section, "Content" seems to be more contextually accurate than "Site". I realize however that this is subjective.

I've labelled this as "DO NOT MERGE" to give folks a chance to weigh in.