### PR TITLE
Hide Apple service in Connections

### DIFF
--- a/client/state/sharing/services/selectors.js
+++ b/client/state/sharing/services/selectors.js
@@ -114,6 +114,11 @@ export function getEligibleKeyringServices( state, siteId, type ) {
 			return false;
 		}
 
+		// Omit Apple as we cannot let users disconnect without losing their name and email
+		if ( 'apple' === service.ID ) {
+			return false;
+		}
+
 		return true;
 	} );
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We're adding Apple as a new external service to login with. We don't want it to appear on the Connections page as Apple is not a typical service, just a login service and we won't be able to get the user `name` and `email` back if the connection is removed (unless the user goes to https://appleid.apple.com/account/manage and removes WordPress from the authorized apps).

#### Testing instructions

- Try to login with apple using server side patch D30973
- Go to http://calypso.localhost:3000/marketing/connections (select any site)
- Notice Apple is hidden in "Other Connections" even though you can see in the `/me/keyring-connections` response in dev tools
