### PR TITLE
Prevent domain search filters from persisting

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -205,6 +205,9 @@ class RegisterDomainStep extends React.Component {
 				this.state.railcarId = this.getNewRailcarId();
 			}
 		}
+
+		this.state.filters = this.getInitialFiltersState();
+		this.state.lastFilters = this.getInitialFiltersState();
 	}
 
 	getState() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We want to prevent the filter settings from persisting in the browser when a user opens search in a new tab.

#### Testing instructions

* Start with a search such as: http://calypso.localhost:3000/start/domain/domain-only?new=asdfasdfasdfasdfasdfawerwerwaerwe&search=yes
* Set a TLD filter using the "More Extensions" dropdown.
* Open a new tab with the same URL.
* Make sure that the TLD filter is not set.
* Try the same thing using filters in the Filters "gear" button.
