### PR TITLE
Signup: don't resume from last step in flow after refresh

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -15,7 +14,6 @@ import {
 	indexOf,
 	isEqual,
 	kebabCase,
-	last,
 	map,
 	pick,
 	startsWith,
@@ -76,7 +74,6 @@ import {
 	canResumeFlow,
 	getCompletedSteps,
 	getDestination,
-	getFilteredSteps,
 	getFirstInvalidStep,
 	getStepUrl,
 	persistSignupDestination,
@@ -153,8 +150,8 @@ class Signup extends React.Component {
 		this.updateShouldShowLoadingScreen();
 
 		if ( canResumeFlow( this.props.flowName, this.props.progress ) ) {
-			// Resume progress if possible
-			return this.resumeProgress();
+			// Resume from the current window location
+			return;
 		}
 
 		if ( this.getPositionInFlow() !== 0 ) {
@@ -406,28 +403,6 @@ class Signup extends React.Component {
 		}
 		return redirectTo + path;
 	};
-
-	firstUnsubmittedStepName = () => {
-		const currentSteps = flows.getFlow( this.props.flowName ).steps,
-			signupProgress = getFilteredSteps( this.props.flowName, this.props.progress ),
-			nextStepName = currentSteps[ signupProgress.length ],
-			firstInProgressStep = find( signupProgress, { status: 'in-progress' } ) || {},
-			firstInProgressStepName = firstInProgressStep.stepName;
-
-		return firstInProgressStepName || nextStepName || last( currentSteps );
-	};
-
-	resumeProgress() {
-		const firstUnsubmittedStep = this.firstUnsubmittedStepName();
-		const stepSectionName = firstUnsubmittedStep.stepSectionName;
-
-		// set `resumingStep` so we don't render/animate anything until we have mounted this step
-		this.setState( { firstUnsubmittedStep } );
-
-		return page.redirect(
-			getStepUrl( this.props.flowName, firstUnsubmittedStep, stepSectionName, this.props.locale )
-		);
-	}
 
 	// `flowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.


### PR DESCRIPTION
#### A couple of user stories

##### The "I want to start over" story
![start-again-master-smol](https://user-images.githubusercontent.com/1500769/62258026-89004d00-b45c-11e9-9856-e4156f88f65c.gif)
[Original video](https://cld.wthms.co/jmfDDO)

##### The "close laptop lid" story
![back-refresh-master-smol](https://user-images.githubusercontent.com/1500769/62257648-81d83f80-b45a-11e9-809c-818bc061db4e.gif)
[Original video](https://cld.wthms.co/YEvHXd)

#### Changes proposed in this Pull Request

Removes code that redirected to the "last in-progress step" in the flow after `<Signup>` was first mounted. This means the location after refresh is determined by the url, as one would expect.

If any redirection happens, it's to the beginning of the flow e.g. a redirect to the beginning will happen if:
1. there's no data in `localStorage`. We need to go back to collect all those dependencies again.
2. you manually enter the url for a step that's _past_ the "last in-progress step".

One could argue that in the case of (2) that it should go back to the "last in-progress step". But I can't think of a user story for this. Whereas "staying on the same page after refresh" covers spoty interent, closing-reopening laptop lid, browser crash and restore, automattic OS updates.

Discussed in a number of places:
- Automattic/zelda-private#109
- #34299
- At team meetup

Fixes Automattic/zelda-private#109

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

The expected behaviour for each of the test steps depends on whether the state was persisted or not. Just a reminder:
- With persisted state: `ENABLE_FEATURES=no-force-sympathy npm start`
- No persisted state: `ENABLE_FEATURES=force-sympathy npm start`

##### Start again
- `/start`, proceed through flow but don't complete
- Go back to `/start` using whatever method you like except clicking "back"
- You should have started the onboarding flow again (regardless of the local storage state)

##### Close laptop lid
- `/start`, proceed through flow but don't complete
- Click back
- Refresh (to simulate coming back later)
- You should have either:
  - stayed on the step you were just on (with local storage)
  - gone back to site type step, but still logged in (without local storage)

##### ~Hot linking past incomplete steps~
- ~`/start`, choose blog~
- ~You should be on the site topic step~
- ~Manually navigate to `/start/site-style-with-preview`~
- ~You should have been redirected to the start the onboarding flow again (regardless of the local storage state)~
_Edit: this wasn't straight forward to implement_

Manually test these changes trying to break it by:
- trying it both logged in and out
- having two tabs open that share the same local storage
- switching flows
- clearing or keeping localhost