### PR TITLE
Jetpack premium blocks: Add plan param to post-checkout redirect url.

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -414,6 +414,8 @@ export class Checkout extends React.Component {
 			// We cannot simply compare `hostname` to `selectedSiteSlug`, since the latter
 			// might contain a path in the case of Jetpack subdirectory installs.
 			if ( adminUrl && redirectTo.startsWith( `${ adminUrl }post.php?` ) ) {
+				const plan = get( query, [ 'plan' ] );
+				const action = get( query, [ 'action' ] );
 				const sanitizedRedirectTo = formatUrl( {
 					protocol,
 					hostname,
@@ -421,7 +423,8 @@ export class Checkout extends React.Component {
 					pathname,
 					query: {
 						post: parseInt( get( query, [ 'post' ] ), 10 ),
-						action: 'edit',
+						...( action && { action } ),
+						...( plan && { plan } ),
 					},
 				} );
 				return sanitizedRedirectTo;

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -414,17 +414,15 @@ export class Checkout extends React.Component {
 			// We cannot simply compare `hostname` to `selectedSiteSlug`, since the latter
 			// might contain a path in the case of Jetpack subdirectory installs.
 			if ( adminUrl && redirectTo.startsWith( `${ adminUrl }post.php?` ) ) {
-				const plan = get( query, [ 'plan' ] );
-				const action = get( query, [ 'action' ] );
 				const sanitizedRedirectTo = formatUrl( {
 					protocol,
 					hostname,
 					port,
 					pathname,
 					query: {
-						post: parseInt( get( query, [ 'post' ] ), 10 ),
-						...( action && { action } ),
-						...( plan && { plan } ),
+						post: parseInt( query.post, 10 ),
+						action: 'edit',
+						plan_upgraded: 1,
 					},
 				} );
 				return sanitizedRedirectTo;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!-- Would you like this feature to be tested by Beta testers?
Please add testing instructions to to-test.md in a new commit as part of your PR. -->

Fixes #13003 (partially)

Related: https://github.com/Automattic/jetpack/pull/13218

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->

Adds a ~`plan`~ `plan_upgraded` URL parameter to the post-checkout redirect url in Jetpack upgrades. This will be passed on redirection once a plan has been upgraded successfully after clicking on the "upgrade nudge".

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Checkout the underlying branch and the related branch in Jetpack.
* Load a non-premium jetpack site.
* Add the "simple payments" block and click on the `upgrade nudge`.
* On redirection back to the editor, confirm that the URL contains the parameter `&plan_upgraded=1`
