### PR TITLE
Checkout: Test using Google Places API for smoother checkout

### DIFF
--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -8,11 +8,13 @@ import PropTypes from 'prop-types';
 import { loadScript } from '@automattic/load-script';
 import config from 'config';
 import { getLocaleSlug } from 'i18n-calypso';
+import { identity, noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import SearchCard from 'components/search-card';
+import Search from 'components/search';
 import Prediction from './prediction';
 
 /**
@@ -21,15 +23,24 @@ import Prediction from './prediction';
 import './style.scss';
 
 let autocompleteService = null;
+let sessionToken = null;
 
 class LocationSearch extends Component {
 	static propTypes = {
 		onPredictionClick: PropTypes.func,
+		onSearch: PropTypes.func,
 		predictionsTransformation: PropTypes.func,
+		types: PropTypes.arrayOf( PropTypes.string ),
+		hidePredictionsOnClick: PropTypes.bool,
+		card: PropTypes.bool,
 	};
 
 	static defaultProps = {
-		predictionsTransformation: predictions => predictions,
+		onSearch: noop,
+		predictionsTransformation: identity,
+		types: [ 'establishment' ],
+		hidePredictionsOnClick: false,
+		card: true,
 	};
 
 	state = {
@@ -65,14 +76,20 @@ class LocationSearch extends Component {
 
 	handleSearch = query => {
 		query = query.trim();
+		this.props.onSearch( query );
 
 		this.setState( { loading: true, query }, () => {
 			if ( query ) {
+				if ( ! sessionToken ) {
+					// eslint-disable-next-line no-undef
+					sessionToken = new google.maps.places.AutocompleteSessionToken();
+				}
 				autocompleteService.getPlacePredictions(
 					{
 						input: query,
-						types: [ 'establishment' ],
+						types: this.props.types,
 						language: getLocaleSlug(),
+						sessionToken,
 					},
 					this.updatePredictions
 				);
@@ -82,31 +99,48 @@ class LocationSearch extends Component {
 		} );
 	};
 
-	renderPrediction = prediction => {
-		const { onPredictionClick } = this.props;
+	handlePredictionClick = prediction => {
+		if ( this.props.hidePredictionsOnClick ) {
+			this.setState( { predictions: [] } );
+		}
 
+		this.props.onPredictionClick( prediction, sessionToken );
+		sessionToken = null;
+	};
+
+	renderPrediction = prediction => {
 		return (
 			<Prediction
 				key={ prediction.place_id }
-				onPredictionClick={ onPredictionClick }
+				onPredictionClick={ this.handlePredictionClick }
 				prediction={ prediction }
 			/>
 		);
 	};
 
+	renderSearchCard( searchProps ) {
+		return <SearchCard { ...searchProps } className="location-search__search-card is-compact" />;
+	}
+
+	renderSearch( searchProps ) {
+		return <Search { ...searchProps } />;
+	}
+
 	render() {
-		const { predictions, loading } = this.state;
+		const { predictions } = this.state;
+		const searchProps = {
+			onSearch: this.handleSearch,
+			delaySearch: true,
+			delayTimeout: 500,
+			disableAutocorrect: true,
+			searching: this.props.loading,
+		};
 
 		return (
 			<Fragment>
-				<SearchCard
-					onSearch={ this.handleSearch }
-					delaySearch={ true }
-					delayTimeout={ 500 }
-					disableAutocorrect={ true }
-					searching={ loading }
-					className="location-search__search-card is-compact"
-				/>
+				{ this.props.card
+					? this.renderSearchCard( searchProps )
+					: this.renderSearch( searchProps ) }
 
 				{ predictions && predictions.map( this.renderPrediction ) }
 			</Fragment>

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -41,6 +41,7 @@ class LocationSearch extends Component {
 		types: [ 'establishment' ],
 		hidePredictionsOnClick: false,
 		card: true,
+		placeholder: 'Search for your address by street or city',
 	};
 
 	state = {
@@ -134,6 +135,7 @@ class LocationSearch extends Component {
 			delayTimeout: 500,
 			disableAutocorrect: true,
 			searching: this.props.loading,
+			placeholder: this.props.placeholder,
 		};
 
 		return (

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -16,6 +16,7 @@ import { identity, noop } from 'lodash';
 import SearchCard from 'components/search-card';
 import Search from 'components/search';
 import Prediction from './prediction';
+import { Input } from 'my-sites/domains/components/form';
 
 /**
  * Style dependencies
@@ -32,7 +33,8 @@ class LocationSearch extends Component {
 		predictionsTransformation: PropTypes.func,
 		types: PropTypes.arrayOf( PropTypes.string ),
 		hidePredictionsOnClick: PropTypes.bool,
-		card: PropTypes.bool,
+		inputType: PropTypes.string,
+		inputProps: PropTypes.object,
 	};
 
 	static defaultProps = {
@@ -40,7 +42,8 @@ class LocationSearch extends Component {
 		predictionsTransformation: identity,
 		types: [ 'establishment' ],
 		hidePredictionsOnClick: false,
-		card: true,
+		inputType: 'search-card',
+		inputProps: {},
 		placeholder: 'Search for your address by street or city',
 	};
 
@@ -100,6 +103,15 @@ class LocationSearch extends Component {
 		} );
 	};
 
+	handleInputChange( onInputChange ) {
+		return event => {
+			onInputChange( event );
+
+			const { value } = event.target;
+			this.handleSearch( value );
+		};
+	}
+
 	handlePredictionClick = prediction => {
 		if ( this.props.hidePredictionsOnClick ) {
 			this.setState( { predictions: [] } );
@@ -119,16 +131,7 @@ class LocationSearch extends Component {
 		);
 	};
 
-	renderSearchCard( searchProps ) {
-		return <SearchCard { ...searchProps } className="location-search__search-card is-compact" />;
-	}
-
-	renderSearch( searchProps ) {
-		return <Search { ...searchProps } />;
-	}
-
-	render() {
-		const { predictions } = this.state;
+	renderInput() {
 		const searchProps = {
 			onSearch: this.handleSearch,
 			delaySearch: true,
@@ -137,14 +140,38 @@ class LocationSearch extends Component {
 			searching: this.props.loading,
 			placeholder: this.props.placeholder,
 		};
+		const onInputChange = this.props.inputProps.onChange ? this.props.inputProps.onChange : noop;
+
+		switch ( this.props.inputType ) {
+			case 'card':
+				return <Search { ...searchProps } />;
+
+			case 'input':
+				return (
+					<Input
+						{ ...this.props.inputProps }
+						onChange={ this.handleInputChange( onInputChange ) }
+						placeholder={ this.props.placeholder }
+					/>
+				);
+
+			case 'search-card':
+			default:
+				return (
+					<SearchCard { ...searchProps } className="location-search__search-card is-compact" />
+				);
+		}
+	}
+
+	render() {
+		const { predictions } = this.state;
 
 		return (
 			<Fragment>
-				{ this.props.card
-					? this.renderSearchCard( searchProps )
-					: this.renderSearch( searchProps ) }
-
-				{ predictions && predictions.map( this.renderPrediction ) }
+				{ this.renderInput() }
+				<div className="location-search__predictions">
+					{ predictions && predictions.map( this.renderPrediction ) }
+				</div>
 			</Fragment>
 		);
 	}

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -105,7 +105,7 @@ class LocationSearch extends Component {
 			this.setState( { predictions: [] } );
 		}
 
-		this.props.onPredictionClick( prediction, sessionToken );
+		this.props.onPredictionClick( prediction, sessionToken, this.state.query );
 		sessionToken = null;
 	};
 

--- a/client/blocks/location-search/index.jsx
+++ b/client/blocks/location-search/index.jsx
@@ -8,11 +8,12 @@ import PropTypes from 'prop-types';
 import { loadScript } from '@automattic/load-script';
 import config from 'config';
 import { getLocaleSlug } from 'i18n-calypso';
-import { identity, noop } from 'lodash';
+import { identity, isEmpty, noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
+import CompactCard from 'components/card/compact';
 import SearchCard from 'components/search-card';
 import Search from 'components/search';
 import Prediction from './prediction';
@@ -163,14 +164,28 @@ class LocationSearch extends Component {
 		}
 	}
 
-	render() {
+	renderPredictions() {
 		const { predictions } = this.state;
 
 		return (
 			<Fragment>
+				{ predictions.map( this.renderPrediction ) }
+				<CompactCard className="location-search__attribution">
+					<img
+						src="https://s1.wp.com/i/powered-by-google-on-white-hdpi.png"
+						alt="Powered by Google"
+					/>
+				</CompactCard>
+			</Fragment>
+		);
+	}
+
+	render() {
+		return (
+			<Fragment>
 				{ this.renderInput() }
 				<div className="location-search__predictions">
-					{ predictions && predictions.map( this.renderPrediction ) }
+					{ ! isEmpty( this.state.predictions ) && this.renderPredictions() }
 				</div>
 			</Fragment>
 		);

--- a/client/blocks/location-search/prediction.jsx
+++ b/client/blocks/location-search/prediction.jsx
@@ -5,7 +5,7 @@
  */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -42,7 +42,7 @@ export default class Prediction extends Component {
 
 		return (
 			<CompactCard
-				tabindex="0"
+				tabIndex="0"
 				className="location-search__prediction"
 				onClick={ this.handlePredictionClick }
 				onKeyDown={ this.handlePredictionKeyDown }

--- a/client/blocks/location-search/prediction.jsx
+++ b/client/blocks/location-search/prediction.jsx
@@ -31,11 +31,22 @@ export default class Prediction extends Component {
 		}
 	};
 
+	handlePredictionKeyDown = event => {
+		if ( event.key === 'Enter' ) {
+			this.handlePredictionClick();
+		}
+	};
+
 	render() {
 		const { prediction } = this.props;
 
 		return (
-			<CompactCard className="location-search__prediction" onClick={ this.handlePredictionClick }>
+			<CompactCard
+				tabindex="0"
+				className="location-search__prediction"
+				onClick={ this.handlePredictionClick }
+				onKeyDown={ this.handlePredictionKeyDown }
+			>
 				<strong>{ prediction.structured_formatting.main_text }</strong>
 				<br />
 				{ prediction.structured_formatting.secondary_text }

--- a/client/blocks/location-search/style.scss
+++ b/client/blocks/location-search/style.scss
@@ -1,5 +1,7 @@
 .location-search__prediction {
 	cursor: pointer;
+	width: 100%;
+
 	&:hover {
 		color: var( --color-primary-light );
 	}

--- a/client/blocks/location-search/style.scss
+++ b/client/blocks/location-search/style.scss
@@ -14,3 +14,12 @@
 	top: 0;
 	right: 16px;
 }
+
+.location-search__attribution {
+	text-align: right;
+	padding: 10px;
+}
+
+.location-search__attribution > img {
+	height: 15px;
+}

--- a/client/blocks/location-search/style.scss
+++ b/client/blocks/location-search/style.scss
@@ -5,6 +5,11 @@
 	&:hover {
 		color: var( --color-primary-light );
 	}
+
+	&:focus {
+		box-shadow:	0 0 0 2px var( --color-primary );
+		z-index: 1;
+	}
 }
 
 .location-search__prediction-icon {

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -20,6 +20,7 @@ import UsAddressFieldset from './us-address-fieldset';
 import EuAddressFieldset from './eu-address-fieldset';
 import UkAddressFieldset from './uk-address-fieldset';
 import { Input, HiddenInput } from 'my-sites/domains/components/form';
+import { abtest } from 'lib/abtest';
 
 export class RegionAddressFieldsets extends Component {
 	static propTypes = {
@@ -60,23 +61,28 @@ export class RegionAddressFieldsets extends Component {
 
 	render() {
 		const { getFieldProps, translate, shouldAutoFocusAddressField } = this.props;
+		const usePlacesApi = abtest( 'placesApiInCheckout' ) === 'placesApi';
 
 		return (
 			<div>
 				<div>
-					<Input
-						ref={ shouldAutoFocusAddressField ? this.inputRefCallback : noop }
-						label={ translate( 'Address' ) }
-						maxLength={ 40 }
-						{ ...getFieldProps( 'address-1' ) }
-					/>
+					{ ! usePlacesApi && (
+						<Input
+							ref={ shouldAutoFocusAddressField ? this.inputRefCallback : noop }
+							label={ translate( 'Address' ) }
+							maxLength={ 40 }
+							{ ...getFieldProps( 'address-1' ) }
+						/>
+					) }
 
-					<HiddenInput
-						label={ translate( 'Address Line 2' ) }
-						text={ translate( '+ Add Address Line 2' ) }
-						maxLength={ 40 }
-						{ ...getFieldProps( 'address-2', true ) }
-					/>
+					{ ! usePlacesApi && (
+						<HiddenInput
+							label={ translate( 'Address Line 2' ) }
+							text={ translate( '+ Add Address Line 2' ) }
+							maxLength={ 40 }
+							{ ...getFieldProps( 'address-2', true ) }
+						/>
+					) }
 				</div>
 				{ this.getRegionAddressFieldset() }
 			</div>

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -29,6 +29,7 @@ export class RegionAddressFieldsets extends Component {
 		countryCode: PropTypes.string,
 		shouldAutoFocusAddressField: PropTypes.bool,
 		hasCountryStates: PropTypes.bool,
+		manualLocationInput: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -37,6 +38,7 @@ export class RegionAddressFieldsets extends Component {
 		countryCode: 'US',
 		shouldAutoFocusAddressField: false,
 		hasCountryStates: false,
+		manualLocationInput: false,
 	};
 
 	inputRefCallback( input ) {
@@ -60,13 +62,19 @@ export class RegionAddressFieldsets extends Component {
 	}
 
 	render() {
-		const { getFieldProps, translate, shouldAutoFocusAddressField } = this.props;
+		const {
+			getFieldProps,
+			translate,
+			shouldAutoFocusAddressField,
+			manualLocationInput,
+		} = this.props;
 		const usePlacesApi = abtest( 'placesApiInCheckout' ) === 'placesApi';
+		const showAddressFields = ! usePlacesApi || manualLocationInput;
 
 		return (
 			<div>
 				<div>
-					{ ! usePlacesApi && (
+					{ showAddressFields && (
 						<Input
 							ref={ shouldAutoFocusAddressField ? this.inputRefCallback : noop }
 							label={ translate( 'Address' ) }
@@ -75,7 +83,7 @@ export class RegionAddressFieldsets extends Component {
 						/>
 					) }
 
-					{ ! usePlacesApi && (
+					{ showAddressFields && (
 						<HiddenInput
 							label={ translate( 'Address Line 2' ) }
 							text={ translate( '+ Add Address Line 2' ) }

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -350,9 +350,10 @@ export class ContactDetailsFormFields extends Component {
 		} );
 	}
 
-	handleAddressPredictionClick = ( { place_id: placeId }, sessionToken ) => {
+	handleAddressPredictionClick = ( { place_id: placeId }, sessionToken, query ) => {
 		if ( placeId === CREATE_NEW_PLACE_ID ) {
 			this.setState( { locationSelected: true } );
+			analytics.tracks.recordEvent( 'calypso_contact_information_manual_address_click', { query } );
 			return;
 		}
 

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -479,6 +479,8 @@ export class ContactDetailsFormFields extends Component {
 		const { translate, needsFax, hasCountryStates, labelTexts } = this.props;
 		const countryCode = this.getCountryCode();
 		const usePlacesApi = abtest( 'placesApiInCheckout' ) === 'placesApi';
+		const hasAddress = ! isEmpty( get( this.state.form, 'address1.value', '' ) );
+		const showAddressFields = ! usePlacesApi || this.state.locationSelected || hasAddress;
 
 		return (
 			<div className="contact-details-form-fields__contact-details">
@@ -520,7 +522,7 @@ export class ContactDetailsFormFields extends Component {
 				) }
 
 				<div className="contact-details-form-fields__row">
-					{ ( ! usePlacesApi || this.state.locationSelected ) &&
+					{ showAddressFields &&
 						this.createField(
 							'country-code',
 							CountrySelect,
@@ -532,7 +534,7 @@ export class ContactDetailsFormFields extends Component {
 						) }
 				</div>
 
-				{ ( ! usePlacesApi || this.state.locationSelected ) && countryCode && (
+				{ showAddressFields && countryCode && (
 					<RegionAddressFieldsets
 						getFieldProps={ this.getFieldProps }
 						countryCode={ countryCode }

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -31,7 +31,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormFooter from 'my-sites/domains/domain-management/components/form-footer';
 import FormButton from 'components/forms/form-button';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
-import FormLabel from 'components/forms/form-label';
 import { countries } from 'components/phone-input/data';
 import formState from 'lib/form-state';
 import analytics from 'lib/analytics';
@@ -466,14 +465,18 @@ export class ContactDetailsFormFields extends Component {
 	}
 
 	renderLocationSearch() {
+		const { translate } = this.props;
+		const inputProps = {
+			label: translate( 'Address' ),
+			maxLength: 40,
+			...this.getFieldProps( 'address-1' ),
+		};
+
 		return (
 			<div className="contact-details-form-fields__field location-search">
-				<FormLabel htmlFor="location-search">
-					{ this.props.translate( 'Address search' ) }
-				</FormLabel>
 				<LocationSearch
-					name="location-search"
-					card={ false }
+					inputType="input"
+					inputProps={ inputProps }
 					types={ [ 'address' ] }
 					onSearch={ this.handleLocationSearch }
 					onPredictionClick={ this.handleAddressPredictionClick }

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -10,14 +10,15 @@ import {
 	noop,
 	get,
 	deburr,
+	find,
 	kebabCase,
 	pick,
 	head,
+	includes,
 	isEqual,
 	isEmpty,
 	camelCase,
 	identity,
-	includes,
 } from 'lodash';
 import { localize } from 'i18n-calypso';
 
@@ -30,6 +31,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormFooter from 'my-sites/domains/domain-management/components/form-footer';
 import FormButton from 'components/forms/form-button';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
+import FormLabel from 'components/forms/form-label';
 import { countries } from 'components/phone-input/data';
 import formState from 'lib/form-state';
 import analytics from 'lib/analytics';
@@ -37,6 +39,7 @@ import { tryToGuessPostalCodeFormat } from 'lib/postal-code';
 import { toIcannFormat } from 'components/phone-input/phone-number';
 import NoticeErrorMessage from 'my-sites/checkout/checkout/notice-error-message';
 import RegionAddressFieldsets from './custom-form-fieldsets/region-address-fieldsets';
+import LocationSearch from 'blocks/location-search';
 import notices from 'notices';
 import { CALYPSO_CONTACT } from 'lib/url/support';
 import getCountries from 'state/selectors/get-countries';
@@ -46,6 +49,7 @@ import {
 	CHECKOUT_UK_ADDRESS_FORMAT_COUNTRY_CODES,
 } from './custom-form-fieldsets/constants';
 import { getPostCodeLabelText } from './custom-form-fieldsets/utils';
+import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -119,6 +123,7 @@ export class ContactDetailsFormFields extends Component {
 			phoneCountryCode: this.props.countryCode || this.props.userCountryCode,
 			form: null,
 			submissionCount: 0,
+			locationSelected: false,
 		};
 
 		this.inputRefs = {};
@@ -132,6 +137,7 @@ export class ContactDetailsFormFields extends Component {
 	shouldComponentUpdate( nextProps, nextState ) {
 		return (
 			( nextProps.isSubmitting === false && this.props.isSubmitting === true ) ||
+			nextState.locationSelected !== this.state.locationSelected ||
 			nextState.phoneCountryCode !== this.state.phoneCountryCode ||
 			! isEqual( nextProps.contactDetails, this.props.contactDetails ) ||
 			! isEqual( nextState.form, this.state.form ) ||
@@ -323,6 +329,63 @@ export class ContactDetailsFormFields extends Component {
 		} );
 	};
 
+	updateAddressField( addressComponents, componentTypes, fieldName, useShortName = false ) {
+		let newValue = '';
+		componentTypes.forEach( componentType => {
+			const addressComponent = find(
+				addressComponents,
+				this.findAddressComponent( componentType )
+			);
+			if ( addressComponent ) {
+				newValue += useShortName ? addressComponent.short_name : addressComponent.long_name;
+				newValue += ' ';
+			}
+		} );
+
+		this.formStateController.handleFieldChange( {
+			name: fieldName,
+			value: newValue.trim(),
+		} );
+	}
+
+	handleAddressPredictionClick = ( prediction, sessionToken ) => {
+		// eslint-disable-next-line no-undef
+		const placesService = new google.maps.places.PlacesService( document.createElement( 'div' ) );
+		placesService.getDetails(
+			{
+				placeId: prediction.place_id,
+				fields: [ 'address_component' ],
+				sessionToken,
+			},
+			( { address_components: addressComponents }, status ) => {
+				// eslint-disable-next-line no-undef
+				if ( status === google.maps.places.PlacesServiceStatus.OK ) {
+					this.updateAddressField( addressComponents, [ 'postal_code' ], 'postalCode' );
+					this.updateAddressField( addressComponents, [ 'country' ], 'countryCode', true );
+					this.updateAddressField( addressComponents, [ 'locality' ], 'city' );
+					this.updateAddressField(
+						addressComponents,
+						[ 'street_address', 'route', 'street_number' ],
+						'address1'
+					);
+					if ( this.props.hasCountryStates ) {
+						this.updateAddressField(
+							addressComponents,
+							[ 'administrative_area_level_1' ],
+							'state',
+							true
+						);
+					}
+
+					this.formStateController.sanitize();
+					this.formStateController.validate();
+				}
+
+				this.setState( { locationSelected: true } );
+			}
+		);
+	};
+
 	getFieldProps = ( name, needsChildRef = false ) => {
 		const ref = needsChildRef
 			? { inputRef: this.getRefCallback( name ) }
@@ -358,9 +421,64 @@ export class ContactDetailsFormFields extends Component {
 		return get( this.state.form, 'countryCode.value', '' );
 	}
 
+	findAddressComponent( type ) {
+		return addressComponent => {
+			return includes( get( addressComponent, 'types', [] ), type );
+		};
+	}
+
+	renderLocationSearch() {
+		return (
+			<div className="contact-details-form-fields__field location-search">
+				<FormLabel htmlFor="location-search">
+					{ this.props.translate( 'Address search' ) }
+				</FormLabel>
+				<LocationSearch
+					name="location-search"
+					card={ false }
+					types={ [ 'address' ] }
+					onSearch={ this.handleLocationSearch }
+					onPredictionClick={ this.handleAddressPredictionClick }
+					hidePredictionsOnClick={ true }
+				/>
+			</div>
+		);
+	}
+
+	handleLocationSearch = query => {
+		if ( query.length === 0 ) {
+			this.setState( { locationSelected: false } );
+			this.formStateController.handleFieldChange( {
+				name: 'postalCode',
+				value: '',
+			} );
+			this.formStateController.handleFieldChange( {
+				name: 'countryCode',
+				value: '',
+			} );
+			this.formStateController.handleFieldChange( {
+				name: 'city',
+				value: '',
+			} );
+			this.formStateController.handleFieldChange( {
+				name: 'address1',
+				value: '',
+			} );
+			this.formStateController.handleFieldChange( {
+				name: 'address2',
+				value: '',
+			} );
+			this.formStateController.handleFieldChange( {
+				name: 'state',
+				value: '',
+			} );
+		}
+	};
+
 	renderContactDetailsFields() {
 		const { translate, needsFax, hasCountryStates, labelTexts } = this.props;
 		const countryCode = this.getCountryCode();
+		const usePlacesApi = abtest( 'placesApiInCheckout' ) === 'placesApi';
 
 		return (
 			<div className="contact-details-form-fields__contact-details">
@@ -397,19 +515,24 @@ export class ContactDetailsFormFields extends Component {
 						} ) }
 				</div>
 
+				{ usePlacesApi && (
+					<div className="contact-details-form-fields__row">{ this.renderLocationSearch() }</div>
+				) }
+
 				<div className="contact-details-form-fields__row">
-					{ this.createField(
-						'country-code',
-						CountrySelect,
-						{
-							label: translate( 'Country' ),
-							countriesList: this.props.countriesList,
-						},
-						true
-					) }
+					{ ( ! usePlacesApi || this.state.locationSelected ) &&
+						this.createField(
+							'country-code',
+							CountrySelect,
+							{
+								label: translate( 'Country' ),
+								countriesList: this.props.countriesList,
+							},
+							true
+						) }
 				</div>
 
-				{ countryCode && (
+				{ ( ! usePlacesApi || this.state.locationSelected ) && countryCode && (
 					<RegionAddressFieldsets
 						getFieldProps={ this.getFieldProps }
 						countryCode={ countryCode }

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -88,6 +88,11 @@
 
 }
 
+.contact-details-form-fields__field.location-search > .search {
+	margin-bottom: 0;
+	border: 1px solid var( --color-neutral-100 );
+}
+
 .contact-details-form-fields__extra-fields {
 	margin-top: 15px;
 }

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -88,16 +88,12 @@
 
 }
 
-.contact-details-form-fields__field.location-search > .search {
-	margin-bottom: 0;
-	border: 1px solid var( --color-neutral-100 );
-}
-
 .contact-details-form-fields__extra-fields {
 	margin-top: 15px;
 }
 
 .contact-details-form-fields__field.first-name,
+.contact-details-form-fields__field.location-search,
 .form__hidden-input .form__hidden-input {
 	margin-top: 0;
 }

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -101,7 +101,10 @@
 .contact-details-form-fields__field.location-search {
 	.address-1 {
 		position: relative;
-		z-index: 1;
+
+		&:focus {
+			z-index: 1;
+		}
 	}
 
 	.location-search__predictions {
@@ -109,6 +112,5 @@
 		z-index: 0;
 		position: relative;
 	}
-
 }
 

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -99,12 +99,9 @@
 }
 
 .contact-details-form-fields__field.location-search {
-	.address-1 {
+	.address-1:focus {
 		position: relative;
-
-		&:focus {
-			z-index: 1;
-		}
+		z-index: 1;
 	}
 
 	.location-search__predictions {

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -98,3 +98,17 @@
 	margin-top: 0;
 }
 
+.contact-details-form-fields__field.location-search {
+	.address-1 {
+		position: relative;
+		z-index: 1;
+	}
+
+	.location-search__predictions {
+		margin: 0 1px;
+		z-index: 0;
+		position: relative;
+	}
+
+}
+

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -143,6 +143,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       countryCode="IT"
       getFieldProps={[Function]}
       hasCountryStates={false}
+      manualLocationInput={false}
       shouldAutoFocusAddressField={false}
       translate={[Function]}
     />

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -151,4 +151,12 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	placesApiInCheckout: {
+		datestamp: '20190819',
+		variations: {
+			original: 50,
+			placesApi: 50,
+		},
+		defaultVariation: 'original',
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -152,7 +152,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	placesApiInCheckout: {
-		datestamp: '20190909',
+		datestamp: '20190923',
 		variations: {
 			original: 50,
 			placesApi: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -152,7 +152,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	placesApiInCheckout: {
-		datestamp: '20190819',
+		datestamp: '20190909',
 		variations: {
 			original: 50,
 			placesApi: 50,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are required to collect address contact info when registering a domain - however, the data has to be in the correct format, it's a PITA to fill out, etc. Using the Google Places API could help with that and ensure consistent and valid data.

The way I've approached it was to hide the address fields at first and require the user to use the Google Places API to search for their address first. If they can't find it, only then they can choose to fill it out manually.

A/B test name: `placesApiInCheckout`

#### Testing instructions

Try adding a domain to your site (signup or existing one, either way is the same). During checkout, you'll be prompted to enter your contact details.

Make sure that for the `original` variation there are no regressions (especially for new users, when the contact form is empty).

Try different addresses you could think of - especially in exotic countries, etc. (Google Places API has a slightly weird way of returning addresses and it might need tweaking)

The last suggestion is always a placeholder one that allows you fill out the form manually. To help figure out if/how often users select it, I've added a `calypso_contact_information_manual_address_click` event.

#### Screenshots

<img width="743" alt="Screenshot 2019-08-21 at 20 48 59" src="https://user-images.githubusercontent.com/3392497/63467904-0d3f6200-c456-11e9-9e65-879d5e230434.png">
<img width="689" alt="Screenshot 2019-08-26 at 15 53 27" src="https://user-images.githubusercontent.com/3392497/63718463-296a4700-c83a-11e9-86d3-dffe0f8f3bab.png">

