### PR TITLE
Make quickstart offer page work without a site slug.

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -456,14 +456,6 @@ export class Checkout extends React.Component {
 				: '/checkout/thank-you/plans';
 		}
 
-		if ( cart.create_new_blog ) {
-			return `${ signupDestination }/${ pendingOrReceiptId }`;
-		}
-
-		if ( ! selectedSiteSlug ) {
-			return '/checkout/thank-you/features';
-		}
-
 		// If cart is empty, then send the user to a generic page (not post-purchase related).
 		// For example, this case arises when a Skip button is clicked on a concierge upsell
 		// nudge opened by a direct link to /offer-support-session.
@@ -472,7 +464,15 @@ export class Checkout extends React.Component {
 			isEmpty( getAllCartItems( cart ) ) &&
 			! previousRoute.includes( '/checkout' )
 		) {
-			return `/stats/day/${ selectedSiteSlug }`;
+			return signupDestination;
+		}
+
+		if ( cart.create_new_blog ) {
+			return `${ signupDestination }/${ pendingOrReceiptId }`;
+		}
+
+		if ( ! selectedSiteSlug ) {
+			return '/checkout/thank-you/features';
 		}
 
 		if ( this.props.isJetpackNotAtomic ) {
@@ -538,7 +538,7 @@ export class Checkout extends React.Component {
 			// A user just purchased one of the qualifying plans
 			// Show them the concierge session upsell page
 			if ( 'offer' === abtest( 'conciergeUpsellDial' ) ) {
-				return `/checkout/${ selectedSiteSlug }/offer-quickstart-session/${ pendingOrReceiptId }`;
+				return `/checkout/offer-quickstart-session/${ pendingOrReceiptId }/${ selectedSiteSlug }`;
 			}
 		}
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -459,11 +459,7 @@ export class Checkout extends React.Component {
 		// If cart is empty, then send the user to a generic page (not post-purchase related).
 		// For example, this case arises when a Skip button is clicked on a concierge upsell
 		// nudge opened by a direct link to /offer-support-session.
-		if (
-			':receiptId' === pendingOrReceiptId &&
-			isEmpty( getAllCartItems( cart ) ) &&
-			! previousRoute.includes( '/checkout' )
-		) {
+		if ( ':receiptId' === pendingOrReceiptId && isEmpty( getAllCartItems( cart ) ) ) {
 			return signupDestination;
 		}
 

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -31,7 +31,7 @@ export function checkout( context, next ) {
 	const selectedSite = getSelectedSite( state );
 
 	let product;
-	if ( selectedSite && selectedSite.siteSlug !== domainOrProduct ) {
+	if ( selectedSite && selectedSite.slug !== domainOrProduct ) {
 		product = domainOrProduct;
 	} else {
 		product = context.params.product;
@@ -179,6 +179,8 @@ export function sitePicker( context, next ) {
 
 export function redirectToSupportSession( context ) {
 	const { receiptId, site } = context.params;
+
+	// Redirect the old URL structure to the new URL structure to maintain backwards compatibility.
 	if ( context.params.receiptId ) {
 		page.redirect( `/checkout/offer-support-session/${ receiptId }/${ site }` );
 	}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -34,7 +34,7 @@ export function checkout( context, next ) {
 	}
 
 	let product;
-	if ( selectedSite.domain !== domainOrProduct ) {
+	if ( selectedSite && selectedSite.domain !== domainOrProduct ) {
 		product = domainOrProduct;
 	} else {
 		product = context.params.product;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -21,12 +21,24 @@ import CheckoutThankYouComponent from './checkout-thank-you';
 import UpsellNudge from './upsell-nudge';
 import { isGSuiteRestricted } from 'lib/gsuite';
 import { getRememberedCoupon } from 'lib/upgrades/actions';
+import { sites } from 'my-sites/controller';
 
 export function checkout( context, next ) {
-	const { feature, plan, product, purchaseId } = context.params;
+	const { feature, plan, domainOrProduct, purchaseId } = context.params;
 
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
+
+	if ( ! selectedSite ) {
+		sites( context, next );
+	}
+
+	let product;
+	if ( selectedSite.domain !== domainOrProduct ) {
+		product = domainOrProduct;
+	} else {
+		product = context.params.product;
+	}
 
 	if ( 'thank-you' === product ) {
 		return;

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -30,6 +30,11 @@ export function checkout( context, next ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
 
+	if ( ! selectedSite && '/checkout/no-site' !== context.pathname ) {
+		sites( context, next );
+		return;
+	}
+
 	let product;
 	if ( selectedSite && selectedSite.slug !== domainOrProduct ) {
 		product = domainOrProduct;
@@ -162,17 +167,6 @@ export function upsellNudge( context, next ) {
 			/>
 		</CheckoutContainer>
 	);
-
-	next();
-}
-
-export function sitePicker( context, next ) {
-	const state = context.store.getState();
-	const selectedSite = getSelectedSite( state );
-
-	if ( ! selectedSite ) {
-		sites( context, next );
-	}
 
 	next();
 }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -5,6 +5,7 @@
 import i18n from 'i18n-calypso';
 import React from 'react';
 import { get, isEmpty } from 'lodash';
+import page from 'page';
 
 /**
  * Internal Dependencies
@@ -29,12 +30,8 @@ export function checkout( context, next ) {
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
 
-	if ( ! selectedSite ) {
-		sites( context, next );
-	}
-
 	let product;
-	if ( selectedSite && selectedSite.domain !== domainOrProduct ) {
+	if ( selectedSite && selectedSite.siteSlug !== domainOrProduct ) {
 		product = domainOrProduct;
 	} else {
 		product = context.params.product;
@@ -167,4 +164,23 @@ export function upsellNudge( context, next ) {
 	);
 
 	next();
+}
+
+export function sitePicker( context, next ) {
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+
+	if ( ! selectedSite ) {
+		sites( context, next );
+	}
+
+	next();
+}
+
+export function redirectToSupportSession( context ) {
+	const { receiptId, site } = context.params;
+	if ( context.params.receiptId ) {
+		page.redirect( `/checkout/offer-support-session/${ receiptId }/${ site }` );
+	}
+	page.redirect( `/checkout/offer-support-session/${ site }` );
 }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -27,7 +27,7 @@ export default function() {
 	const isLoggedOut = ! user.get();
 
 	if ( isLoggedOut ) {
-		page( '/checkout/:site/offer-quickstart-session', upsellNudge, makeLayout, clientRender );
+		page( '/checkout/offer-quickstart-session', upsellNudge, makeLayout, clientRender );
 
 		page( '/checkout*', redirectLoggedOut );
 
@@ -95,7 +95,7 @@ export default function() {
 
 	if ( config.isEnabled( 'upsell/concierge-session' ) ) {
 		page(
-			'/checkout/:site/(add|offer)-support-session/pending/:orderId',
+			'/checkout/:site?/(add|offer)-support-session/pending/:orderId',
 			siteSelection,
 			checkoutPending,
 			makeLayout,
@@ -103,7 +103,7 @@ export default function() {
 		);
 
 		page(
-			'/checkout/:site/(add|offer)-support-session/:receiptId?',
+			'/checkout/:site?/(add|offer)-support-session/:receiptId?',
 			siteSelection,
 			upsellNudge,
 			makeLayout,
@@ -111,7 +111,7 @@ export default function() {
 		);
 
 		page(
-			'/checkout/:site/offer-quickstart-session/pending/:orderId',
+			'/checkout/offer-quickstart-session/pending/:orderId',
 			siteSelection,
 			checkoutPending,
 			makeLayout,
@@ -119,7 +119,7 @@ export default function() {
 		);
 
 		page(
-			'/checkout/:site/offer-quickstart-session/:receiptId?',
+			'/checkout/offer-quickstart-session/:receiptId?',
 			siteSelection,
 			upsellNudge,
 			makeLayout,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -16,7 +16,7 @@ import {
 } from './controller';
 import SiftScience from 'lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
-import { noSite, siteSelection } from 'my-sites/controller';
+import { noSite, siteSelection, sites } from 'my-sites/controller';
 import config from 'config';
 import userFactory from 'lib/user';
 
@@ -127,7 +127,11 @@ export default function() {
 		);
 	}
 
-	page( '/checkout/:domain/:product?', siteSelection, checkout, makeLayout, clientRender );
+	page( '/checkout/:domain', siteSelection, checkout, makeLayout, clientRender );
+
+	page( '/checkout/:product', siteSelection, sites, makeLayout, clientRender );
+
+	page( '/checkout/:product/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );
 
 	// Visiting /renew without a domain is invalid and should be redirected to /me/purchases
 	page( '/checkout/:product/renew/:purchaseId', '/me/purchases' );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -13,6 +13,8 @@ import {
 	checkoutThankYou,
 	gsuiteNudge,
 	upsellNudge,
+	redirectToSupportSession,
+	sitePicker,
 } from './controller';
 import SiftScience from 'lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
@@ -102,8 +104,19 @@ export default function() {
 			clientRender
 		);
 
+		// For backwards compatibility, retaining the old URL structure.
+		page( '/checkout/:site/(add|offer)-support-session/:receiptId?', redirectToSupportSession );
+
 		page(
-			'/checkout/:site?/(add|offer)-support-session/:receiptId?',
+			'/checkout/(add|offer)-support-session/:site?',
+			siteSelection,
+			upsellNudge,
+			makeLayout,
+			clientRender
+		);
+
+		page(
+			'/checkout/(add|offer)-support-session/:receiptId/:site',
 			siteSelection,
 			upsellNudge,
 			makeLayout,
@@ -119,7 +132,15 @@ export default function() {
 		);
 
 		page(
-			'/checkout/offer-quickstart-session/:receiptId?',
+			'/checkout/offer-quickstart-session/:site?',
+			siteSelection,
+			upsellNudge,
+			makeLayout,
+			clientRender
+		);
+
+		page(
+			'/checkout/offer-quickstart-session/:receiptId/:site',
 			siteSelection,
 			upsellNudge,
 			makeLayout,
@@ -127,9 +148,23 @@ export default function() {
 		);
 	}
 
-	page( '/checkout/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );
+	page(
+		'/checkout/:domainOrProduct',
+		siteSelection,
+		sitePicker,
+		checkout,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/checkout/:product/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );
+	page(
+		'/checkout/:product/:domainOrProduct',
+		siteSelection,
+		sitePicker,
+		checkout,
+		makeLayout,
+		clientRender
+	);
 
 	// Visiting /renew without a domain is invalid and should be redirected to /me/purchases
 	page( '/checkout/:product/renew/:purchaseId', '/me/purchases' );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -104,10 +104,10 @@ export default function() {
 		);
 
 		// For backwards compatibility, retaining the old URL structure.
-		page( '/checkout/:site/(add|offer)-support-session/:receiptId?', redirectToSupportSession );
+		page( '/checkout/:site/add-support-session/:receiptId?', redirectToSupportSession );
 
 		page(
-			'/checkout/(add|offer)-support-session/:site?',
+			'/checkout/offer-support-session/:site?',
 			siteSelection,
 			upsellNudge,
 			makeLayout,
@@ -115,7 +115,7 @@ export default function() {
 		);
 
 		page(
-			'/checkout/(add|offer)-support-session/:receiptId/:site',
+			'/checkout/offer-support-session/:receiptId/:site',
 			siteSelection,
 			upsellNudge,
 			makeLayout,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -14,7 +14,6 @@ import {
 	gsuiteNudge,
 	upsellNudge,
 	redirectToSupportSession,
-	sitePicker,
 } from './controller';
 import SiftScience from 'lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
@@ -124,7 +123,7 @@ export default function() {
 		);
 
 		page(
-			'/checkout/offer-quickstart-session/pending/:orderId',
+			'/checkout/offer-quickstart-session/pending/:site/:orderId',
 			siteSelection,
 			checkoutPending,
 			makeLayout,
@@ -148,23 +147,9 @@ export default function() {
 		);
 	}
 
-	page(
-		'/checkout/:domainOrProduct',
-		siteSelection,
-		sitePicker,
-		checkout,
-		makeLayout,
-		clientRender
-	);
+	page( '/checkout/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );
 
-	page(
-		'/checkout/:product/:domainOrProduct',
-		siteSelection,
-		sitePicker,
-		checkout,
-		makeLayout,
-		clientRender
-	);
+	page( '/checkout/:product/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );
 
 	// Visiting /renew without a domain is invalid and should be redirected to /me/purchases
 	page( '/checkout/:product/renew/:purchaseId', '/me/purchases' );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -96,7 +96,7 @@ export default function() {
 
 	if ( config.isEnabled( 'upsell/concierge-session' ) ) {
 		page(
-			'/checkout/:site?/(add|offer)-support-session/pending/:orderId',
+			'/checkout/(add|offer)-support-session/pending/:site/:orderId',
 			siteSelection,
 			checkoutPending,
 			makeLayout,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -16,7 +16,7 @@ import {
 } from './controller';
 import SiftScience from 'lib/siftscience';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'controller';
-import { noSite, siteSelection, sites } from 'my-sites/controller';
+import { noSite, siteSelection } from 'my-sites/controller';
 import config from 'config';
 import userFactory from 'lib/user';
 
@@ -127,9 +127,7 @@ export default function() {
 		);
 	}
 
-	page( '/checkout/:domain', siteSelection, checkout, makeLayout, clientRender );
-
-	page( '/checkout/:product', siteSelection, sites, makeLayout, clientRender );
+	page( '/checkout/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );
 
 	page( '/checkout/:product/:domainOrProduct', siteSelection, checkout, makeLayout, clientRender );
 

--- a/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/concierge-quickstart-session/index.jsx
@@ -65,7 +65,7 @@ export class ConciergeQuickstartSession extends PureComponent {
 	}
 
 	body() {
-		const { translate, productCost, productDisplayCost, currencyCode } = this.props;
+		const { translate, productCost, productDisplayCost, currencyCode, receiptId } = this.props;
 		const fullCost = Math.round( productCost * 2.021 );
 		return (
 			<>
@@ -192,15 +192,17 @@ export class ConciergeQuickstartSession extends PureComponent {
 							</b>{' '}
 						</p>
 						<p>
-							{ translate(
-								'Please notice, this is a one-time offer because you just got a new plan and we want you to make the most out of it! Regular price for {{em}}Quick Start{{/em}} sessions is %(oldPrice)s.',
-								{
-									components: { b: <b />, em: <em /> },
-									args: {
-										oldPrice: formatCurrency( fullCost, currencyCode ),
-									},
-								}
-							) }
+							{ receiptId
+								? translate(
+										'Please notice, this is a one-time offer because you just got a new plan and we want you to make the most out of it! Regular price for {{em}}Quick Start{{/em}} sessions is %(oldPrice)s.',
+										{
+											components: { b: <b />, em: <em /> },
+											args: {
+												oldPrice: formatCurrency( fullCost, currencyCode ),
+											},
+										}
+								  )
+								: '' }
 						</p>
 						<p>
 							<em>

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -173,13 +173,15 @@ export class UpsellNudge extends React.Component {
 	};
 
 	handleClickAccept = buttonAction => {
-		const { trackUpsellButtonClick, upsellType, upgradeItem } = this.props;
+		const { trackUpsellButtonClick, upsellType, siteSlug, upgradeItem } = this.props;
 
 		trackUpsellButtonClick(
 			`calypso_${ upsellType.replace( /-/g, '_' ) }_${ buttonAction }_button_click`
 		);
 
-		page( `/checkout/${ upgradeItem }` );
+		return siteSlug
+			? page( `/checkout/${ upgradeItem }/${ siteSlug }` )
+			: page( `/checkout/${ upgradeItem }` );
 	};
 }
 

--- a/client/my-sites/checkout/upsell-nudge/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/index.jsx
@@ -173,12 +173,13 @@ export class UpsellNudge extends React.Component {
 	};
 
 	handleClickAccept = buttonAction => {
-		const { trackUpsellButtonClick, upsellType, siteSlug, upgradeItem } = this.props;
+		const { trackUpsellButtonClick, upsellType, upgradeItem } = this.props;
 
 		trackUpsellButtonClick(
 			`calypso_${ upsellType.replace( /-/g, '_' ) }_${ buttonAction }_button_click`
 		);
-		page( `/checkout/${ siteSlug }/${ upgradeItem }` );
+
+		page( `/checkout/${ upgradeItem }` );
 	};
 }
 

--- a/client/state/selectors/is-eligible-for-signup-destination.js
+++ b/client/state/selectors/is-eligible-for-signup-destination.js
@@ -45,5 +45,5 @@ export default function isEligibleForSignupDestination( state, siteId, cart ) {
 		return isNewSite( state, siteId ) && isEligibleForDotcomChecklist( state, siteId );
 	}
 
-	return isNewSite( state, siteId );
+	return '/' === destination ? false : isNewSite( state, siteId );
 }

--- a/client/state/selectors/is-eligible-for-signup-destination.js
+++ b/client/state/selectors/is-eligible-for-signup-destination.js
@@ -40,6 +40,11 @@ export default function isEligibleForSignupDestination( state, siteId, cart ) {
 	}
 
 	const destination = retrieveSignupDestination();
+
+	if ( destination === '/' ) {
+		return false;
+	}
+
 	if ( destination && destination.includes( '/checklist/' ) ) {
 		return isNewSite( state, siteId ) && isEligibleForDotcomChecklist( state, siteId );
 	}

--- a/client/state/selectors/is-eligible-for-signup-destination.js
+++ b/client/state/selectors/is-eligible-for-signup-destination.js
@@ -41,10 +41,6 @@ export default function isEligibleForSignupDestination( state, siteId, cart ) {
 
 	const destination = retrieveSignupDestination();
 
-	if ( destination === '/' ) {
-		return false;
-	}
-
 	if ( destination && destination.includes( '/checklist/' ) ) {
 		return isNewSite( state, siteId ) && isEligibleForDotcomChecklist( state, siteId );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the site slug from the concierge session upsell nudges.
* In https://github.com/Automattic/wp-calypso/pull/33749, concierge upsell nudges were made visible while signed out, however the URL still required the site slug. Combined with the changes in this PR, a URL like http://calypso.localhost:3000/checkout/offer-quickstart-session will now work, either signed out or signed in. 
* If the account has multiple sites, then clicking the `Yes..` button on the upsell nudge will open a site picker before the checkout page is shown:

![giphy (1)](https://user-images.githubusercontent.com/1269602/61937403-67aae700-afac-11e9-951e-cdc03535735b.gif)

* If the account has only a single site, then clicking the `Yes..` button on the upsell nudge will proceed to checkout directly.

* The following are our concierge upsell nudge URLs:
    - http://calypso.localhost:3000/checkout/offer-quickstart-session (visible signed out + signed in)
    - http://calypso.localhost:3000/checkout/offer-support-session (visible only signed in)


#### URL structure for /checkout

Another important change that has gone in is that the /checkout URL now works with interchangeable site slug and product query parameters. On production, we can see the following behaviour:
- `/checkout/{SITE_SLUG}` will display the checkout page if there's an existing item in cart. 
- `/checkout/{SITE_SLUG}/business` will display the checkout page and added the Business plan product to cart. 
- Interchanging the params - `/checkout/business/{SITE_SLUG}` -  **will not** work.

In this PR, the site slug and product params are interchangeable. So:
- `/checkout/{SITE_SLUG}` and `/checkout/business` will both work. The former opens the checkout page for the site(provided there's an existing item in the cart), and the latter will add business plan to cart and show the checkout page if single site, or site picker if multisite.
- `/checkout/{SITE_SLUG}/business` and `/checkout/business/{SITE_SLUG}` both will add the business plan to cart and show the checkout page.

_Context for this change_:

Clicking the `Get Started` button on the offer page(while signed out) will redirect to `/checkout/concierge-session`(since we still don't have the site_slug at this point). After the user signs in, we redirect to `/checkout/concierge-session/SITE_SLUG`. So, we need the /checkout route to have the product item as the first param and site_slug as the second param. If we make this the route definition, then we need to replace all calls to /checkout/domain/product to /checkout/product/domain in several places across the codebase(prone to errors). So, the the less disruptive thing to do would be to make both routes - /domain/product and /product/domain - to work for /checkout. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**

* While signed out of Calypso, visit http://calypso.localhost:3000/checkout/offer-quickstart-session and verify that you see the offer page.
* Click the `Get Started` button and login with an account having a single site. 
* Verify that you are taken to the checkout page with a support session item added to cart. 
* Complete the purchase and you should now see a Thank You page. 

**Scenario 2**

* Similar to _Scenario 1_, visit the offer page while signed out and click `Get Started`
* Now login with an account that has multiple sites.
* After logging in, verify that you are shown the site picker view.

<img width="1402" alt="Screenshot 2019-07-26 at 3 52 50 PM" src="https://user-images.githubusercontent.com/1269602/61945393-764dca00-afbd-11e9-9b73-13fbdc64c668.png">

* Select a site, and then you should be taken to the checkout page. 
* Complete purchase and you should now be taken to a Thank You page.


**Scenario 3**

* Begin the signup flow starting at `/start`(put yourself in the `control` variant of `showPlanUpsellNudge` AB test).
* Add a Blogger or Personal or Premium plan to cart and complete checkout.
* Verify that you are shown the Quick Start session offer nudge.
    - Click the `Yes..` button and complete purchase. Verify that you are taken to Checklist page.
    - Click the `No..` button and verify that you are taken to Checklist page.

**Scenario 4**

* While signed in to an account having a single site, paste the following URLs in your browser tab:
    - http://calypso.localhost:3000/checkout/offer-support-session
    - http://calypso.localhost:3000/checkout/offer-quickstart-session
* In both cases you should see the corresponding upsell nudge content. 
    - Clicking the `Yes ..` button should take you to the checkout page with support session item added to cart.
    - Clicking the `No ..` button should take you to Reader.

**Scenario 5**

* Similar to Scenario 4 , but signed in to an account having multiple sites.
* Visiting the upsell nudge URLs should show the offer content. 
* Clicking the `Yes ...` button should now show a site picker. Select a site and then you should be taken to the checkout page with a support session item added.
* Also try accessing http://calypso.localhost:3000/checkout/offer-quickstart-session/{SITE_SLUG} and verify that the offer page opens. Clicking `Yes..` will proceed to checkout **without** a site picker since we have mentioned the site slug in the URL.

**Scenario 6**

* Go through the domain only signup flow beginning at `/start/domain` and verify that you are able to complete purchase of a domain (we are testing that the /checkout/no-site route used in this flow works).

**Scenario 7**

Testing backward compatibility of support session URL.

* While signed in to Calypso, verify that pasting the old support-session nudge URL in the browser `/checkout/{SITE_SLUG}/add-support-session` will redirect to the new URL structure - `/checkout/offer-support-session/{SITE_SLUG}`

**Scenario 8**

* In /plans and /themes routes, add an item to cart and checkout. Verify that the checkout page opens with the item added to cart(we're testing this since we have interchangeable query params for /checkout route -> /checkout/slug/product and /checkout/product/slug).

**Scenario 9**

* Create an account with .blog subdomain such as `XXXXXXX.home.blog`.
* Open the offer page `http://calypso.localhost:3000/checkout/offer-quickstart-session` and verify that you are able to complete purchase.
(This test is to ensure that .blog subdomains open the checkout page).

**Scenario 10**
. 
This is to test the fix introduced [here](https://github.com/Automattic/wp-calypso/pull/34862/files#diff-9fb6954da8e43d925d96340213cf613fR48), which fixes a bug of setting destination as / when a user of a newly created site buys a concierge session using the direct link /checkout/offer-support-session or /checkout/offer-quickstart-session.

* For a newly created site(i.e site created < 30 minutes ago), access `checkout/offer-quickstart-session` and complete purchase. Verify that you are taken to the Thank You page (in production, you would see that this takes to `/` destination which is a bug). 






