### PR TITLE
Marketing Tools: Refactor to use new components

### DIFF
--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -11,7 +11,7 @@ import { TranslateResult } from 'i18n-calypso';
 import PromoCard, { Props as PromoCardProps } from './promo-card';
 import PromoCardCta, { Props as PromoCardCtaProps } from './promo-card/cta';
 
-interface PromoSectionCardProps extends PromoCardProps {
+export interface PromoSectionCardProps extends PromoCardProps {
 	body: string | TranslateResult;
 	actions?: PromoCardCtaProps;
 }

--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, ReactNode, isValidElement } from 'react';
 import { get } from 'lodash';
 
 /**
@@ -13,7 +13,7 @@ import PromoCardCta, { Props as PromoCardCtaProps } from './promo-card/cta';
 
 export interface PromoSectionCardProps extends PromoCardProps {
 	body: string | TranslateResult;
-	actions?: PromoCardCtaProps;
+	actions?: PromoCardCtaProps | ReactNode;
 }
 
 export interface Props {
@@ -34,11 +34,13 @@ const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 	actions,
 } ) => {
 	const cta = get( actions, 'cta', null );
+	const ctaNode = ! cta && isValidElement( actions ) ? actions : null;
 	const learnMoreLink = get( actions, 'learnMoreLink', null );
 	return (
 		<PromoCard isPrimary={ !! isPrimary } title={ title } image={ image }>
 			<p>{ body }</p>
 			{ cta && <PromoCardCta cta={ cta } learnMoreLink={ learnMoreLink } /> }
+			{ ctaNode }
 		</PromoCard>
 	);
 };

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -37,9 +37,6 @@
 				flex-grow: 0;
 			}
 		}
-
-
-		background-color: var( --color-primary-0 );
 	}
 
 	.action-panel__cta {

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -90,7 +90,7 @@
 		}
 		img {
 			margin: 0 20px 0 0;
-	    width: 64px;
+			width: 64px;
 		}
 	}
 }

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -77,6 +77,24 @@
 	}
 }
 
+.is-section-marketing {
+	.promo-card:not( .is-primary ) {
+		.action-panel__cta {
+			padding-top: 0;
+		}
+		.action-panel__figure {
+			max-width: 64px;
+		}
+		.action-panel__body p {
+			flex-grow: 0;
+		}
+		img {
+			margin: 0 20px 0 0;
+	    width: 64px;
+		}
+	}
+}
+
 .sharing-settings {
 	// labels, checkboxes, radio
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -19,6 +19,11 @@ import { marketingConnections, marketingTraffic } from 'my-sites/marketing/paths
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
 
+import PromoSection, {
+	Props as PromoSectionProps,
+	PromoSectionCardProps,
+} from 'components/promo-section';
+
 /**
  * Types
  */
@@ -60,9 +65,50 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 		page( marketingConnections( selectedSiteSlug ) );
 	};
 
+	const getLogoCard = (): PromoSectionCardProps => {
+		return {
+			title: translate( 'Want to build a great brand? Start with a great logo' ),
+			body: translate(
+				"A custom logo helps your brand pop and makes your site memorable. Our partner Looka is standing by if you'd like some professional help."
+			),
+			image: {
+				path: '/calypso/images/marketing/looka-logo.svg',
+			},
+			actions: {
+				cta: {
+					text: translate( 'Create A Logo' ),
+					action: {
+						url: 'http://logojoy.grsm.io/looka',
+						onClick: handleCreateALogoClick,
+					},
+				},
+			},
+		};
+	};
+
+	const promos: PromoSectionProps = {
+		header: {
+			title: translate( 'Drive more traffic to your site with better SEO' ),
+			body: translate(
+				"Optimize your site for search engines and get more exposure for your business. Let's make the most of your site's built-in SEO tools!"
+			),
+			image: {
+				path: '/calypso/images/illustrations/illustration-404.svg',
+			},
+			actions: {
+				cta: {
+					text: translate( 'Boost My Traffic' ),
+					action: handleBoostMyTrafficClick,
+				},
+			},
+		},
+		promos: [ getLogoCard() ],
+	};
+
 	return (
 		<Fragment>
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
+			<PromoSection { ...promos } />
 
 			<MarketingToolsHeader handleButtonClick={ handleBoostMyTrafficClick } />
 

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -23,17 +23,9 @@ import QueryKeyringServices from 'components/data/query-keyring-services';
 import QuerySiteKeyrings from 'components/data/query-site-keyrings';
 import QuerySiteVouchers from 'components/data/query-site-vouchers';
 import GoogleVoucherDetails from 'my-sites/checkout/checkout-thank-you/google-voucher';
-
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { recordTracksEvent as recordTracksEventAction } from 'state/analytics/actions';
-
-import Button from 'components/button';
-import MarketingToolsGoogleAdwordsFeature from './google-adwords';
-import MarketingToolsFeature from './feature';
-import MarketingToolsGoogleMyBusinessFeature from './google-my-business-feature';
-import MarketingToolsHeader from './header';
 import { marketingConnections, marketingTraffic } from 'my-sites/marketing/paths';
-
 import PromoSection, {
 	Props as PromoSectionProps,
 	PromoSectionCardProps,
@@ -274,60 +266,6 @@ export const MarketingTools: FunctionComponent< Props > = ( {
 
 			<PageViewTracker path="/marketing/tools/:site" title="Marketing > Tools" />
 			<PromoSection { ...promos } />
-
-			<MarketingToolsHeader handleButtonClick={ handleBoostMyTrafficClick } />
-
-			<div className="tools__feature-list">
-				<MarketingToolsFeature
-					title={ translate( 'Want to build a great brand? Start with a great logo' ) }
-					description={ translate(
-						"A custom logo helps your brand pop and makes your site memorable. Our partner Looka is standing by if you'd like some professional help."
-					) }
-					imagePath="/calypso/images/marketing/looka-logo.svg"
-				>
-					<Button
-						compact
-						onClick={ handleCreateALogoClick }
-						href="http://logojoy.grsm.io/looka"
-						target="_blank"
-					>
-						{ translate( 'Create A Logo' ) }
-					</Button>
-				</MarketingToolsFeature>
-
-				<MarketingToolsFeature
-					title={ translate( 'Get social, and share your blog posts where the people are' ) }
-					description={ translate(
-						"Use your site's Publicize tools to connect your site and your social media accounts, and share your new posts automatically. Connect to Twitter, Facebook, LinkedIn, and more."
-					) }
-					imagePath="/calypso/images/marketing/social-media-logos.svg"
-				>
-					<Button compact onClick={ handleStartSharingClick }>
-						{ translate( 'Start Sharing' ) }
-					</Button>
-				</MarketingToolsFeature>
-
-				<MarketingToolsGoogleMyBusinessFeature />
-
-				<MarketingToolsGoogleAdwordsFeature />
-
-				<MarketingToolsFeature
-					title={ translate( 'Need an expert to help realize your vision? Hire one!' ) }
-					description={ translate(
-						"We've partnered with Upwork, a network of freelancers with a huge pool of WordPress experts. Hire a pro to help build your dream site."
-					) }
-					imagePath="/calypso/images/marketing/upwork-logo.png"
-				>
-					<Button
-						compact
-						onClick={ handleFindYourExpertClick }
-						href={ '/experts/upwork?source=marketingtools' }
-						target="_blank"
-					>
-						{ translate( 'Find Your Expert' ) }
-					</Button>
-				</MarketingToolsFeature>
-			</div>
 		</Fragment>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change updates the marketing tools page to use the new components created for the earn page.

#### Testing instructions

Use calypso.live and go to `/marketing/tools`. ~~Currently, both versions are shown on the page for comparison and the CSS needs updating.~~ This has been updated so the PR is ready for review. The styling has changed slightly, but is in line with the new `/earn/` section, which also uses the same pattern.

The focus now (alongside the usual code checks) would be to ensure that the functionality remains the same at that the styling changes are acceptable.

Fixes #34531 
