### PR TITLE
FSE: Update the close button

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -299,6 +299,7 @@ class Full_Site_Editing {
 			array(
 				'editorPostType'          => get_current_screen()->post_type,
 				'featureFlags'            => $feature_flags->get_flags(),
+				'closeButtonLabel'        => $this->get_close_button_label(),
 				'closeButtonUrl'          => esc_url( $this->get_close_button_url() ),
 				'editTemplatePartBaseUrl' => esc_url( $this->get_edit_template_part_base_url() ),
 			)
@@ -323,7 +324,7 @@ class Full_Site_Editing {
 			'a8c/navigation-menu',
 			array(
 				'attributes'      => [
-					'className'     => [
+					'className' => [
 						'default' => '',
 						'type'    => 'string',
 					],
@@ -397,6 +398,51 @@ class Full_Site_Editing {
 	}
 
 	/**
+	 * Returns the parent post ID if sent as query param when editing a Template Part from a
+	 * Post/Page or a Template.
+	 *
+	 * @return null|string The parent post ID, or null if not set.
+	 */
+	public function get_parent_post_id() {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		if ( ! isset( $_GET['fse_parent_post'] ) ) {
+			return null;
+		}
+
+		$parent_post_id = absint( $_GET['fse_parent_post'] );
+		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
+
+		if ( empty( $parent_post_id ) ) {
+			return null;
+		}
+
+		return $parent_post_id;
+	}
+
+	/**
+	 * Returns the label for the Gutenberg close button.
+	 *
+	 * When we edit a Template Part from a Post/Page or a Template, we want to replace the close
+	 * icon with a "Back to" button, to clarify that it will take us back to the previous editing
+	 * view, and not the Template Part CPT list.
+	 *
+	 * @return null|string Override label string if it should be inserted, or null otherwise.
+	 */
+	public function get_close_button_label() {
+		$parent_post_id = $this->get_parent_post_id();
+
+		if ( ! $parent_post_id ) {
+			return null;
+		}
+
+		$parent_post_type        = get_post_type( $parent_post_id );
+		$parent_post_type_object = get_post_type_object( $parent_post_type );
+
+		/* translators: %s: "Back to Post", "Back to Page", "Back to Template", etc. */
+		return sprintf( __( 'Back to %s', 'full-site-editing' ), $parent_post_type_object->labels->singular_name );
+	}
+
+	/**
 	 * Returns the URL for the Gutenberg close button.
 	 *
 	 * In some cases we want to override the default value which would take us to post listing
@@ -406,15 +452,9 @@ class Full_Site_Editing {
 	 * @return null|string Override URL string if it should be inserted, or null otherwise.
 	 */
 	public function get_close_button_url() {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( ! isset( $_GET['fse_parent_post'] ) ) {
-			return null;
-		}
+		$parent_post_id = $this->get_parent_post_id();
 
-		$parent_post_id = absint( $_GET['fse_parent_post'] );
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
-
-		if ( empty( $parent_post_id ) ) {
+		if ( ! $parent_post_id ) {
 			return null;
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/index.js
@@ -5,16 +5,13 @@
  */
 import domReady from '@wordpress/dom-ready';
 
-domReady( () => {
-	// We only want this override when closing Template Part CPT (e.g. header) to navigate back to parent page.
-	if ( 'wp_template_part' !== fullSiteEditing.editorPostType ) {
-		return;
-	}
+/**
+ * Internal dependencies
+ */
+import './style.scss';
 
-	// Keep the default URL if the override hasn't been provided by the plugin.
-	if ( ! fullSiteEditing.closeButtonUrl ) {
-		return;
-	}
+domReady( () => {
+	const { closeButtonLabel, closeButtonUrl, editorPostType } = fullSiteEditing;
 
 	const editPostHeaderInception = setInterval( () => {
 		const closeButton = document.querySelector( '.edit-post-fullscreen-mode-close__toolbar a' );
@@ -24,8 +21,22 @@ domReady( () => {
 		}
 		clearInterval( editPostHeaderInception );
 
-		if ( fullSiteEditing.closeButtonUrl ) {
-			closeButton.href = fullSiteEditing.closeButtonUrl;
+		// When closing Template Part CPT (e.g. header) to navigate back to parent page...
+		if ( 'wp_template_part' === editorPostType && closeButtonUrl ) {
+			const newCloseButton = document.createElement( 'a' );
+			newCloseButton.href = closeButtonUrl;
+			newCloseButton.innerHTML = closeButtonLabel;
+			newCloseButton.className = 'components-button components-icon-button is-button is-default';
+			newCloseButton.setAttribute( 'aria-label', closeButtonLabel );
+
+			const parentContainer = document.querySelector( '.edit-post-fullscreen-mode-close__toolbar' );
+			parentContainer.replaceChild( newCloseButton, closeButton );
+		} else {
+			// Otherwise just replace the left caret with an X icon.
+			// The size is 28 instead of 20 because `dashicons-no-alt` looks smaller than `dashicons-arrow-left-alt2`.
+			closeButton.innerHTML =
+				'<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="28" height="28" viewBox="0 0 20 20"><path d="M14.95 6.46l-3.54 3.54 3.54 3.54-1.41 1.41-3.54-3.53-3.53 3.53-1.42-1.42 3.53-3.53-3.53-3.53 1.42-1.42 3.53 3.53 3.54-3.53z"></path></svg>';
+			closeButton.classList.add( 'a8c-close-button' );
 		}
 	} );
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/close-button-override/style.scss
@@ -1,0 +1,13 @@
+.edit-post-fullscreen-mode-close__toolbar a {
+	&.is-button.is-default {
+		height: auto;
+		span {
+			display: none;
+		}
+	}
+
+	&.a8c-close-button {
+		// Adjust the button padding to accommodate the bigger icon size.
+		padding: 4px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* When opening a Template Parts from another editor view (e.g. by clicking "Edit Header" while editing a Page), replace the "back" icon of the Close button with a "Back to [Parent Post Type]" (e.g. "Back to Page") button.
Since the Close button is not customizable via plugin, to avoid displaying a mislabelled tooltip on hover/focus, I had to replace the original button, generated via React, with a manually created one that doesn't have the tooltip logic.

  Note: I'd avoid using the parent post title because the header isn't really designed to contain variable strings, especially if using the editor's Top Toolbar option.

* In any other case, replace the "back" icon with a "cross" icon to clarify that we are not navigating back, but closing the editor.
Again, I had to replace the icon with an hardcoded `dashicon-no-alt` SVG element.

  Note 1: the tooltip is incorrect (i's always "View Post" instead of using the appropriate post type singular name), but that's actually a Gutenberg (or WP REST API maybe?) shortcoming.

  Note 2: I've manually increased the cross icon size because it's slightly smaller by default. See:

  | Default | Adjusted |
  | - | - |
  | ![Default](https://user-images.githubusercontent.com/2070010/62232571-7afbef00-b3be-11e9-9b61-aca096266226.png) | ![Adjusted](https://user-images.githubusercontent.com/2070010/62232570-7a635880-b3be-11e9-8550-7f628ba9a08e.png) |

#### Screenshots

Template Parts when opened from another editor view (in this case from a Page):

![Screenshot 2019-07-31 at 17 54 26](https://user-images.githubusercontent.com/2070010/62232019-25731280-b3bd-11e9-8bfe-1f2f8881d317.png)

Otherwise (including Template Parts when opened from the Template Parts list):

![Screenshot 2019-07-31 at 17 54 46](https://user-images.githubusercontent.com/2070010/62232056-3b80d300-b3bd-11e9-85c4-a8d432a33368.png)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Edit a Page, a Template, or a Template Part (from their own post type list).
* ⚠️ Make sure the back icon is an X.
* From a Page, click on "Edit Header".
* ⚠️ Make sure the back icon of the Template Part editor is a "Back to Page" button.
* From a Template, click on "Edit Header".
* ⚠️ Make sure the back icon of the Template Part editor is a "Back to Template" button.

Fixes #34927
Fixes #34929
