### PR TITLE
Block editor: debounce block picker search tracking

### DIFF
--- a/apps/wpcom-block-editor/src/common/tracking/wpcom-block-picker-search-term-handler.js
+++ b/apps/wpcom-block-editor/src/common/tracking/wpcom-block-picker-search-term-handler.js
@@ -1,7 +1,30 @@
 /**
+ * External dependencies
+ */
+import { debounce } from 'lodash';
+
+/**
  * Internal dependencies
  */
 import tracksRecordEvent from './track-record-event';
+
+const trackSearchTermNotFound = ( event, target ) => {
+	const search_term = target.value;
+
+	if ( search_term.length < 3 ) {
+		return;
+	}
+
+	tracksRecordEvent( 'wpcom_block_picker_search_term', { search_term } );
+
+	// Create a separate event for search with no results to make it easier to filter by them
+	const hasResults = document.querySelectorAll( '.block-editor-inserter__no-results' ).length === 0;
+	if ( hasResults ) {
+		return;
+	}
+
+	tracksRecordEvent( 'wpcom_block_picker_no_results', { search_term } );
+};
 
 /**
  * Return the event definition object to track `wpcom_block_picker_no_results`.
@@ -12,21 +35,5 @@ import tracksRecordEvent from './track-record-event';
 export default () => ( {
 	selector: '.block-editor-inserter__search',
 	type: 'keyup',
-	handler: ( event, target ) => {
-		const search_term = target.value;
-		if ( search_term.length < 3 ) {
-			return;
-		}
-
-		tracksRecordEvent( 'wpcom_block_picker_search_term', { search_term } );
-
-		// Create a separate event for search with no results to make it easier to filter by them
-		const hasResults =
-			document.querySelectorAll( '.block-editor-inserter__no-results' ).length === 0;
-		if ( hasResults ) {
-			return;
-		}
-
-		tracksRecordEvent( 'wpcom_block_picker_no_results', { search_term } );
-	},
+	handler: debounce( trackSearchTermNotFound, 500 ),
 } );

--- a/apps/wpcom-block-editor/src/common/tracking/wpcom-block-picker-search-term-handler.js
+++ b/apps/wpcom-block-editor/src/common/tracking/wpcom-block-picker-search-term-handler.js
@@ -8,7 +8,7 @@ import { debounce } from 'lodash';
  */
 import tracksRecordEvent from './track-record-event';
 
-const trackSearchTermNotFound = ( event, target ) => {
+const trackSearchTerm = ( event, target ) => {
 	const search_term = target.value;
 
 	if ( search_term.length < 3 ) {
@@ -35,5 +35,5 @@ const trackSearchTermNotFound = ( event, target ) => {
 export default () => ( {
 	selector: '.block-editor-inserter__search',
 	type: 'keyup',
-	handler: debounce( trackSearchTermNotFound, 500 ),
+	handler: debounce( trackSearchTerm, 500 ),
 } );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add `debounce` to "search term, no results" event in block-editor tracking

#### Testing instructions

- Sandbox your site,
- Build the app to your sandboxed files:
    ```
    npx lerna run build --scope='@automattic/wpcom-block-editor' -- -- --output-path=/PARTH_TO_SANDBOX/widgets.wp.com/wpcom-block-editor
    ```
- Confirm that when typing "123456" in block picker search input, you only get one event, not for each number separately.

You can turn debugging for tracks events on by throwing this in console`localStorage.debug='calypso:analytics:tracks'`