### PR TITLE
Fix analytics utils after split-up.

### DIFF
--- a/client/lib/analytics/utils/get-normalized-hashed-user-email.js
+++ b/client/lib/analytics/utils/get-normalized-hashed-user-email.js
@@ -9,7 +9,7 @@ import hashPii from './hash-pii';
  * @param {Object} user The current user
  * @return {false|string} The current user email after normalization
  */
-export function getNormalizedHashedUserEmail( user ) {
+export default function getNormalizedHashedUserEmail( user ) {
 	const currentUser = user.get();
 	if ( currentUser && currentUser.email ) {
 		return hashPii( currentUser.email.toLowerCase().replace( /\s/g, '' ) );

--- a/client/lib/analytics/utils/index.js
+++ b/client/lib/analytics/utils/index.js
@@ -12,3 +12,5 @@ export { default as mayWeTrackCurrentUserGdpr } from './may-we-track-current-use
 export { default as isCurrentUserMaybeInGdprZone } from './is-current-user-maybe-in-gdpr-zone';
 export { default as urlParseAmpCompatible } from './url-parse-amp-compatible';
 export { default as shouldReportOmitBlogId } from './should-report-omit-blog-id';
+export { default as saveCouponQueryArgument } from './save-coupon-query-argument';
+export { default as getNormalizedHashedUserEmail } from './get-normalized-hashed-user-email';

--- a/client/lib/analytics/utils/save-coupon-query-argument.js
+++ b/client/lib/analytics/utils/save-coupon-query-argument.js
@@ -8,7 +8,7 @@ import urlParseAmpCompatible from './url-parse-amp-compatible';
 /**
  * Remembers `?coupon` query argument via `localStorage`.
  */
-export function saveCouponQueryArgument() {
+export default function saveCouponQueryArgument() {
 	// Read coupon query argument, return early if there is none.
 	const parsedUrl = urlParseAmpCompatible( location.href );
 	const couponCode = parsedUrl.query.coupon;


### PR DESCRIPTION
Two functions were not being reexported. Fixes bug introduced in #34553.

#### Changes proposed in this Pull Request

* Add re-exports for split-out functions.
* Ensure that the functions are exported as their module's default export.

#### Testing instructions

No special testing instructions.