### PR TITLE
FSE: Remove unnecessary template part blocks spacings

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -32,7 +32,7 @@
 	display: flex;
 	position: absolute;
 	top: 0;
-	left: 0;
+	left: 2px;
 	width: 100%;
 	height: 100%;
 	justify-content: center;
@@ -72,11 +72,14 @@
 				> .block-editor-block-list__block-edit {
 					&::before {
 						border-left: 3px solid rgba( 145, 151, 162, 0.25 );
-						margin-left: 3px;
+						margin-left: 2px;
+						top: 0;
+						bottom: 0;
 					}
 
 					& > .block-editor-block-list__breadcrumb {
-						margin-left: 3px;
+						margin-left: 2px;
+						top: 0;
 					}
 				}
 			}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -33,15 +33,7 @@
 		&:first-child {
 			[data-block] {
 				.template-block {
-					padding-top: 0;
 					padding-bottom: 3rem;
-				}
-			}
-		}
-		&:last-child {
-			[data-block] {
-				.template-block {
-					padding-bottom: 0;
 				}
 			}
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -31,18 +31,7 @@
 		display: block;
 	}
 
-	.wp-block[data-type='a8c/template'] {
-		[data-block] {
-			margin: 0;
-		}
-		&:first-child {
-			padding-top: 1rem;
-			padding-bottom: 4rem;
-			[data-block] {
-				.template-block {
-					padding: 0;
-				}
-			}
-		}
+	.wp-block[data-type='a8c/template'] [data-block] {
+		margin: 0;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -24,8 +24,13 @@
 
 .post-type-page {
 	.edit-post-visual-editor {
-		padding: 0;
+		padding: 0 0 4px;
 	}
+
+	.block-editor-writing-flow {
+		display: block;
+	}
+
 	.wp-block[data-type='a8c/template'] {
 		[data-block] {
 			margin: 0;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -36,9 +36,11 @@
 			margin: 0;
 		}
 		&:first-child {
+			padding-top: 1rem;
+			padding-bottom: 4rem;
 			[data-block] {
 				.template-block {
-					padding-bottom: 3rem;
+					padding: 0;
 				}
 			}
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -13,11 +13,37 @@
 	.edit-post-layout__content {
 		background: #eee;
 	}
-	
+
 	.edit-post-layout__content .edit-post-visual-editor {
 		flex: none;
 		margin: 40px;
-		box-shadow: 0 0 20px 0 rgba(0,0,0,0.1);
+		box-shadow: 0 0 20px 0 rgba( 0, 0, 0, 0.1 );
 		background: #fff;
+	}
+}
+
+.post-type-page {
+	.edit-post-visual-editor {
+		padding: 0;
+	}
+	.wp-block[data-type='a8c/template'] {
+		[data-block] {
+			margin: 0;
+		}
+		&:first-child {
+			[data-block] {
+				.template-block {
+					padding-top: 0;
+					padding-bottom: 3rem;
+				}
+			}
+		}
+		&:last-child {
+			[data-block] {
+				.template-block {
+					padding-bottom: 0;
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove unnecessary margins and paddings across template part blocks when displayed in a page editor, in order to make them look as similar as possible to the front end.

Note: it's not pixel perfect, but I doubt we'll ever get that, considering blocks are spaced differently than their rendered counterparts.

| Before | After |
| - | - |
| ![Screenshot 2019-08-07 at 18 50 51](https://user-images.githubusercontent.com/2070010/62646055-629f4d80-b945-11e9-8268-5542de98e2d9.png) | ![Screenshot 2019-08-07 at 18 49 52](https://user-images.githubusercontent.com/2070010/62646056-629f4d80-b945-11e9-93f1-173d24f48066.png) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Do all the FSE environment thing: delete the template parts; deactivate the Modern Business theme; delete the `modern-business-fse-template-data` option; reactivate Modern Business.
* Edit a page and check if the header and footer are spaced roughly like they are when viewing or previewing the page on the front end.

Fixes #34890
