### PR TITLE
Earn: Update copy removing implicit guarantee that WordAds payments will always be made by end-of-month.

### DIFF
--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -144,7 +144,7 @@ class WordAdsEarnings extends Component {
 				}
 			),
 			payout = translate(
-				'Outstanding amount of $%(amountOwed)s will be paid by the last business day of the month.',
+				'Outstanding amount of $%(amountOwed)s will be paid approximately 45 days following the end of the month in which it was earned.',
 				{
 					comment: 'Payout will proceed.',
 					args: { amountOwed: owed },

--- a/client/my-sites/stats/wordads/earnings.jsx
+++ b/client/my-sites/stats/wordads/earnings.jsx
@@ -129,6 +129,7 @@ class WordAdsEarnings extends Component {
 		);
 	}
 
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	payoutNotice() {
 		const { earnings, numberFormat, translate } = this.props;
 		const owed =
@@ -267,7 +268,7 @@ class WordAdsEarnings extends Component {
 					<h1 className="ads__module-header-title module-header-title">{ header_text }</h1>
 					<ul className="ads__module-header-actions module-header-actions">
 						<li className="ads__module-header-action module-header-action toggle-info">
-							{ /* eslint-disable */ }
+							{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
 							<a
 								href="#"
 								className="ads__module-header-action-link module-header-action-link"
@@ -275,7 +276,6 @@ class WordAdsEarnings extends Component {
 								title={ translate( 'Show or hide panel information' ) }
 								onClick={ this.handleInfoToggle( type ) }
 							>
-								{ /* eslint-enable */ }
 								<Gridicon icon={ infoIcon } />
 							</a>
 						</li>
@@ -317,7 +317,7 @@ class WordAdsEarnings extends Component {
 						</h1>
 						<ul className="ads__module-header-actions module-header-actions">
 							<li className="ads__module-header-action module-header-action toggle-info">
-								{ /* eslint-disable */ }
+								{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
 								<a
 									href="#"
 									className="ads__module-header-action-link module-header-action-link"
@@ -325,7 +325,6 @@ class WordAdsEarnings extends Component {
 									title={ translate( 'Show or hide panel information' ) }
 									onClick={ this.handleEarningsNoticeToggle }
 								>
-									{ /* eslint-disable */ }
 									<Gridicon icon={ infoIcon } />
 								</a>
 							</li>
@@ -355,6 +354,7 @@ class WordAdsEarnings extends Component {
 					: null }
 			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Current copy on the earning page says `Outstanding amount of $[amount] will be paid by the last business day of the month.` This is not always true as payments are sometimes made after then end of the month.

Our TOS indicates that we have 45 days following the end of the month in which revenue was earned to process the payments. This pull request updates the earning page copy to better be in line with our TOS. It's still our intention to pay by EOM, but this gives us some more leeway with customers.

#### Testing instructions

* View earnings page of site with outstanding earnings > $100
* Click the "Information" icon for the Totals header
* Verify copy is updated to read `Outstanding amount of $[amount] will be paid approximately 45 days following the end of the month in which it was earned.`
