### PR TITLE
Full Site Editing: remove Templates from Calypso's sidebar

### DIFF
--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -142,6 +142,11 @@ class SiteMenu extends PureComponent {
 			return null;
 		}
 
+		// Hide Full Site Editing templates CPT. This shouldn't be editable directly.
+		if ( 'wp_template' === menuItem.name ) {
+			return null;
+		}
+
 		// Hide the sidebar link for multiple site view if it's not in calypso, or
 		// if it opts not to be shown.
 		const isEnabled = ! menuItem.config || config.isEnabled( menuItem.config );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Removes Full Site Editing templates item from the sidebar so they can't be accesed directly. Note that we can't do this on FSE plugin side since we'd have to disable `show_in_rest` when registering this CPT, but that would interfere with some templates functionality that we need in Gutenberg (e.g. the template previews wouldn't work while editing a full page).

#### Testing instructions

1. Spin up Calypso locally with this PR.
2. Switch site to one of your FSE enabled sites on Dotcom (it should have `full-site-editing` sticker applied).
3. You should no longer see the `Templates` item in the sidebar.
4. If you check the sidebar for this same site in production on wordpress.com, you should be able to see both `Templates and Template Parts` entries.
5. Note that I haven't removed Template Parts in this patch on purpose, since this CPT is going to be phased away in upcoming FSE plugin sync.

| Before | After |
| - | - |
| <img width="276" alt="Screenshot 2019-08-06 at 05 10 17" src="https://user-images.githubusercontent.com/1182160/62508817-4eeecc80-b809-11e9-9375-e0d9a19f1f0e.png">| <img width="273" alt="Screenshot 2019-08-06 at 05 10 46" src="https://user-images.githubusercontent.com/1182160/62508826-57470780-b809-11e9-925a-0145d447b0ca.png"> |
