### PR TITLE
Add hotjar tracking to checkout

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -93,6 +93,7 @@ import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import getPreviousPath from 'state/selectors/get-previous-path.js';
 import config from 'config';
 import { abtest } from 'lib/abtest';
+import { loadTrackingTool } from 'state/analytics/actions';
 import {
 	persistSignupDestination,
 	retrieveSignupDestination,
@@ -111,6 +112,7 @@ export class Checkout extends React.Component {
 		couponCode: PropTypes.string,
 		isJetpackNotAtomic: PropTypes.bool,
 		selectedFeature: PropTypes.string,
+		loadTrackingTool: PropTypes.func.isRequired,
 	};
 
 	state = {
@@ -139,6 +141,7 @@ export class Checkout extends React.Component {
 			applyCoupon( this.props.couponCode );
 		}
 
+		this.props.loadTrackingTool( 'HotJar' );
 		window.scrollTo( 0, 0 );
 	}
 
@@ -902,5 +905,6 @@ export default connect(
 		clearSitePlans,
 		fetchReceiptCompleted,
 		requestSite,
+		loadTrackingTool,
 	}
 )( localize( Checkout ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds HotJar tracking to our checkout page so we can gather more data about how people are using our checkout screen. The script respect the do not track property set in the browser and all data collected is masked and  anonymous to protect people's information.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make your way to the checkout screen either via `/start` or buy upgrading an existing site
* Check the network tab in dev tools to ensure the hotjar script is loading. 

