### PR TITLE
Private by Default: Determine the setting by siteType / Segment selection

### DIFF
--- a/client/lib/signup/private-by-default.ts
+++ b/client/lib/signup/private-by-default.ts
@@ -7,27 +7,17 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { abtest } from 'lib/abtest';
+import { getSiteTypePropertyValue } from './site-type';
 
 const debug = debugFactory( 'calypso:signup:private-by-default' );
 
-interface PrivateByDefaultSiteSettings {
-	flowName?: string;
-	lastKnownFlow?: string;
-}
-
 /**
  * Should the site be private by default
- * @param siteSettings PrivateByDefaultSiteSettings
+ * @param siteType The selected site type / segment. Corresponds with the `slug` in ./site-type.js
  * @returns `true` for private by default & `false` for not
  */
-export function shouldBePrivateByDefault( {
-	flowName,
-	lastKnownFlow,
-}: Readonly< PrivateByDefaultSiteSettings > ): boolean {
-	const flowToCheck = flowName || lastKnownFlow || '';
-
-	if ( flowToCheck.match( /^ecommerce/ ) ) {
-		// ecommerce plans go atomic after checkout. These sites should default to public for now.
+export function shouldBePrivateByDefault( siteType: string = '' ): boolean {
+	if ( getSiteTypePropertyValue( 'slug', siteType, 'forcePublicSite' ) ) {
 		return false;
 	}
 
@@ -36,13 +26,11 @@ export function shouldBePrivateByDefault( {
 
 /**
  * Get the numeric value that should be provided to the "new site" endpoint
- *
- * @param dependencies The `dependencies` passed to the `apiRequestFunction` step action function call
- * @param stepData The `stepData` passed to the `apiRequestFunction` step action function call
+ * @param siteType The selected site type / segment. Corresponds with the `slug` in ./site-type.js
  * @returns `-1` for private by default & `1` for public
  */
-export function getNewSitePublicSetting( dependencies: object, stepData: object ): number {
-	debug( 'getNewSitePublicSetting input', { dependencies, stepData } );
+export function getNewSitePublicSetting( siteType: string = '' ): number {
+	debug( 'getNewSitePublicSetting input', { siteType } );
 
-	return shouldBePrivateByDefault( stepData ) ? -1 : 1;
+	return shouldBePrivateByDefault( siteType ) ? -1 : 1;
 }

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -151,6 +151,7 @@ export function getAllSiteTypes() {
 			siteTopicLabel: i18n.translate( 'What type of products do you sell?' ),
 			customerType: 'business',
 			purchaseRequired: true,
+			forcePublicSite: true,
 		},
 	];
 }

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -164,7 +164,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				title: siteTitle,
 			},
 		},
-		public: getNewSitePublicSetting( dependencies, stepData ),
+		public: getNewSitePublicSetting( siteType ),
 		validate: false,
 	};
 
@@ -485,11 +485,13 @@ export function createAccount(
 export function createSite( callback, dependencies, stepData, reduxStore ) {
 	const { themeSlugWithRepo } = dependencies;
 	const { site } = stepData;
+	const state = reduxStore.getState();
+	const siteType = getSiteType( state ).trim();
 
 	const data = {
 		blog_name: site,
 		blog_title: '',
-		public: getNewSitePublicSetting( dependencies, stepData ),
+		public: getNewSitePublicSetting( siteType ),
 		options: { theme: themeSlugWithRepo },
 		validate: false,
 	};

--- a/client/lib/signup/test/private-by-default.js
+++ b/client/lib/signup/test/private-by-default.js
@@ -9,50 +9,52 @@ jest.mock( 'lib/abtest', () => ( {
 
 describe( 'getNewSitePublicSetting()', () => {
 	test( 'should return `-1` by default', () => {
-		expect( getNewSitePublicSetting( {}, {} ) ).toBe( -1 );
+		expect( getNewSitePublicSetting() ).toBe( -1 );
 	} );
 
-	test( 'should return `-1` for onboarding flow', () => {
-		expect( getNewSitePublicSetting( null, { flowName: 'onboarding' } ) ).toBe( -1 );
+	test( 'should return `-1` for invalid siteType', () => {
+		expect( getNewSitePublicSetting( 'someOtherSiteType' ) ).toBe( -1 );
 	} );
 
-	test( 'should return `1` for ecommerce flow', () => {
-		expect( getNewSitePublicSetting( null, { flowName: 'ecommerce' } ) ).toBe( 1 );
+	test( 'should return `-1` for business segment', () => {
+		expect( getNewSitePublicSetting( 'business' ) ).toBe( -1 );
 	} );
 
-	test( 'should return `1` for ecommerce-onboarding flow', () => {
-		expect( getNewSitePublicSetting( null, { flowName: 'ecommerce-onboarding' } ) ).toBe( 1 );
+	test( 'should return `-1` for blog segment', () => {
+		expect( getNewSitePublicSetting( 'blog' ) ).toBe( -1 );
+	} );
+
+	test( 'should return `1` for online-store segment', () => {
+		expect( getNewSitePublicSetting( 'online-store' ) ).toBe( 1 );
+	} );
+
+	test( 'should return `-1` for professional segment', () => {
+		expect( getNewSitePublicSetting( 'professional' ) ).toBe( -1 );
 	} );
 } );
 
 describe( 'shouldBePrivateByDefault()', () => {
-	test( 'should throw with no input', () => {
-		expect( () => shouldBePrivateByDefault() ).toThrow( TypeError );
+	test( 'should be true with no input', () => {
+		expect( shouldBePrivateByDefault() ).toBe( true );
 	} );
 
-	test( 'should return `true` with no flowName or lastKnownFlow', () => {
-		expect( shouldBePrivateByDefault( { notFlowName: 'really' } ) ).toBe( true );
+	test( 'should return `true` for invalid siteType', () => {
+		expect( shouldBePrivateByDefault( 'someOtherSiteType' ) ).toBe( true );
 	} );
 
-	test( 'should return `true` for onboarding flow', () => {
-		expect( shouldBePrivateByDefault( { flowName: 'onboarding' } ) ).toBe( true );
+	test( 'should return `true` for business segment', () => {
+		expect( shouldBePrivateByDefault( 'business' ) ).toBe( true );
 	} );
 
-	test( 'should return `false` for ecommerce flow', () => {
-		expect( shouldBePrivateByDefault( { flowName: 'ecommerce' } ) ).toBe( false );
+	test( 'should return `true` for blog segment', () => {
+		expect( shouldBePrivateByDefault( 'blog' ) ).toBe( true );
 	} );
 
-	test( 'should return `false` for ecommerce-onboarding flow', () => {
-		expect( shouldBePrivateByDefault( { flowName: 'ecommerce-onboarding' } ) ).toBe( false );
+	test( 'should return `false` for online-store segment', () => {
+		expect( shouldBePrivateByDefault( 'online-store' ) ).toBe( false );
 	} );
 
-	test( 'should use lastKnownFlow if flowName is missing', () => {
-		expect( shouldBePrivateByDefault( { lastKnownFlow: 'ecommerce' } ) ).toBe( false );
-	} );
-
-	test( 'flowName takes precedence over lastKnownFlow', () => {
-		expect(
-			shouldBePrivateByDefault( { flowName: 'onboarding', lastKnownFlow: 'ecommerce' } )
-		).toBe( true );
+	test( 'should return `true` for professional segment', () => {
+		expect( shouldBePrivateByDefault( 'professional' ) ).toBe( true );
 	} );
 } );


### PR DESCRIPTION
Note: This is targeting the branch in #34193.  If that lands first, this will be retargeted against master.

In #34888, @andrewserong & @p-jackson rightly noted that this functionality would be better tied to the selected segment (as opposed to the particular flows).

This updates the lib to do just that (simplifying the API in the process).

We had intentionally had the function accept a wide range of data in case we needed to add more exceptions, but it hasn't turned out that we've needed to do so, so the less code the better :)

#### Changes proposed in this Pull Request

* Simplify `shouldBePrivateByDefault` & `getNewSitePublicSetting` to only accept a single argument: `siteType`
* Change callers
* Update tests

#### Testing instructions

* Manually test
  * Run branch
  * Change `privateByDefault` AB test setting to `selected`
  * Create a new site using the default flow (`/start`)
  * The created site should be private by default for any segment except for `online-store`
* Run automated tests `npm run test-client client/lib/signup/test/private-by-default.js`

