### PR TITLE
Split the plan upgrade test into two tests

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,15 +106,6 @@ export default {
 		defaultVariation: 'notSkippable',
 		allowExistingUsers: true,
 	},
-	defaultMonthlyJetpackPlan: {
-		datestamp: '20190722',
-		variations: {
-			monthlyPlan: 50,
-			yearlyPlan: 50,
-		},
-		defaultVariation: 'yearlyPlan',
-		allowExistingUsers: true,
-	},
 	showPlanUpsellGSuite: {
 		datestamp: '20190805',
 		variations: {

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -121,6 +121,8 @@ export default {
 			variantShowPlanBump: 50,
 			control: 50,
 		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
 	},
 	privateByDefault: {
 		datestamp: '20190730',

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -106,14 +106,30 @@ export default {
 		defaultVariation: 'notSkippable',
 		allowExistingUsers: true,
 	},
-	showPlanUpsellNudge: {
-		datestamp: '20190712',
+	defaultMonthlyJetpackPlan: {
+		datestamp: '20190722',
 		variations: {
-			variantShowNudge: 0,
-			control: 100,
+			monthlyPlan: 50,
+			yearlyPlan: 50,
+		},
+		defaultVariation: 'yearlyPlan',
+		allowExistingUsers: true,
+	},
+	showPlanUpsellGSuite: {
+		datestamp: '20190805',
+		variations: {
+			variantShowPlanBump: 50,
+			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
+	},
+	showPlanUpsellConcierge: {
+		datestamp: '20190805',
+		variations: {
+			variantShowPlanBump: 50,
+			control: 50,
+		},
 	},
 	privateByDefault: {
 		datestamp: '20190730',

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -404,11 +404,23 @@ export class Checkout extends React.Component {
 		return '/';
 	}
 
-	maybeShowPlanUpgradeOffer( receiptId ) {
+	maybeShowPlanBumpOfferGSuite( receiptId ) {
 		const { cart, selectedSiteSlug } = this.props;
 
 		if ( hasPersonalPlan( cart ) ) {
-			if ( 'variantShowNudge' === abtest( 'showPlanUpsellNudge' ) ) {
+			if ( 'variantShowPlanBump' === abtest( 'showPlanUpsellGSuite' ) ) {
+				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
+			}
+		}
+
+		return;
+	}
+
+	maybeShowPlanBumpOfferConcierge( receiptId ) {
+		const { cart, selectedSiteSlug } = this.props;
+
+		if ( hasPersonalPlan( cart ) ) {
+			if ( 'variantShowPlanBump' === abtest( 'showPlanUpsellConcierge' ) ) {
 				return `/checkout/${ selectedSiteSlug }/offer-plan-upgrade/premium/${ receiptId }`;
 			}
 		}
@@ -431,7 +443,7 @@ export class Checkout extends React.Component {
 				const domainsForGSuite = this.getEligibleDomainFromCart();
 				if ( domainsForGSuite.length ) {
 					return (
-						this.maybeShowPlanUpgradeOffer( pendingOrReceiptId ) ||
+						this.maybeShowPlanBumpOfferGSuite( pendingOrReceiptId ) ||
 						`/checkout/${ selectedSiteSlug }/with-gsuite/${
 							domainsForGSuite[ 0 ].meta
 						}/${ pendingOrReceiptId }`
@@ -457,7 +469,7 @@ export class Checkout extends React.Component {
 			( hasBloggerPlan( cart ) || hasPersonalPlan( cart ) || hasPremiumPlan( cart ) ) &&
 			! previousRoute.includes( `/checkout/${ selectedSiteSlug }/offer-plan-upgrade` )
 		) {
-			const upgradePath = this.maybeShowPlanUpgradeOffer( pendingOrReceiptId );
+			const upgradePath = this.maybeShowPlanBumpOfferConcierge( pendingOrReceiptId );
 			if ( upgradePath ) {
 				return upgradePath;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* We introduced a plan upgrade test in https://github.com/Automattic/wp-calypso/pull/33344 that pitches a Premium plan upgrade offer to those users who purchase a Personal plan. The upgrade offer was shown against the GSuite offer and Concierge offer in a single test.
* For better granularity in results, we are now splitting this test into two tests. For users who checkout and purchase a Personal plan:
    1. If they also purchase a domain, then we will show plan upgrade vs GSuite in a 50/50 `showPlanUpsellGSuite` test.
    2. If they don't purchase a domain, then we will show plan upgrade vs quick start offer in a 50/50 `showPlanUpsellConcierge` test. 
* This PR closes the earlier test `showPlanUpsellNudge`.

Plan upgrade offer:

![calypso localhost_3000_checkout_sss152240826 wordpress com_offer-plan-upgrade_premium_123](https://user-images.githubusercontent.com/1269602/61631074-02eb4600-aca7-11e9-9bd4-4ffac7fe3b1c.png)


#### Testing instructions


**Scenario 1** _(Testing behaviour of `showPlanUpsellConcierge` A/B test)_

* Signup for a new account from http://calypso.localhost:3000/start.
* Add a Personal plan to cart and complete the purchase
* Verify the following:
    - That you are shown the premium upgrade upsell if on the `variantShowPlanBump` variation of `showPlanUpsellConcierge` test.
    - That you are shown the concierge upsell if on the `control` variation of `showPlanUpsellConcierge` test.

If on the plan upsell nudge, verify the following:
- Clicking the `No thanks ...` button should take you site preview.
- Clicking the `Yes, I'd love to try ....` button should take you to the checkout page with the Premium plan added to cart and **credits applied**. Verify that after you complete the purchase, you are **not shown the concierge upsell** but instead taken to site preview(http://calypso.localhost:3000/view/{SITE_SLUG}

If on the concierge upsell nudge, verify the following:
- Clicking Skip on the nudge should take you to checklist.
- Clicking Accept on the nudge, and completing the concierge session purchase should take you checklist. _**No more upsell nudges should be shown**_.

**Scenario 2** _(Testing behaviour of `showPlanUpsellGSuite` A/B test)_

* Signup for a new account from http://calypso.localhost:3000/start.
* Add a Personal plan AND domain to cart and complete the purchase
* Verify the following:
    - That you are shown the premium upgrade upsell if on the `variantShowPlanBump` variation of `showPlanUpsellGSuite` test.
    - That you are shown the GSuite upsell if on the `control` variation of `showPlanUpsellGSuite` test.

If on the plan upsell nudge, verify the following:
- Clicking the `No thanks ...` button should take you site preview.
- Clicking the `Yes, I'd love to try ....` button should take you to the checkout page with the Premium plan added to cart and **credits applied**. Verify that after you complete the purchase, you are **not shown the GSuite upsell** but instead taken to site preview(http://calypso.localhost:3000/view/{SITE_SLUG}

If on the GSuite upsell nudge, verify the following:
- Clicking Skip on the nudge should take you to site preview
- Clicking Accept on the nudge, and completing the concierge session purchase should take you checklist. _**No more upsell nudges should be shown.**_

**Scenario 3** (Test that the offer is shown when upgrading from a lower tier plan to Personal)
* Login to a site having a Free or Blogger plan, go to /plans and upgrade to Personal
* After purchase completes, verify the following:
    - That you are shown the premium upgrade upsell if on the `variantShowPlanBump` variation of `showPlanUpsellConcierge` test.
    - That you are shown the concierge upsell if on the `control` variation of `showPlanUpsellConcierge` test.
In both cases above, complete the upsell purchase and verify that you are not show any more upsell nudges.

**Scenario 4** 
* Verify status quo i.e current behaviour is maintained for non-Personal plan purchases.
* Add a Blogger/Premium plan to cart and complete signup. Verify that only the concierge upsell nudge is shown.
