### PR TITLE
Remove dependency on wpcom-oauth.

### DIFF
--- a/client/auth/controller.js
+++ b/client/auth/controller.js
@@ -1,11 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import page from 'page';
+import { stringify } from 'qs';
 
 /**
  * Internal dependencies
@@ -16,7 +14,6 @@ import { getToken } from 'lib/oauth-token';
 import wpcom from 'lib/wp';
 import config from 'config';
 import store from 'store';
-import WPOAuth from 'wpcom-oauth';
 import userFactory from 'lib/user';
 import Main from 'components/main';
 import PulsingDot from 'components/pulsing-dot';
@@ -25,6 +22,8 @@ import PulsingDot from 'components/pulsing-dot';
  * Style dependencies
  */
 import './style.scss';
+
+const WP_AUTHORIZE_ENDPOINT = 'https://public-api.wordpress.com/oauth2/authorize';
 
 export default {
 	oauthLogin: function( context, next ) {
@@ -46,17 +45,17 @@ export default {
 			const protocol = process.env.PROTOCOL || config( 'protocol' );
 			const host = process.env.HOST || config( 'hostname' );
 			const port = process.env.PORT || config( 'port' );
-			const oauthSettings = {
+			const redirectUri = `${ protocol }://${ host }:${ port }/api/oauth/token`;
+
+			const params = {
 				response_type: 'token',
 				client_id: config( 'oauth_client_id' ),
-				client_secret: 'n/a',
-				url: {
-					redirect: `${ protocol }://${ host }:${ port }/api/oauth/token`,
-				},
+				redirect_uri: redirectUri,
+				scope: 'global',
+				blog_id: 0,
 			};
 
-			const wpoauth = WPOAuth( oauthSettings );
-			authUrl = wpoauth.urlToConnect( { scope: 'global', blog_id: 0 } );
+			authUrl = `${ WP_AUTHORIZE_ENDPOINT }?${ stringify( params ) }`;
 		}
 
 		context.primary = <ConnectComponent authUrl={ authUrl } />;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -24079,15 +24079,6 @@
 				"wpcom-xhr-request": "^1.1.2"
 			}
 		},
-		"wpcom-oauth": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/wpcom-oauth/-/wpcom-oauth-0.3.4.tgz",
-			"integrity": "sha512-EJfIhiIRsgppbaTN2+GuTnGdtCG+0Lie0Fbu9G9vxBnyReLP52uUK8EFqjt42QSm6sx2MjIDTtsMEAgqVgqXnA==",
-			"requires": {
-				"debug": "*",
-				"superagent": "^3.8.3"
-			}
-		},
 		"wpcom-proxy-request": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/wpcom-proxy-request/-/wpcom-proxy-request-5.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,6 @@
 		"webpack-bundle-analyzer": "3.4.1",
 		"webpack-dev-middleware": "3.7.0",
 		"wpcom": "5.4.2",
-		"wpcom-oauth": "0.3.4",
 		"wpcom-proxy-request": "5.0.2",
 		"wpcom-xhr-request": "1.1.3",
 		"yamlparser": "0.0.2",


### PR DESCRIPTION
`wpcom-oauth` is a server-side package that was being imported into server-side and client-side Calypso solely for the purpose of generating an OAuth URL. This is essentially just a string template, which has now been inlined into the corresponding controller.

`wpcom-oauth` had several dependencies itself (notably `superagent`), which we can now continue to work towards removing from Calypso.

The code in question appears to only be used in the context of the desktop app.

#### Changes proposed in this Pull Request

* Remove dependency on `wpcom-oauth`, performing the OAuth URL creation in Calypso.

#### Testing instructions

* Ensure that the OAuth mechanism continues to work correctly in the desktop app.
