### PR TITLE
Jetpack Connect: Add Browser Title

### DIFF
--- a/client/jetpack-connect/jetpack-new-site/index.jsx
+++ b/client/jetpack-connect/jetpack-new-site/index.jsx
@@ -13,6 +13,7 @@ import { localize } from 'i18n-calypso';
 import Button from 'components/button';
 import Card from 'components/card';
 import config from 'config';
+import DocumentHead from 'components/data/document-head';
 import JetpackLogo from 'components/jetpack-logo';
 import BackButton from 'components/back-button';
 import SiteUrlInput from '../site-url-input';
@@ -76,6 +77,7 @@ class JetpackNewSite extends Component {
 	render() {
 		return (
 			<div>
+				<DocumentHead title={ this.props.translate( 'Add New Site' ) } />
 				<BackButton onClick={ this.handleBack } />
 				<div className="jetpack-new-site__main jetpack-new-site">
 					<div className="jetpack-new-site__header">

--- a/client/jetpack-connect/main-wrapper.jsx
+++ b/client/jetpack-connect/main-wrapper.jsx
@@ -14,6 +14,7 @@ import config from 'config';
 import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 import JetpackHeader from 'components/jetpack-header';
 import Main from 'components/main';
+import DocumentHead from 'components/data/document-head';
 import { retrieveMobileRedirect } from './persistence-utils';
 
 export class JetpackConnectMainWrapper extends PureComponent {
@@ -30,7 +31,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 	};
 
 	render() {
-		const { isWide, className, children, partnerSlug } = this.props;
+		const { isWide, className, children, partnerSlug, translate } = this.props;
 
 		const isWoo = config.isEnabled( 'jetpack/connect/woocommerce' ) && this.props.isWoo;
 
@@ -45,6 +46,7 @@ export class JetpackConnectMainWrapper extends PureComponent {
 
 		return (
 			<Main className={ classNames( className, wrapperClassName ) }>
+				<DocumentHead title={ translate( 'Jetpack Connect' ) } />
 				<div className="jetpack-connect__main-logo">
 					<JetpackHeader
 						partnerSlug={ partnerSlug }

--- a/client/jetpack-connect/test/main-wrapper.jsx
+++ b/client/jetpack-connect/test/main-wrapper.jsx
@@ -3,6 +3,8 @@
  * @jest-environment jsdom
  */
 
+jest.mock( 'components/data/document-head', () => 'DocumentHead' );
+
 /**
  * External dependencies
  */


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Switches the browser title for the Jetpack Connect flow and for the screen where you can add a new site. Currently, the browser title is identical to the previous page which the user was on, or WordPress.com. 

#### Testing instructions

**Route:** `jetpack/new/` (can be accessed by clicking "Add New Site" in sidebar)
**Title:** Add New Site (the wording is from the heading that appears on the page)

**Route:** `jetpack/connect/` (also includes connections from wp-admin)
**Title:** Jetpack Connect (until Checkout, where the title is "Checkout")

<img width="332" alt="Screenshot 2019-08-03 at 16 27 40" src="https://user-images.githubusercontent.com/43215253/62413834-a1629a00-b60b-11e9-85c2-edb40701ca62.png">

1. Are the correct titles reflected in the browser?
2. Is the wording okay?

cc @simison 

Fixes #32430
