### PR TITLE
Docs: Move `isFocusOnShow` prop to correct section

### DIFF
--- a/client/components/popover/README.md
+++ b/client/components/popover/README.md
@@ -54,6 +54,10 @@ cases this is not needed but if you want to also have a label
 that can trigger the opening and closing of the Popover then you need to pass
 in the label component as a reference.
 
+#### `isFocusOnShow { bool } - default: false`
+
+Focuses the Popover when it shows. Useful for controlling/improving keyboard navigation.
+
 #### `isVisible { bool } default - false`
 
 By controlling the popover's visibility through the `isVisible` property, the
@@ -132,10 +136,6 @@ rendered as a button.
 #### `className { string } - optional`
 
 Sets a custom className on the button or link.
-
-#### `isFocusOnShow { bool } - default: false`
-
-Focuses the Popover when it shows. Useful for controlling/improving keyboard navigation.
 
 #### `isSelected { bool } - default: false`
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Moves the description for the new `isFocusOnShow` prop added in #32849 to be under the correct heading (main `Popover`), instead of under `PopoverMenuItem`.

@ItsJonQ I stumbled upon this because I was precisely looking for something like this prop. Thanks for adding it! 🙌 