### PR TITLE
Signup: get Redux store from page.js context as prop, not from legacy React context

### DIFF
--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -136,6 +136,7 @@ export default {
 		context.store.dispatch( setCurrentFlowName( flowName ) );
 
 		context.primary = React.createElement( SignupComponent, {
+			store: context.store,
 			path: context.path,
 			initialContext,
 			locale: getLocale( context.params ),

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -97,13 +97,8 @@ function dependenciesContainCartItem( dependencies ) {
 }
 
 class Signup extends React.Component {
-	static displayName = 'Signup';
-
-	static contextTypes = {
-		store: PropTypes.object,
-	};
-
 	static propTypes = {
+		store: PropTypes.object.isRequired,
 		domainsWithPlansOnly: PropTypes.bool,
 		isLoggedIn: PropTypes.bool,
 		loadTrackingTool: PropTypes.func.isRequired,
@@ -122,16 +117,12 @@ class Signup extends React.Component {
 		shouldShowMockups: PropTypes.bool,
 	};
 
-	constructor( props, context ) {
-		super( props, context );
-
-		this.state = {
-			controllerHasReset: false,
-			shouldShowLoadingScreen: false,
-			resumingStep: undefined,
-			previousFlowName: null,
-		};
-	}
+	state = {
+		controllerHasReset: false,
+		shouldShowLoadingScreen: false,
+		resumingStep: undefined,
+		previousFlowName: null,
+	};
 
 	UNSAFE_componentWillMount() {
 		// Signup updates the cart through `SignupCart`. To prevent
@@ -153,7 +144,7 @@ class Signup extends React.Component {
 		this.signupFlowController = new SignupFlowController( {
 			flowName: this.props.flowName,
 			providedDependencies,
-			reduxStore: this.context.store,
+			reduxStore: this.props.store,
 			onComplete: this.handleSignupFlowControllerCompletion,
 		} );
 


### PR DESCRIPTION
Part of the React Redux v7 migration in #32129. We need the Redux store to initialize the `SignupController`, but getting it from the legacy React context is not forward-compatible. This patch uses a prop instead, passed from the page.js handler that renders the `Signup` component.

**How to test:**
Test that signup works 🙂 Passing e2e suite should be sufficient.