### PR TITLE
Earn: make View ad dashboard card title consistent with the others

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -220,7 +220,7 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 						page( `/checkout/${ selectedSiteSlug }/premium/` );
 					},
 			  };
-		const title = hasSetupAds ? translate( 'View Ad Dashboard' ) : translate( 'Earn ad revenue' );
+		const title = hasSetupAds ? translate( 'View ad dashboard' ) : translate( 'Earn ad revenue' );
 		const body = hasSetupAds
 			? translate(
 					"Check out your ad earnings history, including total earnings, total paid to date, and the amount that you've still yet to be paid."


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* update Ad card to use sentence case so it's consistent with the other card titles

#### Testing instructions

* make sure it uses sentence case

### Before

<img width="490" alt="Captura de Pantalla 2019-08-05 a la(s) 16 51 20" src="https://user-images.githubusercontent.com/1041600/62491113-77db7700-b7a1-11e9-9dfa-64d5f91cbcf1.png">

### After

<img width="481" alt="Captura de Pantalla 2019-08-05 a la(s) 16 51 44" src="https://user-images.githubusercontent.com/1041600/62491112-7742e080-b7a1-11e9-84b8-2cbc2973ee7f.png">
