### PR TITLE
Plan Downgrades

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -585,10 +585,12 @@ class CancelPurchaseForm extends React.Component {
 			}
 
 			if ( surveyStep === steps.DOWNGRADE_STEP ) {
+				const { precision } = getCurrencyDefaults( purchase.currencyCode );
+				const planCost = parseFloat( this.props.downgradePlanPrice ).toFixed( precision );
 				return (
 					<DowngradeStep
 						currencySymbol={ purchase.currencySymbol }
-						planCost={ this.props.downgradePlanPrice }
+						planCost={ planCost }
 						refundAmount={ this.getRefundAmount() }
 					/>
 				);

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -46,7 +46,7 @@ import isSurveyFilledIn from './is-survey-filled-in';
 import stepsForProductAndSurvey from './steps-for-product-and-survey';
 import enrichedSurveyData from './enriched-survey-data';
 import { CANCEL_FLOW_TYPE } from './constants';
-import { getIncludedDomainPurchase, getDowngradePlanRawPrice } from 'state/purchases/selectors';
+import { getDowngradePlanRawPrice } from 'state/purchases/selectors';
 import QueryPlans from 'components/data/query-plans';
 import QuerySitePlans from 'components/data/query-site-plans';
 
@@ -757,7 +757,6 @@ export default connect(
 		isAtomicSite: isSiteAutomatedTransfer( state, purchase.siteId ),
 		isImport: !! getSiteImportEngine( state, purchase.siteId ),
 		precancellationChatAvailable: isPrecancellationChatAvailable( state ),
-		includedDomainPurchase: getIncludedDomainPurchase( state, purchase ),
 		downgradePlanPrice: getDowngradePlanRawPrice( state, purchase ),
 	} ),
 	{

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -33,7 +33,7 @@ import BusinessATStep from './step-components/business-at-step';
 import UpgradeATStep from './step-components/upgrade-at-step';
 import PrecancellationChatButton from './precancellation-chat-button';
 import DowngradeStep from './step-components/downgrade-step';
-import { getName } from 'lib/purchases';
+import { getName, isRefundable } from 'lib/purchases';
 import { isGoogleApps } from 'lib/products-values';
 import { radioOption } from './radio-option';
 import {
@@ -524,6 +524,11 @@ class CancelPurchaseForm extends React.Component {
 	getRefundAmount = () => {
 		const { purchase, downgradePlanPrice, includedDomainPurchase } = this.props;
 		const { precision } = getCurrencyDefaults( purchase.currencyCode );
+
+		if ( ! isRefundable( purchase ) ) {
+			return 0;
+		}
+
 		const refundAmount =
 			purchase.refundAmount +
 			( includedDomainPurchase ? includedDomainPurchase.costToUnbundle : 0 ) -
@@ -533,11 +538,11 @@ class CancelPurchaseForm extends React.Component {
 			return 0;
 		}
 
-		return purchase.currencySymbol + parseFloat( refundAmount ).toFixed( precision );
+		return parseFloat( refundAmount ).toFixed( precision );
 	};
 
 	surveyContent() {
-		const { translate, isImport, showSurvey } = this.props;
+		const { translate, isImport, showSurvey, purchase } = this.props;
 		const { surveyStep } = this.state;
 
 		if ( showSurvey ) {
@@ -588,6 +593,7 @@ class CancelPurchaseForm extends React.Component {
 			if ( surveyStep === steps.DOWNGRADE_STEP ) {
 				return (
 					<DowngradeStep
+						currencySymbol={ purchase.currencySymbol }
 						planCost={ this.props.downgradePlanPrice }
 						refundAmount={ this.getRefundAmount() }
 					/>

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -524,21 +524,13 @@ class CancelPurchaseForm extends React.Component {
 	};
 
 	getRefundAmount = () => {
-		const { purchase, downgradePlanPrice, includedDomainPurchase } = this.props;
-		const { precision } = getCurrencyDefaults( purchase.currencyCode );
-
-		if ( ! isRefundable( purchase ) ) {
-			return 0;
-		}
-
+		const { purchase } = this.props;
+		const { refundOptions, currencyCode } = purchase;
+		const { precision } = getCurrencyDefaults( currencyCode );
 		const refundAmount =
-			purchase.refundAmount +
-			( includedDomainPurchase ? includedDomainPurchase.costToUnbundle : 0 ) -
-			downgradePlanPrice;
-
-		if ( refundAmount < 0 ) {
-			return 0;
-		}
+			isRefundable( purchase ) && refundOptions[ 0 ] && refundOptions[ 0 ].refund_amount
+				? refundOptions[ 0 ].refund_amount
+				: 0;
 
 		return parseFloat( refundAmount ).toFixed( precision );
 	};

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -47,6 +47,8 @@ import stepsForProductAndSurvey from './steps-for-product-and-survey';
 import enrichedSurveyData from './enriched-survey-data';
 import { CANCEL_FLOW_TYPE } from './constants';
 import { getIncludedDomainPurchase, getDowngradePlanRawPrice } from 'state/purchases/selectors';
+import QueryPlans from 'components/data/query-plans';
+import QuerySitePlans from 'components/data/query-site-plans';
 
 /**
  * Style dependencies
@@ -738,6 +740,7 @@ class CancelPurchaseForm extends React.Component {
 	}
 
 	render() {
+		const { selectedSite } = this.props;
 		return (
 			<Dialog
 				isVisible={ this.props.isVisible }
@@ -746,6 +749,8 @@ class CancelPurchaseForm extends React.Component {
 				className="cancel-purchase-form__dialog"
 			>
 				{ this.surveyContent() }
+				<QueryPlans />
+				{ selectedSite && <QuerySitePlans siteId={ selectedSite.ID } /> }
 			</Dialog>
 		);
 	}

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -31,6 +31,7 @@ import initialSurveyState from './initial-survey-state';
 import BusinessATStep from './step-components/business-at-step';
 import UpgradeATStep from './step-components/upgrade-at-step';
 import PrecancellationChatButton from './precancellation-chat-button';
+import DowngradeStep from './step-components/downgrade-step';
 import { getName } from 'lib/purchases';
 import { isGoogleApps } from 'lib/products-values';
 import { radioOption } from './radio-option';
@@ -259,6 +260,11 @@ class CancelPurchaseForm extends React.Component {
 		this.props.onClickFinalConfirm();
 
 		this.recordEvent( 'calypso_purchases_cancel_form_submit' );
+	};
+
+	downgradePlan = () => {
+		this.props.downgradePlan();
+		this.recordEvent( 'calypso_purchases_downgrade_form_submit' );
 	};
 
 	renderQuestionOne = () => {
@@ -562,6 +568,10 @@ class CancelPurchaseForm extends React.Component {
 				return <UpgradeATStep />;
 			}
 
+			if ( surveyStep === steps.DOWNGRADE_STEP ) {
+				return <DowngradeStep />;
+			}
+
 			return (
 				<div>
 					<FormSectionHeading>
@@ -644,6 +654,13 @@ class CancelPurchaseForm extends React.Component {
 				onClick: this.onSubmit,
 				isPrimary: true,
 			},
+			downgrade = {
+				action: 'downgrade',
+				disabled: this.state.isSubmitting,
+				label: translate( 'Switch to Personal' ),
+				onClick: this.downgradePlan,
+				isPrimary: true,
+			},
 			remove = {
 				action: 'remove',
 				disabled,
@@ -667,6 +684,10 @@ class CancelPurchaseForm extends React.Component {
 				default:
 					return firstButtons.concat( [ ...prevButton, cancel ] );
 			}
+		}
+
+		if ( this.state.surveyStep === steps.DOWNGRADE_STEP ) {
+			return firstButtons.concat( [ prev, downgrade, next ] );
 		}
 
 		return firstButtons.concat(

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -1,0 +1,64 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { noop } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { getSelectedSite } from 'state/ui/selectors';
+import { recordTracksEvent } from 'state/analytics/actions';
+import FormSectionHeading from 'components/forms/form-section-heading';
+import FormFieldset from 'components/forms/form-fieldset';
+
+export class DowngradeStep extends Component {
+	static propTypes = {
+		recordTracksEvent: PropTypes.func.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		translate: noop,
+	};
+
+	onClick = () => {
+		this.props.recordTracksEvent( 'calypso_cancellation_downgrade_step_click' );
+	};
+
+	render() {
+		const { translate } = this.props;
+
+		return (
+			<div>
+				<FormSectionHeading>
+					{ translate( 'Would you rather switch to a lower-tier plan?' ) }
+				</FormSectionHeading>
+				<FormFieldset>
+					<p>
+						{ translate(
+							'You can downgrade to Personal and get a partial refund or continue to the next step and cancel the plan.'
+						) }
+					</p>
+				</FormFieldset>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = state => ( {
+	selectedSite: getSelectedSite( state ),
+} );
+const mapDispatchToProps = { recordTracksEvent };
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( localize( DowngradeStep ) );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -21,7 +21,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 export class DowngradeStep extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
-		selectedSite: PropTypes.object.isRequired,
+		refundAmount: PropTypes.string.isRequired,
+		planCost: PropTypes.string.isRequired,
 		translate: PropTypes.func.isRequired,
 	};
 
@@ -34,7 +35,7 @@ export class DowngradeStep extends Component {
 	};
 
 	render() {
-		const { translate } = this.props;
+		const { translate, refundAmount, planCost } = this.props;
 
 		return (
 			<div>
@@ -43,9 +44,16 @@ export class DowngradeStep extends Component {
 				</FormSectionHeading>
 				<FormFieldset>
 					<p>
-						{ translate(
-							'You can downgrade to Personal and get a partial refund or continue to the next step and cancel the plan.'
-						) }
+						{ refundAmount
+							? translate(
+									'You can downgrade to Personal and get a partial refund of %(refundAmount)s or ' +
+										'continue to the next step and cancel the plan.',
+									{ args: { refundAmount } }
+							  )
+							: translate(
+									'You can downgrade to Personal and the new plan will renew at only %(planCost)s.',
+									{ args: { planCost } }
+							  ) }
 					</p>
 				</FormFieldset>
 			</div>

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -21,8 +21,8 @@ import FormFieldset from 'components/forms/form-fieldset';
 export class DowngradeStep extends Component {
 	static propTypes = {
 		recordTracksEvent: PropTypes.func.isRequired,
-		refundAmount: PropTypes.string.isRequired,
-		planCost: PropTypes.string.isRequired,
+		refundAmount: PropTypes.string,
+		planCost: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 	};
 

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -35,7 +35,8 @@ export class DowngradeStep extends Component {
 	};
 
 	render() {
-		const { translate, refundAmount, planCost } = this.props;
+		const { translate, refundAmount, planCost, currencySymbol } = this.props;
+		const amount = currencySymbol + ( refundAmount ? refundAmount : planCost );
 
 		return (
 			<div>
@@ -46,13 +47,13 @@ export class DowngradeStep extends Component {
 					<p>
 						{ refundAmount
 							? translate(
-									'You can downgrade to Personal and get a partial refund of %(refundAmount)s or ' +
+									'You can downgrade to Personal and get a partial refund of %(amount)s or ' +
 										'continue to the next step and cancel the plan.',
-									{ args: { refundAmount } }
+									{ args: { amount } }
 							  )
 							: translate(
-									'You can downgrade to Personal and the new plan will renew at only %(planCost)s.',
-									{ args: { planCost } }
+									'You can downgrade to Personal and the new plan will renew at only %(amount)s.',
+									{ args: { amount } }
 							  ) }
 					</p>
 				</FormFieldset>

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -17,6 +17,7 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import FormSectionHeading from 'components/forms/form-section-heading';
 import FormFieldset from 'components/forms/form-fieldset';
+import userUtils from 'lib/user/utils';
 
 export class DowngradeStep extends Component {
 	static propTypes = {
@@ -38,25 +39,46 @@ export class DowngradeStep extends Component {
 		const { translate, refundAmount, planCost, currencySymbol } = this.props;
 		const canRefund = !! parseFloat( refundAmount );
 		const amount = currencySymbol + ( canRefund ? refundAmount : planCost );
-
+		const isEnglishLocale = 'en' === userUtils.getLocaleSlug();
+		let refundDetails, refundTitle, refundReason;
+		if ( isEnglishLocale ) {
+			refundTitle = translate( 'Would you rather switch to a more affordable plan?' );
+			refundReason = (
+				<p>
+					{ translate(
+						'WordPress.com Personal still gives you access to email and chat support, ' +
+							'removal of ads, and more — and for 50% of the cost of your current plan.'
+					) }
+				</p>
+			);
+			refundDetails = canRefund
+				? translate(
+						'You can downgrade and get a partial refund of %(amount)s or ' +
+							'continue to the next step and cancel the plan.',
+						{ args: { amount } }
+				  )
+				: translate( 'You can downgrade and the new plan will renew at only %(amount)s.', {
+						args: { amount },
+				  } );
+		} else {
+			refundTitle = translate( 'Would you rather switch to a lower-tier plan?' );
+			refundDetails = canRefund
+				? translate(
+						'You can downgrade to Personal and get a partial refund of %(amount)s or ' +
+							'continue to the next step and cancel the plan.',
+						{ args: { amount } }
+				  )
+				: translate(
+						'You can downgrade to Personal and the new plan will renew at only %(amount)s.',
+						{ args: { amount } }
+				  );
+		}
 		return (
 			<div>
-				<FormSectionHeading>
-					{ translate( 'Would you rather switch to a lower-tier plan?' ) }
-				</FormSectionHeading>
+				<FormSectionHeading>{ refundTitle }</FormSectionHeading>
 				<FormFieldset>
-					<p>
-						{ canRefund
-							? translate(
-									'You can downgrade to Personal and get a partial refund of %(amount)s or ' +
-										'continue to the next step and cancel the plan.',
-									{ args: { amount } }
-							  )
-							: translate(
-									'You can downgrade to Personal and the new plan will renew at only %(amount)s.',
-									{ args: { amount } }
-							  ) }
-					</p>
+					{ refundReason }
+					<p>{ refundDetails }</p>
 				</FormFieldset>
 			</div>
 		);

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -39,7 +39,7 @@ export class DowngradeStep extends Component {
 		const { translate, refundAmount, planCost, currencySymbol } = this.props;
 		const canRefund = !! parseFloat( refundAmount );
 		const amount = currencySymbol + ( canRefund ? refundAmount : planCost );
-		const isEnglishLocale = 'en' === userUtils.getLocaleSlug();
+		const isEnglishLocale = [ 'en', 'en-gb' ].indexOf( userUtils.getLocaleSlug() ) >= 0;
 		let refundDetails, refundTitle, refundReason;
 		if ( isEnglishLocale ) {
 			refundTitle = translate( 'Would you rather switch to a more affordable plan?' );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/downgrade-step.jsx
@@ -36,7 +36,8 @@ export class DowngradeStep extends Component {
 
 	render() {
 		const { translate, refundAmount, planCost, currencySymbol } = this.props;
-		const amount = currencySymbol + ( refundAmount ? refundAmount : planCost );
+		const canRefund = !! parseFloat( refundAmount );
+		const amount = currencySymbol + ( canRefund ? refundAmount : planCost );
 
 		return (
 			<div>
@@ -45,7 +46,7 @@ export class DowngradeStep extends Component {
 				</FormSectionHeading>
 				<FormFieldset>
 					<p>
-						{ refundAmount
+						{ canRefund
 							? translate(
 									'You can downgrade to Personal and get a partial refund of %(amount)s or ' +
 										'continue to the next step and cancel the plan.',

--- a/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps-for-product-and-survey.js
@@ -17,6 +17,7 @@ import { abtest } from 'lib/abtest';
 import * as steps from './steps';
 
 const BUSINESS_PLANS = findPlansKeys( { group: GROUP_WPCOM, type: TYPE_BUSINESS } );
+const PREMIUM_PLANS = findPlansKeys( { group: GROUP_WPCOM, type: TYPE_PREMIUM } );
 const PERSONAL_PREMIUM_PLANS = []
 	.concat( findPlansKeys( { group: GROUP_WPCOM, type: TYPE_PERSONAL } ) )
 	.concat( findPlansKeys( { group: GROUP_WPCOM, type: TYPE_PREMIUM } ) );
@@ -39,6 +40,12 @@ export default function stepsForProductAndSurvey(
 
 		if ( includesProduct( PERSONAL_PREMIUM_PLANS, product ) ) {
 			return [ steps.INITIAL_STEP, steps.UPGRADE_AT_STEP, steps.FINAL_STEP ];
+		}
+	}
+
+	if ( survey && survey.questionOneRadio === 'onlyNeedFree' ) {
+		if ( includesProduct( PREMIUM_PLANS, product ) ) {
+			return [ steps.INITIAL_STEP, steps.DOWNGRADE_STEP, steps.FINAL_STEP ];
 		}
 	}
 

--- a/client/components/marketing-survey/cancel-purchase-form/steps.js
+++ b/client/components/marketing-survey/cancel-purchase-form/steps.js
@@ -5,4 +5,5 @@ export const HAPPYCHAT_STEP = 'happychat_step';
 export const FINAL_STEP = 'final_step';
 export const BUSINESS_AT_STEP = 'business_at_step';
 export const UPGRADE_AT_STEP = 'upgrade_at_step';
+export const DOWNGRADE_STEP = 'downgrade_step';
 export const DEFAULT_STEPS_WITH_HAPPYCHAT = [ INITIAL_STEP, HAPPYCHAT_STEP, FINAL_STEP ];

--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -63,6 +63,7 @@ function createPurchaseObject( purchase ) {
 		productName: purchase.product_name,
 		productSlug: purchase.product_slug,
 		refundAmount: Number( purchase.refund_amount ),
+		refundOptions: purchase.refund_options,
 		refundText: purchase.refund_text,
 		refundPeriodInDays: purchase.refund_period_in_days,
 		renewDate: purchase.renew_date,

--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -29,8 +29,7 @@ import notices from 'notices';
 import { confirmCancelDomain, purchasesRoot } from 'me/purchases/paths';
 import { refreshSitePlans } from 'state/sites/plans/actions';
 import { cancellationEffectDetail, cancellationEffectHeadline } from './cancellation-effect';
-import { getPlan, findPlansKeys } from 'lib/plans';
-import { TYPE_PERSONAL } from 'lib/plans/constants';
+import { getDowngradePlanFromPurchase } from 'state/purchases/selectors';
 
 class CancelPurchaseButton extends Component {
 	static propTypes = {
@@ -183,22 +182,19 @@ class CancelPurchaseButton extends Component {
 		);
 	};
 
-	downgradePlan = () => {
+	downgradeClick = () => {
 		const { purchase } = this.props;
-
-		const plan = getPlan( purchase.productSlug );
-		const newPlanKeys = findPlansKeys( {
-			group: plan.group,
-			type: TYPE_PERSONAL,
-			term: plan.term,
-		} );
-		const downgradeTo = getPlan( newPlanKeys[ 0 ] ).getProductId();
+		const downgradePlan = getDowngradePlanFromPurchase( purchase );
 
 		this.setDisabled( true );
 
 		cancelAndRefundPurchase(
 			purchase.id,
-			{ product_id: purchase.productId, type: 'downgrade', to_product_id: downgradeTo },
+			{
+				product_id: purchase.productId,
+				type: 'downgrade',
+				to_product_id: downgradePlan.getProductId(),
+			},
 			( error, response ) => {
 				this.setDisabled( false );
 
@@ -307,7 +303,7 @@ class CancelPurchaseButton extends Component {
 					isVisible={ this.state.showDialog }
 					onClose={ this.closeDialog }
 					onClickFinalConfirm={ this.submitCancelAndRefundPurchase }
-					downgradePlan={ this.downgradePlan }
+					downgradeClick={ this.downgradeClick }
 					flowType={ this.getCancellationFlowType() }
 				/>
 			</div>

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -120,7 +120,7 @@ export const getDowngradePlanRawPrice = ( state, purchase ) => {
 	if ( ! plan ) {
 		return null;
 	}
-	return getPlanRawPrice( state, plan.getProductId(), false );
+	return getPlanRawPrice( state, plan.getProductId() );
 };
 
 /**

--- a/client/state/purchases/selectors.js
+++ b/client/state/purchases/selectors.js
@@ -16,7 +16,9 @@ import {
 	isDomainRegistration,
 	isDomainMapping,
 } from 'lib/products-values';
-
+import { getPlan, findPlansKeys } from 'lib/plans';
+import { TYPE_PERSONAL } from 'lib/plans/constants';
+import { getPlanRawPrice } from 'state/plans/selectors';
 /**
  * Return the list of purchases from state object
  *
@@ -96,6 +98,29 @@ export const getIncludedDomainPurchase = ( state, subscriptionPurchase ) => {
 	);
 
 	return domainPurchase;
+};
+
+export const getDowngradePlanFromPurchase = purchase => {
+	const plan = getPlan( purchase.productSlug );
+	if ( ! plan ) {
+		return null;
+	}
+
+	const newPlanKeys = findPlansKeys( {
+		group: plan.group,
+		type: TYPE_PERSONAL,
+		term: plan.term,
+	} );
+
+	return getPlan( newPlanKeys[ 0 ] );
+};
+
+export const getDowngradePlanRawPrice = ( state, purchase ) => {
+	const plan = getDowngradePlanFromPurchase( purchase );
+	if ( ! plan ) {
+		return null;
+	}
+	return getPlanRawPrice( state, plan.getProductId(), false );
 };
 
 /**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This will add support for self-serving downgrades for Premium to Personal through the cancelation survey.

#### Testing instructions

1. Buy Personal, then upgrade to Premium
2. Go to Manage Purchases, Click Cancel and refund. Don't confirm the refund, just verify that the price is the price of the Premium plan
3. In the cancelation survey, select that the plan was too expensive
4. Confirm that you can downgrade and get a partial refund. This time proceed and cancel the plan
5. Add a plan from Store Admin. This plan will be non-refundable because it's added by an admin user
6. Repeat step 3. This time the message should be different, stating that the plan will renew at the price of Personal

Fixes #
