### PR TITLE
Earn: don't show the menu item if user can't access it

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -4,6 +4,9 @@
 	&:hover .template-block__overlay {
 		display: flex;
 	}
+	.components-button .components-spinner {
+		margin-top: 4px;
+	}
 }
 
 .template-block.alignfull {

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -42,6 +42,7 @@ import {
 	getSite,
 	isJetpackSite,
 	canCurrentUserUseAds,
+	canCurrentUserUseEarn,
 	canCurrentUserUseStore,
 } from 'state/sites/selectors';
 import canCurrentUserManagePlugins from 'state/selectors/can-current-user-manage-plugins';
@@ -190,6 +191,12 @@ export class MySitesSidebar extends Component {
 	};
 
 	earn() {
+		const { site, canUserUseEarn } = this.props;
+
+		if ( site && ! canUserUseEarn ) {
+			return null;
+		}
+
 		const { path, translate } = this.props;
 
 		return (
@@ -725,6 +732,7 @@ function mapStateToProps( state ) {
 		canUserViewStats: canCurrentUser( state, siteId, 'view_stats' ),
 		canUserManagePlugins: canCurrentUserManagePlugins( state ),
 		canUserUseStore: canCurrentUserUseStore( state, siteId ),
+		canUserUseEarn: canCurrentUserUseEarn( state, siteId ),
 		canUserUseAds: canCurrentUserUseAds( state, siteId ),
 		canUserUpgradeSite: canCurrentUserUpgradeSite( state, siteId ),
 		currentUser,

--- a/client/state/sites/selectors/can-current-user-use-earn.js
+++ b/client/state/sites/selectors/can-current-user-use-earn.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import canCurrentUser from 'state/selectors/can-current-user';
+import { getSelectedSiteId } from 'state/ui/selectors';
+import getSite from './get-site';
+
+/**
+ * Returns true if current user can see the Earn option in menu and corresponding page.
+ *
+ * @param  {Object}   state  Global state tree
+ * @param  {Number}   siteId Site ID
+ * @return {?Boolean}        Whether user can access the Earn section.
+ */
+export default function canCurrentUserUseEarn( state, siteId = null ) {
+	if ( ! siteId ) {
+		siteId = getSelectedSiteId( state );
+	}
+	const site = getSite( state, siteId );
+	return site && !! canCurrentUser( state, siteId, 'manage_options' );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* introduces a new selector: `canCurrentUserUseEarn`, that can be used to check whether user can access an Earn feature. It's not strictly needed, but it makes for readability.
* use the new `canCurrentUserUseEarn` to hide the **Earn** sidebar item for users that are not administrators.

#### Testing instructions

* test with an admin user and any other role. Only admins should have the Earn menu item in the sidebar.

Fixes #35088
