### PR TITLE
Full Site Editing: add revision history for template parts

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -163,6 +163,7 @@ class Full_Site_Editing {
 				'supports'              => array(
 					'title',
 					'editor',
+					'revisions',
 				),
 			)
 		);
@@ -323,7 +324,7 @@ class Full_Site_Editing {
 			'a8c/navigation-menu',
 			array(
 				'attributes'      => [
-					'className'     => [
+					'className' => [
 						'default' => '',
 						'type'    => 'string',
 					],


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Previously the revisions were turned of for template parts making it
impossible for users to revert back to theme defaults header/footer
if needed.

#### Testing instructions

1. Navigate to header editing view in your FSE enabled test site.
2. Make a couple of updates to the header.
3. You should be able to see the revisions button in the sidebar:

<img width="333" alt="Screenshot 2019-07-31 at 20 44 05" src="https://user-images.githubusercontent.com/1182160/62238974-4d21a500-b3d4-11e9-92fe-58c58c3a6ed6.png">

Fixes https://github.com/Automattic/wp-calypso/issues/35023
