### PR TITLE
Validate phone number in concierge booking form

### DIFF
--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -20,6 +20,7 @@ import FormLabel from 'components/forms/form-label';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
+import FormPhoneInput from 'components/forms/form-phone-input';
 import IsRebrandCitiesSite from './is-rebrand-cities-site';
 import Timezone from 'components/timezone';
 import Site from 'blocks/site';
@@ -31,6 +32,9 @@ import { getCurrentUserLocale } from 'state/current-user/selectors';
 import PrimaryHeader from '../shared/primary-header';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { getLanguage } from 'lib/i18n-utils';
+import getCountries from 'state/selectors/get-countries';
+import QuerySmsCountries from 'components/data/query-countries/sms';
+import FormInputValidation from 'components/forms/form-input-validation';
 
 class InfoStep extends Component {
 	static propTypes = {
@@ -39,6 +43,10 @@ class InfoStep extends Component {
 		userSettings: PropTypes.object,
 		onComplete: PropTypes.func.isRequired,
 		site: PropTypes.object.isRequired,
+	};
+
+	state = {
+		validation: '',
 	};
 
 	setTimezone = timezone => {
@@ -56,6 +64,17 @@ class InfoStep extends Component {
 		this.updateSignupForm( 'isRebrandCitiesSite', value );
 	};
 
+	onChange = phoneNumber => {
+		if ( phoneNumber.phoneNumber && ! phoneNumber.isValid ) {
+			this.setState( {
+				validation: this.props.translate( 'Please enter a valid phone number.' ),
+			} );
+		} else {
+			this.setState( { validation: '' } );
+		}
+		this.updateSignupForm( 'phoneNumber', phoneNumber.phoneNumberFull );
+	};
+
 	setFieldValue = ( { target: { name, value } } ) => {
 		this.updateSignupForm( name, value );
 	};
@@ -64,6 +83,10 @@ class InfoStep extends Component {
 		const {
 			signupForm: { firstname, message },
 		} = this.props;
+
+		if ( this.state.validation ) {
+			return false;
+		}
 
 		return !! firstname.trim() && !! message.trim();
 	};
@@ -90,7 +113,7 @@ class InfoStep extends Component {
 		const {
 			currentUserLocale,
 			onComplete,
-			signupForm: { firstname, lastname, message, timezone, phoneNumber },
+			signupForm: { firstname, lastname, message, timezone },
 			site,
 			translate,
 		} = this.props;
@@ -142,18 +165,20 @@ class InfoStep extends Component {
 					</FormFieldset>
 
 					<FormFieldset>
-						<FormLabel>{ translate( "What's your phone number?" ) }</FormLabel>
-						<FormTextInput
+						<QuerySmsCountries />
+						<FormPhoneInput
 							name="phoneNumber"
-							placeholder={ translate( 'Enter your phone number including the country code' ) }
-							onChange={ this.setFieldValue }
-							value={ phoneNumber }
+							countriesList={ this.props.countriesList }
+							onChange={ this.onChange }
+							className="book__info-step-phone-input"
 						/>
 						<FormSettingExplanation>
-							{ translate(
-								'We will not call you — this is so that we can send you a reminder. Check your email for the link to join our screenshare.'
-							) }
+							{ translate( 'We will not call you — this is so that we can send you a reminder.' ) }
 						</FormSettingExplanation>
+
+						{ this.state.validation && (
+							<FormInputValidation isError text={ this.state.validation } />
+						) }
 					</FormFieldset>
 
 					<FormFieldset>
@@ -196,6 +221,7 @@ export default connect(
 		currentUserLocale: getCurrentUserLocale( state ),
 		signupForm: getConciergeSignupForm( state ),
 		userSettings: getUserSettings( state ),
+		countriesList: getCountries( state, 'sms' ),
 	} ),
 	{
 		updateConciergeSignupForm,

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -72,7 +72,13 @@ class InfoStep extends Component {
 		} else {
 			this.setState( { validation: '' } );
 		}
-		this.updateSignupForm( 'phoneNumber', phoneNumber.phoneNumberFull );
+
+		this.props.updateConciergeSignupForm( {
+			...this.props.signupForm,
+			countryCode: phoneNumber.countryData.numeric_code,
+			phoneNumberWithoutCountryCode: phoneNumber.phoneNumber,
+			phoneNumber: phoneNumber.phoneNumberFull,
+		} );
 	};
 
 	setFieldValue = ( { target: { name, value } } ) => {
@@ -113,7 +119,14 @@ class InfoStep extends Component {
 		const {
 			currentUserLocale,
 			onComplete,
-			signupForm: { firstname, lastname, message, timezone },
+			signupForm: {
+				firstname,
+				lastname,
+				message,
+				timezone,
+				countryCode,
+				phoneNumberWithoutCountryCode,
+			},
 			site,
 			translate,
 		} = this.props;
@@ -170,6 +183,8 @@ class InfoStep extends Component {
 							name="phoneNumber"
 							countriesList={ this.props.countriesList }
 							onChange={ this.onChange }
+							initialCountryCode={ countryCode }
+							initialPhoneNumber={ phoneNumberWithoutCountryCode }
 							className="book__info-step-phone-input"
 						/>
 						<FormSettingExplanation>

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -77,7 +77,7 @@ class InfoStep extends Component {
 			...this.props.signupForm,
 			countryCode: phoneNumber.countryData.numeric_code,
 			phoneNumberWithoutCountryCode: phoneNumber.phoneNumber,
-			phoneNumber: phoneNumber.phoneNumberFull,
+			phoneNumber: phoneNumber.phoneNumber ? phoneNumber.phoneNumberFull : '',
 		} );
 	};
 

--- a/client/me/concierge/book/info-step.js
+++ b/client/me/concierge/book/info-step.js
@@ -75,7 +75,7 @@ class InfoStep extends Component {
 
 		this.props.updateConciergeSignupForm( {
 			...this.props.signupForm,
-			countryCode: phoneNumber.countryData.numeric_code,
+			countryCode: phoneNumber.countryData.code,
 			phoneNumberWithoutCountryCode: phoneNumber.phoneNumber,
 			phoneNumber: phoneNumber.phoneNumber ? phoneNumber.phoneNumberFull : '',
 		} );

--- a/client/me/concierge/style.scss
+++ b/client/me/concierge/style.scss
@@ -55,6 +55,14 @@
 	margin-right: 10px;
 }
 
+.book__info-step-phone-input {
+	display: flex;
+	& fieldset {
+		flex: 1;
+		margin-bottom: 0;
+	}
+}
+
 .book__schedule-button,
 .cancel__schedule-button,
 .reschedule__schedule-button,

--- a/client/state/concierge/signup-form/reducer.js
+++ b/client/state/concierge/signup-form/reducer.js
@@ -35,6 +35,15 @@ export const phoneNumber = createReducer( '', {
 	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.phoneNumber,
 } );
 
+export const countryCode = createReducer( '', {
+	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) => action.signupForm.countryCode,
+} );
+
+export const phoneNumberWithoutCountryCode = createReducer( '', {
+	[ CONCIERGE_SIGNUP_FORM_UPDATE ]: ( state, action ) =>
+		action.signupForm.phoneNumberWithoutCountryCode,
+} );
+
 export const status = createReducer( null, {
 	[ CONCIERGE_UPDATE_BOOKING_STATUS ]: ( state, action ) => action.status,
 } );
@@ -47,4 +56,6 @@ export default combineReducers( {
 	status,
 	isRebrandCitiesSite,
 	phoneNumber,
+	countryCode,
+	phoneNumberWithoutCountryCode,
 } );

--- a/client/state/concierge/signup-form/test/reducer.js
+++ b/client/state/concierge/signup-form/test/reducer.js
@@ -28,7 +28,7 @@ describe( 'concierge/signupForm/reducer', () => {
 		timezone: 'UTC',
 		message: 'hello',
 		phoneNumber: '+910123456789',
-		countryCode: '+91',
+		countryCode: 'IN',
 		phoneNumberWithoutCountryCode: '987654321',
 		status: 'booking',
 		isRebrandCitiesSite: true,

--- a/client/state/concierge/signup-form/test/reducer.js
+++ b/client/state/concierge/signup-form/test/reducer.js
@@ -14,6 +14,8 @@ import signupForm, {
 	timezone,
 	message,
 	phoneNumber,
+	countryCode,
+	phoneNumberWithoutCountryCode,
 	status,
 	isRebrandCitiesSite,
 } from '../reducer';
@@ -25,7 +27,9 @@ describe( 'concierge/signupForm/reducer', () => {
 		lastname: 'Bar',
 		timezone: 'UTC',
 		message: 'hello',
-		phoneNumber: '0123456789',
+		phoneNumber: '+910123456789',
+		countryCode: '+91',
+		phoneNumberWithoutCountryCode: '987654321',
 		status: 'booking',
 		isRebrandCitiesSite: true,
 	};
@@ -91,6 +95,28 @@ describe( 'concierge/signupForm/reducer', () => {
 		} );
 	} );
 
+	describe( 'countryCode', () => {
+		test( 'should be defaulted as empty string.', () => {
+			expect( countryCode( undefined, {} ) ).toEqual( '' );
+		} );
+
+		test( 'should return the country code of the update action', () => {
+			expect( countryCode( {}, updateForm ) ).toEqual( mockSignupForm.countryCode );
+		} );
+	} );
+
+	describe( 'phoneNumberWithoutCountryCode', () => {
+		test( 'should be defaulted as empty string.', () => {
+			expect( phoneNumberWithoutCountryCode( undefined, {} ) ).toEqual( '' );
+		} );
+
+		test( 'should return the phone number without country code of the update action', () => {
+			expect( phoneNumberWithoutCountryCode( {}, updateForm ) ).toEqual(
+				mockSignupForm.phoneNumberWithoutCountryCode
+			);
+		} );
+	} );
+
 	describe( 'status', () => {
 		test( 'should be defaulted as null', () => {
 			expect( status( undefined, {} ) ).toBeNull();
@@ -121,6 +147,8 @@ describe( 'concierge/signupForm/reducer', () => {
 				timezone: moment.tz.guess(),
 				message: '',
 				phoneNumber: '',
+				countryCode: '',
+				phoneNumberWithoutCountryCode: '',
 				status: null,
 				isRebrandCitiesSite: false,
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add phone number validation in the booking page.
* Adds a new country code field before the phone number field. The appointment booking will not proceed if the phone number validation fails.

**Screen recording:**

Check this for how the validation works - https://cloudup.com/cTDVyIobbF6

**Screenshot:**

<img width="732" alt="Screenshot 2019-08-05 at 7 34 39 PM" src="https://user-images.githubusercontent.com/1269602/62470831-e7109580-b7b8-11e9-997d-eea579010e4b.png">



#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
For all the scenarios below, you need to either be on an account having a Business/eCommerce plan, OR an account with a purchased concierge session.

**Scenario 1 (Empty phone field should be allowed)**
* Go to /me/concierge
* Leave the Phone number field empty.
* Verify that you are the `Continue to calendar` button shows enabled. Then proceed to complete the booking.
* Head to the MC tool /happiness/concierge and check if your booking shows up. Verify that the Phone number field shown in the MC tool is empty.

**Scenario 2 (Invalid phone number should be disallowed)**
* Go to /me/concierge
* Select any country and enter an invalid number for that country. For e.g. if you select USA, then enter a number with an invalid area code.
* Verify that the phone number field shows an error message, and that the `Continue to calendar` button becomes disabled.

**Scenario 3 (valid phone number should be alllowed)**
* Go to /me/concierge
* Select any country and enter a valid number for that country. For e.g. if you select USA, then enter a number with a valid area code. 
* Verify that the phone number field validates successfully, and that the `Continue to calendar` button shows as  enabled.
* Proceed to complete the booking, and verify that your booking shows up in the MC tool with the correct phone number value.

**Scenario 4 (verify that the redux store stores the phone number value)**
* Go to /me/concierge
* Enter a valid phone number and click `Continue to calendar`  button
* Now hit the Back button on the form.

<img width="732" alt="Screenshot 2019-08-05 at 7 53 53 PM" src="https://user-images.githubusercontent.com/1269602/62471703-d9f4a600-b7ba-11e9-8ae3-e4c9a68393f6.png">

* Verify that the booking form shows the phone number that you entered before with the correct country code and number.
* Modify the phone number field to another valid number, and proceed to complete the booking.
* Verify in the MC tool that your new number shows up in the booking confirmation.

Fixes # https://github.com/Automattic/concierge-admin/issues/37
