### PR TITLE
Fix ImageEditor figure element overlapping Notice component

### DIFF
--- a/client/blocks/image-editor/index.jsx
+++ b/client/blocks/image-editor/index.jsx
@@ -257,8 +257,6 @@ class ImageEditor extends React.Component {
 
 		return (
 			<div className={ classes }>
-				{ noticeText && this.renderNotice() }
-
 				<CloseOnEscape onEscape={ this.onCancel } />
 				<QuerySites siteId={ siteId } />
 
@@ -277,6 +275,8 @@ class ImageEditor extends React.Component {
 						/>
 					</div>
 				</figure>
+
+				{ noticeText && this.renderNotice() }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix ImageEditor figure element overlapping Notice component

#### Testing instructions

1. Disconnect from internet
2. Go to http://calypso.localhost:3000/devdocs/blocks/image-editor

**Before**
<img width="1020" alt="Screen Shot 2019-07-24 at 15 52 05" src="https://user-images.githubusercontent.com/3068563/61820778-1bd13400-ae2c-11e9-8e52-af8bcf9715bf.png">

**After**
![](https://cld.wthms.co/vLfXKz+)