### PR TITLE
Full Site Editing: Change and/or hide Customizer links if FSE is active

### DIFF
--- a/client/blocks/product-purchase-features-list/index.jsx
+++ b/client/blocks/product-purchase-features-list/index.jsx
@@ -45,6 +45,7 @@ import { isWordadsInstantActivationEligible } from 'lib/ads/utils';
 import { hasDomainCredit } from 'state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
 /**
  * Style dependencies
@@ -63,7 +64,13 @@ export class ProductPurchaseFeaturesList extends Component {
 
 	// TODO: Define feature list.
 	getEcommerceFeatures() {
-		const { isPlaceholder, plan, planHasDomainCredit, selectedSite } = this.props;
+		const {
+			isPlaceholder,
+			plan,
+			planHasDomainCredit,
+			selectedSite,
+			showCustomizerFeature,
+		} = this.props;
 		return (
 			<Fragment>
 				<HappinessSupportCard
@@ -76,7 +83,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
-				<CustomizeTheme selectedSite={ selectedSite } />
+				{ showCustomizerFeature && <CustomizeTheme selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme selectedSite={ selectedSite } />
 				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
@@ -87,7 +94,13 @@ export class ProductPurchaseFeaturesList extends Component {
 	}
 
 	getBusinessFeatures() {
-		const { isPlaceholder, plan, planHasDomainCredit, selectedSite } = this.props;
+		const {
+			isPlaceholder,
+			plan,
+			planHasDomainCredit,
+			selectedSite,
+			showCustomizerFeature,
+		} = this.props;
 		return (
 			<Fragment>
 				<HappinessSupportCard
@@ -108,7 +121,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<GoogleAnalyticsStats selectedSite={ selectedSite } />
 				<GoogleMyBusiness selectedSite={ selectedSite } />
 				<AdvertisingRemoved isBusinessPlan selectedSite={ selectedSite } />
-				<CustomizeTheme selectedSite={ selectedSite } />
+				{ showCustomizerFeature && <CustomizeTheme selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				<FindNewTheme selectedSite={ selectedSite } />
 				{ isEnabled( 'manage/plugins/upload' ) && <UploadPlugins selectedSite={ selectedSite } /> }
@@ -120,7 +133,13 @@ export class ProductPurchaseFeaturesList extends Component {
 	}
 
 	getPremiumFeatures() {
-		const { isPlaceholder, plan, planHasDomainCredit, selectedSite } = this.props;
+		const {
+			isPlaceholder,
+			plan,
+			planHasDomainCredit,
+			selectedSite,
+			showCustomizerFeature,
+		} = this.props;
 
 		return (
 			<Fragment>
@@ -128,7 +147,7 @@ export class ProductPurchaseFeaturesList extends Component {
 				<CustomDomain selectedSite={ selectedSite } hasDomainCredit={ planHasDomainCredit } />
 				<AdvertisingRemoved isBusinessPlan={ false } selectedSite={ selectedSite } />
 				<GoogleVouchers selectedSite={ selectedSite } />
-				<CustomizeTheme selectedSite={ selectedSite } />
+				{ showCustomizerFeature && <CustomizeTheme selectedSite={ selectedSite } /> }
 				<VideoAudioPosts selectedSite={ selectedSite } plan={ plan } />
 				{ isWordadsInstantActivationEligible( selectedSite ) && (
 					<MonetizeSite selectedSite={ selectedSite } />
@@ -298,6 +317,7 @@ export default connect(
 			isAutomatedTransfer,
 			selectedSite,
 			planHasDomainCredit: hasDomainCredit( state, selectedSiteId ),
+			showCustomizerFeature: ! isSiteUsingFullSiteEditing( state, selectedSiteId ),
 		};
 	},
 	{

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -82,6 +82,8 @@ import isFetchingTransfer from 'state/selectors/is-fetching-atomic-transfer';
 import getSiteSlug from 'state/sites/selectors/get-site-slug.js';
 import { recordStartTransferClickInThankYou } from 'state/domains/actions';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
+import { getActiveTheme } from 'state/themes/selectors';
+import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 
 /**
  * Style dependencies
@@ -530,7 +532,7 @@ export class CheckoutThankYou extends React.Component {
 	};
 
 	productRelatedMessages = () => {
-		const { selectedSite, sitePlans, displayMode } = this.props;
+		const { selectedSite, sitePlans, displayMode, customizeUrl } = this.props;
 		const purchases = getPurchases( this.props );
 		const failedPurchases = getFailedPurchases( this.props );
 		const hasFailedPurchases = failedPurchases.length > 0;
@@ -588,6 +590,7 @@ export class CheckoutThankYou extends React.Component {
 				{ ComponentClass && (
 					<div className="checkout-thank-you__purchase-details-list">
 						<ComponentClass
+							customizeUrl={ customizeUrl }
 							domain={ domain }
 							purchases={ purchases }
 							failedPurchases={ failedPurchases }
@@ -608,6 +611,7 @@ export default connect(
 	( state, props ) => {
 		const siteId = getSelectedSiteId( state );
 		const planSlug = getSitePlanSlug( state, siteId );
+		const activeTheme = getActiveTheme( state, siteId );
 
 		return {
 			isFetchingTransfer: isFetchingTransfer( state, siteId ),
@@ -622,6 +626,7 @@ export default connect(
 				get( getAtomicTransfer( state, siteId ), 'status', transferStates.PENDING ),
 			isEmailVerified: isCurrentUserEmailVerified( state ),
 			selectedSiteSlug: getSiteSlug( state, siteId ),
+			customizeUrl: getCustomizeOrEditFrontPageUrl( state, activeTheme, siteId ),
 		};
 	},
 	dispatch => {

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -10,7 +10,6 @@ import { useTranslate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
 import GoogleVoucherDetails from './google-voucher';
@@ -29,14 +28,14 @@ import customizeThemeImage from 'assets/images/upgrades/customize-theme.svg';
 import mediaPostImage from 'assets/images/upgrades/media-post.svg';
 import wordAdsImage from 'assets/images/upgrades/word-ads.svg';
 
-const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchases } ) => {
+const PremiumPlanDetails = ( {
+	selectedSite,
+	sitePlans,
+	selectedFeature,
+	purchases,
+	customizeUrl,
+} ) => {
 	const translate = useTranslate();
-	const adminUrl = selectedSite.URL + '/wp-admin/';
-	const customizerInAdmin =
-		adminUrl + 'customize.php?return=' + encodeURIComponent( window.location.href );
-	const customizeLink = config.isEnabled( 'manage/customize' )
-		? '/customize/' + selectedSite.slug
-		: customizerInAdmin;
 	const plan = find( sitePlans.data, isPremium ),
 		isPremiumPlan = isPremium( selectedSite.plan );
 	const googleAppsWasPurchased = purchases.some( isGoogleApps );
@@ -99,8 +98,7 @@ const PremiumPlanDetails = ( { selectedSite, sitePlans, selectedFeature, purchas
 							"Change your site's entire look in a few clicks."
 					) }
 					buttonText={ translate( 'Start customizing' ) }
-					href={ customizeLink }
-					target={ config.isEnabled( 'manage/customize' ) ? undefined : '_blank' }
+					href={ customizeUrl }
 				/>
 			) }
 

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -20,7 +20,6 @@ import {
 	getActiveTheme,
 	getCanonicalTheme,
 	getThemeDetailsUrl,
-	getThemeCustomizeUrl,
 	getThemeForumUrl,
 	isActivatingTheme,
 	hasActivatedTheme,
@@ -28,6 +27,7 @@ import {
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 
 /**
  * Style dependencies
@@ -220,7 +220,7 @@ export default connect(
 			siteId,
 			currentTheme,
 			detailsUrl: getThemeDetailsUrl( state, currentThemeId, siteId ),
-			customizeUrl: getThemeCustomizeUrl( state, currentThemeId, siteId ),
+			customizeUrl: getCustomizeOrEditFrontPageUrl( state, currentThemeId, siteId ),
 			forumUrl: getThemeForumUrl( state, currentThemeId, siteId ),
 			isActivating: !! isActivatingTheme( state, siteId ),
 			hasActivated: !! hasActivatedTheme( state, siteId ),

--- a/client/my-sites/themes/thanks-modal.jsx
+++ b/client/my-sites/themes/thanks-modal.jsx
@@ -27,6 +27,7 @@ import {
 } from 'state/themes/selectors';
 import { clearActivated } from 'state/themes/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { requestSite } from 'state/sites/actions';
 import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 
 /**
@@ -40,6 +41,7 @@ class ThanksModal extends Component {
 		source: PropTypes.oneOf( [ 'details', 'list', 'upload' ] ).isRequired,
 		// Connected props
 		clearActivated: PropTypes.func.isRequired,
+		refreshSite: PropTypes.func.isRequired,
 		currentTheme: PropTypes.shape( {
 			author: PropTypes.string,
 			author_uri: PropTypes.string,
@@ -54,6 +56,13 @@ class ThanksModal extends Component {
 		isThemeWpcom: PropTypes.bool.isRequired,
 		siteId: PropTypes.number,
 	};
+
+	componentDidUpdate( prevProps ) {
+		// re-fetch the site to ensure we have the right cusotmizer link for FSE or not
+		if ( prevProps.hasActivated === false && this.props.hasActivated === true ) {
+			this.props.refreshSite( this.props.siteId );
+		}
+	}
 
 	onCloseModal = () => {
 		this.props.clearActivated( this.props.siteId );
@@ -227,5 +236,10 @@ export default connect(
 			isThemeWpcom: isWpcomTheme( state, currentThemeId ),
 		};
 	},
-	{ clearActivated }
+	dispatch => {
+		return {
+			clearActivated: siteId => dispatch( clearActivated( siteId ) ),
+			refreshSite: siteId => dispatch( requestSite( siteId ) ),
+		};
+	}
 )( ThanksModal );

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -22,7 +22,6 @@ import {
 import {
 	getThemeSignupUrl,
 	getThemePurchaseUrl,
-	getThemeCustomizeUrl,
 	getThemeDetailsUrl,
 	getThemeSupportUrl,
 	getJetpackUpgradeUrlIfPremiumTheme,
@@ -35,6 +34,7 @@ import {
 import { isJetpackSite, isJetpackSiteMultiSite } from 'state/sites/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
 import { getCurrentUser } from 'state/current-user/selectors';
+import getCustomizeOrEditFrontPageUrl from 'state/selectors/get-customize-or-edit-front-page-url';
 
 const purchase = config.isEnabled( 'upgrades/checkout' )
 	? {
@@ -110,7 +110,7 @@ const customize = {
 		comment: 'label in the dialog for selecting a site for which to customize a theme',
 	} ),
 	icon: 'customize',
-	getUrl: getThemeCustomizeUrl,
+	getUrl: getCustomizeOrEditFrontPageUrl,
 	hideForTheme: ( state, themeId, siteId ) =>
 		! canCurrentUser( state, siteId, 'edit_theme_options' ) ||
 		! isThemeActive( state, themeId, siteId ),

--- a/client/state/selectors/get-customize-or-edit-front-page-url.js
+++ b/client/state/selectors/get-customize-or-edit-front-page-url.js
@@ -1,0 +1,30 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import { getThemeCustomizeUrl, isThemeActive } from 'state/themes/selectors';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import getFrontPageEditorUrl from 'state/selectors/get-front-page-editor-url';
+
+/**
+ * Returns the URL for opening customizing the given site in either the block editor with
+ * Full Site Editing, or the Customizer for unsupported sites. Can be used wherever
+ * @see getThemeCustomizeUrl is used as a drop-in replacement.
+ *
+ * Ensure that your view makes use of the `QueryBlogStickers` component to function properly.
+ *
+ * @param  {Object}   state   Global state tree
+ * @param  {String}   themeId Theme ID
+ * @param  {Number}   siteId  Site ID to open the customizer or block editor for
+ * @return {String}           Customizer or Block Editor URL
+ */
+export default function getCustomizeOrEditFrontPageUrl( state, themeId, siteId ) {
+	if (
+		! isSiteUsingFullSiteEditing( state, siteId ) ||
+		! isThemeActive( state, themeId, siteId )
+	) {
+		return getThemeCustomizeUrl( state, themeId, siteId );
+	}
+	return getFrontPageEditorUrl( state, siteId );
+}

--- a/client/state/selectors/get-front-page-editor-url.js
+++ b/client/state/selectors/get-front-page-editor-url.js
@@ -1,0 +1,22 @@
+/** @format */
+
+/**
+ * Internal dependencies
+ */
+import getEditorUrl from 'state/selectors/get-editor-url';
+import getSiteFrontPage from 'state/sites/selectors/get-site-front-page';
+
+/**
+ * Gets the editor URL for the current site's home page
+ * @param {Object} state  Global state tree
+ * @param {Object} siteId Site ID
+ * @return {(Boolean|String)} false if there is no homepage set, the editor URL if there is one
+ */
+export default function getFrontPageEditorUrl( state, siteId ) {
+	const frontPageId = getSiteFrontPage( state, siteId );
+	// this will be zero if no homepage is set
+	if ( 0 === frontPageId ) {
+		return false;
+	}
+	return getEditorUrl( state, siteId, frontPageId, 'page' );
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR hides and/or change links to the Customizer throughout the UI for those using FSE.

#### Testing instructions

* select a site in Calypso with the `full-site-editing` blog sticker and the Modern Business theme
* (you may need to clear your cache)

#### 1. These links throughout the Themes screen should go to the block editor for the homepage:

At the top of `/themes`:
<img width="743" alt="Screen Shot 2019-07-19 at 1 29 13 PM" src="https://user-images.githubusercontent.com/1464705/61564402-3b7eeb80-aa2b-11e9-8caf-e4f51123ca5e.png">

Activate the Modern Business theme:
<img width="465" alt="image" src="https://user-images.githubusercontent.com/195089/62250241-04f18b00-b3b2-11e9-82ef-c187071d7e8c.png">

Click "Customize" on the Modern Business theme:
<img width="324" alt="image" src="https://user-images.githubusercontent.com/195089/62250322-3b2f0a80-b3b2-11e9-8bff-9a6641a4ef7b.png">

"Customize Site" on the Modern Business theme info page
<img width="699" alt="image" src="https://user-images.githubusercontent.com/195089/62313466-72ef8e00-b456-11e9-98db-9c6a12601163.png">

#### 2. Purchase a premium plan for your Simple site. In the `thank-you` screen, the "Start customizing" link should take you to the block editor for your homepage
<img width="721" alt="image" src="https://user-images.githubusercontent.com/195089/62313623-da0d4280-b456-11e9-8553-e709b3995444.png">

#### 3. On a site with a premium plan, under Plan → My Plan, scroll through "Premium plan features," there should NOT be a Customization card
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/195089/62313813-40926080-b457-11e9-8a5d-46c71ac7d053.png">

See #34791