### PR TITLE
Remove type-review team as codeowner for all ts/tsx

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,8 +66,7 @@
 /test @Automattic/team-calypso
 
 # Types, TypeScript, and type annotations
-*.ts @Automattic/type-review
-*.tsx @Automattic/type-review
+/client/types.ts @Automattic/type-review
 /docs/coding-guidelines/typescript* @Automattic/type-review
 
 # G Suite


### PR DESCRIPTION
Code reviews are becoming overwhelming for any changes to TypeScript files. Remove type-review group as codeowner for all TypeScript.