### PR TITLE
Checklist: Show a notice and disable site launch when email needs confimation

### DIFF
--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -20,7 +20,7 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 }
 
-.checklist__task-launch-site-blocked-notice {
+.checklist__task-notice {
 	margin: 10px 0 0;
 }
 

--- a/client/components/checklist/style.scss
+++ b/client/components/checklist/style.scss
@@ -20,6 +20,10 @@ $chevron-animation: transform 0.15s cubic-bezier( 0.175, 0.885, 0.32, 1.275 );
 	}
 }
 
+.checklist__task-launch-site-blocked-notice {
+	margin: 10px 0 0;
+}
+
 .checklist__task {
 	width: 100%;
 	order: 1;

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -214,9 +214,7 @@ class Task extends PureComponent {
 											className="checklist__task-launch-site-blocked-notice"
 											showDismiss={ false }
 										>
-											{ translate(
-												'Please confirm your email address before launching your site.'
-											) }
+											{ translate( 'Confirm your email address before launching your site.' ) }
 										</Notice>
 									) }
 								</div>

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -231,7 +231,11 @@ class Task extends PureComponent {
 	}
 }
 
-export default connect( ( state, { completed, id } ) => ( {
-	isBlockedLaunchSiteTask:
-		'site_launched' === id && ! completed && ! isCurrentUserEmailVerified( state ),
-} ) )( localize( Task ) );
+export default connect( ( state, { completed, disableIcon, id } ) => {
+	const isBlockedLaunchSiteTask =
+		'site_launched' === id && ! completed && ! isCurrentUserEmailVerified( state );
+	return {
+		disableIcon: isBlockedLaunchSiteTask || disableIcon,
+		isBlockedLaunchSiteTask,
+	};
+} )( localize( Task ) );

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -7,8 +7,6 @@ import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
-import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
-import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -32,7 +30,9 @@ class Task extends PureComponent {
 		duration: PropTypes.string,
 		href: PropTypes.string,
 		inProgress: PropTypes.bool,
+		isButtonDisabled: PropTypes.bool,
 		isWarning: PropTypes.bool,
+		noticeText: PropTypes.string,
 		onClick: PropTypes.func,
 		onTaskClick: PropTypes.func,
 		onDismiss: PropTypes.func,
@@ -135,9 +135,10 @@ class Task extends PureComponent {
 			description,
 			duration,
 			href,
-			isBlockedLaunchSiteTask,
+			isButtonDisabled,
 			inProgress,
 			isWarning,
+			noticeText,
 			onClick,
 			target,
 			title,
@@ -196,7 +197,7 @@ class Task extends PureComponent {
 								<div className="checklist__task-action-wrapper">
 									<Button
 										className="checklist__task-action"
-										disabled={ isBlockedLaunchSiteTask }
+										disabled={ isButtonDisabled }
 										href={ href }
 										onClick={ onClick }
 										primary={ ! collapsed }
@@ -209,12 +210,9 @@ class Task extends PureComponent {
 											{ translate( 'Skip' ) }
 										</Button>
 									) }
-									{ isBlockedLaunchSiteTask && (
-										<Notice
-											className="checklist__task-launch-site-blocked-notice"
-											showDismiss={ false }
-										>
-											{ translate( 'Confirm your email address before launching your site.' ) }
+									{ !! noticeText && (
+										<Notice className="checklist__task-notice" showDismiss={ false }>
+											{ noticeText }
 										</Notice>
 									) }
 								</div>
@@ -229,11 +227,4 @@ class Task extends PureComponent {
 	}
 }
 
-export default connect( ( state, { completed, disableIcon, id } ) => {
-	const isBlockedLaunchSiteTask =
-		'site_launched' === id && ! completed && ! isCurrentUserEmailVerified( state );
-	return {
-		disableIcon: isBlockedLaunchSiteTask || disableIcon,
-		isBlockedLaunchSiteTask,
-	};
-} )( localize( Task ) );
+export default localize( Task );

--- a/client/components/checklist/task.js
+++ b/client/components/checklist/task.js
@@ -7,6 +7,8 @@ import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 import React, { Fragment, PureComponent } from 'react';
 import { localize } from 'i18n-calypso';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import { connect } from 'react-redux';
 
 /**
  * Internal dependencies
@@ -14,6 +16,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import CompactCard from 'components/card/compact';
 import Focusable from 'components/focusable';
+import Notice from 'components/notice';
 import ScreenReaderText from 'components/screen-reader-text';
 import Spinner from 'components/spinner';
 
@@ -132,6 +135,7 @@ class Task extends PureComponent {
 			description,
 			duration,
 			href,
+			isBlockedLaunchSiteTask,
 			inProgress,
 			isWarning,
 			onClick,
@@ -192,6 +196,7 @@ class Task extends PureComponent {
 								<div className="checklist__task-action-wrapper">
 									<Button
 										className="checklist__task-action"
+										disabled={ isBlockedLaunchSiteTask }
 										href={ href }
 										onClick={ onClick }
 										primary={ ! collapsed }
@@ -203,6 +208,16 @@ class Task extends PureComponent {
 										<Button className="checklist__task-skip" onClick={ onDismiss }>
 											{ translate( 'Skip' ) }
 										</Button>
+									) }
+									{ isBlockedLaunchSiteTask && (
+										<Notice
+											className="checklist__task-launch-site-blocked-notice"
+											showDismiss={ false }
+										>
+											{ translate(
+												'Please confirm your email address before launching your site.'
+											) }
+										</Notice>
 									) }
 								</div>
 							</div>
@@ -216,4 +231,7 @@ class Task extends PureComponent {
 	}
 }
 
-export default localize( Task );
+export default connect( ( state, { completed, id } ) => ( {
+	isBlockedLaunchSiteTask:
+		'site_launched' === id && ! completed && ! isCurrentUserEmailVerified( state ),
+} ) )( localize( Task ) );

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -604,7 +604,8 @@ class WpcomChecklistComponent extends PureComponent {
 	};
 
 	renderSiteLaunchedTask = ( TaskComponent, baseProps, task ) => {
-		const { translate } = this.props;
+		const { needsVerification, translate } = this.props;
+		const disabled = ! baseProps.completed && needsVerification;
 
 		return (
 			<TaskComponent
@@ -615,6 +616,11 @@ class WpcomChecklistComponent extends PureComponent {
 				description={ translate(
 					'Your site is private and only visible to you. When you are ready, launch your site to make it public.'
 				) }
+				disableIcon={ disabled }
+				isButtonDisabled={ disabled }
+				noticeText={
+					disabled ? translate( 'Confirm your email address before launching your site.' ) : null
+				}
 				onClick={ this.handleLaunchSite( task ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }
 				title={ translate( 'Launch your site' ) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -337,8 +337,6 @@ class WpcomChecklistComponent extends PureComponent {
 			siteSlug,
 			closePopover: closePopover,
 			trackTaskDisplay: this.trackTaskDisplay,
-			// only render an unclickable grey circle
-			disableIcon: ! task.isCompleted && 'email_verified' === task.id,
 		};
 
 		if ( this.shouldRenderTask( task.id ) ) {
@@ -374,6 +372,8 @@ class WpcomChecklistComponent extends PureComponent {
 						},
 					}
 				) }
+				// only render an unclickable grey circle
+				disableIcon={ ! baseProps.isCompleted }
 				duration={ translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ) }
 				onClick={ this.handleSendVerificationEmail }
 				title={ translate( 'Confirm your email address' ) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -613,7 +613,7 @@ class WpcomChecklistComponent extends PureComponent {
 				buttonText={ translate( 'Launch site' ) }
 				completedTitle={ translate( 'You launched your site' ) }
 				description={ translate(
-					'Your site is private and only visible to you. Launch your site, when you are ready to make it public.'
+					'Your site is private and only visible to you. When you are ready, launch your site to make it public.'
 				) }
 				onClick={ this.handleLaunchSite( task ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -619,7 +619,7 @@ class WpcomChecklistComponent extends PureComponent {
 				disableIcon={ disabled }
 				isButtonDisabled={ disabled }
 				noticeText={
-					disabled ? translate( 'Confirm your email address before launching your site.' ) : null
+					disabled && translate( 'Confirm your email address before launching your site.' )
 				}
 				onClick={ this.handleLaunchSite( task ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -614,7 +614,7 @@ class WpcomChecklistComponent extends PureComponent {
 				buttonText={ translate( 'Launch site' ) }
 				completedTitle={ translate( 'You launched your site' ) }
 				description={ translate(
-					'Your site is private and only visible to you. When you are ready, launch your site to make it public.'
+					"Your site is private and only visible to you. When you're ready, launch your site to make it public."
 				) }
 				disableIcon={ disabled }
 				isButtonDisabled={ disabled }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -372,8 +372,8 @@ class WpcomChecklistComponent extends PureComponent {
 						},
 					}
 				) }
-				// only render an unclickable grey circle
-				disableIcon={ ! baseProps.isCompleted }
+				// only render an unclickable grey circle when email conformation is incomplete
+				disableIcon={ ! baseProps.completed }
 				duration={ translate( '%d minute', '%d minutes', { count: 1, args: [ 1 ] } ) }
 				onClick={ this.handleSendVerificationEmail }
 				title={ translate( 'Confirm your email address' ) }


### PR DESCRIPTION
~~**NOTE: Retrain on master before landing!** Targeting the branch in #34193 as it makes this a lot easier to test if PBD is enabled.~~

<img width="740" alt="Screen Shot 2019-07-29 at 2 18 25 PM" src="https://user-images.githubusercontent.com/1587282/62072027-c0c48600-b20b-11e9-8ccb-71333e08410c.png">

#### Changes proposed in this Pull Request

* Connect the checklist task item to the state tree
* Map state & own props to derived value `isBlockedLaunchSiteTask`
* disable button when value is true
* show a notice when value is true
* CSS change to add a margin

#### Testing instructions

* Run this branch
* Create a new account in an incognito window (`/start`)
* You should land at the checklist upon signup completion
* The "Launch your site" item should not be completable
* Verify your email
* Reload the checklist
* The "Launch your site" item should be completable

Fixes an item in Automattic/zelda-private#112