### PR TITLE
Private Site: Enable Private option for Atomic

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -37,6 +37,7 @@ import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { isJetpackSite, isCurrentPlanPaid } from 'state/sites/selectors';
+import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
 import scrollTo from 'lib/scroll-to';
@@ -293,9 +294,13 @@ export class SiteSettingsFormGeneral extends Component {
 			handleRadio,
 			isRequestingSettings,
 			eventTracker,
+			siteIsAtomic,
 			siteIsJetpack,
 			translate,
 		} = this.props;
+
+		const showPrivateSiteOption =
+			! siteIsJetpack || siteIsAtomic || config.isEnabled( 'private-site/force-option-on-jetpack' );
 
 		return (
 			<FormFieldset>
@@ -333,7 +338,7 @@ export class SiteSettingsFormGeneral extends Component {
 					) }
 				</FormSettingExplanation>
 
-				{ ! siteIsJetpack && (
+				{ showPrivateSiteOption && (
 					<div>
 						<FormLabel>
 							<FormRadio
@@ -605,6 +610,7 @@ const connectComponent = connect(
 		return {
 			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
 			needsVerification: ! isCurrentUserEmailVerified( state ),
+			siteIsAtomic: isSiteAutomatedTransfer( state, siteId ),
 			siteIsJetpack,
 			siteIsVip: isVipSite( state, siteId ),
 			siteSlug: getSelectedSiteSlug( state ),

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -37,7 +37,7 @@ import { isBusiness } from 'lib/products-values';
 import { FEATURE_NO_BRANDING, PLAN_BUSINESS } from 'lib/plans/constants';
 import QuerySiteSettings from 'components/data/query-site-settings';
 import { isJetpackSite, isCurrentPlanPaid } from 'state/sites/selectors';
-import isSiteAutomatedTransfer from 'state/selectors/is-site-automated-transfer';
+import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { preventWidows } from 'lib/formatting';
 import scrollTo from 'lib/scroll-to';
@@ -610,7 +610,7 @@ const connectComponent = connect(
 		return {
 			isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
 			needsVerification: ! isCurrentUserEmailVerified( state ),
-			siteIsAtomic: isSiteAutomatedTransfer( state, siteId ),
+			siteIsAtomic: isSiteWpcomAtomic( state, siteId ),
 			siteIsJetpack,
 			siteIsVip: isVipSite( state, siteId ),
 			siteSlug: getSelectedSiteSlug( state ),


### PR DESCRIPTION
**Blocked** by Automattic/wpcomsh#343

#### Changes proposed in this Pull Request

* Show the `Private` radio option for atomic sites (or jetpack sites when the config flag is set)

#### Testing instructions

* Set up wpcomsh on your connected test Jetpack site
* Apply the branch in Automattic/wpcomsh#322
* Load Calyspo with the `private-site/force-option-on-jetpack` flag enabled (e.g. for the current state of the branch, you could do https://hash-db72bf172c183ad120cbf9aacf22d3fef0b7b520.calypso.live/?flags=private-site/force-option-on-jetpack)
* Browse to `/settings/general` & look for the `Privacy` section
* Change the setting
  * It should update the site setting and should behave according to test instructions in Automattic/wpcomsh#322
