### PR TITLE
Signup: remove index check on Signup progress store.

### DIFF
--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -60,10 +60,7 @@ function removeUnneededSteps( state, { flowName } ) {
 		flowSteps = flowSteps.filter( item => item !== 'user' );
 	}
 
-	return state.filter(
-		( step, index ) =>
-			flowSteps.includes( step.stepName ) && index === flowSteps.indexOf( step.stepName )
-	);
+	return state.filter( step => flowSteps.includes( step.stepName ) );
 }
 
 function saveStep( state, { step } ) {


### PR DESCRIPTION
Temp fix for #32506 suggested here: .

Discussion: p1564772075203400-slack-CJEQFAAJU

**To test:**
- change the [flow config for the business flow](https://github.com/Automattic/wp-calypso/blob/master/client/signup/config/flows-pure.js#L38) from the `plans` step to `plans-business`
- logged-out, visit `calypso.localhost:3000/start/business/`
- create a new user
- select "Online Store" segment
- you should be forked to `calypso.localhost:3000/start/ecommerce-onboarding/domains`
- complete Signup, trying to find some of the back [button issues mentioned here](https://github.com/Automattic/wp-calypso/issues/32506#issuecomment-501559157)