### PR TITLE
Updated simple payments copy on the plan screen

### DIFF
--- a/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
+++ b/client/blocks/product-purchase-features-list/sell-online-paypal.jsx
@@ -21,9 +21,9 @@ export default localize( ( { isJetpack, translate } ) => {
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
-				buttonText={ translate( 'Start earning' ) }
+				buttonText={ translate( 'Sell online' ) }
 				description={ translate(
-					'Add a PayPal payment button and start selling your goods and services.'
+					'Add a payment button to any post or page to collect PayPal payments for physical products, digital goods, services, or donations.'
 				) }
 				href={
 					isJetpack


### PR DESCRIPTION
## Description

@simison highlighted that we might want to synchronize the copy for the two simple payments promotions that now reside within Calypso. Here's the first on the plans page:

![plans](https://user-images.githubusercontent.com/5634774/62642843-9615b400-b914-11e9-9b15-d515d4cc5ded.png)

Here's the second on the new Earn page:

![earn](https://user-images.githubusercontent.com/5634774/62642884-a9288400-b914-11e9-8691-71a9221957e8.png)

Going into this, I had every intention of making them identical, but after reviewing this, I decided to keep the headlines the way they are for now. 

I actually prefer "Sell online with PayPal" as a headline, but I don't think this headline works well on the Earn screen:

![paypal](https://user-images.githubusercontent.com/5634774/62643072-1cca9100-b915-11e9-8a7b-2bfc566f7b6e.png)

To me, it makes it harder to tell a difference (at-a-glance) between simple payments and recurring payments. 

In the end I opted to keep the Earn section copy the same and then updated the paragraph text and button copy on the plans screen promo.

## Thoughts

I'm totally open to feedback on this.