### PR TITLE
Manage purchase: fix when Jetpack site isn't available

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -330,13 +330,15 @@ class PurchaseMeta extends Component {
 					<em className="manage-purchase__detail-label">{ translate( 'Subscription Renewal' ) }</em>
 					<span className="manage-purchase__detail">{ subsRenewText }</span>
 					<span className="manage-purchase__detail">{ subsBillingText }</span>
-					<span className="manage-purchase__detail">
-						<AutoRenewToggle
-							planName={ site.plan.product_name_short }
-							siteDomain={ site.domain }
-							purchase={ purchase }
-						/>
-					</span>
+					{ site && (
+						<span className="manage-purchase__detail">
+							<AutoRenewToggle
+								planName={ site.plan.product_name_short }
+								siteDomain={ site.domain }
+								purchase={ purchase }
+							/>
+						</span>
+					) }
 				</li>
 			);
 		}


### PR DESCRIPTION
`<PurchaseMeta>` component breaks Calypso when `site` is `null`:
```
TypeError: site is null
    renderExpiration app:///./client/me/purchases/manage-purchase/purchase-meta.jsx:345
```

See pNPgK-4Gf-p2 for context.

#### Changes proposed in this Pull Request

* Add `site` check in `<PurchaseMeta>` component

#### Testing instructions

- You need a Jetpack site with a plan, and site disconnected
- Open `/me/purchases` and choose your plan from the list for disconnected site
- Not entirely sure yet what then as most of the time this just works. :-)


