### PR TITLE
Revamp Earn > Ads section

### DIFF
--- a/client/lib/ads/utils.js
+++ b/client/lib/ads/utils.js
@@ -5,7 +5,7 @@
  */
 
 import { userCan } from 'lib/site/utils';
-import { isBusiness, isPremium, isEcommerce } from 'lib/products-values';
+import { isPremium, isBusiness, isEcommerce } from 'lib/products-values';
 
 /**
  * Returns true if the site has WordAds access
@@ -32,8 +32,10 @@ export function canAccessWordads( site ) {
 }
 
 export function canAccessAds( site ) {
-	return ( canAccessWordads( site ) || canUpgradeToUseWordAds( site ) ) 
-	&& userCan( 'manage_options', site )
+	return (
+		( canAccessWordads( site ) || canUpgradeToUseWordAds( site ) ) &&
+		userCan( 'manage_options', site )
+	);
 }
 
 export function isWordadsInstantActivationEligible( site ) {

--- a/client/my-sites/earn/ads/form-settings.jsx
+++ b/client/my-sites/earn/ads/form-settings.jsx
@@ -16,6 +16,7 @@ import { connect } from 'react-redux';
  */
 import Button from 'components/button';
 import Card from 'components/card';
+import FoldableCard from 'components/foldable-card';
 import StateSelector from 'components/forms/us-state-selector';
 import CompactFormToggle from 'components/forms/form-toggle/compact';
 import FormSectionHeading from 'components/forms/form-section-heading';
@@ -349,16 +350,6 @@ class AdsFormSettings extends Component {
 		return (
 			<div>
 				<FormFieldset>
-					<FormLabel htmlFor="paypal">{ translate( 'PayPal E-mail Address' ) }</FormLabel>
-					<FormTextInput
-						name="paypal"
-						id="paypal"
-						value={ this.state.paypal || '' }
-						onChange={ this.handleChange }
-						disabled={ this.state.isLoading }
-					/>
-				</FormFieldset>
-				<FormFieldset>
 					<FormLabel htmlFor="who_owns">{ translate( 'Who owns this site?' ) }</FormLabel>
 					<FormSelect
 						name="who_owns"
@@ -395,7 +386,6 @@ class AdsFormSettings extends Component {
 
 		return (
 			<div>
-				<FormSectionHeading>{ translate( 'Tax Reporting Information' ) }</FormSectionHeading>
 				<FormFieldset disabled={ 'yes' !== this.state.us_resident }>
 					<FormLabel htmlFor="taxid">
 						{ translate( 'Social Security Number or US Tax ID' ) }
@@ -501,12 +491,20 @@ class AdsFormSettings extends Component {
 					/>
 					<span>
 						{ translate(
-							'I have read and agree to the {{a}}Automattic Ads Terms of Service{{/a}}.',
+							'I have read and agree to the {{a}}Automattic Ads Terms of Service{{/a}}. {{br/}}I agree to post only {{b}}family-friendly content{{/b}} and will not purchase non-human traffic.',
 							{
 								components: {
 									a: (
 										<a
 											href="https://wordpress.com/automattic-ads-tos/"
+											target="_blank"
+											rel="noopener noreferrer"
+										/>
+									),
+									br: <br />,
+									b: (
+										<a
+											href="https://wordads.co/2012/09/06/wordads-is-for-family-safe-sites/"
 											target="_blank"
 											rel="noopener noreferrer"
 										/>
@@ -526,30 +524,101 @@ class AdsFormSettings extends Component {
 
 		return (
 			<Fragment>
-				<SectionHeader label={ translate( 'Ads Settings' ) }>
+				<FoldableCard
+					actionButtonIcon="cog"
+					header={
+						<div>
+							<h1 className="export-card__title">
+								<strong>{ translate( 'MyTestWebsite.com' ) }</strong>
+							</h1>
+							<h2 className="export-card__subtitle">
+								<em>{ translate( 'Application submitted 3 days ago.' ) }</em>
+							</h2>
+						</div>
+					}
+				>
+					<form
+						id="wordads-account"
+						onSubmit={ this.handleSubmit }
+						onChange={ this.props.markChanged }
+					>
+						<FormSectionHeading>{ translate( '1. Site Owner' ) }</FormSectionHeading>
+
+						{ this.siteOwnerOptions() }
+						{ this.state.us_checked ? this.taxOptions() : null }
+
+						<FormSectionHeading>{ translate( '2. Payment Information' ) }</FormSectionHeading>
+						<FormFieldset>
+							<FormLabel htmlFor="paypal">{ translate( 'PayPal E-mail Address' ) }</FormLabel>
+							<FormTextInput
+								name="paypal"
+								id="paypal"
+								value={ this.state.paypal || '' }
+								onChange={ this.handleChange }
+								disabled={ this.state.isLoading }
+							/>
+						</FormFieldset>
+
+						<FormSectionHeading>{ translate( '3. Ad Placements' ) }</FormSectionHeading>
+						<FormFieldset>
+							<FormLegend>
+								<em>
+									{ translate(
+										'We can automatically place ads on your site, or you can manually insert them yourself. {{br/}}Which would you prefer?',
+										{
+											components: {
+												br: <br />,
+											},
+										}
+									) }
+								</em>
+							</FormLegend>
+							<br />
+							{
+								// @TODO need to update these values
+							 }
+							<CompactFormToggle
+								checked={ !! this.state.display_options.enable_header_ad }
+								disabled={ this.state.isLoading }
+								onChange={ this.handleDisplayToggle( 'enable_header_ad' ) }
+							>
+								{ translate( 'Automatically place ads to maximize revenue.' ) }
+							</CompactFormToggle>
+						</FormFieldset>
+
+						<FormSectionHeading>{ translate( '4. Terms of Service' ) }</FormSectionHeading>
+						{ this.acceptCheckbox() }
+						<Button compact primary onClick={ this.handleSubmit } disabled={ isPending }>
+							{ isPending ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+						</Button>
+					</form>
+				</FoldableCard>
+
+				<SectionHeader label={ translate( 'Placements' ) }>
 					<Button compact primary onClick={ this.handleSubmit } disabled={ isPending }>
-						{ isPending ? translate( 'Saving…' ) : translate( 'Save Settings' ) }
+						{ isPending ? translate( 'Saving…' ) : translate( 'Update Placements' ) }
 					</Button>
 				</SectionHeader>
 
 				<Card>
 					<form
-						id="wordads-settings"
+						id="wordads-placements"
 						onSubmit={ this.handleSubmit }
 						onChange={ this.props.markChanged }
 					>
 						{ ! this.props.siteIsJetpack ? this.showAdsToOptions() : null }
 
 						{ ! this.props.siteIsJetpack ? this.displayOptions() : null }
-
-						<FormSectionHeading>{ translate( 'Site Owner Information' ) }</FormSectionHeading>
-						{ this.siteOwnerOptions() }
-						{ this.state.us_checked ? this.taxOptions() : null }
-
-						<FormSectionHeading>{ translate( 'Terms of Service' ) }</FormSectionHeading>
-						{ this.acceptCheckbox() }
+						<Button compact primary onClick={ this.handleSubmit } disabled={ isPending }>
+							{ isPending ? translate( 'Saving…' ) : translate( 'Update Placements' ) }
+						</Button>
 					</form>
 				</Card>
+
+				{
+					// @TODO update link
+				 }
+				<Card href="/stats/ads/day/site">View Ads Earnings</Card>
 			</Fragment>
 		);
 	}

--- a/client/my-sites/earn/ads/index.jsx
+++ b/client/my-sites/earn/ads/index.jsx
@@ -1,0 +1,375 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import {
+	isWordadsInstantActivationEligible,
+	//	canUpgradeToUseWordAds,
+	canAccessAds,
+} from 'lib/ads/utils';
+import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
+import { isPremium, isBusiness, isEcommerce } from 'lib/products-values';
+//import Card from 'components/card';
+import ActionCard from 'components/action-card';
+import Banner from 'components/banner';
+import EmptyContent from 'components/empty-content';
+import UpgradeNudgeExpanded from 'blocks/upgrade-nudge-expanded';
+//import FormButton from 'components/forms/form-button';
+//import FeatureExample from 'components/feature-example';
+import canCurrentUser from 'state/selectors/can-current-user';
+import {
+	isRequestingWordAdsApprovalForSite,
+	getWordAdsErrorForSite,
+	getWordAdsSuccessForSite,
+} from 'state/wordads/approve/selectors';
+import { isSiteWordadsUnsafe } from 'state/wordads/status/selectors';
+import { wordadsUnsafeValues } from 'state/wordads/status/schema';
+
+//import InfiniteScroll from 'components/infinite-scroll';
+//import QueryMembershipsEarnings from 'components/data/query-memberships-earnings';
+//import QueryMembershipsSettings from 'components/data/query-memberships-settings';
+//import { requestSubscribers } from 'state/memberships/subscribers/actions';
+
+//import { decodeEntities } from 'lib/formatting';
+//import Gravatar from 'components/gravatar';
+//import Button from 'components/button';
+//import StripeConnectButton from 'components/stripe-connect-button';
+import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
+//import UpgradeNudge from 'blocks/upgrade-nudge';
+import { PLAN_PREMIUM, PLAN_JETPACK_PREMIUM, FEATURE_WORDADS_INSTANT } from 'lib/plans/constants';
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+//import SectionHeader from 'components/section-header';
+//import QueryMembershipProducts from 'components/data/query-memberships';
+//import CompactCard from 'components/card/compact';
+//import Gridicon from 'components/gridicon';
+import { userCan } from 'lib/site/utils';
+//import EllipsisMenu from 'components/ellipsis-menu';
+//import PopoverMenuItem from 'components/popover/menu-item';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class AdsSection extends Component {
+	static propTypes = {
+		adsProgramName: PropTypes.string,
+		isUnsafe: PropTypes.oneOf( wordadsUnsafeValues ),
+		requestingWordAdsApproval: PropTypes.bool.isRequired,
+		//		requestWordAdsApproval: PropTypes.func.isRequired,
+		section: PropTypes.string.isRequired,
+		site: PropTypes.object,
+		wordAdsError: PropTypes.string,
+		wordAdsSuccess: PropTypes.bool,
+	};
+
+	handleDismissWordAdsError = () => {
+		const { siteId } = this.props;
+		this.props.dismissWordAdsError( siteId );
+	};
+
+	constructor( props ) {
+		super( props );
+	}
+
+	//	componentDidMount() {}
+	//	componentDidUpdate() {}
+
+	renderBannerWelcome() {
+		return (
+			<ActionCard
+				headerText={ 'Start Earning Income from Your Site' }
+				mainText={
+					'WordAds is the leading advertising optimization platform for WordPress sites, where the internet’s top ad suppliers bid against each other to deliver their ads to your site, maximizing your revenue.'
+				}
+				buttonText={ 'Learn More on WordAds.co' }
+				buttonIcon="external"
+				buttonPrimary={ false }
+				buttonHref="https://wordads.co"
+				buttonTarget="_blank"
+			>
+				<img
+					src="/calypso/images/illustrations/dotcom-wordads.svg"
+					width="170"
+					height="143"
+					alt="WordPress logo"
+				/>
+			</ActionCard>
+		);
+	}
+
+	renderBannerApplicationReview() {
+		return (
+			<ActionCard
+				headerText={ "We're currently reviewing your application..." }
+				mainText={
+					"Our ads engineers are hard at work validating your site's content and traffic for advertisers. We'll be in touch shortly."
+				}
+			>
+				<img
+					src="/calypso/images/illustrations/waitTime.svg"
+					width="170"
+					height="143"
+					alt="WordPress logo"
+				/>
+			</ActionCard>
+		);
+	}
+
+	renderBannerApplicationApprove() {
+		return (
+			<ActionCard
+				headerText={ 'Welcome to WordAds!' }
+				mainText={
+					'We’ll work behind the scenes to maximize your earning potential and monitor ad quality. On your end, the more you grow your audience and increase your pageviews, the more you can expect to earn.'
+				}
+			>
+				<img
+					src="/calypso/images/illustrations/wordAds.svg"
+					width="170"
+					height="143"
+					alt="WordPress logo"
+				/>
+			</ActionCard>
+		);
+	}
+
+	renderBannerApplicationDenyBrandSafety() {
+		return (
+			<ActionCard
+				headerText={ "Your content isn't a good fit for ads." }
+				mainText={
+					"Our advertisers have strict requirements for the type of content they're willing to monetize."
+				}
+			>
+				<img
+					src="/calypso/images/illustrations/security-issue.svg"
+					width="170"
+					height="143"
+					alt="WordPress logo"
+				/>
+			</ActionCard>
+		);
+	}
+
+	renderBannerApplicationDenyTraffic() {
+		return (
+			<Fragment>
+				<ActionCard
+					headerText={ 'You need more traffic to join WordAds.' }
+					mainText={
+						"Keep building your audience, and as soon as you have enough traffic, we'll approve your application."
+					}
+				>
+					<img
+						src="/calypso/images/illustrations/whoops.svg"
+						width="170"
+						height="143"
+						alt="WordPress logo"
+					/>
+				</ActionCard>
+				<br />
+
+				<Banner
+					title="Upgrade to a Premium Plan to bypass traffic restrictions."
+					description="Sites with a Premium Plan can run ads, regardless of how much traffic they have."
+					callToAction="Upgrade to Premium"
+					disableHref
+					event="track_event"
+					href="https://wordpress.com/"
+					icon="star"
+					prices={ [ 10.99, 9.99 ] }
+				/>
+			</Fragment>
+		);
+	}
+
+	statsNotice() {
+		return (
+			<ActionCard
+				buttonPrimary
+				buttonHref="https://wordpress.com"
+				headerText="Monitor Your Ads Performance"
+				mainText="In the stats section, you can monitor the daily performance of the ads running on your site. After each month is finalized, you'll find a revenue report below (usually around 15 days after the close of the month)."
+				buttonText="View Daily Stats"
+			/>
+		);
+	}
+
+	renderUpsell() {
+		const { translate, isJetpack, adsProgramName } = this.props;
+		return (
+			<UpgradeNudgeExpanded
+				plan={ isJetpack ? PLAN_JETPACK_PREMIUM : PLAN_PREMIUM }
+				title={ translate( 'Upgrade to the Premium plan and start earning' ) }
+				subtitle={ translate(
+					"By upgrading to the Premium plan, you'll be able to monetize your site through the %(program)s program.",
+					{ args: { program: adsProgramName } }
+				) }
+				highlightedFeature={ FEATURE_WORDADS_INSTANT }
+				benefits={ [
+					translate( 'Instantly enroll into the %(program)s network.', {
+						args: { program: adsProgramName },
+					} ),
+					translate( 'Earn money from your content and traffic.' ),
+				] }
+			/>
+		);
+	}
+
+	renderEmptyContent() {
+		return (
+			<EmptyContent
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+				title={ this.props.translate( 'You are not authorized to view this page' ) }
+			/>
+		);
+	}
+
+	render() {
+		const { site, translate, isUnsafe, wordAdsError } = this.props;
+		const contentUnsafe = [ 'mature', 'spam', 'other' ].includes( isUnsafe );
+		const jetpackPremium =
+			site.jetpack &&
+			( isPremium( site.plan ) || isBusiness( site.plan ) || isEcommerce( site.plan ) );
+
+		let notice = null;
+		let component = this.props.children;
+
+		// No access.
+		if ( ! canAccessAds( site ) ) {
+			return this.renderEmptyContent();
+		}
+
+		// Error for non-admins.
+		if ( ! userCan( 'manage_options', this.props.site ) ) {
+			return (
+				<Notice
+					status="is-warning"
+					text={ this.props.translate( 'Only site administrators can edit Ads settings.' ) }
+					showDismiss={ false }
+				/>
+			);
+		}
+
+		// Has not applied.
+		// @TODO do jetpack sites have this option set?
+		if ( ! site.options.wordads ) {
+			// If site has qualifying plan.
+			if ( isWordadsInstantActivationEligible( site ) ) {
+				// Application.
+				return <div>Application goes here.</div>;
+			} else {
+				// @TODO do we need this? if ( canUpgradeToUseWordAds( site ) ) {
+
+				return <div>{ this.renderUpsell() }</div>;
+			}
+		} else {
+			// If Error.
+			if ( wordAdsError ) {
+				return (
+					<Notice
+						classname="ads__activate-notice"
+						status="is-error"
+						onDismissClick={ this.handleDismissWordAdsError }
+					>
+						{ this.props.wordAdsError }
+					</Notice>
+				);
+			}
+
+			// Not safe.
+			if ( contentUnsafe ) {
+				return this.renderBannerApplicationDenyBrandSafety();
+			}
+
+			// If private.
+			if ( isUnsafe === 'private' ) {
+				return (
+					<Notice
+						classname="ads__activate-notice"
+						status="is-warning"
+						showDismiss={ false }
+						text={ translate(
+							'Your site is marked as private. It needs to be public so that visitors can see the ads.'
+						) }
+					>
+						<NoticeAction href={ '/settings/general/' + this.props.siteSlug }>
+							{ translate( 'Change privacy settings' ) }
+						</NoticeAction>
+					</Notice>
+				);
+			}
+
+			/*
+			if ( 'Application is pending / in review' ) {
+				return (
+					<div>
+						{ this.renderBannerApplicationReview() }
+						{
+							// @TODO add new application
+						}
+					</div>
+				);
+			}
+
+			elseif ( 'application is rejected for traffic too low' ) {
+				return (
+					<div>
+						{ this.renderBannerApplicationDenyTraffic() }
+						{
+							// @TODO add new application
+						}
+					</div>
+				);
+			}
+			*/
+			return (
+				<Fragment>
+					{ /* Recently approved. */ }
+					{ this.props.wordAdsSuccess && this.renderBannerApplicationApprove() }
+
+					{ /* Regular display for WordAds users. */ }
+					{ component }
+
+					{ /* Recently approved. */ }
+					{ this.props.wordAdsSuccess && this.statsNotice() }
+				</Fragment>
+			);
+		}
+	}
+}
+
+const mapStateToProps = state => {
+	const site = getSelectedSite( state );
+	const siteId = getSelectedSiteId( state );
+	const isJetpack = isJetpackSite( state, siteId );
+	return {
+		site,
+		siteId,
+		siteSlug: getSelectedSiteSlug( state ),
+		canManageOptions: canCurrentUser( state, siteId, 'manage_options' ),
+		requestingWordAdsApproval: isRequestingWordAdsApprovalForSite( state, site ),
+		wordAdsError: getWordAdsErrorForSite( state, site ),
+		wordAdsSuccess: getWordAdsSuccessForSite( state, site ),
+		isUnsafe: isSiteWordadsUnsafe( state, siteId ),
+		adsProgramName: isJetpackSite( state, siteId ) ? 'Jetpack Ads' : 'WordAds',
+		paidPlan: isSiteOnPaidPlan( state, siteId ),
+		isJetpack: isJetpack,
+		status: 'new',
+	};
+};
+
+export default connect( mapStateToProps )( localize( AdsSection ) );

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -204,24 +204,21 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getAdsCard = () => {
-		const cta =
-			hasWordAds || hasSetupAds
-				? {
-						text: hasSetupAds ? translate( 'View Ad Dashboard' ) : translate( 'Earn Ad Revenue' ),
-						action: () => {
-							trackCtaButton( 'ads' );
-							page(
-								`/earn/${ hasSetupAds ? 'ads-earnings' : 'ads-settings' }/${ selectedSiteSlug }`
-							);
-						},
-				  }
-				: {
-						text: translate( 'Upgrade to a Premium Plan' ),
-						action: () => {
-							trackUpgrade( 'premium', 'ads' );
-							page( `/checkout/${ selectedSiteSlug }/premium/` );
-						},
-				  };
+		const cta = hasWordAds
+			? {
+					text: hasSetupAds ? translate( 'View Ad Dashboard' ) : translate( 'Earn Ad Revenue' ),
+					action: () => {
+						trackCtaButton( 'ads' );
+						page( `/earn/ads/${ selectedSiteSlug }` );
+					},
+			  }
+			: {
+					text: translate( 'Upgrade to a Premium Plan' ),
+					action: () => {
+						trackUpgrade( 'premium', 'ads' );
+						page( `/checkout/${ selectedSiteSlug }/premium/` );
+					},
+			  };
 		const title = hasSetupAds ? translate( 'View ad dashboard' ) : translate( 'Earn ad revenue' );
 		const body = hasSetupAds
 			? translate(

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -19,13 +19,12 @@ import NavItem from 'components/section-nav/item';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
-import WordAdsEarnings from 'my-sites/stats/wordads/earnings';
 import AdsSettings from 'my-sites/earn/ads/form-settings';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';
 import Home from './home';
-import AdsWrapper from './ads/wrapper';
+import AdsSection from './ads/index';
 import MembershipsSection from './memberships';
 import MembershipsProductsSection from './memberships/products';
 import { canAccessAds } from 'lib/ads/utils';
@@ -53,14 +52,9 @@ class EarningsMain extends Component {
 
 		if ( canAccessAds( this.props.site ) ) {
 			tabs.push( {
-				title: translate( 'Earnings' ),
-				path: '/earn/ads-earnings' + pathSuffix,
-				id: 'ads-earnings',
-			} );
-			tabs.push( {
-				title: translate( 'Settings' ),
-				path: '/earn/ads-settings' + pathSuffix,
-				id: 'ads-settings',
+				title: translate( 'Ads' ),
+				path: '/earn/ads' + pathSuffix,
+				id: 'ads',
 			} );
 		}
 
@@ -69,17 +63,11 @@ class EarningsMain extends Component {
 
 	getComponent( section ) {
 		switch ( section ) {
-			case 'ads-earnings':
+			case 'ads':
 				return (
-					<AdsWrapper section={ this.props.section }>
-						<WordAdsEarnings site={ this.props.site } />
-					</AdsWrapper>
-				);
-			case 'ads-settings':
-				return (
-					<AdsWrapper section={ this.props.section }>
+					<AdsSection section={ this.props.section }>
 						<AdsSettings />
-					</AdsWrapper>
+					</AdsSection>
 				);
 			case 'payments':
 				return <MembershipsSection section={ this.props.section } query={ this.props.query } />;
@@ -122,6 +110,7 @@ class EarningsMain extends Component {
 			case 'payments':
 				return translate( 'Recurring Payments' );
 
+			case 'ads':
 			case 'ads-earnings':
 			case 'ads-settings':
 				return translate( 'Ads' );
@@ -187,7 +176,7 @@ class EarningsMain extends Component {
 				<DocumentHead title={ layoutTitles[ section ] } />
 				<SidebarNavigation />
 				{ this.getHeaderCake() }
-				{ section && this.getSectionNav( section ) }
+				{ /* section && this.getSectionNav( section ) */ }
 				{ component }
 			</Main>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Combine `Ads Earnings` & `Ads Settings` into a unified display.
* Improve display as described in pMyNb-4Dw-p2
* Replace [`earn/ads/wrapper.jsx`](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/earn/ads/wrapper.jsx) with the new `earn/ads/index.jsx` file in this PR. (We can remove the wrapper file once the code here is more stable).

#### Testing instructions

* TBD