### PR TITLE
Earn: replace tabs with HeaderCake component

### DIFF
--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -50,7 +50,8 @@ class EarningsMain extends Component {
 		const { siteSlug, translate } = this.props;
 		const pathSuffix = siteSlug ? '/' + siteSlug : '';
 		const tabs = [];
-		if ( config.isEnabled( 'memberships' ) ) {
+
+		if ( config.isEnabled( 'memberships' ) && ! config.isEnabled( 'earn-relayout' ) ) {
 			tabs.push( {
 				title: translate( 'Recurring Payments' ),
 				path: '/earn/payments' + pathSuffix,
@@ -125,17 +126,16 @@ class EarningsMain extends Component {
 	getHeaderText = () => {
 		const { translate } = this.props;
 
-		switch ( this.getCurrentPath().replace( /^\/earn\/([-a-z]*)(\/.*)?$/gm, '$1' ) ) {
+		switch ( this.props.section ) {
 			case 'payments':
 				return translate( 'Recurring Payments' );
 
 			case 'ads-earnings':
 			case 'ads-settings':
 				return translate( 'Ads' );
-				return translate( 'Ads Earnings' );
 
-			case 'ads-settings':
-				return translate( 'Ads Settings' );
+			default:
+				return '';
 		}
 	};
 
@@ -167,9 +167,10 @@ class EarningsMain extends Component {
 				/>
 				<DocumentHead title={ layoutTitles[ section ] } />
 				<SidebarNavigation />
-				{ config.isEnabled( 'earn-relayout' ) ? (
+				{ config.isEnabled( 'earn-relayout' ) && (
 					<HeaderCake backHref={ this.goBack() }>{ this.getHeaderText() }</HeaderCake>
-				) : (
+				) }
+				{ ( 'payments' !== this.props.section || ! config.isEnabled( 'earn-relayout' ) ) && (
 					<SectionNav selectedText={ this.getSelectedText() }>
 						<NavTabs>
 							{ this.getFilters().map( filterItem => {

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -130,6 +130,8 @@ class EarningsMain extends Component {
 				return translate( 'Recurring Payments' );
 
 			case 'ads-earnings':
+			case 'ads-settings':
+				return translate( 'Ads' );
 				return translate( 'Ads Earnings' );
 
 			case 'ads-settings':

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -16,6 +16,7 @@ import { localize } from 'i18n-calypso';
 import SectionNav from 'components/section-nav';
 import NavTabs from 'components/section-nav/tabs';
 import NavItem from 'components/section-nav/item';
+import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import WordAdsEarnings from 'my-sites/stats/wordads/earnings';
@@ -101,6 +102,48 @@ class EarningsMain extends Component {
 		this.props.dismissWordAdsError( siteId );
 	};
 
+	/**
+	 * Remove any query parameters from the path before using it to
+	 * identify which screen the user is seeing.
+	 *
+	 * @returns {String} Path to current screen.
+	 */
+	getCurrentPath = () => {
+		let currentPath = this.props.path;
+		const queryStartPosition = currentPath.indexOf( '?' );
+		if ( queryStartPosition > -1 ) {
+			currentPath = currentPath.substring( 0, queryStartPosition );
+		}
+		return currentPath;
+	};
+
+	/**
+	 * Check the current path and returns an appropriate title.
+	 *
+	 * @returns {String} Header text for current screen.
+	 */
+	getHeaderText = () => {
+		const { translate } = this.props;
+
+		switch ( this.getCurrentPath().replace( /^\/earn\/([-a-z]*)(\/.*)?$/gm, '$1' ) ) {
+			case 'payments':
+				return translate( 'Recurring Payments' );
+
+			case 'ads-earnings':
+				return translate( 'Ads Earnings' );
+
+			case 'ads-settings':
+				return translate( 'Ads Settings' );
+		}
+	};
+
+	/**
+	 * Goes back to Earn home.
+	 *
+	 * @returns {string} Path to Earn home. Has site slug append if it exists.
+	 */
+	goBack = () => ( this.props.siteSlug ? '/earn/' + this.props.siteSlug : '' );
+
 	render() {
 		const { adsProgramName, section, translate } = this.props;
 		const component = this.getComponent( this.props.section );
@@ -112,13 +155,7 @@ class EarningsMain extends Component {
 			'payments-plans': translate( 'Recurring Payments plans' ),
 		};
 
-		// Remove any query parameters from the path before using it to
-		// identify which navigation tab is the active one.
-		let currentPath = this.props.path;
-		const queryStartPosition = currentPath.indexOf( '?' );
-		if ( queryStartPosition > -1 ) {
-			currentPath = currentPath.substring( 0, queryStartPosition );
-		}
+		const currentPath = this.getCurrentPath();
 
 		return (
 			<Main className="earn">
@@ -128,21 +165,25 @@ class EarningsMain extends Component {
 				/>
 				<DocumentHead title={ layoutTitles[ section ] } />
 				<SidebarNavigation />
-				<SectionNav selectedText={ this.getSelectedText() }>
-					<NavTabs>
-						{ this.getFilters().map( filterItem => {
-							return (
-								<NavItem
-									key={ filterItem.id }
-									path={ filterItem.path }
-									selected={ filterItem.path === currentPath }
-								>
-									{ filterItem.title }
-								</NavItem>
-							);
-						} ) }
-					</NavTabs>
-				</SectionNav>
+				{ config.isEnabled( 'earn-relayout' ) ? (
+					<HeaderCake backHref={ this.goBack() }>{ this.getHeaderText() }</HeaderCake>
+				) : (
+					<SectionNav selectedText={ this.getSelectedText() }>
+						<NavTabs>
+							{ this.getFilters().map( filterItem => {
+								return (
+									<NavItem
+										key={ filterItem.id }
+										path={ filterItem.path }
+										selected={ filterItem.path === currentPath }
+									>
+										{ filterItem.title }
+									</NavItem>
+								);
+							} ) }
+						</NavTabs>
+					</SectionNav>
+				) }
 				{ component }
 			</Main>
 		);


### PR DESCRIPTION
This PR seeks to replace the tabs in the Earn section with a header component that has a single arrow to go back to the Earn home–that has yet to be developed.
For now this feature is behind the config flag `earn-relayout`.

#### Changes proposed in this Pull Request

* replaces navigation tabs in Earn section with a header cake for each sub screen.

#### Testing instructions

* Launch Calypso live and go to `earn/payments/elio.blog?flags=earn-relayout`
* You should see the header cake component

<img width="813" alt="Captura de Pantalla 2019-07-24 a la(s) 12 24 53" src="https://user-images.githubusercontent.com/1041600/61806717-955a2980-ae0e-11e9-8f3a-b9b9b9675e31.png">

* the Back button should point to `/earn/yoursite.tld`. For now it will go nowhere since the page doesn't exist.

* on Ads screens, the tabs should still be there, and the header cake on top

<img width="751" alt="Captura de Pantalla 2019-07-24 a la(s) 16 00 41" src="https://user-images.githubusercontent.com/1041600/61820892-576bfe00-ae2c-11e9-986e-80c7eb390e0e.png">

* remove the flag in the URL and you should see the previous tabs

<img width="765" alt="Captura de Pantalla 2019-07-24 a la(s) 12 25 04" src="https://user-images.githubusercontent.com/1041600/61806715-955a2980-ae0e-11e9-9c59-49c57056b79c.png">

Fixes #34525
