### PR TITLE
Private-by-Default: AB Test the launch 90% selected 10% not

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -140,5 +140,7 @@ export default {
 			selected: 90,
 			control: 10,
 		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -134,4 +134,11 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	privateByDefault: {
+		datestamp: '20190730',
+		variations: {
+			selected: 90,
+			control: 10,
+		},
+	},
 };

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -15,7 +15,7 @@ import { parse as parseURL } from 'url';
 import wpcom from 'lib/wp';
 /* eslint-enable no-restricted-imports */
 import userFactory from 'lib/user';
-import { getSavedVariations } from 'lib/abtest';
+import { abtest, getSavedVariations } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import {
 	updatePrivacyForDomain,
@@ -167,7 +167,7 @@ export function createSiteWithCart(
 				title: siteTitle,
 			},
 		},
-		public: -1,
+		public: abtest( 'privateByDefault' ) === 'selected' ? -1 : 1,
 		validate: false,
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* new config item `privateByDefault`
* consult `privateByDefault` for `newSiteParams`

#### Testing instructions

##### Existing User

* Go to `/start` and create a new site
* Run `JSON.parse(localStorage.getItem('ABTests')).privateByDefault_20190730` in console
* You should have been assigned to a test group

##### New user in "control"

* Go to `/start` in incognito mode
* Assign yourself to **control** group from the dev menu
* Create a new site
* See in checklist that site has been launched

##### New user in "selected"

* Go to `/start` in incognito mode
* Assign yourself to **selected** group from the dev menu
* Create a new site
* See in checklist that site has *not* been launched