### PR TITLE
Fix VideoEditor figure element overlapping Notice component

### DIFF
--- a/client/blocks/video-editor/index.jsx
+++ b/client/blocks/video-editor/index.jsx
@@ -167,8 +167,6 @@ class VideoEditor extends Component {
 
 		return (
 			<div className={ classes }>
-				{ error && this.renderError() }
-
 				<figure>
 					<div className="video-editor__content">
 						<div className="video-editor__preview-wrapper">
@@ -202,6 +200,8 @@ class VideoEditor extends Component {
 						/>
 					</div>
 				</figure>
+
+				{ error && this.renderError() }
 			</div>
 		);
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix VideoEditor figure element overlapping Notice component

#### Testing instructions

1. Go to `/devdocs/blocks/video-editor`
2. I'm not sure how to trigger this error organically, so I forced it by toggling the `error` state here: https://github.com/Automattic/wp-calypso/blob/b01ba148c1583ed6a74f56a32a7e7f4a909076ab/client/blocks/video-editor/index.jsx#L50

**Before**

![](https://cld.wthms.co/rQDhSl+)

**After**

![](https://cld.wthms.co/23d5dx+)