### PR TITLE
FSE: Use correct theme slug for the WP_Template class

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -346,7 +346,7 @@ class Full_Site_Editing {
 			return;
 		}
 
-		$template         = new WP_Template( $this->theme_slug );
+		$template         = new WP_Template();
 		$template_content = $template->get_page_template_content();
 
 		// Bail if the template has no post content block.
@@ -414,7 +414,7 @@ class Full_Site_Editing {
 	 */
 	public function set_block_template( $editor_settings ) {
 		if ( $this->is_full_site_page() ) {
-			$fse_template    = new WP_Template( $this->theme_slug );
+			$fse_template    = new WP_Template();
 			$template_blocks = $fse_template->get_template_blocks();
 
 			$template = array();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -346,7 +346,7 @@ class Full_Site_Editing {
 			return;
 		}
 
-		$template         = new WP_Template();
+		$template         = new WP_Template( $this->theme_slug );
 		$template_content = $template->get_page_template_content();
 
 		// Bail if the template has no post content block.
@@ -414,7 +414,7 @@ class Full_Site_Editing {
 	 */
 	public function set_block_template( $editor_settings ) {
 		if ( $this->is_full_site_page() ) {
-			$fse_template    = new WP_Template();
+			$fse_template    = new WP_Template( $this->theme_slug );
 			$template_blocks = $fse_template->get_template_blocks();
 
 			$template = array();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -41,12 +41,30 @@ class WP_Template {
 
 	/**
 	 * A8C_WP_Template constructor.
-	 *
-	 * @param string $theme_slug The theme slug used to identify theme-specific template data.
 	 */
-	public function __construct( $theme_slug ) {
-		$this->current_theme_name = $theme_slug;
+	public function __construct() {
+		$this->current_theme_name = $this->normalize_theme_slug( get_option( 'stylesheet' ) );
 	}
+
+	/**
+	 * Returns normalized theme slug for the current theme.
+	 *
+	 * Normalize WP.com theme slugs that differ from those that we'll get on self hosted sites.
+	 * For example, we will get 'modern-business' when retrieving theme slug on self hosted sites,
+	 * but due to WP.com setup, on Simple sites we'll get 'pub/modern-business' for the theme.
+	 *
+	 * @param string $theme_slug Theme slug to check support for.
+	 *
+	 * @return string Normalized theme slug.
+	 */
+	public function normalize_theme_slug( $theme_slug ) {
+		if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
+			$theme_slug = str_replace( 'pub/', '', $theme_slug );
+		}
+
+		return $theme_slug;
+	}
+
 
 	/**
 	 * Checks whether the provided template type is supported in FSE.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -41,9 +41,11 @@ class WP_Template {
 
 	/**
 	 * A8C_WP_Template constructor.
+	 *
+	 * @param string $theme_slug The theme slug used to identify theme-specific template data.
 	 */
-	public function __construct() {
-		$this->current_theme_name = get_option( 'stylesheet' );
+	public function __construct( $theme_slug ) {
+		$this->current_theme_name = $theme_slug;
 	}
 
 	/**


### PR DESCRIPTION
@gwwar and I debugged a strange issue in FSE where the API was unable to determine the correct ID for a template. Interestingly, this because we used a normalized version of the theme name (i.e. `modern-business`) to insert the data, but the denormalized version to retrieve the data (i.e. `pub/modern-business`).

One would think that you could simply pass down the correct theme name through the constructor, as we do for the template data inserter class. BUT ALAS! In the API context (i.e. the context through which we get the blocks for the page), the theme name is set to `a8c/public-api`. This gets set in the parent `Full_Site_Editing` class, and if you pass it down, it won't be able to find the correct template, because no template has been set for that theme! For some dumb and also very convenient reason, the `WP_Template` class does not have this same problem. It knows the correct theme name in the API context, even though the parent which calls it does not.

#### Changes proposed in this Pull Request
* Copy-paste the denormalize function for use in the WP_Template class.

#### Testing instructions
1. Use an FSE-enabled test site.
2. Sandbox that test site, as well as the API.
1. Sync this change to your sandbox environment.
2. Open your test site and navigate to an existing page for editing.
3. The header/footer template parts should load correctly. Before, the loading spinner spun indefinitely.

For followup: make sure that the FSE classes are always in the correct blog context, not the API blog context.

Also see D31440#626448-code