### PR TITLE
Replace dom-scroll-into-view with native methods.

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -9,7 +9,6 @@ import { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
 import { filter, find, flow, get, includes, isEmpty, noop } from 'lodash';
-import scrollIntoView from 'dom-scroll-into-view';
 import debugFactory from 'debug';
 
 /**
@@ -121,9 +120,11 @@ class SiteSelector extends Component {
 			return;
 		}
 
-		scrollIntoView( highlightedSiteElem, selectorElement, {
-			onlyScrollIfNeeded: true,
-		} );
+		if ( highlightedSiteElem.scrollIntoViewIfNeeded ) {
+			highlightedSiteElem.scrollIntoViewIfNeeded( false );
+		} else if ( highlightedSiteElem.scrollIntoView ) {
+			highlightedSiteElem.scrollIntoView( { block: 'nearest', scrollMode: 'if-needed' } );
+		}
 	}
 
 	computeHighlightedSite() {

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -28,6 +28,7 @@ import SitePlaceholder from 'blocks/site/placeholder';
 import Search from 'components/search';
 import SiteSelectorAddSite from './add-site';
 import searchSites from 'components/search-sites';
+import scrollIntoViewport from 'lib/scroll-into-viewport';
 
 /**
  * Style dependencies
@@ -120,11 +121,10 @@ class SiteSelector extends Component {
 			return;
 		}
 
-		if ( highlightedSiteElem.scrollIntoViewIfNeeded ) {
-			highlightedSiteElem.scrollIntoViewIfNeeded( false );
-		} else if ( highlightedSiteElem.scrollIntoView ) {
-			highlightedSiteElem.scrollIntoView( { block: 'nearest', scrollMode: 'if-needed' } );
-		}
+		scrollIntoViewport( highlightedSiteElem, {
+			block: 'nearest',
+			scrollMode: 'if-needed',
+		} );
 	}
 
 	computeHighlightedSite() {

--- a/client/components/token-field/suggestions-list.jsx
+++ b/client/components/token-field/suggestions-list.jsx
@@ -1,14 +1,10 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import scrollIntoView from 'dom-scroll-into-view';
 
 class SuggestionsList extends React.PureComponent {
 	static propTypes = {
@@ -28,9 +24,9 @@ class SuggestionsList extends React.PureComponent {
 		suggestions: Object.freeze( [] ),
 	};
 
-	componentDidUpdate( prevProps ) {
-		let node;
+	listRef = React.createRef();
 
+	componentDidUpdate( prevProps ) {
 		// only have to worry about scrolling selected suggestion into view
 		// when already expanded
 		if (
@@ -40,11 +36,14 @@ class SuggestionsList extends React.PureComponent {
 			this.props.scrollIntoView
 		) {
 			this._scrollingIntoView = true;
-			node = this.refs.list;
+			const node = this.listRef.current;
 
-			scrollIntoView( node.children[ this.props.selectedIndex ], node, {
-				onlyScrollIfNeeded: true,
-			} );
+			const child = node && node.children[ this.props.selectedIndex ];
+			if ( child && child.scrollIntoViewIfNeeded ) {
+				child.scrollIntoViewIfNeeded( false );
+			} else if ( child && child.scrollIntoView ) {
+				child.scrollIntoView( { block: 'nearest', scrollMode: 'if-needed' } );
+			}
 
 			setTimeout(
 				function() {
@@ -56,15 +55,14 @@ class SuggestionsList extends React.PureComponent {
 	}
 
 	_computeSuggestionMatch = suggestion => {
-		let match = this.props.displayTransform( this.props.match || '' ).toLocaleLowerCase(),
-			indexOfMatch;
+		const match = this.props.displayTransform( this.props.match || '' ).toLocaleLowerCase();
 
 		if ( match.length === 0 ) {
 			return null;
 		}
 
 		suggestion = this.props.displayTransform( suggestion );
-		indexOfMatch = suggestion.toLocaleLowerCase().indexOf( match );
+		const indexOfMatch = suggestion.toLocaleLowerCase().indexOf( match );
 
 		return {
 			suggestionBeforeMatch: suggestion.substring( 0, indexOfMatch ),
@@ -83,7 +81,7 @@ class SuggestionsList extends React.PureComponent {
 		// why, since usually a div isn't focusable by default
 		// TODO does this still apply now that it's a <ul> and not a <div>?
 		return (
-			<ul ref="list" className={ classes } tabIndex="-1">
+			<ul ref={ this.listRef } className={ classes } tabIndex="-1">
 				{ this._renderSuggestions() }
 			</ul>
 		);
@@ -93,12 +91,13 @@ class SuggestionsList extends React.PureComponent {
 		return map(
 			this.props.suggestions,
 			function( suggestion, index ) {
-				let match = this._computeSuggestionMatch( suggestion ),
-					classes = classNames( 'token-field__suggestion', {
-						'is-selected': index === this.props.selectedIndex,
-					} );
+				const match = this._computeSuggestionMatch( suggestion );
+				const classes = classNames( 'token-field__suggestion', {
+					'is-selected': index === this.props.selectedIndex,
+				} );
 
 				return (
+					// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
 					<li
 						className={ classes }
 						key={ suggestion }

--- a/client/components/token-field/suggestions-list.jsx
+++ b/client/components/token-field/suggestions-list.jsx
@@ -5,6 +5,7 @@ import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import scrollIntoViewport from 'lib/scroll-into-viewport';
 
 class SuggestionsList extends React.PureComponent {
 	static propTypes = {
@@ -39,10 +40,11 @@ class SuggestionsList extends React.PureComponent {
 			const node = this.listRef.current;
 
 			const child = node && node.children[ this.props.selectedIndex ];
-			if ( child && child.scrollIntoViewIfNeeded ) {
-				child.scrollIntoViewIfNeeded( false );
-			} else if ( child && child.scrollIntoView ) {
-				child.scrollIntoView( { block: 'nearest', scrollMode: 'if-needed' } );
+			if ( child ) {
+				scrollIntoViewport( child, {
+					block: 'nearest',
+					scrollMode: 'if-needed',
+				} );
 			}
 
 			setTimeout(

--- a/client/layout/guided-tours/positioning.ts
+++ b/client/layout/guided-tours/positioning.ts
@@ -188,7 +188,7 @@ function validatePlacement( placement: DialogPosition, target: Element | null ):
 }
 
 function scrollIntoView( target: Element, scrollContainer: Element | null ) {
-	// TODO(lsinger): consider replacing with Element.scrollIntoView
+	// TODO(lsinger): consider replacing with lib/scroll-into-viewport
 	const container = scrollContainer || getScrollableSidebar();
 	const { top, bottom } = target.getBoundingClientRect();
 	const clientHeight = isMobile() ? document.documentElement.clientHeight : container.clientHeight;

--- a/client/layout/guided-tours/positioning.ts
+++ b/client/layout/guided-tours/positioning.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { find, startsWith } from 'lodash';
+import { CSSProperties } from 'react';
 
 /**
  * Internal dependencies
@@ -9,7 +10,6 @@ import { find, startsWith } from 'lodash';
 import { isMobile } from 'lib/viewport';
 import scrollTo from 'lib/scroll-to';
 import { Coordinate, DialogPosition, ArrowPosition } from './types';
-import { CSSProperties } from 'react';
 
 const DIALOG_WIDTH = 410;
 const DIALOG_HEIGHT = 150;
@@ -188,7 +188,7 @@ function validatePlacement( placement: DialogPosition, target: Element | null ):
 }
 
 function scrollIntoView( target: Element, scrollContainer: Element | null ) {
-	// TODO(lsinger): consider replacing with http://yiminghe.me/dom-scroll-into-view/
+	// TODO(lsinger): consider replacing with Element.scrollIntoView
 	const container = scrollContainer || getScrollableSidebar();
 	const { top, bottom } = target.getBoundingClientRect();
 	const clientHeight = isMobile() ? document.documentElement.clientHeight : container.clientHeight;

--- a/client/lib/scroll-into-viewport/index.js
+++ b/client/lib/scroll-into-viewport/index.js
@@ -1,12 +1,10 @@
-/**
- * Walks from a given node with `nextNodeProp` as the next node in a graph, summing the values in `valueProp`.
- * e.g. recursivelyWalkAndSum( node, 'offsetTop', 'offsetParent' ).
- *
- * @format
- * @param {number} [value=0} - The initial value
- * @returns {number} - Summed value at the end of the walk
- */
+const SUPPORTS_SCROLL_BEHAVIOR =
+	typeof document !== 'undefined' &&
+	document.documentElement &&
+	'scrollBehavior' in document.documentElement.style;
 
+// Walks from a given node with `nextNodeProp` as the next node in a graph, summing the values in `valueProp`.
+// e.g. recursivelyWalkAndSum( node, 'offsetTop', 'offsetParent' ).
 export function recursivelyWalkAndSum( node, valueProp, nextNodeProp, value = 0 ) {
 	value += node[ valueProp ];
 	if ( ! node[ nextNodeProp ] ) {
@@ -16,37 +14,79 @@ export function recursivelyWalkAndSum( node, valueProp, nextNodeProp, value = 0 
 }
 
 /**
- * Checks whether the given bounds are within the viewport
- * @param {number} elementStart
- * @param {number} elementEnd
- * @returns {boolean}
+ * Checks whether the given bounds are within the viewport.
+ * @param {number} elementStart - The element start bound
+ * @param {number} elementEnd - The element end bound
+ * @returns {boolean} Boolean indicating whether the bounds are within the viewport
  */
 function isInViewportRange( elementStart, elementEnd ) {
-	let viewportStart = window.scrollY,
-		viewportEnd = document.documentElement.clientHeight + window.scrollY;
+	const viewportStart = window.scrollY;
+	const viewportEnd = document.documentElement.clientHeight + window.scrollY;
 	return elementStart > viewportStart && elementEnd < viewportEnd;
 }
 
 /**
- * Scroll an element into the viewport if it's not already inside the viewport
- * @param {HTMLElement} element
+ * Implements a fallback mechanism to scroll an element into the viewport if it's not
+ * already inside the viewport.
+ * @param {HTMLElement} element - The element to be scrolled into view.
+ * @param {String} behavior - Whether to use a smooth or auto scroll behavior.
+ * @param {String} scrollMode - Whether to always scroll, or only scroll when needed.
  */
-function scrollIntoViewport( element ) {
-	const elementStartY = recursivelyWalkAndSum( element, 'offsetTop', 'offsetParent' ),
-		elementEndY = elementStartY + element.offsetHeight;
-	if ( isInViewportRange( elementStartY, elementEndY ) ) {
+function fallbackScrollIntoViewport( element, behavior, scrollMode ) {
+	const elementStartY = recursivelyWalkAndSum( element, 'offsetTop', 'offsetParent' );
+	const elementEndY = elementStartY + element.offsetHeight;
+
+	if ( isInViewportRange( elementStartY, elementEndY ) && scrollMode === 'if-needed' ) {
 		return;
 	}
 
 	try {
-		window.scroll( {
-			top: elementStartY,
-			left: 0,
-			behavior: 'smooth',
-		} );
+		window.scroll( { top: elementStartY, left: 0, behavior } );
 	} catch ( e ) {
 		window.scrollTo( 0, elementStartY );
 	}
 }
 
-export default scrollIntoViewport;
+/**
+ * Scroll an element into the viewport.
+ * @param {HTMLElement} element - The element to be scrolled into view.
+ * @param {Object} options - Options to use for the scrolling (same as the options for Element.scrollIntoView).
+ */
+export default function scrollIntoViewport( element, options = {} ) {
+	const { behavior = 'auto', block = 'start', scrollMode = 'always', ...otherOptions } = options;
+
+	if ( ! element ) {
+		return;
+	}
+
+	if (
+		element.scrollIntoViewIfNeeded &&
+		( behavior === 'auto' || ! SUPPORTS_SCROLL_BEHAVIOR ) &&
+		( block === 'center' || block === 'nearest' ) &&
+		scrollMode === 'if-needed' &&
+		otherOptions === undefined
+	) {
+		// We can use `scrollIntoViewIfNeeded` if it's available, we're not doing smooth scrolling
+		// (either because we don't want it or because it's not available in the browser),
+		// and we only want to scroll if needed.
+		// Also, only the 'center' and 'nearest' block modes are supported.
+		element.scrollIntoViewIfNeeded( block === 'center' );
+		return;
+	}
+
+	if ( element.scrollIntoView ) {
+		try {
+			// Use element.scrollIntoView if available.
+			// This is the most complete implementation in newer browsers.
+			// However, in older browsers it may throw an error if the options object is not supported,
+			// or it may simply treat it as a boolean and ignore the various options.
+			element.scrollIntoView( options );
+			return;
+		} catch ( error ) {
+			// Move on to fallback.
+		}
+	}
+
+	// Low fidelity implementation of scrollIntoView. Always assumes block = 'start'.
+	fallbackScrollIntoViewport( element, behavior, scrollMode );
+}

--- a/client/my-sites/checkout/cart/secondary-cart.jsx
+++ b/client/my-sites/checkout/cart/secondary-cart.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -59,7 +57,10 @@ class SecondaryCart extends Component {
 	componentDidUpdate( prevProps, prevState ) {
 		if ( ! prevState.cartVisible && this.state.cartVisible ) {
 			const node = ReactDom.findDOMNode( this.cartBodyRef );
-			scrollIntoViewport( node );
+			scrollIntoViewport( node, {
+				behavior: 'smooth',
+				scrollMode: 'if-needed',
+			} );
 		}
 	}
 

--- a/client/my-sites/domains/components/form/input.jsx
+++ b/client/my-sites/domains/components/form/input.jsx
@@ -16,7 +16,19 @@ import scrollIntoViewport from 'lib/scroll-into-viewport';
 export default class Input extends React.Component {
 	static defaultProps = { autoFocus: false, autoComplete: 'on' };
 
-	inputRef = React.createRef();
+	inputRef = element => {
+		this.inputElement = element;
+
+		if ( ! this.props.inputRef ) {
+			return;
+		}
+
+		if ( typeof inputRef === 'function' ) {
+			this.props.inputRef( element );
+		} else {
+			this.props.inputRef.current = element;
+		}
+	};
 
 	componentDidMount() {
 		this.setupInputModeHandlers();
@@ -50,7 +62,7 @@ export default class Input extends React.Component {
 	}
 
 	focus = () => {
-		const node = this.inputRef.current;
+		const node = this.inputElement;
 		if ( node ) {
 			node.focus();
 			scrollIntoViewport( node, {
@@ -98,7 +110,6 @@ export default class Input extends React.Component {
 					id={ this.props.name }
 					value={ this.props.value }
 					name={ this.props.name }
-					ref={ this.inputRef }
 					autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 					autoComplete={ this.props.autoComplete }
 					disabled={ this.props.disabled }
@@ -107,7 +118,7 @@ export default class Input extends React.Component {
 					onChange={ this.props.onChange }
 					onClick={ this.recordFieldClick }
 					isError={ this.props.isError }
-					inputRef={ this.props.inputRef }
+					inputRef={ this.inputRef }
 				/>
 				{ this.props.errorMessage && (
 					<FormInputValidation id={ validationId } text={ this.props.errorMessage } isError />

--- a/client/my-sites/domains/components/form/input.jsx
+++ b/client/my-sites/domains/components/form/input.jsx
@@ -1,26 +1,22 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import ReactDom from 'react-dom';
 import React from 'react';
 import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
-
 import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import FormInputValidation from 'components/forms/form-input-validation';
 import analytics from 'lib/analytics';
 import scrollIntoViewport from 'lib/scroll-into-viewport';
 
-export default class extends React.Component {
-	static displayName = 'Input';
+export default class Input extends React.Component {
 	static defaultProps = { autoFocus: false, autoComplete: 'on' };
+
+	inputRef = React.createRef();
 
 	componentDidMount() {
 		this.setupInputModeHandlers();
@@ -28,9 +24,9 @@ export default class extends React.Component {
 	}
 
 	setupInputModeHandlers = () => {
-		const inputElement = ReactDom.findDOMNode( this.refs.input );
+		const inputElement = this.inputRef.current;
 
-		if ( this.props.inputMode === 'numeric' ) {
+		if ( inputElement && this.props.inputMode === 'numeric' ) {
 			// This forces mobile browsers to use a numeric keyboard. We have to
 			// toggle the pattern on and off to avoid getting errors against the
 			// masked value (which could contain characters other than digits).
@@ -54,9 +50,14 @@ export default class extends React.Component {
 	}
 
 	focus = () => {
-		const node = ReactDom.findDOMNode( this.refs.input );
-		node.focus();
-		scrollIntoViewport( node );
+		const node = this.inputRef.current;
+		if ( node ) {
+			node.focus();
+			scrollIntoViewport( node, {
+				behavior: 'smooth',
+				scrollMode: 'if-needed',
+			} );
+		}
 	};
 
 	autoFocusInput = () => {
@@ -97,7 +98,7 @@ export default class extends React.Component {
 					id={ this.props.name }
 					value={ this.props.value }
 					name={ this.props.name }
-					ref="input"
+					ref={ this.inputRef }
 					autoFocus={ this.props.autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 					autoComplete={ this.props.autoComplete }
 					disabled={ this.props.disabled }

--- a/client/my-sites/domains/components/form/state-select.jsx
+++ b/client/my-sites/domains/components/form/state-select.jsx
@@ -1,16 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
-import ReactDom from 'react-dom';
 
 /**
  * Internal dependencies
@@ -19,13 +15,15 @@ import FormLabel from 'components/forms/form-label';
 import FormSelect from 'components/forms/form-select';
 import FormInputValidation from 'components/forms/form-input-validation';
 import { getCountryStates } from 'state/country-states/selectors';
-import Input from './input';
 import QueryCountryStates from 'components/data/query-country-states';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import scrollIntoViewport from 'lib/scroll-into-viewport';
+import Input from './input';
 
 class StateSelect extends Component {
 	static instances = 0;
+
+	inputRef = React.createRef();
 
 	componentWillMount() {
 		this.instance = ++this.constructor.instances;
@@ -40,12 +38,13 @@ class StateSelect extends Component {
 	};
 
 	focus() {
-		const node = ReactDom.findDOMNode( this.refs.input );
+		const node = this.inputRef.current;
 		if ( node ) {
 			node.focus();
-			scrollIntoViewport( node );
-		} else {
-			this.refs.state.focus();
+			scrollIntoViewport( node, {
+				behavior: 'smooth',
+				scrollMode: 'if-needed',
+			} );
 		}
 	}
 
@@ -70,7 +69,7 @@ class StateSelect extends Component {
 			<div>
 				{ countryCode && <QueryCountryStates countryCode={ countryCode } /> }
 				{ isEmpty( countryStates ) ? (
-					<Input ref="input" { ...this.props } />
+					<Input ref={ this.inputRef } { ...this.props } />
 				) : (
 					<div className={ classes }>
 						<FormLabel htmlFor={ `${ this.constructor.name }-${ this.instance }` }>
@@ -79,7 +78,7 @@ class StateSelect extends Component {
 						<FormSelect
 							aria-invalid={ isError }
 							aria-describedby={ validationId }
-							ref="input"
+							ref={ this.inputRef }
 							id={ `${ this.constructor.name }-${ this.instance }` }
 							name={ name }
 							value={ value }

--- a/client/my-sites/domains/components/form/state-select.jsx
+++ b/client/my-sites/domains/components/form/state-select.jsx
@@ -23,7 +23,19 @@ import Input from './input';
 class StateSelect extends Component {
 	static instances = 0;
 
-	inputRef = React.createRef();
+	inputRef = element => {
+		this.inputElement = element;
+
+		if ( ! this.props.inputRef ) {
+			return;
+		}
+
+		if ( typeof inputRef === 'function' ) {
+			this.props.inputRef( element );
+		} else {
+			this.props.inputRef.current = element;
+		}
+	};
 
 	componentWillMount() {
 		this.instance = ++this.constructor.instances;
@@ -38,7 +50,7 @@ class StateSelect extends Component {
 	};
 
 	focus() {
-		const node = this.inputRef.current;
+		const node = this.inputElement;
 		if ( node ) {
 			node.focus();
 			scrollIntoViewport( node, {
@@ -60,7 +72,6 @@ class StateSelect extends Component {
 			onBlur,
 			onChange,
 			isError,
-			inputRef,
 			selectText,
 		} = this.props;
 		const validationId = `validation-field-${ this.props.name }`;
@@ -69,7 +80,7 @@ class StateSelect extends Component {
 			<div>
 				{ countryCode && <QueryCountryStates countryCode={ countryCode } /> }
 				{ isEmpty( countryStates ) ? (
-					<Input ref={ this.inputRef } { ...this.props } />
+					<Input inputRef={ this.inputRef } { ...this.props } />
 				) : (
 					<div className={ classes }>
 						<FormLabel htmlFor={ `${ this.constructor.name }-${ this.instance }` }>
@@ -78,7 +89,6 @@ class StateSelect extends Component {
 						<FormSelect
 							aria-invalid={ isError }
 							aria-describedby={ validationId }
-							ref={ this.inputRef }
 							id={ `${ this.constructor.name }-${ this.instance }` }
 							name={ name }
 							value={ value }
@@ -87,7 +97,7 @@ class StateSelect extends Component {
 							onChange={ onChange }
 							onClick={ this.recordStateSelectClick }
 							isError={ isError }
-							inputRef={ inputRef }
+							inputRef={ this.inputRef }
 						>
 							<option key="--" value="" disabled="disabled">
 								{ selectText || this.props.translate( 'Select State' ) }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
 		"diff": "3.5.0",
 		"doctrine": "3.0.0",
 		"dom-helpers": "3.4.0",
-		"dom-scroll-into-view": "1.2.1",
 		"dompurify": "1.0.10",
 		"draft-js": "0.10.5",
 		"email-validator": "2.0.4",


### PR DESCRIPTION
The usage that is made of `dom-scroll-into-view` (a 3rd party `npm` module) in Calypso is all achievable through native methods on the web platform. Making the replacement saves us about 1.6KB (compressed) in the critical path.

This feature should work in older browsers, with some amount of graceful degradation. Namely, elements may always scroll to the top, even if scrolling is not necessary. I believe this is acceptable, as the core functionality remains intact.

#### Changes proposed in this Pull Request

* Rewrite usage of `dom-scroll-into-view` with native `scrollIntoViewIfNeeded ` and `scrollIntoView`.

#### Testing instructions

To test site selector:

* Click "Switch sites" to open the site selector
* Shrink your browser window vertically so that not all elements fit and scrolling is needed
* Scroll through elements with up and down arrow keys on your keyboard, and ensure that the list scrolling behaviour is correct, with items popping into view as you scroll.


To test token field:

* Go to "Manage" -> "Domains"
* Click "Add Domain"
* Start typing in the text field
* Once a list of results comes up, click "More extensions"
* Click the text field (it has the placeholder text "Select an extension") to focus it
* Scroll through elements with up and down arrow keys on your keyboard, and ensure that the list scrolling behaviour is correct, with items popping into view as you scroll.
