### PR TITLE
Checklist: reinstate grabbing the front page from site options

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -25,12 +25,7 @@ import QuerySiteChecklist from 'components/data/query-site-checklist';
 import { successNotice } from 'state/notices/actions';
 import { getPostsForQuery } from 'state/posts/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import {
-	getSiteOption,
-	getSiteSlug,
-	getSiteFrontPage,
-	isCurrentPlanPaid,
-} from 'state/sites/selectors';
+import { getSiteOption, getSiteSlug, isCurrentPlanPaid } from 'state/sites/selectors';
 import { recordTracksEvent } from 'state/analytics/actions';
 import { requestGuidedTour } from 'state/ui/guided-tours/actions';
 import { requestSiteChecklistTaskUpdate } from 'state/checklist/actions';
@@ -1046,7 +1041,11 @@ const getTaskUrls = createSelector(
 		const posts = getPostsForQuery( state, siteId, FIRST_TEN_SITE_POSTS_QUERY );
 		const firstPostID = get( find( posts, { type: 'post' } ), [ 0, 'ID' ] );
 		const contactPageUrl = getPageEditorUrl( state, siteId, getContactPage( posts ) );
-		const frontPageUrl = getPageEditorUrl( state, siteId, getSiteFrontPage( state, siteId ) );
+		const frontPageUrl = getPageEditorUrl(
+			state,
+			siteId,
+			getSiteOption( state, siteId, 'page_on_front' )
+		);
 
 		return {
 			post_published: getPageEditorUrl( state, siteId, firstPostID ),


### PR DESCRIPTION
## Changes proposed in this Pull Request

https://github.com/Automattic/wp-calypso/pull/35141 altered the way we get the front page url to use site settings, which are obtained via a query component. 

Here we are returning to the status quo, and grabbing the front page from site options until we work out if it's better to use site settings.

### Current

<img width="896" alt="Screen Shot 2019-08-08 at 11 25 06 am" src="https://user-images.githubusercontent.com/6458278/62670137-7c887100-b9d5-11e9-8f40-c76f274694c7.png">

### After this PR's changes

<img width="981" alt="Screen Shot 2019-08-08 at 11 32 17 am" src="https://user-images.githubusercontent.com/6458278/62670132-76929000-b9d5-11e9-8778-7b38d328d64c.png">


## Testing instructions

1. Fire up the branch
2. Create a site (or use a newish site) 
3. Head to the checklist

You should be able to see the update homepage checklist item

