### PR TITLE
Janitorial: Updating SVG attributes to React-friendly camelCase

### DIFF
--- a/client/components/gauge/index.jsx
+++ b/client/components/gauge/index.jsx
@@ -65,15 +65,15 @@ export default class extends React.PureComponent {
 							d={ this.getPathDefinition( 100 ) }
 							fill="none"
 							stroke={ colorBg }
-							stroke-width={ lineWidth }
-							stroke-linecap="round"
+							strokeWidth={ lineWidth }
+							strokeLinecap="round"
 						/>
 						<path
 							d={ this.getPathDefinition( percentage ) }
 							fill="none"
 							stroke={ colorFg }
-							stroke-width={ lineWidth }
-							stroke-linecap="round"
+							strokeWidth={ lineWidth }
+							strokeLinecap="round"
 						/>
 					</svg>
 					<span className="gauge__label" style={ labelStyles }>

--- a/client/my-sites/plan-features/index.jsx
+++ b/client/my-sites/plan-features/index.jsx
@@ -114,7 +114,7 @@ export class PlanFeatures extends Component {
 							initialSelectedIndex={ initialSelectedIndex }
 						>
 							<table className={ tableClasses }>
-								<caption class="screen-reader-text">
+								<caption className="plan-features__screen-reader-text screen-reader-text">
 									{ translate( 'Available plans to choose from' ) }
 								</caption>
 								<tbody>


### PR DESCRIPTION
## Changes proposed in this Pull Request

Patrick Swayze starred in the 80s disaster/thriller film movie _Red Dawn_. 

The sequel, _Red Warn_, is presently being broadcast in Calypso development consoles around the world.

## Stats
<img width="681" alt="Screen Shot 2019-08-08 at 2 58 05 pm" src="https://user-images.githubusercontent.com/6458278/62676168-33dcb200-b9ed-11e9-94d6-566aa8710b96.png">

<img width="666" alt="Screen Shot 2019-08-08 at 2 58 10 pm" src="https://user-images.githubusercontent.com/6458278/62676169-33dcb200-b9ed-11e9-988a-456f61fa513d.png">

## Plans
<img width="612" alt="Screen Shot 2019-08-08 at 3 09 14 pm" src="https://user-images.githubusercontent.com/6458278/62676539-96827d80-b9ee-11e9-86b7-aa5a60bf0ed9.png">


But only for a limited time! This PR updates the attributes to `camelCase`, and uses `className` instead of `class`.

🍿 

## Testing instructions

Visit `http://calypso.localhost:3000/stats/day/{yoursite.wordpress.com}`, then skip over to `http://calypso.localhost:3000/plans/{yoursite.wordpress.com}` and lament the axing of the biggest console blockbuster of the summer.
