### PR TITLE
Transfer 'logged out' state to 'logged in' state for signup reducer

### DIFF
--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -140,11 +140,11 @@ export async function getStateFromLocalStorage( reducer, subkey, forceLoggedOutU
 }
 
 function getReduxStateKey( forceLoggedOutUser = false ) {
-	return getReduxStateKeyForUserId( get( user.get(), 'ID', null ), forceLoggedOutUser );
+	return getReduxStateKeyForUserId( forceLoggedOutUser ? null : get( user.get(), 'ID', null ) );
 }
 
-function getReduxStateKeyForUserId( userId, forceLoggedOutUser = false ) {
-	if ( ! userId || forceLoggedOutUser ) {
+function getReduxStateKeyForUserId( userId ) {
+	if ( ! userId ) {
 		return 'redux-state-logged-out';
 	}
 	return 'redux-state-' + userId;
@@ -246,7 +246,7 @@ async function getInitialStoredState( initialReducer ) {
 		}
 
 		if ( storedState ) {
-			initialStoredState = initialReducer( initialStoredState || {}, {
+			initialStoredState = initialReducer( initialStoredState, {
 				type: APPLY_STORED_STATE,
 				storageKey,
 				storedState,

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -15,7 +15,6 @@ import { getStoredItem, setStoredItem, clearStorage } from 'lib/browser-storage'
 import { isSupportSession } from 'lib/user/support-user-interop';
 import config from 'config';
 import User from 'lib/user';
-import { getInitialState as getEmptyState } from 'state/utils/get-initial-state';
 
 /**
  * Module variables
@@ -236,10 +235,6 @@ async function getInitialStoredState( initialReducer ) {
 	}
 
 	let initialStoredState = await getStateFromLocalStorage( initialReducer );
-	if ( ! initialStoredState ) {
-		initialStoredState = getEmptyState( initialReducer );
-	}
-
 	const storageKeys = [ ...initialReducer.getStorageKeys() ];
 
 	async function loadReducerState( { storageKey, reducer } ) {
@@ -251,7 +246,7 @@ async function getInitialStoredState( initialReducer ) {
 		}
 
 		if ( storedState ) {
-			initialStoredState = initialReducer( initialStoredState, {
+			initialStoredState = initialReducer( initialStoredState || {}, {
 				type: APPLY_STORED_STATE,
 				storageKey,
 				storedState,

--- a/client/state/signup/reducer.js
+++ b/client/state/signup/reducer.js
@@ -3,7 +3,7 @@
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withStorageKey } from 'state/utils';
 import dependencyStore from './dependency-store/reducer';
 import progress from './progress/reducer';
 import optionalDependencies from './optional-dependencies/reducer';
@@ -11,11 +11,14 @@ import steps from './steps/reducer';
 import flow from './flow/reducer';
 import verticals from './verticals/reducer';
 
-export default combineReducers( {
-	dependencyStore,
-	optionalDependencies,
-	progress,
-	steps,
-	flow,
-	verticals,
-} );
+export default withStorageKey(
+	'signup',
+	combineReducers( {
+		dependencyStore,
+		optionalDependencies,
+		progress,
+		steps,
+		flow,
+		verticals,
+	} )
+);

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -265,7 +265,7 @@ describe( 'initial-state', () => {
 				} );
 
 				test( 'does not build initial state using IndexedDB state', () => {
-					expect( state.currentUser.id ).toBeNull();
+					expect( state.currentUser ).toBeUndefined();
 				} );
 
 				test( 'does not add timestamp to store', () => {
@@ -365,7 +365,7 @@ describe( 'initial-state', () => {
 				} );
 
 				test( 'does not build initial state using IndexedDB state', () => {
-					expect( state.postTypes.items ).toEqual( {} );
+					expect( state.postTypes ).toBeUndefined();
 				} );
 
 				test( 'does not add timestamp to initial state', () => {

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -265,7 +265,7 @@ describe( 'initial-state', () => {
 				} );
 
 				test( 'does not build initial state using IndexedDB state', () => {
-					expect( state.currentUser ).toBeUndefined();
+					expect( state.currentUser.id ).toBeNull();
 				} );
 
 				test( 'does not add timestamp to store', () => {
@@ -365,11 +365,134 @@ describe( 'initial-state', () => {
 				} );
 
 				test( 'does not build initial state using IndexedDB state', () => {
-					expect( state.postTypes ).toBeUndefined();
+					expect( state.postTypes.items ).toEqual( {} );
 				} );
 
 				test( 'does not add timestamp to initial state', () => {
 					expect( state._timestamp ).toBeUndefined();
+				} );
+			} );
+
+			describe( 'with empty persisted signup state for logged in user, and persisted state for logged out user', () => {
+				let state, consoleErrorSpy, getStoredItemSpy;
+
+				const _timestamp = Date.now();
+				const storedState = {
+					'redux-state-logged-out:signup': {
+						dependencyStore: {
+							siteType: 'blog',
+							siteTitle: 'Logged out test title',
+						},
+						progress: [
+							{
+								stepName: 'logged-out-step',
+								status: 'completed',
+							},
+						],
+						_timestamp,
+					},
+				};
+				const serverState = {};
+
+				beforeAll( async () => {
+					isEnabled.enablePersistRedux();
+					window.initialReduxState = serverState;
+					consoleErrorSpy = jest.spyOn( global.console, 'error' );
+					getStoredItemSpy = jest
+						.spyOn( browserStorage, 'getStoredItem' )
+						.mockImplementation( key => storedState[ key ] );
+
+					state = await getInitialState( initialReducer );
+				} );
+
+				afterAll( () => {
+					window.initialReduxState = null;
+					isEnabled.disablePersistRedux();
+					consoleErrorSpy.mockRestore();
+					getStoredItemSpy.mockRestore();
+				} );
+
+				test( 'builds initial state without errors', () => {
+					expect( consoleErrorSpy ).not.toHaveBeenCalled();
+				} );
+
+				test( 'builds initial signup state from logged out state', () => {
+					expect( state.signup.dependencyStore ).toEqual(
+						storedState[ 'redux-state-logged-out:signup' ].dependencyStore
+					);
+					expect( state.signup.progress ).toEqual(
+						storedState[ 'redux-state-logged-out:signup' ].progress
+					);
+				} );
+
+				test( 'does not add timestamp to initial state', () => {
+					expect( state._timestamp ).toBeUndefined();
+				} );
+			} );
+
+			describe( 'with existing persisted signup state for logged in user, and persisted state for logged out user', () => {
+				let state, consoleErrorSpy, getStoredItemSpy;
+
+				const _timestamp = Date.now();
+				const storedState = {
+					'redux-state-123456789:signup': {
+						dependencyStore: {
+							siteType: 'blog',
+							siteTitle: 'Logged in test title',
+						},
+						progress: [
+							{
+								stepName: 'logged-in-step',
+								status: 'completed',
+							},
+						],
+						_timestamp,
+					},
+					'redux-state-logged-out:signup': {
+						dependencyStore: {
+							siteType: 'blog',
+							siteTitle: 'Logged out test title',
+						},
+						progress: [
+							{
+								stepName: 'logged-out-step',
+								status: 'completed',
+							},
+						],
+						_timestamp,
+					},
+				};
+				const serverState = {};
+
+				beforeAll( async () => {
+					isEnabled.enablePersistRedux();
+					window.initialReduxState = serverState;
+					consoleErrorSpy = jest.spyOn( global.console, 'error' );
+					getStoredItemSpy = jest
+						.spyOn( browserStorage, 'getStoredItem' )
+						.mockImplementation( key => storedState[ key ] );
+
+					state = await getInitialState( initialReducer );
+				} );
+
+				afterAll( () => {
+					window.initialReduxState = null;
+					isEnabled.disablePersistRedux();
+					consoleErrorSpy.mockRestore();
+					getStoredItemSpy.mockRestore();
+				} );
+
+				test( 'builds initial state without errors', () => {
+					expect( consoleErrorSpy ).not.toHaveBeenCalled();
+				} );
+
+				test( 'builds initial signup state from logged in state', () => {
+					expect( state.signup.dependencyStore ).toEqual(
+						storedState[ 'redux-state-123456789:signup' ].dependencyStore
+					);
+					expect( state.signup.progress ).toEqual(
+						storedState[ 'redux-state-123456789:signup' ].progress
+					);
 				} );
 			} );
 		} );

--- a/client/state/utils/reducer-utils.js
+++ b/client/state/utils/reducer-utils.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { mapValues, reduce, reduceRight } from 'lodash';
+import { get, mapValues, reduce, reduceRight } from 'lodash';
 import { combineReducers as combine } from 'redux'; // eslint-disable-line wpcalypso/import-no-redux-combine-reducers
 
 /**
@@ -153,7 +153,7 @@ function applyStoredState( reducers, state, action ) {
 		}
 
 		// Descend into nested state levels, possibly the storageKey will be found there?
-		const prevStateForKey = state[ key ];
+		const prevStateForKey = get( state, key );
 		const nextStateForKey = reducer( prevStateForKey, action );
 		hasChanged = hasChanged || nextStateForKey !== prevStateForKey;
 		return nextStateForKey;


### PR DESCRIPTION
This change enables signup state to persist across the logged out / logged in boundary by transferring state from a logged out store to a logged in store.

Tests are included to ensure that state is transferred from a logged out session to a logged in one. However due to our current signup flows that begin with the account creation / login step, this is difficult to test manually. This PR is part of the functionality that will enable an A/B test for moving the `user` step in signup flow to the end of the flow. More discussion on: https://github.com/Automattic/wp-calypso/pull/34770

#### Changes proposed in this Pull Request

* Wrap the signup reducer in `withStorageKey` so that signup state is stored in its own key, e.g. `redux-state-logged-out:signup`
* In `initial-state`, if there is no stored state for the signup for a logged in user, load the state from the logged out persisted store.
* `getInitialState` will now return an 'empty' state with default values instead of `null` if no stored state is found. This is to allow `initialStoredState` to be used when iterating over the storage keys and looking for stored `signup` data, otherwise `initialReducer` will throws errors.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![image](https://user-images.githubusercontent.com/14988353/62094366-35f19300-b2c0-11e9-9a0f-d201f27142f4.png)

* From a logged out session (or incognito browser) go to: http://calypso.localhost:3000/start
* In Dev Tools, open up the Application tab, select IndexedDB under Storage, then `calypso` and `calypso_store`. You should see an additional store `redux-state-logged-out:signup` containing the signup state.
* Log in to an account from the `user` step in signup, and refresh the storage view in dev tools. You should now see an additional `redux-state-<userID>:signup` store, e.g. `redux-state-123456789:signup`, also containing signup state.
* To ensure no regressions, proceed through the signup process until the `domains-with-preview` step. Reload the page and ensure that you are resumed back to the page you were working on.
* Complete signup and create a site.


