### PR TITLE
Show monthly Jetpack plan by default

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -14,7 +14,6 @@ import FormattedHeader from 'components/formatted-header';
 import PlansFeaturesMain from 'my-sites/plans-features-main';
 import PlansSkipButton from 'components/plans/plans-skip-button';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { abtest } from 'lib/abtest';
 
 /**
  * Constants
@@ -54,8 +53,7 @@ class JetpackPlansGrid extends Component {
 
 	render() {
 		const { interval } = this.props;
-		const defaultInterval =
-			abtest( 'defaultMonthlyJetpackPlan' ) === 'monthlyPlan' ? 'monthly' : 'yearly';
+		const defaultInterval = 'monthly';
 
 		return (
 			<MainWrapper isWide className="jetpack-connect__hide-plan-icons">

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -115,15 +115,6 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
-	defaultMonthlyJetpackPlan: {
-		datestamp: '20190722',
-		variations: {
-			monthlyPlan: 50,
-			yearlyPlan: 50,
-		},
-		defaultVariation: 'yearlyPlan',
-		allowExistingUsers: true,
-	},
 	checkoutSealsCopyBundle: {
 		datestamp: '20190613',
 		variations: {
@@ -133,7 +124,7 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 		//localeTargets: 'any',
-  },
+	},
 	showImportFlowInSiteTypeStep: {
 		datestamp: '20991231',
 		variations: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Show monthly Jetpack plans by default

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Connect a Jetpack site
* Observe plans page in the connect flow - is it showing monthly prices? If so, it works!
* Switch to yearly (and back) on the plans page should work