### PR TITLE
Fix/contributor featured image

### DIFF
--- a/client/post-editor/editor-featured-image/dropzone.jsx
+++ b/client/post-editor/editor-featured-image/dropzone.jsx
@@ -8,6 +8,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { head, uniqueId } from 'lodash';
 import { localize } from 'i18n-calypso';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -23,9 +24,14 @@ import { editPost } from 'state/posts/actions';
 import { getSelectedSiteId, getSelectedSite } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { userCan } from 'lib/site/utils';
 
 class FeaturedImageDropZone extends Component {
 	onFilesDrop = files => {
+		if ( ! this.props.site || ! userCan( 'upload_files', this.props.site ) ) {
+			return false;
+		}
+
 		/**
 		 * Filter files for `image` media prefix and return the first image.
 		 *
@@ -79,12 +85,18 @@ class FeaturedImageDropZone extends Component {
 	};
 
 	render() {
+		const { site, translate } = this.props;
+		const canUploadFiles = userCan( 'upload_files', site );
+		const textLabel = canUploadFiles
+			? translate( 'Set as Featured Image' )
+			: translate( 'You are not authorized to upload files to this site' );
+		const icon = canUploadFiles ? <FeaturedImageDropZoneIcon /> : <Gridicon icon="cross" />;
 		return (
 			<DropZone
 				className="editor-featured-image__dropzone"
 				dropZoneName="featuredImage"
-				icon={ <FeaturedImageDropZoneIcon /> }
-				textLabel={ this.props.translate( 'Set as Featured Image' ) }
+				icon={ icon }
+				textLabel={ textLabel }
 				onFilesDrop={ this.onFilesDrop }
 			/>
 		);

--- a/client/post-editor/editor-featured-image/style.scss
+++ b/client/post-editor/editor-featured-image/style.scss
@@ -14,6 +14,10 @@
 .editor-featured-image__dropzone {
 	margin-top: 0;
 	margin-bottom: 0;
+
+	.drop-zone__content-text {
+		padding: 10px;
+	}
 }
 
 .editor-featured-image__current-image {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Require upload file permission to drag-and-drop Featured Image.

#### Testing instructions

1. Edit a post as a *Contributor* using *Classic Editor*.
2. With Classic Editor open and Featured Image panel visible, drag an image file over the Featured Image panel.

*BEFORE:*
<img width="304" alt="screenshot_808" src="https://user-images.githubusercontent.com/127594/61761154-b2e1b180-ad82-11e9-8787-f224542634be.png">

*AFTER:*
<img width="292" alt="screenshot_807" src="https://user-images.githubusercontent.com/127594/61761161-baa15600-ad82-11e9-9b0d-81acb8f5efea.png">

*

Fixes #34764
