### PR TITLE
Refactor the post checkout code

### DIFF
--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -20,7 +20,6 @@ import ChecklistShowShare from './share';
 import GetAppsBlock from 'blocks/get-apps';
 import QueryActiveTheme from 'components/data/query-active-theme';
 import QueryCanonicalTheme from 'components/data/query-canonical-theme';
-import { trackClick } from '../themes/helpers';
 
 /**
  * State dependencies
@@ -30,7 +29,7 @@ import isSiteOnPaidPlan from 'state/selectors/is-site-on-paid-plan';
 import { getCurrentUser } from 'state/current-user/selectors';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug, isJetpackSite, isNewSite } from 'state/sites/selectors';
-import { getActiveTheme, getCanonicalTheme, getThemeDetailsUrl } from 'state/themes/selectors';
+import { getActiveTheme, getCanonicalTheme } from 'state/themes/selectors';
 
 /**
  * Style dependencies
@@ -41,10 +40,6 @@ class ChecklistMain extends PureComponent {
 	state = { complete: false };
 
 	handleCompletionUpdate = ( { complete } ) => void this.setState( { complete } );
-
-	trackClick = ( eventName, verb ) => {
-		trackClick( 'current theme', eventName, verb );
-	};
 
 	/**
 	 * Redirect Jetpack checklists to /plans/my-plan/:siteSlug
@@ -107,21 +102,13 @@ class ChecklistMain extends PureComponent {
 
 			case 'theme':
 				return translate(
-					'Your theme {{a}}%(themeName)s{{/a}} by %(themeAuthor)s is now active on your site. ' +
+					'Your theme %(themeName)s by %(themeAuthor)s is now active on your site. ' +
 						"Now that your site has been created, it's time to get it ready for you to share. " +
 						"We've prepared a list of things that will help you get there quickly.",
 					{
 						args: {
 							themeName: currentTheme && currentTheme.name,
 							themeAuthor: currentTheme && currentTheme.author,
-						},
-						components: {
-							a: (
-								<a
-									href={ this.props.detailsUrl }
-									onClick={ () => this.trackClick( 'theme info', 'click' ) }
-								/>
-							),
 						},
 					}
 				);
@@ -225,8 +212,7 @@ export default connect( ( state, props ) => {
 	if ( props.displayMode && 'theme' === props.displayMode ) {
 		const currentThemeId = getActiveTheme( state, siteId );
 		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
-		const detailsUrl = getThemeDetailsUrl( state, currentThemeId, siteId );
-		themeInfo = { currentTheme, detailsUrl, currentThemeId };
+		themeInfo = { currentTheme, currentThemeId };
 	}
 
 	return {

--- a/client/my-sites/checklist/main.jsx
+++ b/client/my-sites/checklist/main.jsx
@@ -221,14 +221,11 @@ export default connect( ( state, props ) => {
 	const siteId = getSelectedSiteId( state );
 	const isAtomic = isSiteAutomatedTransfer( state, siteId );
 	const isJetpack = isJetpackSite( state, siteId );
-	let currentThemeId,
-		currentTheme,
-		detailsUrl,
-		themeInfo = {};
+	let themeInfo = {};
 	if ( props.displayMode && 'theme' === props.displayMode ) {
-		currentThemeId = getActiveTheme( state, siteId );
-		currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
-		detailsUrl = getThemeDetailsUrl( state, currentThemeId, siteId );
+		const currentThemeId = getActiveTheme( state, siteId );
+		const currentTheme = currentThemeId && getCanonicalTheme( state, siteId, currentThemeId );
+		const detailsUrl = getThemeDetailsUrl( state, currentThemeId, siteId );
 		themeInfo = { currentTheme, detailsUrl, currentThemeId };
 	}
 

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -443,9 +443,6 @@ export class CheckoutThankYou extends React.Component {
 					<PlanThankYouCard siteId={ this.props.selectedSite.ID } { ...planProps } />
 				</Main>
 			);
-		} else if ( wasJetpackPlanPurchased ) {
-			page( `/plans/my-plan/${ this.props.siteId }?thank-you&install=all` );
-			return null;
 		}
 
 		if ( this.props.domainOnlySiteFlow && purchases.length > 0 && ! failedPurchases.length ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -402,6 +402,7 @@ export class Checkout extends React.Component {
 
 	maybeRedirectToGSuiteNudge( pendingOrReceiptId, stepResult ) {
 		const { isNewlyCreatedSite, selectedSiteSlug, cart } = this.props;
+
 		if ( isNewlyCreatedSite && stepResult && isEmpty( stepResult.failed_purchases ) ) {
 			const hasGoogleAppsInCart = hasGoogleApps( cart );
 
@@ -428,6 +429,7 @@ export class Checkout extends React.Component {
 
 	maybeRedirectToConciergeNudge( pendingOrReceiptId ) {
 		const { cart, selectedSiteSlug, previousRoute } = this.props;
+
 		// For a user purchasing a qualifying plan, show either a plan upgrade upsell or concierge upsell.
 		// This tests the flow that was not eligible for G Suite.
 		// If the user has upgraded a plan from seeing our upsell(we find this by checking the previous route is /offer-plan-upgrade),

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -553,7 +553,10 @@ export class Checkout extends React.Component {
 			return `${ signupDestination }?d=gsuite`;
 		}
 
-		const redirectPathForGSuiteUpsell = this.maybeRedirectToGSuiteNudge( pendingOrReceiptId );
+		const redirectPathForGSuiteUpsell = this.maybeRedirectToGSuiteNudge(
+			pendingOrReceiptId,
+			stepResult
+		);
 		if ( redirectPathForGSuiteUpsell ) {
 			return redirectPathForGSuiteUpsell;
 		}

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -358,6 +358,21 @@ export class Checkout extends React.Component {
 		return flatten( Object.values( purchases ) );
 	}
 
+	getUrlWithQueryParam( url, queryParams ) {
+		const { protocol, hostname, port, pathname, query } = parseUrl( url, true );
+
+		return formatUrl( {
+			protocol,
+			hostname,
+			port,
+			pathname,
+			query: {
+				...query,
+				...queryParams,
+			},
+		} );
+	}
+
 	getEligibleDomainFromCart() {
 		const domainRegistrations = getDomainRegistrations( this.props.cart );
 		const domainsInSignupContext = filter( domainRegistrations, { extra: { context: 'signup' } } );
@@ -462,7 +477,8 @@ export class Checkout extends React.Component {
 		// I wouldn't be surprised if it doesn't work as intended in some scenarios.
 		// Especially around the G Suite / Concierge / Checklist logic.
 
-		let renewalItem, displayModeParam;
+		let renewalItem,
+			displayModeParam = {};
 		const {
 			cart,
 			redirectTo,
@@ -567,18 +583,19 @@ export class Checkout extends React.Component {
 		}
 
 		if ( hasConciergeSession( cart ) ) {
-			displayModeParam = 'd=concierge';
+			displayModeParam = { d: 'concierge' };
 		}
-
-		const queryParam = displayModeParam ? `?${ displayModeParam }` : '';
 
 		// pendingOrReceiptId takes a value of ':receiptId' if a redirect payment has been selected,
 		// in which case we want to go to a thank you page.
 		if ( ':receiptId' !== pendingOrReceiptId && this.props.isEligibleForSignupDestination ) {
-			return `${ signupDestination }${ queryParam }`;
+			return this.getUrlWithQueryParam( signupDestination, displayModeParam );
 		}
 
-		return `${ this.getFallbackDestination( pendingOrReceiptId ) }${ queryParam }`;
+		return this.getUrlWithQueryParam(
+			this.getFallbackDestination( pendingOrReceiptId ),
+			displayModeParam
+		);
 	};
 
 	handleCheckoutExternalRedirect( redirectUrl ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -34,6 +34,7 @@ import {
 	hasBloggerPlan,
 	hasPersonalPlan,
 	hasPremiumPlan,
+	hasEcommercePlan,
 	hasPlan,
 	hasOnlyRenewalItems,
 	hasTransferProduct,
@@ -600,7 +601,9 @@ export class Checkout extends React.Component {
 
 		// Removes the destination cookie only if redirecting to the signup destination.
 		// (e.g. if the destination is an upsell nudge, it does not remove the cookie).
-		if ( redirectPath.includes( destinationFromCookie ) ) {
+		// An exception is when we have an eCommerce plan in cart, in which case we always
+		// take to the thank you page so destination cookie can be cleared.
+		if ( redirectPath.includes( destinationFromCookie ) || hasEcommercePlan( cart ) ) {
 			clearSignupDestinationCookie();
 		}
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -394,7 +394,7 @@ export class Checkout extends React.Component {
 		// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
 		if ( selectedSiteSlug && ( ! isReceiptEmpty || ! isCartEmpty ) ) {
 			if ( isJetpackNotAtomic ) {
-				return `/plans/my-plan/${ selectedSiteSlug }?thank-you`;
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
 			}
 			return selectedFeature && isValidFeatureKey( selectedFeature )
 				? `/checkout/thank-you/features/${ selectedFeature }/${ selectedSiteSlug }/${ pendingOrReceiptId }`

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -394,7 +394,7 @@ export class Checkout extends React.Component {
 		// - does not have a receipt number but has an item in cart(as in the case of paying with a redirect payment type)
 		if ( selectedSiteSlug && ( ! isReceiptEmpty || ! isCartEmpty ) ) {
 			if ( isJetpackNotAtomic ) {
-				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you`;
 			}
 			return selectedFeature && isValidFeatureKey( selectedFeature )
 				? `/checkout/thank-you/features/${ selectedFeature }/${ selectedSiteSlug }/${ pendingOrReceiptId }`

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -114,7 +114,7 @@ export function generateFlows( {
 			steps: [ 'domains-theme-preselected', 'plans', 'user' ],
 			destination: getChecklistThemeDestination,
 			description: 'Preselect a theme to activate/buy from an external source',
-			lastModified: '2016-01-27',
+			lastModified: '2019-08-20',
 		},
 
 		main: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -17,6 +17,7 @@ export function generateFlows( {
 	getRedirectDestination = noop,
 	getSignupDestination = noop,
 	getThankYouNoSiteDestination = noop,
+	getChecklistThemeDestination = noop,
 } = {} ) {
 	const flows = {
 		account: {
@@ -111,7 +112,7 @@ export function generateFlows( {
 
 		'with-theme': {
 			steps: [ 'domains-theme-preselected', 'plans', 'user' ],
-			destination: getSiteDestination,
+			destination: getChecklistThemeDestination,
 			description: 'Preselect a theme to activate/buy from an external source',
 			lastModified: '2016-01-27',
 		},

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -57,11 +57,16 @@ function getThankYouNoSiteDestination() {
 	return `/checkout/thank-you/no-site`;
 }
 
+function getChecklistThemeDestination( dependencies ) {
+	return `/checklist/${ dependencies.siteSlug }?d=theme`;
+}
+
 const flows = generateFlows( {
 	getSiteDestination,
 	getRedirectDestination,
 	getSignupDestination,
 	getThankYouNoSiteDestination,
+	getChecklistThemeDestination,
 } );
 
 function removeUserStepFromFlow( flow ) {

--- a/client/state/selectors/is-eligible-for-signup-destination.js
+++ b/client/state/selectors/is-eligible-for-signup-destination.js
@@ -1,22 +1,8 @@
 /** @format */
 /**
- * External dependencies
- */
-import { isEmpty } from 'lodash';
-
-/**
  * Internal dependencies
  */
-import { isNewSite } from 'state/sites/selectors';
-import {
-	getAllCartItems,
-	hasDomainMapping,
-	hasDomainRegistration,
-	hasTransferProduct,
-	hasPlan,
-	hasConciergeSession,
-	hasEcommercePlan,
-} from 'lib/cart-values/cart-items';
+import { hasEcommercePlan } from 'lib/cart-values/cart-items';
 import isEligibleForDotcomChecklist from './is-eligible-for-dotcom-checklist';
 import { retrieveSignupDestination } from 'signup/utils';
 
@@ -27,23 +13,15 @@ import { retrieveSignupDestination } from 'signup/utils';
  * @return {Boolean} True if current user is able to see the checklist after checkout
  */
 export default function isEligibleForSignupDestination( state, siteId, cart ) {
-	if ( ! isEmpty( getAllCartItems( cart ) ) ) {
-		if (
-			hasDomainMapping( cart ) ||
-			hasDomainRegistration( cart ) ||
-			hasTransferProduct( cart ) ||
-			( ! hasPlan( cart ) && ! hasConciergeSession( cart ) ) ||
-			hasEcommercePlan( cart )
-		) {
-			return false;
-		}
+	if ( hasEcommercePlan( cart ) ) {
+		return false;
 	}
 
 	const destination = retrieveSignupDestination();
 
 	if ( destination && destination.includes( '/checklist/' ) ) {
-		return isNewSite( state, siteId ) && isEligibleForDotcomChecklist( state, siteId );
+		return isEligibleForDotcomChecklist( state, siteId );
 	}
 
-	return '/' === destination ? false : isNewSite( state, siteId );
+	return true;
 }

--- a/client/state/selectors/is-eligible-for-signup-destination.js
+++ b/client/state/selectors/is-eligible-for-signup-destination.js
@@ -19,7 +19,11 @@ export default function isEligibleForSignupDestination( state, siteId, cart ) {
 
 	const destination = retrieveSignupDestination();
 
-	if ( destination && destination.includes( '/checklist/' ) ) {
+	if ( ! destination ) {
+		return false;
+	}
+
+	if ( destination.includes( '/checklist/' ) ) {
 		return isEligibleForDotcomChecklist( state, siteId );
 	}
 

--- a/test/e2e/specs/wp-signup-spec.js
+++ b/test/e2e/specs/wp-signup-spec.js
@@ -58,7 +58,6 @@ import EmailClient from '../lib/email-client.js';
 import NewUserRegistrationUnavailableComponent from '../lib/components/new-user-domain-registration-unavailable-component';
 import DeleteAccountFlow from '../lib/flows/delete-account-flow';
 import DeletePlanFlow from '../lib/flows/delete-plan-flow';
-import ThemeDialogComponent from '../lib/components/theme-dialog-component';
 import SignUpStep from '../lib/flows/sign-up-step';
 
 import * as sharedSteps from '../lib/shared-steps/wp-signup-spec';
@@ -1384,10 +1383,7 @@ describe( `[${ host }] Sign Up  (${ screenSize }, ${ locale })`, function() {
 			return await securePaymentComponent.waitForPageToDisappear();
 		} );
 
-		step( 'Can see the theme thanks dialog', async function() {
-			const themeDialogComponent = await ThemeDialogComponent.Expect( driver );
-			await themeDialogComponent.goToThemeDetail();
-		} );
+		sharedSteps.canSeeTheOnboardingChecklist();
 
 		step( 'Can delete the plan', async function() {
 			return await new DeletePlanFlow( driver ).deletePlan( 'theme' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Make the fallback  destination as Thank You page if there's a site slug and item in cart, else `/`.
* Removes a bunch of code which is no longer needed in `client/state/selectors/is-eligible-for-signup-destination.js`. 
    - removes a few redundant checks. We no longer need to check each cart item and return the Thank You page for non-plan products, since the default fallback destination is now the Thank you page.
    - we no longer need the check for `isNewSite`, which was used to determine if we should show the Thank You page for in-site purchases. As said in the previous bullet point, every purchase made outside of a signup flow will now always show the Thank You page.

#### Fixes
https://github.com/Automattic/wp-calypso/issues/35068 and  https://github.com/Automattic/wp-calypso/issues/35284

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**

* Begin at http://calypso.localhost:3000/start and complete the signup flow with a plan purchase. 
* Post checkout you will be shown a Quick Start session upsell.
* Clicking Yes(and completing purchase) or No should both take to signup destination,
which is checklist for most flows, and thank you page if you have an eCommerce plan in the cart. Verify with/without eCommerce plan.


**Scenario 2**

* On an existing account, add new site and purchase a paid plan. Verify that you are taken to the appropriate signup destination(which is checklist for most flows, and thank you page if you have an eCommerce plan in the cart).

**Scenario 3**(private by default launch flow)

* Verify that https://github.com/Automattic/wp-calypso/issues/35284 is fixed.

**Scenario 4**(testing in-site purchases)

* On an existing new account(less than 30 minutes old), upgrade your plan to the next tier.
* Post checkout, you should be taken to the Thank You page.
* Purchase other products, such as a domain or theme. Verify that you are taken to the Thank You page post checkout.(this verifies that we no longer need the `isNewSite` check as described in the PR description)

**Scenario 5**

* Go through the /start/business flow and add a custom domain to cart. Complete purchase.
* You will not be shown the Quick Start nudge for business plan purchase, however you will see a GSuite upsell(in sandbox, GSuite can be purchased only for .blog domains. Check FG for more details).
* Verify that the final destination is the checklist.

**Scenario 6**(Jetpack tests)

_Jetpack connect_

* Spin up a Jetpack connected instance at https://jurassic.ninja
* Go through the setup flow (note that you will get redirect to a wordpress.com URL when you click the Set up Jetpack button in wp-admin, so ensure that you stay on calypso.localhost URL).
* Verify that after purchasing a Jetpack plan, you are taken to my-plans page /plans/my-plan/SITE_SLUG?thank-you=&install=all

_Jetpack upgrade_

Verify that https://github.com/Automattic/wp-calypso/issues/35068 is fixed.

**Scenario 7**

* Begin at /start and purchase a plan
* Pay with a redirect payment type such as Giropay(proxy through Europe) or PayPal
* Verify that post purchase, you are taken to the checkout pending page(destination is not respected for redirected payment types for the moment, and is tracked in https://github.com/Automattic/wp-calypso/issues/34333.

**Scenario 8**

* Begin at http://calypso.localhost:3000/themes and select to purchase any Premium plan.
* Go through the `with-theme` signup flow and complete checkout - try both with a free plan and a paid plan.
* In both scenarios(free plan or paid plan), verify that you are taken to the checklist page with a theme specific sub-header text:
<img width="981" alt="Screenshot 2019-08-20 at 5 23 03 PM" src="https://user-images.githubusercontent.com/1269602/63351334-a9953600-c37c-11e9-87dc-6b6ee7bae18d.png">
