### PR TITLE
Let the Spinner be positioned and not only centered.

### DIFF
--- a/client/components/spinner/index.jsx
+++ b/client/components/spinner/index.jsx
@@ -17,14 +17,16 @@ export default class Spinner extends PureComponent {
 	static propTypes = {
 		className: PropTypes.string,
 		size: PropTypes.number,
+		align: PropTypes.oneOf( [ 'right', 'left' ] ),
 	};
 
 	static defaultProps = {
 		size: 20,
+		align: null,
 	};
 
 	render() {
-		const className = classNames( 'spinner', this.props.className );
+		const className = classNames( 'spinner', this.props.align, this.props.className );
 
 		const style = {
 			width: this.props.size,

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -12,7 +12,7 @@
 .spinner__outer, .spinner__inner {
 	margin: auto;
 	box-sizing: border-box;
-  border: 0.1em solid transparent;
+	border: 0.1em solid transparent;
 	border-radius: 50%;
 	animation: 3s linear infinite;
 	animation-name: rotate-spinner;
@@ -24,8 +24,8 @@
 
 .spinner__inner {
 	width: 100%;
-  height: 100%;
+	height: 100%;
 	border-top-color: var( --color-accent );
-  border-right-color: var( --color-accent );
-  opacity: 0.4;
+	border-right-color: var( --color-accent );
+	opacity: 0.4;
 }

--- a/client/components/spinner/style.scss
+++ b/client/components/spinner/style.scss
@@ -7,6 +7,15 @@
 .spinner {
 	display: flex;
 	align-items: center;
+
+	&.right {
+		margin-left: auto;
+		margin-right: 0.5em;
+	}
+	&.left {
+		margin-left: 0.5em;
+		margin-right: auto;
+	}
 }
 
 .spinner__outer, .spinner__inner {

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -172,7 +172,7 @@ export class ThreatAlert extends Component {
 											dateFormat="ll"
 										/>
 									</span>
-									{ inProgress && <Spinner /> }
+									{ inProgress && <Spinner align="right" /> }
 									{ inProgress && (
 										<Interval onTick={ this.refreshRewindState } period={ EVERY_TEN_SECONDS } />
 									) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add new `align` property to the Spinner, to enable better positioning when it's not meant to be centered.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test it with / without the added `align` attribute.  Nothing should break with it there or missing.

Vizrecs:

Before:

![Screen Shot 2019-07-25 at 1 13 56 PM](https://user-images.githubusercontent.com/941023/61901444-c9f0e280-aeed-11e9-8a6f-ce186a7c2eda.png)

After:

<img width="1369" alt="Screen Shot 2019-07-25 at 2 51 52 PM" src="https://user-images.githubusercontent.com/941023/61901435-c52c2e80-aeed-11e9-854a-7aa55a90c3c6.png">

