### PR TITLE
Fix: Destination for redirect payments should not be /stats

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -439,7 +439,8 @@ export class Checkout extends React.Component {
 		// nudge opened by a direct link to /offer-support-session.
 		if (
 			':receiptId' === pendingOrReceiptId &&
-			isEmpty( getAllCartItems( cart ) && ! previousRoute.includes( '/checkout' ) )
+			isEmpty( getAllCartItems( cart ) ) &&
+			! previousRoute.includes( '/checkout' )
 		) {
 			return `/stats/day/${ selectedSiteSlug }`;
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* If a redirect payment type such as PayPal or Giropay is chosen to pay for a plan, then soon after payment completes, the user is taken to the stats page `/stats/day/{SITE_SLUG}` as the destination.
* To reproduce the bug, try the steps listed in the _Testing Instructions_ below without applying this PR, and you would be taken to `/stats/day` page.
* The bug is caused by an incorrect parenthesis structure, which causes an `isEmpty()` check to go awry.

#### Testing instructions

* Proxy yourself through Europe.
* Go through the signup flow from /start, and add any plan to cart.
* Choose a redirect payment type such as Giropay. While sandboxed, you will be redirected to the test instance(check [screenshot](https://cloudup.com/cRGETdZTJud)) with an Authorize payment option.
* After authorizing payment, verify that you are taken to a Thank You page.
