### PR TITLE
[WIP] Try/add site title to step progress for back button

### DIFF
--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -63,18 +63,13 @@ export class NavigationLink extends Component {
 	}
 
 	getPreviousStepTitle() {
-		const { labelText, stepName, signupProgress, translate } = this.props;
+		const { labelText, translate } = this.props;
 
 		if ( labelText ) {
 			return labelText;
 		}
 
-		const currentStepIndex = findIndex( signupProgress, { stepName } );
-
-		const previousStep = find(
-			signupProgress.slice( 0, currentStepIndex ).reverse(),
-			step => ! step.wasSkipped
-		);
+		const previousStep = this.getPreviousStep();
 
 		return get( previousStep, 'stepTitle', translate( 'Back' ) );
 	}

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -62,6 +62,23 @@ export class NavigationLink extends Component {
 		return previousStep || { stepName: null };
 	}
 
+	getPreviousStepTitle() {
+		const { labelText, stepName, signupProgress, translate } = this.props;
+
+		if ( labelText ) {
+			return labelText;
+		}
+
+		const currentStepIndex = findIndex( signupProgress, { stepName } );
+
+		const previousStep = find(
+			signupProgress.slice( 0, currentStepIndex ).reverse(),
+			step => ! step.wasSkipped
+		);
+
+		return get( previousStep, 'stepTitle', translate( 'Back' ) );
+	}
+
 	getBackUrl() {
 		if ( this.props.direction !== 'back' ) {
 			return;
@@ -131,7 +148,7 @@ export class NavigationLink extends Component {
 
 		if ( this.props.direction === 'back' ) {
 			backGridicon = <Gridicon icon="arrow-left" size={ 18 } />;
-			text = labelText ? labelText : translate( 'Back' );
+			text = this.getPreviousStepTitle();
 		}
 
 		if ( this.props.direction === 'forward' ) {

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -94,7 +94,10 @@ class AboutStep extends Component {
 		} );
 		this.setFormState( this.formStateController.getInitialState() );
 
-		this.props.saveSignupStep( { stepName: this.props.stepName } );
+		this.props.saveSignupStep( {
+			stepName: this.props.stepName,
+			stepTitle: this.props.translate( 'Let’s create a site.' ),
+		} );
 	}
 
 	componentWillUnmount() {

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -136,6 +136,10 @@ class DomainsStep extends React.Component {
 		}
 	}
 
+	componentDidMount() {
+		this.props.saveSignupStep( { stepName: this.props.stepName, stepTitle: this.getHeaderText() } );
+	}
+
 	static getDerivedStateFromProps( nextProps, prevState ) {
 		let showTrademarkClaimsNotice = prevState.showTrademarkClaimsNotice;
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -66,7 +66,11 @@ export class PlansStep extends Component {
 			document.head.appendChild( salesTeamScript );
 		}
 
-		this.props.saveSignupStep( { stepName: this.props.stepName } );
+		this.props.saveSignupStep( {
+			stepName: this.props.stepName,
+			stepTitle:
+				this.props.headerText || this.props.translate( "Pick a plan that's right for you." ),
+		} );
 	}
 
 	onSelectPlan = cartItem => {

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -46,7 +46,10 @@ export class SiteStyleStep extends Component {
 	};
 
 	componentDidMount() {
-		this.props.saveSignupStep( { stepName: this.props.stepName } );
+		this.props.saveSignupStep( {
+			stepName: this.props.stepName,
+			stepTitle: this.props.translate( 'Choose a style' ),
+		} );
 	}
 
 	handleStyleOptionChange = event =>

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -43,7 +43,10 @@ class SiteTitleStep extends Component {
 	};
 
 	componentDidMount() {
-		this.props.saveSignupStep( { stepName: this.props.stepName } );
+		this.props.saveSignupStep( {
+			stepName: this.props.stepName,
+			stepTitle: getSiteTypePropertyValue( 'slug', this.props.siteType, 'siteTitleLabel' ),
+		} );
 	}
 
 	handleInputChange = ( { currentTarget: { value = '' } } ) => this.props.setSiteTitle( value );

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -37,7 +37,10 @@ class SiteTopicStep extends Component {
 	};
 
 	componentDidMount() {
-		this.props.saveSignupStep( { stepName: this.props.stepName } );
+		this.props.saveSignupStep( {
+			stepName: this.props.stepName,
+			stepTitle: getSiteTypePropertyValue( 'slug', this.props.siteType, 'siteTopicHeader' ) || '',
+		} );
 	}
 
 	submitSiteTopic = ( { isUserInput, name, slug } ) => {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -21,7 +21,10 @@ const siteTypeToFlowname = {
 
 class SiteType extends Component {
 	componentDidMount() {
-		this.props.saveSignupStep( { stepName: this.props.stepName } );
+		this.props.saveSignupStep( {
+			stepName: this.props.stepName,
+			stepTitle: this.props.translate( 'What kind of site are you building?' ),
+		} );
 	}
 
 	submitStep = siteTypeValue => {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -85,7 +85,7 @@ export class UserStep extends Component {
 	}
 
 	componentDidMount() {
-		this.props.saveSignupStep( { stepName: this.props.stepName } );
+		this.props.saveSignupStep( { stepName: this.props.stepName, stepTitle: this.getHeaderText() } );
 	}
 
 	setSubHeaderText( props ) {


### PR DESCRIPTION
## Changes proposed in this Pull Request

An experimental PR that adds a previous step label to the signup back button if one is available.

![Aug-02-2019 17-06-13](https://user-images.githubusercontent.com/6458278/62351170-23898a80-b548-11e9-9c7c-828598f7888c.gif)

There are alternative ways of grabbing the site title. Defining them in each step seems like a lot of work. We might add them as a prop to the step definition objects instead.

## Known issues

The titles are too long in smaller screen widths

<img width="300" alt="Screen Shot 2019-08-02 at 5 10 18 pm" src="https://user-images.githubusercontent.com/6458278/62351329-87ac4e80-b548-11e9-98b4-aad18cced7f4.png">

We could either tweak the copy or the design or both. Or even add the step title as a help tip.

## Testing instructions

Start at `/start` and navigate through the steps.

Check out the back button label!!!

(half) resolves https://github.com/Automattic/wp-calypso/issues/34390