### PR TITLE
Replace missing references to the wordpress-com.js file

### DIFF
--- a/client/boot/README.md
+++ b/client/boot/README.md
@@ -10,8 +10,7 @@ client/boot/
 ├── app.js
 ├── common.js
 ├── dev-modules.js
-└── project/
-    └── wordpress-com.js
+└── polyfills.js
 ```
 
 There is a single entry point for the Webpack client build: `client/boot/app.js`. It is responsible for handling a lot of features we want to happen on every page.
@@ -31,24 +30,3 @@ The major ones are shared between all projects and live in `client/boot/common.j
 - Starting page.js
 
 _*_ All development tools are now located in `client/boot/dev-modules.js` file and are guarded with environment check to make sure they are never bundled into production builds.
-
-All remaining handlers remain in the project specific file `client/boot/project/${ projectName }.js`. This open possibilities to create custom configurations tailored to particular projects.
-Example of project (`WordPress.com`) specific features (see `client/boot/project/wordpress-com.js`):
-- Setting the document title
-- Passing layout to all page handlers
-- Setting up analytics
-- Rendering the main layout template
-- Focussing parts of the layout based on the query string
-- Handling query strings
-- Loading various helpers (Happychat initialization, keyboard shortcuts)
-
-### Project specific API
-
-Each project is capable of hooking in its own custom functionality. It is possible by implementing any of the following API methods:
-
-* `locales( currentUser )`
-* `utils()`
-* `configureReduxStore( currentUser, reduxStore )`
-* `setupMiddlewares( currentUser, reduxStore )`
-
-They are all optional and they may be exported from the project file. Each provide function is executed just after its corresponding shared method with the same signature.

--- a/client/extensions/README.md
+++ b/client/extensions/README.md
@@ -13,7 +13,7 @@ Before you get started we encourage you to get familiar with our [development va
 
 ## Defining a new section
 
-Create a new directory within `/client/extensions` with your plugin name. Add a `package.json` file at the root of your directory. Add a `section` field in the same format as those found in `client/wordpress-com.js`:
+Create a new directory within `/client/extensions` with your plugin name. Add a `package.json` file at the root of your directory. Add a `section` field in the same format as those found in `client/sections.js`:
 
 ```json
 {

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -63,7 +63,7 @@ This wraps up the more introductory part; if you're interested in more details, 
 
 ## Section Definitions
 
-More formally, sections are defined in [`client/sections.js`](../client/sections.js) (or in the file imported from there -- `wordpress-com.js` for WordPress.com). While that file's format should be intuitive enough to understand, we use quite a bit of magic to turn it into actual routing and code-splitting code. Most of it is documented in [`server/bundler/README.md`](../server/bundler/README.md).
+More formally, sections are defined in [`client/sections.js`](../client/sections.js). While that file's format should be intuitive enough to understand, we use quite a bit of magic to turn it into actual routing and code-splitting code. Most of it is documented in [`server/bundler/README.md`](../server/bundler/README.md).
 
 ## Site-specific URLs
 


### PR DESCRIPTION
I was reading the docs and found some references to this file.

#### Changes proposed in this Pull Request

* Replace missing references to the `wordpress-com.js` file
