### PR TITLE
Add better messages

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -293,6 +293,35 @@ class MembershipsSection extends Component {
 	renderStripeConnected() {
 		return (
 			<div>
+				{ this.props.query.stripe_connect_success === 'earn' && (
+					<Notice
+						status="is-success"
+						showDismiss={ false }
+						text={ this.props.translate(
+							'Congrats! Your site is now connected to Stripe. You can now add your first payment plan.'
+						) }
+					>
+						<NoticeAction href={ `/earn/payments-plans/${ this.props.siteSlug }` } icon="create">
+							{ this.props.translate( 'Add a Payment Plan' ) }
+						</NoticeAction>
+					</Notice>
+				) }
+				{ this.props.query.stripe_connect_success === 'gutenberg' && (
+					<Notice
+						status="is-success"
+						showDismiss={ false }
+						text={ this.props.translate(
+							'Congrats! Your site is now connected to Stripe. You can now close this window, Click "Re-check connection" and add your first payment plan.'
+						) }
+					>
+						<NoticeAction
+							href={ `https://support.wordpress.com/recurring-payments-button/#stripe-account-connected` }
+							icon="external"
+						>
+							{ this.props.translate( 'Learn how' ) }
+						</NoticeAction>
+					</Notice>
+				) }
 				{ this.renderEarnings() }
 				{ this.renderSubscriberList() }
 				{ this.renderProducts() }

--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -311,7 +311,7 @@ class MembershipsSection extends Component {
 						status="is-success"
 						showDismiss={ false }
 						text={ this.props.translate(
-							'Congrats! Your site is now connected to Stripe. You can now close this window, Click "Re-check connection" and add your first payment plan.'
+							'Congrats! Your site is now connected to Stripe. You can now close this window, click "Re-check connection" and add your first payment plan.'
 						) }
 					>
 						<NoticeAction

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -98,7 +98,7 @@ export const handleMembershipGetSettings = dispatchRequest( {
 		http(
 			{
 				method: 'GET',
-				path: `/sites/${ action.siteId }/memberships/status`,
+				path: `/sites/${ action.siteId }/memberships/status?source=calypso`,
 				apiNamespace: 'wpcom/v2',
 			},
 			action


### PR DESCRIPTION
This introduces a notice that is displayed only with a parameter to serve as a landing page post stripe connection redirect.
Currently when a user connects stripe account, we drop them directly to docs, which is less than ideal. This page is the proper place to manage recurring payments.

We have 2 flows.

a) when users connects stripe account from the earn section itself

<img width="876" alt="Zrzut ekranu 2019-08-7 o 16 00 46" src="https://user-images.githubusercontent.com/3775068/62630056-8f943600-b92e-11e9-8cf0-a1d6fc513692.png">

b) when the user connects to stripe from the Gutenberg block

<img width="870" alt="Zrzut ekranu 2019-08-7 o 16 00 31" src="https://user-images.githubusercontent.com/3775068/62630133-a89ce700-b92e-11e9-9f38-4e6420f11eca.png">

ONce this PR is merged, we will replace the current redirect with this URL.

#### Testing instructions

- Check URL /earn/payments/[SITE]?stripe_connect_success=earn
- Check URL /earn/payments/[SITE]?stripe_connect_success=gutenberg


