### PR TITLE
Update inbound transfer message

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize } from 'i18n-calypso';
+import { localize, moment } from 'i18n-calypso';
 import { endsWith, get, isEmpty, noop } from 'lodash';
 import page from 'page';
 import { stringify } from 'qs';
@@ -519,10 +519,13 @@ class TransferDomainStep extends React.Component {
 
 							this.setState( {
 								notice: this.props.translate(
-									"We don't support transfers for domains ending with {{strong}}.%(tld)s{{/strong}}, " +
-										'but you can {{a}}map it{{/a}} instead.',
+									'Domain transfers are temporarily disabled until %(transferEnableDate)s, ' +
+										'but you can {{a}}map your domain{{/a}} instead.',
 									{
-										args: { tld },
+										args: {
+											tld: tld,
+											transferEnableDate: moment( '2019-07-30T08:00:00' ).format( 'LL' ),
+										},
 										components: {
 											strong: <strong />,
 											a: <a href="#" onClick={ this.goToMapDomainStep } />, // eslint-disable-line jsx-a11y/anchor-is-valid


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes the inbound transfer message until the migration is over. We will revert this change once we've completed the migration and everything is tested properly.

For more information, see p99Zz8-DI-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build this branch locally
* Browse to http://calypso.localhost:3000/domains/add/transfer/
* Choose a site when prompted
* Attempt to start a transfer for a `.com` or `.net` domain that is already taken
* Make sure the message explains that transfers have been disabled until July 30