### PR TITLE
[wip] starter-page-templates: use PreviewBlock component

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -11,6 +11,30 @@ import { withInstanceId } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
 import { BlockPreview } from '@wordpress/block-editor';
 
+/**
+ * Renders the block preview content for the template.
+ * It the templates blocks are not ready yet or not exist,
+ * it tries to render a static image, or simply return null.
+ *
+ * @param {string} preview     Image URL for the static preview.
+ * @param {string} previewAlt  Alt text to for the <img />
+ * @param {array}  blocks      Parsed blocks to dynamic preview.
+ * @return {null|*}            Preview block component.
+ */
+function renderBlockPreview( { preview, previewAlt, blocks } ) {
+	if ( ! blocks || ! blocks.length ) {
+		if ( ! preview ) {
+			return null;
+		}
+
+		return (
+			<img className="template-selector-control__media" src={ preview } alt={ previewAlt || '' } />
+		);
+	}
+
+	return <BlockPreview blocks={ blocks } viewportWidth={ 1024 } />;
+}
+
 function TemplateSelectorControl( {
 	label,
 	className,
@@ -45,7 +69,7 @@ function TemplateSelectorControl( {
 							aria-describedby={ help ? `${ id }__help` : undefined }
 						>
 							<div className="template-selector-control__media-wrap">
-								<BlockPreview blocks={ option.blocks } />
+								{ renderBlockPreview( option ) }
 							</div>
 							{ option.label }
 						</button>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -24,7 +24,6 @@ function TemplateSelectorControl( {
 	}
 
 	const id = `template-selector-control-${ instanceId }`;
-	const handleButtonClick = event => onClick( event.target.value );
 
 	return (
 		<BaseControl
@@ -41,7 +40,7 @@ function TemplateSelectorControl( {
 							id={ `${ id }-${ option.value }` }
 							className="template-selector-control__label"
 							value={ option.value }
-							onClick={ handleButtonClick }
+							onClick={ () => onClick( option.value ) }
 							aria-describedby={ help ? `${ id }__help` : undefined }
 						>
 							<div className="template-selector-control__media-wrap">

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -11,10 +11,14 @@ import { withInstanceId } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
 import { parse as parseBlocks } from '@wordpress/blocks';
+import { BlockPreview } from '@wordpress/block-editor';
 
 class TemplateSelectorControl extends Component {
 	renderTemplatePreview( { content, preview, previewAlt } ) {
-		const { BlockPreview } = window.wp.blockEditor;
+		if ( ! content ) {
+			return null;
+		}
+
 		return (
 			<BlockPreview blocks={ parseBlocks( content ) } /> || (
 				<img className="template-selector-control__media" src={ preview } alt={ previewAlt } />

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -10,14 +10,16 @@ import classnames from 'classnames';
 import { withInstanceId } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
 import { Component } from '@wordpress/element';
+import { parse as parseBlocks } from '@wordpress/blocks';
 
 class TemplateSelectorControl extends Component {
-	renderTemplatePreview( { preview, previewAlt } ) {
-		if ( ! preview ) {
-			return null;
-		}
-
-		return <img className="template-selector-control__media" src={ preview } alt={ previewAlt } />;
+	renderTemplatePreview( { content, preview, previewAlt } ) {
+		const { BlockPreview } = window.wp.blockEditor;
+		return (
+			<BlockPreview blocks={ parseBlocks( content ) } /> || (
+				<img className="template-selector-control__media" src={ preview } alt={ previewAlt } />
+			)
+		);
 	}
 
 	render() {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -9,58 +9,56 @@ import classnames from 'classnames';
  */
 import { withInstanceId } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
+import { Component } from '@wordpress/element';
 
-function TemplateSelectorControl( {
-	label,
-	className,
-	help,
-	instanceId,
-	onClick,
-	templates = [],
-} ) {
-	const id = `template-selector-control-${ instanceId }`;
-	const handleButtonClick = event => onClick( event.target.value );
-
-	if ( isEmpty( templates ) ) {
-		return null;
-	}
-
-	const renderTemplatePreview = ( { preview, previewAlt = '' } ) => {
+class TemplateSelectorControl extends Component {
+	renderTemplatePreview( { preview, previewAlt } ) {
 		if ( ! preview ) {
 			return null;
 		}
 
 		return <img className="template-selector-control__media" src={ preview } alt={ previewAlt } />;
-	};
+	}
 
-	return (
-		<BaseControl
-			label={ label }
-			id={ id }
-			help={ help }
-			className={ classnames( className, 'template-selector-control' ) }
-		>
-			<ul className="template-selector-control__options">
-				{ templates.map( ( option, index ) => (
-					<li key={ `${ id }-${ index }` } className="template-selector-control__option">
-						<button
-							type="button"
-							id={ `${ id }-${ index }` }
-							className="template-selector-control__label"
-							value={ option.value }
-							onClick={ handleButtonClick }
-							aria-describedby={ help ? `${ id }__help` : undefined }
-						>
-							<div className="template-selector-control__media-wrap">
-								{ renderTemplatePreview( option ) }
-							</div>
-							{ option.label }
-						</button>
-					</li>
-				) ) }
-			</ul>
-		</BaseControl>
-	);
+	render() {
+		const { label, className, help, instanceId, onClick, templates = [] } = this.props;
+
+		if ( isEmpty( templates ) ) {
+			return null;
+		}
+
+		const id = `template-selector-control-${ instanceId }`;
+		const handleButtonClick = event => onClick( event.target.value );
+
+		return (
+			<BaseControl
+				label={ label }
+				id={ id }
+				help={ help }
+				className={ classnames( className, 'template-selector-control' ) }
+			>
+				<ul className="template-selector-control__options">
+					{ templates.map( ( option, index ) => (
+						<li key={ `${ id }-${ index }` } className="template-selector-control__option">
+							<button
+								type="button"
+								id={ `${ id }-${ index }` }
+								className="template-selector-control__label"
+								value={ option.value }
+								onClick={ handleButtonClick }
+								aria-describedby={ help ? `${ id }__help` : undefined }
+							>
+								<div className="template-selector-control__media-wrap">
+									{ this.renderTemplatePreview( option ) }
+								</div>
+								{ option.label }
+							</button>
+						</li>
+					) ) }
+				</ul>
+			</BaseControl>
+		);
+	}
 }
 
 export default withInstanceId( TemplateSelectorControl );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -25,6 +25,14 @@ function TemplateSelectorControl( {
 		return null;
 	}
 
+	const renderTemplatePreview = ( { preview, previewAlt = '' } ) => {
+		if ( ! preview ) {
+			return null;
+		}
+
+		return <img className="template-selector-control__media" src={ preview } alt={ previewAlt } />;
+	};
+
 	return (
 		<BaseControl
 			label={ label }
@@ -44,13 +52,7 @@ function TemplateSelectorControl( {
 							aria-describedby={ help ? `${ id }__help` : undefined }
 						>
 							<div className="template-selector-control__media-wrap">
-								{ option.preview && (
-									<img
-										className="template-selector-control__media"
-										src={ option.preview }
-										alt={ option.previewAlt || '' }
-									/>
-								) }
+								{ renderTemplatePreview( option ) }
 							</div>
 							{ option.label }
 						</button>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -9,62 +9,68 @@ import classnames from 'classnames';
  */
 import { withInstanceId } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
-import { Component } from '@wordpress/element';
-import { parse as parseBlocks } from '@wordpress/blocks';
+import { useMemo, useState } from '@wordpress/element';
+import { parse } from '@wordpress/blocks';
 import { BlockPreview } from '@wordpress/block-editor';
 
-class TemplateSelectorControl extends Component {
-	renderTemplatePreview( { content, preview, previewAlt } ) {
+function TemplateSelectorControl( {
+	label,
+	className,
+	help,
+	instanceId,
+	onClick,
+	templates = [],
+} ) {
+	const [ templateIndex, setTemplateIndex ] = useState( 0 );
+	const template = templates[ templateIndex ];
+
+	const renderTemplatePreview = ( { content, preview, previewAlt } ) => {
 		if ( ! content ) {
+			setTemplateIndex( templateIndex + 1 );
 			return null;
 		}
 
 		return (
-			<BlockPreview blocks={ parseBlocks( content ) } /> || (
+			<BlockPreview blocks={ parse( content ) } /> || (
 				<img className="template-selector-control__media" src={ preview } alt={ previewAlt } />
 			)
 		);
+	};
+
+	const renderBlocks = useMemo( () => renderTemplatePreview( template ), templates );
+
+	if ( isEmpty( templates ) ) {
+		return null;
 	}
 
-	render() {
-		const { label, className, help, instanceId, onClick, templates = [] } = this.props;
+	const id = `template-selector-control-${ instanceId }`;
+	const handleButtonClick = event => onClick( event.target.value );
 
-		if ( isEmpty( templates ) ) {
-			return null;
-		}
-
-		const id = `template-selector-control-${ instanceId }`;
-		const handleButtonClick = event => onClick( event.target.value );
-
-		return (
-			<BaseControl
-				label={ label }
-				id={ id }
-				help={ help }
-				className={ classnames( className, 'template-selector-control' ) }
-			>
-				<ul className="template-selector-control__options">
-					{ templates.map( ( option, index ) => (
-						<li key={ `${ id }-${ index }` } className="template-selector-control__option">
-							<button
-								type="button"
-								id={ `${ id }-${ index }` }
-								className="template-selector-control__label"
-								value={ option.value }
-								onClick={ handleButtonClick }
-								aria-describedby={ help ? `${ id }__help` : undefined }
-							>
-								<div className="template-selector-control__media-wrap">
-									{ this.renderTemplatePreview( option ) }
-								</div>
-								{ option.label }
-							</button>
-						</li>
-					) ) }
-				</ul>
-			</BaseControl>
-		);
-	}
+	return (
+		<BaseControl
+			label={ label }
+			id={ id }
+			help={ help }
+			className={ classnames( className, 'template-selector-control' ) }
+		>
+			<ul className="template-selector-control__options">
+				{ templates.map( ( option, index ) => (
+					<li key={ `${ id }-${ index }` } className="template-selector-control__option">
+						<button
+							type="button"
+							id={ `${ id }-${ index }` }
+							className="template-selector-control__label"
+							value={ option.value }
+							onClick={ handleButtonClick }
+							aria-describedby={ help ? `${ id }__help` : undefined }
+						>
+							<div className="template-selector-control__media-wrap">{ renderBlocks }</div>
+						</button>
+					</li>
+				) ) }
+			</ul>
+		</BaseControl>
+	);
 }
 
 export default withInstanceId( TemplateSelectorControl );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -9,8 +9,6 @@ import classnames from 'classnames';
  */
 import { withInstanceId } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
-import { useMemo, useState } from '@wordpress/element';
-import { parse } from '@wordpress/blocks';
 import { BlockPreview } from '@wordpress/block-editor';
 
 function TemplateSelectorControl( {
@@ -21,24 +19,6 @@ function TemplateSelectorControl( {
 	onClick,
 	templates = [],
 } ) {
-	const [ templateIndex, setTemplateIndex ] = useState( 0 );
-	const template = templates[ templateIndex ];
-
-	const renderTemplatePreview = ( { content, preview, previewAlt } ) => {
-		if ( ! content ) {
-			setTemplateIndex( templateIndex + 1 );
-			return null;
-		}
-
-		return (
-			<BlockPreview blocks={ parse( content ) } /> || (
-				<img className="template-selector-control__media" src={ preview } alt={ previewAlt } />
-			)
-		);
-	};
-
-	const renderBlocks = useMemo( () => renderTemplatePreview( template ), templates );
-
 	if ( isEmpty( templates ) ) {
 		return null;
 	}
@@ -54,17 +34,20 @@ function TemplateSelectorControl( {
 			className={ classnames( className, 'template-selector-control' ) }
 		>
 			<ul className="template-selector-control__options">
-				{ templates.map( ( option, index ) => (
-					<li key={ `${ id }-${ index }` } className="template-selector-control__option">
+				{ templates.map( option => (
+					<li key={ `${ id }-${ option.value }` } className="template-selector-control__option">
 						<button
 							type="button"
-							id={ `${ id }-${ index }` }
+							id={ `${ id }-${ option.value }` }
 							className="template-selector-control__label"
 							value={ option.value }
 							onClick={ handleButtonClick }
 							aria-describedby={ help ? `${ id }__help` : undefined }
 						>
-							<div className="template-selector-control__media-wrap">{ renderBlocks }</div>
+							<div className="template-selector-control__media-wrap">
+								<BlockPreview blocks={ option.blocks } />
+							</div>
+							{ option.label }
 						</button>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -25,7 +25,6 @@ class TemplatePreview extends Component {
 
 	constructor( props ) {
 		super();
-
 		if ( props.rawBlocks ) {
 			this.state.blocks = parseBlocks( props.rawBlocks );
 		}
@@ -46,6 +45,7 @@ class TemplatePreview extends Component {
 		return (
 			<img className="template-selector-control__media" src={preview} alt={ previewAlt || '' }/>
 		);
+
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -41,14 +41,13 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 			const el = itemRef ? itemRef.current : null;
 
 			if ( ! el ) {
-				console.time( `tpl-${ value }` );
+				console.timeEnd( `tpl-${ value }` );
 				setCssClasses( '' );
 				return;
 			}
 
 			// Try to pick up the editor styles wrapper element.
 			const editorStylesWrapperEl = el.querySelector( '.editor-styles-wrapper' );
-
 			if ( editorStylesWrapperEl ) {
 				setTimeout( () => {
 					editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
@@ -65,7 +64,7 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 				window.clearTimeout( timerId );
 			}
 		};
-	}, [ blocks.length ] );
+	}, [ blocks, value ] );
 
 	const itemClasses = classnames(
 		"template-selector-control__preview-wrap",
@@ -81,7 +80,7 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 			onClick={ () => onSelect( value, label, parseBlocks( rawBlocks ) ) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
-			<div className={ itemClasses }>
+			<div ref={ itemRef } className={ itemClasses }>
 				{ blocks && blocks.length ? (
 					<BlockPreview blocks={ blocks } viewportWidth={ 800 } />
 				) : null }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -23,12 +23,11 @@ class TemplateSelectorItem extends Component {
 		blocks: [],
 	};
 
-	componentDidMount() {
-		if (
-			this.props.rawBlocks &&
-			( ! this.state.blocks || ! this.state.blocks.length )
-		) {
-			this.state.blocks = parseBlocks( this.props.rawBlocks );
+	constructor( props ) {
+		super();
+
+		if ( props.rawBlocks ) {
+			this.state.blocks = parseBlocks( props.rawBlocks );
 		}
 	}
 
@@ -36,33 +35,32 @@ class TemplateSelectorItem extends Component {
 		const { blocks } = this.state;
 		const { id, value, help, onSelect, label } = this.props;
 
-		return <button
-			type="button"
-			id={ `${ id }-${ value }` }
-			className="template-selector-control__label"
-			value={ value }
-			onClick={ () => onSelect( {
-				slug: value,
-				blocks,
-				title: label,
-			} ) }
-			aria-describedby={ help ? `${ id }__help` : undefined }
-		>
-			<div className="template-selector-control__preview-wrap">
-				{ ( blocks && blocks.length ) ?
-					<BlockPreview
-						blocks={ blocks }
-						viewportWidth={ 800 }
-					/> :
-					null
+		return (
+			<button
+				type="button"
+				id={ `${ id }-${ value }` }
+				className="template-selector-control__label"
+				value={ value }
+				onClick={ () =>
+					onSelect( {
+						slug: value,
+						blocks,
+						title: label,
+					} )
 				}
-			</div>
+				aria-describedby={ help ? `${ id }__help` : undefined }
+			>
+				<div className="template-selector-control__preview-wrap">
+					{ blocks && blocks.length ? (
+						<BlockPreview blocks={ blocks } viewportWidth={ 800 } />
+					) : null }
+				</div>
 
-			{ label }
-		</button>
+				{ label }
+			</button>
+		);
 	}
 }
-
 
 function TemplateSelectorControl( {
 	label,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -33,21 +33,13 @@ class TemplatePreview extends Component {
 	}
 
 	render() {
-		const { preview, previewAlt } = this.props;
 		const { blocks } = this.state;
 
-		if ( blocks && blocks.length ) {
-			return <BlockPreview blocks={ blocks } viewportWidth={ 1024 } />;
-		}
-
-		if ( ! preview ) {
+		if ( ! blocks || ! blocks.length ) {
 			return null;
 		}
 
-		return (
-			<img className="template-selector-control__media" src={ preview } alt={ previewAlt || '' }/>
-		);
-
+		return <BlockPreview blocks={ blocks } viewportWidth={ 1024 } />;
 	}
 }
 
@@ -85,11 +77,7 @@ function TemplateSelectorControl( {
 							aria-describedby={ help ? `${ id }__help` : undefined }
 						>
 							<div className="template-selector-control__media-wrap">
-								<TemplatePreview
-									preview={ option.preview }
-									altPreview={ option.altPreview }
-									rawBlocks={ option.rawBlocks }
-								/>
+								<TemplatePreview rawBlocks={ option.rawBlocks } />
 							</div>
 							{ option.label }
 						</button>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -28,7 +28,7 @@ const { siteInformation = {} } = window.starterPageTemplatesConfig;
  */
 const TemplateDynamicPreview = ( { value, rawBlocks } ) => {
 	const itemRef = useRef( null );
-	const [ cssClasses, setCssClasses ] = useState( 'is-rendering' );
+	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
 
 	const blocks = useMemo( () => parseBlocks( rawBlocks ).slice( 0, 10 ), [ rawBlocks ] );
 
@@ -38,7 +38,7 @@ const TemplateDynamicPreview = ( { value, rawBlocks } ) => {
 
 			if ( ! el ) {
 				console.timeEnd( `tpl-${ value }` );
-				setCssClasses( '' );
+				setDynamicCssClasses( '' );
 				return;
 			}
 
@@ -48,7 +48,7 @@ const TemplateDynamicPreview = ( { value, rawBlocks } ) => {
 				setTimeout( () => {
 					editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
 				}, 0 );
-				setCssClasses( 'editor-styles-wrapper' );
+				setDynamicCssClasses( 'editor-styles-wrapper' );
 			}
 		}, 0 );
 
@@ -62,10 +62,8 @@ const TemplateDynamicPreview = ( { value, rawBlocks } ) => {
 		};
 	}, [ blocks, value ] );
 
-	const itemClasses = classnames( 'template-selector-control__preview-wrap', cssClasses );
-
 	return (
-		<div ref={ itemRef } className={ itemClasses }>
+		<div ref={ itemRef } className={ dynamicCssClasses }>
 			{ blocks && blocks.length ? <BlockPreview blocks={ blocks } viewportWidth={ 800 } /> : null }
 		</div>
 	);
@@ -93,7 +91,11 @@ const TemplateSelectorItem = ( {
 			rawBlocks={ replacePlaceholders( rawBlocks, siteInformation ) }
 		/>
 	) : (
-		<img src={ preview } alt={ previewAlt || '' } />
+		<img
+			className="template-selector-control__media"
+			src={ preview }
+			alt={ previewAlt || '' }
+		/>
 	);
 
 	return (
@@ -105,7 +107,9 @@ const TemplateSelectorItem = ( {
 			onClick={ () => onSelect( value, label, parseBlocks( rawBlocks ) ) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
-			{ innerPreview }
+			<div className="template-selector-control__preview-wrap">
+				{ innerPreview }
+			</div>
 			{ label }
 		</button>
 	);
@@ -118,6 +122,7 @@ function TemplateSelectorControl( {
 	instanceId,
 	onTemplateSelect = noop,
 	templates = [],
+	dynamicPreview = false,
 } ) {
 	if ( isEmpty( templates ) ) {
 		return null;
@@ -144,6 +149,7 @@ function TemplateSelectorControl( {
 							preview={ preview }
 							previewAlt={ previewAlt }
 							rawBlocks={ replacePlaceholders( content, siteInformation ) }
+							dynamicPreview={ dynamicPreview }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -23,10 +23,12 @@ class TemplatePreview extends Component {
 		blocks: [],
 	};
 
-	constructor( props ) {
-		super();
-		if ( props.rawBlocks ) {
-			this.state.blocks = parseBlocks( props.rawBlocks );
+	componentDidMount() {
+		if (
+			this.props.rawBlocks &&
+			( ! this.state.blocks || ! this.state.blocks.length )
+		) {
+			this.state.blocks = parseBlocks( this.props.rawBlocks );
 		}
 	}
 
@@ -34,7 +36,7 @@ class TemplatePreview extends Component {
 		const { preview, previewAlt } = this.props;
 		const { blocks } = this.state;
 
-		if ( blocks || blocks.length ) {
+		if ( blocks && blocks.length ) {
 			return <BlockPreview blocks={ blocks } viewportWidth={ 1024 } />;
 		}
 
@@ -43,7 +45,7 @@ class TemplatePreview extends Component {
 		}
 
 		return (
-			<img className="template-selector-control__media" src={preview} alt={ previewAlt || '' }/>
+			<img className="template-selector-control__media" src={ preview } alt={ previewAlt || '' }/>
 		);
 
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -32,7 +32,7 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 	const itemRef = useRef( null );
 	const [ cssClasses, setCssClasses ] = useState( 'is-rendering' );
 
-	const blocks = useMemo( () => parseBlocks( rawBlocks ), [ rawBlocks ] );
+	const blocks = useMemo( () => ( parseBlocks( rawBlocks ) ).slice( 0, 10 ), [ rawBlocks ] );
 
 	useLayoutEffect( () => {
 		const timerId = setTimeout( () => {
@@ -62,6 +62,10 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 		};
 	}, [] );
 
+	if ( ! rawBlocks ) {
+		return null;
+	}
+
 	const itemClasses = classnames(
 		"template-selector-control__preview-wrap",
 		cssClasses,
@@ -73,7 +77,7 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 			id={ `${ id }-${ value }` }
 			className="template-selector-control__label"
 			value={ value }
-			onClick={ () => onSelect( value, label, blocks ) }
+			onClick={ () => onSelect( value, label, parseBlocks( rawBlocks ) ) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
 			<div ref={ itemRef } className={ itemClasses }>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
  */
 import { withInstanceId } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
-import { Component } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { parse as parseBlocks } from '@wordpress/blocks';
 import { BlockPreview } from '@wordpress/block-editor';
 
@@ -23,48 +23,34 @@ const {
 	siteInformation = {},
 } = window.starterPageTemplatesConfig;
 
-/**
+/*
  * It renders the block preview content for the template.
  * It the templates blocks are not ready yet or not exist,
  * it tries to render a static image, or simply return null.
  */
-class TemplateSelectorItem extends Component {
-	state = {
-		blocks: [],
-	};
+const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } ) => {
 
-	constructor( props ) {
-		super();
+	const blocks = useMemo( () => parseBlocks( rawBlocks ), [ rawBlocks ] );
 
-		if ( props.rawBlocks ) {
-			this.state.blocks = parseBlocks( props.rawBlocks );
-		}
-	}
+	return (
+		<button
+			type="button"
+			id={ `${ id }-${ value }` }
+			className="template-selector-control__label"
+			value={ value }
+			onClick={ () => onSelect( value, label, blocks ) }
+			aria-describedby={ help ? `${ id }__help` : undefined }
+		>
+			<div className="template-selector-control__preview-wrap">
+				{ blocks && blocks.length ? (
+					<BlockPreview blocks={ blocks } viewportWidth={ 800 } />
+				) : null }
+			</div>
 
-	render() {
-		const { blocks } = this.state;
-		const { id, value, help, onSelect, label } = this.props;
-
-		return (
-			<button
-				type="button"
-				id={ `${ id }-${ value }` }
-				className="template-selector-control__label"
-				value={ value }
-				onClick={ () => onSelect( value, label, blocks ) }
-				aria-describedby={ help ? `${ id }__help` : undefined }
-			>
-				<div className="template-selector-control__preview-wrap">
-					{ blocks && blocks.length ? (
-						<BlockPreview blocks={ blocks } viewportWidth={ 800 } />
-					) : null }
-				</div>
-
-				{ label }
-			</button>
-		);
-	}
-}
+			{ label }
+		</button>
+	);
+};
 
 function TemplateSelectorControl( {
 	label,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -32,13 +32,16 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 	const itemRef = useRef( null );
 	const [ cssClasses, setCssClasses ] = useState( 'is-rendering' );
 
-	const blocks = useMemo( () => ( parseBlocks( rawBlocks ) ).slice( 0, 10 ), [ rawBlocks ] );
+	const blocks = useMemo( () => ( parseBlocks( rawBlocks ) ), [ rawBlocks ] );
+
+	console.time( `tpl-${ value }` );
 
 	useLayoutEffect( () => {
 		const timerId = setTimeout( () => {
 			const el = itemRef ? itemRef.current : null;
 
 			if ( ! el ) {
+				console.time( `tpl-${ value }` );
 				setCssClasses( '' );
 				return;
 			}
@@ -54,6 +57,8 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 			}
 		}, 0 );
 
+		console.timeEnd( `tpl-${ value }` );
+
 		// Cleanup
 		return () => {
 			if ( timerId ) {
@@ -61,10 +66,6 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 			}
 		};
 	}, [] );
-
-	if ( ! rawBlocks ) {
-		return null;
-	}
 
 	const itemClasses = classnames(
 		"template-selector-control__preview-wrap",
@@ -80,7 +81,7 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 			onClick={ () => onSelect( value, label, parseBlocks( rawBlocks ) ) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
-			<div ref={ itemRef } className={ itemClasses }>
+			<div className={ itemClasses }>
 				{ blocks && blocks.length ? (
 					<BlockPreview blocks={ blocks } viewportWidth={ 800 } />
 				) : null }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -48,9 +48,13 @@ class TemplateSelectorItem extends Component {
 			} ) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
-			<div className="template-selector-control__media-wrap">
-				{ ( blocks && blocks.length ) &&
-					<BlockPreview blocks={ blocks } viewportWidth={1024}/>
+			<div className="template-selector-control__preview-wrap">
+				{ ( blocks && blocks.length ) ?
+					<BlockPreview
+						blocks={ blocks }
+						viewportWidth={ 800 }
+					/> :
+					null
 				}
 			</div>
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -51,13 +51,7 @@ class TemplateSelectorItem extends Component {
 				id={ `${ id }-${ value }` }
 				className="template-selector-control__label"
 				value={ value }
-				onClick={ () =>
-					onSelect( {
-						slug: value,
-						blocks,
-						title: label,
-					} )
-				}
+				onClick={ () => onSelect( value, label, blocks ) }
 				aria-describedby={ help ? `${ id }__help` : undefined }
 			>
 				<div className="template-selector-control__preview-wrap">

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -65,7 +65,7 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 				window.clearTimeout( timerId );
 			}
 		};
-	}, [] );
+	}, [ blocks.length ] );
 
 	const itemClasses = classnames(
 		"template-selector-control__preview-wrap",

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -47,7 +47,9 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 			const editorStylesWrapperEl = el.querySelector( '.editor-styles-wrapper' );
 
 			if ( editorStylesWrapperEl ) {
-				editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
+				setTimeout( () => {
+					editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
+				}, 0 );
 				setCssClasses( 'editor-styles-wrapper' );
 			}
 		}, 0 );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -32,7 +32,7 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 	const itemRef = useRef( null );
 	const [ cssClasses, setCssClasses ] = useState( 'is-rendering' );
 
-	const blocks = useMemo( () => ( parseBlocks( rawBlocks ) ), [ rawBlocks ] );
+	const blocks = useMemo( () => ( parseBlocks( rawBlocks ) ).slice( 0, 10 ), [ rawBlocks ] );
 
 	console.time( `tpl-${ value }` );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty } from 'lodash';
+import { isEmpty, noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -18,7 +18,7 @@ import { BlockPreview } from '@wordpress/block-editor';
  * It the templates blocks are not ready yet or not exist,
  * it tries to render a static image, or simply return null.
  */
-class TemplatePreview extends Component {
+class TemplateSelectorItem extends Component {
 	state = {
 		blocks: [],
 	};
@@ -34,12 +34,28 @@ class TemplatePreview extends Component {
 
 	render() {
 		const { blocks } = this.state;
+		const { id, value, help, onSelect, label } = this.props;
 
-		if ( ! blocks || ! blocks.length ) {
-			return null;
-		}
+		return <button
+			type="button"
+			id={ `${ id }-${ value }` }
+			className="template-selector-control__label"
+			value={ value }
+			onClick={ () => onSelect( {
+				slug: value,
+				blocks,
+				title: label,
+			} ) }
+			aria-describedby={ help ? `${ id }__help` : undefined }
+		>
+			<div className="template-selector-control__media-wrap">
+				{ ( blocks && blocks.length ) &&
+					<BlockPreview blocks={ blocks } viewportWidth={1024}/>
+				}
+			</div>
 
-		return <BlockPreview blocks={ blocks } viewportWidth={ 1024 } />;
+			{ label }
+		</button>
 	}
 }
 
@@ -49,7 +65,7 @@ function TemplateSelectorControl( {
 	className,
 	help,
 	instanceId,
-	onClick,
+	onTemplateSelect = noop,
 	templates = [],
 } ) {
 	if ( isEmpty( templates ) ) {
@@ -68,19 +84,14 @@ function TemplateSelectorControl( {
 			<ul className="template-selector-control__options">
 				{ templates.map( option => (
 					<li key={ `${ id }-${ option.value }` } className="template-selector-control__option">
-						<button
-							type="button"
-							id={ `${ id }-${ option.value }` }
-							className="template-selector-control__label"
+						<TemplateSelectorItem
+							id={ id }
 							value={ option.value }
-							onClick={ () => onClick( option.value ) }
-							aria-describedby={ help ? `${ id }__help` : undefined }
-						>
-							<div className="template-selector-control__media-wrap">
-								<TemplatePreview rawBlocks={ option.rawBlocks } />
-							</div>
-							{ option.label }
-						</button>
+							label={ option.label }
+							help={ help }
+							onSelect={ onTemplateSelect }
+							rawBlocks={ option.rawBlocks }
+						/>
 					</li>
 				) ) }
 			</ul>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -69,29 +69,11 @@ const TemplateDynamicPreview = ( { value, rawBlocks, blocksInPreview = 10 } ) =>
 	);
 };
 
-const TemplateSelectorItem = ( {
-	id,
-	value,
-	help,
-	onSelect,
-	label,
-	rawBlocks,
-	dynamicPreview = false,
-	preview,
-	previewAlt = '',
-	blocksInPreview,
-} ) => {
+const TemplateSelectorItem = ( props ) => {
+	const { id, value, onSelect, label, rawBlocks, help, dynamicPreview, preview, previewAlt } = props;
+
 	const innerPreview = dynamicPreview ? (
-		<TemplateDynamicPreview
-			id={ id }
-			value={ value }
-			label={ replacePlaceholders( label, siteInformation ) }
-			help={ help }
-			onSelect={ onSelect }
-			preview={ preview }
-			rawBlocks={ replacePlaceholders( rawBlocks, siteInformation ) }
-			blocksInPreview={ blocksInPreview }
-		/>
+		<TemplateDynamicPreview { ...props } />
 	) : (
 		<img
 			className="template-selector-control__media"

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -14,6 +14,16 @@ import { parse as parseBlocks } from '@wordpress/blocks';
 import { BlockPreview } from '@wordpress/block-editor';
 
 /**
+ * Internal dependencies
+ */
+import replacePlaceholders from '../utils/replace-placeholders';
+
+// Load config passed from backend.
+const {
+	siteInformation = {},
+} = window.starterPageTemplatesConfig;
+
+/**
  * It renders the block preview content for the template.
  * It the templates blocks are not ready yet or not exist,
  * it tries to render a static image, or simply return null.
@@ -84,15 +94,15 @@ function TemplateSelectorControl( {
 			className={ classnames( className, 'template-selector-control' ) }
 		>
 			<ul className="template-selector-control__options">
-				{ templates.map( option => (
-					<li key={ `${ id }-${ option.value }` } className="template-selector-control__option">
+				{ templates.map( template => (
+					<li key={ `${ id }-${ template.value }` } className="template-selector-control__template">
 						<TemplateSelectorItem
 							id={ id }
-							value={ option.value }
-							label={ option.label }
+							value={ template.slug }
+							label={ replacePlaceholders( template.title, siteInformation ) }
 							help={ help }
 							onSelect={ onTemplateSelect }
-							rawBlocks={ option.rawBlocks }
+							rawBlocks={ replacePlaceholders( template.content, siteInformation ) }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -9,31 +9,46 @@ import classnames from 'classnames';
  */
 import { withInstanceId } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
+import { Component } from '@wordpress/element';
+import { parse as parseBlocks } from '@wordpress/blocks';
 import { BlockPreview } from '@wordpress/block-editor';
 
 /**
- * Renders the block preview content for the template.
+ * It renders the block preview content for the template.
  * It the templates blocks are not ready yet or not exist,
  * it tries to render a static image, or simply return null.
- *
- * @param {string} preview     Image URL for the static preview.
- * @param {string} previewAlt  Alt text to for the <img />
- * @param {array}  blocks      Parsed blocks to dynamic preview.
- * @return {null|*}            Preview block component.
  */
-function renderBlockPreview( { preview, previewAlt, blocks } ) {
-	if ( ! blocks || ! blocks.length ) {
+class TemplatePreview extends Component {
+	state = {
+		blocks: [],
+	};
+
+	constructor( props ) {
+		super();
+
+		if ( props.rawBlocks ) {
+			this.state.blocks = parseBlocks( props.rawBlocks );
+		}
+	}
+
+	render() {
+		const { preview, previewAlt } = this.props;
+		const { blocks } = this.state;
+
+		if ( blocks || blocks.length ) {
+			return <BlockPreview blocks={ blocks } viewportWidth={ 1024 } />;
+		}
+
 		if ( ! preview ) {
 			return null;
 		}
 
 		return (
-			<img className="template-selector-control__media" src={ preview } alt={ previewAlt || '' } />
+			<img className="template-selector-control__media" src={preview} alt={ previewAlt || '' }/>
 		);
 	}
-
-	return <BlockPreview blocks={ blocks } viewportWidth={ 1024 } />;
 }
+
 
 function TemplateSelectorControl( {
 	label,
@@ -68,7 +83,11 @@ function TemplateSelectorControl( {
 							aria-describedby={ help ? `${ id }__help` : undefined }
 						>
 							<div className="template-selector-control__media-wrap">
-								{ renderBlockPreview( option ) }
+								<TemplatePreview
+									preview={ option.preview }
+									altPreview={ option.altPreview }
+									rawBlocks={ option.rawBlocks }
+								/>
 							</div>
 							{ option.label }
 						</button>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -26,11 +26,11 @@ const { siteInformation = {} } = window.starterPageTemplatesConfig;
  * It the templates blocks are not ready yet or not exist,
  * it tries to render a static image, or simply return null.
  */
-const TemplateDynamicPreview = ( { value, rawBlocks } ) => {
+const TemplateDynamicPreview = ( { value, rawBlocks, blocksInPreview = 10 } ) => {
 	const itemRef = useRef( null );
 	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
 
-	const blocks = useMemo( () => parseBlocks( rawBlocks ).slice( 0, 10 ), [ rawBlocks ] );
+	const blocks = useMemo( () => parseBlocks( rawBlocks ).slice( 0, blocksInPreview ), [ rawBlocks ] );
 
 	useLayoutEffect( () => {
 		const timerId = setTimeout( () => {
@@ -79,6 +79,7 @@ const TemplateSelectorItem = ( {
 	dynamicPreview = false,
 	preview,
 	previewAlt = '',
+	blocksInPreview,
 } ) => {
 	const innerPreview = dynamicPreview ? (
 		<TemplateDynamicPreview
@@ -89,6 +90,7 @@ const TemplateSelectorItem = ( {
 			onSelect={ onSelect }
 			preview={ preview }
 			rawBlocks={ replacePlaceholders( rawBlocks, siteInformation ) }
+			blocksInPreview={ blocksInPreview }
 		/>
 	) : (
 		<img

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -79,7 +79,7 @@ class PageTemplateModal extends Component {
 							<TemplateSelectorControl
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ map( this.props.templates, template => ( {
-									content: template.content,
+									content: replacePlaceholders( template.content, this.props.siteInformation ),
 									label: template.title,
 									value: template.slug,
 									preview: template.preview,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -79,6 +79,7 @@ class PageTemplateModal extends Component {
 							<TemplateSelectorControl
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ map( this.props.templates, template => ( {
+									content: template.content,
 									label: template.title,
 									value: template.slug,
 									preview: template.preview,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -34,19 +34,19 @@ class PageTemplateModal extends Component {
 		}
 	}
 
-	selectTemplate = newTemplate => {
+	selectTemplate = ( { title, slug, blocks } ) => {
 		this.setState( { isOpen: false } );
-		trackSelection( this.props.segment.id, this.props.vertical.id, newTemplate );
+		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 
-		const template = this.props.templates[ newTemplate ];
-		this.props.saveTemplateChoice( template );
+		// const template = this.props.templates[ slug ];
+		this.props.saveTemplateChoice( slug );
 
 		// Skip inserting if there's nothing to insert.
-		if ( template.blocks.length === 0 ) {
+		if ( blocks.length === 0 ) {
 			return;
 		}
 
-		this.props.insertTemplate( template );
+		this.props.insertTemplate( title, blocks );
 	};
 
 	closeModal = () => {
@@ -79,7 +79,7 @@ class PageTemplateModal extends Component {
 									previewAlt: template.description,
 									rawBlocks: template.content,
 								} ) ) }
-								onClick={ newTemplate => this.selectTemplate( newTemplate ) }
+								onTemplateSelect={ newTemplate => this.selectTemplate( newTemplate ) }
 							/>
 						</fieldset>
 					</form>
@@ -102,26 +102,26 @@ const PageTemplatesPlugin = compose(
 
 		const editorDispatcher = dispatch( 'core/editor' );
 		return {
-			saveTemplateChoice: template => {
+			saveTemplateChoice: slug => {
 				// Save selected template slug in meta.
 				const currentMeta = ownProps.getMeta();
 				editorDispatcher.editPost( {
 					meta: {
 						...currentMeta,
-						_starter_page_template: template.slug,
+						_starter_page_template: slug,
 					},
 				} );
 			},
-			insertTemplate: template => {
+			insertTemplate: ( title, blocks ) => {
 				// Set post title.
 				editorDispatcher.editPost( {
-					title: template.title,
+					title: title,
 				} );
 
 				// Insert blocks.
 				const postContentBlock = ownProps.postContentBlock;
 				editorDispatcher.insertBlocks(
-					template.blocks,
+					blocks,
 					0,
 					postContentBlock ? postContentBlock.clientId : '',
 					false

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -74,6 +74,7 @@ class PageTemplateModal extends Component {
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
 								onTemplateSelect={ ( slug, title, blocks ) => this.selectTemplate( slug, title, blocks ) }
+								dynamicPreview={ false }
 							/>
 						</fieldset>
 					</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -75,8 +75,8 @@ class PageTemplateModal extends Component {
 									// blocks: template.blocks,
 									label: template.title,
 									value: template.slug,
-									preview: template.preview,
-									previewAlt: template.description,
+									// preview: template.preview,
+									// previewAlt: template.description,
 									rawBlocks: template.content,
 								} ) ) }
 								onTemplateSelect={ newTemplate => this.selectTemplate( newTemplate ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -23,6 +23,7 @@ class PageTemplateModal extends Component {
 	};
 
 	constructor( props ) {
+		console.time( 'PageTemplateModal' );
 		super();
 		this.state.isOpen = ! isEmpty( props.templates );
 	}
@@ -31,6 +32,8 @@ class PageTemplateModal extends Component {
 		if ( this.state.isOpen ) {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}
+
+		console.timeEnd( 'PageTemplateModal' );
 	}
 
 	selectTemplate = ( slug, title, blocks ) => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, map, reduce, once } from 'lodash';
+import { isEmpty, map, keyBy, reduce, once } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Modal } from '@wordpress/components';
@@ -73,11 +73,12 @@ class PageTemplateModal extends Component {
 							<TemplateSelectorControl
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ map( this.props.templates, template => ( {
-									blocks: template.blocks,
+									// blocks: template.blocks,
 									label: template.title,
 									value: template.slug,
 									preview: template.preview,
 									previewAlt: template.description,
+									rawBlocks: template.content,
 								} ) ) }
 								onClick={ newTemplate => this.selectTemplate( newTemplate ) }
 							/>
@@ -165,10 +166,11 @@ const getTemplatesForPlugin = once( () =>
 );
 
 registerPlugin( 'page-templates', {
+
 	render: () => {
 		return (
 			<PageTemplatesPlugin
-				templates={ getTemplatesForPlugin() }
+				templates={ templates }
 				vertical={ vertical }
 				segment={ segment }
 				siteInformation={ siteInformation }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, map, reduce, once } from 'lodash';
+import { isEmpty } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Modal } from '@wordpress/components';
@@ -13,7 +13,6 @@ import '@wordpress/nux';
 /**
  * Internal dependencies
  */
-import replacePlaceholders from './utils/replace-placeholders';
 import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
 import { trackDismiss, trackSelection, trackView, initializeWithIdentity } from './utils/tracking';

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,13 +1,12 @@
 /**
  * External dependencies
  */
-import { isEmpty, map, keyBy, reduce, once } from 'lodash';
+import { isEmpty, map, reduce, once } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Modal } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { parse as parseBlocks } from '@wordpress/blocks';
 import { Component } from '@wordpress/element';
 import '@wordpress/nux';
 
@@ -157,7 +156,7 @@ const getTemplatesForPlugin = once( () =>
 					...template,
 					title: replacePlaceholders( template.title, siteInformation ),
 					content,
-					blocks: parseBlocks( content ),
+					// blocks: parseBlocks( content ),
 				},
 			};
 		},
@@ -166,11 +165,12 @@ const getTemplatesForPlugin = once( () =>
 );
 
 registerPlugin( 'page-templates', {
-
 	render: () => {
+		// console.time( 'populating templates with blocks' );
+
 		return (
 			<PageTemplatesPlugin
-				templates={ templates }
+				templates={ getTemplatesForPlugin() }
 				vertical={ vertical }
 				segment={ segment }
 				siteInformation={ siteInformation }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -125,7 +125,6 @@ const PageTemplatesPlugin = compose(
 
 // Load config passed from backend.
 const {
-	siteInformation = {},
 	templates = [],
 	vertical,
 	segment,
@@ -143,7 +142,6 @@ registerPlugin( 'page-templates', {
 				templates={ templates }
 				vertical={ vertical }
 				segment={ segment }
-				siteInformation={ siteInformation }
 			/>
 		);
 	},

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -34,7 +34,7 @@ class PageTemplateModal extends Component {
 		}
 	}
 
-	selectTemplate = ( { title, slug, blocks } ) => {
+	selectTemplate = ( slug, title, blocks ) => {
 		this.setState( { isOpen: false } );
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 
@@ -71,7 +71,7 @@ class PageTemplateModal extends Component {
 							<TemplateSelectorControl
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
-								onTemplateSelect={ newTemplate => this.selectTemplate( newTemplate ) }
+								onTemplateSelect={ ( slug, title, blocks ) => this.selectTemplate( slug, title, blocks ) }
 							/>
 						</fieldset>
 					</form>
@@ -106,9 +106,7 @@ const PageTemplatesPlugin = compose(
 			},
 			insertTemplate: ( title, blocks ) => {
 				// Set post title.
-				editorDispatcher.editPost( {
-					title: title,
-				} );
+				editorDispatcher.editPost( { title } );
 
 				// Insert blocks.
 				const postContentBlock = ownProps.postContentBlock;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -38,7 +38,6 @@ class PageTemplateModal extends Component {
 		this.setState( { isOpen: false } );
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 
-		// const template = this.props.templates[ slug ];
 		this.props.saveTemplateChoice( slug );
 
 		// Skip inserting if there's nothing to insert.
@@ -71,14 +70,7 @@ class PageTemplateModal extends Component {
 						<fieldset className="page-template-modal__list">
 							<TemplateSelectorControl
 								label={ __( 'Template', 'full-site-editing' ) }
-								templates={ map( this.props.templates, template => ( {
-									// blocks: template.blocks,
-									label: template.title,
-									value: template.slug,
-									// preview: template.preview,
-									// previewAlt: template.description,
-									rawBlocks: template.content,
-								} ) ) }
+								templates={ this.props.templates }
 								onTemplateSelect={ newTemplate => this.selectTemplate( newTemplate ) }
 							/>
 						</fieldset>
@@ -144,31 +136,11 @@ if ( tracksUserData ) {
 	initializeWithIdentity( tracksUserData );
 }
 
-// Enhance templates with their parsed blocks and processed titles. Key by their slug.
-const getTemplatesForPlugin = once( () =>
-	reduce(
-		templates,
-		( templatesBySlug, template ) => {
-			const content = replacePlaceholders( template.content, siteInformation );
-			return {
-				...templatesBySlug,
-				[ template.slug ]: {
-					...template,
-					title: replacePlaceholders( template.title, siteInformation ),
-					content,
-					// blocks: parseBlocks( content ),
-				},
-			};
-		},
-		{}
-	)
-);
-
 registerPlugin( 'page-templates', {
 	render: () => {
 		return (
 			<PageTemplatesPlugin
-				templates={ getTemplatesForPlugin() }
+				templates={ templates }
 				vertical={ vertical }
 				segment={ segment }
 				siteInformation={ siteInformation }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -166,8 +166,6 @@ const getTemplatesForPlugin = once( () =>
 
 registerPlugin( 'page-templates', {
 	render: () => {
-		// console.time( 'populating templates with blocks' );
-
 		return (
 			<PageTemplatesPlugin
 				templates={ getTemplatesForPlugin() }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -115,13 +115,18 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		display: block;
 		margin: 0 auto 14px;
 		border-bottom: 1px solid #a1aab2;
-		background: #f6f6f6;
+		//background: #f6f6f6;
 		border-radius: 0;
 		overflow: hidden;
 		padding: 0 5% 110%;
 		box-sizing: content-box;
 		position: relative;
 		pointer-events: none;
+		opacity: 1;
+
+		&.is-rendering {
+			opacity: 0.5;
+		}
 	}
 
 	.template-selector-control__media {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -160,5 +160,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 .block-editor-block-preview__container .editor-styles-wrapper {
 	.block-editor-block-list__block[data-type='core/cover'] {
 		width: 100%;
+		left: 0;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -162,9 +162,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 // Preview adjustments.
-.block-editor-block-preview__container .editor-styles-wrapper {
+.editor-styles-wrapper .block-editor-block-preview__container {
 	.block-editor-block-list__block[data-type='core/cover'] {
 		width: 100%;
-		left: 0;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -110,15 +110,15 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 	}
 
-	.template-selector-control__media-wrap {
-		width: 100%;
+	.template-selector-control__preview-wrap {
+		width: 90%;
 		display: block;
 		margin: 0 auto 14px;
 		border-bottom: 1px solid #a1aab2;
 		background: #f6f6f6;
 		border-radius: 0;
 		overflow: hidden;
-		padding-bottom: 110%;
+		padding: 0 5% 110%;
 		box-sizing: content-box;
 		position: relative;
 		pointer-events: none;
@@ -153,5 +153,12 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 .page-template-modal__action-use {
 	@media screen and ( min-width: 960px ) {
 		margin-right: 1em;
+	}
+}
+
+// Preview adjustments.
+.block-editor-block-preview__container .editor-styles-wrapper {
+	.block-editor-block-list__block[data-type='core/cover'] {
+		width: 100%;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -111,14 +111,14 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	.template-selector-control__preview-wrap {
-		width: 90%;
+		width: 100%;
 		display: block;
 		margin: 0 auto 14px;
 		border-bottom: 1px solid #a1aab2;
-		//background: #f6f6f6;
+		background: #f6f6f6;
 		border-radius: 0;
 		overflow: hidden;
-		padding: 0 5% 110%;
+		padding-bottom: 110%;
 		box-sizing: content-box;
 		position: relative;
 		pointer-events: none;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders.js
@@ -18,6 +18,10 @@ const KEY_MAP = {
 };
 
 const replacePlaceholders = ( pageContent, siteInformation = {} ) => {
+	if ( ! pageContent ) {
+		return null;
+	}
+
 	return pageContent.replace( /{{(\w+)}}/g, ( match, placeholder ) => {
 		const defaultValue = PLACEHOLDER_DEFAULTS[ placeholder ];
 		const key = KEY_MAP[ placeholder ];

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/replace-placeholders.js
@@ -19,7 +19,7 @@ const KEY_MAP = {
 
 const replacePlaceholders = ( pageContent, siteInformation = {} ) => {
 	if ( ! pageContent ) {
-		return null;
+		return '';
 	}
 
 	return pageContent.replace( /{{(\w+)}}/g, ( match, placeholder ) => {


### PR DESCRIPTION
This PR replaces the statics images used in the modal by using the `<PreviewBlock />` component.

Issues: #34975

### About performance

It's the hardest point to tackle.

#### Measuring

One thing that I've added to this PR is a way to measure [how long takes rendering the templates modal](https://github.com/Automattic/wp-calypso/pull/35022/commits/1e45996b147b9aef635bc88d86f4dcd287547673). For this, I've added a `console.time()` in the constructor method, and a `console.timeEnd()` in the `componentDidMount()` one. The value is in order of `600ms`, while it's just `30ms` approx in the current approach (static images)


Dynamic preview: `PageTemplateModal: 605.723876953125ms`
Static preview: `PageTemplateModal: 32.3720703125ms`


## How it looks

### Twenty Nineteen
![image](https://user-images.githubusercontent.com/77539/62657077-0421a180-b93c-11e9-8ee0-39e301a8fdcf.png)

### Modern Business
![image](https://user-images.githubusercontent.com/77539/62657566-2bc53980-b93d-11e9-83bb-bc348b7a637f.png)
