### PR TITLE
File download stats: adapt to changed API response format

### DIFF
--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -257,8 +257,8 @@ class StatsListItem extends React.Component {
 					};
 				}
 				itemLabel = (
-					<a onClick={ onClickHandler } href={ href }>
-						{ decodeEntities( labelItem.label ) }
+					<a onClick={ onClickHandler } href={ href } title={ labelItem.linkTitle }>
+						<Emojify>{ decodeEntities( labelItem.label ) }</Emojify>
 					</a>
 				);
 			} else {

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -19,7 +19,6 @@ import {
 	parseOrdersChartData,
 	parseStoreStatsReferrers,
 	rangeOfPeriod,
-	getWpcomFilesBaseUrl,
 } from '../utils';
 
 describe( 'utils', () => {
@@ -169,30 +168,6 @@ describe( 'utils', () => {
 
 		test( 'should return correctly year format for short (new) formats', () => {
 			expect( getPeriodFormat( 'year', '2017' ) ).toBe( 'YYYY' );
-		} );
-	} );
-
-	describe( 'getWpcomFilesBaseUrl', () => {
-		test( 'should return null with an empty site object', () => {
-			expect( getWpcomFilesBaseUrl( null ) ).toEqual( false );
-		} );
-
-		test( 'should return the correct files URL for a mapped domain', () => {
-			expect(
-				getWpcomFilesBaseUrl( { wpcom_url: 'discover.wordpress.com', URL: 'http://example.com' } )
-			).toEqual( 'https://discover.files.wordpress.com' );
-		} );
-
-		test( 'should return the correct files URL for a wpcom domain', () => {
-			expect(
-				getWpcomFilesBaseUrl( { wpcom_url: null, URL: 'http://discover.wordpress.com' } )
-			).toEqual( 'https://discover.files.wordpress.com' );
-		} );
-
-		test( 'should return null if URL contains a non-wpcom domain and wpcom_url is empty', () => {
-			expect( getWpcomFilesBaseUrl( { wpcom_url: null, URL: 'http://example.com' } ) ).toEqual(
-				false
-			);
 		} );
 	} );
 

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -14,10 +12,8 @@ import {
 	map,
 	concat,
 	flatten,
-	endsWith,
 } from 'lodash';
 import { moment, translate } from 'i18n-calypso';
-import { withoutHttp } from 'lib/url';
 
 /**
  * Internal dependencies
@@ -45,25 +41,6 @@ export function getPeriodFormat( period, date ) {
 		default:
 			return 'YYYY-MM-DD';
 	}
-}
-
-/**
- * Returns the base URL for downloadable files on *.wordpress.com sites.
- *
- * @param  {Object} site Site object
- * @return {String} URL
- */
-export function getWpcomFilesBaseUrl( site ) {
-	if ( ! site ) {
-		return false;
-	}
-
-	// For mapped domains, wpcom_url will contain the *.wordpress.com domain
-	// Otherwise, use the site.URL without protocol
-	const wpcomUrl =
-		site.wpcom_url || ( endsWith( site.URL, '.wordpress.com' ) && withoutHttp( site.URL ) );
-
-	return wpcomUrl && 'https://' + wpcomUrl.replace( '.wordpress.com', '.files.wordpress.com' );
 }
 
 /**
@@ -988,11 +965,9 @@ export const normalizers = {
 	 *
 	 * @param  {Object} data   Stats data
 	 * @param  {Object} query  Stats query
-	 * @param  {Int}    siteId Site ID
-	 * @param  {Object} site   Site Object
 	 * @return {Array}         Parsed data array
 	 */
-	statsFileDownloads( data, query, siteId, site ) {
+	statsFileDownloads( data, query ) {
 		if ( ! data || ! query.period || ! query.date ) {
 			return [];
 		}
@@ -1001,12 +976,12 @@ export const normalizers = {
 		const statsData = get( data, [ 'days', startOf, 'files' ], [] );
 
 		return statsData.map( item => {
-			const wpcomFilesBaseUrl = getWpcomFilesBaseUrl( site );
 			return {
 				label: item.filename,
 				page: null,
 				value: item.downloads,
-				link: wpcomFilesBaseUrl + item.filename,
+				link: item.download_url,
+				linkTitle: item.relative_url,
 				labelIcon: 'external',
 			};
 		} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In D31276-code, we are making the following changes to the API response format for file download stats:
- `filename` only contains the base filename
- `relative_url` contains the URL path from root (e.g. `/2019/08/file.pdf`) - this was previously `filename`
- `download_url` is the full download URL for the file, which we previously deduced in Calypso but is now supplied by the endpoint

This PR updates the Calypso implementation to take account of these API changes.

#### Testing instructions

Apply patch D31276-code so you have the API changes.

Head to http://calypso.localhost:3000/stats/day on a site that's had recent file downloads. Ensure that the download information is shown in the File Downloads panel and that clicking the file name correctly downloads the file.