### PR TITLE
Update signup progress state to a keyed object

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
-import { capitalize, findLast, get, includes, isArray } from 'lodash';
+import { capitalize, findLast, get, includes, size } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
@@ -146,7 +146,7 @@ class Login extends Component {
 				window.location.href = url;
 			} );
 		} else {
-			if ( isArray( this.props.signupProgress ) ) {
+			if ( size( this.props.signupProgress ) ) {
 				const lastStep = findLast( this.props.signupProgress, step => step.stepName !== 'user' );
 				if ( lastStep ) {
 					this.props.setResumeAfterLogin( lastStep );

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
-import { capitalize, findLast, get, includes, size } from 'lodash';
+import { capitalize, findLast, get, includes, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
@@ -146,7 +146,7 @@ class Login extends Component {
 				window.location.href = url;
 			} );
 		} else {
-			if ( size( this.props.signupProgress ) ) {
+			if ( ! isEmpty( this.props.signupProgress ) ) {
 				const lastStep = findLast( this.props.signupProgress, step => step.stepName !== 'user' );
 				if ( lastStep ) {
 					this.props.setResumeAfterLogin( lastStep );

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -6,6 +6,7 @@
 /**
  * External dependencies
  */
+import { isEmpty, size } from 'lodash';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 
@@ -49,25 +50,6 @@ describe( 'flow-controller', () => {
 			expect( signupFlowController._reduxStore ).toBe( store );
 		} );
 
-		test( 'should remove steps not needed by the current flow on init', () => {
-			const store = createSignupStore( {
-				signup: {
-					progress: [ { stepName: 'stepA' }, { stepName: 'stepB' }, { stepName: 'stepC' } ],
-				},
-			} );
-			expect( getSignupProgress( store.getState() ) ).toHaveLength( 3 );
-
-			signupFlowController = new SignupFlowController( {
-				flowName: 'simple_flow',
-				onComplete: () => {},
-				reduxStore: store,
-			} );
-
-			const progress = getSignupProgress( store.getState() );
-			expect( progress ).toHaveLength( 2 );
-			expect( progress.map( step => step.stepName ) ).toEqual( [ 'stepA', 'stepB' ] );
-		} );
-
 		test( 'should reset stores if there are processing steps in the state upon instantitaion', () => {
 			const store = createSignupStore( {
 				signup: {
@@ -85,7 +67,7 @@ describe( 'flow-controller', () => {
 				reduxStore: store,
 			} );
 
-			expect( getSignupProgress( store.getState() ) ).toHaveLength( 0 );
+			expect( isEmpty( getSignupProgress( store.getState() ) ) ).toBe( true );
 		} );
 
 		test( 'should reset stores if user is logged in and there is a user step in the saved progress', () => {
@@ -101,7 +83,7 @@ describe( 'flow-controller', () => {
 				reduxStore: store,
 			} );
 
-			expect( getSignupProgress( store.getState() ) ).toHaveLength( 0 );
+			expect( isEmpty( getSignupProgress( store.getState() ) ) ).toBe( true );
 		} );
 	} );
 
@@ -201,7 +183,7 @@ describe( 'flow-controller', () => {
 					stepName: 'delayedStep',
 					stepCallback: function() {
 						const progress = getSignupProgress( store.getState() );
-						expect( progress ).toHaveLength( 2 );
+						expect( size( progress ) ).toBe( 2 );
 					},
 				} )
 			);
@@ -222,7 +204,8 @@ describe( 'flow-controller', () => {
 					stepName: 'delayedStep',
 					stepCallback: function() {
 						const progress = getSignupProgress( store.getState() );
-						expect( progress[ 1 ].status ).toBe( 'completed' );
+						const step = progress.stepA;
+						expect( step.status ).toBe( 'completed' );
 					},
 				} )
 			);

--- a/client/lib/signup/test/flow-controller.js
+++ b/client/lib/signup/test/flow-controller.js
@@ -6,7 +6,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, size } from 'lodash';
+import { size } from 'lodash';
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 
@@ -67,7 +67,7 @@ describe( 'flow-controller', () => {
 				reduxStore: store,
 			} );
 
-			expect( isEmpty( getSignupProgress( store.getState() ) ) ).toBe( true );
+			expect( getSignupProgress( store.getState() ) ).toEqual( {} );
 		} );
 
 		test( 'should reset stores if user is logged in and there is a user step in the saved progress', () => {
@@ -83,7 +83,7 @@ describe( 'flow-controller', () => {
 				reduxStore: store,
 			} );
 
-			expect( isEmpty( getSignupProgress( store.getState() ) ) ).toBe( true );
+			expect( getSignupProgress( store.getState() ) ).toEqual( {} );
 		} );
 	} );
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -451,11 +451,11 @@ class Signup extends React.Component {
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToNextStep = ( nextFlowName = this.props.flowName ) => {
-		const flowSteps = flows.getFlow( nextFlowName ).steps,
-			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
-			nextStepName = flowSteps[ currentStepIndex + 1 ],
-			nextProgressItem = this.props.progress[ currentStepIndex + 1 ],
-			nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
+		const flowSteps = flows.getFlow( nextFlowName ).steps;
+		const currentStepIndex = indexOf( flowSteps, this.props.stepName );
+		const nextStepName = flowSteps[ currentStepIndex + 1 ];
+		const nextProgressItem = get( this.props.progress, nextStepName );
+		const nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
 
 		if ( nextFlowName !== this.props.flowName ) {
 			this.props.removeUnneededSteps( nextFlowName );

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import { get, findLast } from 'lodash';
+import { get, findLast, findIndex } from 'lodash';
 import Gridicon from 'gridicons';
 import classnames from 'classnames';
 
@@ -54,10 +54,9 @@ export class NavigationLink extends Component {
 	getPreviousStep() {
 		const { flowName, signupProgress, stepName } = this.props;
 
-		const previousStep = findLast(
-			getFilteredSteps( flowName, signupProgress ),
-			step => ! step.wasSkipped && step.stepName !== stepName
-		);
+		let steps = getFilteredSteps( flowName, signupProgress );
+		steps = steps.slice( 0, findIndex( steps, step => step.stepName === stepName ) );
+		const previousStep = findLast( steps, step => ! step.wasSkipped && step.stepName !== stepName );
 
 		return previousStep || { stepName: null };
 	}

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { localize, getLocaleSlug } from 'i18n-calypso';
-import { find, findIndex, get } from 'lodash';
+import { get, findLast } from 'lodash';
 import Gridicon from 'gridicons';
 import classnames from 'classnames';
 
@@ -18,6 +18,7 @@ import { getStepUrl } from 'signup/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { submitSignupStep } from 'state/signup/progress/actions';
 import { getSignupProgress } from 'state/signup/progress/selectors';
+import { getFilteredSteps } from '../utils';
 
 /**
  * Style dependencies
@@ -33,7 +34,7 @@ export class NavigationLink extends Component {
 		cssClass: PropTypes.string,
 		positionInFlow: PropTypes.number,
 		previousPath: PropTypes.string,
-		signupProgress: PropTypes.array,
+		signupProgress: PropTypes.object,
 		stepName: PropTypes.string.isRequired,
 		// Allows to force a back button in the first step for example.
 		allowBackFirstStep: PropTypes.bool,
@@ -51,13 +52,11 @@ export class NavigationLink extends Component {
 	 * @return {Object} The previous step object
 	 */
 	getPreviousStep() {
-		const { stepName, signupProgress } = this.props;
+		const { flowName, signupProgress, stepName } = this.props;
 
-		const currentStepIndex = findIndex( signupProgress, { stepName } );
-
-		const previousStep = find(
-			signupProgress.slice( 0, currentStepIndex ).reverse(),
-			step => ! step.wasSkipped
+		const previousStep = findLast(
+			getFilteredSteps( flowName, signupProgress ),
+			step => ! step.wasSkipped && step.stepName !== stepName
 		);
 
 		return previousStep || { stepName: null };
@@ -75,8 +74,8 @@ export class NavigationLink extends Component {
 		const previousStep = this.getPreviousStep();
 
 		const stepSectionName = get(
-			find( this.props.signupProgress, { stepName: previousStep.stepName } ),
-			'stepSectionName',
+			this.props.signupProgress,
+			[ previousStep.stepName, 'stepSectionName' ],
 			''
 		);
 

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -56,7 +56,7 @@ export class NavigationLink extends Component {
 
 		let steps = getFilteredSteps( flowName, signupProgress );
 		steps = steps.slice( 0, findIndex( steps, step => step.stepName === stepName ) );
-		const previousStep = findLast( steps, step => ! step.wasSkipped && step.stepName !== stepName );
+		const previousStep = findLast( steps, step => ! step.wasSkipped );
 
 		return previousStep || { stepName: null };
 	}

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -12,11 +12,14 @@ import { noop } from 'lodash';
 import { NavigationLink } from '../';
 import EMPTY_COMPONENT from 'components/empty-component';
 
-jest.mock( 'signup/utils', () => ( { getStepUrl: jest.fn() } ) );
+jest.mock( 'signup/utils', () => ( {
+	getStepUrl: jest.fn(),
+	getFilteredSteps: jest.fn(),
+} ) );
 jest.mock( 'gridicons', () => require( 'components/empty-component' ) );
 
 const signupUtils = require( 'signup/utils' );
-const { getStepUrl } = signupUtils;
+const { getStepUrl, getFilteredSteps } = signupUtils;
 
 describe( 'NavigationLink', () => {
 	const Gridicon = EMPTY_COMPONENT;
@@ -25,11 +28,11 @@ describe( 'NavigationLink', () => {
 		stepName: 'test:step2',
 		positionInFlow: 1,
 		stepSectionName: 'test:section',
-		signupProgress: [
-			{ stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
-			{ stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: false },
-			{ stepName: 'test:step3', stepSectionName: 'test:section3', wasSkipped: false },
-		],
+		signupProgress: {
+			'test:step1': { stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
+			'test:step2': { stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: false },
+			'test:step3': { stepName: 'test:step3', stepSectionName: 'test:section3', wasSkipped: false },
+		},
 		recordTracksEvent: noop,
 		submitSignupStep: noop,
 		goToNextStep: jest.fn(),
@@ -77,6 +80,11 @@ describe( 'NavigationLink', () => {
 	test( 'should set a proper url as href prop when the direction is "back".', () => {
 		expect( getStepUrl ).not.toHaveBeenCalled();
 
+		getFilteredSteps.mockReturnValue( {
+			'test:step1': { stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
+			'test:step2': { stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: false },
+		} );
+
 		const wrapper = shallow( <NavigationLink { ...props } direction="back" /> );
 
 		// It should call getStepUrl()
@@ -85,6 +93,9 @@ describe( 'NavigationLink', () => {
 
 		// when it is the first step
 		getStepUrl.mockReset();
+		getFilteredSteps.mockReturnValue( {
+			'test:step1': { stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
+		} );
 		wrapper.setProps( { stepName: 'test:step1' } ); // set the first step
 		expect( getStepUrl ).toHaveBeenCalled();
 		expect( getStepUrl ).toHaveBeenCalledWith( 'test:flow', null, '', 'en' );

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -80,10 +80,10 @@ describe( 'NavigationLink', () => {
 	test( 'should set a proper url as href prop when the direction is "back".', () => {
 		expect( getStepUrl ).not.toHaveBeenCalled();
 
-		getFilteredSteps.mockReturnValue( {
-			'test:step1': { stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
-			'test:step2': { stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: false },
-		} );
+		getFilteredSteps.mockReturnValue( [
+			{ stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
+			{ stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: false },
+		] );
 
 		const wrapper = shallow( <NavigationLink { ...props } direction="back" /> );
 
@@ -93,9 +93,9 @@ describe( 'NavigationLink', () => {
 
 		// when it is the first step
 		getStepUrl.mockReset();
-		getFilteredSteps.mockReturnValue( {
-			'test:step1': { stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
-		} );
+		getFilteredSteps.mockReturnValue( [
+			{ stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
+		] );
 		wrapper.setProps( { stepName: 'test:step1' } ); // set the first step
 		expect( getStepUrl ).toHaveBeenCalled();
 		expect( getStepUrl ).toHaveBeenCalledWith( 'test:flow', null, '', 'en' );

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -39,6 +39,10 @@ describe( 'NavigationLink', () => {
 		translate: str => `translated:${ str }`,
 	};
 
+	beforeEach( () => {
+		getFilteredSteps.mockReturnValue( Object.values( props.signupProgress ) );
+	} );
+
 	afterEach( () => {
 		getStepUrl.mockReset();
 		props.goToNextStep.mockReset();
@@ -79,11 +83,6 @@ describe( 'NavigationLink', () => {
 
 	test( 'should set a proper url as href prop when the direction is "back".', () => {
 		expect( getStepUrl ).not.toHaveBeenCalled();
-
-		getFilteredSteps.mockReturnValue( [
-			{ stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
-			{ stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: false },
-		] );
 
 		const wrapper = shallow( <NavigationLink { ...props } direction="back" /> );
 

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -95,9 +95,7 @@ describe( 'utils', () => {
 					} );
 
 					test( 'it should return only the step objects that match the flow', () => {
-						expect( result ).toContain( userStep );
-						expect( result ).toContain( siteTypeStep );
-						expect( result ).not.toContain( someOtherStep );
+						expect( result ).toEqual( [ userStep, siteTypeStep ] );
 					} );
 				} );
 

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -17,6 +17,7 @@ import {
 	getStepName,
 	getLocale,
 	getFlowName,
+	getFilteredSteps,
 } from '../utils';
 import flows from 'signup/config/flows';
 
@@ -69,6 +70,73 @@ describe( 'utils', () => {
 
 		test( 'should return the default flow if the flow is missing', () => {
 			expect( getFlowName( {} ) ).toBe( defaultFlowName );
+		} );
+	} );
+
+	describe( 'getFilteredSteps', () => {
+		describe( 'when the given flow is found in the config', () => {
+			const exampleFlowName = 'onboarding';
+
+			describe( 'when there are a number of steps in the progress state', () => {
+				describe( 'and some of them match that flow', () => {
+					const userStep = { stepName: 'user' };
+					const siteTypeStep = { stepName: 'site-type' };
+					const someOtherStep = { stepName: 'some-other-step' };
+					const exampleSteps = {
+						user: userStep,
+						'site-type': siteTypeStep,
+						'some-other-step': someOtherStep,
+					};
+
+					const result = getFilteredSteps( exampleFlowName, exampleSteps );
+
+					test( 'it returns an array', () => {
+						expect( Array.isArray( result ) ).toBe( true );
+					} );
+
+					test( 'it should return only the step objects that match the flow', () => {
+						expect( result ).toContain( userStep );
+						expect( result ).toContain( siteTypeStep );
+						expect( result ).not.toContain( someOtherStep );
+					} );
+				} );
+
+				describe( 'but none of them match that flow', () => {
+					const exampleSteps = {
+						'some-step': { stepName: 'some-step' },
+						'some-other-step': { stepName: 'some-other-step' },
+					};
+					const result = getFilteredSteps( exampleFlowName, exampleSteps );
+
+					test( 'it should return an empty array', () => {
+						expect( result ).toHaveLength( 0 );
+						expect( Array.isArray( result ) ).toBe( true );
+					} );
+				} );
+			} );
+
+			describe( 'when there are no steps in the progress state', () => {
+				const result = getFilteredSteps( exampleFlowName, {} );
+
+				test( 'it should return an empty array', () => {
+					expect( result ).toHaveLength( 0 );
+					expect( Array.isArray( result ) ).toBe( true );
+				} );
+			} );
+		} );
+
+		describe( 'when the given flow is not found in the config', () => {
+			const exampleFlowName = 'some-bad-flow';
+			const exampleSteps = {
+				user: { stepName: 'user' },
+				'site-type': { stepName: 'site-type' },
+			};
+			const result = getFilteredSteps( exampleFlowName, exampleSteps );
+
+			test( 'it should return an empty array', () => {
+				expect( result ).toHaveLength( 0 );
+				expect( Array.isArray( result ) ).toBe( true );
+			} );
 		} );
 	} );
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -3,7 +3,7 @@
  * Exernal dependencies
  */
 import cookie from 'cookie';
-import { filter, find, includes, indexOf, isEmpty, pick } from 'lodash';
+import { filter, find, includes, indexOf, isEmpty, pick, sortBy } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -177,7 +177,13 @@ export function getDesignTypeForSiteGoals( siteGoals, flow ) {
 
 export function getFilteredSteps( flowName, progress ) {
 	const flow = flows.getFlow( flowName );
-	return filter( progress, step => includes( flow.steps, step.stepName ) );
+
+	return sortBy(
+		// filter steps...
+		filter( progress, step => includes( flow.steps, step.stepName ) ),
+		// then order according to the flow definition...
+		( { stepName } ) => flow.steps.indexOf( stepName )
+	);
 }
 
 export function getFirstInvalidStep( flowName, progress ) {

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -178,6 +178,10 @@ export function getDesignTypeForSiteGoals( siteGoals, flow ) {
 export function getFilteredSteps( flowName, progress ) {
 	const flow = flows.getFlow( flowName );
 
+	if ( ! flow ) {
+		return [];
+	}
+
 	return sortBy(
 		// filter steps...
 		filter( progress, step => includes( flow.steps, step.stepName ) ),

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -40,6 +40,10 @@ const updateStep = ( state, newStepState ) => {
 	const { stepName, status } = newStepState;
 	const stepState = get( state, stepName );
 
+	if ( ! stepState ) {
+		return state;
+	}
+
 	debug( `Updating step ${ stepName }` );
 
 	if ( status === 'pending' || status === 'completed' ) {

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -3,132 +3,116 @@
 /**
  * External dependencies
  */
-import { get, find, map } from 'lodash';
+import { has, keyBy, get } from 'lodash';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import stepsConfig from 'signup/config/steps-pure';
-import flows from 'signup/config/flows-pure';
 import {
 	SIGNUP_COMPLETE_RESET,
 	SIGNUP_PROGRESS_COMPLETE_STEP,
 	SIGNUP_PROGRESS_INVALIDATE_STEP,
 	SIGNUP_PROGRESS_PROCESS_STEP,
-	SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
 	SIGNUP_PROGRESS_RESUME_AFTER_LOGIN_SET,
 	SIGNUP_PROGRESS_SAVE_STEP,
 	SIGNUP_PROGRESS_SUBMIT_STEP,
 } from 'state/action-types';
 import { createReducer } from 'state/utils';
 import { schema } from './schema';
-import userFactory from 'lib/user';
 
 const debug = debugFactory( 'calypso:state:signup:progress:reducer' );
 
 //
+// Helper Functions
+//
+const addStep = ( state, step ) => {
+	debug( `Adding step ${ step.stepName }` );
+
+	return {
+		...state,
+		[ step.stepName ]: step,
+	};
+};
+
+const updateStep = ( state, newStepState ) => {
+	const { stepName, status } = newStepState;
+	const stepState = get( state, stepName );
+
+	debug( `Updating step ${ stepName }` );
+
+	if ( status === 'pending' || status === 'completed' ) {
+		// This can only happen when submitting a step
+		//
+		// Steps that are resubmitted may decide to omit the `wasSkipped` status of a step if e.g.
+		// the user goes back and chooses to not skip a step. If a step is submitted without it,
+		// we explicitly remove it from the step data.
+		const { wasSkipped, ...commonStepArgs } = stepState;
+
+		return {
+			...state,
+			[ stepName ]: {
+				...commonStepArgs,
+				...newStepState,
+			},
+		};
+	}
+
+	return {
+		...state,
+		[ stepName ]: {
+			...stepState,
+			...newStepState,
+		},
+	};
+};
+
+//
 // Action handlers
 //
-function overwriteSteps( state, { steps = [] } ) {
-	// When called without action.steps, this is basically a state reset function.
-	return Array.isArray( steps ) ? steps : [];
-}
 
-function completeStep( state, { step } ) {
-	return updateStep( state, { ...step, status: 'completed' } );
-}
+// When called without action.steps, this is basically a state reset function.
+const overwriteSteps = ( state, { steps = {} } ) => keyBy( steps, 'stepName' );
 
-function invalidateStep( state, { step, errors } ) {
-	const newStep = { ...step, errors, status: 'invalid' };
-	if ( find( state, { stepName: newStep.stepName } ) ) {
-		return updateStep( state, newStep );
-	}
-	return addStep( state, newStep );
-}
+const completeStep = ( state, { step } ) => updateStep( state, { ...step, status: 'completed' } );
 
-function processStep( state, { step } ) {
-	return updateStep( state, { ...step, status: 'processing' } );
-}
+const invalidateStep = ( state, { step, errors } ) => {
+	const newStepState = { ...step, errors, status: 'invalid' };
 
-function removeUnneededSteps( state, { flowName } ) {
-	let flowSteps = [];
-	const user = userFactory();
+	return has( state, step.stepName )
+		? updateStep( state, newStepState )
+		: addStep( state, newStepState );
+};
 
-	flowSteps = get( flows, [ flowName, 'steps' ], [] );
+const processStep = ( state, { step } ) => updateStep( state, { ...step, status: 'processing' } );
 
-	if ( user && user.get() ) {
-		flowSteps = flowSteps.filter( item => item !== 'user' );
-	}
-
-	return state.filter( step => flowSteps.includes( step.stepName ) );
-}
-
-function saveStep( state, { step } ) {
-	if ( find( state, { stepName: step.stepName } ) ) {
-		return updateStep( state, step );
-	}
-
-	return addStep( state, { ...step, status: 'in-progress' } );
-}
+const saveStep = ( state, { step } ) =>
+	has( state, step.stepName )
+		? updateStep( state, step )
+		: addStep( state, { ...step, status: 'in-progress' } );
 
 function setResumeAfterLogin( state, { resumeStep } ) {
 	debug( `Setting resume after login for step ${ resumeStep.stepName }` );
 	return updateStep( state, { ...resumeStep, status: 'in-progress' } );
 }
 
-function submitStep( state, { step } ) {
+const submitStep = ( state, { step } ) => {
 	const stepHasApiRequestFunction = get( stepsConfig, [ step.stepName, 'apiRequestFunction' ] );
 	const status = stepHasApiRequestFunction ? 'pending' : 'completed';
 
-	if ( find( state, { stepName: step.stepName } ) ) {
-		return updateStep( state, { ...step, status } );
-	}
+	return has( state, step.stepName )
+		? updateStep( state, { ...step, status } )
+		: addStep( state, { ...step, status } );
+};
 
-	return addStep( state, { ...step, status } );
-}
-
-//
-// Helper Functions
-//
-function addStep( state, step ) {
-	debug( `Adding step ${ step.stepName }` );
-	return [ ...state, step ];
-}
-
-function updateStep( state, newStep ) {
-	debug( `Updating step ${ newStep.stepName }` );
-	return map( state, function( step ) {
-		if ( step.stepName === newStep.stepName ) {
-			const { status } = newStep;
-			if ( status === 'pending' || status === 'completed' ) {
-				// This can only happen when submitting a step
-				//
-				// Steps that are resubmitted may decide to omit the `wasSkipped` status of a step if e.g.
-				// the user goes back and chooses to not skip a step. If a step is submitted without it,
-				// we explicitly remove it from the step data.
-				const { wasSkipped, ...commonStepArgs } = step;
-				return { ...commonStepArgs, ...newStep };
-			}
-
-			return { ...step, ...newStep };
-		}
-
-		return step;
-	} );
-}
-
-//
-// Reducer export
-//
 export default createReducer(
-	[],
+	{},
 	{
 		[ SIGNUP_COMPLETE_RESET ]: overwriteSteps,
 		[ SIGNUP_PROGRESS_COMPLETE_STEP ]: completeStep,
 		[ SIGNUP_PROGRESS_INVALIDATE_STEP ]: invalidateStep,
 		[ SIGNUP_PROGRESS_PROCESS_STEP ]: processStep,
-		[ SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS ]: removeUnneededSteps,
 		[ SIGNUP_PROGRESS_RESUME_AFTER_LOGIN_SET ]: setResumeAfterLogin,
 		[ SIGNUP_PROGRESS_SAVE_STEP ]: saveStep,
 		[ SIGNUP_PROGRESS_SUBMIT_STEP ]: submitStep,

--- a/client/state/signup/progress/schema.js
+++ b/client/state/signup/progress/schema.js
@@ -1,19 +1,21 @@
 /** @format */
 export const schema = {
-	type: 'array',
-	items: {
-		type: 'object',
-		properties: {
-			formData: {
-				type: 'object',
-				properties: {
-					url: { type: 'string' },
+	type: 'object',
+	patternProperties: {
+		'^[w-]+$': {
+			type: 'object',
+			properties: {
+				formData: {
+					type: 'object',
+					properties: {
+						url: { type: 'string' },
+					},
 				},
+				lastUpdated: { type: 'number' },
+				// Valid status values: 'completed', 'processing', 'pending', 'in-progress' and 'invalid'
+				status: { type: 'string' },
+				stepName: { type: 'string' },
 			},
-			lastUpdated: { type: 'number' },
-			// Valid status values: 'completed', 'processing', 'pending', 'in-progress' and 'invalid'
-			status: { type: 'string' },
-			stepName: { type: 'string' },
 		},
 	},
 };

--- a/client/state/signup/progress/selectors.js
+++ b/client/state/signup/progress/selectors.js
@@ -6,7 +6,7 @@
 
 import { get } from 'lodash';
 
-const initialState = [];
+const initialState = {};
 export function getSignupProgress( state ) {
 	return get( state, 'signup.progress', initialState );
 }

--- a/client/state/signup/progress/test/reducer.js
+++ b/client/state/signup/progress/test/reducer.js
@@ -9,7 +9,6 @@ import {
 	SIGNUP_PROGRESS_COMPLETE_STEP,
 	SIGNUP_PROGRESS_INVALIDATE_STEP,
 	SIGNUP_PROGRESS_PROCESS_STEP,
-	SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
 	SIGNUP_PROGRESS_RESUME_AFTER_LOGIN_SET,
 	SIGNUP_PROGRESS_SAVE_STEP,
 	SIGNUP_PROGRESS_SUBMIT_STEP,
@@ -29,12 +28,12 @@ jest.mock( 'signup/config/steps-pure', () => ( {
 } ) );
 
 describe( 'reducer', () => {
-	test( 'should return an empty at first', () => {
-		expect( reducer( undefined, { type: 'init' } ) ).toHaveLength( 0 );
+	test( 'should return an empty object at first', () => {
+		expect( Object.keys( reducer( undefined, { type: 'init' } ) ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should store a new step', () => {
-		const initialState = [];
+		const initialState = {};
 		const action = {
 			type: SIGNUP_PROGRESS_SUBMIT_STEP,
 			step: {
@@ -43,52 +42,54 @@ describe( 'reducer', () => {
 			},
 		};
 		const finalState = reducer( initialState, action );
-		expect( finalState ).toHaveLength( 1 );
-		expect( finalState[ 0 ].stepName ).toBe( 'site-selection' );
+		expect( Object.keys( finalState ) ).toHaveLength( 1 );
+		expect( finalState[ 'site-selection' ].stepName ).toBe( 'site-selection' );
 	} );
 
 	test( 'should not store the same step twice', () => {
-		let state = [];
-
-		state = reducer( state, {
-			type: SIGNUP_PROGRESS_SUBMIT_STEP,
-			step: {
-				stepName: 'site-selection',
-				formData: { url: 'my-site.wordpress.com' },
+		const actions = [
+			{
+				type: SIGNUP_PROGRESS_SUBMIT_STEP,
+				step: {
+					stepName: 'site-selection',
+					formData: { url: 'my-site.wordpress.com' },
+				},
 			},
-		} );
-
-		state = reducer( state, {
-			type: SIGNUP_PROGRESS_SUBMIT_STEP,
-			step: {
-				stepName: 'site-selection',
+			{
+				type: SIGNUP_PROGRESS_SUBMIT_STEP,
+				step: {
+					stepName: 'site-selection',
+				},
 			},
-		} );
+		];
 
-		expect( state ).toHaveLength( 1 );
-		expect( state[ 0 ] ).toMatchObject( {
+		const state = actions.reduce( reducer, [] );
+
+		expect( Object.keys( state ) ).toHaveLength( 1 );
+		expect( state[ 'site-selection' ] ).toMatchObject( {
 			stepName: 'site-selection',
 			formData: { url: 'my-site.wordpress.com' },
 			status: 'completed',
 		} );
 	} );
 
-	test( 'should store multiple steps in order', () => {
-		let state = [];
+	test( 'should store multiple steps', () => {
+		const actions = [
+			{
+				type: SIGNUP_PROGRESS_SUBMIT_STEP,
+				step: { stepName: 'site-selection' },
+			},
+			{
+				type: SIGNUP_PROGRESS_SUBMIT_STEP,
+				step: { stepName: 'theme-selection' },
+			},
+		];
 
-		state = reducer( state, {
-			type: SIGNUP_PROGRESS_SUBMIT_STEP,
-			step: { stepName: 'site-selection' },
-		} );
+		const state = actions.reduce( reducer, [] );
 
-		state = reducer( state, {
-			type: SIGNUP_PROGRESS_SUBMIT_STEP,
-			step: { stepName: 'theme-selection' },
-		} );
-
-		expect( state ).toHaveLength( 2 );
-		expect( state[ 0 ].stepName ).toBe( 'site-selection' );
-		expect( state[ 1 ].stepName ).toBe( 'theme-selection' );
+		expect( Object.keys( state ) ).toHaveLength( 2 );
+		expect( state[ 'site-selection' ].stepName ).toBe( 'site-selection' );
+		expect( state[ 'theme-selection' ].stepName ).toBe( 'theme-selection' );
 	} );
 
 	test( 'should mark only new saved steps as in-progress', () => {
@@ -111,49 +112,49 @@ describe( 'reducer', () => {
 
 		const state = actions.reduce( reducer, [] );
 
-		expect( state[ 0 ].status ).not.toBe( 'in-progress' );
-		expect( state[ 1 ].status ).toBe( 'in-progress' );
+		expect( state[ 'site-selection' ].status ).not.toBe( 'in-progress' );
+		expect( state[ 'last-step' ].status ).toBe( 'in-progress' );
 	} );
 
 	test( 'should set the status of a signup step', () => {
-		let state = [];
+		let state = {};
 
 		state = reducer( state, {
 			type: SIGNUP_PROGRESS_SUBMIT_STEP,
 			step: { stepName: 'site-selection' },
 		} );
-		expect( state[ 0 ].status ).toBe( 'completed' );
+		expect( state[ 'site-selection' ].status ).toBe( 'completed' );
 
 		state = reducer( state, {
 			type: SIGNUP_PROGRESS_COMPLETE_STEP,
 			step: { stepName: 'site-selection' },
 		} );
-		expect( state[ 0 ].status ).toBe( 'completed' );
+		expect( state[ 'site-selection' ].status ).toBe( 'completed' );
 	} );
 
 	describe( 'setting and resetting the state', () => {
 		test( 'should handle resetting the state', () => {
-			const initialState = [ { test: 123 } ];
+			const initialState = { test: { test: 123 } };
 			const action = { type: SIGNUP_COMPLETE_RESET };
-			const finalState = [];
+			const finalState = {};
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 	} );
 
 	describe( 'completing a step', () => {
 		test( 'should mark the new step with the "completed" status', () => {
-			const initialState = [ { stepName: 'example', status: 'something' } ];
+			const initialState = { example: { stepName: 'example', status: 'something' } };
 			const action = {
 				type: SIGNUP_PROGRESS_COMPLETE_STEP,
 				step: { stepName: 'example', exampleValue: 'some value' },
 			};
-			const finalState = [
-				{ stepName: 'example', exampleValue: 'some value', status: 'completed' },
-			];
+			const finalState = {
+				example: { stepName: 'example', exampleValue: 'some value', status: 'completed' },
+			};
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 		test( 'should not add a new step if no steps match by name', () => {
-			const initialState = [ { stepName: 'example', status: 'something' } ];
+			const initialState = { example: { stepName: 'example', status: 'something' } };
 			const action = {
 				type: SIGNUP_PROGRESS_COMPLETE_STEP,
 				step: { stepName: 'differentName', exampleValue: 'some value' },
@@ -163,54 +164,72 @@ describe( 'reducer', () => {
 	} );
 
 	describe( 'invalidating a step', () => {
-		test( "should append a step with error data and 'invalid' status if the step's name is unique", () => {
-			const initialState = [ { stepName: 'whatever' } ];
+		test( "should add a step with error data and 'invalid' status if the step's name is unique", () => {
+			const initialState = { whatever: { stepName: 'whatever' } };
 			const action = {
 				type: SIGNUP_PROGRESS_INVALIDATE_STEP,
 				step: { stepName: 'something' },
 				errors: [ new Error( 'something' ) ],
 			};
-			const finalState = [
-				{ stepName: 'whatever' },
-				{ stepName: 'something', status: 'invalid', errors: [ new Error( 'something' ) ] },
-			];
+			const finalState = {
+				whatever: { stepName: 'whatever' },
+				something: {
+					stepName: 'something',
+					status: 'invalid',
+					errors: [ new Error( 'something' ) ],
+				},
+			};
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 
 		test( "should update a step with error data and 'invalid' status if the step's name is not unique", () => {
-			const initialState = [ { stepName: 'something' } ];
+			const initialState = {
+				something: {
+					stepName: 'something',
+				},
+			};
 			const action = {
 				type: SIGNUP_PROGRESS_INVALIDATE_STEP,
 				step: { stepName: 'something', value: 'example' },
 				errors: [ new Error( 'something' ) ],
 			};
-			const finalState = [
-				{
+			const finalState = {
+				something: {
 					errors: [ new Error( 'something' ) ],
 					status: 'invalid',
 					stepName: 'something',
 					value: 'example',
 				},
-			];
+			};
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 	} );
 
 	describe( 'processing a step', () => {
 		test( 'should update the step with a "processing" status', () => {
-			const initialState = [ { stepName: 'example', status: 'something' } ];
+			const initialState = {
+				example: {
+					stepName: 'example',
+					status: 'something',
+				},
+			};
 			const action = {
 				type: SIGNUP_PROGRESS_PROCESS_STEP,
 				step: { stepName: 'example', exampleValue: 'some value' },
 			};
-			const finalState = [
-				{ stepName: 'example', exampleValue: 'some value', status: 'processing' },
-			];
+			const finalState = {
+				example: { stepName: 'example', exampleValue: 'some value', status: 'processing' },
+			};
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 
 		test( 'should not add a new step if no steps match by name', () => {
-			const initialState = [ { stepName: 'example', status: 'something' } ];
+			const initialState = {
+				example: {
+					stepName: 'example',
+					status: 'something',
+				},
+			};
 			const action = {
 				type: SIGNUP_PROGRESS_PROCESS_STEP,
 				step: { stepName: 'differentName', exampleValue: 'some value' },
@@ -219,59 +238,42 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	describe( 'removing unneded steps', () => {
-		test( 'should remove steps that are not in the new flow', () => {
-			const initialState = [
-				{ stepName: 'something', value: 'great something' },
-				{ stepName: 'everything', value: 'great everything' },
-				{ stepName: 'nothing', value: 'great nothing' },
-				{ stepName: 'one', value: 'great one' },
-			];
-
-			const action = { type: SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS, flowName: 'new-flow' };
-
-			const finalState = [
-				{ stepName: 'something', value: 'great something' },
-				{ stepName: 'everything', value: 'great everything' },
-			];
-
-			expect( reducer( initialState, action ) ).toEqual( finalState );
-		} );
-	} );
-
 	describe( 'saving a step', () => {
 		describe( 'saving a new step', () => {
-			test( 'should append a new step to the state if step name is unique', () => {
-				const initialState = [ { stepName: 'whatever' } ];
+			test( 'should add a new step to the state if step name is unique', () => {
+				const initialState = { whatever: { stepName: 'whatever' } };
 				const action = {
 					type: SIGNUP_PROGRESS_SAVE_STEP,
 					step: { stepName: 'something' },
 				};
 				const state = reducer( initialState, action );
-				expect( state ).toHaveLength( 2 );
-				expect( state[ 1 ].stepName ).toEqual( 'something' );
+				expect( Object.keys( state ) ).toHaveLength( 2 );
+				expect( state.something ).toBeTruthy();
+				expect( state.whatever ).toBeTruthy();
 			} );
 			test( 'should mark the new step with an "in-progress" status', () => {
-				const initialState = [ { stepName: 'whatever' } ];
+				const initialState = { whatever: { stepName: 'whatever' } };
 				const action = {
 					type: SIGNUP_PROGRESS_SAVE_STEP,
 					step: { stepName: 'something' },
 				};
-				const finalState = [
-					{ stepName: 'whatever' },
-					{ stepName: 'something', status: 'in-progress' },
-				];
+				const finalState = {
+					whatever: { stepName: 'whatever' },
+					something: { stepName: 'something', status: 'in-progress' },
+				};
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 		} );
 		describe( 'saving an existing step', () => {
 			test( 'should update the existing step with the provided data', () => {
-				const initialState = [ { stepName: 'whatever', oldValue: 'example' } ];
+				const initialState = { whatever: { stepName: 'whatever', oldValue: 'example' } };
 				const action = {
 					type: SIGNUP_PROGRESS_SAVE_STEP,
 					step: { stepName: 'whatever', newValue: 'example' },
 				};
-				const finalState = [ { newValue: 'example', oldValue: 'example', stepName: 'whatever' } ];
+				const finalState = {
+					whatever: { newValue: 'example', oldValue: 'example', stepName: 'whatever' },
+				};
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 		} );
@@ -280,39 +282,43 @@ describe( 'reducer', () => {
 	describe( 'submitting a step', () => {
 		describe( 'saving a new step', () => {
 			test( 'should update the step with a "pending" status if the step has a corresponding API request function', () => {
-				const initialState = [ { stepName: 'some-step' } ];
+				const initialState = { 'some-step': { stepName: 'some-step' } };
 				const action = {
 					type: SIGNUP_PROGRESS_SUBMIT_STEP,
 					step: { stepName: 'stepWithAPI', updateValue: 'some value' },
 				};
-				const finalState = [
-					{ stepName: 'some-step' },
-					{ stepName: 'stepWithAPI', updateValue: 'some value', status: 'pending' },
-				];
+				const finalState = {
+					'some-step': { stepName: 'some-step' },
+					stepWithAPI: { stepName: 'stepWithAPI', updateValue: 'some value', status: 'pending' },
+				};
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 			test( 'should update the step with a "completed" status if the step does not have a corresponding API request function', () => {
-				const initialState = [ { stepName: 'some-step' } ];
+				const initialState = { 'some-step': { stepName: 'some-step' } };
 				const action = {
 					type: SIGNUP_PROGRESS_SUBMIT_STEP,
 					step: { stepName: 'stepWithoutAPI', updateValue: 'some value' },
 				};
-				const finalState = [
-					{ stepName: 'some-step' },
-					{ stepName: 'stepWithoutAPI', updateValue: 'some value', status: 'completed' },
-				];
+				const finalState = {
+					'some-step': { stepName: 'some-step' },
+					stepWithoutAPI: {
+						stepName: 'stepWithoutAPI',
+						updateValue: 'some value',
+						status: 'completed',
+					},
+				};
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 		} );
 		describe( 'saving an existing step', () => {
 			test( 'should update the step with a "pending" status if the step has a corresponding API request function', () => {
 				// It should also drop the wasSkipped value
-				const initialState = [
-					{
+				const initialState = {
+					stepWithAPI: {
 						stepName: 'stepWithAPI',
 						wasSkipped: true,
 					},
-				];
+				};
 				const action = {
 					type: SIGNUP_PROGRESS_SUBMIT_STEP,
 					step: {
@@ -320,26 +326,30 @@ describe( 'reducer', () => {
 						updateValue: 'some value',
 					},
 				};
-				const finalState = [
-					{ stepName: 'stepWithAPI', updateValue: 'some value', status: 'pending' },
-				];
+				const finalState = {
+					stepWithAPI: { stepName: 'stepWithAPI', updateValue: 'some value', status: 'pending' },
+				};
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 			test( 'should update the step with a "completed" status if the step does not have a corresponding API request function', () => {
 				// It should also drop the wasSkipped value
-				const initialState = [
-					{
+				const initialState = {
+					stepWithoutAPI: {
 						stepName: 'stepWithoutAPI',
 						wasSkipped: true,
 					},
-				];
+				};
 				const action = {
 					type: SIGNUP_PROGRESS_SUBMIT_STEP,
 					step: { stepName: 'stepWithoutAPI', updateValue: 'some value' },
 				};
-				const finalState = [
-					{ stepName: 'stepWithoutAPI', updateValue: 'some value', status: 'completed' },
-				];
+				const finalState = {
+					stepWithoutAPI: {
+						stepName: 'stepWithoutAPI',
+						updateValue: 'some value',
+						status: 'completed',
+					},
+				};
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 		} );
@@ -347,12 +357,12 @@ describe( 'reducer', () => {
 
 	describe( 'resuming a step', () => {
 		test( 'should update the step with an "in-progress" status', () => {
-			const initialState = [ { stepName: 'example', status: 'completed' } ];
+			const initialState = { example: { stepName: 'example', status: 'completed' } };
 			const action = {
 				type: SIGNUP_PROGRESS_RESUME_AFTER_LOGIN_SET,
 				resumeStep: { stepName: 'example' },
 			};
-			const finalState = [ { stepName: 'example', status: 'in-progress' } ];
+			const finalState = { example: { stepName: 'example', status: 'in-progress' } };
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 	} );

--- a/client/state/signup/progress/test/selectors.js
+++ b/client/state/signup/progress/test/selectors.js
@@ -11,27 +11,20 @@ import { expect } from 'chai';
 import { getSignupProgress } from '../selectors';
 
 describe( 'selectors', () => {
-	test( 'should return empty array as a default state', () => {
+	test( 'should return empty, plain object as a default state', () => {
 		const state = { signup: undefined };
-		expect( getSignupProgress( state, [] ) ).to.be.eql( [] );
+		expect( getSignupProgress( state ) ).to.be.eql( {} );
 	} );
 
-	test( 'should return signupDependencyStore instance from the state', () => {
-		const state = {
-			signup: {
-				progress: [
-					{
-						status: 'completed',
-						stepName: 'site-selection',
-					},
-				],
-			},
-		};
-		expect( getSignupProgress( state, [] ) ).to.be.eql( [
-			{
+	test( 'should select progress from the state', () => {
+		const progress = {
+			'site-selection': {
 				status: 'completed',
 				stepName: 'site-selection',
 			},
-		] );
+		};
+		const state = { signup: { progress } };
+
+		expect( getSignupProgress( state ) ).to.be.eql( progress );
 	} );
 } );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -383,12 +383,12 @@ describe( 'initial-state', () => {
 							siteType: 'blog',
 							siteTitle: 'Logged out test title',
 						},
-						progress: [
-							{
+						progress: {
+							'logged-out-step': {
 								stepName: 'logged-out-step',
 								status: 'completed',
 							},
-						],
+						},
 						_timestamp,
 					},
 				};
@@ -440,12 +440,12 @@ describe( 'initial-state', () => {
 							siteType: 'blog',
 							siteTitle: 'Logged in test title',
 						},
-						progress: [
-							{
+						progress: {
+							'logged-in-step': {
 								stepName: 'logged-in-step',
 								status: 'completed',
 							},
-						],
+						},
 						_timestamp,
 					},
 					'redux-state-logged-out:signup': {
@@ -453,12 +453,12 @@ describe( 'initial-state', () => {
 							siteType: 'blog',
 							siteTitle: 'Logged out test title',
 						},
-						progress: [
-							{
+						progress: {
+							'logged-out-step': {
 								stepName: 'logged-out-step',
 								status: 'completed',
 							},
-						],
+						},
 						_timestamp,
 					},
 				};


### PR DESCRIPTION
> ~Note: This should be landed after #34770 is landed to avoid conflicts~

#### Changes proposed in this Pull Request

* Convert the signup progress store from an ordered array to an object, keyed by the names of the steps progressed.
* Access the relevant progress state according to the current flow.

#### Some notes:

Rather than the progress state being an exact representation of the steps currently progressed in the current flow, this approach attempts to make the progress store a collection of any steps that have been progressed during the signup journey.
Currently, when we switch flow we have to run logic on the progress store in an attempt to remove steps that are no longer needed, which is hard to do accurately and is causing bugs. It also means that we'd eagerly get rid of a step's progress if it didn't apply to the incoming flow, though it might become relevant again if the customer were to change their mind and switch back to that original flow. In this new approach we would hold on to the progress of every step that the customer has seen, regardless of its present usefulness and wouldn't need to attempt to keep the progress in sync with the flows.
In order to display the `3 out of 6 steps` information we just use the list of step names provided by the flow definition and match up the relevant steps found in the progress store. 

There are a few more notes over at #34885 (superseded by this PR) 

#### Testing instructions

**Testing user step last A/B test behaviour**
- Please follow the test instructions found in #34770 - whether that PR is landed yet the behaviour should remain the same as described there.
- More test instructions to come soon...




Fixes #32506
