### PR TITLE
FSE: Fix description block jumping around in the editor

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { PlainText } from '@wordpress/editor';
+import { RichText } from '@wordpress/editor';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
@@ -34,9 +34,11 @@ function SiteDescriptionEdit( {
 
 	return (
 		<Fragment>
-			<PlainText
+			<RichText
 				className={ className }
 				value={ option }
+				tagName="p"
+				formattingControls={ [] }
 				onChange={ value => handleChange( value ) }
 				placeholder={ __( 'Site Description' ) }
 				aria-label={ __( 'Site Description' ) }


### PR DESCRIPTION
This fixes an issue where the text would jump around when selecting the description textbox in the post editor. 

**No Jumping:**
![2019-08-01 13 18 35](https://user-images.githubusercontent.com/6265975/62324800-1b095500-b45f-11e9-83e2-18e3257c3425.gif)

This will also give us more flexibility in the future to expand what users can do with this block. For example, we can disable multiline input and allow people to do bold/italics and stuff like that. For now, I have not included that support since it will mean changing the rendering logic in php, which is beyond the scope of this PR.

#### Changes proposed in this Pull Request

* Use RichText instead of PlainText for the block. This works because PlainText uses an autoresizer library under the hood. I think that library causes the jumping around. In this case, RichText does not use that library.

#### Testing instructions
* Pull the code and run it in your local FSE environment
* Navigate to the header template part editor
* Click into the text of the site description block. Previously, this would have caused the text to jump around. (See #34886.)
* Verify that you see no jumping around even after making changes to the text, selecting other blocks, and selecting in and out of the description block.
* Verify that making a change to the text in the site description block and updating it still causes the front end to update correctly.

Fixes #34886