### PR TITLE
Narrow scope for 3rd party cookie redirect to just Atomic sites

### DIFF
--- a/client/gutenberg/editor/controller.js
+++ b/client/gutenberg/editor/controller.js
@@ -18,7 +18,8 @@ import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
 import { addQueryArgs } from 'lib/route';
 import { getSelectedEditor } from 'state/selectors/get-selected-editor';
 import { requestSelectedEditor } from 'state/selected-editor/actions';
-import { getSiteUrl, isJetpackSite } from 'state/sites/selectors';
+import { getSiteUrl } from 'state/sites/selectors';
+import isSiteWpcomAtomic from 'state/selectors/is-site-wpcom-atomic';
 import { isEnabled } from 'config';
 import { Placeholder } from './placeholder';
 import { makeLayout, render } from 'controller';
@@ -89,7 +90,7 @@ export const authenticate = ( context, next ) => {
 
 	const isAuthenticated =
 		sessionStorage.getItem( storageKey ) || // Previously authenticated.
-		! isJetpackSite( state, siteId ) || // Simple sites users are always authenticated.
+		! isSiteWpcomAtomic( state, siteId ) || // Simple sites users are always authenticated.
 		isEnabled( 'desktop' ) || // The desktop app can store third-party cookies.
 		context.query.authWpAdmin; // Redirect back from the WP Admin login page to Calypso.
 	if ( isAuthenticated ) {


### PR DESCRIPTION
Currently Jetpack sites without SSO enabled are not redirecting back to Calypso as wp_safe_redirect is sanitizing the redirect_to and sending user to wp-admin instead

#### Changes proposed in this Pull Request

* Checks if site is Atomic before redirecting 

**note:**  - this fix re-introduces the Safari 3rd party cookie issue again for Jetpack site users.

#### Testing instructions

* Apply patch to local calypso dev ennviroment
* Try to edit a page in a simple site - no login redirect should occur
* Try to edit a page in a Jetpack site  - no login redirect should occur
* Try to edit a page in an Atomic site - an initial redirect to the auth the site should occur and a redirect back to the editor


