### PR TITLE
Masterbar: Better descriptive text for Gravatar icon

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -149,9 +149,9 @@ class MasterbarLoggedIn extends React.Component {
 					tooltip={ translate( 'Update your profile, personal settings, and more' ) }
 					preloadSection={ this.preloadMe }
 				>
-					<Gravatar user={ this.props.user } alt="Me" size={ 18 } />
+					<Gravatar user={ this.props.user } alt={ translate( 'My Profile' ) } size={ 18 } />
 					<span className="masterbar__item-me-label">
-						{ translate( 'Me', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
+						{ translate( 'My Profile', { context: 'Toolbar, must be shorter than ~12 chars' } ) }
 					</span>
 				</Item>
 				<Notifications


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates the alt text and accompanying menu item label from "Me" to "My Profile" since this is a more descriptive name for the page which the Gravatar links to. Contextual note in the code suggests this needs to be less than 12 characters and "My Profile" is 10 characters.

<img width="306" alt="Screen Shot 2019-08-06 at 10 55 46 AM" src="https://user-images.githubusercontent.com/2124984/62550782-d0118800-b838-11e9-86d4-757c273f98bb.png">

<img width="489" alt="Screen Shot 2019-08-06 at 10 54 55 AM" src="https://user-images.githubusercontent.com/2124984/62550781-d0118800-b838-11e9-97c3-ef1ac51bfa05.png">

#### Testing instructions

* Switch to this PR and log in
* Check the source for the Gravatar image in the masterbar 

Fixes #34800
