### PR TITLE
Site Importer: Extract WPCOM API call that starts the import to a separate function

### DIFF
--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -6,6 +6,7 @@
  */
 import debugFactory from 'debug';
 import { camelCase, isPlainObject, omit, pick, reject, snakeCase } from 'lodash';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies.
@@ -1915,6 +1916,21 @@ Undocumented.prototype.updateImporter = function( siteId, importerStatus ) {
 	return this.wpcom.req.post( {
 		path: `/sites/${ siteId }/imports/${ importerStatus.importerId }`,
 		formData: [ [ 'importStatus', JSON.stringify( importerStatus ) ] ],
+	} );
+};
+
+Undocumented.prototype.importWithSiteImporter = function(
+	siteId,
+	importerStatus,
+	params,
+	targetUrl
+) {
+	debug( `/sites/${ siteId }/site-importer/import-site?${ stringify( params ) }` );
+
+	return this.wpcom.req.post( {
+		path: `/sites/${ siteId }/site-importer/import-site?${ stringify( params ) }`,
+		apiNamespace: 'wpcom/v2',
+		formData: [ [ 'import_status', JSON.stringify( importerStatus ) ], [ 'site_url', targetUrl ] ],
 	} );
 };
 

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1943,7 +1943,6 @@ Undocumented.prototype.uploadExportFile = function( siteId, params ) {
 		const req = this.wpcom.req.post(
 			{
 				path: `/sites/${ siteId }/imports/new`,
-
 				formData: [
 					[ 'importStatus', JSON.stringify( params.importStatus ) ],
 					[ 'import', params.file ],

--- a/client/lib/wpcom-undocumented/lib/undocumented.js
+++ b/client/lib/wpcom-undocumented/lib/undocumented.js
@@ -1943,6 +1943,7 @@ Undocumented.prototype.uploadExportFile = function( siteId, params ) {
 		const req = this.wpcom.req.post(
 			{
 				path: `/sites/${ siteId }/imports/new`,
+
 				formData: [
 					[ 'importStatus', JSON.stringify( params.importStatus ) ],
 					[ 'import', params.file ],

--- a/client/state/imports/site-importer/actions.js
+++ b/client/state/imports/site-importer/actions.js
@@ -148,7 +148,7 @@ export const importSite = ( {
 
 	wpcom
 		.undocumented()
-		.importWithSiteImporter( site.ID, toApi( importerStatus ), params, targetSiteUrl )
+		.importWithSiteImporter( siteId, toApi( importerStatus ), params, targetSiteUrl )
 		.then( response => {
 			// At this point we're assuming that an import is going to happen
 			// so we set the user's editor to Gutenberg in order to make sure

--- a/client/state/imports/site-importer/actions.js
+++ b/client/state/imports/site-importer/actions.js
@@ -146,15 +146,9 @@ export const importSite = ( {
 	dispatch( recordTracksEvent( 'calypso_site_importer_start_import_request', trackingParams ) );
 	dispatch( startSiteImporterImport() );
 
-	wpcom.req
-		.post( {
-			path: `/sites/${ siteId }/site-importer/import-site?${ stringify( params ) }`,
-			apiNamespace: 'wpcom/v2',
-			formData: [
-				[ 'import_status', JSON.stringify( toApi( importerStatus ) ) ],
-				[ 'site_url', targetSiteUrl ],
-			],
-		} )
+	wpcom
+		.undocumented()
+		.importWithSiteImporter( site.ID, toApi( importerStatus ), params, targetSiteUrl )
 		.then( response => {
 			// At this point we're assuming that an import is going to happen
 			// so we set the user's editor to Gutenberg in order to make sure


### PR DESCRIPTION
This PR is part of series to extract more focused changes out of #32449 

This PR extracts a direct call to `wpcom.req.post` to the `wp.undocumented` API for easier use in the future. 

# To test

* Checkout branch or use Calypso.live link
* Go to Imports
* Choose Wix
* Enter a site URL
* Continue through the Preview step
* Make sure the import auto progresses after clicking Next on the Preview screen
* Make sure there are no JS errors in the Developer console.
* Repeat for a GoDaddy site