### PR TITLE
Earn: remove exclamation mark from buttons

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -68,7 +68,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					action: { url: supportLink, onClick: () => trackCtaButton( 'simple-payments' ) },
 			  }
 			: {
-					text: translate( 'Upgrade to a Premium Plan!' ),
+					text: translate( 'Upgrade to a Premium Plan' ),
 					action: () => {
 						trackUpgrade( 'premium', 'simple-payments' );
 						page( `/checkout/${ selectedSiteSlug }/premium/` );
@@ -214,7 +214,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 					},
 			  }
 			: {
-					text: translate( 'Upgrade to a Premium Plan!' ),
+					text: translate( 'Upgrade to a Premium Plan' ),
 					action: () => {
 						trackUpgrade( 'premium', 'ads' );
 						page( `/checkout/${ selectedSiteSlug }/premium/` );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

*  this PR removes the exclamation mark from the buttons that the user can click to upgrade the plan so it's consistent with the others.

#### Testing instructions

* make sure the buttons don't have an exclamation mark

#### Before

<img width="804" alt="Captura de Pantalla 2019-08-01 a la(s) 20 12 03" src="https://user-images.githubusercontent.com/1041600/62333262-27aa9f00-b499-11e9-8c2f-872550f2c1ef.png">

#### After

<img width="792" alt="Captura de Pantalla 2019-08-01 a la(s) 20 16 22" src="https://user-images.githubusercontent.com/1041600/62333289-401ab980-b499-11e9-8ec8-0dae4c0a630e.png">

