### PR TITLE
Update signup progress state to a keyed object

### DIFF
--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -11,11 +11,11 @@ import {
 	flatMap,
 	forEach,
 	get,
-	includes,
 	isEmpty,
 	keys,
 	pick,
 	reject,
+	reduce,
 } from 'lodash';
 import page from 'page';
 
@@ -26,7 +26,7 @@ import analytics from 'lib/analytics';
 import flows from 'signup/config/flows';
 import steps from 'signup/config/steps';
 import wpcom from 'lib/wp';
-import { getStepUrl } from 'signup/utils';
+import { getStepUrl, getFilteredSteps } from 'signup/utils';
 import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
@@ -100,6 +100,7 @@ assign( SignupFlowController.prototype, {
 
 	_resetStoresIfUserHasLoggedIn: function() {
 		if (
+			// TODO: Address this properly if we move forward with the user step being last
 			isUserLoggedIn( this._reduxStore.getState() ) &&
 			find( getSignupProgress( this._reduxStore.getState() ), { stepName: 'user' } )
 		) {
@@ -193,8 +194,9 @@ assign( SignupFlowController.prototype, {
 
 	_process: function() {
 		const currentSteps = this._flow.steps;
-		const signupProgress = filter( getSignupProgress( this._reduxStore.getState() ), step =>
-			includes( currentSteps, step.stepName )
+		const signupProgress = getFilteredSteps(
+			this._flowName,
+			getSignupProgress( this._reduxStore.getState() )
 		);
 		const pendingSteps = filter( signupProgress, { status: 'pending' } );
 		const completedSteps = filter( signupProgress, { status: 'completed' } );
@@ -225,9 +227,9 @@ assign( SignupFlowController.prototype, {
 		);
 		const dependenciesSatisfied = dependencies.length === keys( dependenciesFound ).length;
 		const currentSteps = this._flow.steps;
-		const signupProgress = filter(
-			getSignupProgress( this._reduxStore.getState() ),
-			( { stepName } ) => includes( currentSteps, stepName )
+		const signupProgress = getFilteredSteps(
+			this._flowName,
+			getSignupProgress( this._reduxStore.getState() )
 		);
 		const allStepsSubmitted =
 			reject( signupProgress, { status: 'in-progress' } ).length === currentSteps.length;
@@ -290,7 +292,8 @@ assign( SignupFlowController.prototype, {
 			get( steps, [ stepName, 'providesDependencies' ], [] )
 		);
 
-		return getSignupProgress( this._reduxStore.getState() ).reduce(
+		return reduce(
+			getSignupProgress( this._reduxStore.getState() ),
 			( current, step ) => ( {
 				...current,
 				...pick( step.providedDependencies, requiredDependencies ),

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import {
 	assign,
 	defer,
+	isEmpty,
 	find,
 	get,
 	includes,
@@ -466,11 +467,11 @@ class Signup extends React.Component {
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToNextStep = ( nextFlowName = this.props.flowName ) => {
-		const flowSteps = flows.getFlow( nextFlowName ).steps,
-			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
-			nextStepName = flowSteps[ currentStepIndex + 1 ],
-			nextProgressItem = this.props.progress[ currentStepIndex + 1 ],
-			nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
+		const flowSteps = flows.getFlow( nextFlowName ).steps;
+		const currentStepIndex = indexOf( flowSteps, this.props.stepName );
+		const nextStepName = flowSteps[ currentStepIndex + 1 ];
+		const nextProgressItem = get( this.props.progress, nextStepName );
+		const nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
 
 		if ( nextFlowName !== this.props.flowName ) {
 			this.props.removeUnneededSteps( nextFlowName );
@@ -512,6 +513,7 @@ class Signup extends React.Component {
 	}
 
 	getFlowLength() {
+		// this would need to change if we used journeys
 		return flows.getFlow( this.props.flowName ).steps.length;
 	}
 
@@ -587,13 +589,24 @@ class Signup extends React.Component {
 	}
 
 	render() {
+		console.log( this.props.progress );
+
 		if (
 			! this.props.stepName ||
-			( this.getPositionInFlow() > 0 && this.props.progress.length === 0 ) ||
+			( this.getPositionInFlow() > 0 && isEmpty( this.props.progress ) ) ||
 			this.state.resumingStep
 		) {
+			console.log( 'rendering null', {
+				stepName: this.props.stepName,
+				pos: this.getPositionInFlow(),
+				emptyProgress: isEmpty( this.props.progress ),
+				resumingStep: this.state.resumingStep,
+			} );
+
 			return null;
 		}
+
+		console.log( 'not rendering null...' );
 
 		// Removes flicker of steps that have been removed from the flow
 		const waitToRenderReturnValue = this.shouldWaitToRender();

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -13,6 +13,7 @@ import classNames from 'classnames';
  */
 import FormattedHeader from 'components/formatted-header';
 import NavigationLink from 'signup/navigation-link';
+import { getFilteredSteps } from '../utils';
 
 /**
  * Style dependencies
@@ -51,7 +52,7 @@ class StepWrapper extends Component {
 				stepName={ this.props.stepName }
 				stepSectionName={ this.props.stepSectionName }
 				backUrl={ this.props.backUrl }
-				signupProgress={ this.props.signupProgress }
+				signupProgress={ getFilteredSteps( this.props.flowName, this.props.signupProgress ) }
 				labelText={ this.props.backLabelText }
 				allowBackFirstStep={ this.props.allowBackFirstStep }
 			/>

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -66,7 +66,7 @@ class DomainsStep extends React.Component {
 		path: PropTypes.string.isRequired,
 		positionInFlow: PropTypes.number.isRequired,
 		queryObject: PropTypes.object,
-		signupProgress: PropTypes.array.isRequired,
+		signupProgress: PropTypes.object.isRequired,
 		step: PropTypes.object,
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -33,7 +33,7 @@ class SiteTitleStep extends Component {
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
 		setSiteTitle: PropTypes.func.isRequired,
-		signupProgress: PropTypes.array,
+		signupProgress: PropTypes.object,
 		stepName: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		siteTitle: PropTypes.string,

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -26,7 +26,7 @@ class SiteTopicStep extends Component {
 		isUserInput: PropTypes.bool,
 		positionInFlow: PropTypes.number.isRequired,
 		submitSiteVertical: PropTypes.func.isRequired,
-		signupProgress: PropTypes.array,
+		signupProgress: PropTypes.object,
 		stepName: PropTypes.string,
 		siteType: PropTypes.string,
 		translate: PropTypes.func.isRequired,

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -3,7 +3,7 @@
  * Exernal dependencies
  */
 import cookie from 'cookie';
-import { filter, find, includes, indexOf, isEmpty, pick } from 'lodash';
+import { filter, find, includes, indexOf, isEmpty, pick, sortBy } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -177,7 +177,13 @@ export function getDesignTypeForSiteGoals( siteGoals, flow ) {
 
 export function getFilteredSteps( flowName, progress ) {
 	const flow = flows.getFlow( flowName );
-	return filter( progress, step => includes( flow.steps, step.stepName ) );
+
+	return sortBy(
+		// filter steps...
+		filter( progress, step => includes( flow.steps, step.stepName ) ),
+		// then order according to the flow definition...
+		( { stepName } ) => flow.steps.indexOf( stepName )
+	);
 }
 
 export function getFirstInvalidStep( flowName, progress ) {

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -3,126 +3,117 @@
 /**
  * External dependencies
  */
-import { get, find, map } from 'lodash';
+import { has, keyBy, get } from 'lodash';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import stepsConfig from 'signup/config/steps-pure';
-import flows from 'signup/config/flows-pure';
 import {
 	SIGNUP_COMPLETE_RESET,
 	SIGNUP_PROGRESS_COMPLETE_STEP,
 	SIGNUP_PROGRESS_INVALIDATE_STEP,
 	SIGNUP_PROGRESS_PROCESS_STEP,
-	SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
+	SIGNUP_PROGRESS_RESUME_AFTER_LOGIN_SET,
 	SIGNUP_PROGRESS_SAVE_STEP,
 	SIGNUP_PROGRESS_SUBMIT_STEP,
 } from 'state/action-types';
 import { createReducer } from 'state/utils';
 import { schema } from './schema';
-import userFactory from 'lib/user';
 
 const debug = debugFactory( 'calypso:state:signup:progress:reducer' );
 
 //
+// Helper Functions
+//
+const addStep = ( state, step ) => {
+	debug( `Adding step ${ step.stepName }` );
+
+	return {
+		...state,
+		[ step.stepName ]: step,
+	};
+};
+
+const updateStep = ( state, newStepState ) => {
+	const { stepName, status } = newStepState;
+	const stepState = get( state, stepName );
+
+	debug( `Updating step ${ stepName }` );
+
+	if ( status === 'pending' || status === 'completed' ) {
+		// This can only happen when submitting a step
+		//
+		// Steps that are resubmitted may decide to omit the `wasSkipped` status of a step if e.g.
+		// the user goes back and chooses to not skip a step. If a step is submitted without it,
+		// we explicitly remove it from the step data.
+		const { wasSkipped, ...commonStepArgs } = stepState;
+
+		return {
+			...state,
+			[ stepName ]: {
+				...commonStepArgs,
+				...newStepState,
+			},
+		};
+	}
+
+	return {
+		...state,
+		[ stepName ]: {
+			...stepState,
+			...newStepState,
+		},
+	};
+};
+
+//
 // Action handlers
 //
-function overwriteSteps( state, { steps = [] } ) {
-	// When called without action.steps, this is basically a state reset function.
-	return Array.isArray( steps ) ? steps : [];
+
+// When called without action.steps, this is basically a state reset function.
+const overwriteSteps = ( state, { steps = {} } ) => keyBy( steps, 'stepName' );
+
+const completeStep = ( state, { step } ) => updateStep( state, { ...step, status: 'completed' } );
+
+const invalidateStep = ( state, { step, errors } ) => {
+	const newStepState = { ...step, errors, status: 'invalid' };
+
+	return has( state, step.stepName )
+		? updateStep( state, newStepState )
+		: addStep( state, newStepState );
+};
+
+const processStep = ( state, { step } ) => updateStep( state, { ...step, status: 'processing' } );
+
+const saveStep = ( state, { step } ) =>
+	has( state, step.stepName )
+		? updateStep( state, step )
+		: addStep( state, { ...step, status: 'in-progress' } );
+
+function setResumeAfterLogin( state, { resumeStep } ) {
+	debug( `Setting resume after login for step ${ resumeStep.stepName }` );
+	return updateStep( state, { ...resumeStep, status: 'in-progress' } );
 }
 
-function completeStep( state, { step } ) {
-	return updateStep( state, { ...step, status: 'completed' } );
-}
-
-function invalidateStep( state, { step, errors } ) {
-	const newStep = { ...step, errors, status: 'invalid' };
-	if ( find( state, { stepName: newStep.stepName } ) ) {
-		return updateStep( state, newStep );
-	}
-	return addStep( state, newStep );
-}
-
-function processStep( state, { step } ) {
-	return updateStep( state, { ...step, status: 'processing' } );
-}
-
-function removeUnneededSteps( state, { flowName } ) {
-	let flowSteps = [];
-	const user = userFactory();
-
-	flowSteps = get( flows, [ flowName, 'steps' ], [] );
-
-	if ( user && user.get() ) {
-		flowSteps = flowSteps.filter( item => item !== 'user' );
-	}
-
-	return state.filter( step => flowSteps.includes( step.stepName ) );
-}
-
-function saveStep( state, { step } ) {
-	if ( find( state, { stepName: step.stepName } ) ) {
-		return updateStep( state, step );
-	}
-
-	return addStep( state, { ...step, status: 'in-progress' } );
-}
-
-function submitStep( state, { step } ) {
+const submitStep = ( state, { step } ) => {
 	const stepHasApiRequestFunction = get( stepsConfig, [ step.stepName, 'apiRequestFunction' ] );
 	const status = stepHasApiRequestFunction ? 'pending' : 'completed';
 
-	if ( find( state, { stepName: step.stepName } ) ) {
-		return updateStep( state, { ...step, status } );
-	}
+	return has( state, step.stepName )
+		? updateStep( state, { ...step, status } )
+		: addStep( state, { ...step, status } );
+};
 
-	return addStep( state, { ...step, status } );
-}
-
-//
-// Helper Functions
-//
-function addStep( state, step ) {
-	debug( `Adding step ${ step.stepName }` );
-	return [ ...state, step ];
-}
-
-function updateStep( state, newStep ) {
-	debug( `Updating step ${ newStep.stepName }` );
-	return map( state, function( step ) {
-		if ( step.stepName === newStep.stepName ) {
-			const { status } = newStep;
-			if ( status === 'pending' || status === 'completed' ) {
-				// This can only happen when submitting a step
-				//
-				// Steps that are resubmitted may decide to omit the `wasSkipped` status of a step if e.g.
-				// the user goes back and chooses to not skip a step. If a step is submitted without it,
-				// we explicitly remove it from the step data.
-				const { wasSkipped, ...commonStepArgs } = step;
-				return { ...commonStepArgs, ...newStep };
-			}
-
-			return { ...step, ...newStep };
-		}
-
-		return step;
-	} );
-}
-
-//
-// Reducer export
-//
 export default createReducer(
-	[],
+	{},
 	{
 		[ SIGNUP_COMPLETE_RESET ]: overwriteSteps,
 		[ SIGNUP_PROGRESS_COMPLETE_STEP ]: completeStep,
 		[ SIGNUP_PROGRESS_INVALIDATE_STEP ]: invalidateStep,
 		[ SIGNUP_PROGRESS_PROCESS_STEP ]: processStep,
-		[ SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS ]: removeUnneededSteps,
+		[ SIGNUP_PROGRESS_RESUME_AFTER_LOGIN_SET ]: setResumeAfterLogin,
 		[ SIGNUP_PROGRESS_SAVE_STEP ]: saveStep,
 		[ SIGNUP_PROGRESS_SUBMIT_STEP ]: submitStep,
 	},

--- a/client/state/signup/progress/schema.js
+++ b/client/state/signup/progress/schema.js
@@ -1,19 +1,21 @@
 /** @format */
 export const schema = {
-	type: 'array',
-	items: {
-		type: 'object',
-		properties: {
-			formData: {
-				type: 'object',
-				properties: {
-					url: { type: 'string' },
+	type: 'object',
+	patternProperties: {
+		'^[w-]+$': {
+			type: 'object',
+			properties: {
+				formData: {
+					type: 'object',
+					properties: {
+						url: { type: 'string' },
+					},
 				},
+				lastUpdated: { type: 'number' },
+				// Valid status values: 'completed', 'processing', 'pending', 'in-progress' and 'invalid'
+				status: { type: 'string' },
+				stepName: { type: 'string' },
 			},
-			lastUpdated: { type: 'number' },
-			// Valid status values: 'completed', 'processing', 'pending', 'in-progress' and 'invalid'
-			status: { type: 'string' },
-			stepName: { type: 'string' },
 		},
 	},
 };

--- a/client/state/signup/progress/selectors.js
+++ b/client/state/signup/progress/selectors.js
@@ -6,7 +6,7 @@
 
 import { get } from 'lodash';
 
-const initialState = [];
+const initialState = {};
 export function getSignupProgress( state ) {
 	return get( state, 'signup.progress', initialState );
 }


### PR DESCRIPTION
See https://github.com/Automattic/wp-calypso/pull/35049.

This PR does the same thing, but bases off of master.