### PR TITLE
FSE: Change and/or hide links to the Customizer for those using FSE and a compatible theme

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -45,6 +45,8 @@ import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import QueryBlogStickers from 'components/data/query-blog-stickers';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
 /**
  * Style dependencies
@@ -63,7 +65,13 @@ export class ProductPurchaseFeaturesList extends Component {
 
 	// TODO: Define feature list.
 	getEcommerceFeatures() {
-		const { isPlaceholder, plan, planHasDomainCredit, selectedSite } = this.props;
+		const {
+			isPlaceholder,
+			plan,
+			planHasDomainCredit,
+			selectedSite,
+			hasFullSiteEditing,
+		} = this.props;
 		return (
 			<Fragment>
 				<HappinessSupportCard
@@ -76,7 +84,8 @@ export class ProductPurchaseFeaturesList extends Component {
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
-				<CustomizeTheme selectedSite={ selectedSite } />
+				<QueryBlogStickers blogId={ selectedSite.ID } />
+				{ ! hasFullSiteEditing && <CustomizeTheme selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme selectedSite={ selectedSite } />
 				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
@@ -87,7 +96,13 @@ export class ProductPurchaseFeaturesList extends Component {
 	}
 
 	getBusinessFeatures() {
-		const { isPlaceholder, plan, planHasDomainCredit, selectedSite } = this.props;
+		const {
+			isPlaceholder,
+			plan,
+			planHasDomainCredit,
+			selectedSite,
+			hasFullSiteEditing,
+		} = this.props;
 		return (
 			<Fragment>
 				<HappinessSupportCard
@@ -108,7 +123,8 @@ export class ProductPurchaseFeaturesList extends Component {
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
-				<CustomizeTheme selectedSite={ selectedSite } />
+				<QueryBlogStickers blogId={ selectedSite.ID } />
+				{ ! hasFullSiteEditing && <CustomizeTheme selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme selectedSite={ selectedSite } />
 				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
@@ -120,7 +136,13 @@ export class ProductPurchaseFeaturesList extends Component {
 	}
 
 	getPremiumFeatures() {
-		const { isPlaceholder, plan, planHasDomainCredit, selectedSite } = this.props;
+		const {
+			isPlaceholder,
+			plan,
+			planHasDomainCredit,
+			selectedSite,
+			hasFullSiteEditing,
+		} = this.props;
 
 		return (
 			<Fragment>
@@ -128,7 +150,8 @@ export class ProductPurchaseFeaturesList extends Component {
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<AdvertisingRemoved isBusinessPlan={ false } selectedSite={ selectedSite } />
 				<GoogleVouchers selectedSite={ selectedSite } />
-				<CustomizeTheme selectedSite={ selectedSite } />
+				<QueryBlogStickers blogId={ selectedSite.ID } />
+				{ ! hasFullSiteEditing && <CustomizeTheme selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
@@ -298,6 +321,7 @@ export default connect(
 			isAutomatedTransfer,
 			selectedSite,
 			planHasDomainCredit: hasDomainCredit( state, selectedSiteId ),
+			hasFullSiteEditing: isSiteUsingFullSiteEditing( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -82,6 +82,8 @@ import isFetchingTransfer from 'state/selectors/is-fetching-atomic-transfer';
 import getSiteSlug from 'state/sites/selectors/get-site-slug.js';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { getActiveTheme } from 'state/themes/selectors';
+import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 
 /**
  * Style dependencies
@@ -530,7 +532,7 @@ export class CheckoutThankYou extends React.Component {
 	};
 
 	productRelatedMessages = () => {
-		const { selectedSite, sitePlans, displayMode } = this.props;
+		const { selectedSite, sitePlans, displayMode, customizeUrl } = this.props;
 		const purchases = getPurchases( this.props );
 		const failedPurchases = getFailedPurchases( this.props );
 		const hasFailedPurchases = failedPurchases.length > 0;
@@ -588,6 +590,7 @@ export class CheckoutThankYou extends React.Component {
 				{ ComponentClass && (
 					<div className="checkout-thank-you__purchase-details-list">
 						<ComponentClass
+							customizeUrl={ customizeUrl }
 							domain={ domain }
 							purchases={ purchases }
 							failedPurchases={ failedPurchases }
@@ -608,6 +611,7 @@ export default connect(
 	( state, props ) => {
 		const siteId = getSelectedSiteId( state );
 		const planSlug = getSitePlanSlug( state, siteId );
+		const activeTheme = getActiveTheme( state, siteId );
 
 		return {
 			isFetchingTransfer: isFetchingTransfer( state, siteId ),
@@ -622,6 +626,7 @@ export default connect(
 				get( getAtomicTransfer( state, siteId ), 'status', transferStates.PENDING ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			selectedSiteSlug: getSiteSlug( state, siteId ),
+			customizeUrl: getCustomizeOrEditFrontPageUrl( state, activeTheme, siteId ),
 		};
 	},
 	dispatch => {

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -10,7 +10,6 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
 import GoogleVoucherDetails from './google-voucher';
@@ -19,6 +18,7 @@ import { isPremium, isGoogleApps } from 'lib/products-values';
 import { newPost } from 'lib/paths';
 import PurchaseDetail from 'components/purchase-detail';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
+import QueryBlogStickers from 'components/data/query-blog-stickers';
 
 /**
  * Image dependencies
@@ -29,14 +29,14 @@ import customizeThemeImage from 'assets/images/upgrades/customize-theme.svg';
 import mediaPostImage from 'assets/images/upgrades/media-post.svg';
 import wordAdsImage from 'assets/images/upgrades/word-ads.svg';
 
-const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchases } ) => {
+const PremiumPlanDetails = ( {
+	selectedSite,
+	sitePlans,
+	selectedFeature,
+	purchases,
+	customizeUrl,
+} ) => {
 	const translate = useTranslate();
-	const adminUrl = selectedSite.URL + '/wp-admin/';
-	const customizerInAdmin =
-		adminUrl + 'customize.php?return=' + encodeURIComponent( window.location.href );
-	const customizeLink = config.isEnabled( 'manage/customize' )
-		? '/customize/' + selectedSite.slug
-		: customizerInAdmin;
 	const plan = find( sitePlans.data, isPremium ),
 		isPremiumPlan = isPremium( selectedSite.plan );
 	const googleAppsWasPurchased = purchases.some( isGoogleApps );
@@ -89,19 +89,24 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 			/>
 
 			{ ! selectedFeature && (
-				<PurchaseDetail
-					icon={
-						<img alt={ translate( 'Customize Theme Illustration' ) } src={ customizeThemeImage } />
-					}
-					title={ translate( 'Customize your theme' ) }
-					description={ translate(
-						"You now have direct control over your site's fonts and colors in the customizer. " +
-							"Change your site's entire look in a few clicks."
-					) }
-					buttonText={ translate( 'Start customizing' ) }
-					href={ customizeLink }
-					target={ config.isEnabled( 'manage/customize' ) ? undefined : '_blank' }
-				/>
+				<>
+					<QueryBlogStickers blogId={ selectedSite.ID } />
+					<PurchaseDetail
+						icon={
+							<img
+								alt={ translate( 'Customize Theme Illustration' ) }
+								src={ customizeThemeImage }
+							/>
+						}
+						title={ translate( 'Customize your theme' ) }
+						description={ translate(
+							"You now have direct control over your site's fonts and colors in the customizer. " +
+								"Change your site's entire look in a few clicks."
+						) }
+						buttonText={ translate( 'Start customizing' ) }
+						href={ customizeUrl }
+					/>
+				</>
 			) }
 
 			<PurchaseDetail

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -19,6 +19,7 @@ import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import ExternalLink from 'components/external-link';
 import JetpackLogo from 'components/jetpack-logo';
+import QueryBlogStickers from 'components/data/query-blog-stickers';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarItem from 'layout/sidebar/item';
@@ -54,6 +55,7 @@ import {
 } from 'state/my-sites/sidebar/actions';
 import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
 import isVipSite from 'state/selectors/is-vip-site';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import {
 	SIDEBAR_SECTION_SITE,
 	SIDEBAR_SECTION_DESIGN,
@@ -233,7 +235,14 @@ export class MySitesSidebar extends Component {
 	}
 
 	design() {
-		const { path, site, translate, canUserEditThemeOptions } = this.props,
+		const {
+				path,
+				site,
+				translate,
+				canUserEditThemeOptions,
+				siteId,
+				isFullSiteEditing,
+			} = this.props,
 			jetpackEnabled = isEnabled( 'manage/themes-jetpack' );
 		let themesLink;
 
@@ -251,16 +260,19 @@ export class MySitesSidebar extends Component {
 
 		return (
 			<ul>
-				<SidebarItem
-					label={ translate( 'Customize' ) }
-					selected={ itemLinkMatches( '/customize', path ) }
-					link={ this.props.customizeUrl }
-					onNavigate={ this.trackCustomizeClick }
-					icon="customize"
-					preloadSectionName="customize"
-					forceInternalLink
-					expandSection={ this.expandDesignSection }
-				/>
+				<QueryBlogStickers blogId={ siteId } />
+				{ ! isFullSiteEditing && (
+					<SidebarItem
+						label={ translate( 'Customize' ) }
+						selected={ itemLinkMatches( '/customize', path ) }
+						link={ this.props.customizeUrl }
+						onNavigate={ this.trackCustomizeClick }
+						icon="customize"
+						preloadSectionName="customize"
+						forceInternalLink
+						expandSection={ this.expandDesignSection }
+					/>
+				) }
 				<SidebarItem
 					label={ translate( 'Themes' ) }
 					selected={ itemLinkMatches( themesLink, path ) }
@@ -738,6 +750,7 @@ function mapStateToProps( state ) {
 		isManageSectionOpen,
 		isAtomicSite: !! isSiteAutomatedTransfer( state, selectedSiteId ),
 		isVip: isVipSite( state, selectedSiteId ),
+		isFullSiteEditing: isSiteUsingFullSiteEditing( state, siteId ),
 		siteId,
 		site,
 		siteSuffix: site ? '/' + site.slug : '',

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -60,6 +60,7 @@ import ThemeFeaturesCard from './theme-features-card';
 import { FEATURE_UNLIMITED_PREMIUM_THEMES, PLAN_PREMIUM } from 'lib/plans/constants';
 import { hasFeature } from 'state/sites/plans/selectors';
 import getPreviousRoute from 'state/selectors/get-previous-route';
+import QueryBlogStickers from 'components/data/query-blog-stickers';
 
 /**
  * Style dependencies
@@ -682,6 +683,7 @@ class ThemeSheet extends React.Component {
 				<PageViewTracker path={ analyticsPath } title={ analyticsPageTitle } />
 				{ this.renderBar() }
 				<QueryActiveTheme siteId={ siteId } />
+				<QueryBlogStickers blogId={ siteId } />
 				<ThanksModal source={ 'details' } />
 				{ pageUpsellBanner }
 				<HeaderCake

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -20,7 +20,6 @@ import {
 	getActiveTheme,
 	getCanonicalTheme,
 	getThemeDetailsUrl,
-	getThemeCustomizeUrl,
 	getThemeForumUrl,
 	isActivatingTheme,
 	hasActivatedTheme,
@@ -28,6 +27,7 @@ import {
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 
 /**
  * Style dependencies
@@ -220,7 +220,7 @@ export default connect(
 			siteId,
 			currentTheme,
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
-			customizeUrl: getThemeCustomizeUrl( state, currentThemeId, siteId ),
+			customizeUrl: getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId ),
 			forumUrl: getThemeForumUrl( state, currentThemeId, siteId ),
 			isActivating: !! isActivatingTheme( state, siteId ),
 			hasActivated: !! hasActivatedTheme( state, siteId ),

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -22,7 +22,6 @@ import {
 import {
 	getThemeSignupUrl,
 	getThemePurchaseUrl,
-	getThemeCustomizeUrl,
 	getThemeDetailsUrl,
 	getThemeSupportUrl,
 	getJetpackUpgradeUrlIfPremiumTheme,
@@ -35,6 +34,7 @@ import {
 import { isJetpackSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getCurrentUser } from 'state/current-user/selectors';
+import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 
 const purchase = config.isEnabled( 'upgrades/checkout' )
 	? {
@@ -110,7 +110,7 @@ const customize = {
 		comment: 'label in the dialog for selecting a site for which to customize a theme',
 	} ),
 	icon: 'customize',
-	getUrl: getThemeCustomizeUrl,
+	getUrl: getCustomizeOrEditFrontPageUrl,
 	hideForTheme: ( state, themeId, siteId ) =>
 		! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
 		! isThemeActive( state, themeId, siteId ),

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -14,6 +14,7 @@ import { compact, includes, isEqual, property, snakeCase } from 'lodash';
  */
 import { trackClick } from './helpers';
 import QueryThemes from 'components/data/query-themes';
+import QueryBlogStickers from 'components/data/query-blog-stickers';
 import ThemesList from 'components/themes-list';
 import ThemesSelectionHeader from './themes-selection-header';
 import { recordGoogleEvent, recordTracksEvent } from 'state/analytics/actions';
@@ -142,11 +143,12 @@ class ThemesSelection extends Component {
 	};
 
 	render() {
-		const { source, query, listLabel, themesCount, upsellUrl } = this.props;
+		const { source, query, listLabel, themesCount, upsellUrl, siteId } = this.props;
 
 		return (
 			<div className="themes__selection">
 				<QueryThemes query={ query } siteId={ source } />
+				<QueryBlogStickers blogId={ siteId } />
 				<ThemesSelectionHeader label={ listLabel } count={ themesCount } />
 				<ThemesList
 					upsellUrl={ upsellUrl }

--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getThemeCustomizeUrl, isThemeActive } from 'state/themes/selectors';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import getFrontPageEditorUrlUrl from 'state/selectors/get-front-page-editor-url';
+
+/**
+ * Returns the URL for opening customizing the given site in either the block editor with
+ * Full Site Editing, or the Customizer for unsupported sites. Can be used wherever
+ * @see getThemeCustomizeUrl is used as a drop-in replacement.
+ *
+ * Ensure that your view makes use of the `QueryBlogStickers` component to function properly.
+ *
+ * @param  {Object}   state   Global state tree
+ * @param  {String}   themeId Theme ID
+ * @param  {Number}   siteId  Site ID to open the customizer or block editor for
+ * @return {String}           Customizer or Block Editor URL
+ */
+export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId ) {
+	if (
+		! isSiteUsingFullSiteEditing( state, siteId ) ||
+		! isThemeActive( state, themeId, siteId )
+	) {
+		return getThemeCustomizeUrl( state, themeId, siteId );
+	}
+	return getFrontPageEditorUrlUrl( state, siteId );
+}

--- a/client/state/selectors/get-front-page-editor-url.js
+++ b/client/state/selectors/get-front-page-editor-url.js
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import getEditorUrl from 'state/selectors/get-editor-url';
+import getSiteFrontPage from 'state/sites/selectors/get-site-front-page';
+
+/**
+ * Gets the editor URL for the current site's home page
+ * @param {Object} state  Global state tree
+ * @param {Object} siteId Site ID
+ * @return {(Boolean|String)} false if there is no homepage set, the editor URL if there is one
+ */
+export default function getFrontPageEditorUrl( state, siteId ) {
+	const frontPageId = getSiteFrontPage( state, siteId );
+	// this will be zero if no homepage is set
+	if ( 0 === frontPageId ) {
+		return false;
+	}
+	return getEditorUrl( state, siteId, frontPageId, 'page' );
+}

--- a/client/state/selectors/is-site-using-full-site-editing.js
+++ b/client/state/selectors/is-site-using-full-site-editing.js
@@ -10,6 +10,14 @@ import { includes } from 'lodash';
  */
 import getBlogStickers from 'state/selectors/get-blog-stickers';
 import { hasStaticFrontPage } from 'state/sites/selectors';
+import { getActiveTheme } from 'state/themes/selectors';
+
+/**
+ * List of themes that are supported by Full Site Editing so we can call it "active"
+ *
+ * @type {Array}
+ */
+const supportedThemes = [ 'modern-business' ];
 
 /**
  * Checks if a site is using the new Full Site Editing experience
@@ -19,5 +27,10 @@ import { hasStaticFrontPage } from 'state/sites/selectors';
  */
 export default function isSiteUsingFullSiteEditing( state, siteId ) {
 	const stickers = getBlogStickers( state, siteId );
-	return hasStaticFrontPage( state, siteId ) && includes( stickers, 'full-site-editing' );
+	const activeTheme = getActiveTheme( state, siteId );
+	return (
+		hasStaticFrontPage( state, siteId ) &&
+		includes( supportedThemes, activeTheme ) &&
+		includes( stickers, 'full-site-editing' )
+	);
 }

--- a/client/state/selectors/is-site-using-full-site-editing.js
+++ b/client/state/selectors/is-site-using-full-site-editing.js
@@ -1,0 +1,23 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { includes } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getBlogStickers from 'state/selectors/get-blog-stickers';
+import { hasStaticFrontPage } from 'state/sites/selectors';
+
+/**
+ * Checks if a site is using the new Full Site Editing experience
+ * @param {Object} state  Global state tree
+ * @param {Object} siteId Site ID
+ * @return {Boolean} True if the site is using Full Site Editing, otherwise false
+ */
+export default function isSiteUsingFullSiteEditing( state, siteId ) {
+	const stickers = getBlogStickers( state, siteId );
+	return hasStaticFrontPage( state, siteId ) && includes( stickers, 'full-site-editing' );
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

**NOTE**: #34791 also references some backend changes which can be found in D31096-code

Hide and/or change links to the Customizer throughout the UI for those using FSE

### Testing instructions

This one's a doozy, strap in. On a site with the `full-site-editing` blog sticker and the Modern Business theme active, verify the following:

#### 1. The **Customize** link under **Design** should not be present.
<img width="274" alt="image" src="https://user-images.githubusercontent.com/195089/62250020-73821900-b3b1-11e9-94fe-647e528f795b.png">

#### 2. These links throughout the Themes screen should go to the block editor for the homepage:

At the top of `/themes`:
<img width="743" alt="Screen Shot 2019-07-19 at 1 29 13 PM" src="https://user-images.githubusercontent.com/1464705/61564402-3b7eeb80-aa2b-11e9-8caf-e4f51123ca5e.png">

Activate the Modern Business theme:
<img width="465" alt="image" src="https://user-images.githubusercontent.com/195089/62250241-04f18b00-b3b2-11e9-82ef-c187071d7e8c.png">

Click "Customize" on the Modern Business theme:
<img width="324" alt="image" src="https://user-images.githubusercontent.com/195089/62250322-3b2f0a80-b3b2-11e9-8bff-9a6641a4ef7b.png">

"Customize Site" on the Modern Business theme info page
<img width="699" alt="image" src="https://user-images.githubusercontent.com/195089/62313466-72ef8e00-b456-11e9-98db-9c6a12601163.png">

#### 3. Purchase a premium plan for your Simple site. In the `thank-you` screen, the "Start customizing" link should take you to the block editor for your homepage
<img width="721" alt="image" src="https://user-images.githubusercontent.com/195089/62313623-da0d4280-b456-11e9-8553-e709b3995444.png">

#### 4. On a site with a premium plan, under Plan → My Plan, scroll through "Premium plan features," there should NOT be a Customization card
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/195089/62313813-40926080-b457-11e9-8a5d-46c71ac7d053.png">