### PR TITLE
Update copy for Jetpack connection "site type" question

### DIFF
--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -50,7 +50,10 @@ class JetpackSiteType extends Component {
 						) }
 					/>
 
-					<SiteTypeForm submitForm={ this.handleSubmit } />
+					<SiteTypeForm
+						showDescriptions={ false }
+						submitForm={ this.handleSubmit }
+					/>
 
 					<SkipButton
 						onClick={ this.goToNextStep }

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -44,16 +44,11 @@ class JetpackSiteType extends Component {
 			<MainWrapper isWide>
 				<div className="jetpack-connect__step">
 					<FormattedHeader
-						headerText={ translate( 'What are we building today?' ) }
-						subHeaderText={ translate(
-							'Choose the best starting point for your site. You can add or change features later.'
-						) }
+						headerText={ translate( 'What type of site are you connecting to Jetpack?' ) }
+						subHeaderText={ translate( "We'll use this info to your Jetpack experience." ) }
 					/>
 
-					<SiteTypeForm
-						showDescriptions={ false }
-						submitForm={ this.handleSubmit }
-					/>
+					<SiteTypeForm showDescriptions={ false } submitForm={ this.handleSubmit } />
 
 					<SkipButton
 						onClick={ this.goToNextStep }

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -45,7 +45,7 @@ class JetpackSiteType extends Component {
 				<div className="jetpack-connect__step">
 					<FormattedHeader
 						headerText={ translate( 'What type of site are you connecting to Jetpack?' ) }
-						subHeaderText={ translate( "We'll use this info to your Jetpack experience." ) }
+						subHeaderText={ translate( "We'll use this to customize your Jetpack experience." ) }
 					/>
 
 					<SiteTypeForm showDescriptions={ false } submitForm={ this.handleSubmit } />

--- a/client/jetpack-connect/site-type.js
+++ b/client/jetpack-connect/site-type.js
@@ -48,7 +48,11 @@ class JetpackSiteType extends Component {
 						subHeaderText={ translate( "We'll use this to customize your Jetpack experience." ) }
 					/>
 
-					<SiteTypeForm showDescriptions={ false } submitForm={ this.handleSubmit } />
+					<SiteTypeForm
+						showDescriptions={ false }
+						showPurchaseRequired={ false }
+						submitForm={ this.handleSubmit }
+					/>
 
 					<SkipButton
 						onClick={ this.goToNextStep }

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -21,7 +21,7 @@ import './style.scss';
 
 class SiteTypeForm extends Component {
 	static propTypes = {
-		showDescriptions: PropTypes.boolean,
+		showDescriptions: PropTypes.bool,
 		showPurchaseRequired: PropTypes.boolean,
 		siteType: PropTypes.string,
 		submitForm: PropTypes.func.isRequired,

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -76,6 +76,6 @@ class SiteTypeForm extends Component {
 	}
 }
 
-export default connect( {
+export default connect( null, {
 	recordTracksEvent,
 } )( localize( SiteTypeForm ) );

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -22,6 +22,7 @@ import './style.scss';
 class SiteTypeForm extends Component {
 	static propTypes = {
 		showDescriptions: PropTypes.boolean,
+		showPurchaseRequired: PropTypes.boolean,
 		siteType: PropTypes.string,
 		submitForm: PropTypes.func.isRequired,
 
@@ -31,6 +32,7 @@ class SiteTypeForm extends Component {
 
 	static defaultProps = {
 		showDescriptions: true,
+		showPurchaseRequired: true,
 	};
 
 	handleSubmit = type => {
@@ -41,7 +43,7 @@ class SiteTypeForm extends Component {
 	};
 
 	render() {
-		const { showDescriptions, translate } = this.props;
+		const { showDescriptions, showPurchaseRequired, translate } = this.props;
 
 		return (
 			<>
@@ -57,16 +59,14 @@ class SiteTypeForm extends Component {
 						>
 							<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
 							{ showDescriptions && (
-								<>
-									<span className="site-type__option-description">
-										{ siteTypeProperties.description }
-									</span>
-									{ siteTypeProperties.purchaseRequired && (
-										<Badge className="site-type__option-badge" type="info">
-											{ translate( 'Purchase required' ) }
-										</Badge>
-									) }
-								</>
+								<span className="site-type__option-description">
+									{ siteTypeProperties.description }
+								</span>
+							) }
+							{ showPurchaseRequired && siteTypeProperties.purchaseRequired && (
+								<Badge className="site-type__option-badge" type="info">
+									{ translate( 'Purchase required' ) }
+								</Badge>
 							) }
 						</Card>
 					) ) }

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -22,7 +22,7 @@ import './style.scss';
 class SiteTypeForm extends Component {
 	static propTypes = {
 		showDescriptions: PropTypes.bool,
-		showPurchaseRequired: PropTypes.boolean,
+		showPurchaseRequired: PropTypes.bool,
 		siteType: PropTypes.string,
 		submitForm: PropTypes.func.isRequired,
 

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -13,8 +13,6 @@ import Badge from 'components/badge';
 import Card from 'components/card';
 import { getAllSiteTypes } from 'lib/signup/site-type';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
 
 /**
  * Style dependencies
@@ -23,11 +21,16 @@ import './style.scss';
 
 class SiteTypeForm extends Component {
 	static propTypes = {
+		showDescriptions: PropTypes.boolean,
 		siteType: PropTypes.string,
 		submitForm: PropTypes.func.isRequired,
 
 		// from localize() HoC
 		translate: PropTypes.func.isRequired,
+	};
+
+	static defaultProps = {
+		showDescriptions: true,
 	};
 
 	handleSubmit = type => {
@@ -38,8 +41,10 @@ class SiteTypeForm extends Component {
 	};
 
 	render() {
+		const { showDescriptions, translate } = this.props;
+
 		return (
-			<Fragment>
+			<>
 				<Card className="site-type__wrapper">
 					{ getAllSiteTypes().map( siteTypeProperties => (
 						<Card
@@ -51,29 +56,26 @@ class SiteTypeForm extends Component {
 							onClick={ this.handleSubmit.bind( this, siteTypeProperties.slug ) }
 						>
 							<strong className="site-type__option-label">{ siteTypeProperties.label }</strong>
-							<span className="site-type__option-description">
-								{ siteTypeProperties.description }
-							</span>
-							{ ! this.props.isJetpack && siteTypeProperties.purchaseRequired && (
-								<Badge className="site-type__option-badge" type="info">
-									{ this.props.translate( 'Purchase required' ) }
-								</Badge>
+							{ showDescriptions && (
+								<>
+									<span className="site-type__option-description">
+										{ siteTypeProperties.description }
+									</span>
+									{ siteTypeProperties.purchaseRequired && (
+										<Badge className="site-type__option-badge" type="info">
+											{ translate( 'Purchase required' ) }
+										</Badge>
+									) }
+								</>
 							) }
 						</Card>
 					) ) }
 				</Card>
-			</Fragment>
+			</>
 		);
 	}
 }
 
-export default connect(
-	state => ( {
-		// TODO: Better handling for Jetpack flows in the site-type lib,
-		// so we don't depend on injecting conditionals into components like this.
-		isJetpack: !! isJetpackSite( state, getSelectedSiteId( state ) ),
-	} ),
-	{
-		recordTracksEvent,
-	}
-)( localize( SiteTypeForm ) );
+export default connect( {
+	recordTracksEvent,
+} )( localize( SiteTypeForm ) );


### PR DESCRIPTION
Copy updates to "site type" step in Jetpack connect.

Resolves https://github.com/Automattic/wp-calypso/issues/34328

#### Changes proposed in this Pull Request

* Update question's copy
* Add `showDescriptions` instead of checking for `isJetpack` to hide both descriptions and "purchase required" badge
* Hide descriptions under the site types

#### Testing instructions

- Have a new Jetpack site https://jurassic.ninja/
- Connect the site, append `&calypso_env=development` in connection URL to get to local version
- Note how "site type" question doesn't have descriptions under options
- Note updated question copy
