### PR TITLE
Types: Fix URL type in lib/route

### DIFF
--- a/client/lib/route/index.ts
+++ b/client/lib/route/index.ts
@@ -6,6 +6,11 @@ import urlModule from 'url';
 import { pickBy } from 'lodash';
 import { Primitive } from 'utility-types';
 
+/**
+ * Internal dependencies
+ */
+import { URL } from 'types';
+
 export * from './path';
 
 const appendQueryString = ( basepath: string, querystring: string ): string =>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

#34644 introduced a type mistake, `URL` was intended to be the `string` alias:

But the import wasn't included, so the browser global `window.URL` is incorrectly used. Add the import to fix the type.

#### Testing instructions

Verify the type error is fixed: 