### PR TITLE
Extract masterbar-visibility and section from ui.

### DIFF
--- a/client/state/ui/actions.js
+++ b/client/state/ui/actions.js
@@ -1,14 +1,9 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
-	MASTERBAR_TOGGLE_VISIBILITY,
 	SELECTED_SITE_SET,
 	ROUTE_SET,
-	SECTION_SET,
 	PREVIEW_IS_SHOWING,
 	NOTIFICATIONS_PANEL_TOGGLE,
 	NAVIGATE,
@@ -16,6 +11,12 @@ import {
 } from 'state/action-types';
 
 import 'state/data-layer/wpcom/sites/jitm';
+
+/**
+ * Re-exports
+ */
+export { setSection } from './section/actions';
+export { showMasterbar, hideMasterbar } from './masterbar-visibility/actions';
 
 /**
  * Returns an action object to be used in signalling that a site has been set
@@ -59,15 +60,6 @@ export function setRoute( path, query = {} ) {
 	};
 }
 
-export function setSection( section, options = {} ) {
-	options.type = SECTION_SET;
-	if ( section ) {
-		options.section = section;
-	}
-	options.hasSidebar = options.hasSidebar === false ? false : true;
-	return options;
-}
-
 export function setPreviewShowing( isShowing ) {
 	return {
 		type: PREVIEW_IS_SHOWING,
@@ -105,17 +97,3 @@ export const replaceHistory = ( path, saveContext ) => ( {
 	path,
 	saveContext,
 } );
-
-/**
- * Hide the masterbar.
- *
- * @return {Object} Action object
- */
-export const hideMasterbar = () => ( { type: MASTERBAR_TOGGLE_VISIBILITY, isVisible: false } );
-
-/**
- * Show the masterbar.
- *
- * @return {Object} Action object
- */
-export const showMasterbar = () => ( { type: MASTERBAR_TOGGLE_VISIBILITY, isVisible: true } );

--- a/client/state/ui/masterbar-visibility/actions.js
+++ b/client/state/ui/masterbar-visibility/actions.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { MASTERBAR_TOGGLE_VISIBILITY } from 'state/action-types';
+
+/**
+ * Hide the masterbar.
+ *
+ * @return {Object} Action object
+ */
+export const hideMasterbar = () => ( { type: MASTERBAR_TOGGLE_VISIBILITY, isVisible: false } );
+
+/**
+ * Show the masterbar.
+ *
+ * @return {Object} Action object
+ */
+export const showMasterbar = () => ( { type: MASTERBAR_TOGGLE_VISIBILITY, isVisible: true } );

--- a/client/state/ui/masterbar-visibility/reducer.js
+++ b/client/state/ui/masterbar-visibility/reducer.js
@@ -1,0 +1,7 @@
+/**
+ * Internal dependencies
+ */
+import { MASTERBAR_TOGGLE_VISIBILITY } from 'state/action-types';
+
+export default ( state = true, { type, isVisible } ) =>
+	type === MASTERBAR_TOGGLE_VISIBILITY ? isVisible : state;

--- a/client/state/ui/reducer.js
+++ b/client/state/ui/reducer.js
@@ -1,11 +1,7 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
-	MASTERBAR_TOGGLE_VISIBILITY,
 	SELECTED_SITE_SET,
 	SECTION_SET,
 	PREVIEW_IS_SHOWING,
@@ -22,6 +18,7 @@ import guidedTour from './guided-tours/reducer';
 import gutenbergOptInDialog from './gutenberg-opt-in-dialog/reducer';
 import language from './language/reducer';
 import layoutFocus from './layout-focus/reducer';
+import masterbarVisibility from './masterbar-visibility/reducer';
 import mediaModal from './media-modal/reducer';
 import npsSurveyNotice from './nps-survey-notice/reducer';
 import oauth2Clients from './oauth2-clients/reducer';
@@ -30,6 +27,7 @@ import postTypeList from './post-type-list/reducer';
 import preview from './preview/reducer';
 import reader from './reader/reducer';
 import route from './route/reducer';
+import section from './section/reducer';
 import themeSetup from './theme-setup/reducers';
 
 /**
@@ -51,15 +49,6 @@ export function selectedSiteId( state = null, action ) {
 export const siteSelectionInitialized = createReducer( false, {
 	[ SELECTED_SITE_SET ]: () => true,
 } );
-
-//TODO: do we really want to mix strings and booleans?
-export function section( state = false, action ) {
-	switch ( action.type ) {
-		case SECTION_SET:
-			return action.section !== undefined ? action.section : state;
-	}
-	return state;
-}
 
 export function hasSidebar( state = true, action ) {
 	switch ( action.type ) {
@@ -94,9 +83,6 @@ export const isNotificationsOpen = function( state = false, { type } ) {
 	}
 	return state;
 };
-
-export const masterbarVisibility = ( state = true, { type, isVisible } ) =>
-	type === MASTERBAR_TOGGLE_VISIBILITY ? isVisible : state;
 
 const reducer = combineReducers( {
 	actionLog,

--- a/client/state/ui/section/actions.js
+++ b/client/state/ui/section/actions.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { SECTION_SET } from 'state/action-types';
+
+export function setSection( section, options = {} ) {
+	options.type = SECTION_SET;
+	if ( section ) {
+		options.section = section;
+	}
+	options.hasSidebar = options.hasSidebar === false ? false : true;
+	return options;
+}

--- a/client/state/ui/section/actions.js
+++ b/client/state/ui/section/actions.js
@@ -4,10 +4,14 @@
 import { SECTION_SET } from 'state/action-types';
 
 export function setSection( section, options = {} ) {
-	options.type = SECTION_SET;
+	const action = {
+		...options,
+		type: SECTION_SET,
+		hasSidebar: options.hasSidebar === false ? false : true,
+	};
 	if ( section ) {
-		options.section = section;
+		action.section = section;
 	}
-	options.hasSidebar = options.hasSidebar === false ? false : true;
-	return options;
+
+	return action;
 }

--- a/client/state/ui/section/reducer.js
+++ b/client/state/ui/section/reducer.js
@@ -1,0 +1,13 @@
+/**
+ * Internal dependencies
+ */
+import { SECTION_SET } from 'state/action-types';
+
+//TODO: do we really want to mix strings and booleans?
+export default function section( state = false, action ) {
+	switch ( action.type ) {
+		case SECTION_SET:
+			return action.section !== undefined ? action.section : state;
+	}
+	return state;
+}


### PR DESCRIPTION
The reducers and actions for `state.ui.masterbarVisibility` and `state.ui.section` were part of the main state.ui modules. This change splits them out, to allow for using them without depending on all of `state.ui`.

Split-out actions are re-exported in the main actions file to maintain compatibility for now.

This started out as a set of changes in #33642, but @jsnajdr wisely suggested pulling them out into a simpler PR. It's not as obvious here why having these utilities in a new file is useful, so please consult #33642 if you'd like to see that.

#### Changes proposed in this Pull Request

* Move `masterbarVisibility` reducers and actions into their own files.
* Move `section` reducers and actions into their own files.
* Re-export `masterbarVisibility` and `section` actions from main actions file, to maintain compatibility for now.

#### Testing instructions

The standard set of tests should be enough to ensure everything stays working, as no logic has been changed (only where it lives), and any errors would likely have an immediate breaking impact on the entire application.
