### PR TITLE
Data: Add QuerySiteFrontPage component

### DIFF
--- a/client/components/data/query-site-front-page/index.js
+++ b/client/components/data/query-site-front-page/index.js
@@ -1,0 +1,69 @@
+/**
+ * External dependencies
+ */
+
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * Internal dependencies
+ */
+import getSiteSetting from 'state/selectors/get-site-setting';
+import { updateSiteSettings } from 'state/site-settings/actions';
+import { getSiteOption } from 'state/sites/selectors';
+
+class QuerySiteFrontPage extends Component {
+	static propTypes = {
+		siteId: PropTypes.number,
+	};
+
+	componentDidMount() {
+		const { showOnFrontSetting, pageOnFrontSetting } = this.props;
+		if ( showOnFrontSetting && pageOnFrontSetting ) {
+			return;
+		}
+
+		this.setFrontPageSettings();
+	}
+
+	componentDidUpdate( { showOnFrontSetting, pageOnFrontSetting } ) {
+		if ( showOnFrontSetting && pageOnFrontSetting ) {
+			return;
+		}
+
+		this.setFrontPageSettings();
+	}
+
+	setFrontPageSettings() {
+		const { showOnFrontOption, pageOnFrontOption, pageForPostsOption, updateSettings } = this.props;
+
+		updateSettings( {
+			show_on_front: showOnFrontOption,
+			page_for_posts: parseInt( pageOnFrontOption, 10 ),
+			page_on_front: parseInt( pageForPostsOption, 10 ),
+		} );
+	}
+
+	render() {
+		return null;
+	}
+}
+
+const mapStateToProps = ( state, { siteId } ) => ( {
+	showOnFrontOption: getSiteOption( state, siteId, 'show_on_front' ),
+	pageOnFrontOption: getSiteOption( state, siteId, 'page_on_front' ),
+	pageForPostsOption: getSiteOption( state, siteId, 'page_for_posts' ),
+
+	showOnFrontSetting: getSiteSetting( state, siteId, 'show_on_front' ),
+	pageOnFrontSetting: getSiteSetting( state, siteId, 'page_on_front' ),
+} );
+
+const mapDispatchToProps = ( dispatch, { siteId } ) => ( {
+	updateSettings: settings => dispatch( updateSiteSettings( siteId, settings ) ),
+} );
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( QuerySiteFrontPage );

--- a/client/components/data/query-site-front-page/index.js
+++ b/client/components/data/query-site-front-page/index.js
@@ -19,29 +19,25 @@ class QuerySiteFrontPage extends Component {
 	};
 
 	componentDidMount() {
-		const { showOnFrontSetting, pageOnFrontSetting } = this.props;
-		if ( showOnFrontSetting && pageOnFrontSetting ) {
+		if ( this.props.showOnFrontSetting ) {
 			return;
 		}
-
 		this.setFrontPageSettings();
 	}
 
-	componentDidUpdate( { showOnFrontSetting, pageOnFrontSetting } ) {
-		if ( showOnFrontSetting && pageOnFrontSetting ) {
+	componentDidUpdate() {
+		if ( this.props.showOnFrontSetting ) {
 			return;
 		}
-
 		this.setFrontPageSettings();
 	}
 
 	setFrontPageSettings() {
 		const { showOnFrontOption, pageOnFrontOption, pageForPostsOption, updateSettings } = this.props;
-
 		updateSettings( {
 			show_on_front: showOnFrontOption,
-			page_for_posts: parseInt( pageOnFrontOption, 10 ),
-			page_on_front: parseInt( pageForPostsOption, 10 ),
+			page_for_posts: pageOnFrontOption,
+			page_on_front: pageForPostsOption,
 		} );
 	}
 
@@ -56,7 +52,6 @@ const mapStateToProps = ( state, { siteId } ) => ( {
 	pageForPostsOption: getSiteOption( state, siteId, 'page_for_posts' ),
 
 	showOnFrontSetting: getSiteSetting( state, siteId, 'show_on_front' ),
-	pageOnFrontSetting: getSiteSetting( state, siteId, 'page_on_front' ),
 } );
 
 const mapDispatchToProps = ( dispatch, { siteId } ) => ( {

--- a/client/components/data/query-site-front-page/index.js
+++ b/client/components/data/query-site-front-page/index.js
@@ -36,8 +36,8 @@ class QuerySiteFrontPage extends Component {
 		const { showOnFrontOption, pageOnFrontOption, pageForPostsOption, updateSettings } = this.props;
 		updateSettings( {
 			show_on_front: showOnFrontOption,
-			page_for_posts: pageOnFrontOption,
-			page_on_front: pageForPostsOption,
+			page_for_posts: pageForPostsOption,
+			page_on_front: pageOnFrontOption,
 		} );
 	}
 

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -22,6 +22,7 @@ import ChecklistPromptTask from './checklist-prompt/task';
 import getSiteChecklist from 'state/selectors/get-site-checklist';
 import QueryPosts from 'components/data/query-posts';
 import QuerySiteChecklist from 'components/data/query-site-checklist';
+import QuerySiteFrontPage from 'components/data/query-site-front-page';
 import { successNotice } from 'state/notices/actions';
 import { getPostsForQuery } from 'state/posts/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -297,6 +298,7 @@ class WpcomChecklistComponent extends PureComponent {
 			<>
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 				{ siteId && <QueryPosts siteId={ siteId } query={ FIRST_TEN_SITE_POSTS_QUERY } /> }
+				{ siteId && <QuerySiteFrontPage siteId={ siteId } /> }
 				<ChecklistComponent
 					isPlaceholder={ ! taskStatuses }
 					updateCompletion={ updateCompletion }

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -85,7 +85,7 @@ export default class PageList extends Component {
 		return (
 			<div>
 				<QueryPosts siteId={ siteId } query={ query } />
-				<QuerySiteFrontPage siteId={ siteId } />
+				{ siteId && <QuerySiteFrontPage siteId={ siteId } /> }
 				<ConnectedPages incrementPage={ this.incrementPage } query={ query } siteId={ siteId } />
 			</div>
 		);

--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -16,7 +16,7 @@ import { flowRight, isEqual, size, without } from 'lodash';
  */
 import ListEnd from 'components/list-end';
 import QueryPosts from 'components/data/query-posts';
-import QuerySiteSettings from 'components/data/query-site-settings';
+import QuerySiteFrontPage from 'components/data/query-site-front-page';
 import Page from './page';
 import { preload } from 'sections-helper';
 import InfiniteScroll from 'components/infinite-scroll';
@@ -85,7 +85,7 @@ export default class PageList extends Component {
 		return (
 			<div>
 				<QueryPosts siteId={ siteId } query={ query } />
-				<QuerySiteSettings siteId={ siteId } />
+				<QuerySiteFrontPage siteId={ siteId } />
 				<ConnectedPages incrementPage={ this.incrementPage } query={ query } siteId={ siteId } />
 			</div>
 		);

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -19,6 +19,7 @@ import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
 import ExternalLink from 'components/external-link';
 import JetpackLogo from 'components/jetpack-logo';
+import QuerySiteFrontPage from 'components/data/query-site-front-page';
 import Sidebar from 'layout/sidebar';
 import SidebarFooter from 'layout/sidebar/footer';
 import SidebarItem from 'layout/sidebar/item';
@@ -727,8 +728,10 @@ export class MySitesSidebar extends Component {
 	}
 
 	render() {
+		const { siteId } = this.props;
 		return (
 			<Sidebar className="sidebar__streamlined-nav-drawer">
+				{ siteId && <QuerySiteFrontPage siteId={ siteId } /> }
 				<SidebarRegion>
 					<CurrentSite />
 					{ this.renderSidebarMenus() }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a new `QuerySiteFrontPage` component responsible to grab the front page options from the `sites` store and sending them to the `siteSettings` one, where it's going to be used by various actions and selectors across Calypso.
* Put it at work in all the cases it should be used. (I've tried to add it to the wrapping components, if used multiple times in the same section like in Pages.)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a FSE site:
  * Check if the Customizer link in the sidebar is hidden.
  * Check if the actions in the Pages list include "Set as Homepage", but not "Set as Posts Page".
* On a non-FSE site:
  * Check if the Customizer link is visible.
  * If the site has a static front page, check if both "Set as Homepage" and "Set as Posts Page" actions are available in the Pages list.