### PR TITLE
Stats: Improve Colour Contrast

### DIFF
--- a/assets/stylesheets/shared/functions/_z-index.scss
+++ b/assets/stylesheets/shared/functions/_z-index.scss
@@ -59,7 +59,6 @@ $z-layers: (
 		'.reader-following-search': 1,
 		'.following-manage__url-follow': 1,
 		'.following__intro-close-icon': 1,
-		'.post-trends__title': 1,
 		'.post-trends__scroll': 1,
 		'.plugin-item__label': 1,
 		'.wp-editor-tools': 1,

--- a/client/components/chart/style.scss
+++ b/client/components/chart/style.scss
@@ -61,7 +61,7 @@ $y-axis-padding: 0 20px 0 10px;
 	height: 200px;
 	padding: $y-axis-padding;
 	font-size: 11px;
-	color: var( --color-neutral-400 );
+	color: var( --color-text-subtle );
 	margin-bottom: 30px;
 }
 

--- a/client/my-sites/stats/annual-site-stats/style.scss
+++ b/client/my-sites/stats/annual-site-stats/style.scss
@@ -42,7 +42,7 @@
 }
 
 .annual-site-stats__stat-title {
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	font-size: 11px;
 	text-transform: uppercase;
 

--- a/client/my-sites/stats/most-popular/style.scss
+++ b/client/my-sites/stats/most-popular/style.scss
@@ -37,7 +37,7 @@
 }
 
 .most-popular__percentage {
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	display: block;
 	margin-top: -1em;
 	font-size: 14px;

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -8,23 +8,6 @@
 	}
 }
 
-.post-trends__title {
-	color: var( --color-neutral-400 );
-	margin-left: 11px;
-	height: 40px;
-	font-weight: 600;
-	position: relative;
-	z-index: z-index( 'root', '.post-trends__title' );
-}
-
-.post-trends__value {
-	text-align: center;
-	font-size: 16px;
-	font-weight: 300;
-	color: var( --color-neutral-500 );
-	margin: 20px 0 30px;
-}
-
 .post-trends__year {
 	position: relative;
 		top: 0;
@@ -115,7 +98,7 @@
 .post-trends__label {
 	text-align: center;
 	font-size: 11px;
-	color: var( --color-neutral-400 );
+	color: var( --color-text-subtle );
 	margin-top: 10px;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;

--- a/client/my-sites/stats/stats-error/style.scss
+++ b/client/my-sites/stats/stats-error/style.scss
@@ -5,7 +5,7 @@
 
 	// Error messages
 	&.is-error {
-		color: var( --color-neutral-light );
+		color: var( --color-text-subtle );
 
 		.stats-module.is-showing-error & {
 			display: inline-block;

--- a/client/my-sites/stats/stats-list/style.scss
+++ b/client/my-sites/stats/stats-list/style.scss
@@ -589,7 +589,7 @@ ul.module-content-list-legend {
 .module-content-list-legend .module-content-list-item .module-content-list-item-label {
 	@extend %placeholder;
 
-	color: var( --color-neutral-light );
+	color: var( --color-text-subtle );
 	font-weight: bold;
 
 	// Limit width when loading for placeholders to take less visual space

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -465,7 +465,7 @@ ul.module-header-actions {
 	}
 
 	.stats-module & td.highest-count {
-		color: var( --color-warning );
+		color: var( --color-accent );
 		position: relative;
 	}
 
@@ -491,7 +491,7 @@ ul.module-header-actions {
 		}
 
 		&.is-same {
-			color: var( --color-neutral-light );
+			color: var( --color-text-subtle );
 		}
 
 		&.is-rising,

--- a/client/my-sites/stats/stats-tabs/style.scss
+++ b/client/my-sites/stats/stats-tabs/style.scss
@@ -192,7 +192,7 @@
 		// Low state ('disabled')
 		.is-low,
 		&.is-low a .value {
-			color: var( --color-neutral-light );
+			color: var( --color-text-subtle );
 		}
 
 		// Individual tab loading state

--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -20,7 +20,7 @@
 
 	th {
 		font-size: 11px;
-		color: var( --color-neutral-400 );
+		color: var( --color-text-subtle );
 	}
 }
 
@@ -32,7 +32,7 @@
 		background: none;
 		text-align: left;
 		font-size: 11px;
-		color: var( --color-neutral-400 );
+		color: var( --color-text-subtle );
 	}
 
 	&.level-0 {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates several of the colour variables for Stats to --text-subtle so there's adequate contrast. It also cleans up some styling for a class that no longer exists. 

#### Testing instructions

I've tried to keep it clear in the commit message for what each variable replaces, but do also check to ensure that there's no other contrast issues in Stats. 

- The "All Time Views" table title
- Stats chart y-axis
- "No x viewed/recorded" in the cards at the bottom 
- Titles for those cards at the bottom
- "Posting Activity" months
- "Most popular day and hour" percentage (under Insights)
- Publicize "Service" heading
- "No Change" (see the stats for an individual post)
- Changes the highest value on the page above from a faint golden to accent (fixes #33775)

Fixes #35101 and #33775
