### PR TITLE
#34926 Auto save post if dirty before navigating to template part

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -99,8 +99,8 @@ const TemplateEdit = compose(
 			if ( ! isDirty ) {
 				return;
 			}
-			setNavigateToTemplate( true );
 			event.preventDefault();
+			setNavigateToTemplate( true );
 			savePost();
 		};
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -14,7 +14,7 @@ import { BlockEdit } from '@wordpress/editor';
 import { Button, Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { compose, withState } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Fragment, useEffect } from '@wordpress/element';
+import { Fragment, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -27,9 +27,8 @@ const TemplateEdit = compose(
 	withState( { templateClientId: null } ),
 	withSelect( ( select, { attributes, templateClientId } ) => {
 		const { getEntityRecord } = select( 'core' );
-		const { getCurrentPostId } = select( 'core/editor' );
+		const { getCurrentPostId, isEditedPostDirty } = select( 'core/editor' );
 		const { getBlock } = select( 'core/block-editor' );
-
 		const { templateId } = attributes;
 		const currentPostId = getCurrentPostId();
 		const template = templateId && getEntityRecord( 'postType', 'wp_template_part', templateId );
@@ -44,13 +43,14 @@ const TemplateEdit = compose(
 			template,
 			templateBlock: getBlock( templateClientId ),
 			templateTitle: get( template, [ 'title', 'rendered' ], '' ),
+			isDirty: isEditedPostDirty(),
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
 		const { receiveBlocks } = dispatch( 'core/block-editor' );
 		const { template, templateClientId, setState } = ownProps;
-
 		return {
+			savePost: dispatch( 'core/editor' ).savePost,
 			receiveTemplateBlocks: () => {
 				if ( ! template || templateClientId ) {
 					return;
@@ -75,6 +75,8 @@ const TemplateEdit = compose(
 		template,
 		templateBlock,
 		templateTitle,
+		isDirty,
+		savePost,
 	} ) => {
 		if ( ! template ) {
 			return (
@@ -83,12 +85,24 @@ const TemplateEdit = compose(
 				</Placeholder>
 			);
 		}
-
+		const [ navigateToTemplate, setNavigateToTemplate ] = useState( false );
 		useEffect( () => {
+			if ( navigateToTemplate && ! isDirty ) {
+				window.location.href = editTemplatePartUrl;
+			}
 			receiveTemplateBlocks();
 		} );
 
 		const { align, className } = attributes;
+
+		const save = event => {
+			if ( ! isDirty ) {
+				return;
+			}
+			setNavigateToTemplate( true );
+			event.preventDefault();
+			savePost();
+		};
 
 		return (
 			<div
@@ -114,8 +128,8 @@ const TemplateEdit = compose(
 								'This block is part of your site template and may appear on multiple pages.'
 							) }
 						>
-							<Button href={ editTemplatePartUrl } isDefault>
-								{ sprintf( __( 'Edit %s' ), templateTitle ) }
+							<Button href={ editTemplatePartUrl } onClick={ save } isDefault>
+								{ navigateToTemplate ? <Spinner /> : sprintf( __( 'Edit %s' ), templateTitle ) }
 							</Button>
 						</Placeholder>
 					</Fragment>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -4,6 +4,9 @@
 	&:hover .template-block__overlay {
 		display: flex;
 	}
+	.components-button .components-spinner {
+		margin-top: 4px;
+	}
 }
 
 .template-block.alignfull {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Save the current page before navigating to a template part if the user clicks the 'Edit Header/Footer' button when a page is in a dirty state. This prevents the user seeing the insaved changes warning

#### Testing instructions

* See #34926 for details about how to replicate the existing issue 
* Apply this patch to your local FSE test environment
* Add a new page and before saving click on the 'Edit Header' button. The page should save and you should navigate to the Header template without any unsaved changes warning. The button text should change to a spinner while the save is in progress. Repeat for the 'Edit Footer' button.

![saving](https://user-images.githubusercontent.com/3629020/62262467-f4521b00-b46c-11e9-9b1e-6795ec9a655c.gif)

* Edit an existing page, change some of the content and click on the 'Edit Header' button. The page should save and you should navigate to the Header template without any unsaved changes warning. Repeat for the 'Edit Footer' button.
* Repeat all of the above but with pages with no changes - you should navigate direct to template part with no save initiated. 
* Right clicking on either 'Edit Header' or 'Edit Footer' should allow you to open the link in a new tab like a standard hyperlink - no save will be initiated in this instance

**Before**

![before](https://user-images.githubusercontent.com/3629020/62262803-231cc100-b46e-11e9-8ef4-faeac7f3e08a.gif)

**After**

![after](https://user-images.githubusercontent.com/3629020/62262812-2a43cf00-b46e-11e9-8097-7d2938de06ce.gif)

Fixes #34926
