### PR TITLE
Coupons: extend auto-apply time window to 30 days

### DIFF
--- a/client/lib/analytics/utils.js
+++ b/client/lib/analytics/utils.js
@@ -478,15 +478,15 @@ export function saveCouponQueryArgument() {
 	// Read coupon list from localStorage, create new if it's not there yet, refresh existing.
 	const couponsJson = localStorage.getItem( MARKETING_COUPONS_KEY );
 	const coupons = JSON.parse( couponsJson ) || {};
-	const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
+	const THIRTY_DAYS_MILLISECONDS = 30 * 24 * 60 * 60 * 1000;
 	const now = Date.now();
 	debug( 'Found coupons in localStorage: ', coupons );
 
 	coupons[ couponCode ] = now;
 
-	// Delete coupons if they're older than a week.
+	// Delete coupons if they're older than 30 days.
 	Object.keys( coupons ).forEach( key => {
-		if ( now > coupons[ key ] + ONE_WEEK_MILLISECONDS ) {
+		if ( now > coupons[ key ] + THIRTY_DAYS_MILLISECONDS ) {
 			delete coupons[ key ];
 		}
 	} );

--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -166,15 +166,15 @@ export function getRememberedCoupon() {
 		'TXAM',
 		'FBSAVE15',
 	];
-	const ONE_WEEK_MILLISECONDS = 7 * 24 * 60 * 60 * 1000;
+	const THIRTY_DAYS_MILLISECONDS = 30 * 24 * 60 * 60 * 1000;
 	const now = Date.now();
 	debug( 'Found coupons in localStorage: ', coupons );
 
-	// delete coupons if they're older than a week; find the most recent one
+	// delete coupons if they're older than thirty days; find the most recent one
 	let mostRecentTimestamp = 0;
 	let mostRecentCouponCode = null;
 	Object.keys( coupons ).forEach( key => {
-		if ( now > coupons[ key ] + ONE_WEEK_MILLISECONDS ) {
+		if ( now > coupons[ key ] + THIRTY_DAYS_MILLISECONDS ) {
 			delete coupons[ key ];
 		} else if ( coupons[ key ] > mostRecentTimestamp ) {
 			mostRecentCouponCode = key;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Extends the time window within which remembered coupons will auto-apply during signup to 30 days. 

#### Testing instructions

Inspect the changes. Ensure no issues during signup and checkout. 
