### PR TITLE
Show a successful notice after dismissing the auto-renewal cancellation survey if there is no error.

### DIFF
--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -18,7 +18,7 @@ import { isFetchingUserPurchases } from 'state/purchases/selectors';
 import { fetchUserPurchases } from 'state/purchases/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
 import isSiteAtomic from 'state/selectors/is-site-automated-transfer';
-import { errorNotice } from 'state/notices/actions';
+import { successNotice, errorNotice } from 'state/notices/actions';
 import AutoRenewDisablingDialog from './auto-renew-disabling-dialog';
 import FormToggle from 'components/forms/form-toggle';
 
@@ -42,11 +42,20 @@ class AutoRenewToggle extends Component {
 		showAutoRenewDisablingDialog: false,
 		isTogglingToward: null,
 		isRequesting: false,
+		requestHasFailed: false,
 	};
 
 	onCloseAutoRenewDisablingDialog = () => {
+		const { isTogglingToward, requestHasFailed } = this.state;
+
+		// Intentionally written in this way because it is not a successful / failing condition
+		if ( isTogglingToward === false && ! requestHasFailed ) {
+			this.props.successNotice( 'Auto-renewal has been turned off successfully.' );
+		}
+
 		this.setState( {
 			showAutoRenewDisablingDialog: false,
+			requestHasFailed: false,
 		} );
 	};
 
@@ -78,6 +87,10 @@ class AutoRenewToggle extends Component {
 						? translate( "We've failed to enable auto-renewal for you. Please try again." )
 						: translate( "We've failed to disable auto-renewal for you. Please try again." )
 				);
+
+				this.setState( {
+					requestHasFailed: true,
+				} );
 			}
 
 			this.props.fetchUserPurchases( currentUserId );
@@ -148,6 +161,7 @@ export default connect(
 	{
 		fetchUserPurchases,
 		recordTracksEvent,
+		successNotice,
 		errorNotice,
 	}
 )( localize( AutoRenewToggle ) );

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -42,20 +42,11 @@ class AutoRenewToggle extends Component {
 		showAutoRenewDisablingDialog: false,
 		isTogglingToward: null,
 		isRequesting: false,
-		requestHasFailed: false,
 	};
 
 	onCloseAutoRenewDisablingDialog = () => {
-		const { isTogglingToward, requestHasFailed } = this.state;
-
-		// Intentionally written in this way because it is not a successful / failing condition
-		if ( isTogglingToward === false && ! requestHasFailed ) {
-			this.props.successNotice( 'Auto-renewal has been turned off successfully.' );
-		}
-
 		this.setState( {
 			showAutoRenewDisablingDialog: false,
-			requestHasFailed: false,
 		} );
 	};
 
@@ -81,19 +72,22 @@ class AutoRenewToggle extends Component {
 				isRequesting: false,
 			} );
 
-			if ( ! success ) {
-				this.props.errorNotice(
+			if ( success ) {
+				this.props.successNotice(
 					isTogglingToward
-						? translate( "We've failed to enable auto-renewal for you. Please try again." )
-						: translate( "We've failed to disable auto-renewal for you. Please try again." )
+						? translate( 'Auto-renewal has been turned on successfully.' )
+						: translate( 'Auto-renewal has been turned off successfully.' )
 				);
+				this.props.fetchUserPurchases( currentUserId );
 
-				this.setState( {
-					requestHasFailed: true,
-				} );
+				return;
 			}
 
-			this.props.fetchUserPurchases( currentUserId );
+			this.props.errorNotice(
+				isTogglingToward
+					? translate( "We've failed to enable auto-renewal for you. Please try again." )
+					: translate( "We've failed to disable auto-renewal for you. Please try again." )
+			);
 		} );
 
 		this.props.recordTracksEvent( 'calypso_purchases_manage_purchase_toggle_auto_renew', {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR resolves #34622, originally proposed by @katinthehatsite, by showing a successful notice after the survey if there is no error:

![demo-successful-notice-after-survey](https://user-images.githubusercontent.com/1842898/62432627-5491d700-b763-11e9-8b04-5d960e90815c.gif)

#### Testing instructions

##### Successful case

1. Go to `/me/purchases` and access the management page of any non-G-suite subscription.
1. Turn off the auto-renewal and the survey should appear.
1. Complete or skip the survey, and then a successful notice should appear.

##### Erroneous case

There are two quick ways of artificially creating an error: 
1. Cut the Internet connection.
1. Manually update the [disableAutoRenew() function](https://github.com/Automattic/wp-calypso/blob/master/client/lib/upgrades/actions/purchases.js#L47) as:
```
export function disableAutoRenew( purchaseId, onComplete ) {
    onComplete( false );
}
```

After any of those, going through the same testing steps above should leave you with an error notice without the newly-added successful notice.

