### PR TITLE
Checkout: switch e2e tests to the stripe based credit card fields

### DIFF
--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -51,7 +51,6 @@ import {
 import { getTld } from 'lib/domains';
 import { displayError, clear } from 'lib/upgrades/notices';
 import { removeNestedProperties } from 'lib/cart/store/cart-analytics';
-import { isE2ETest } from 'lib/e2e';
 
 /**
  * Module variables
@@ -94,8 +93,7 @@ export class SecurePaymentForm extends Component {
 
 		if (
 			this.props.cart &&
-			this.props.cart.allowed_payment_methods.includes( 'WPCOM_Billing_Stripe_Payment_Method' ) &&
-			! isE2ETest()
+			this.props.cart.allowed_payment_methods.includes( 'WPCOM_Billing_Stripe_Payment_Method' )
 		) {
 			this.shouldUseStripeElements = true;
 		}

--- a/test/e2e/lib/components/secure-payment-component.js
+++ b/test/e2e/lib/components/secure-payment-component.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { By, promise } from 'selenium-webdriver';
+import { By, promise, until } from 'selenium-webdriver';
 import config from 'config';
 
 /**
@@ -42,6 +42,20 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		);
 	}
 
+	async setInElementsIframe( iframeSelector, what, value ) {
+		await this.driver.wait(
+			until.ableToSwitchToFrame( By.css( iframeSelector ) ),
+			this.explicitWaitMS,
+			'Could not locate the ElementInput iFrame.'
+		);
+
+		await driverHelper.setWhenSettable( this.driver, By.name( what ), value, {
+			pauseBetweenKeysMS: 50,
+		} );
+
+		return await this.driver.switchTo().defaultContent();
+	}
+
 	async enterTestCreditCardDetails( {
 		cardHolder,
 		cardNumber,
@@ -57,15 +71,19 @@ export default class SecurePaymentComponent extends AsyncBaseContainer {
 		await driverHelper.setWhenSettable( this.driver, By.id( 'name' ), cardHolder, {
 			pauseBetweenKeysMS: pauseBetweenKeysMS,
 		} );
-		await driverHelper.setWhenSettable( this.driver, By.id( 'number' ), cardNumber, {
-			pauseBetweenKeysMS: pauseBetweenKeysMS,
-		} );
-		await driverHelper.setWhenSettable( this.driver, By.id( 'expiration-date' ), cardExpiry, {
-			pauseBetweenKeysMS: pauseBetweenKeysMS,
-		} );
-		await driverHelper.setWhenSettable( this.driver, By.id( 'cvv' ), cardCVV, {
-			pauseBetweenKeysMS: pauseBetweenKeysMS,
-		} );
+
+		await this.setInElementsIframe(
+			'.credit-card-form-fields .number iframe',
+			'cardnumber',
+			cardNumber
+		);
+		await this.setInElementsIframe( '.credit-card-form-fields .cvv iframe', 'cvc', cardCVV );
+		await this.setInElementsIframe(
+			'.credit-card-form-fields .expiration-date iframe',
+			'exp-date',
+			cardExpiry
+		);
+
 		await driverHelper.clickWhenClickable(
 			this.driver,
 			By.css( `div.country select option[value="${ cardCountryCode }"]` )

--- a/test/e2e/lib/data-helper.js
+++ b/test/e2e/lib/data-helper.js
@@ -234,7 +234,7 @@ export function getTestCreditCardDetails() {
 		cardHolder: 'End To End Testing',
 		cardType: 'VISA',
 		cardNumber: '4242 4242 4242 4242', // https://stripe.com/docs/testing#cards
-		cardExpiry: '02/49',
+		cardExpiry: '02 / 28',
 		cardCVV: '300',
 		cardCountryCode: 'TR', // using Turkey to force Stripe as payment processor
 		cardPostCode: '4000',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This updates our e2e tests for the new Stripe.js based credit card fields (see #34469)

#### Testing instructions

*`./node_modules/.bin/mocha specs/wp-signup-spec.js` worked for me.

