### PR TITLE
(2P) FSE: fix broken reference to REST API controller due to namespace

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-starter-page-templates.php
@@ -72,6 +72,15 @@ class Starter_Page_Templates {
 	}
 
 	/**
+	 * Register rest api endpoint for side-loading images.
+	 */
+	public function register_rest_api() {
+		require_once __DIR__ . '/class-wp-rest-sideload-image-controller.php';
+
+		( new \WP_REST_Sideload_Image_Controller() )->register_routes();
+	}
+
+	/**
 	 * Pass error message to frontend JavaScript console.
 	 *
 	 * @param string $message Error message.


### PR DESCRIPTION
Previously the global namespace wasn’t explicitly defined and therefore the `A8C\FSE` namespace was being used. This lead to the class being undefined.

The PR updates so that the REST Controller is referenced in the correct (global) namespace.

This does raise the issue of whether global classes should be placed in a dedicated directory to further reinforce that they are no within the main Plugin namespace.

#### Testing instructions

1. On `master` load `wp-admin` with the Plugin active
2. See error message:
<img width="813" alt="Screen Shot 2019-08-13 at 11 51 48" src="https://user-images.githubusercontent.com/444434/62936691-64906300-bdc2-11e9-9b00-4e93b119f0e3.png">
3. Check out this PR
4. Repeat Step 2 - see no error message.



