### PR TITLE
Reader: remove @wordpresscom attribution on Twitter share

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -46,7 +46,6 @@ const actionMap = {
 			query: {
 				text: post.title,
 				url: post.URL,
-				via: 'wordpressdotcom',
 			},
 		};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When sharing to Twitter via Reader, we currently include 'via @wordpresscom' at the end of the tweet. There has been some concern that this associates us with dubious content, so this PR removes the attribution.

Ideally this attribution would be applied selectively, but since we don't currently hold any information about flagged sites in Reader, removing it altogether seems the simplest solution for now.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
<img width="897" alt="Screen Shot 2019-08-02 at 13 45 16" src="https://user-images.githubusercontent.com/17325/62338208-ced81680-b52b-11e9-977a-9d138d538128.png">

In your Following stream at http://calypso.localhost:3000/, find a post with a share icon and share via Twitter. The resulting tweet should not mention @wordpresscom.

Before:

<img width="662" alt="Screen Shot 2019-08-02 at 13 45 22" src="https://user-images.githubusercontent.com/17325/62338218-d5668e00-b52b-11e9-889d-b92a08f90fa8.png">

After:

<img width="662" alt="Screen Shot 2019-08-02 at 13 44 53" src="https://user-images.githubusercontent.com/17325/62338228-db5c6f00-b52b-11e9-8f02-eddd24433c08.png">
