### PR TITLE
FSE: Apply the template parts' theme classes to the editor

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -88,11 +88,11 @@ const TemplateEdit = compose(
 			receiveTemplateBlocks();
 		} );
 
-		const { align } = attributes;
+		const { align, className } = attributes;
 
 		return (
 			<div
-				className={ classNames( 'template-block', {
+				className={ classNames( 'template-block', className, {
 					[ `align${ align }` ]: align,
 				} ) }
 			>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/index.js
@@ -10,4 +10,5 @@ import './blocks/site-logo';
 import './plugins/template-selector-sidebar';
 import './plugins/close-button-override';
 import './plugins/template-update-confirmation';
+import './plugins/editor-template-classes';
 import './editor';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
@@ -1,0 +1,56 @@
+/* global fullSiteEditing */
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+import { endsWith, get, map } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { withSelect } from '@wordpress/data';
+import { registerPlugin } from '@wordpress/plugins';
+
+const EditorTemplateClasses = withSelect( select => {
+	const { getEntityRecord } = select( 'core' );
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const templatePartClasses = map( getEditedPostAttribute( 'template_part_types' ), typeId => {
+		const typeName = get(
+			getEntityRecord( 'taxonomy', 'wp_template_part_type', typeId ),
+			'name',
+			''
+		);
+		if ( endsWith( typeName, '-header' ) ) {
+			return 'site-header site-branding';
+		}
+		if ( endsWith( typeName, '-footer' ) ) {
+			return 'site-footer';
+		}
+	} );
+	return { templatePartClasses };
+} )( ( { templatePartClasses } ) => {
+	const blockListInception = setInterval( () => {
+		const blockList = document.querySelector(
+			'.editor-block-list__layout.block-editor-block-list__layout'
+		);
+
+		if ( ! blockList ) {
+			return;
+		}
+		clearInterval( blockListInception );
+
+		blockList.className = classNames(
+			'editor-block-list__layout',
+			'block-editor-block-list__layout',
+			...templatePartClasses
+		);
+	} );
+
+	return null;
+} );
+
+if ( 'wp_template_part' === fullSiteEditing.editorPostType ) {
+	registerPlugin( 'fse-editor-template-classes', {
+		render: EditorTemplateClasses,
+	} );
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
@@ -42,6 +42,7 @@ const EditorTemplateClasses = withSelect( select => {
 			'editor-writing-flow',
 			...templatePartClasses
 		);
+		blockList.style.padding = 0;
 	} );
 
 	return null;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/editor-template-classes/index.js
@@ -30,9 +30,7 @@ const EditorTemplateClasses = withSelect( select => {
 	return { templatePartClasses };
 } )( ( { templatePartClasses } ) => {
 	const blockListInception = setInterval( () => {
-		const blockList = document.querySelector(
-			'.editor-block-list__layout.block-editor-block-list__layout'
-		);
+		const blockList = document.querySelector( '.block-editor-writing-flow.editor-writing-flow' );
 
 		if ( ! blockList ) {
 			return;
@@ -40,8 +38,8 @@ const EditorTemplateClasses = withSelect( select => {
 		clearInterval( blockListInception );
 
 		blockList.className = classNames(
-			'editor-block-list__layout',
-			'block-editor-block-list__layout',
+			'block-editor-writing-flow',
+			'editor-writing-flow',
 			...templatePartClasses
 		);
 	} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Require https://github.com/Automattic/themes/pull/1165

To apply the theme CSS classes to the pre-generated header and footer Template Parts, FSE (in the theme) wraps them with a Group block containing other wrappers with those classes.
This is a problem for several reasons:
- Group blocks have behaviours incompatible with a Template Part (e.g. users can change their background color).
- The Template Part allows to add blocks outside of the Group, but the CSS classes would only be applied to the Group.
- The Group can be deleted, and the Template Part would lose the CSS classes altogether.
- The wrappers (inside the Group) with the CSS classes can be deleted via code, or could be lost if Gutenberg needs to parse and "clean" the block if it notice there's something off going on.

This proposal moves the theme CSS classes away from the Group (and wrappers) block, and into the Template Part block itself (see https://github.com/Automattic/themes/pull/1165).

This is enough to handle how the Template Part block looks like in a Template, but not how it looks like in the Template Part editor.

For that, I took advantage of the `wp_template_part_type` taxonomy, and added a hidden plugin that automagically adds the theme CSS classes to the Block Editor according to what Template Part Types are checked.

#### Screenshots

This is how a Template Part looks now, with some of its inconsistencies:

![Screenshot 2019-07-31 at 15 02 57](https://user-images.githubusercontent.com/2070010/62219375-1d5ba880-b3a6-11e9-88f3-eb1e910633d8.png)

This is how a Template Part would look with this PR:

![Screenshot 2019-07-31 at 14 59 19](https://user-images.githubusercontent.com/2070010/62219519-66136180-b3a6-11e9-940c-72f053d5ded0.png)

Since the header CSS classes depend on the Template Part Type, unchecking it would make the header lose its style:

![Screenshot 2019-07-31 at 14 59 28](https://user-images.githubusercontent.com/2070010/62219667-a541b280-b3a6-11e9-883a-37521b50628b.png)

This is how the Template Part would look inside a Template with this PR:

![Screenshot 2019-07-31 at 15 00 28](https://user-images.githubusercontent.com/2070010/62219736-c1455400-b3a6-11e9-8860-a65962fae18d.png)

#### Caveats

- By basically hard-coding the `.site-header`, `.site-branding`, and `.site-footer` classes into FSE, this effectively tighten the coupling between FSE and the Modern Business theme.
It could make sense to figure out a way for (any) theme to tell FSE which classes are required for the various template parts.

- This relies on the theme/plugin activation logic, that creates a Template containing the Template Parts already pre-filled with the correct CSS classes.
But what happens if the user decides to use a different Template Part? (...can they?)
They would need to go to the Template, select the Template Part, open its block sidebar, and add back the appropriate CSS classes.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout both this PR and https://github.com/Automattic/themes/pull/1165.
* Deactivate the Modern Business theme by activating any other theme, and unset the `modern-business-fse-template-data` option. Delete all Templates and Template Parts. (this step might be overkill?)
* Activate the Modern Business theme.
* ⚠️ Edit a pre-generated Template Part and make sure it uses the expected styles. (E.g. the Navigation block contained in the header Template Part is supposed to be centered.)
* ⚠️ Try checking and unchecking the Template Part Types (e.g. toggling between header and footer, making sure the Navigation block changes its alignment).
* ⚠️ Edit the Template and make sure the Template Parts contained in it use the expected styles.
* ⚠️ Try viewing a page using the Template on the front-end, and make sure it looks as expected. 

Fixes #34887
