### PR TITLE
Add basic event for tracking when the blue screen is rendered

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -214,6 +214,22 @@ class Signup extends React.Component {
 	}
 
 	componentDidUpdate( prevProps ) {
+		const { flowName, stepName } = this.props;
+		const positionInFlowPrev = indexOf( flows.getFlow( flowName ).steps, prevProps.stepName );
+
+		// TODO: Here we're tracking the impact of a bug that renders a
+		// blank screen. Remove when this bug is fixed.
+		if (
+			! ( positionInFlowPrev > 0 && prevProps.progress.length === 0 ) &&
+			this.getPositionInFlow() > 0 &&
+			this.props.progress.length === 0
+		) {
+			analytics.tracks.recordEvent( 'calypso_signup_bsod_render', {
+				flow: flowName,
+				step: stepName,
+			} );
+		}
+
 		if (
 			get( this.props.signupDependencies, 'siteType' ) !==
 			get( prevProps.signupDependencies, 'siteType' )

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -217,14 +217,13 @@ class Signup extends React.Component {
 		const { flowName, stepName } = this.props;
 		const positionInFlowPrev = indexOf( flows.getFlow( flowName ).steps, prevProps.stepName );
 
-		// TODO: Here we're tracking the impact of a bug that renders a
-		// blank screen. Remove when this bug is fixed.
+		// TODO: Here we're tracking the impact of a bug that renders a blank screen. Remove when this bug is fixed.
 		if (
 			! ( positionInFlowPrev > 0 && prevProps.progress.length === 0 ) &&
 			this.getPositionInFlow() > 0 &&
 			this.props.progress.length === 0
 		) {
-			analytics.tracks.recordEvent( 'calypso_signup_bsod_render', {
+			analytics.tracks.recordEvent( 'calypso_signup_error_main_render_null', {
 				flow: flowName,
 				step: stepName,
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds tracking for the events where blank screens are being rendered in `signup/main.js` as mentioned in #32506. Do note that this issue is something that exists outside of #32506 too, as there have been other ways to reproduce this blank screen issue.

#### Testing instructions

Reproduce the blank screen rendering issue - I'm not sure how to right now as #32506 was recently fixed
