### PR TITLE
Signup: cleaning up the flows utils

### DIFF
--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -19,21 +19,9 @@ const user = userFactory();
 const { defaultFlowName } = flows;
 
 export function getFlowName( parameters ) {
-	const flow =
-		parameters.flowName && isFlowName( parameters.flowName )
-			? parameters.flowName
-			: defaultFlowName;
-	return maybeFilterFlowName( flow, flows.filterFlowName );
-}
-
-function maybeFilterFlowName( flowName, filterCallback ) {
-	if ( filterCallback && typeof filterCallback === 'function' ) {
-		const filteredFlow = filterCallback( flowName );
-		if ( isFlowName( filteredFlow ) ) {
-			return filteredFlow;
-		}
-	}
-	return flowName;
+	return parameters.flowName && isFlowName( parameters.flowName )
+		? parameters.flowName
+		: defaultFlowName;
 }
 
 function isFlowName( pathFragment ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request

A follow up from the hit single https://github.com/Automattic/wp-calypso/pull/34834

Since `flows.filterFlowName` did nothing [and we removed it anyway](https://github.com/Automattic/wp-calypso/pull/34834), we don't need to _maybe filter_ anything.

## Testing instructions

`npm run test-client client/signup/test/utils.js`

And create a site from `/start` just in case :)
