### PR TITLE
Resolve the capitalizing issue  at Manage >> Settings #35292

### DIFF
--- a/client/my-sites/site-settings/composing/publish-confirmation.jsx
+++ b/client/my-sites/site-settings/composing/publish-confirmation.jsx
@@ -50,7 +50,7 @@ class PublishConfirmation extends Component {
 		if ( showPublishFlow ) {
 			return (
 				<FormFieldset>
-					<FormLabel>{ translate( 'Show publish confirmation' ) }</FormLabel>
+					<FormLabel>{ translate( 'Show Publish Confirmation' ) }</FormLabel>
 					<FormSettingExplanation isIndented>
 						{ translate(
 							'The Block Editor handles the Publish confirmation setting. ' +

--- a/client/my-sites/site-settings/custom-content-types/index.jsx
+++ b/client/my-sites/site-settings/custom-content-types/index.jsx
@@ -127,7 +127,7 @@ class CustomContentTypes extends Component {
 
 	renderBlogPostSettings() {
 		const { translate } = this.props;
-		const fieldLabel = translate( 'Blog posts' );
+		const fieldLabel = translate( 'Blog Posts' );
 		const fieldDescription = translate( 'On blog pages, the number of posts to show per page.' );
 
 		return (

--- a/client/my-sites/site-settings/form-writing.jsx
+++ b/client/my-sites/site-settings/form-writing.jsx
@@ -118,7 +118,7 @@ class SiteSettingsFormWriting extends Component {
 					isSaving={ isSavingSettings }
 					onButtonClick={ handleSubmitForm }
 					showButton
-					title={ translate( 'Content types' ) }
+					title={ translate( 'Content Types' ) }
 				/>
 				<CustomContentTypes
 					handleAutosavingToggle={ handleAutosavingToggle }

--- a/client/my-sites/site-settings/media-settings-writing.jsx
+++ b/client/my-sites/site-settings/media-settings-writing.jsx
@@ -80,7 +80,7 @@ class MediaSettingsWriting extends Component {
 								{ translate( 'Show photo metadata in carousel, when available' ) }
 							</CompactFormToggle>
 							<FormLabel className={ labelClassName } htmlFor="carousel_background_color">
-								{ translate( 'Background color' ) }
+								{ translate( 'Background Color' ) }
 							</FormLabel>
 							<FormSelect
 								name="carousel_background_color"


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This fix aims to resolve the Capitalization Inconsistencies at `Manage > Settings: Section Headings and Options`

#### Testing instructions

* Goto Calypso dashboard: `Manage >> Settings` and check for capitalization inconsistencies
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



Fixes #35292
