### PR TITLE
Remove string refs from SelectDropdown.

### DIFF
--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -15,58 +12,58 @@ import Gridicon from 'gridicons';
 import Count from 'components/count';
 import TranslatableString from 'components/translatable/proptype';
 
-class SelectDropdownItem extends Component {
-	static propTypes = {
-		children: TranslatableString.isRequired,
-		compactCount: PropTypes.bool,
-		path: PropTypes.string,
-		isDropdownOpen: PropTypes.bool,
-		selected: PropTypes.bool,
-		onClick: PropTypes.func,
-		count: PropTypes.number,
-		disabled: PropTypes.bool,
-		icon: PropTypes.element,
-	};
+const SelectDropdownItem = React.forwardRef( ( props, ref ) => {
+	const optionClassName = classNames( props.className, {
+		'select-dropdown__item': true,
+		'is-selected': props.selected,
+		'is-disabled': props.disabled,
+		'has-icon': !! props.icon,
+	} );
 
-	static defaultProps = {
-		isDropdownOpen: false,
-		selected: false,
-	};
-
-	render() {
-		const optionClassName = classNames( this.props.className, {
-			'select-dropdown__item': true,
-			'is-selected': this.props.selected,
-			'is-disabled': this.props.disabled,
-			'has-icon': !! this.props.icon,
-		} );
-
-		return (
-			<li className="select-dropdown__option">
-				<a
-					ref="itemLink"
-					href={ this.props.path }
-					className={ optionClassName }
-					onClick={ this.props.disabled ? null : this.props.onClick }
-					data-bold-text={ this.props.value || this.props.children }
-					role="menuitem"
-					tabIndex={ this.props.isDropdownOpen ? 0 : '' }
-					aria-selected={ this.props.selected }
-					data-e2e-title={ this.props.e2eTitle }
-				>
-					<span className="select-dropdown__item-text">
-						{ this.props.icon && this.props.icon.type === Gridicon ? this.props.icon : null }
-						{ this.props.children }
+	return (
+		<li className="select-dropdown__option">
+			<a
+				ref={ ref }
+				href={ props.path }
+				className={ optionClassName }
+				onClick={ props.disabled ? null : props.onClick }
+				data-bold-text={ props.value || props.children }
+				role="option"
+				tabIndex={ props.isDropdownOpen ? 0 : '' }
+				aria-selected={ props.selected }
+				data-e2e-title={ props.e2eTitle }
+			>
+				<span className="select-dropdown__item-text">
+					{ props.icon && props.icon.type === Gridicon ? props.icon : null }
+					{ props.children }
+				</span>
+				{ 'number' === typeof props.count && (
+					<span data-text={ props.count } className="select-dropdown__item-count">
+						<Count count={ props.count } compact={ props.compactCount } />
 					</span>
-					{ 'number' === typeof this.props.count && (
-						<span data-text={ this.props.count } className="select-dropdown__item-count">
-							<Count count={ this.props.count } compact={ this.props.compactCount } />
-						</span>
-					) }
-				</a>
-			</li>
-		);
-	}
-}
+				) }
+			</a>
+		</li>
+	);
+} );
+
+SelectDropdownItem.displayName = 'SelectDropdownItem';
+
+SelectDropdownItem.propTypes = {
+	children: TranslatableString.isRequired,
+	compactCount: PropTypes.bool,
+	path: PropTypes.string,
+	isDropdownOpen: PropTypes.bool,
+	selected: PropTypes.bool,
+	onClick: PropTypes.func,
+	count: PropTypes.number,
+	disabled: PropTypes.bool,
+	icon: PropTypes.element,
+};
+
+SelectDropdownItem.defaultProps = {
+	isDropdownOpen: false,
+	selected: false,
+};
 
 export default SelectDropdownItem;

--- a/client/components/select-dropdown/test/index.js
+++ b/client/components/select-dropdown/test/index.js
@@ -294,12 +294,7 @@ describe( 'index', () => {
 
 			sinon.assert.calledOnce( fakeEvent.preventDefault );
 
-			const {
-				refs: {
-					dropdownContainer: { focus: focusSpy },
-				},
-				closeDropdown: closeDropdownSpy,
-			} = fakeContext;
+			const { closeDropdown: closeDropdownSpy, focusContainer: focusSpy } = fakeContext;
 			sinon.assert.calledOnce( closeDropdownSpy );
 			sinon.assert.calledOnce( focusSpy );
 		} );
@@ -327,16 +322,12 @@ describe( 'index', () => {
 
 		function prepareFakeContext() {
 			return {
-				refs: {
-					dropdownContainer: {
-						focus: sinon.spy(),
-					},
-				},
 				activateItem: sinon.spy(),
 				closeDropdown: sinon.spy(),
 				focusSibling: sinon.spy(),
 				navigateItemByTabKey: sinon.spy(),
 				openDropdown: sinon.spy(),
+				focusContainer: sinon.spy(),
 			};
 		}
 


### PR DESCRIPTION
It's been rewritten to use `React.createRef` instead.
In addition, `SelectDropdownItem` has been rewritten as a functional component, and some ARIA fixes were added.

#### Changes proposed in this Pull Request

* Rewrite `SelectDropdown` to use `React.createRef` instead of string refs.
* Rewrite `SelectDropdownItem` as a functional component with ref forwarding.
* Fix some ARIA attributes on `SelectDropdown` and `SelectDropdownItem`.

#### Testing instructions

* Go to e.g. `stats/insights`
* Try the dropdown in "Comments" and ensure that it works correctly with the mouse.
* Ensure that it also works correctly with the keyboard. Note that the "focus" state is very hard to see (it's just a thin black outline), but hitting <kbd>Space</kbd> should select the currently focused item.

**Note:** If I added you as a reviewer and you're not familiar with this code, sorry about that, I'm just going by GitHub recommendations! If that's the case, please feel free to remove yourself or ignore the PR. And if you can point me to a better reviewer, please do! 🙂
