### PR TITLE
Update clickable banner to be more obviously clickable

### DIFF
--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -35,7 +35,7 @@ import PluginAutomatedTransfer from 'my-sites/plugins/plugin-automated-transfer'
 import { getExtensionSettingsPath } from 'my-sites/plugins/utils';
 import { userCan } from 'lib/site/utils';
 import Banner from 'components/banner';
-import { TYPE_BUSINESS, FEATURE_UPLOAD_PLUGINS } from 'lib/plans/constants';
+import { TYPE_BUSINESS } from 'lib/plans/constants';
 import { findFirstSimilarPlanKey } from 'lib/plans';
 import { isBusiness, isEcommerce, isEnterprise } from 'lib/products-values';
 import { addSiteFragment } from 'lib/route';
@@ -589,7 +589,7 @@ export class PluginMeta extends Component {
 
 	handleUpgradeNudgeClick = () => {
 		const { slug } = this.props;
-		const href = `/plans/${ slug }?feature=${ FEATURE_UPLOAD_PLUGINS }`;
+		const href = `/checkout/${ slug }/business`;
 		page.redirect( href );
 	};
 
@@ -605,7 +605,6 @@ export class PluginMeta extends Component {
 			<div className="plugin-meta__upgrade_nudge">
 				<Banner
 					event="calypso_plugin_detail_page_upgrade_nudge"
-					disableHref={ true }
 					onClick={ this.handleUpgradeNudgeClick }
 					plan={ plan }
 					title={ title }

--- a/client/my-sites/plugins/plugin-meta/index.jsx
+++ b/client/my-sites/plugins/plugin-meta/index.jsx
@@ -8,7 +8,6 @@ import classNames from 'classnames';
 import { get, includes, some } from 'lodash';
 import Gridicon from 'gridicons';
 import { localize, moment } from 'i18n-calypso';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -587,14 +586,9 @@ export class PluginMeta extends Component {
 		);
 	};
 
-	handleUpgradeNudgeClick = () => {
-		const { slug } = this.props;
-		const href = `/checkout/${ slug }/business`;
-		page.redirect( href );
-	};
-
 	renderUpsell() {
-		const { translate } = this.props;
+		const { translate, slug } = this.props;
+		const bannerURL = `/checkout/${ slug }/business`;
 		const plan = findFirstSimilarPlanKey( this.props.selectedSite.plan.product_slug, {
 			type: TYPE_BUSINESS,
 		} );
@@ -605,7 +599,7 @@ export class PluginMeta extends Component {
 			<div className="plugin-meta__upgrade_nudge">
 				<Banner
 					event="calypso_plugin_detail_page_upgrade_nudge"
-					onClick={ this.handleUpgradeNudgeClick }
+					href={ bannerURL }
 					plan={ plan }
 					title={ title }
 				/>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import { concat, find, flow, get, flatMap, includes } from 'lodash';
 import PropTypes from 'prop-types';
-import page from 'page';
 
 /**
  * Internal dependencies
@@ -411,12 +410,6 @@ export class PluginsBrowser extends Component {
 		this.props.doSearch( term );
 	};
 
-	handleUpgradeNudgeClick = () => {
-		const { siteSlug } = this.props;
-		const href = `/checkout/${ siteSlug }/business`;
-		page.redirect( href );
-	};
-
 	getSearchBar() {
 		const suggestedSearches = [
 			this.props.translate( 'Engagement', { context: 'Plugins suggested search term' } ),
@@ -553,7 +546,8 @@ export class PluginsBrowser extends Component {
 			return null;
 		}
 
-		const { translate } = this.props;
+		const { translate, siteSlug } = this.props;
+		const bannerURL = `/checkout/${ siteSlug }/business`;
 		const plan = findFirstSimilarPlanKey( this.props.sitePlan.product_slug, {
 			type: TYPE_BUSINESS,
 		} );
@@ -562,7 +556,7 @@ export class PluginsBrowser extends Component {
 		return (
 			<Banner
 				event="calypso_plugins_browser_upgrade_nudge"
-				onClick={ this.handleUpgradeNudgeClick }
+				href={ bannerURL }
 				plan={ plan }
 				title={ title }
 			/>

--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -47,7 +47,6 @@ import { findFirstSimilarPlanKey } from 'lib/plans';
 import Banner from 'components/banner';
 import { isEnabled } from 'config';
 import wpcomFeaturesAsPlugins from './wpcom-features-as-plugins';
-import { abtest } from 'lib/abtest';
 import QuerySiteRecommendedPlugins from 'components/data/query-site-recommended-plugins';
 
 /**
@@ -563,7 +562,6 @@ export class PluginsBrowser extends Component {
 		return (
 			<Banner
 				event="calypso_plugins_browser_upgrade_nudge"
-				disableHref={ true }
 				onClick={ this.handleUpgradeNudgeClick }
 				plan={ plan }
 				title={ title }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When you visit the plugins screen, it's not obvious that the upgrade banner is clickable. This PR updates the banner so that people know they can click it. I also updated the location you're sent to on the plugin page so that it matches what we're doing on the plugins page which is send you right to the cart with the plan in there.

**Before**
![image](https://user-images.githubusercontent.com/6981253/62792622-af963780-ba9d-11e9-9ec5-e37f87830f9a.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/62792641-b91f9f80-ba9d-11e9-9b57-32c8425042cd.png)


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


**For plugins**
* Visit `/plugins/{site-slug}` for a site that is on any plan lower than business.
* Click on the banner to make sure it takes you to the cart with the business plan.

**For a single plugin**
* Visit `/plugins/{site-slug}` for a site that is on any plan lower than business.
* Click on any plugin
* Click on the banner to make sure it takes you to the cart with the business plan.
