### PR TITLE
Signup: Adds fallback header and subheader text for import url step

### DIFF
--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -264,16 +264,21 @@ class ImportURLStepComponent extends Component {
 	render() {
 		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
 
+		const headerText = translate( 'Where can we find your old site?' );
+		const subHeaderText = translate(
+			'Enter your Wix or GoDaddy GoCentral site URL, sometimes called a domain name or site address.'
+		);
+
 		return (
 			<StepWrapper
 				className="import-url"
 				flowName={ flowName }
 				stepName={ stepName }
 				positionInFlow={ positionInFlow }
-				headerText={ translate( 'Where can we find your old site?' ) }
-				subHeaderText={ translate(
-					'Enter your Wix or GoDaddy GoCentral site URL, sometimes called a domain name or site address.'
-				) }
+				headerText={ headerText }
+				fallbackHeaderText={ headerText }
+				subHeaderText={ subHeaderText }
+				fallbackSubHeaderText={ subHeaderText }
 				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
 			/>

--- a/client/signup/steps/import-url/style.scss
+++ b/client/signup/steps/import-url/style.scss
@@ -30,8 +30,6 @@
 
 
 .import-url {
-	position: relative;
-
 	&__form {
 		position: relative;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds fallback text to `start/import/from-url` step.

Since the user step was moved to the beginning of the import flow in #35002, the header and subheader text is not displaying when the import url step comes second, for newly created users.

Before

![image](https://user-images.githubusercontent.com/363749/62234579-93edab80-b390-11e9-8bb3-ff62ec2d2ad7.png)

After

<img width="1269" alt="Screen Shot 2019-07-31 at 16 47 39" src="https://user-images.githubusercontent.com/1699996/62250615-f48de000-b3b2-11e9-8739-89d59bb45609.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start/import`, logged out
* Complete the user step
* The `start/import/from-url` step should display header and subheader text
