### PR TITLE
FSE: Update FSE frame based on feedback

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -16,8 +16,12 @@
 
 	.edit-post-layout__content .edit-post-visual-editor {
 		flex: none;
-		margin: 40px;
-		box-shadow: 0 0 20px 0 rgba( 0, 0, 0, 0.1 );
+		margin: 36px 32px;
+		box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14), 0 3px 1px -2px rgba(0,0,0,0.12), 0 1px 5px 0 rgba(0,0,0,0.20);
+
+		@media (max-width: 768px) {
+  			margin: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Addressing feedback in: https://github.com/Automattic/wp-calypso/pull/35116#issuecomment-518696096

Before: 

<img width="939" alt="Screen Shot 2019-08-08 at 2 13 10 PM" src="https://user-images.githubusercontent.com/1464705/62738248-b0b85d80-b9e6-11e9-9123-0b99c9e9d26e.png">

After:

<img width="938" alt="Screen Shot 2019-08-08 at 2 12 33 PM" src="https://user-images.githubusercontent.com/1464705/62738255-b31ab780-b9e6-11e9-9834-4d6d3ca40a55.png">

#### Testing instructions

* Edit or start a new page and confirm the frame looks like the after picture above.