### PR TITLE
Update browserslist to 4.6.6.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -34,7 +34,7 @@
 				"@wordpress/browserslist-config": "2.3.0",
 				"autoprefixer": "9.4.4",
 				"babel-loader": "8.0.5",
-				"browserslist": "4.5.4",
+				"browserslist": "4.6.6",
 				"caniuse-api": "3.0.0",
 				"css-loader": "2.1.1",
 				"duplicate-package-checker-webpack-plugin": "3.0.0",
@@ -57,14 +57,37 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.5.4",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-					"integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+					"version": "4.6.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+					"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30000955",
-						"electron-to-chromium": "^1.3.122",
-						"node-releases": "^1.1.13"
+						"caniuse-lite": "^1.0.30000984",
+						"electron-to-chromium": "^1.3.191",
+						"node-releases": "^1.1.25"
+					},
+					"dependencies": {
+						"caniuse-lite": {
+							"version": "1.0.30000988",
+							"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz",
+							"integrity": "sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ==",
+							"dev": true
+						},
+						"electron-to-chromium": {
+							"version": "1.3.211",
+							"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.211.tgz",
+							"integrity": "sha512-GZAiK3oHrs0K+LwH+HD+bdjZ17v40oQQdXbbd3dgrwgbENvazrGpcuIADSAREWnxzo9gADB1evuizrbXsnoU2Q==",
+							"dev": true
+						},
+						"node-releases": {
+							"version": "1.1.26",
+							"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
+							"integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+							"dev": true,
+							"requires": {
+								"semver": "^5.3.0"
+							}
+						}
 					}
 				}
 			}
@@ -5951,6 +5974,7 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz",
 			"integrity": "sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30000974",
 				"electron-to-chromium": "^1.3.150",
@@ -5960,18 +5984,61 @@
 				"electron-to-chromium": {
 					"version": "1.3.155",
 					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.155.tgz",
-					"integrity": "sha512-/ci/XgZG8jkLYOgOe3mpJY1onxPPTDY17y7scldhnSjjZqV6VvREG/LvwhRuV7BJbnENFfuDWZkSqlTh4x9ZjQ=="
+					"integrity": "sha512-/ci/XgZG8jkLYOgOe3mpJY1onxPPTDY17y7scldhnSjjZqV6VvREG/LvwhRuV7BJbnENFfuDWZkSqlTh4x9ZjQ==",
+					"dev": true
 				}
 			}
 		},
 		"browserslist-useragent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/browserslist-useragent/-/browserslist-useragent-3.0.0.tgz",
-			"integrity": "sha512-WtTf+Mk4cmQB7Wwnq6P0R5IjY5Y+fjHvEeNpbxCtD0Lgfe5NEojLL63c1PgW6BIFZbmncpNNoOsSlhYS0SxSTw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/browserslist-useragent/-/browserslist-useragent-3.0.2.tgz",
+			"integrity": "sha512-/UPzK9xZnk5mwwWx4wcuBKAKx/mD3MNY8sUuZ2NPqnr4RVFWZogX+8mOP0cQEYo8j78sHk0hiDNaVXZ1U3hM9A==",
 			"requires": {
-				"browserslist": "^4.3.6",
-				"semver": "^5.6.0",
+				"browserslist": "^4.6.6",
+				"semver": "^6.3.0",
 				"useragent": "^2.3.0"
+			},
+			"dependencies": {
+				"browserslist": {
+					"version": "4.6.6",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.6.tgz",
+					"integrity": "sha512-D2Nk3W9JL9Fp/gIcWei8LrERCS+eXu9AM5cfXA8WEZ84lFks+ARnZ0q/R69m2SV3Wjma83QDDPxsNKXUwdIsyA==",
+					"requires": {
+						"caniuse-lite": "^1.0.30000984",
+						"electron-to-chromium": "^1.3.191",
+						"node-releases": "^1.1.25"
+					}
+				},
+				"caniuse-lite": {
+					"version": "1.0.30000988",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz",
+					"integrity": "sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ=="
+				},
+				"electron-to-chromium": {
+					"version": "1.3.211",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.211.tgz",
+					"integrity": "sha512-GZAiK3oHrs0K+LwH+HD+bdjZ17v40oQQdXbbd3dgrwgbENvazrGpcuIADSAREWnxzo9gADB1evuizrbXsnoU2Q=="
+				},
+				"node-releases": {
+					"version": "1.1.26",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.26.tgz",
+					"integrity": "sha512-fZPsuhhUHMTlfkhDLGtfY80DSJTjOcx+qD1j5pqPkuhUHVS7xHZIg9EE4DHK8O3f0zTxXHX5VIkDG8pu98/wfQ==",
+					"requires": {
+						"semver": "^5.3.0"
+					},
+					"dependencies": {
+						"semver": {
+							"version": "5.7.0",
+							"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+							"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+						}
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
 			}
 		},
 		"bser": {
@@ -6202,7 +6269,8 @@
 		"caniuse-lite": {
 			"version": "1.0.30000974",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
-			"integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww=="
+			"integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==",
+			"dev": true
 		},
 		"capture-exit": {
 			"version": "2.0.0",
@@ -8891,12 +8959,6 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.2.tgz",
 			"integrity": "sha512-PcW2a0tyTuPHz3tWyYqtK6r1fZ3gp+3Sop8Ph+ZYN81Ob5rwmbHEzaqs10N3BEsaGTkh/ooniXK+WwszGlc2+Q=="
-		},
-		"electron-to-chromium": {
-			"version": "1.3.148",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.148.tgz",
-			"integrity": "sha512-nuCOlXNlGMQmdzihIPGm2K3Yf3H1hke/1rK381i02pH8wNliJU9hVNnOi/xjmxt+mjABd/BzufP5nPHWKshLWA==",
-			"dev": true
 		},
 		"elliptic": {
 			"version": "6.4.1",
@@ -15570,6 +15632,7 @@
 			"version": "1.1.23",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
 			"integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
+			"dev": true,
 			"requires": {
 				"semver": "^5.3.0"
 			}

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"body-parser": "1.18.3",
 		"bounding-client-rect": "1.0.5",
 		"browser-filesaver": "1.1.1",
-		"browserslist-useragent": "3.0.0",
+		"browserslist-useragent": "3.0.2",
 		"chalk": "2.4.2",
 		"chokidar": "2.1.6",
 		"chrono-node": "1.3.5",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/browserslist-config": "2.3.0",
 		"autoprefixer": "9.4.4",
 		"babel-loader": "8.0.5",
-		"browserslist": "4.5.4",
+		"browserslist": "4.6.6",
 		"caniuse-api": "3.0.0",
 		"css-loader": "2.1.1",
 		"duplicate-package-checker-webpack-plugin": "3.0.0",


### PR DESCRIPTION
The old version is causing issues with babel transpilation.

#### Changes proposed in this Pull Request

* Update `browserslist` dependency in `packages/calypso-build` to 4.6.6
* Update `browserslist-useragent` dependency in Calypso to 3.0.2

#### Testing instructions

* Use an evergreen browser (e.g. current Chrome)
* Ensure that the live branch works normally. Opening a few pages should suffice.

Bundle sizes should go down as reported by the icfy bot.
