### PR TITLE
Signup: Link import from main signup flow by adding site type step

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -637,14 +637,17 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 }
 
 export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) {
-	let siteType, siteTypeValue;
-
-	if ( nextProps.flowName === 'import' ) {
-		siteType = siteTypeValue = 'import';
-	} else {
-		siteType = get( nextProps, [ 'initialContext', 'query', 'site_type' ], null );
-		siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
+	if ( isEmpty( nextProps.initialContext && nextProps.initialContext.query ) ) {
+		return;
 	}
+
+	const {
+		initialContext: {
+			query: { site_type: siteType },
+		},
+	} = nextProps;
+
+	const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
 
 	let fulfilledDependencies = [];
 

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -637,17 +637,16 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 }
 
 export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) {
-	if ( isEmpty( nextProps.initialContext && nextProps.initialContext.query ) ) {
-		return;
+	// debugger;
+	let siteType, siteTypeValue;
+
+	if ( nextProps.flowName === 'import' ) {
+		siteType = siteTypeValue = 'import';
+	} else {
+		siteType = get( nextProps, [ 'initialContext', 'query', 'site_type' ], null );
+		siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
 	}
 
-	const {
-		initialContext: {
-			query: { site_type: siteType },
-		},
-	} = nextProps;
-
-	const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
 	let fulfilledDependencies = [];
 
 	if ( siteTypeValue ) {

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -637,7 +637,6 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 }
 
 export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) {
-	// debugger;
 	let siteType, siteTypeValue;
 
 	if ( nextProps.flowName === 'import' ) {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -281,7 +281,7 @@ export function generateFlows( {
 	};
 
 	flows.import = {
-		steps: [ 'from-url', 'user', 'domains' ],
+		steps: [ 'user', 'site-type', 'from-url', 'domains' ],
 		destination: ( { importEngine, importSiteUrl, siteSlug } ) =>
 			addQueryArgs(
 				{

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -10,7 +10,6 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Badge from 'components/badge';
-import Button from 'components/button';
 import Card from 'components/card';
 import { getAllSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -63,11 +62,6 @@ class SiteTypeForm extends Component {
 						</Card>
 					) ) }
 				</Card>
-				<div className="site-type__import-button">
-					<Button borderless onClick={ this.handleSubmit.bind( this, 'import' ) }>
-						{ this.props.translate( 'Already have a website?' ) }
-					</Button>
-				</div>
 			</Fragment>
 		);
 	}

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -10,6 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Badge from 'components/badge';
+import Button from 'components/button';
 import Card from 'components/card';
 import { getAllSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -62,6 +63,11 @@ class SiteTypeForm extends Component {
 						</Card>
 					) ) }
 				</Card>
+				<div className="site-type__import-button">
+					<Button borderless onClick={ this.handleSubmit.bind( this, 'import' ) }>
+						{ this.props.translate( 'Already have a website?' ) }
+					</Button>
+				</div>
 			</Fragment>
 		);
 	}

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -16,6 +16,7 @@ import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
 
 const siteTypeToFlowname = {
+	import: 'import',
 	'online-store': 'ecommerce-onboarding',
 };
 

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 
@@ -14,9 +14,9 @@ import StepWrapper from 'signup/step-wrapper';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
+import Button from 'components/button';
 
 const siteTypeToFlowname = {
-	import: 'import',
 	'online-store': 'ecommerce-onboarding',
 };
 
@@ -32,12 +32,32 @@ class SiteType extends Component {
 		this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
 	};
 
+	renderImportButton = () => {
+		if ( 'import' === this.props.flowName ) {
+			return null;
+		}
+
+		return (
+			<div className="site-type__import-button">
+				<Button borderless onClick={ this.props.goToNextStep.bind( this, 'import' ) }>
+					{ this.props.translate( 'Already have a website?' ) }
+				</Button>
+			</div>
+		);
+	};
+
+	renderContent = () => (
+		<Fragment>
+			<SiteTypeForm submitForm={ this.submitStep } siteType={ this.props.siteType } />
+			{ this.renderImportButton() }
+		</Fragment>
+	);
+
 	render() {
 		const {
 			flowName,
 			positionInFlow,
 			signupProgress,
-			siteType,
 			stepName,
 			translate,
 			hasInitializedSitesBackUrl,
@@ -58,7 +78,7 @@ class SiteType extends Component {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
-				stepContent={ <SiteTypeForm submitForm={ this.submitStep } siteType={ siteType } /> }
+				stepContent={ this.renderContent() }
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }
 				backLabelText={ hasInitializedSitesBackUrl ? translate( 'Back to My Sites' ) : null }

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -84,3 +84,20 @@
 		transform: translateX( 0 );
 	}
 }
+
+.site-type__import-button {
+	text-align: center;
+	margin-top: 20px;
+
+	.button.is-borderless {
+		padding: 0;
+		color: var( --color-white );
+		font-size: 14px;
+		font-weight: 500;
+		text-decoration: underline;
+
+		svg {
+			fill: var( --color-white );
+		}
+	}
+}


### PR DESCRIPTION
**Option 1** for linking to import flow from main signup flow

- Move user step to beginning of import flow
- Add site type step to import flow
- Redirect to import flow without setting site type

**Problems**

1. When entering import signup flow by clicking on "Already have a website?", the Back link in the next step (`/start/import/from-url`) has unexpected behavior.
    - If creating a new user in the signup flow, the "Back" link takes you `/start/import/user` with the user form already filled out.
    - If already logged in, the "Back" link takes you to `/start/import/site-type` rather than taking you back to the main flow.
1. We don't capture a site type when switching flows, so you are redirected to the site type flow again, at the end of the import flow.
1. When starting with the import flow (`/start/import`), the "Online Store" site type redirects to the ecommerce flow, rather than continuing with the import flow.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Visit `/start` logged out
- Create a new user and proceed to the site type step
- Click "Already have a website?" to be redirected to the import flow
