### PR TITLE
Checkout: Limit post-checkout external redirects

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -410,7 +410,7 @@ export class Checkout extends React.Component {
 
 			// We cannot simply compare `hostname` to `selectedSiteSlug`, since the latter
 			// might contain a path in the case of Jetpack subdirectory installs.
-			if ( redirectTo.startsWith( adminUrl ) && pathname.endsWith( '/wp-admin/post.php' ) ) {
+			if ( adminUrl && redirectTo.startsWith( `${ adminUrl }post.php?` ) ) {
 				const sanitizedRedirectTo = formatUrl( {
 					protocol,
 					hostname,
@@ -421,7 +421,6 @@ export class Checkout extends React.Component {
 						action: 'edit',
 					},
 				} );
-
 				return sanitizedRedirectTo;
 			}
 		}

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -8,6 +8,7 @@ import i18n, { localize } from 'i18n-calypso';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { format as formatUrl, parse as parseUrl } from 'url';
 
 /**
  * Internal dependencies
@@ -97,6 +98,7 @@ import {
 	retrieveSignupDestination,
 	clearSignupDestinationCookie,
 } from 'signup/utils';
+import { isExternal } from 'lib/url';
 
 /**
  * Style dependencies
@@ -394,8 +396,34 @@ export class Checkout extends React.Component {
 		} = this.props;
 		const domainReceiptId = get( getGoogleApps( cart ), '[0].extra.receipt_for_domain', 0 );
 
+		const adminUrl = get( selectedSite, [ 'options', 'admin_url' ] );
+
+		// If we're given an explicit `redirectTo` query arg, make sure it's either internal
+		// (i.e. on WordPress.com), or a Jetpack or WP.com site's block editor (in wp-admin).
+		// This is required for Jetpack's (and WP.com's) paid blocks Upgrade Nudge.
 		if ( redirectTo ) {
-			return redirectTo;
+			if ( ! isExternal( redirectTo ) ) {
+				return redirectTo;
+			}
+
+			const { protocol, hostname, port, pathname, query } = parseUrl( redirectTo, true, true );
+
+			// We cannot simply compare `hostname` to `selectedSiteSlug`, since the latter
+			// might contain a path in the case of Jetpack subdirectory installs.
+			if ( redirectTo.startsWith( adminUrl ) && pathname.endsWith( '/wp-admin/post.php' ) ) {
+				const sanitizedRedirectTo = formatUrl( {
+					protocol,
+					hostname,
+					port,
+					pathname,
+					query: {
+						post: parseInt( get( query, [ 'post' ] ), 10 ),
+						action: 'edit',
+					},
+				} );
+
+				return sanitizedRedirectTo;
+			}
 		}
 
 		// Note: this function is called early on for redirect-type payment methods, when the receipt isn't set yet.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Limit the external URLs that a `redirect_to` query arg can send a user to, post-checkout, to the wp-admin block editor of the site that the purchase is performed for. (This is needed for https://github.com/Automattic/jetpack/pull/13081).

For more information, see p3btAN-18h-p2.

#### Testing instructions

Try e.g.

* `http://calypso.localhost:3000/checkout/example.wordpress.com/premium?redirect_to=%2Fpost%2Fexample.wordpress.com%2F1` (internal, block editor, should redirect)
* `http://calypso.localhost:3000/checkout/example.wordpress.com/premium?redirect_to=https%3A%2F%2Fexample.wordpress.com%2Fwp-admin%2Fpost.php%3Fpost%3D1%26action%3Dedit` (external, wp-admin block editor, should redirect)
* `http://calypso.localhost:3000/checkout/example.wordpress.com/premium?redirect_to=https%3A%2F%2Fgoogle.com` (external, shouldn’t redirect)

(remember to replace `example.wordpress.com` with a site you own!)
