### PR TITLE
Signup: Default import in site type test to show

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -140,7 +140,7 @@ export default {
 			show: 50,
 			hide: 50,
 		},
-		defaultVariation: 'hide',
+		defaultVariation: 'show',
 		allowExistingUsers: true,
 	},
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the A/B test introduced in #34731 to default to `show`, which causes the import option to appear on the `site-type` step of signup beneath all of the site-type options:

![image](https://user-images.githubusercontent.com/363749/62497977-419ef700-b7a3-11e9-8454-a75a3d10cdc8.png)

Note: Currently, this is gated by a feature-flag only enabled in development and wpcalypso. The test is future-dated to ease testing in development, therefore you should be defaulted into the test.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start` in an incognito window, with either Calypso checked out locally or with `calypso.live` (the flag to enable the test, `signup/import-flow` is enabled in both environments).
* Complete the user step and advance to the site-type screen.
* Verify that the "Already have a website?" link appears beneath the site-type options.

See p3Ex-3u7-p2
