### PR TITLE
Signup: Connect progress state directly in navigation link

### DIFF
--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -548,7 +548,6 @@ class Signup extends React.Component {
 								goToStep={ this.goToStep }
 								previousFlowName={ this.state.previousFlowName }
 								flowName={ this.props.flowName }
-								signupProgress={ this.props.progress }
 								signupDependencies={ this.props.signupDependencies }
 								stepSectionName={ this.props.stepSectionName }
 								positionInFlow={ this.getPositionInFlow() }

--- a/client/signup/navigation-link/index.jsx
+++ b/client/signup/navigation-link/index.jsx
@@ -17,6 +17,7 @@ import Button from 'components/button';
 import { getStepUrl } from 'signup/utils';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { submitSignupStep } from 'state/signup/progress/actions';
+import { getSignupProgress } from 'state/signup/progress/selectors';
 
 /**
  * Style dependencies
@@ -161,6 +162,8 @@ export class NavigationLink extends Component {
 }
 
 export default connect(
-	null,
+	state => ( {
+		signupProgress: getSignupProgress( state ),
+	} ),
 	{ recordTracksEvent, submitSignupStep }
 )( localize( NavigationLink ) );

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -51,7 +51,6 @@ class StepWrapper extends Component {
 				stepName={ this.props.stepName }
 				stepSectionName={ this.props.stepSectionName }
 				backUrl={ this.props.backUrl }
-				signupProgress={ this.props.signupProgress }
 				labelText={ this.props.backLabelText }
 				allowBackFirstStep={ this.props.allowBackFirstStep }
 			/>

--- a/client/signup/steps/about/index.jsx
+++ b/client/signup/steps/about/index.jsx
@@ -522,7 +522,6 @@ class AboutStep extends Component {
 		const {
 			flowName,
 			positionInFlow,
-			signupProgress,
 			stepName,
 			translate,
 			hasInitializedSitesBackUrl,
@@ -541,7 +540,6 @@ class AboutStep extends Component {
 				fallbackHeaderText={ headerText }
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
-				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }

--- a/client/signup/steps/clone-cloning/index.jsx
+++ b/client/signup/steps/clone-cloning/index.jsx
@@ -26,7 +26,6 @@ class CloneCloningStep extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		signupDependencies: PropTypes.object,
 	};
@@ -138,14 +137,7 @@ class CloneCloningStep extends Component {
 	};
 
 	render() {
-		const {
-			flowName,
-			stepName,
-			positionInFlow,
-			signupProgress,
-			originSiteName,
-			translate,
-		} = this.props;
+		const { flowName, stepName, positionInFlow, originSiteName, translate } = this.props;
 
 		const headerText = translate( "We're cloning %(originSiteName)s — sit tight!", {
 			args: { originSiteName },
@@ -161,7 +153,6 @@ class CloneCloningStep extends Component {
 				subHeaderText={ '' }
 				fallbackSubHeaderText={ '' }
 				positionInFlow={ positionInFlow }
-				signupProgress={ signupProgress }
 				stepContent={ this.renderStepContent() }
 			/>
 		);

--- a/client/signup/steps/clone-credentials/index.jsx
+++ b/client/signup/steps/clone-credentials/index.jsx
@@ -29,7 +29,6 @@ class CloneCredentialsStep extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		signupDependencies: PropTypes.object,
 	};
@@ -80,14 +79,7 @@ class CloneCredentialsStep extends Component {
 	}
 
 	render() {
-		const {
-			flowName,
-			stepName,
-			positionInFlow,
-			signupProgress,
-			translate,
-			destinationSiteName,
-		} = this.props;
+		const { flowName, stepName, positionInFlow, translate, destinationSiteName } = this.props;
 
 		const headerText = translate( 'Enter your server credentials' );
 		const subHeaderText = translate(
@@ -105,7 +97,6 @@ class CloneCredentialsStep extends Component {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				positionInFlow={ positionInFlow }
-				signupProgress={ signupProgress }
 				stepContent={ this.renderStepContent() }
 			/>
 		);

--- a/client/signup/steps/clone-destination/index.jsx
+++ b/client/signup/steps/clone-destination/index.jsx
@@ -31,7 +31,6 @@ class CloneDestinationStep extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		signupDependencies: PropTypes.object,
 	};
@@ -212,7 +211,7 @@ class CloneDestinationStep extends Component {
 	}
 
 	render() {
-		const { flowName, stepName, positionInFlow, signupProgress, translate } = this.props;
+		const { flowName, stepName, positionInFlow, translate } = this.props;
 
 		const headerText = translate( 'Getting started' );
 		const subHeaderText = translate(
@@ -229,7 +228,6 @@ class CloneDestinationStep extends Component {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				positionInFlow={ positionInFlow }
-				signupProgress={ signupProgress }
 				stepContent={ this.renderStepContent() }
 			/>
 		);

--- a/client/signup/steps/clone-jetpack/index.jsx
+++ b/client/signup/steps/clone-jetpack/index.jsx
@@ -26,7 +26,6 @@ class CloneJetpackStep extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		signupDependencies: PropTypes.object,
 	};
@@ -72,7 +71,7 @@ class CloneJetpackStep extends Component {
 	}
 
 	render() {
-		const { flowName, stepName, positionInFlow, signupProgress, translate } = this.props;
+		const { flowName, stepName, positionInFlow, translate } = this.props;
 
 		const headerText = translate( 'Your Jetpack connection' );
 		const subHeaderText = translate(
@@ -88,7 +87,6 @@ class CloneJetpackStep extends Component {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				positionInFlow={ positionInFlow }
-				signupProgress={ signupProgress }
 				stepContent={ this.renderStepContent() }
 			/>
 		);

--- a/client/signup/steps/clone-point/index.jsx
+++ b/client/signup/steps/clone-point/index.jsx
@@ -36,7 +36,6 @@ class ClonePointStep extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		signupDependencies: PropTypes.object,
 	};
@@ -171,7 +170,7 @@ class ClonePointStep extends Component {
 	}
 
 	render() {
-		const { flowName, stepName, positionInFlow, signupProgress, translate } = this.props;
+		const { flowName, stepName, positionInFlow, translate } = this.props;
 
 		const headerText = translate( 'Clone point' );
 		const subHeaderText = translate(
@@ -187,7 +186,6 @@ class ClonePointStep extends Component {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				positionInFlow={ positionInFlow }
-				signupProgress={ signupProgress }
 				stepContent={ this.renderStepContent() }
 			/>
 		);

--- a/client/signup/steps/clone-ready/index.jsx
+++ b/client/signup/steps/clone-ready/index.jsx
@@ -28,7 +28,6 @@ class CloneReadyStep extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		signupDependencies: PropTypes.object,
 	};
@@ -143,7 +142,7 @@ class CloneReadyStep extends Component {
 	}
 
 	render() {
-		const { flowName, stepName, positionInFlow, signupProgress, translate } = this.props;
+		const { flowName, stepName, positionInFlow, translate } = this.props;
 
 		const headerText = translate( 'Ready to clone!' );
 
@@ -157,7 +156,6 @@ class CloneReadyStep extends Component {
 				subHeaderText={ '' }
 				fallbackSubHeaderText={ '' }
 				positionInFlow={ positionInFlow }
-				signupProgress={ signupProgress }
 				stepContent={ this.renderStepContent() }
 			/>
 		);

--- a/client/signup/steps/clone-start/index.jsx
+++ b/client/signup/steps/clone-start/index.jsx
@@ -27,7 +27,6 @@ class CloneStartStep extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		signupDependencies: PropTypes.object,
 	};
@@ -163,14 +162,7 @@ class CloneStartStep extends Component {
 	}
 
 	render() {
-		const {
-			flowName,
-			stepName,
-			positionInFlow,
-			signupProgress,
-			originSiteName,
-			translate,
-		} = this.props;
+		const { flowName, stepName, positionInFlow, originSiteName, translate } = this.props;
 
 		const headerText = translate( "Let's clone %(origin)s", { args: { origin: originSiteName } } );
 		const subHeaderText = translate(
@@ -187,7 +179,6 @@ class CloneStartStep extends Component {
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
 				positionInFlow={ positionInFlow }
-				signupProgress={ signupProgress }
 				stepContent={ this.renderStepContent() }
 			/>
 		);

--- a/client/signup/steps/creds-complete/index.jsx
+++ b/client/signup/steps/creds-complete/index.jsx
@@ -35,7 +35,11 @@ class CredsCompleteStep extends Component {
 		return (
 			<Card className="creds-complete__card">
 				<h3 className="creds-complete__title">{ translate( 'Your site is set up and ready!' ) }</h3>
-				<img className="creds-complete__image" src="/calypso/images/upgrades/thank-you.svg" />
+				<img
+					className="creds-complete__image"
+					alt={ translate( 'Thank You' ) }
+					src="/calypso/images/upgrades/thank-you.svg"
+				/>
 				<p className="creds-complete__description">
 					{ get( signupDependencies, 'rewindconfig', false ) &&
 						translate(

--- a/client/signup/steps/creds-complete/index.jsx
+++ b/client/signup/steps/creds-complete/index.jsx
@@ -25,7 +25,6 @@ class CredsCompleteStep extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		signupDependencies: PropTypes.object,
 	};
@@ -61,7 +60,6 @@ class CredsCompleteStep extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderStepContent() }
 				goToNextStep={ this.skipStep }
 				hideFormattedHeader={ true }

--- a/client/signup/steps/creds-confirm/index.jsx
+++ b/client/signup/steps/creds-confirm/index.jsx
@@ -30,7 +30,6 @@ class CredsConfirmStep extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 
 		// Connected props
@@ -93,7 +92,6 @@ class CredsConfirmStep extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderStepContent() }
 				goToNextStep={ this.skipStep }
 				hideFormattedHeader={ true }

--- a/client/signup/steps/creds-permission/index.jsx
+++ b/client/signup/steps/creds-permission/index.jsx
@@ -28,7 +28,6 @@ class CredsPermissionStep extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 	};
 
@@ -80,7 +79,6 @@ class CredsPermissionStep extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderStepContent() }
 				goToNextStep={ this.skipStep }
 				hideFormattedHeader={ true }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -66,7 +66,6 @@ class DomainsStep extends React.Component {
 		path: PropTypes.string.isRequired,
 		positionInFlow: PropTypes.number.isRequired,
 		queryObject: PropTypes.object,
-		signupProgress: PropTypes.array.isRequired,
 		step: PropTypes.object,
 		stepName: PropTypes.string.isRequired,
 		stepSectionName: PropTypes.string,
@@ -625,7 +624,6 @@ class DomainsStep extends React.Component {
 				stepName={ this.props.stepName }
 				backUrl={ backUrl }
 				positionInFlow={ this.props.positionInFlow }
-				signupProgress={ this.props.signupProgress }
 				headerText={ headerText }
 				subHeaderText={ fallbackSubHeaderText }
 				fallbackHeaderText={ headerText }

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -264,7 +264,7 @@ class ImportURLStepComponent extends Component {
 	};
 
 	render() {
-		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
+		const { flowName, positionInFlow, stepName, translate } = this.props;
 
 		const headerText = translate( 'Where can we find your old site?' );
 		const subHeaderText = translate(
@@ -281,7 +281,6 @@ class ImportURLStepComponent extends Component {
 				fallbackHeaderText={ headerText }
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
-				signupProgress={ signupProgress }
 				stepContent={ this.renderContent() }
 			/>
 		);

--- a/client/signup/steps/passwordless/index.jsx
+++ b/client/signup/steps/passwordless/index.jsx
@@ -249,7 +249,6 @@ export class PasswordlessStep extends Component {
 				headerText={ this.props.headerText }
 				subHeaderText={ this.props.translate( 'Create a WordPress.com account' ) }
 				positionInFlow={ this.props.positionInFlow }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderStepContent() }
 			/>
 		);

--- a/client/signup/steps/plans-atomic-store/index.jsx
+++ b/client/signup/steps/plans-atomic-store/index.jsx
@@ -134,14 +134,7 @@ export class PlansAtomicStoreStep extends Component {
 	}
 
 	plansFeaturesSelection() {
-		const {
-			flowName,
-			stepName,
-			positionInFlow,
-			signupProgress,
-			translate,
-			designType,
-		} = this.props;
+		const { flowName, stepName, positionInFlow, translate, designType } = this.props;
 
 		let headerText = translate( "Pick a plan that's right for you." );
 
@@ -156,7 +149,6 @@ export class PlansAtomicStoreStep extends Component {
 				positionInFlow={ positionInFlow }
 				headerText={ headerText }
 				fallbackHeaderText={ headerText }
-				signupProgress={ signupProgress }
 				isWideLayout={ true }
 				stepContent={ this.plansFeaturesList() }
 			/>

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -169,15 +169,7 @@ export class PlansStep extends Component {
 	}
 
 	plansFeaturesSelection() {
-		const {
-			flowName,
-			stepName,
-			positionInFlow,
-			signupProgress,
-			translate,
-			selectedSite,
-			siteSlug,
-		} = this.props;
+		const { flowName, stepName, positionInFlow, translate, selectedSite, siteSlug } = this.props;
 
 		const headerText = this.props.headerText || translate( "Pick a plan that's right for you." );
 
@@ -198,7 +190,6 @@ export class PlansStep extends Component {
 				headerText={ headerText }
 				fallbackHeaderText={ fallbackHeaderText }
 				subHeaderText={ subHeaderText }
-				signupProgress={ signupProgress }
 				isWideLayout={ true }
 				stepContent={ this.plansFeaturesList() }
 				allowBackFirstStep={ !! selectedSite }

--- a/client/signup/steps/reader-landing/index.jsx
+++ b/client/signup/steps/reader-landing/index.jsx
@@ -28,7 +28,7 @@ class ReaderLandingStep extends Component {
 	};
 
 	render() {
-		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
+		const { flowName, positionInFlow, stepName, translate } = this.props;
 
 		return (
 			<div className="reader-landing">
@@ -40,7 +40,6 @@ class ReaderLandingStep extends Component {
 					subHeaderText={ translate(
 						'Read posts from all the sites you follow, find great new reads, and stay up-to-date on comments and replies in one convenient place: the WordPress.com Reader.'
 					) }
-					signupProgress={ signupProgress }
 					stepContent={ <ReaderLandingStepContent onButtonClick={ this.handleButtonClick } /> }
 				/>
 			</div>

--- a/client/signup/steps/rebrand-cities-welcome/index.jsx
+++ b/client/signup/steps/rebrand-cities-welcome/index.jsx
@@ -52,7 +52,7 @@ class RebrandCitiesWelcomeStep extends Component {
 	}
 
 	render() {
-		const { flowName, positionInFlow, signupProgress, stepName, translate } = this.props;
+		const { flowName, positionInFlow, stepName, translate } = this.props;
 
 		return (
 			<div className="rebrand-cities-welcome">
@@ -69,7 +69,6 @@ class RebrandCitiesWelcomeStep extends Component {
 							'to get your business online. We’ll need you to create a WordPress.com ' +
 							'account to get you started.'
 					) }
-					signupProgress={ signupProgress }
 					stepContent={ this.renderContent() }
 				/>
 			</div>

--- a/client/signup/steps/rewind-add-creds/index.jsx
+++ b/client/signup/steps/rewind-add-creds/index.jsx
@@ -27,7 +27,6 @@ class RewindAddCreds extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 
 		// Connected props
@@ -71,7 +70,6 @@ class RewindAddCreds extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.stepContent() }
 				hideFormattedHeader={ true }
 				hideSkip={ true }

--- a/client/signup/steps/rewind-form-creds/index.jsx
+++ b/client/signup/steps/rewind-form-creds/index.jsx
@@ -29,7 +29,6 @@ class RewindFormCreds extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 
 		// Connected props
@@ -88,7 +87,6 @@ class RewindFormCreds extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.stepContent() }
 				hideFormattedHeader={ true }
 				hideSkip={ true }

--- a/client/signup/steps/rewind-migrate/index.jsx
+++ b/client/signup/steps/rewind-migrate/index.jsx
@@ -27,7 +27,6 @@ class RewindMigrate extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 
 		// Connected props
@@ -90,7 +89,6 @@ class RewindMigrate extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.stepContent() }
 				hideFormattedHeader={ true }
 				hideSkip={ true }

--- a/client/signup/steps/rewind-were-backing/index.jsx
+++ b/client/signup/steps/rewind-were-backing/index.jsx
@@ -26,7 +26,6 @@ class RewindWereBacking extends Component {
 		flowName: PropTypes.string,
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 
 		// Connected props
@@ -67,7 +66,6 @@ class RewindWereBacking extends Component {
 				flowName={ this.props.flowName }
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.stepContent() }
 				hideFormattedHeader={ true }
 				hideSkip={ true }

--- a/client/signup/steps/site-or-domain/index.jsx
+++ b/client/signup/steps/site-or-domain/index.jsx
@@ -177,7 +177,6 @@ class SiteOrDomain extends Component {
 					positionInFlow={ this.props.positionInFlow }
 					fallbackHeaderText={ headerText }
 					fallbackSubHeaderText={ subHeaderText }
-					signupProgress={ this.props.signupProgress }
 				/>
 			);
 		}
@@ -191,7 +190,6 @@ class SiteOrDomain extends Component {
 				subHeaderText={ this.props.subHeaderText }
 				fallbackHeaderText={ this.props.headerText }
 				fallbackSubHeaderText={ this.props.subHeaderText }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderScreen() }
 			/>
 		);

--- a/client/signup/steps/site-picker/index.jsx
+++ b/client/signup/steps/site-picker/index.jsx
@@ -63,7 +63,6 @@ class SitePicker extends Component {
 				positionInFlow={ this.props.positionInFlow }
 				fallbackHeaderText={ this.props.headerText }
 				fallbackSubHeaderText={ this.props.subHeaderText }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderScreen() }
 			/>
 		);

--- a/client/signup/steps/site-style/index.jsx
+++ b/client/signup/steps/site-style/index.jsx
@@ -38,7 +38,6 @@ export class SiteStyleStep extends Component {
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
 		showSiteMockups: PropTypes.bool,
-		signupProgress: PropTypes.array,
 		styleOptions: PropTypes.array.isRequired,
 		stepName: PropTypes.string,
 		siteStyle: PropTypes.string,
@@ -121,14 +120,7 @@ export class SiteStyleStep extends Component {
 	}
 
 	render() {
-		const {
-			flowName,
-			positionInFlow,
-			showSiteMockups,
-			signupProgress,
-			stepName,
-			translate,
-		} = this.props;
+		const { flowName, positionInFlow, showSiteMockups, stepName, translate } = this.props;
 		const headerText = translate( 'Choose a style' );
 		// for the time being we just want to fall back to the default value.
 		// If we come to add segment specific copy for this item, update the first 2 args.
@@ -144,7 +136,6 @@ export class SiteStyleStep extends Component {
 					fallbackHeaderText={ headerText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ subHeaderText }
-					signupProgress={ signupProgress }
 					stepContent={ this.renderContent() }
 					showSiteMockups={ showSiteMockups }
 				/>

--- a/client/signup/steps/site-title/index.jsx
+++ b/client/signup/steps/site-title/index.jsx
@@ -33,7 +33,6 @@ class SiteTitleStep extends Component {
 		goToNextStep: PropTypes.func.isRequired,
 		positionInFlow: PropTypes.number,
 		setSiteTitle: PropTypes.func.isRequired,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		translate: PropTypes.func.isRequired,
 		siteTitle: PropTypes.string,
@@ -92,14 +91,7 @@ class SiteTitleStep extends Component {
 	};
 
 	render() {
-		const {
-			flowName,
-			positionInFlow,
-			showSiteMockups,
-			signupProgress,
-			siteType,
-			stepName,
-		} = this.props;
+		const { flowName, positionInFlow, showSiteMockups, siteType, stepName } = this.props;
 		const headerText = getSiteTypePropertyValue( 'slug', siteType, 'siteTitleLabel' );
 		const subHeaderText = getSiteTypePropertyValue( 'slug', siteType, 'siteTitleSubheader' );
 
@@ -113,7 +105,6 @@ class SiteTitleStep extends Component {
 					fallbackHeaderText={ headerText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ subHeaderText }
-					signupProgress={ signupProgress }
 					stepContent={ this.renderSiteTitleStep() }
 					showSiteMockups={ showSiteMockups }
 				/>

--- a/client/signup/steps/site-topic/index.jsx
+++ b/client/signup/steps/site-topic/index.jsx
@@ -26,7 +26,6 @@ class SiteTopicStep extends Component {
 		isUserInput: PropTypes.bool,
 		positionInFlow: PropTypes.number.isRequired,
 		submitSiteVertical: PropTypes.func.isRequired,
-		signupProgress: PropTypes.array,
 		stepName: PropTypes.string,
 		siteType: PropTypes.string,
 		translate: PropTypes.func.isRequired,
@@ -62,7 +61,6 @@ class SiteTopicStep extends Component {
 					fallbackHeaderText={ headerText }
 					subHeaderText={ subHeaderText }
 					fallbackSubHeaderText={ subHeaderText }
-					signupProgress={ this.props.signupProgress }
 					stepContent={
 						<SiteTopicForm submitForm={ this.submitSiteTopic } siteType={ this.props.siteType } />
 					}

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -84,7 +84,6 @@ class SiteType extends Component {
 		const {
 			flowName,
 			positionInFlow,
-			signupProgress,
 			stepName,
 			translate,
 			hasInitializedSitesBackUrl,
@@ -104,7 +103,6 @@ class SiteType extends Component {
 				fallbackHeaderText={ headerText }
 				subHeaderText={ subHeaderText }
 				fallbackSubHeaderText={ subHeaderText }
-				signupProgress={ signupProgress }
 				stepContent={ this.renderStepContent() }
 				allowBackFirstStep={ !! hasInitializedSitesBackUrl }
 				backUrl={ hasInitializedSitesBackUrl }

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -299,7 +299,6 @@ class Site extends React.Component {
 				stepName={ this.props.stepName }
 				positionInFlow={ this.props.positionInFlow }
 				fallbackHeaderText={ this.props.translate( 'Create your site.' ) }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderSiteForm() }
 			/>
 		);

--- a/client/signup/steps/site/index.jsx
+++ b/client/signup/steps/site/index.jsx
@@ -249,7 +249,7 @@ class Site extends React.Component {
 			<ValidationFieldset errorMessages={ this.getErrorMessagesWithLogin( 'site' ) }>
 				<FormLabel htmlFor="site">{ this.props.translate( 'Choose a site address' ) }</FormLabel>
 				<FormTextInput
-					autoFocus={ true }
+					autoFocus={ true } // eslint-disable-line jsx-a11y/no-autofocus
 					autoCapitalize={ 'off' }
 					className="site__site-url"
 					disabled={ fieldDisabled }

--- a/client/signup/steps/survey/index.jsx
+++ b/client/signup/steps/survey/index.jsx
@@ -21,6 +21,7 @@ import { getStepUrl } from 'signup/utils';
 import FormTextInputWithAction from 'components/forms/form-text-input-with-action';
 import { setSurvey } from 'state/signup/steps/survey/actions';
 import { submitSignupStep } from 'state/signup/progress/actions';
+import { getSignupProgress } from 'state/signup/progress/selectors';
 
 /**
  * Style dependencies
@@ -129,7 +130,6 @@ class SurveyStep extends React.Component {
 				subHeaderText={
 					this.props.surveySiteType === 'blog' ? blogSubHeaderText : siteSubHeaderText
 				}
-				signupProgress={ this.props.signupProgress }
 				stepContent={
 					this.props.stepSectionName === 'other' ? this.renderOther() : this.renderOptionList()
 				}
@@ -188,6 +188,8 @@ class SurveyStep extends React.Component {
 }
 
 export default connect(
-	null,
+	state => ( {
+		signupProgress: getSignupProgress( state ),
+	} ),
 	{ setSurvey, submitSignupStep }
 )( localize( SurveyStep ) );

--- a/client/signup/steps/test-step/index.jsx
+++ b/client/signup/steps/test-step/index.jsx
@@ -21,7 +21,6 @@ export default class TestStep extends React.Component {
 					positionInFlow={ this.props.positionInFlow }
 					headerText="This is a test step"
 					subHeaderText="Go ahead and click the button to continue. It'll blow your mind!"
-					signupProgress={ this.props.signupProgress }
 					goToNextStep={ this.props.goToNextStep }
 				/>
 				<SubmitStepButton

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -318,7 +318,6 @@ export class UserStep extends Component {
 				subHeaderText={ this.state.subHeaderText }
 				positionInFlow={ this.props.positionInFlow }
 				fallbackHeaderText={ this.props.translate( 'Create your account.' ) }
-				signupProgress={ this.props.signupProgress }
 				stepContent={ this.renderSignupForm() }
 			/>
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR aims to remove the unnecessary drilling of the `signupProgress` prop starting in `signup/main.jsx`:

https://github.com/Automattic/wp-calypso/blob/d4b2860cfb7a74095e45536dffbbc4ca7cc3a96e/client/signup/main.jsx#L551

For the most part, `signupProgress` is only used in the [NavigationLink](https://github.com/Automattic/wp-calypso/blob/d4b2860cfb7a74095e45536dffbbc4ca7cc3a96e/client/signup/navigation-link/index.jsx) deeper down in the component tree. Currently we have to vigilantly make sure that we pass this prop through when creating new steps, which leaves us with around 20 places (each and every step component) which we would have to update if ever we made a change to the way we handle the progress state or 20 different `propType` definitions if the shape of the progress were to change.

This PR connects the prop directly at the points of consumption, removing a lot of repeated references.

#### Testing instructions

- Starting at http://calypso.localhost:3000/start
- Progress through the signup flow
  - check at each step that the back buttons `href` points to the expected previous step

Please also just do a quick search through the project locally to make sure I've not missed any steps that might still pass the prop, and that I've not left any step that _does_ require the `signupProgress` prop unconnected.