### PR TITLE
Full Site Editing: add `test-fse` flow to signup for horizon and localhost

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -9,7 +9,7 @@ import { translate } from 'i18n-calypso';
 /**
  * Internal dependencies
  */
-import config from 'config';
+import { isEnabled } from 'config';
 import { addQueryArgs } from 'lib/route';
 
 export function generateFlows( {
@@ -202,7 +202,7 @@ export function generateFlows( {
 		},
 	};
 
-	if ( config.isEnabled( 'rewind/clone-site' ) ) {
+	if ( isEnabled( 'rewind/clone-site' ) ) {
 		flows[ 'clone-site' ] = {
 			steps: [
 				'clone-start',
@@ -220,7 +220,7 @@ export function generateFlows( {
 		};
 	}
 
-	if ( config.isEnabled( 'signup/atomic-store-flow' ) ) {
+	if ( isEnabled( 'signup/atomic-store-flow' ) ) {
 		// Important: For any changes done to the ecommerce flow,
 		// please copy the same changes to ecommerce-onboarding flow too
 		flows.ecommerce = {
@@ -238,7 +238,7 @@ export function generateFlows( {
 		};
 	}
 
-	if ( config.isEnabled( 'signup/wpcc' ) ) {
+	if ( isEnabled( 'signup/wpcc' ) ) {
 		flows.wpcc = {
 			steps: [ 'oauth2-user' ],
 			destination: getRedirectDestination,
@@ -356,6 +356,22 @@ export function generateFlows( {
 		description: 'Signup flow for creating an online store, with user step in last position',
 		lastModified: '2019-07-19',
 	};
+
+	if ( isEnabled( 'signup/full-site-editing' ) ) {
+		flows[ 'test-fse' ] = {
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'domains-with-preview',
+				'plans',
+			],
+			destination: getSignupDestination,
+			description: 'A copy of `onboarding` for testing Full Site Editing',
+			lastModified: '2019-08-08',
+		};
+	}
 
 	return flows;
 }

--- a/config/development.json
+++ b/config/development.json
@@ -155,6 +155,7 @@
 		"sign-in-with-apple": true,
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": true,
+		"signup/full-site-editing": true,
 		"signup/import-flow": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -96,6 +96,7 @@
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
 		"settings/theme-setup": false,
+		"signup/full-site-editing": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,


### PR DESCRIPTION
This flow, only enabled on horizon and in local development, will allow us to open up Full Site Editing to more broad testing.

#### Changes proposed in this Pull Request

* Add a `/start/fse-test` flow to signup

#### Testing instructions

* sandbox `public-api.wordpress.com`
* apply D31362-code to your sandbox
* Create a new site with **a new user** through http://calypso.localhost:3000/start/test-fse
* Verify that, after the site is created, your site is enrolled in Full Site Editing by seeing that the Customizer link in the sidebar:

<img width="274" alt="image" src="https://user-images.githubusercontent.com/195089/62250020-73821900-b3b1-11e9-94fe-647e528f795b.png">

Fixes #35179