### PR TITLE
Update the CTA button copy from "Download a backup" to "Download a current backup"

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -154,7 +154,7 @@ class AutoRenewDisablingDialog extends Component {
 				<ul>
 					<li>
 						<Button href={ exportPath } primary>
-							{ translate( 'Download a backup' ) }
+							{ translate( 'Download a current backup' ) }
 						</Button>
 					</li>
 					<li>


### PR DESCRIPTION
#### Changes proposed in this Pull Request
This PR updates the CTA button copy of the auto-renewal disabling dialog for atomic sites from "Download a backup" to "Download a current backup" for further clarifying the timeliness:
<img width="638" alt="螢幕快照 2019-07-29 下午3 55 59" src="https://user-images.githubusercontent.com/1842898/62032505-6849b480-b21c-11e9-87ab-edcad1b38e0a.png">

More context can be found in p2-p7DVsv-6SJ#comment-1658

cc @carladoria 

#### Testing instructions

1. Log in as a site owner of an atomic site.
1. Go to the purchase management page of the associated Business / eCommerce plan.
1. Turn off the auto-renewal by the toggle, click "confirm cancellation", and the dialog with the updated copy should show like the screenshot above.
