### PR TITLE
Earn: rename ctaProps to actions

### DIFF
--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -13,7 +13,7 @@ import PromoCardCta, { Props as PromoCardCtaProps } from './promo-card/cta';
 
 interface PromoSectionCardProps extends PromoCardProps {
 	body: string | TranslateResult;
-	ctaProps?: PromoCardCtaProps;
+	actions?: PromoCardCtaProps;
 }
 
 export interface Props {
@@ -31,10 +31,10 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 	title,
 	image,
 	body,
-	ctaProps,
+	actions,
 } ) => {
-	const cta = get( ctaProps, 'cta', null );
-	const learnMoreLink = get( ctaProps, 'learnMoreLink', null );
+	const cta = get( actions, 'cta', null );
+	const learnMoreLink = get( actions, 'learnMoreLink', null );
 	return (
 		<PromoCard isPrimary={ !! isPrimary } title={ title } image={ image }>
 			<p>{ body }</p>

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -83,7 +83,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			image: {
 				path: '/calypso/images/earn/simple-payments.svg',
 			},
-			ctaProps: {
+			actions: {
 				cta,
 				learnMoreLink,
 			},
@@ -135,7 +135,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			image: {
 				path: '/calypso/images/earn/recurring.svg',
 			},
-			ctaProps: {
+			actions: {
 				cta,
 				learnMoreLink,
 			},
@@ -165,7 +165,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			image: {
 				path: '/calypso/images/earn/referral.svg',
 			},
-			ctaProps: {
+			actions: {
 				cta,
 			},
 		};
@@ -214,7 +214,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			image: {
 				path: '/calypso/images/earn/ads.svg',
 			},
-			ctaProps: {
+			actions: {
 				cta,
 				learnMoreLink,
 			},


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* this renames the `ctaProps` of the `PromoSectionCard` component to `actions` to avoid confusions with its own property `cta`

#### Testing instructions

* just a smoke test to ensure things are working just like before
