### PR TITLE
Add caniuse-lite as a direct dependency.

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6267,10 +6267,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000974",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
-			"integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==",
-			"dev": true
+			"version": "1.0.30000988",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000988.tgz",
+			"integrity": "sha512-lPj3T8poYrRc/bniW5SQPND3GRtSrQdUM/R4mCYTbZxyi3jQiggLvZH4+BYUuX0t4TXjU+vMM7KFDQg+rSzZUQ=="
 		},
 		"capture-exit": {
 			"version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"bounding-client-rect": "1.0.5",
 		"browser-filesaver": "1.1.1",
 		"browserslist-useragent": "3.0.2",
+		"caniuse-lite": "1.0.30000988",
 		"chalk": "2.4.2",
 		"chokidar": "2.1.6",
 		"chrono-node": "1.3.5",


### PR DESCRIPTION
This library is used by `caniuse-api`, `browserslist`, `browserslist-useragent`, and others. It contains information on what browser versions are available and what features they contain.

As such, it should be kept up to date and regularly updated, but it's been falling behind, since Renovate doesn't appear to pick it up as an indirect dependency.

This change turns it into a direct dependency for that purpose. It also updates it to the latest available version.

#### Changes proposed in this Pull Request

* Add `caniuse-lite` as a direct dependency
* Update it to the latest version

#### Testing instructions

* Use an evergreen browser (e.g. current Chrome)
* Ensure that the live branch works normally. Opening a few pages should suffice.

Bundle sizes should as reported by the icfy bot should remain the same or go down.
