### PR TITLE
Sharing: Reposition SupportInfo icon next to Sharing Button labels

### DIFF
--- a/client/my-sites/marketing/buttons/appearance.jsx
+++ b/client/my-sites/marketing/buttons/appearance.jsx
@@ -157,6 +157,7 @@ class SharingButtonsAppearance extends Component {
 						) }
 						link="https://support.wordpress.com/likes/"
 						privacyLink={ false }
+						position={ 'bottom left' }
 					/>
 				</label>
 			</fieldset>

--- a/client/my-sites/marketing/buttons/appearance.jsx
+++ b/client/my-sites/marketing/buttons/appearance.jsx
@@ -148,16 +148,16 @@ class SharingButtonsAppearance extends Component {
 						onChange={ this.onReblogsLikesCheckboxClicked }
 						disabled={ ! this.props.initialized }
 					/>
-          			<SupportInfo
+					<span>
+						{ translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }
+					</span>
+					<SupportInfo
 						text={ translate(
 							'Give your readers the ability to show appreciation for your posts.'
 						) }
 						link="https://support.wordpress.com/likes/"
 						privacyLink={ false }
-					/>	
-					<span>
-						{ translate( 'Show like button', { context: 'Sharing options: Checkbox label' } ) }
-					</span>
+					/>
 				</label>
 			</fieldset>
 		);

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -207,16 +207,16 @@ class SharingButtonsOptions extends Component {
 						onChange={ this.handleChange }
 						disabled={ ! initialized }
 					/>
-          			<SupportInfo
+					<span>
+						{ translate( 'On for all posts', { context: 'Sharing options: Comment Likes' } ) }
+					</span>
+					<SupportInfo
 						text={ translate(
 							"Encourage your community by giving readers the ability to show appreciation for one another's comments."
 						) }
 						link="https://support.wordpress.com/comment-likes/"
 						privacyLink={ false }
 					/>
-					<span>
-						{ translate( 'On for all posts', { context: 'Sharing options: Comment Likes' } ) }
-					</span>
 				</label>
 			</fieldset>
 		);

--- a/client/my-sites/marketing/buttons/options.jsx
+++ b/client/my-sites/marketing/buttons/options.jsx
@@ -216,6 +216,7 @@ class SharingButtonsOptions extends Component {
 						) }
 						link="https://support.wordpress.com/comment-likes/"
 						privacyLink={ false }
+						position={ 'bottom left' }
 					/>
 				</label>
 			</fieldset>

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -580,9 +580,20 @@
 	margin-right: 8px;
 }
 
+.sharing-buttons__fieldset input[type='radio'] + span,
+.sharing-buttons__fieldset input[type='checkbox'] + span {
+	margin-left: 0;
+}
+
 .sharing-buttons__fieldset label {
-	display: block;
+	display: flex;
 	cursor: pointer;
+}
+
+.sharing-buttons__fieldset .support-info {
+	float: none;
+	margin-left: 4px;
+	margin-top: 2px;
 }
 
 .sharing-buttons__fieldset-heading {

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -592,7 +592,7 @@
 
 .sharing-buttons__fieldset .support-info {
 	float: none;
-	margin-left: 4px;
+	margin-left: 6px;
 	margin-top: 2px;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Addresses #33364; the SupportInfo icon is too distant from the label it's referring to, and the position of the pop-up covers the label. This PR refactors the CSS to bring the label and the corresponding SupportInfo icon closer together for visual clarity, and sets the `position` prop to `bottom left` for better readability with the surrounding content.

**Before**

<img width="968" alt="Screen Shot 2019-08-06 at 12 07 12 PM" src="https://user-images.githubusercontent.com/2124984/62557832-c17d9d80-b845-11e9-832c-643a0435a933.png">

<img width="970" alt="Screen Shot 2019-08-06 at 12 49 22 PM" src="https://user-images.githubusercontent.com/2124984/62559894-e3791f00-b849-11e9-8f7c-dc8ebd5d5ddf.png">


**After**

<img width="956" alt="Screen Shot 2019-08-06 at 12 59 06 PM" src="https://user-images.githubusercontent.com/2124984/62559947-01df1a80-b84a-11e9-851c-50d6e74cba72.png">

<img width="971" alt="Screen Shot 2019-08-06 at 12 57 12 PM" src="https://user-images.githubusercontent.com/2124984/62559897-e6740f80-b849-11e9-8a53-a7c7433ca78b.png">


#### Testing instructions

* Switch to this PR and navigate to `/marketing/sharing-buttons`
* Check positioning of SupportInfo icons on the page, under the *Reblog & Like* and *Comment Likes* sections. 
* Make sure nothing else is visually disrupted on the page as a result of these changes.