### PR TITLE
Add workaround for #35068

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -473,6 +473,13 @@ export class Checkout extends React.Component {
 		}
 
 		if ( this.props.isJetpackNotAtomic ) {
+			// @FIXME temporary fix for plans purcahsed via `/plans` or WP Admin for connected sites
+			// @see https://github.com/Automattic/wp-calypso/issues/35068
+			// Do not use the fallback `/` route after checkout
+			if ( selectedSiteSlug && signupDestination === '/' ) {
+				// Matches route from client/my-sites/checkout/checkout-thank-you/index.jsx:445
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you`;
+			}
 			return signupDestination;
 		}
 


### PR DESCRIPTION
Workaround for #35068. @niranjan-uma-shankar is working on a better solution that will superseded this, but a temporary fix is required.

Prevents Jetpack purchases from being redirected to `/` after checkout.
Should be sent to `/plans/my-plan/SITE_SLUG?thank-you`

#### Testing instructions

* Confirm #35608 cannot be reproduced.