### PR TITLE
FSE: Prevent newlines in Site Title and Description blocks

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -6,6 +6,7 @@ import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ function SiteDescriptionEdit( {
 	shouldUpdateSiteOption,
 	isSelected,
 	setAttributes,
+	insertDefaultBlock,
 } ) {
 	const inititalDescription = __( 'Site description loading…' );
 
@@ -32,12 +34,21 @@ function SiteDescriptionEdit( {
 
 	const { option } = siteOptions;
 
+	const onKeyDown = event => {
+		if ( event.keyCode !== ENTER ) {
+			return;
+		}
+		event.preventDefault();
+		insertDefaultBlock();
+	};
+
 	return (
 		<Fragment>
 			<PlainText
 				className={ className }
 				value={ option }
 				onChange={ value => handleChange( value ) }
+				onKeyDown={ onKeyDown }
 				placeholder={ __( 'Site Description' ) }
 				aria-label={ __( 'Site Description' ) }
 			/>
@@ -46,17 +57,25 @@ function SiteDescriptionEdit( {
 }
 
 export default compose( [
-	withDispatch( dispatch => ( {
-		createErrorNotice: dispatch( 'core/notices' ).createErrorNotice,
-	} ) ),
-	withSelect( select => {
+	withSelect( ( select, { clientId } ) => {
 		const { isSavingPost, isPublishingPost, isAutosavingPost, isCurrentPostPublished } = select(
 			'core/editor'
 		);
+		const { getBlockIndex, getBlockRootClientId } = select( 'core/block-editor' );
+		const rootClientId = getBlockRootClientId( clientId );
+		const blockIndex = getBlockIndex( clientId, rootClientId );
+
 		return {
+			blockIndex,
+			rootClientId,
 			shouldUpdateSiteOption:
 				( ( isSavingPost() && isCurrentPostPublished() ) || isPublishingPost() ) &&
 				! isAutosavingPost(),
 		};
 	} ),
+	withDispatch( ( dispatch, { blockIndex, rootClientId } ) => ( {
+		createErrorNotice: dispatch( 'core/notices' ).createErrorNotice,
+		insertDefaultBlock: () =>
+			dispatch( 'core/block-editor' ).insertDefaultBlock( {}, rootClientId, blockIndex + 1 ),
+	} ) ),
 ] )( SiteDescriptionEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -19,6 +19,7 @@ function SiteDescriptionEdit( {
 	shouldUpdateSiteOption,
 	isSelected,
 	setAttributes,
+	isLocked,
 	insertDefaultBlock,
 } ) {
 	const inititalDescription = __( 'Site description loading…' );
@@ -39,7 +40,9 @@ function SiteDescriptionEdit( {
 			return;
 		}
 		event.preventDefault();
-		insertDefaultBlock();
+		if ( ! isLocked ) {
+			insertDefaultBlock();
+		}
 	};
 
 	return (
@@ -61,12 +64,12 @@ export default compose( [
 		const { isSavingPost, isPublishingPost, isAutosavingPost, isCurrentPostPublished } = select(
 			'core/editor'
 		);
-		const { getBlockIndex, getBlockRootClientId } = select( 'core/block-editor' );
+		const { getBlockIndex, getBlockRootClientId, getTemplateLock } = select( 'core/block-editor' );
 		const rootClientId = getBlockRootClientId( clientId );
-		const blockIndex = getBlockIndex( clientId, rootClientId );
 
 		return {
-			blockIndex,
+			blockIndex: getBlockIndex( clientId, rootClientId ),
+			isLocked: !! getTemplateLock( rootClientId ),
 			rootClientId,
 			shouldUpdateSiteOption:
 				( ( isSavingPost() && isCurrentPostPublished() ) || isPublishingPost() ) &&

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
@@ -11,6 +11,7 @@ import { PlainText } from '@wordpress/editor';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
+import { ENTER } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ function SiteTitleEdit( {
 	shouldUpdateSiteOption,
 	isSelected,
 	setAttributes,
+	insertDefaultBlock,
 } ) {
 	const inititalTitle = __( 'Site title loading…' );
 	const { siteOptions, handleChange } = useSiteOptions(
@@ -36,12 +38,21 @@ function SiteTitleEdit( {
 
 	const { option } = siteOptions;
 
+	const onKeyDown = event => {
+		if ( event.keyCode !== ENTER ) {
+			return;
+		}
+		event.preventDefault();
+		insertDefaultBlock();
+	};
+
 	return (
 		<Fragment>
 			<PlainText
 				className={ classNames( 'site-title', className ) }
 				value={ option }
 				onChange={ value => handleChange( value ) }
+				onKeyDown={ onKeyDown }
 				placeholder={ __( 'Site Title' ) }
 				aria-label={ __( 'Site Title' ) }
 			/>
@@ -50,17 +61,25 @@ function SiteTitleEdit( {
 }
 
 export default compose( [
-	withDispatch( dispatch => ( {
-		createErrorNotice: dispatch( 'core/notices' ).createErrorNotice,
-	} ) ),
-	withSelect( select => {
+	withSelect( ( select, { clientId } ) => {
 		const { isSavingPost, isPublishingPost, isAutosavingPost, isCurrentPostPublished } = select(
 			'core/editor'
 		);
+		const { getBlockIndex, getBlockRootClientId } = select( 'core/block-editor' );
+		const rootClientId = getBlockRootClientId( clientId );
+		const blockIndex = getBlockIndex( clientId, rootClientId );
+
 		return {
+			blockIndex,
+			rootClientId,
 			shouldUpdateSiteOption:
 				( ( isSavingPost() && isCurrentPostPublished() ) || isPublishingPost() ) &&
 				! isAutosavingPost(),
 		};
 	} ),
+	withDispatch( ( dispatch, { blockIndex, rootClientId } ) => ( {
+		createErrorNotice: dispatch( 'core/notices' ).createErrorNotice,
+		insertDefaultBlock: () =>
+			dispatch( 'core/block-editor' ).insertDefaultBlock( {}, rootClientId, blockIndex + 1 ),
+	} ) ),
 ] )( SiteTitleEdit );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
@@ -24,6 +24,7 @@ function SiteTitleEdit( {
 	shouldUpdateSiteOption,
 	isSelected,
 	setAttributes,
+	isLocked,
 	insertDefaultBlock,
 } ) {
 	const inititalTitle = __( 'Site title loading…' );
@@ -43,7 +44,9 @@ function SiteTitleEdit( {
 			return;
 		}
 		event.preventDefault();
-		insertDefaultBlock();
+		if ( ! isLocked ) {
+			insertDefaultBlock();
+		}
 	};
 
 	return (
@@ -65,12 +68,12 @@ export default compose( [
 		const { isSavingPost, isPublishingPost, isAutosavingPost, isCurrentPostPublished } = select(
 			'core/editor'
 		);
-		const { getBlockIndex, getBlockRootClientId } = select( 'core/block-editor' );
+		const { getBlockIndex, getBlockRootClientId, getTemplateLock } = select( 'core/block-editor' );
 		const rootClientId = getBlockRootClientId( clientId );
-		const blockIndex = getBlockIndex( clientId, rootClientId );
 
 		return {
-			blockIndex,
+			blockIndex: getBlockIndex( clientId, rootClientId ),
+			isLocked: !! getTemplateLock( rootClientId ),
 			rootClientId,
 			shouldUpdateSiteOption:
 				( ( isSavingPost() && isCurrentPostPublished() ) || isPublishingPost() ) &&

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/editor": "^9.2.4",
 		"@wordpress/element": "^2.3.0",
 		"@wordpress/i18n": "^3.3.0",
+		"@wordpress/keycodes": "^2.4.0",
 		"@wordpress/nux": "^3.4.0",
 		"@wordpress/plugins": "^2.2.0",
 		"@wordpress/url": "^2.5.0",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change the `keyDown` event for Site Title and Site Description blocks so that hitting <kbd>Enter</kbd> will insert a new default block instead of typing a newline.

I've basically reused the same code of the block toolbar's insert actions, and also kept the template lock logic (even though I'm still unsure how it works 😅 ):
https://github.com/WordPress/gutenberg/blob/6d3312ae7d5ce4632032092a74b61e18cbb8dd5b/packages/block-editor/src/components/block-actions/index.js#L108-L114

| Before | After |
| - | - |
| ![Aug-02-2019 15-01-50](https://user-images.githubusercontent.com/2070010/62375573-870abc80-b536-11e9-924e-382438d040ab.gif) | ![Aug-02-2019 15-01-28](https://user-images.githubusercontent.com/2070010/62375585-8d993400-b536-11e9-9b12-141602515341.gif) |

#### Testing instructions

* Edit a FSE Template Part, and do the followings for both the Site Title and Site Description blocks.
* Select a block in order to edit it and try hitting <kbd>Enter</kbd>.
* Make sure it inserts a new block after the selected one.

Fixes #34419