### PR TITLE
Earn Page: Add a third state to the ads card

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -231,7 +231,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		<Fragment>
 			{ ! hasWordAds && <QueryWordadsStatus siteId={ siteId } /> }
 			{ ! isFreePlan && <QueryMembershipsSettings siteId={ siteId } /> }
-			<PromoSection { ...promos } />;
+			<PromoSection { ...promos } />
 		</Fragment>
 	);
 };

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -177,7 +177,10 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const cta = hasWordAds
 			? {
 					text: hasSetupAds ? translate( 'View Ad Dashboard' ) : translate( 'Earn Ad Revenue' ),
-					action: () => page( `/earn/ads-earnings/${ selectedSiteSlug }` ),
+					action: () =>
+						page(
+							`/earn/${ hasSetupAds ? 'ads-earnings' : 'ads-settings' }/${ selectedSiteSlug }`
+						),
 			  }
 			: {
 					text: translate( 'Upgrade to Premium Plan' ),

--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -161,7 +161,7 @@ class EarningsMain extends Component {
 	getSectionNav = section => {
 		const currentPath = this.getCurrentPath();
 
-		return 'payments' !== section || ! config.isEnabled( 'earn-relayout' ) ? (
+		return ! section.startsWith( 'payments' ) || ! config.isEnabled( 'earn-relayout' ) ? (
 			<SectionNav selectedText={ this.getSelectedText() }>
 				<NavTabs>
 					{ this.getFilters().map( filterItem => {


### PR DESCRIPTION
This change checks the status of WordAds on the current site, and if it's active or has been requested, displays a third version of the `PromoCard` encouraging the customer to view their ads dashboard.

#### Testing instructions

With sites both enrolled in WordAds and not, navigate to the `/earn/` section (probably using calypso live and the `?flags=earn-relayout` flag being easiest) and review what is displayed for the ads promo. Without a plan, the prompt should be to upgrade. With a plan, the prompt should be to start earning ad revenue and once it's setup, the CTA is to view the dashboard.

#### N.B. 
There appears to be a fair amount of different logic around the status of WordAds on a site. I'm not 100% sure whether I'm checking the correct properties at the moment. Thoughts are welcome, and I'll do some more checking.
