### PR TITLE
Plans: Use Jetpack Colours for Jetpack Sites

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -8,10 +8,10 @@ $plan-features-sidebar-width: 272px;
 .is-jetpack-site.is-section-plans {
 	.plans-features-main {
 		@include jetpack-connect-colors();
-	}
-	
-	.plan-features__header-title {
-		color: var( --color-neutral-700 );
+		
+		.plan-features__header-title {
+			color: var( --color-text );
+		}
 	}
 }
 

--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -1,5 +1,19 @@
+@import 'jetpack-connect/colors.scss';
+
 $plan-features-header-banner-height: 20px;
 $plan-features-sidebar-width: 272px;
+
+/* Colors for Jetpack sites */
+
+.is-jetpack-site.is-section-plans {
+	.plans-features-main {
+		@include jetpack-connect-colors();
+	}
+	
+	.plan-features__header-title {
+		color: var( --color-neutral-700 );
+	}
+}
 
 /* Breakpoints 1150px, */
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

For Jetpack sites, use Jetpack colours for the Plans table, except for the title of the plan (I feel it looks odd in green, so I used the variable from the Jetpack Connect table)

<img width="1142" alt="Screenshot 2019-08-08 at 10 34 01" src="https://user-images.githubusercontent.com/43215253/62692170-12b59a80-b9c8-11e9-8a17-4c2c51204746.png">

#### Testing instructions

Visit `/plans/` on a Jetpack site and verify that the screenshot looks as above, but it doesn't on a WordPress.com site, or in any other plans tables.

Fixes #30054
