### PR TITLE
Rewind Alerts: Updates to site alerts UI for DB results

### DIFF
--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -184,6 +184,10 @@ export class ThreatAlert extends Component {
 		} = this.props;
 		const infectedPosts = [];
 
+		if ( ! rows ) {
+			return [];
+		}
+
 		function findObjectIndexInArray( array, attr, value ) {
 			for ( let i = 0; i < array.length; i++ ) {
 				if ( array[ i ][ attr ] === value ) {
@@ -220,10 +224,10 @@ export class ThreatAlert extends Component {
 	renderCardContent() {
 		const { threat, translate } = this.props;
 
+		const infectedPosts = this.getGroupedThreatRows();
+
 		switch ( this.getDetailType( threat ) ) {
 			case 'database':
-				const infectedPosts = this.getGroupedThreatRows();
-
 				return (
 					<Fragment>
 						{ infectedPosts.map( ( infectedPost, postKey ) => (
@@ -254,10 +258,10 @@ export class ThreatAlert extends Component {
 													'This link is included in post ID %(postId)d and %(revCount)d associated revision.',
 													'This link is included in post ID %(postId)d and %(revCount)d associated revisions.',
 													{
-														count: infectedPost.links.length,
+														count: infectedPost.links.length - 1,
 														args: {
 															postId: infectedPost.minId,
-															revCount: infectedPost.links.length,
+															revCount: infectedPost.links.length - 1,
 														},
 													}
 												) }

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -12,118 +12,24 @@ import Interval, { EVERY_TEN_SECONDS } from 'lib/interval';
  * Internal dependencies
  */
 import ActivityIcon from '../activity-log-item/activity-icon';
+import Button from 'components/button';
+import Card from 'components/card';
 import DiffViewer from 'components/diff-viewer';
 import FoldableCard from 'components/foldable-card';
 import { JETPACK_CONTACT_SUPPORT } from 'lib/url/support';
+import InfoPopover from 'components/info-popover';
 import MarkedLines from 'components/marked-lines';
 import TimeSince from 'components/time-since';
 import PopoverMenuItem from 'components/popover/menu-item';
 import SplitButton from 'components/split-button';
 import { fixThreatAlert, ignoreThreatAlert } from 'state/jetpack/site-alerts/actions';
 import { requestRewindState } from 'state/rewind/actions';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 /**
  * Style dependencies
  */
 import './threat-alert.scss';
-
-const detailType = threat => {
-	if ( threat.hasOwnProperty( 'diff' ) ) {
-		return 'core';
-	}
-
-	if ( threat.hasOwnProperty( 'context' ) ) {
-		return 'file';
-	}
-
-	if ( threat.hasOwnProperty( 'extension' ) ) {
-		// 'plugin' or 'theme'
-		return threat.extension.type;
-	}
-
-	return 'none';
-};
-
-const headerTitle = ( translate, threat ) => {
-	const { extension, filename } = threat;
-	const basename = s => s.replace( /.*\//, '' );
-
-	switch ( detailType( threat ) ) {
-		case 'core':
-			return translate( 'The file {{filename/}} has been modified from its original.', {
-				components: {
-					filename: (
-						<code className="activity-log__threat-alert-filename">{ basename( filename ) }</code>
-					),
-				},
-			} );
-
-		case 'file':
-			return translate( 'The file {{filename/}} contains a malicious code pattern.', {
-				components: {
-					filename: (
-						<code className="activity-log__threat-alert-filename">{ basename( filename ) }</code>
-					),
-				},
-			} );
-
-		case 'plugin':
-			return translate(
-				'The plugin {{pluginSlug/}} (version {{version/}}) has a publicly known vulnerability.',
-				{
-					components: {
-						pluginSlug: <span className="activity-log__threat-alert-slug">{ extension.slug }</span>,
-						version: (
-							<span className="activity-log__threat-alert-version">{ extension.version }</span>
-						),
-					},
-				}
-			);
-
-		case 'theme':
-			return translate(
-				'The theme {{themeSlug/}} (version {{version/}}) has a publicly known vulnerability.',
-				{
-					components: {
-						themeSlug: <span className="activity-log__threat-alert-slug">{ extension.slug }</span>,
-						version: (
-							<span className="activity-log__threat-alert-version">{ extension.version }</span>
-						),
-					},
-				}
-			);
-
-		case 'none':
-		default:
-			return translate( 'Threat found' );
-	}
-};
-
-const headerSubtitle = ( translate, threat ) => {
-	switch ( detailType( threat ) ) {
-		case 'core':
-			return translate( 'Vulnerability found in WordPress' );
-
-		case 'file':
-			return translate( 'Threat found ({{signature/}})', {
-				components: {
-					signature: (
-						<span className="activity-log__threat-alert-signature">{ threat.signature }</span>
-					),
-				},
-			} );
-
-		case 'plugin':
-			return translate( 'Vulnerability found in plugin' );
-
-		case 'theme':
-			return translate( 'Vulnerability found in theme' );
-
-		case 'none':
-		default:
-			return translate( 'Miscellaneous vulnerability' );
-	}
-};
 
 export class ThreatAlert extends Component {
 	state = { requesting: false };
@@ -138,9 +44,228 @@ export class ThreatAlert extends Component {
 		this.props.ignoreThreatAlert( this.props.siteId, this.props.threat.id );
 	};
 
-	refreshRewindState = () => {
-		this.props.requestRewindState( this.props.siteId );
-	};
+	refreshRewindState = () => this.props.requestRewindState( this.props.siteId );
+
+	getDetailType() {
+		const { threat } = this.props;
+
+		if ( threat.hasOwnProperty( 'diff' ) ) {
+			return 'core';
+		}
+
+		if ( threat.hasOwnProperty( 'context' ) ) {
+			return 'file';
+		}
+
+		if ( threat.hasOwnProperty( 'extension' ) ) {
+			// 'plugin' or 'theme'
+			return threat.extension.type;
+		}
+
+		if ( 'Suspicious.Links' === threat.signature ) {
+			return 'database';
+		}
+
+		return 'none';
+	}
+
+	renderTitle() {
+		const {
+			threat,
+			threat: { extension, filename },
+			translate,
+		} = this.props;
+
+		const basename = s => s.replace( /.*\//, '' );
+
+		switch ( this.getDetailType( threat ) ) {
+			case 'core':
+				return translate( 'The file {{filename/}} has been modified from its original.', {
+					components: {
+						filename: (
+							<code className="activity-log__threat-alert-filename">{ basename( filename ) }</code>
+						),
+					},
+				} );
+
+			case 'file':
+				return translate( 'The file {{filename/}} contains a malicious code pattern.', {
+					components: {
+						filename: (
+							<code className="activity-log__threat-alert-filename">{ basename( filename ) }</code>
+						),
+					},
+				} );
+
+			case 'plugin':
+				return translate(
+					'The plugin {{pluginSlug/}} (version {{version/}}) has a publicly known vulnerability.',
+					{
+						components: {
+							pluginSlug: (
+								<span className="activity-log__threat-alert-slug">{ extension.slug }</span>
+							),
+							version: (
+								<span className="activity-log__threat-alert-version">{ extension.version }</span>
+							),
+						},
+					}
+				);
+
+			case 'theme':
+				return translate(
+					'The theme {{themeSlug/}} (version {{version/}}) has a publicly known vulnerability.',
+					{
+						components: {
+							themeSlug: (
+								<span className="activity-log__threat-alert-slug">{ extension.slug }</span>
+							),
+							version: (
+								<span className="activity-log__threat-alert-version">{ extension.version }</span>
+							),
+						},
+					}
+				);
+
+			case 'database':
+				return translate(
+					'Jetpack identified %(threatCount)d threat in your database.',
+					'Jetpack identified %(threatCount)d threats in your database.',
+					{
+						count: Object.keys( threat.rows ).length,
+						args: {
+							threatCount: Object.keys( threat.rows ).length,
+						},
+					}
+				);
+
+			case 'none':
+			default:
+				return translate( 'Threat found' );
+		}
+	}
+
+	renderSubtitle() {
+		const { threat, translate } = this.props;
+
+		switch ( this.getDetailType( threat ) ) {
+			case 'core':
+				return translate( 'Vulnerability found in WordPress' );
+
+			case 'file':
+				return translate( 'Threat found ({{signature/}})', {
+					components: {
+						signature: (
+							<span className="activity-log__threat-alert-signature">{ threat.signature }</span>
+						),
+					},
+				} );
+
+			case 'plugin':
+				return translate( 'Vulnerability found in plugin' );
+
+			case 'theme':
+				return translate( 'Vulnerability found in theme' );
+
+			case 'database':
+				return null;
+
+			case 'none':
+			default:
+				return translate( 'Miscellaneous vulnerability' );
+		}
+	}
+
+	formatGroupedPosts() {
+		const {
+			threat: { rows },
+		} = this.props;
+
+		Object.keys( rows ).map( idx => {
+			const row = rows[ idx ];
+
+			if ( ! indexedRows[ row.description ] ) {
+				indexedRows[ row.description ] = [];
+			}
+
+			indexedRows[ row.description ].push( row.url );
+		} );
+
+		return indexedRows;
+	}
+
+	renderCardContent() {
+		const { threat, translate } = this.props;
+
+		switch ( this.getDetailType( threat ) ) {
+			case 'database':
+				const rows = this.formatGroupedPosts();
+
+				return (
+					<Fragment>
+						{ Object.keys( rows ).map( ( title, rowKey ) => (
+							<Card key={ rowKey }>
+								<ActivityIcon activityIcon="posts" activityStatus="error" />
+								<div>
+									<strong>{ title }</strong>
+								</div>
+								<div>
+									<em>
+										{ this.props.translate(
+											'%(urlCount)d suspicious link on post',
+											'%(urlCount)d suspicious links on post',
+											{
+												count: Object.keys( rows[ title ] ).length,
+												args: {
+													urlCount: Object.keys( rows[ title ] ).length,
+												},
+											}
+										) }
+									</em>
+									<InfoPopover position="left">
+										{ translate( 'Suspicious links flagged by Jetpack Security Scanner' ) }
+									</InfoPopover>
+								</div>
+								<ol>
+									{ Object.keys( rows[ title ] ).map( ( url, urlIndex ) => (
+										<li key={ urlIndex }>{ rows[ title ][ url ] }</li>
+									) ) }
+								</ol>
+								<Button compact>{ translate( 'Edit post' ) }</Button>
+							</Card>
+						) ) }
+					</Fragment>
+				);
+			default:
+				return (
+					<Fragment>
+						<p className="activity-log__threat-alert-description">{ threat.description }</p>
+						{ threat.filename ? (
+							<Fragment>
+								<p>
+									{ translate( 'Threat {{threatSignature/}} found in file:', {
+										comment:
+											'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
+										components: {
+											threatSignature: (
+												<span className="activity-log__threat-alert-signature">
+													{ threat.signature }
+												</span>
+											),
+										},
+									} ) }
+								</p>
+								<pre className="activity-log__threat-alert-filename">{ threat.filename }</pre>
+							</Fragment>
+						) : (
+							<p className="activity-log__threat-alert-signature">{ threat.signature }</p>
+						) }
+						{ threat.context && <MarkedLines context={ threat.context } /> }
+						{ threat.diff && <DiffViewer diff={ threat.diff } /> }
+					</Fragment>
+				);
+		}
+	}
 
 	render() {
 		const { threat, translate } = this.props;
@@ -156,11 +281,13 @@ export class ThreatAlert extends Component {
 					actionButton={ <span /> }
 					header={
 						<Fragment>
-							<ActivityIcon activityIcon="notice-outline" activityStatus="error" />
+							{ 'database' !== this.getDetailType() ? (
+								<ActivityIcon activityIcon="notice-outline" activityStatus="error" />
+							) : null }
 							<div className="activity-log__threat-alert-header">
 								<div className="activity-log__threat-header-top">
 									<span className="activity-log__threat-alert-title">
-										{ headerTitle( translate, threat ) }
+										{ this.renderTitle() }
 										<TimeSince
 											className="activity-log__threat-alert-time-since"
 											date={ threat.firstDetected }
@@ -199,45 +326,27 @@ export class ThreatAlert extends Component {
 										) }
 									</SplitButton>
 								</div>
-								<span className="activity-log__threat-alert-type">
-									{ headerSubtitle( translate, threat ) }
-								</span>
+								<span className="activity-log__threat-alert-type">{ this.renderSubtitle() }</span>
 							</div>
 						</Fragment>
 					}
 				>
-					<Fragment>
-						<p className="activity-log__threat-alert-description">{ threat.description }</p>
-						{ threat.filename ? (
-							<Fragment>
-								<p>
-									{ translate( 'Threat {{threatSignature/}} found in file:', {
-										comment:
-											'filename follows in separate line; e.g. "PHP.Injection.5 in: `post.php`"',
-										components: {
-											threatSignature: (
-												<span className="activity-log__threat-alert-signature">
-													{ threat.signature }
-												</span>
-											),
-										},
-									} ) }
-								</p>
-								<pre className="activity-log__threat-alert-filename">{ threat.filename }</pre>
-							</Fragment>
-						) : (
-							<p className="activity-log__threat-alert-signature">{ threat.signature }</p>
-						) }
-						{ threat.context && <MarkedLines context={ threat.context } /> }
-						{ threat.diff && <DiffViewer diff={ threat.diff } /> }
-					</Fragment>
+					{ this.renderCardContent() }
 				</FoldableCard>
 			</Fragment>
 		);
 	}
 }
 
+const mapStateToProps = state => ( {
+	siteSlug: getSelectedSiteSlug( state ),
+} );
+
 export default connect(
-	null,
-	{ fixThreatAlert, ignoreThreatAlert, requestRewindState }
+	mapStateToProps,
+	{
+		fixThreatAlert,
+		ignoreThreatAlert,
+		requestRewindState,
+	}
 )( localize( ThreatAlert ) );

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -129,7 +129,7 @@ export class ThreatAlert extends Component {
 
 			case 'database':
 				return translate(
-					'Jetpack identified %(threatCount)d threat in your database.',
+					'Jetpack identified $(threatCount)d threat in your database.',
 					'Jetpack identified %(threatCount)d threats in your database.',
 					{
 						count: Object.keys( threat.rows ).length,
@@ -181,6 +181,8 @@ export class ThreatAlert extends Component {
 			threat: { rows },
 		} = this.props;
 
+		let indexedRows = {};
+
 		Object.keys( rows ).map( idx => {
 			const row = rows[ idx ];
 
@@ -192,6 +194,25 @@ export class ThreatAlert extends Component {
 		} );
 
 		return indexedRows;
+	}
+
+	getEditUrl( title ) {
+		const {
+			siteSlug,
+			threat: { rows },
+		} = this.props;
+
+		const postId = 0;
+
+		Object.keys( rows ).map( idx => {
+			console.log( rows[ idx ].description, title );
+			if ( rows[ idx ].description == title ) {
+				console.log( 'match!' );
+				return `/post/${ siteSlug }/${ rows[ idx ].id }`;
+			}
+		} );
+
+		return null;
 	}
 
 	renderCardContent() {
@@ -231,7 +252,9 @@ export class ThreatAlert extends Component {
 										<li key={ urlIndex }>{ rows[ title ][ url ] }</li>
 									) ) }
 								</ol>
-								<Button compact>{ translate( 'Edit post' ) }</Button>
+								<Button compact href={ this.getEditUrl( title ) }>
+									{ translate( 'Edit post' ) }
+								</Button>
 							</Card>
 						) ) }
 					</Fragment>

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -215,26 +215,6 @@ export class ThreatAlert extends Component {
 		return infectedPosts;
 	}
 
-	formatGroupedPosts() {
-		const {
-			threat: { rows },
-		} = this.props;
-
-		let indexedRows = {};
-
-		Object.keys( rows ).map( idx => {
-			const row = rows[ idx ];
-
-			if ( ! indexedRows[ row.description ] ) {
-				indexedRows[ row.description ] = [];
-			}
-
-			indexedRows[ row.description ].push( row.url );
-		} );
-
-		return indexedRows;
-	}
-
 	renderCardContent() {
 		const { threat, translate } = this.props;
 

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -130,7 +130,7 @@ export class ThreatAlert extends Component {
 
 			case 'database':
 				return translate(
-					'Jetpack identified $(threatCount)d threat in your database.',
+					'Jetpack identified %(threatCount)d threat in your database.',
 					'Jetpack identified %(threatCount)d threats in your database.',
 					{
 						count: Object.keys( threat.rows ).length,
@@ -182,10 +182,10 @@ export class ThreatAlert extends Component {
 			threat: { rows },
 			siteSlug,
 		} = this.props;
-		let infectedPosts = [];
+		const infectedPosts = [];
 
 		function findObjectIndexInArray( array, attr, value ) {
-			for ( var i = 0; i < array.length; i++ ) {
+			for ( let i = 0; i < array.length; i++ ) {
 				if ( array[ i ][ attr ] === value ) {
 					return i;
 				}
@@ -202,12 +202,14 @@ export class ThreatAlert extends Component {
 					postTitle: row.description,
 					editUrl: `/post/${ siteSlug }/${ row.id }`,
 					ids: [ parseInt( row.id ) ],
+					minId: parseInt( row.id ),
 					links: [ row.url ],
 				} );
 			} else {
 				infectedPosts[ postIndex ].ids.push( parseInt( row.id ) );
 				infectedPosts[ postIndex ].links.push( row.url );
 				const minId = Math.min.apply( null, infectedPosts[ postIndex ].ids );
+				infectedPosts[ postIndex ].minId = minId;
 				infectedPosts[ postIndex ].editUrl = `/post/${ siteSlug }/${ minId }`;
 			}
 		} );
@@ -246,9 +248,21 @@ export class ThreatAlert extends Component {
 												}
 											) }
 										</em>
-										<InfoPopover position="left" className="threat-alert__database-row-info">
-											{ translate( 'Suspicious links flagged by Jetpack Security Scanner' ) }
-										</InfoPopover>
+										<div className="threat-alert__database-row-info">
+											<InfoPopover>
+												{ translate(
+													'This link is included in post ID %(postId)d and %(revCount)d associated revision.',
+													'This link is included in post ID %(postId)d and %(revCount)d associated revisions.',
+													{
+														count: infectedPost.links.length,
+														args: {
+															postId: infectedPost.minId,
+															revCount: infectedPost.links.length,
+														},
+													}
+												) }
+											</InfoPopover>
+										</div>
 									</div>
 									<ol className="threat-alert__database-row-list">
 										{ infectedPost.links.map( ( link, linkKey ) => (

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -7,6 +7,7 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import Spinner from 'components/spinner';
 import Interval, { EVERY_TEN_SECONDS } from 'lib/interval';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
@@ -196,25 +197,6 @@ export class ThreatAlert extends Component {
 		return indexedRows;
 	}
 
-	getEditUrl( title ) {
-		const {
-			siteSlug,
-			threat: { rows },
-		} = this.props;
-
-		const postId = 0;
-
-		Object.keys( rows ).map( idx => {
-			console.log( rows[ idx ].description, title );
-			if ( rows[ idx ].description == title ) {
-				console.log( 'match!' );
-				return `/post/${ siteSlug }/${ rows[ idx ].id }`;
-			}
-		} );
-
-		return null;
-	}
-
 	renderCardContent() {
 		const { threat, translate } = this.props;
 
@@ -225,34 +207,38 @@ export class ThreatAlert extends Component {
 				return (
 					<Fragment>
 						{ Object.keys( rows ).map( ( title, rowKey ) => (
-							<Card key={ rowKey }>
-								<ActivityIcon activityIcon="posts" activityStatus="error" />
-								<div>
-									<strong>{ title }</strong>
+							<Card key={ rowKey } className="threat-alert__database-row">
+								<div className="threat-alert__database-row-icon">
+									<ActivityIcon activityIcon="posts" activityStatus="error" />
 								</div>
-								<div>
-									<em>
-										{ this.props.translate(
-											'%(urlCount)d suspicious link on post',
-											'%(urlCount)d suspicious links on post',
-											{
-												count: Object.keys( rows[ title ] ).length,
-												args: {
-													urlCount: Object.keys( rows[ title ] ).length,
-												},
-											}
-										) }
-									</em>
-									<InfoPopover position="left">
-										{ translate( 'Suspicious links flagged by Jetpack Security Scanner' ) }
-									</InfoPopover>
+								<div className="threat-alert__database-row-content">
+									<div>
+										<strong>{ title }</strong>
+									</div>
+									<div>
+										<em>
+											{ this.props.translate(
+												'%(urlCount)d suspicious link on post',
+												'%(urlCount)d suspicious links on post',
+												{
+													count: Object.keys( rows[ title ] ).length,
+													args: {
+														urlCount: Object.keys( rows[ title ] ).length,
+													},
+												}
+											) }
+										</em>
+										<InfoPopover position="left" className="threat-alert__database-row-info">
+											{ translate( 'Suspicious links flagged by Jetpack Security Scanner' ) }
+										</InfoPopover>
+									</div>
+									<ol className="threat-alert__database-row-list">
+										{ Object.keys( rows[ title ] ).map( ( url, urlIndex ) => (
+											<li key={ urlIndex }>{ rows[ title ][ url ] }</li>
+										) ) }
+									</ol>
 								</div>
-								<ol>
-									{ Object.keys( rows[ title ] ).map( ( url, urlIndex ) => (
-										<li key={ urlIndex }>{ rows[ title ][ url ] }</li>
-									) ) }
-								</ol>
-								<Button compact href={ this.getEditUrl( title ) }>
+								<Button className="threat-alert__database-row-action" compact>
 									{ translate( 'Edit post' ) }
 								</Button>
 							</Card>
@@ -293,20 +279,22 @@ export class ThreatAlert extends Component {
 	render() {
 		const { threat, translate } = this.props;
 		const inProgress = this.state.requesting || threat.fixer_status === 'in_progress';
+		const className = classNames( {
+			'activity-log__threat-alert': true,
+			'activity-log__threat-alert-database': 'database' === this.getDetailType(),
+		} );
 
 		return (
 			<Fragment>
 				<FoldableCard
-					className="activity-log__threat-alert"
+					className={ className }
 					highlight="error"
 					compact
 					clickableHeader={ true }
 					actionButton={ <span /> }
 					header={
 						<Fragment>
-							{ 'database' !== this.getDetailType() ? (
-								<ActivityIcon activityIcon="notice-outline" activityStatus="error" />
-							) : null }
+							<ActivityIcon activityIcon="notice-outline" activityStatus="error" />
 							<div className="activity-log__threat-alert-header">
 								<div className="activity-log__threat-header-top">
 									<span className="activity-log__threat-alert-title">

--- a/client/my-sites/activity/activity-log/threat-alert.scss
+++ b/client/my-sites/activity/activity-log/threat-alert.scss
@@ -16,6 +16,7 @@
 	.activity-log-item__activity-icon {
 		margin-right: 16px;
 		padding: 7px;
+		width: 24px;
 
 		@include breakpoint( '>480px' ) {
 			padding-left: 8px;

--- a/client/my-sites/activity/activity-log/threat-alert.scss
+++ b/client/my-sites/activity/activity-log/threat-alert.scss
@@ -106,3 +106,38 @@
 		content: '\00b7\2004';
 	}
 }
+
+.threat-alert__database-row {
+	box-shadow: none;
+	border-bottom: 1px solid #e1e2e2;
+	padding: 1rem 0 1rem 3rem;
+	margin-bottom: 0;
+}
+
+.threat-alert__database-row-icon {
+	display: inline-block;
+	float: left;
+}
+
+.threat-alert__database-row-content {
+	display: inline-block;
+}
+
+.threat-alert__database-row-action {
+	display: inline-block;
+	float: right;
+}
+
+.threat-alert__database-row-list {
+	margin: 1rem 0 0 1rem;
+}
+
+.threat-alert__database-row-info {
+	position: relative;
+	left: 0.3rem;
+	top: 0.15rem;
+}
+
+.activity-log__threat-alert-database .foldable-card__content {
+	padding: 0 !important;
+}

--- a/client/my-sites/activity/activity-log/threat-alert.scss
+++ b/client/my-sites/activity/activity-log/threat-alert.scss
@@ -133,6 +133,7 @@
 }
 
 .threat-alert__database-row-info {
+	display: inline-block;
 	position: relative;
 	left: 0.3rem;
 	top: 0.15rem;


### PR DESCRIPTION
This PR updates and advances the site alerts UI which lives atop the Activity Log.

**Changes proposed here:**
1. Enumerate the `rows` data contained in the threat to show each occurrence of the threat (rows in the database - think multiple post revisions containing a "single" threat)
2. Generally speaking, cleaned up the design as per conversations with designers.
3. Created [a specific method](https://github.com/Automattic/wp-calypso/pull/34928/files#diff-53890264063d8c736879d0bb69761f93R185) for figuring out which rows belong to which posts, so that the "edit post" button links to the correct place.
4. Generally speaking, cleaned up the `ThreatAlert` component to make future iterations quick & easy.

**Before:**
<img width="1063" alt="Screen Shot 2019-08-12 at 11 26 59 AM" src="https://user-images.githubusercontent.com/5528445/62877197-88857300-bcf4-11e9-8548-893d682481c5.png">

**After:**
<img width="1066" alt="Screen Shot 2019-08-12 at 11 21 57 AM" src="https://user-images.githubusercontent.com/5528445/62877208-8cb19080-bcf4-11e9-8d57-3cb99a3cebb5.png">

**Testing:**
- Fire up your Calypso dev and load a site that contains malicious database results.
- Ensure the design matches what's in the screenshot above.
- Check to be sure that each "edit post" button links to the correct post, with the correct post id associated with the published post.
- Ensure that the "ignore threat" button actually works.