### PR TITLE
Customer Home: Update the checklist return URLs for Jetpack sites

### DIFF
--- a/client/jetpack-connect/jetpack-only.js
+++ b/client/jetpack-connect/jetpack-only.js
@@ -11,6 +11,7 @@
 import React, { Component } from 'react';
 import page from 'page';
 import { connect } from 'react-redux';
+import { checklistUrl } from 'my-sites/customer-home';
 
 /**
  * Internal dependencies
@@ -29,7 +30,7 @@ const jetpackOnly = WrappedComponent => {
 
 			if ( notJetpack ) {
 				// Redirect to My Plan page if this is not a Jetpack site
-				page.redirect( `/plans/my-plan/${ siteSlug }` );
+				page.redirect( checklistUrl().replace( ':site', siteSlug ) );
 			} else if ( ! siteId ) {
 				// Redirect to /jetpack/connect if this is not a valid connected site
 				page.redirect( `/jetpack/connect` );

--- a/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-backups-rewind-tour/index.js
@@ -23,6 +23,7 @@ import {
 } from 'layout/guided-tours/config-elements';
 import { not } from 'layout/guided-tours/utils';
 import { getSelectedSiteId } from 'state/ui/selectors';
+import { checklistUrl } from 'my-sites/customer-home';
 
 function whenWeCanAutoconfigure( state ) {
 	const siteId = getSelectedSiteId( state );
@@ -33,7 +34,7 @@ function whenWeCanAutoconfigure( state ) {
 
 const JetpackBackupsRewindTourButtons = ( { backText, translate } ) => (
 	<Fragment>
-		<SiteLink isButton isPrimaryButton={ false } href="/plans/my-plan/:site">
+		<SiteLink isButton isPrimaryButton={ false } href={ checklistUrl() }>
 			{ backText || translate( 'Return to the checklist' ) }
 		</SiteLink>
 		<Quit>{ translate( 'No, thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-lazy-images-tour/index.js
@@ -17,6 +17,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
+import { checklistUrl } from 'my-sites/customer-home';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackLazyImagesTour = makeTour(
@@ -46,9 +47,7 @@ export const JetpackLazyImagesTour = makeTour(
 							click
 							hidden
 						/>
-						<SiteLink href="/plans/my-plan/:site">
-							{ translate( 'Return to the checklist' ) }
-						</SiteLink>
+						<SiteLink href={ checklistUrl() }>{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -70,7 +69,7 @@ export const JetpackLazyImagesTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href="/plans/my-plan/:site">
+						<SiteLink isButton href={ checklistUrl() }>
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-monitoring-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-monitoring-tour/index.js
@@ -19,6 +19,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
+import { checklistUrl } from 'my-sites/customer-home';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackMonitoringTour = makeTour(
@@ -48,9 +49,7 @@ export const JetpackMonitoringTour = makeTour(
 							click
 							hidden
 						/>
-						<SiteLink href="/plans/my-plan/:site">
-							{ translate( 'Return to the checklist' ) }
-						</SiteLink>
+						<SiteLink href={ checklistUrl() }>{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -71,7 +70,7 @@ export const JetpackMonitoringTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href="/plans/my-plan/:site">
+						<SiteLink isButton href={ checklistUrl() }>
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -19,6 +19,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
+import { checklistUrl } from 'my-sites/customer-home';
 
 const JETPACK_TOGGLE_SELECTOR = '.plugin-item-jetpack .form-toggle__switch';
 
@@ -74,9 +75,7 @@ export const JetpackPluginUpdatesTour = makeTour(
 							click
 							hidden
 						/>
-						<SiteLink href="/plans/my-plan/:site">
-							{ translate( 'Return to the checklist' ) }
-						</SiteLink>
+						<SiteLink href={ checklistUrl() }>{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -97,7 +96,7 @@ export const JetpackPluginUpdatesTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href="/plans/my-plan/:site">
+						<SiteLink isButton href={ checklistUrl() }>
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-search-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-search-tour/index.js
@@ -17,6 +17,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
+import { checklistUrl } from 'my-sites/customer-home';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackSearchTour = makeTour(
@@ -46,9 +47,7 @@ export const JetpackSearchTour = makeTour(
 							click
 							hidden
 						/>
-						<SiteLink href="/plans/my-plan/:site">
-							{ translate( 'Return to the checklist' ) }
-						</SiteLink>
+						<SiteLink href={ checklistUrl() }>{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -69,7 +68,7 @@ export const JetpackSearchTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href="/plans/my-plan/:site">
+						<SiteLink isButton href={ checklistUrl() }>
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-sign-in-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-sign-in-tour/index.js
@@ -19,6 +19,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
+import { checklistUrl } from 'my-sites/customer-home';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackSignInTour = makeTour(
@@ -43,9 +44,7 @@ export const JetpackSignInTour = makeTour(
 					</p>
 					<ButtonRow>
 						<Continue target=".sso__card .form-toggle__switch" step="finish" click hidden />
-						<SiteLink href="/plans/my-plan/:site">
-							{ translate( 'Return to the checklist' ) }
-						</SiteLink>
+						<SiteLink href={ checklistUrl() }>{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -67,7 +66,7 @@ export const JetpackSignInTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href="/plans/my-plan/:site">
+						<SiteLink isButton href={ checklistUrl() }>
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-site-accelerator-tour/index.js
@@ -17,6 +17,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
+import { checklistUrl } from 'my-sites/customer-home';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackSiteAcceleratorTour = makeTour(
@@ -46,9 +47,7 @@ export const JetpackSiteAcceleratorTour = makeTour(
 							click
 							hidden
 						/>
-						<SiteLink href="/plans/my-plan/:site">
-							{ translate( 'Return to the checklist' ) }
-						</SiteLink>
+						<SiteLink href={ checklistUrl() }>{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -70,7 +69,7 @@ export const JetpackSiteAcceleratorTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href="/plans/my-plan/:site">
+						<SiteLink isButton href={ checklistUrl() }>
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
+++ b/client/layout/guided-tours/tours/jetpack-video-hosting-tour/index.js
@@ -17,6 +17,7 @@ import {
 	Step,
 	Tour,
 } from 'layout/guided-tours/config-elements';
+import { checklistUrl } from 'my-sites/customer-home';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackVideoHostingTour = makeTour(
@@ -51,9 +52,7 @@ export const JetpackVideoHostingTour = makeTour(
 							click
 							hidden
 						/>
-						<SiteLink href="/plans/my-plan/:site">
-							{ translate( 'Return to the checklist' ) }
-						</SiteLink>
+						<SiteLink href={ checklistUrl() }>{ translate( 'Return to the checklist' ) }</SiteLink>
 					</ButtonRow>
 				</Fragment>
 			) }
@@ -74,7 +73,7 @@ export const JetpackVideoHostingTour = makeTour(
 						) }
 					</p>
 					<ButtonRow>
-						<SiteLink isButton href="/plans/my-plan/:site">
+						<SiteLink isButton href={ checklistUrl() }>
 							{ translate( "Yes, let's do it." ) }
 						</SiteLink>
 						<Quit>{ translate( 'No thanks.' ) }</Quit>

--- a/client/my-sites/customer-home/index.js
+++ b/client/my-sites/customer-home/index.js
@@ -10,9 +10,13 @@ import page from 'page';
 import { navigation, siteSelection, sites } from 'my-sites/controller';
 import home from './controller';
 import { makeLayout, render as clientRender } from 'controller';
+import { isEnabled } from 'config';
 
 export default function() {
 	page( '/home', siteSelection, sites, makeLayout, clientRender );
 
 	page( '/home/:siteId', siteSelection, navigation, home, makeLayout, clientRender );
 }
+
+export const checklistUrl = () =>
+	isEnabled( 'customer-home' ) ? '/home/:site' : '/plans/my-plan/:site';


### PR DESCRIPTION
This adds a check for the new home section and if enabled ensures that
the Jetpack customers are redirected to that section rather than the
`/my-plans/plan/:site` page.

If the Jetpack connect flow is visited by a non-Jetpack site this will
also redirect to the home section rather than the previous plan page.

#### Testing instructions

Go through the checklist items with a Jetpack site and ensure that the return URL is to `/home/:site`

Go to `/jetpack/connect/site-topic/:site` with a Jetpack site and ensure that it loads correctly. Do the same with a non-Jetpack site and ensure that you are redirected to `/home/:site`

Fixes #35287
