### PR TITLE
Signup: Add tracks event when switching to import flow

### DIFF
--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -17,6 +17,7 @@ import { isEnabled } from 'config';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
+import { recordTracksEvent } from 'state/analytics/actions';
 
 const siteTypeToFlowname = {
 	import: 'import-onboarding',
@@ -28,7 +29,13 @@ class SiteType extends Component {
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 	}
 
-	handleImportFlowClick = () => this.submitStep( 'import' );
+	handleImportFlowClick = () => {
+		this.props.recordTracksEvent( 'calypso_signup_import_cta_click', {
+			flow: this.props.flowName,
+			step: this.props.stepName,
+		} );
+		this.submitStep( 'import' );
+	};
 
 	submitStep = siteTypeValue => {
 		this.props.submitSiteType( siteTypeValue );
@@ -119,5 +126,5 @@ export default connect(
 		siteType: getSiteType( state ) || 'blog',
 		hasInitializedSitesBackUrl: hasInitializedSites( state ) ? '/sites/' : false,
 	} ),
-	{ saveSignupStep, submitSiteType }
+	{ recordTracksEvent, saveSignupStep, submitSiteType }
 )( localize( SiteType ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add the tracks event `calypso_signup_import_cta_click` when clicking "Already have a website?" on the site type step, in signup.

<img width="768" alt="Screen Shot 2019-07-15 at 13 39 52" src="https://user-images.githubusercontent.com/1699996/62567319-8f256d80-b850-11e9-8374-b182c70f7ef2.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Turn on debugging for Calpyso analytics by entering `localStorage.setItem( 'debug', 'calypso:analytics:tracks' );` in the browser console and refresh the page
* Visit `/start`
* Complete the user step, if logged out
* Click "Already have a website?" on the site type step
* You should see the tracks event `calypso_signup_import_cta_click` recorded in the console with the `step` and `flow` properties.
