### PR TITLE
Change the primary button from "I'll keep it" to "Confirm cancellation".

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/auto-renew-disabling-dialog/index.jsx
@@ -201,11 +201,9 @@ class AutoRenewDisablingDialog extends Component {
 			>
 				<h2 className="auto-renew-disabling-dialog__header">{ translate( 'Before you go…' ) }</h2>
 				<p>{ description }</p>
-				<Button onClick={ this.onClickGeneralConfirm }>
+				<Button onClick={ this.closeAndCleanup }>{ translate( "I'll keep it" ) }</Button>
+				<Button onClick={ this.onClickGeneralConfirm } primary>
 					{ translate( 'Confirm cancellation' ) }
-				</Button>
-				<Button onClick={ this.closeAndCleanup } primary>
-					{ translate( "I'll keep it" ) }
 				</Button>
 			</Dialog>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Props @p3ob7o for pointing this out. While we certainly prefer users to stay with us, it is confusing since all the other purchase cancellation / removal flows are having the confirming button as the primary one.

For more details, please refer to p2-p1HpG7-7gK/#comment-33207

Current:
![image](https://user-images.githubusercontent.com/1842898/62274385-5c573000-b472-11e9-8e71-d9e33cdea696.png)

After:
<img width="509" alt="螢幕快照 2019-08-01 下午3 29 54" src="https://user-images.githubusercontent.com/1842898/62274289-27e37400-b472-11e9-9c7b-49ad99a782db.png">
Note that the order has been swapped as well, since the primary buttons are on the right hand side for all the other marketing survey forms.

#### Testing instructions

1. Turn off the auto-renewal of a subscription.
1. See the updated button order and the confirming button as the primary one.