### PR TITLE
FSE: Add fse-enabled class to body to enabling targeting of css only if plugin enabled

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -459,9 +459,7 @@ class Full_Site_Editing {
 	 * @return array classes to be applied to body.
 	 */
 	public function add_fse_body_class( $classes ) {
-		if ( class_exists( 'A8C\FSE\WP_Template' ) ) {
-			$classes[] = 'fse-enabled';
-		}
+		$classes[] = 'fse-enabled';
 		return $classes;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -36,6 +36,7 @@ class Full_Site_Editing {
 		add_filter( 'wp_insert_post_data', array( $this, 'remove_template_components' ), 10, 2 );
 		add_filter( 'admin_body_class', array( $this, 'toggle_editor_post_title_visibility' ) );
 		add_filter( 'block_editor_settings', array( $this, 'set_block_template' ) );
+		add_filter( 'body_class', array( $this, 'add_fse_body_class' ) );
 	}
 
 	/**
@@ -449,6 +450,19 @@ class Full_Site_Editing {
 	 */
 	public function is_full_site_page() {
 		return 'page' === get_post_type();
+	}
+
+	/**
+	 * Add fse-enabled class to body so we can target css only if plugin enabled.
+	 *
+	 * @param array $classes classes to be applied to body.
+	 * @return array classes to be applied to body.
+	 */
+	public function add_fse_body_class( $classes ) {
+		if ( class_exists( 'A8C\FSE\WP_Template' ) ) {
+			$classes[] = 'fse-enabled';
+		}
+		return $classes;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add body class to indicate that fse plugin is enabled 

#### Testing instructions

* Apply branch to FSE test environment.
* Enable FSE plugin and check that `.fse-enabled` class exists on body element in the front-end
* Disable FSE plugin and check that `.fse-enabled` class is not present on body element in front-end


Related to https://github.com/Automattic/themes/pull/1211
