### PR TITLE
Checklist: set noticeText to null to appease the propType

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -619,7 +619,7 @@ class WpcomChecklistComponent extends PureComponent {
 				disableIcon={ disabled }
 				isButtonDisabled={ disabled }
 				noticeText={
-					disabled && translate( 'Confirm your email address before launching your site.' )
+					disabled ? translate( 'Confirm your email address before launching your site.' ) : null
 				}
 				onClick={ this.handleLaunchSite( task ) }
 				onDismiss={ this.handleTaskDismiss( task.id ) }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reinstate the ternary I pulled out of #34971 in https://github.com/Automattic/wp-calypso/pull/34971/commits/741136dd3559b174ede909aedad7304338a5b971 -- the PropType check was failing.

#### Testing instructions

* Follow test plan in #34971 
  * You should see no warning in the console about an invalid propType `noticeText`
