### PR TITLE
Fix broken link to yearly plans

### DIFF
--- a/client/my-sites/plan-interval-discount/index.js
+++ b/client/my-sites/plan-interval-discount/index.js
@@ -37,7 +37,7 @@ class PlanIntervalDiscount extends Component {
 	}
 
 	renderYearlyViewDiscountInfo() {
-		const { currencyCode, discountPrice, originalPrice } = this.props;
+		const { basePlansPath, currencyCode, discountPrice, originalPrice } = this.props;
 
 		// Ensure we have required props.
 		if ( ! currencyCode || ! discountPrice || ! originalPrice ) {
@@ -45,11 +45,17 @@ class PlanIntervalDiscount extends Component {
 		}
 
 		const price = this.getDiscountPriceObject();
-		const { translate } = this.props;
-		return translate( 'Save {{b}}%(symbol)s%(integer)s%(fraction)s{{/b}} over monthly.', {
-			args: price,
-			components: { b: <b /> },
-		} );
+		const { siteSlug, translate } = this.props;
+		return translate(
+			'Save {{b}}%(symbol)s%(integer)s%(fraction)s{{/b}} over {{Link}}monthly{{/Link}}.',
+			{
+				args: price,
+				components: {
+					b: <b />,
+					Link: <a href={ plansLink( basePlansPath, siteSlug, 'monthly', true ) } />,
+				},
+			}
+		);
 	}
 
 	renderMonthlyViewDiscountInfo() {
@@ -67,7 +73,7 @@ class PlanIntervalDiscount extends Component {
 			{
 				args: price,
 				components: {
-					Link: <a href={ plansLink( basePlansPath, siteSlug, 'yearly' ) } />,
+					Link: <a href={ plansLink( basePlansPath, siteSlug, 'yearly', true ) } />,
 					b: <b />,
 				},
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug found by @simison in https://github.com/Automattic/wp-calypso/pull/35202#pullrequestreview-272405430
* Yearly link in plan discount prompt didn't work
* This PR also links back to monthly from a similar location

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go through the connect flow on the new Jetpack site
* When you get to the plans page, try clicking the "yearly" link within the plan description. It should switch to yearly pricing.
* Click the "monthly" link, should go back to monthly.

