### PR TITLE
Stats: add stats availability warning for file downloads

### DIFF
--- a/client/my-sites/stats/stats-module/availability-warning.tsx
+++ b/client/my-sites/stats/stats-module/availability-warning.tsx
@@ -3,6 +3,7 @@
  */
 import React, { FunctionComponent } from 'react';
 import moment from 'moment';
+import Gridicon from 'gridicons';
 
 interface Props {
 	statType?: string;
@@ -25,7 +26,11 @@ const StatsModuleAvailabilityWarning: FunctionComponent< Props > = ( {
 		return null;
 	}
 
-	return <div>oops - complete stats might not be available for this period</div>;
+	return (
+		<div className="stats-module__availability-warning">
+			<Gridicon icon="info-outline" size="18" /> info info info
+		</div>
+	);
 };
 
 export default StatsModuleAvailabilityWarning;

--- a/client/my-sites/stats/stats-module/availability-warning.tsx
+++ b/client/my-sites/stats/stats-module/availability-warning.tsx
@@ -1,0 +1,31 @@
+/**
+ * External dependencies
+ */
+import React, { FunctionComponent } from 'react';
+import moment from 'moment';
+
+interface Props {
+	statType?: string;
+	startOfPeriod?: moment.Moment;
+}
+
+// File downloads were only recorded from 28th June 2019 onwards,
+// so we want to warn the user if the start date is earlier
+const fileDownloadsRecordingStartDate = '2019-06-29T00:00:00Z';
+
+const StatsModuleAvailabilityWarning: FunctionComponent< Props > = ( {
+	statType,
+	startOfPeriod,
+} ) => {
+	if ( statType !== 'statsFileDownloads' ) {
+		return null;
+	}
+
+	if ( ! startOfPeriod || startOfPeriod.isAfter( fileDownloadsRecordingStartDate ) ) {
+		return null;
+	}
+
+	return <div>oops - complete stats might not be available for this period</div>;
+};
+
+export default StatsModuleAvailabilityWarning;

--- a/client/my-sites/stats/stats-module/availability-warning.tsx
+++ b/client/my-sites/stats/stats-module/availability-warning.tsx
@@ -32,7 +32,7 @@ const StatsModuleAvailabilityWarning: FunctionComponent< Props & LocalizeProps >
 		<div className="stats-module__availability-warning">
 			<Gridicon icon="info-outline" size="24" />
 			<p className="stats-module__availability-warning-message">
-				{ translate( 'File download stats were not recorded before June 28th 2019.' ) }
+				{ translate( 'File download counts were not recorded before June 28th 2019.' ) }
 			</p>
 		</div>
 	);

--- a/client/my-sites/stats/stats-module/availability-warning.tsx
+++ b/client/my-sites/stats/stats-module/availability-warning.tsx
@@ -4,6 +4,7 @@
 import React, { FunctionComponent } from 'react';
 import moment from 'moment';
 import Gridicon from 'gridicons';
+import { localize, LocalizeProps } from 'i18n-calypso';
 
 interface Props {
 	statType?: string;
@@ -14,9 +15,10 @@ interface Props {
 // so we want to warn the user if the start date is earlier
 const fileDownloadsRecordingStartDate = '2019-06-29T00:00:00Z';
 
-const StatsModuleAvailabilityWarning: FunctionComponent< Props > = ( {
+const StatsModuleAvailabilityWarning: FunctionComponent< Props & LocalizeProps > = ( {
 	statType,
 	startOfPeriod,
+	translate,
 } ) => {
 	if ( statType !== 'statsFileDownloads' ) {
 		return null;
@@ -28,9 +30,12 @@ const StatsModuleAvailabilityWarning: FunctionComponent< Props > = ( {
 
 	return (
 		<div className="stats-module__availability-warning">
-			<Gridicon icon="info-outline" size="18" /> info info info
+			<Gridicon icon="info-outline" size="24" />
+			<p className="stats-module__availability-warning-message">
+				{ translate( 'File download stats were not recorded before June 28th 2019.' ) }
+			</p>
 		</div>
 	);
 };
 
-export default StatsModuleAvailabilityWarning;
+export default localize( StatsModuleAvailabilityWarning );

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -168,10 +168,6 @@ class StatsModule extends Component {
 				{ siteId && statType && (
 					<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 				) }
-				<StatsModuleAvailabilityWarning
-					statType={ statType }
-					startOfPeriod={ period && period.startOf }
-				/>
 				{ ! isAllTime && (
 					<SectionHeader
 						className={ headerClass }
@@ -188,6 +184,10 @@ class StatsModule extends Component {
 					{ noData && <ErrorPanel message={ moduleStrings.empty } /> }
 					{ hasError && <ErrorPanel /> }
 					{ this.props.children }
+					<StatsModuleAvailabilityWarning
+						statType={ statType }
+						startOfPeriod={ period && period.startOf }
+					/>
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<StatsList moduleName={ path } data={ data } />

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -180,10 +180,12 @@ class StatsModule extends Component {
 					</SectionHeader>
 				) }
 				<Card compact className={ cardClasses }>
-					statType === 'statsFileDownloads' && <StatsModuleAvailabilityWarning
-						statType={ statType }
-						startOfPeriod={ period && period.startOf }
-					/>
+					{ statType === 'statsFileDownloads' && (
+						<StatsModuleAvailabilityWarning
+							statType={ statType }
+							startOfPeriod={ period && period.startOf }
+						/>
+					) }
 					{ isAllTime && <AllTimeNav path={ path } query={ query } period={ period } /> }
 					{ noData && <ErrorPanel message={ moduleStrings.empty } /> }
 					{ hasError && <ErrorPanel /> }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -180,14 +180,14 @@ class StatsModule extends Component {
 					</SectionHeader>
 				) }
 				<Card compact className={ cardClasses }>
-					{ isAllTime && <AllTimeNav path={ path } query={ query } period={ period } /> }
-					{ noData && <ErrorPanel message={ moduleStrings.empty } /> }
-					{ hasError && <ErrorPanel /> }
-					{ this.props.children }
 					<StatsModuleAvailabilityWarning
 						statType={ statType }
 						startOfPeriod={ period && period.startOf }
 					/>
+					{ isAllTime && <AllTimeNav path={ path } query={ query } period={ period } /> }
+					{ noData && <ErrorPanel message={ moduleStrings.empty } /> }
+					{ hasError && <ErrorPanel /> }
+					{ this.props.children }
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />
 					<StatsList moduleName={ path } data={ data } />

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -16,6 +16,7 @@ import { includes } from 'lodash';
  */
 import ErrorPanel from '../stats-error';
 import StatsModuleExpand from './expand';
+import StatsModuleAvailabilityWarning from './availability-warning';
 import StatsList from '../stats-list';
 import StatsListLegend from '../stats-list/legend';
 import DatePicker from '../stats-date-picker';
@@ -167,6 +168,10 @@ class StatsModule extends Component {
 				{ siteId && statType && (
 					<QuerySiteStats statType={ statType } siteId={ siteId } query={ query } />
 				) }
+				<StatsModuleAvailabilityWarning
+					statType={ statType }
+					startOfPeriod={ period && period.startOf }
+				/>
 				{ ! isAllTime && (
 					<SectionHeader
 						className={ headerClass }

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -180,7 +180,7 @@ class StatsModule extends Component {
 					</SectionHeader>
 				) }
 				<Card compact className={ cardClasses }>
-					<StatsModuleAvailabilityWarning
+					statType === 'statsFileDownloads' && <StatsModuleAvailabilityWarning
 						statType={ statType }
 						startOfPeriod={ period && period.startOf }
 					/>

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -572,6 +572,21 @@ ul.module-header-actions {
 }
 
 .stats-module__availability-warning {
+	padding: 12px 20px 0;
+	margin-bottom: -18px;
+	display: flex;
+
+	.gridicon {
+		fill: var( --color-text-subtle );
+	}
+}
+
+.stats-module__availability-warning-message {
+	font-size: 14px;
+	margin-left: 8px;
+	color: var( --color-text-subtle );
+}
+
+.stats__module-list .stats-module__availability-warning-message {
 	font-size: 12px;
-	padding: 8px 20px 0;
 }

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -570,3 +570,8 @@ ul.module-header-actions {
 .stats-module__header.is-refreshing {
 	animation: loading-fade 1.6s ease-in-out infinite;
 }
+
+.stats-module__availability-warning {
+	font-size: 12px;
+	padding: 8px 20px 0;
+}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -573,7 +573,9 @@ ul.module-header-actions {
 
 .stats-module__availability-warning {
 	padding: 12px 20px 0;
-	margin-bottom: -18px;
+	.stats-module__availability-warning-message {
+		margin-bottom: 0;
+	}
 	display: flex;
 
 	.gridicon {

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -573,9 +573,6 @@ ul.module-header-actions {
 
 .stats-module__availability-warning {
 	padding: 12px 20px 0;
-	.stats-module__availability-warning-message {
-		margin-bottom: 0;
-	}
 	display: flex;
 
 	.gridicon {
@@ -586,6 +583,7 @@ ul.module-header-actions {
 .stats-module__availability-warning-message {
 	font-size: 14px;
 	margin-left: 8px;
+	margin-bottom: 0;
 	color: var( --color-text-subtle );
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

File download stats were only recorded from 28th June 2019 onwards. This PR adds a warning for any users trying to view file download stats from before 29th June at midnight.

#### Testing instructions

Try viewing the file download stats module for a period that starts before 2019-06-29, for example:

http://calypso.localhost:3000/stats/year/example.com

The info message should appear in the stats module:

<img width="1079" alt="Screen Shot 2019-08-13 at 12 43 06" src="https://user-images.githubusercontent.com/17325/62907550-ec2ca080-bdc7-11e9-8a97-dcac7176b584.png">
<img width="370" alt="Screen Shot 2019-08-13 at 12 42 59" src="https://user-images.githubusercontent.com/17325/62907552-ec2ca080-bdc7-11e9-85ae-61b7cd845351.png">
