### PR TITLE
Make the copy of the auto-renewal cancellation survey be aware of the product.

### DIFF
--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -19,6 +19,7 @@ import FormFieldset from 'components/forms/form-fieldset';
 import FormLabel from 'components/forms/form-label';
 import FormRadio from 'components/forms/form-radio';
 import { submitSurvey } from 'lib/upgrades/actions';
+import { isDomainRegistration, isPlan } from 'lib/products-values';
 import enrichedSurveyData from 'components/marketing-survey/cancel-purchase-form/enriched-survey-data';
 import PrecancellationChatButton from 'components/marketing-survey/cancel-purchase-form/precancellation-chat-button';
 import './style.scss';
@@ -38,14 +39,39 @@ class CancelAutoRenewalForm extends Component {
 
 	radioButtons = {};
 
+	getProductString = () => {
+		const { purchase, translate } = this.props;
+
+		if ( isDomainRegistration( purchase ) ) {
+			return translate( 'domain' );
+		}
+
+		if ( isPlan( purchase ) ) {
+			return translate( 'plan' );
+		}
+
+		return translate( 'subscription' );
+	};
+
 	constructor( props ) {
 		super( props );
 
 		const { translate } = props;
+		const product = this.getProductString();
 
 		this.radioButtons = [
-			[ 'let-it-expire', translate( "I'm going to let this plan expire." ) ],
-			[ 'manual-renew', translate( "I'm going to renew the plan, but will do it manually." ) ],
+			[
+				'let-it-expire',
+				translate( "I'm going to let this %(product)s expire.", {
+					args: { product },
+				} ),
+			],
+			[
+				'manual-renew',
+				translate( "I'm going to renew the %(product)s, but will do it manually.", {
+					args: { product },
+				} ),
+			],
 			[ 'not-sure', translate( "I'm not sure." ) ],
 		];
 	}
@@ -92,6 +118,7 @@ class CancelAutoRenewalForm extends Component {
 		const { response } = this.state;
 
 		const disableSubmit = ! response;
+		const product = this.getProductString();
 
 		return (
 			<Dialog
@@ -106,7 +133,10 @@ class CancelAutoRenewalForm extends Component {
 					<p>
 						{ translate(
 							"Auto-renewal is now off. Before you go, we'd love to know: " +
-								"are you letting this plan expire completely, or do you think you'll renew it manually?"
+								"are you letting this %(product)s expire completely, or do you think you'll renew it manually?",
+							{
+								args: { product },
+							}
 						) }
 					</p>
 					{ this.radioButtons.map( radioButton =>

--- a/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
+++ b/client/components/marketing-survey/cancel-auto-renewal-form/index.jsx
@@ -39,14 +39,16 @@ class CancelAutoRenewalForm extends Component {
 
 	radioButtons = {};
 
-	getProductString = () => {
+	getProductTypeString = () => {
 		const { purchase, translate } = this.props;
 
 		if ( isDomainRegistration( purchase ) ) {
+			/* translators: as in "domain name"*/
 			return translate( 'domain' );
 		}
 
 		if ( isPlan( purchase ) ) {
+			/* translators: as in "Premium plan" or "Personal plan"*/
 			return translate( 'plan' );
 		}
 
@@ -57,19 +59,21 @@ class CancelAutoRenewalForm extends Component {
 		super( props );
 
 		const { translate } = props;
-		const product = this.getProductString();
+		const productType = this.getProductTypeString();
 
 		this.radioButtons = [
 			[
 				'let-it-expire',
-				translate( "I'm going to let this %(product)s expire.", {
-					args: { product },
+				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+				translate( "I'm going to let this %(productType)s expire.", {
+					args: { productType },
 				} ),
 			],
 			[
 				'manual-renew',
-				translate( "I'm going to renew the %(product)s, but will do it manually.", {
-					args: { product },
+				/* translators: %(productType)s will be either "plan", "domain", or "subscription". */
+				translate( "I'm going to renew the %(productType)s, but will do it manually.", {
+					args: { productType },
 				} ),
 			],
 			[ 'not-sure', translate( "I'm not sure." ) ],
@@ -118,7 +122,7 @@ class CancelAutoRenewalForm extends Component {
 		const { response } = this.state;
 
 		const disableSubmit = ! response;
-		const product = this.getProductString();
+		const productType = this.getProductTypeString();
 
 		return (
 			<Dialog
@@ -133,9 +137,10 @@ class CancelAutoRenewalForm extends Component {
 					<p>
 						{ translate(
 							"Auto-renewal is now off. Before you go, we'd love to know: " +
-								"are you letting this %(product)s expire completely, or do you think you'll renew it manually?",
+								"are you letting this %(productType)s expire completely, or do you think you'll renew it manually?",
 							{
-								args: { product },
+								args: { productType },
+								comment: '%(productType)s will be either "plan", "domain", or "subscription".',
 							}
 						) }
 					</p>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to resolve #35224, by introducing product-specific terms.

For a plan:
![image](https://user-images.githubusercontent.com/1842898/62917610-817f6300-bdcf-11e9-939b-b27dc539f48b.png)

For a domain:
![image](https://user-images.githubusercontent.com/1842898/62917622-8b08cb00-bdcf-11e9-9244-e7ad90ad4025.png)

For anything else we haven't thought of in advance, it defaults to "subscription":
![image](https://user-images.githubusercontent.com/1842898/62917984-e9827900-bdd0-11e9-8594-179146a3df3a.png)

#### Testing instructions

1. Disable auto-renewal of a plan subscription and see the plan-specific copy show up.
1. Disable auto-renewal of a domain registration and see the domain-specific copy show up.
1. There doesn't seem to be an obvious way to see the defaults. One way is to hard-code `isPlan()` and `isDomainRegistration()` to always return `false`.
