### PR TITLE
Remove unneeded disables of no-unused-vars ESLint rule

### DIFF
--- a/client/blocks/inline-help/inline-help-contact-view.jsx
+++ b/client/blocks/inline-help/inline-help-contact-view.jsx
@@ -19,9 +19,9 @@ import isSupportVariationDetermined from 'state/selectors/is-support-variation-d
 import TrackComponentView from 'lib/analytics/track-component-view';
 
 const InlineHelpContactView = ( {
-	/* eslint-disable no-unused-vars, no-shadow */
+	/* eslint-disable no-shadow */
 	isSupportVariationDetermined = false,
-	/* eslint-enable no-unused-vars, no-shadow */
+	/* eslint-enable no-shadow */
 	supportVariation,
 	selectedSite,
 } ) => {

--- a/client/components/emojify/index.jsx
+++ b/client/components/emojify/index.jsx
@@ -71,7 +71,7 @@ export default class Emojify extends PureComponent {
 			tagName: WrapperTagName,
 			twemojiUrl,
 			...other
-		} = this.props; // eslint-disable-line no-unused-vars
+		} = this.props;
 		const classes = classNames( className, 'emojify' );
 
 		return (

--- a/client/components/redux-forms/redux-form-radio/index.jsx
+++ b/client/components/redux-forms/redux-form-radio/index.jsx
@@ -11,7 +11,6 @@ import { Field } from 'redux-form';
  */
 import FormRadio from 'components/forms/form-radio';
 
-// eslint-disable-next-line no-unused-vars
 const RadioRenderer = ( { input, meta, type, ...props } ) => (
 	<FormRadio { ...input } { ...props } />
 );

--- a/client/components/redux-forms/redux-form-select/index.jsx
+++ b/client/components/redux-forms/redux-form-select/index.jsx
@@ -11,7 +11,6 @@ import { Field } from 'redux-form';
  */
 import FormSelect from 'components/forms/form-select';
 
-// eslint-disable-next-line no-unused-vars
 const SelectRenderer = ( { input, meta, ...props } ) => <FormSelect { ...input } { ...props } />;
 
 const ReduxFormSelect = props => <Field component={ SelectRenderer } { ...props } />;

--- a/client/components/redux-forms/redux-form-text-input/index.jsx
+++ b/client/components/redux-forms/redux-form-text-input/index.jsx
@@ -11,7 +11,6 @@ import { Field } from 'redux-form';
  */
 import FormTextInput from 'components/forms/form-text-input';
 
-// eslint-disable-next-line no-unused-vars
 const TextInputRenderer = ( { input, meta, ...props } ) => (
 	<FormTextInput { ...input } { ...props } />
 );

--- a/client/components/redux-forms/redux-form-textarea/index.jsx
+++ b/client/components/redux-forms/redux-form-textarea/index.jsx
@@ -11,7 +11,6 @@ import { Field } from 'redux-form';
  */
 import FormTextarea from 'components/forms/form-textarea';
 
-// eslint-disable-next-line no-unused-vars
 const TextareaRenderer = ( { input, meta, ...props } ) => (
 	<FormTextarea { ...input } { ...props } />
 );

--- a/client/components/redux-forms/redux-form-toggle/index.jsx
+++ b/client/components/redux-forms/redux-form-toggle/index.jsx
@@ -13,7 +13,6 @@ import { Field } from 'redux-form';
  */
 import FormToggle from 'components/forms/form-toggle/compact';
 
-// eslint-disable-next-line no-unused-vars
 const ToggleRenderer = ( { input, meta, text, type, ...otherProps } ) => (
 	<FormToggle { ...input } { ...otherProps }>
 		{ text }

--- a/client/extensions/woocommerce/app/store-stats/referrers/index.js
+++ b/client/extensions/woocommerce/app/store-stats/referrers/index.js
@@ -65,7 +65,7 @@ class Referrers extends Component {
 			const basePath = '/store/stats/referrers';
 			const {
 				queryParams: { referrer, ...queryParams },
-			} = this.props; // eslint-disable-line no-unused-vars
+			} = this.props;
 			const widgetPath = getWidgetPath( unit, slug, queryParams );
 			this.state.filter = '';
 			this.state.selectedReferrer = {};

--- a/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
+++ b/client/extensions/woocommerce/app/store-stats/store-stats-period-nav/index.js
@@ -40,7 +40,6 @@ const StoreStatsPeriodNav = ( {
 	statType,
 	queryParams,
 } ) => {
-	// eslint-disable-next-line no-unused-vars
 	const { startDate, ...intervalQuery } = queryParams;
 	const intervalQueryString = qs.stringify( intervalQuery, { addQueryPrefix: true } );
 	return (

--- a/client/lib/analytics/index.js
+++ b/client/lib/analytics/index.js
@@ -597,11 +597,7 @@ const analytics = {
 	},
 
 	statsd: {
-		/* eslint-enable no-unused-vars */
-		recordTiming: function( pageUrl, eventType, duration /* triggerName */ ) {
-			// ignore triggerName for now, it has no obvious place in statsd
-			/* eslint-disable no-unused-vars */
-
+		recordTiming: function( pageUrl, eventType, duration ) {
 			if ( config( 'boom_analytics_enabled' ) ) {
 				const featureSlug = getFeatureSlugFromPageUrl( pageUrl );
 

--- a/client/lib/upgrades/notices.jsx
+++ b/client/lib/upgrades/notices.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React from 'react'; // eslint-disable-line no-unused-vars
+import React from 'react';
 import { flatten, get, values } from 'lodash';
 import i18n from 'i18n-calypso';
 

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -44,8 +44,7 @@ class AutoRenewToggle extends Component {
 		isRequesting: false,
 	};
 
-	/* eslint-disable-next-line no-unused-vars */
-	componentDidUpdate( prevProps, prevState ) {
+	componentDidUpdate() {
 		if ( ! this.state.showAutoRenewDisablingDialog && this.state.pendingNotice ) {
 			this.props.createNotice( ...this.state.pendingNotice );
 

--- a/client/my-sites/stats/stats-download-csv/README.md
+++ b/client/my-sites/stats/stats-download-csv/README.md
@@ -5,7 +5,7 @@ The download csv component creates a download link that allows a stats-list to b
 #### How to use:
 
 ```js
-import DownloadCsv from 'my-sites/stats/download-csv';
+import DownloadCsv from 'my-sites/stats/stats-download-csv';
 
 const MyComponent = () => {
     return (

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -73,7 +73,7 @@ class StatsDownloadCsv extends Component {
 
 		return (
 			<Button
-				className="download-csv"
+				className="stats-download-csv"
 				compact
 				onClick={ this.downloadCsv }
 				disabled={ disabled }

--- a/client/my-sites/stats/stats-download-csv/index.jsx
+++ b/client/my-sites/stats/stats-download-csv/index.jsx
@@ -65,7 +65,7 @@ class StatsDownloadCsv extends Component {
 	render() {
 		const { data, siteId, statType, query, translate, isLoading, borderless } = this.props;
 		try {
-			const isFileSaverSupported = !! new Blob(); // eslint-disable-line no-unused-vars
+			new Blob(); // eslint-disable-line no-new
 		} catch ( e ) {
 			return null;
 		}

--- a/client/my-sites/stats/stats-module/style.scss
+++ b/client/my-sites/stats/stats-module/style.scss
@@ -553,7 +553,7 @@ ul.module-header-actions {
 	justify-content: center;
 	align-items: center;
 
-	.button.download-csv {
+	.button.stats-download-csv {
 		color: var( --color-text-subtle );
 
 		&[disabled],

--- a/client/state/data-layer/wpcom-http/utils.js
+++ b/client/state/data-layer/wpcom-http/utils.js
@@ -63,7 +63,7 @@ const getRequestStatus = action => {
 };
 
 export const getRequestKey = fullAction => {
-	const { meta, ...action } = fullAction; // eslint-disable-line no-unused-vars
+	const { meta, ...action } = fullAction;
 	const requestKey = get( meta, 'dataLayer.requestKey' );
 
 	return requestKey ? requestKey : deterministicStringify( action );

--- a/client/state/data-layer/wpcom/jetpack/settings/index.js
+++ b/client/state/data-layer/wpcom/jetpack/settings/index.js
@@ -116,10 +116,8 @@ export const saveJetpackSettings = action => ( dispatch, getState ) => {
 // the save request has finished. Tracking those requests is necessary for
 // displaying an up to date progress indicator for some steps.
 // We also need this to store a regenerated post-by-email address in Redux state.
-export const handleSaveSuccess = (
-	{ siteId },
-	{ data: { code, message, ...updatedSettings } } // eslint-disable-line no-unused-vars
-) => saveJetpackSettingsSuccess( siteId, updatedSettings );
+export const handleSaveSuccess = ( { siteId }, { data: { code, message, ...updatedSettings } } ) =>
+	saveJetpackSettingsSuccess( siteId, updatedSettings );
 
 export const handleSaveFailure = ( { siteId }, { meta: { settings: previousSettings } } ) => [
 	updateJetpackSettings( siteId, previousSettings ),

--- a/client/state/themes/actions.js
+++ b/client/state/themes/actions.js
@@ -76,7 +76,7 @@ import accept from 'lib/accept';
 
 import 'state/data-layer/wpcom/theme-filters';
 
-const debug = debugFactory( 'calypso:themes:actions' ); //eslint-disable-line no-unused-vars
+const debug = debugFactory( 'calypso:themes:actions' );
 
 // Set destination for 'back' button on theme sheet
 export function setBackPath( path ) {

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -46,7 +46,7 @@ const isDevelopment = process.env.NODE_ENV !== 'production';
  * @return {object}                                webpack config
  */
 function getWebpackConfig(
-	env = {}, // eslint-disable-line no-unused-vars
+	env = {},
 	{
 		entry,
 		'output-chunk-filename': outputChunkFilename,


### PR DESCRIPTION
Most of them are not needed since we enabled the `ignoreRestSiblings` flag that allows usage like this:
```js
const { a, b, c, ...otherProps } = props;
```
which creates an `otherProps` object by removing fields `a`, `b` and `c` from `props`. The `a`, `b`, `c` variables are not supposed to be used and ESLint knows it.

As a drive-by fix (to keep linking CI job green) I'm fixing class name of `StatsDownloadCsv` component.