### PR TITLE
Jetpack Checklist: Update Modal Design

### DIFF
--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -1,31 +1,41 @@
 .current-plan-thank-you {
+	display: flex;
+	flex-direction: row;
 	max-width: 720px;
-	text-align: center;
 
 	@include breakpoint( '>800px' ) {
 		font-size: 16px;
+		padding: 20px 0;
+	}
 
-		a {
-			font-size: 14px;
+	h1 {
+		@include breakpoint( '<660px' ) {
+			text-align: center;
+		}
+	}
+
+	a {
+		font-size: 14px;
+
+		@include breakpoint( '<660px' ) {
+			text-align: center;
+			width: 100%;
 		}
 	}
 
 	.progress-bar {
-		max-width: 80%;
+		@include breakpoint( '>660px' ) {
+			max-width: 80%;
+		}
 	}
 }
 
 .current-plan-thank-you__illustration {
-	display: none;
-	margin-bottom: 18px;
+	margin-right: 32px;
+	width: 35%;
 
-	@include breakpoint( '>480px' ) {
-		display: inline;
-		margin-bottom: 18px;
-		width: 70%;
-	}
-	@include breakpoint( '>800px' ) {
-		width: 52%;
+	@include breakpoint( '<660px' ) {
+		display: none;
 	}
 }
 

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -1,8 +1,4 @@
-@import 'jetpack-connect/colors.scss';
-
-.current-plan-thank-you {
-	@include jetpack-connect-colors();
-	
+.current-plan-thank-you {	
 	display: flex;
 	flex-direction: row;
 	max-width: 720px;
@@ -31,6 +27,8 @@
 	}
 	
 	.button {
+		background-color: var( --color-primary );
+		border-color: var( --color-primary-dark );
 		padding-right: 80px;
 		padding-left: 80px;
 		
@@ -38,6 +36,12 @@
 			text-align: center;
 			width: 100%;
 		}
+		
+		&:hover,
+		&:focus {
+			background-color: var( --color-primary-400 );
+			border-color: var( --color-primary-dark );
+		}	
 	}
 }
 

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -1,4 +1,4 @@
-.current-plan-thank-you {	
+.current-plan-thank-you {
 	display: flex;
 	flex-direction: row;
 	max-width: 720px;
@@ -10,7 +10,7 @@
 
 	&__title {
 		font-size: 24px;
-		
+
 		@include breakpoint( '<660px' ) {
 			text-align: center;
 		}
@@ -18,30 +18,30 @@
 
 	&__link {
 		font-size: 14px;
-	}	
+	}
 
 	.progress-bar {
 		@include breakpoint( '>660px' ) {
 			max-width: 80%;
 		}
 	}
-	
+
 	.button {
 		background-color: var( --color-primary );
 		border-color: var( --color-primary-dark );
 		padding-right: 80px;
 		padding-left: 80px;
-		
+
 		@include breakpoint( '<660px' ) {
 			text-align: center;
 			width: 100%;
 		}
-		
+
 		&:hover,
 		&:focus {
 			background-color: var( --color-primary-400 );
 			border-color: var( --color-primary-dark );
-		}	
+		}
 	}
 }
 

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -1,4 +1,8 @@
+@import 'jetpack-connect/colors.scss';
+
 .current-plan-thank-you {
+	@include jetpack-connect-colors();
+	
 	display: flex;
 	flex-direction: row;
 	max-width: 720px;
@@ -18,16 +22,21 @@
 
 	&__link {
 		font-size: 14px;
-
-		@include breakpoint( '<660px' ) {
-			text-align: center;
-			width: 100%;
-		}
-	}
+	}	
 
 	.progress-bar {
 		@include breakpoint( '>660px' ) {
 			max-width: 80%;
+		}
+	}
+	
+	.button {
+		padding-right: 80px;
+		padding-left: 80px;
+		
+		@include breakpoint( '<660px' ) {
+			text-align: center;
+			width: 100%;
 		}
 	}
 }

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/style.scss
@@ -8,13 +8,15 @@
 		padding: 20px 0;
 	}
 
-	h1 {
+	&__title {
+		font-size: 24px;
+		
 		@include breakpoint( '<660px' ) {
 			text-align: center;
 		}
 	}
 
-	a {
+	&__link {
 		font-size: 14px;
 
 		@include breakpoint( '<660px' ) {
@@ -37,8 +39,4 @@
 	@include breakpoint( '<660px' ) {
 		display: none;
 	}
-}
-
-.current-plan-thank-you__title {
-	font-size: 24px;
 }

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -52,31 +52,33 @@ export class ThankYouCard extends Component {
 						src={ illustration }
 					/>
 				) }
-				{ title && <h1 className="current-plan-thank-you__title">{ title }</h1> }
-				{ children }
-				{ showCalypsoIntro && (
-					<p>
-						{ preventWidows(
-							translate(
-								'This is your new WordPress.com dashboard. You can manage your site ' +
-									'here, or return to your self-hosted WordPress dashboard using the ' +
-									'link at the bottom of your checklist.'
-							)
-						) }
-					</p>
-				) }
-				{ showContinueButton && (
-					<Button href={ dismissUrl } onClick={ this.startChecklistTour } primary>
-						{ translate( 'Continue' ) }
-					</Button>
-				) }
-				{ showHideMessage && (
-					<p>
-						<a href={ dismissUrl } onClick={ this.startChecklistTour }>
-							{ translate( 'Hide message' ) }
-						</a>
-					</p>
-				) }
+				<div>
+					{ title && <h1 className="current-plan-thank-you__title">{ title }</h1> }
+					{ children }
+					{ showCalypsoIntro && (
+						<p>
+							{ preventWidows(
+								translate(
+									'This is your new WordPress.com dashboard. You can manage your site ' +
+										'here, or return to your self-hosted WordPress dashboard using the ' +
+										'link at the bottom of your checklist.'
+								)
+							) }
+						</p>
+					) }
+					{ showContinueButton && (
+						<Button href={ dismissUrl } onClick={ this.startChecklistTour } primary>
+							{ translate( 'Continue' ) }
+						</Button>
+					) }
+					{ showHideMessage && (
+						<p>
+							<a href={ dismissUrl } onClick={ this.startChecklistTour }>
+								{ translate( 'Hide message' ) }
+							</a>
+						</p>
+					) }
+				</div>
 			</div>
 		);
 	}

--- a/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
+++ b/client/my-sites/plans/current-plan/current-plan-thank-you/thank-you.js
@@ -73,7 +73,11 @@ export class ThankYouCard extends Component {
 					) }
 					{ showHideMessage && (
 						<p>
-							<a href={ dismissUrl } onClick={ this.startChecklistTour }>
+							<a
+								href={ dismissUrl }
+								className="current-plan-thank-you__link"
+								onClick={ this.startChecklistTour }
+							>
 								{ translate( 'Hide message' ) }
 							</a>
 						</p>

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -122,7 +122,10 @@ class CurrentPlan extends Component {
 				<QuerySitePlans siteId={ selectedSiteId } />
 				{ shouldQuerySiteDomains && <QuerySiteDomains siteId={ selectedSiteId } /> }
 
-				<Dialog isVisible={ showThankYou }>
+				<Dialog
+					baseClassName="current-plan__dialog dialog__content dialog__backdrop"
+					isVisible={ showThankYou }
+				>
 					{ isFreePlan ? <FreePlanThankYou /> : <PaidPlanThankYou /> }
 				</Dialog>
 

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -1,3 +1,13 @@
+.current-plan__dialog.dialog__backdrop {
+	background-color: rgba( var( --color-neutral-dark-rgb ), 0.85 );
+	box-shadow: none;
+	margin: 0;
+	
+	.dialog__backdrop__content {
+		background-color: var( --color-surface );
+	}
+}
+
 .current-plan__header {
 	display: flex;
 	flex-flow: row wrap;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the modal design when finishing the Jetpack Checklist

#### Testing instructions

Visit `plans/my-plan/site.jurassic.ninja?thank-you=` and check the modal design - any changes to be made?

**Desktop:**

<img width="1028" alt="Screenshot 2019-08-03 at 17 38 18" src="https://user-images.githubusercontent.com/43215253/62414597-839a3280-b615-11e9-9d73-c8d6c37ddf0e.png">

<img width="801" alt="Screenshot 2019-08-03 at 17 38 44" src="https://user-images.githubusercontent.com/43215253/62414599-8dbc3100-b615-11e9-9855-47b67ca9f3d9.png">


**Mobile:**

<img width="431" alt="Screenshot 2019-08-03 at 17 12 29" src="https://user-images.githubusercontent.com/43215253/62414570-2aca9a00-b615-11e9-8917-a54e8876f2cd.png">

<img width="434" alt="Screenshot 2019-08-03 at 17 37 48" src="https://user-images.githubusercontent.com/43215253/62414594-75e4ad00-b615-11e9-8343-d6bddaa7c85d.png">

Please also verify the module design for the paid plan - I could get flashes of it to appear for a quick second, but couldn't properly test all the variants.

cc @simison, @jeffgolenski 

Fixes #33731
