### PR TITLE
Fix bug which lost site URL when selecting Jetpack plan duration from discount link

### DIFF
--- a/client/my-sites/plan-features/header.jsx
+++ b/client/my-sites/plan-features/header.jsx
@@ -391,8 +391,8 @@ PlanFeaturesHeader.defaultProps = {
 	siteSlug: '',
 };
 
-export default connect( ( state, { isInSignup, planType, relatedMonthlyPlan } ) => {
-	const selectedSiteId = isInSignup ? null : getSelectedSiteId( state );
+export default connect( ( state, { planType, relatedMonthlyPlan } ) => {
+	const selectedSiteId = getSelectedSiteId( state );
 	const currentSitePlan = getCurrentPlan( state, selectedSiteId );
 	const isYearly = !! relatedMonthlyPlan;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Fixes a bug exposed by https://github.com/Automattic/wp-calypso/pull/35227
* In-plan yearly/monthly discount link for Jetpack was losing context of site slug
* This may break other things, as it removes an isInSignup check from the plans header - please check all places we use this component

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Connect a new Jetpack site
* On plans page, click "yearly" link for discount offer
* Buy plan
* Should go to checkout - previously was landing the user on the "enter URL" page for the Jetpack flow

#### Update

Turns out, this value was originally (in 2016) set to null in order to hide the plan duration toggle for Jetpack users (https://github.com/Automattic/wp-calypso/commit/43a2a5d10d65f1d4f900833f41533dd399ab6e7b). Given that, I feel more comfortable reverting it. Hopefully it doesn't break anything for non-Jetpack users.

