### PR TITLE
Update translations of private site header and visit site link

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -173,7 +173,7 @@ class Login extends Component {
 				},
 			} );
 		} else if ( privateSite ) {
-			headerText = translate( 'This is a private WordPress.com site.' );
+			headerText = translate( 'This is a private WordPress.com site' );
 		} else if ( oauth2Client ) {
 			headerText = translate( 'Howdy! Log in to %(clientTitle)s with your WordPress.com account.', {
 				args: {

--- a/client/blocks/visit-site/index.jsx
+++ b/client/blocks/visit-site/index.jsx
@@ -39,7 +39,10 @@ export default function VisitSite( { siteSlug } ) {
 
 	return (
 		<div className="visit-site">
-			{ translate( 'or visit {{siteLink/}}', { components: { siteLink } } ) }
+			{ translate( 'or visit {{siteLink/}}', {
+				components: { siteLink },
+				context: 'Alternative link under login/site-selection header, leads to site frontend.',
+			} ) }
 		</div>
 	);
 }

--- a/client/login/wp-login/private-site.jsx
+++ b/client/login/wp-login/private-site.jsx
@@ -23,7 +23,7 @@ export default function PrivateSite() {
 			</div>
 
 			<h2 className="wp-login__private-site-header">
-				{ translate( 'This is a private WordPress.com site.' ) }
+				{ translate( 'This is a private WordPress.com site' ) }
 			</h2>
 
 			<p>


### PR DESCRIPTION
Followup to changes in #34541 that fixup the translations there:
- remove period after private site header: fuzzybot will save the old translations
- add context to the "or visit site" translation string
