### PR TITLE
Signup: widening the site preview label 

### DIFF
--- a/client/components/signup-site-preview/style.scss
+++ b/client/components/signup-site-preview/style.scss
@@ -158,7 +158,7 @@
 		font-weight: 600;
 		color: var( --color-neutral-500 );
 		display: block;
-		width: 60%;
+		width: 65%;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;

--- a/client/components/signup-site-preview/style.scss
+++ b/client/components/signup-site-preview/style.scss
@@ -158,9 +158,13 @@
 		font-weight: 600;
 		color: var( --color-neutral-500 );
 		display: block;
-		width: 50%;
+		width: 60%;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 		background: var( --color-neutral-0 );
 		border-radius: 16px;
 		cursor: default;
+		padding: 0 6px;
 	}
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request

Because the width of the mobile site preview label is fixed at `50%`, when there are more characters than the little blighter can handle, it wraps onto a second line, and the text is cut off.

<img width="455" alt="Screen Shot 2019-07-28 at 3 48 30 pm" src="https://user-images.githubusercontent.com/6458278/62002868-2d7a4a80-b150-11e9-8662-9636412d856f.png">

😱 

This PR widens the label area:

<img width="387" alt="Screen Shot 2019-07-28 at 3 52 00 pm" src="https://user-images.githubusercontent.com/6458278/62002872-379c4900-b150-11e9-8451-b8ec2b2c8a1d.png">

And adds `ellipsis` should the text get very wordy:

<img width="350" alt="Screen Shot 2019-07-28 at 3 52 20 pm" src="https://user-images.githubusercontent.com/6458278/62002873-3834df80-b150-11e9-8072-9bce65130a6d.png">

## Testing instructions

Switch your browser language to French/Spanish/Russian... try a few languages!

Check that, if there is overflow in the grey area, we add an ellipsis and it doesn't wrap.

Fixes #34774
