### PR TITLE
EditCardDetails: Wait for response from updateCreditCard

### DIFF
--- a/client/blocks/credit-card-form/helpers.js
+++ b/client/blocks/credit-card-form/helpers.js
@@ -85,7 +85,7 @@ async function updateCreditCard( {
 } ) {
 	const cardDetails = kebabCaseFormFields( formFieldValues );
 	const updatedCreditCardApiParams = getParamsForApi( cardDetails, token, apiParams );
-	const response = wpcom.updateCreditCard( updatedCreditCardApiParams );
+	const response = await wpcom.updateCreditCard( updatedCreditCardApiParams );
 	if ( response.error ) {
 		throw new Error( response );
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In #34963, a bug was introduced in the update credit card flow. When a card is updated, it calls `Undocumented.prototype.updateCreditCard()` and then notifies the user of the result. However, I missed an `await` before that function, which means that we never actually wait for the result before telling the user that the card is updated. It will also miss any errors that might occur during the update process.

#### Testing instructions

1. Sandbox the store.
2. Make sure you have purchased something, then visit http://calypso.localhost:3000/me/purchases, click on a purchase, and then click on "Change Payment Method"
3. Fill out all the fields with a test card (eg: `4242424242424242`) and submit the form. It will help to use a unique name for the cardholder name.
4. Reload the resulting page (to force calypso to fetch the updated card data), then visit the purchase you updated again and click the "Payment method" text/icon. 
5. Be sure that the cardholder name shown is the same as the one you updated above.
