### PR TITLE
Signup: make onboarding flow the default

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -1,15 +1,5 @@
 /** @format */
 export default {
-	improvedOnboarding: {
-		datestamp: '20190314',
-		variations: {
-			main: 0,
-			onboarding: 100,
-		},
-		defaultVariation: 'main',
-		allowExistingUsers: true,
-		localeTargets: 'any',
-	},
 	cartNudgeUpdateToPremium: {
 		datestamp: '20180917',
 		variations: {

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -24,7 +24,6 @@ import { addItems, removeItem } from 'lib/upgrades/actions';
 import { getAllCartItems } from 'lib/cart-values/cart-items';
 import { isDotComPlan } from 'lib/products-values';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { abtest } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -40,12 +39,9 @@ export class GSuiteNudge extends React.Component {
 
 	handleSkipClick = () => {
 		const { siteSlug, receiptId, isEligibleForChecklist } = this.props;
-
-		const destination = abtest( 'improvedOnboarding' ) === 'onboarding' ? 'view' : 'checklist';
-
 		page(
 			isEligibleForChecklist
-				? `/${ destination }/${ siteSlug }`
+				? `/view/${ siteSlug }`
 				: `/checkout/thank-you/${ siteSlug }/${ receiptId }`
 		);
 	};

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -24,6 +24,7 @@ import { addItems, removeItem } from 'lib/upgrades/actions';
 import { getAllCartItems } from 'lib/cart-values/cart-items';
 import { isDotComPlan } from 'lib/products-values';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { getCurrentFlowName } from 'state/signup/flow/selectors';
 
 /**
  * Style dependencies
@@ -35,13 +36,14 @@ export class GSuiteNudge extends React.Component {
 		domain: PropTypes.string.isRequired,
 		receiptId: PropTypes.number.isRequired,
 		selectedSiteId: PropTypes.number.isRequired,
+		isOnboardingFlow: PropTypes.bool.isRequired,
 	};
 
 	handleSkipClick = () => {
-		const { siteSlug, receiptId, isEligibleForChecklist } = this.props;
+		const { siteSlug, receiptId, isEligibleForChecklist, isOnboardingFlow } = this.props;
 		page(
 			isEligibleForChecklist
-				? `/view/${ siteSlug }`
+				? `/${ isOnboardingFlow ? 'view' : 'checklist' }/${ siteSlug }`
 				: `/checkout/thank-you/${ siteSlug }/${ receiptId }`
 		);
 	};
@@ -109,5 +111,6 @@ export default connect( ( state, props ) => {
 		siteSlug: getSiteSlug( state, props.selectedSiteId ),
 		siteTitle: getSiteTitle( state, props.selectedSiteId ),
 		isEligibleForChecklist,
+		isOnboardingFlow: 'onboarding' === getCurrentFlowName( state ),
 	};
 } )( localize( GSuiteNudge ) );

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -24,7 +24,6 @@ import { addItems, removeItem } from 'lib/upgrades/actions';
 import { getAllCartItems } from 'lib/cart-values/cart-items';
 import { isDotComPlan } from 'lib/products-values';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
-import { getCurrentFlowName } from 'state/signup/flow/selectors';
 
 /**
  * Style dependencies
@@ -36,14 +35,13 @@ export class GSuiteNudge extends React.Component {
 		domain: PropTypes.string.isRequired,
 		receiptId: PropTypes.number.isRequired,
 		selectedSiteId: PropTypes.number.isRequired,
-		isOnboardingFlow: PropTypes.bool.isRequired,
 	};
 
 	handleSkipClick = () => {
-		const { siteSlug, receiptId, isEligibleForChecklist, isOnboardingFlow } = this.props;
+		const { siteSlug, receiptId, isEligibleForChecklist } = this.props;
 		page(
 			isEligibleForChecklist
-				? `/${ isOnboardingFlow ? 'view' : 'checklist' }/${ siteSlug }`
+				? `/checklist/${ siteSlug }`
 				: `/checkout/thank-you/${ siteSlug }/${ receiptId }`
 		);
 	};
@@ -111,6 +109,5 @@ export default connect( ( state, props ) => {
 		siteSlug: getSiteSlug( state, props.selectedSiteId ),
 		siteTitle: getSiteTitle( state, props.selectedSiteId ),
 		isEligibleForChecklist,
-		isOnboardingFlow: 'onboarding' === getCurrentFlowName( state ),
 	};
 } )( localize( GSuiteNudge ) );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -11,7 +11,6 @@ import { assign, get, includes, indexOf, reject } from 'lodash';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
-import { abtest } from 'lib/abtest';
 import { generateFlows } from 'signup/config/flows-pure';
 
 const user = userFactory();
@@ -83,12 +82,14 @@ function filterDestination( destination, dependencies ) {
 	return destination;
 }
 
+function getDefaultFlowName() {
+	return config.isEnabled( 'signup/onboarding-flow' ) ? 'onboarding' : 'main';
+}
+
 const Flows = {
 	filterDestination,
 
-	defaultFlowName: config.isEnabled( 'signup/onboarding-flow' )
-		? abtest( 'improvedOnboarding' )
-		: 'main',
+	defaultFlowName: getDefaultFlowName(),
 	excludedSteps: [],
 
 	/**

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -11,6 +11,7 @@ import { assign, get, includes, indexOf, reject } from 'lodash';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
+import { abtest } from 'lib/abtest';
 import { generateFlows } from 'signup/config/flows-pure';
 
 const user = userFactory();

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -32,6 +32,8 @@ jest.mock( 'signup/config/flows-pure', () => ( {
 } ) );
 
 describe( 'utils', () => {
+	const defaultFlowName = flows.defaultFlowName;
+
 	describe( 'getLocale', () => {
 		test( 'should find the locale anywhere in the params', () => {
 			expect( getLocale( { lang: 'fr' } ) ).toBe( 'fr' );
@@ -66,7 +68,7 @@ describe( 'utils', () => {
 		} );
 
 		test( 'should return the default flow if the flow is missing', () => {
-			expect( getFlowName( {} ) ).toBe( 'main' );
+			expect( getFlowName( {} ) ).toBe( defaultFlowName );
 		} );
 	} );
 
@@ -80,7 +82,7 @@ describe( 'utils', () => {
 		} );
 
 		test( 'should redirect to the default flow if the flow is the default', () => {
-			expect( getValidPath( { flowName: 'main' } ) ).toBe( '/start/user' );
+			expect( getValidPath( { flowName: defaultFlowName } ) ).toBe( '/start/user' );
 		} );
 
 		test( 'should redirect invalid steps to the default flow if no flow is present', () => {

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1718,11 +1718,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
-			return await overrideABTests.setOverriddenABTests(
-				driver,
-				'improvedOnboarding',
-				'onboarding'
-			);
 		} );
 
 		step( 'Can visit the start page', async function() {
@@ -1808,11 +1803,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 
 		before( async function() {
 			await driverManager.ensureNotLoggedIn( driver );
-			return await overrideABTests.setOverriddenABTests(
-				driver,
-				'improvedOnboarding',
-				'onboarding'
-			);
 		} );
 
 		step( 'Can enter the account flow and see the account details page', async function() {

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -108,10 +108,26 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			);
 		} );
 
-		step( 'Can see the "About" page, and enter some site information', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
-			return await aboutPage.submitForm();
+		step( 'Can see the "Site Type" page, and enter some site information', async function() {
+			const siteTypePage = await SiteTypePage.Expect( driver );
+			return await siteTypePage.selectBusinessType();
+		} );
+
+		step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
+			const siteTopicPage = await SiteTopicPage.Expect( driver );
+			await siteTopicPage.enterSiteTopic( 'Tech Blog' );
+			return await siteTopicPage.submitForm();
+		} );
+
+		step( 'Can see the "Site title" page, and enter the site title', async function() {
+			const siteTitlePage = await SiteTitlePage.Expect( driver );
+			await siteTitlePage.enterSiteTitle( blogName );
+			return await siteTitlePage.submitForm();
+		} );
+
+		step( 'Can see the "Site style" page, and continue with the default style', async function() {
+			const siteTitlePage = await SiteStylePage.Expect( driver );
+			return await siteTitlePage.submitForm();
 		} );
 
 		step(
@@ -215,10 +231,26 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			);
 		} );
 
-		step( 'Can see the "About" page, and enter some site information', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
-			return await aboutPage.submitForm();
+		step( 'Can see the "Site Type" page, and enter some site information', async function() {
+			const siteTypePage = await SiteTypePage.Expect( driver );
+			return await siteTypePage.selectBusinessType();
+		} );
+
+		step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
+			const siteTopicPage = await SiteTopicPage.Expect( driver );
+			await siteTopicPage.enterSiteTopic( 'Tech Blog' );
+			return await siteTopicPage.submitForm();
+		} );
+
+		step( 'Can see the "Site title" page, and enter the site title', async function() {
+			const siteTitlePage = await SiteTitlePage.Expect( driver );
+			await siteTitlePage.enterSiteTitle( blogName );
+			return await siteTitlePage.submitForm();
+		} );
+
+		step( 'Can see the "Site style" page, and continue with the default style', async function() {
+			const siteTitlePage = await SiteStylePage.Expect( driver );
+			return await siteTitlePage.submitForm();
 		} );
 
 		step(
@@ -269,7 +301,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		} );
 
 		step( 'Can visit the start page', async function() {
-			await StartPage.Visit( driver, StartPage.getStartURL( { culture: locale } ) );
+			await StartPage.Visit( driver, StartPage.getStartURL( { flow: 'main', culture: locale } ) );
 		} );
 
 		step( 'Can see the account page and enter account details', async function() {
@@ -403,14 +435,26 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			);
 		} );
 
-		step( 'Can accept defaults for about page', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.enterSiteDetails( 'Step Back', 'Store Test Topic', { sell: true } );
-			await aboutPage.submitForm();
-			await driverHelper.waitTillNotPresent( driver, By.css( '.signup is-store-nux' ) ); // Wait for /start/store-nux/themes to load
-			await driver.navigate().back();
-			await aboutPage.unsetCheckBox( { sell: true } );
-			await aboutPage.submitForm();
+		step( 'Can see the "Site Type" page, and enter some site information', async function() {
+			const siteTypePage = await SiteTypePage.Expect( driver );
+			return await siteTypePage.selectBusinessType();
+		} );
+
+		step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
+			const siteTopicPage = await SiteTopicPage.Expect( driver );
+			await siteTopicPage.enterSiteTopic( 'Tech Blog' );
+			return await siteTopicPage.submitForm();
+		} );
+
+		step( 'Can see the "Site title" page, and enter the site title', async function() {
+			const siteTitlePage = await SiteTitlePage.Expect( driver );
+			await siteTitlePage.enterSiteTitle( blogName );
+			return await siteTitlePage.submitForm();
+		} );
+
+		step( 'Can see the "Site style" page, and continue with the default style', async function() {
+			const siteTitlePage = await SiteStylePage.Expect( driver );
+			return await siteTitlePage.submitForm();
 		} );
 
 		step( 'Can then see the domains page ', async function() {
@@ -1167,9 +1211,26 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			);
 		} );
 
-		step( 'Can see the about page and accept defaults', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
-			return await aboutPage.submitForm();
+		step( 'Can see the "Site Type" page, and enter some site information', async function() {
+			const siteTypePage = await SiteTypePage.Expect( driver );
+			return await siteTypePage.selectBlogType();
+		} );
+
+		step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
+			const siteTopicPage = await SiteTopicPage.Expect( driver );
+			await siteTopicPage.enterSiteTopic( 'Tech Blog' );
+			return await siteTopicPage.submitForm();
+		} );
+
+		step( 'Can see the "Site title" page, and enter the site title', async function() {
+			const siteTitlePage = await SiteTitlePage.Expect( driver );
+			await siteTitlePage.enterSiteTitle( blogName );
+			return await siteTitlePage.submitForm();
+		} );
+
+		step( 'Can see the "Site style" page, and continue with the default style', async function() {
+			const siteTitlePage = await SiteStylePage.Expect( driver );
+			return await siteTitlePage.submitForm();
 		} );
 
 		step(
@@ -1363,7 +1424,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 				driver,
 				StartPage.getStartURL( {
 					culture: locale,
-					flow: 'onboarding',
 					query: 'vertical=art',
 				} )
 			);
@@ -1483,10 +1543,26 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			}
 		);
 
-		step( 'Can see the "About" page, and enter some site information', async function() {
-			const aboutPage = await AboutPage.Expect( driver );
-			await aboutPage.enterSiteDetails( blogName, 'Electronics' );
-			return await aboutPage.submitForm();
+		step( 'Can see the "Site Type" page, and enter some site information', async function() {
+			const siteTypePage = await SiteTypePage.Expect( driver );
+			return await siteTypePage.selectBlogType();
+		} );
+
+		step( 'Can see the "Site Topic" page, and enter the site topic', async function() {
+			const siteTopicPage = await SiteTopicPage.Expect( driver );
+			await siteTopicPage.enterSiteTopic( 'Tech Blog' );
+			return await siteTopicPage.submitForm();
+		} );
+
+		step( 'Can see the "Site title" page, and enter the site title', async function() {
+			const siteTitlePage = await SiteTitlePage.Expect( driver );
+			await siteTitlePage.enterSiteTitle( blogName );
+			return await siteTitlePage.submitForm();
+		} );
+
+		step( 'Can see the "Site style" page, and continue with the default style', async function() {
+			const siteTitlePage = await SiteStylePage.Expect( driver );
+			return await siteTitlePage.submitForm();
 		} );
 
 		step(


### PR DESCRIPTION
## Changes proposed in this Pull Request

- Makes `onboarding` the default signup flow. 
- Axes `main` as the fallback.
- Deletes the ab test since it's 100% anyway. 
- Modifies e2e tests that expect to see the main flow.
- Edits default flow name unit tests.
- Never looks back.

<img src="https://user-images.githubusercontent.com/6458278/62273459-fa51f700-b480-11e9-9e01-a54467e82ef0.gif" width="200"  />

## Testing instructions

1. Head over to `/start`
2. And the current flow name (`state.signup.flow.currentFlowName`) should be '`onboarding`'
3. Make a free site. You should see the checklist after redirection.

Fixes https://github.com/Automattic/zelda-private/issues/8
