### PR TITLE
Private-by-Default: Fix free to ecomm plan upgrade on private sites

### DIFF
--- a/client/lib/upgrades/notices.jsx
+++ b/client/lib/upgrades/notices.jsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react'; // eslint-disable-line no-unused-vars
-import { flatten, values } from 'lodash';
+import { flatten, get, values } from 'lodash';
 import i18n from 'i18n-calypso';
 
 /**
@@ -39,10 +39,11 @@ function getErrorFromApi( errorMessage ) {
 }
 
 export function displayError( error ) {
-	if ( typeof error.message === 'object' ) {
-		notices.error( <ValidationErrorList messages={ flatten( values( error.message ) ) } /> );
+	const message = get( error, 'message' );
+	if ( typeof message === 'object' ) {
+		notices.error( <ValidationErrorList messages={ flatten( values( message ) ) } /> );
 	} else {
-		notices.error( getErrorFromApi( error.message ) );
+		notices.error( getErrorFromApi( message ) );
 	}
 }
 

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -193,7 +193,7 @@ export class SecurePaymentForm extends Component {
 		} );
 	};
 
-	submitTransaction( event ) {
+	async submitTransaction( event ) {
 		event && event.preventDefault();
 
 		const params = pick( this.props, [ 'cart', 'transaction' ] );
@@ -213,12 +213,12 @@ export class SecurePaymentForm extends Component {
 			params.transaction.payment.paymentMethod = 'WPCOM_Billing_MoneyPress_Paygate';
 		}
 
-		this.maybeSetSiteToPublic( { cart: params.cart } );
+		await this.maybeSetSiteToPublic( { cart: params.cart } );
 
 		submitTransaction( params );
 	}
 
-	maybeSetSiteToPublic( { cart } ) {
+	async maybeSetSiteToPublic( { cart } ) {
 		const { isJetpack, selectedSiteId, siteIsPrivate } = this.props;
 
 		if ( isJetpack || ! siteIsPrivate ) {
@@ -233,10 +233,13 @@ export class SecurePaymentForm extends Component {
 		} );
 
 		if ( forcedAtomicProducts.length ) {
-			defer( () => {
-				// Until Atomic sites support being private / unlaunched, set them to public on upgrade
-				this.props.saveSiteSettings( selectedSiteId, { blog_public: 1 } );
-				debug( 'Setting site to public because it is an Atomic plan' );
+			await new Promise( resolve => {
+				defer( async () => {
+					// Until Atomic sites support being private / unlaunched, set them to public on upgrade
+					await this.props.saveSiteSettings( selectedSiteId, { blog_public: 1 } );
+					debug( 'Setting site to public because it is an Atomic plan' );
+					resolve();
+				} );
 			} );
 		}
 	}

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -217,7 +217,7 @@ export class SecurePaymentForm extends Component {
 			await this.maybeSetSiteToPublic( { cart: params.cart } );
 		} catch ( e ) {
 			debug( 'Error setting site to public', e );
-			// TODO: Bubble this up to the error notice
+			displayError();
 			return;
 		}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

If the checkout determines the site needs to be switched to `blog_public=1` before purchasing, then it now waits for the site setting to finish saving before proceeding to submit the transaction.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Fixes #
