### PR TITLE
[WIP] FSE: Remove the editor background color

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -14,10 +14,14 @@
 		background: #eee;
 	}
 	
-	.edit-post-layout__content .edit-post-visual-editor {
+	 .edit-post-layout__content .edit-post-visual-editor {
 		flex: none;
 		margin: 40px;
-		box-shadow: 0 0 20px 0 rgba(0,0,0,0.1);
-		background: #fff;
+		box-shadow: 0 0 20px 0 rgba( 0, 0, 0, 0.1 );
 	}
 }
+
+// If you uncomment this style, the color gets set:
+// .editor-styles-wrapper {
+// 	background: #fff;
+// }


### PR DESCRIPTION
We are now handling this in the theme stylesheet per https://github.com/Automattic/themes/pull/1219.

_Note, this is just to make sure that the other PR is working correctly for testing purposes. I think we should actually not change this so that there's a fallback in case the theme does not specify it._

Testing:
1. Pull this branch
2. Run FSE 
3. Open the page editor and verify the background is gray, matching the border
4. Pull https://github.com/Automattic/themes/pull/1219
5. Verify that the editor background is white (not working yet)