### PR TITLE
Earn: update feature cards copy

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -79,13 +79,15 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			: { url: supportLink, onClick: () => trackLearnLink( 'simple-payments' ) };
 		return {
 			title: translate( 'Collect one-time payments' ),
-			body: translate(
-				'Add a payment button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations. {{em}}Available to any site with a Premium plan{{/em}}.',
-				{
-					components: {
-						em: <em />,
-					},
-				}
+			body: (
+				<Fragment>
+					{ translate(
+						'Add a payment button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations.'
+					) }{' '}
+					{ ! hasSimplePayments && (
+						<em>{ translate( 'Available to any site with a Premium plan.' ) }</em>
+					) }
+				</Fragment>
 			),
 			image: {
 				path: '/calypso/images/earn/simple-payments.svg',
@@ -121,18 +123,18 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 		const title = hasConnectedAccount
 			? translate( 'Manage Recurring Payments' )
 			: translate( 'Collect recurring payments' );
-		const body = hasConnectedAccount
-			? translate(
-					"Manage your subscribers, or your current subscription options and review the total revenue that you've made from recurring payments."
-			  )
-			: translate(
-					'Charge for services, collect membership dues, or take recurring donations. Automate recurring payments, and use your site to earn reliable revenue. {{em}}Available to any site with a paid plan{{/em}}.',
-					{
-						components: {
-							em: <em />,
-						},
-					}
-			  );
+		const body = hasConnectedAccount ? (
+			translate(
+				"Manage your subscribers, or your current subscription options and review the total revenue that you've made from recurring payments."
+			)
+		) : (
+			<Fragment>
+				{ translate(
+					'Charge for services, collect membership dues, or take recurring donations. Automate recurring payments, and use your site to earn reliable revenue.'
+				) }{' '}
+				{ isFreePlan && <em>{ translate( 'Available to any site with a paid plan.' ) }</em> }
+			</Fragment>
+		);
 		const learnMoreLink = isFreePlan
 			? {
 					url: 'https://en.support.wordpress.com/recurring-payments/',
@@ -171,22 +173,15 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 						onClick: () => trackCtaButton( 'referral-wpcom' ),
 				  },
 		};
-		const components = {
-			components: {
-				em: <em />,
-			},
-		};
 
 		return {
 			title: translate( 'Earn cash from referrals' ),
 			body: isJetpackNotAtomic
 				? translate(
-						"Promote Jetpack to friends, family, and website visitors and you'll earn a referral payment for every paying customer you send our way. {{em}}Available on every plan{{/em}}.",
-						components
+						"Promote Jetpack to friends, family, and website visitors and you'll earn a referral payment for every paying customer you send our way."
 				  )
 				: translate(
-						"Promote WordPress.com to friends, family, and website visitors and you'll earn a referral payment for every paying customer you send our way. {{em}}Available on every plan{{/em}}.",
-						components
+						"Promote WordPress.com to friends, family, and website visitors and you'll earn a referral payment for every paying customer you send our way."
 				  ),
 			image: {
 				path: '/calypso/images/earn/referral.svg',
@@ -226,14 +221,14 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 			? translate(
 					"Check out your ad earnings history, including total earnings, total paid to date, and the amount that you've still yet to be paid."
 			  )
-			: translate(
-					'Publish as you normally would, display advertisements on all your posts and pages, and make money each time someone visits your site. {{em}}Available to sites with a Premium plan{{/em}}.',
-					{
-						components: {
-							em: <em />,
-						},
-					}
-			  );
+			:(
+			<Fragment>
+				{ translate(
+					'Publish as you normally would, display advertisements on all your posts and pages, and make money each time someone visits your site.'
+				) }{' '}
+				{ ! hasWordAds && <em>{ translate( 'Available to sites with a Premium plan.' ) }</em> }
+			</Fragment>
+		);
 		const learnMoreLink = ! ( hasWordAds || hasSetupAds )
 			? { url: 'https://wordads.co/', onClick: () => trackLearnLink( 'ads' ) }
 			: null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* to display the "Available to..." line only if plan requirements are not met

#### Testing instructions

* test with a site that has free, personal and premium plans. Ensure that the "Available to..." is shown accordigly:
- hidden if the plan covers the feature
- visible if the user has to upgrade to acquire the feature

### Plans that do not meet requirements

<img width="926" alt="Captura de Pantalla 2019-08-05 a la(s) 16 40 44" src="https://user-images.githubusercontent.com/1041600/62490578-0222db80-b7a0-11e9-9bda-514f1167f226.png">

### Plan that covers all features

<img width="928" alt="Captura de Pantalla 2019-08-05 a la(s) 16 40 56" src="https://user-images.githubusercontent.com/1041600/62490576-0222db80-b7a0-11e9-9a5b-19e0f2ff6cd4.png">
