### PR TITLE
FSE: Hide the UI for the post content slot in the editor

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
@@ -1,3 +1,5 @@
+/* global wp */
+
 /**
  * External dependencies
  */
@@ -25,3 +27,20 @@ registerBlockType( 'a8c/post-content', {
 	edit,
 	save,
 } );
+
+const { createHigherOrderComponent } = wp.compose;
+const addContentSlotClassname = createHigherOrderComponent( BlockListBlock => {
+	return props => {
+		if ( props.name !== 'a8c/post-content' ) {
+			return <BlockListBlock { ...props } />;
+		}
+
+		return <BlockListBlock { ...props } className={ 'post-content__block' } />;
+	};
+}, 'addContentSlotClassname' );
+
+wp.hooks.addFilter(
+	'editor.BlockListBlock',
+	'full-site-editing/blocks/post-content',
+	addContentSlotClassname
+);

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
@@ -5,6 +5,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -39,7 +40,7 @@ const addContentSlotClassname = createHigherOrderComponent( BlockListBlock => {
 	};
 }, 'addContentSlotClassname' );
 
-wp.hooks.addFilter(
+addFilter(
 	'editor.BlockListBlock',
 	'full-site-editing/blocks/post-content',
 	addContentSlotClassname

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/style.scss
@@ -33,3 +33,36 @@
 		display: block;
 	}
 }
+
+/* Hide the content slot block UI */
+.block-editor-block-list__layout {
+	.post-content__block {
+		> .block-editor-block-list__block-edit {
+			&::before {
+				transition: none;
+			}
+
+			> .block-editor-block-list__breadcrumb {
+				display: none;
+			}
+		}
+
+		&.is-selected {
+			> .block-editor-block-list__block-edit::before {
+				border: none;
+				box-shadow: none;
+			}
+
+			.block-editor-block-contextual-toolbar {
+				display: none;
+			}
+		}
+
+		&.is-hovered {
+			> .block-editor-block-list__block-edit::before {
+				border: none;
+				box-shadow: none;
+			}
+		}
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -3,3 +3,36 @@
 		display: none;
 	}
 }
+
+/* Hide the content slot block UI */
+.block-editor-block-list__layout {
+	.post-content__block {
+		> .block-editor-block-list__block-edit {
+			&::before {
+				transition: none;
+			}
+
+			> .block-editor-block-list__breadcrumb {
+				display: none;
+			}
+		}
+
+		&.is-selected {
+			> .block-editor-block-list__block-edit::before {
+				border: none;
+				box-shadow: none;
+			}
+
+			.block-editor-block-contextual-toolbar {
+				display: none;
+			}
+		}
+
+		&.is-hovered {
+			> .block-editor-block-list__block-edit::before {
+				border: none;
+				box-shadow: none;
+			}
+		}
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -3,36 +3,3 @@
 		display: none;
 	}
 }
-
-/* Hide the content slot block UI */
-.block-editor-block-list__layout {
-	.post-content__block {
-		> .block-editor-block-list__block-edit {
-			&::before {
-				transition: none;
-			}
-
-			> .block-editor-block-list__breadcrumb {
-				display: none;
-			}
-		}
-
-		&.is-selected {
-			> .block-editor-block-list__block-edit::before {
-				border: none;
-				box-shadow: none;
-			}
-
-			.block-editor-block-contextual-toolbar {
-				display: none;
-			}
-		}
-
-		&.is-hovered {
-			> .block-editor-block-list__block-edit::before {
-				border: none;
-				box-shadow: none;
-			}
-		}
-	}
-}

--- a/apps/full-site-editing/package-lock.json
+++ b/apps/full-site-editing/package-lock.json
@@ -700,9 +700,9 @@
 			}
 		},
 		"@wordpress/hooks": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.3.0.tgz",
-			"integrity": "sha512-N7ijZUcBbcTO6AsITS66On3X14fkT3+e3rNbx/w4AANnUDmP4Nqkl+OiMWqM3gjr936hReAqIqprKKTQ98DBYQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.4.0.tgz",
+			"integrity": "sha512-z3+8Yq4IQ3DOvUF4VsXOfntdyk1fJ8RZBYlZTW8WfmHV7VKTDbX3LfHXmC2VCjXhVkeWQVKozi2weoEYopfGKA==",
 			"requires": {
 				"@babel/runtime": "^7.4.4"
 			}

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -38,6 +38,7 @@
 		"@wordpress/edit-post": "^3.3.4",
 		"@wordpress/editor": "^9.2.4",
 		"@wordpress/element": "^2.3.0",
+		"@wordpress/hooks": "^2.4.0",
 		"@wordpress/i18n": "^3.3.0",
 		"@wordpress/nux": "^3.4.0",
 		"@wordpress/plugins": "^2.2.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The UI for the post content slot is not needed and distracts from editing the post content blocks themselves. This could change in the future if we add settings, but it is not true right now.

This PR adds a top level classname to the post content slot block, and uses that classname to hide the editor UI using CSS. It's a bit of a hack, although I'm not sure there is any other way of hiding block UI at this point (happy to be pointed to something).

Before:

<img width="1538" alt="Screen Shot 2019-08-01 at 9 41 19 PM" src="https://user-images.githubusercontent.com/1464705/62344975-326b3100-b4a5-11e9-843e-dcd8617fdbbb.png">

After:

<img width="1258" alt="Screen Shot 2019-08-01 at 9 40 51 PM" src="https://user-images.githubusercontent.com/1464705/62344982-35feb800-b4a5-11e9-8c60-2119c2d7d39c.png">

#### Testing instructions

* Create or edit a new page, and confirm that you can select any block inside the page content area and not see any UI for the content slot block.
* Click around different areas of the page and confirm at no point do you see content slot block UI, or any flashes of it.

Fixes #34889
