### PR TITLE
Components: Add a PlanGate component to conditionally display content

### DIFF
--- a/client/components/plan-gate/README.md
+++ b/client/components/plan-gate/README.md
@@ -14,10 +14,11 @@ import { FEATURE_GOOGLE_MY_BUSINESS } from 'lib/plans/constants';
 const PlanGateExample = () => {
 	return (
 		<div>
-			<PlanGate feature={ FEATURE_GOOGLE_MY_BUSINESS }>
-				<Button>Upgrade to Business</Button>
-				<p>You've got the Google My Business feature</p>
-			</PlanGate>
+			<PlanGate
+				feature={ FEATURE_GOOGLE_MY_BUSINESS }
+				noFeatureContent={ <Button>Upgrade to Business</Button> }
+				hasFeatureContent={ <p>You have got the Google My Business feature</p> }
+				/>
 		</div>
 	);
 }

--- a/client/components/plan-gate/README.md
+++ b/client/components/plan-gate/README.md
@@ -1,0 +1,24 @@
+Plan Gate
+=========
+
+A conditional component that displays the first child when a feature
+is not present on customer's plan, and the second child when it is.
+
+## Usage
+
+```es6
+import PlanGate from 'components/plan-gate';
+import Button from 'components/button';
+import { FEATURE_GOOGLE_MY_BUSINESS } from 'lib/plans/constants';
+
+const PlanGateExample = () => {
+	return (
+		<div>
+			<PlanGate feature={ FEATURE_GOOGLE_MY_BUSINESS }>
+				<Button>Upgrade to Business</Button>
+				<p>You've got the Google My Business feature</p>
+			</PlanGate>
+		</div>
+	);
+}
+```

--- a/client/components/plan-gate/docs/example.jsx
+++ b/client/components/plan-gate/docs/example.jsx
@@ -15,10 +15,11 @@ import { FEATURE_GOOGLE_MY_BUSINESS } from 'lib/plans/constants';
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 const PlanGateExample = () => (
 	<div className="design-assets__group">
-		<PlanGate feature={ FEATURE_GOOGLE_MY_BUSINESS }>
-			<Button>Upgrade to Business</Button>
-			<p>You've got the Google My Business feature</p>
-		</PlanGate>
+		<PlanGate
+			feature={ FEATURE_GOOGLE_MY_BUSINESS }
+			noFeatureContent={ <Button>Upgrade to Business</Button> }
+			hasFeatureContent={ <p>You have got the Google My Business feature</p> }
+		/>
 	</div>
 );
 /* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/client/components/plan-gate/docs/example.jsx
+++ b/client/components/plan-gate/docs/example.jsx
@@ -1,0 +1,28 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PlanGate from 'components/plan-gate';
+import Button from 'components/button';
+import { FEATURE_GOOGLE_MY_BUSINESS } from 'lib/plans/constants';
+
+/* eslint-disable wpcalypso/jsx-classname-namespace */
+const PlanGateExample = () => (
+	<div className="design-assets__group">
+		<PlanGate feature={ FEATURE_GOOGLE_MY_BUSINESS }>
+			<Button>Upgrade to Business</Button>
+			<p>You've got the Google My Business feature</p>
+		</PlanGate>
+	</div>
+);
+/* eslint-enable wpcalypso/jsx-classname-namespace */
+
+PlanGateExample.displayName = 'PlanGate';
+
+export default PlanGateExample;

--- a/client/components/plan-gate/index.tsx
+++ b/client/components/plan-gate/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { connect } from 'react-redux';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, ReactNode } from 'react';
 
 /**
  * Internal dependencies
@@ -19,24 +19,22 @@ interface ConnectedProps {
 
 interface ExternalProps {
 	feature: string;
-	children: JSX.Element[];
+	hasFeatureContent: ReactNode; // Content to show when plan covers the feature.
+	noFeatureContent: ReactNode; // Content shown when plan doesn't cover the feature.
 }
 
 const PlanGate: FunctionComponent< ConnectedProps & ExternalProps > = ( {
 	hasPlanFeature,
-	children,
+	hasFeatureContent,
+	noFeatureContent,
 } ) => {
-	if ( hasPlanFeature ) {
-		return children[ 1 ];
-	}
-
-	return children[ 0 ];
+	return hasPlanFeature ? hasFeatureContent : noFeatureContent;
 };
 
 export default connect< ConnectedProps, {}, ExternalProps >( ( state, { feature } ) => {
 	const selectedSiteId = getSelectedSiteId( state );
 
 	return {
-		hasPlanFeature: selectedSiteId ? hasFeature( state, selectedSiteId, feature ) : false,
+		hasPlanFeature: selectedSiteId ? hasFeature( state, selectedSiteId, feature ) : null,
 	};
 } )( PlanGate );

--- a/client/components/plan-gate/index.tsx
+++ b/client/components/plan-gate/index.tsx
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { connect } from 'react-redux';
+import { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { hasFeature } from 'state/sites/plans/selectors';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+/**
+ * Types
+ */
+interface ConnectedProps {
+	hasPlanFeature: boolean;
+}
+
+interface ExternalProps {
+	feature: string;
+	children: JSX.Element[];
+}
+
+const PlanGate: FunctionComponent< ConnectedProps & ExternalProps > = ( {
+	hasPlanFeature,
+	children,
+} ) => {
+	if ( hasPlanFeature ) {
+		return children[ 1 ];
+	}
+
+	return children[ 0 ];
+};
+
+export default connect< ConnectedProps, {}, ExternalProps >( ( state, { feature } ) => {
+	const selectedSiteId = getSelectedSiteId( state );
+
+	return {
+		hasPlanFeature: selectedSiteId ? hasFeature( state, selectedSiteId, feature ) : false,
+	};
+} )( PlanGate );

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -59,6 +59,7 @@ export { default as Notices } from 'components/notice/docs/example';
 export { default as PaginationExample } from 'components/pagination/docs/example';
 export { default as PaymentLogo } from 'components/payment-logo/docs/example';
 export { default as PieChart } from 'components/pie-chart/docs/example';
+export { default as PlanGate } from 'components/plan-gate/docs/example';
 export { default as Popovers } from 'components/popover/docs/example';
 export { default as ProgressBar } from '@automattic/calypso-ui/src/progress-bar/docs/example';
 export { default as Ranges } from 'components/forms/range/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -87,6 +87,7 @@ import Notices from 'components/notice/docs/example';
 import PaginationExample from 'components/pagination/docs/example';
 import PaymentLogo from 'components/payment-logo/docs/example';
 import PieChart from 'components/pie-chart/docs/example';
+import PlanGate from 'components/plan-gate/docs/example';
 import PlansSkipButton from 'components/plans/plans-skip-button/docs/example';
 import PodcastIndicator from 'components/podcast-indicator/docs/example';
 import Popovers from 'components/popover/docs/example';
@@ -247,6 +248,7 @@ class DesignAssets extends React.Component {
 					<PaginationExample readmeFilePath="pagination" />
 					<PaymentLogo readmeFilePath="payment-logo" />
 					<PieChart readmeFilePath="pie-chart" />
+					<PlanGate readmeFilePath="plan-gate" />
 					<PlansSkipButton readmeFilePath="plans/plans-skip-button" />
 					<PodcastIndicator readmeFilePath="podcast-indicator" />
 					<Popovers readmeFilePath="popover" />


### PR DESCRIPTION
As part of the project to redesign the 'Earn' section we're developing
various generic components to help with the layout that can be reused in
other areas. This one conditionally renders one or other of its child
components based on whether the currently selected site has a feature on
its plan.

The component takes the feature name as a prop, and renders the first
child if the feature is unavailable. If the feature is present on the
plan, then the second child is rendered.

#### Testing

There is an example added to devdocs that can be seen at:

http://calypso.localhost:3000/devdocs/design/plan-gate

I'll see if I can add another where the feature is available.
