### PR TITLE
Site settings: add source information to the disconnection survey.

### DIFF
--- a/client/my-sites/site-settings/disconnect-site/confirm.jsx
+++ b/client/my-sites/site-settings/disconnect-site/confirm.jsx
@@ -51,6 +51,9 @@ class ConfirmDisconnection extends PureComponent {
 				response: find( this.constructor.reasonWhitelist, r => r === reason ),
 				text: isArray( text ) ? text.join() : text,
 			},
+			source: {
+				from: 'Calypso',
+			},
 		};
 
 		submitSurvey(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `source` property to the object sent with the Jetpack disconnect survey response info. 

The data saved in the marketing survey data table will come from various places within both Calypso and wp-admin. The extra parameter will allow us to split the data by the `source` of it, if needed.

#### Testing instructions
- go through the site disconnect flow starting at `http://calypso.localhost:3000/settings/disconnect-site/:site` for a connected Jetpack site
- proceed to the confirmation screen upon selection
- press Disconnect
- in the Network panel check that the data being sent to the survey endpoint in .com contains the relevant information:

<img width="270" alt="Screenshot 2019-07-26 at 22 27 16" src="https://user-images.githubusercontent.com/13561163/61979893-71a50800-aff5-11e9-84b7-e5f1383d654a.png">


Note: I added an extra layer source-> from in case we wish to expand it for more precise info e.g. from + section
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
