### PR TITLE
SelectDropdown: cleanup code and migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -15,6 +15,5 @@
 @import 'components/main/style';
 @import 'components/popover/style';
 @import 'components/segmented-control/style';
-@import 'components/select-dropdown/style';
 @import 'components/tooltip/style';
 @import 'layout/sidebar/style';

--- a/client/components/section-nav/tabs.jsx
+++ b/client/components/section-nav/tabs.jsx
@@ -11,7 +11,6 @@ import { debounce } from 'lodash';
 /**
  * Internal Dependencies
  */
-import DropdownItem from 'components/select-dropdown/item';
 import SelectDropdown from 'components/select-dropdown';
 import { getWindowInnerWidth } from 'lib/viewport';
 import afterLayoutFlush from 'lib/after-layout-flush';
@@ -120,9 +119,9 @@ class NavTabs extends Component {
 				return null;
 			}
 			return (
-				<DropdownItem { ...child.props } key={ 'navTabsDropdown-' + index }>
+				<SelectDropdown.Item { ...child.props } key={ 'navTabsDropdown-' + index }>
 					{ child.props.children }
-				</DropdownItem>
+				</SelectDropdown.Item>
 			);
 		} );
 

--- a/client/components/select-dropdown/README.md
+++ b/client/components/select-dropdown/README.md
@@ -16,7 +16,6 @@ A good example for this case is navigation. Sometimes the option that is selecte
 ```js
 import React from 'react';
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
 
 export default class extends React.Component {
 	// ...
@@ -24,10 +23,10 @@ export default class extends React.Component {
 	render() {
 		return (
 			<SelectDropdown selectedText="Published">
-				<DropdownItem selected={ true } path="/published">Published</DropdownItem>
-				<DropdownItem path="/scheduled">Scheduled</DropdownItem>
-				<DropdownItem path="/drafts">Drafts</DropdownItem>
-				<DropdownItem path="/trashed">Trashed</DropdownItem>
+				<SelectDropdown.Item selected path="/published">Published</SelectDropdown.Item>
+				<SelectDropdown.Item path="/scheduled">Scheduled</SelectDropdown.Item>
+				<SelectDropdown.Item path="/drafts">Drafts</SelectDropdown.Item>
+				<SelectDropdown.Item path="/trashed">Trashed</SelectDropdown.Item>
 			</SelectDropdown>
 		);
 	} 
@@ -92,24 +91,22 @@ Optional bool to disable dropdown item.
 
 `onClick`
 
-Optional callback that will be applied when a `DropdownItem` has been clicked. This could be used for updating a parent's state, tracking analytics, etc.
+Optional callback that will be applied when a `SelectDropdown.Item` has been clicked. This could be used for updating a parent's state, tracking analytics, etc.
 
 ### Label
 
-An item "label" can be added like as a sibling to `DropdownItem`. The purpose
-of this `DropdownLabel` component is used to display a static item, for example, to group
+An item "label" can be added like as a sibling to `SelectDropdown.Item`. The purpose
+of this `SelectDropdown.Label` component is used to display a static item, for example, to group
 items.
 
 ### Separator
 
-As a sibling to `DropdownItem`, an item "separator" or horizontal line can be used to visually separate items.
+As a sibling to `SelectDropdown.Item`, an item "separator" or horizontal line can be used to visually separate items.
 
 ![separator example screenshot](https://cldup.com/CWEH2K9PUf.png)
 
 ```js
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
-import DropdownSeparator from 'components/select-dropdown/separator';
 
 export default class extends React.Component {
 
@@ -118,12 +115,12 @@ export default class extends React.Component {
 	render() {
 		return (
 			<SelectDropdown selectedText="Published">
-				<DropdownLabel><em>Post status<em></DropdownLabel>
-				<DropdownItem selected={ true } path="/published">Published</DropdownItem>
-				<DropdownItem path="/scheduled">Scheduled</DropdownItem>
-				<DropdownItem path="/drafts">Drafts</DropdownItem>
-				<DropdownSeparator />
-				<DropdownItem path="/trashed">Trashed</DropdownItem>
+				<SelectDropdown.Label><em>Post status<em></SelectDropdown.Label>
+				<SelectDropdown.Item selected path="/published">Published</SelectDropdown.Item>
+				<SelectDropdown.Item path="/scheduled">Scheduled</SelectDropdown.Item>
+				<SelectDropdown.Item path="/drafts">Drafts</SelectDropdown.Item>
+				<SelectDropdown.Separator />
+				<SelectDropdown.Item path="/trashed">Trashed</SelectDropdown.Item>
 			</SelectDropdown>
 		);
 	}
@@ -142,6 +139,7 @@ A good example for this case is a form element. You don't want to have to write 
 
 ```js
 import SelectDropdown from 'components/select-dropdown';
+
 var options = [
 	{ label: 'Post status', isLabel: true },
 	{ value: 'published', label: 'Published' },
@@ -203,7 +201,7 @@ Optional callback that will be run after the dropdown is opened or closed. An ev
 
 ### Label
 
-Adding `isLabel` key set to `true` into the item object will create a `DropdownLabel` component.
+Adding `isLabel` key set to `true` into the item object will create a `SelectDropdown.Label` component.
 
 ```js
 var options = [

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -11,9 +11,6 @@ import Gridicon from 'gridicons';
  * Internal dependencies
  */
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
-import DropdownLabel from 'components/select-dropdown/label';
-import DropdownSeparator from 'components/select-dropdown/separator';
 
 class SelectDropdownExample extends React.PureComponent {
 	static displayName = 'SelectDropdownExample';
@@ -29,18 +26,12 @@ class SelectDropdownExample extends React.PureComponent {
 		],
 	};
 
-	constructor( props ) {
-		super( props );
-
-		const initialState = {
-			childSelected: 'Published',
-			selectedCount: 10,
-			compactButtons: false,
-			selectedIcon: <Gridicon icon="align-image-left" size={ 18 } />,
-		};
-
-		this.state = initialState;
-	}
+	state = {
+		childSelected: 'Published',
+		selectedCount: 10,
+		compactButtons: false,
+		selectedIcon: <Gridicon icon="align-image-left" size={ 18 } />,
+	};
 
 	toggleButtons = () => {
 		this.setState( { compactButtons: ! this.state.compactButtons } );
@@ -51,9 +42,9 @@ class SelectDropdownExample extends React.PureComponent {
 
 		return (
 			<div className="docs__select-dropdown-container">
-				<a className="docs__design-toggle button" onClick={ this.toggleButtons }>
+				<button className="docs__design-toggle button" onClick={ this.toggleButtons }>
 					{ toggleButtonsText }
-				</a>
+				</button>
 
 				<h3>Items passed as options prop</h3>
 				<SelectDropdown
@@ -69,43 +60,43 @@ class SelectDropdownExample extends React.PureComponent {
 					selectedText={ this.state.childSelected }
 					selectedCount={ this.state.selectedCount }
 				>
-					<DropdownLabel>
+					<SelectDropdown.Label>
 						<strong>Statuses</strong>
-					</DropdownLabel>
+					</SelectDropdown.Label>
 
-					<DropdownItem
+					<SelectDropdown.Item
 						count={ 10 }
 						selected={ this.state.childSelected === 'Published' }
 						onClick={ this.getSelectItemHandler( 'Published', 10 ) }
 					>
 						Published
-					</DropdownItem>
+					</SelectDropdown.Item>
 
-					<DropdownItem
+					<SelectDropdown.Item
 						count={ 4 }
 						selected={ this.state.childSelected === 'Scheduled' }
 						onClick={ this.getSelectItemHandler( 'Scheduled', 4 ) }
 					>
 						Scheduled
-					</DropdownItem>
+					</SelectDropdown.Item>
 
-					<DropdownItem
+					<SelectDropdown.Item
 						count={ 3343 }
 						selected={ this.state.childSelected === 'Drafts' }
 						onClick={ this.getSelectItemHandler( 'Drafts', 3343 ) }
 					>
 						Drafts
-					</DropdownItem>
+					</SelectDropdown.Item>
 
-					<DropdownSeparator />
+					<SelectDropdown.Separator />
 
-					<DropdownItem
+					<SelectDropdown.Item
 						count={ 3 }
 						selected={ this.state.childSelected === 'Trashed' }
 						onClick={ this.getSelectItemHandler( 'Trashed', 3 ) }
 					>
 						Trashed
-					</DropdownItem>
+					</SelectDropdown.Item>
 				</SelectDropdown>
 
 				<h3 style={ { marginTop: 20 } }>With Icons in Items Passed as Options</h3>
@@ -143,11 +134,11 @@ class SelectDropdownExample extends React.PureComponent {
 					selectedText={ this.state.childSelected }
 					selectedIcon={ this.state.selectedIcon }
 				>
-					<DropdownLabel>
+					<SelectDropdown.Label>
 						<strong>Statuses</strong>
-					</DropdownLabel>
+					</SelectDropdown.Label>
 
-					<DropdownItem
+					<SelectDropdown.Item
 						selected={ this.state.childSelected === 'Published' }
 						icon={ <Gridicon icon="align-image-left" size={ 18 } /> }
 						onClick={ this.getSelectItemHandler(
@@ -157,9 +148,9 @@ class SelectDropdownExample extends React.PureComponent {
 						) }
 					>
 						Published
-					</DropdownItem>
+					</SelectDropdown.Item>
 
-					<DropdownItem
+					<SelectDropdown.Item
 						selected={ this.state.childSelected === 'Scheduled' }
 						icon={ <Gridicon icon="calendar" size={ 18 } /> }
 						onClick={ this.getSelectItemHandler(
@@ -169,9 +160,9 @@ class SelectDropdownExample extends React.PureComponent {
 						) }
 					>
 						Scheduled
-					</DropdownItem>
+					</SelectDropdown.Item>
 
-					<DropdownItem
+					<SelectDropdown.Item
 						selected={ this.state.childSelected === 'Drafts' }
 						icon={ <Gridicon icon="create" size={ 18 } /> }
 						onClick={ this.getSelectItemHandler(
@@ -181,11 +172,11 @@ class SelectDropdownExample extends React.PureComponent {
 						) }
 					>
 						Drafts
-					</DropdownItem>
+					</SelectDropdown.Item>
 
-					<DropdownSeparator />
+					<SelectDropdown.Separator />
 
-					<DropdownItem
+					<SelectDropdown.Item
 						selected={ this.state.childSelected === 'Trashed' }
 						icon={ <Gridicon icon="trash" size={ 18 } /> }
 						onClick={ this.getSelectItemHandler(
@@ -195,7 +186,7 @@ class SelectDropdownExample extends React.PureComponent {
 						) }
 					>
 						Trashed
-					</DropdownItem>
+					</SelectDropdown.Item>
 				</SelectDropdown>
 
 				<h3 style={ { marginTop: 20 } }>max-width: 220px;</h3>
@@ -206,17 +197,17 @@ class SelectDropdownExample extends React.PureComponent {
 					selectedText="Published publish publish publish"
 					selectedCount={ 10 }
 				>
-					<DropdownLabel>
+					<SelectDropdown.Label>
 						<strong>Statuses</strong>
-					</DropdownLabel>
-					<DropdownItem count={ 10 } selected={ true }>
+					</SelectDropdown.Label>
+					<SelectDropdown.Item count={ 10 } selected={ true }>
 						Published publish publish publish
-					</DropdownItem>
-					<DropdownItem count={ 4 }> Scheduled scheduled</DropdownItem>
-					<DropdownItem count={ 3343 }>Drafts</DropdownItem>
-					<DropdownItem disabled={ true }>Disabled Item</DropdownItem>
-					<DropdownSeparator />
-					<DropdownItem count={ 3 }>Trashed</DropdownItem>
+					</SelectDropdown.Item>
+					<SelectDropdown.Item count={ 4 }> Scheduled scheduled</SelectDropdown.Item>
+					<SelectDropdown.Item count={ 3343 }>Drafts</SelectDropdown.Item>
+					<SelectDropdown.Item disabled={ true }>Disabled Item</SelectDropdown.Item>
+					<SelectDropdown.Separator />
+					<SelectDropdown.Item count={ 3 }>Trashed</SelectDropdown.Item>
 				</SelectDropdown>
 
 				<h3 style={ { marginTop: 20 } }>Disabled State</h3>

--- a/client/components/select-dropdown/docs/example.jsx
+++ b/client/components/select-dropdown/docs/example.jsx
@@ -235,10 +235,12 @@ class SelectDropdownExample extends React.PureComponent {
 			selectedIcon: icon,
 		} );
 
+		// eslint-disable-next-line no-console
 		console.log( 'Select Dropdown Item (selected):', childSelected );
 	};
 
 	onDropdownSelect( option ) {
+		// eslint-disable-next-line no-console
 		console.log( 'Select Dropdown (selected):', option );
 	}
 }

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -157,15 +157,14 @@ class SelectDropdown extends Component {
 		let refIndex = 0;
 
 		if ( this.props.children ) {
-			// add keys and refs to children
-			return React.Children.map( this.props.children, ( child, index ) => {
+			// add refs and focus-on-click handlers to children
+			return React.Children.map( this.props.children, child => {
 				if ( ! child ) {
 					return null;
 				}
 
 				return React.cloneElement( child, {
 					ref: child.type === DropdownItem ? this.setItemRef( refIndex++ ) : null,
-					key: 'item-' + index,
 					onClick: event => {
 						this.dropdownContainerRef.current.focus();
 						if ( typeof child.props.onClick === 'function' ) {

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -159,12 +159,12 @@ class SelectDropdown extends Component {
 		if ( this.props.children ) {
 			// add refs and focus-on-click handlers to children
 			return React.Children.map( this.props.children, child => {
-				if ( ! child ) {
+				if ( ! child || child.type !== DropdownItem ) {
 					return null;
 				}
 
 				return React.cloneElement( child, {
-					ref: child.type === DropdownItem ? this.setItemRef( refIndex++ ) : null,
+					ref: this.setItemRef( refIndex++ ),
 					onClick: event => {
 						this.dropdownContainerRef.current.focus();
 						if ( typeof child.props.onClick === 'function' ) {

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -12,13 +12,17 @@ import Gridicon from 'gridicons';
 /**
  * Internal dependencies
  */
-import DropdownItem from 'components/select-dropdown/item';
-import DropdownSeparator from 'components/select-dropdown/separator';
-import DropdownLabel from 'components/select-dropdown/label';
+import DropdownItem from './item';
+import DropdownSeparator from './separator';
+import DropdownLabel from './label';
 import Count from 'components/count';
 import TranslatableString from 'components/translatable/proptype';
 
 class SelectDropdown extends Component {
+	static Item = DropdownItem;
+	static Separator = DropdownSeparator;
+	static Label = DropdownLabel;
+
 	static propTypes = {
 		selectedText: TranslatableString,
 		selectedIcon: PropTypes.element,

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -5,7 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { filter, find, findIndex, get, map, noop } from 'lodash';
+import { filter, find, get, noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -327,17 +327,19 @@ class SelectDropdown extends Component {
 		let items, focusedIndex;
 
 		if ( this.props.options.length ) {
-			items = map( filter( this.props.options, item => item && ! item.isLabel ), 'value' );
+			items = filter( this.props.options, item => item && ! item.isLabel );
 
 			focusedIndex =
-				typeof this.focused === 'number' ? this.focused : items.indexOf( this.state.selected );
+				typeof this.focused === 'number'
+					? this.focused
+					: items.findIndex( item => item.value === this.state.selected );
 		} else {
 			items = filter( this.props.children, item => item.type === DropdownItem );
 
 			focusedIndex =
 				typeof this.focused === 'number'
 					? this.focused
-					: findIndex( items, item => item.props.selected );
+					: items.findIndex( item => item.props.selected );
 		}
 
 		const increment = direction === 'previous' ? -1 : 1;

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -18,6 +18,11 @@ import DropdownLabel from './label';
 import Count from 'components/count';
 import TranslatableString from 'components/translatable/proptype';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class SelectDropdown extends Component {
 	static Item = DropdownItem;
 	static Separator = DropdownSeparator;

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -68,19 +68,6 @@ class SelectDropdown extends Component {
 		this.itemRefs[ index ] = itemEl;
 	};
 
-	componentWillReceiveProps( nextProps ) {
-		if ( this.state.isOpen ) {
-			this.closeDropdown();
-		}
-
-		if (
-			typeof this.state.selected !== 'undefined' &&
-			this.props.initialSelected !== nextProps.initialSelected
-		) {
-			this.setState( { selected: nextProps.initialSelected } );
-		}
-	}
-
 	componentWillUnmount() {
 		window.removeEventListener( 'click', this.handleOutsideClick );
 	}

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -103,15 +103,21 @@ class SelectDropdown extends Component {
 	}
 
 	getInitialSelectedItem() {
+		// This method is only useful for the case when the component is uncontrolled, i.e., the
+		// selected state is in local state as opposed to being maintained by parent container.
+		// The `SelectDropdown` is uncontrolled iff the items are specified as `options` prop.
+		// (And is controlled when the items are specified as `children`.)
+		if ( ! this.props.options.length ) {
+			return null;
+		}
+
+		// Use the `initialSelected` prop if specified
 		if ( this.props.initialSelected ) {
 			return this.props.initialSelected;
 		}
 
-		if ( ! this.props.options.length ) {
-			return;
-		}
-
-		const selectedItem = find( this.props.options, value => ! value.isLabel );
+		// Otherwise find the first option that is an item, i.e., not label or separator
+		const selectedItem = find( this.props.options, item => item && ! item.isLabel );
 		return selectedItem && selectedItem.value;
 	}
 

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -3,8 +3,6 @@
 /**
  * External dependencies
  */
-
-import ReactDom from 'react-dom';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { filter, find, findIndex, map, result } from 'lodash';
@@ -69,6 +67,8 @@ class SelectDropdown extends Component {
 
 		this.state = initialState;
 	}
+
+	dropdownContainerRef = React.createRef();
 
 	componentWillReceiveProps( nextProps ) {
 		if ( this.state.isOpen ) {
@@ -161,7 +161,7 @@ class SelectDropdown extends Component {
 					ref: child.type === DropdownItem ? 'item-' + refIndex : null,
 					key: 'item-' + index,
 					onClick: event => {
-						this.refs.dropdownContainer.focus();
+						this.dropdownContainerRef.current.focus();
 						if ( typeof child.props.onClick === 'function' ) {
 							child.props.onClick( event );
 						}
@@ -219,7 +219,7 @@ class SelectDropdown extends Component {
 		return (
 			<div style={ this.props.style } className={ dropdownClassName }>
 				<div
-					ref="dropdownContainer"
+					ref={ this.dropdownContainerRef }
 					className="select-dropdown__container"
 					onKeyDown={ this.navigateItem }
 					tabIndex={ this.props.tabIndex || 0 }
@@ -301,7 +301,7 @@ class SelectDropdown extends Component {
 			selected: option.value,
 		} );
 
-		this.refs.dropdownContainer.focus();
+		this.dropdownContainerRef.current.focus();
 	}
 
 	navigateItem = event => {
@@ -327,7 +327,7 @@ class SelectDropdown extends Component {
 			case 27: // escape
 				event.preventDefault();
 				this.closeDropdown();
-				this.refs.dropdownContainer.focus();
+				this.dropdownContainerRef.current.focus();
 				break;
 		}
 	};
@@ -384,7 +384,7 @@ class SelectDropdown extends Component {
 	}
 
 	handleOutsideClick = event => {
-		if ( ! ReactDom.findDOMNode( this.refs.dropdownContainer ).contains( event.target ) ) {
+		if ( ! this.dropdownContainerRef.current.contains( event.target ) ) {
 			this.closeDropdown();
 		}
 	};

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -55,6 +55,8 @@ class SelectDropdown extends Component {
 
 	static instances = 0;
 
+	instanceId = ++SelectDropdown.instances;
+
 	constructor( props ) {
 		super( props );
 
@@ -66,12 +68,6 @@ class SelectDropdown extends Component {
 		}
 
 		this.state = initialState;
-	}
-
-	componentWillMount() {
-		this.setState( {
-			instanceId: ++SelectDropdown.instances,
-		} );
 	}
 
 	componentWillReceiveProps( nextProps ) {
@@ -184,22 +180,16 @@ class SelectDropdown extends Component {
 
 		return this.props.options.map( function( item, index ) {
 			if ( ! item ) {
-				return (
-					<DropdownSeparator key={ 'dropdown-separator-' + this.state.instanceId + '-' + index } />
-				);
+				return <DropdownSeparator key={ 'dropdown-separator-' + index } />;
 			}
 
 			if ( item.isLabel ) {
-				return (
-					<DropdownLabel key={ 'dropdown-label-' + this.state.instanceId + '-' + index }>
-						{ item.label }
-					</DropdownLabel>
-				);
+				return <DropdownLabel key={ 'dropdown-label-' + index }>{ item.label }</DropdownLabel>;
 			}
 
 			const dropdownItem = (
 				<DropdownItem
-					key={ 'dropdown-item-' + this.state.instanceId + '-' + item.value }
+					key={ 'dropdown-item-' + item.value }
 					ref={ 'item-' + refIndex }
 					isDropdownOpen={ this.state.isOpen }
 					selected={ this.state.selected === item.value }
@@ -237,17 +227,14 @@ class SelectDropdown extends Component {
 					onKeyDown={ this.navigateItem }
 					tabIndex={ this.props.tabIndex || 0 }
 					aria-haspopup="true"
-					aria-owns={ 'select-submenu-' + this.state.instanceId }
-					aria-controls={ 'select-submenu-' + this.state.instanceId }
+					aria-owns={ 'select-submenu-' + this.instanceId }
+					aria-controls={ 'select-submenu-' + this.instanceId }
 					aria-expanded={ this.state.isOpen }
 					aria-disabled={ this.props.disabled }
 					data-tip-target={ this.props.tipTarget }
 					onClick={ this.toggleDropdown }
 				>
-					<div
-						id={ 'select-dropdown-' + this.state.instanceId }
-						className="select-dropdown__header"
-					>
+					<div id={ 'select-dropdown-' + this.instanceId } className="select-dropdown__header">
 						<span className="select-dropdown__header-text">
 							{ selectedIcon && selectedIcon.type === Gridicon ? selectedIcon : null }
 							{ selectedText }
@@ -259,10 +246,10 @@ class SelectDropdown extends Component {
 					</div>
 
 					<ul
-						id={ 'select-submenu-' + this.state.instanceId }
+						id={ 'select-submenu-' + this.instanceId }
 						className="select-dropdown__options"
 						role="menu"
-						aria-labelledby={ 'select-dropdown-' + this.state.instanceId }
+						aria-labelledby={ 'select-dropdown-' + this.instanceId }
 						aria-expanded={ this.state.isOpen }
 					>
 						{ this.dropdownOptions() }

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -5,7 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { filter, find, findIndex, map, result } from 'lodash';
+import { filter, find, findIndex, get, map } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -102,8 +102,7 @@ class SelectDropdown extends Component {
 		}
 
 		// Otherwise find the first option that is an item, i.e., not label or separator
-		const selectedItem = find( this.props.options, item => item && ! item.isLabel );
-		return selectedItem && selectedItem.value;
+		return get( find( this.props.options, item => item && ! item.isLabel ), 'value' );
 	}
 
 	getSelectedText() {
@@ -115,8 +114,7 @@ class SelectDropdown extends Component {
 		}
 
 		// return currently selected text
-		const selectedValue = selected || this.getInitialSelectedItem();
-		return result( find( options, { value: selectedValue } ), 'label' );
+		return get( find( options, { value: selected } ), 'label' );
 	}
 
 	getSelectedIcon() {
@@ -128,8 +126,7 @@ class SelectDropdown extends Component {
 		}
 
 		// return currently selected icon
-		const selectedValue = selected || this.getInitialSelectedItem();
-		return result( find( options, { value: selectedValue } ), 'icon' );
+		return get( find( options, { value: selected } ), 'icon' );
 	}
 
 	dropdownOptions() {

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -163,7 +163,6 @@ class SelectDropdown extends Component {
 					const newChild = React.cloneElement( child, {
 						ref: child.type === DropdownItem ? 'item-' + refIndex : null,
 						key: 'item-' + index,
-						isDropdownOpen: this.state.isOpen,
 						onClick: function( event ) {
 							self.refs.dropdownContainer.focus();
 							if ( typeof child.props.onClick === 'function' ) {
@@ -195,7 +194,6 @@ class SelectDropdown extends Component {
 				<DropdownItem
 					key={ 'dropdown-item-' + item.value }
 					ref={ 'item-' + refIndex }
-					isDropdownOpen={ this.state.isOpen }
 					selected={ this.state.selected === item.value }
 					onClick={ this.onSelectItem( item ) }
 					path={ item.path }

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -64,7 +64,7 @@ class SelectDropdown extends Component {
 		const initialState = { isOpen: false };
 
 		if ( props.options.length ) {
-			initialState.selected = this.getInitialSelectedItem( props );
+			initialState.selected = this.getInitialSelectedItem();
 		}
 
 		this.state = initialState;
@@ -102,18 +102,16 @@ class SelectDropdown extends Component {
 		}
 	}
 
-	getInitialSelectedItem( props ) {
-		props = props || this.props;
-
-		if ( props.initialSelected ) {
-			return props.initialSelected;
+	getInitialSelectedItem() {
+		if ( this.props.initialSelected ) {
+			return this.props.initialSelected;
 		}
 
-		if ( ! props.options.length ) {
+		if ( ! this.props.options.length ) {
 			return;
 		}
 
-		const selectedItem = find( props.options, value => ! value.isLabel );
+		const selectedItem = find( this.props.options, value => ! value.isLabel );
 		return selectedItem && selectedItem.value;
 	}
 
@@ -126,7 +124,7 @@ class SelectDropdown extends Component {
 		}
 
 		// return currently selected text
-		const selectedValue = selected || this.getInitialSelectedItem( this.props );
+		const selectedValue = selected || this.getInitialSelectedItem();
 		return result( find( options, { value: selectedValue } ), 'label' );
 	}
 
@@ -139,7 +137,7 @@ class SelectDropdown extends Component {
 		}
 
 		// return currently selected icon
-		const selectedValue = selected || this.getInitialSelectedItem( this.props );
+		const selectedValue = selected || this.getInitialSelectedItem();
 		return result( find( options, { value: selectedValue } ), 'icon' );
 	}
 

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -149,39 +149,34 @@ class SelectDropdown extends Component {
 
 	dropdownOptions() {
 		let refIndex = 0;
-		const self = this;
 
 		if ( this.props.children ) {
 			// add keys and refs to children
-			return React.Children.map(
-				this.props.children,
-				function( child, index ) {
-					if ( ! child ) {
-						return null;
-					}
+			return React.Children.map( this.props.children, ( child, index ) => {
+				if ( ! child ) {
+					return null;
+				}
 
-					const newChild = React.cloneElement( child, {
-						ref: child.type === DropdownItem ? 'item-' + refIndex : null,
-						key: 'item-' + index,
-						onClick: function( event ) {
-							self.refs.dropdownContainer.focus();
-							if ( typeof child.props.onClick === 'function' ) {
-								child.props.onClick( event );
-							}
-						},
-					} );
+				const newChild = React.cloneElement( child, {
+					ref: child.type === DropdownItem ? 'item-' + refIndex : null,
+					key: 'item-' + index,
+					onClick: event => {
+						this.refs.dropdownContainer.focus();
+						if ( typeof child.props.onClick === 'function' ) {
+							child.props.onClick( event );
+						}
+					},
+				} );
 
-					if ( child.type === DropdownItem ) {
-						refIndex++;
-					}
+				if ( child.type === DropdownItem ) {
+					refIndex++;
+				}
 
-					return newChild;
-				},
-				this
-			);
+				return newChild;
+			} );
 		}
 
-		return this.props.options.map( function( item, index ) {
+		return this.props.options.map( ( item, index ) => {
 			if ( ! item ) {
 				return <DropdownSeparator key={ 'dropdown-separator-' + index } />;
 			}
@@ -206,7 +201,7 @@ class SelectDropdown extends Component {
 			refIndex++;
 
 			return dropdownItem;
-		}, this );
+		} );
 	}
 
 	render() {
@@ -364,26 +359,17 @@ class SelectDropdown extends Component {
 		let items, focusedIndex;
 
 		if ( this.props.options.length ) {
-			items = map(
-				filter( this.props.options, item => {
-					return item && ! item.isLabel;
-				} ),
-				'value'
-			);
+			items = map( filter( this.props.options, item => item && ! item.isLabel ), 'value' );
 
 			focusedIndex =
 				typeof this.focused === 'number' ? this.focused : items.indexOf( this.state.selected );
 		} else {
-			items = filter( this.props.children, function( item ) {
-				return item.type === DropdownItem;
-			} );
+			items = filter( this.props.children, item => item.type === DropdownItem );
 
 			focusedIndex =
 				typeof this.focused === 'number'
 					? this.focused
-					: findIndex( items, function( item ) {
-							return item.props.selected;
-					  } );
+					: findIndex( items, item => item.props.selected );
 		}
 
 		const increment = direction === 'previous' ? -1 : 1;

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -173,8 +173,7 @@ class SelectDropdown extends Component {
 	}
 
 	render() {
-		const dropdownClassName = classNames( this.props.className, {
-			'select-dropdown': true,
+		const dropdownClassName = classNames( 'select-dropdown', this.props.className, {
 			'is-compact': this.props.compact,
 			'is-open': this.state.isOpen && ! this.props.disabled,
 			'is-disabled': this.props.disabled,

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -5,7 +5,7 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { filter, find, findIndex, get, map } from 'lodash';
+import { filter, find, findIndex, get, map, noop } from 'lodash';
 import classNames from 'classnames';
 import Gridicon from 'gridicons';
 
@@ -43,8 +43,8 @@ class SelectDropdown extends Component {
 
 	static defaultProps = {
 		options: [],
-		onSelect: () => {},
-		onToggle: () => {},
+		onSelect: noop,
+		onToggle: noop,
 		style: {},
 	};
 

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -99,7 +99,7 @@ class SelectDropdown extends Component {
 		// The `SelectDropdown` is uncontrolled iff the items are specified as `options` prop.
 		// (And is controlled when the items are specified as `children`.)
 		if ( ! this.props.options.length ) {
-			return null;
+			return undefined;
 		}
 
 		// Use the `initialSelected` prop if specified

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -379,7 +379,7 @@ class SelectDropdown extends Component {
 			return;
 		}
 
-		ReactDom.findDOMNode( this.refs[ 'item-' + newIndex ].refs.itemLink ).focus();
+		this.refs[ 'item-' + newIndex ].focusLink();
 		this.focused = newIndex;
 	}
 

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -18,9 +18,6 @@ import DropdownLabel from 'components/select-dropdown/label';
 import Count from 'components/count';
 import TranslatableString from 'components/translatable/proptype';
 
-/**
- * SelectDropdown
- */
 class SelectDropdown extends Component {
 	static propTypes = {
 		selectedText: TranslatableString,

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -191,6 +191,7 @@ class SelectDropdown extends Component {
 					className="select-dropdown__container"
 					onKeyDown={ this.navigateItem }
 					tabIndex={ this.props.tabIndex || 0 }
+					role="button"
 					aria-haspopup="true"
 					aria-owns={ 'select-submenu-' + this.instanceId }
 					aria-controls={ 'select-submenu-' + this.instanceId }

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -70,6 +70,12 @@ class SelectDropdown extends Component {
 
 	dropdownContainerRef = React.createRef();
 
+	itemRefs = [];
+
+	setItemRef = index => itemEl => {
+		this.itemRefs[ index ] = itemEl;
+	};
+
 	componentWillReceiveProps( nextProps ) {
 		if ( this.state.isOpen ) {
 			this.closeDropdown();
@@ -157,8 +163,8 @@ class SelectDropdown extends Component {
 					return null;
 				}
 
-				const newChild = React.cloneElement( child, {
-					ref: child.type === DropdownItem ? 'item-' + refIndex : null,
+				return React.cloneElement( child, {
+					ref: child.type === DropdownItem ? this.setItemRef( refIndex++ ) : null,
 					key: 'item-' + index,
 					onClick: event => {
 						this.dropdownContainerRef.current.focus();
@@ -167,12 +173,6 @@ class SelectDropdown extends Component {
 						}
 					},
 				} );
-
-				if ( child.type === DropdownItem ) {
-					refIndex++;
-				}
-
-				return newChild;
 			} );
 		}
 
@@ -185,10 +185,10 @@ class SelectDropdown extends Component {
 				return <DropdownLabel key={ 'dropdown-label-' + index }>{ item.label }</DropdownLabel>;
 			}
 
-			const dropdownItem = (
+			return (
 				<DropdownItem
 					key={ 'dropdown-item-' + item.value }
-					ref={ 'item-' + refIndex }
+					ref={ this.setItemRef( refIndex++ ) }
 					selected={ this.state.selected === item.value }
 					onClick={ this.onSelectItem( item ) }
 					path={ item.path }
@@ -197,10 +197,6 @@ class SelectDropdown extends Component {
 					{ item.label }
 				</DropdownItem>
 			);
-
-			refIndex++;
-
-			return dropdownItem;
 		} );
 	}
 
@@ -379,7 +375,7 @@ class SelectDropdown extends Component {
 			return;
 		}
 
-		this.refs[ 'item-' + newIndex ].focusLink();
+		this.itemRefs[ newIndex ].focusLink();
 		this.focused = newIndex;
 	}
 

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -58,11 +58,6 @@ class SelectDropdown extends Component {
 	constructor( props ) {
 		super( props );
 
-		// bounds
-		this.navigateItem = this.navigateItem.bind( this );
-		this.toggleDropdown = this.toggleDropdown.bind( this );
-		this.handleOutsideClick = this.handleOutsideClick.bind( this );
-
 		// state
 		const initialState = { isOpen: false };
 
@@ -277,7 +272,7 @@ class SelectDropdown extends Component {
 		);
 	}
 
-	toggleDropdown() {
+	toggleDropdown = () => {
 		if ( this.props && this.props.disabled ) {
 			return;
 		}
@@ -285,7 +280,7 @@ class SelectDropdown extends Component {
 		this.setState( {
 			isOpen: ! this.state.isOpen,
 		} );
-	}
+	};
 
 	openDropdown() {
 		if ( this.props && this.props.disabled ) {
@@ -325,7 +320,7 @@ class SelectDropdown extends Component {
 		this.refs.dropdownContainer.focus();
 	}
 
-	navigateItem( event ) {
+	navigateItem = event => {
 		switch ( event.keyCode ) {
 			case 9: //tab
 				this.navigateItemByTabKey( event );
@@ -351,7 +346,7 @@ class SelectDropdown extends Component {
 				this.refs.dropdownContainer.focus();
 				break;
 		}
-	}
+	};
 
 	navigateItemByTabKey( event ) {
 		if ( ! this.state.isOpen ) {
@@ -413,11 +408,11 @@ class SelectDropdown extends Component {
 		this.focused = newIndex;
 	}
 
-	handleOutsideClick( event ) {
+	handleOutsideClick = event => {
 		if ( ! ReactDom.findDOMNode( this.refs.dropdownContainer ).contains( event.target ) ) {
 			this.closeDropdown();
 		}
-	}
+	};
 }
 
 export default SelectDropdown;

--- a/client/components/select-dropdown/index.jsx
+++ b/client/components/select-dropdown/index.jsx
@@ -55,18 +55,10 @@ class SelectDropdown extends Component {
 
 	instanceId = ++SelectDropdown.instances;
 
-	constructor( props ) {
-		super( props );
-
-		// state
-		const initialState = { isOpen: false };
-
-		if ( props.options.length ) {
-			initialState.selected = this.getInitialSelectedItem();
-		}
-
-		this.state = initialState;
-	}
+	state = {
+		isOpen: false,
+		selected: this.getInitialSelectedItem(),
+	};
 
 	dropdownContainerRef = React.createRef();
 

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -20,7 +20,6 @@ class SelectDropdownItem extends Component {
 		children: TranslatableString.isRequired,
 		compactCount: PropTypes.bool,
 		path: PropTypes.string,
-		isDropdownOpen: PropTypes.bool,
 		selected: PropTypes.bool,
 		onClick: PropTypes.func,
 		count: PropTypes.number,
@@ -29,7 +28,6 @@ class SelectDropdownItem extends Component {
 	};
 
 	static defaultProps = {
-		isDropdownOpen: false,
 		selected: false,
 	};
 
@@ -50,7 +48,7 @@ class SelectDropdownItem extends Component {
 					onClick={ this.props.disabled ? null : this.props.onClick }
 					data-bold-text={ this.props.value || this.props.children }
 					role="menuitem"
-					tabIndex={ this.props.isDropdownOpen ? 0 : '' }
+					tabIndex="0"
 					aria-selected={ this.props.selected }
 					data-e2e-title={ this.props.e2eTitle }
 				>

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -31,6 +31,13 @@ class SelectDropdownItem extends Component {
 		selected: false,
 	};
 
+	linkRef = React.createRef();
+
+	// called by the parent `SelectDropdown` component to focus the item on keyboard navigation
+	focusLink() {
+		this.linkRef.current.focus();
+	}
+
 	render() {
 		const optionClassName = classNames( this.props.className, {
 			'select-dropdown__item': true,
@@ -42,7 +49,7 @@ class SelectDropdownItem extends Component {
 		return (
 			<li className="select-dropdown__option">
 				<a
-					ref="itemLink"
+					ref={ this.linkRef }
 					href={ this.props.path }
 					className={ optionClassName }
 					onClick={ this.props.disabled ? null : this.props.onClick }

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -39,11 +39,10 @@ class SelectDropdownItem extends Component {
 	}
 
 	render() {
-		const optionClassName = classNames( this.props.className, {
-			'select-dropdown__item': true,
+		const optionClassName = classNames( 'select-dropdown__item', this.props.className, {
 			'is-selected': this.props.selected,
 			'is-disabled': this.props.disabled,
-			'has-icon': !! this.props.icon,
+			'has-icon': this.props.icon,
 		} );
 
 		return (

--- a/client/components/select-dropdown/item.jsx
+++ b/client/components/select-dropdown/item.jsx
@@ -56,7 +56,7 @@ class SelectDropdownItem extends Component {
 					data-bold-text={ this.props.value || this.props.children }
 					role="menuitem"
 					tabIndex="0"
-					aria-selected={ this.props.selected }
+					aria-current={ this.props.selected }
 					data-e2e-title={ this.props.e2eTitle }
 				>
 					<span className="select-dropdown__item-text">

--- a/client/components/select-dropdown/label.jsx
+++ b/client/components/select-dropdown/label.jsx
@@ -1,26 +1,15 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 
-/**
- * Module variables
- */
-
-/**
- * Prevents the event from bubbling up the DOM tree
- * @param {SyntheticEvent} event - Browser's native event wrapper
- * @return {void}
- */
+// Prevents the event from bubbling up the DOM tree
 const stopPropagation = event => event.stopPropagation();
 
-export default function SelectDropdownLabel( props ) {
+export default function SelectDropdownLabel( { children } ) {
 	return (
-		<li onClick={ stopPropagation } className="select-dropdown__label">
-			<label>{ props.children }</label>
+		<li onClick={ stopPropagation } role="presentation" className="select-dropdown__label">
+			<label>{ children }</label>
 		</li>
 	);
 }

--- a/client/components/select-dropdown/separator.jsx
+++ b/client/components/select-dropdown/separator.jsx
@@ -1,11 +1,13 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 
-const SelectDropdownSeparator = () => <li className="select-dropdown__separator" />;
+// Prevents the event from bubbling up the DOM tree
+const stopPropagation = event => event.stopPropagation();
 
-export default SelectDropdownSeparator;
+export default function SelectDropdownSeparator() {
+	return (
+		<li onClick={ stopPropagation } role="presentation" className="select-dropdown__separator" />
+	);
+}

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -10,10 +10,6 @@ $compact-header-height: 35;
 .select-dropdown {
 	height: #{$header-height}px;
 
-	&.is-open {
-		overflow: visible;
-	}
-
 	&.is-compact {
 		height: #{$compact-header-height}px;
 	}
@@ -156,15 +152,13 @@ $compact-header-height: 35;
 	box-sizing: border-box;
 	padding: 0;
 	list-style: none;
-	margin: 0;
+	margin: -1px 0 0;
 	background-color: var( --color-white );
 	border: 1px solid var( --color-neutral-100 );
 	border-top: 0;
 	// var( --color-primary ) for outer (with focus shadow), $gray for border with header
 	border-radius: 0 0 4px 4px;
-	height: 0;
-	overflow: hidden;
-	opacity: 0;
+	visibility: hidden;
 
 	.accessible-focus & {
 		border: solid 1px var( --color-primary );
@@ -172,9 +166,7 @@ $compact-header-height: 35;
 	}
 
 	.select-dropdown.is-open & {
-		margin-top: -1px;
-		height: auto;
-		opacity: 1;
+		visibility: visible;
 	}
 }
 

--- a/client/components/select-dropdown/style.scss
+++ b/client/components/select-dropdown/style.scss
@@ -9,6 +9,11 @@ $compact-header-height: 35;
 
 .select-dropdown {
 	height: #{$header-height}px;
+	overflow: hidden;
+
+	&.is-open {
+		overflow: visible;
+	}
 
 	&.is-compact {
 		height: #{$compact-header-height}px;

--- a/client/components/select-dropdown/test/index.js
+++ b/client/components/select-dropdown/test/index.js
@@ -42,48 +42,31 @@ describe( 'index', () => {
 		} );
 
 		test( 'should execute toggleDropdown when clicked', () => {
-			const toggleDropdownStub = sinon.stub( SelectDropdown.prototype, 'toggleDropdown' );
-
 			const dropdown = shallowRenderDropdown();
-			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
 
-			sinon.assert.calledOnce( toggleDropdownStub );
-			toggleDropdownStub.restore();
+			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
+			expect( dropdown.find( '.select-dropdown.is-open' ) ).to.have.lengthOf( 1 );
 		} );
 
 		test( 'should not respond when clicked when disabled', () => {
-			const toggleDropdownSpy = sinon.spy( SelectDropdown.prototype, 'toggleDropdown' );
-
-			const dropdown = shallowRenderDropdown( {
-				disabled: true,
-			} );
+			const dropdown = shallowRenderDropdown( { disabled: true } );
 
 			expect( dropdown.find( '.select-dropdown.is-disabled' ) ).to.have.lengthOf( 1 );
 
 			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
-
-			sinon.assert.called( toggleDropdownSpy );
-
 			expect( dropdown.find( '.select-dropdown.is-open' ) ).to.be.empty;
 
 			// Repeat to be sure
 			dropdown.find( '.select-dropdown__container' ).simulate( 'click' );
-
-			sinon.assert.called( toggleDropdownSpy );
-
 			expect( dropdown.find( '.select-dropdown.is-open' ) ).to.be.empty;
-
-			toggleDropdownSpy.restore();
 		} );
 
-		test( 'should be possible to control the dropdown via keyboard', () => {
-			const navigateItemStub = sinon.stub( SelectDropdown.prototype, 'navigateItem' );
-
+		test( 'should be possible to open the dropdown via keyboard', () => {
 			const dropdown = shallowRenderDropdown();
-			dropdown.find( '.select-dropdown__container' ).simulate( 'keydown' );
 
-			sinon.assert.calledOnce( navigateItemStub );
-			navigateItemStub.restore();
+			// simulate pressing 'space' key
+			dropdown.find( '.select-dropdown__container' ).simulate( 'keydown', createKeyEvent( 32 ) );
+			expect( dropdown.find( '.select-dropdown.is-open' ) ).to.have.lengthOf( 1 );
 		} );
 	} );
 
@@ -119,88 +102,35 @@ describe( 'index', () => {
 			expect( initialSelectedText ).to.equal( 'Published' );
 		} );
 
-		test( "should return the `label` associated to the initial selected option, when there isn't any selected option", () => {
-			const getInitialSelectedItemStub = sinon.stub(
-				SelectDropdown.prototype,
-				'getInitialSelectedItem'
-			);
-			getInitialSelectedItemStub.returns( undefined );
-
-			const dropdown = shallowRenderDropdown();
-
-			getInitialSelectedItemStub.resetHistory().returns( 'scheduled' );
-
+		test( 'should return the `label` associated to the initial selected option', () => {
+			const dropdown = shallowRenderDropdown( { initialSelected: 'scheduled' } );
 			const initialSelectedText = dropdown.instance().getSelectedText();
-
-			sinon.assert.calledOnce( getInitialSelectedItemStub );
 			expect( initialSelectedText ).to.equal( 'Scheduled' );
-
-			getInitialSelectedItemStub.restore();
 		} );
 	} );
 
 	describe( 'selectItem', () => {
 		test( 'should run the `onSelect` hook, and then update the state', () => {
-			const setStateStub = sinon.stub( React.Component.prototype, 'setState' );
-
 			const dropdownOptions = getDropdownOptions();
 			const onSelectSpy = sinon.spy();
 			const dropdown = mount(
 				<SelectDropdown options={ dropdownOptions } onSelect={ onSelectSpy } />
 			);
 
-			setStateStub.resetHistory();
-
 			const newSelectedOption = dropdownOptions[ 2 ];
 			dropdown.instance().selectItem( newSelectedOption );
-
-			sinon.assert.calledOnce( onSelectSpy );
-			sinon.assert.calledOnce( setStateStub );
-			sinon.assert.calledWith( setStateStub, { selected: newSelectedOption.value } );
-
-			setStateStub.restore();
-		} );
-	} );
-
-	describe( 'disabled', () => {
-		test( 'should ignore all toggling when disabled', () => {
-			function runToggleDropdownTest( isCurrentlyOpen ) {
-				const setStateSpy = sinon.spy();
-				const fakeContext = {
-					setState: setStateSpy,
-					props: {
-						disabled: true,
-					},
-					state: {
-						isOpen: isCurrentlyOpen,
-					},
-				};
-
-				SelectDropdown.prototype.toggleDropdown.call( fakeContext );
-
-				sinon.assert.notCalled( setStateSpy );
-			}
-
-			runToggleDropdownTest( true );
-			runToggleDropdownTest( false );
+			expect( dropdown.state( 'selected' ) ).to.equal( newSelectedOption.value );
 		} );
 	} );
 
 	describe( 'toggleDropdown', () => {
 		test( 'should toggle the `isOpen` state property', () => {
 			function runToggleDropdownTest( isCurrentlyOpen ) {
-				const setStateSpy = sinon.spy();
-				const fakeContext = {
-					setState: setStateSpy,
-					state: {
-						isOpen: isCurrentlyOpen,
-					},
-				};
+				const dropdown = shallowRenderDropdown();
+				dropdown.setState( { isOpen: isCurrentlyOpen } );
 
-				SelectDropdown.prototype.toggleDropdown.call( fakeContext );
-
-				sinon.assert.calledOnce( setStateSpy );
-				sinon.assert.calledWith( setStateSpy, { isOpen: ! isCurrentlyOpen } );
+				dropdown.instance().toggleDropdown();
+				expect( dropdown.state( 'isOpen' ) ).to.equal( ! isCurrentlyOpen );
 			}
 
 			runToggleDropdownTest( true );
@@ -210,73 +140,52 @@ describe( 'index', () => {
 
 	describe( 'openDropdown', () => {
 		test( 'should set the `isOpen` state property equal `true`', () => {
-			const setStateSpy = sinon.spy();
-			const fakeContext = {
-				setState: setStateSpy,
-			};
-
-			SelectDropdown.prototype.openDropdown.call( fakeContext );
-
-			sinon.assert.calledOnce( setStateSpy );
-			sinon.assert.calledWith( setStateSpy, { isOpen: true } );
+			const dropdown = shallowRenderDropdown();
+			dropdown.instance().openDropdown();
+			expect( dropdown.state( 'isOpen' ) ).to.equal( true );
 		} );
 	} );
 
 	describe( 'closeDropdown', () => {
 		test( "shouldn't do anything when the dropdown is already closed", () => {
-			const setStateSpy = sinon.spy();
-			const fakeContext = {
-				setState: setStateSpy,
-				state: {
-					isOpen: false,
-				},
-			};
-
-			SelectDropdown.prototype.closeDropdown.call( fakeContext );
-
-			sinon.assert.notCalled( setStateSpy );
+			const dropdown = shallowRenderDropdown();
+			dropdown.instance().closeDropdown();
+			expect( dropdown.state( 'isOpen' ) ).to.equal( false );
 		} );
 
 		test( 'should set the `isOpen` state property equal `false`', () => {
-			const setStateSpy = sinon.spy();
-			const fakeContext = {
-				focused: 1,
-				setState: setStateSpy,
-				state: {
-					isOpen: true,
-				},
-			};
+			const dropdown = shallowRenderDropdown();
+			dropdown.setState( { isOpen: true } );
+			dropdown.instance().focused = 1;
 
-			SelectDropdown.prototype.closeDropdown.call( fakeContext );
-
-			sinon.assert.calledOnce( setStateSpy );
-			sinon.assert.calledWith( setStateSpy, { isOpen: false } );
-
-			expect( fakeContext.focused ).to.be.undefined;
+			dropdown.instance().closeDropdown();
+			expect( dropdown.state( 'isOpen' ) ).to.equal( false );
+			expect( dropdown.instance().focused ).to.be.undefined;
 		} );
 	} );
 
 	describe( 'navigateItem', () => {
 		test( "permits to navigate through the dropdown's options by pressing the TAB key", () => {
 			const tabKeyCode = 9;
-			const fakeEvent = prepareFakeEvent( tabKeyCode );
-			const fakeContext = prepareFakeContext();
+			const tabEvent = createKeyEvent( tabKeyCode );
 
-			SelectDropdown.prototype.navigateItem.call( fakeContext, fakeEvent );
+			const dropdown = mountDropdown();
+			dropdown.setState( { isOpen: true } );
 
-			sinon.assert.calledOnce( fakeContext.navigateItemByTabKey );
-			sinon.assert.calledWith( fakeContext.navigateItemByTabKey, fakeEvent );
+			dropdown.find( '.select-dropdown__container' ).simulate( 'keydown', tabEvent );
+			expect( dropdown.instance().focused ).to.equal( 1 );
 		} );
 
 		test( 'permits to select an option by pressing ENTER, or SPACE', () => {
 			function runNavigateItemTest( keyCode ) {
-				const fakeEvent = prepareFakeEvent( keyCode );
-				const fakeContext = prepareFakeContext();
+				const dropdown = shallowRenderDropdown();
+				const activateItemSpy = sinon.spy( dropdown.instance(), 'activateItem' );
+				const keyEvent = createKeyEvent( keyCode );
 
-				SelectDropdown.prototype.navigateItem.call( fakeContext, fakeEvent );
-
-				sinon.assert.calledOnce( fakeEvent.preventDefault );
-				sinon.assert.calledOnce( fakeContext.activateItem );
+				dropdown.find( '.select-dropdown__container' ).simulate( 'keydown', keyEvent );
+				expect( dropdown.state( 'isOpen' ) ).to.equal( true );
+				sinon.assert.calledOnce( keyEvent.preventDefault );
+				sinon.assert.calledOnce( activateItemSpy );
 			}
 
 			const enterKeyCode = 13;
@@ -287,65 +196,37 @@ describe( 'index', () => {
 
 		test( 'permits to close the dropdown by pressing ESCAPE', () => {
 			const escapeKeyCode = 27;
-			const fakeEvent = prepareFakeEvent( escapeKeyCode );
-			const fakeContext = prepareFakeContext();
+			const escEvent = createKeyEvent( escapeKeyCode );
 
-			SelectDropdown.prototype.navigateItem.call( fakeContext, fakeEvent );
+			const dropdown = mountDropdown();
+			dropdown.setState( { isOpen: true } );
 
-			sinon.assert.calledOnce( fakeEvent.preventDefault );
-
-			const {
-				refs: {
-					dropdownContainer: { focus: focusSpy },
-				},
-				closeDropdown: closeDropdownSpy,
-			} = fakeContext;
-			sinon.assert.calledOnce( closeDropdownSpy );
-			sinon.assert.calledOnce( focusSpy );
+			const container = dropdown.find( '.select-dropdown__container' );
+			container.simulate( 'keydown', escEvent );
+			expect( dropdown.state( 'isOpen' ) ).to.equal( false );
+			sinon.assert.calledOnce( escEvent.preventDefault );
+			// check that container was focused
+			expect( container.instance() ).to.equal( document.activeElement );
 		} );
 
-		test( "permits to open the dropdown, and navigate through the dropdown's options by pressing the arrow UP/DOWN keys", () => {
-			function runNavigateItemTest( { keyCode, direction } ) {
-				const fakeEvent = prepareFakeEvent( keyCode );
-				const fakeContext = prepareFakeContext();
+		describe( "permits to open the dropdown, and navigate through the dropdown's options by ", () => {
+			function runNavigateItemTest( { keyCode, nextFocused } ) {
+				const keyEvent = createKeyEvent( keyCode );
+				const dropdown = mountDropdown();
+				dropdown.instance().focused = 1;
 
-				SelectDropdown.prototype.navigateItem.call( fakeContext, fakeEvent );
+				dropdown.find( '.select-dropdown__container' ).simulate( 'keydown', keyEvent );
+				expect( dropdown.state( 'isOpen' ) ).to.equal( true );
 
-				sinon.assert.calledOnce( fakeEvent.preventDefault );
-
-				sinon.assert.calledOnce( fakeContext.focusSibling );
-				sinon.assert.calledWith( fakeContext.focusSibling, direction );
-
-				sinon.assert.calledOnce( fakeContext.openDropdown );
+				dropdown.find( '.select-dropdown__container' ).simulate( 'keydown', keyEvent );
+				expect( dropdown.instance().focused ).to.equal( nextFocused );
 			}
 
-			const arrowUp = { keyCode: 38, direction: 'previous' };
-			const arrowDown = { keyCode: 40, direction: 'next' };
+			const arrowUp = { keyCode: 38, nextFocused: 0 };
+			const arrowDown = { keyCode: 40, nextFocused: 2 };
 
 			[ arrowUp, arrowDown ].forEach( runNavigateItemTest );
 		} );
-
-		function prepareFakeContext() {
-			return {
-				refs: {
-					dropdownContainer: {
-						focus: sinon.spy(),
-					},
-				},
-				activateItem: sinon.spy(),
-				closeDropdown: sinon.spy(),
-				focusSibling: sinon.spy(),
-				navigateItemByTabKey: sinon.spy(),
-				openDropdown: sinon.spy(),
-			};
-		}
-
-		function prepareFakeEvent( keyCode ) {
-			return {
-				keyCode,
-				preventDefault: sinon.spy(),
-			};
-		}
 	} );
 
 	/**
@@ -371,5 +252,12 @@ describe( 'index', () => {
 			null,
 			{ value: 'trashed', label: 'Trashed' },
 		];
+	}
+
+	function createKeyEvent( keyCode ) {
+		return {
+			keyCode,
+			preventDefault: sinon.spy(),
+		};
 	}
 } );

--- a/client/components/select-dropdown/test/item.js
+++ b/client/components/select-dropdown/test/item.js
@@ -28,20 +28,6 @@ describe( 'item', () => {
 			expect( dropdownItem.children( 'a.select-dropdown__item' ).length ).to.eql( 1 );
 			expect( dropdownItem.find( 'span.select-dropdown__item-text' ).text() ).to.eql( 'Published' );
 		} );
-
-		test( 'should not have `tabindex` attribute, when the parent dropdown is closed', () => {
-			const dropdownItem = shallow(
-				<SelectDropdownItem isDropdownOpen={ false }>Published</SelectDropdownItem>
-			);
-			expect( dropdownItem.children( { tabIndex: 0 } ).length ).to.eql( 0 );
-		} );
-
-		test( 'should have `tabindex` attribute set to `0`, only when the parent dropdown is open (issue#9206)', () => {
-			const dropdownItem = shallow(
-				<SelectDropdownItem isDropdownOpen={ true }>Published</SelectDropdownItem>
-			);
-			expect( dropdownItem.children( { tabIndex: 0 } ).length ).to.eql( 1 );
-		} );
 	} );
 
 	describe( 'when the component is clicked', () => {

--- a/client/components/tinymce/plugins/contact-form/dialog/field.jsx
+++ b/client/components/tinymce/plugins/contact-form/dialog/field.jsx
@@ -21,7 +21,6 @@ import FormCheckbox from 'components/forms/form-checkbox';
 import FormTextValidation from 'components/forms/form-input-validation';
 import FormSettingExplanation from 'components/forms/form-setting-explanation';
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
 import TokenField from 'components/token-field';
 import FieldRemoveButton from './field-remove-button';
 import FieldEditButton from './field-edit-button';
@@ -51,7 +50,7 @@ class ContactFormDialogField extends React.PureComponent {
 		}
 
 		let { options } = this.props;
-		options = !! options ? options.split( ',' ) : [];
+		options = options ? options.split( ',' ) : [];
 
 		const optionsValidationError = ! options || options.length === 0;
 
@@ -119,13 +118,13 @@ class ContactFormDialogField extends React.PureComponent {
 					<FormLabel>{ this.props.translate( 'Field Type' ) }</FormLabel>
 					<SelectDropdown selectedText={ getLabel( this.props.type ) }>
 						{ fieldTypes.map( fieldType => (
-							<DropdownItem
+							<SelectDropdown.Item
 								key={ 'field-type-' + fieldType }
 								selected={ this.props.type === fieldType }
 								onClick={ () => this.props.onUpdate( { type: fieldType } ) }
 							>
 								{ getLabel( fieldType ) }
-							</DropdownItem>
+							</SelectDropdown.Item>
 						) ) }
 					</SelectDropdown>
 				</FormFieldset>

--- a/client/components/web-preview/toolbar.jsx
+++ b/client/components/web-preview/toolbar.jsx
@@ -16,7 +16,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
 import ClipboardButtonInput from 'components/clipboard-button-input';
 import { recordTracksEvent } from 'state/analytics/actions';
 
@@ -121,7 +120,7 @@ class PreviewToolbar extends Component {
 						ref={ this.setDropdown }
 					>
 						{ devicesToShow.map( device => (
-							<DropdownItem
+							<SelectDropdown.Item
 								key={ device }
 								selected={ device === currentDevice }
 								onClick={ partial( setDeviceViewport, device ) }
@@ -129,7 +128,7 @@ class PreviewToolbar extends Component {
 								e2eTitle={ device }
 							>
 								{ this.devices[ device ].title }
-							</DropdownItem>
+							</SelectDropdown.Item>
 						) ) }
 					</SelectDropdown>
 				) }

--- a/client/devdocs/design/playground.jsx
+++ b/client/devdocs/design/playground.jsx
@@ -20,7 +20,6 @@ import * as playgroundScope from 'devdocs/design/playground-scope';
 import DocumentHead from 'components/data/document-head';
 import fetchComponentsUsageStats from 'state/components-usage-stats/actions';
 import Main from 'components/main';
-import DropdownItem from 'components/select-dropdown/item';
 import SelectDropdown from 'components/select-dropdown';
 import { getExampleCodeFromComponent } from './playground-utils';
 
@@ -116,9 +115,9 @@ class DesignAssets extends React.Component {
 					const exampleCode = getExampleCodeFromComponent( exampleComponent );
 					return (
 						exampleCode && (
-							<DropdownItem key={ name } onClick={ this.addComponent( exampleCode ) }>
+							<SelectDropdown.Item key={ name } onClick={ this.addComponent( exampleCode ) }>
 								{ name }
-							</DropdownItem>
+							</SelectDropdown.Item>
 						)
 					);
 				} ) }

--- a/client/me/billing-history/transactions-header.jsx
+++ b/client/me/billing-history/transactions-header.jsx
@@ -14,9 +14,6 @@ import { find, isEqual } from 'lodash';
  * Internal dependencies
  */
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
-import DropdownLabel from 'components/select-dropdown/label';
-import DropdownSeparator from 'components/select-dropdown/separator';
 import { recordGoogleEvent } from 'state/analytics/actions';
 import { setApp, setDate } from 'state/ui/billing-transactions/actions';
 import getBillingTransactionAppFilterValues from 'state/selectors/get-billing-transaction-app-filter-values';
@@ -107,7 +104,7 @@ class TransactionsHeader extends React.Component {
 				onClick={ this.handleAppsPopoverLinkClick }
 				className="billing-history__transactions-header-select-dropdown"
 			>
-				<DropdownLabel>{ translate( 'Recent Transactions' ) }</DropdownLabel>
+				<SelectDropdown.Label>{ translate( 'Recent Transactions' ) }</SelectDropdown.Label>
 				{ this.renderDatePicker(
 					'Newest',
 					translate( 'Newest' ),
@@ -117,8 +114,8 @@ class TransactionsHeader extends React.Component {
 					},
 					null
 				) }
-				<DropdownSeparator />
-				<DropdownLabel>{ translate( 'By Month' ) }</DropdownLabel>
+				<SelectDropdown.Separator />
+				<SelectDropdown.Label>{ translate( 'By Month' ) }</SelectDropdown.Label>
 				{ dateFilters.map( function( { count, title, value }, index ) {
 					let analyticsEvent = 'Current Month';
 
@@ -151,14 +148,14 @@ class TransactionsHeader extends React.Component {
 		analyticsEvent = 'undefined' === typeof analyticsEvent ? titleKey : analyticsEvent;
 
 		return (
-			<DropdownItem
+			<SelectDropdown.Item
 				key={ titleKey }
 				selected={ isSelected }
 				onClick={ this.getDatePopoverItemClickHandler( analyticsEvent, value ) }
 				count={ count }
 			>
 				{ titleTranslated }
-			</DropdownItem>
+			</SelectDropdown.Item>
 		);
 	}
 
@@ -173,7 +170,7 @@ class TransactionsHeader extends React.Component {
 				onClick={ this.handleAppsPopoverLinkClick }
 				className="billing-history__transactions-header-select-dropdown"
 			>
-				<DropdownLabel>{ translate( 'App Name' ) }</DropdownLabel>
+				<SelectDropdown.Label>{ translate( 'App Name' ) }</SelectDropdown.Label>
 				{ this.renderAppPicker( translate( 'All Apps' ), 'all' ) }
 				{ appFilters.map( function( { title, value, count } ) {
 					return this.renderAppPicker( title, value, count, 'Specific App' );
@@ -186,14 +183,14 @@ class TransactionsHeader extends React.Component {
 		const selected = app === this.props.filter.app;
 
 		return (
-			<DropdownItem
+			<SelectDropdown.Item
 				key={ app }
 				selected={ selected }
 				onClick={ this.getAppPopoverItemClickHandler( analyticsEvent, app ) }
 				count={ count }
 			>
 				{ title }
-			</DropdownItem>
+			</SelectDropdown.Item>
 		);
 	}
 }

--- a/client/me/help/help-contact-form/index.jsx
+++ b/client/me/help/help-contact-form/index.jsx
@@ -21,7 +21,6 @@ import FormLabel from 'components/forms/form-label';
 import SegmentedControl from 'components/segmented-control';
 import ControlItem from 'components/segmented-control/item';
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
 import FormTextarea from 'components/forms/form-textarea';
 import FormTextInput from 'components/forms/form-text-input';
 import FormButton from 'components/forms/form-button';
@@ -237,7 +236,7 @@ export class HelpContactForm extends React.PureComponent {
 					selectedText={ selectedItem ? selectedItem.label : translate( 'Select an option' ) }
 				>
 					{ options.map( option => (
-						<DropdownItem { ...option.props }>{ option.label }</DropdownItem>
+						<SelectDropdown.Item { ...option.props }>{ option.label }</SelectDropdown.Item>
 					) ) }
 				</SelectDropdown>
 			</div>

--- a/client/my-sites/plugins/plugin-list-header/index.jsx
+++ b/client/my-sites/plugins/plugin-list-header/index.jsx
@@ -17,8 +17,6 @@ import SectionHeader from 'components/section-header';
 import ButtonGroup from 'components/button-group';
 import Button from 'components/button';
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
-import DropdownSeparator from 'components/select-dropdown/separator';
 import BulkSelect from 'components/bulk-select';
 import analytics from 'lib/analytics';
 
@@ -286,36 +284,32 @@ export class PluginsListHeader extends PureComponent {
 			<SelectDropdown
 				compact
 				className="plugin-list-header__actions-dropdown"
-				key="plugin-list-header__actions_dropdown"
 				selectedText={ translate( 'Actions' ) }
 			>
-				<DropdownItem key="plugin__actions_title" selected={ true } value="Actions">
+				<SelectDropdown.Item selected value="Actions">
 					{ translate( 'Actions' ) }
-				</DropdownItem>
+				</SelectDropdown.Item>
 
-				<DropdownSeparator key="plugin__actions_separator_1" />
+				<SelectDropdown.Separator />
 
-				<DropdownItem
-					key="plugin__actions_activate"
+				<SelectDropdown.Item
 					disabled={ ! this.props.haveUpdatesSelected }
 					onClick={ this.props.updateSelected }
 				>
 					{ translate( 'Update' ) }
-				</DropdownItem>
+				</SelectDropdown.Item>
 
-				<DropdownSeparator key="plugin__actions_separator_1" />
+				<SelectDropdown.Separator />
 				{ isJetpackOnlySelected && (
-					<DropdownItem
-						key="plugin__actions_activate"
+					<SelectDropdown.Item
 						disabled={ ! this.props.haveInactiveSelected }
 						onClick={ this.props.activateSelected }
 					>
 						{ translate( 'Activate' ) }
-					</DropdownItem>
+					</SelectDropdown.Item>
 				) }
 				{ isJetpackOnlySelected && (
-					<DropdownItem
-						key="plugin__actions_disconnect"
+					<SelectDropdown.Item
 						disabled={ ! this.props.haveActiveSelected }
 						onClick={
 							isJetpackSelected
@@ -324,37 +318,34 @@ export class PluginsListHeader extends PureComponent {
 						}
 					>
 						{ translate( 'Deactivate' ) }
-					</DropdownItem>
+					</SelectDropdown.Item>
 				) }
 
-				<DropdownSeparator key="plugin__actions_separator_2" />
+				<SelectDropdown.Separator />
 
-				<DropdownItem
-					key="plugin__actions_autoupdate"
+				<SelectDropdown.Item
 					disabled={ ! this.canUpdatePlugins() }
 					onClick={ this.props.setAutoupdateSelected }
 				>
 					{ translate( 'Autoupdate' ) }
-				</DropdownItem>
+				</SelectDropdown.Item>
 
-				<DropdownItem
-					key="plugin__actions_disable_autoupdate"
+				<SelectDropdown.Item
 					disabled={ ! this.canUpdatePlugins() }
 					onClick={ this.props.unsetAutoupdateSelected }
 				>
 					{ translate( 'Disable Autoupdates' ) }
-				</DropdownItem>
+				</SelectDropdown.Item>
 
-				<DropdownSeparator key="plugin__actions_separator_3" />
+				<SelectDropdown.Separator />
 
-				<DropdownItem
-					key="plugin__actions_remove"
+				<SelectDropdown.Item
 					className="plugin-list-header__actions-remove-item"
 					disabled={ ! needsRemoveButton }
 					onClick={ this.props.removePluginNotice }
 				>
 					{ translate( 'Remove' ) }
-				</DropdownItem>
+				</SelectDropdown.Item>
 			</SelectDropdown>
 		);
 	}

--- a/client/post-editor/editor-page-templates/index.jsx
+++ b/client/post-editor/editor-page-templates/index.jsx
@@ -16,7 +16,6 @@ import { localize } from 'i18n-calypso';
 import QueryPageTemplates from 'components/data/query-page-templates';
 import AccordionSection from 'components/accordion/section';
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
 import EditorDrawerLabel from 'post-editor/editor-drawer/label';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getEditorPostId } from 'state/ui/editor/selectors';
@@ -99,13 +98,13 @@ class EditorPageTemplates extends Component {
 									// to extract this out into a separate component
 									// with its own click handler, that would severely
 									// harm the readability of this component.
-									<DropdownItem
+									<SelectDropdown.Item
 										key={ file }
 										selected={ file === template }
 										onClick={ () => this.selectTemplate( file ) }
 									>
 										{ label }
-									</DropdownItem>
+									</SelectDropdown.Item>
 								) ) }
 							</SelectDropdown>
 						</EditorDrawerLabel>

--- a/client/post-editor/editor-publish-date/style.scss
+++ b/client/post-editor/editor-publish-date/style.scss
@@ -1,4 +1,6 @@
-@import 'components/select-dropdown/style';
+// copied from select-dropdown styles
+$option-height: 40;
+$side-margin: 16;
 
 .editor-publish-date {
 	height: 43px;

--- a/client/post-editor/editor-visibility/index.jsx
+++ b/client/post-editor/editor-visibility/index.jsx
@@ -19,7 +19,6 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormTextInput from 'components/forms/form-text-input';
 import SelectDropdown from 'components/select-dropdown';
-import DropdownItem from 'components/select-dropdown/item';
 import { hasTouch } from 'lib/touch-detect';
 import { recordEditorEvent, recordEditorStat } from 'state/posts/stats';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -258,7 +257,7 @@ class EditorVisibility extends React.Component {
 						selectedIcon={ selectedItem.icon }
 					>
 						{ dropdownItems.map( option => (
-							<DropdownItem
+							<SelectDropdown.Item
 								selected={ option.value === visibility }
 								key={ option.value }
 								value={ option.value }
@@ -266,7 +265,7 @@ class EditorVisibility extends React.Component {
 								icon={ option.icon }
 							>
 								{ option.label }
-							</DropdownItem>
+							</SelectDropdown.Item>
 						) ) }
 					</SelectDropdown>
 					{ 'password' === visibility ? this.renderPasswordInput() : null }

--- a/client/post-editor/media-modal/gallery/fields.jsx
+++ b/client/post-editor/media-modal/gallery/fields.jsx
@@ -14,7 +14,6 @@ import { localize } from 'i18n-calypso';
  */
 import EditorMediaModalFieldset from '../fieldset';
 import SelectDropdown from 'components/select-dropdown';
-import SelectDropdownItem from 'components/select-dropdown/item';
 import FormCheckbox from 'components/forms/form-checkbox';
 import { GalleryColumnedTypes, GallerySizeableTypes } from 'lib/media/constants';
 import { isModuleActive } from 'lib/site/utils';
@@ -107,7 +106,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 						const label = options[ value ];
 
 						return (
-							<SelectDropdownItem
+							<SelectDropdown.Item
 								key={ 'value-' + value }
 								selected={ value === settings[ settingName ] }
 								onClick={ () =>
@@ -115,7 +114,7 @@ export class EditorMediaModalGalleryFields extends React.Component {
 								}
 							>
 								{ label }
-							</SelectDropdownItem>
+							</SelectDropdown.Item>
 						);
 					} ) }
 				</SelectDropdown>


### PR DESCRIPTION
The `SelectDropdown` component accumulated a lot of cruft over the years, so I did a comprehensive cleanup as part of the CSS migration.

Please review commit by commit, I tried to keep them very small and explain everything.

Similar to `SegmentedControl` in #35051, I put the subcomponents as static properties on the main component:
```jsx
<SelectDropdown>
  <SelectDropdown.Item />
  <SelectDropdown.Label />
  <SelectDropdown.Separator />
</SelectDropdown>
```
