### PR TITLE
Color schemes: Fix persistence schema

### DIFF
--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */

--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -3,6 +3,13 @@
  */
 import { compact } from 'lodash';
 
+/**
+ * !! Note !!
+ *
+ * Every _value_ present in this list should appear in the colorScheme enum array in
+ * `client/state/preferences/schema.js` or preferences state persistence may be invalidated.
+ */
+
 export default function( translate ) {
 	return compact( [
 		{

--- a/client/state/preferences/schema.js
+++ b/client/state/preferences/schema.js
@@ -62,15 +62,15 @@ export const remoteValuesSchema = {
 		colorScheme: {
 			type: 'string',
 			enum: [
-				'default',
-				'light',
-				'dark',
 				'classic-blue',
 				'classic-bright',
-				'laser-black',
-				'powder-snow',
+				'contrast',
+				'midnight',
 				'nightfall',
+				'ocean',
+				'powder-snow',
 				'sakura',
+				'sunset',
 			],
 		},
 		'store-dashboardStatsWidgetUnit': {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The persisted user settings for selected color scheme were not being reused in state.

This resulted in console warnings:

![Screen Shot 2019-08-02 at 12 14 33](https://user-images.githubusercontent.com/841763/62363266-45224c00-b51f-11e9-9cc0-b0a2098eb90c.png)

This means the persisted state was rejected and not used.

#### Testing instructions

* Use a previously missing theme and verify that no console warnings are produced (must be dev environment).
