### PR TITLE
Jetpack product installer: Log errors to logstash

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -23,6 +23,7 @@ import {
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import { getPluginKeys, requestPluginKeys } from 'state/data-getters/wpcom/jetpack-blogs/keys';
 import { SiteId, TimeoutMS } from 'client/types';
+import { logToLogstash } from 'state/logstash/actions';
 
 type PluginStateDescriptor = string;
 type PluginSlug = 'akismet' | 'vaultpress';
@@ -66,11 +67,11 @@ interface State {
 
 export class JetpackProductInstall extends Component< Props, State > {
 	state = {
-		initiatedInstalls: new Set(),
+		initiatedInstalls: new Set< PluginSlug >(),
 	};
 
-	retries = 0;
-	tracksEventSent = false;
+	retries: number = 0;
+	tracksEventSent: boolean = false;
 
 	componentDidMount() {
 		this.requestInstallationStatus();
@@ -287,6 +288,20 @@ export class JetpackProductInstall extends Component< Props, State > {
 				status_akismet: status ? status.akismet_status : '(unknown)',
 				status_vaultpress: status ? status.vaultpress_status : '(unknown)',
 			} );
+
+			this.props.logToLogstash( {
+				feature: 'calypso_jetpack_product_install',
+				message: 'plugin installer error',
+				...( this.props.siteId && { site_id: this.props.siteId } ),
+				extra: {
+					pluginStatus: this.props.status,
+					knownPluginKeys: {
+						// Clean plugin keys for logging
+						akismet: !! this.props.pluginKeys && !! this.props.pluginKeys.akismet,
+						vaultpress: !! this.props.pluginKeys && !! this.props.pluginKeys.vaultpress,
+					},
+				},
+			} );
 		}
 
 		return (
@@ -315,10 +330,10 @@ export class JetpackProductInstall extends Component< Props, State > {
 
 interface ConnectedProps {
 	siteId: SiteId | null;
-	pluginKeys: { akismet: string; vaultpress: string } | null;
+	pluginKeys: { [key in PluginSlug]: string } | null;
 	progressComplete: ReturnType< typeof getJetpackProductInstallProgress >;
 	requestedInstalls: PluginSlug[];
-	status: ReturnType< typeof getJetpackProductInstallProgress >;
+	status: ReturnType< typeof getJetpackProductInstallStatus >;
 }
 
 function mapStateToProps( state ): ConnectedProps {
@@ -348,17 +363,14 @@ function mapStateToProps( state ): ConnectedProps {
 	};
 }
 
-interface ConnectedDispatchProps {
-	recordTracksEvent: typeof recordTracksEvent;
-	requestJetpackProductInstallStatus: typeof requestJetpackProductInstallStatus;
-	startJetpackProductInstall: typeof startJetpackProductInstall;
-}
-
-const mapDispatchToProps: ConnectedDispatchProps = {
+const mapDispatchToProps = {
 	recordTracksEvent,
 	requestJetpackProductInstallStatus,
 	startJetpackProductInstall,
+	logToLogstash,
 };
+
+type ConnectedDispatchProps = typeof mapDispatchToProps;
 
 export default connect(
 	mapStateToProps,

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -297,8 +297,8 @@ export class JetpackProductInstall extends Component< Props, State > {
 					pluginStatus: this.props.status,
 					knownPluginKeys: {
 						// Clean plugin keys for logging
-						akismet: !! this.props.pluginKeys && !! this.props.pluginKeys.akismet,
-						vaultpress: !! this.props.pluginKeys && !! this.props.pluginKeys.vaultpress,
+						akismet: !! ( this.props.pluginKeys && this.props.pluginKeys.akismet ),
+						vaultpress: !! ( this.props.pluginKeys && this.props.pluginKeys.vaultpress ),
 					},
 				},
 			} );

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -290,8 +290,8 @@ export class JetpackProductInstall extends Component< Props, State > {
 			} );
 
 			this.props.logToLogstash( {
-				feature: 'calypso_jetpack_product_install',
-				message: 'plugin installer error',
+				feature: 'calypso_client',
+				message: 'Jetpack plugin installer error',
 				...( this.props.siteId && { site_id: this.props.siteId } ),
 				extra: {
 					pluginStatus: this.props.status,

--- a/client/state/logstash/actions.ts
+++ b/client/state/logstash/actions.ts
@@ -1,20 +1,25 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
 import { LOGSTASH } from 'state/action-types';
-
 import 'state/data-layer/wpcom/logstash';
+
+interface LogToLogstashParams {
+	feature: string;
+	message: string;
+	extra?: any;
+	site_id?: number;
+	[key: string]: any;
+}
 
 /**
  * Log to logstash. This method is inefficient because
  * the data goes over the REST API, so use sparingly.
  *
- * @param {Object} params same as wpcom log2logstash params arg
- * @returns {Object} Action object
+ * @param params wpcom log2logstash params. @see PCYsg-5T4-p2
+ * @returns      Action object
  */
-export function logToLogstash( params ) {
+export function logToLogstash( params: LogToLogstashParams ) {
 	return {
 		type: LOGSTASH,
 		params: { params: JSON.stringify( params ) },

--- a/client/state/logstash/actions.ts
+++ b/client/state/logstash/actions.ts
@@ -4,8 +4,18 @@
 import { LOGSTASH } from 'state/action-types';
 import 'state/data-layer/wpcom/logstash';
 
+/**
+ * Parameters sent to logstash endpoint.
+ *
+ * @see PCYsg-5T4-p2
+ */
 interface LogToLogstashParams {
-	feature: string;
+	/**
+	 * Feature name.
+	 *
+	 * Should be whitelisted. @see D31385-code
+	 */
+	feature: 'calypso_ssr' | 'calypso_client';
 	message: string;
 	extra?: any;
 	site_id?: number;
@@ -16,7 +26,7 @@ interface LogToLogstashParams {
  * Log to logstash. This method is inefficient because
  * the data goes over the REST API, so use sparingly.
  *
- * @param params wpcom log2logstash params. @see PCYsg-5T4-p2
+ * @param params wpcom log2logstash params.
  * @returns      Action object
  */
 export function logToLogstash( params: LogToLogstashParams ) {


### PR DESCRIPTION
Split from https://github.com/Automattic/wp-calypso/pull/35279
Requires D31385-code

#### Changes proposed in this Pull Request

* Add logstash logging to jetpack product install

#### Testing instructions

I don't know how to hit this case organically. Here's a patch to force it when plugin install completes successfully:

```patch
diff --git a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
index eb21c18be7..4bc957a22f 100644
--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -277,7 +277,7 @@ export class JetpackProductInstall extends Component< Props, State > {
 		const hasErrorInstalling =
 			! this.shouldRefetchInstallationStatus() && this.installationHasRecoverableErrors();
 
-		if ( hasErrorInstalling && ! this.tracksEventSent ) {
+		if ( ( hasErrorInstalling || progressComplete === 100 ) && ! this.tracksEventSent ) {
 			this.tracksEventSent = true;
 			const { status } = this.props;
 
```

- With D31385-code and public-api sandboxed
- Apply the above patch
- Purchase a plan for a Jetpack site without Akismet and VaultPress installed.
- Wait for successful completion
- The patch ensures we'll log on error.
- Watch the network for a logstash request. Check logstash logs.