### PR TITLE
Checkout: Move stripe custom hooks to lib/stripe

### DIFF
--- a/client/my-sites/checkout/checkout/stripe-elements-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/stripe-elements-payment-box.jsx
@@ -3,53 +3,15 @@
 /**
  * External dependencies
  */
-import { loadScript } from '@automattic/load-script';
-import debugFactory from 'debug';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { localize } from 'i18n-calypso';
 import { StripeProvider, Elements } from 'react-stripe-elements';
 
 /**
  * Internal dependencies
  */
-import { getStripeConfiguration } from 'lib/store-transactions';
 import CreditCardPaymentBox from './credit-card-payment-box';
-
-const debug = debugFactory( 'calypso:stripe-elements-payment-box' );
-
-function useStripeJs( stripeConfiguration ) {
-	const [ stripeJs, setStripeJs ] = useState( null );
-	useEffect( () => {
-		if ( ! stripeConfiguration ) {
-			return;
-		}
-		if ( window.Stripe ) {
-			debug( 'stripe.js already loaded' );
-			setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
-			return;
-		}
-		debug( 'loading stripe.js...' );
-		loadScript( stripeConfiguration.js_url, function( error ) {
-			if ( error ) {
-				debug( 'stripe.js script ' + error.src + ' failed to load.' );
-				return;
-			}
-			debug( 'stripe.js loaded!' );
-			setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
-		} );
-	}, [ stripeConfiguration ] );
-	return stripeJs;
-}
-
-function useStripeConfiguration( country ) {
-	const [ stripeConfiguration, setStripeConfiguration ] = useState();
-	useEffect( () => {
-		getStripeConfiguration( { country } ).then( configuration =>
-			setStripeConfiguration( configuration )
-		);
-	}, [ country ] );
-	return stripeConfiguration;
-}
+import { useStripeConfiguration, useStripeJs } from 'lib/stripe';
 
 export function StripeElementsPaymentBox( {
 	translate,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

As part of modifying the "Add new card" form in #34848, we will need to use the stripe custom hooks on more than one component. This PR extracts them from `StripeElementsPaymentBox`. This should not have any functional change.

#### Testing instructions

To test the Stripe.js based CC fields, enable store sandbox mode.

Try purchasing a plan, entering a new credit card, and submitting the form. Verify that the payment is successful.