### PR TITLE
lib/stripe: Catch errors when calling window.Stripe

### DIFF
--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -149,20 +149,27 @@ export function useStripeJs( stripeConfiguration ) {
 		if ( ! stripeConfiguration ) {
 			return;
 		}
-		if ( window.Stripe ) {
-			debug( 'stripe.js already loaded' );
-			setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
-			return;
-		}
-		debug( 'loading stripe.js...' );
-		loadScript( stripeConfiguration.js_url, function( error ) {
-			if ( error ) {
-				debug( 'stripe.js script ' + error.src + ' failed to load.' );
+		try {
+			if ( window.Stripe ) {
+				debug( 'stripe.js already loaded' );
+				setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
 				return;
 			}
-			debug( 'stripe.js loaded!' );
-			setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
-		} );
+			debug( 'loading stripe.js...' );
+			loadScript( stripeConfiguration.js_url, function( error ) {
+				if ( error ) {
+					debug( 'stripe.js script ' + error.src + ' failed to load.' );
+					return;
+				}
+				debug( 'stripe.js loaded!' );
+				setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
+			} );
+		} catch ( error ) {
+			if ( error ) {
+				debug( 'error while loading stripeJs', error );
+				return;
+			}
+		}
 	}, [ stripeConfiguration ] );
 	return stripeJs;
 }


### PR DESCRIPTION
In some cases, calling `window.Stripe()` may throw an error. For
example, if you try to load calypso locally (non-https) and you use the
production (non-sandboxed) API. This change will guard against those
errors and simply never load stripeJs.

Props to @spen for spotting this bug.

#### Testing instructions

1. Load Calypso locally with this patch, add a plan to your cart, and go to the checkout page.
2. Verify that you see the non-stripe form fields (you should see dots in the card number field and not numbers).
3. Click the "Paypal" tab, then click back on the "Credit or debit card" tab.
4. Verify that you once again see the non-stripe form fields.
5. Sandbox the API.
6. Repeat steps 1-4 but verify that you see the stripe form fields (you should see numbers in the card number field and not dots).