### PR TITLE
Signup: Link import from main signup flow without site type

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -281,7 +281,7 @@ export function generateFlows( {
 	};
 
 	flows.import = {
-		steps: [ 'from-url', 'user', 'domains' ],
+		steps: [ 'user', 'from-url', 'domains' ],
 		destination: ( { importEngine, importSiteUrl, siteSlug } ) =>
 			addQueryArgs(
 				{

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -14,6 +14,7 @@ import StepWrapper from 'signup/step-wrapper';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
+import Button from 'components/button';
 
 const siteTypeToFlowname = {
 	'online-store': 'ecommerce-onboarding',
@@ -31,12 +32,22 @@ class SiteType extends Component {
 		this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
 	};
 
+	renderContent = () => (
+		<Fragment>
+			<SiteTypeForm submitForm={ this.submitStep } siteType={ this.props.siteType } />
+			<div className="site-type__import-button">
+				<Button borderless onClick={ this.props.goToNextStep.bind( this, 'import' ) }>
+					{ this.props.translate( 'Already have a website?' ) }
+				</Button>
+			</div>
+		</Fragment>
+	);
+
 	render() {
 		const {
 			flowName,
 			positionInFlow,
 			signupProgress,
-			siteType,
 			stepName,
 			translate,
 			hasInitializedSitesBackUrl,
@@ -57,7 +68,7 @@ class SiteType extends Component {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
-				stepContent={ <SiteTypeForm submitForm={ this.submitStep } siteType={ siteType } /> }
+				stepContent={ this.renderContent() }
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }
 				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to My Sites' ) : null }

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -84,3 +84,20 @@
 		transform: translateX( 0 );
 	}
 }
+
+.site-type__import-button {
+	text-align: center;
+	margin-top: 20px;
+
+	.button.is-borderless {
+		padding: 0;
+		color: var( --color-white );
+		font-size: 14px;
+		font-weight: 500;
+		text-decoration: underline;
+
+		svg {
+			fill: var( --color-white );
+		}
+	}
+}


### PR DESCRIPTION
**Option 2** for linking to import flow from the main signup flow

- Move user step to beginning of import flow

**Problems**

When creating a new user in the signup flow and redirecting to the import flow, the user lands on `/start/import/user` with the step already completed.

This happens because `user.get()` returns false from https://github.com/Automattic/wp-calypso/blob/master/client/state/signup/progress/reducer.js#L59 until the page is reloaded.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/start` logged out
- Create a new user and proceed to the site type step
- Click "Already have a website?" to be redirected to the import flow
