### PR TITLE
Private by Default: Put behind a config flag & enable in dev

### DIFF
--- a/client/lib/signup/private-by-default.ts
+++ b/client/lib/signup/private-by-default.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isEnabled } from 'config';
 import debugFactory from 'debug';
 
 /**
@@ -17,6 +18,10 @@ const debug = debugFactory( 'calypso:signup:private-by-default' );
  * @returns `true` for private by default & `false` for not
  */
 export function shouldBePrivateByDefault( siteType: string = '' ): boolean {
+	if ( ! isEnabled( 'private-by-default/non-atomic-plans' ) ) {
+		return false;
+	}
+
 	if ( getSiteTypePropertyValue( 'slug', siteType, 'forcePublicSite' ) ) {
 		return false;
 	}

--- a/config/development.json
+++ b/config/development.json
@@ -127,6 +127,7 @@
 		"post-editor/media-advanced": false,
 		"posts/post-type-list/bulk-edit": false,
 		"press-this": true,
+		"private-by-default/non-atomic-plans": true,
 		"privacy-policy": true,
 		"publicize-preview": true,
 		"push-notifications": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable new feature flag in development: `private-by-default/non-atomic-plans`
* If that's not enabled, return false for `shouldBePrivateByDefault`

#### Testing instructions

* Smoke test :)
