### PR TITLE
FSE: Properly namespace all PHP

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -8,8 +8,10 @@
  * License: GPLv2 or later
  * Text Domain: full-site-editing
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
+
+namespace A8C\FSE;
 
 /**
  * Plugin version.
@@ -18,12 +20,12 @@
  *
  * @var string
  */
-define( 'A8C_FSE_VERSION', '0.4' );
+define( 'PLUGIN_VERSION', '0.4' );
 
 /**
  * Load Full Site Editing.
  */
-function a8c_load_full_site_editing() {
+function load_full_site_editing() {
 	/**
 	 * Can be used to disable Full Site Editing functionality.
 	 *
@@ -35,24 +37,24 @@ function a8c_load_full_site_editing() {
 		return;
 	}
 
-	require_once __DIR__ . '/lib/feature-flags/class-a8c-full-site-editing-feature-flags.php';
+	require_once __DIR__ . '/lib/feature-flags/class-feature-flags.php';
 	require_once __DIR__ . '/full-site-editing/blocks/navigation-menu/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/post-content/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/site-description/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/site-title/index.php';
 	require_once __DIR__ . '/full-site-editing/blocks/template/index.php';
-	require_once __DIR__ . '/full-site-editing/class-a8c-rest-templates-controller.php';
+	require_once __DIR__ . '/full-site-editing/class-rest-templates-controller.php';
 	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
-	require_once __DIR__ . '/full-site-editing/utils/class-a8c-wp-template.php';
+	require_once __DIR__ . '/full-site-editing/utils/class-wp-template.php';
 
 	Full_Site_Editing::get_instance();
 }
-add_action( 'plugins_loaded', 'a8c_load_full_site_editing' );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_full_site_editing' );
 
 /**
  * Load Posts List Block.
  */
-function a8c_load_posts_list_block() {
+function load_posts_list_block() {
 	if ( class_exists( 'Posts_List_Block' ) ) {
 		return;
 	}
@@ -73,12 +75,12 @@ function a8c_load_posts_list_block() {
 
 	Posts_List_Block::get_instance();
 }
-add_action( 'plugins_loaded', 'a8c_load_posts_list_block' );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_posts_list_block' );
 
 /**
  * Load Starter_Page_Templates.
  */
-function a8c_load_starter_page_templates() {
+function load_starter_page_templates() {
 	/**
 	 * Can be used to disable the Starter Page Templates.
 	 *
@@ -94,4 +96,4 @@ function a8c_load_starter_page_templates() {
 
 	Starter_Page_Templates::get_instance();
 }
-add_action( 'plugins_loaded', 'a8c_load_starter_page_templates' );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\load_starter_page_templates' );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/navigation-menu/index.php
@@ -1,16 +1,18 @@
 <?php
 /**
- * Render navigation menu block file
+ * Render navigation menu block file.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
+
+namespace A8C\FSE;
 
 /**
  * Render the navigation menu.
  *
  * @return string
  */
-function a8c_fse_render_navigation_menu_block() {
+function render_navigation_menu_block() {
 	$menu = wp_nav_menu(
 		[
 			'echo'           => false,
@@ -25,7 +27,7 @@ function a8c_fse_render_navigation_menu_block() {
 	?>
 	<nav class="main-navigation wp-block-a8c-navigation-menu">
 		<div class="menu-nav-container">
-			<?php echo $menu ? $menu : a8c_fse_get_fallback_navigation_menu(); ?>
+			<?php echo $menu ? $menu : get_fallback_navigation_menu(); ?>
 		</div>
 	</nav>
 	<!-- #site-navigation -->
@@ -40,7 +42,7 @@ function a8c_fse_render_navigation_menu_block() {
  *
  * @return string
  */
-function a8c_fse_get_fallback_navigation_menu() {
+function get_fallback_navigation_menu() {
 	$menu = wp_page_menu(
 		[
 			'after'       => false,

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.php
@@ -2,8 +2,10 @@
 /**
  * Render post content block file.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
+
+namespace A8C\FSE;
 
 /**
  * Renders post content.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/index.php
@@ -2,8 +2,10 @@
 /**
  * Render site description file.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
+
+namespace A8C\FSE;
 
 /**
  * Renders the site description (tagline) block.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/index.php
@@ -2,8 +2,10 @@
 /**
  * Render site title block.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
+
+namespace A8C\FSE;
 
 /**
  * Renders the site title and allows for editing in the full site editor.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.php
@@ -2,8 +2,10 @@
 /**
  * Render template block file.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
+
+namespace A8C\FSE;
 
 /**
  * Renders template.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -2,8 +2,10 @@
 /**
  * Full site editing file.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
+
+namespace A8C\FSE;
 
 /**
  * Class Full_Site_Editing
@@ -12,14 +14,14 @@ class Full_Site_Editing {
 	/**
 	 * Class instance.
 	 *
-	 * @var Full_Site_Editing
+	 * @var \A8C\FSE\Full_Site_Editing
 	 */
 	private static $instance = null;
 
 	/**
 	 * Custom post types.
 	 *
-	 * @var Full_Site_Editing
+	 * @var array
 	 */
 	private $template_post_types = [ 'wp_template_part' ];
 
@@ -39,7 +41,7 @@ class Full_Site_Editing {
 	/**
 	 * Creates instance.
 	 *
-	 * @return \Full_Site_Editing
+	 * @return \A8C\FSE\Full_Site_Editing
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
@@ -86,7 +88,7 @@ class Full_Site_Editing {
 				'rewrite'               => false,
 				'show_in_rest'          => true,
 				'rest_base'             => 'template_parts',
-				'rest_controller_class' => 'A8C_REST_Templates_Controller',
+				'rest_controller_class' => __NAMESPACE__ . '\REST_Templates_Controller',
 				'capability_type'       => 'template_part',
 				'capabilities'          => array(
 					// You need to be able to edit posts, in order to read templates in their raw form.
@@ -178,7 +180,7 @@ class Full_Site_Editing {
 			true
 		);
 
-		$feature_flags = A8C_Full_Site_Editing_Feature_Flags::get_instance();
+		$feature_flags = Feature_Flags::get_instance();
 
 		wp_localize_script(
 			'a8c-full-site-editing-script',
@@ -216,35 +218,35 @@ class Full_Site_Editing {
 						'type'    => 'string',
 					],
 				],
-				'render_callback' => 'a8c_fse_render_navigation_menu_block',
+				'render_callback' => __NAMESPACE__ . '\render_navigation_menu_block',
 			)
 		);
 
 		register_block_type(
 			'a8c/post-content',
 			array(
-				'render_callback' => 'render_post_content_block',
+				'render_callback' => __NAMESPACE__ . '\render_post_content_block',
 			)
 		);
 
 		register_block_type(
 			'a8c/site-description',
 			array(
-				'render_callback' => 'render_site_description_block',
+				'render_callback' => __NAMESPACE__ . '\render_site_description_block',
 			)
 		);
 
 		register_block_type(
 			'a8c/template',
 			array(
-				'render_callback' => 'render_template_block',
+				'render_callback' => __NAMESPACE__ . '\render_template_block',
 			)
 		);
 
 		register_block_type(
 			'a8c/site-title',
 			array(
-				'render_callback' => 'render_site_title_block',
+				'render_callback' => __NAMESPACE__ . '\render_site_title_block',
 			)
 		);
 	}
@@ -256,13 +258,13 @@ class Full_Site_Editing {
 	 * @return null|string The parent post ID, or null if not set.
 	 */
 	public function get_parent_post_id() {
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification
 		if ( ! isset( $_GET['fse_parent_post'] ) ) {
 			return null;
 		}
 
 		$parent_post_id = absint( $_GET['fse_parent_post'] );
-		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+		// phpcs:enable WordPress.Security.NonceVerification
 
 		if ( empty( $parent_post_id ) ) {
 			return null;
@@ -345,7 +347,7 @@ class Full_Site_Editing {
 
 	/** This will merge the post content with the post template, modifiying the $post parameter.
 	 *
-	 * @param WP_Post $post Post instance.
+	 * @param \WP_Post $post Post instance.
 	 */
 	public function merge_template_and_post( $post ) {
 		// Bail if not a REST API Request.
@@ -358,7 +360,7 @@ class Full_Site_Editing {
 			return;
 		}
 
-		$template         = new A8C_WP_Template();
+		$template         = new WP_Template();
 		$template_content = $template->get_page_template_content();
 
 		// Bail if the template has no post content block.
@@ -426,7 +428,7 @@ class Full_Site_Editing {
 	 */
 	public function set_block_template( $editor_settings ) {
 		if ( $this->is_full_site_page() ) {
-			$fse_template    = new A8C_WP_Template();
+			$fse_template    = new WP_Template();
 			$template_blocks = $fse_template->get_template_blocks();
 
 			$template = array();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-rest-templates-controller.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-rest-templates-controller.php
@@ -1,14 +1,16 @@
 <?php
 /**
- * A8C REST Templates Controller file.
+ * REST Templates Controller file.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
+
+namespace A8C\FSE;
 
 /**
  * Based on `WP_REST_Blocks_Controller` from core
  */
-class A8C_REST_Templates_Controller extends WP_REST_Posts_Controller {
+class REST_Templates_Controller extends \WP_REST_Posts_Controller {
 
 	/**
 	 * Checks if a template can be read.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/utils/class-wp-template.php
@@ -1,14 +1,16 @@
 <?php
 /**
- * A8C WP Template file.
+ * WP Template file.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
 
+namespace A8C\FSE;
+
 /**
- * Class A8C_WP_Template
+ * Class WP_Template
  */
-class A8C_WP_Template {
+class WP_Template {
 	/**
 	 * Header template part type constant.
 	 *

--- a/apps/full-site-editing/full-site-editing-plugin/lib/feature-flags/class-feature-flags.php
+++ b/apps/full-site-editing/full-site-editing-plugin/lib/feature-flags/class-feature-flags.php
@@ -4,17 +4,19 @@
 /**
  * Feature flags file.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
 
+namespace A8C\FSE;
+
 /**
- * Class A8C_Full_Site_Editing_Feature_Flags
+ * Class Feature_Flags
  */
-class A8C_Full_Site_Editing_Feature_Flags {
+class Feature_Flags {
 	/**
 	 * Class instance.
 	 *
-	 * @var A8C_Full_Site_Editing_Feature_Flags
+	 * @var \A8C\FSE\Feature_Flags
 	 */
 	private static $instance = null;
 
@@ -42,7 +44,7 @@ class A8C_Full_Site_Editing_Feature_Flags {
 	/**
 	 * Creates instance.
 	 *
-	 * @return A8C_Full_Site_Editing_Feature_Flags
+	 * @return \A8C\FSE\Feature_Flags
 	 */
 	public static function get_instance() {
 		if ( is_null( self::$instance ) ) {

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/class-posts-list-block.php
@@ -2,8 +2,10 @@
 /**
  * Posts list block file.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
+
+namespace A8C\FSE;
 
 /**
  * Class Post_List_Block
@@ -13,7 +15,7 @@ class Posts_List_Block {
 	/**
 	 * Class instance.
 	 *
-	 * @var Posts_List_Block
+	 * @var \A8C\FSE\Posts_List_Block
 	 */
 	private static $instance = null;
 
@@ -29,7 +31,7 @@ class Posts_List_Block {
 	/**
 	 * Creates instance.
 	 *
-	 * @return \Posts_List_Block
+	 * @return \A8C\FSE\Posts_List_Block
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
@@ -101,7 +103,7 @@ class Posts_List_Block {
 	 * @return string
 	 */
 	public function render_a8c_post_list_block( $attributes, $content ) {
-		$posts_list = new WP_Query(
+		$posts_list = new \WP_Query(
 			array(
 				'post_type'        => 'post',
 				'posts_per_page'   => $attributes['postsPerPage'],
@@ -112,7 +114,7 @@ class Posts_List_Block {
 
 		add_filter( 'excerpt_more', array( $this, 'custom_excerpt_read_more' ) );
 
-		$content = a8c_pl_render_template(
+		$content = render_template(
 			'posts-list',
 			array(
 				'posts_list' => $posts_list,

--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/utils.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/utils.php
@@ -2,45 +2,45 @@
 /**
  * Template functions.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
 
-if ( ! function_exists( 'a8c_pl_render_template' ) ) {
-	/**
-	 * OUTPUT BUFFERED LOAD TEMPLATE PART.
-	 *
-	 * Loads a given template using output buffering.
-	 * Optionally including $data to be passed into template.
-	 *
-	 * @param string $template_name Name of the template to be located.
-	 * @param array  $data          Optional. Associative array of data to be passed into the template. Default empty array.
-	 * @return string
-	 */
-	function a8c_pl_render_template( $template_name, $data = array() ) {
+namespace A8C\FSE;
 
-		if ( ! strpos( $template_name, '.php' ) ) {
-			$template_name = $template_name . '.php';
-		}
+/**
+ * OUTPUT BUFFERED LOAD TEMPLATE PART.
+ *
+ * Loads a given template using output buffering.
+ * Optionally including $data to be passed into template.
+ *
+ * @param string $template_name Name of the template to be located.
+ * @param array  $data          Optional. Associative array of data to be passed into the template. Default empty array.
+ * @return string
+ */
+function render_template( $template_name, $data = array() ) {
 
-		$template_file = __DIR__ . '/templates/' . $template_name;
-
-		if ( ! file_exists( $template_file ) ) {
-			return '';
-		}
-
-		// Optionally provided an assoc array of data to pass to template
-		// and it will be extracted into variables.
-		if ( is_array( $data ) ) {
-			foreach ( $data as $name => $value ) {
-				$GLOBALS[ $name ] = $value;
-			}
-		}
-
-		ob_start();
-		require_once $template_file;
-		$content = ob_get_contents();
-		ob_end_clean();
-
-		return $content;
+	if ( ! strpos( $template_name, '.php' ) ) {
+		$template_name = $template_name . '.php';
 	}
+
+	$template_file = __DIR__ . '/templates/' . $template_name;
+
+	if ( ! file_exists( $template_file ) ) {
+		return '';
+	}
+
+	// Optionally provided an assoc array of data to pass to template
+	// and it will be extracted into variables.
+	if ( is_array( $data ) ) {
+		foreach ( $data as $name => $value ) {
+			$GLOBALS[ $name ] = $value;
+		}
+	}
+
+	ob_start();
+	require_once $template_file;
+	$content = ob_get_contents();
+	ob_end_clean();
+
+	return $content;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -2,8 +2,10 @@
 /**
  * Starter page templates file.
  *
- * @package full-site-editing
+ * @package A8C\FSE
  */
+
+namespace A8C\FSE;
 
 /**
  * Class Starter_Page_Templates
@@ -29,7 +31,7 @@ class Starter_Page_Templates {
 	/**
 	 * Creates instance.
 	 *
-	 * @return \Starter_Page_Templates
+	 * @return \A8C\FSE\Starter_Page_Templates
 	 */
 	public static function get_instance() {
 		if ( null === self::$instance ) {
@@ -169,7 +171,7 @@ class Starter_Page_Templates {
 	 */
 	public function fetch_vertical_data() {
 		$vertical_id        = get_option( 'site_vertical', 'default' );
-		$transient_key      = implode( '_', [ 'starter_page_templates', A8C_FSE_VERSION, $vertical_id, get_locale() ] );
+		$transient_key      = implode( '_', [ 'starter_page_templates', PLUGIN_VERSION, $vertical_id, get_locale() ] );
 		$vertical_templates = get_transient( $transient_key );
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.


### PR DESCRIPTION
Adds a common namespace.
See https://developer.wordpress.org/plugins/plugin-basics/best-practices/#prefix-everything

This is largely untested. So far I've only made sure that the plugin doesn't fatal and SPT works as expected. The FSE side definitely needs more testing.

Fixes #34795
