### PR TITLE
[ WIP ] Try storing signup progress in a keyed object vs an array

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -253,9 +253,9 @@ class Signup extends React.Component {
 	}
 
 	updateShouldShowLoadingScreen = ( progress = this.props.progress ) => {
-		const hasInvalidSteps = !! getFirstInvalidStep( this.props.flowName, progress ),
-			waitingForServer = ! hasInvalidSteps && this.isEveryStepSubmitted( progress ),
-			startLoadingScreen = waitingForServer && ! this.state.shouldShowLoadingScreen;
+		const hasInvalidSteps = !! getFirstInvalidStep( this.props.flowName, progress );
+		const waitingForServer = ! hasInvalidSteps && this.isEveryStepSubmitted( progress );
+		const startLoadingScreen = waitingForServer && ! this.state.shouldShowLoadingScreen;
 
 		if ( ! this.isEveryStepSubmitted( progress ) ) {
 			this.goToFirstInvalidStep( progress );
@@ -401,11 +401,11 @@ class Signup extends React.Component {
 	};
 
 	firstUnsubmittedStepName = () => {
-		const currentSteps = flows.getFlow( this.props.flowName ).steps,
-			signupProgress = getFilteredSteps( this.props.flowName, this.props.progress ),
-			nextStepName = currentSteps[ signupProgress.length ],
-			firstInProgressStep = find( signupProgress, { status: 'in-progress' } ) || {},
-			firstInProgressStepName = firstInProgressStep.stepName;
+		const currentSteps = flows.getFlow( this.props.flowName ).steps;
+		const signupProgress = getFilteredSteps( this.props.flowName, this.props.progress );
+		const nextStepName = currentSteps[ signupProgress.length ];
+		const firstInProgressStep = find( signupProgress, { status: 'in-progress' } ) || {};
+		const firstInProgressStepName = firstInProgressStep.stepName;
 
 		return firstInProgressStepName || nextStepName || last( currentSteps );
 	};
@@ -456,11 +456,11 @@ class Signup extends React.Component {
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToNextStep = ( nextFlowName = this.props.flowName ) => {
-		const flowSteps = flows.getFlow( nextFlowName ).steps,
-			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
-			nextStepName = flowSteps[ currentStepIndex + 1 ],
-			nextProgressItem = this.props.progress[ currentStepIndex + 1 ],
-			nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
+		const flowSteps = flows.getFlow( nextFlowName ).steps;
+		const currentStepIndex = indexOf( flowSteps, this.props.stepName );
+		const nextStepName = flowSteps[ currentStepIndex + 1 ];
+		const nextProgressItem = get( this.props.progress, nextStepName );
+		const nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
 
 		if ( nextFlowName !== this.props.flowName ) {
 			this.props.removeUnneededSteps( nextFlowName );
@@ -621,6 +621,7 @@ export default connect(
 		const signupDependencies = getSignupDependencyStore( state );
 		const siteId = getSiteId( state, signupDependencies.siteSlug );
 		const siteDomains = getDomainsBySiteId( state, siteId );
+
 		return {
 			domainsWithPlansOnly: getCurrentUser( state )
 				? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
  */
 import FormattedHeader from 'components/formatted-header';
 import NavigationLink from 'signup/navigation-link';
+import { getFilteredSteps } from '../utils';
 
 /**
  * Style dependencies
@@ -43,6 +44,7 @@ class StepWrapper extends Component {
 		if ( this.props.shouldHideNavButtons ) {
 			return null;
 		}
+
 		return (
 			<NavigationLink
 				direction="back"
@@ -51,7 +53,7 @@ class StepWrapper extends Component {
 				stepName={ this.props.stepName }
 				stepSectionName={ this.props.stepSectionName }
 				backUrl={ this.props.backUrl }
-				signupProgress={ this.props.signupProgress }
+				signupProgress={ getFilteredSteps( this.props.flowName, this.props.signupProgress ) }
 				labelText={ this.props.backLabelText }
 				allowBackFirstStep={ this.props.allowBackFirstStep }
 			/>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -66,7 +66,7 @@ class DomainsStep extends React.Component {
 		path: PropTypes.string.isRequired,
 		positionInFlow: PropTypes.number.isRequired,
 		queryObject: PropTypes.object,
-		signupProgress: PropTypes.array.isRequired,
+		signupProgress: PropTypes.object.isRequired,
 		step: PropTypes.object,
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -33,7 +33,9 @@ class SiteTitleStep extends Component {
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
 		setSiteTitle: PropTypes.func.isRequired,
-		signupProgress: PropTypes.array,
+		// should this not be connected
+		// would we ever need this component to take different values for this and others?
+		signupProgress: PropTypes.object,
 		stepName: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		siteTitle: PropTypes.string,

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -26,7 +26,7 @@ class SiteTopicStep extends Component {
 		isUserInput: PropTypes.bool,
 		positionInFlow: PropTypes.number.isRequired,
 		submitSiteVertical: PropTypes.func.isRequired,
-		signupProgress: PropTypes.array,
+		signupProgress: PropTypes.object,
 		stepName: PropTypes.string,
 		siteType: PropTypes.string,
 		translate: PropTypes.func.isRequired,

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -3,7 +3,7 @@
  * Exernal dependencies
  */
 import cookie from 'cookie';
-import { filter, find, includes, indexOf, isEmpty, pick } from 'lodash';
+import { filter, find, includes, indexOf, isEmpty, pick, sortBy } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -177,7 +177,13 @@ export function getDesignTypeForSiteGoals( siteGoals, flow ) {
 
 export function getFilteredSteps( flowName, progress ) {
 	const flow = flows.getFlow( flowName );
-	return filter( progress, step => includes( flow.steps, step.stepName ) );
+
+	return sortBy(
+		// filter steps...
+		filter( progress, step => includes( flow.steps, step.stepName ) ),
+		// then order according to the flow definition...
+		( { stepName } ) => flow.steps.indexOf( stepName )
+	);
 }
 
 export function getFirstInvalidStep( flowName, progress ) {

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -3,121 +3,103 @@
 /**
  * External dependencies
  */
-import { get, find, map } from 'lodash';
+import { has, keyBy, get } from 'lodash';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import stepsConfig from 'signup/config/steps-pure';
-import flows from 'signup/config/flows-pure';
 import {
 	SIGNUP_COMPLETE_RESET,
 	SIGNUP_PROGRESS_COMPLETE_STEP,
 	SIGNUP_PROGRESS_INVALIDATE_STEP,
 	SIGNUP_PROGRESS_PROCESS_STEP,
-	SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
 	SIGNUP_PROGRESS_SAVE_STEP,
 	SIGNUP_PROGRESS_SUBMIT_STEP,
 } from 'state/action-types';
 import { createReducer } from 'state/utils';
 import { schema } from './schema';
-import userFactory from 'lib/user';
 
 const debug = debugFactory( 'calypso:state:signup:progress:reducer' );
 
 //
+// Helper Functions
+//
+const addStep = ( state, step ) => {
+	debug( `Adding step ${ step.stepName }` );
+
+	return {
+		...state,
+		[ step.stepName ]: step,
+	};
+};
+
+const updateStep = ( state, newStepState ) => {
+	const { stepName, status } = newStepState;
+	const stepState = get( state, stepName );
+
+	debug( `Updating step ${ stepName }` );
+
+	if ( status === 'pending' || status === 'completed' ) {
+		// This can only happen when submitting a step
+		//
+		// Steps that are resubmitted may decide to omit the `wasSkipped` status of a step if e.g.
+		// the user goes back and chooses to not skip a step. If a step is submitted without it,
+		// we explicitly remove it from the step data.
+		const { wasSkipped, ...commonStepArgs } = stepState;
+
+		return {
+			...state,
+			[ stepName ]: {
+				...commonStepArgs,
+				...newStepState,
+			},
+		};
+	}
+
+	return {
+		...state,
+		[ stepName ]: {
+			...stepState,
+			...newStepState,
+		},
+	};
+};
+
+//
 // Action handlers
 //
-function overwriteSteps( state, { steps = [] } ) {
-	// When called without action.steps, this is basically a state reset function.
-	return Array.isArray( steps ) ? steps : [];
-}
 
-function completeStep( state, { step } ) {
-	return updateStep( state, { ...step, status: 'completed' } );
-}
+// When called without action.steps, this is basically a state reset function.
+const overwriteSteps = ( state, { steps = {} } ) => keyBy( steps, 'stepName' );
 
-function invalidateStep( state, { step, errors } ) {
-	const newStep = { ...step, errors, status: 'invalid' };
-	if ( find( state, { stepName: newStep.stepName } ) ) {
-		return updateStep( state, newStep );
-	}
-	return addStep( state, newStep );
-}
+const completeStep = ( state, { step } ) => updateStep( state, { ...step, status: 'completed' } );
 
-function processStep( state, { step } ) {
-	return updateStep( state, { ...step, status: 'processing' } );
-}
+const invalidateStep = ( state, { step, errors } ) => {
+	const newStepState = { ...step, errors, status: 'invalid' };
 
-function removeUnneededSteps( state, { flowName } ) {
-	let flowSteps = [];
-	const user = userFactory();
+	return has( state, step.stepName )
+		? updateStep( state, newStepState )
+		: addStep( state, newStepState );
+};
 
-	flowSteps = get( flows, [ flowName, 'steps' ], [] );
+const processStep = ( state, { step } ) => updateStep( state, { ...step, status: 'processing' } );
 
-	if ( user && user.get() ) {
-		flowSteps = flowSteps.filter( item => item !== 'user' );
-	}
+const saveStep = ( state, { step } ) =>
+	has( state, step.stepName )
+		? updateStep( state, step )
+		: addStep( state, { ...step, status: 'in-progress' } );
 
-	return state.filter(
-		( step, index ) =>
-			flowSteps.includes( step.stepName ) && index === flowSteps.indexOf( step.stepName )
-	);
-}
-
-function saveStep( state, { step } ) {
-	if ( find( state, { stepName: step.stepName } ) ) {
-		return updateStep( state, step );
-	}
-
-	return addStep( state, { ...step, status: 'in-progress' } );
-}
-
-function submitStep( state, { step } ) {
+const submitStep = ( state, { step } ) => {
 	const stepHasApiRequestFunction = get( stepsConfig, [ step.stepName, 'apiRequestFunction' ] );
 	const status = stepHasApiRequestFunction ? 'pending' : 'completed';
 
-	if ( find( state, { stepName: step.stepName } ) ) {
-		return updateStep( state, { ...step, status } );
-	}
+	return has( state, step.stepName )
+		? updateStep( state, { ...step, status } )
+		: addStep( state, { ...step, status } );
+};
 
-	return addStep( state, { ...step, status } );
-}
-
-//
-// Helper Functions
-//
-function addStep( state, step ) {
-	debug( `Adding step ${ step.stepName }` );
-	return [ ...state, step ];
-}
-
-function updateStep( state, newStep ) {
-	debug( `Updating step ${ newStep.stepName }` );
-	return map( state, function( step ) {
-		if ( step.stepName === newStep.stepName ) {
-			const { status } = newStep;
-			if ( status === 'pending' || status === 'completed' ) {
-				// This can only happen when submitting a step
-				//
-				// Steps that are resubmitted may decide to omit the `wasSkipped` status of a step if e.g.
-				// the user goes back and chooses to not skip a step. If a step is submitted without it,
-				// we explicitly remove it from the step data.
-				const { wasSkipped, ...commonStepArgs } = step;
-				return { ...commonStepArgs, ...newStep };
-			}
-
-			return { ...step, ...newStep };
-		}
-
-		return step;
-	} );
-}
-
-//
-// Reducer export
-//
 export default createReducer(
 	[],
 	{
@@ -125,7 +107,7 @@ export default createReducer(
 		[ SIGNUP_PROGRESS_COMPLETE_STEP ]: completeStep,
 		[ SIGNUP_PROGRESS_INVALIDATE_STEP ]: invalidateStep,
 		[ SIGNUP_PROGRESS_PROCESS_STEP ]: processStep,
-		[ SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS ]: removeUnneededSteps,
+		// [ SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS ]: removeUnneededSteps,
 		[ SIGNUP_PROGRESS_SAVE_STEP ]: saveStep,
 		[ SIGNUP_PROGRESS_SUBMIT_STEP ]: submitStep,
 	},

--- a/client/state/signup/progress/schema.js
+++ b/client/state/signup/progress/schema.js
@@ -1,19 +1,21 @@
 /** @format */
 export const schema = {
-	type: 'array',
-	items: {
-		type: 'object',
-		properties: {
-			formData: {
-				type: 'object',
-				properties: {
-					url: { type: 'string' },
+	type: 'object',
+	patternProperties: {
+		'^[w-]+$': {
+			type: 'object',
+			properties: {
+				formData: {
+					type: 'object',
+					properties: {
+						url: { type: 'string' },
+					},
 				},
+				lastUpdated: { type: 'number' },
+				// Valid status values: 'completed', 'processing', 'pending', 'in-progress' and 'invalid'
+				status: { type: 'string' },
+				stepName: { type: 'string' },
 			},
-			lastUpdated: { type: 'number' },
-			// Valid status values: 'completed', 'processing', 'pending', 'in-progress' and 'invalid'
-			status: { type: 'string' },
-			stepName: { type: 'string' },
 		},
 	},
 };

--- a/client/state/signup/progress/selectors.js
+++ b/client/state/signup/progress/selectors.js
@@ -6,7 +6,7 @@
 
 import { get } from 'lodash';
 
-const initialState = [];
+const initialState = {};
 export function getSignupProgress( state ) {
 	return get( state, 'signup.progress', initialState );
 }


### PR DESCRIPTION
**Note:** this PR has been superseded by #35049

Currently as we branch between flows we run `removeUnneededSteps`. 
https://github.com/Automattic/wp-calypso/blob/master/client/state/signup/progress/reducer.js#L53

This attempts to reconcile the progress (steps) the customer has already made with the new flow that they're switching to. In theory, if they have completed 3 steps, then switch to a new branch that also contains those steps, that progress should be kept.
The problem is that it's current logic fails when any step in progress has a different index to that of the incoming flow - in some cases this causes blank screens to be rendered.

The mindset here is that an array of progressed steps will reliably match up with the steps list as defined in the flows definition in flows-pure, but this is naive, especially given that we allow for steps to be added to the progress state even when those steps are never shown in the UI and are never part of the flow definition (the definitions may be 'pure', but the state is not).

- We should never add steps to progress state if it doesn't relate to a visible step for the user. In my opinion, doing so is a hack of convenience, and should be handled elsewhere.
- We have to ask why are we comparing the indexes? My guess, it's because *ordering* matters, rather than indexes - our code should reflect that intention.

We could keep adding to that logic to meet our nuanced needs, but to me that seems like we're kicking the can down the road and potentially opening up new bugs. I would rather suggest a new approach to how we store the progress.
Instead of an array, I'd like to suggest an object of steps keyed by their step name:

```js
[
	siteTypeProgressState,
	siteTitleProgressState,
]
// becomes:
{
	'site-type': siteTypeProgressState,
	'site-title': siteTitleProgressState,
}
```

That way, we can hold on to any extraneous state pieces and use the flow definition to reconcile the state/data we need:


```js
// lets use these 2 flows for example:
onboarding: {
	steps: [
		'user',
		'site-type',
		'site-topic-with-preview',
		'site-title-with-preview',
		'site-style-with-preview',
		'domains-with-preview',
		'plans',
	],
},
onboarding-alternative: {
	steps: [
		'user',
		'site-type',
		'site-topic',
		'site-title',
		'site-style',
		'domains',
		'plans',
	],
}

// ...and consider that we're starting with 'user', 'site-type' and 'site-topic-with-preview' in progress, we switch from 'onboarding' to 'onboarding-alternative'. Note that they have gone forward to complete 'site-topic-with-preview', then back to 'site-type', changed their minds and branched to the alternative flow:

const progressState = {
	'user': userProgressState,
	'site-type': siteTypeProgressState,
	'site-topic-with-preview': siteTitleProgressState,
}
```

We can use the steps list ( `[ 'user', 'site-type', 'site-topic', ... ]` ) to select the correct data from `progressState` and ignore 'site-topic-with-preview'.

In doing it this way, we don't need to run logic that filters out the progress store and resets it, we take what we need based on the current flow and let the flow definition determine everything.

The only other part of this puzzle, is that we need to know which step is teh current step. That's easy enough - we just need to keep that in state too.
