### PR TITLE
Fix duplicate HSTS TLDs in checkout terms

### DIFF
--- a/client/my-sites/checkout/checkout/domain-registration-hsts.jsx
+++ b/client/my-sites/checkout/checkout/domain-registration-hsts.jsx
@@ -30,7 +30,11 @@ class DomainRegistrationHsts extends React.PureComponent {
 			domains,
 			( tlds, domain ) => {
 				if ( isHstsRequired( domain.product_slug, productsList ) ) {
-					tlds.push( '.' + getTld( domain.meta ) );
+					const tld = '.' + getTld( domain.meta );
+
+					if ( tlds.indexOf( tld ) === -1 ) {
+						tlds.push( tld );
+					}
 				}
 
 				return tlds;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes duplicate HSTS TLDs in checkout terms when there are multiple domains in the shopping cart for at least one of the following TLDs: .dev, .page, .app.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Manage -> Domains for one of your sites
* Click the 'Add Domain' button
* Enter a domain ending in either one of .dev, .app, .page and click the 'Select' button
* Click the back button when prompted to add G Suite, and repeat the steps above until you have added at least two domains ending in .dev, .app or .page
* Finally skip G Suite, enter your contact details, and then click on 'Continue', which should bring you to the checkout page.

Before applying this fix, you would see each TLD multiple times, depending on how many domains you added for that TLD:

<img width="685" alt="hsts_before" src="https://user-images.githubusercontent.com/13062352/62615067-dd984200-b90c-11e9-8b77-4fbbeabf6924.png">

After applying this fix, you should see TLDs appearing only once, as shown in the screenshot below:

<img width="697" alt="hsts_fixed" src="https://user-images.githubusercontent.com/13062352/62615120-f7d22000-b90c-11e9-91ac-fa9410fd448e.png">
