### PR TITLE
Revert "Update inbound transfer message"

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -6,7 +6,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { localize, moment } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { endsWith, get, isEmpty, noop } from 'lodash';
 import page from 'page';
 import { stringify } from 'qs';
@@ -519,13 +519,10 @@ class TransferDomainStep extends React.Component {
 
 							this.setState( {
 								notice: this.props.translate(
-									'Domain transfers are temporarily disabled until %(transferEnableDate)s, ' +
-										'but you can {{a}}map your domain{{/a}} instead.',
+									"We don't support transfers for domains ending with {{strong}}.%(tld)s{{/strong}}, " +
+										'but you can {{a}}map it{{/a}} instead.',
 									{
-										args: {
-											tld: tld,
-											transferEnableDate: moment( '2019-07-30T08:00:00' ).format( 'LL' ),
-										},
+										args: { tld },
 										components: {
 											strong: <strong />,
 											a: <a href="#" onClick={ this.goToMapDomainStep } />, // eslint-disable-line jsx-a11y/anchor-is-valid


### PR DESCRIPTION
Reverts Automattic/wp-calypso#34891

Since we're done with the migration, we can revert this temporary message now.

Test by making sure that the previous message is shown when transfers are enabled.