### PR TITLE
Plan-features:fix invalid property warning

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -114,7 +114,7 @@ export class PlanFeatures extends Component {
 							initialSelectedIndex={ initialSelectedIndex }
 						>
 							<table className={ tableClasses }>
-								<caption class="screen-reader-text">
+								<caption className="plan-features__content screen-reader-text">
 									{ translate( 'Available plans to choose from' ) }
 								</caption>
 								<tbody>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fix the following warning:
> Warning: Invalid DOM property `class`. Did you mean `className`?

#### Testing instructions

Visit the plans page, make sure no warning appears in the dev console.

