### PR TITLE
Plans: Show a Confirmation Dialog When Upgrading Will Launch Site

### DIFF
--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -18,6 +18,7 @@ import formatCurrency from '@automattic/format-currency';
  */
 import FoldableCard from 'components/foldable-card';
 import Notice from 'components/notice';
+import EmailVerificationDialog from 'components/email-verification/email-verification-dialog';
 import PlanFeaturesActions from './actions';
 import PlanFeaturesHeader from './header';
 import PlanFeaturesItem from './item';
@@ -201,28 +202,9 @@ export class PlanFeatures extends Component {
 
 		if ( ! isEmailVerfied ) {
 			return (
-				<Dialog
-					isVisible
-					buttons={ [
-						{
-							action: 'resend',
-							label: translate( 'Resend email' ),
-							onClick: () => alert( 'TODO' ),
-						},
-						{ action: 'ok', label: translate( 'OK' ), isPrimary: true },
-					] }
-					onClose={ () => {
-						this.setState( {
-							showingSiteLaunchDialog: false,
-							choosingPlanSlug: null,
-						} );
-					} }
-					//additionalClassNames=""
-				>
-					<h1>
-						{ translate( 'Please confirm your email address before upgrading to this plan.' ) }
-					</h1>
-				</Dialog>
+				<EmailVerificationDialog
+					onClose={ () => this.setState( { showingSiteLaunchDialog: false } ) }
+				/>
 			);
 		}
 

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -17,6 +17,7 @@ import formatCurrency from '@automattic/format-currency';
  * Internal dependencies
  */
 import FoldableCard from 'components/foldable-card';
+import InlineSupportLink from 'components/inline-support-link';
 import Notice from 'components/notice';
 import EmailVerificationDialog from 'components/email-verification/email-verification-dialog';
 import PlanFeaturesActions from './actions';
@@ -233,9 +234,17 @@ export class PlanFeatures extends Component {
 						choosingPlanSlug: '',
 					} );
 				} }
-				//additionalClassNames=""
 			>
-				<h1>{ translate( 'If you continue, your site will be publicly visible.' ) }</h1>
+				<h1>{ translate( 'Site Privacy' ) }</h1>
+				{ translate( 'Your site is only visible to you and users you approve.' ) }
+				<br />
+				{ translate( 'If you continue with this plan, your site will be publicly visible.' ) }
+				<br />
+				<InlineSupportLink
+					showIcon={ false }
+					supportLink="https://support.wordpress.com/settings/privacy-settings/"
+					supportPostId={ 1507 }
+				/>
 			</Dialog>
 		);
 	}

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -24,7 +24,10 @@ import PlanFeaturesItem from './item';
 import SpinnerLine from 'components/spinner-line';
 import QueryActivePromotions from 'components/data/query-active-promotions';
 import { abtest } from 'lib/abtest';
-import { getCurrentUserCurrencyCode } from 'state/current-user/selectors';
+import {
+	getCurrentUserCurrencyCode,
+	isCurrentUserEmailVerified,
+} from 'state/current-user/selectors';
 import { getPlan, getPlanBySlug, getPlanRawPrice, getPlanSlug } from 'state/plans/selectors';
 import { getSignupDependencyStore } from 'state/signup/dependency-store/selectors';
 import { planItem as getCartItemForPlan } from 'lib/cart-values/cart-items';
@@ -189,11 +192,38 @@ export class PlanFeatures extends Component {
 	}
 
 	renderSiteLaunchDialog() {
-		const { selectedSiteSlug, translate } = this.props;
+		const { isEmailVerfied, selectedSiteSlug, translate } = this.props;
 		const { choosingPlanSlug = '', showingSiteLaunchDialog } = this.state;
 
 		if ( ! showingSiteLaunchDialog ) {
 			return null;
+		}
+
+		if ( ! isEmailVerfied ) {
+			return (
+				<Dialog
+					isVisible
+					buttons={ [
+						{
+							action: 'resend',
+							label: translate( 'Resend email' ),
+							onClick: () => alert( 'TODO' ),
+						},
+						{ action: 'ok', label: translate( 'OK' ), isPrimary: true },
+					] }
+					onClose={ () => {
+						this.setState( {
+							showingSiteLaunchDialog: false,
+							choosingPlanSlug: null,
+						} );
+					} }
+					//additionalClassNames=""
+				>
+					<h1>
+						{ translate( 'Please confirm your email address before upgrading to this plan.' ) }
+					</h1>
+				</Dialog>
+			);
 		}
 
 		const destination = addQueryArgs(
@@ -201,20 +231,18 @@ export class PlanFeatures extends Component {
 			'/start/launch-site'
 		);
 
-		const infoDialogButtons = [
-			{ action: 'cancel', label: translate( 'Cancel' ) },
-			{
-				action: 'continue',
-				label: translate( "Let's do it!" ),
-				isPrimary: true,
-				onClick: () => page( destination ),
-			},
-		];
-
 		return (
 			<Dialog
 				isVisible
-				buttons={ infoDialogButtons }
+				buttons={ [
+					{ action: 'cancel', label: translate( 'Cancel' ) },
+					{
+						action: 'continue',
+						label: translate( "Let's do it!" ),
+						isPrimary: true,
+						onClick: () => page( destination ),
+					},
+				] }
 				onClose={ () => {
 					this.setState( {
 						showingSiteLaunchDialog: false,
@@ -975,6 +1003,7 @@ export default connect(
 
 		return {
 			canPurchase,
+			isEmailVerfied: isCurrentUserEmailVerified( state ),
 			isJetpack,
 			planProperties,
 			selectedSiteSlug,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -194,14 +194,14 @@ export class PlanFeatures extends Component {
 	}
 
 	renderSiteLaunchDialog() {
-		const { isEmailVerfied, selectedSiteSlug, translate } = this.props;
+		const { isEmailVerified, selectedSiteSlug, translate } = this.props;
 		const { choosingPlanSlug, showingSiteLaunchDialog } = this.state;
 
 		if ( ! showingSiteLaunchDialog ) {
 			return null;
 		}
 
-		if ( ! isEmailVerfied ) {
+		if ( ! isEmailVerified ) {
 			return (
 				<EmailVerificationDialog
 					onClose={ () =>
@@ -236,10 +236,10 @@ export class PlanFeatures extends Component {
 				} }
 			>
 				<h1>{ translate( 'Site Privacy' ) }</h1>
-				{ translate( 'Your site is only visible to you and users you approve.' ) }
-				<br />
-				{ translate( 'If you continue with this plan, your site will be publicly visible.' ) }
-				<br />
+				<p>{ translate( 'Your site is only visible to you and users you approve.' ) }</p>
+				<p>
+					{ translate( 'If you continue with this plan, your site will be publicly visible.' ) }
+				</p>
 				<InlineSupportLink
 					showIcon={ false }
 					supportLink="https://support.wordpress.com/settings/privacy-settings/"
@@ -996,7 +996,7 @@ export default connect(
 
 		return {
 			canPurchase,
-			isEmailVerfied: isCurrentUserEmailVerified( state ),
+			isEmailVerified: isCurrentUserEmailVerified( state ),
 			isJetpack,
 			planProperties,
 			selectedSiteSlug,

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -573,12 +573,6 @@ export class PlanFeatures extends Component {
 			return;
 		}
 
-		const args = {};
-		// Auto-apply the coupon code to the cart for WPCOM sites
-		if ( ! displayJetpackPlans && withDiscount ) {
-			args.coupon = withDiscount;
-		}
-
 		if ( isPrivateAndGoingAtomic ) {
 			if ( isInSignup ) {
 				// Let signup do its thing
@@ -589,6 +583,12 @@ export class PlanFeatures extends Component {
 				choosingPlanSlug: productSlug,
 			} );
 			return;
+		}
+
+		const args = {};
+		// Auto-apply the coupon code to the cart for WPCOM sites
+		if ( ! displayJetpackPlans && withDiscount ) {
+			args.coupon = withDiscount;
 		}
 
 		page( addQueryArgs( args, `/checkout/${ selectedSiteSlug }/${ planPath }` ) );

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -194,7 +194,7 @@ export class PlanFeatures extends Component {
 
 	renderSiteLaunchDialog() {
 		const { isEmailVerfied, selectedSiteSlug, translate } = this.props;
-		const { choosingPlanSlug = '', showingSiteLaunchDialog } = this.state;
+		const { choosingPlanSlug, showingSiteLaunchDialog } = this.state;
 
 		if ( ! showingSiteLaunchDialog ) {
 			return null;
@@ -203,7 +203,9 @@ export class PlanFeatures extends Component {
 		if ( ! isEmailVerfied ) {
 			return (
 				<EmailVerificationDialog
-					onClose={ () => this.setState( { showingSiteLaunchDialog: false } ) }
+					onClose={ () =>
+						this.setState( { showingSiteLaunchDialog: false, choosingPlanSlug: '' } )
+					}
 				/>
 			);
 		}
@@ -228,7 +230,7 @@ export class PlanFeatures extends Component {
 				onClose={ () => {
 					this.setState( {
 						showingSiteLaunchDialog: false,
-						choosingPlanSlug: null,
+						choosingPlanSlug: '',
 					} );
 				} }
 				//additionalClassNames=""

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -951,7 +951,7 @@ export default connect(
 					planObject: planObject,
 					planPath: getPlanPath( plan ) || '',
 					popular: popular,
-					productSlug: planObject.product_slug,
+					productSlug: get( planObject, 'product_slug' ),
 					newPlan: newPlan,
 					bestValue: bestValue,
 					hideMonthly: false,


### PR DESCRIPTION
Note: This is targeting the branch in #35003. Let's see if this is a better way to handle this & merge it in there if so.

#### Changes proposed in this Pull Request

* Instead of showing a notice in the plan description, show an "are you sure" dialog

#### Testing instructions

* Follow test plan in #35003, but instead of seeing a notice on the plan, you should be asked to confirm your action before you're taken to the launch flow.
