### PR TITLE
Import in Signup: remove blogger plan

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -15,7 +15,6 @@ import {
 	PLAN_PREMIUM,
 	PLAN_BUSINESS,
 	TYPE_FREE,
-	TYPE_BLOGGER,
 	TYPE_PERSONAL,
 	TYPE_PREMIUM,
 	TYPE_BUSINESS,
@@ -183,7 +182,7 @@ export function generateSteps( {
 			providesDependencies: [ 'cartItem' ],
 			fulfilledStepCallback: isPlanFulfilled,
 			props: {
-				planTypes: [ TYPE_FREE, TYPE_BLOGGER, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ],
+				planTypes: [ TYPE_FREE, TYPE_PERSONAL, TYPE_PREMIUM, TYPE_BUSINESS ],
 			},
 		},
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR removes the blogger plan from the import plans step. It was erroneously left behind in #34231.

#### Testing instructions


* Follow testing instructions from #34231, but verify that the blogger plan doesn't appear on the plans step

