### PR TITLE
Update the Threat Alert UI to indicate if a fix is in progress.

### DIFF
--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -149,6 +149,7 @@ export class ThreatAlert extends Component {
 
 	render() {
 		const { threat, translate } = this.props;
+		const inProgress = this.state.requesting || threat.fixer_status === 'in_progress';
 
 		return (
 			<Fragment>
@@ -171,8 +172,8 @@ export class ThreatAlert extends Component {
 											dateFormat="ll"
 										/>
 									</span>
-									{ this.state.requesting && <Spinner /> }
-									{ this.state.requesting && (
+									{ inProgress && <Spinner /> }
+									{ inProgress && (
 										<Interval onTick={ this.refreshRewindState } period={ EVERY_TEN_SECONDS } />
 									) }
 									<SplitButton
@@ -182,7 +183,7 @@ export class ThreatAlert extends Component {
 											threat.fixable ? translate( 'Fix threat' ) : translate( 'Ignore threat' )
 										}
 										onClick={ threat.fixable ? this.handleFix : this.handleIgnore }
-										disabled={ this.state.requesting }
+										disabled={ inProgress }
 									>
 										<PopoverMenuItem
 											onClick={ () => debug( 'documentation clicked' ) }

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -7,7 +7,7 @@ import { localize } from 'i18n-calypso';
 import debugFactory from 'debug';
 import { connect } from 'react-redux';
 import Spinner from 'components/spinner';
-import Interval, { EVERY_FIVE_SECONDS } from 'lib/interval';
+import Interval, { EVERY_TEN_SECONDS } from 'lib/interval';
 
 /**
  * Internal dependencies
@@ -173,7 +173,7 @@ export class ThreatAlert extends Component {
 									</span>
 									{ this.state.requesting && <Spinner /> }
 									{ this.state.requesting && (
-										<Interval onTick={ this.refreshRewindState } period={ EVERY_FIVE_SECONDS } />
+										<Interval onTick={ this.refreshRewindState } period={ EVERY_TEN_SECONDS } />
 									) }
 									<SplitButton
 										compact


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the polling interval from five to ten seconds
* If a fixer is in progress 916-gh-jetpack-backups , disable the button same as if it had just been clicked.

#### Testing instructions

* View the activity log for the relevant site, with an in-progress fixer running.  `threat.fixer_status` should be `in_progress`
* Confirm it looks like this (forgive the color scheme)

![Screen Shot 2019-07-25 at 1 13 56 PM](https://user-images.githubusercontent.com/941023/61894279-16342680-aede-11e9-916e-4b606c91bb9f.png)
