### PR TITLE
Signup: add `flow` prop to `calypso_user_registration_complete` track event

### DIFF
--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -376,9 +376,9 @@ const analytics = {
 		recordSignupStartInFloodlight();
 	},
 
-	recordRegistration: function() {
+	recordRegistration: function( { flow } ) {
 		// Tracks
-		analytics.tracks.recordEvent( 'calypso_user_registration_complete' );
+		analytics.tracks.recordEvent( 'calypso_user_registration_complete', { flow } );
 		// Google Analytics
 		analytics.ga.recordEvent( 'Signup', 'calypso_user_registration_complete' );
 		// Marketing

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -533,7 +533,7 @@ export function createAccount(
 					userData.ID;
 
 				// Fire after a new user registers.
-				analytics.recordRegistration();
+				analytics.recordRegistration( { flow: flowName } );
 				analytics.identifyUser( username, userId );
 
 				const providedDependencies = assign( { username }, bearerToken );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the `flow` property to the `calypso_user_registration_complete` track event
* Property value is the name of the current flow
* New property is named `flow` for consistency with `calypso_signup_start` and `calypso_signup_complete`

Ref: pau2Xa-mj-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Open an incognito window for each of the following flows and filter the network tab by `calypso_user_registration_complete`. Persist the network logs because sometimes the event is sent as the last step in the flow. Check that the `t.gif` request is sent after completing the user step, and that it has a `flow` query parameter with the correct value.

* `/start` should have `?flow=onboarding`
* `/start/import` should have `?flow=import`
* `/start/account` should have `?flow=account`

Fixes Automattic/zelda-private#90
