### PR TITLE
Add WooCommerce onboarding styles to the WC Helper connection flow

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -3,7 +3,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
 import { capitalize, findLast, get, includes, isArray } from 'lodash';
@@ -41,6 +41,7 @@ import PushNotificationApprovalPoller from './two-factor-authentication/push-not
 import userFactory from 'lib/user';
 import AsyncLoad from 'components/async-load';
 import VisitSite from 'blocks/visit-site';
+import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
 
 /**
  * Style dependencies
@@ -160,6 +161,7 @@ class Login extends Component {
 		const {
 			isJetpack,
 			isJetpackWooCommerceFlow,
+			wccomFrom,
 			isManualRenewalImmediateLoginAttempt,
 			linkingSocialService,
 			oauth2Client,
@@ -197,7 +199,7 @@ class Login extends Component {
 					"'clientTitle' is the name of the app that uses WordPress.com authentication (e.g. 'Akismet' or 'VaultPress')",
 			} );
 
-			if ( isWooOAuth2Client( oauth2Client ) ) {
+			if ( isWooOAuth2Client( oauth2Client ) && ! wccomFrom ) {
 				preHeader = <Gridicon icon="my-sites" size={ 72 } />;
 				postHeader = (
 					<p>
@@ -215,6 +217,40 @@ class Login extends Component {
 									br: <br />,
 								},
 							}
+						) }
+					</p>
+				);
+			}
+
+			if (
+				config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+				isWooOAuth2Client( oauth2Client ) &&
+				wccomFrom
+			) {
+				preHeader = (
+					<Fragment>
+						{ 'cart' === wccomFrom ? (
+							<WooCommerceConnectCartHeader />
+						) : (
+							<div className="login__woocommerce-logo">
+								<div className={ classNames( 'connect-header' ) }>
+									<svg width={ 200 } viewBox={ '0 0 1270 170' }>
+										<AsyncLoad
+											require="components/jetpack-header/woocommerce"
+											darkColorScheme={ false }
+											placeholder={ null }
+										/>
+									</svg>
+								</div>
+							</div>
+						) }
+					</Fragment>
+				);
+				headerText = translate( 'Log in with a WordPress.com account' );
+				postHeader = (
+					<p className="login__header-subtitle">
+						{ translate(
+							'Log in to WooCommerce.com with your WordPress.com account to connect your store and manage your extensions'
 						) }
 					</p>
 				);
@@ -381,6 +417,7 @@ export default connect(
 		isJetpackWooCommerceFlow:
 			'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' ),
 		signupProgress: getSignupProgress( state ),
+		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -23,7 +23,6 @@ import FormsButton from 'components/forms/form-button';
 import FormInputValidation from 'components/forms/form-input-validation';
 import Card from 'components/card';
 import Divider from './divider';
-import ExternalLink from 'components/external-link';
 import { fetchMagicLoginRequestEmail } from 'state/login/magic-login/actions';
 import FormPasswordInput from 'components/forms/form-password-input';
 import FormTextInput from 'components/forms/form-text-input';
@@ -37,7 +36,7 @@ import {
 	loginUser,
 	resetAuthAccountType,
 } from 'state/login/actions';
-import { isCrowdsignalOAuth2Client } from 'lib/oauth2-clients';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import { login } from 'lib/paths';
 import { preventWidows } from 'lib/formatting';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
@@ -368,30 +367,6 @@ export class LoginForm extends Component {
 						</div>
 					</div>
 
-					{ config.isEnabled( 'signup/social' ) && (
-						<p className="login__form-terms">
-							{ preventWidows(
-								this.props.translate(
-									// To make any changes to this copy please speak to the legal team
-									'By creating an account, ' +
-										'you agree to our {{tosLink}}Terms of Service{{/tosLink}}.',
-									{
-										components: {
-											tosLink: (
-												<ExternalLink
-													href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-													target="_blank"
-													rel="noopener noreferrer"
-												/>
-											),
-										},
-									}
-								),
-								5
-							) }
-						</p>
-					) }
-
 					<div className="login__form-footer">
 						<div className="login__form-action">
 							<Button
@@ -437,6 +412,7 @@ export class LoginForm extends Component {
 			requestError,
 			socialAccountIsLinking: linkingSocialUser,
 			isJetpackWooCommerceFlow,
+			wccomFrom,
 		} = this.props;
 		const isOauthLogin = !! oauth2Client;
 		const isPasswordHidden = this.isUsernameOrEmailView();
@@ -454,6 +430,15 @@ export class LoginForm extends Component {
 		}
 
 		if ( config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow ) {
+			return this.renderWooCommerce();
+		}
+
+		if (
+			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+			oauth2Client &&
+			isWooOAuth2Client( oauth2Client ) &&
+			wccomFrom
+		) {
 			return this.renderWooCommerce();
 		}
 
@@ -653,6 +638,7 @@ export default connect(
 			userEmail:
 				getInitialQueryArguments( state ).email_address ||
 				getCurrentQueryArguments( state ).email_address,
+			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 		};
 	},
 	{

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -435,7 +435,6 @@ export class LoginForm extends Component {
 
 		if (
 			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-			oauth2Client &&
 			isWooOAuth2Client( oauth2Client ) &&
 			wccomFrom
 		) {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -1,4 +1,4 @@
-.layout:not( .is-jetpack-woocommerce-flow ) {
+.layout:not( .is-jetpack-woocommerce-flow ):not( .is-wccom-oauth-flow ) {
 	.login.is-jetpack {
 		.button.is-primary {
 			background-color: var( --color-jetpack );
@@ -7,8 +7,24 @@
 	}
 }
 
-.layout.is-jetpack-woocommerce-flow {
-	.login__jetpack-logo {
+.layout.is-wccom-oauth-flow {
+	.layout__content {
+		padding-top: 48px;
+	}
+
+	.masterbar {
+		display: none;
+	}
+
+	.wp-login__footer-links {
+		display: none;
+	}
+}
+
+.layout.is-jetpack-woocommerce-flow,
+.layout.is-wccom-oauth-flow {
+	.login__jetpack-logo,
+	.login__woocommerce-logo {
 		text-align: center;
 		border-bottom: 1px solid var( --color-gray-50 );
 		position: absolute;
@@ -22,7 +38,14 @@
 		}
 	}
 
-	.jetpack-header {
+	.login__woocommerce-logo {
+		svg > g {
+			transform: translateX( 50% );
+		}
+	}
+
+	.jetpack-header,
+	.connect-header {
 		margin: 0;
 		text-align: center;
 		margin-right: auto;

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -871,7 +871,6 @@ class SignupForm extends Component {
 			( config.isEnabled( 'jetpack/connect/woocommerce' ) &&
 				this.props.isJetpackWooCommerceFlow ) ||
 			( config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-				this.props.oauth2Client &&
 				isWooOAuth2Client( this.props.oauth2Client ) &&
 				this.props.wccomFrom )
 		) {

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -31,7 +31,7 @@ import PropTypes from 'prop-types';
  * Internal dependencies
  */
 import { localizeUrl } from 'lib/i18n-utils';
-import { isCrowdsignalOAuth2Client } from 'lib/oauth2-clients';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import wpcom from 'lib/wp';
 import config from 'config';
 import analytics from 'lib/analytics';
@@ -408,6 +408,7 @@ class SignupForm extends Component {
 			redirectTo: this.props.redirectToAfterLoginUrl,
 			locale: this.props.locale,
 			oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
+			wccomFrom: this.props.wccomFrom,
 		} );
 	}
 
@@ -867,8 +868,12 @@ class SignupForm extends Component {
 		}
 
 		if (
-			config.isEnabled( 'jetpack/connect/woocommerce' ) &&
-			this.props.isJetpackWooCommerceFlow
+			( config.isEnabled( 'jetpack/connect/woocommerce' ) &&
+				this.props.isJetpackWooCommerceFlow ) ||
+			( config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+				this.props.oauth2Client &&
+				isWooOAuth2Client( this.props.oauth2Client ) &&
+				this.props.wccomFrom )
 		) {
 			const logInUrl = config.isEnabled( 'login/native-login-links' )
 				? this.getLoginLink()
@@ -933,6 +938,7 @@ export default connect(
 		sectionName: getSectionName( state ),
 		isJetpackWooCommerceFlow:
 			'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' ),
+		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 	} ),
 	{
 		trackLoginMidFlow: () => recordTracksEvent( 'calypso_signup_login_midflow' ),

--- a/client/components/logged-out-form/link-item.scss
+++ b/client/components/logged-out-form/link-item.scss
@@ -7,7 +7,7 @@
 	cursor: pointer;
 	text-decoration: underline;
 
-	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings ) .layout:not( .dops ) &,
+	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings ) .layout:not( .dops ):not( .is-wccom-oauth-flow ) &,
 	body.is-section-signup:not( .is-section-jetpack-connect ):not( .is-section-settings ) .layout.gravatar & {
 		color: var( --color-white );
 

--- a/client/document/index.jsx
+++ b/client/document/index.jsx
@@ -62,6 +62,7 @@ class Document extends React.Component {
 			feedbackURL,
 			inlineScriptNonce,
 			isSupportSession,
+			isWCComConnect,
 			addEvergreenCheck,
 			requestFrom,
 		} = this.props;
@@ -145,6 +146,7 @@ class Document extends React.Component {
 									[ 'is-group-' + sectionGroup ]: sectionGroup,
 									[ 'is-section-' + sectionName ]: sectionName,
 									'is-jetpack-woocommerce-flow': isJetpackWooCommerceFlow,
+									'is-wccom-oauth-flow': isWCComConnect,
 								} ) }
 							>
 								<div className="masterbar" />

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
@@ -4,10 +4,11 @@
  * External dependencies
  */
 import React from 'react';
+import { localize } from 'i18n-calypso';
 
 import './style.scss';
 
-const WooCommercConnectCartHeader = () => {
+const WooCommercConnectCartHeader = ( { translate } ) => {
 	return (
 		<div className="woocommerce-connect-cart-header is-stepper">
 			<div className="woocommerce-connect-cart-header__stepper">
@@ -45,7 +46,9 @@ const WooCommercConnectCartHeader = () => {
 							</svg>
 						</div>
 						<div className="woocommerce-connect-cart-header__stepper-step-text">
-							<span className="woocommerce-connect-cart-header__stepper-step-label">Cart</span>
+							<span className="woocommerce-connect-cart-header__stepper-step-label">
+								{ translate( 'Cart' ) }
+							</span>
 						</div>
 					</div>
 					<div className="woocommerce-connect-cart-header__stepper-step-divider" />
@@ -54,7 +57,9 @@ const WooCommercConnectCartHeader = () => {
 							<span className="woocommerce-connect-cart-header__stepper-step-number">2</span>
 						</div>
 						<div className="woocommerce-connect-cart-header__stepper-step-text">
-							<span className="woocommerce-connect-cart-header__stepper-step-label">Payment</span>
+							<span className="woocommerce-connect-cart-header__stepper-step-label">
+								{ translate( 'Payment' ) }
+							</span>
 						</div>
 					</div>
 					<div className="woocommerce-connect-cart-header__stepper-step-divider" />
@@ -64,7 +69,7 @@ const WooCommercConnectCartHeader = () => {
 						</div>
 						<div className="woocommerce-connect-cart-header__stepper-step-text">
 							<span className="woocommerce-connect-cart-header__stepper-step-label">
-								Installation
+								{ translate( 'Installation' ) }
 							</span>
 						</div>
 					</div>
@@ -74,4 +79,4 @@ const WooCommercConnectCartHeader = () => {
 	);
 };
 
-export default WooCommercConnectCartHeader;
+export default localize( WooCommercConnectCartHeader );

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
@@ -5,8 +5,73 @@
  */
 import React from 'react';
 
+import './style.scss';
+
 const WooCommercConnectCartHeader = () => {
-	return <div>test</div>;
+	return (
+		<div className="woocommerce-connect-cart-header is-stepper">
+			<div className="woocommerce-connect-cart-header__stepper">
+				<div className="woocommerce-connect-cart-header__stepper-steps">
+					<div className="woocommerce-connect-cart-header__stepper-step is-complete">
+						<div className="woocommerce-connect-cart-header__stepper-step-icon">
+							<span className="woocommerce-connect-cart-header__stepper-step-number">1</span>
+							<svg
+								role="img"
+								aria-hidden="true"
+								focusable="false"
+								width="18"
+								height="18"
+								viewBox="0 0 18 18"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<mask
+									id="mask0"
+									mask-type="alpha"
+									maskUnits="userSpaceOnUse"
+									x="2"
+									y="3"
+									width="14"
+									height="12"
+								>
+									<path
+										d="M6.59631 11.9062L3.46881 8.77875L2.40381 9.83625L6.59631 14.0287L15.5963 5.02875L14.5388 3.97125L6.59631 11.9062Z"
+										fill="white"
+									/>
+								</mask>
+								<g mask="url(#mask0)">
+									<rect width="18" height="18" fill="white" />
+								</g>
+							</svg>
+						</div>
+						<div className="woocommerce-connect-cart-header__stepper-step-text">
+							<span className="woocommerce-connect-cart-header__stepper-step-label">Cart</span>
+						</div>
+					</div>
+					<div className="woocommerce-connect-cart-header__stepper-step-divider" />
+					<div className="woocommerce-connect-cart-header__stepper-step is-active">
+						<div className="woocommerce-connect-cart-header__stepper-step-icon">
+							<span className="woocommerce-connect-cart-header__stepper-step-number">2</span>
+						</div>
+						<div className="woocommerce-connect-cart-header__stepper-step-text">
+							<span className="woocommerce-connect-cart-header__stepper-step-label">Payment</span>
+						</div>
+					</div>
+					<div className="woocommerce-connect-cart-header__stepper-step-divider" />
+					<div className="woocommerce-connect-cart-header__stepper-step">
+						<div className="woocommerce-connect-cart-header__stepper-step-icon">
+							<span className="woocommerce-connect-cart-header__stepper-step-number">3</span>
+						</div>
+						<div className="woocommerce-connect-cart-header__stepper-step-text">
+							<span className="woocommerce-connect-cart-header__stepper-step-label">
+								Installation
+							</span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
 };
 
 export default WooCommercConnectCartHeader;

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
@@ -1,0 +1,12 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React from 'react';
+
+const WooCommercConnectCartHeader = () => {
+	return <div>test</div>;
+};
+
+export default WooCommercConnectCartHeader;

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/index.js
@@ -69,7 +69,7 @@ const WooCommercConnectCartHeader = ( { translate } ) => {
 						</div>
 						<div className="woocommerce-connect-cart-header__stepper-step-text">
 							<span className="woocommerce-connect-cart-header__stepper-step-label">
-								{ translate( 'Installation' ) }
+								{ ( translate( 'Installation' ), { context: 'Navigation item' } ) }
 							</span>
 						</div>
 					</div>

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/style.scss
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/style.scss
@@ -1,0 +1,116 @@
+/* @todo color variables */
+.woocommerce-connect-cart-header {
+	height: 56px;
+	border-bottom: 1px solid #e1e2e2;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: #fff;
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+	svg > g {
+		transform: none;
+	}
+
+	@include breakpoint( '<800px' ) {
+		position: fixed;
+		z-index: 999;
+		width: 100%;
+		bottom: 0;
+		top: initial;
+		border-top: 1px solid $muriel-gray-50;
+		border-bottom: none;
+	}
+}
+
+.layout.is-section-signup {
+	.woocommerce-connect-cart-header__stepper-step-icon {
+		margin-top: 4px;
+	}
+
+	.woocommerce-connect-cart-header__stepper-step-text {
+		margin-top: -5px;
+	}
+
+	.woocommerce-connect-cart-header__stepper-step-divider {
+		margin-top: 24px;
+	}
+}
+
+.woocommerce-connect-cart-header__stepper {
+	margin: 0 16px;
+	width: 100%;
+	max-width: 500px;
+}
+
+.woocommerce-connect-cart-header__stepper-steps {
+	margin: 0;
+	display: flex;
+    justify-content: space-around;
+}
+
+.woocommerce-connect-cart-header__stepper-step {
+	display: inline-flex;
+	padding: 8px;
+	font-weight: 400;
+	position: relative;
+}
+
+.woocommerce-connect-cart-header__stepper-step-icon {
+	font-size: 16px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	min-width: 24px;
+	margin-right: 12px;
+	background: #e1e2e2;
+	color: #50575d;
+	border-radius: 50%;
+}
+
+.woocommerce-connect-cart-header__stepper-step.is-active .woocommerce-connect-cart-header__stepper-step-icon,
+.woocommerce-connect-cart-header__stepper-step.is-complete .woocommerce-connect-cart-header__stepper-step-icon {
+	background: #673d99;
+	color: #fff;
+}
+
+.woocommerce-connect-cart-header__stepper-step.is-complete .woocommerce-connect-cart-header__stepper-step-number {
+	display: none;
+}
+
+.woocommerce-connect-cart-header__stepper-step svg {
+	display: none;
+}
+
+.woocommerce-connect-cart-header__stepper-step.is-complete svg {
+	display: inline;
+}
+
+.woocommerce-connect-cart-header__stepper-step .woocommerce-connect-cart-header__stepper-step-label {
+	color: #1a1a1a;
+	line-height: 24px;
+	font-size: 16px;
+
+	@include breakpoint( '<800px' ) {
+		display: none;
+		padding-top: 24px;
+	}
+}
+
+.woocommerce-connect-cart-header__stepper-step .woocommerce-connect-cart-header__stepper-step-label {
+	color: #2b2d2f;
+}
+.woocommerce-connect-cart-header__stepper-step.is-complete .woocommerce-connect-cart-header__stepper-step-label {
+	color: #1a1a1a;
+}
+
+.woocommerce-connect-cart-header__stepper-step-divider {
+	align-self: flex-start;
+	flex-grow: 1;
+	border-bottom: 1px solid #e1e2e2;
+	margin-top: 20px;
+}

--- a/client/extensions/woocommerce/components/woocommerce-connect-cart-header/style.scss
+++ b/client/extensions/woocommerce/components/woocommerce-connect-cart-header/style.scss
@@ -1,11 +1,10 @@
-/* @todo color variables */
 .woocommerce-connect-cart-header {
 	height: 56px;
-	border-bottom: 1px solid #e1e2e2;
+	border-bottom: 1px solid var( --color-gray-50 );
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	background: #fff;
+	background: var( --color-white );
 	position: absolute;
 	left: 0;
 	top: 0;
@@ -67,15 +66,15 @@
 	height: 24px;
 	min-width: 24px;
 	margin-right: 12px;
-	background: #e1e2e2;
-	color: #50575d;
+	background: var( --color-gray-50 );
+	color: var( --color-gray-600 );
 	border-radius: 50%;
 }
 
 .woocommerce-connect-cart-header__stepper-step.is-active .woocommerce-connect-cart-header__stepper-step-icon,
 .woocommerce-connect-cart-header__stepper-step.is-complete .woocommerce-connect-cart-header__stepper-step-icon {
-	background: #673d99;
-	color: #fff;
+	background: var( --color-hot-purple-600 );
+	color: var( --color-white );
 }
 
 .woocommerce-connect-cart-header__stepper-step.is-complete .woocommerce-connect-cart-header__stepper-step-number {
@@ -91,7 +90,7 @@
 }
 
 .woocommerce-connect-cart-header__stepper-step .woocommerce-connect-cart-header__stepper-step-label {
-	color: #1a1a1a;
+	color: var( --color-gray-900 );
 	line-height: 24px;
 	font-size: 16px;
 
@@ -102,15 +101,15 @@
 }
 
 .woocommerce-connect-cart-header__stepper-step .woocommerce-connect-cart-header__stepper-step-label {
-	color: #2b2d2f;
+	color: var( --color-gray-800 );
 }
 .woocommerce-connect-cart-header__stepper-step.is-complete .woocommerce-connect-cart-header__stepper-step-label {
-	color: #1a1a1a;
+	color: var( --color-gray-900 );
 }
 
 .woocommerce-connect-cart-header__stepper-step-divider {
 	align-self: flex-start;
 	flex-grow: 1;
-	border-bottom: 1px solid #e1e2e2;
+	border-bottom: 1px solid var( --color-gray-50 );
 	margin-top: 20px;
 }

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -1042,6 +1042,7 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 		.signup-form__woocommerce .card {
 			padding-bottom: 0;
+			padding-top: 8px;
 		}
 
 		.form-input-validation {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -52,6 +52,8 @@ import { isCommunityTranslatorEnabled } from 'components/community-translator/ut
 import { isE2ETest } from 'lib/e2e';
 import BodySectionCssClass from './body-section-css-class';
 import { retrieveMobileRedirect } from 'jetpack-connect/persistence-utils';
+import { isWooOAuth2Client } from 'lib/oauth2-clients';
+import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 
 /**
  * Style dependencies
@@ -122,6 +124,13 @@ class Layout extends Component {
 					'is-jetpack-woocommerce-flow':
 						config.isEnabled( 'jetpack/connect/woocommerce' ) &&
 						this.props.isJetpackWooCommerceFlow,
+				},
+				{
+					'is-wccom-oauth-flow':
+						config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+						this.props.oauth2Client &&
+						isWooOAuth2Client( this.props.oauth2Client ) &&
+						this.props.wccomFrom,
 				}
 			),
 			loadingClass = classnames( {
@@ -199,6 +208,9 @@ export default connect( state => {
 	const isJetpackWooCommerceFlow =
 		( 'jetpack-connect' === sectionName || 'login' === sectionName ) &&
 		'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' );
+	const oauth2Client = getCurrentOAuth2Client( state );
+	const wccomFrom = get( getCurrentQueryArguments( state ), 'wccom-from' );
+
 	return {
 		masterbarIsHidden:
 			! masterbarIsVisible( state ) || noMasterbarForSection || noMasterbarForRoute,
@@ -206,6 +218,8 @@ export default connect( state => {
 		isJetpackLogin,
 		isJetpackWooCommerceFlow,
 		isJetpackMobileFlow,
+		oauth2Client,
+		wccomFrom,
 		isLoading: isSectionLoading( state ),
 		isSupportSession: isSupportSession( state ),
 		sectionGroup,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -128,7 +128,6 @@ class Layout extends Component {
 				{
 					'is-wccom-oauth-flow':
 						config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-						this.props.oauth2Client &&
 						isWooOAuth2Client( this.props.oauth2Client ) &&
 						this.props.wccomFrom,
 				}

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -64,7 +64,6 @@ const LayoutLoggedOut = ( {
 			config.isEnabled( 'jetpack/connect/woocommerce' ) && isJetpackWooCommerceFlow,
 		'is-wccom-oauth-flow':
 			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-			useOAuth2Layout &&
 			isWooOAuth2Client( oauth2Client ) &&
 			wccomFrom,
 	};

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -11,5 +11,5 @@ export const isCrowdsignalOAuth2Client = oauth2Client => {
 };
 
 export const isWooOAuth2Client = oauth2Client => {
-	return includes( [ 50019, 50915, 50916 ], oauth2Client.id );
+	return oauth2Client && includes( [ 50019, 50915, 50916 ], oauth2Client.id );
 };

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -11,5 +11,6 @@ export const isCrowdsignalOAuth2Client = oauth2Client => {
 };
 
 export const isWooOAuth2Client = oauth2Client => {
+	// 50019 => WooCommerce Dev, 50915 => WooCommerce Staging, 50916 => WooCommerce Production.
 	return oauth2Client && includes( [ 50019, 50915, 50916 ], oauth2Client.id );
 };

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -19,6 +19,7 @@ export function login( {
 	emailAddress,
 	socialService,
 	oauth2ClientId,
+	wccomFrom,
 	site,
 } = {} ) {
 	let url = config( 'login_url' );
@@ -63,6 +64,10 @@ export function login( {
 
 	if ( isWoo ) {
 		url = addQueryArgs( { from: 'woocommerce-setup-wizard' }, url );
+	}
+
+	if ( wccomFrom ) {
+		url = addQueryArgs( { 'wccom-from': wccomFrom }, url );
 	}
 
 	return url;

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -81,5 +81,11 @@ describe( 'index', () => {
 
 			expect( url ).to.equal( '/log-in/jetpack?from=woocommerce-setup-wizard' );
 		} );
+
+		test( 'should return the login url with WooCommerce.com handler', () => {
+			const url = login( { isNative: true, oauth2ClientId: 12345, wccomFrom: 'testing' } );
+
+			expect( url ).to.equal( '/log-in?client_id=12345&wccom-from=testing' );
+		} );
 	} );
 } );

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -19,7 +19,7 @@ import { stringify } from 'qs';
 import config, { isEnabled } from 'config';
 import ExternalLink from 'components/external-link';
 import LoggedOutFormBackLink from 'components/logged-out-form/back-link';
-import { isCrowdsignalOAuth2Client } from 'lib/oauth2-clients';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import { addQueryArgs } from 'lib/url';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
@@ -170,6 +170,22 @@ export class LoginLinks extends React.Component {
 			return null;
 		}
 
+		// @todo Implement a muriel version of the email login links for the WooCommerce onboarding flows
+		if (
+			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+			this.props.oauth2Client &&
+			isWooOAuth2Client( this.props.oauth2Client ) &&
+			this.props.wccomFrom
+		) {
+			return null;
+		}
+		if (
+			config.isEnabled( 'jetpack/connect/woocommerce' ) &&
+			this.props.isJetpackWooCommerceFlow
+		) {
+			return null;
+		}
+
 		// The email address from the URL (if present) is added to the login
 		// parameters in this.handleMagicLoginLinkClick(). But it's left out
 		// here deliberately, to ensure that if someone copies this link to
@@ -211,7 +227,7 @@ export class LoginLinks extends React.Component {
 
 	renderSignUpLink() {
 		// Taken from client/layout/masterbar/logged-out.jsx
-		const { currentQuery, currentRoute, oauth2Client, pathname, translate } = this.props;
+		const { currentQuery, currentRoute, oauth2Client, pathname, translate, wccomFrom } = this.props;
 
 		let signupUrl = config( 'signup_url' );
 		const signupFlow = get( currentQuery, 'signup_flow' );
@@ -250,6 +266,22 @@ export class LoginLinks extends React.Component {
 			signupUrl = `${ signupUrl }/${ oauth2Flow }?${ stringify( oauth2Params ) }`;
 		}
 
+		if (
+			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+			oauth2Client &&
+			isWooOAuth2Client( oauth2Client ) &&
+			wccomFrom
+		) {
+			const redirectTo = get( currentQuery, 'redirect_to', '' );
+			const oauth2Params = {
+				oauth2_client_id: oauth2Client.id,
+				'wccom-from': wccomFrom,
+				oauth2_redirect: redirectTo,
+			};
+
+			signupUrl = `${ signupUrl }/wpcc?${ stringify( oauth2Params ) }`;
+		}
+
 		return (
 			<a
 				href={ signupUrl }
@@ -283,6 +315,9 @@ export default connect(
 		isLoggedIn: Boolean( getCurrentUserId( state ) ),
 		oauth2Client: getCurrentOAuth2Client( state ),
 		query: getCurrentQueryArguments( state ),
+		isJetpackWooCommerceFlow:
+			'woocommerce-setup-wizard' === get( getCurrentQueryArguments( state ), 'from' ),
+		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 	} ),
 	{
 		recordTracksEvent,

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -173,7 +173,6 @@ export class LoginLinks extends React.Component {
 		// @todo Implement a muriel version of the email login links for the WooCommerce onboarding flows
 		if (
 			config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
-			this.props.oauth2Client &&
 			isWooOAuth2Client( this.props.oauth2Client ) &&
 			this.props.wccomFrom
 		) {

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -153,11 +153,11 @@ $image-height: 47px;
 	}
 }
 
-.layout.is-jetpack-login:not( .is-jetpack-woocommerce-flow ) {
+.layout.is-jetpack-login:not( .is-jetpack-woocommerce-flow ):not( .is-wccom-oauth-flow ) {
 	@include jetpack-connect-colors();
 }
 
-.layout.is-jetpack-woocommerce-flow {
+.layout.is-jetpack-woocommerce-flow, .layout.is-wccom-oauth-flow {
 	@include woocommerce-colors();
 }
 
@@ -218,7 +218,8 @@ $image-height: 47px;
 	}
 }
 
-.layout.is-jetpack-woocommerce-flow {
+.layout.is-jetpack-woocommerce-flow,
+.layout.is-wccom-oauth-flow {
 	background-color: var( --color-woocommerce-onboarding-background );
 
 	.wp-login__links {
@@ -244,6 +245,8 @@ $image-height: 47px;
 
 	.login__form {
 		@include elevation ( 2dp );
+		padding-bottom: 0;
+		padding-top: 8px;
 	}
 
 	.login__form input:focus,

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -279,6 +279,9 @@ $image-height: 47px;
 	.login__social {
 		box-shadow: none;
 		padding-top: 0;
+		margin-right: auto;
+		margin-left: auto;
+		width: 300px;
 	}
 
 	.login__social-buttons {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -25,6 +25,7 @@ import { saveSignupStep, submitSignupStep } from 'state/signup/progress/actions'
 import { WPCC } from 'lib/url/support';
 import config from 'config';
 import AsyncLoad from 'components/async-load';
+import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
 
 function getSocialServiceFromClientId( clientId ) {
 	if ( ! clientId ) {
@@ -249,17 +250,21 @@ export class UserStep extends Component {
 		if ( isWooOAuth2Client( oauth2Client ) && wccomFrom ) {
 			return (
 				<Fragment>
-					<div className={ classNames( 'login__woocommerce-logo' ) }>
-						<div className={ classNames( 'connect-header' ) }>
-							<svg width={ 200 } viewBox={ '0 0 1270 170' }>
-								<AsyncLoad
-									require="components/jetpack-header/woocommerce"
-									darkColorScheme={ false }
-									placeholder={ null }
-								/>
-							</svg>
+					{ 'cart' === wccomFrom ? (
+						<WooCommerceConnectCartHeader />
+					) : (
+						<div className={ classNames( 'login__woocommerce-logo' ) }>
+							<div className={ classNames( 'connect-header' ) }>
+								<svg width={ 200 } viewBox={ '0 0 1270 170' }>
+									<AsyncLoad
+										require="components/jetpack-header/woocommerce"
+										darkColorScheme={ false }
+										placeholder={ null }
+									/>
+								</svg>
+							</div>
 						</div>
-					</div>
+					) }
 					<div className={ classNames( 'login__form-header' ) }>
 						{ translate( 'Create a WordPress.com account' ) }
 					</div>

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -128,7 +128,7 @@ body.is-section-signup .layout:not( .dops ) .step-wrapper {
 }
 
 // Signup headings
-body.is-section-signup .layout:not( .dops ) .formatted-header,
+body.is-section-signup .layout:not( .dops ):not( .is-wccom-oauth-flow ) .formatted-header,
 body.is-section-signup .layout.gravatar .formatted-header {
 	margin: 0 0 16px;
 
@@ -162,4 +162,145 @@ body.is-section-signup .layout.gravatar .formatted-header {
 .is-section-signup .layout__content,
 .is-section-signup .layout__primary {
 	overflow: visible;
+}
+
+.layout.is-wccom-oauth-flow {
+	@import 'jetpack-connect/colors.scss';
+	@include woocommerce-colors();
+	background-color: var( --color-woocommerce-onboarding-background );
+	height: 100%;
+
+	.woocommerce-muriel-text-control,
+	.muriel-input-text {
+		border-color: var( --color-gray-200 );
+
+		.text-control__label,
+		.components-base-control__label {
+			color: var( --color-gray-500 );
+			font-size: 12px;
+			font-weight: normal;
+		}
+
+		&.active {
+			box-shadow: 0 0 0 2px var( --color-hot-purple-600 );
+			border-color: transparent;
+		}
+	}
+
+	.login__form-footer {
+		text-align: center;
+		.button {
+			max-width: 310px;
+			height: 48px;
+
+			&.is-primary {
+				border: 0;
+			}
+		}
+	}
+
+	.layout__content {
+		padding-top: 48px;
+	}
+
+	.masterbar {
+		display: none;
+	}
+
+	.wp-login__footer-links {
+		display: none;
+	}
+
+	.login__woocommerce-logo {
+		text-align: center;
+		border-bottom: 1px solid var( --color-gray-50 );
+		position: absolute;
+		left: 0;
+		top: 0;
+		width: 100%;
+		height: 56px;
+
+		svg > g {
+			transform: translateX( 50% );
+		}
+	}
+
+	.connect-header {
+		margin: 0;
+		text-align: center;
+		margin-right: auto;
+		margin-left: auto;
+		padding-left: 0;
+		display: block;
+		height: 56px;
+		border-bottom: 1px solid var( --color-woocommerce-header-border );
+		background: #fff;
+
+		svg {
+			margin-top: 15px;
+		}
+	}
+
+	.login__form-header {
+		margin-top: 32px;
+	}
+
+	.formatted-header {
+		max-width: 476px;
+		margin-right: auto;
+		margin-left: auto;
+
+		.formatted-header__subtitle {
+			color: var( --color-primary-100 );
+			margin-top: 1em;
+			font-size: 16px;
+			line-height: 24px;
+			font-weight: 400;
+		}
+	}
+
+	.logged-out-form {
+		max-width: 476px;
+	}
+
+	.logged-out-form__link-item {
+		text-align: center;
+		text-decoration: underline;
+		color: var( --color-gray-600 );
+		font-size: 14px;
+	}
+
+	.signup-form__terms-of-service-link,
+	.signup-form__terms-of-service-link a {
+		text-align: left;
+		color: var( --color-gray-600 );
+	}
+
+	.signup-form__social {
+		padding-bottom: 0;
+		margin-top: 16px;
+		p {
+			font-size: 12px;
+			color: var( --color-gray-600 );
+		}
+
+		.social-buttons__button {
+			border: 1px solid $muriel-woo-purple-500;
+			color: $muriel-woo-purple-500;
+			box-shadow: none;
+		}
+	}
+	
+
+	.logged-out-form__footer {
+		text-align: center;
+		.button.is-primary {
+			border: 0;
+			box-shadow: none;
+			max-width: 310px;
+			margin-right: auto;
+			margin-left: auto;
+			height: 48px;
+		}
+	}
 }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -234,7 +234,7 @@ body.is-section-signup .layout.gravatar .formatted-header {
 		display: block;
 		height: 56px;
 		border-bottom: 1px solid var( --color-woocommerce-header-border );
-		background: #fff;
+		background: var( --color-white );
 
 		svg {
 			margin-top: 15px;

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -288,6 +288,8 @@ body.is-section-signup .layout.gravatar .formatted-header {
 			border: 1px solid $muriel-woo-purple-500;
 			color: $muriel-woo-purple-500;
 			box-shadow: none;
+			max-width: 250px;
+			height: 48px;
 		}
 	}
 	

--- a/config/development.json
+++ b/config/development.json
@@ -189,6 +189,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
+		"woocommerce/onboarding-oauth": true,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": false
 	}

--- a/config/production.json
+++ b/config/production.json
@@ -137,6 +137,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
+		"woocommerce/onboarding-oauth": false,
 		"wpcom-user-bootstrap": true
 	},
 	"rtl": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -144,6 +144,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
+		"woocommerce/onboarding-oauth": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -157,6 +157,7 @@
 		"woocommerce/extension-settings-tax": true,
 		"woocommerce/extension-wcservices": true,
 		"woocommerce/extension-wcservices/international-labels": true,
+		"woocommerce/onboarding-oauth": false,
 		"woocommerce/store-on-non-atomic-sites": true,
 		"wpcom-user-bootstrap": true
 	},

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -46,6 +46,7 @@ import { login } from 'lib/paths';
 import { logSectionResponse } from './analytics';
 import analytics from '../lib/analytics';
 import { getLanguage, filterLanguageRevisions } from 'lib/i18n-utils';
+import { isWooOAuth2Client } from 'lib/oauth2-clients';
 
 const debug = debugFactory( 'calypso:pages' );
 
@@ -301,6 +302,14 @@ function getDefaultContext( request ) {
 
 	const target = getBuildTargetFromRequest( request );
 
+	const oauthClientId = request.query.oauth2_client_id || request.query.client_id;
+	const isWCComConnect =
+		config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
+		( 'login' === request.context.sectionName || 'signup' === request.context.sectionName ) &&
+		request.query[ 'wccom-from' ] &&
+		oauthClientId &&
+		isWooOAuth2Client( { id: parseInt( oauthClientId ) } );
+
 	const context = Object.assign( {}, request.context, {
 		commitSha: process.env.hasOwnProperty( 'COMMIT_SHA' ) ? process.env.COMMIT_SHA : '(unknown)',
 		compileDebug: process.env.NODE_ENV === 'development',
@@ -311,6 +320,7 @@ function getDefaultContext( request ) {
 		isRTL: config( 'rtl' ),
 		isDebug,
 		requestFrom: request.query.from,
+		isWCComConnect,
 		badge: false,
 		lang,
 		entrypoint: getFilesForEntrypoint( target, 'entry-main' ),

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -307,7 +307,6 @@ function getDefaultContext( request ) {
 		config.isEnabled( 'woocommerce/onboarding-oauth' ) &&
 		( 'login' === request.context.sectionName || 'signup' === request.context.sectionName ) &&
 		request.query[ 'wccom-from' ] &&
-		oauthClientId &&
 		isWooOAuth2Client( { id: parseInt( oauthClientId ) } );
 
 	const context = Object.assign( {}, request.context, {


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-admin/issues/2600. This PR implements the Muriel WooCommerce onboarding designs to the helper OAuth login and sign-up flows. This uses a special query parameter, so other connection flows will remain the same for now.

Related (where this flow was implemented for the Jetpack connection): #33073, #34380.

#### Screenshots

<img width="1680" alt="Screen Shot 2019-08-07 at 11 06 42 AM" src="https://user-images.githubusercontent.com/689165/62636158-03224d00-b907-11e9-9b47-d4e78c17350a.png">

<img width="1680" alt="Screen Shot 2019-08-07 at 11 06 54 AM" src="https://user-images.githubusercontent.com/689165/62636177-09182e00-b907-11e9-866f-906b26c6cd7e.png">

<img width="1680" alt="Screen Shot 2019-08-07 at 11 07 09 AM" src="https://user-images.githubusercontent.com/689165/62636074-e4bc5180-b906-11e9-8357-2f368c7076bc.png">

#### Testing Directions

* Run `master` of https://github.com/woocommerce/wc-admin.
* In your local WordPress install, add `define( 'WOOCOMMERCE_CALYPSO_LOCAL', true );` to your `wp-config.php`.
* Logout of WooCommerce.com and WordPress.com (otherwise you may immediately end up on the authorization screen).
* Go to WooCommerce > Extensions > WooCommerce.com Subscriptions and disconnect from WooCommerce.com.
* Go to the dashboard and click the connection task.
	* If you don’t see the connection task:
		* Make sure you have skipped the profiler and have `items_purchased` set to true: https://gist.github.com/justinshreve/da09cc57ec8e0d07ac8e919cef7a926c. 
		* In WooCommerce Admin, edit `client/dashboard/index.js` and set `requiredTasksComplete` to false.
* If you have the above patches applied, you should end up on the onboarding themed login page. Verify things look correct, you can login, and that you can also go to the signup form.
* Verify things look correct on the signup form, you can signup, etc.
* You can change `wccom-from=onboarding` in the header to `wccom-from=cart` and view the cart stepper header.
* Logging in or signing up should redirect you to the unthemed WooCommerce.com connection page.

Additional testing:

In `wp-calypso` edit the `config/development.json` feature flag file and disable the new code by setting `woocommerce/onboarding-oauth` to false. Restart Calypso. You can test the connection again and verify that you see the existing OAuth styles.

#### Additional Notes/Questions
* During a rebase, the Apple sign-in button was added. This area is starting to feel a bit like Nascar with multiple sign-in buttons that take up the same space as the normal login field. I left it alone for now, but was wondering if we want to do something in our flow @jameskoster? We can address this in a follow-up PR.
* The lost password flow still has WP.com colors. I will create a separate issue for this as it will require more work to figure out how to get this to work per the designs.