### PR TITLE
App Promo: First pass at sending a magic link via the mobile app promo.

### DIFF
--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -178,8 +178,7 @@ export class AppPromo extends React.Component {
 				>
 					<Gridicon icon="cross" size={ 24 } />
 				</button>
-				<a
-					href="#"
+				<button
 					onClick={ this.sendMagicLink }
 					className="app-promo__link"
 					title="Try the mobile app!"
@@ -192,7 +191,7 @@ export class AppPromo extends React.Component {
 						alt="WordPress Desktop Icon"
 					/>
 					{ 'WordPress.com in the palm of your hands — download the mobile app.' }
-				</a>
+				</button>
 				<Dialog className="app-promo__dialog" isVisible={ this.state.showDialog } buttons={ buttons } onClose={ this.onCloseDialog }>
 					<h1>{ translate( 'Check your mail!' ) }</h1>
 					<p>{ translate( "We've sent you an email with links to download and effortlessly log in to the mobile app. Be sure to use them from your mobile device!" ) }</p>
@@ -206,7 +205,6 @@ export class AppPromo extends React.Component {
 			return null;
 		}
 		const { promoItem } = this.state;
-		return this.mobilePromo();
 		return ( promoItem.type === 'mobile' ) ? this.mobilePromo() : this.desktopPromo( promoItem );
 	}
 }

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -193,9 +193,9 @@ export class AppPromo extends React.Component {
 					/>
 					{ 'WordPress.com in the palm of your hands — download the mobile app.' }
 				</a>
-				<Dialog isVisible={ this.state.showDialog } buttons={ buttons } onClose={ this.onCloseDialog }>
+				<Dialog className="app-promo__dialog" isVisible={ this.state.showDialog } buttons={ buttons } onClose={ this.onCloseDialog }>
 					<h1>{ translate( 'Check your mail!' ) }</h1>
-					<p>{ translate( "We've sent you links to download and log in to the mobile app. Use the links from your mobile device." ) }</p>
+					<p>{ translate( "We've sent you an email with links to download and effortlessly log in to the mobile app. Be sure to use them from your mobile device!" ) }</p>
 				</Dialog>
 			</div>
 		)
@@ -206,6 +206,7 @@ export class AppPromo extends React.Component {
 			return null;
 		}
 		const { promoItem } = this.state;
+		return this.mobilePromo();
 		return ( promoItem.type === 'mobile' ) ? this.mobilePromo() : this.desktopPromo( promoItem );
 	}
 }

--- a/client/blocks/app-promo/index.jsx
+++ b/client/blocks/app-promo/index.jsx
@@ -20,7 +20,6 @@ import wpcom from 'lib/wp';
 import Dialog from 'components/dialog'
 import { fetchUserSettings } from 'state/user-settings/actions';
 import getUserSettings from 'state/selectors/get-user-settings';
-import hasUserSettings from 'state/selectors/has-user-settings';
 
 /**
  * Style dependencies
@@ -125,9 +124,7 @@ export class AppPromo extends React.Component {
 		this.setState( { showDialog: true } );
 	};
 
-	onCloseDialog = ( action ) => {
-		// action is the `action` property of the button clicked to close the dialog. If the dialog is closed
-		// by pressing ESC or clicking outside of the dialog, action will be `undefined`
+	onCloseDialog = () => {
 		this.setState( { showDialog: false } );
 	};
 	
@@ -165,7 +162,7 @@ export class AppPromo extends React.Component {
 		)
 	}
 	
-	mobilePromo = ( promoItem ) => {
+	mobilePromo = () => {
 		const { translate } = this.props;
 		const buttons = [
 			{ action: 'cancel', label: translate( 'OK' ) },
@@ -182,6 +179,7 @@ export class AppPromo extends React.Component {
 					<Gridicon icon="cross" size={ 24 } />
 				</button>
 				<a
+					href="#"
 					onClick={ this.sendMagicLink }
 					className="app-promo__link"
 					title="Try the mobile app!"
@@ -197,7 +195,7 @@ export class AppPromo extends React.Component {
 				</a>
 				<Dialog isVisible={ this.state.showDialog } buttons={ buttons } onClose={ this.onCloseDialog }>
 					<h1>{ translate( 'Check your mail!' ) }</h1>
-					<p>{ translate( "We've sent you links to download and log in to the mobile app.  Use the links from your mobile device." ) }</p>
+					<p>{ translate( "We've sent you links to download and log in to the mobile app. Use the links from your mobile device." ) }</p>
 				</Dialog>
 			</div>
 		)
@@ -208,7 +206,7 @@ export class AppPromo extends React.Component {
 			return null;
 		}
 		const { promoItem } = this.state;
-		return ( promoItem.type == 'mobile' ) ? this.mobilePromo( promoItem ) : this.desktopPromo( promoItem );
+		return ( promoItem.type === 'mobile' ) ? this.mobilePromo() : this.desktopPromo( promoItem );
 	}
 }
 

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -46,3 +46,7 @@
 .app-promo__dialog {
 	max-width: 480px;
 }
+
+button.app-promo__link {
+	text-align: left;
+}

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -42,3 +42,7 @@
 		cursor: pointer;
 	}
 }
+
+.app-promo__dialog {
+	max-width: 480px;
+}

--- a/client/blocks/app-promo/style.scss
+++ b/client/blocks/app-promo/style.scss
@@ -39,5 +39,6 @@
 
 	&:hover {
 		text-decoration: underline;
+		cursor: pointer;
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR modifies the app promo component to email the user a magic link when clicked. An instructional dialog is shown to the user to coach them about next steps. 


#### Testing instructions

* Refresh the page a few times to see both the desktop and mobile promos.
- Ensure the desktop promo is correctly shown, and tapping it takes you to the correct page.
- Ensure the mobile promo is correctly shown and tapping it displays a dialog with instructions to check your mail on your mobile device.  Check your email and confirm that you received the magic link email. (Note: a8c accounts can not use magic links.)

![app-promo-magic-link](https://user-images.githubusercontent.com/1435271/61836710-0ae1ec00-ae47-11e9-8dcd-fc7fe130f33d.gif)
