### PR TITLE
Fix duplicate posts in Reader streams.

### DIFF
--- a/client/state/reader/streams/reducer.js
+++ b/client/state/reader/streams/reducer.js
@@ -1,9 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-import { findIndex, last, takeRightWhile, takeWhile, filter } from 'lodash';
+import { findIndex, last, takeRightWhile, takeWhile, filter, uniqWith } from 'lodash';
 import moment from 'moment';
 
 /**
@@ -27,11 +25,11 @@ import { combineXPosts } from './utils';
  * Contains a list of post-keys representing the items of a stream.
  */
 export const items = ( state = [], action ) => {
-	let streamItems;
+	let streamItems, gap, newState, newXPosts;
 
 	switch ( action.type ) {
 		case READER_STREAMS_PAGE_RECEIVE:
-			const { gap } = action.payload;
+			gap = action.payload.gap;
 			streamItems = action.payload.streamItems;
 
 			if ( gap ) {
@@ -59,10 +57,10 @@ export const items = ( state = [], action ) => {
 				return combineXPosts( [ ...beforeGap, ...streamItems, ...nextGap, ...afterGap ] );
 			}
 
-			const newState = [ ...state, ...streamItems ];
+			newState = uniqWith( [ ...state, ...streamItems ], keysAreEqual );
 
 			// Find any x-posts
-			const newXPosts = filter( streamItems, postKey => postKey.xPostMetadata );
+			newXPosts = filter( streamItems, postKey => postKey.xPostMetadata );
 
 			if ( ! newXPosts ) {
 				return newState;
@@ -96,7 +94,7 @@ export const PENDING_ITEMS_DEFAULT = { lastUpdated: null, items: [] };
  * This is the data backing the orange "${number} new posts" pill.
  */
 export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
-	let streamItems, maxDate;
+	let streamItems, maxDate, minDate, newItems, newXPosts;
 	switch ( action.type ) {
 		case READER_STREAMS_PAGE_RECEIVE:
 			streamItems = action.payload.streamItems;
@@ -118,7 +116,7 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 			}
 
 			maxDate = moment( streamItems[ 0 ].date );
-			const minDate = moment( last( streamItems ).date );
+			minDate = moment( last( streamItems ).date );
 
 			// only retain posts that are newer than ones we already have
 			if ( state.lastUpdated ) {
@@ -131,10 +129,10 @@ export const pendingItems = ( state = PENDING_ITEMS_DEFAULT, action ) => {
 				return state;
 			}
 
-			let newItems = [ ...streamItems ];
+			newItems = [ ...streamItems ];
 
 			// Find any x-posts and filter out duplicates
-			const newXPosts = filter( newItems, postKey => postKey.xPostMetadata );
+			newXPosts = filter( newItems, postKey => postKey.xPostMetadata );
 
 			if ( newXPosts ) {
 				newItems = combineXPosts( newItems );


### PR DESCRIPTION
In certain conditions, a Reader stream (such as "following") could show duplicates of the same post. This change should prevent that.

This is an issue that has bugged me for a while, but I finally had the opportunity to hunt down and fix.

#### Changes proposed in this Pull Request

* Prevent duplicate items in Reader stream state.
* Clean up the modified file to fix some linting errors.

#### Testing instructions

I'm sure it triggers in more situations, but this one is guaranteed, for me:

* Modify your "following" sites so that your entire stream consists of a single post (e.g., remove all sites except for a single site, that happens to contain a single post).
* Go to Reader.
* Refresh the entire page using the browser refresh button, to start with clean state.
* Verify that there is a single post in the "following" stream.
* Click the "My Sites" button in the masterbar.
* Click the "Reader" button in the masterbar to go back.
* Ensure that there's a single copy of the post, rather than two, as before the fix.

**Note**: If I added you as a reviewer and you're not familiar with this code, sorry about that, I'm just going by GitHub recommendations! If that's the case, please feel free to remove yourself or ignore the PR. And if you can point me to a better reviewer, please do! 🙂

Fixes #25402.