### PR TITLE
Site Redirect: Prevent Purchases on Atomic Sites

### DIFF
--- a/client/my-sites/domains/domain-search/site-redirect.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -13,10 +11,13 @@ import { localize } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
+import EmptyContent from 'components/empty-content';
 import HeaderCake from 'components/header-cake';
 import Main from 'components/main';
 import SiteRedirectStep from './site-redirect-step';
 import isSiteUpgradeable from 'state/selectors/is-site-upgradeable';
+import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
+import { getSiteAdminUrl } from 'state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import QueryProductsList from 'components/data/query-products-list';
 import { getProductsList } from 'state/products-list/selectors';
@@ -26,6 +27,7 @@ class SiteRedirect extends Component {
 		cart: PropTypes.object.isRequired,
 		selectedSite: PropTypes.object.isRequired,
 		selectedSiteSlug: PropTypes.string.isRequired,
+		isSiteAtomic: PropTypes.bool.isRequired,
 		isSiteUpgradeable: PropTypes.bool.isRequired,
 		productsList: PropTypes.object.isRequired,
 		translate: PropTypes.func.isRequired,
@@ -52,7 +54,26 @@ class SiteRedirect extends Component {
 	}
 
 	render() {
-		const { cart, selectedSite, productsList, translate } = this.props;
+		const {
+			cart,
+			selectedSite,
+			selectedSiteAdminUrl,
+			isSiteAtomic,
+			productsList,
+			translate,
+		} = this.props;
+
+		if ( isSiteAtomic ) {
+			return (
+				<EmptyContent
+					illustration="/calypso/images/illustrations/illustration-empty-results.svg"
+					title={ translate( 'Site Redirects are not available for this site.' ) }
+					line={ translate( 'Try searching for a redirection plugin instead.' ) }
+					action={ translate( 'Explore the Plugin Directory!' ) }
+					actionURL={ selectedSiteAdminUrl }
+				/>
+			);
+		}
 
 		return (
 			<Main>
@@ -72,6 +93,8 @@ export default connect( state => ( {
 	selectedSite: getSelectedSite( state ),
 	selectedSiteId: getSelectedSiteId( state ),
 	selectedSiteSlug: getSelectedSiteSlug( state ),
+	selectedSiteAdminUrl: getSiteAdminUrl( state, getSelectedSiteId( state ), 'plugin-install.php' ),
+	isSiteAtomic: isSiteWpcomAtomic( state, getSelectedSiteId( state ) ),
 	isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
 	productsList: getProductsList( state ),
 } ) )( localize( SiteRedirect ) );

--- a/client/my-sites/domains/domain-search/site-redirect.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect.jsx
@@ -93,7 +93,11 @@ export default connect( state => ( {
 	selectedSite: getSelectedSite( state ),
 	selectedSiteId: getSelectedSiteId( state ),
 	selectedSiteSlug: getSelectedSiteSlug( state ),
-	selectedSiteAdminUrl: getSiteAdminUrl( state, getSelectedSiteId( state ), 'plugin-install.php' ),
+	selectedSiteAdminUrl: getSiteAdminUrl(
+		state,
+		getSelectedSiteId( state ),
+		'/plugin-install.php?s=redirect&tab=search'
+	),
 	isSiteAtomic: isSiteWpcomAtomic( state, getSelectedSiteId( state ) ),
 	isSiteUpgradeable: isSiteUpgradeable( state, getSelectedSiteId( state ) ),
 	productsList: getProductsList( state ),

--- a/client/my-sites/domains/domain-search/site-redirect.jsx
+++ b/client/my-sites/domains/domain-search/site-redirect.jsx
@@ -68,8 +68,8 @@ class SiteRedirect extends Component {
 				<EmptyContent
 					illustration="/calypso/images/illustrations/illustration-empty-results.svg"
 					title={ translate( 'Site Redirects are not available for this site.' ) }
-					line={ translate( 'Try searching for a redirection plugin instead.' ) }
-					action={ translate( 'Explore the Plugin Directory!' ) }
+					line={ translate( "Try searching plugins for 'redirect'." ) }
+					action={ translate( 'Explore the Plugin Directory' ) }
 					actionURL={ selectedSiteAdminUrl }
 				/>
 			);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes a flow when Atomic sites visit `/domains/add/site-redirect/` then upgrade.

#### Testing instructions

Visit `/domains/add/site-redirect/` on an Atomic site and verify this error appears, but it doesn't on other sites. Clicking the CTA should lead to the Plugin Install page in wp-admin with a search for redirect plugins

<img width="1206" alt="Screenshot 2019-07-30 at 08 46 36" src="https://user-images.githubusercontent.com/43215253/62110601-b1dee180-b2a6-11e9-897e-f3a6710e8bd6.png">

cc @michelleweber is the copy okay?

> Site Redirects are not available for this site.
> Try searching for a redirection plugin instead.
> Explore the Plugin Directory!

cc @donpark 

Fixes #34189
