### PR TITLE
Recurring Payments Text: Pass Colour Contrast Check

### DIFF
--- a/client/components/action-panel/style.scss
+++ b/client/components/action-panel/style.scss
@@ -19,7 +19,7 @@
 .action-panel__body {
 	font-size: 14px;
 	line-height: 20px;
-	color: var( --color-neutral-400 );
+	color: var( --color-text-subtle );
 	overflow: hidden;
 
 	p {

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -1,4 +1,3 @@
-
 .memberships__module-header {
 	background: var( --color-white );
 	height: 40px;
@@ -6,7 +5,6 @@
 	padding-left: 24px;
 	position: relative;
 }
-
 
 .memberships__module-header-title {
 	@extend %mobile-interface-element;
@@ -31,7 +29,7 @@
 	padding-right: 10px;
 }
 .memberships__onboarding-column-image {
-	display:none;
+	display: none;
 	@include breakpoint( '>800px' ) {
 		display: block;
 		flex: 1;
@@ -40,7 +38,6 @@
 	}
 }
 
-
 .memberships__onboarding-header {
 	font-size: 24px;
 	margin-bottom: 24px;
@@ -48,10 +45,10 @@
 .memberships__onboarding-paragraph {
 	font-size: 15px;
 	margin-bottom: 24px;
-	color: var( --color-neutral-400 );
+	color: var( --color-text-subtle );
 }
 .memberships__onboarding-benefits {
-	color: var( --color-neutral-400 );
+	color: var( --color-text-subtle );
 	margin-top: 24px;
 }
 .memberships__onboarding-benefits > div {
@@ -64,7 +61,6 @@
 .memberships__earnings-breakdown-list {
 	margin: 0;
 }
-
 
 .memberships__earnings-breakdown-label {
 	color: var( --color-neutral-600 );
@@ -92,7 +88,6 @@
 		padding: 10px 24px;
 		text-align: left;
 	}
-
 }
 
 .memberships__earnings-breakdown-label {
@@ -107,7 +102,6 @@
 		line-height: 1.6;
 	}
 }
-
 
 .memberships__earnings-breakdown-value {
 	width: 100%;
@@ -191,7 +185,6 @@
 	}
 }
 
-
 .memberships__subscriber-subscribed {
 	color: var( --color-text-subtle );
 	font-size: 12px;
@@ -201,7 +194,6 @@
 .memberships__module-footer {
 	margin-top: 20px;
 }
-
 
 .memberships__module-products-title {
 	margin-bottom: 10px;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

You can see this at `/earn/payments/site`

<img width="822" alt="Screenshot 2019-07-26 at 17 16 42" src="https://user-images.githubusercontent.com/43215253/61966048-98e5e000-afc9-11e9-800d-2e40a5bca472.png">

The current ratio is 3.51:1, which fails the colour ratio check as it should be over 4.5:1. --neutral-500 works for this purpose (on the Ocean scheme at least), but I think that --text-subtle is the better variable to use here as it's intended for these purposes.

**Old ratio:** 3.51:1
**New ratio:** 6.79:1
