### PR TITLE
Signup: Move user step to beginning of import flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -281,7 +281,7 @@ export function generateFlows( {
 	};
 
 	flows.import = {
-		steps: [ 'from-url', 'user', 'domains' ],
+		steps: [ 'user', 'from-url', 'domains' ],
 		destination: ( { importEngine, importSiteUrl, siteSlug } ) =>
 			addQueryArgs(
 				{
@@ -293,7 +293,7 @@ export function generateFlows( {
 			),
 		description: 'A flow to kick off an import during signup',
 		disallowResume: true,
-		lastModified: '2018-09-12',
+		lastModified: '2019-07-30',
 	};
 
 	flows.reader = {

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -1552,7 +1552,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 	} );
 
 	describe( 'Import a site while signing up @parallel', function() {
-		// Currently must use a Wix site to be importable through this flow.
+		// Currently must use a Wix or GoDaddy site to be importable through this flow.
 		const siteURL = 'https://hi6822.wixsite.com/eat-here-its-good';
 		const userName = dataHelper.getNewBlogName();
 		const emailAddress = dataHelper.getEmailAddress( userName, signupInboxId );
@@ -1564,12 +1564,24 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await driverManager.ensureNotLoggedIn( driver );
 		} );
 
-		step( 'Can visit import in signup page and prefill url', async function() {
-			await StartPage.Visit(
+		step( 'Can start the import signup flow', async function() {
+			return await StartPage.Visit(
 				driver,
 				StartPage.getStartURL( { culture: locale, flow: 'import', query: `url=${ siteURL }` } )
 			);
+		} );
 
+		step( 'Can then enter account details and continue', async function() {
+			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
+
+			return await createYourAccountPage.enterAccountDetailsAndSubmit(
+				emailAddress,
+				userName,
+				passwordForTestAccounts
+			);
+		} );
+
+		step( 'Can then prefill url of site to import using a query param', async function() {
 			const importFromURLPage = await ImportFromURLPage.Expect( driver );
 			const urlValue = await importFromURLPage.getURLInputValue();
 
@@ -1631,16 +1643,6 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 					}
 				}
 			}
-		} );
-
-		step( 'Can then enter account details and continue', async function() {
-			const createYourAccountPage = await CreateYourAccountPage.Expect( driver );
-
-			return await createYourAccountPage.enterAccountDetailsAndSubmit(
-				emailAddress,
-				userName,
-				passwordForTestAccounts
-			);
 		} );
 
 		step(


### PR DESCRIPTION
DO NOT MERGE until D30989-code has been deployed, to ensure email verification redirect works correctly for the `import` flow.

#### Changes proposed in this Pull Request

Moves the user step to the beginning of the import flow, to more closely match the main signup flow. This prevents some UX issues with flow switching, such as in https://github.com/Automattic/wp-calypso/pull/34731

#### Testing instructions

- Visit `/start/import` and complete the signup flow.
- There should be no issues completing the flow or moving back and foward between steps.
