### PR TITLE
Checkout: Update styles for checkout processing screen

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -307,3 +307,297 @@
 		width: 340px;
 	}
 }
+
+/* Gridicon Floaties */
+@keyframes floating {
+	0% {
+		opacity: 0;
+		transform: scale( 0.8 ) translateY( 0 ) translateX( 0 ) rotate( 0 );
+	}
+	70% {
+		opacity: 1;
+		transform: scale( 1 ) translateY( 30px ) translateX( 30px ) rotate( -20deg );
+	}
+	100% {
+		opacity: 0;
+		transform: scale( 0.8 ) translateY( 0 ) translateX( 0 ) rotate( 0 );
+	}
+}
+
+@keyframes focus {
+	0%,
+	100% {
+		opacity: 0.1;
+		filter: blur( 1px );
+	}
+	70% {
+		opacity: 0.2;
+		filter: blur( 4px );
+	}
+}
+
+.checkout-processing-screen__floaties {
+	pointer-events: none;
+	position: fixed;
+	top: 40px;
+	right: 0;
+	bottom: 0;
+	max-height: calc( 100vw - 30px );
+	opacity: 0.1;
+	animation: focus 5s infinite ease-in-out;
+
+	@include breakpoint( '>660px' ) {
+		left: 0;
+	}
+
+	@include breakpoint( '<660px' ) {
+		transform: scale( 0.8 );
+		left: 130px;
+		top: -120px;
+	}
+
+	@include breakpoint( '>960px' ) {
+		transform: scale( 1.2 );
+	}
+
+	@include breakpoint( '>1040px' ) {
+		transform: scale( 1.5 );
+	}
+
+	.gridicon {
+		fill: var( --color-text-subtle );
+		position: absolute;
+		height: auto;
+		width: auto;
+		opacity: 0;
+		transform: scale( 0.8 );
+		animation: floating 10s infinite ease-in-out;
+	}
+	.gridicons-add {
+		top: 0;
+		left: calc( 50% - 320px );
+		height: 150px;
+		width: 150px;
+	}
+	.gridicons-aside {
+		top: 150px;
+		left: calc( 50% + 310px );
+		height: 70px;
+		width: 70px;
+		animation-delay: 6s;
+	}
+	.gridicons-attachment {
+		height: 60px;
+		width: 60px;
+		top: 70px;
+		left: calc( 50% + 220px );
+		animation-delay: 7s;
+	}
+	.gridicons-audio {
+		height: 80px;
+		width: 80px;
+		top: 170px;
+		left: calc( 50% - 220px );
+		transform: rotate( -30deg );
+		animation-delay: 6s;
+	}
+	.gridicons-bell {
+		height: 120px;
+		width: 120px;
+		top: 10px;
+		left: calc( 50% + 290px );
+		animation-delay: 10s;
+	}
+	.gridicons-book {
+		top: 340px;
+		left: calc( 50% - 300px );
+		height: 100px;
+		width: 100px;
+		animation-delay: 1s;
+	}
+	.gridicons-camera {
+		top: 300px;
+		left: calc( 50% + 200px );
+		height: 160px;
+		width: 160px;
+		transform: rotate( -10deg );
+		animation-delay: 3s;
+	}
+	.gridicons-comment {
+		left: calc( 50% + 130px );
+		top: 167px;
+		height: 140px;
+		width: 140px;
+		transform: rotate( 12deg );
+	}
+	.gridicons-globe {
+		height: 100px;
+		width: 100px;
+		top: 220px;
+		left: calc( 50% - 330px );
+		animation-delay: 3s;
+	}
+	.gridicons-pencil {
+		height: 220px;
+		width: 220px;
+		top: -110px;
+		left: calc( 50% + 110px );
+		animation-delay: 1s;
+	}
+	.gridicons-phone {
+		height: 80px;
+		width: 80px;
+		top: 130px;
+		left: calc( 50% - 390px );
+		animation-delay: 6s;
+	}
+	.gridicons-reader {
+		height: 130px;
+		width: 130px;
+		top: 360px;
+		left: calc( 50% - 170px );
+		transform: rotate( 12deg );
+		animation-delay: 8s;
+	}
+	.gridicons-star {
+		height: 90px;
+		width: 90px;
+		top: 380px;
+		left: calc( 50% + 60px );
+	}
+	.gridicons-video {
+		top: 245px;
+		left: calc( 50% - 160px );
+		animation-delay: 3s;
+	}
+	.gridicons-align-image-right {
+		top: 280px;
+		left: calc( 50% + 90px );
+		animation-delay: 7s;
+	}
+	.gridicons-bookmark {
+		top: 460px;
+		height: 110px;
+		width: 110px;
+		left: calc( 50% - 440px );
+		animation-delay: 5s;
+	}
+	.gridicons-briefcase {
+		top: 320px;
+		height: 80px;
+		width: 80px;
+		left: calc( 50% - 450px );
+		animation-delay: 1s;
+	}
+	.gridicons-calendar {
+		top: 460px;
+		left: calc( 50% + 300px );
+		height: 80px;
+		width: 80px;
+		animation-delay: 2s;
+	}
+	.gridicons-clipboard {
+		top: 240px;
+		left: calc( 50% + 290px );
+		height: 50px;
+		animation-delay: 6s;
+	}
+	.gridicons-cloud-upload {
+		top: 180px;
+		left: calc( 50% - 280px );
+		height: 40px;
+		width: 40px;
+		animation-delay: 5s;
+	}
+	.gridicons-cog {
+		top: 110px;
+		left: calc( 50% + 160px );
+		height: 40px;
+		width: 40px;
+		animation-delay: 1s;
+	}
+	.gridicons-customize {
+		top: 240px;
+		height: 40px;
+		width: 40px;
+		left: calc( 50% - 400px );
+		animation-delay: 1s;
+	}
+	.gridicons-help {
+		top: 460px;
+		left: calc( 50% + 160px );
+		height: 90px;
+		width: 90px;
+		animation-delay: 1s;
+	}
+	.gridicons-link {
+		top: 60px;
+		left: calc( 50% - 160px );
+		height: 50px;
+		width: 50px;
+		transform: rotate( -45deg );
+		animation-delay: 5s;
+	}
+	.gridicons-lock {
+		top: 60px;
+		left: calc( 50% - 400px );
+		height: 50px;
+		width: 50px;
+		animation-delay: 6s;
+	}
+	.gridicons-pages {
+		top: 70px;
+		left: calc( 50% + 70px );
+		height: 50px;
+		width: 50px;
+		animation-delay: 8s;
+	}
+	.gridicons-share {
+		top: 280px;
+		left: calc( 50% + 360px );
+		animation-delay: 2s;
+	}
+	.gridicons-stats {
+		top: 470px;
+		left: calc( 50% - 270px );
+		height: 80px;
+		width: 80px;
+		animation-delay: 9s;
+	}
+}
+
+.checkout-processing-screen__content {
+	position: relative;
+	z-index: 1;
+	max-width: 500px;
+	margin: 0 auto;
+	padding-bottom: 30px;
+	color: var( --color-white );
+}
+
+/* Title */
+@keyframes fade-in {
+	0% {
+		transform: translateY( 0 );
+		opacity: 0;
+	}
+	100% {
+		transform: translateY( -80px );
+		opacity: 1;
+	}
+}
+
+.checkout-thank-you__wordpress-logo {
+	height: 180px;
+	width: 180px;
+	fill: var( --color-text-subtle );
+	margin: 0 auto;
+	display: block;
+	transition: transform 0.8s cubic-bezier( 0.075, 0.82, 0.165, 1 );
+	transform: scale( 0.13333 );
+	transform-origin: 50% 0;
+
+	&.is-large {
+		transform: scale( 1 );
+	}
+}

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -336,7 +336,7 @@
 	}
 }
 
-.checkout-processing-screen__floaties {
+.checkout-thank-you__floaties {
 	pointer-events: none;
 	position: fixed;
 	top: 40px;
@@ -587,12 +587,13 @@
 	}
 }
 
-.checkout-thank-you .empty-content__title {
+.is-section-checkout-thank-you .empty-content__title {
 	font-size: 20px;
 	font-weight: normal;
 }
 
-.checkout-thank-you .empty-content__line {
+.is-section-checkout-thank-you .empty-content__line {
+	font-size: 16px;
 	font-weight: normal;
 }
 

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -587,10 +587,19 @@
 	}
 }
 
+.checkout-thank-you .empty-content__title {
+	font-size: 20px;
+	font-weight: normal;
+}
+
+.checkout-thank-you .empty-content__line {
+	font-weight: normal;
+}
+
 .checkout-thank-you__wordpress-logo {
 	height: 180px;
 	width: 180px;
-	fill: var( --color-text-subtle );
+	fill: var( --color-accent );
 	margin: 0 auto;
 	display: block;
 	transition: transform 0.8s cubic-bezier( 0.075, 0.82, 0.165, 1 );

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -600,7 +600,7 @@
 .checkout-thank-you__wordpress-logo {
 	height: 180px;
 	width: 180px;
-	fill: var( --color-accent );
+	fill: var( --color-primary );
 	margin: 0 auto;
 	display: block;
 	transition: transform 0.8s cubic-bezier( 0.075, 0.82, 0.165, 1 );

--- a/client/my-sites/checkout/checkout-thank-you/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/style.scss
@@ -600,7 +600,7 @@
 .checkout-thank-you__wordpress-logo {
 	height: 180px;
 	width: 180px;
-	fill: var( --color-primary );
+	fill: var( --color-wpcom );
 	margin: 0 auto;
 	display: block;
 	transition: transform 0.8s cubic-bezier( 0.075, 0.82, 0.165, 1 );

--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
@@ -9,6 +9,7 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { identity } from 'lodash';
+import Gridicon from 'gridicons';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { getSiteSlug } from 'state/sites/selectors';
 import getAtomicTransfer from 'state/selectors/get-atomic-transfer';
 import { transferStates } from 'state/atomic-transfer/constants';
+import WordPressLogo from 'components/wordpress-logo';
 
 class TransferPending extends PureComponent {
 	static propTypes = {
@@ -70,11 +72,50 @@ class TransferPending extends PureComponent {
 		}
 	}
 
+	renderFloaties() {
+		// Non standard gridicon sizes are used here because we display giant, floating icons on the page with an animation
+		/* eslint-disable wpcalypso/jsx-gridicon-size, wpcalypso/jsx-classname-namespace */
+		return (
+			<div className="checkout-processing-screen__floaties">
+				<Gridicon icon="add" size={ 64 } />
+				<Gridicon icon="aside" size={ 64 } />
+				<Gridicon icon="attachment" size={ 64 } />
+				<Gridicon icon="audio" size={ 64 } />
+				<Gridicon icon="bell" size={ 64 } />
+				<Gridicon icon="book" size={ 64 } />
+				<Gridicon icon="camera" size={ 64 } />
+				<Gridicon icon="comment" size={ 64 } />
+				<Gridicon icon="globe" size={ 64 } />
+				<Gridicon icon="pencil" size={ 64 } />
+				<Gridicon icon="phone" size={ 64 } />
+				<Gridicon icon="reader" size={ 64 } />
+				<Gridicon icon="star" size={ 64 } />
+				<Gridicon icon="video" size={ 64 } />
+				<Gridicon icon="align-image-right" size={ 64 } />
+				<Gridicon icon="bookmark" size={ 64 } />
+				<Gridicon icon="briefcase" size={ 64 } />
+				<Gridicon icon="calendar" size={ 64 } />
+				<Gridicon icon="clipboard" size={ 64 } />
+				<Gridicon icon="cloud-upload" size={ 64 } />
+				<Gridicon icon="cog" size={ 64 } />
+				<Gridicon icon="customize" size={ 64 } />
+				<Gridicon icon="help" size={ 64 } />
+				<Gridicon icon="link" size={ 64 } />
+				<Gridicon icon="lock" size={ 64 } />
+				<Gridicon icon="pages" size={ 64 } />
+				<Gridicon icon="share" size={ 64 } />
+				<Gridicon icon="stats" size={ 64 } />
+			</div>
+		);
+		/* eslint-enable wpcalypso/jsx-gridicon-size, wpcalypso/jsx-classname-namespace */
+	}
+
 	render() {
 		const { siteSlug, translate } = this.props;
 
 		return (
 			<Main className="checkout-thank-you__transfer-pending">
+				{ this.renderFloaties() }
 				<PageViewTracker
 					path={
 						siteSlug
@@ -84,9 +125,9 @@ class TransferPending extends PureComponent {
 					title="Checkout Pending"
 					properties={ siteSlug && { site: siteSlug } }
 				/>
+				<WordPressLogo size={ 180 } className="checkout-thank-you__wordpress-logo is-large" />
 				<EmptyContent
-					illustration={ '/calypso/images/illustrations/illustration-shopping-bags.svg' }
-					illustrationWidth={ 500 }
+					illustration={ false }
 					title={ translate( 'Processing…' ) }
 					line={ translate( "Almost there – we're currently finalizing your order." ) }
 				/>

--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
@@ -76,7 +76,7 @@ class TransferPending extends PureComponent {
 		// Non standard gridicon sizes are used here because we display giant, floating icons on the page with an animation
 		/* eslint-disable wpcalypso/jsx-gridicon-size, wpcalypso/jsx-classname-namespace */
 		return (
-			<div className="checkout-processing-screen__floaties">
+			<div className="checkout-thank-you__floaties">
 				<Gridicon icon="add" size={ 64 } />
 				<Gridicon icon="aside" size={ 64 } />
 				<Gridicon icon="attachment" size={ 64 } />

--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending.jsx
@@ -9,7 +9,7 @@ import React, { PureComponent } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { identity } from 'lodash';
-import Gridicon from 'gridicons';
+import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
@@ -127,7 +127,7 @@ class TransferPending extends PureComponent {
 				/>
 				<WordPressLogo size={ 180 } className="checkout-thank-you__wordpress-logo is-large" />
 				<EmptyContent
-					illustration={ false }
+					illustration={ '' }
 					title={ translate( 'Processing…' ) }
 					line={ translate( "Almost there – we're currently finalizing your order." ) }
 				/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the processing screen at checkout to look and behave more like the one from signup.
* Adds floating/fading icons and replaces the illustration with the WP logo.
* Updated colors, font sizes, and weights to match [Muriel guidelines](https://murieldesignsystem.blog/design/typography).

**Before**

<img width="771" alt="57728224-67fc3d00-7661-11e9-8fba-696808523afe" src="https://user-images.githubusercontent.com/2124984/62308594-9cf38100-b453-11e9-830d-8f3fda5996cc.png">

**After**

<img width="1280" alt="Screen Shot 2019-08-01 at 12 44 01 PM" src="https://user-images.githubusercontent.com/2124984/62311565-12fae680-b45a-11e9-8b27-b2a97f6365fa.png">

#### Testing instructions

* Switch to this PR, navigate to `/start`
* Sign up for a site with an eCommerce plan
* Check out with free credits
* Note the processing screen changes

Fixes #33037