### PR TITLE
Fix missing template warning by updating post type name

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-notice/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/plugins/template-update-notice/index.js
@@ -7,7 +7,7 @@ import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 domReady( () => {
-	if ( 'wp_template_part' !== fullSiteEditing.editorPostType ) {
+	if ( 'wp_template' !== fullSiteEditing.editorPostType ) {
 		return;
 	}
 	dispatch( 'core/notices' ).createNotice(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change template check to look for wp_template instead of wp_template_part

#### Testing instructions

* Apply patch to local FSE dev environment
* Attempt to edit a template header or footer part
* Observe that the template edit warning appears at top of editor

**Before**

<img width="712" alt="before-fix" src="https://user-images.githubusercontent.com/3629020/62431865-9466b780-b77f-11e9-9a9a-13c767769726.png">

**After**

<img width="662" alt="after-fix" src="https://user-images.githubusercontent.com/3629020/62431861-90d33080-b77f-11e9-948c-9a2a114beaf8.png">

Fixes #35131
