### PR TITLE
Promo Section: Make external links open in a new tab

### DIFF
--- a/client/components/promo-section/promo-card/cta.tsx
+++ b/client/components/promo-section/promo-card/cta.tsx
@@ -64,6 +64,9 @@ function buttonProps( button: CtaButton, isPrimary: boolean ) {
 		: {
 				[ typeof button.action === 'string' ? 'href' : 'onClick' ]: button.action,
 		  };
+	if ( undefined !== actionProps.href ) {
+		actionProps.target = '_blank';
+	}
 	return {
 		className: 'promo-card__cta-button',
 		primary: isPrimary,
@@ -85,9 +88,11 @@ const PromoCardCta: FunctionComponent< Props & ConnectedProps > = ( {
 		learnMore = isCtaAction( learnMoreLink )
 			? {
 					href: learnMoreLink.url,
+					target: '_blank',
 					onClick: learnMoreLink.onClick,
 			  }
 			: {
+					target: '_blank',
 					href: learnMoreLink,
 			  };
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change adds a `target="_blank"` property to any CTA action that is
defined with a URL or href, rather than a callback function. It's
assumed that these actions are external links.

#### Testing instructions

On the new earn page click on some of the links like 'Learn More' and check they open in a new tab.