### PR TITLE
Syntax: fix JSX syntax error in Gauge component

### DIFF
--- a/client/components/gauge/index.jsx
+++ b/client/components/gauge/index.jsx
@@ -65,15 +65,15 @@ export default class extends React.PureComponent {
 							d={ this.getPathDefinition( 100 ) }
 							fill="none"
 							stroke={ colorBg }
-							stroke-width={ lineWidth }
-							stroke-linecap="round"
+							strokeWidth={ lineWidth }
+							strokeLinecap="round"
 						/>
 						<path
 							d={ this.getPathDefinition( percentage ) }
 							fill="none"
 							stroke={ colorFg }
-							stroke-width={ lineWidth }
-							stroke-linecap="round"
+							strokeWidth={ lineWidth }
+							strokeLinecap="round"
 						/>
 					</svg>
 					<span className="gauge__label" style={ labelStyles }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Change SVG attributes `stroke-width` and `stroke-linecap` to JSX syntax compliant `strokeWidth` and `strokeLinecap`. 

#### Testing instructions

1. Using Chrome, navigate to a page using Gauge component, like https://calypso.localhost:3000/stats/day/{site_slug} when site icon is not set (may need an Atomic or Jetpack site).

<img width="752" alt="screenshot_839" src="https://user-images.githubusercontent.com/127594/62744979-e9affc80-b9fd-11e9-88c3-da8d70a97f01.png">


2. Verify that DevTools Console does not show following warnings:

<img width="633" alt="screenshot_840" src="https://user-images.githubusercontent.com/127594/62745118-5c20dc80-b9fe-11e9-95dd-b52d437c2038.png">
<img width="639" alt="screenshot_841" src="https://user-images.githubusercontent.com/127594/62745122-5fb46380-b9fe-11e9-9f01-89cb2e0154df.png">

*

Fixes #
