### PR TITLE
Fix typo on WooCommerce + Jetpack Connect auto-authorize check

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -235,7 +235,7 @@ export class JetpackAuthorize extends Component {
 			this.isSso() ||
 			( 'woocommerce-services-auto-authorize' === from ||
 				( ! config.isEnabled( 'jetpack/connect/woocommerce' ) &&
-					'woocommerce-setup-wizard' === ' from' ) ) ||
+					'woocommerce-setup-wizard' === from ) ) ||
 			( ! this.props.isAlreadyOnSitesList &&
 				! alreadyAuthorized &&
 				( this.props.calypsoStartedConnection || authApproved ) )


### PR DESCRIPTION
This PR fixes a typo (introduced in #34414) in the Jetpack + WooCommerce auto authorization connection logic. Props @gravityrail for finding the issue.

#### Testing instructions

* Run `npm run test-client` and make sure all tests pass.

Browser:

* Disconnect Jetpack from your site
* Click “Setup Jetpack”.
* On the connection/authorization screen ( https://wordpress.com/jetpack/connect/authorize?client_id= ….. ) copy and paste the whole URL.
* Replace `https://wordpress.com` with ` http://calypso.localhost:3000` and replace the `from` parameter in the URL (it may be something like `connection-banner` or `landing-page-bottom`) with  `from=woocommerce-setup-wizard` . See Pastebin `213d5`  or ping me if you have issues.
* Visit the URL, and you should see the approval screen (and not auto-authorize).

Note, you can also test using WooCommerce Admin (directions are in #34414).

#### Screenshots 

<img width="603" alt="Screen Shot 2019-08-01 at 4 17 41 PM" src="https://user-images.githubusercontent.com/689165/62324619-ece43f00-b477-11e9-9f70-2c8388fc14b6.png">

