### PR TITLE
EditCardDetails: Switch to Stripe Elements

### DIFF
--- a/client/blocks/credit-card-form/helpers.js
+++ b/client/blocks/credit-card-form/helpers.js
@@ -47,6 +47,7 @@ export async function saveOrUpdateCreditCard( {
 		siteSlug,
 		token,
 		translate,
+		stripeConfiguration,
 	} );
 }
 
@@ -82,9 +83,15 @@ async function updateCreditCard( {
 	siteSlug,
 	token,
 	translate,
+	stripeConfiguration,
 } ) {
 	const cardDetails = kebabCaseFormFields( formFieldValues );
-	const updatedCreditCardApiParams = getParamsForApi( cardDetails, token, apiParams );
+	const updatedCreditCardApiParams = getParamsForApi(
+		cardDetails,
+		token,
+		stripeConfiguration,
+		apiParams
+	);
 	const response = await wpcom.updateCreditCard( updatedCreditCardApiParams );
 	if ( response.error ) {
 		throw new Error( response );
@@ -110,7 +117,7 @@ async function updateCreditCard( {
 	} );
 }
 
-export function getParamsForApi( cardDetails, cardToken, extraParams = {} ) {
+export function getParamsForApi( cardDetails, cardToken, stripeConfiguration, extraParams = {} ) {
 	return {
 		...extraParams,
 		country: cardDetails.country,
@@ -125,7 +132,8 @@ export function getParamsForApi( cardDetails, cardToken, extraParams = {} ) {
 		city: cardDetails.city,
 		state: cardDetails.state,
 		phone_number: cardDetails[ 'phone-number' ],
-		cardToken,
+		payment_partner: stripeConfiguration ? stripeConfiguration.processor_id : '',
+		paygate_token: cardToken,
 	};
 }
 

--- a/client/blocks/credit-card-form/test/index.js
+++ b/client/blocks/credit-card-form/test/index.js
@@ -115,7 +115,8 @@ describe( 'Credit Card Form', () => {
 				city: 'city',
 				state: 'state',
 				phone_number: '+31222222',
-				cardToken: {},
+				paygate_token: {},
+				payment_partner: '',
 			} );
 		} );
 	} );

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1146,9 +1146,15 @@ Undocumented.prototype.transactions = function( method, data, fn ) {
 };
 
 Undocumented.prototype.updateCreditCard = function( params, fn ) {
-	const data = pick( params, [ 'country', 'zip', 'month', 'year', 'name' ] );
-	data.paygate_token = params.cardToken;
-
+	const data = pick( params, [
+		'country',
+		'zip',
+		'month',
+		'year',
+		'name',
+		'payment_partner',
+		'paygate_token',
+	] );
 	return this.wpcom.req.post( '/upgrades/' + params.purchaseId + '/update-credit-card', data, fn );
 };
 

--- a/client/me/purchases/payment/edit-card-details/index.jsx
+++ b/client/me/purchases/payment/edit-card-details/index.jsx
@@ -29,6 +29,9 @@ import { getStoredCardById, hasLoadedStoredCardsFromServer } from 'state/stored-
 import { isRequestingSites } from 'state/sites/selectors';
 import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { withStripe } from 'lib/stripe';
+
+const CreditCardFormWithStripe = withStripe( CreditCardForm, { needs_intent: true } );
 
 function EditCardDetails( props ) {
 	const isDataLoading = ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
@@ -78,7 +81,7 @@ function EditCardDetails( props ) {
 				{ titles.editCardDetails }
 			</HeaderCake>
 
-			<CreditCardForm
+			<CreditCardFormWithStripe
 				apiParams={ { purchaseId: props.purchase.id } }
 				createCardToken={ createCardUpdateToken }
 				initialValues={ props.card }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the `EditCardDetails` component to use Stripe Elements and Payment Intents (see previous work in #34848).

Depends on:
- [x] Clean up of `EditCardDetails`: #35237
- [x] Fixing a missing endpoint field: D31360-code

#### Testing instructions

2. Sandbox the API and the store.
3. Make sure you have purchased something, then visit http://calypso.localhost:3000/me/purchases, click on a purchase, and then click on "Change Payment Method"
4. Verify that the placeholder for the card number field is numbers and not dots (this verifies that you are seeing the Stripe field).
4. Fill out all the fields with a unique cardholder name (something different than the subscription's current cardholder name) and with a Stripe test card (eg: `4242 4242 4242 4242`) and submit the form.
5. Verify that you get a success message and are redirected to the purchase page again.
5. Reload the resulting page (to force calypso to fetch the updated card data), then click the "Payment method" text/icon.
6. Be sure that the cardholder name shown is the same as the one you updated above.