### PR TITLE
Store: fix tax rates auto-calculation notice not updating

### DIFF
--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -67,7 +67,7 @@ class TaxesRates extends Component {
 
 	renderLocation = () => {
 		const {
-			areTaxesEnabled,
+			taxesEnabled,
 			countryName,
 			loadedSettingsGeneral,
 			loadedLocations,
@@ -75,7 +75,7 @@ class TaxesRates extends Component {
 			translate,
 		} = this.props;
 
-		if ( ! areTaxesEnabled || ! loadedSettingsGeneral || ! loadedLocations ) {
+		if ( ! taxesEnabled || ! loadedSettingsGeneral || ! loadedLocations ) {
 			return null;
 		}
 
@@ -109,9 +109,9 @@ class TaxesRates extends Component {
 	};
 
 	renderCalculationStatus = () => {
-		const { areTaxesEnabled, translate } = this.props;
+		const { taxesEnabled, translate } = this.props;
 
-		if ( ! areTaxesEnabled ) {
+		if ( ! taxesEnabled ) {
 			return (
 				<Notice showDismiss={ false } status="is-warning">
 					{ translate(
@@ -137,8 +137,8 @@ class TaxesRates extends Component {
 	};
 
 	possiblyRenderRates = () => {
-		const { areTaxesEnabled, taxRates, translate } = this.props;
-		if ( ! areTaxesEnabled ) {
+		const { taxesEnabled, taxRates, translate } = this.props;
+		if ( ! taxesEnabled ) {
 			return null;
 		}
 
@@ -257,7 +257,7 @@ class TaxesRates extends Component {
 
 function mapStateToProps( state, ownProps ) {
 	const address = getStoreLocation( state, ownProps.siteId );
-	const areTaxesEnabled = areTaxCalculationsEnabled( state, ownProps.siteId );
+	const taxesEnabled = areTaxCalculationsEnabled( state, ownProps.siteId );
 	const countries = getAllCountries( state, ownProps.siteId );
 	const loadedLocations = areLocationsLoaded( state, ownProps.siteId );
 	const loadedSettingsGeneral = areSettingsGeneralLoaded( state, ownProps.siteId );
@@ -277,7 +277,7 @@ function mapStateToProps( state, ownProps ) {
 
 	return {
 		address,
-		areTaxesEnabled,
+		taxesEnabled,
 		countries,
 		countryName,
 		loadedLocations,

--- a/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
+++ b/client/extensions/woocommerce/app/settings/taxes/taxes-rates.js
@@ -17,7 +17,6 @@ import Gridicon from 'gridicons';
  */
 import {
 	areSettingsGeneralLoaded,
-	areTaxCalculationsEnabled,
 	getStoreLocation,
 } from 'woocommerce/state/sites/settings/general/selectors';
 import {
@@ -257,7 +256,6 @@ class TaxesRates extends Component {
 
 function mapStateToProps( state, ownProps ) {
 	const address = getStoreLocation( state, ownProps.siteId );
-	const taxesEnabled = areTaxCalculationsEnabled( state, ownProps.siteId );
 	const countries = getAllCountries( state, ownProps.siteId );
 	const loadedLocations = areLocationsLoaded( state, ownProps.siteId );
 	const loadedSettingsGeneral = areSettingsGeneralLoaded( state, ownProps.siteId );
@@ -277,7 +275,6 @@ function mapStateToProps( state, ownProps ) {
 
 	return {
 		address,
-		taxesEnabled,
 		countries,
 		countryName,
 		loadedLocations,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In `Store > Settings > Taxes`, under `Tax rates`, display `We'll automatically calculate and...` feedback should be displayed only when auto tax calculations is enabled.

In `tax-rates.js`, `areTaxesEnabled` prop was being used but `taxesEnabled` prop was being updated. Renamed `areTaxesEnabled` prop to `taxesEnabled` for more consistent naming.

#### Testing instructions

On a test site with WooCommerce Store setup:

1. Navigate to https://wordpress.com/store/settings/taxes/{site_slug}
2. Navigate to Store > Settings > Taxes
3. Under "Tax rates", `We'll automatically calculate and...` feedback should only be visible when tax calculation is enabled.
4. Toggle "Tax calculations enabled" control to verify.

*Before:*
![tax-rates-before](https://user-images.githubusercontent.com/127594/62500915-52e50500-b79d-11e9-8657-d38a5ce3fb76.gif)

*After:*
![tax-rates-after](https://user-images.githubusercontent.com/127594/62500925-5d070380-b79d-11e9-97fd-4c93a669aad5.gif)

*

Fixes #33461
