### PR TITLE
FSE: Match block spacing between page and template editing

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -43,7 +43,6 @@
 
 .block-editor-block-list__layout {
 	.template__block-container {
-		
 		.wp-block {
 			margin-top: 15px;
 			margin-bottom: 15px;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -43,6 +43,12 @@
 
 .block-editor-block-list__layout {
 	.template__block-container {
+
+		.wp-block {
+			margin-top: 15px;
+			margin-bottom: 15px;
+		}
+
 		&.is-hovered {
 			cursor: pointer;
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -43,7 +43,7 @@
 
 .block-editor-block-list__layout {
 	.template__block-container {
-
+		
 		.wp-block {
 			margin-top: 15px;
 			margin-bottom: 15px;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -12,6 +12,15 @@
 	.editor-post-switch-to-draft {
 		display: none;
 	}
+
+	.editor-block-list__layout {
+		padding-top: 28px;
+	}
+
+	.editor-styles-wrapper [data-block] {
+		margin-top: 15px;
+		margin-bottom: 15px;
+	}
 }
 
 .post-type-page, .post-type-wp_template {

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -18,8 +18,20 @@
 	}
 
 	.editor-styles-wrapper [data-block] {
-		margin-top: 15px;
-		margin-bottom: 15px;
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+
+	.block-editor-block-list__block {
+	    margin-top: 0;
+		margin-bottom: 0;
+		transition: ease all 0.5s;
+		&:hover, &.is-selected {
+			transition: ease all 0.5s;
+			transition-delay: 0.3s;
+			margin-top: 28px;
+		    margin-bottom: 28px;
+		}
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -18,20 +18,8 @@
 	}
 
 	.editor-styles-wrapper [data-block] {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
-
-	.block-editor-block-list__block {
-	    margin-top: 0;
-		margin-bottom: 0;
-		transition: ease all 0.5s;
-		&:hover, &.is-selected {
-			transition: ease all 0.5s;
-			transition-delay: 0.3s;
-			margin-top: 28px;
-		    margin-bottom: 28px;
-		}
+		margin-top: 15px;
+		margin-bottom: 15px;
 	}
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Modify the margins of the template blocks in page and template edit views

#### Testing instructions

* Checkout this patch to your FSE test enviroment
* Edit a page and compare the spacing of the header template block in the page edit view with the spacing when editing the header template. The spacing between blocks in both should match. 

**before**

<img width="866" alt="before" src="https://user-images.githubusercontent.com/3629020/62841563-cfc43180-bcfd-11e9-8613-5bced2c47c40.png">

**after**

<img width="981" alt="after" src="https://user-images.githubusercontent.com/3629020/62841572-d81c6c80-bcfd-11e9-95dc-8c4028f44907.png">

Fixes #35257
