### PR TITLE
FSE: Fix empty Navigation Block on sites created with an empty menu

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -1,26 +1,36 @@
 <?php
 /**
- * Render navigation menus.
+ * Render navigation menu block file
  *
  * @package full-site-editing
  */
-function a8c_fse_render_navigation_menu_block( $attributes ) {
+
+/**
+ * Render the navigation menu.
+ *
+ * @return string
+ */
+function a8c_fse_render_navigation_menu_block() {
+	$menu = wp_nav_menu(
+		[
+			'echo'           => false,
+			'menu_class'     => 'main-menu',
+			'fallback_cb'    => 'a8c_fse_get_fallback_navigation_menu',
+			'theme_location' => 'menu-1',
+		]
+	);
+
 	ob_start();
-	// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralText
+	// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 	?>
 	<nav class="main-navigation wp-block-a8c-navigation-menu">
 		<div class="menu-nav-container">
-			<?php
-			echo wp_nav_menu([
-				'theme_location' => 'menu-1',
-				'menu_class'     => 'main-menu',
-				'fallback_cb' => 'a8c_fse_get_fallback_navigation_menu'
-			]);
-			?>
+			<?php echo $menu ? $menu : a8c_fse_get_fallback_navigation_menu(); ?>
 		</div>
 	</nav>
 	<!-- #site-navigation -->
 	<?php
+	// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
 	return ob_get_clean();
 }
 
@@ -28,24 +38,26 @@ function a8c_fse_render_navigation_menu_block( $attributes ) {
  * Render a list of all site pages as a fallback
  * for when a menu does not exist.
  *
- * @package full-site-editing
+ * @return string
  */
 function a8c_fse_get_fallback_navigation_menu() {
-	$menu = wp_page_menu([
-		'echo' => 0,
-		'sort_column' => 'post_date',
-		'container' => 'ul',
-		'menu_class' => 'main-menu default-menu',
-		'before' => false,
-		'after' => false
-	]);
+	$menu = wp_page_menu(
+		[
+			'after'       => false,
+			'before'      => false,
+			'container'   => 'ul',
+			'echo'        => false,
+			'menu_class'  => 'main-menu default-menu',
+			'sort_column' => 'post_date',
+		]
+	);
 
 	/**
 	 * Filter the fallback page menu to use the same
 	 * CSS class structure as a regularly built menu
 	 * so we don't have to duplicate CSS selectors everywhere.
 	 */
-	$original_classes = [ 'children', 'page_item_has_sub-menu' ];
+	$original_classes    = [ 'children', 'page_item_has_sub-menu' ];
 	$replacement_classes = [ 'sub-menu', 'menu-item-has-children' ];
 
 	return str_replace( $original_classes, $replacement_classes, $menu );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a secondary fallback to `wp_nav_menu` in the Navigation block's server side rendering to prevent displaying an empty block when the requested menu is empty.

We were relying on the `fallback_cb` option to display a default menu when `wp_nav_menu` failed to return one.
As it turns out, the callback is only called if no menu was found, or if the menu is empty **and the theme location is not specified** (see https://core.trac.wordpress.org/browser/tags/5.2/src/wp-includes/nav-menu-template.php#L144).
We do specify it (`menu-1`), and so, when a site is created with an existing but empty menu in `menu-1`, `wp_nav_menu` bailed silently without calling the fallback.

_Sorry for the very dirty diff, but I had to do some changes to clear PHPCS._

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new simple site on a Business vertical and selecting the Modern Business theme.
* Add the `full-site-editing` sticker to the site`.
* Sandbox the site and the API.
* Paste the file modified in this PR on top of the `wp-content/plugins/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php` in the sandbox.
* Edit a page, and make sure the menu is displayed in the template parts.
* Edit a template part, and make sure the menu is displayed there as well.

Fixes #34853