### PR TITLE
Checklist: Reset the "expanded" task state when changing sites

### DIFF
--- a/client/components/checklist/checklist.js
+++ b/client/components/checklist/checklist.js
@@ -3,12 +3,15 @@
  */
 import classNames from 'classnames';
 import React, { Children, PureComponent, cloneElement } from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { isFunction, times } from 'lodash';
 import { localize } from 'i18n-calypso';
+
 /**
  * Internal dependencies
  */
+import { getSelectedSiteId } from 'state/ui/selectors';
 import TaskPlaceholder from './task-placeholder';
 import Card from 'components/card';
 
@@ -21,6 +24,7 @@ class Checklist extends PureComponent {
 		showChecklistHeader: PropTypes.bool,
 		checklistFooter: PropTypes.node,
 		updateCompletion: PropTypes.func,
+		siteId: PropTypes.number,
 		translate: PropTypes.func,
 	};
 
@@ -30,6 +34,12 @@ class Checklist extends PureComponent {
 
 	componentDidMount() {
 		this.notifyCompletion();
+	}
+
+	componentWillReceiveProps( { siteId } ) {
+		if ( siteId !== this.props.siteId ) {
+			this.setState( { expandedTaskIndex: undefined } );
+		}
 	}
 
 	componentDidUpdate() {
@@ -145,4 +155,6 @@ class Checklist extends PureComponent {
 	}
 }
 
-export default localize( Checklist );
+export default connect( state => ( {
+	siteId: getSelectedSiteId( state ),
+} ) )( localize( Checklist ) );


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="755" alt="Screen Shot 2019-08-06 at 10 09 42 AM" src="https://user-images.githubusercontent.com/1587282/62549373-60020280-b836-11e9-8c72-1e8db454f45c.png"> | <img width="759" alt="Screen Shot 2019-08-06 at 10 39 13 AM" src="https://user-images.githubusercontent.com/1587282/62549414-74de9600-b836-11e9-8dd5-3bc42c04f39c.png"> |

#### Changes proposed in this Pull Request

* Connect the checklist component to the state tree
* Select the current `siteId`
* When receiving a different `siteId` prop, set the `expandedTaskIndex` local state value back to `undefined`

#### Testing instructions

##### Confirm issue

* Run prod (or master)
* Select a site which has not launched
* Browse to the checklist
* Expand the `Launch Your Site` item
* Switch to a site which has already launched
* Notice the `Launch Your Site` item is still expanded and rendered improperly

##### Confirm fix

* Run this branch
* Repeat the above
* The checklist should render properly -- `Launch Your Site` should not be expanded nor should you be able to expand it in the UI