### PR TITLE
Front Page: Refactor to use site options instead of site settings.

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -16,7 +16,6 @@ import { flowRight, isEqual, size, without } from 'lodash';
  */
 import ListEnd from 'components/list-end';
 import QueryPosts from 'components/data/query-posts';
-import QuerySiteSettings from 'components/data/query-site-settings';
 import Page from './page';
 import { preload } from 'sections-helper';
 import InfiniteScroll from 'components/infinite-scroll';
@@ -85,7 +84,6 @@ export default class PageList extends Component {
 		return (
 			<div>
 				<QueryPosts siteId={ siteId } query={ query } />
-				<QuerySiteSettings siteId={ siteId } />
 				<ConnectedPages incrementPage={ this.incrementPage } query={ query } siteId={ siteId } />
 			</div>
 		);

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -39,7 +39,7 @@ import { withoutNotice } from 'state/notices/actions';
 import { shouldRedirectGutenberg } from 'state/selectors/should-redirect-gutenberg';
 import getEditorUrl from 'state/selectors/get-editor-url';
 import { getEditorDuplicatePostPath } from 'state/ui/editor/selectors';
-import { updateSiteFrontPage } from 'state/site-settings/actions';
+import { updateSiteFrontPage } from 'state/sites/actions';
 import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import canCurrentUser from 'state/selectors/can-current-user';
 

--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -224,8 +224,8 @@ class Page extends Component {
 
 	setFrontPage = () =>
 		this.props.updateSiteFrontPage( this.props.siteId, {
-			isPageOnFront: true,
-			frontPageId: this.props.page.ID,
+			show_on_front: 'page',
+			page_on_front: this.props.page.ID,
 		} );
 
 	getFrontPageItem() {
@@ -251,8 +251,8 @@ class Page extends Component {
 
 	setPostsPage = () =>
 		this.props.updateSiteFrontPage( this.props.siteId, {
-			isPageOnFront: true,
-			postsPageId: this.props.page.ID,
+			show_on_front: 'page',
+			page_for_posts: this.props.page.ID,
 		} );
 
 	getPostsPageItem() {

--- a/client/state/data-layer/wpcom/sites/homepage/index.js
+++ b/client/state/data-layer/wpcom/sites/homepage/index.js
@@ -11,7 +11,7 @@ import { registerHandlers } from 'state/data-layer/handler-registry';
 import { http } from 'state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'state/data-layer/wpcom-http/utils';
 import { bypassDataLayer } from 'state/data-layer/utils';
-import { updateSiteSettings } from 'state/site-settings/actions';
+import { updateSiteFrontPage } from 'state/sites/actions';
 
 const updateSiteFrontPageRequest = action =>
 	http(
@@ -34,7 +34,7 @@ const setSiteFrontPage = (
 ) => dispatch => {
 	dispatch(
 		bypassDataLayer(
-			updateSiteSettings( siteId, {
+			updateSiteFrontPage( siteId, {
 				show_on_front: is_page_on_front ? 'page' : 'posts',
 				page_for_posts: parseInt( page_for_posts_id, 10 ),
 				page_on_front: parseInt( page_on_front_id, 10 ),

--- a/client/state/data-layer/wpcom/sites/homepage/index.js
+++ b/client/state/data-layer/wpcom/sites/homepage/index.js
@@ -20,7 +20,7 @@ const updateSiteFrontPageRequest = action =>
 			method: 'POST',
 			apiVersion: '1.1',
 			body: {
-				is_page_on_front: get( action.frontPageOptions, 'show_on_front' ),
+				is_page_on_front: 'page' === get( action.frontPageOptions, 'show_on_front' ),
 				page_on_front_id: get( action.frontPageOptions, 'page_on_front' ),
 				page_for_posts_id: get( action.frontPageOptions, 'page_for_posts' ),
 			},

--- a/client/state/data-layer/wpcom/sites/homepage/index.js
+++ b/client/state/data-layer/wpcom/sites/homepage/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { noop } from 'lodash';
+import { get, noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -20,9 +20,9 @@ const updateSiteFrontPageRequest = action =>
 			method: 'POST',
 			apiVersion: '1.1',
 			body: {
-				is_page_on_front: action.isPageOnFront,
-				page_for_posts_id: action.postsPageId,
-				page_on_front_id: action.frontPageId,
+				is_page_on_front: get( action.frontPageOptions, 'show_on_front' ),
+				page_on_front_id: get( action.frontPageOptions, 'page_on_front' ),
+				page_for_posts_id: get( action.frontPageOptions, 'page_for_posts' ),
 			},
 		},
 		action
@@ -30,14 +30,14 @@ const updateSiteFrontPageRequest = action =>
 
 const setSiteFrontPage = (
 	{ siteId },
-	{ is_page_on_front, page_for_posts_id, page_on_front_id }
+	{ is_page_on_front, page_on_front_id, page_for_posts_id }
 ) => dispatch => {
 	dispatch(
 		bypassDataLayer(
 			updateSiteFrontPage( siteId, {
 				show_on_front: is_page_on_front ? 'page' : 'posts',
-				page_for_posts: parseInt( page_for_posts_id, 10 ),
 				page_on_front: parseInt( page_on_front_id, 10 ),
+				page_for_posts: parseInt( page_for_posts_id, 10 ),
 			} )
 		)
 	);

--- a/client/state/pages/test/selectors.js
+++ b/client/state/pages/test/selectors.js
@@ -15,11 +15,13 @@ describe( 'selectors', () => {
 		test( 'should return true if the page is set as the front page', () => {
 			const result = isFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'page',
-								page_on_front: 1,
+								options: {
+									show_on_front: 'page',
+									page_on_front: 1,
+								},
 							},
 						},
 					},
@@ -34,11 +36,13 @@ describe( 'selectors', () => {
 		test( 'should return false if the page is not set as the front page', () => {
 			const result = isFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'page',
-								page_on_front: 2,
+								options: {
+									show_on_front: 'page',
+									page_on_front: 2,
+								},
 							},
 						},
 					},
@@ -53,11 +57,13 @@ describe( 'selectors', () => {
 		test( 'should return false if a static page is not set as the front page', () => {
 			const result = isFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'posts',
-								page_on_front: 0,
+								options: {
+									show_on_front: 'posts',
+									page_on_front: 0,
+								},
 							},
 						},
 					},
@@ -72,7 +78,7 @@ describe( 'selectors', () => {
 		test( 'should return false if the site is not known', () => {
 			const result = isFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {},
 					},
 				},
@@ -88,10 +94,12 @@ describe( 'selectors', () => {
 		test( 'should return true if the page is set as the posts page', () => {
 			const result = isPostsPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								page_for_posts: 1,
+								options: {
+									page_for_posts: 1,
+								},
 							},
 						},
 					},
@@ -106,10 +114,12 @@ describe( 'selectors', () => {
 		test( 'should return false if the page is not set as the posts page', () => {
 			const result = isPostsPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								page_for_posts: 2,
+								options: {
+									page_for_posts: 2,
+								},
 							},
 						},
 					},
@@ -124,7 +134,7 @@ describe( 'selectors', () => {
 		test( 'should return false if the site is not known', () => {
 			const result = isPostsPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {},
 					},
 				},

--- a/client/state/selectors/test/is-site-using-full-site-editing.js
+++ b/client/state/selectors/test/is-site-using-full-site-editing.js
@@ -18,14 +18,10 @@ describe( 'isSiteUsingFullSiteEditing', () => {
 				items: {
 					123: {
 						is_fse_active: true,
-					},
-				},
-			},
-			siteSettings: {
-				items: {
-					123: {
-						show_on_front: 'page',
-						page_on_front: 2,
+						options: {
+							show_on_front: 'page',
+							page_on_front: 2,
+						},
 					},
 				},
 			},
@@ -40,14 +36,10 @@ describe( 'isSiteUsingFullSiteEditing', () => {
 				items: {
 					123: {
 						is_fse_active: true,
-					},
-				},
-			},
-			siteSettings: {
-				items: {
-					123: {
-						show_on_front: 'posts',
-						page_on_front: 0,
+						options: {
+							show_on_front: 'posts',
+							page_on_front: 0,
+						},
 					},
 				},
 			},
@@ -60,14 +52,11 @@ describe( 'isSiteUsingFullSiteEditing', () => {
 		const state = {
 			sites: {
 				items: {
-					123: {},
-				},
-			},
-			siteSettings: {
-				items: {
 					123: {
-						show_on_front: 'page',
-						page_on_front: 2,
+						options: {
+							show_on_front: 'page',
+							page_on_front: 2,
+						},
 					},
 				},
 			},

--- a/client/state/site-settings/actions.js
+++ b/client/state/site-settings/actions.js
@@ -14,9 +14,8 @@ import {
 	SITE_SETTINGS_SAVE_FAILURE,
 	SITE_SETTINGS_SAVE_SUCCESS,
 	SITE_SETTINGS_UPDATE,
-	SITE_FRONT_PAGE_UPDATE,
 } from 'state/action-types';
-import { normalizeSettings, getDefaultSiteFrontPageSettings } from './utils';
+import { normalizeSettings } from './utils';
 
 import 'state/data-layer/wpcom/sites/homepage';
 
@@ -58,7 +57,7 @@ export function updateSiteSettings( siteId, settings ) {
  * @return {Function}      Action thunk
  */
 export function requestSiteSettings( siteId ) {
-	return ( dispatch, getState ) => {
+	return dispatch => {
 		dispatch( {
 			type: SITE_SETTINGS_REQUEST,
 			siteId,
@@ -68,16 +67,10 @@ export function requestSiteSettings( siteId ) {
 			.undocumented()
 			.settings( siteId )
 			.then( ( { name, description, settings } ) => {
-				// Front page settings are not currently returned by the `sites/:site/settings` endpoint.
-				// This makes sure that, if there are no front page settings in state yet,
-				// they default to their site option values.
-				const siteFrontPageSettings = getDefaultSiteFrontPageSettings( getState(), siteId );
-
 				const savedSettings = {
 					...normalizeSettings( settings ),
 					blogname: name,
 					blogdescription: description,
-					...siteFrontPageSettings,
 				};
 
 				dispatch( receiveSiteSettings( siteId, savedSettings ) );
@@ -126,11 +119,3 @@ export function saveSiteSettings( siteId, settings ) {
 			} );
 	};
 }
-
-export const updateSiteFrontPage = ( siteId, { isPageOnFront, frontPageId, postsPageId } ) => ( {
-	type: SITE_FRONT_PAGE_UPDATE,
-	siteId,
-	isPageOnFront,
-	frontPageId,
-	postsPageId,
-} );

--- a/client/state/site-settings/utils.js
+++ b/client/state/site-settings/utils.js
@@ -5,12 +5,6 @@
 import { isPlainObject, values } from 'lodash';
 
 /**
- * Internal dependencies
- */
-import { getSiteOption } from 'state/sites/selectors';
-import getSiteSetting from 'state/selectors/get-site-setting';
-
-/**
  * Normalize API Settings
  *
  * @format
@@ -38,18 +32,3 @@ export function normalizeSettings( settings ) {
 		return memo;
 	}, {} );
 }
-
-export const getDefaultSiteFrontPageSettings = ( state, siteId ) => {
-	if ( getSiteSetting( state, siteId, 'show_on_front' ) ) {
-		return {
-			show_on_front: getSiteSetting( state, siteId, 'show_on_front' ),
-			page_on_front: getSiteSetting( state, siteId, 'page_on_front' ),
-			page_for_posts: getSiteSetting( state, siteId, 'page_for_posts' ),
-		};
-	}
-	return {
-		show_on_front: getSiteOption( state, siteId, 'show_on_front' ),
-		page_on_front: getSiteOption( state, siteId, 'page_on_front' ),
-		page_for_posts: getSiteOption( state, siteId, 'page_for_posts' ),
-	};
-};

--- a/client/state/sites/actions.js
+++ b/client/state/sites/actions.js
@@ -25,6 +25,7 @@ import {
 	SITES_REQUEST_SUCCESS,
 	SITES_REQUEST_FAILURE,
 	SITE_PLUGIN_UPDATED,
+	SITE_FRONT_PAGE_UPDATE,
 } from 'state/action-types';
 import { SITE_REQUEST_FIELDS, SITE_REQUEST_OPTIONS } from 'state/sites/constants';
 
@@ -187,4 +188,20 @@ export function deleteSite( siteId ) {
 export const sitePluginUpdated = siteId => ( {
 	type: SITE_PLUGIN_UPDATED,
 	siteId,
+} );
+
+/**
+ * Returns an action object to be used to update the site front page options.
+ *
+ * @param  {Number} siteId Site ID
+ * @param  {Object} frontPageOptions Object containing the three optional front page options.
+ * @param  {String} [frontPageOptions.show_on_front] What to show in homepage. Can be 'page' or 'posts'.
+ * @param  {Number} [frontPageOptions.page_on_front] If `show_on_front = 'page'`, the front page ID.
+ * @param  {Number} [frontPageOptions.page_for_posts] If `show_on_front = 'page'`, the posts page ID.
+ * @return {Object} Action object
+ */
+export const updateSiteFrontPage = ( siteId, frontPageOptions ) => ( {
+	type: SITE_FRONT_PAGE_UPDATE,
+	siteId,
+	frontPageOptions,
 } );

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -53,8 +53,7 @@ export function items( state = null, action ) {
 		return null;
 	}
 	switch ( action.type ) {
-		case WORDADS_SITE_APPROVE_REQUEST_SUCCESS:
-			// eslint-disable-next-line no-case-declarations
+		case WORDADS_SITE_APPROVE_REQUEST_SUCCESS: {
 			const prevSite = state[ action.siteId ];
 			if ( prevSite ) {
 				return Object.assign( {}, state, {
@@ -62,16 +61,17 @@ export function items( state = null, action ) {
 				} );
 			}
 			return state;
+		}
 
 		case SITE_RECEIVE:
-		case SITES_RECEIVE:
+		case SITES_RECEIVE: {
 			// Normalize incoming site(s) to array
-			// eslint-disable-next-line no-case-declarations
+
 			const sites = action.site ? [ action.site ] : action.sites;
 
 			// SITES_RECEIVE occurs when we receive the entire set of user
 			// sites (replace existing state). Otherwise merge into state.
-			// eslint-disable-next-line no-case-declarations
+
 			const initialNextState = SITES_RECEIVE === action.type ? {} : state;
 
 			return reduce(
@@ -92,6 +92,7 @@ export function items( state = null, action ) {
 				},
 				initialNextState || {}
 			);
+		}
 
 		case SITE_DELETE_RECEIVE:
 		case JETPACK_DISCONNECT_RECEIVE:
@@ -135,8 +136,7 @@ export function items( state = null, action ) {
 					}
 
 					switch ( key ) {
-						case 'blog_public':
-							// eslint-disable-next-line no-case-declarations
+						case 'blog_public': {
 							const isPrivate = parseInt( settings.blog_public, 10 ) === -1;
 
 							if ( site.is_private === isPrivate ) {
@@ -148,8 +148,8 @@ export function items( state = null, action ) {
 								is_private: isPrivate,
 							};
 							break;
-						case 'site_icon':
-							// eslint-disable-next-line no-case-declarations
+						}
+						case 'site_icon': {
 							const mediaId = settings.site_icon;
 							// Return unchanged if next icon matches current value,
 							// accounting for the fact that a non-existent icon property is
@@ -175,6 +175,7 @@ export function items( state = null, action ) {
 								};
 							}
 							break;
+						}
 					}
 
 					if ( memo === state ) {

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -36,6 +36,7 @@ import {
 	THEME_ACTIVATE_SUCCESS,
 	WORDADS_SITE_APPROVE_REQUEST_SUCCESS,
 	SITE_PLUGIN_UPDATED,
+	SITE_FRONT_PAGE_UPDATE,
 } from 'state/action-types';
 import { sitesSchema, hasAllSitesListSchema } from './schema';
 import { combineReducers, createReducer, keyedReducer } from 'state/utils';
@@ -53,6 +54,7 @@ export function items( state = null, action ) {
 	}
 	switch ( action.type ) {
 		case WORDADS_SITE_APPROVE_REQUEST_SUCCESS:
+			// eslint-disable-next-line no-case-declarations
 			const prevSite = state[ action.siteId ];
 			if ( prevSite ) {
 				return Object.assign( {}, state, {
@@ -64,10 +66,12 @@ export function items( state = null, action ) {
 		case SITE_RECEIVE:
 		case SITES_RECEIVE:
 			// Normalize incoming site(s) to array
+			// eslint-disable-next-line no-case-declarations
 			const sites = action.site ? [ action.site ] : action.sites;
 
 			// SITES_RECEIVE occurs when we receive the entire set of user
 			// sites (replace existing state). Otherwise merge into state.
+			// eslint-disable-next-line no-case-declarations
 			const initialNextState = SITES_RECEIVE === action.type ? {} : state;
 
 			return reduce(
@@ -132,6 +136,7 @@ export function items( state = null, action ) {
 
 					switch ( key ) {
 						case 'blog_public':
+							// eslint-disable-next-line no-case-declarations
 							const isPrivate = parseInt( settings.blog_public, 10 ) === -1;
 
 							if ( site.is_private === isPrivate ) {
@@ -144,6 +149,7 @@ export function items( state = null, action ) {
 							};
 							break;
 						case 'site_icon':
+							// eslint-disable-next-line no-case-declarations
 							const mediaId = settings.site_icon;
 							// Return unchanged if next icon matches current value,
 							// accounting for the fact that a non-existent icon property is
@@ -212,6 +218,23 @@ export function items( state = null, action ) {
 						total: siteUpdates.total - 1,
 					},
 				},
+			};
+		}
+
+		case SITE_FRONT_PAGE_UPDATE: {
+			const { siteId, frontPageOptions } = action;
+			const site = state[ siteId ];
+			if ( ! site ) {
+				break;
+			}
+
+			return {
+				...state,
+				[ siteId ]: merge( {}, site, {
+					options: {
+						...frontPageOptions,
+					},
+				} ),
 			};
 		}
 	}

--- a/client/state/sites/selectors/get-site-front-page-type.js
+++ b/client/state/sites/selectors/get-site-front-page-type.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import getSiteSetting from 'state/selectors/get-site-setting';
+import { getSiteOption } from 'state/sites/selectors';
 
 /**
  * Returns the front page type.
@@ -11,5 +11,5 @@ import getSiteSetting from 'state/selectors/get-site-setting';
  * @return {String} 'posts' if blog posts are set as the front page or 'page' if a static page is
  */
 export default function getSiteFrontPageType( state, siteId ) {
-	return getSiteSetting( state, siteId, 'show_on_front' );
+	return getSiteOption( state, siteId, 'show_on_front' );
 }

--- a/client/state/sites/selectors/get-site-front-page.js
+++ b/client/state/sites/selectors/get-site-front-page.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import getSiteSetting from 'state/selectors/get-site-setting';
+import { getSiteOption } from 'state/sites/selectors';
 
 /**
  * Returns the ID of the static page set as the front page, or 0 if a static page is not set.
@@ -11,5 +11,5 @@ import getSiteSetting from 'state/selectors/get-site-setting';
  * @return {Number} ID of the static page set as the front page, or 0 if a static page is not set
  */
 export default function getSiteFrontPage( state, siteId ) {
-	return getSiteSetting( state, siteId, 'page_on_front' );
+	return getSiteOption( state, siteId, 'page_on_front' );
 }

--- a/client/state/sites/selectors/get-site-posts-page.js
+++ b/client/state/sites/selectors/get-site-posts-page.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import getSiteSetting from 'state/selectors/get-site-setting';
+import { getSiteOption } from 'state/sites/selectors';
 
 /**
  * Returns the ID of the static page set as the page for posts, or 0 if a static page is not set.
@@ -11,5 +11,5 @@ import getSiteSetting from 'state/selectors/get-site-setting';
  * @return {Number} ID of the static page set as page for posts, or 0 if a static page is not set
  */
 export default function getSitePostsPage( state, siteId ) {
-	return getSiteSetting( state, siteId, 'page_for_posts' );
+	return getSiteOption( state, siteId, 'page_for_posts' );
 }

--- a/client/state/sites/test/selectors.js
+++ b/client/state/sites/test/selectors.js
@@ -2187,11 +2187,13 @@ describe( 'selectors', () => {
 		test( 'should return falsey if the site does not have a static page set as the front page', () => {
 			const frontPage = getSiteFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'posts',
-								page_on_front: 0,
+								options: {
+									show_on_front: 'posts',
+									page_on_front: 0,
+								},
 							},
 						},
 					},
@@ -2205,7 +2207,7 @@ describe( 'selectors', () => {
 		test( 'should return falsey if the site is not known', () => {
 			const frontPage = getSiteFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {},
 					},
 				},
@@ -2218,11 +2220,13 @@ describe( 'selectors', () => {
 		test( 'should return the page ID if the site has a static page set as the front page', () => {
 			const frontPage = getSiteFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'page',
-								page_on_front: 1,
+								options: {
+									show_on_front: 'page',
+									page_on_front: 1,
+								},
 							},
 						},
 					},
@@ -2238,11 +2242,13 @@ describe( 'selectors', () => {
 		test( 'should return false if the site does not have a static page set as the front page', () => {
 			const hasFrontPage = hasStaticFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'posts',
-								page_on_front: 0,
+								options: {
+									show_on_front: 'posts',
+									page_on_front: 0,
+								},
 							},
 						},
 					},
@@ -2256,10 +2262,12 @@ describe( 'selectors', () => {
 		test( 'should return false if the site does not have a `page_on_front` value', () => {
 			const hasFrontPage = hasStaticFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'posts',
+								options: {
+									show_on_front: 'posts',
+								},
 							},
 						},
 					},
@@ -2273,7 +2281,7 @@ describe( 'selectors', () => {
 		test( 'should return false if the site is not known', () => {
 			const hasFrontPage = hasStaticFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {},
 					},
 				},
@@ -2286,11 +2294,13 @@ describe( 'selectors', () => {
 		test( 'should return true if the site has a static page set as the front page', () => {
 			const hasFrontPage = hasStaticFrontPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'page',
-								page_on_front: 42,
+								options: {
+									show_on_front: 'page',
+									page_on_front: 42,
+								},
 							},
 						},
 					},
@@ -2306,12 +2316,14 @@ describe( 'selectors', () => {
 		test( 'should return falsey if the site does not have a static page set as the posts page', () => {
 			const postsPage = getSitePostsPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'posts',
-								page_on_front: 0,
-								page_for_posts: 0,
+								options: {
+									show_on_front: 'posts',
+									page_on_front: 0,
+									page_for_posts: 0,
+								},
 							},
 						},
 					},
@@ -2325,7 +2337,7 @@ describe( 'selectors', () => {
 		test( 'should return falsey if the site is not known', () => {
 			const postsPage = getSitePostsPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {},
 					},
 				},
@@ -2338,12 +2350,14 @@ describe( 'selectors', () => {
 		test( 'should return the page ID if the site has a static page set as the posts page', () => {
 			const postsPage = getSitePostsPage(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'page',
-								page_on_front: 1,
-								page_for_posts: 2,
+								options: {
+									show_on_front: 'page',
+									page_on_front: 1,
+									page_for_posts: 2,
+								},
 							},
 						},
 					},
@@ -2359,7 +2373,7 @@ describe( 'selectors', () => {
 		test( 'should return falsey if the site is not known', () => {
 			const frontPageType = getSiteFrontPageType(
 				{
-					siteSettings: {
+					sites: {
 						items: {},
 					},
 				},
@@ -2372,12 +2386,14 @@ describe( 'selectors', () => {
 		test( "should return the site's front page type", () => {
 			const frontPageType = getSiteFrontPageType(
 				{
-					siteSettings: {
+					sites: {
 						items: {
 							77203074: {
-								show_on_front: 'page',
-								page_on_front: 1,
-								page_for_posts: 2,
+								options: {
+									show_on_front: 'page',
+									page_on_front: 1,
+									page_for_posts: 2,
+								},
 							},
 						},
 					},


### PR DESCRIPTION
#### Context

In #35141 and #35189 I've added the "Set as Homepage" and "Set as Posts Page" actions by using the `/sites/:site/homepage` endpoint to save the front page options, instead of extending the `/sites/:site/settings` endpoint, which would have required involving Jetpack, and complicating our FSE release.

This approach required more data in state. In particular it required to transfer the front page options to the `siteSettings` store to be manipulated, and then a `QuerySiteFrontPage` component (#35201) to keep them updated on boot.

Though, I've realized that I was overcomplicating the solution: forcing options into settings was brittle, and could easily lead to stale data.

In this PR I've simply revert everything to use the site options instead of the settings, and update accordingly both the data layer and the usages of the front page actions.

#### Changes proposed in this Pull Request

* Revert the logic introduced in #35141 and #35189: now the front page options will rely again on site options, instead of site settings.
* Also revert all the changed tests.
* Move the `updateSiteFrontPage` action to `sites`, along with a new reducer case. Update the data layer accordingly.
* Update the usage of the action in the Pages list.
* Simplify the various parameter names, to be the same as their respective WP options.

#### Testing instructions

* On a FSE site:
  * Check if the Customizer link in the sidebar is hidden.
  * Check if the actions in the Pages list include "Set as Homepage", but not "Set as Posts Page".
* On a non-FSE site:
  * Check if the Customizer link is visible.
  * If the site has a static front page, check if both "Set as Homepage" and "Set as Posts Page" actions are available in the Pages list.
* Try setting pages as homepage and posts page.
* Make sure the update works, and the changes stick after a reload.