### PR TITLE
Prevent duplicate Babel object spread helpers.

### DIFF
--- a/packages/calypso-build/CHANGELOG.md
+++ b/packages/calypso-build/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [Unreleased]
+
+- Added transform-runtime versioning to babel/default.js
+  This will need to be kept up to date while https://github.com/babel/babel/issues/10261 is unresolved.
+
 # 3.0.0
 
 - Switch to `@wordpress/dependency-extraction-webpack-plugin` from

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -22,6 +22,7 @@ module.exports = () => ( {
 				helpers: true,
 				regenerator: false,
 				useESModules: false,
+				version: '7.5.5', // needed so that helpers aren't duplicated
 			},
 		],
 	],

--- a/packages/calypso-build/babel/default.js
+++ b/packages/calypso-build/babel/default.js
@@ -22,7 +22,9 @@ module.exports = () => ( {
 				helpers: true,
 				regenerator: false,
 				useESModules: false,
-				version: '7.5.5', // needed so that helpers aren't duplicated
+				// Needed so that helpers aren't duplicated.
+				// This will need to be kept up to date while https://github.com/babel/babel/issues/10261 is unresolved.
+				version: '7.5.5',
 			},
 		],
 	],


### PR DESCRIPTION
Somewhere on the range of version 7.5 of Babel, the object spread helper was updated (to fix some edge cases, I believe).

When we upgraded our version of Babel to 7.5.5, it started trying to use the new helper to perform object spreads. This would have been fine, since the relevant package (`transform-runtime`) was part of the upgrade, but Babel sadly assumes that its version is older, instead of auto-detecting.

This change explicitly indicates which version of the `transform-runtime` we're using, fixing the issue. It unfortunately adds extra maintenance overhead to Babel upgrades, but the Babel authors are considering adding the aforementioned auto-detection, at which point we could remove the explicit definition.

CC @jsnajdr, who'd been looking at the bundle size increase with me.

#### Changes proposed in this Pull Request

* Explicitly indicate which version of Babel's `transform-runtime` we're using, to prevent helper duplication.

#### Testing instructions

There should be no special testing needed other than opening the live branch and ensuring nothing breaks after visiting a page or two. Babel transformations are so low level that a mistake would likely break everything.

To confirm the bundle size improvements, ~~the icfy bot should be enough~~ see my comments below.