### PR TITLE
Full Site Editing: replace stylesheet calls with get_stylesheet

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -67,7 +67,7 @@ class Full_Site_Editing {
 		add_filter( 'bulk_actions-edit-wp_template_type', [ $this, 'remove_delete_bulk_action_for_template_taxonomy' ] );
 		add_action( 'pre_delete_term', [ $this, 'restrict_template_taxonomy_deletion' ], 10, 2 );
 
-		$this->theme_slug           = $this->normalize_theme_slug( get_option( 'stylesheet' ) );
+		$this->theme_slug           = $this->normalize_theme_slug( get_stylesheet() );
 		$this->wp_template_inserter = new WP_Template_Inserter( $this->theme_slug );
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -43,7 +43,7 @@ class WP_Template {
 	 * A8C_WP_Template constructor.
 	 */
 	public function __construct() {
-		$this->current_theme_name = $this->normalize_theme_slug( get_option( 'stylesheet' ) );
+		$this->current_theme_name = $this->normalize_theme_slug( get_stylesheet() );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Replace `get_option( 'stylesheet' )` with `get_stylesheet()` call. Functionally they are almost the same, but I think `get_stylesheet()` is more idiomatic because it applies the `stylesheet` filter to the result return from `get_option( 'stylesheet' )` call.

#### Testing instructions

1. Smoke test the plugin.
2. Verify that there are no other usages of `get_option( 'stylesheet' )` in the codebase.