### PR TITLE
WordAds: Tab in Stats for Non-Admin (Take 2)

### DIFF
--- a/client/blocks/stats-navigation/index.js
+++ b/client/blocks/stats-navigation/index.js
@@ -16,6 +16,7 @@ import FollowersCount from 'blocks/followers-count';
 import isGoogleMyBusinessLocationConnectedSelector from 'state/selectors/is-google-my-business-location-connected';
 import isSiteStore from 'state/selectors/is-site-store';
 import { getSiteOption } from 'state/sites/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import { navItems, intervals as intervalConstants } from './constants';
 import config from 'config';
 
@@ -103,7 +104,7 @@ export default connect( ( state, { siteId } ) => {
 			siteId
 		),
 		isStore: isSiteStore( state, siteId ),
-		isWordAds: getSiteOption( state, siteId, 'wordads' ),
+		isWordAds: getSiteOption( state, siteId, 'wordads' ) && canCurrentUser( state, siteId, 'manage_options' ),
 		siteId,
 	};
 } )( StatsNavigation );


### PR DESCRIPTION
@sixhours sorry, I turned #34643 into a bit of a disaster 😅 I still need to figure out rebasing but I think this should do? 

**See #34643 for details and testing instructions**

> What about something like "WordAds are not enabled on your site"?

That sounds good to me, except I think that WordAds usually isn't referred to in the plural sense, so I updated it to "WordAds is". 

<img width="1155" alt="Screenshot 2019-07-26 at 20 32 23" src="https://user-images.githubusercontent.com/43215253/61976747-7d3c0300-afe4-11e9-8405-2e140646bf75.png">

> I like "Explore WordAds", but I don't think we usually use exclamation points or other punctuation on action buttons. 

Removed the exclamation mark 👍 

> Would you mind rebasing the current branch against master to make sure there haven't been other changes before I deploy this?

Me never actually ended up figuring out how to do this. :) I'll take a look at a few guides now, though neither of these files have been touched so I think it should be safe.

Sorry again about messing up the PRs!