### PR TITLE
Me: Use Stripe Elements for "Add Card" form

### DIFF
--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -58,7 +58,12 @@ export function CreditCardForm( {
 	const [ formFieldValues, setFormFieldValues ] = useState( getInitializedFields( initialValues ) );
 	const [ touchedFormFields, setTouchedFormFields ] = useState( {} );
 	const [ formFieldErrors, setFormFieldErrors ] = useState(
-		camelCaseFormFields( validatePaymentDetails( kebabCaseFormFields( formFieldValues ) ).errors )
+		camelCaseFormFields(
+			validatePaymentDetails(
+				kebabCaseFormFields( formFieldValues ),
+				stripe ? 'stripe' : 'credit-card'
+			).errors
+		)
 	);
 	const [ debouncedFieldErrors, setDebouncedFieldErrors ] = useDebounce( formFieldErrors, 1000 );
 
@@ -71,7 +76,12 @@ export function CreditCardForm( {
 		setDebouncedFieldErrors( { ...debouncedFieldErrors, ...clearedErrors } );
 		// Debounce updating validation errors
 		setFormFieldErrors(
-			camelCaseFormFields( validatePaymentDetails( kebabCaseFormFields( newValues ) ).errors )
+			camelCaseFormFields(
+				validatePaymentDetails(
+					kebabCaseFormFields( newValues ),
+					stripe ? 'stripe' : 'credit-card'
+				).errors
+			)
 		);
 	};
 

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -31,7 +31,7 @@ import {
 	assignAllFormFields,
 	areFormFieldsEmpty,
 	useDebounce,
-	saveCreditCard,
+	saveOrUpdateCreditCard,
 	makeAsyncCreateCardToken,
 } from './helpers';
 
@@ -125,17 +125,20 @@ export function CreditCardForm( {
 				};
 				return createStripeSetupIntent( stripe, stripeConfiguration, paymentDetailsForStripe );
 			};
-			await saveCreditCard( {
+			const parseStripeToken = response => response.payment_method;
+			const parsePaygateToken = response => response.token;
+			await saveOrUpdateCreditCard( {
 				createCardToken: stripe ? createStripeSetupIntentAsync : createCardTokenAsync,
 				saveStoredCard,
 				translate,
-				successCallback,
 				apiParams,
 				purchase,
 				siteSlug,
 				formFieldValues,
 				stripeConfiguration,
+				parseTokenFromResponse: stripe ? parseStripeToken : parsePaygateToken,
 			} );
+			successCallback();
 		} catch ( error ) {
 			debug( 'Error while submitting', error );
 			setFormSubmitting( false );

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -59,6 +59,7 @@ export function CreditCardForm( {
 	translate,
 	stripe,
 	stripeConfiguration,
+	isStripeLoading,
 } ) {
 	const [ formSubmitting, setFormSubmitting ] = useState( false );
 	const [ formFieldValues, setFormFieldValues ] = useState( getInitializedFields( initialValues ) );
@@ -162,6 +163,7 @@ export function CreditCardForm( {
 					card={ kebabCaseFormFields( formFieldValues ) }
 					countriesList={ countriesList }
 					stripe={ stripe }
+					isStripeLoading={ isStripeLoading }
 					eventFormName="Edit Card Details Form"
 					onFieldChange={ onFieldChange }
 					getErrorMessage={ getErrorMessage }
@@ -206,6 +208,7 @@ CreditCardForm.propTypes = {
 	heading: PropTypes.string,
 	onCancel: PropTypes.func,
 	stripe: PropTypes.object,
+	isStripeLoading: PropTypes.bool,
 	translate: PropTypes.func.isRequired,
 };
 

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -7,6 +7,7 @@ import { localize } from 'i18n-calypso';
 import { camelCase, values } from 'lodash';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
+import debugFactory from 'debug';
 
 /**
  * Internal dependencies
@@ -38,6 +39,8 @@ import {
  * Style dependencies
  */
 import './style.scss';
+
+const debug = debugFactory( 'calypso:credit-card-form' );
 
 export function CreditCardForm( {
 	apiParams = {},
@@ -134,6 +137,7 @@ export function CreditCardForm( {
 				stripeConfiguration,
 			} );
 		} catch ( error ) {
+			debug( 'Error while submitting', error );
 			setFormSubmitting( false );
 			error &&
 				notices.error(

--- a/client/components/credit-card/stored-card.jsx
+++ b/client/components/credit-card/stored-card.jsx
@@ -41,7 +41,7 @@ export const getCreditCardSummary = ( translate, type, digits ) => {
 
 const StoredCard = ( { lastDigits, cardType, name, expiry, translate, moment } ) => {
 	// The use of `MM/YY` should not be localized as it is an ISO standard across credit card forms: https://en.wikipedia.org/wiki/ISO/IEC_7813
-	const expirationDate = moment( expiry ).format( 'MM/YY' );
+	const expirationDate = expiry ? moment( expiry ).format( 'MM/YY' ) : null;
 
 	const type = cardType && cardType.toLocaleLowerCase();
 	const cardClasses = classNames( 'credit-card__stored-card', {
@@ -61,20 +61,21 @@ const StoredCard = ( { lastDigits, cardType, name, expiry, translate, moment } )
 			</span>
 			<span className="credit-card__stored-card-name">{ name }</span>
 			<span className="credit-card__stored-card-expiration-date">
-				{ translate( 'Expires %(date)s', {
-					args: { date: expirationDate },
-					context: 'date is of the form MM/YY',
-				} ) }
+				{ expirationDate &&
+					translate( 'Expires %(date)s', {
+						args: { date: expirationDate },
+						context: 'date is of the form MM/YY',
+					} ) }
 			</span>
 		</div>
 	);
 };
 
 StoredCard.propTypes = {
-	lastDigits: PropTypes.string.isRequired,
+	lastDigits: PropTypes.string,
 	cardType: PropTypes.string.isRequired,
 	name: PropTypes.string.isRequired,
-	expiry: PropTypes.string.isRequired,
+	expiry: PropTypes.string,
 };
 
 export default compose(

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -76,6 +76,30 @@ export async function createStripePaymentMethod( stripe, paymentDetails ) {
 	return paymentMethod;
 }
 
+export async function createStripeSetupIntent( stripe, stripeConfiguration, paymentDetails ) {
+	debug( 'creating setup intent...', paymentDetails );
+	const { setupIntent, error } = await stripe.handleCardSetup(
+		stripeConfiguration.setup_intent_id,
+		{
+			payment_method_data: {
+				billing_details: paymentDetails,
+			},
+		}
+	);
+	debug( 'setup intent creation complete', setupIntent, error );
+	if ( error ) {
+		// Note that this is a promise rejection
+		if ( error.type === 'validation_error' ) {
+			throw new StripeValidationError(
+				error.code,
+				getValidationErrorsFromStripeError( error ) || {}
+			);
+		}
+		throw new Error( error.message );
+	}
+	return setupIntent;
+}
+
 /**
  * Confirm any PaymentIntent from Stripe response and carry out 3DS or
  * other next_actions if they are required.

--- a/client/lib/wpcom-undocumented/lib/me.js
+++ b/client/lib/wpcom-undocumented/lib/me.js
@@ -135,13 +135,13 @@ UndocumentedMe.prototype.changeUsername = function( username, action, callback )
  * Get a list of the user's stored cards
  *
  * @param {object} [cardToken] Payment key
- * @param {Function} [callback] The callback function
+ * @param {object} [additionalData] Any additional data to send in the request
  *
  * @return {Promise} A promise for the request
  * @api public
  */
-UndocumentedMe.prototype.storedCardAdd = function( cardToken, callback ) {
-	debug( '/me/stored-cards' );
+UndocumentedMe.prototype.storedCardAdd = function( cardToken, additionalData = {} ) {
+	debug( '/me/stored-cards', cardToken, additionalData );
 
 	return this.wpcom.req.post(
 		{
@@ -150,8 +150,8 @@ UndocumentedMe.prototype.storedCardAdd = function( cardToken, callback ) {
 		{
 			payment_key: cardToken,
 			use_for_existing: true,
-		},
-		callback
+			...additionalData,
+		}
 	);
 };
 

--- a/client/me/purchases/add-credit-card/index.jsx
+++ b/client/me/purchases/add-credit-card/index.jsx
@@ -21,6 +21,9 @@ import Main from 'components/main';
 import titles from 'me/purchases/titles';
 import { billingHistory } from 'me/purchases/paths';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { withStripe } from 'lib/stripe';
+
+const CreditCardFormWithStripe = withStripe( CreditCardForm, { needs_intent: true } );
 
 function AddCreditCard( props ) {
 	const createAddCardToken = ( ...args ) => createCardToken( 'card_add', ...args );
@@ -34,8 +37,7 @@ function AddCreditCard( props ) {
 			<DocumentHead title={ concatTitle( titles.purchases, titles.addCreditCard ) } />
 
 			<HeaderCake onClick={ goToBillingHistory }>{ titles.addCreditCard }</HeaderCake>
-
-			<CreditCardForm
+			<CreditCardFormWithStripe
 				createCardToken={ createAddCardToken }
 				recordFormSubmitEvent={ recordFormSubmitEvent }
 				saveStoredCard={ props.addStoredCard }

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -1,8 +1,12 @@
 /** @format */
-// External dependencies
+/**
+ * External dependencies
+ */
 import i18n from 'i18n-calypso';
 
-// Internal dependencies
+/**
+ * Internal dependencies
+ */
 import {
 	STORED_CARDS_ADD_COMPLETED,
 	STORED_CARDS_DELETE,

--- a/client/state/stored-cards/actions.js
+++ b/client/state/stored-cards/actions.js
@@ -19,18 +19,16 @@ import {
 import wp from 'lib/wp';
 
 export const addStoredCard = cardData => dispatch => {
-	return new Promise( ( resolve, reject ) => {
-		wp.undocumented()
-			.me()
-			.storedCardAdd( cardData.token, ( error, data ) => {
-				error ? reject( error ) : resolve( data );
+	return wp
+		.undocumented()
+		.me()
+		.storedCardAdd( cardData.token, cardData.additionalData )
+		.then( item => {
+			dispatch( {
+				type: STORED_CARDS_ADD_COMPLETED,
+				item,
 			} );
-	} ).then( item => {
-		dispatch( {
-			type: STORED_CARDS_ADD_COMPLETED,
-			item,
 		} );
-	} );
 };
 
 export const fetchStoredCards = () => dispatch => {

--- a/client/state/stored-cards/test/actions.js
+++ b/client/state/stored-cards/test/actions.js
@@ -47,7 +47,7 @@ describe( 'actions', () => {
 		test( 'should dispatch complete action when API returns card item', () => {
 			sandbox.stub( wp, 'undocumented' ).callsFake( () => ( {
 				me: () => ( {
-					storedCardAdd: ( token, callback ) => callback( null, item ),
+					storedCardAdd: async () => item,
 				} ),
 			} ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This uses the Stripe Elements form fields introduced in #34469 for the "Add Card" form at `/me/purchases/add-credit-card`. Previously they were only used in the Checkout form (and only in some circumstances).

![Screen Shot 2019-08-02 at 6 10 25 PM](https://user-images.githubusercontent.com/2036909/62401418-13c27400-b551-11e9-84d3-9d7e4b6cd58b.png)

To do:

- [x] Split off fixes for CreditCardForm. #34963
- [x] Split off refactor of AddCreditCard to functional component. #34980
- [x] Split off moving hooks to lib/stripe. #34981
- [x] Fix form styles so that stripe elements look like regular elements (not sure why those style aren't being used).
- [x] Show validation errors on stripe fields.
- [x] Make form submission work with stripe fields 
- [x] Make sure form submission handles 3DS authentication.
- [x] Make sure payments made with these cards are successful.
- [x] Make sure `use_for_existing` works as expected (there's an issue with using it on cards added with stripe details).

## Testing instructions

- Sandbox the API and the store.
- Load Calypso with this PR using either a local copy or the calypso.live implementation.
- Make sure you have a purchase on your test site.
- On the front-end, visit `/me/purchases/add-credit-card`. Make sure that you see the Stripe form fields (placeholder numbers in the credit card number field, not dots).
- Enter a new test card with a unique Cardholder Name (you'll need to identify this name later) and click "Save Card".
- Verify that you get a success message in the upper right.
- Visit `/me/purchases` and click on any upgrade.
- In the lower right, click on the "Payment method" text/icon.
- Be sure the cardholder name that shows up matches the one you entered above.

Because this diff also touches the checkout flow, please also follow the testing instructions in #34469.