### PR TITLE
FSE: Fix back navigation from template part editor

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -549,8 +549,8 @@ function handleCloseEditor( calypsoPort ) {
 		);
 
 		// We only want to navigate back if the client tells us to.
-		// We need to give it a chance to set ift is dirty
-		// before we can navigate away from the page.
+		// We need to give it a chance to set if the post is dirty
+		// before we can navigate away.
 		port1.onmessage = ( { data } ) => {
 			port1.close(); // We only want to recieve this once.
 			// data is the URL to which we go back:

--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -536,12 +536,17 @@ function handleInsertClassicBlockMedia( calypsoPort ) {
 function handleCloseEditor( calypsoPort ) {
 	$( '#editor' ).on( 'click', '.edit-post-fullscreen-mode-close__toolbar a', e => {
 		e.preventDefault();
-		calypsoPort.postMessage( {
-			action: 'closeEditor',
-			payload: {
-				unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
-			},
-		} );
+
+		if ( calypsoifyGutenberg.closeUrl && calypsoifyGutenberg.shouldDoServerBackNav ) {
+			window.open( calypsoifyGutenberg.closeUrl, '_top' );
+		} else {
+			calypsoPort.postMessage( {
+				action: 'closeEditor',
+				payload: {
+					unsavedChanges: select( 'core/editor' ).isEditedPostDirty(),
+				},
+			} );
+		}
 	} );
 }
 
@@ -653,6 +658,30 @@ async function openTemplatePartEditor( calypsoPort ) {
 	} );
 }
 
+/**
+ * Ensures the calypsoifyGutenberg close URL matches the one on the client.
+ * This is important because we modify the close URL client side in the
+ * context of template part blocks in FSE. Also stores a variable which checks
+ * if we should perform a server-side navigation on close.
+ *
+ * @param {MessagePort} calypsoPort Port used for communication with parent frame.
+ */
+function getCloseButtonDetails( calypsoPort ) {
+	const { port1, port2 } = new MessageChannel();
+	calypsoPort.postMessage(
+		{
+			action: 'getCloseButtonDetails',
+			payload: {},
+		},
+		[ port2 ]
+	);
+	port1.onmessage = ( { data } ) => {
+		const { closeUrl, shouldDoServerBackNav } = data;
+		calypsoifyGutenberg.closeUrl = closeUrl;
+		calypsoifyGutenberg.shouldDoServerBackNav = shouldDoServerBackNav;
+	};
+}
+
 function initPort( message ) {
 	if ( 'initPort' !== message.data.action ) {
 		return;
@@ -733,6 +762,8 @@ function initPort( message ) {
 		openCustomizer( calypsoPort );
 
 		openTemplatePartEditor( calypsoPort );
+
+		getCloseButtonDetails( calypsoPort );
 	}
 
 	window.removeEventListener( 'message', initPort, false );

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -94,7 +94,7 @@ enum EditorActions {
 	ConversionRequest = 'triggerConversionRequest',
 	OpenCustomizer = 'openCustomizer',
 	GetTemplatePartEditorUrl = 'getTemplatePartEditorUrl',
-	GetCloseButtonDetails = 'getCloseButtonDetails',
+	GetCloseButtonUrl = 'getCloseButtonUrl',
 }
 
 class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedFormProps, State > {
@@ -232,12 +232,7 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 
 		if ( EditorActions.CloseEditor === action || EditorActions.GoToAllPosts === action ) {
 			const { unsavedChanges = false } = payload;
-			if ( unsavedChanges ) {
-				this.props.markChanged();
-			} else {
-				this.props.markSaved();
-			}
-			this.props.navigate( this.props.closeUrl );
+			this.onCloseEditor( unsavedChanges, ports[ 0 ] );
 		}
 
 		if ( EditorActions.OpenRevisions === action ) {
@@ -267,12 +262,25 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			this.sendTemplatePartEditorUrl( templatePartId );
 		}
 
-		if ( EditorActions.GetCloseButtonDetails === action ) {
+		if ( EditorActions.GetCloseButtonUrl === action ) {
 			const { closeUrl } = this.props;
-			ports[ 0 ].postMessage( {
-				closeUrl: `${ window.location.origin }${ closeUrl }`,
-				shouldDoServerBackNav: this.shouldDoServerBackNav(),
-			} );
+			ports[ 0 ].postMessage( `${ window.location.origin }${ closeUrl }` );
+		}
+	};
+
+	onCloseEditor = ( hasUnsavedChanges: boolean, messagePort: MessagePort ) => {
+		const { closeUrl } = this.props;
+
+		if ( hasUnsavedChanges ) {
+			this.props.markChanged();
+		} else {
+			this.props.markSaved();
+		}
+
+		if ( this.shouldDoServerBackNav() ) {
+			messagePort.postMessage( `${ window.location.origin }${ closeUrl }` );
+		} else {
+			this.props.navigate( closeUrl );
 		}
 	};
 

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -60,7 +60,7 @@ interface Props {
 	postType: T.PostType;
 	pressThis: any;
 	siteAdminUrl: T.URL | null;
-	fseParentPostId: T.PostId;
+	fseParentPageId: T.PostId;
 }
 
 interface State {
@@ -94,6 +94,7 @@ enum EditorActions {
 	ConversionRequest = 'triggerConversionRequest',
 	OpenCustomizer = 'openCustomizer',
 	GetTemplatePartEditorUrl = 'getTemplatePartEditorUrl',
+	GetCloseButtonDetails = 'getCloseButtonDetails',
 }
 
 class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedFormProps, State > {
@@ -265,6 +266,21 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 			this.templateParts.push( [ templatePartId, ports[ 0 ] ] );
 			this.sendTemplatePartEditorUrl( templatePartId );
 		}
+
+		if ( EditorActions.GetCloseButtonDetails === action ) {
+			const { closeUrl } = this.props;
+			ports[ 0 ].postMessage( {
+				closeUrl: `${ window.location.origin }${ closeUrl }`,
+				shouldDoServerBackNav: this.shouldDoServerBackNav(),
+			} );
+		}
+	};
+
+	// If we are on a template part and have a parent page
+	// ID, we want to do a server nav back to that page.
+	shouldDoServerBackNav = () => {
+		const { fseParentPageId, postType } = this.props;
+		return null != fseParentPageId && 'wp_template_part' === postType;
 	};
 
 	loadRevision = ( {


### PR DESCRIPTION
We were having a lot of trouble getting `navigate` to work correctly between different gutenberg editor instances. As a result, we decided to do the navigation server side. Previously, Miguel enabled server navigation for opening the template part editor #34766. This PR also enables server back navigation specifically for navigating back from the template part post type. There was another attempt at fixing this in #34738, but my guess is that switching to the server side nav to get into a template part somehow messed something up with navigating back from template parts.

Here's a really interesting find. If we get rid of this entire PR, we could also fix this bug by doing this instead: 

```js
// This:
this.props.navigate( `${ window.location.origin }${this.props.closeUrl}` );

// Instead of:
this.props.navigate( this.props.closeUrl );
```

However, this brings back the bug where you get two unsaved changes prompts. I think @mmtr did a lot of work on that and ended up having to switch to a server side approach, so it makes sense to stick with the current approach, I think, unless we find something that fixes all this in one fell swoop.

**Navigation working in this PR:**
![2019-07-30 16 49 17](https://user-images.githubusercontent.com/6265975/62173241-2e46e400-b2ea-11e9-9ff0-08168411a41b.gif)

**Navigation not working without this PR:**
![2019-07-30 16 54 24](https://user-images.githubusercontent.com/6265975/62173402-c9d85480-b2ea-11e9-9d4c-989ab55eca0a.gif)

### Changes proposed in this Pull Request
- Updates the closeUrl in the calypsoifyGutenberg global object with the correct closeUrl from the client. I initially did this for a different possible solution for this. It's not needed for this PR per se, but I still think it's good to keep this URL in sync, since it is used by some other things in the bridge server.
- Update the close button override. Before, we just sent a message to the client to tell it to navigate. We still do that, but now the client decides if it wants to send a message back to the server, which tells the server to do the navigation instead. We wait until the client sends a message back to us so that the "Unsaved Changes" state stuff can update correctly. (I.e. the functions which update that are called before we send the message back to the server triggering the navigation.)

### Testing Prereqs
1. Have the calypso setup running.
2. Have the iframe bridge server setup running. You can see the steps for doing that here: PCYsg-l4k-p2. I personally synced the build to my sandbox with unison.
3. Sandbox `widgets.wp.com` so that it hits off your sandbox for the iframe server code.
4. Make sure your sandbox is running :)
5. Make sure that your sandbox has FSE enabled: PCYsg-ly5-p2 ("Activating the plugin on WordPress.com").
6. Sync the build of FSE to your sandbox from this branch, just to make sure everything is consistent.
7. Make sure you have FSE and the modern business theme active on your sandbox site. (i.e. go into the page editor and double check that template parts are visible) 

Now that you have a bajillion terminals open,
### Testing
1. Go to `http://calypso.localhost:3000/pages/{your-sandbox-site}`
2. Open one of your pages. _Make sure you can see the template parts_
3. Click on a template part. _Make sure that it takes you to the template part editor_
4. In the template part editor, everything should look normal. Nothing to see here :)
5. Click the back button in the template part editor. **Make sure it navigates back to the page editor you were looking at before you went into the post. This is the goal of the PR**
6. Once in the page editor again, click the back button again and make sure it takes you back to the all pages view.
6. Try steps 1-6 again with a different page, just to be sure nothing weird happens in between.
7. Go to `http://calypso.localhost:3000/posts/{your-sandbox-site}` and open one of your posts.
8. Make sure that the back button from the post editor takes you back to the all posts view. 
9. Finally, go back into the template part editor (via the page editor) again.
10. Make some changes to the template part without saving.
11. Click the back button. You should get a single prompt telling informing you of unsaved changes. You should **not** get two prompts.
12. If you click "leave", it should go back to the previous page.
13. If you click "cancel", it should stay on the template part editor.

Fixes #34864