### PR TITLE
Add multi select and gallery support to classic block

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -169,6 +169,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			this.setState( {
 				classicBlockEditorId: data.editorId,
 				isMediaModalVisible: true,
+				multiple: true,
 			} );
 		}
 
@@ -492,6 +493,8 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			currentIFrameUrl,
 		} = this.state;
 
+		const isUsingClassicBlock = !! classicBlockEditorId;
+
 		return (
 			<Fragment>
 				<PageViewTracker
@@ -526,8 +529,8 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 					<EditorMediaModal
 						disabledDataSources={ getDisabledDataSources( allowedTypes ) }
 						enabledFilters={ getEnabledFilters( allowedTypes ) }
-						galleryViewEnabled={ false }
-						isGutenberg={ ! classicBlockEditorId }
+						galleryViewEnabled={ isUsingClassicBlock }
+						isGutenberg={ ! isUsingClassicBlock }
 						onClose={ this.closeMediaModal }
 						onInsertMedia={ this.insertClassicBlockMedia }
 						single={ ! multiple }


### PR DESCRIPTION
#### Changes proposed in this Pull Request
When we switched to the Calypso media manager for the classic block, we never added support for multi-image selection or galleries. This PR adds that support. Now, when using the media picker from the classic block, you can select multiple images to create a gallery:

![ezgif-2-5ba984ab9fc7](https://user-images.githubusercontent.com/6265975/61837632-88ebc600-ae3a-11e9-8a1d-b861b89d358c.gif)

#### Testing instructions
0. Have a local Calypso install set up
1. Checkout and run this branch on your calypso setup
2. Go to a post in the block editor (either editing or creating a new one is fine)
3. Insert the `/classic` block
4. Inside the classic block, choose the "add media" button
5. Select multiple images by using the shift or cmd button
6. The primary button should change to say "continue"
7. Click continue and make sure you see the gallery creation screen
8. After clicking insert on this screen, the gallery should appear inside the classic block, and after publishing the post, it should also appear on the frontend.
9. Make sure you can only select single images while using the normal image block
10. Makes sure you can still select multiple images while using the actual gallery block

Fixes #32348