### PR TITLE
Gutenberg: Fix E2E tests for 6.2.0 RC

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -63,3 +63,4 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 = 0.1 =
 * Initial Release
+

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -63,4 +63,3 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 = 0.1 =
 * Initial Release
-

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -144,6 +144,7 @@ export default class LoginFlow {
 
 		if ( usingGutenberg ) {
 			const gEditorComponent = await GutenbergEditorComponent.Expect( this.driver );
+			await gEditorComponent.dismissPageTemplateSelector();
 			await gEditorComponent.closeSidebar();
 		}
 

--- a/test/e2e/lib/gutenberg/gutenberg-editor-component.js
+++ b/test/e2e/lib/gutenberg/gutenberg-editor-component.js
@@ -350,4 +350,13 @@ export default class GutenbergEditorComponent extends AsyncBaseContainer {
 			By.css( '.edit-post-fullscreen-mode-close__toolbar, .edit-post-header-toolbar__back' )
 		);
 	}
+
+	async dismissPageTemplateSelector() {
+		if ( await driverHelper.isElementPresent( this.driver, By.css( '.page-template-modal' ) ) ) {
+			await driverHelper.clickWhenClickable(
+				this.driver,
+				By.css( '.page-template-modal .components-modal__header button' )
+			);
+		}
+	}
 }

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1249,6 +1249,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the sign up processing page which will finish automatically move along',
 			async function() {
+				if ( process.env.HORIZON_TESTS === 'true' ) {
+					return this.skip();
+				}
 				return await new SignUpStep( driver ).continueAlong( blogName, passwordForTestAccounts );
 			}
 		);
@@ -1256,6 +1259,9 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 		step(
 			'Can then see the secure payment page with the chosen theme in the cart',
 			async function() {
+				if ( process.env.HORIZON_TESTS === 'true' ) {
+					return this.skip();
+				}
 				const securePaymentComponent = await SecurePaymentComponent.Expect( driver );
 				const products = await securePaymentComponent.getProductsNames();
 				assert(


### PR DESCRIPTION
While running the E2E tests against Horizon to check the Gutenberg upgrade to 6.2.0, we noticed some failures caused by the starter page template selector showing up:

https://20473-102822243-gh.circle-artifacts.com/0/home/circleci/wp-calypso/wp-calypso/test/e2e/screenshots/FAILED-EN-DESKTOP-can-log-in-1564525465885.png

This PR includes an additional step that dismiss that modal if present (it is not present in production), so the rest of the steps can be executed normally.
