### PR TITLE
FSE: Add header logo placeholder

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -12,6 +12,7 @@ import { addFilter } from '@wordpress/hooks';
  */
 import edit from './edit';
 import './style.scss';
+import './site-logo';
 
 if ( 'wp_template' !== fullSiteEditing.editorPostType ) {
 	registerBlockType( 'a8c/template', {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/site-logo.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/site-logo.js
@@ -14,7 +14,7 @@ const addFSESiteLogoClassname = createHigherOrderComponent( BlockListBlock => {
 			return <BlockListBlock { ...props } />;
 		}
 
-		return <BlockListBlock { ...props } className="template__block-site-logo-placeholder" />;
+		return <BlockListBlock { ...props } className="template__site-logo" />;
 	};
 }, 'addFSESiteLogoClassname' );
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/site-logo.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/site-logo.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+
+const addFSESiteLogoClassname = createHigherOrderComponent( BlockListBlock => {
+	return props => {
+		if ( props.attributes.className !== 'fse-site-logo' ) {
+			return <BlockListBlock { ...props } />;
+		}
+
+		return <BlockListBlock { ...props } className="template__block-site-logo-placeholder" />;
+	};
+}, 'addFSESiteLogoClassname' );
+
+addFilter( 'editor.BlockListBlock', 'full-site-editing/blocks/template', addFSESiteLogoClassname );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/site-logo.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/site-logo.js
@@ -1,12 +1,9 @@
+/* eslint-disable wpcalypso/import-docblock */
 /**
  * WordPress dependencies
  */
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { addFilter } from '@wordpress/hooks';
-
-/**
- * Internal dependencies
- */
 
 const addFSESiteLogoClassname = createHigherOrderComponent( BlockListBlock => {
 	return props => {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -86,3 +86,12 @@
 		}
 	}
 }
+
+// don't display the site logo action buttons if not editing the template
+.block-editor-page:not( .post-type-wp_template ) {
+	.fse-site-logo {
+		.components-placeholder__fieldset, .components-placeholder__instructions {
+			display: none;
+		}
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -86,3 +86,9 @@
 		}
 	}
 }
+
+.editor-styles-wrapper {
+	.wp-block.template__block-site-logo-placeholder {
+		width: 400px;
+	}
+}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -86,9 +86,3 @@
 		}
 	}
 }
-
-.editor-styles-wrapper {
-	.wp-block.template__block-site-logo-placeholder {
-		width: 400px;
-	}
-}


### PR DESCRIPTION
**Important Note** This PR currently depends on timing of merge of https://github.com/Automattic/themes/pull/1167/files - this will only currently work if that PR is not merged after - will need some modification if merged after that.

#### Changes proposed in this Pull Request

* Add class to FSE site logo placeholder in order to allow targeting of CSS to placeholder image

#### Testing instructions

* Check out branch for https://github.com/Automattic/themes/pull/1197, build Modern Business and copy to FSE test environment
* Build this branch for FSE test environment
* Remove existing FSE templates, remove modern-business-fse-template-data flag and then re-activate modern business theme.
* Check that the Header template includes a site logo placeholder, and that when a image is added it centre aligns in the front end.

**Note:** as specified in #35124 the image placeholder should display narrower than the default one - currently fixed to 380px. Only the placeholder image is the reduced size, I have kept the actually block sizing the same to avoid having to test all the edge cases of different image sizes if we played with the actual block width.

**Header in editor after patch applied and templates rebuilt**

<img width="688" alt="Screen Shot 2019-08-06 at 10 26 02 AM" src="https://user-images.githubusercontent.com/3629020/62500122-43b39500-b839-11e9-9338-404dcc23aa22.png">

**Front end view**
<img width="538" alt="Screen Shot 2019-08-06 at 10 30 37 AM" src="https://user-images.githubusercontent.com/3629020/62500143-53cb7480-b839-11e9-8de7-9ff6bcda73ad.png">



Fixes #35124
