### PR TITLE
Full Site Editing: create default About and Contact pages

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -101,15 +101,18 @@ function load_starter_page_templates() {
 add_action( 'plugins_loaded', __NAMESPACE__ . '\load_starter_page_templates' );
 
 /**
- * Inserts default template data for current theme during plugin activation.
+ * Inserts default full site editing data for current theme during plugin activation.
+ *
  * We usually perform this on theme activation hook, but this is needed to handle
- * the cases in which FSE supported theme was activated prior to the plugin.
+ * the cases in which FSE supported theme was activated prior to the plugin. This will
+ * populate the default header and footer for current theme, and create About and Contact
+ * pages provided that they don't already exist.
  */
 function populate_wp_template_data() {
 	require_once __DIR__ . '/full-site-editing/class-full-site-editing.php';
 	require_once __DIR__ . '/full-site-editing/templates/class-wp-template-inserter.php';
 
 	$fse = Full_Site_Editing::get_instance();
-	$fse->wp_template_inserter->insert_default_template_data();
+	$fse->insert_default_data();
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -57,7 +57,7 @@ class Full_Site_Editing {
 		add_filter( 'wp_insert_post_data', [ $this, 'remove_template_components' ], 10, 2 );
 		add_filter( 'admin_body_class', [ $this, 'toggle_editor_post_title_visibility' ] );
 		add_filter( 'block_editor_settings', [ $this, 'set_block_template' ] );
-		add_action( 'after_switch_theme', [ $this, 'insert_theme_template_data' ] );
+		add_action( 'after_switch_theme', [ $this, 'insert_default_data' ] );
 		add_filter( 'body_class', array( $this, 'add_fse_body_class' ) );
 
 		$this->theme_slug           = $this->normalize_theme_slug( get_option( 'stylesheet' ) );
@@ -94,18 +94,19 @@ class Full_Site_Editing {
 	 * This insertion will only happen if theme supports FSE.
 	 * It is hooked into after_switch_theme action.
 	 */
-	public function insert_theme_template_data() {
+	public function insert_default_data() {
 		// Bail if theme doesn't support FSE.
 		if ( ! $this->is_supported_theme( $this->theme_slug ) ) {
 			return;
 		}
 
-		// Bail if the data is already present.
-		if ( $this->wp_template_inserter->is_template_data_inserted() ) {
-			return;
+		if ( ! $this->wp_template_inserter->is_template_data_inserted() ) {
+			$this->wp_template_inserter->insert_default_template_data();
 		}
 
-		$this->wp_template_inserter->insert_default_template_data();
+		if ( ! $this->wp_template_inserter->is_pages_data_inserted() ) {
+			$this->wp_template_inserter->insert_default_pages();
+		}
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -42,6 +42,15 @@ class WP_Template_Inserter {
 	private $fse_template_data_option;
 
 	/**
+	 * This site option will be used to indicate that default page data has already been
+	 * inserted for this theme, in order to prevent this functionality from running
+	 * more than once.
+	 *
+	 * @var string $fse_page_data_option
+	 */
+	private $fse_page_data_option = 'fse-page-data-v1';
+
+	/**
 	 * WP_Template_Inserter constructor.
 	 *
 	 * @param string $theme_slug Current theme slug.
@@ -155,6 +164,72 @@ class WP_Template_Inserter {
 		wp_set_object_terms( $footer_id, "$this->theme_slug-footer", 'wp_template_type' );
 
 		add_option( $this->fse_template_data_option, true );
+	}
+
+	/**
+	 * Determines whether default pages have already been created.
+	 *
+	 * @return bool True if default pages have already been created, false otherwise.
+	 */
+	public function is_pages_data_inserted() {
+		return get_option( $this->fse_page_data_option ) ? true : false;
+	}
+
+	/**
+	 * Inserts default About and Contact pages based on Starter Page Templates content.
+	 *
+	 * The insertion will not happen if this data has been already inserted or if pages
+	 * with 'About' and 'Contact' titles already exist.
+	 */
+	public function insert_default_pages() {
+		// Bail if this data has already been inserted.
+		if ( $this->is_pages_data_inserted() ) {
+			return;
+		}
+
+		$request_url = 'https://public-api.wordpress.com/wpcom/v2/verticals/m1/templates';
+		$response    = wp_remote_get( $request_url );
+
+		if ( is_wp_error( $response ) ) {
+			return;
+		}
+
+		$api_response = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		$about_page_content   = '';
+		$contact_page_content = '';
+
+		if ( ! empty( $api_response['templates'][6]['content'] ) ) {
+			$about_page_content = $api_response['templates'][6]['content'];
+		}
+
+		if ( ! empty( $api_response['templates'][1]['content'] ) ) {
+			$contact_page_content = $api_response['templates'][1]['content'];
+		}
+
+		if ( empty( get_page_by_title( 'About' ) ) ) {
+			wp_insert_post(
+				[
+					'post_title'   => 'About',
+					'post_content' => $about_page_content,
+					'post_status'  => 'publish',
+					'post_type'    => 'page',
+				]
+			);
+		}
+
+		if ( empty( get_page_by_title( 'Contact' ) ) ) {
+			wp_insert_post(
+				[
+					'post_title'   => 'Contact',
+					'post_content' => $contact_page_content,
+					'post_status'  => 'publish',
+					'post_type'    => 'page',
+				]
+			);
+		}
+
+		update_option( $this->fse_page_data_option, true );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -199,6 +199,10 @@ class WP_Template_Inserter {
 		$about_page_content   = '';
 		$contact_page_content = '';
 
+		/*
+		 * Array of returned templates is not keyed by name, so we have to access it directly like this.
+		 * About page is at position 6 in the array, and Contact page at 1.
+		 */
 		if ( ! empty( $api_response['templates'][6]['content'] ) ) {
 			$about_page_content = $api_response['templates'][6]['content'];
 		}
@@ -210,7 +214,7 @@ class WP_Template_Inserter {
 		if ( empty( get_page_by_title( 'About' ) ) ) {
 			wp_insert_post(
 				[
-					'post_title'   => 'About',
+					'post_title'   => _x( 'About', 'Default page title', 'full-site-editing' ),
 					'post_content' => $about_page_content,
 					'post_status'  => 'publish',
 					'post_type'    => 'page',
@@ -221,7 +225,7 @@ class WP_Template_Inserter {
 		if ( empty( get_page_by_title( 'Contact' ) ) ) {
 			wp_insert_post(
 				[
-					'post_title'   => 'Contact',
+					'post_title'   => _x( 'Contact', 'Default page title', 'full-site-editing' ),
 					'post_content' => $contact_page_content,
 					'post_status'  => 'publish',
 					'post_type'    => 'page',

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -187,8 +187,14 @@ class WP_Template_Inserter {
 			return;
 		}
 
-		$request_url = 'https://public-api.wordpress.com/wpcom/v2/verticals/m1/templates';
-		$response    = wp_remote_get( $request_url );
+		$request_url = add_query_arg(
+			[
+				'_locale' => $this->get_iso_639_locale(),
+			],
+			'https://public-api.wordpress.com/wpcom/v2/verticals/m1/templates'
+		);
+
+		$response = wp_remote_get( $request_url );
 
 		if ( is_wp_error( $response ) ) {
 			return;
@@ -234,6 +240,23 @@ class WP_Template_Inserter {
 		}
 
 		update_option( $this->fse_page_data_option, true );
+	}
+
+	/**
+	 * Returns ISO 639 conforming locale string.
+	 *
+	 * @return string ISO 639 locale string
+	 */
+	public function get_iso_639_locale() {
+		$language = strtolower( get_locale() );
+
+		if ( in_array( $language, [ 'zh_tw', 'zh-tw', 'zh_cn', 'zh-cn' ], true ) ) {
+			$language = str_replace( '_', '-', $language );
+		} else {
+			$language = preg_replace( '/([-_].*)$/i', '', $language );
+		}
+
+		return $language;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Create default About and Contact pages on plugin activation or theme switching
provided that these don't already exist.

Fixes https://github.com/Automattic/wp-calypso/issues/35176

#### Testing instructions

1. Make sure that you test site doesn't have About and Contact pages.
2. Reactivate FSE plugin **or** switch to Modern Business theme while the plugin is active.
3. Verify that About and Contact pages have been inserted and populated with default SPT content.
4. Verify that repeating step 2 doesn't duplicate these pages.
5. If site already had pages with these titles, the created shouldn't occur.

