### PR TITLE
Site Importer: Make auto select author use defer

### DIFF
--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -50,6 +50,18 @@ class ImporterAuthorMapping extends React.Component {
 		const { hasSingleAuthor, onSelect: selectAuthor } = this.props;
 
 		if ( hasSingleAuthor ) {
+			/**
+			 * Using `defer` here is a leftover from using Flux store here.
+			 *
+			 * It's not ideal and should be refactored in the future to read
+			 * the state, instead of automating the UI in this way.
+			 *
+			 * This effort is quite big as it requires refactoring a a few things on more fundamental
+			 * level in the imports section.
+			 *
+			 * TODO: Refactor this to not automate the UI but use proper state
+			 * TODO: A better way might be to handle this call in the backend and leave the UI out of the decision
+			 */
 			defer( () => selectAuthor( this.props.currentUser ) );
 		}
 	}

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -51,12 +51,12 @@ class ImporterAuthorMapping extends React.Component {
 
 		if ( hasSingleAuthor ) {
 			/**
-			 * Using `defer` here is a leftover from using Flux store here.
+			 * Using `defer` here is a leftover from using Flux store in the past.
 			 *
 			 * It's not ideal and should be refactored in the future to read
 			 * the state, instead of automating the UI in this way.
 			 *
-			 * This effort is quite big as it requires refactoring a a few things on more fundamental
+			 * This effort is quite big as it requires refactoring a few things on more fundamental
 			 * level in the imports section.
 			 *
 			 * TODO: Refactor this to not automate the UI but use proper state

--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
 import { connect } from 'react-redux';
+import { defer } from 'lodash';
 
 /**
  * Internal dependencies
@@ -49,7 +50,7 @@ class ImporterAuthorMapping extends React.Component {
 		const { hasSingleAuthor, onSelect: selectAuthor } = this.props;
 
 		if ( hasSingleAuthor ) {
-			selectAuthor( this.props.currentUser );
+			defer( () => selectAuthor( this.props.currentUser ) );
 		}
 	}
 


### PR DESCRIPTION
This PR is part of series to extract more focused changes out of #32449 

Th call to `selectAuthor` was not wrapped in a `defer` statement which could carried some issues with the Flux backend previously. 

The change would make sure that calls to the function wouldn't cause any `Cannot dispatch while already dispatching` errors which would crash the flow.

# To test

* Checkout branch or use Calypso.live link
* Go to Imports
* Choose Wix or GoDaddy
* Enter a site URL
* Continue through the Preview step
* Make sure the import auto progresses after clicking Next on the Preview screen
* Make sure there are no JS errors in the Developer console.