### PR TITLE
Earn: hide store card if site is Jetpack

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -4,7 +4,7 @@
 import { connect } from 'react-redux';
 import React, { FunctionComponent } from 'react';
 import page from 'page';
-import { get } from 'lodash';
+import { get, compact } from 'lodash';
 
 /**
  * Internal dependencies
@@ -14,6 +14,7 @@ import { SiteSlug } from 'types';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
 import getSiteBySlug from 'state/sites/selectors/get-site-by-slug';
 import { hasFeature, getCurrentPlan } from 'state/sites/plans/selectors';
+import { isJetpackSite } from 'state/sites/selectors';
 import PromoSection, { Props as PromoSectionProps } from 'components/promo-section';
 import {
 	FEATURE_WORDADS_INSTANT,
@@ -24,11 +25,13 @@ import {
 
 interface ConnectedProps {
 	selectedSiteSlug: SiteSlug;
+	isAJetpackSite: boolean;
 	currentPlan: string;
 }
 
 const Home: FunctionComponent< ConnectedProps > = ( {
 	selectedSiteSlug,
+	isAJetpackSite,
 	currentPlan,
 	hasSimplePayments,
 	hasWordAds,
@@ -112,6 +115,10 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	 * @returns {object} Object with props to render a PromoCard.
 	 */
 	const getStoreCard = () => {
+		if ( isAJetpackSite ) {
+			return null;
+		}
+
 		const cta = hasUploadPlugins
 			? {
 					text: translate( 'Set Up a Simple Store' ),
@@ -180,7 +187,12 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			},
 			body: translate( 'There is a range of ways to earn money through your WordPress.com Site.' ),
 		},
-		promos: [ getSimplePaymentsCard(), getRecurringPaymentsCard(), getStoreCard(), getAdsCard() ],
+		promos: compact( [
+			getSimplePaymentsCard(),
+			getRecurringPaymentsCard(),
+			getStoreCard(),
+			getAdsCard(),
+		] ),
 	};
 
 	return <PromoSection { ...promos } />;
@@ -196,5 +208,6 @@ export default connect< ConnectedProps, {}, {} >( state => {
 		hasWordAds: hasFeature( state, site.ID, FEATURE_WORDADS_INSTANT ),
 		hasUploadPlugins: hasFeature( state, site.ID, FEATURE_UPLOAD_PLUGINS ),
 		hasSimplePayments: hasFeature( state, site.ID, FEATURE_SIMPLE_PAYMENTS ),
+		isAJetpackSite: isJetpackSite( state, site.ID ),
 	};
 } )( Home );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* hide the Store card for Jetpack sites

### Before 

<img width="743" alt="Captura de Pantalla 2019-07-26 a la(s) 15 16 29" src="https://user-images.githubusercontent.com/1041600/61972671-81522b80-afb8-11e9-8293-f6529f2c0f93.png">


### After

<img width="746" alt="Captura de Pantalla 2019-07-26 a la(s) 15 16 39" src="https://user-images.githubusercontent.com/1041600/61972678-88793980-afb8-11e9-92f2-a1113a852cf8.png">


#### Testing instructions

* test with a Jetpack site and ensure the card is not shown
