### PR TITLE
Link to the concierge landing page

### DIFF
--- a/client/me/concierge/book/confirmation-step.js
+++ b/client/me/concierge/book/confirmation-step.js
@@ -19,20 +19,20 @@ class ConfirmationStep extends Component {
 		this.props.recordTracksEvent( 'calypso_concierge_book_confirmation_step' );
 	}
 
+	handleClick = () => {
+		window.location.reload();
+	};
+
 	render() {
-		const { site, translate } = this.props;
+		const { translate } = this.props;
 
 		return (
 			<Confirmation
 				description={ translate( 'We will send you an email with information on how to prepare.' ) }
 				title={ translate( 'Your session is booked!' ) }
 			>
-				<Button
-					className="book__schedule-button"
-					href={ `/stats/day/${ site.slug }` }
-					primary={ true }
-				>
-					{ translate( 'Return to your dashboard' ) }
+				<Button className="book__schedule-button" onClick={ this.handleClick } primary={ true }>
+					{ translate( 'Check your appointment details' ) }
 				</Button>
 			</Confirmation>
 		);

--- a/client/me/concierge/book/confirmation-step.js
+++ b/client/me/concierge/book/confirmation-step.js
@@ -32,7 +32,7 @@ class ConfirmationStep extends Component {
 				title={ translate( 'Your session is booked!' ) }
 			>
 				<Button className="book__schedule-button" onClick={ this.handleClick } primary={ true }>
-					{ translate( 'Go to your appointment dashboard' ) }
+					{ translate( 'Go to your session dashboard' ) }
 				</Button>
 			</Confirmation>
 		);

--- a/client/me/concierge/book/confirmation-step.js
+++ b/client/me/concierge/book/confirmation-step.js
@@ -32,7 +32,7 @@ class ConfirmationStep extends Component {
 				title={ translate( 'Your session is booked!' ) }
 			>
 				<Button className="book__schedule-button" onClick={ this.handleClick } primary={ true }>
-					{ translate( 'Check your appointment details' ) }
+					{ translate( 'Go to your appointment dashboard' ) }
 				</Button>
 			</Confirmation>
 		);

--- a/client/me/concierge/book/confirmation-step.js
+++ b/client/me/concierge/book/confirmation-step.js
@@ -32,7 +32,7 @@ class ConfirmationStep extends Component {
 				title={ translate( 'Your session is booked!' ) }
 			>
 				<Button className="book__schedule-button" onClick={ this.handleClick } primary={ true }>
-					{ translate( 'Go to your session dashboard' ) }
+					{ translate( 'View your session dashboard' ) }
 				</Button>
 			</Confirmation>
 		);

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -19,8 +19,14 @@ class ConfirmationStep extends Component {
 		this.props.recordTracksEvent( 'calypso_concierge_reschedule_confirmation_step' );
 	}
 
+	handleClick = () => {
+		const { site } = this.props;
+
+		window.location.href = `/me/concierge/${ site.slug }/book`;
+	};
+
 	render() {
-		const { site, translate } = this.props;
+		const { translate } = this.props;
 
 		return (
 			<Confirmation
@@ -29,10 +35,10 @@ class ConfirmationStep extends Component {
 			>
 				<Button
 					className="reschedule__schedule-button"
-					href={ `/stats/day/${ site.slug }` }
+					onClick={ this.handleClick }
 					primary={ true }
 				>
-					{ translate( 'Return to your dashboard' ) }
+					{ translate( 'Check your appointment details' ) }
 				</Button>
 			</Confirmation>
 		);

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -38,7 +38,7 @@ class ConfirmationStep extends Component {
 					onClick={ this.handleClick }
 					primary={ true }
 				>
-					{ translate( 'Check your appointment details' ) }
+					{ translate( 'Go to your appointment dashboard' ) }
 				</Button>
 			</Confirmation>
 		);

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -38,7 +38,7 @@ class ConfirmationStep extends Component {
 					onClick={ this.handleClick }
 					primary={ true }
 				>
-					{ translate( 'Go to your appointment dashboard' ) }
+					{ translate( 'Go to your session dashboard' ) }
 				</Button>
 			</Confirmation>
 		);

--- a/client/me/concierge/reschedule/confirmation-step.js
+++ b/client/me/concierge/reschedule/confirmation-step.js
@@ -38,7 +38,7 @@ class ConfirmationStep extends Component {
 					onClick={ this.handleClick }
 					primary={ true }
 				>
-					{ translate( 'Go to your session dashboard' ) }
+					{ translate( 'View your session dashboard' ) }
 				</Button>
 			</Confirmation>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* In the confirmation step, the CTA should link to the appointment dashboard.
* An updated appointment dashboard is being implemented in #34950 

Confirmation step after scheduling a new session:

<img width="742" alt="Screenshot 2019-08-06 at 1 53 47 PM" src="https://user-images.githubusercontent.com/1269602/62523744-0ad3ea00-b852-11e9-8ef9-62495f869485.png">

Confirmation step after rescheduling a session:

<img width="738" alt="Screenshot 2019-08-06 at 1 54 35 PM" src="https://user-images.githubusercontent.com/1269602/62523773-1aebc980-b852-11e9-970a-c5b8cbf6d841.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**

1. Schedule a new appointment. Verify that int the confirmation step, you see the `Go to your appointment dashboard` button.
2. Click the button and verify that you are taken to the appointment page - /me/concierge/{SITE_SLUG

**Scenario 2**

1. Reschedule the appointment. Verify that int the confirmation step, you see the `Go to your appointment dashboard` button.
2. Click the button and verify that you are taken to the appointment page - /me/concierge/{SITE_SLUG

