### PR TITLE
Full Site Editing: hide Templates from the wp-admin sidebar

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -83,10 +83,10 @@ class Full_Site_Editing {
 				),
 				'menu_icon'             => 'dashicons-layout',
 				'public'                => false,
-				'show_ui'               => true,
-				'show_in_menu'          => true,
+				'show_ui'               => true, // Otherwise we'd get permission error when trying to edit them.
+				'show_in_menu'          => false,
 				'rewrite'               => false,
-				'show_in_rest'          => true,
+				'show_in_rest'          => true, // Otherwise previews won't be generated in full page view.
 				'rest_base'             => 'templates',
 				'rest_controller_class' => __NAMESPACE__ . '\REST_Templates_Controller',
 				'capability_type'       => 'template',


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes templates entry from the sidebar so they can't be accesed directly.

#### Testing instructions

1. Verify that Templates entry is no longer visible in the wp-admin sidebar.
2. Verify that previews for header and footer are still loaded on when editing the full page.
3. Make sure that you can still edit these parts separately.

For development and testing purposes, you'll still be able to manually access these via `wp-admin/edit.php?post_type=wp_template`.