### PR TITLE
Site Selector: Change appearance and placement of private site icon/flag

### DIFF
--- a/client/blocks/site/index.jsx
+++ b/client/blocks/site/index.jsx
@@ -143,12 +143,11 @@ class Site extends React.Component {
 				>
 					<SiteIcon site={ site } size={ this.props.compact ? 24 : 32 } />
 					<div className="site__info">
-						<div className="site__title">
+						<div className="site__title">{ site.title }</div>
+						<div className="site__domain">
 							{ /* eslint-disable wpcalypso/jsx-gridicon-size */ }
 							{ this.props.site.is_private && (
-								<span className="site__badge">
-									<Gridicon icon="lock" size={ 14 } />
-								</span>
+								<span className="site__badge site__badge-private">{ translate( 'Private' ) }</span>
 							) }
 							{ site.options && site.options.is_redirect && (
 								<span className="site__badge">
@@ -161,9 +160,6 @@ class Site extends React.Component {
 								</span>
 							) }
 							{ /* eslint-enable wpcalypso/jsx-gridicon-size */ }
-							{ site.title }
-						</div>
-						<div className="site__domain">
 							{ this.props.homeLink
 								? translate( 'View %(domain)s', {
 										args: { domain: site.domain },

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -92,7 +92,7 @@
 	height: 30px;
 	width: 30px;
 	overflow: hidden;
-	align-self: center;
+	align-self: flex-start;
 	margin-right: 8px;
 	flex: 0 0 auto;
 }
@@ -108,7 +108,7 @@
 	display: block;
 	font-size: 13px;
 	font-weight: 400;
-	line-height: 1.4;
+	line-height: 1.3;
 }
 
 .site__domain {
@@ -117,6 +117,7 @@
 	max-width: 95%;
 	font-size: 11px;
 	line-height: 1.4;
+	margin-top: 2px;
 }
 
 .site__title,
@@ -142,7 +143,7 @@
 	transform: translate3d( 0, 0, 0 );
 	position: absolute;
 	left: 16px;
-	top: 17px;
+	top: 16px;
 
 	.gridicon {
 		margin-top: 5px;
@@ -168,7 +169,17 @@
 }
 
 .site__badge {
-	color: var( --color-neutral );
+	color: var( --sidebar-gridicon-fill );
 	margin-right: 4px;
 	vertical-align: middle;
+}
+
+.site__badge.site__badge-private {
+	background: var( --sidebar-menu-hover-background );
+	color: var( --sidebar-menu-hover-color );
+	font-size: 12px;
+	border-radius: 12px;
+	display: inline-block;
+	padding: 2px 10px;
+	vertical-align: baseline;
 }

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -186,10 +186,6 @@
 		@include long-content-fade( $color: var( --sidebar-background-gradient ) );
 	}
 	
-	.site__badge {
-		color: var( --sidebar-gridicon-fill );
-	}
-	
 	.site-selector {
 		&.is-large .site-selector__sites {
 			border-color: var( --sidebar-border-color );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Moves the site badge underneath the site title and next to the site domain
* Uses text "Private" for better clarity, rather than a lock icon
* Note this also moves other icon types (site redirect and domain-only sites) underneath the site title and next to the site domain.
* Should we update the site redirect and domain-only site badges to use text instead of an icon, too? This would provide more clarity and is a more accessible approach, since screen readers can't see the icons.
* Alternative solution to the one proposed in #35012

**Before**

<img width="273" alt="Screen Shot 2019-08-08 at 3 58 04 PM" src="https://user-images.githubusercontent.com/2124984/62733962-c2553180-b9f5-11e9-9125-b6763a0e0beb.png">

<img width="273" alt="Screen Shot 2019-08-08 at 3 58 15 PM" src="https://user-images.githubusercontent.com/2124984/62733963-c2553180-b9f5-11e9-9aeb-4cae2a4a34f8.png">

**After**

<img width="272" alt="Screen Shot 2019-08-08 at 3 56 21 PM" src="https://user-images.githubusercontent.com/2124984/62733970-c8e3a900-b9f5-11e9-9fa7-f4139da512a7.png">

<img width="273" alt="Screen Shot 2019-08-08 at 3 56 40 PM" src="https://user-images.githubusercontent.com/2124984/62733971-c8e3a900-b9f5-11e9-9435-44c31c586974.png">

#### Testing instructions

* Switch to this PR
* Check the sidebar on a site that is private; you should see the above site privacy flag next to the domain.
* Check other color schemes to ensure there's sufficient contrast.
* Check other instances of the site selector (Write button in the masterbar, site selector when viewing a URL that has no site specified) to ensure they appear as expected.
* Check sites that use the redirect and/or domain-only icons to note the changed positions.
