### PR TITLE
Fix for Jetpack SSO 3rd party cookie blocking issue with gutenframe

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -118,6 +118,15 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 		MediaStore.on( 'change', this.updateImageBlocks );
 		window.addEventListener( 'message', this.onMessage, false );
 
+		this.handleThirdPartyiFrameDomains();
+	}
+
+	componentWillUnmount() {
+		MediaStore.off( 'change', this.updateImageBlocks );
+		window.removeEventListener( 'message', this.onMessage, false );
+	}
+
+	handleThirdPartyiFrameDomains() {
 		// get the domain of the iframed editor so we can check if it is 3rd party domain.
 		// If so we want to initially redirect to that domain to set auth cookie to prevent
 		// 3rd party cookie blocking by browser security
@@ -139,12 +148,12 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			// check query params from parent frame to check if we have already redirected back from 3rd party auth.
 			if ( parentQuery.thirdPartyAuthed ) {
 				// If successfully redirected save to session storage so we don't need to redirect on every editor load
-				sessionStorage.setItem( `${ iFrameDomain }ThirdPartyAuthed`, 'true' );
+				sessionStorage.setItem( `calypsoify_${ iFrameDomain }_thirdPartyAuthed`, 'true' );
 			}
 
 			// if 3rd party iFrame is not authenticated yet then redirect to that domain to auth
 			// and redirect back here with 3rdPartyAuthed param set
-			if ( ! sessionStorage.getItem( `${ iFrameDomain }ThirdPartyAuthed` ) ) {
+			if ( ! sessionStorage.getItem( `calypsoify_${ iFrameDomain }_thirdPartyAuthed` ) ) {
 				// Add new params to existing in case there are new calypsoify query params added in future that
 				// need to be included in the redirect
 				parentQuery.thirdPartyAuthed = 'true';
@@ -157,11 +166,6 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 				window.location.href = `${ iFrameProtocol }//${ iFrameDomain }/wp-login.php?redirect_to=${ returnURL }`;
 			}
 		}
-	}
-
-	componentWillUnmount() {
-		MediaStore.off( 'change', this.updateImageBlocks );
-		window.removeEventListener( 'message', this.onMessage, false );
 	}
 
 	onMessage = ( { data, origin }: MessageEvent ) => {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -126,7 +126,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			.replace( 'https://', '' )
 			.split( /[/?#]/ )[ 0 ];
 
-		// get the query params from parent frame to check if we have already readirected back from 3rd party auth
+		// get the query params from parent frame to check if we have already redirected back from 3rd party auth
 		const urlParams = new URLSearchParams( window.location.search );
 
 		// if editor iFrame is a different domain then redirect to that domain to auth
@@ -603,8 +603,6 @@ const mapStateToProps = (
 	const siteAdminUrl = getSiteAdminUrl( state, siteId, postId ? 'post.php' : 'post-new.php' );
 
 	const iframeUrl = addQueryArgs( queryArgs, siteAdminUrl );
-	// console.log( iframeUrl );
-	// console.log( window.location.hostname );
 
 	// Prevents the iframe from loading using a cached frame nonce.
 	const shouldLoadIframe = ! isRequestingSites( state ) && ! isRequestingSite( state, siteId );

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -19,6 +19,7 @@ import { addQueryArgs } from 'lib/route';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import { requestSelectedEditor } from 'state/selected-editor/actions';
 import { getSiteUrl, isJetpackSite } from 'state/sites/selectors';
+import { isEnabled } from 'config';
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/block-editor/post/' ) ) {
@@ -87,6 +88,7 @@ export const authenticate = ( context, next ) => {
 	const isAuthenticated =
 		sessionStorage.getItem( storageKey ) || // Previously authenticated.
 		! isJetpackSite( state, siteId ) || // Simple sites users are always authenticated.
+		isEnabled( 'desktop' ) || // The desktop app can store third-party cookies.
 		context.query.authWpAdmin; // Redirect back from the WP Admin login page to Calypso.
 	if ( isAuthenticated ) {
 		sessionStorage.setItem( storageKey, 'true' );

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -71,7 +71,6 @@ function handleJetpackSSO( context ) {
 	// with 3rd party cookie setting being blocked by the browser
 	const state = context.store.getState();
 	const currentRoute = getCurrentRoute( state );
-
 	const { URL: selectedSiteUrl, domain: selectedSiteDomain, jetpack } = getSelectedSite( state );
 
 	if ( ! jetpack ) {

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -5,8 +5,6 @@
 import React from 'react';
 import page from 'page';
 import { get, isInteger } from 'lodash';
-import urlLib from 'url';
-import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -14,13 +12,13 @@ import { stringify } from 'qs';
 import { shouldLoadGutenberg } from 'state/selectors/should-load-gutenberg';
 import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
 import { EDITOR_START } from 'state/action-types';
-import { getSelectedSiteId, getSelectedSiteSlug, getSelectedSite } from 'state/ui/selectors';
-import getCurrentRoute from 'state/selectors/get-current-route';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import CalypsoifyIframe from './calypsoify-iframe';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { addQueryArgs } from 'lib/route';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import { requestSelectedEditor } from 'state/selected-editor/actions';
+import { getSiteUrl, isJetpackSite } from 'state/sites/selectors';
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/block-editor/post/' ) ) {
@@ -65,47 +63,41 @@ function waitForSiteIdAndSelectedEditor( context ) {
 	} );
 }
 
-function handleJetpackSSO( context ) {
-	// If we are dealing with an Atomic or Jetpack site we need to make sure that Jetpack SSO
-	// has been handled before we load the editor in an iFrame in order to prevent any issues
-	// with 3rd party cookie setting being blocked by the browser
+/**
+ * Ensures the user is authenticated in WP Admin so the iframe can be loaded successfully.
+ *
+ * Simple sites users are always authenticated since the iframe is loaded through a *.wordpress.com URL (first-party
+ * cookie).
+ *
+ * Atomic and Jetpack sites will load the iframe through a different domain (third-party cookie). This can prevent the
+ * auth cookies from being stored while embedding WP Admin in Calypso (i.e. if the browser is preventing cross-site
+ * tracking), so we redirect the user to the WP Admin login page in order to store the auth cookie. Users will be
+ * redirected back to Calypso when they are authenticated in WP Admin.
+ *
+ * @param {Object} context  Shared context in the route.
+ * @param {Function} next   Next registered callback for the route.
+ * @returns {*}             Whatever the next callback returns.
+ */
+export const authenticate = ( context, next ) => {
 	const state = context.store.getState();
-	const currentRoute = getCurrentRoute( state );
-	const { URL: selectedSiteUrl, domain: selectedSiteDomain, jetpack } = getSelectedSite( state );
 
-	if ( ! jetpack ) {
-		return;
+	const siteId = getSelectedSiteId( state );
+	const storageKey = `gutenframe_${ siteId }_is_authenticated`;
+
+	const isAuthenticated =
+		sessionStorage.getItem( storageKey ) || // Previously authenticated.
+		! isJetpackSite( state, siteId ) || // Simple sites users are always authenticated.
+		context.query.authWpAdmin; // Redirect back from the WP Admin login page to Calypso.
+	if ( isAuthenticated ) {
+		sessionStorage.setItem( storageKey, 'true' );
+		return next();
 	}
 
-	const {
-		hostname: parentDomain,
-		protocol: parentProtocol,
-		port,
-		query: parentQuery,
-	} = urlLib.parse( window.location.href, true );
-	const parentPort = port ? `:${ port }` : '';
-
-	// check query params from parent frame to check if we have already redirected back from Jetpack auth.
-	if ( parentQuery.jetpackSSO ) {
-		// If successfully redirected save to session storage so we don't need to redirect on every editor load
-		sessionStorage.setItem( `calypsoify_${ selectedSiteDomain }_jetpackSSO`, 'true' );
-		return;
-	}
-
-	if ( sessionStorage.getItem( `calypsoify_${ selectedSiteDomain }_jetpackSSO` ) ) {
-		return;
-	}
-
-	// if site is not authenticated yet then redirect to that domain to auth
-	// and redirect back here with jetpackSSO param set
-	parentQuery.jetpackSSO = 'true';
-	const returnURL = encodeURIComponent(
-		`${ parentProtocol }//${ parentDomain }${ parentPort }${ currentRoute }?${ stringify(
-			parentQuery
-		) }`
-	);
-	window.location.href = `${ selectedSiteUrl }/wp-login.php?redirect_to=${ returnURL }`;
-}
+	const returnUrl = addQueryArgs( { authWpAdmin: true }, window.location.href );
+	const siteUrl = getSiteUrl( state, siteId );
+	const wpAdminLoginUrl = addQueryArgs( { redirect_to: returnUrl }, `${ siteUrl }/wp-login.php` );
+	window.location.replace( wpAdminLoginUrl );
+};
 
 export const redirect = async ( context, next ) => {
 	const {
@@ -143,7 +135,6 @@ function getPressThisData( query ) {
 export const post = ( context, next ) => {
 	// See post-editor/controller.js for reference.
 
-	handleJetpackSSO( context );
 	const postId = getPostID( context );
 	const postType = determinePostType( context );
 	const jetpackCopy = parseInt( get( context, 'query.jetpack-copy', null ) );

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -103,7 +103,7 @@ export const authenticate = ( context, next ) => {
 	render( context );
 
 	// We could use `window.location.href` to generate the return URL but there are some potential race conditions that
-	// can cause the browser to don't update it before redirecting to WP Admin. To avoid that, we manually generate the
+	// can cause the browser to not update it before redirecting to WP Admin. To avoid that, we manually generate the
 	// URL from the relevant parts.
 	let origin = `${ window.location.protocol }//${ window.location.hostname }`;
 	if ( window.location.port ) {

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -102,7 +102,18 @@ export const authenticate = ( context, next ) => {
 	makeLayout( context, noop );
 	render( context );
 
-	const returnUrl = addQueryArgs( { authWpAdmin: true }, window.location.href );
+	// We could use `window.location.href` to generate the return URL but there are some potential race conditions that
+	// can cause the browser to don't update it before redirecting to WP Admin. To avoid that, we manually generate the
+	// URL from the relevant parts.
+	let origin = `${ window.location.protocol }//${ window.location.hostname }`;
+	if ( window.location.port ) {
+		origin += `:${ window.location.port }`;
+	}
+	const returnUrl = addQueryArgs(
+		{ ...context.query, authWpAdmin: true },
+		`${ origin }${ context.path }`
+	);
+
 	const siteUrl = getSiteUrl( state, siteId );
 	const wpAdminLoginUrl = addQueryArgs( { redirect_to: returnUrl }, `${ siteUrl }/wp-login.php` );
 	window.location.replace( wpAdminLoginUrl );

--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -4,7 +4,7 @@
  */
 import React from 'react';
 import page from 'page';
-import { get, isInteger } from 'lodash';
+import { get, isInteger, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,6 +20,8 @@ import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import { requestSelectedEditor } from 'state/selected-editor/actions';
 import { getSiteUrl, isJetpackSite } from 'state/sites/selectors';
 import { isEnabled } from 'config';
+import { Placeholder } from './placeholder';
+import { makeLayout, render } from 'controller';
 
 function determinePostType( context ) {
 	if ( context.path.startsWith( '/block-editor/post/' ) ) {
@@ -94,6 +96,11 @@ export const authenticate = ( context, next ) => {
 		sessionStorage.setItem( storageKey, 'true' );
 		return next();
 	}
+
+	// Shows the editor placeholder while doing the redirection.
+	context.primary = <Placeholder />;
+	makeLayout( context, noop );
+	render( context );
 
 	const returnUrl = addQueryArgs( { authWpAdmin: true }, window.location.href );
 	const siteUrl = getSiteUrl( state, siteId );

--- a/client/gutenberg/editor/index.js
+++ b/client/gutenberg/editor/index.js
@@ -8,7 +8,7 @@ import page from 'page';
  * Internal dependencies
  */
 import { siteSelection, sites } from 'my-sites/controller';
-import { post, redirect } from './controller';
+import { authenticate, post, redirect } from './controller';
 import config from 'config';
 import { makeLayout, render as clientRender } from 'controller';
 
@@ -20,6 +20,7 @@ export default function() {
 		'/block-editor/post/:site/:post?',
 		siteSelection,
 		redirect,
+		authenticate,
 		post,
 		makeLayout,
 		clientRender
@@ -31,6 +32,7 @@ export default function() {
 		'/block-editor/page/:site/:post?',
 		siteSelection,
 		redirect,
+		authenticate,
 		post,
 		makeLayout,
 		clientRender
@@ -43,6 +45,7 @@ export default function() {
 			'/block-editor/edit/:customPostType/:site/:post?',
 			siteSelection,
 			redirect,
+			authenticate,
 			post,
 			makeLayout,
 			clientRender


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some browsers can prevent the cookies to be stored if they are coming from a different domain than the one we're currently visiting. This was causing issues to AT sites with a custom domain when using Gutenframe.

This PR seeks to solve that by performing a redirection to the custom domain, so the authentication cookies can be stored and then we redirect back to Calypso.

#### Testing instructions

* Make sure you have an AT test site using a custom domain.
* Make sure that the "Prevent cross-site tracking" option is enabled in the Safari privacy settings:
<img width="886" alt="Screen Shot 2019-08-02 at 12 10 35" src="https://user-images.githubusercontent.com/1233880/62341513-a72e8180-b51e-11e9-975f-7c5dbaf0d13e.png">

* Make sure there are no cookies saved for the custom domain of your AT test site:
<img width="886" alt="Screen Shot 2019-08-02 at 12 13 18" src="https://user-images.githubusercontent.com/1233880/62341628-042a3780-b51f-11e9-814c-1556ca9e0167.png">
<img width="886" alt="Screen Shot 2019-08-02 at 12 13 55" src="https://user-images.githubusercontent.com/1233880/62341630-08eeeb80-b51f-11e9-9ddd-1c49150a8117.png">

* Start Calypso running on master.
* In Safari, go to `calypso.localhost:3000/block-editor/post` and select your AT test site.
  * If you're asked to enter your credentials, go first to `wordpress.com/login` and enter your credentials there, so the `wordpress.com` auth cookies can be stored and read by `calypso.localhost`.
* The editor should hang on the loading screen.
* Switch to this branch and reload `calypso.localhost:3000/block-editor/post`.
* You should notice the URL redirect to your custom domain to authenticate, and then redirect back to Calypso. This redirect should only happen once per browser session.
 
Fixes #33142.