### PR TITLE
Feature Flags: Disable earn-relayout in staging and wpcalypso

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -31,7 +31,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"earn-relayout": true,
+		"earn-relayout": false,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -39,7 +39,7 @@
 		"domains/gdpr-consent-page": true,
 		"domains/kracken-ui/exact-match-filter": true,
 		"domains/kracken-ui/pagination": true,
-		"earn-relayout": true,
+		"earn-relayout": false,
 		"external-media": true,
 		"external-media/google-photos": true,
 		"external-media/free-photo-library": true,


### PR DESCRIPTION
We've started committing changes to the earn section behind a feature
flag, but as the flag was enabled in staging, it was being shown to
users not in development and essentially broke this section of the
application.

This disables the feature flag by default for now until the work is
ready for testing.
