### PR TITLE
Signup: convert getUsernameSuggestion to action thunk, don't read Redux store from context

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -24,7 +24,6 @@ import {
 } from 'lib/cart-values/cart-items';
 
 // State actions and selectors
-import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
 import { getDesignType } from 'state/signup/steps/design-type/selectors';
 import { getSiteTitle } from 'state/signup/steps/site-title/selectors';
 import { getSurveyVertical, getSurveySiteType } from 'state/signup/steps/survey/selectors';
@@ -269,68 +268,6 @@ export function setThemeOnSite( callback, { siteSlug, themeSlugWithRepo } ) {
 		.changeTheme( siteSlug, { theme: themeSlugWithRepo.split( '/' )[ 1 ] }, function( errors ) {
 			callback( isEmpty( errors ) ? undefined : [ errors ] );
 		} );
-}
-
-/**
- * Gets username suggestions from the API.
- *
- * Ask the API to validate a username.
- *
- * If the API returns a suggestion, then the username is already taken.
- * If there is no error from the API, then the username is free.
- *
- * @param {string} username The username to get suggestions for.
- * @param {object} reduxState The Redux state object
- */
-export function getUsernameSuggestion( username, reduxState ) {
-	const fields = {
-		givesuggestions: 1,
-		username: username,
-	};
-
-	// Clear out the local storage variable before sending the call.
-	reduxState.dispatch( {
-		type: SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET,
-		data: '',
-	} );
-
-	wpcom.undocumented().validateNewUser( fields, ( error, response ) => {
-		if ( error || ! response ) {
-			return null;
-		}
-
-		/**
-		 * Default the suggested username to `username` because if the validation succeeds would mean
-		 * that the username is free
-		 */
-		let resultingUsername = username;
-
-		/**
-		 * Only start checking for suggested username if the API returns an error for the validation.
-		 */
-		if ( ! response.success ) {
-			const { messages } = response;
-
-			/**
-			 * The only case we want to update username field is when the username is already taken.
-			 *
-			 * This ensures that the validation is done
-			 *
-			 * Check for:
-			 *    - username taken error -
-			 *    - a valid suggested username
-			 */
-			if ( messages.username && messages.username.taken && messages.suggested_username ) {
-				resultingUsername = messages.suggested_username.data;
-			}
-		}
-
-		// Save the suggested username for later use
-		reduxState.dispatch( {
-			type: SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET,
-			data: resultingUsername,
-		} );
-	} );
 }
 
 export function addPlanToCart( callback, dependencies, stepProvidedItems, reduxStore ) {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -26,7 +26,6 @@ import {
 	domainTransfer,
 } from 'lib/cart-values/cart-items';
 import { DOMAINS_WITH_PLANS_ONLY } from 'state/current-user/constants';
-import { getUsernameSuggestion } from 'lib/signup/step-actions';
 import {
 	recordAddDomainButtonClick,
 	recordAddDomainButtonClickInMapDomain,
@@ -49,6 +48,7 @@ import { getVerticalForDomainSuggestions } from 'state/signup/steps/site-vertica
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
 import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions';
 import { isDomainStepSkippable } from 'signup/config/steps';
+import { fetchUsernameSuggestion } from 'state/signup/optional-dependencies/actions';
 
 /**
  * Style dependencies
@@ -72,10 +72,6 @@ class DomainsStep extends React.Component {
 		stepSectionName: PropTypes.string,
 		selectedSite: PropTypes.object,
 		vertical: PropTypes.string,
-	};
-
-	static contextTypes = {
-		store: PropTypes.object,
 	};
 
 	getDefaultState = () => ( {
@@ -258,7 +254,7 @@ class DomainsStep extends React.Component {
 		this.props.goToNextStep();
 
 		// Start the username suggestion process.
-		getUsernameSuggestion( siteUrl.split( '.' )[ 0 ], this.context.store );
+		this.props.fetchUsernameSuggestion( siteUrl.split( '.' )[ 0 ] );
 	};
 
 	handleAddMapping = ( sectionName, domain, state ) => {
@@ -713,5 +709,6 @@ export default connect(
 		setDesignType,
 		saveSignupStep,
 		submitSignupStep,
+		fetchUsernameSuggestion,
 	}
 )( localize( DomainsStep ) );

--- a/client/state/signup/optional-dependencies/actions.js
+++ b/client/state/signup/optional-dependencies/actions.js
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import wpcom from 'lib/wp';
+import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
+
+export const setUsernameSuggestion = data => ( {
+	type: SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET,
+	data,
+} );
+
+/**
+ * Action thunk creator that gets username suggestions from the API.
+ *
+ * Ask the API to validate a username.
+ *
+ * If the API returns a suggestion, then the username is already taken.
+ * If there is no error from the API, then the username is free.
+ *
+ * @param {string} username The username to get suggestions for.
+ * @returns {ActionThunk} Redux action thunk
+ */
+export const fetchUsernameSuggestion = username => async dispatch => {
+	// Clear out the state variable before sending the call.
+	dispatch( setUsernameSuggestion( '' ) );
+
+	const response = await wpcom.undocumented().validateNewUser( {
+		givesuggestions: 1,
+		username,
+	} );
+
+	if ( ! response ) {
+		return null;
+	}
+
+	/**
+	 * Default the suggested username to `username` because if the validation succeeds would mean
+	 * that the username is free
+	 */
+	let resultingUsername = username;
+
+	/**
+	 * Only start checking for suggested username if the API returns an error for the validation.
+	 */
+	if ( ! response.success ) {
+		const { messages } = response;
+
+		/**
+		 * The only case we want to update username field is when the username is already taken.
+		 *
+		 * This ensures that the validation is done
+		 *
+		 * Check for:
+		 *    - username taken error -
+		 *    - a valid suggested username
+		 */
+		if ( messages.username && messages.username.taken && messages.suggested_username ) {
+			resultingUsername = messages.suggested_username.data;
+		}
+	}
+
+	// Save the suggested username for later use
+	dispatch( setUsernameSuggestion( resultingUsername ) );
+
+	return resultingUsername;
+};


### PR DESCRIPTION
Reading `store` from React context is an undocumented API that breaks with React Redux 7.
Let's convert the `getUsernameSuggestion` function to a Redux action thunk. That's a much
more mainstream way to get access to Redux store methods.

This is a spinoff PR from #32129, the big PR that upgrades React Redux to v7. This change can be merged independently.

**How to test:**
Go through a flow that has `domains` step first and the `user` at the end. The only current one is `desktop`.

Verify that after picking a domain, a suggested username is stored in `state.signup.optionalDependencies.suggestedUsername` and that it's pre-filled in the `user` step form.