### PR TITLE
Add/private by default  poll transfer status thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -121,7 +121,7 @@ export class CheckoutThankYou extends React.Component {
 		fetchAtomicTransfer: identity,
 	};
 
-	maybeFetchAtomicTransfer() {
+	maybeFetchAtomicTransfer = () => {
 		const { atomicTransfer, selectedSite } = this.props;
 
 		if ( ! isEmpty( atomicTransfer ) ) {
@@ -130,7 +130,7 @@ export class CheckoutThankYou extends React.Component {
 		if ( selectedSite && ! this.props.isFetchingTransfer ) {
 			this.props.fetchAtomicTransfer( selectedSite );
 		}
-	}
+	};
 
 	componentDidMount() {
 		this.redirectIfThemePurchased();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Poll for the atomic transfer status on the checkout "thank you" page

#### Testing instructions

* `/start`
* select the `control` group of the `privateByDefault` AB Test
* Create a free plan site in any segment
* Set it private (`Manage | Settings | Privacy`)
* Click `Plan | Business Sites and Online Stores`
* Click the `Upgrade` for the `eCommerce` plan
  * you should see the "going public" dialog
* Click `Let's do it`
* Complete the checkout
* You should not be stuck at the "Processing" screen.

Fixes #
