### PR TITLE
Signup: add escape hatch AB test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -171,13 +171,12 @@ export default {
 		assignmentMethod: 'userId',
 	},
 	signupEscapeHatch: {
-		datestamp: '20190821',
+		datestamp: '20190826',
 		variations: {
 			variant: 50,
 			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
-		localeTargets: 'any',
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -170,4 +170,13 @@ export default {
 		defaultVariation: 'hide',
 		assignmentMethod: 'userId',
 	},
+	signupEscapeHatch: {
+		datestamp: '20190809',
+		variations: {
+			variant: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -171,12 +171,13 @@ export default {
 		assignmentMethod: 'userId',
 	},
 	signupEscapeHatch: {
-		datestamp: '20190809',
+		datestamp: '20190812',
 		variations: {
 			variant: 50,
 			control: 50,
 		},
 		defaultVariation: 'control',
 		allowExistingUsers: true,
+		localeTargets: 'any',
 	},
 };

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -171,7 +171,7 @@ export default {
 		assignmentMethod: 'userId',
 	},
 	signupEscapeHatch: {
-		datestamp: '20190812',
+		datestamp: '20190821',
 		variations: {
 			variant: 50,
 			control: 50,

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -153,5 +153,13 @@ export function getAllSiteTypes() {
 			purchaseRequired: true,
 			forcePublicSite: true,
 		},
+		{
+			id: 6, // This value must correspond with its sibling in the /segments API results
+			slug: 'blank-canvas',
+			label: i18n.translate( 'Blank Canvas' ),
+			description: i18n.translate( 'Start with a blank site.' ),
+			theme: 'pub/refresh-2019',
+			designType: 'blog',
+		},
 	];
 }

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -8,6 +8,13 @@ import { find, get } from 'lodash';
 /**
  * Internal dependencies
  */
+import { abtest } from 'lib/abtest';
+
+const allowedSiteSegments = [ 1, 2, 3, 4 ];
+
+if ( 'variant' === abtest( 'signupEscapeHatch' ) ) {
+	allowedSiteSegments.push( 6 );
+}
 
 const getSiteTypePropertyDefaults = propertyKey =>
 	get(
@@ -75,7 +82,7 @@ export function getSiteTypePropertyValue( key, value, property, siteTypes = getA
  * @param  {Array} allowedSiteTypes Optional array of segment ids so that we can return all, some or no site type definitions.
  * @return {Array} current list of site types
  */
-export function getAllSiteTypes( allowedSiteTypes = [ 1, 2, 3, 4 ] ) {
+export function getAllSiteTypes( allowedSiteTypes = allowedSiteSegments ) {
 	return [
 		{
 			id: 2, // This value must correspond with its sibling in the /segments API results

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -10,10 +10,10 @@ import { find, get } from 'lodash';
  */
 import { abtest } from 'lib/abtest';
 
-const allowedSiteSegments = [ 1, 2, 3, 4 ];
+const allowedSiteTypeIds = [ 1, 2, 3, 4 ];
 
 if ( 'variant' === abtest( 'signupEscapeHatch' ) ) {
-	allowedSiteSegments.push( 6 );
+	allowedSiteTypeIds.push( 6 );
 }
 
 const getSiteTypePropertyDefaults = propertyKey =>
@@ -79,10 +79,10 @@ export function getSiteTypePropertyValue( key, value, property, siteTypes = getA
  *
  * Please don't modify the IDs for now until we can integrate the /segments API into Calypso.
  *
- * @param  {Array} allowedSiteTypes Optional array of segment ids so that we can return all, some or no site type definitions.
- * @return {Array} current list of site types
+ * @param  {Array} siteTypeIds Optional array of segment ids so that we can return all, some or no site type definitions.
+ * @return {Array}             current list of site types
  */
-export function getAllSiteTypes( allowedSiteTypes = allowedSiteSegments ) {
+export function getAllSiteTypes( siteTypeIds = allowedSiteTypeIds ) {
 	return [
 		{
 			id: 2, // This value must correspond with its sibling in the /segments API results
@@ -168,5 +168,5 @@ export function getAllSiteTypes( allowedSiteTypes = allowedSiteSegments ) {
 			description: i18n.translate( 'Create a blank website.' ),
 			theme: 'pub/refresh-2019',
 		},
-	].filter( siteType => allowedSiteTypes.indexOf( siteType.id ) >= 0 );
+	].filter( siteType => siteTypeIds.indexOf( siteType.id ) >= 0 );
 }

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -72,9 +72,10 @@ export function getSiteTypePropertyValue( key, value, property, siteTypes = getA
  *
  * Please don't modify the IDs for now until we can integrate the /segments API into Calypso.
  *
- * @return {array} current list of site types
+ * @param  {Array} allowedSiteTypes Optional array of segment ids so that we can return all, some or no site type definitions.
+ * @return {Array} current list of site types
  */
-export function getAllSiteTypes() {
+export function getAllSiteTypes( allowedSiteTypes = [ 1, 2, 3, 4 ] ) {
 	return [
 		{
 			id: 2, // This value must correspond with its sibling in the /segments API results
@@ -156,10 +157,9 @@ export function getAllSiteTypes() {
 		{
 			id: 6, // This value must correspond with its sibling in the /segments API results
 			slug: 'blank-canvas',
-			label: i18n.translate( 'Blank Canvas' ),
-			description: i18n.translate( 'Start with a blank site.' ),
+			label: i18n.translate( 'Start from scratch' ),
+			description: i18n.translate( 'Create a blank website.' ),
 			theme: 'pub/refresh-2019',
-			designType: 'blog',
 		},
-	];
+	].filter( siteType => allowedSiteTypes.indexOf( siteType.id ) >= 0 );
 }

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -9,8 +9,9 @@ import { find, get } from 'lodash';
  * Internal dependencies
  */
 
-// This ensures we don't return site type definitions for segments we don't wish to render in the UI, e.g., when rendering the list on the site type step.
-const allowedSiteTypeIds = [ 1, 2, 3, 4 ];
+// Default value for `siteTypeIds` argument in `getAllSiteTypes()`.
+// Allows for overriding to ensurs we don't return site type definitions for segments we don't wish to render in the UI, e.g., when rendering the list on the site type step.
+const allowedSiteTypeIds = [ 1, 2, 3, 4, 6 ];
 
 const getSiteTypePropertyDefaults = propertyKey =>
 	get(

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -8,13 +8,9 @@ import { find, get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { abtest } from 'lib/abtest';
 
+// This ensures we don't return site type definitions for segments we don't wish to render in the UI, e.g., when rendering the list on the site type step.
 const allowedSiteTypeIds = [ 1, 2, 3, 4 ];
-
-if ( 'variant' === abtest( 'signupEscapeHatch' ) ) {
-	allowedSiteTypeIds.push( 6 );
-}
 
 const getSiteTypePropertyDefaults = propertyKey =>
 	get(

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -10,7 +10,7 @@ import { find, get } from 'lodash';
  */
 
 // Default value for `siteTypeIds` argument in `getAllSiteTypes()`.
-// Allows for overriding to ensurs we don't return site type definitions for segments we don't wish to render in the UI, e.g., when rendering the list on the site type step.
+// Allows for overriding to ensure we don't return site type definitions for segments we don't wish to render in the UI, e.g., when rendering the list on the site type step.
 const allowedSiteTypeIds = [ 1, 2, 3, 4, 6 ];
 
 const getSiteTypePropertyDefaults = propertyKey =>

--- a/client/lib/signup/site-type.js
+++ b/client/lib/signup/site-type.js
@@ -165,7 +165,7 @@ export function getAllSiteTypes( siteTypeIds = allowedSiteTypeIds ) {
 			id: 6, // This value must correspond with its sibling in the /segments API results
 			slug: 'blank-canvas',
 			label: i18n.translate( 'Start from scratch' ),
-			description: i18n.translate( 'Create a blank website.' ),
+			description: i18n.translate( 'Skip setup and start with a blank website.' ),
 			theme: 'pub/refresh-2019',
 		},
 	].filter( siteType => siteTypeIds.indexOf( siteType.id ) >= 0 );

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -138,6 +138,13 @@ export function generateFlows( {
 			lastModified: '2019-06-20',
 		},
 
+		'blank-slate': {
+			steps: [ 'user', 'site-type', 'domains', 'plans' ],
+			destination: getSignupDestination,
+			description: 'A blank slate flow used with the `signupEscapeHatch` AB test',
+			lastModified: '2019-08-09',
+		},
+
 		desktop: {
 			steps: [ 'about', 'themes', 'domains', 'plans', 'user' ],
 			destination: getSignupDestination,

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -138,7 +138,7 @@ export function generateFlows( {
 			lastModified: '2019-06-20',
 		},
 
-		'blank-slate': {
+		'blank-canvas': {
 			steps: [ 'user', 'site-type', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'A blank slate flow used with the `signupEscapeHatch` AB test',

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -28,11 +28,13 @@ class SiteTypeForm extends Component {
 
 		// from localize() HoC
 		translate: PropTypes.func.isRequired,
+		siteTypeDefinitions: PropTypes.array,
 	};
 
 	static defaultProps = {
 		showDescriptions: true,
 		showPurchaseRequired: true,
+		siteTypeDefinitions: getAllSiteTypes(),
 	};
 
 	handleSubmit = type => {
@@ -43,12 +45,12 @@ class SiteTypeForm extends Component {
 	};
 
 	render() {
-		const { showDescriptions, showPurchaseRequired, translate } = this.props;
+		const { showDescriptions, showPurchaseRequired, siteTypeDefinitions, translate } = this.props;
 
 		return (
 			<>
 				<Card className="site-type__wrapper">
-					{ getAllSiteTypes().map( siteTypeProperties => (
+					{ siteTypeDefinitions.map( siteTypeProperties => (
 						<Card
 							className="site-type__option"
 							key={ siteTypeProperties.id }
@@ -76,6 +78,9 @@ class SiteTypeForm extends Component {
 	}
 }
 
-export default connect( null, {
-	recordTracksEvent,
-} )( localize( SiteTypeForm ) );
+export default connect(
+	null,
+	{
+		recordTracksEvent,
+	}
+)( localize( SiteTypeForm ) );

--- a/client/signup/steps/site-type/form.jsx
+++ b/client/signup/steps/site-type/form.jsx
@@ -34,7 +34,8 @@ class SiteTypeForm extends Component {
 	static defaultProps = {
 		showDescriptions: true,
 		showPurchaseRequired: true,
-		siteTypeDefinitions: getAllSiteTypes(),
+		// Specify which site types we'd like to render in the UI
+		siteTypeDefinitions: getAllSiteTypes( [ 1, 2, 3, 4 ] ),
 	};
 
 	handleSubmit = type => {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -17,32 +17,17 @@ import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
-import { getAllSiteTypes } from 'lib/signup/site-type';
 
 const siteTypeToFlowname = {
 	import: 'import-onboarding',
-	'blank-slate': 'blank-slate',
+	'blank-canvas': 'blank-canvas',
 	'online-store': 'ecommerce-onboarding',
 };
-
-const allowedSiteTypes = [ 1, 2, 3, 4 ];
-if ( 'variant' === abtest( 'signupEscapeHatch' ) ) {
-	allowedSiteTypes.push( 6 );
-}
-const siteTypeDefinitions = getAllSiteTypes( allowedSiteTypes );
 
 class SiteType extends Component {
 	componentDidMount() {
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 	}
-
-	handleBlankSlateClick = () => {
-		this.props.recordTracksEvent( 'calypso_signup_blank_slate_cta_click', {
-			flow: this.props.flowName,
-			step: this.props.stepName,
-		} );
-		this.submitStep( 'blank-slate' );
-	};
 
 	handleImportFlowClick = () => {
 		this.props.recordTracksEvent( 'calypso_signup_import_cta_click', {
@@ -89,7 +74,6 @@ class SiteType extends Component {
 					goToNextStep={ this.props.goToNextStep }
 					submitForm={ this.submitStep }
 					siteType={ siteType }
-					siteTypeDefinitions={ siteTypeDefinitions }
 				/>
 				{ this.renderImportButton() }
 			</Fragment>

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -91,7 +91,7 @@ class SiteType extends Component {
 
 		const headerText = translate( 'What kind of site are you building?' );
 		const subHeaderText = translate(
-			'This is just a starting point. You can add or change features later.'
+			"Choose a site type, answer a few questions, and we'll start you off with a fresh site and customized content."
 		);
 
 		return (

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -37,6 +37,8 @@ class SiteType extends Component {
 		this.submitStep( 'import' );
 	};
 
+	handleBlankCanvasButtonClick = () => this.submitStep( 'blank-canvas' );
+
 	submitStep = siteTypeValue => {
 		this.props.submitSiteType( siteTypeValue );
 
@@ -65,6 +67,20 @@ class SiteType extends Component {
 		);
 	}
 
+	renderStartWithBlankCanvasButton() {
+		if ( 'variant' !== abtest( 'signupEscapeHatch' ) ) {
+			return null;
+		}
+
+		return (
+			<div className="site-type__blank-canvas">
+				<Button borderless onClick={ this.handleBlankCanvasButtonClick }>
+					{ this.props.translate( 'Skip setup and start with a blank website.' ) }
+				</Button>
+			</div>
+		);
+	}
+
 	renderStepContent() {
 		const { siteType } = this.props;
 
@@ -75,6 +91,7 @@ class SiteType extends Component {
 					submitForm={ this.submitStep }
 					siteType={ siteType }
 				/>
+				{ this.renderStartWithBlankCanvasButton() }
 				{ this.renderImportButton() }
 			</Fragment>
 		);

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -20,6 +20,7 @@ import { recordTracksEvent } from 'state/analytics/actions';
 
 const siteTypeToFlowname = {
 	import: 'import-onboarding',
+	'blank-slate': 'blank-slate',
 	'online-store': 'ecommerce-onboarding',
 };
 
@@ -27,6 +28,14 @@ class SiteType extends Component {
 	componentDidMount() {
 		this.props.saveSignupStep( { stepName: this.props.stepName } );
 	}
+
+	handleBlankSlateClick = () => {
+		this.props.recordTracksEvent( 'calypso_signup_blank_slate_cta_click', {
+			flow: this.props.flowName,
+			step: this.props.stepName,
+		} );
+		this.submitStep( 'blank-slate' );
+	};
 
 	handleImportFlowClick = () => {
 		this.props.recordTracksEvent( 'calypso_signup_import_cta_click', {
@@ -64,6 +73,20 @@ class SiteType extends Component {
 		);
 	}
 
+	renderBlankSlateButton() {
+		if ( 'variant' !== abtest( 'signupEscapeHatch' ) ) {
+			return null;
+		}
+
+		return (
+			<div className="site-type__blank-slate">
+				<Button borderless onClick={ this.handleBlankSlateClick }>
+					{ this.props.translate( 'Need a site in a hurry? Start one from scratch.' ) }
+				</Button>
+			</div>
+		);
+	}
+
 	renderStepContent() {
 		const { siteType } = this.props;
 
@@ -75,6 +98,7 @@ class SiteType extends Component {
 					siteType={ siteType }
 				/>
 				{ this.renderImportButton() }
+				{ this.renderBlankSlateButton() }
 			</Fragment>
 		);
 	}

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -17,12 +17,19 @@ import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { getAllSiteTypes } from 'lib/signup/site-type';
 
 const siteTypeToFlowname = {
 	import: 'import-onboarding',
 	'blank-slate': 'blank-slate',
 	'online-store': 'ecommerce-onboarding',
 };
+
+const allowedSiteTypes = [ 1, 2, 3, 4 ];
+if ( 'variant' === abtest( 'signupEscapeHatch' ) ) {
+	allowedSiteTypes.push( 6 );
+}
+const siteTypeDefinitions = getAllSiteTypes( allowedSiteTypes );
 
 class SiteType extends Component {
 	componentDidMount() {
@@ -73,20 +80,6 @@ class SiteType extends Component {
 		);
 	}
 
-	renderBlankSlateButton() {
-		if ( 'variant' !== abtest( 'signupEscapeHatch' ) ) {
-			return null;
-		}
-
-		return (
-			<div className="site-type__blank-slate">
-				<Button borderless onClick={ this.handleBlankSlateClick }>
-					{ this.props.translate( 'Need a site in a hurry? Start one from scratch.' ) }
-				</Button>
-			</div>
-		);
-	}
-
 	renderStepContent() {
 		const { siteType } = this.props;
 
@@ -96,9 +89,9 @@ class SiteType extends Component {
 					goToNextStep={ this.props.goToNextStep }
 					submitForm={ this.submitStep }
 					siteType={ siteType }
+					siteTypeDefinitions={ siteTypeDefinitions }
 				/>
 				{ this.renderImportButton() }
-				{ this.renderBlankSlateButton() }
 			</Fragment>
 		);
 	}

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -108,7 +108,7 @@ class SiteType extends Component {
 
 		const headerText = translate( 'What kind of site are you building?' );
 		const subHeaderText = translate(
-			"Choose a site type, answer a few questions, and we'll start you off with a fresh site and customized content."
+			'This is just a starting point. You can add or change features later.'
 		);
 
 		return (

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -85,6 +85,7 @@
 	}
 }
 
+.site-type__blank-canvas,
 .site-type__import-button {
 	text-align: center;
 	margin-top: 20px;
@@ -97,3 +98,4 @@
 		text-decoration: underline;
 	}
 }
+

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -85,7 +85,6 @@
 	}
 }
 
-.site-type__blank-slate,
 .site-type__import-button {
 	text-align: center;
 	margin-top: 20px;

--- a/client/signup/steps/site-type/style.scss
+++ b/client/signup/steps/site-type/style.scss
@@ -85,6 +85,7 @@
 	}
 }
 
+.site-type__blank-slate,
 .site-type__import-button {
 	text-align: center;
 	margin-top: 20px;


### PR DESCRIPTION
## Changes proposed in this Pull Request

We bet that adding an "escape hatch" to signup, we will increase signup completion for experienced users.

This escape hatch would be an option to skip every site setup-related step and jump straight to the domains step. After site creation we drop the user into the checklist as usual.

<img width="736" alt="Screen Shot 2019-08-19 at 11 39 35 am" src="https://user-images.githubusercontent.com/6458278/63233902-0e199d80-c276-11e9-9ffd-3029f5e7edb0.png">


## Testing instructions

1. Apply D31408-code
2. Set the ab test `signupEscapeHatch` to `variant`
3. At the site type step, select **Start from scratch** and continue on to create a site. The `calypso_signup_actions_submit_step` tracks action should contain the following values:
```
step: site-type
site_type: blank-canvas
theme_slug_with_repo: pub/refresh-2019
```
4. The headstarted site should be unstyled and have one, simple homepage:

<img width="648" alt="Screen Shot 2019-08-19 at 11 58 17 am" src="https://user-images.githubusercontent.com/6458278/63234467-ab75d100-c278-11e9-9726-ca25252bb8a7.png">



Fixes https://github.com/Automattic/zelda-private/issues/128
