### PR TITLE
Disregard template validity in the context of FSE

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/template-validity-override/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/template-validity-override/index.js
@@ -19,7 +19,5 @@ const unsubscribe = subscribe( () => {
 	}
 	if ( select( 'core/editor' ).isValidTemplate() === false ) {
 		dispatch( 'core/editor' ).setTemplateValidity( true );
-		// should only need to do this once
-		unsubscribe();
 	}
 } );


### PR DESCRIPTION
This is VERY much a hack around https://github.com/WordPress/gutenberg/issues/11681

Previously, it worked to just hack this once at the beginning. But the error message is also popping up when performing undo in Gutenberg. I admit it's possible that something different could be happening in this case. But I haven't been able to come up with a reason why -  my best guess is that it also triggers the same template validity issues that we had to hack when the editor loads. I realize this is not a great patch, so I'm open to other suggestions. Note that we won't be able to ditch this check entirely because of the core gutenberg issue.

The downsides of this approach: we never get warned if the template is invalid for good reasons. However, I've tried to get something to break in the editor after the template validity goes wrong after performing undo, but everything works as expected. So I don't really think that anything is going wrong under the hood.
 
#### Changes proposed in this Pull Request

* Always disregard template validity in the context of FSE.

### Testing instructions
1. Pull this code and run it in your local FSE setup
2. Open a page with FSE enabled.
3. Make an edit to a block inside the post content area.
4.  Click undo in the top toolbar. Previously, the template validity notice would pop up per #34831. You should no longer see any notice when clicking undo.

Fixes #34831
cc @mmtr who originally authored this hack to only happen once.