### PR TITLE
FSE: Disable template classname setting

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -19,10 +19,13 @@ if ( 'wp_template' !== fullSiteEditing.editorPostType ) {
 		description: __( 'Display a template.' ),
 		icon: 'layout',
 		category: 'layout',
-		attributes: { templateId: { type: 'number' } },
+		attributes: {
+			templateId: { type: 'number' },
+			className: { type: 'string' },
+		},
 		supports: {
 			anchor: false,
-			customClassName: true, // Needed to support the classname we inject
+			customClassName: false,
 			html: false,
 			reusable: false,
 		},


### PR DESCRIPTION
Since we want to do some work on the sidebar for the template block ([#](https://github.com/Automattic/wp-calypso/pull/35158#issuecomment-519234414)), we need to disable all settings in the sidebar. (just to be safe)

In this case, we just use `className` as an attribute rather than using `customClassName` to support our header/footer classnames.

#### Changes proposed in this Pull Request
* Disables customClassName for the template block
* Adds className as an attribute so it can still be used

#### Testing instructions
1. Pull this PR and run FSE on your local install
2. Inspect the the DOM in the page editor and verify that you still see `site-header site-branding` around the header template block:
<img width="962" alt="Screen Shot 2019-08-07 at 1 43 34 PM" src="https://user-images.githubusercontent.com/6265975/62656622-759c2880-b919-11e9-8d0a-cee3c27aabdd.png">

3. Comment out these lines of code: https://github.com/Automattic/wp-calypso/blob/8ec371ae52014c5b6cc2c3fcfd32be75f0e4e530/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js#L108-L120
4. Now, when you open the settings sidebar and go to "block settings" you should not be able to see the "custom class name" field.
<img width="1078" alt="Screen Shot 2019-08-07 at 1 41 57 PM" src="https://user-images.githubusercontent.com/6265975/62656656-8cdb1600-b919-11e9-8119-29cb018acbdd.png">

5. Make updates to the page, header, and footer, and make sure they are reflected on the front end.

cc @jeraldjuice 