### PR TITLE
Signup: log flow forking render error

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -210,13 +210,17 @@ class Signup extends React.Component {
 
 		// TODO: Here we're tracking the impact of a bug that renders a blank screen. Remove when this bug is fixed.
 		if (
+			prevProps.flowName &&
+			prevProps.flowName !== flowName && // Specifically tracking flow forking bug.
 			! ( positionInFlowPrev > 0 && prevProps.progress.length === 0 ) &&
 			this.getPositionInFlow() > 0 &&
 			this.props.progress.length === 0
 		) {
-			analytics.tracks.recordEvent( 'calypso_signup_error_main_render_null', {
+			analytics.tracks.recordEvent( 'calypso_signup_error_forking_null_render', {
 				flow: flowName,
 				step: stepName,
+				previous_flow: prevProps.flowName,
+				previous_step: prevProps.stepName,
 			} );
 		}
 

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -216,7 +216,7 @@ class Signup extends React.Component {
 			this.getPositionInFlow() > 0 &&
 			this.props.progress.length === 0
 		) {
-			analytics.tracks.recordEvent( 'calypso_signup_error_forking_null_render', {
+			analytics.tracks.recordEvent( 'calypso_signup_error_forked_flow_null_render', {
 				flow: flowName,
 				step: stepName,
 				previous_flow: prevProps.flowName,


### PR DESCRIPTION
The event added in #35093 fires every time a site is created in addition to the flow forking error it was meant to track. This PR verifies that a flow has just been changed when the conditions are met.

**To Test:**
- change the [flow config for the business flow](https://github.com/Automattic/wp-calypso/blob/master/client/signup/config/flows-pure.js#L38) from the `plans` step to `plans-business`
- logged-out, visit `calypso.localhost:3000/start/business/`
- enter `localStorage.setItem( 'debug', 'calypso:analytics:tracks' );` in the console and refresh the page to log tracks events
- create a new user
- select "Online Store" segment
- you should be forked to `calypso.localhost:3000/start/ecommerce-onboarding/domains` and see a blank screen
- verify that the `calypso_signup_error_forking_null_render` event fires with the correct props
- click the browser back button and complete signup with a different segment
- verify that the `calypso_signup_error_forking_null_render` event doesn't fire again