### PR TITLE
Sidebar: Add persistent notice for un-launched sites.

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -78,6 +78,8 @@ class CurrentSite extends Component {
 					</span>
 				) }
 
+				<AsyncLoad require="my-sites/current-site/launch-status-notice" placeholder={ null } />
+
 				{ selectedSite ? (
 					<div>
 						<Site site={ selectedSite } homeLink={ true } />
@@ -85,6 +87,7 @@ class CurrentSite extends Component {
 				) : (
 					<AllSites />
 				) }
+
 				<AsyncLoad
 					require="my-sites/current-site/notice"
 					placeholder={ null }

--- a/client/my-sites/current-site/launch-status-notice.jsx
+++ b/client/my-sites/current-site/launch-status-notice.jsx
@@ -1,0 +1,60 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { localize } from 'i18n-calypso';
+
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import { isJetpackSite, isCurrentPlanPaid } from 'state/sites/selectors';
+import { launchSite } from 'state/sites/launch/actions';
+
+/**
+ * Internal dependencies
+ */
+import Notice from 'components/notice';
+import NoticeAction from 'components/notice/notice-action';
+import { connect } from 'react-redux';
+
+export const LaunchStatusNotice = ( { translate, siteSlug, siteIsLaunched, siteIsJetpack } ) => {
+	if ( siteIsLaunched || siteIsJetpack ) {
+		return null;
+	}
+
+	// TODO: if user has paid plan && domain, this should just dispatch the launchSite action directly
+	// similar logic is in my-sites/site-settings/form-general.jsx#L405
+	const noticeAction = `/start/launch-site?siteSlug=${ siteSlug }`;
+
+	return (
+		<Notice
+			icon="info-outline"
+			isCompact
+			status="is-info"
+			text={ translate( 'Your site is private and only visible to you.', {
+				comment: 'Sidebar notice to user about whether or not their site is public.',
+			} ) }
+		>
+			<NoticeAction href={ noticeAction }>
+				{ translate( 'Launch', { context: 'verb' } ) }
+			</NoticeAction>
+		</Notice>
+	);
+};
+
+export default connect(
+	state => {
+		const siteId = getSelectedSiteId( state );
+
+		return {
+			siteSlug: getSelectedSiteSlug( state ),
+			siteIsJetpack: isJetpackSite( state, siteId ),
+			siteIsLaunched: ! isUnlaunchedSite( state, siteId ),
+			needsVerification: ! isCurrentUserEmailVerified( state ),
+			isPaidPlan: isCurrentPlanPaid( state, siteId ),
+		};
+	},
+	{ recordTracksEvent, launchSite }
+)( localize( LaunchStatusNotice ) );

--- a/client/my-sites/current-site/launch-status-notice.jsx
+++ b/client/my-sites/current-site/launch-status-notice.jsx
@@ -3,44 +3,33 @@
  * External dependencies
  */
 import React from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
-
-import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
-import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
-import { isJetpackSite, isCurrentPlanPaid } from 'state/sites/selectors';
-import { launchSite } from 'state/sites/launch/actions';
 
 /**
  * Internal dependencies
  */
 import Notice from 'components/notice';
-import NoticeAction from 'components/notice/notice-action';
-import { connect } from 'react-redux';
+import { recordTracksEvent } from 'state/analytics/actions';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import isUnlaunchedSite from 'state/selectors/is-unlaunched-site';
+import { isCurrentUserEmailVerified } from 'state/current-user/selectors';
+import { isJetpackSite, isCurrentPlanPaid } from 'state/sites/selectors';
+import { launchSite } from 'state/sites/launch/actions';
 
-export const LaunchStatusNotice = ( { translate, siteSlug, siteIsLaunched, siteIsJetpack } ) => {
+export const LaunchStatusNotice = ( { translate, siteIsLaunched, siteIsJetpack } ) => {
 	if ( siteIsLaunched || siteIsJetpack ) {
 		return null;
 	}
-
-	// TODO: if user has paid plan && domain, this should just dispatch the launchSite action directly
-	// similar logic is in my-sites/site-settings/form-general.jsx#L405
-	const noticeAction = `/start/launch-site?siteSlug=${ siteSlug }`;
 
 	return (
 		<Notice
 			icon="info-outline"
 			isCompact
-			status="is-info"
-			text={ translate( 'Your site is private and only visible to you.', {
+			text={ translate( 'Your site is only visible to you.', {
 				comment: 'Sidebar notice to user about whether or not their site is public.',
 			} ) }
-		>
-			<NoticeAction href={ noticeAction }>
-				{ translate( 'Launch', { context: 'verb' } ) }
-			</NoticeAction>
-		</Notice>
+		/>
 	);
 };
 
@@ -49,7 +38,6 @@ export default connect(
 		const siteId = getSelectedSiteId( state );
 
 		return {
-			siteSlug: getSelectedSiteSlug( state ),
 			siteIsJetpack: isJetpackSite( state, siteId ),
 			siteIsLaunched: ! isUnlaunchedSite( state, siteId ),
 			needsVerification: ! isCurrentUserEmailVerified( state ),

--- a/client/my-sites/current-site/style.scss
+++ b/client/my-sites/current-site/style.scss
@@ -92,7 +92,7 @@
 
 .sidebar .notice.is-compact {
 	display: flex;
-	margin: 4px;
+	border-radius: 0;
 
 	.notice__text {
 		width: 100%;


### PR DESCRIPTION
In #35007, we'll be re-enabling the Private by Default feature for all new sites. This PR adds a persistent notice to the sidebar for sites that are un-launched and includes an action to launch the site.

Ideally both this and the domains nudge wouldn't be shown at the same time, but the domains nudge have a significant amount of revenue attached to it, so removing it might become a blocker.

https://github.com/Automattic/zelda-private/issues/112

![Screen Shot 2019-07-30 at 11 17 27 PM](https://user-images.githubusercontent.com/942359/62183216-4db03200-b327-11e9-9bc1-62a40bebc966.png)

**ToDo:**
- match action of nudge to that of the Checklist and settings page launch buttons, based on paid plan and domain status