### PR TITLE
Full Site Editing: hide customizer if FSE is active

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -55,6 +55,7 @@ import {
 } from 'state/my-sites/sidebar/actions';
 import { canCurrentUserUpgradeSite } from '../../state/sites/selectors';
 import isVipSite from 'state/selectors/is-vip-site';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import {
 	SIDEBAR_SECTION_SITE,
 	SIDEBAR_SECTION_DESIGN,
@@ -240,7 +241,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	design() {
-		const { path, site, translate, canUserEditThemeOptions } = this.props,
+		const { path, site, translate, canUserEditThemeOptions, showCustomizerLink } = this.props,
 			jetpackEnabled = isEnabled( 'manage/themes-jetpack' );
 		let themesLink;
 
@@ -258,16 +259,18 @@ export class MySitesSidebar extends Component {
 
 		return (
 			<ul>
-				<SidebarItem
-					label={ translate( 'Customize' ) }
-					selected={ itemLinkMatches( '/customize', path ) }
-					link={ this.props.customizeUrl }
-					onNavigate={ this.trackCustomizeClick }
-					icon="customize"
-					preloadSectionName="customize"
-					forceInternalLink
-					expandSection={ this.expandDesignSection }
-				/>
+				{ showCustomizerLink && (
+					<SidebarItem
+						label={ translate( 'Customize' ) }
+						selected={ itemLinkMatches( '/customize', path ) }
+						link={ this.props.customizeUrl }
+						onNavigate={ this.trackCustomizeClick }
+						icon="customize"
+						preloadSectionName="customize"
+						forceInternalLink
+						expandSection={ this.expandDesignSection }
+					/>
+				) }
 				<SidebarItem
 					label={ translate( 'Themes' ) }
 					selected={ itemLinkMatches( themesLink, path ) }
@@ -746,6 +749,7 @@ function mapStateToProps( state ) {
 		isManageSectionOpen,
 		isAtomicSite: !! isSiteAutomatedTransfer( state, selectedSiteId ),
 		isVip: isVipSite( state, selectedSiteId ),
+		showCustomizerLink: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
 		siteId,
 		site,
 		siteSuffix: site ? '/' + site.slug : '',

--- a/client/state/selectors/is-site-using-full-site-editing.js
+++ b/client/state/selectors/is-site-using-full-site-editing.js
@@ -1,0 +1,24 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import getRawSite from 'state/selectors/get-raw-site';
+import { hasStaticFrontPage } from 'state/sites/selectors';
+
+/**
+ * Checks if a site is using the new Full Site Editing experience
+ * @param {Object} state  Global state tree
+ * @param {Object} siteId Site ID
+ * @return {Boolean} True if the site is using Full Site Editing, otherwise false
+ */
+export default function isSiteUsingFullSiteEditing( state, siteId ) {
+	const site = getRawSite( state, siteId );
+	const isActive = get( site, 'is_fse_active', false );
+	return isActive && hasStaticFrontPage( state, siteId );
+}

--- a/client/state/selectors/test/is-site-using-full-site-editing.js
+++ b/client/state/selectors/test/is-site-using-full-site-editing.js
@@ -7,7 +7,8 @@ import isSiteUsingFullSiteEditing from '../is-site-using-full-site-editing';
 
 describe( 'isSiteUsingFullSiteEditing', () => {
 	test( 'returns false if site does not exist', () => {
-		const isFSE = isSiteUsingFullSiteEditing( {}, 1 );
+		const state = { sites: { items: {} } };
+		const isFSE = isSiteUsingFullSiteEditing( state, 1 );
 		expect( isFSE ).toBe( false );
 	} );
 

--- a/client/state/selectors/test/is-site-using-full-site-editing.js
+++ b/client/state/selectors/test/is-site-using-full-site-editing.js
@@ -1,0 +1,57 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import isSiteUsingFullSiteEditing from '../is-site-using-full-site-editing';
+
+describe( 'isSiteUsingFullSiteEditing', () => {
+	test( 'returns false if site does not exist', () => {
+		const isFSE = isSiteUsingFullSiteEditing( {}, 1 );
+		expect( isFSE ).toBe( false );
+	} );
+
+	test( 'returns true if site exists, has is_fse_active true, and page_on_front', () => {
+		const state = {
+			sites: {
+				items: {
+					123: {
+						is_fse_active: true,
+						options: { page_on_front: 2 },
+					},
+				},
+			},
+		};
+		const isFSE = isSiteUsingFullSiteEditing( state, 123 );
+		expect( isFSE ).toBe( true );
+	} );
+
+	test( 'returns false if site exists, has is_fse_active true and no page_on_front,', () => {
+		const state = {
+			sites: {
+				items: {
+					123: {
+						is_fse_active: true,
+						options: { page_on_front: 0 },
+					},
+				},
+			},
+		};
+		const isFSE = isSiteUsingFullSiteEditing( state, 123 );
+		expect( isFSE ).toBe( false );
+	} );
+
+	test( 'returns false if site exists, has no is_fse_active prop, and page_on_front', () => {
+		const state = {
+			sites: {
+				items: {
+					123: {
+						options: { page_on_front: 2 },
+					},
+				},
+			},
+		};
+		const isFSE = isSiteUsingFullSiteEditing( state, 123 );
+		expect( isFSE ).toBe( false );
+	} );
+} );

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -17,6 +17,7 @@ export const SITE_REQUEST_FIELDS = [
 	'visible',
 	'lang',
 	'launch_status',
+	'is_fse_active',
 ].join();
 
 export const SITE_REQUEST_OPTIONS = [


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* introduce `isSiteUsingFullSiteEditing` selector
* use it to hide the Customizer sidebar link for sites with Full Site Editing active

#### Testing instructions

* sandbox `public-api.wordpress.com`
* apply D31148-code
* select a site in Calypso with the `full-site-editing` blog sticker and the Modern Business theme
* (you may need to clear your cache)
* you should see the Customizer link hidden in the sidebar:

<img width="274" alt="image" src="https://user-images.githubusercontent.com/195089/62250020-73821900-b3b1-11e9-94fe-647e528f795b.png">

Partial resolution of #34791
Supercedes #35035
