### PR TITLE
Checkout: Disable stripe fields while loading stripe

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -10,6 +10,7 @@
 
 @import 'components/button/style';
 @import 'components/card/style';
+@import 'components/credit-card-form-fields/style';
 @import 'components/date-picker/style';
 @import 'components/dialog/style';
 @import 'components/main/style';
@@ -18,3 +19,4 @@
 @import 'components/select-dropdown/style';
 @import 'components/tooltip/style';
 @import 'layout/sidebar/style';
+@import 'blocks/credit-card-form/style';

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -102,7 +102,14 @@ StripeElementErrors.propTypes = {
 	fieldName: PropTypes.string.isRequired,
 };
 
-function CreditCardNumberField( { translate, stripe, createField, getErrorMessage, card } ) {
+function CreditCardNumberField( {
+	translate,
+	stripe,
+	isStripeLoading,
+	createField,
+	getErrorMessage,
+	card,
+} ) {
 	const cardNumberLabel = translate( 'Card Number', {
 		comment: 'Card number label on credit card form',
 	} );
@@ -131,6 +138,7 @@ function CreditCardNumberField( { translate, stripe, createField, getErrorMessag
 		inputMode: 'numeric',
 		label: cardNumberLabel,
 		placeholder: '•••• •••• •••• ••••',
+		disabled: !! isStripeLoading, // isStripeLoading might be undefined
 	} );
 }
 
@@ -140,9 +148,17 @@ CreditCardNumberField.propTypes = {
 	getErrorMessage: PropTypes.func.isRequired,
 	stripe: PropTypes.object,
 	card: PropTypes.object.isRequired,
+	isStripeLoading: PropTypes.bool,
 };
 
-function CreditCardExpiryAndCvvFields( { translate, stripe, createField, getErrorMessage, card } ) {
+function CreditCardExpiryAndCvvFields( {
+	translate,
+	stripe,
+	isStripeLoading,
+	createField,
+	getErrorMessage,
+	card,
+} ) {
 	const cvcLabel = translate( 'Security Code {{span}}("CVC" or "CVV"){{/span}}', {
 		components: {
 			span: <span className="credit-card-form-fields__explainer" />,
@@ -191,6 +207,7 @@ function CreditCardExpiryAndCvvFields( { translate, stripe, createField, getErro
 			{ createField( 'expiration-date', Input, {
 				inputMode: 'numeric',
 				label: expiryLabel,
+				disabled: !! isStripeLoading, // isStripeLoading might be undefined
 				placeholder: translate( 'MM/YY', {
 					comment: 'Expiry placeholder for Expiry date on credit card form',
 				} ),
@@ -198,6 +215,7 @@ function CreditCardExpiryAndCvvFields( { translate, stripe, createField, getErro
 
 			{ createField( 'cvv', Input, {
 				inputMode: 'numeric',
+				disabled: !! isStripeLoading, // isStripeLoading might be undefined
 				placeholder: ' ',
 				label: translate( 'Security Code {{span}}("CVC" or "CVV"){{/span}} {{infoPopover/}}', {
 					components: {
@@ -216,6 +234,7 @@ CreditCardExpiryAndCvvFields.propTypes = {
 	getErrorMessage: PropTypes.func.isRequired,
 	card: PropTypes.object.isRequired,
 	stripe: PropTypes.object,
+	isStripeLoading: PropTypes.bool,
 };
 
 export class CreditCardFormFields extends React.Component {
@@ -228,6 +247,7 @@ export class CreditCardFormFields extends React.Component {
 		autoFocus: PropTypes.bool,
 		isNewTransaction: PropTypes.bool,
 		stripe: PropTypes.object,
+		isStripeLoading: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -324,6 +344,7 @@ export class CreditCardFormFields extends React.Component {
 					<CreditCardNumberField
 						translate={ this.props.translate }
 						stripe={ this.props.stripe }
+						isStripeLoading={ this.props.isStripeLoading }
 						createField={ this.createField }
 						getErrorMessage={ this.props.getErrorMessage }
 						card={ this.props.card }
@@ -334,6 +355,7 @@ export class CreditCardFormFields extends React.Component {
 					<CreditCardExpiryAndCvvFields
 						translate={ this.props.translate }
 						stripe={ this.props.stripe }
+						isStripeLoading={ this.props.isStripeLoading }
 						createField={ this.createField }
 						getErrorMessage={ this.props.getErrorMessage }
 						card={ this.props.card }

--- a/client/components/credit-card-form-fields/style.scss
+++ b/client/components/credit-card-form-fields/style.scss
@@ -81,3 +81,26 @@
 	flex: 0 0 42px;
 	margin-right: 10px;
 }
+
+// Specific for Stripe Elements while we use it in parallel to existing cc fields
+.credit-card-form-fields__element {
+	padding: 12px 14px 3px;
+	border: 1px solid var( --color-neutral-100 );
+	font-size: 16px;
+	line-height: 1.5;
+	min-height: 1.5em;
+	margin-top: 5px;
+
+	&.has-focus {
+		box-shadow: 0 0 0 2px var( --color-primary-100 );
+		border-color: var( --color-primary );
+
+		&.is-error {
+			box-shadow: 0 0 0 2px var( --color-error-100 );
+		}
+	}
+
+	&.is-error {
+		border-color: var( --color-error );
+	}
+}

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -483,8 +483,8 @@ export function createCardToken( requestType, cardDetails, callback, forcedPayga
 	return createPaygateToken( requestType, cardDetails, callback );
 }
 
-export async function getStripeConfiguration( { country } ) {
-	const config = await wpcom.stripeConfiguration( { country } );
+export async function getStripeConfiguration( requestArgs ) {
+	const config = await wpcom.stripeConfiguration( requestArgs );
 	debug( 'Stripe configuration', config );
 	return config;
 }

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -44,6 +44,9 @@ export { StripeValidationError };
  * example, `name` (string), `address` (object with `country` [string] and
  * `postal_code` [string]).
  *
+ * On success, the Promise will be resolved with an object that contains the
+ * PaymentMethod token in the `id` field.
+ *
  * If there is an error, it will include a `message` field which can be used to
  * display the error. It will also include a `type` and possibly other fields
  * depending on the type. For example, validation errors should be type

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -4,8 +4,9 @@
  * External dependencies
  */
 import debugFactory from 'debug';
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { loadScript } from '@automattic/load-script';
+import { injectStripe, StripeProvider, Elements } from 'react-stripe-elements';
 
 /**
  * Internal dependencies
@@ -188,4 +189,26 @@ export function useStripeConfiguration( country ) {
 		);
 	}, [ country ] );
 	return stripeConfiguration;
+}
+
+/**
+ * HOC to render a component with StripeJS
+ *
+ * @param {object} WrappedComponent The component to wrap
+ * @return {object} WrappedComponent
+ */
+export function withStripe( WrappedComponent ) {
+	const StripeInjectedWrappedComponent = injectStripe( WrappedComponent );
+	return props => {
+		const stripeConfiguration = useStripeConfiguration();
+		const stripeJs = useStripeJs( stripeConfiguration );
+
+		return (
+			<StripeProvider stripe={ stripeJs }>
+				<Elements>
+					<StripeInjectedWrappedComponent { ...props } />
+				</Elements>
+			</StripeProvider>
+		);
+	};
 }

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -181,16 +181,16 @@ export function useStripeJs( stripeConfiguration ) {
 /**
  * React custom Hook for loading the Stripe Configuration
  *
- * @param {string} country (optional) The country code
+ * @param {object} requestArgs (optional) Can include `country` or `needs_intent`
  * @return {object} Stripe Configuration as returned by the stripe configuration endpoint
  */
-export function useStripeConfiguration( country ) {
+export function useStripeConfiguration( requestArgs = {} ) {
 	const [ stripeConfiguration, setStripeConfiguration ] = useState();
 	useEffect( () => {
-		getStripeConfiguration( { country } ).then( configuration =>
+		getStripeConfiguration( requestArgs ).then( configuration =>
 			setStripeConfiguration( configuration )
 		);
-	}, [ country ] );
+	}, [ requestArgs ] );
 	return stripeConfiguration;
 }
 
@@ -198,12 +198,13 @@ export function useStripeConfiguration( country ) {
  * HOC to render a component with StripeJS
  *
  * @param {object} WrappedComponent The component to wrap
+ * @param {object} configurationArgs (optional) Options for configuration endpoint request. Can include `country` or `needs_intent`
  * @return {object} WrappedComponent
  */
-export function withStripe( WrappedComponent ) {
+export function withStripe( WrappedComponent, configurationArgs = {} ) {
 	const StripeInjectedWrappedComponent = injectStripe( WrappedComponent );
 	return props => {
-		const stripeConfiguration = useStripeConfiguration();
+		const stripeConfiguration = useStripeConfiguration( configurationArgs );
 		const stripeJs = useStripeJs( stripeConfiguration );
 
 		return (

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -206,7 +206,10 @@ export function withStripe( WrappedComponent ) {
 		return (
 			<StripeProvider stripe={ stripeJs }>
 				<Elements>
-					<StripeInjectedWrappedComponent { ...props } />
+					<StripeInjectedWrappedComponent
+						stripeConfiguration={ stripeConfiguration }
+						{ ...props }
+					/>
 				</Elements>
 			</StripeProvider>
 		);

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -157,8 +157,8 @@ export function useStripeJs( stripeConfiguration ) {
 		try {
 			if ( window.Stripe ) {
 				debug( 'stripe.js already loaded' );
-				setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
 				setStripeLoading( false );
+				setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
 				return;
 			}
 			debug( 'loading stripe.js...' );
@@ -168,12 +168,13 @@ export function useStripeJs( stripeConfiguration ) {
 					return;
 				}
 				debug( 'stripe.js loaded!' );
-				setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
 				setStripeLoading( false );
+				setStripeJs( window.Stripe( stripeConfiguration.public_key ) );
 			} );
 		} catch ( error ) {
 			if ( error ) {
 				debug( 'error while loading stripeJs', error );
+				setStripeLoading( false );
 				return;
 			}
 		}

--- a/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-payment-box.jsx
@@ -86,6 +86,7 @@ class CreditCardPaymentBox extends React.Component {
 		onSubmit: PropTypes.func,
 		translate: PropTypes.func.isRequired,
 		stripe: PropTypes.object,
+		isStripeLoading: PropTypes.bool,
 		stripeConfiguration: PropTypes.object,
 	};
 
@@ -207,7 +208,16 @@ class CreditCardPaymentBox extends React.Component {
 	};
 
 	render = () => {
-		const { cart, cards, countriesList, initialCard, transaction, stripe, translate } = this.props;
+		const {
+			cart,
+			cards,
+			countriesList,
+			initialCard,
+			transaction,
+			stripe,
+			isStripeLoading,
+			translate,
+		} = this.props;
 
 		return (
 			<React.Fragment>
@@ -218,6 +228,7 @@ class CreditCardPaymentBox extends React.Component {
 						initialCard={ initialCard }
 						transaction={ transaction }
 						stripe={ stripe }
+						isStripeLoading={ isStripeLoading }
 						translate={ translate }
 					/>
 

--- a/client/my-sites/checkout/checkout/credit-card-selector.jsx
+++ b/client/my-sites/checkout/checkout/credit-card-selector.jsx
@@ -82,6 +82,7 @@ class CreditCardSelector extends React.Component {
 					hasStoredCards={ this.props.cards.length > 0 }
 					selected={ selected }
 					stripe={ this.props.stripe }
+					isStripeLoading={ this.props.isStripeLoading }
 				/>
 			</CreditCard>
 		);

--- a/client/my-sites/checkout/checkout/new-card-form.jsx
+++ b/client/my-sites/checkout/checkout/new-card-form.jsx
@@ -24,6 +24,7 @@ class NewCardForm extends Component {
 		transaction: PropTypes.object.isRequired,
 		selected: PropTypes.bool,
 		stripe: PropTypes.object,
+		isStripeLoading: PropTypes.bool,
 	};
 
 	getErrorMessage = fieldName => {
@@ -41,6 +42,7 @@ class NewCardForm extends Component {
 				onFieldChange={ this.handleFieldChange }
 				getErrorMessage={ this.getErrorMessage }
 				stripe={ this.props.stripe }
+				isStripeLoading={ this.props.isStripeLoading }
 			/>
 		);
 	};

--- a/client/my-sites/checkout/checkout/stripe-elements-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/stripe-elements-payment-box.jsx
@@ -5,13 +5,14 @@
  */
 import React from 'react';
 import { localize } from 'i18n-calypso';
-import { StripeProvider, Elements } from 'react-stripe-elements';
 
 /**
  * Internal dependencies
  */
 import CreditCardPaymentBox from './credit-card-payment-box';
-import { useStripeConfiguration, useStripeJs } from 'lib/stripe';
+import { withStripe } from 'lib/stripe';
+
+const CreditCardPaymentBoxWithStripe = withStripe( CreditCardPaymentBox );
 
 export function StripeElementsPaymentBox( {
 	translate,
@@ -25,29 +26,21 @@ export function StripeElementsPaymentBox( {
 	presaleChatAvailable,
 	cards,
 } ) {
-	// TODO: send the country to useStripeConfiguration
-	const stripeConfiguration = useStripeConfiguration();
-	const stripeJs = useStripeJs( stripeConfiguration );
 	return (
-		<StripeProvider stripe={ stripeJs }>
-			<Elements>
-				<CreditCardPaymentBox
-					translate={ translate }
-					cards={ cards }
-					transaction={ transaction }
-					cart={ cart }
-					countriesList={ countriesList }
-					initialCard={ initialCard }
-					selectedSite={ selectedSite }
-					onSubmit={ onSubmit }
-					transactionStep={ transaction.step }
-					presaleChatAvailable={ presaleChatAvailable }
-					stripeConfiguration={ stripeConfiguration }
-				>
-					{ children }
-				</CreditCardPaymentBox>
-			</Elements>
-		</StripeProvider>
+		<CreditCardPaymentBoxWithStripe
+			translate={ translate }
+			cards={ cards }
+			transaction={ transaction }
+			cart={ cart }
+			countriesList={ countriesList }
+			initialCard={ initialCard }
+			selectedSite={ selectedSite }
+			onSubmit={ onSubmit }
+			transactionStep={ transaction.step }
+			presaleChatAvailable={ presaleChatAvailable }
+		>
+			{ children }
+		</CreditCardPaymentBoxWithStripe>
 	);
 }
 export default localize( StripeElementsPaymentBox );

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1207,27 +1207,3 @@
 		box-shadow: none;
 	}
 }
-
-// Specific for Stripe Elements while we use it in parallel to existing cc fields
-.credit-card-form-fields__element {
-	padding: 12px 14px 3px;
-	border: 1px solid var( --color-neutral-100 );
-	font-size: 16px;
-	line-height: 1.5;
-	min-height: 1.5em;
-	margin-top: 5px;
-
-	&.has-focus {
-		box-shadow: 0 0 0 2px var( --color-primary-100 );
-		border-color: var( --color-primary );
-
-		&.is-error {
-			box-shadow: 0 0 0 2px var( --color-error-100 );
-		}
-	}
-
-	&.is-error {
-		border-color: var( --color-error );
-	}
-
-}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The Stripe Elements form fields introduced in #34469 depend on Stripe.js being loaded, which in turn depends on the Stripe configuration being retrieved from the WPCOM API. While these are loading (using the `useStripeJs` custom React hook), the `stripe` object is not yet available and so the checkout form will temporarily render the old Paygate form fields before switching to the Stripe Elements fields. This is not a great UX, even when the network is fast.

In this PR, we add a new variable returned by the hook called `isStripeLoading` which will be true until the `stripe` object is available. We then change the checkout form to render disabled fields until the correct fields are available. To make this usable elsewhere easily, we also put all that into a Higher Order Component called `withStripe()`.

Note that we can't render disabled _Stripe Elements_ fields, because they won't render without stripe being loaded (catch-22), so we're displaying the old-style fields and disabling _them_.

#### Videos

##### Before

![Screen Capture on 2019-08-04 at 11-27-03](https://user-images.githubusercontent.com/844866/62421477-eee21400-b6aa-11e9-9600-1699493af328.gif)

##### After

![disabling-fields](https://user-images.githubusercontent.com/2036909/62646357-2c99a380-b91c-11e9-94dd-b8595ef49e8e.gif)

#### Testing instructions

- Add a plan to your cart.
- Visit the checkout page.
- Verify that the credit card form fields (just the number, expiry, and cvv) are disabled very briefly before being refreshed.