### PR TITLE
Reader: fix Button warning on Following Manage

### DIFF
--- a/client/reader/following-manage/feed-search-results.jsx
+++ b/client/reader/following-manage/feed-search-results.jsx
@@ -1,6 +1,5 @@
-/** @format */
 /**
- * External Dependencies
+ * External dependencies
  */
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -11,7 +10,7 @@ import Gridicon from 'gridicons';
 import classnames from 'classnames';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import Button from 'components/button';
 import ReaderSubscriptionListItemPlaceholder from 'blocks/reader-subscription-list-item/placeholder';
@@ -96,7 +95,6 @@ class FollowingManageSearchFeedsResults extends React.Component {
 					<div className="following-manage__show-more">
 						<Button
 							compact
-							icon
 							onClick={ onShowMoreResultsClicked }
 							className="following-manage__show-more-button button"
 						>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

@psealock noticed a warning whilst loading Following Manage locally. We're trying to set the `icon` property of the `Button` component which appears to no longer exist.

![download](https://user-images.githubusercontent.com/17325/62671419-f24b0780-b9ea-11e9-874c-7c35d292db38.png)

#### Testing instructions

Visit http://calypso.localhost:3000/following/manage?q=code and ensure there's no warning shown in the console.

Ensure that the 'Show More' button still works at the end of the feed search results.

<img width="750" alt="Screen Shot 2019-08-08 at 14 43 15" src="https://user-images.githubusercontent.com/17325/62671407-e2332800-b9ea-11e9-9216-13e6ad907367.png">
