### PR TITLE
Checklist: Swapping 'launched' for 'created' to make it consistent with the header

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -611,7 +611,7 @@ class WpcomChecklistComponent extends PureComponent {
 				{ ...baseProps }
 				bannerImageSrc="/calypso/images/stats/tasks/launch.svg"
 				buttonText={ translate( 'Launch site' ) }
-				completedTitle={ translate( '' + 'You created your site' ) }
+				completedTitle={ translate( 'You created your site' ) }
 				description={ translate(
 					'Your site is private and only visible to you. Launch your site, when you are ready to make it public.'
 				) }

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -611,7 +611,7 @@ class WpcomChecklistComponent extends PureComponent {
 				{ ...baseProps }
 				bannerImageSrc="/calypso/images/stats/tasks/launch.svg"
 				buttonText={ translate( 'Launch site' ) }
-				completedTitle={ translate( 'You launched your site' ) }
+				completedTitle={ translate( '' + 'You created your site' ) }
 				description={ translate(
 					'Your site is private and only visible to you. Launch your site, when you are ready to make it public.'
 				) }


### PR DESCRIPTION
## Changes proposed in this Pull Request

"You launched your site" seems to contradict the main heading, and (with private-by-default) confuses terms. 

We're changing it to "You created your site".

<img width="797" alt="Screen Shot 2019-07-30 at 5 51 34 pm" src="https://user-images.githubusercontent.com/6458278/62110874-b4672880-b2f2-11e9-868a-2846d9480c77.png">

## Testing instructions

Create a new site at `/start`

Check that the checklist item reflects the new copy

Fixes https://github.com/Automattic/wp-calypso/issues/34215
