### PR TITLE
Sidebar: Fix "Add New Site" Button Colour

### DIFF
--- a/client/layout/sidebar/style.scss
+++ b/client/layout/sidebar/style.scss
@@ -522,7 +522,7 @@ form.sidebar__button input {
 	font-size: 11px;
 	font-weight: 600;
 	padding: 8px;
-	color: var( --sidebar-footer-button-color );
+	color: var( --sidebar-heading-color );
 	line-height: 2.1;
 	margin-right: auto;
 
@@ -535,7 +535,7 @@ form.sidebar__button input {
 	}
 
 	&:hover {
-		color: var( --color-neutral-700 );
+		color: var( --sidebar-text-color );
 	}
 
 	@include breakpoint( '<660px' ) {

--- a/packages/calypso-color-schemes/src/shared/_color-schemes.scss
+++ b/packages/calypso-color-schemes/src/shared/_color-schemes.scss
@@ -277,7 +277,6 @@
 	--sidebar-text-color: #{$muriel-gray-800};
 	--sidebar-gridicon-fill: #{$muriel-gray-500};
 	--sidebar-heading-color: #{$muriel-gray-500};
-	--sidebar-footer-button-color: #{$muriel-gray-700};
 	--sidebar-menu-link-secondary-text-color: #{$muriel-gray-700};
 	--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-white )};
 	--sidebar-menu-selected-background-color: #{$muriel-blue-50};
@@ -918,7 +917,6 @@
 		--sidebar-border-color: #{$muriel-gray-100};
 		--sidebar-gridicon-fill: #{$muriel-gray-500};
 		--sidebar-heading-color: #{$muriel-gray-900};
-		--sidebar-footer-button-color: #{$muriel-gray-900};
 		--sidebar-menu-link-secondary-text-color: #{$muriel-gray-500};
 		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-50 )};
 		--sidebar-menu-selected-background-color: #{$muriel-gray-600};
@@ -1045,7 +1043,6 @@
 		--sidebar-text-color: #{$muriel-white};
 		--sidebar-gridicon-fill: #{$muriel-white};
 		--sidebar-heading-color: #{$muriel-gray-200};
-		--sidebar-footer-button-color: #{$muriel-white};
 		--sidebar-menu-link-secondary-text-color: #{$muriel-white};
 		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-blue-600 )};
 		--sidebar-menu-selected-background-color: #{$muriel-hot-orange-900};
@@ -1174,7 +1171,6 @@
 		--sidebar-text-color: #{$muriel-pink-800};
 		--sidebar-gridicon-fill: #{$muriel-pink-600};
 		--sidebar-heading-color: #{$muriel-pink-700};
-		--sidebar-footer-button-color: #{$muriel-gray-900};
 		--sidebar-menu-link-secondary-text-color: #{$muriel-pink-700};
 		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-pink-100 )};
 		--sidebar-menu-selected-background-color: #{$muriel-hot-blue-50};
@@ -1303,7 +1299,6 @@
 		--sidebar-text-color: #{$muriel-white};
 		--sidebar-gridicon-fill: #{$muriel-white};
 		--sidebar-heading-color: #{$muriel-blue-50};
-		--sidebar-footer-button-color: #{$muriel-blue-50};
 		--sidebar-menu-link-secondary-text-color: #{$muriel-blue-50};
 		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-blue-500 )};
 		--sidebar-menu-selected-background-color: #{$muriel-yellow-300};
@@ -1432,7 +1427,6 @@
 		--sidebar-text-color: #{$muriel-white};
 		--sidebar-gridicon-fill: #{$muriel-white};
 		--sidebar-heading-color: #{$muriel-red-50};
-		--sidebar-footer-button-color: #{$muriel-white};
 		--sidebar-menu-link-secondary-text-color: #{$muriel-red-50};
 		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-red-600 )};
 		--sidebar-menu-selected-background-color: #{$muriel-hot-yellow-500};
@@ -1561,7 +1555,6 @@
 		--sidebar-text-color: #{$muriel-white};
 		--sidebar-gridicon-fill: #{$muriel-white};
 		--sidebar-heading-color: #{$muriel-gray-100};
-		--sidebar-footer-button-color: #{$muriel-gray-900};
 		--sidebar-menu-link-secondary-text-color: #{$muriel-gray-300};
 		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-gray-800 )};
 		--sidebar-menu-selected-background-color: #{$muriel-red-600};
@@ -1689,7 +1682,6 @@
 		--sidebar-text-color: #{$muriel-gray-900};
 		--sidebar-gridicon-fill: #{$muriel-gray-700};
 		--sidebar-heading-color: #{$muriel-gray-700};
-		--sidebar-footer-button-color: #{$muriel-gray-900};
 		--sidebar-menu-link-secondary-text-color: #{$muriel-gray-700};
 		--sidebar-menu-a-first-child-after-background: #{hex-to-rgb( $muriel-white )};
 		--sidebar-menu-selected-background-color: #{$muriel-gray-900};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

`--sidebar-footer-button-color` was a variable added two years ago, and it seems better to just use the same styling as this button, so there's no discrepancy between those with multiple sites and just one site.

<img width="206" alt="Screenshot 2019-07-30 at 09 07 00" src="https://user-images.githubusercontent.com/43215253/62111874-74c81e80-b2a9-11e9-8e37-65cea0102154.png">

As such, this PR proposes removing the `--sidebar-footer-button-color` variable as it's only used once here. Not only does that mean the link is visible in Midnight:

<img width="192" alt="Screenshot 2019-07-30 at 09 08 21" src="https://user-images.githubusercontent.com/43215253/62111957-9f19dc00-b2a9-11e9-8ad0-d799d6ad9ee1.png">

It also no longer has hover issues in Nightfall.

**Before:**

<img width="149" alt="Screenshot 2019-07-30 at 09 09 12" src="https://user-images.githubusercontent.com/43215253/62112007-bbb61400-b2a9-11e9-8776-a51b12bb5721.png">

**After:**

<img width="132" alt="Screenshot 2019-07-30 at 09 11 47" src="https://user-images.githubusercontent.com/43215253/62112157-15b6d980-b2aa-11e9-91b0-c309f45c0000.png">

#### Testing instructions

On an account with just one site, visit "My Sites" and look at & hover over "Add New Site" at the bottom. Try all the schemes, they should be identical to "Add New Site" on an account with multiple sites.

cc @sixhours 

Fixes #34974
