### PR TITLE
FSE: Implement alternate template selector design

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -1,0 +1,3 @@
+const TemplateSelectorPreview = () => <div className="template-selector-preview" />;
+
+export default TemplateSelectorPreview;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -17,6 +17,7 @@ import '@wordpress/nux';
 import replacePlaceholders from './utils/replace-placeholders';
 import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
+import TemplateSelectorPreview from './components/template-selector-preview';
 import { trackDismiss, trackSelection, trackView, initializeWithIdentity } from './utils/tracking';
 
 class PageTemplateModal extends Component {
@@ -88,6 +89,7 @@ class PageTemplateModal extends Component {
 							/>
 						</fieldset>
 					</form>
+					<TemplateSelectorPreview />
 				</div>
 			</Modal>
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -11,6 +11,9 @@
 	word-wrap: normal !important;
 }
 
+$template-selector-border-color: #a1aab2;
+$template-selector-empty-background: #f6f6f6;
+
 // Modal Overlay
 .page-template-modal-screen-overlay {
 	animation: none;
@@ -78,7 +81,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			// stylelint-disable unit-whitelist
 			grid-template-columns: repeat(
 				auto-fit,
-				minmax( 200px, 1fr )
+				minmax( 110px, 1fr )
 			); // allow grid to take over number of cols on large screens
 			// stylelint-enable unit-whitelist
 		}
@@ -93,7 +96,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		width: 100%;
 		font-size: 14px;
 		text-align: center;
-		border: 1px solid #a1aab2;
+		border: 1px solid $template-selector-border-color;
 		border-radius: 6px;
 		cursor: pointer;
 		background: none;
@@ -115,7 +118,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		display: block;
 		margin: 0 auto 14px;
 		border-bottom: 1px solid #a1aab2;
-		background: #f6f6f6;
+		background: $template-selector-empty-background;
 		border-radius: 0;
 		overflow: hidden;
 		padding-bottom: 110%;
@@ -154,4 +157,28 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	@media screen and ( min-width: 960px ) {
 		margin-right: 1em;
 	}
+}
+
+.page-template-modal__form {
+	@media screen and ( min-width: 660px ) {
+		max-width: 50%;
+	}
+}
+
+// Template Selector Preview
+
+.template-selector-preview {
+	@media screen and ( max-width: 659px ) {
+		display: none;
+	}
+
+	position: fixed;
+	top: 93px;
+	bottom: 25px;
+	right: 32px;
+	width: calc( 50% - 50px );
+	background: $template-selector-empty-background;
+	border: 1px solid $template-selector-border-color;
+	border-radius: 6px;
+	pointer-events: none;
 }


### PR DESCRIPTION
The goal of this PR is to implement the new alternate template selector design suggested in https://github.com/Automattic/wp-calypso/issues/35232

### Creative

We're using the following mockup as a reference

<img width="1163" alt="62886512-16129400-bcf0-11e9-8430-ca1225e5e0b9 (1)" src="https://user-images.githubusercontent.com/1562646/62941945-88aa6f00-bdd7-11e9-91c2-68452db658ec.png">
