### PR TITLE
FSE: Update FSE editor css to remove template-block space

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -3,3 +3,14 @@
 		display: none;
 	}
 }
+
+.post-type-page, .post-type-wp_template_part {
+	.editor-styles-wrapper {
+		padding: 0;
+		margin: 0;
+	}
+
+	.template-block {
+		margin-top: -28px;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This removes the spacing above template part blocks.

Before:

<img width="1614" alt="before" src="https://user-images.githubusercontent.com/1464705/62333084-d7bae080-b476-11e9-91d8-69a5aa7f3323.png">

After:

<img width="1614" alt="after" src="https://user-images.githubusercontent.com/1464705/62333000-7dba1b00-b476-11e9-9747-947ab76d0767.png">

#### Testing instructions

* Create a new page or edit an existing page and confirm the space before the header template block has been removed.
* Edit the header template and confirm spacing here still works correctly.
* Create or edit a post and confirm editor spacing is not affected.

Fixes: https://github.com/Automattic/wp-calypso/issues/34890
