### PR TITLE
Login: Update login screens with new TOS copy

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -552,7 +552,7 @@ export class LoginForm extends Component {
 							{ preventWidows(
 								this.props.translate(
 									// To make any changes to this copy please speak to the legal team
-									'By continuing with any of the options below, ' +
+									'By creating an account, ' +
 										'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
 									{
 										components: {
@@ -612,7 +612,7 @@ export class LoginForm extends Component {
 					<p className="login__form-terms login__form-terms-bottom">
 						{ preventWidows(
 							this.props.translate(
-								'By continuing with any of the options above, ' +
+								'By creating an account, ' +
 									'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
 								{
 									components: {

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -373,7 +373,7 @@ export class LoginForm extends Component {
 							{ preventWidows(
 								this.props.translate(
 									// To make any changes to this copy please speak to the legal team
-									'By continuing with any of the options below, ' +
+									'By creating an account, ' +
 										'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
 									{
 										components: {

--- a/client/blocks/signup-form/crowdsignal.jsx
+++ b/client/blocks/signup-form/crowdsignal.jsx
@@ -140,17 +140,11 @@ class CrowdsignalSignupForm extends Component {
 
 				<div className="signup-form__crowdsignal-tos">
 					<span>
-						{ translate(
-							'By creating an account via any of the options above,{{br/}}you agree to our {{a}}Terms of Service{{/a}}.',
-							{
-								components: {
-									a: (
-										<a href="https://wordpress.com/tos" target="_blank" rel="noopener noreferrer" />
-									),
-									br: <br />,
-								},
-							}
-						) }
+						{ translate( 'By creating an account, you agree to our {{a}}Terms of Service{{/a}}.', {
+							components: {
+								a: <a href="https://wordpress.com/tos" target="_blank" rel="noopener noreferrer" />,
+							},
+						} ) }
 					</span>
 				</div>
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates TOS copy on Crowdsignal and WP.com login screens to reflect the same copy as signup applied in #33819

**Before**

<img width="568" alt="Screen Shot 2019-07-26 at 4 26 14 PM" src="https://user-images.githubusercontent.com/2124984/61979529-1c9bce80-afc2-11e9-8728-8001cb182bde.png">

**After**
<img width="584" alt="Screen Shot 2019-07-26 at 4 18 46 PM" src="https://user-images.githubusercontent.com/2124984/61979167-1eb15d80-afc1-11e9-9124-338d3f766d14.png">

#### Testing instructions

* Switch to this PR and view `/log-in` when logged out of WP.com; you should see the new copy ("By creating an account...") below the login form.
* Visit [this URL](https://hash-af88d92b05f9cc341ef8163a6910767f7a843e52.calypso.live/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D6189c57e7683dcc63fdbd510e71e8e6e42536a323dca2f7ceac48d6dfecc2f6e%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1) when logged out of WP.com and Crowdsignal; verify any copy changes are there. (It appears you can't test Crowdsignal's login form locally, so calypso.live is required)

Fixes #34847