### PR TITLE
Show NPS survey to all supported en locales

### DIFF
--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -139,7 +139,7 @@ export class NpsSurvey extends PureComponent {
 
 	shouldShowPromotion() {
 		return (
-			[ 'en', 'en-gb' ].indexOf( getLocaleSlug() ) &&
+			[ 'en', 'en-gb' ].indexOf( getLocaleSlug() ) >= 0 &&
 			this.props.isBusinessUser &&
 			isNumber( this.state.score ) &&
 			this.state.score < 7

--- a/client/blocks/nps-survey/index.jsx
+++ b/client/blocks/nps-survey/index.jsx
@@ -139,7 +139,7 @@ export class NpsSurvey extends PureComponent {
 
 	shouldShowPromotion() {
 		return (
-			'en' === getLocaleSlug() &&
+			[ 'en', 'en-gb' ].indexOf( getLocaleSlug() ) &&
 			this.props.isBusinessUser &&
 			isNumber( this.state.score ) &&
 			this.state.score < 7


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The NPS survey is not working for `en-gb` locale, so this PR fixes the issue. 

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* In `/me/account`, set your Interface Language as English(UK).
* Sandbox and apply a local change to your sandbox that will force the NPS survey to always show(so that it's easier to test) - the details for making the local change is mentioned in the Testing Instructions for D31028-code. You don't need to apply the patch, just follow the instructions in D31028-code on how to make the local change in your sandbox.
* Verify that concierge promotion is shown in the NPS popup for en-gb locale.

Fixes: https://github.com/Automattic/wp-calypso/issues/35025
