### PR TITLE
Earn: update labels of ad earnings and settings tabs

### DIFF
--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -61,12 +61,16 @@ class EarningsMain extends Component {
 
 		if ( canAccessAds( this.props.site ) ) {
 			tabs.push( {
-				title: translate( 'Ads Earnings' ),
+				title: config.isEnabled( 'earn-relayout' )
+					? translate( 'Earnings' )
+					: translate( 'Ads Earnings' ),
 				path: '/earn/ads-earnings' + pathSuffix,
 				id: 'ads-earnings',
 			} );
 			tabs.push( {
-				title: translate( 'Ads Settings' ),
+				title: config.isEnabled( 'earn-relayout' )
+					? translate( 'Settings' )
+					: translate( 'Ads Settings' ),
 				path: '/earn/ads-settings' + pathSuffix,
 				id: 'ads-settings',
 			} );


### PR DESCRIPTION
Fixes #34526

#### Changes proposed in this Pull Request

Updates the labels of the tabs for Ads Earnings and Ads Settings so they're just Earnings and Settings, because there will be an Ads in the header cake above them.
This change is behind the `earn-relayout` flag so it won't be visible to other users.

#### Testing instructions

* go to `earn/ads-earnings/YOURSITE?flags=earn-relayout`

* make sure tab labels look like

<img width="766" alt="Captura de Pantalla 2019-07-24 a la(s) 16 55 14" src="https://user-images.githubusercontent.com/1041600/61824529-9bfb9780-ae34-11e9-9a9d-1fb6a593b41e.png">

* now remove the config flag in the URL, navigate again and ensure the tab labels for Ads look like

<img width="743" alt="Captura de Pantalla 2019-07-24 a la(s) 16 55 33" src="https://user-images.githubusercontent.com/1041600/61824528-9bfb9780-ae34-11e9-8a11-88314bbaee97.png">
