### PR TITLE
Add A/B tests to remove blog and website flows

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -152,4 +152,22 @@ export default {
 		defaultVariation: 'first',
 		allowExistingUsers: true,
 	},
+	removeBlogFlow: {
+		datestamp: '20190813',
+		variations: {
+			remove: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
+	removeWebsiteFlow: {
+		datestamp: '20190813',
+		variations: {
+			remove: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -38,6 +38,7 @@ import SignupHeader from 'signup/signup-header';
 import QuerySiteDomains from 'components/data/query-site-domains';
 
 // Libraries
+import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import * as oauthToken from 'lib/oauth-token';
 import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
@@ -160,6 +161,14 @@ class Signup extends React.Component {
 			const destinationStep = flows.getFlow( this.props.flowName ).steps[ 0 ];
 			this.setState( { resumingStep: destinationStep } );
 			return page.redirect( getStepUrl( this.props.flowName, destinationStep, this.props.locale ) );
+		}
+
+		if ( 'remove' === abtest( 'removeBlogFlow' ) && 'blog' === this.props.flowName ) {
+			return page.redirect( '/start' );
+		}
+
+		if ( 'remove' === abtest( 'removeWebsiteFlow' ) && 'website' === this.props.flowName ) {
+			return page.redirect( '/start' );
 		}
 
 		this.recordStep();

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -164,11 +164,15 @@ class Signup extends React.Component {
 		}
 
 		if ( 'remove' === abtest( 'removeBlogFlow' ) && 'blog' === this.props.flowName ) {
-			return page.redirect( '/start' );
+			const destinationStep = flows.getFlow( 'onboarding' ).steps[ 0 ];
+			this.setState( { resumingStep: destinationStep } );
+			return page.redirect( getStepUrl( 'onboarding', destinationStep, this.props.locale ) );
 		}
 
 		if ( 'remove' === abtest( 'removeWebsiteFlow' ) && 'website' === this.props.flowName ) {
-			return page.redirect( '/start' );
+			const destinationStep = flows.getFlow( 'onboarding' ).steps[ 0 ];
+			this.setState( { resumingStep: destinationStep } );
+			return page.redirect( getStepUrl( 'onboarding', destinationStep, this.props.locale ) );
 		}
 
 		this.recordStep();


### PR DESCRIPTION
This PR adds two 50/50 A/B tests to effectively remove the `blog` and `website` flows.

So that the A/B tests can be filtered by the flow name, this test doesn't actually _remove_ the flows, but instead redirects the user to the main onboarding flow.

#### Changes proposed in this Pull Request

* Add `removeBlogFlow` A/B test with 50/50 split
* Add `removeWebsiteFlow` A/B test with 50/50 split
* If the user falls in the variation group (`remove`) and the flowName matches `blog` or `website` (depending on the A/B test activated), redirect to the onboarding flow (`/start/`).

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

![image](https://user-images.githubusercontent.com/14988353/62915357-74ff0880-bdd7-11e9-9e69-5f7917918150.png)

##### Test removing the `blog` flow

* In your browser, set the A/B test for `removeBlogFlow` to `remove`.
* Browse to `http://calypso.localhost:3000/start/blog`, and it should redirect you to the main `onboarding` flow at `http://calypso.localhost:3000/start/`
* Set the A/B test for `removeBlogFlow` to `control`.
* Browse to `http://calypso.localhost:3000/start/blog` and it should keep you on the existing `blog` flow.

Variation `remove` (first step of onboarding flow):

![image](https://user-images.githubusercontent.com/14988353/62915508-053d4d80-bdd8-11e9-996d-8e8bcb5a59de.png)

Control `blog` flow (after logging in):

![image](https://user-images.githubusercontent.com/14988353/62915479-f35baa80-bdd7-11e9-8688-546127bde3c2.png)

---

##### Test removing the `website` flow

* In your browser, set the A/B test for `removeWebsiteFlow` to `remove`.
* Browse to `http://calypso.localhost:3000/start/website`, and it should redirect you to the main `onboarding` flow at `http://calypso.localhost:3000/start/`
* Set the A/B test for `removeWebsiteFlow` to `control`.
* Browse to `http://calypso.localhost:3000/start/website` and it should keep you on the existing `website` flow.

Variation `remove` (first step of onboarding flow):

![image](https://user-images.githubusercontent.com/14988353/62915508-053d4d80-bdd8-11e9-996d-8e8bcb5a59de.png)

Control `website` flow (after logging in):

![image](https://user-images.githubusercontent.com/14988353/62915799-163a8e80-bdd9-11e9-91f6-bf7444c6cdbe.png)


