### PR TITLE
Earn: introduce analytics for plan upgrade buttons

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -24,6 +24,7 @@ import {
 	FEATURE_SIMPLE_PAYMENTS,
 	FEATURE_UPLOAD_PLUGINS,
 } from 'lib/plans/constants';
+import analytics from 'lib/analytics';
 
 interface ConnectedProps {
 	siteId: number;
@@ -65,7 +66,14 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			  }
 			: {
 					text: translate( 'Upgrade to Premium Plan' ),
-					action: () => page( `/checkout/${ selectedSiteSlug }/premium/` ),
+					action: () => {
+						analytics.tracks.recordEvent( 'calypso_earn_upgrade', {
+							plan: 'premium',
+							feature: 'simple-payments',
+						} );
+
+						page( `/checkout/${ selectedSiteSlug }/premium/` );
+					},
 			  };
 		const learnMoreLink = hasSimplePayments ? null : supportLink;
 		return {
@@ -95,7 +103,14 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const cta = isFreePlan
 			? {
 					text: translate( 'Upgrade to a Paid Plan' ),
-					action: () => page( `/plans/${ selectedSiteSlug }` ),
+					action: () => {
+						analytics.tracks.recordEvent( 'calypso_earn_upgrade', {
+							plan: 'any-paid-plan',
+							feature: 'recurring-payments',
+						} );
+
+						page( `/plans/${ selectedSiteSlug }` );
+					},
 			  }
 			: {
 					text: translate( 'Collect Recurring Payments' ),
@@ -147,7 +162,14 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			  }
 			: {
 					text: translate( 'Upgrade to Business Plan' ),
-					action: () => page( `/checkout/${ selectedSiteSlug }/business/` ),
+					action: () => {
+						analytics.tracks.recordEvent( 'calypso_earn_upgrade', {
+							plan: 'business',
+							feature: 'store',
+						} );
+
+						page( `/checkout/${ selectedSiteSlug }/business/` );
+					},
 			  };
 		return {
 			title: translate( 'Sell a few items' ),
@@ -183,7 +205,14 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			  }
 			: {
 					text: translate( 'Upgrade to Premium Plan' ),
-					action: () => page( `/checkout/${ selectedSiteSlug }/premium/` ),
+					action: () => {
+						analytics.tracks.recordEvent( 'calypso_earn_upgrade', {
+							plan: 'premium',
+							feature: 'ads',
+						} );
+
+						page( `/checkout/${ selectedSiteSlug }/premium/` );
+					},
 			  };
 		const title = hasSetupAds ? translate( 'View Ad Dashboard' ) : translate( 'Earn ad revenue' );
 		const body = hasSetupAds
@@ -212,7 +241,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 
 	const promos: PromoSectionProps = {
 		header: {
-			title: translate( 'Start earning money' ),
+			title: translate( 'Start earning money now' ),
 			image: {
 				path: '/calypso/images/earn/earn-section.svg',
 			},


### PR DESCRIPTION
Fixes #34521

#### Changes proposed in this Pull Request

* track clicks on upgrade buttons saving two properties:
**plan**: the target plan upgrade
**feature**: the card in which the upgrade button was clicked
* add "now" word to reuse translation as mentioned in https://github.com/Automattic/wp-calypso/pull/34896#discussion_r307886518

#### Testing instructions

* click on upgrade buttons and ensure tracks are fired


