### PR TITLE
Calypso Build: Fix typo in output-library-target

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Update Jest config to be able to handle `import`s otherwise handled by Webpack's `file-loader` and `sass-loader`.
 - Update Jest setup to properly initialize Enzyme's adapter.
+- Fix typo that prevented the `output-library-target` argument from being passed to Webpack.
 
 # 2.0.0
 

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -52,7 +52,7 @@ function getWebpackConfig(
 		'output-chunk-filename': outputChunkFilename,
 		'output-path': outputPath = path.join( process.cwd(), 'dist' ),
 		'output-filename': outputFilename = '[name].js',
-		'output-libary-target': outputLibraryTarget = 'window',
+		'output-library-target': outputLibraryTarget = 'window',
 	}
 ) {
 	const workerCount = 1;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

https://www.youtube.com/watch?v=poncZ1K9Tio&feature=youtu.be&t=67

Found while working on https://github.com/Automattic/jetpack/pull/13070

#### Testing instructions

Try something like this:

```js
const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );

const webpackConfig = getBaseWebpackConfig(
	{ WP: false },
	{
		entry: {
			index: path.join( __dirname, './index.js' ),
		},
		'output-chunk-filename': '[name].[chunkhash].js',
		'output-library-target': 'commonjs2',
		'output-path': path.join( __dirname, '_inc', 'blocks' ),
		'output-pathinfo': true,
	}
);

console.log( webpackConfig );
```

On `master`, the output will contain

```
output: {
	/*...*/
	libraryTarget: 'window'
}
 /*...*/
```

i.e. using the default value (`window`) for `libraryTarget` rather than setting it to the desired value (`commonjs2`).

Now try the same with this branch -- it should work as desired.