### PR TITLE
Marketing survey for auto-renewal cancellation.

### DIFF
--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -58,7 +58,10 @@ class CancelAutoRenewalForm extends Component {
 		const { purchase, selectedSite } = this.props;
 		const { response, feedback } = this.state;
 
-		const surveyData = { response, feedback };
+		const surveyData = {
+			response,
+			feedback: feedback.trim(),
+		};
 
 		submitSurvey(
 			'calypso-cancel-auto-renewal',
@@ -99,6 +102,8 @@ class CancelAutoRenewalForm extends Component {
 		const { translate, isVisible, onClose } = this.props;
 		const { response, feedback } = this.state;
 
+		const disableSubmit = ! response || ( response === OTHER_FEEDBACK && ! feedback.trim() );
+
 		return (
 			<Dialog
 				className="cancel-auto-renewal-form__dialog"
@@ -128,7 +133,9 @@ class CancelAutoRenewalForm extends Component {
 				</FormFieldset>
 
 				<FormButtonsBar>
-					<FormButton onClick={ this.onSubmit }>{ translate( 'Submit' ) }</FormButton>
+					<FormButton onClick={ this.onSubmit } disabled={ disableSubmit }>
+						{ translate( 'Submit' ) }
+					</FormButton>
 					<FormButton isPrimary={ false } onClick={ onClose }>
 						{ translate( 'Skip' ) }
 					</FormButton>

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -48,9 +48,9 @@ class CancelAutoRenewalForm extends Component {
 		const { translate } = props;
 
 		this.radioButtons = [
-			[ 'take-a-break', translate( "Yes, I'm just taking a break for now." ) ],
-			[ 'manual-renew', translate( 'Yes, I want to renew manually.' ) ],
-			[ 'stop-renew', translate( "No, I don't have any plans to renew it." ) ],
+			[ 'let-it-expire', translate( "I'm going to let this plan expire." ) ],
+			[ 'manual-renew', translate( "I'm going to renew the plan, but will do it manually." ) ],
+			[ 'not-sure', translate( "I'm not sure." ) ],
 			[ OTHER_FEEDBACK, translate( 'Another reason' ) ],
 		];
 	}
@@ -117,8 +117,8 @@ class CancelAutoRenewalForm extends Component {
 				<FormFieldset>
 					<p>
 						{ translate(
-							'We have processed your request. Your feedback could help us improve our products.' +
-								'Do you think you might use your current subscription after it expires?'
+							"Auto-renewal is now off. Before you go, we'd love to know: " +
+								"are you letting this plan expire completely, or do you think you'll renew it manually?"
 						) }
 					</p>
 					{ this.radioButtons.map( radioButton =>

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize, moment } from 'i18n-calypso';
@@ -25,6 +26,14 @@ import './style.scss';
 const OTHER_FEEDBACK = 'other-feedback';
 
 class CancelAutoRenewalForm extends Component {
+	static propTypes = {
+		purchase: PropTypes.object.isRequired,
+		selectedSite: PropTypes.object.isRequired,
+		isVisible: PropTypes.bool,
+		onClose: PropTypes.func.isRequired,
+		translate: PropTypes.func.isRequired,
+	};
+
 	state = {
 		response: '',
 		feedback: '',

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -11,9 +11,20 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import Dialog from 'components/dialog';
-import Button from 'components/button';
+import FormSectionHeading from 'components/forms/form-section-heading';
+import FormButton from 'components/forms/form-button';
+import FormButtonsBar from 'components/forms/form-buttons-bar';
+import FormFieldset from 'components/forms/form-fieldset';
+import FormLabel from 'components/forms/form-label';
+import FormRadio from 'components/forms/form-radio';
+import FormTextInput from 'components/forms/form-text-input';
 
 class CancelAutoRenewalForm extends Component {
+	state = {
+		checkedRadio: '',
+		feedback: '',
+	};
+
 	onSubmit = () => {
 		this.props.onClose();
 	};
@@ -22,19 +33,81 @@ class CancelAutoRenewalForm extends Component {
 		this.props.onClose();
 	};
 
+	onRadioChange = event => {
+		this.setState( {
+			checkedRadio: event.currentTarget.value,
+		} );
+	};
+
+	onEnterFeedback = event => {
+		this.setState( {
+			feedback: event.target.value,
+		} );
+	};
+
 	render() {
 		const { translate, isVisible } = this.props;
+		const { checkedRadio, feedback } = this.state;
 
 		return (
 			<Dialog isVisible={ isVisible } onClose={ this.closeDialog }>
-				<h2 className="cancel-auto-renewal-form__header">
-					{ translate( 'Your thoughts are important for us.' ) }
-				</h2>
+				<FormSectionHeading className="cancel-auto-renewal-form__header">
+					{ translate( 'Your thoughts are needed.' ) }
+				</FormSectionHeading>
+				<FormFieldset>
+					<p>
+						{ translate(
+							'We have processed your request. Your feedback could help us improve our products.' +
+								'Do you think you might use your current subscription after it expires?'
+						) }
+					</p>
+					<FormLabel>
+						<FormRadio
+							value="radio-1"
+							onChange={ this.onRadioChange }
+							checked={ checkedRadio === 'radio-1' }
+						/>
+						<span>{ translate( "Yes, I'm just taking a break for now." ) }</span>
+					</FormLabel>
+					<FormLabel>
+						<FormRadio
+							value="radio-2"
+							onChange={ this.onRadioChange }
+							checked={ checkedRadio === 'radio-2' }
+						/>
+						<span>{ translate( 'Yes, I want to renew manually.' ) }</span>
+					</FormLabel>
+					<FormLabel>
+						<FormRadio
+							value="radio-3"
+							onChange={ this.onRadioChange }
+							checked={ checkedRadio === 'radio-3' }
+						/>
+						<span>{ translate( 'No, I don’t have any plans to renew it.' ) }</span>
+					</FormLabel>
+					<FormLabel>
+						<FormRadio
+							value="radio-4"
+							onChange={ this.onRadioChange }
+							checked={ checkedRadio === 'radio-4' }
+						/>
+						<span>{ translate( 'Another reason' ) }</span>
+					</FormLabel>
+					{ checkedRadio === 'radio-4' && (
+						<FormTextInput
+							placeholder={ translate( 'Please enter your feedback here.' ) }
+							value={ feedback }
+							onChange={ this.onEnterFeedback }
+						/>
+					) }
+				</FormFieldset>
 
-				<Button onClick={ this.closeDialog }>{ translate( 'Skip' ) }</Button>
-				<Button primary onClick={ this.onSubmit }>
-					{ translate( 'Submit' ) }
-				</Button>
+				<FormButtonsBar>
+					<FormButton onClick={ this.onSubmit }>{ translate( 'Submit' ) }</FormButton>
+					<FormButton isPrimary={ false } onClick={ this.closeDialog }>
+						{ translate( 'Skip' ) }
+					</FormButton>
+				</FormButtonsBar>
 			</Dialog>
 		);
 	}

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -1,0 +1,43 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Dialog from 'components/dialog';
+import Button from 'components/button';
+
+class CancelAutoRenewalForm extends Component {
+	onSubmit = () => {
+		this.props.onClose();
+	};
+
+	closeDialog = () => {
+		this.props.onClose();
+	};
+
+	render() {
+		const { translate, isVisible } = this.props;
+
+		return (
+			<Dialog isVisible={ isVisible } onClose={ this.closeDialog }>
+				<h2 className="cancel-auto-renewal-form__header">
+					{ translate( 'Your thoughts are important for us.' ) }
+				</h2>
+
+				<Button onClick={ this.closeDialog }>{ translate( 'Skip' ) }</Button>
+				<Button primary onClick={ this.onSubmit }>
+					{ translate( 'Submit' ) }
+				</Button>
+			</Dialog>
+		);
+	}
+}
+
+export default connect()( localize( CancelAutoRenewalForm ) );

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -50,7 +50,7 @@ class CancelAutoRenewalForm extends Component {
 		this.radioButtons = [
 			[ 'take-a-break', translate( "Yes, I'm just taking a break for now." ) ],
 			[ 'manual-renew', translate( 'Yes, I want to renew manually.' ) ],
-			[ 'stop-renew', translate( 'No, I don’t have any plans to renew it.' ) ],
+			[ 'stop-renew', translate( "No, I don't have any plans to renew it." ) ],
 			[ OTHER_FEEDBACK, translate( 'Another reason' ) ],
 		];
 	}

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -82,8 +82,9 @@ class CancelAutoRenewalForm extends Component {
 	};
 
 	createRadioButton = ( value, text ) => {
+		// adding `key` for resolving the unique key prop requirement when performing `map`
 		return (
-			<FormLabel>
+			<FormLabel key={ value }>
 				<FormRadio
 					value={ value }
 					onChange={ this.onRadioChange }

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -18,6 +18,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
+import './style.scss';
 
 class CancelAutoRenewalForm extends Component {
 	state = {
@@ -50,7 +51,11 @@ class CancelAutoRenewalForm extends Component {
 		const { checkedRadio, feedback } = this.state;
 
 		return (
-			<Dialog isVisible={ isVisible } onClose={ this.closeDialog }>
+			<Dialog
+				className="cancel-auto-renewal-form__dialog"
+				isVisible={ isVisible }
+				onClose={ this.closeDialog }
+			>
 				<FormSectionHeading className="cancel-auto-renewal-form__header">
 					{ translate( 'Your thoughts are needed.' ) }
 				</FormSectionHeading>

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -18,13 +18,10 @@ import FormButtonsBar from 'components/forms/form-buttons-bar';
 import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
-import FormTextInput from 'components/forms/form-text-input';
 import { submitSurvey } from 'lib/upgrades/actions';
 import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import PrecancellationChatButton from 'components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import './style.scss';
-
-const OTHER_FEEDBACK = 'other-feedback';
 
 class CancelAutoRenewalForm extends Component {
 	static propTypes = {
@@ -37,7 +34,6 @@ class CancelAutoRenewalForm extends Component {
 
 	state = {
 		response: '',
-		feedback: '',
 	};
 
 	radioButtons = {};
@@ -51,17 +47,15 @@ class CancelAutoRenewalForm extends Component {
 			[ 'let-it-expire', translate( "I'm going to let this plan expire." ) ],
 			[ 'manual-renew', translate( "I'm going to renew the plan, but will do it manually." ) ],
 			[ 'not-sure', translate( "I'm not sure." ) ],
-			[ OTHER_FEEDBACK, translate( 'Another reason' ) ],
 		];
 	}
 
 	onSubmit = () => {
 		const { purchase, selectedSite } = this.props;
-		const { response, feedback } = this.state;
+		const { response } = this.state;
 
 		const surveyData = {
 			response,
-			feedback: feedback.trim(),
 		};
 
 		submitSurvey(
@@ -76,12 +70,6 @@ class CancelAutoRenewalForm extends Component {
 	onRadioChange = event => {
 		this.setState( {
 			response: event.currentTarget.value,
-		} );
-	};
-
-	onEnterFeedback = event => {
-		this.setState( {
-			feedback: event.target.value,
 		} );
 	};
 
@@ -101,9 +89,9 @@ class CancelAutoRenewalForm extends Component {
 
 	render() {
 		const { translate, isVisible, purchase, onClose } = this.props;
-		const { response, feedback } = this.state;
+		const { response } = this.state;
 
-		const disableSubmit = ! response || ( response === OTHER_FEEDBACK && ! feedback.trim() );
+		const disableSubmit = ! response;
 
 		return (
 			<Dialog
@@ -123,13 +111,6 @@ class CancelAutoRenewalForm extends Component {
 					</p>
 					{ this.radioButtons.map( radioButton =>
 						this.createRadioButton( radioButton[ 0 ], radioButton[ 1 ] )
-					) }
-					{ response === OTHER_FEEDBACK && (
-						<FormTextInput
-							placeholder={ translate( 'Please enter your feedback here.' ) }
-							value={ feedback }
-							onChange={ this.onEnterFeedback }
-						/>
 					) }
 				</FormFieldset>
 

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -21,6 +21,7 @@ import FormRadio from 'components/forms/form-radio';
 import FormTextInput from 'components/forms/form-text-input';
 import { submitSurvey } from 'lib/upgrades/actions';
 import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enriched-survey-data';
+import PrecancellationChatButton from 'components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import './style.scss';
 
 const OTHER_FEEDBACK = 'other-feedback';
@@ -99,7 +100,7 @@ class CancelAutoRenewalForm extends Component {
 	};
 
 	render() {
-		const { translate, isVisible, onClose } = this.props;
+		const { translate, isVisible, purchase, onClose } = this.props;
 		const { response, feedback } = this.state;
 
 		const disableSubmit = ! response || ( response === OTHER_FEEDBACK && ! feedback.trim() );
@@ -139,6 +140,7 @@ class CancelAutoRenewalForm extends Component {
 					<FormButton isPrimary={ false } onClick={ onClose }>
 						{ translate( 'Skip' ) }
 					</FormButton>
+					<PrecancellationChatButton purchase={ purchase } onClick={ onClose } />
 				</FormButtonsBar>
 			</Dialog>
 		);

--- a/client/components/marketing-survey/cancel-auto-renewal-form/style.scss
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/style.scss
@@ -1,0 +1,3 @@
+.cancel-auto-renewal-form__dialog {
+	max-width: 472px;
+}

--- a/client/components/marketing-survey/cancel-purchase-form/constants.js
+++ b/client/components/marketing-survey/cancel-purchase-form/constants.js
@@ -8,12 +8,4 @@ export const CANCEL_FLOW_TYPE = {
 	// When users effectively cancelling the auto-renewal by
 	// cancelling a subscription out of the refund window
 	CANCEL_AUTORENEW: 'cancel_autorenew',
-
-	// When users turns off the auto-renewal through a control
-	// that is specifically for enabling / disabling auto-renewal.
-	// At the moment of writing this, it is a toggle in the purchase management page.
-	// It is called 'survey only' because when the survey pops up the auto-renewal
-	// will be turned off already for the legal compliance reason, instead of
-	// needing users to do any final confirm.
-	CANCEL_AUTORENEW_SURVEY_ONLY: 'cancel_autorenew_survey_only',
 };

--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -197,8 +197,6 @@ class CancelPurchaseForm extends React.Component {
 				return 'refund';
 			case CANCEL_FLOW_TYPE.CANCEL_AUTORENEW:
 				return 'cancel-autorenew';
-			case CANCEL_FLOW_TYPE.CANCEL_AUTORENEW_SURVEY_ONLY:
-				return 'cancel-autorenew-survey-only';
 			default:
 				// Although we shouldn't allow it to reach here, we still include this default in case we forgot to add proper mappings.
 				return 'general';
@@ -551,10 +549,7 @@ class CancelPurchaseForm extends React.Component {
 		const close = {
 				action: 'close',
 				disabled,
-				label:
-					flowType === CANCEL_FLOW_TYPE.CANCEL_AUTORENEW_SURVEY_ONLY
-						? translate( 'Skip' )
-						: translate( "I'll Keep It" ),
+				label: translate( "I'll Keep It" ),
 			},
 			chat = (
 				<PrecancellationChatButton
@@ -588,13 +583,6 @@ class CancelPurchaseForm extends React.Component {
 				label: translate( 'Remove Now' ),
 				onClick: this.onSubmit,
 				isPrimary: true,
-			},
-			submit = {
-				action: 'submit',
-				disabled: this.state.isSubmitting,
-				label: translate( 'Submit' ),
-				onClick: this.onSubmit,
-				isPrimary: true,
 			};
 
 		const firstButtons =
@@ -609,8 +597,6 @@ class CancelPurchaseForm extends React.Component {
 			switch ( flowType ) {
 				case CANCEL_FLOW_TYPE.REMOVE:
 					return firstButtons.concat( [ ...prevButton, remove ] );
-				case CANCEL_FLOW_TYPE.CANCEL_AUTORENEW_SURVEY_ONLY:
-					return firstButtons.concat( [ ...prevButton, submit ] );
 				default:
 					return firstButtons.concat( [ ...prevButton, cancel ] );
 			}

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -12,7 +12,7 @@ import { localize } from 'i18n-calypso';
  */
 import Button from 'components/button';
 import Dialog from 'components/dialog';
-import CancelPurchaseForm from 'components/marketing-survey/cancel-purchase-form';
+import CancelAutoRenewalForm from 'components/marketing-survey/cancel-auto-renewal-form';
 import { isDomainRegistration, isPlan } from 'lib/products-values';
 import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
 import { getSite } from 'state/sites/selectors';
@@ -213,13 +213,11 @@ class AutoRenewDisablingDialog extends Component {
 		const { purchase, isVisible, selectedSite } = this.props;
 
 		return (
-			<CancelPurchaseForm
+			<CancelAutoRenewalForm
 				purchase={ purchase }
 				selectedSite={ selectedSite }
 				isVisible={ isVisible }
 				onClose={ this.closeAndCleanup }
-				onClickFinalConfirm={ this.closeAndCleanup }
-				flowType={ 'cancel_autorenew_survey_only' }
 			/>
 		);
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR implements a new marketing survey specifically for the auto-renewal cancellation:
![demo-auto-renewal-survey](https://user-images.githubusercontent.com/1842898/62270243-201ed200-b468-11e9-8511-dc57ad714f2a.gif)

Currently we are reusing `<CancelPurchaseForm>`. However, it is confusing sometimes because its original purpose doesn't match.

In sum, this PR consists of:

1. A new component, `<CancelAutoRenewalForm>`, for the auto-renewal cancellation survey. The content is directly brought from what @semihakocer has proposed in p2-p9jf6J-1GZ from the very beginning.
1. The survey data uses a new ID, `cancel-auto-renewal`, instead of reusing `remove-calypso-purchase`. It ended up very hard to segment the data using the same ID.
1. The code for the auto-renewal cancellation survey has been removed from `<CancelPurchaseForm>`.

#### Testing instructions

1. Turn off auto-renewal and the new survey should appear.
1. Open the network inspector, submit the form, and see the POST request to `/marketing/survey` contains the data as expected.
