### PR TITLE
Pages: Add "Set as Posts Page" action to the pages list

### DIFF
--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -15,6 +15,7 @@ import classNames from 'classnames';
  */
 import Card from 'components/card';
 import { getSiteFrontPageType, getSitePostsPage, getSiteFrontPage } from 'state/sites/selectors';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
 /**
  * Style dependencies
@@ -68,11 +69,13 @@ class BlogPostsPage extends React.Component {
 				<span>
 					<Gridicon size={ 12 } icon="not-visible" className="blog-posts-page__not-used-icon" />
 					{ this.props.translate( 'Not in use.' ) + ' ' }
-					{ this.props.translate( '"%(pageTitle)s" is the homepage.', {
-						args: {
-							pageTitle: this.getPageTitle( this.props.frontPage ),
-						},
-					} ) }
+					{ // Prevent displaying '"Untitled" is the homepage.' while the settings are loading.
+					!! this.props.frontPage &&
+						this.props.translate( '"%(pageTitle)s" is the homepage.', {
+							args: {
+								pageTitle: this.getPageTitle( this.props.frontPage ),
+							},
+						} ) }
 				</span>
 			);
 		}
@@ -84,6 +87,11 @@ class BlogPostsPage extends React.Component {
 					{ translate( 'The homepage is showing your latest posts.' ) }
 				</span>
 			);
+		}
+
+		// Prevent displaying '"Untitled" page is showing your latest posts.' while the settings are loading.
+		if ( ! this.props.postsPage ) {
+			return null;
 		}
 
 		return (
@@ -98,7 +106,12 @@ class BlogPostsPage extends React.Component {
 	}
 
 	render() {
-		const { translate } = this.props;
+		const { isFullSiteEditing, translate } = this.props;
+
+		if ( isFullSiteEditing ) {
+			return null;
+		}
+
 		const isStaticHomePageWithNoPostsPage =
 			this.props.frontPageType === 'page' && ! this.props.postsPage;
 		const isCurrentlySetAsHomepage = this.props.frontPageType === 'posts';
@@ -145,5 +158,6 @@ export default connect( ( state, props ) => {
 		isFrontPage: getSiteFrontPageType( state, props.site.ID ) === 'posts',
 		postsPage: getSitePostsPage( state, props.site.ID ),
 		frontPage: getSiteFrontPage( state, props.site.ID ),
+		isFullSiteEditing: isSiteUsingFullSiteEditing( state, props.site.ID ),
 	};
 } )( localize( BlogPostsPage ) );

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -40,6 +40,7 @@ import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenbe
 import getEditorUrl from 'state/selectors/get-editor-url';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { updateSiteFrontPage } from 'state/site-settings/actions';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
 
@@ -231,8 +232,8 @@ class Page extends Component {
 
 		if (
 			'publish' !== this.props.page.status ||
-			this.props.isFrontPage ||
-			( this.props.hasStaticFrontPage && this.props.isPostsPage )
+			! this.props.hasStaticFrontPage ||
+			this.props.isFrontPage
 		) {
 			return null;
 		}
@@ -246,6 +247,38 @@ class Page extends Component {
 			<PopoverMenuItem key="item" onClick={ this.setFrontPage }>
 				<Gridicon icon="house" size={ 18 } />
 				{ translate( 'Set as Homepage' ) }
+			</PopoverMenuItem>,
+		];
+	}
+
+	setPostsPage = () =>
+		this.props.updateSiteFrontPage( this.props.siteId, {
+			isPageOnFront: true,
+			postsPageId: this.props.page.ID,
+		} );
+
+	getPostsPageItem() {
+		const { isFullSiteEditing, page, translate } = this.props;
+
+		if (
+			isFullSiteEditing ||
+			! this.props.hasStaticFrontPage ||
+			'publish' !== this.props.page.status ||
+			this.props.isPostsPage ||
+			this.props.isFrontPage
+		) {
+			return null;
+		}
+
+		if ( ! utils.userCan( 'edit_post', page ) ) {
+			return null;
+		}
+
+		return [
+			<MenuSeparator key="separator" />,
+			<PopoverMenuItem key="item" onClick={ this.setPostsPage }>
+				<Gridicon icon="posts" size={ 18 } />
+				{ translate( 'Set as Posts Page' ) }
 			</PopoverMenuItem>,
 		];
 	}
@@ -390,6 +423,7 @@ class Page extends Component {
 		const publishItem = this.getPublishItem();
 		const editItem = this.getEditItem();
 		const frontPageItem = this.getFrontPageItem();
+		const postsPageItem = this.getPostsPageItem();
 		const restoreItem = this.getRestoreItem();
 		const sendToTrashItem = this.getSendToTrashItem();
 		const copyItem = this.getCopyItem();
@@ -418,6 +452,7 @@ class Page extends Component {
 				{ copyItem }
 				{ restoreItem }
 				{ frontPageItem }
+				{ postsPageItem }
 				{ sendToTrashItem }
 				{ moreInfoItem }
 			</EllipsisMenu>
@@ -652,6 +687,7 @@ const mapState = ( state, props ) => {
 		parentEditorUrl: getEditorUrl( state, pageSiteId, get( props, 'page.parent.ID' ), 'page' ),
 		wpAdminGutenberg: shouldRedirectGutenberg( state, pageSiteId ),
 		duplicateUrl: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' ),
+		isFullSiteEditing: isSiteUsingFullSiteEditing( state, pageSiteId ),
 	};
 };
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -41,6 +41,7 @@ import getEditorUrl from 'state/selectors/get-editor-url';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
 import { updateSiteFrontPage } from 'state/site-settings/actions';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
+import canCurrentUser from 'state/selectors/can-current-user';
 
 const recordEvent = partial( recordGoogleEvent, 'Pages' );
 
@@ -228,17 +229,14 @@ class Page extends Component {
 		} );
 
 	getFrontPageItem() {
-		const { page, translate } = this.props;
+		const { canManageOptions, translate } = this.props;
 
 		if (
+			! canManageOptions ||
 			'publish' !== this.props.page.status ||
 			! this.props.hasStaticFrontPage ||
 			this.props.isFrontPage
 		) {
-			return null;
-		}
-
-		if ( ! utils.userCan( 'edit_post', page ) ) {
 			return null;
 		}
 
@@ -258,19 +256,16 @@ class Page extends Component {
 		} );
 
 	getPostsPageItem() {
-		const { isFullSiteEditing, page, translate } = this.props;
+		const { canManageOptions, isFullSiteEditing, translate } = this.props;
 
 		if (
+			! canManageOptions ||
 			isFullSiteEditing ||
 			! this.props.hasStaticFrontPage ||
 			'publish' !== this.props.page.status ||
 			this.props.isPostsPage ||
 			this.props.isFrontPage
 		) {
-			return null;
-		}
-
-		if ( ! utils.userCan( 'edit_post', page ) ) {
 			return null;
 		}
 
@@ -688,6 +683,7 @@ const mapState = ( state, props ) => {
 		wpAdminGutenberg: shouldRedirectGutenberg( state, pageSiteId ),
 		duplicateUrl: getEditorDuplicatePostPath( state, props.page.site_ID, props.page.ID, 'page' ),
 		isFullSiteEditing: isSiteUsingFullSiteEditing( state, pageSiteId ),
+		canManageOptions: canCurrentUser( state, pageSiteId, 'manage_options' ),
 	};
 };
 

--- a/client/state/selectors/test/is-site-using-full-site-editing.js
+++ b/client/state/selectors/test/is-site-using-full-site-editing.js
@@ -18,7 +18,14 @@ describe( 'isSiteUsingFullSiteEditing', () => {
 				items: {
 					123: {
 						is_fse_active: true,
-						options: { page_on_front: 2 },
+					},
+				},
+			},
+			siteSettings: {
+				items: {
+					123: {
+						show_on_front: 'page',
+						page_on_front: 2,
 					},
 				},
 			},
@@ -33,7 +40,14 @@ describe( 'isSiteUsingFullSiteEditing', () => {
 				items: {
 					123: {
 						is_fse_active: true,
-						options: { page_on_front: 0 },
+					},
+				},
+			},
+			siteSettings: {
+				items: {
+					123: {
+						show_on_front: 'posts',
+						page_on_front: 0,
 					},
 				},
 			},
@@ -46,8 +60,14 @@ describe( 'isSiteUsingFullSiteEditing', () => {
 		const state = {
 			sites: {
 				items: {
+					123: {},
+				},
+			},
+			siteSettings: {
+				items: {
 					123: {
-						options: { page_on_front: 2 },
+						show_on_front: 'page',
+						page_on_front: 2,
 					},
 				},
 			},

--- a/client/state/site-settings/utils.js
+++ b/client/state/site-settings/utils.js
@@ -41,7 +41,11 @@ export function normalizeSettings( settings ) {
 
 export const getDefaultSiteFrontPageSettings = ( state, siteId ) => {
 	if ( getSiteSetting( state, siteId, 'show_on_front' ) ) {
-		return {};
+		return {
+			show_on_front: getSiteSetting( state, siteId, 'show_on_front' ),
+			page_on_front: getSiteSetting( state, siteId, 'page_on_front' ),
+			page_for_posts: getSiteSetting( state, siteId, 'page_for_posts' ),
+		};
 	}
 	return {
 		show_on_front: getSiteOption( state, siteId, 'show_on_front' ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Follow up to #35141

* Add a "Set to Posts Page" action to the pages list.
* Fix missing front page settings when `QuerySiteSettings` trigger a new request.
* Fix the user capabilities checks (front page settings are site options, not page properties).
* Hide the `BlogPostsPage` component if the site is FSE.

![Screenshot 2019-08-07 at 13 18 57](https://user-images.githubusercontent.com/2070010/62622301-f22d0800-b915-11e9-9bb7-8a982516b192.png)

#### Testing instructions

* Navigate to `/pages/:site`.
* On a non-FSE site that uses a static front page (you can set it in the Customizer's homepage settings, or in WP-Admin in Settings -> Reading):
  * Try the "Set as Homepage" action that should appear for all pages except the homepage itself.
  * Try the "Set as Posts Page" that should appear for all pages except both the posts and home page.
  * Make sure the `BlogPostsPage` card (the one above the list titled "Blog Posts") shows up, and its description is correct on all changes.
* On a non-FSE site that doesn't use a static front page:
  * Make sure both actions are hidden everywhere.
* On an FSE site:
  * Make sure only the "Set as Homepage" shows up, while "Set as Posts Page" is hidden.
  * Make sure the `BlogPostsPage` card is hidden.