### PR TITLE
CrowdSignal Login: TOS copy should reflect button copy

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -552,8 +552,7 @@ export class LoginForm extends Component {
 							{ preventWidows(
 								this.props.translate(
 									// To make any changes to this copy please speak to the legal team
-									'By creating an account, ' +
-										'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
+									'By continuing, ' + 'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
 									{
 										components: {
 											tosLink: (

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -606,29 +606,6 @@ export class LoginForm extends Component {
 						/>
 					</Fragment>
 				) }
-
-				{ config.isEnabled( 'signup/social' ) && isCrowdsignalOAuth2Client( oauth2Client ) && (
-					<p className="login__form-terms login__form-terms-bottom">
-						{ preventWidows(
-							this.props.translate(
-								'By creating an account, ' +
-									'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
-								{
-									components: {
-										tosLink: (
-											<a
-												href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-												target="_blank"
-												rel="noopener noreferrer"
-											/>
-										),
-									},
-								}
-							),
-							5
-						) }
-					</p>
-				) }
 			</form>
 		);
 	}

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -570,6 +570,28 @@ export class LoginForm extends Component {
 						</p>
 					) }
 
+					{ config.isEnabled( 'signup/social' ) && isCrowdsignalOAuth2Client( oauth2Client ) && (
+						<p className="login__form-terms login__form-terms-bottom">
+							{ preventWidows(
+								this.props.translate(
+									'By continuing, ' + 'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
+									{
+										components: {
+											tosLink: (
+												<a
+													href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+													target="_blank"
+													rel="noopener noreferrer"
+												/>
+											),
+										},
+									}
+								),
+								5
+							) }
+						</p>
+					) }
+
 					<div className="login__form-action">
 						<FormsButton primary disabled={ isFormDisabled }>
 							{ this.isPasswordView() || this.isFullView()

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -201,7 +201,7 @@
 		}
 
 		.login__divider {
-			margin: 30px auto;
+			margin: 10px auto;
 			text-transform: lowercase;
 
 			span {
@@ -248,6 +248,7 @@
 				@include breakpoint( '>660px' ) {
 					display: block;
 					position: initial;
+					margin-bottom: 30px;
 				}
 			}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves the TOS reminder above the Continue buttons
* Updates the TOS copy to reflect the same language as the buttons

**Before**

<img width="586" alt="Screen Shot 2019-07-29 at 2 08 35 PM" src="https://user-images.githubusercontent.com/2124984/62071419-78589880-b20a-11e9-82c6-567371f26cff.png">


**After**

<img width="577" alt="Screen Shot 2019-07-29 at 1 55 40 PM" src="https://user-images.githubusercontent.com/2124984/62071422-7b538900-b20a-11e9-8bd9-bc46c163a540.png">


#### Testing instructions

* [Click this link](https://hash-b8d6152c1590016d82c78b4ada2955ac617b396e.calypso.live/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3Dfefa66fb5886f5dc36655b354934808093da631717389e6ef6b4b3471527e123%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1) and look for copy and visual changes