### PR TITLE
 Add "continue as user" option to login.

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { useTranslate } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import Gravatar from 'components/gravatar';
+
+/**
+ * Style dependencies
+ */
+import './continue-as-user.scss';
+
+export default function ContinueAsUser( { user, redirectUrl } ) {
+	const translate = useTranslate();
+
+	if ( ! user || ! redirectUrl ) {
+		return null;
+	}
+
+	const userName = user.display_name || user.username;
+	const redirectLink = (
+		<a href={ redirectUrl }>
+			<Gravatar user={ user } size={ 16 } />
+			{ userName }
+		</a>
+	);
+
+	return (
+		<div className="continue-as-user">
+			{ translate( 'or continue as {{userName/}}', {
+				components: { userName: redirectLink },
+				comment: 'Alternative link under login header, skips login to continue as current user.',
+			} ) }
+		</div>
+	);
+}

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -26,9 +26,9 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery } ) {
 	useEffect( () => {
 		async function validateUrl( redirectUrl ) {
 			try {
-				const response = await wpcom.req.get(
-					`/me/validate-redirect?redirect_url=${ redirectUrl }`
-				);
+				const response = await wpcom.req.get( '/me/validate-redirect', {
+					redirect_url: redirectUrl,
+				} );
 				if ( response ) {
 					setValidatedRedirectUrl( response.redirect_to || '/' );
 				}

--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -38,16 +38,12 @@ function ContinueAsUser( { currentUser, redirectUrlFromQuery } ) {
 			}
 		}
 
-		if ( ! currentUser || ! redirectUrlFromQuery ) {
+		if ( ! redirectUrlFromQuery ) {
 			return;
 		}
 
 		validateUrl( redirectUrlFromQuery );
-	}, [ currentUser, redirectUrlFromQuery ] );
-
-	if ( ! currentUser ) {
-		return null;
-	}
+	}, [ redirectUrlFromQuery ] );
 
 	const userName = currentUser.display_name || currentUser.username;
 

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -1,0 +1,18 @@
+.continue-as-user {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var( --color-text-subtle );
+	font-size: 14px;
+
+	> a {
+		display: inline-flex;
+		align-items: center;
+		// Match avatar height.
+		height: 16px;
+	}
+
+	.gravatar {
+		margin: 0 4px;
+	}
+}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -172,15 +172,12 @@ class Login extends Component {
 			twoStepNonce,
 			fromSite,
 			currentUser,
+			twoFactorEnabled,
 		} = this.props;
 
 		let headerText = translate( 'Log in to your account' );
 		let preHeader = null;
 		let postHeader = null;
-
-		if ( currentUser ) {
-			postHeader = <ContinueAsUser />;
-		}
 
 		if ( isManualRenewalImmediateLoginAttempt ) {
 			headerText = translate( 'Log in to update your payment details and renew your subscription' );
@@ -308,6 +305,9 @@ class Login extends Component {
 		} else if ( fromSite ) {
 			// if redirected from Calypso URL with a site slug, offer a link to that site's frontend
 			postHeader = <VisitSite siteSlug={ fromSite } />;
+		} else if ( currentUser && ! twoFactorEnabled ) {
+			// someone is already logged in, offer to proceed to the app without a new login
+			postHeader = <ContinueAsUser />;
 		}
 
 		return (

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -15,8 +14,6 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import config from 'config';
-import ErrorNotice from './error-notice';
-import LoginForm from './login-form';
 import {
 	getRedirectToSanitized,
 	getRequestNotice,
@@ -25,23 +22,22 @@ import {
 	getSocialAccountIsLinking,
 	getSocialAccountLinkService,
 } from 'state/login/selectors';
+import { getCurrentUser } from 'state/current-user/selectors';
 import { wasManualRenewalImmediateLoginAttempted } from 'state/immediate-login/selectors';
 import { getCurrentOAuth2Client } from 'state/ui/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'state/selectors/get-current-query-arguments';
 import getPartnerSlugFromQuery from 'state/selectors/get-partner-slug-from-query';
 import { setResumeAfterLogin } from 'state/signup/progress/actions';
 import { getSignupProgress } from 'state/signup/progress/selectors';
-import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analytics/actions';
-import VerificationCodeForm from './two-factor-authentication/verification-code-form';
-import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';
+import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import { login } from 'lib/paths';
-import Notice from 'components/notice';
-import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
 import userFactory from 'lib/user';
+import Notice from 'components/notice';
 import AsyncLoad from 'components/async-load';
 import VisitSite from 'blocks/visit-site';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
+import ContinueAsUser from './continue-as-user';
 
 /**
  * Style dependencies
@@ -170,11 +166,17 @@ class Login extends Component {
 			translate,
 			twoStepNonce,
 			fromSite,
+			currentUser,
+			redirectTo,
 		} = this.props;
 
 		let headerText = translate( 'Log in to your account' );
 		let preHeader = null;
 		let postHeader = null;
+
+		if ( currentUser ) {
+			postHeader = <ContinueAsUser user={ currentUser } redirectUrl={ redirectTo || '/' } />;
+		}
 
 		if ( isManualRenewalImmediateLoginAttempt ) {
 			headerText = translate( 'Log in to update your payment details and renew your subscription' );
@@ -405,6 +407,7 @@ class Login extends Component {
 
 export default connect(
 	state => ( {
+		currentUser: getCurrentUser( state ),
 		redirectTo: getRedirectToSanitized( state ),
 		requestNotice: getRequestNotice( state ),
 		twoFactorEnabled: isTwoFactorEnabled( state ),

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -38,6 +38,11 @@ import AsyncLoad from 'components/async-load';
 import VisitSite from 'blocks/visit-site';
 import WooCommerceConnectCartHeader from 'extensions/woocommerce/components/woocommerce-connect-cart-header';
 import ContinueAsUser from './continue-as-user';
+import ErrorNotice from './error-notice';
+import LoginForm from './login-form';
+import VerificationCodeForm from './two-factor-authentication/verification-code-form';
+import WaitingTwoFactorNotificationApproval from './two-factor-authentication/waiting-notification-approval';
+import PushNotificationApprovalPoller from './two-factor-authentication/push-notification-approval-poller';
 
 /**
  * Style dependencies

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -9,7 +9,6 @@ import { capitalize, findLast, get, includes, isEmpty } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
-import { parse as qsParse } from 'qs';
 
 /**
  * Internal dependencies
@@ -34,7 +33,6 @@ import { recordTracksEventWithClientId as recordTracksEvent } from 'state/analyt
 import { isCrowdsignalOAuth2Client, isWooOAuth2Client } from 'lib/oauth2-clients';
 import { login } from 'lib/paths';
 import userFactory from 'lib/user';
-import wpcom from 'lib/wp';
 import Notice from 'components/notice';
 import AsyncLoad from 'components/async-load';
 import VisitSite from 'blocks/visit-site';
@@ -76,47 +74,16 @@ class Login extends Component {
 
 	static defaultProps = { isJetpack: false, isJetpackWooCommerceFlow: false };
 
-	state = { validatedRedirectToQueryParam: null };
-
-	async validateRedirectUrl() {
-		// TODO (sgomes): Replace with URLSearchParams when polyfilled (see #35408).
-		// const query = new URLSearchParams( window.location.search );
-		// const redirectUrl = query.get( 'redirect_to' );
-		const query = qsParse( window.location.search, { ignoreQueryPrefix: true } );
-		const redirectUrl = query.redirect_to;
-		if ( ! redirectUrl ) {
-			return;
-		}
-
-		try {
-			const response = await wpcom.req.get( `/me/validate-redirect?redirect_url=${ redirectUrl }` );
-			if ( response ) {
-				this.setState( { validatedRedirectToQueryParam: response.redirect_to || '/' } );
-			}
-		} catch {
-			// Ignore error, set the redirect link as a default `/`.
-			this.setState( { validatedRedirectToQueryParam: '/' } );
-		}
-	}
-
 	componentDidMount() {
 		if ( ! this.props.twoFactorEnabled && this.props.twoFactorAuthType ) {
 			// Disallow access to the 2FA pages unless the user has 2FA enabled
 			page( login( { isNative: true } ) );
 		}
 
-		if ( this.props.currentUser ) {
-			this.validateRedirectUrl();
-		}
-
 		window.scrollTo( 0, 0 );
 	}
 
 	componentDidUpdate( prevProps ) {
-		if ( this.props.currentUser && ! prevProps.currentUser ) {
-			this.validateRedirectUrl();
-		}
-
 		const hasNotice = this.props.requestNotice !== prevProps.requestNotice;
 		const isNewPage = this.props.twoFactorAuthType !== prevProps.twoFactorAuthType;
 
@@ -207,20 +174,12 @@ class Login extends Component {
 			currentUser,
 		} = this.props;
 
-		const { validatedRedirectToQueryParam } = this.state;
-
 		let headerText = translate( 'Log in to your account' );
 		let preHeader = null;
 		let postHeader = null;
 
 		if ( currentUser ) {
-			// Render ContinueAsUser straight away, even before validation.
-			// This helps avoid jarring layout shifts. It's not ideal that the link URL changes transparently
-			// like that, but it is better than the alternative, and in practice it should happen quicker than
-			// the user can notice.
-			postHeader = (
-				<ContinueAsUser user={ currentUser } redirectUrl={ validatedRedirectToQueryParam || '/' } />
-			);
+			postHeader = <ContinueAsUser />;
 		}
 
 		if ( isManualRenewalImmediateLoginAttempt ) {

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -156,7 +156,7 @@
 		color: var( --color-primary );
 	}
 
-	.visit-site {
+	.visit-site, .continue-as-user {
 		margin: -12px 0 24px;
 	}
 }

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -32,7 +32,7 @@ const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, redirectUri }
  * `context.primary` and `context.secondary` to populate it.
  */
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );
-export const makeForcedLoggedOutLayout = makeLayout;
+export const makeLoggedOutLayout = makeLayout;
 
 export function redirectLoggedIn( { isLoggedIn, res }, next ) {
 	// TODO: Make it work also for development env

--- a/client/controller/index.node.js
+++ b/client/controller/index.node.js
@@ -32,6 +32,7 @@ const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, redirectUri }
  * `context.primary` and `context.secondary` to populate it.
  */
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );
+export const makeForcedLoggedOutLayout = makeLayout;
 
 export function redirectLoggedIn( { isLoggedIn, res }, next ) {
 	// TODO: Make it work also for development env

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -44,6 +44,14 @@ export const ReduxWrappedLayout = ( { store, primary, secondary, redirectUri } )
 
 export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );
 
+const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, redirectUri } ) => (
+	<ReduxProvider store={ store }>
+		<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
+	</ReduxProvider>
+);
+
+export const makeForcedLoggedOutLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );
+
 /**
  * Isomorphic routing helper, client side
  *

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -50,7 +50,7 @@ const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, redirectUri }
 	</ReduxProvider>
 );
 
-export const makeForcedLoggedOutLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );
+export const makeLoggedOutLayout = makeLayoutMiddleware( ReduxWrappedLoggedOutLayout );
 
 /**
  * Isomorphic routing helper, client side

--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -46,7 +46,9 @@ export const makeLayout = makeLayoutMiddleware( ReduxWrappedLayout );
 
 const ReduxWrappedLoggedOutLayout = ( { store, primary, secondary, redirectUri } ) => (
 	<ReduxProvider store={ store }>
-		<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
+		<MomentProvider>
+			<LayoutLoggedOut primary={ primary } secondary={ secondary } redirectUri={ redirectUri } />
+		</MomentProvider>
 	</ReduxProvider>
 );
 

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -11,7 +11,7 @@ import {
 	redirectDefaultLocale,
 } from './controller';
 import { setShouldServerSideRenderLogin } from './ssr';
-import { makeLayout } from 'controller';
+import { makeForcedLoggedOutLayout } from 'controller';
 import { setUpLocale } from 'controller/shared';
 import { redirectLoggedIn } from 'controller/web-util';
 
@@ -22,10 +22,16 @@ export default router => {
 			setUpLocale,
 			redirectLoggedIn,
 			magicLoginUse,
-			makeLayout
+			makeForcedLoggedOutLayout
 		);
 
-		router( `/log-in/link/${ lang }`, setUpLocale, redirectLoggedIn, magicLogin, makeLayout );
+		router(
+			`/log-in/link/${ lang }`,
+			setUpLocale,
+			redirectLoggedIn,
+			magicLogin,
+			makeForcedLoggedOutLayout
+		);
 	}
 
 	if ( config.isEnabled( 'login/wp-login' ) ) {
@@ -42,7 +48,7 @@ export default router => {
 			setUpLocale,
 			login,
 			setShouldServerSideRenderLogin,
-			makeLayout
+			makeForcedLoggedOutLayout
 		);
 	}
 };

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -11,7 +11,7 @@ import {
 	redirectDefaultLocale,
 } from './controller';
 import { setShouldServerSideRenderLogin } from './ssr';
-import { makeForcedLoggedOutLayout } from 'controller';
+import { makeLoggedOutLayout } from 'controller';
 import { setUpLocale } from 'controller/shared';
 import { redirectLoggedIn } from 'controller/web-util';
 
@@ -22,7 +22,7 @@ export default router => {
 			setUpLocale,
 			redirectLoggedIn,
 			magicLoginUse,
-			makeForcedLoggedOutLayout
+			makeLoggedOutLayout
 		);
 
 		router(
@@ -30,7 +30,7 @@ export default router => {
 			setUpLocale,
 			redirectLoggedIn,
 			magicLogin,
-			makeForcedLoggedOutLayout
+			makeLoggedOutLayout
 		);
 	}
 
@@ -48,7 +48,7 @@ export default router => {
 			setUpLocale,
 			login,
 			setShouldServerSideRenderLogin,
-			makeForcedLoggedOutLayout
+			makeLoggedOutLayout
 		);
 	}
 };

--- a/test/e2e/lib/flows/login-flow.js
+++ b/test/e2e/lib/flows/login-flow.js
@@ -1,6 +1,11 @@
 /** @format */
 
 /**
+ * External dependencies
+ */
+import { By } from 'selenium-webdriver';
+
+/**
  * Internal dependencies
  */
 import LoginPage from '../pages/login-page.js';
@@ -16,6 +21,7 @@ import SidebarComponent from '../components/sidebar-component.js';
 import NavBarComponent from '../components/nav-bar-component.js';
 
 import * as dataHelper from '../data-helper';
+import * as driverHelper from '../driver-helper';
 import * as driverManager from '../driver-manager';
 import * as loginCookieHelper from '../login-cookie-helper';
 import PagesPage from '../pages/pages-page';
@@ -60,7 +66,12 @@ export default class LoginFlow {
 			( await loginCookieHelper.useLoginCookies( this.driver, this.account.username ) )
 		) {
 			console.log( 'Reusing login cookie for ' + this.account.username );
-			return await this.driver.navigate().refresh();
+			await this.driver.navigate().refresh();
+			const continueSelector = By.css( 'div.continue-as-user a' );
+			if ( await driverHelper.isElementPresent( this.driver, continueSelector ) ) {
+				await driverHelper.clickWhenClickable( this.driver, continueSelector );
+			}
+			return;
 		}
 
 		console.log( 'Logging in as ' + this.account.username );


### PR DESCRIPTION
This PR adds a link for the user to continue as the currently logged-in user as part of the login screen. This is only displayed if the user is already logged in, of course. It's hopefully a clearer mechanism to indicate that the user is already logged in and they don't need to enter their details again.

![image](https://user-images.githubusercontent.com/409615/62880253-e5991d00-bd24-11e9-8f44-87235143847c.png)

In addition, this PR changes the login pages to always use the logged-out layout, in order for the change to make sense as a whole.

This PR started out as a part of #33642 with changes initially proposed by @jsnajdr.

#### Changes proposed in this Pull Request

* Add "continue as user" option to login.
* Force the login pages to use logged-out layout.

#### Testing instructions

* Ensure you're logged in
* Open `/log-in` on the live branch
* Ensure that you see the "continue as user option and that it works normally

In addition to this, please ensure that all other login functionality continues working normally.
