### PR TITLE
FSE: Add a retry to the request for fse templates and default page content

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -79,9 +79,9 @@ class WP_Template_Inserter {
 			'body' => [ 'theme_slug' => $this->theme_slug ],
 		];
 
-		$response = wp_remote_get( $request_url, $request_args );
+		$response = $this->fetch_retry( $request_url, $request_args );
 
-		if ( is_wp_error( $response ) ) {
+		if ( ! $response ) {
 			return;
 		}
 
@@ -96,6 +96,31 @@ class WP_Template_Inserter {
 		if ( ! empty( $api_response['footers'] ) ) {
 			$this->footer_content = $api_response['footers'][0];
 		}
+	}
+
+	/**
+	 * Retries a call to wp_remote_get on error.
+	 *
+	 * @param string $request_url Url of the api call to make.
+	 * @param string $request_args Addtional arguments for the api call.
+	 * @param int    $attempt The number of the attempt being made.
+	 * @return array wp_remote_get reponse array
+	 */
+	private function fetch_retry( $request_url, $request_args = null, $attempt = 1 ) {
+		$max_retries = 3;
+
+		$response = wp_remote_get( $request_url, $request_args );
+
+		if ( ! is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( $attempt >= $max_retries ) {
+			return;
+		}
+
+		$attempt++;
+		$this->fetch_retry( $request_url, $request_args, $attempt );
 	}
 
 	/**
@@ -194,9 +219,9 @@ class WP_Template_Inserter {
 			'https://public-api.wordpress.com/wpcom/v2/verticals/m1/templates'
 		);
 
-		$response = wp_remote_get( $request_url );
+		$response = $this->fetch_retry( $request_url );
 
-		if ( is_wp_error( $response ) ) {
+		if ( ! $response ) {
 			return;
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -119,6 +119,7 @@ class WP_Template_Inserter {
 			return;
 		}
 
+		sleep( pow( 2, $attempt ) );
 		$attempt++;
 		$this->fetch_retry( $request_url, $request_args, $attempt );
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php
@@ -115,7 +115,7 @@ class WP_Template_Inserter {
 			return $response;
 		}
 
-		if ( $attempt >= $max_retries ) {
+		if ( $attempt > $max_retries ) {
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds 3 retries on error for the requests to the API for template and default page data

#### Testing instructions

* Checkout patch to your FSE test environment
* Deactivate modern-business theme and remove `fse-page-data-v1` & `modern-business-fse-template-data-v1` options
* Re-enable modern-business and check that template and default page data has been populated correctly
* Not sure on best/easiest way to test the retries, but one option is to change API address at https://github.com/Automattic/wp-calypso/blob/master/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php#L76 to a bogus address and add some debugging to check that https://github.com/Automattic/wp-calypso/blob/add/fse-template-content-retry/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template-inserter.php#L109 is called 4 times in total before activation continues. In this circumstance no template data will be added.

Part of fix for #35077
