### PR TITLE
Update blog and website signup flows

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -571,17 +571,9 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 }
 
 export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) {
-	if ( isEmpty( nextProps.initialContext && nextProps.initialContext.query ) ) {
-		return;
-	}
-
-	const {
-		initialContext: {
-			query: { site_type: siteType },
-		},
-	} = nextProps;
-
-	const siteTypeValue = getSiteTypePropertyValue( 'slug', siteType, 'slug' );
+	const flowName = get( nextProps, [ 'initialContext', 'params', 'flowName' ] );
+	const siteType = get( nextProps, [ 'initialContext', 'query', 'site_type' ] );
+	const siteTypeValue = siteType ? getSiteTypePropertyValue( 'slug', siteType, 'slug' ) : undefined;
 	let fulfilledDependencies = [];
 
 	if ( siteTypeValue ) {
@@ -590,6 +582,15 @@ export function isSiteTypeFulfilled( stepName, defaultDependencies, nextProps ) 
 
 		nextProps.submitSiteType( siteType );
 		recordExcludeStepEvent( stepName, siteType );
+
+		// nextProps.submitSiteType( siteType ) above provides dependencies
+		fulfilledDependencies = fulfilledDependencies.concat( [ 'siteType', 'themeSlugWithRepo' ] );
+	} else if ( flowName === 'blog' ) {
+		debug( 'Site type value set by flowName = %s', flowName );
+		debug( 'Site type value = blog' );
+
+		nextProps.submitSiteType( 'blog' );
+		recordExcludeStepEvent( stepName, 'blog' );
 
 		// nextProps.submitSiteType( siteType ) above provides dependencies
 		fulfilledDependencies = fulfilledDependencies.concat( [ 'siteType', 'themeSlugWithRepo' ] );

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -377,6 +377,20 @@ describe( 'isSiteTypeFulfilled()', () => {
 		expect( flows.excludeStep ).toHaveBeenCalledWith( 'site-type' );
 	} );
 
+	test( 'should remove a fulfilled step when flowName is blog', () => {
+		const stepName = 'site-type';
+		const initialContext = { params: { flowName: 'blog' } };
+		const nextProps = { initialContext, submitSiteType };
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+		expect( submitSiteType ).not.toHaveBeenCalled();
+
+		isSiteTypeFulfilled( stepName, undefined, nextProps );
+
+		expect( submitSiteType ).toHaveBeenCalledWith( 'blog' );
+		expect( flows.excludeStep ).toHaveBeenCalledWith( 'site-type' );
+	} );
+
 	test( 'should not remove unfulfilled step', () => {
 		const stepName = 'site-type';
 		const initialContext = {};

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -86,18 +86,19 @@ export function generateFlows( {
 			lastModified: '2019-08-05',
 		},
 
-		blog: {
-			steps: [ 'user', 'blog-themes', 'domains', 'plans' ],
-			destination: getSiteDestination,
-			description: 'Signup flow starting with blog themes',
-			lastModified: '2017-09-01',
-		},
-
 		website: {
-			steps: [ 'user', 'website-themes', 'domains', 'plans' ],
-			destination: getSiteDestination,
-			description: 'Signup flow starting with website themes',
-			lastModified: '2017-09-01',
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'site-style-with-preview',
+				'domains-with-preview',
+				'plans',
+			],
+			destination: getSignupDestination,
+			description: 'Signup flow for creating a website',
+			lastModified: '2019-08-12',
 		},
 
 		'rebrand-cities': {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -86,6 +86,21 @@ export function generateFlows( {
 			lastModified: '2019-08-05',
 		},
 
+		blog: {
+			steps: [
+				'user',
+				'site-type',
+				'site-topic-with-preview',
+				'site-title-with-preview',
+				'site-style-with-preview',
+				'domains-with-preview',
+				'plans',
+			],
+			destination: getSignupDestination,
+			description: 'Signup flow for creating a blog',
+			lastModified: '2019-08-12',
+		},
+
 		website: {
 			steps: [
 				'user',


### PR DESCRIPTION
Update the `blog` flow to pre-select the blog site-type, and to otherwise use the same steps as the `onboarding` flow.

This PR also updates the `/start/website` flow to use the same steps as `onboarding`. Since this flow is still linked to from various places (such as social media ads), I haven't removed it, but I also haven't created any differences between this flow and the standard `onboarding` flow.

#### Changes proposed in this Pull Request

* Update the `/start/blog` flow to use the same steps as `onboarding`
* Update the `isSiteTypeFulfilled` function to skip the site-type step if the flowName is `blog`
* Update the `/start/website` flow to use the same steps as `onboarding`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

##### Test `/start/blog`

* Go to `http://calypso.localhost:3000/start/blog`
* After logging in / creating an account, this should take you directly to the `site-topic-with-preview` step: http://calypso.localhost:3000/start/blog/site-topic-with-preview
* You should be able to create a site just as if you had selected the `blog` site type on the standard onboarding flow.

##### Test `/start/website`

* Go to `http://calypso.localhost:3000/start/website`
* This should take you to the user step `http://calypso.localhost:3000/start/website/user`.
* After creating an account or logging in, on the `site-type` step, select Online Store.
* This should switch you to `http://calypso.localhost:3000/start/ecommerce-onboarding/domains`
* If you click Back, this should return you to the `website` flow, e.g. `http://calypso.localhost:3000/start/website/site-type`

Further testing:

* Test creating a blog / business / professional site from the `/start/website` flow
* Test creating an `ecommerce` site from the `/start/website` flow

In both cases, the flow should be identical to using the `onboarding` flow.