### PR TITLE
Earn Page: Update Store card logic

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -28,7 +28,6 @@ interface ConnectedProps {
 	isFreePlan: boolean;
 	hasSimplePayments: boolean;
 	hasWordAds: boolean;
-	hasUploadPlugins: boolean;
 	hasConnectedAccount: boolean;
 	hasSetupAds: boolean;
 	canUserUseStore: boolean;
@@ -41,7 +40,6 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	isFreePlan,
 	hasSimplePayments,
 	hasWordAds,
-	hasUploadPlugins,
 	hasConnectedAccount,
 	hasSetupAds,
 	canUserUseStore,


### PR DESCRIPTION
The store card is now only hidden for self-hosted Jetpack sites, and any
other site that isn't Atomic is encouraged to upgrade to the eCommerce
plan.

We will probably need to update this italicised text "Available to sites with a Business plan."

#### Testing instructions

Use calypso.live and the `earn-relayout` feature flag, to view the `/earn` page using various sites. The behaviour should be:

* Atomic site - Setup a simple store
* Simple site - Upgrade to eCommerce
* Self-hosted Jetpack site - Card hidden

Fixes #34934 
Although the card will still display, the experience is the same as the Store link in the sidebar.
