### PR TITLE
Earn: get always a boolean value for connected payments account

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -248,8 +248,11 @@ export default connect< ConnectedProps, {}, {} >( state => {
 		hasUploadPlugins: hasFeature( state, site.ID, FEATURE_UPLOAD_PLUGINS ),
 		hasSimplePayments: hasFeature( state, site.ID, FEATURE_SIMPLE_PAYMENTS ),
 		isAJetpackSite: isJetpackSite( state, site.ID ),
-		hasConnectedAccount:
-			null !== get( state, [ 'memberships', 'settings', site.ID, 'connectedAccountId' ], null ),
+		hasConnectedAccount: !! get(
+			state,
+			[ 'memberships', 'settings', site.ID, 'connectedAccountId' ],
+			false
+		),
 		hasSetupAds: site.options.wordads || isRequestingWordAdsApprovalForSite( state, site ),
 	};
 } )( Home );


### PR DESCRIPTION
This PR fixes an issue with the Collect Recurring Payments card, where if you started the process to connect the Stripe account but didn't finish it, the value in `state.memberships.settings.%SITEID%.connectedAccountId` is no longer `null` but false.
This was causing the wrong texts to show up in this card, because the `hasConnectedAccount` was being set to false when the value was null, because of a comparison against null, but true when the value was false due to the comparison against null.

#### Changes proposed in this Pull Request

* get always a boolean value instead of `null`.

#### Testing instructions

* go to `earn/SITESLUG?flags=earn-relayout` in a brand new site
* make sure you see the card Collect Recurring Payments
* upgrade to a paid plan, go to `earn/payments/SITESLUG?flags=earn-relayout`
* click the button to connect the account but close it
* remove the plan
* go back to the card and ensure it's not saying Manage Recurring Payments, but Collect Recurring Payments

Follow up #34948
