### PR TITLE
Private by Default: Dynamically set the private by default setting

### DIFF
--- a/client/lib/signup/private-by-default.ts
+++ b/client/lib/signup/private-by-default.ts
@@ -12,14 +12,13 @@ const debug = debugFactory( 'calypso:signup:private-by-default' );
 
 /**
  * Should the site be private by default
- *
- * @param dependenciesAndStepData a combination of the `dependencies` & `stepData` objects passed to the `apiRequestFunction` step action function call
  * @returns `true` for private by default & `false` for not
  */
-export function shouldBePrivateByDefault( dependenciesAndStepData: object ): boolean {
-	debug( { dependenciesAndStepData } );
-
-	// Put any circumstances which should NOT be private by default here
+export function shouldBePrivateByDefault( { flowName = '' }: { flowName?: string } = {} ): boolean {
+	if ( flowName.match( /^ecommerce/ ) ) {
+		// ecommerce plans go atomic after checkout. These sites should default to public for now.
+		return false;
+	}
 
 	return abtest( 'privateByDefault' ) === 'selected';
 }
@@ -27,9 +26,12 @@ export function shouldBePrivateByDefault( dependenciesAndStepData: object ): boo
 /**
  * Get the numeric value that should be provided to the "new site" endpoint
  *
- * @param dependenciesAndStepData a combination of the `dependencies` & `stepData` objects passed to the `apiRequestFunction` step action function call
+ * @param dependencies The `dependencies` passed to the `apiRequestFunction` step action function call
+ * @param stepData The `stepData` passed to the `apiRequestFunction` step action function call
  * @returns `1` for private by default & `1` for public
  */
-export function getNewSitePublicSetting( dependenciesAndStepData: object ): number {
-	return shouldBePrivateByDefault( dependenciesAndStepData ) ? -1 : 1;
+export function getNewSitePublicSetting( dependencies: object, stepData: object ): number {
+	debug( 'getNewSitePublicSetting input', { dependencies, stepData } );
+
+	return shouldBePrivateByDefault( { ...stepData } ) ? -1 : 1;
 }

--- a/client/lib/signup/private-by-default.ts
+++ b/client/lib/signup/private-by-default.ts
@@ -12,6 +12,7 @@ const debug = debugFactory( 'calypso:signup:private-by-default' );
 
 interface PrivateByDefaultSiteSettings {
 	flowName?: string;
+	lastKnownFlow?: string;
 }
 
 /**
@@ -20,9 +21,12 @@ interface PrivateByDefaultSiteSettings {
  * @returns `true` for private by default & `false` for not
  */
 export function shouldBePrivateByDefault( {
-	flowName = '',
-}: Readonly<PrivateByDefaultSiteSettings> ): boolean {
-	if ( flowName.match( /^ecommerce/ ) ) {
+	flowName,
+	lastKnownFlow,
+}: Readonly< PrivateByDefaultSiteSettings > ): boolean {
+	const flowToCheck = flowName || lastKnownFlow || '';
+
+	if ( flowToCheck.match( /^ecommerce/ ) ) {
 		// ecommerce plans go atomic after checkout. These sites should default to public for now.
 		return false;
 	}

--- a/client/lib/signup/private-by-default.ts
+++ b/client/lib/signup/private-by-default.ts
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import debugFactory from 'debug';
+
+/**
+ * Internal dependencies
+ */
+import { abtest } from 'lib/abtest';
+
+const debug = debugFactory( 'calypso:signup:private-by-default' );
+
+/**
+ * Should the site be private by default
+ *
+ * @param dependenciesAndStepData a combination of the `dependencies` & `stepData` objects passed to the `apiRequestFunction` step action function call
+ * @returns `true` for private by default & `false` for not
+ */
+export function shouldBePrivateByDefault( dependenciesAndStepData: object ): boolean {
+	debug( { dependenciesAndStepData } );
+
+	// Put any circumstances which should NOT be private by default here
+
+	return abtest( 'privateByDefault' ) === 'selected';
+}
+
+/**
+ * Get the numeric value that should be provided to the "new site" endpoint
+ *
+ * @param dependenciesAndStepData a combination of the `dependencies` & `stepData` objects passed to the `apiRequestFunction` step action function call
+ * @returns `1` for private by default & `1` for public
+ */
+export function getNewSitePublicSetting( dependenciesAndStepData: object ): number {
+	return shouldBePrivateByDefault( dependenciesAndStepData ) ? -1 : 1;
+}

--- a/client/lib/signup/private-by-default.ts
+++ b/client/lib/signup/private-by-default.ts
@@ -40,5 +40,5 @@ export function shouldBePrivateByDefault( {
 export function getNewSitePublicSetting( dependencies: object, stepData: object ): number {
 	debug( 'getNewSitePublicSetting input', { dependencies, stepData } );
 
-	return shouldBePrivateByDefault( { ...stepData } ) ? -1 : 1;
+	return shouldBePrivateByDefault( stepData ) ? -1 : 1;
 }

--- a/client/lib/signup/private-by-default.ts
+++ b/client/lib/signup/private-by-default.ts
@@ -21,7 +21,7 @@ interface PrivateByDefaultSiteSettings {
  */
 export function shouldBePrivateByDefault( {
 	flowName = '',
-}: PrivateByDefaultSiteSettings ): boolean {
+}: Readonly<PrivateByDefaultSiteSettings> ): boolean {
 	if ( flowName.match( /^ecommerce/ ) ) {
 		// ecommerce plans go atomic after checkout. These sites should default to public for now.
 		return false;

--- a/client/lib/signup/private-by-default.ts
+++ b/client/lib/signup/private-by-default.ts
@@ -10,11 +10,18 @@ import { abtest } from 'lib/abtest';
 
 const debug = debugFactory( 'calypso:signup:private-by-default' );
 
+interface PrivateByDefaultSiteSettings {
+	flowName?: string;
+}
+
 /**
  * Should the site be private by default
+ * @param siteSettings PrivateByDefaultSiteSettings
  * @returns `true` for private by default & `false` for not
  */
-export function shouldBePrivateByDefault( { flowName = '' }: { flowName?: string } = {} ): boolean {
+export function shouldBePrivateByDefault( {
+	flowName = '',
+}: PrivateByDefaultSiteSettings ): boolean {
 	if ( flowName.match( /^ecommerce/ ) ) {
 		// ecommerce plans go atomic after checkout. These sites should default to public for now.
 		return false;

--- a/client/lib/signup/private-by-default.ts
+++ b/client/lib/signup/private-by-default.ts
@@ -35,7 +35,7 @@ export function shouldBePrivateByDefault( {
  *
  * @param dependencies The `dependencies` passed to the `apiRequestFunction` step action function call
  * @param stepData The `stepData` passed to the `apiRequestFunction` step action function call
- * @returns `1` for private by default & `1` for public
+ * @returns `-1` for private by default & `1` for public
  */
 export function getNewSitePublicSetting( dependencies: object, stepData: object ): number {
 	debug( 'getNewSitePublicSetting input', { dependencies, stepData } );

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -165,7 +165,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				title: siteTitle,
 			},
 		},
-		public: getNewSitePublicSetting( { ...dependencies, ...stepData } ),
+		public: getNewSitePublicSetting( dependencies, stepData ),
 		validate: false,
 	};
 
@@ -556,7 +556,7 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 	const data = {
 		blog_name: site,
 		blog_title: '',
-		public: getNewSitePublicSetting( { ...dependencies, ...stepData } ),
+		public: getNewSitePublicSetting( dependencies, stepData ),
 		options: { theme: themeSlugWithRepo },
 		validate: false,
 	};

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -15,7 +15,7 @@ import { parse as parseURL } from 'url';
 import wpcom from 'lib/wp';
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
-import { abtest, getSavedVariations } from 'lib/abtest';
+import { getSavedVariations } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import {
 	updatePrivacyForDomain,
@@ -42,6 +42,7 @@ import { getSelectedImportEngine, getNuxUrlInputValue } from 'state/importer-nux
 // Current directory dependencies
 import { isValidLandingPageVertical } from './verticals';
 import { getSiteTypePropertyValue } from './site-type';
+import { getNewSitePublicSetting } from './private-by-default';
 import SignupCart from './cart';
 import { promisify } from '../../utils';
 
@@ -125,10 +126,8 @@ function getSiteVertical( state ) {
 	return ( getSiteVerticalName( state ) || getSurveyVertical( state ) ).trim();
 }
 
-export function createSiteWithCart(
-	callback,
-	dependencies,
-	{
+export function createSiteWithCart( callback, dependencies, stepData, reduxStore ) {
+	const {
 		cartItem,
 		domainItem,
 		flowName,
@@ -138,9 +137,8 @@ export function createSiteWithCart(
 		siteUrl,
 		themeSlugWithRepo,
 		themeItem,
-	},
-	reduxStore
-) {
+	} = stepData;
+
 	const state = reduxStore.getState();
 
 	const designType = getDesignType( state ).trim();
@@ -167,7 +165,7 @@ export function createSiteWithCart(
 				title: siteTitle,
 			},
 		},
-		public: abtest( 'privateByDefault' ) === 'selected' ? -1 : 1,
+		public: getNewSitePublicSetting( { ...dependencies, ...stepData } ),
 		validate: false,
 	};
 
@@ -551,11 +549,14 @@ export function createAccount(
 	}
 }
 
-export function createSite( callback, { themeSlugWithRepo }, { site }, reduxStore ) {
+export function createSite( callback, dependencies, stepData, reduxStore ) {
+	const { themeSlugWithRepo } = dependencies;
+	const { site } = stepData;
+
 	const data = {
 		blog_name: site,
 		blog_title: '',
-		public: -1,
+		public: getNewSitePublicSetting( { ...dependencies, ...stepData } ),
 		options: { theme: themeSlugWithRepo },
 		validate: false,
 	};

--- a/client/lib/signup/test/private-by-default.js
+++ b/client/lib/signup/test/private-by-default.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import { getNewSitePublicSetting, shouldBePrivateByDefault } from '../private-by-default';
+
+describe( 'getNewSitePublicSetting()', () => {
+	test( 'should return `-1` by default', () => {
+		expect( getNewSitePublicSetting() ).toBe( -1 );
+	} );
+} );
+
+describe( 'shouldBePrivateByDefault()', () => {
+	test( 'should return `true` by default', () => {
+		expect( shouldBePrivateByDefault() ).toBeTrue;
+	} );
+} );

--- a/client/lib/signup/test/private-by-default.js
+++ b/client/lib/signup/test/private-by-default.js
@@ -7,10 +7,34 @@ describe( 'getNewSitePublicSetting()', () => {
 	test( 'should return `-1` by default', () => {
 		expect( getNewSitePublicSetting() ).toBe( -1 );
 	} );
+
+	test( 'should return `-1` for onboarding flow', () => {
+		expect( getNewSitePublicSetting( null, { flowName: 'onboarding' } ) ).toBe( -1 );
+	} );
+
+	test( 'should return `1` for ecommerce flow', () => {
+		expect( getNewSitePublicSetting( null, { flowName: 'ecommerce' } ) ).toBe( 1 );
+	} );
+
+	test( 'should return `1` for ecommerce-onboarding flow', () => {
+		expect( getNewSitePublicSetting( null, { flowName: 'ecommerce-onboarding' } ) ).toBe( 1 );
+	} );
 } );
 
 describe( 'shouldBePrivateByDefault()', () => {
 	test( 'should return `true` by default', () => {
 		expect( shouldBePrivateByDefault() ).toBeTrue;
+	} );
+
+	test( 'should return `true` for onboarding flow', () => {
+		expect( shouldBePrivateByDefault( { flowName: 'onboarding' } ) ).toBeTrue;
+	} );
+
+	test( 'should return `false` for ecommerce flow', () => {
+		expect( shouldBePrivateByDefault( { flowName: 'ecommerce' } ) ).toBeFalse;
+	} );
+
+	test( 'should return `false` for ecommerce-onboarding flow', () => {
+		expect( shouldBePrivateByDefault( { flowName: 'ecommerce-onboarding' } ) ).toBeFalse;
 	} );
 } );

--- a/client/lib/signup/test/private-by-default.js
+++ b/client/lib/signup/test/private-by-default.js
@@ -22,19 +22,23 @@ describe( 'getNewSitePublicSetting()', () => {
 } );
 
 describe( 'shouldBePrivateByDefault()', () => {
-	test( 'should return `true` by default', () => {
-		expect( shouldBePrivateByDefault() ).toBeTrue;
+	test( 'should throw with no input', () => {
+		expect( () => shouldBePrivateByDefault() ).toThrowError( TypeError );
+	} );
+
+	test( 'should return `true` with no flowName', () => {
+		expect( shouldBePrivateByDefault( { notFlowName: 'really' } ) ).toBe( true );
 	} );
 
 	test( 'should return `true` for onboarding flow', () => {
-		expect( shouldBePrivateByDefault( { flowName: 'onboarding' } ) ).toBeTrue;
+		expect( shouldBePrivateByDefault( { flowName: 'onboarding' } ) ).toBe( true );
 	} );
 
 	test( 'should return `false` for ecommerce flow', () => {
-		expect( shouldBePrivateByDefault( { flowName: 'ecommerce' } ) ).toBeFalse;
+		expect( shouldBePrivateByDefault( { flowName: 'ecommerce' } ) ).toBe( false );
 	} );
 
 	test( 'should return `false` for ecommerce-onboarding flow', () => {
-		expect( shouldBePrivateByDefault( { flowName: 'ecommerce-onboarding' } ) ).toBeFalse;
+		expect( shouldBePrivateByDefault( { flowName: 'ecommerce-onboarding' } ) ).toBe( false );
 	} );
 } );

--- a/client/lib/signup/test/private-by-default.js
+++ b/client/lib/signup/test/private-by-default.js
@@ -23,7 +23,7 @@ describe( 'getNewSitePublicSetting()', () => {
 
 describe( 'shouldBePrivateByDefault()', () => {
 	test( 'should throw with no input', () => {
-		expect( () => shouldBePrivateByDefault() ).toThrowError( TypeError );
+		expect( () => shouldBePrivateByDefault() ).toThrow( TypeError );
 	} );
 
 	test( 'should return `true` with no flowName', () => {

--- a/client/lib/signup/test/private-by-default.js
+++ b/client/lib/signup/test/private-by-default.js
@@ -5,7 +5,7 @@ import { getNewSitePublicSetting, shouldBePrivateByDefault } from '../private-by
 
 describe( 'getNewSitePublicSetting()', () => {
 	test( 'should return `-1` by default', () => {
-		expect( getNewSitePublicSetting() ).toBe( -1 );
+		expect( getNewSitePublicSetting( {}, {} ) ).toBe( -1 );
 	} );
 
 	test( 'should return `-1` for onboarding flow', () => {
@@ -26,7 +26,7 @@ describe( 'shouldBePrivateByDefault()', () => {
 		expect( () => shouldBePrivateByDefault() ).toThrow( TypeError );
 	} );
 
-	test( 'should return `true` with no flowName', () => {
+	test( 'should return `true` with no flowName or lastKnownFlow', () => {
 		expect( shouldBePrivateByDefault( { notFlowName: 'really' } ) ).toBe( true );
 	} );
 
@@ -40,5 +40,15 @@ describe( 'shouldBePrivateByDefault()', () => {
 
 	test( 'should return `false` for ecommerce-onboarding flow', () => {
 		expect( shouldBePrivateByDefault( { flowName: 'ecommerce-onboarding' } ) ).toBe( false );
+	} );
+
+	test( 'should use lastKnownFlow if flowName is missing', () => {
+		expect( shouldBePrivateByDefault( { lastKnownFlow: 'ecommerce' } ) ).toBe( false );
+	} );
+
+	test( 'flowName takes precedence over lastKnownFlow', () => {
+		expect(
+			shouldBePrivateByDefault( { flowName: 'onboarding', lastKnownFlow: 'ecommerce' } )
+		).toBe( true );
 	} );
 } );

--- a/client/lib/signup/test/private-by-default.js
+++ b/client/lib/signup/test/private-by-default.js
@@ -3,6 +3,10 @@
  */
 import { getNewSitePublicSetting, shouldBePrivateByDefault } from '../private-by-default';
 
+jest.mock( 'lib/abtest', () => ( {
+	abtest: testName => ( testName === 'privateByDefault' ? 'selected' : '' ),
+} ) );
+
 describe( 'getNewSitePublicSetting()', () => {
 	test( 'should return `-1` by default', () => {
 		expect( getNewSitePublicSetting( {}, {} ) ).toBe( -1 );


### PR DESCRIPTION
NOTE: Currently targeting the branch in #34193 -- merge or retrain on master if that lands first

#### Changes proposed in this Pull Request

* New signup lib file for private-by-default
* New functions:
  * `shouldBePrivateByDefault`
  * `getNewSitePublicSetting`

#### Testing instructions

* Manually test
  * Run branch
  * Create a new site using the default flow (`/start`)
  * The created site should be private by default
* Run automated tests `npm run test-client client/lib/signup/test/private-by-default.js`
