### PR TITLE
Checkout: Switch to flexbox for checkout contact details form

### DIFF
--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -345,18 +345,12 @@ export class ContactDetailsFormFields extends Component {
 		};
 	};
 
-	createField = ( name, componentClass, additionalProps, needsChildRef ) => (
-		<div className={ `contact-details-form-fields__container ${ kebabCase( name ) }` }>
-			{ createElement(
-				componentClass,
-				Object.assign(
-					{},
-					{ ...this.getFieldProps( name, needsChildRef ) },
-					{ ...additionalProps }
-				)
-			) }
-		</div>
-	);
+	createField = ( name, componentClass, additionalProps, needsChildRef ) => {
+		return createElement(
+			componentClass,
+			Object.assign( {}, { ...this.getFieldProps( name, needsChildRef ) }, { ...additionalProps } )
+		);
+	};
 
 	getCountryCode() {
 		return get( this.state.form, 'countryCode.value', '' );
@@ -368,42 +362,50 @@ export class ContactDetailsFormFields extends Component {
 
 		return (
 			<div className="contact-details-form-fields__contact-details">
-				{ this.createField(
-					'organization',
-					HiddenInput,
-					{
-						label: translate( 'Organization' ),
-						text: labelTexts.organization || translate( '+ Add organization name' ),
-					},
-					true
-				) }
+				<div className="contact-details-form-fields__row">
+					{ this.createField(
+						'organization',
+						HiddenInput,
+						{
+							label: translate( 'Organization' ),
+							text: labelTexts.organization || translate( '+ Add organization name' ),
+						},
+						true
+					) }
+				</div>
 
-				{ this.createField( 'email', Input, {
-					label: translate( 'Email' ),
-				} ) }
-
-				{ this.createField( 'phone', FormPhoneMediaInput, {
-					label: translate( 'Phone' ),
-					onChange: this.handlePhoneChange,
-					countriesList: this.props.countriesList,
-					countryCode: this.state.phoneCountryCode,
-					enableStickyCountry: false,
-				} ) }
-
-				{ needsFax &&
-					this.createField( 'fax', Input, {
-						label: translate( 'Fax' ),
+				<div className="contact-details-form-fields__row">
+					{ this.createField( 'email', Input, {
+						label: translate( 'Email' ),
 					} ) }
 
-				{ this.createField(
-					'country-code',
-					CountrySelect,
-					{
-						label: translate( 'Country' ),
+					{ this.createField( 'phone', FormPhoneMediaInput, {
+						label: translate( 'Phone' ),
+						onChange: this.handlePhoneChange,
 						countriesList: this.props.countriesList,
-					},
-					true
-				) }
+						countryCode: this.state.phoneCountryCode,
+						enableStickyCountry: false,
+					} ) }
+				</div>
+
+				<div className="contact-details-form-fields__row">
+					{ needsFax &&
+						this.createField( 'fax', Input, {
+							label: translate( 'Fax' ),
+						} ) }
+				</div>
+
+				<div className="contact-details-form-fields__row">
+					{ this.createField(
+						'country-code',
+						CountrySelect,
+						{
+							label: translate( 'Country' ),
+							countriesList: this.props.countriesList,
+						},
+						true
+					) }
+				</div>
 
 				{ countryCode && (
 					<RegionAddressFieldsets
@@ -420,7 +422,7 @@ export class ContactDetailsFormFields extends Component {
 	renderGAppsFieldset() {
 		const countryCode = this.getCountryCode();
 		return (
-			<div className="contact-details-form-fields__g-apps g-apps-fieldset">
+			<div className="contact-details-form-fields__row g-apps-fieldset">
 				<CountrySelect
 					label={ this.props.translate( 'Country' ) }
 					countriesList={ this.props.countriesList }
@@ -441,13 +443,15 @@ export class ContactDetailsFormFields extends Component {
 
 		return (
 			<FormFieldset className="contact-details-form-fields">
-				{ this.createField( 'first-name', Input, {
-					label: translate( 'First Name' ),
-				} ) }
+				<div className="contact-details-form-fields__row">
+					{ this.createField( 'first-name', Input, {
+						label: translate( 'First Name' ),
+					} ) }
 
-				{ this.createField( 'last-name', Input, {
-					label: translate( 'Last Name' ),
-				} ) }
+					{ this.createField( 'last-name', Input, {
+						label: translate( 'Last Name' ),
+					} ) }
+				</div>
 
 				{ this.props.needsOnlyGoogleAppsDetails
 					? this.renderGAppsFieldset()

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -90,6 +90,3 @@
 	margin-top: 0;
 }
 
-.contact-details-form-fields__container > div.hidden-input {
-	margin-top: 0;
-}

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -1,92 +1,64 @@
 .contact-details-form-fields {
-
 	margin-bottom: 0;
+	display: flex;
+	flex-flow: column nowrap;
+	width: 100%;
 
-	.contact-details-form-fields__container.country-code,
-	.contact-details-form-fields__container.state {
-		label + select {
-			width: 100%;
-		}
+	.contact-details-form-fields__row,
+	.custom-form-fieldsets__address-fields {
+		width: 100%;
+		display: flex;
+		flex-flow: row wrap;
+	}
+
+	.contact-details-form-fields__field {
+		display: flex;
+		flex-flow: column nowrap;
+		flex-grow: 1;
+		flex-basis: 0;
+		margin-top: 15px;
 	}
 
 	@include breakpoint( '>660px' ) {
-		.contact-details-form-fields__container {
-			position: relative;
-			float: left;
-			width: 100%;
+		.contact-details-form-fields__field.last-name,
+		.contact-details-form-fields__field.phone {
+			margin-left: 7px;
 		}
+	}
 
-		.hidden-input a,
-		.contact-details-form-fields__field {
-			//float: left;
-			width: 100%;
-		}
-		.contact-details-form-fields__field.last-name {
-			margin-top: 0;
-		}
-
-		.contact-details-form-fields__container.last-name,
-		.contact-details-form-fields__container.phone,
-		.contact-details-form-fields__container.postal-code {
-			float: right;
-		}
-
-		.contact-details-form-fields__container.email,
-		.contact-details-form-fields__container.first-name,
-		.contact-details-form-fields__container.last-name,
-		.contact-details-form-fields__container.phone {
-			width: calc( 50% - 7px );
-		}
-
-		.contact-details-form-fields__field.city,
+	@include breakpoint( '>960px' ) {
 		.contact-details-form-fields__field.postal-code,
 		.contact-details-form-fields__field.state {
-			width: calc( 33% - 7px );
-			float: left;
-		}
-
-		.contact-details-form-fields__field.postal-code,
-		.contact-details-form-fields__field.state {
-			margin-left: 12px;
-		}
-
-		.g-apps-fieldset {
-			.country {
-				margin-top: 15px;
-				width: calc( 66% - 8px );
-				float: left;
-			}
-			.postal-code {
-				margin-top: 15px;
-				width: 33%;
-				float: right;
-				margin-left: 0;
-			}
+			margin-left: 7px;
 		}
 
 		.eu-address-fieldset {
 			.postal-code {
-				float: left;
-				width: calc( 33% - 7px );
 				margin-left: 0;
 			}
 
 			.city {
-				float: right;
-				width: calc( 66% );
+				margin-left: 7px;
 			}
 		}
 
-		.uk-address-fieldset {
+		.g-apps-fieldset {
 			.postal-code {
-				width: calc( 33% - 7px );
-				float: right;
-				margin-left: 0;
+				max-width: 150px;
 			}
+		}
+	}
 
-			.city {
-				width: calc( 66% );
-			}
+	@include breakpoint( '<660px' ) {
+		.contact-details-form-fields__row {
+			flex-flow: column wrap;
+		}
+	}
+
+	@include breakpoint( '<960px' ) {
+		.custom-form-fieldsets__address-fields,
+		.g-apps-fieldset {
+			flex-flow: column wrap;
 		}
 	}
 
@@ -108,22 +80,13 @@
 
 }
 
-.contact-details-form-fields__contact-details {
-	clear: both;
-	overflow: hidden;
-}
-
-.contact-details-form-fields__container.country-code {
-	float: none;
-	overflow: hidden;
-}
-
-.contact-details-form-fields__extra-fields,
-.contact-details-form-fields__field {
+.contact-details-form-fields__extra-fields {
 	margin-top: 15px;
 }
 
-.contact-details-form-fields__field.first-name {
+.contact-details-form-fields__field.first-name,
+.contact-details-form-fields__field.last-name,
+.form__hidden-input .form__hidden-input {
 	margin-top: 0;
 }
 

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -35,7 +35,7 @@
 		.eu-address-fieldset {
 			.postal-code {
 				margin-left: 0;
-				max-width: 150px;
+				max-width: 33%;
 			}
 
 			.city {
@@ -43,9 +43,15 @@
 			}
 		}
 
+		.uk-address-fieldset {
+			.postal-code {
+				max-width: 33%;
+			}
+		}
+
 		.g-apps-fieldset {
 			.postal-code {
-				max-width: 150px;
+				max-width: 33%;
 			}
 		}
 	}

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -1,19 +1,16 @@
 .contact-details-form-fields {
 	margin-bottom: 0;
 	display: flex;
-	flex-flow: column wrap;
+	flex-direction: column;
 	width: 100%;
 
 	.contact-details-form-fields__row,
 	.custom-form-fieldsets__address-fields {
 		width: 100%;
 		display: flex;
-		flex-flow: row wrap;
 	}
 
 	.contact-details-form-fields__field {
-		display: flex;
-		flex-flow: column wrap;
 		flex-grow: 1;
 		flex-basis: 0;
 		margin-top: 15px;
@@ -23,6 +20,10 @@
 		.contact-details-form-fields__field.last-name,
 		.contact-details-form-fields__field.phone {
 			margin-left: 7px;
+		}
+
+		.contact-details-form-fields__field.last-name {
+			margin-top: 0;
 		}
 	}
 
@@ -58,14 +59,14 @@
 
 	@include breakpoint( '<660px' ) {
 		.contact-details-form-fields__row {
-			flex-flow: column wrap;
+			flex-direction: column;
 		}
 	}
 
 	@include breakpoint( '<960px' ) {
 		.custom-form-fieldsets__address-fields,
 		.g-apps-fieldset {
-			flex-flow: column wrap;
+			flex-direction: column;
 		}
 	}
 
@@ -92,7 +93,6 @@
 }
 
 .contact-details-form-fields__field.first-name,
-.contact-details-form-fields__field.last-name,
 .form__hidden-input .form__hidden-input {
 	margin-top: 0;
 }

--- a/client/components/domains/contact-details-form-fields/style.scss
+++ b/client/components/domains/contact-details-form-fields/style.scss
@@ -1,7 +1,7 @@
 .contact-details-form-fields {
 	margin-bottom: 0;
 	display: flex;
-	flex-flow: column nowrap;
+	flex-flow: column wrap;
 	width: 100%;
 
 	.contact-details-form-fields__row,
@@ -13,7 +13,7 @@
 
 	.contact-details-form-fields__field {
 		display: flex;
-		flex-flow: column nowrap;
+		flex-flow: column wrap;
 		flex-grow: 1;
 		flex-basis: 0;
 		margin-top: 15px;
@@ -35,6 +35,7 @@
 		.eu-address-fieldset {
 			.postal-code {
 				margin-left: 0;
+				max-width: 150px;
 			}
 
 			.city {

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
   className="contact-details-form-fields"
 >
   <div
-    className="contact-details-form-fields__container first-name"
+    className="contact-details-form-fields__row first-name"
   >
     <Input
       additionalClasses="contact-details-form-fields__field"
@@ -24,7 +24,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
     />
   </div>
   <div
-    className="contact-details-form-fields__container last-name"
+    className="contact-details-form-fields__row last-name"
   >
     <Input
       additionalClasses="contact-details-form-fields__field"
@@ -46,7 +46,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
     className="contact-details-form-fields__contact-details"
   >
     <div
-      className="contact-details-form-fields__container organization"
+      className="contact-details-form-fields__row organization"
     >
       <HiddenInput
         additionalClasses="contact-details-form-fields__field"
@@ -65,7 +65,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       />
     </div>
     <div
-      className="contact-details-form-fields__container email"
+      className="contact-details-form-fields__row email"
     >
       <Input
         additionalClasses="contact-details-form-fields__field"
@@ -84,7 +84,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       />
     </div>
     <div
-      className="contact-details-form-fields__container phone"
+      className="contact-details-form-fields__row phone"
     >
       <FormPhoneMediaInput
         additionalClasses="contact-details-form-fields__field"
@@ -115,7 +115,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       />
     </div>
     <div
-      className="contact-details-form-fields__container country-code"
+      className="contact-details-form-fields__row country-code"
     >
       <CountrySelect
         additionalClasses="contact-details-form-fields__field"

--- a/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
+++ b/client/components/domains/contact-details-form-fields/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
   className="contact-details-form-fields"
 >
   <div
-    className="contact-details-form-fields__row first-name"
+    className="contact-details-form-fields__row"
   >
     <Input
       additionalClasses="contact-details-form-fields__field"
@@ -22,10 +22,6 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       onChange={[Function]}
       value="Osso"
     />
-  </div>
-  <div
-    className="contact-details-form-fields__row last-name"
-  >
     <Input
       additionalClasses="contact-details-form-fields__field"
       autoComplete="on"
@@ -46,7 +42,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
     className="contact-details-form-fields__contact-details"
   >
     <div
-      className="contact-details-form-fields__row organization"
+      className="contact-details-form-fields__row"
     >
       <HiddenInput
         additionalClasses="contact-details-form-fields__field"
@@ -65,7 +61,7 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       />
     </div>
     <div
-      className="contact-details-form-fields__row email"
+      className="contact-details-form-fields__row"
     >
       <Input
         additionalClasses="contact-details-form-fields__field"
@@ -82,10 +78,6 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
         onChange={[Function]}
         value="osso@buco.com"
       />
-    </div>
-    <div
-      className="contact-details-form-fields__row phone"
-    >
       <FormPhoneMediaInput
         additionalClasses="contact-details-form-fields__field"
         countriesList={
@@ -115,7 +107,10 @@ exports[`ContactDetailsFormFields default fields should render 1`] = `
       />
     </div>
     <div
-      className="contact-details-form-fields__row country-code"
+      className="contact-details-form-fields__row"
+    />
+    <div
+      className="contact-details-form-fields__row"
     >
       <CountrySelect
         additionalClasses="contact-details-form-fields__field"

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -65,13 +65,9 @@ describe( 'ContactDetailsFormFields', () => {
 
 			const wrapper = shallow( <ContactDetailsFormFields { ...newProps } /> );
 
-			expect( wrapper.find( '.contact-details-form-fields__container.first-name' ) ).toHaveLength(
-				1
-			);
-			expect( wrapper.find( '.contact-details-form-fields__container.last-name' ) ).toHaveLength(
-				1
-			);
-			expect( wrapper.find( '.contact-details-form-fields__container.phone' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.contact-details-form-fields__row.first-name' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.contact-details-form-fields__row.last-name' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.contact-details-form-fields__row.phone' ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -121,13 +117,13 @@ describe( 'ContactDetailsFormFields', () => {
 		test( 'should not render fax field by default', () => {
 			const wrapper = shallow( <ContactDetailsFormFields { ...defaultProps } /> );
 
-			expect( wrapper.find( '.contact-details-form-fields__container.fax' ) ).toHaveLength( 0 );
+			expect( wrapper.find( '.contact-details-form-fields__row.fax' ) ).toHaveLength( 0 );
 		} );
 
 		test( 'should render fax field when fax required', () => {
 			const wrapper = shallow( <ContactDetailsFormFields { ...defaultProps } needsFax={ true } /> );
 
-			expect( wrapper.find( '.contact-details-form-fields__container.fax' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.contact-details-form-fields__row.fax' ) ).toHaveLength( 1 );
 		} );
 	} );
 

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -121,13 +121,13 @@ describe( 'ContactDetailsFormFields', () => {
 		test( 'should not render fax field by default', () => {
 			const wrapper = shallow( <ContactDetailsFormFields { ...defaultProps } /> );
 
-			expect( wrapper.find( '.contact-details-form-fields__row.fax' ) ).toHaveLength( 0 );
+			expect( wrapper.find( '.contact-details-form-fields__field.fax' ) ).toHaveLength( 0 );
 		} );
 
 		test( 'should render fax field when fax required', () => {
 			const wrapper = shallow( <ContactDetailsFormFields { ...defaultProps } needsFax={ true } /> );
 
-			expect( wrapper.find( '.contact-details-form-fields__row.fax' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.contact-details-form-fields__field.fax' ) ).toHaveLength( 1 );
 		} );
 	} );
 

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -64,10 +64,11 @@ describe( 'ContactDetailsFormFields', () => {
 			const newProps = { ...defaultProps, contactDetails: {} };
 
 			const wrapper = shallow( <ContactDetailsFormFields { ...newProps } /> );
+			//expect( wrapper.debug() ).toEqual( '' );
 
-			expect( wrapper.find( '.contact-details-form-fields__field.first-name' ) ).toHaveLength( 1 );
-			expect( wrapper.find( '.contact-details-form-fields__field.last-name' ) ).toHaveLength( 1 );
-			expect( wrapper.find( '.contact-details-form-fields__field.phone' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '[name="first-name"]' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '[name="last-name"]' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '[name="phone"]' ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -121,13 +122,13 @@ describe( 'ContactDetailsFormFields', () => {
 		test( 'should not render fax field by default', () => {
 			const wrapper = shallow( <ContactDetailsFormFields { ...defaultProps } /> );
 
-			expect( wrapper.find( '.contact-details-form-fields__field.fax' ) ).toHaveLength( 0 );
+			expect( wrapper.find( '[name="fax"]' ) ).toHaveLength( 0 );
 		} );
 
 		test( 'should render fax field when fax required', () => {
 			const wrapper = shallow( <ContactDetailsFormFields { ...defaultProps } needsFax={ true } /> );
 
-			expect( wrapper.find( '.contact-details-form-fields__field.fax' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '[name="fax"]' ) ).toHaveLength( 1 );
 		} );
 	} );
 

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -65,9 +65,9 @@ describe( 'ContactDetailsFormFields', () => {
 
 			const wrapper = shallow( <ContactDetailsFormFields { ...newProps } /> );
 
-			expect( wrapper.find( '.contact-details-form-fields__row.first-name' ) ).toHaveLength( 1 );
-			expect( wrapper.find( '.contact-details-form-fields__row.last-name' ) ).toHaveLength( 1 );
-			expect( wrapper.find( '.contact-details-form-fields__row.phone' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.contact-details-form-fields__field.first-name' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.contact-details-form-fields__field.last-name' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.contact-details-form-fields__field.phone' ) ).toHaveLength( 1 );
 		} );
 	} );
 
@@ -75,7 +75,9 @@ describe( 'ContactDetailsFormFields', () => {
 		test( 'should not render GAppsFieldset in place of the default contact fields by default', () => {
 			const wrapper = shallow( <ContactDetailsFormFields { ...defaultProps } /> );
 
-			expect( wrapper.find( '.contact-details-form-fields__g-apps' ) ).toHaveLength( 0 );
+			expect( wrapper.find( '.contact-details-form-fields__row.g-apps-fieldset' ) ).toHaveLength(
+				0
+			);
 			expect( wrapper.find( 'RegionAddressFieldsets' ) ).toHaveLength( 1 );
 		} );
 
@@ -84,7 +86,9 @@ describe( 'ContactDetailsFormFields', () => {
 				<ContactDetailsFormFields { ...defaultProps } needsOnlyGoogleAppsDetails={ true } />
 			);
 
-			expect( wrapper.find( '.contact-details-form-fields__g-apps' ) ).toHaveLength( 1 );
+			expect( wrapper.find( '.contact-details-form-fields__row.g-apps-fieldset' ) ).toHaveLength(
+				1
+			);
 			expect( wrapper.find( 'RegionAddressFieldsets' ) ).toHaveLength( 0 );
 		} );
 	} );

--- a/client/components/domains/contact-details-form-fields/test/index.js
+++ b/client/components/domains/contact-details-form-fields/test/index.js
@@ -64,7 +64,6 @@ describe( 'ContactDetailsFormFields', () => {
 			const newProps = { ...defaultProps, contactDetails: {} };
 
 			const wrapper = shallow( <ContactDetailsFormFields { ...newProps } /> );
-			//expect( wrapper.debug() ).toEqual( '' );
 
 			expect( wrapper.find( '[name="first-name"]' ) ).toHaveLength( 1 );
 			expect( wrapper.find( '[name="last-name"]' ) ).toHaveLength( 1 );


### PR DESCRIPTION
This has been extracted from https://github.com/Automattic/wp-calypso/pull/34940. It switches the checkout domain contact info form from using floats for the layout to a more cleaner and modern approach using flexbox.

I'm no designer and certainly no CSS expert, so any feedback/improvements are more than welcome.

### Testing

It doesn't matter if you try to add a domain to an existing site or through signup/NUX (but feel free to test both cases ;)).
Easiest is to go to Manage -> Domains -> Add Domain. Select a domain name from the list, `Skip` adding G Suite and you'll be presented with the form:

<img width="743" alt="Screenshot 2019-08-15 at 13 44 14" src="https://user-images.githubusercontent.com/3392497/63098627-d0a9cd00-bf62-11e9-95b7-946718dd2eca.png">


It should look basically the same on production as on the dev branch (there's a slight change in the margins between fields on the same row).

Make sure to test different browsers and OSes, as well on mobile.
Additionally, check different countries - we have three cases, and they all trigger a slightly different order of the address (city/state/postal code) fields:

* United Kingdom
* Any EU country
* United States