### PR TITLE
Update Chromedriver to 76

### DIFF
--- a/test/e2e/lib/driver-manager.js
+++ b/test/e2e/lib/driver-manager.js
@@ -138,7 +138,6 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 				} );
 				options.setProxy( getProxyType() );
 				options.addArguments( '--no-first-run' );
-				options.addArguments( getChromeWindowSize( screenSize ) );
 
 				if ( useCustomUA ) {
 					options.addArguments(
@@ -207,7 +206,7 @@ export async function startBrowser( { useCustomUA = true, resizeBrowserWindow = 
 	await driver
 		.manage()
 		.setTimeouts( { implicit: webDriverImplicitTimeOutMS, pageLoad: webDriverPageLoadTimeOutMS } );
-	if ( resizeBrowserWindow && browser.toLowerCase() !== 'chrome' ) {
+	if ( resizeBrowserWindow ) {
 		await resizeBrowser( driver, screenSize );
 	}
 
@@ -255,39 +254,6 @@ export async function resizeBrowser( driver, screenSize ) {
 				'). Supported values are desktop, tablet and mobile.'
 		);
 	}
-}
-
-export function getChromeWindowSize( screenSize ) {
-	let windowSize;
-	if ( typeof screenSize === 'string' ) {
-		switch ( screenSize.toLowerCase() ) {
-			case 'mobile':
-				windowSize = '--window-size=400,1000';
-				break;
-			case 'tablet':
-				windowSize = '--window-size=1024,1000';
-				break;
-			case 'desktop':
-				windowSize = '--window-size=1440,1000';
-				break;
-			case 'laptop':
-				windowSize = '--window-size=1400,790';
-				break;
-			default:
-				throw new Error(
-					'Unsupported screen size specified (' +
-						screenSize +
-						'). Supported values are desktop, tablet and mobile.'
-				);
-		}
-	} else {
-		throw new Error(
-			'Unsupported screen size specified (' +
-				screenSize +
-				'). Supported values are desktop, tablet and mobile.'
-		);
-	}
-	return windowSize;
 }
 
 export async function clearCookiesAndDeleteLocalStorage( driver, siteURL = null ) {

--- a/test/e2e/package-lock.json
+++ b/test/e2e/package-lock.json
@@ -734,10 +734,30 @@
 			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
 			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
 		},
+		"@types/events": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+			"integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+		},
+		"@types/glob": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+			"integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+			"requires": {
+				"@types/events": "*",
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/long": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
 			"integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
+		},
+		"@types/minimatch": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+			"integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
 		},
 		"@types/node": {
 			"version": "10.12.23",
@@ -3014,11 +3034,11 @@
 			}
 		},
 		"chromedriver": {
-			"version": "74.0.0",
-			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-74.0.0.tgz",
-			"integrity": "sha512-xXgsq0l4gVTY9X5vuccOSVj/iEBm3Bf5MIwzSAASIRJagt4BlWw77SxQq1f4JAJ35/9Ys4NLMA/kWFbd7A/gfQ==",
+			"version": "76.0.0",
+			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-76.0.0.tgz",
+			"integrity": "sha512-jGyqs0N+lMo9iaNQxGKNPiLJWb2L9s2rwbRr1jJeQ37n6JQ1+5YMGviv/Fx5Z08vBWYbAvrKEzFsuYf8ppl+lw==",
 			"requires": {
-				"del": "^3.0.0",
+				"del": "^4.1.1",
 				"extract-zip": "^1.6.7",
 				"mkdirp": "^0.5.1",
 				"request": "^2.88.0",
@@ -3697,16 +3717,24 @@
 			"integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
 		},
 		"del": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-			"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+			"integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
 			"requires": {
+				"@types/glob": "^7.1.1",
 				"globby": "^6.1.0",
-				"is-path-cwd": "^1.0.0",
-				"is-path-in-cwd": "^1.0.0",
-				"p-map": "^1.1.1",
-				"pify": "^3.0.0",
-				"rimraf": "^2.2.8"
+				"is-path-cwd": "^2.0.0",
+				"is-path-in-cwd": "^2.0.0",
+				"p-map": "^2.0.0",
+				"pify": "^4.0.1",
+				"rimraf": "^2.6.3"
+			},
+			"dependencies": {
+				"pify": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+				}
 			}
 		},
 		"delayed-stream": {
@@ -6513,24 +6541,24 @@
 			}
 		},
 		"is-path-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+			"integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
 		},
 		"is-path-in-cwd": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+			"integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
 			"requires": {
-				"is-path-inside": "^1.0.0"
+				"is-path-inside": "^2.1.0"
 			}
 		},
 		"is-path-inside": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+			"integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
 			"requires": {
-				"path-is-inside": "^1.0.1"
+				"path-is-inside": "^1.0.2"
 			}
 		},
 		"is-plain-obj": {
@@ -6981,7 +7009,7 @@
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
 			"integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
 			"requires": {
-				"lodash._reinterpolate": "~3.0.0",
+				"lodash._reinterpolate": "^3.0.0",
 				"lodash.templatesettings": "^4.0.0"
 			}
 		},
@@ -6990,7 +7018,7 @@
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
 			"integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
 			"requires": {
-				"lodash._reinterpolate": "~3.0.0"
+				"lodash._reinterpolate": "^3.0.0"
 			}
 		},
 		"lodash.unescape": {
@@ -8016,9 +8044,9 @@
 			}
 		},
 		"p-map": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-			"integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+			"integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
 		},
 		"p-try": {
 			"version": "2.0.0",

--- a/test/e2e/package.json
+++ b/test/e2e/package.json
@@ -25,7 +25,7 @@
 		"@babel/runtime": "7.3.1",
 		"asana-phrase": "0.0.8",
 		"cached-path-relative": ">=1.0.2",
-		"chromedriver": "^74.0.0",
+		"chromedriver": "^76.0.0",
 		"concurrently": "^3.6.1",
 		"config": "1.28.0",
 		"cryptiles": ">=4.1.2",


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Now that Chrome 76 is the latest, we need to update Chromedriver so we can continue to run tests locally. The latest version changed how we can change the browser width so I updated that as well.

#### Testing instructions

* Ensure you are running Chrome 76
* `npm install` in test/e2e directory
* Run a few tests in desktop and mobile view ie.(from test/e2e directory) `./node_modules/.bin/mocha ./specs/wp-calypso-gutenberg-page-editor-spec.js` and `BROWSERSIZE=mobile ./node_modules/.bin/mocha ./specs/wp-calypso-gutenberg-page-editor-spec.js`
* Ensure that tests pass
