### PR TITLE
Checkout: fix payment with EBANX cards

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -102,12 +102,12 @@ StripeElementErrors.propTypes = {
 	fieldName: PropTypes.string.isRequired,
 };
 
-function CreditCardNumberField( { translate, stripe, createField, getErrorMessage } ) {
+function CreditCardNumberField( { translate, stripe, createField, getErrorMessage, card } ) {
 	const cardNumberLabel = translate( 'Card Number', {
 		comment: 'Card number label on credit card form',
 	} );
 
-	if ( stripe ) {
+	if ( stripe && ! shouldRenderAdditionalCountryFields( card.country ) ) {
 		const elementClasses = {
 			base: 'credit-card-form-fields__element',
 			invalid: 'is-error',
@@ -152,7 +152,7 @@ function CreditCardExpiryAndCvvFields( { translate, stripe, createField, getErro
 		comment: 'Expiry label on credit card form',
 	} );
 
-	if ( stripe ) {
+	if ( stripe && ! shouldRenderAdditionalCountryFields( card.country ) ) {
 		const elementClasses = {
 			base: 'credit-card-form-fields__element',
 			invalid: 'is-error',
@@ -325,6 +325,7 @@ export class CreditCardFormFields extends React.Component {
 						stripe={ this.props.stripe }
 						createField={ this.createField }
 						getErrorMessage={ this.props.getErrorMessage }
+						card={ this.props.card }
 					/>
 				</div>
 

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -139,6 +139,7 @@ CreditCardNumberField.propTypes = {
 	createField: PropTypes.func.isRequired,
 	getErrorMessage: PropTypes.func.isRequired,
 	stripe: PropTypes.object,
+	card: PropTypes.object.isRequired,
 };
 
 function CreditCardExpiryAndCvvFields( { translate, stripe, createField, getErrorMessage, card } ) {

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -56,6 +56,7 @@ import { getTld } from 'lib/domains';
 import { displayError, clear } from 'lib/upgrades/notices';
 import { removeNestedProperties } from 'lib/cart/store/cart-analytics';
 import { abtest } from 'lib/abtest';
+import { isEbanxCreditCardProcessingEnabledForCountry } from 'lib/checkout/processor-specific';
 
 /**
  * Module variables
@@ -199,6 +200,11 @@ export class SecurePaymentForm extends Component {
 			params.cancelUrl += this.props.selectedSite.slug;
 		} else {
 			params.cancelUrl += 'no-site';
+		}
+
+		const cardDetailsCountry = get( params.transaction, 'payment.newCardDetails.country', null );
+		if ( isEbanxCreditCardProcessingEnabledForCountry( cardDetailsCountry ) ) {
+			params.transaction.payment.paymentMethod = 'WPCOM_Billing_MoneyPress_Paygate';
 		}
 
 		submitTransaction( params );


### PR DESCRIPTION
Since we launched the Stripe Elements based form we effectively disabled CC payments with Ebanx. We still render the EBANX fields, but only submit the Elements fields through Stripe.

#### Changes proposed in this Pull Request
This is a temporary fix, and admittedly not the most elegant one, but it works:
- In the credit-card-form-fields component, don't display the stripe elements if the conditions are met for processing with Ebanx
- In the secure-payment-form component, overwrite the paymentMethod so that the `TransactionFlow` knows to process this with Ebanx (ebanx transactions are processed under the `WPCOM_Billing_MoneyPress_Paygate` payment method)

When we remove Paygate related code we can clean this up and come up with a better solution.

#### Testing instructions
- You'll need an account set to BRL currency.
- Add a product to your cart

Then:
- With the country set to anything but Brazil, fill in the credit card form. Check that the credit card placeholder is a number, rather than •••• •••• •••• •••• (this indicates you are using the Stripe Elements based form)
- Test that the payment works. Use `5555 5555 5555 4444` for a successful transaction
- Test again, this time, choosing `Brazil` as your country in the dropdown. This will reset the stripe elements fields and replace them with the regular CC fields (with the •••... placeholder on the number). Fill in the form, use `527.137.415-72`as your CFP if necessary, and submit the form (the same card will work). Make sure the transaction goes through.

