### PR TITLE
Me: CreditCardForm: Refactor as functional component

### DIFF
--- a/client/blocks/credit-card-form/helpers.js
+++ b/client/blocks/credit-card-form/helpers.js
@@ -1,0 +1,152 @@
+/**
+ * External dependencies
+ */
+import { useState, useEffect, useRef } from 'react';
+import { camelCase, kebabCase, debounce } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import notices from 'notices';
+import { handleRenewNowClick, isRenewable } from 'lib/purchases';
+import wpcomFactory from 'lib/wp';
+
+const wpcom = wpcomFactory.undocumented();
+
+export async function saveCreditCard( {
+	createCardToken,
+	saveStoredCard,
+	translate,
+	successCallback,
+	apiParams,
+	purchase,
+	siteSlug,
+	formFieldValues,
+} ) {
+	const cardDetails = kebabCaseFormFields( formFieldValues );
+	const { token } = await createCardTokenAsync( { cardDetails, createCardToken } );
+
+	if ( saveStoredCard ) {
+		await saveStoredCard( { token } );
+		notices.success( translate( 'Card added successfully' ), {
+			persistent: true,
+		} );
+		successCallback();
+		return;
+	}
+
+	const updatedCreditCardApiParams = getParamsForApi( cardDetails, token, apiParams );
+	const response = wpcom.updateCreditCard( updatedCreditCardApiParams );
+	if ( response.error ) {
+		throw new Error( response );
+	}
+
+	if ( purchase && siteSlug && isRenewable( purchase ) ) {
+		const noticeMessage = translate(
+			'Your credit card details were successfully updated, but your subscription has not been renewed yet.'
+		);
+		const noticeOptions = {
+			button: translate( 'Renew Now' ),
+			onClick: function( event, closeFunction ) {
+				handleRenewNowClick( purchase, siteSlug );
+				closeFunction();
+			},
+			persistent: true,
+		};
+		notices.info( noticeMessage, noticeOptions );
+		successCallback();
+		return;
+	}
+	notices.success( response.success, {
+		persistent: true,
+	} );
+	successCallback();
+}
+
+export function getParamsForApi( cardDetails, cardToken, extraParams = {} ) {
+	return {
+		...extraParams,
+		country: cardDetails.country,
+		zip: cardDetails[ 'postal-code' ],
+		month: cardDetails[ 'expiration-date' ].split( '/' )[ 0 ],
+		year: cardDetails[ 'expiration-date' ].split( '/' )[ 1 ],
+		name: cardDetails.name,
+		document: cardDetails.document,
+		street_number: cardDetails[ 'street-number' ],
+		address_1: cardDetails[ 'address-1' ],
+		address_2: cardDetails[ 'address-2' ],
+		city: cardDetails.city,
+		state: cardDetails.state,
+		phone_number: cardDetails[ 'phone-number' ],
+		cardToken,
+	};
+}
+
+export function useDebounce( value, delay ) {
+	const [ debouncedValue, setDebouncedValue ] = useState( value );
+	const debounced = useRef( debounce( newValue => setDebouncedValue( newValue ), delay ) );
+	useEffect( () => debounced.current( value ), [ value ] );
+	return [ debouncedValue, setDebouncedValue ];
+}
+
+function createCardTokenAsync( { cardDetails, createCardToken } ) {
+	return new Promise( ( resolve, reject ) => {
+		createCardToken( cardDetails, ( gatewayError, gatewayData ) => {
+			if ( gatewayError || ! gatewayData.token ) {
+				reject( gatewayError || new Error( 'No card token returned' ) );
+				return;
+			}
+			resolve( gatewayData );
+		} );
+	} );
+}
+
+export function areFormFieldsEmpty( formFieldValues ) {
+	return Object.keys( formFieldValues ).reduce( ( isEmpty, key ) => {
+		return formFieldValues[ key ].length ? false : isEmpty;
+	}, true );
+}
+
+export function kebabCaseFormFields( formFieldValues ) {
+	return Object.keys( formFieldValues ).reduce( ( fields, key ) => {
+		fields[ kebabCase( key ) ] = formFieldValues[ key ];
+		return fields;
+	}, {} );
+}
+
+export function camelCaseFormFields( formFieldValues ) {
+	return Object.keys( formFieldValues ).reduce( ( fields, key ) => {
+		fields[ camelCase( key ) ] = formFieldValues[ key ];
+		return fields;
+	}, {} );
+}
+
+export function assignAllFormFields( formFieldValues, value ) {
+	return Object.keys( formFieldValues ).reduce( ( fields, key ) => {
+		fields[ key ] = value;
+		return fields;
+	}, {} );
+}
+
+export function getInitializedFields( initialValues = {} ) {
+	const fieldNames = [
+		'name',
+		'number',
+		'cvv',
+		'expirationDate',
+		'country',
+		'postalCode',
+		'streetNumber',
+		'address1',
+		'address2',
+		'phoneNumber',
+		'streetNumber',
+		'city',
+		'state',
+		'document',
+		'brand',
+	];
+	return fieldNames.reduce( ( finalFields, fieldName ) => {
+		return { ...finalFields, ...{ [ fieldName ]: initialValues[ fieldName ] || '' } };
+	}, {} );
+}

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
-import { camelCase, forOwn, kebabCase, mapKeys, values } from 'lodash';
+import { camelCase, kebabCase, values, debounce } from 'lodash';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 
@@ -16,7 +16,6 @@ import CompactCard from 'components/card/compact';
 import config from 'config';
 import CreditCardFormFields from 'components/credit-card-form-fields';
 import FormButton from 'components/forms/form-button';
-import formState from 'lib/form-state';
 import notices from 'notices';
 import { validatePaymentDetails } from 'lib/checkout';
 import { handleRenewNowClick, isRenewable } from 'lib/purchases';
@@ -34,40 +33,197 @@ import './style.scss';
 
 const wpcom = wpcomFactory.undocumented();
 
-export class CreditCardForm extends Component {
-	static displayName = 'CreditCardForm';
+function useDebounce( value, delay ) {
+	const [ debouncedValue, setDebouncedValue ] = useState( value );
+	const debounced = useRef( debounce( newValue => setDebouncedValue( newValue ), delay ) );
+	useEffect( () => debounced.current( value ), [ value ] );
+	return [ debouncedValue, setDebouncedValue ];
+}
 
-	static propTypes = {
-		apiParams: PropTypes.object,
-		createCardToken: PropTypes.func.isRequired,
-		countriesList: PropTypes.array.isRequired,
-		initialValues: PropTypes.object,
-		purchase: PropTypes.object,
-		recordFormSubmitEvent: PropTypes.func.isRequired,
-		saveStoredCard: PropTypes.func,
-		siteSlug: PropTypes.string,
-		successCallback: PropTypes.func.isRequired,
-		showUsedForExistingPurchasesInfo: PropTypes.bool,
-		autoFocus: PropTypes.bool,
-		heading: PropTypes.string,
-		onCancel: PropTypes.func,
+export function CreditCardForm( {
+	apiParams = {},
+	createCardToken,
+	countriesList,
+	initialValues,
+	purchase,
+	recordFormSubmitEvent,
+	saveStoredCard = null,
+	siteSlug,
+	successCallback,
+	showUsedForExistingPurchasesInfo = false,
+	autoFocus = true,
+	heading,
+	onCancel,
+	translate,
+	stripe,
+} ) {
+	const [ formSubmitting, setFormSubmitting ] = useState( false );
+	const [ formFieldValues, setFormFieldValues ] = useState( getInitializedFields( initialValues ) );
+	const [ touchedFormFields, setTouchedFormFields ] = useState( {} );
+	const [ formFieldErrors, setFormFieldErrors ] = useState(
+		camelCaseFormFields( validatePaymentDetails( kebabCaseFormFields( formFieldValues ) ).errors )
+	);
+	const [ debouncedFieldErrors, setDebouncedFieldErrors ] = useDebounce( formFieldErrors, 1000 );
+
+	const onFieldChange = rawDetails => {
+		const newValues = { ...formFieldValues, ...camelCaseFormFields( rawDetails ) };
+		setFormFieldValues( newValues );
+		setTouchedFormFields( camelCaseFormFields( rawDetails ) );
+		// Clear the errors of updated fields when typing then display them again after debounce
+		const clearedErrors = assignAllFormFields( camelCaseFormFields( rawDetails ), [] );
+		setDebouncedFieldErrors( { ...debouncedFieldErrors, ...clearedErrors } );
+		// Debounce updating validation errors
+		setFormFieldErrors(
+			camelCaseFormFields( validatePaymentDetails( kebabCaseFormFields( newValues ) ).errors )
+		);
 	};
 
-	static defaultProps = {
-		apiParams: {},
-		initialValues: {},
-		saveStoredCard: null,
-		showUsedForExistingPurchasesInfo: false,
-		autoFocus: true,
+	const getErrorMessage = fieldName => {
+		const camelName = camelCase( fieldName );
+		if ( touchedFormFields[ camelName ] ) {
+			return debouncedFieldErrors[ camelName ];
+		}
+		return formFieldValues[ camelName ] && debouncedFieldErrors[ camelName ];
 	};
 
-	state = {
-		form: null,
-		formSubmitting: false,
-		notice: null,
+	const onSubmit = async event => {
+		event.preventDefault();
+
+		if ( formSubmitting ) {
+			return;
+		}
+		setFormSubmitting( true );
+
+		try {
+			setTouchedFormFields( formFieldErrors );
+			if ( ! areFormFieldsEmpty( formFieldErrors ) ) {
+				throw new Error( translate( 'Your credit card information is not valid' ) );
+			}
+			recordFormSubmitEvent();
+			await saveCreditCard( {
+				createCardToken,
+				saveStoredCard,
+				translate,
+				successCallback,
+				apiParams,
+				purchase,
+				siteSlug,
+				formFieldValues,
+			} );
+		} catch ( error ) {
+			setFormSubmitting( false );
+			error &&
+				notices.error(
+					typeof error.message === 'object' ? (
+						<ValidationErrorList messages={ values( error.message ) } />
+					) : (
+						error.message
+					)
+				);
+		}
 	};
 
-	fieldNames = [
+	return (
+		<form onSubmit={ onSubmit }>
+			<Card className="credit-card-form__content">
+				{ heading && <div className="credit-card-form__heading">{ heading }</div> }
+				<QueryPaymentCountries />
+				<CreditCardFormFields
+					card={ kebabCaseFormFields( formFieldValues ) }
+					countriesList={ countriesList }
+					stripe={ stripe }
+					eventFormName="Edit Card Details Form"
+					onFieldChange={ onFieldChange }
+					getErrorMessage={ getErrorMessage }
+					autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
+				/>
+				<div className="credit-card-form__card-terms">
+					<Gridicon icon="info-outline" size={ 18 } />
+					<p>
+						<TosText translate={ translate } />
+					</p>
+				</div>
+				<UsedForExistingPurchasesInfo
+					translate={ translate }
+					showUsedForExistingPurchasesInfo={ showUsedForExistingPurchasesInfo }
+				/>
+			</Card>
+			<CompactCard className="credit-card-form__footer">
+				<em>{ translate( 'All fields required' ) }</em>
+				{ onCancel && (
+					<FormButton type="button" isPrimary={ false } onClick={ onCancel }>
+						{ translate( 'Cancel' ) }
+					</FormButton>
+				) }
+				<SaveButton translate={ translate } formSubmitting={ formSubmitting } />
+			</CompactCard>
+		</form>
+	);
+}
+
+CreditCardForm.propTypes = {
+	apiParams: PropTypes.object,
+	createCardToken: PropTypes.func.isRequired,
+	countriesList: PropTypes.array.isRequired,
+	initialValues: PropTypes.object,
+	purchase: PropTypes.object,
+	recordFormSubmitEvent: PropTypes.func.isRequired,
+	saveStoredCard: PropTypes.func,
+	siteSlug: PropTypes.string,
+	successCallback: PropTypes.func.isRequired,
+	showUsedForExistingPurchasesInfo: PropTypes.bool,
+	autoFocus: PropTypes.bool,
+	heading: PropTypes.string,
+	onCancel: PropTypes.func,
+	stripe: PropTypes.object,
+	translate: PropTypes.func.isRequired,
+};
+
+function SaveButton( { translate, formSubmitting } ) {
+	return (
+		<FormButton disabled={ formSubmitting } type="submit">
+			{ formSubmitting
+				? translate( 'Saving Card…', {
+						context: 'Button label',
+						comment: 'Credit card',
+				  } )
+				: translate( 'Save Card', {
+						context: 'Button label',
+						comment: 'Credit card',
+				  } ) }
+		</FormButton>
+	);
+}
+
+function areFormFieldsEmpty( formFieldValues ) {
+	return Object.keys( formFieldValues ).reduce( ( isEmpty, key ) => {
+		return formFieldValues[ key ].length ? false : isEmpty;
+	}, true );
+}
+
+function kebabCaseFormFields( formFieldValues ) {
+	return Object.keys( formFieldValues ).reduce( ( fields, key ) => {
+		fields[ kebabCase( key ) ] = formFieldValues[ key ];
+		return fields;
+	}, {} );
+}
+
+function camelCaseFormFields( formFieldValues ) {
+	return Object.keys( formFieldValues ).reduce( ( fields, key ) => {
+		fields[ camelCase( key ) ] = formFieldValues[ key ];
+		return fields;
+	}, {} );
+}
+
+function assignAllFormFields( formFieldValues, value ) {
+	return Object.keys( formFieldValues ).reduce( ( fields, key ) => {
+		fields[ key ] = value;
+		return fields;
+	}, {} );
+}
+
+function getInitializedFields( initialValues = {} ) {
+	const fieldNames = [
 		'name',
 		'number',
 		'cvv',
@@ -84,282 +240,135 @@ export class CreditCardForm extends Component {
 		'document',
 		'brand',
 	];
+	return fieldNames.reduce( ( finalFields, fieldName ) => {
+		return { ...finalFields, ...{ [ fieldName ]: initialValues[ fieldName ] || '' } };
+	}, {} );
+}
 
-	componentWillMount() {
-		const fields = this.fieldNames.reduce( ( result, fieldName ) => {
-			return { ...result, [ fieldName ]: '' };
-		}, {} );
-
-		if ( this.props.initialValues ) {
-			fields.name = this.props.initialValues.name;
-		}
-
-		this.formStateController = formState.Controller( {
-			initialFields: fields,
-			onNewState: this.setFormState,
-			validatorFunction: this.validate,
-		} );
-
-		this.setState( {
-			form: this.formStateController.getInitialState(),
-		} );
-	}
-
-	storeForm = ref => ( this.formElem = ref );
-
-	validate = ( formValues, onComplete ) =>
-		this.formElem && onComplete( null, this.getValidationErrors() );
-
-	setFormState = form => this.formElem && this.setState( { form } );
-
-	endFormSubmitting = () => this.formElem && this.setState( { formSubmitting: false } );
-
-	onFieldChange = rawDetails => {
-		// Maps params from CreditCardFormFields component to work with formState.
-		forOwn( rawDetails, ( value, name ) => {
-			this.formStateController.handleFieldChange( {
-				name,
-				value,
-			} );
-		} );
-	};
-
-	getErrorMessage = fieldName => formState.getFieldErrorMessages( this.state.form, fieldName );
-
-	onSubmit = event => {
-		event.preventDefault();
-
-		if ( this.state.formSubmitting ) {
-			return;
-		}
-
-		this.setState( { formSubmitting: true } );
-
-		this.formStateController.handleSubmit( hasErrors => {
-			if ( hasErrors ) {
-				this.setState( { formSubmitting: false } );
-				return;
-			}
-
-			this.props.recordFormSubmitEvent();
-
-			this.saveCreditCard();
-		} );
-	};
-
-	saveCreditCard() {
-		const {
-			createCardToken,
-			saveStoredCard,
-			translate,
-			successCallback,
-			apiParams,
-			purchase,
-			siteSlug,
-		} = this.props;
-		const cardDetails = this.getCardDetails();
-
-		createCardToken( cardDetails, ( gatewayError, gatewayData ) => {
-			if ( ! this.formElem ) {
-				return;
-			}
-
-			if ( gatewayError ) {
-				this.setState( { formSubmitting: false } );
-				notices.error( gatewayError.message );
-				return;
-			}
-
-			if ( saveStoredCard ) {
-				saveStoredCard( gatewayData )
-					.then( () => {
-						notices.success( translate( 'Card added successfully' ), {
-							persistent: true,
-						} );
-
-						successCallback();
-					} )
-					.catch( ( { message } ) => {
-						this.endFormSubmitting();
-
-						if ( typeof message === 'object' ) {
-							notices.error( <ValidationErrorList messages={ values( message ) } /> );
-						} else {
-							notices.error( message );
-						}
-					} );
-			} else {
-				const updatedCreditCardApiParams = this.getParamsForApi(
-					cardDetails,
-					gatewayData.token,
-					apiParams
-				);
-
-				wpcom.updateCreditCard( updatedCreditCardApiParams, ( apiError, response ) => {
-					if ( apiError ) {
-						this.endFormSubmitting();
-						notices.error( apiError.message );
-						return;
-					}
-
-					if ( response.error ) {
-						this.endFormSubmitting();
-						notices.error( response.error );
-						return;
-					}
-
-					if (
-						purchase &&
-						siteSlug &&
-						isRenewable( purchase ) &&
-						config.isEnabled( 'upgrades/checkout' )
-					) {
-						const noticeMessage = translate(
-							'Your credit card details were successfully updated, but your subscription has not been renewed yet.'
-						);
-						const noticeOptions = {
-							button: translate( 'Renew Now' ),
-							onClick: function( event, closeFunction ) {
-								handleRenewNowClick( purchase, siteSlug );
-								closeFunction();
-							},
-							persistent: true,
-						};
-						notices.info( noticeMessage, noticeOptions );
-					} else {
-						notices.success( response.success, {
-							persistent: true,
-						} );
-					}
-
-					successCallback();
-				} );
-			}
-		} );
-	}
-
-	getParamsForApi( cardDetails, cardToken, extraParams = {} ) {
-		return {
-			...extraParams,
-			country: cardDetails.country,
-			zip: cardDetails[ 'postal-code' ],
-			month: cardDetails[ 'expiration-date' ].split( '/' )[ 0 ],
-			year: cardDetails[ 'expiration-date' ].split( '/' )[ 1 ],
-			name: cardDetails.name,
-			document: cardDetails.document,
-			street_number: cardDetails[ 'street-number' ],
-			address_1: cardDetails[ 'address-1' ],
-			address_2: cardDetails[ 'address-2' ],
-			city: cardDetails.city,
-			state: cardDetails.state,
-			phone_number: cardDetails[ 'phone-number' ],
-			cardToken,
-		};
-	}
-
-	getValidationErrors() {
-		const validationResult = validatePaymentDetails( this.getCardDetails() );
-
-		// Maps keys from credit card validator to work with formState.
-		return mapKeys( validationResult.errors, ( value, key ) => {
-			return camelCase( key );
-		} );
-	}
-
-	getCardDetails() {
-		// Maps keys from formState to work with CreditCardFormFields component and credit card validator.
-		return mapKeys( formState.getAllFieldValues( this.state.form ), ( value, key ) => {
-			return kebabCase( key );
-		} );
-	}
-
-	render() {
-		const { translate, autoFocus, heading, onCancel } = this.props;
-		return (
-			<form onSubmit={ this.onSubmit } ref={ this.storeForm }>
-				<Card className="credit-card-form__content">
-					{ heading && <div className="credit-card-form__heading">{ heading }</div> }
-					<QueryPaymentCountries />
-					<CreditCardFormFields
-						card={ this.getCardDetails() }
-						countriesList={ this.props.countriesList }
-						eventFormName="Edit Card Details Form"
-						onFieldChange={ this.onFieldChange }
-						getErrorMessage={ this.getErrorMessage }
-						// "This prop can reduce usability and accessibility",
-						// but it's already enabled by default and this just
-						// provides a way to disable it, so...
-						// eslint-disable-next-line jsx-a11y/no-autofocus
-						autoFocus={ autoFocus }
+function TosText( { translate } ) {
+	return translate(
+		'By saving a credit card, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if ' +
+			'you use it to pay for a subscription or plan, you authorize your credit card to be charged ' +
+			'on a recurring basis until you cancel, which you can do at any time. ' +
+			'You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} ' +
+			'and {{managePurchasesSupportPage}}how to cancel{{/managePurchasesSupportPage}}.',
+		{
+			components: {
+				tosLink: (
+					<a
+						href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+						target="_blank"
+						rel="noopener noreferrer"
 					/>
-					<div className="credit-card-form__card-terms">
-						<Gridicon icon="info-outline" size={ 18 } />
-						<p>
-							{ translate(
-								'By saving a credit card, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and if ' +
-									'you use it to pay for a subscription or plan, you authorize your credit card to be charged ' +
-									'on a recurring basis until you cancel, which you can do at any time. ' +
-									'You understand {{autoRenewalSupportPage}}how your subscription works{{/autoRenewalSupportPage}} ' +
-									'and {{managePurchasesSupportPage}}how to cancel{{/managePurchasesSupportPage}}.',
-								{
-									components: {
-										tosLink: (
-											<a
-												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-										autoRenewalSupportPage: (
-											<a href={ AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
-										),
-										managePurchasesSupportPage: (
-											<a href={ MANAGE_PURCHASES } target="_blank" rel="noopener noreferrer" />
-										),
-									},
-								}
-							) }
-						</p>
-					</div>
-					{ this.renderUsedForExistingPurchases() }
-				</Card>
-				<CompactCard className="credit-card-form__footer">
-					<em>{ translate( 'All fields required' ) }</em>
-					{ onCancel && (
-						<FormButton type="button" isPrimary={ false } onClick={ onCancel }>
-							{ translate( 'Cancel' ) }
-						</FormButton>
-					) }
-					<FormButton disabled={ this.state.formSubmitting } type="submit">
-						{ this.state.formSubmitting
-							? translate( 'Saving Card…', {
-									context: 'Button label',
-									comment: 'Credit card',
-							  } )
-							: translate( 'Save Card', {
-									context: 'Button label',
-									comment: 'Credit card',
-							  } ) }
-					</FormButton>
-				</CompactCard>
-			</form>
-		);
-	}
-
-	renderUsedForExistingPurchases() {
-		const { translate, showUsedForExistingPurchasesInfo } = this.props;
-
-		if ( ! showUsedForExistingPurchasesInfo ) {
-			return;
+				),
+				autoRenewalSupportPage: (
+					<a href={ AUTO_RENEWAL } target="_blank" rel="noopener noreferrer" />
+				),
+				managePurchasesSupportPage: (
+					<a href={ MANAGE_PURCHASES } target="_blank" rel="noopener noreferrer" />
+				),
+			},
 		}
+	);
+}
 
-		return (
-			<div className="credit-card-form__card-terms">
-				<Gridicon icon="info-outline" size={ 18 } />
-				<p>{ translate( 'This card will be used for future renewals of existing purchases.' ) }</p>
-			</div>
-		);
+function UsedForExistingPurchasesInfo( { translate, showUsedForExistingPurchasesInfo } ) {
+	if ( ! showUsedForExistingPurchasesInfo ) {
+		return null;
 	}
+
+	return (
+		<div className="credit-card-form__card-terms">
+			<Gridicon icon="info-outline" size={ 18 } />
+			<p>{ translate( 'This card will be used for future renewals of existing purchases.' ) }</p>
+		</div>
+	);
+}
+
+function createCardTokenAsync( { cardDetails, createCardToken } ) {
+	return new Promise( ( resolve, reject ) => {
+		createCardToken( cardDetails, ( gatewayError, gatewayData ) => {
+			if ( gatewayError || ! gatewayData.token ) {
+				reject( gatewayError || new Error( 'No card token returned' ) );
+				return;
+			}
+			resolve( gatewayData );
+		} );
+	} );
+}
+
+async function saveCreditCard( {
+	createCardToken,
+	saveStoredCard,
+	translate,
+	successCallback,
+	apiParams,
+	purchase,
+	siteSlug,
+	formFieldValues,
+} ) {
+	const cardDetails = kebabCaseFormFields( formFieldValues );
+	const { token } = await createCardTokenAsync( { cardDetails, createCardToken } );
+
+	if ( saveStoredCard ) {
+		await saveStoredCard( { token } );
+		notices.success( translate( 'Card added successfully' ), {
+			persistent: true,
+		} );
+		successCallback();
+		return;
+	}
+
+	const updatedCreditCardApiParams = getParamsForApi( cardDetails, token, apiParams );
+	const response = wpcom.updateCreditCard( updatedCreditCardApiParams );
+	if ( response.error ) {
+		throw new Error( response );
+	}
+
+	if (
+		purchase &&
+		siteSlug &&
+		isRenewable( purchase ) &&
+		config.isEnabled( 'upgrades/checkout' )
+	) {
+		const noticeMessage = translate(
+			'Your credit card details were successfully updated, but your subscription has not been renewed yet.'
+		);
+		const noticeOptions = {
+			button: translate( 'Renew Now' ),
+			onClick: function( event, closeFunction ) {
+				handleRenewNowClick( purchase, siteSlug );
+				closeFunction();
+			},
+			persistent: true,
+		};
+		notices.info( noticeMessage, noticeOptions );
+		successCallback();
+		return;
+	}
+	notices.success( response.success, {
+		persistent: true,
+	} );
+	successCallback();
+}
+
+export function getParamsForApi( cardDetails, cardToken, extraParams = {} ) {
+	return {
+		...extraParams,
+		country: cardDetails.country,
+		zip: cardDetails[ 'postal-code' ],
+		month: cardDetails[ 'expiration-date' ].split( '/' )[ 0 ],
+		year: cardDetails[ 'expiration-date' ].split( '/' )[ 1 ],
+		name: cardDetails.name,
+		document: cardDetails.document,
+		street_number: cardDetails[ 'street-number' ],
+		address_1: cardDetails[ 'address-1' ],
+		address_2: cardDetails[ 'address-2' ],
+		city: cardDetails.city,
+		state: cardDetails.state,
+		phone_number: cardDetails[ 'phone-number' ],
+		cardToken,
+	};
 }
 
 export default connect( state => ( {

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -13,7 +13,6 @@ import Gridicon from 'gridicons';
  */
 import Card from 'components/card';
 import CompactCard from 'components/card/compact';
-import config from 'config';
 import CreditCardFormFields from 'components/credit-card-form-fields';
 import FormButton from 'components/forms/form-button';
 import notices from 'notices';
@@ -325,12 +324,7 @@ async function saveCreditCard( {
 		throw new Error( response );
 	}
 
-	if (
-		purchase &&
-		siteSlug &&
-		isRenewable( purchase ) &&
-		config.isEnabled( 'upgrades/checkout' )
-	) {
+	if ( purchase && siteSlug && isRenewable( purchase ) ) {
 		const noticeMessage = translate(
 			'Your credit card details were successfully updated, but your subscription has not been renewed yet.'
 		);

--- a/client/blocks/credit-card-form/index.jsx
+++ b/client/blocks/credit-card-form/index.jsx
@@ -32,13 +32,6 @@ import './style.scss';
 
 const wpcom = wpcomFactory.undocumented();
 
-function useDebounce( value, delay ) {
-	const [ debouncedValue, setDebouncedValue ] = useState( value );
-	const debounced = useRef( debounce( newValue => setDebouncedValue( newValue ), delay ) );
-	useEffect( () => debounced.current( value ), [ value ] );
-	return [ debouncedValue, setDebouncedValue ];
-}
-
 export function CreditCardForm( {
 	apiParams = {},
 	createCardToken,
@@ -67,7 +60,7 @@ export function CreditCardForm( {
 	const onFieldChange = rawDetails => {
 		const newValues = { ...formFieldValues, ...camelCaseFormFields( rawDetails ) };
 		setFormFieldValues( newValues );
-		setTouchedFormFields( camelCaseFormFields( rawDetails ) );
+		setTouchedFormFields( { ...touchedFormFields, ...camelCaseFormFields( rawDetails ) } );
 		// Clear the errors of updated fields when typing then display them again after debounce
 		const clearedErrors = assignAllFormFields( camelCaseFormFields( rawDetails ), [] );
 		setDebouncedFieldErrors( { ...debouncedFieldErrors, ...clearedErrors } );
@@ -363,6 +356,13 @@ export function getParamsForApi( cardDetails, cardToken, extraParams = {} ) {
 		phone_number: cardDetails[ 'phone-number' ],
 		cardToken,
 	};
+}
+
+function useDebounce( value, delay ) {
+	const [ debouncedValue, setDebouncedValue ] = useState( value );
+	const debounced = useRef( debounce( newValue => setDebouncedValue( newValue ), delay ) );
+	useEffect( () => debounced.current( value ), [ value ] );
+	return [ debouncedValue, setDebouncedValue ];
 }
 
 export default connect( state => ( {

--- a/client/blocks/credit-card-form/test/index.js
+++ b/client/blocks/credit-card-form/test/index.js
@@ -13,7 +13,7 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { CreditCardForm } from '../';
+import { CreditCardForm, getParamsForApi } from '../';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
@@ -38,10 +38,8 @@ describe( 'Credit Card Form', () => {
 
 	describe( 'getParamsForApi()', () => {
 		test( 'should return expected api params from form credit card values', () => {
-			const wrapper = shallow( <CreditCardForm { ...defaultProps } /> );
-
 			expect(
-				wrapper.instance().getParamsForApi(
+				getParamsForApi(
 					{
 						country: 'AU',
 						'postal-code': '33333',

--- a/client/blocks/credit-card-form/test/index.js
+++ b/client/blocks/credit-card-form/test/index.js
@@ -17,6 +17,7 @@ import { CreditCardForm, getParamsForApi } from '../';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
+	translate: x => x,
 } ) );
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'

--- a/client/blocks/credit-card-form/test/index.js
+++ b/client/blocks/credit-card-form/test/index.js
@@ -15,6 +15,7 @@ import React from 'react';
  */
 import { CreditCardForm } from '../';
 import { getParamsForApi } from '../helpers';
+import CreditCardFormFields from 'components/credit-card-form-fields';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,
@@ -36,6 +37,50 @@ describe( 'Credit Card Form', () => {
 	test( 'does not blow up with default props', () => {
 		const wrapper = shallow( <CreditCardForm { ...defaultProps } /> );
 		expect( wrapper ).toHaveLength( 1 );
+	} );
+
+	test( 'renders CreditCardFormFields', () => {
+		const wrapper = shallow( <CreditCardForm { ...defaultProps } /> );
+		expect( wrapper.find( CreditCardFormFields ) ).toHaveLength( 1 );
+	} );
+
+	test( 'renders CreditCardFormFields with appropriate fields', () => {
+		const wrapper = shallow( <CreditCardForm { ...defaultProps } /> );
+		const child = wrapper.find( CreditCardFormFields );
+		expect( child.prop( 'card' ) ).toEqual( {
+			'address-1': '',
+			'address-2': '',
+			brand: '',
+			city: '',
+			country: '',
+			cvv: '',
+			document: '',
+			'expiration-date': '',
+			name: '',
+			number: '',
+			'phone-number': '',
+			'postal-code': '',
+			state: '',
+			'street-number': '',
+		} );
+	} );
+
+	test( 'has getErrorMessage return no errors for an empty field', () => {
+		const initialValues = { number: '' };
+		const props = { ...defaultProps, initialValues };
+		const wrapper = shallow( <CreditCardForm { ...props } /> );
+		const child = wrapper.find( CreditCardFormFields );
+		const getErrorMessage = child.prop( 'getErrorMessage' );
+		expect( getErrorMessage( 'number' ) ).toEqual( '' );
+	} );
+
+	test( 'has getErrorMessage return the correct errors', () => {
+		const initialValues = { number: '234' };
+		const props = { ...defaultProps, initialValues };
+		const wrapper = shallow( <CreditCardForm { ...props } /> );
+		const child = wrapper.find( CreditCardFormFields );
+		const getErrorMessage = child.prop( 'getErrorMessage' );
+		expect( getErrorMessage( 'number' )[ 0 ] ).toMatch( /invalid/ );
 	} );
 
 	describe( 'getParamsForApi()', () => {

--- a/client/blocks/credit-card-form/test/index.js
+++ b/client/blocks/credit-card-form/test/index.js
@@ -13,7 +13,8 @@ import React from 'react';
 /**
  * Internal dependencies
  */
-import { CreditCardForm, getParamsForApi } from '../';
+import { CreditCardForm } from '../';
+import { getParamsForApi } from '../helpers';
 
 jest.mock( 'i18n-calypso', () => ( {
 	localize: x => x,

--- a/client/lib/checkout/validation.js
+++ b/client/lib/checkout/validation.js
@@ -300,20 +300,17 @@ validators.validStreetNumber = {
  * @returns {object} validation errors, if any
  */
 export function validatePaymentDetails( paymentDetails, paymentType = 'credit-card' ) {
-	const rules = paymentFieldRules( paymentDetails, paymentType );
-	let errors = [];
-	if ( rules ) {
-		errors = Object.keys( rules ).reduce( function( allErrors, fieldName ) {
-			const field = rules[ fieldName ],
-				newErrors = getErrors( field, paymentDetails[ fieldName ], paymentDetails );
+	const rules = paymentFieldRules( paymentDetails, paymentType ) || {};
+	const errors = Object.keys( rules ).reduce( function( allErrors, fieldName ) {
+		const field = rules[ fieldName ];
+		const newErrors = getErrors( field, paymentDetails[ fieldName ], paymentDetails );
 
-			if ( newErrors.length ) {
-				allErrors[ fieldName ] = newErrors;
-			}
+		if ( newErrors.length ) {
+			allErrors[ fieldName ] = newErrors;
+		}
 
-			return allErrors;
-		}, {} );
-	}
+		return allErrors;
+	}, {} );
 	return { errors };
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of modifying the "Add new card" form in #34848, some changes need to be made to the `CreditCardForm` which is used by that flow and several others. That component has several large methods, keeps some of its state in an external persistent object, and has several pieces of unused state. In this PR I've refactored the component into a simpler version which breaks it up into multiple smaller components, helper functions, and simpler state. This should not have any functional change, but it is a large refactor so it bears a lot of testing.

#### Testing instructions

Visit the "Add Card" form at http://calypso.localhost:3000/me/purchases/add-credit-card. Verify that typing in the fields works as expected (without any lag or jumping that might occur if the state object is not working well), that validation errors are displayed if using an invalid card or if there are missing details, and that a valid card can be added successfully.

Here's a list of all the components that use `CreditCardForm` and should be tested in the manner described above:

– `AddCreditCard`: http://calypso.localhost:3000/me/purchases/add-credit-card
– `AppComponents` in devdocs: http://calypso.localhost:3000/devdocs/blocks
– `EditCardDetails`: make sure you have purchased something, then visit http://calypso.localhost:3000/me/purchases, click on a purchase, and then click on "Change Payment Method"
– `AddCardDetails`: follow `EditCardDetails` instructions, but then change the end of the URL so that instead of `/payment/edit/123456` it reads `/payment/add`
– `AddCardDialog` in woocommerce-services: I'm not familiar with Woo, but the URL we need to arrive at is http://calypso.localhost:3000/store/settings/shipping/:site

## Screenshots

An example of some validation errors:

![Screen Shot 2019-07-29 at 5 58 35 PM](https://user-images.githubusercontent.com/2036909/62085826-89190680-b22a-11e9-85ba-accba3f250b3.png)
