### PR TITLE
FSE: Disable template block hover UI

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -43,6 +43,10 @@
 
 .block-editor-block-list__layout {
 	.template__block-container {
+		&.is-hovered {
+			cursor: pointer;
+		}
+
 		&.is-selected {
 			// Hide the toolbar for this block
 			.block-editor-block-contextual-toolbar {
@@ -58,6 +62,7 @@
 			// Need to get super specific to override the core css selectors:
 			&,
 			&.has-child-selected,
+			&.is-hovered,
 			&.is-navigate-mode {
 				> .block-editor-block-list__block-edit {
 					&::before {
@@ -66,20 +71,8 @@
 						outline: none;
 						box-shadow: none;
 					}
-				}
-			}
-			&.is-hovered {
-				> .block-editor-block-list__block-edit {
-					&::before {
-						border-left: 3px solid rgba( 145, 151, 162, 0.25 );
-						margin-left: 2px;
-						top: 0;
-						bottom: 0;
-					}
-
-					& > .block-editor-block-list__breadcrumb {
-						margin-left: 2px;
-						top: 0;
+					> .block-editor-block-list__breadcrumb {
+						display: none;
 					}
 				}
 			}


### PR DESCRIPTION
This is a small design tweak per @apeatling request.

I also added the correct cursor state during hover in order to show the user that they are supposed to click on the header/footer.

#### Testing instructions
1. Pull this branch and run it in your local FSE setup
2. Open the page editor.
3. Hover over the header and footer template blocks, and make sure you see no UI.
4. Select the header or footer template block, then deselect.
5. Hover over the template again and make sure the UI is still hidden
6. Verify that the pointer cursor shows up when hovering over the template blocks.

Fixes #35250
