### PR TITLE
Signup: update existing passwordless signup actions

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -723,13 +723,12 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
  * @param {function} callback Callback function
  * @param {object}   data     POST data object
  */
-export async function createPasswordlessUser( callback, { email } ) {
-	try {
-		const response = await wpcom.undocumented().usersEmailNew( { email }, null );
-		callback( null, response );
-	} catch ( err ) {
-		callback( err );
-	}
+export function createPasswordlessUser( callback, { email } ) {
+	wpcom
+		.undocumented()
+		.usersEmailNew( { email }, null )
+		.then( response => callback( null, response ) )
+		.catch( err => callback( err ) );
 }
 
 /**
@@ -739,10 +738,11 @@ export async function createPasswordlessUser( callback, { email } ) {
  * @param {object}   data     POST data object
  */
 export async function verifyPasswordlessUser( callback, { email, code } ) {
-	try {
-		const response = await wpcom.undocumented().usersEmailVerification( { email, code }, null );
-		callback( null, { email, username: email, bearer_token: response.bearer_token } );
-	} catch ( err ) {
-		callback( err );
-	}
+	wpcom
+		.undocumented()
+		.usersEmailVerification( { email, code }, null )
+		.then( response =>
+			callback( null, { email, username: email, bearer_token: response.bearer_token } )
+		)
+		.catch( err => callback( err ) );
 }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -716,32 +716,33 @@ export function isSiteTopicFulfilled( stepName, defaultDependencies, nextProps )
 	}
 }
 
-export function createPasswordlessUser( callback, dependencies, data ) {
-	const { email } = data;
-
-	wpcom.undocumented().usersEmailNew( { email }, function( error, response ) {
-		if ( error ) {
-			callback( error );
-
-			return;
-		}
-		callback( error, response );
-	} );
+/**
+ * Creates a user account and sends the user a verification code via email to confirm the account.
+ * Returns the dependencies for the step.
+ *
+ * @param {function} callback Callback function
+ * @param {object}   data     POST data object
+ */
+export async function createPasswordlessUser( callback, { email } ) {
+	try {
+		const response = await wpcom.undocumented().usersEmailNew( { email }, null );
+		callback( null, response );
+	} catch ( err ) {
+		callback( err );
+	}
 }
 
-export function verifyPasswordlessUser( callback, dependencies, data ) {
-	const { email, code } = data;
-
-	wpcom.undocumented().usersEmailVerification( { email, code }, function( error, response ) {
-		if ( error ) {
-			callback( error );
-
-			return;
-		}
-		const providedDependencies = assign(
-			{},
-			{ email, username: email, bearer_token: response.token.access_token }
-		);
-		callback( error, providedDependencies );
-	} );
+/**
+ * Verifies a passwordless user code.
+ *
+ * @param {function} callback Callback function
+ * @param {object}   data     POST data object
+ */
+export async function verifyPasswordlessUser( callback, { email, code } ) {
+	try {
+		const response = await wpcom.undocumented().usersEmailVerification( { email, code }, null );
+		callback( null, { username: email, bearer_token: response.bearer_token } );
+	} catch ( err ) {
+		callback( err );
+	}
 }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -742,7 +742,7 @@ export async function verifyPasswordlessUser( callback, { email, code } ) {
 		.undocumented()
 		.usersEmailVerification( { email, code }, null )
 		.then( response =>
-			callback( null, { email, username: email, bearer_token: response.bearer_token } )
+			callback( null, { email, username: email, bearer_token: response.token.access_token } )
 		)
 		.catch( err => callback( err ) );
 }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -741,7 +741,7 @@ export async function createPasswordlessUser( callback, { email } ) {
 export async function verifyPasswordlessUser( callback, { email, code } ) {
 	try {
 		const response = await wpcom.undocumented().usersEmailVerification( { email, code }, null );
-		callback( null, { username: email, bearer_token: response.bearer_token } );
+		callback( null, { email, username: email, bearer_token: response.bearer_token } );
 	} catch ( err ) {
 		callback( err );
 	}

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -77,7 +77,7 @@ export class PasswordlessStep extends Component {
 			submitting: true,
 		} );
 
-		createPasswordlessUser( this.handleUserCreationRequest, null, data );
+		createPasswordlessUser( this.handleUserCreationRequest, data );
 	};
 
 	handleUserCreationRequest = ( error, response ) => {
@@ -101,17 +101,15 @@ export class PasswordlessStep extends Component {
 
 	verifyUser = event => {
 		event.preventDefault();
-		const data = {
-			email: getFieldValue( this.formStore.get(), 'email' ),
-			code: getFieldValue( this.formStore.get(), 'code' ),
-		};
-
 		this.setState( {
 			errorMessages: null,
 			submitting: true,
 		} );
 
-		verifyPasswordlessUser( this.handleUserVerificationRequest, null, data );
+		verifyPasswordlessUser( this.handleUserVerificationRequest, {
+			email: getFieldValue( this.formStore.get(), 'email' ),
+			code: getFieldValue( this.formStore.get(), 'code' ),
+		} );
 	};
 
 	handleUserVerificationRequest = ( error, providedDependencies ) => {


### PR DESCRIPTION
## Changes proposed in this Pull Request

Cleaning up the usersEmail actions and callbacks.

We're also ridding ourselves of the `dependencies` arg, since we don't need it either!

We're not changing any functionality.

#### Testing instructions

1 - Apply In D30608-code, and fire up the branch.
2 - Head to http://calypso.localhost:3000/start/simple and enter your email address
<img width="441" alt="Screen Shot 2019-07-31 at 4 22 09 pm" src="https://user-images.githubusercontent.com/6458278/62188346-66fcc100-b3af-11e9-8a26-0cc2800bf4a0.png">
3 - Check that you receive a verification code via email.
<img width="464" alt="Screen Shot 2019-07-31 at 4 14 37 pm" src="https://user-images.githubusercontent.com/6458278/62188312-4fbdd380-b3af-11e9-94bd-0f312fbbfacf.png">
4 - Check that you can login with said code.
5 - Be nice to your friends and colleagues



