### PR TITLE
Avoid multiple concurrent requests for lang file.

### DIFF
--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -82,6 +82,12 @@ async function getLanguageFile( targetLocaleSlug ) {
 
 	const response = await dedupedGet( url );
 	if ( response.ok ) {
+		if ( response.bodyUsed ) {
+			// If the body was already used, we assume that we already parsed the
+			// response and set the locale in the DOM, so we don't need to do anything
+			// else here.
+			return;
+		}
 		return await response.json();
 	}
 

--- a/client/lib/i18n-utils/switch-locale.js
+++ b/client/lib/i18n-utils/switch-locale.js
@@ -124,17 +124,19 @@ export default function switchLocale( localeSlug ) {
 		getLanguageFile( targetLocaleSlug ).then(
 			// Success.
 			body => {
-				// Handle race condition when we're requested to switch to a different
-				// locale while we're in the middle of request, we should abandon result
-				if ( targetLocaleSlug !== lastRequestedLocale ) {
-					return;
+				if ( body ) {
+					// Handle race condition when we're requested to switch to a different
+					// locale while we're in the middle of request, we should abandon result
+					if ( targetLocaleSlug !== lastRequestedLocale ) {
+						return;
+					}
+
+					i18n.setLocale( body );
+
+					setLocaleInDOM( domLocaleSlug, !! language.rtl );
+
+					loadUserUndeployedTranslations( targetLocaleSlug );
 				}
-
-				i18n.setLocale( body );
-
-				setLocaleInDOM( domLocaleSlug, !! language.rtl );
-
-				loadUserUndeployedTranslations( targetLocaleSlug );
 			},
 			// Failure.
 			() => {


### PR DESCRIPTION
In some cases, multiple concurrent requests for the language JSON file could take place. This behaved normally, but resulted in wasted bandwidth for the user.

This issue was likely introduced in #34712. 

#### Changes proposed in this Pull Request

* De-duplicate network requests when loading a language file.

#### Testing instructions

* Log in
* Set your account language to a locale other than US English
* Go to `/log-in`
* Open DevTools and switch to the network tab
* Refresh page

Before, this could produce multiple network requests for e.g. `en-gb-v1.1.json`. Now, it should produce a single one.