### PR TITLE
Earn Page: Add MC and Tracks analytics to upgrade buttons

### DIFF
--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -6,11 +6,12 @@ import React, { FunctionComponent } from 'react';
 /**
  * Internal dependencies
  */
+import { TranslateResult } from 'i18n-calypso';
 import PromoCard, { Props as PromoCardProps } from './promo-card';
 import PromoCardCta, { Props as PromoCardCtaProps } from './promo-card/cta';
 
 interface PromoSectionCardProps extends PromoCardProps {
-	body: string;
+	body: string | TranslateResult;
 	cta?: PromoCardCtaProps;
 	learnMoreLink?: PromoCardCtaProps;
 }

--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -18,9 +18,14 @@ import { URL } from 'types';
 
 type ClickCallback = () => void;
 
+interface CtaAction {
+	url: URL;
+	onClick: ClickCallback;
+}
+
 export interface CtaButton {
 	text: string;
-	action: URL | ClickCallback;
+	action: URL | ClickCallback | CtaAction;
 }
 
 export type Cta =
@@ -46,11 +51,23 @@ function isCtaButton( cta: Cta ): cta is CtaButton {
 	return undefined !== ( cta as CtaButton ).text;
 }
 
+function isCtaAction( action: any ): action is CtaAction {
+	return undefined !== ( action as CtaAction ).onClick;
+}
+
 function buttonProps( button: CtaButton, isPrimary: boolean ) {
+	const actionProps = isCtaAction( button.action )
+		? {
+				href: button.action.url,
+				onClick: button.action.onClick,
+		  }
+		: {
+				[ typeof button.action === 'string' ? 'href' : 'onClick' ]: button.action,
+		  };
 	return {
 		className: 'promo-card__cta-button',
 		primary: isPrimary,
-		[ typeof button.action === 'string' ? 'href' : 'onClick' ]: button.action,
+		...actionProps,
 	};
 }
 const PromoCardCta: FunctionComponent< Props & ConnectedProps > = ( {
@@ -62,6 +79,18 @@ const PromoCardCta: FunctionComponent< Props & ConnectedProps > = ( {
 	const ctaBtnProps = partialRight( buttonProps, true === isPrimary );
 	let ctaBtn;
 	const translate = useTranslate();
+	let learnMore = null;
+
+	if ( learnMoreLink ) {
+		learnMore = isCtaAction( learnMoreLink )
+			? {
+					href: learnMoreLink.url,
+					onClick: learnMoreLink.onClick,
+			  }
+			: {
+					href: learnMoreLink,
+			  };
+	}
 
 	if ( isCtaButton( cta ) ) {
 		ctaBtn = <Button { ...ctaBtnProps( cta ) }>{ cta.text }</Button>;
@@ -75,8 +104,8 @@ const PromoCardCta: FunctionComponent< Props & ConnectedProps > = ( {
 	return (
 		<ActionPanelCta>
 			{ ctaBtn }
-			{ learnMoreLink && (
-				<Button borderless className="promo-card__cta-learn-more" href={ learnMoreLink }>
+			{ learnMore && (
+				<Button borderless className="promo-card__cta-learn-more" { ...learnMore }>
 					{ translate( 'Learn more' ) }
 				</Button>
 			) }

--- a/client/components/promo-section/promo-card/index.tsx
+++ b/client/components/promo-section/promo-card/index.tsx
@@ -6,6 +6,7 @@ import React, { FunctionComponent } from 'react';
 /**
  * Internal dependencies
  */
+import { TranslateResult } from 'i18n-calypso';
 import ActionPanel from 'components/action-panel';
 import ActionPanelFigure from 'components/action-panel/figure';
 import ActionPanelTitle from 'components/action-panel/title';
@@ -20,13 +21,13 @@ import './style.scss';
 
 export interface Image {
 	path: string;
-	alt?: string;
+	alt?: string | TranslateResult;
 	align?: 'left' | 'right';
 }
 
 export interface Props {
 	image?: Image;
-	title: string;
+	title: string | TranslateResult;
 	isPrimary?: boolean;
 }
 

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -31,6 +31,7 @@ interface ConnectedProps {
 	hasConnectedAccount: boolean;
 	hasSetupAds: boolean;
 	trackUpgrade: ( plan: string, feature: string ) => void;
+	trackLink: ( feature: string ) => void;
 }
 
 const Home: FunctionComponent< ConnectedProps > = ( {
@@ -42,6 +43,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	hasConnectedAccount,
 	hasSetupAds,
 	trackUpgrade,
+	trackLink,
 } ) => {
 	const translate = useTranslate();
 
@@ -56,7 +58,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const cta = hasSimplePayments
 			? {
 					text: translate( 'Collect One-time Payments' ),
-					action: supportLink,
+					action: { url: supportLink, onClick: () => trackLink( 'simple-payments' ) },
 			  }
 			: {
 					text: translate( 'Upgrade to Premium Plan' ),
@@ -65,7 +67,9 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 						page( `/checkout/${ selectedSiteSlug }/premium/` );
 					},
 			  };
-		const learnMoreLink = hasSimplePayments ? null : supportLink;
+		const learnMoreLink = hasSimplePayments
+			? null
+			: { url: supportLink, onClick: () => trackLink( 'simple-payments' ) };
 		return {
 			title: translate( 'Collect one-time payments' ),
 			body: translate(
@@ -118,7 +122,10 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					}
 			  );
 		const learnMoreLink = isFreePlan
-			? 'https://en.support.wordpress.com/recurring-payments/'
+			? {
+					url: 'https://en.support.wordpress.com/recurring-payments/',
+					onClick: () => trackLink( 'recurring-payments' ),
+			  }
 			: null;
 		return {
 			title,
@@ -139,7 +146,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 	const getReferralsCard = () => {
 		const cta = {
 			text: translate( 'Earn Cash from Referrals' ),
-			action: 'https://refer.wordpress.com/',
+			action: { url: 'https://refer.wordpress.com/', onClick: () => trackLink( 'referral' ) },
 		};
 		return {
 			title: translate( 'Earn Cash from Referrals' ),
@@ -192,7 +199,9 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 						},
 					}
 			  );
-		const learnMoreLink = ! hasWordAds ? 'https://wordads.co/' : null;
+		const learnMoreLink = ! hasWordAds
+			? { url: 'https://wordads.co/', onClick: () => trackLink( 'ads' ) }
+			: null;
 		return {
 			title,
 			body,
@@ -253,6 +262,13 @@ export default connect< ConnectedProps, {}, {} >(
 				composeAnalytics(
 					recordTracksEvent( 'calypso_earn_upgrade', { plan, feature } ),
 					bumpStat( 'calypso_earn_upgrade', feature )
+				)
+			),
+		trackLink: ( feature: string ) =>
+			dispatch(
+				composeAnalytics(
+					recordTracksEvent( 'calypso_earn_link', { feature } ),
+					bumpStat( 'calypso_earn_link', feature )
 				)
 			),
 	} )

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -57,7 +57,14 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			  }
 			: {
 					text: translate( 'Upgrade to Premium Plan' ),
-					action: () => page( `/checkout/${ selectedSiteSlug }/premium/` ),
+					action: () => {
+						analytics.tracks.recordEvent( 'calypso_earn_upgrade', {
+							plan: 'premium',
+							feature: 'simple-payments',
+						} );
+
+						page( `/checkout/${ selectedSiteSlug }/premium/` );
+					},
 			  };
 		const learnMoreLink = hasSimplePayments ? null : supportLink;
 		return {
@@ -87,7 +94,14 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const cta = isFreePlan
 			? {
 					text: translate( 'Upgrade to a Paid Plan' ),
-					action: () => page( `/plans/${ selectedSiteSlug }` ),
+					action: () => {
+						analytics.tracks.recordEvent( 'calypso_earn_upgrade', {
+							plan: 'any-paid-plan',
+							feature: 'recurring-payments',
+						} );
+
+						page( `/plans/${ selectedSiteSlug }` );
+					},
 			  }
 			: {
 					text: translate( 'Collect Recurring Payments' ),
@@ -165,7 +179,14 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			  }
 			: {
 					text: translate( 'Upgrade to Premium Plan' ),
-					action: () => page( `/checkout/${ selectedSiteSlug }/premium/` ),
+					action: () => {
+						analytics.tracks.recordEvent( 'calypso_earn_upgrade', {
+							plan: 'premium',
+							feature: 'ads',
+						} );
+
+						page( `/checkout/${ selectedSiteSlug }/premium/` );
+					},
 			  };
 		const title = hasSetupAds ? translate( 'View Ad Dashboard' ) : translate( 'Earn ad revenue' );
 		const body = hasSetupAds
@@ -194,7 +215,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 
 	const promos: PromoSectionProps = {
 		header: {
-			title: translate( 'Start earning money' ),
+			title: translate( 'Start earning money now' ),
 			image: {
 				path: '/calypso/images/earn/earn-section.svg',
 			},

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -149,7 +149,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			action: { url: 'https://refer.wordpress.com/', onClick: () => trackLink( 'referral' ) },
 		};
 		return {
-			title: translate( 'Earn Cash from Referrals' ),
+			title: translate( 'Earn cash from referrals' ),
 			body: translate(
 				"Promote WordPress.com to friends, family, and website visitors and you'll earn a referral payment for every paying customer you send our way. {{em}}Available on every plan{{/em}}.",
 				{


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This is an extension of #34983

* Adds MC and Tracks events to the upgrade buttons on each card.

#### Testing instructions

In the console run `localStorage.setItem('debug', "calypso:analytics:mc,calypso:analytics:tracks")`

Click on the upgrade buttons and observe the debug for the MC and Tracks events which have the name `calypso_earn_upgrade`