### PR TITLE
Jetpack Backup: Add link to support doc from creds entry form

### DIFF
--- a/client/components/rewind-credentials-form/index.jsx
+++ b/client/components/rewind-credentials-form/index.jsx
@@ -154,7 +154,12 @@ export class RewindCredentialsForm extends Component {
 				<QueryRewindState siteId={ siteId } />
 				<div className="rewind-credentials-form__instructions">
 					{ translate(
-						'Please get your credentials from your hosting provider. Their website should explain how to get or create the credentials you need.'
+						'Please get your credentials from your hosting provider. Their website should explain how to get or create the credentials you need. {{link}}Check out our handy guide{{/link}}',
+						{
+							components: {
+								link: <a href="https://jetpack.com/support/activating-jetpack-backups/" />,
+							},
+						}
 					) }
 				</div>
 				<FormFieldset>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add a link to https://jetpack.com/support/activating-jetpack-backups/ in the credentials entry form. This doc provides help with obtaining site server credentials from the host.

**Before:**

<img width="983" alt="Screenshot 2019-08-12 at 11 49 44" src="https://user-images.githubusercontent.com/7767559/62860345-d5b71400-bcf7-11e9-935d-ea8e73a16347.png">

**After:**

<img width="978" alt="Screenshot 2019-08-12 at 11 49 56" src="https://user-images.githubusercontent.com/7767559/62860358-dfd91280-bcf7-11e9-9b20-391956907430.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://calypso.live/start/rewind-setup/rewind-form-creds?branch=add/settings-credential-form-help-link



