### PR TITLE
Memberships: Make stripe redirect not open in a new tab

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -386,7 +386,7 @@ class MembershipsSection extends Component {
 					/>
 				) }
 				{ this.renderOnboarding(
-					<Button primary={ true } href={ this.props.connectUrl } target="_blank">
+					<Button primary={ true } href={ this.props.connectUrl }>
 						{ this.props.translate( 'Connect Stripe to Get Started' ) }{' '}
 						<Gridicon size={ 18 } icon={ 'external' } />
 					</Button>


### PR DESCRIPTION
Previously , in https://github.com/Automattic/wp-calypso/pull/35192 I have introduced new, better flow for connecting stripe.
But it opened in new tab, because I have forgotten to make this change.
