### PR TITLE
Plans: Add Hotjar heatmap tracking to Plans page

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -26,6 +26,7 @@ import PlansNavigation from 'my-sites/plans/navigation';
 import isSiteAutomatedTransferSelector from 'state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'state/sites/selectors';
 import QueryContactDetailsCache from 'components/data/query-contact-details-cache';
+import withTrackingTool from 'lib/analytics/with-tracking-tool';
 
 class Plans extends React.Component {
 	static propTypes = {
@@ -140,4 +141,4 @@ export default connect( state => {
 		displayJetpackPlans: ! isSiteAutomatedTransfer && jetpackSite,
 		canAccessPlans: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 	};
-} )( localize( Plans ) );
+} )( localize( withTrackingTool( 'HotJar' )( Plans ) ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds the Hotjar code to the `/plans` page. 

I'd like to set up a heatmap for this page. I'm interested to find out the users' scroll behavior and how they interact with this page in general.

#### Testing instructions

1. Go to http://calypso.localhost:3000/plans/[site]
2. Confirm if the Hotjar code is being loaded

cc @eidolonnight @scalarbane2 