### PR TITLE
Earn Page: Add a third state to the recurring payments card

### DIFF
--- a/client/my-sites/earn/main.jsx
+++ b/client/my-sites/earn/main.jsx
@@ -161,7 +161,7 @@ class EarningsMain extends Component {
 	getSectionNav = section => {
 		const currentPath = this.getCurrentPath();
 
-		return 'payments' !== section || ! config.isEnabled( 'earn-relayout' ) ? (
+		return ! section.startsWith( 'payments' ) || ! config.isEnabled( 'earn-relayout' ) ? (
 			<SectionNav selectedText={ this.getSelectedText() }>
 				<NavTabs>
 					{ this.getFilters().map( filterItem => {


### PR DESCRIPTION
This change checks the status of the recurring payments feature on a site, and if it's 'active', displays a third variation of the card, encouraging the customer to manage their recurring payment settings and review their earnings. 

The feature is deemed to be active is the customer has gone through the process of connecting their Stripe account.

#### Testing instructions

With sites both with and without connected Stripe accounts, navigate to the `/earn/` section (probably using calypso live and the `?flags=earn-relayout` flag being easiest) and review what is displayed for the recurring payments promo. 

Without a plan, the prompt should be to upgrade. With a plan, the prompt should be to start collecting recurring payments and once it's set up, the title and body text should change to reflect that they can review their recurring payments.