### PR TITLE
Components: Add PromoSection component

### DIFF
--- a/client/components/promo-section/README.md
+++ b/client/components/promo-section/README.md
@@ -1,0 +1,27 @@
+Promo Section
+=============
+
+A compontent to layout [`PromoCard` components](../../components/promo-section/promo-card) to create a page layout used in the Earn section and Marketing Tools.
+
+## Usage
+
+```es6
+import PromoCard from 'my-sites/promo-section/promo-card';
+
+const PromoCardExample = () => {
+  return (
+      <PromoCard title="Under-used Feature">
+            <img
+              src="/calypso/images/wordpress/logo-stars.svg"
+              width="170"
+              height="143"
+              alt="WordPress logo"
+            />
+          <p>
+            This is a description of the action. It gives a bit more detail and explains what we are
+            inviting the user to do.
+          </p>
+      </PromoCard>
+  );
+}
+```

--- a/client/components/promo-section/docs/example.tsx
+++ b/client/components/promo-section/docs/example.tsx
@@ -1,0 +1,65 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PromoSection, { Props as PromoSectionProps } from 'components/promo-section';
+
+const PromoSectionExample = () => {
+	const promos: PromoSectionProps = {
+		header: {
+			title: 'Start earning money',
+			image: {
+				path: '/calypso/images/earn/earn-section.svg',
+			},
+			body: 'There is a range of ways to earn money through your WordPress.com Site.',
+		},
+		promos: [
+			{
+				title: 'Collect one-time payments',
+				body:
+					'Add a payment button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations. Available to any site with a Premium plan.',
+				image: {
+					path: '/calypso/images/earn/simple-payments.svg',
+				},
+				cta: {
+					button: {
+						text: 'Collect One-time Payments',
+						url: '/',
+					},
+				},
+			},
+			{
+				title: 'Collect recurring payments',
+				body:
+					'Charge for services, collect membership dues, or take recurring donations. Automate recurring payments, and use your site to earn reliable revenue. Available to any site with a paid plan.',
+				image: {
+					path: '/calypso/images/earn/recurring.svg',
+				},
+				cta: {
+					button: {
+						text: 'Collect Recurring Payments',
+						url: '/',
+					},
+				},
+			},
+		],
+	};
+
+	return (
+		<div className="design-assets__group">
+			<div>
+				<PromoSection { ...promos } />
+			</div>
+		</div>
+	);
+};
+
+PromoSectionExample.displayName = 'PromoSection';
+
+export default PromoSectionExample;

--- a/client/components/promo-section/docs/example.tsx
+++ b/client/components/promo-section/docs/example.tsx
@@ -50,9 +50,7 @@ const PromoSectionExample = () => {
 
 	return (
 		<div className="design-assets__group">
-			<div>
-				<PromoSection { ...promos } />
-			</div>
+			<PromoSection { ...promos } />
 		</div>
 	);
 };

--- a/client/components/promo-section/docs/example.tsx
+++ b/client/components/promo-section/docs/example.tsx
@@ -10,6 +10,7 @@ import React from 'react';
  */
 import PromoSection, { Props as PromoSectionProps } from 'components/promo-section';
 
+/* eslint-disable wpcalypso/jsx-classname-namespace */
 const PromoSectionExample = () => {
 	const promos: PromoSectionProps = {
 		header: {
@@ -28,10 +29,8 @@ const PromoSectionExample = () => {
 					path: '/calypso/images/earn/simple-payments.svg',
 				},
 				cta: {
-					button: {
-						text: 'Collect One-time Payments',
-						url: '/',
-					},
+					text: 'Collect One-time Payments',
+					url: '/',
 				},
 			},
 			{
@@ -42,10 +41,8 @@ const PromoSectionExample = () => {
 					path: '/calypso/images/earn/recurring.svg',
 				},
 				cta: {
-					button: {
-						text: 'Collect Recurring Payments',
-						url: '/',
-					},
+					text: 'Collect Recurring Payments',
+					url: '/',
 				},
 			},
 		],
@@ -59,6 +56,7 @@ const PromoSectionExample = () => {
 		</div>
 	);
 };
+/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 PromoSectionExample.displayName = 'PromoSection';
 

--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import PromoCard, { Props as PromoCardProps } from './promo-card';
+import PromoCardCta, { Props as PromoCardCtaProps } from './promo-card/cta';
+
+interface PromoSectionCardProps extends PromoCardProps {
+	body: string;
+	cta?: PromoCardCtaProps;
+}
+
+export interface Props {
+	header?: PromoSectionCardProps;
+	promos: PromoSectionCardProps[];
+}
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
+	isPrimary,
+	title,
+	image,
+	body,
+	cta,
+} ) => {
+	return (
+		<PromoCard isPrimary={ !! isPrimary } title={ title } image={ image }>
+			<p>{ body }</p>
+			{ cta && <PromoCardCta { ...cta } /> }
+		</PromoCard>
+	);
+};
+
+const PromoSection: FunctionComponent< Props > = ( { header, promos } ) => {
+	return (
+		<div className="promo-section">
+			{ header && <PromoSectionCard isPrimary={ true } { ...header } /> }
+			<div className="promo-section__promos">
+				{ promos.map( ( promo, i ) => (
+					<div className="promo-section__promo">
+						<PromoSectionCard { ...promo } key={ i } />
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+};
+
+export default PromoSection;

--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -34,7 +34,7 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 	return (
 		<PromoCard isPrimary={ !! isPrimary } title={ title } image={ image }>
 			<p>{ body }</p>
-			{ cta && <PromoCardCta { ...cta } /> }
+			{ cta && <PromoCardCta cta={ cta } /> }
 		</PromoCard>
 	);
 };
@@ -45,9 +45,7 @@ const PromoSection: FunctionComponent< Props > = ( { header, promos } ) => {
 			{ header && <PromoSectionCard isPrimary={ true } { ...header } /> }
 			<div className="promo-section__promos">
 				{ promos.map( ( promo, i ) => (
-					<div className="promo-section__promo">
-						<PromoSectionCard { ...promo } key={ i } />
-					</div>
+					<PromoSectionCard { ...promo } key={ i } />
 				) ) }
 			</div>
 		</div>

--- a/client/components/promo-section/style.scss
+++ b/client/components/promo-section/style.scss
@@ -1,0 +1,21 @@
+.promo-section__promos {
+	position: relative;
+	left: calc( -0.5em );
+	display: flex;
+	flex-wrap: wrap;
+	// margins of the items will "hang off the side" invisibly
+	width: calc( 100% + 1em );
+
+}
+
+.promo-section__promo {
+	display: flex;
+	flex-direction: column;
+	margin: 0.5em;
+	width: calc( 100% - 1em );
+
+	@include breakpoint( '>1040px' ) {
+		width: calc( 50% - 1em );
+	}
+}
+

--- a/client/components/promo-section/style.scss
+++ b/client/components/promo-section/style.scss
@@ -5,17 +5,20 @@
 	flex-wrap: wrap;
 	// margins of the items will "hang off the side" invisibly
 	width: calc( 100% + 1em );
-
-}
-
-.promo-section__promo {
-	display: flex;
 	flex-direction: column;
-	margin: 0.5em;
-	width: calc( 100% - 1em );
-
 	@include breakpoint( '>1040px' ) {
-		width: calc( 50% - 1em );
+		flex-direction: row;
+	}
+
+	.promo-card {
+		display: flex;
+		margin: 0.5em;
+		width: calc( 100% - 1em );
+
+		@include breakpoint( '>1040px' ) {
+			width: calc( 50% - 1em );
+		}
 	}
 }
+
 

--- a/client/devdocs/design/component-examples.js
+++ b/client/devdocs/design/component-examples.js
@@ -61,6 +61,7 @@ export { default as PaymentLogo } from 'components/payment-logo/docs/example';
 export { default as PieChart } from 'components/pie-chart/docs/example';
 export { default as Popovers } from 'components/popover/docs/example';
 export { default as ProgressBar } from '@automattic/calypso-ui/src/progress-bar/docs/example';
+export { default as PromoSection } from 'components/promo-section/docs/example';
 export { default as PromoCard } from 'components/promo-section/promo-card/docs/example';
 export { default as Ranges } from 'components/forms/range/docs/example';
 export { default as Rating } from 'components/rating/docs/example';

--- a/client/devdocs/design/index.jsx
+++ b/client/devdocs/design/index.jsx
@@ -91,6 +91,7 @@ import PlansSkipButton from 'components/plans/plans-skip-button/docs/example';
 import PodcastIndicator from 'components/podcast-indicator/docs/example';
 import Popovers from 'components/popover/docs/example';
 import ProgressBar from '@automattic/calypso-ui/src/progress-bar/docs/example';
+import PromoSection from 'components/promo-section/docs/example';
 import PromoCard from 'components/promo-section/promo-card/docs/example';
 import Ranges from 'components/forms/range/docs/example';
 import Rating from 'components/rating/docs/example';
@@ -252,6 +253,7 @@ class DesignAssets extends React.Component {
 					<PodcastIndicator readmeFilePath="podcast-indicator" />
 					<Popovers readmeFilePath="popover" />
 					<ProgressBar readmeFilePath="progress-bar" />
+					<PromoSection readmeFilePath="promo-section" />
 					<PromoCard readmeFilePath="promo-section/promo-card" />
 					<Ranges readmeFilePath="forms/range" />
 					<Rating readmeFilePath="rating" />


### PR DESCRIPTION
As part of the work on redesigning the earn section, this builds on #34607 to create a component for laying out `PromoCard` components. It allows for a primary header card, followed by a list of cards in a two column layout, reducing to one column on smaller screens.

#### Testing instructions

In Calypso Live, go to `/devdocs/design/promo-section`, and check the layout. 

Fixes #34530

Related to #34844 - We need to work out what we need to merge between these two implementations.

It's reliant on #34607, so that should be merged first.
