### PR TITLE
Make the precancellation chat button available consistently.

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -545,6 +545,7 @@ class CancelPurchaseForm extends React.Component {
 
 	getStepButtons = () => {
 		const { flowType, translate, disableButtons, purchase } = this.props;
+		const { surveyStep } = this.state;
 		const disabled = disableButtons || this.state.isSubmitting;
 
 		const close = {
@@ -555,7 +556,13 @@ class CancelPurchaseForm extends React.Component {
 						? translate( 'Skip' )
 						: translate( "I'll Keep It" ),
 			},
-			chat = <PrecancellationChatButton purchase={ purchase } onClick={ this.closeDialog } />,
+			chat = (
+				<PrecancellationChatButton
+					purchase={ purchase }
+					onClick={ this.closeDialog }
+					surveyStep={ surveyStep }
+				/>
+			),
 			next = {
 				action: 'next',
 				disabled: disabled || ! isSurveyFilledIn( this.state ),
@@ -591,12 +598,11 @@ class CancelPurchaseForm extends React.Component {
 			};
 
 		const firstButtons =
-			config.isEnabled( 'upgrades/precancellation-chat' ) &&
-			this.state.surveyStep !== 'happychat_step'
+			config.isEnabled( 'upgrades/precancellation-chat' ) && surveyStep !== 'happychat_step'
 				? [ chat, close ]
 				: [ close ];
 
-		if ( this.state.surveyStep === steps.FINAL_STEP ) {
+		if ( surveyStep === steps.FINAL_STEP ) {
 			const stepsCount = this.getAllSurveySteps().length;
 			const prevButton = stepsCount > 1 ? [ prev ] : [];
 

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -13,6 +13,7 @@ import { localize, moment } from 'i18n-calypso';
 /**
  * Internal Dependencies
  */
+import config from 'config';
 import { submitSurvey } from 'lib/upgrades/actions';
 import Dialog from 'components/dialog';
 import FormFieldset from 'components/forms/form-fieldset';
@@ -31,6 +32,7 @@ import * as steps from './steps';
 import initialSurveyState from './initial-survey-state';
 import BusinessATStep from './step-components/business-at-step';
 import UpgradeATStep from './step-components/upgrade-at-step';
+import PrecancellationChatButton from './precancellation-chat-button';
 import { getName } from 'lib/purchases';
 import { isGoogleApps } from 'lib/products-values';
 import { radioOption } from './radio-option';
@@ -62,7 +64,6 @@ class CancelPurchaseForm extends React.Component {
 		onClickFinalConfirm: PropTypes.func.isRequired,
 		flowType: PropTypes.string.isRequired,
 		showSurvey: PropTypes.bool.isRequired,
-		extraPrependedButtons: PropTypes.array,
 		translate: PropTypes.func,
 	};
 
@@ -71,7 +72,6 @@ class CancelPurchaseForm extends React.Component {
 		onInputChange: () => {},
 		showSurvey: true,
 		isVisible: false,
-		extraPrependedButtons: [],
 	};
 
 	getAllSurveySteps = () => {
@@ -544,7 +544,7 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	getStepButtons = () => {
-		const { flowType, translate, disableButtons } = this.props;
+		const { flowType, translate, disableButtons, purchase } = this.props;
 		const disabled = disableButtons || this.state.isSubmitting;
 
 		const close = {
@@ -555,6 +555,7 @@ class CancelPurchaseForm extends React.Component {
 						? translate( 'Skip' )
 						: translate( "I'll Keep It" ),
 			},
+			chat = <PrecancellationChatButton purchase={ purchase } onClick={ this.closeDialog } />,
 			next = {
 				action: 'next',
 				disabled: disabled || ! isSurveyFilledIn( this.state ),
@@ -589,7 +590,11 @@ class CancelPurchaseForm extends React.Component {
 				isPrimary: true,
 			};
 
-		const firstButtons = [ ...this.props.extraPrependedButtons, close ];
+		const firstButtons =
+			config.isEnabled( 'upgrades/precancellation-chat' ) &&
+			this.state.surveyStep !== 'happychat_step'
+				? [ chat, close ]
+				: [ close ];
 
 		if ( this.state.surveyStep === steps.FINAL_STEP ) {
 			const stepsCount = this.getAllSurveySteps().length;

--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/index.jsx
@@ -1,0 +1,64 @@
+/** @format */
+/**
+ * External Dependencies
+ */
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal Dependencies
+ */
+import HappychatButton from 'components/happychat/button';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { hasIncludedDomain } from 'lib/purchases';
+import { isDomainRegistration, isPlan } from 'lib/products-values';
+import './style.scss';
+
+class PrecancellationChatButton extends Component {
+	static propTypes = {
+		purchase: PropTypes.object.isRequired,
+		surveyStep: PropTypes.string,
+		onClick: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		surveyStep: '',
+	};
+
+	handleClick = () => {
+		const { purchase, surveyStep, onClick } = this.props;
+
+		this.props.recordTracksEvent( 'calypso_precancellation_chat_click', {
+			survey_step: surveyStep,
+			purchase: purchase.productSlug,
+			is_plan: isPlan( purchase ),
+			is_domain_registration: isDomainRegistration( purchase ),
+			has_included_domain: hasIncludedDomain( purchase ),
+		} );
+
+		onClick();
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<HappychatButton
+				className="precancellation-chat-button__main-button"
+				onClick={ this.handleClick }
+			>
+				{ translate( 'Need help? Chat with us' ) }
+			</HappychatButton>
+		);
+	}
+}
+
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+	}
+)( localize( PrecancellationChatButton ) );

--- a/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/style.scss
+++ b/client/components/marketing-survey/cancel-purchase-form/precancellation-chat-button/style.scss
@@ -1,0 +1,7 @@
+.precancellation-chat-button__main-button {
+	display: block;
+
+	@include breakpoint( '>480px' ) {
+		float: left;
+	}
+}

--- a/client/me/purchases/remove-purchase/index.jsx
+++ b/client/me/purchases/remove-purchase/index.jsx
@@ -17,6 +17,7 @@ import config from 'config';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
+import PrecancellationChatButton from 'components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import { CANCEL_FLOW_TYPE } from 'components/marketing-survey/cancel-purchase-form/constants';
 import GSuiteCancellationPurchaseDialog from 'components/marketing-survey/gsuite-cancel-purchase-dialog';
 import { getIncludedDomain, getName, hasIncludedDomain, isRemovable } from 'lib/purchases';
@@ -33,7 +34,6 @@ import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer'
 import { receiveDeletedSite } from 'state/sites/actions';
 import { setAllSitesSelected } from 'state/ui/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
-import HappychatButton from 'components/happychat/button';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import RemoveDomainDialog from './remove-domain-dialog';
 
@@ -60,17 +60,6 @@ class RemovePurchase extends Component {
 		survey: {},
 	};
 
-	recordChatEvent( eventAction ) {
-		const { purchase } = this.props;
-		this.props.recordTracksEvent( eventAction, {
-			survey_step: this.state.surveyStep,
-			purchase: purchase.productSlug,
-			is_plan: isPlan( purchase ),
-			is_domain_registration: isDomainRegistration( purchase ),
-			has_included_domain: hasIncludedDomain( purchase ),
-		} );
-	}
-
 	closeDialog = () => {
 		this.setState( {
 			isDialogVisible: false,
@@ -83,10 +72,7 @@ class RemovePurchase extends Component {
 		this.setState( { isDialogVisible: true } );
 	};
 
-	onClickChatButton = event => {
-		this.recordChatEvent( 'calypso_precancellation_chat_click' );
-		event.preventDefault();
-
+	onClickChatButton = () => {
 		this.setState( { isDialogVisible: false } );
 	};
 
@@ -139,13 +125,12 @@ class RemovePurchase extends Component {
 		} );
 	};
 
-	getChatButton = () => {
-		return (
-			<HappychatButton className="remove-purchase__chat-button" onClick={ this.onClickChatButton }>
-				{ this.props.translate( 'Need help? Chat with us' ) }
-			</HappychatButton>
-		);
-	};
+	getChatButton = () => (
+		<PrecancellationChatButton
+			onClick={ this.onClickChatButton }
+			purchase={ this.props.purchase }
+		/>
+	);
 
 	getContactUsButton = () => {
 		return (
@@ -179,11 +164,6 @@ class RemovePurchase extends Component {
 
 	renderPlanDialog() {
 		const { purchase, site } = this.props;
-		const prependedChatButton =
-			config.isEnabled( 'upgrades/precancellation-chat' ) &&
-			this.state.surveyStep !== 'happychat_step'
-				? [ this.getChatButton() ]
-				: [];
 
 		return (
 			<CancelPurchaseForm
@@ -195,7 +175,6 @@ class RemovePurchase extends Component {
 				isVisible={ this.state.isDialogVisible }
 				onClose={ this.closeDialog }
 				onClickFinalConfirm={ this.removePurchase }
-				extraPrependedButtons={ prependedChatButton }
 				flowType={ CANCEL_FLOW_TYPE.REMOVE }
 			/>
 		);

--- a/client/me/purchases/remove-purchase/style.scss
+++ b/client/me/purchases/remove-purchase/style.scss
@@ -15,11 +15,3 @@
 		vertical-align: middle;
 	}
 }
-
-.remove-purchase__chat-button {
-	display: block;
-
-	@include breakpoint( '>480px' ) {
-		float: left;
-	}
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to resolve https://github.com/Automattic/wp-calypso/issues/34673 by making the "Need Help? Chat with us" button available on the survey shown for toggling the auto-renewal off:

![image](https://user-images.githubusercontent.com/1842898/61957763-9350c000-aff2-11e9-883e-636cf2b91210.png)

In general, it consists of:

1. Extract the button as a new individual component, `<PrecancellationChatButton>`
1. Reuse the component across `<RemovePurchase>` and `<CancelPurchaseForm>`
1. Remove `extraPrependedButtons` from `<CancelPurchaseForm>`, and make `<PrecancellationChatButton>` one of the available buttons.

One extra effect of doing this is that the button will now available for:

* The removal flow(when a purchase is not refundable and the auto-renewal is off)
* The cancellation flow(when a purchase is or isn't refundable and the auto-renewal is on)
* Toggling off the auto-renewal

Currently the button is only available for the removal flow. If we make this available for toggling off the auto-renewal, I think it makes sense to roll it out for all.

cc @andrewspittle 

#### Testing instructions

To make the button appear, the `isChatAvailable()` and `isPrecancellationChatAvailable()` selector must return `true`. There are two ways to make it happen:

1. Log in to the staging Happychat server and make yourself available there.
1. Manually update the two selectors so they always return true.

I personally prefer the 2nd method. After that, 

1. Turn off the auto-renewal toggle and the chat button should appear in the survey.
1. Go through the cancellation flow by clicking on "Cancel Subscription" button. The chat button should appear in the survey. Note that you need to turn on the auto-renewal to see this button.
1. Go through the removal flow by clicking on "Remove Subscription" button. The chat button should appear in the survey. Note that you need to turn off the auto-renewal on a subscription out of the refund window to see it.
1. In each step, click on the chat button to see if the dialog is dismissed and the chat window appears.