### PR TITLE
Checklist: ensure the checklist sidebar item disappears once tasks are complete

### DIFF
--- a/client/my-sites/checklist/wpcom-checklist/checklist-sidebar-item/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/checklist-sidebar-item/index.jsx
@@ -1,0 +1,73 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import MaterialIcon from 'components/material-icon';
+import { getSelectedSiteId } from 'state/ui/selectors';
+
+export class ChecklistSidebarItem extends Component {
+	static propTypes = {
+		siteSuffix: PropTypes.string.isRequired,
+		taskList: PropTypes.object,
+		onSidebarNavigate: PropTypes.func.isRequired,
+		sidebarItemSelected: PropTypes.bool,
+		hasChecklistLoadedOnce: PropTypes.bool,
+		translate: PropTypes.func.isRequired,
+	};
+
+	render() {
+		const {
+			hasChecklistLoadedOnce,
+			onSidebarNavigate,
+			sidebarItemSelected,
+			siteSuffix,
+			translate,
+			taskList,
+		} = this.props;
+		const classes = classnames( 'checklist-sidebar-item__wrapper', {
+			selected: sidebarItemSelected,
+		} );
+		const { total, completed } = taskList.getCompletionStatus();
+		const isUnfinished = taskList.getFirstIncompleteTask();
+
+		if ( isUnfinished ) {
+			return (
+				<li className={ classes } data-tip-target="checklist">
+					<a onClick={ onSidebarNavigate } href={ `/checklist${ siteSuffix }` }>
+						<MaterialIcon icon="check_circle" />
+						<span className="checklist-sidebar-item__text">{ translate( 'Checklist' ) }</span>
+						{ hasChecklistLoadedOnce && (
+							<span className="checklist-sidebar-item__secondary-text sidebar__menu-link-secondary-text">
+								{ translate( '%(complete)d/%(total)d', {
+									comment: 'Numerical progress indicator, like 5/9',
+									args: {
+										complete: completed,
+										total: total,
+									},
+								} ) }
+							</span>
+						) }
+					</a>
+				</li>
+			);
+		}
+
+		return null;
+	}
+}
+
+export default connect( state => ( {
+	// To prevent flickering only. Because the sidebar is mainly omnipresent, we don't care about future checklist requests
+	// for the selected site
+	hasChecklistLoadedOnce: !! get( state, [ 'checklist', getSelectedSiteId( state ) ], false ),
+} ) )( localize( ChecklistSidebarItem ) );

--- a/client/my-sites/checklist/wpcom-checklist/component.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/component.jsx
@@ -14,6 +14,7 @@ import { localize } from 'i18n-calypso';
  */
 import { getTaskList } from './wpcom-task-list';
 import { Checklist, Task } from 'components/checklist';
+import ChecklistSidebarItem from './checklist-sidebar-item';
 import ChecklistBanner from './checklist-banner';
 import ChecklistBannerTask from './checklist-banner/task';
 import ChecklistNavigation from './checklist-navigation';
@@ -275,6 +276,9 @@ class WpcomChecklistComponent extends PureComponent {
 		let ChecklistComponent = Checklist;
 
 		switch ( viewMode ) {
+			case 'sidebar-item':
+				ChecklistComponent = ChecklistSidebarItem;
+				break;
 			case 'banner':
 				ChecklistComponent = ChecklistBanner;
 				break;
@@ -292,21 +296,30 @@ class WpcomChecklistComponent extends PureComponent {
 			<>
 				{ siteId && <QuerySiteChecklist siteId={ siteId } /> }
 				{ siteId && <QueryPosts siteId={ siteId } query={ FIRST_TEN_SITE_POSTS_QUERY } /> }
-				<ChecklistComponent
-					isPlaceholder={ ! taskStatuses }
-					updateCompletion={ updateCompletion }
-					closePopover={ closePopover }
-					showNotification={ showNotification }
-					setNotification={ setNotification }
-					setStoredTask={ setStoredTask }
-					storedTask={ storedTask }
-					taskList={ taskList }
-					phase2={ phase2 }
-					onExpandTask={ this.trackExpandTask }
-					showChecklistHeader={ true }
-				>
-					{ taskList.getAll().map( task => this.renderTask( task ) ) }
-				</ChecklistComponent>
+				{ 'sidebar-item' === viewMode ? (
+					<ChecklistComponent
+						taskList={ taskList }
+						sidebarItemSelected={ this.props.sidebarItemSelected }
+						onSidebarNavigate={ this.props.onSidebarNavigate }
+						siteSuffix={ this.props.siteSuffix }
+					/>
+				) : (
+					<ChecklistComponent
+						isPlaceholder={ ! taskStatuses }
+						updateCompletion={ updateCompletion }
+						closePopover={ closePopover }
+						showNotification={ showNotification }
+						setNotification={ setNotification }
+						setStoredTask={ setStoredTask }
+						storedTask={ storedTask }
+						taskList={ taskList }
+						phase2={ phase2 }
+						onExpandTask={ this.trackExpandTask }
+						showChecklistHeader={ true }
+					>
+						{ taskList.getAll().map( task => this.renderTask( task ) ) }
+					</ChecklistComponent>
+				) }
 			</>
 		);
 	}

--- a/client/my-sites/checklist/wpcom-checklist/index.jsx
+++ b/client/my-sites/checklist/wpcom-checklist/index.jsx
@@ -25,7 +25,14 @@ class WpcomChecklist extends Component {
 		designType: PropTypes.oneOf( [ 'blog', 'page', 'portfolio', 'store' ] ),
 		siteId: PropTypes.number,
 		taskStatuses: PropTypes.object,
-		viewMode: PropTypes.oneOf( [ 'checklist', 'banner', 'navigation', 'notification', 'prompt' ] ),
+		viewMode: PropTypes.oneOf( [
+			'checklist',
+			'banner',
+			'navigation',
+			'notification',
+			'prompt',
+			'sidebar-item',
+		] ),
 	};
 
 	static defaultProps = {
@@ -65,6 +72,10 @@ function shouldChecklistRender(
 	isSectionEligible,
 	siteId
 ) {
+	if ( viewMode === 'sidebar-item' ) {
+		return true;
+	}
+
 	// Render nothing in notification mode.
 	if ( viewMode === 'notification' ) {
 		return false;

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -27,6 +27,7 @@ import SidebarRegion from 'layout/sidebar/region';
 import SiteMenu from './site-menu';
 import StatsSparkline from 'blocks/stats-sparkline';
 import ToolsMenu from './tools-menu';
+import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 import { isFreeTrial, isPersonal, isPremium, isBusiness, isEcommerce } from 'lib/products-values';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
@@ -163,21 +164,18 @@ export class MySitesSidebar extends Component {
 	};
 
 	checklist() {
-		const { canUserUseChecklistMenu, path, siteSuffix, siteId, translate } = this.props;
+		const { canUserUseChecklistMenu, path, siteId, siteSuffix } = this.props;
 
 		if ( ! siteId || ! canUserUseChecklistMenu ) {
 			return null;
 		}
 
-		const checklistLink = '/checklist' + siteSuffix;
 		return (
-			<SidebarItem
-				tipTarget="menus"
-				label={ translate( 'Checklist' ) }
-				selected={ itemLinkMatches( [ '/checklist' ], path ) }
-				link={ checklistLink }
-				onNavigate={ this.trackChecklistClick }
-				materialIcon="check_circle"
+			<WpcomChecklist
+				viewMode="sidebar-item"
+				sidebarItemSelected={ itemLinkMatches( [ '/checklist' ], path ) }
+				onSidebarNavigate={ this.trackChecklistClick }
+				siteSuffix={ siteSuffix }
 			/>
 		);
 	}


### PR DESCRIPTION
## Changes proposed in this Pull Request

We introduced a **Checklist** sidebar item in Automattic/wp-calypso#35138

Looks great. 

Since the button's label is “_Checklist_” however the expectation is that we should hide it after all the site's checklist items are complete.

See: p7DVsv-75e#comment-22370

In order to hide the checklist sidebar item, we need to know:

1. which tasks appear in the checklist 
2. how many of them are complete

So we went along and created a new `<WpcomChecklist />` component for the checklist sidebar item.

![Aug-08-2019 14-37-16](https://user-images.githubusercontent.com/6458278/62675465-810b5480-b9ea-11e9-9ad2-308e6fc65d2d.gif)

We did it this way because `<WpcomChecklist />` is connected to the current task list, and therefore knows immediately when alll tasks are completed. 

More importantly,  `<WpcomChecklist />` and its dependencies house a shedload of conditions and [exclusions based on availability of task urls](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checklist/wpcom-checklist/component.jsx#L269) among many others, all of which were too cumbersome to move into a new component and/or selectors.

The bonus prize is that we may display to the user the number of checklist items they have to complete in the sidebar, e.g., `3/5`

## Testing instructions

1. **Create a new site at** `/start` ➡️ Watch in wonder as the checklist sidebar item loads and looks ok in your browser

2. **Click items on the sidebar.** ➡️ Our checklist sidebar item shouldn't flicker.

3. **Click on the checklist sidebar item.** ➡️It should be selected, the page should load and a `calypso_mysites_sidebar_checklist_clicked` tracks event should fire.

4. **Tick off the remaining checklist items.** ➡️The count should increment, and the sidebar item should disappear forever.

5. **Switch sites.** ➡️Ensure the sidebar item reflects that site's checklist tasks.

Fixes https://github.com/Automattic/zelda-private/issues/129
