### PR TITLE
FSE: Make the editor background selector less specific

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -18,8 +18,14 @@
 		flex: none;
 		margin: 40px;
 		box-shadow: 0 0 20px 0 rgba( 0, 0, 0, 0.1 );
-		background: #fff;
 	}
+}
+
+// We separate this from the other styles so that
+// the theme style can override this class without
+// having to get as specific.
+.editor-styles-wrapper {
+	background: #fff;
 }
 
 .post-type-page {


### PR DESCRIPTION
We want the theme style to override this color, which it can't do if the selector is extremely specific. This targets the same class the theme style will target (https://github.com/Automattic/themes/pull/1219), so the theme can take priority.

#### Changes proposed in this Pull Request
1. Use a less specific selector to target the editor background color

#### Testing instructions*
1. Pull this change and run it in your local FSE environment. Also use modern business as your theme.
2. Make sure that the editor background color is still white as expected in all editors.
3. Follow the instructions in https://github.com/Automattic/themes/pull/1219 now that these changes are running.