### PR TITLE
Full Site Editing: refactor createHigherOrderComponent usage

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
@@ -1,8 +1,7 @@
-/* global wp */
-
 /**
  * External dependencies
  */
+import { createHigherOrderComponent } from '@wordpress/compose';
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
@@ -30,7 +29,6 @@ registerBlockType( 'a8c/post-content', {
 	save,
 } );
 
-const { createHigherOrderComponent } = wp.compose;
 const addContentSlotClassname = createHigherOrderComponent( BlockListBlock => {
 	return props => {
 		if ( props.name !== 'a8c/post-content' ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Refactor `createHigherOrderComponent` usage for consistency and removing `wp` global usage. Follow up to https://github.com/Automattic/wp-calypso/pull/35081.

#### Testing instructions

* Follow the testing instructions in https://github.com/Automattic/wp-calypso/pull/35081 and make sure that functionality is intact.