### PR TITLE
Templates large preview

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
@@ -17,12 +17,16 @@ const BlockTemplatePreview = ( { blocks, viewportWidth } ) => {
 	}
 
 	return (
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<div className="edit-post-visual-editor">
 			<div className="editor-styles-wrapper">
-				<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+				<div className="editor-writing-flow">
+					<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+				</div>
 			</div>
 		</div>
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);
 };
 
-export default  BlockTemplatePreview;
+export default BlockTemplatePreview;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { BlockPreview } from '@wordpress/block-editor';
+
+const BlockTemplatePreview = ( { blocks, viewportWidth } ) => {
+	if ( ! blocks ) {
+		return null;
+	}
+
+	return <BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />;
+};
+
+export default  BlockTemplatePreview;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
@@ -12,16 +12,12 @@
 import { BlockPreview } from '@wordpress/block-editor';
 
 const BlockTemplatePreview = ( { blocks, viewportWidth } ) => {
-	if ( ! blocks ) {
-		return null;
-	}
-
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<div className="edit-post-visual-editor">
 			<div className="editor-styles-wrapper">
 				<div className="editor-writing-flow">
-					<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+					{ blocks && <BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } /> }
 				</div>
 			</div>
 		</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
@@ -5,6 +5,7 @@
 /**
  * Internal dependencies
  */
+import { useRef, useLayoutEffect, useState } from "@wordpress/element";
 
 /**
  * WordPress dependencies
@@ -12,11 +13,46 @@
 import { BlockPreview } from '@wordpress/block-editor';
 
 const BlockTemplatePreview = ( { blocks, viewportWidth } ) => {
+	const itemRef = useRef( null );
+	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
+
+	useLayoutEffect( () => {
+		const timerId = setTimeout( () => {
+			const el = itemRef ? itemRef.current : null;
+
+			if ( ! el ) {
+				setDynamicCssClasses( '' );
+				return;
+			}
+
+			// Try to pick up the editor styles wrapper element,
+			// and move its `.editor-styles-wrapper` class out of the preview.
+			const editorStylesWrapperEl = el.querySelector( '.editor-styles-wrapper' );
+			if ( editorStylesWrapperEl ) {
+				setTimeout( () => {
+					editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
+				}, 0 );
+				setDynamicCssClasses( 'editor-styles-wrapper' );
+			}
+		}, 0 );
+
+		// Cleanup
+		return () => {
+			if ( timerId ) {
+				window.clearTimeout( timerId );
+			}
+		};
+	}, [ blocks ] );
+
 	if ( ! blocks ) {
 		return null;
 	}
 
-	return <BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />;
+	return (
+		<div ref={ itemRef } className={ dynamicCssClasses }>
+			<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+		</div>
+	);
 };
 
 export default  BlockTemplatePreview;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
@@ -5,7 +5,6 @@
 /**
  * Internal dependencies
  */
-import { useRef, useLayoutEffect, useState } from "@wordpress/element";
 
 /**
  * WordPress dependencies
@@ -13,44 +12,15 @@ import { useRef, useLayoutEffect, useState } from "@wordpress/element";
 import { BlockPreview } from '@wordpress/block-editor';
 
 const BlockTemplatePreview = ( { blocks, viewportWidth } ) => {
-	const itemRef = useRef( null );
-	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
-
-	useLayoutEffect( () => {
-		const timerId = setTimeout( () => {
-			const el = itemRef ? itemRef.current : null;
-
-			if ( ! el ) {
-				setDynamicCssClasses( '' );
-				return;
-			}
-
-			// Try to pick up the editor styles wrapper element,
-			// and move its `.editor-styles-wrapper` class out of the preview.
-			const editorStylesWrapperEl = el.querySelector( '.editor-styles-wrapper' );
-			if ( editorStylesWrapperEl ) {
-				setTimeout( () => {
-					editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
-				}, 0 );
-				setDynamicCssClasses( 'editor-styles-wrapper' );
-			}
-		}, 0 );
-
-		// Cleanup
-		return () => {
-			if ( timerId ) {
-				window.clearTimeout( timerId );
-			}
-		};
-	}, [ blocks ] );
-
 	if ( ! blocks ) {
 		return null;
 	}
 
 	return (
-		<div ref={ itemRef } className={ dynamicCssClasses }>
-			<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+		<div className="edit-post-visual-editor">
+			<div className="editor-styles-wrapper">
+				<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+			</div>
 		</div>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -21,11 +21,29 @@ import replacePlaceholders from '../utils/replace-placeholders';
 // Load config passed from backend.
 const { siteInformation = {} } = window.starterPageTemplatesConfig;
 
-const TemplateDynamicPreview = ( { rawBlocks, blocksInPreview = 10 } ) => {
+const TemplateSelectorItem = ( props ) => {
+	const {
+		id,
+		value,
+		help,
+		onFocus,
+		onSelect,
+		label,
+		rawBlocks,
+		dynamicPreview = false,
+		preview,
+		previewAlt = '',
+		blocksInPreview = 10,
+	} = props;
+
 	const itemRef = useRef( null );
 	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
+	const [ blocksAmount, setBlocksAmount ] = useState( blocksInPreview );
 
-	const blocks = useMemo( () => parseBlocks( rawBlocks ).slice( 0, blocksInPreview ), [ rawBlocks, blocksInPreview ] );
+	const blocks = useMemo( () => ( dynamicPreview ?
+		parseBlocks( rawBlocks ).slice( 0, blocksAmount ) :
+		[]
+	) , [ rawBlocks, blocksAmount, dynamicPreview ] );
 
 	useLayoutEffect( () => {
 		const timerId = setTimeout( () => {
@@ -44,6 +62,9 @@ const TemplateDynamicPreview = ( { rawBlocks, blocksInPreview = 10 } ) => {
 				}, 0 );
 				setDynamicCssClasses( 'editor-styles-wrapper' );
 			}
+
+			// experimental.
+			setBlocksAmount( 100 );
 		}, 0 );
 
 		// Cleanup
@@ -54,28 +75,10 @@ const TemplateDynamicPreview = ( { rawBlocks, blocksInPreview = 10 } ) => {
 		};
 	}, [ blocks ] );
 
-	return (
+	const innerPreview = dynamicPreview ? (
 		<div ref={ itemRef } className={ dynamicCssClasses }>
 			{ blocks && blocks.length ? <BlockPreview blocks={ blocks } viewportWidth={ 800 } /> : null }
 		</div>
-	);
-};
-
-const TemplateSelectorItem = ( props ) => {
-	const {
-		id,
-		value,
-		help,
-		onSelect,
-		label,
-		rawBlocks,
-		dynamicPreview = false,
-		preview,
-		previewAlt = '',
-	} = props;
-
-	const innerPreview = dynamicPreview ? (
-		<TemplateDynamicPreview { ...props } />
 	) : (
 		<img
 			className="template-selector-control__media"
@@ -91,6 +94,7 @@ const TemplateSelectorItem = ( props ) => {
 			className="template-selector-control__label"
 			value={ value }
 			onClick={ () => onSelect( value, label, parseBlocks( rawBlocks ) ) }
+			onMouseEnter={ () => onFocus( value, label, dynamicPreview ? blocks : parseBlocks( rawBlocks ) ) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
 			<div className="template-selector-control__preview-wrap">
@@ -107,6 +111,7 @@ function TemplateSelectorControl( {
 	help,
 	instanceId,
 	onTemplateSelect = noop,
+	onTemplateFocus = noop,
 	templates = [],
 	dynamicPreview = false,
 } ) {
@@ -132,6 +137,7 @@ function TemplateSelectorControl( {
 							label={ replacePlaceholders( title, siteInformation ) }
 							help={ help }
 							onSelect={ onTemplateSelect }
+							onFocus={ onTemplateFocus }
 							preview={ preview }
 							previewAlt={ previewAlt }
 							rawBlocks={ replacePlaceholders( content, siteInformation ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -80,7 +80,7 @@ const TemplateSelectorItem = ( props ) => {
 		<img
 			className="template-selector-control__media"
 			src={ preview }
-			alt={ previewAlt || '' }
+			alt={ previewAlt }
 		/>
 	);
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -21,23 +21,17 @@ import replacePlaceholders from '../utils/replace-placeholders';
 // Load config passed from backend.
 const { siteInformation = {} } = window.starterPageTemplatesConfig;
 
-/*
- * It renders the block preview content for the template.
- * It the templates blocks are not ready yet or not exist,
- * it tries to render a static image, or simply return null.
- */
-const TemplateDynamicPreview = ( { value, rawBlocks, blocksInPreview = 10 } ) => {
+const TemplateDynamicPreview = ( { rawBlocks, blocksInPreview = 10 } ) => {
 	const itemRef = useRef( null );
 	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
 
-	const blocks = useMemo( () => parseBlocks( rawBlocks ).slice( 0, blocksInPreview ), [ rawBlocks ] );
+	const blocks = useMemo( () => parseBlocks( rawBlocks ).slice( 0, blocksInPreview ), [ rawBlocks, blocksInPreview ] );
 
 	useLayoutEffect( () => {
 		const timerId = setTimeout( () => {
 			const el = itemRef ? itemRef.current : null;
 
 			if ( ! el ) {
-				console.timeEnd( `tpl-${ value }` );
 				setDynamicCssClasses( '' );
 				return;
 			}
@@ -52,15 +46,13 @@ const TemplateDynamicPreview = ( { value, rawBlocks, blocksInPreview = 10 } ) =>
 			}
 		}, 0 );
 
-		console.timeEnd( `tpl-${ value }` );
-
 		// Cleanup
 		return () => {
 			if ( timerId ) {
 				window.clearTimeout( timerId );
 			}
 		};
-	}, [ blocks, value ] );
+	}, [ blocks ] );
 
 	return (
 		<div ref={ itemRef } className={ dynamicCssClasses }>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -69,29 +69,21 @@ const TemplateDynamicPreview = ( { value, rawBlocks, blocksInPreview = 10 } ) =>
 	);
 };
 
-const TemplateSelectorItem = ( {
-	id,
-	value,
-	help,
-	onSelect,
-	label,
-	rawBlocks,
-	dynamicPreview = false,
-	preview,
-	previewAlt = '',
-	blocksInPreview,
-} ) => {
+const TemplateSelectorItem = ( props ) => {
+	const {
+		id,
+		value,
+		help,
+		onSelect,
+		label,
+		rawBlocks,
+		dynamicPreview = false,
+		preview,
+		previewAlt = '',
+	} = props;
+
 	const innerPreview = dynamicPreview ? (
-		<TemplateDynamicPreview
-			id={ id }
-			value={ value }
-			label={ replacePlaceholders( label, siteInformation ) }
-			help={ help }
-			onSelect={ onSelect }
-			preview={ preview }
-			rawBlocks={ replacePlaceholders( rawBlocks, siteInformation ) }
-			blocksInPreview={ blocksInPreview }
-		/>
+		<TemplateDynamicPreview { ...props } />
 	) : (
 		<img
 			className="template-selector-control__media"

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -9,101 +9,15 @@ import classnames from 'classnames';
  */
 import { withInstanceId } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
-import { useMemo, useRef, useLayoutEffect, useState } from '@wordpress/element';
-import { parse as parseBlocks } from '@wordpress/blocks';
-import { BlockPreview } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
+import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
 
 // Load config passed from backend.
 const { siteInformation = {} } = window.starterPageTemplatesConfig;
-
-const TemplateSelectorItem = ( props ) => {
-	const {
-		id,
-		value,
-		help,
-		onFocus,
-		onSelect,
-		label,
-		rawBlocks,
-		dynamicPreview = false,
-		preview,
-		previewAlt = '',
-		blocksInPreview = 10,
-	} = props;
-
-	const itemRef = useRef( null );
-	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
-	const [ blocksAmount, setBlocksAmount ] = useState( blocksInPreview );
-
-	const blocks = useMemo( () => ( dynamicPreview ?
-		parseBlocks( rawBlocks ).slice( 0, blocksAmount ) :
-		[]
-	) , [ rawBlocks, blocksAmount, dynamicPreview ] );
-
-	useLayoutEffect( () => {
-		const timerId = setTimeout( () => {
-			const el = itemRef ? itemRef.current : null;
-
-			if ( ! el ) {
-				setDynamicCssClasses( '' );
-				return;
-			}
-
-			// Try to pick up the editor styles wrapper element.
-			const editorStylesWrapperEl = el.querySelector( '.editor-styles-wrapper' );
-			if ( editorStylesWrapperEl ) {
-				setTimeout( () => {
-					editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
-				}, 0 );
-				setDynamicCssClasses( 'editor-styles-wrapper' );
-			}
-
-			// experimental.
-			setBlocksAmount( 100 );
-		}, 0 );
-
-		// Cleanup
-		return () => {
-			if ( timerId ) {
-				window.clearTimeout( timerId );
-			}
-		};
-	}, [ blocks ] );
-
-	const innerPreview = dynamicPreview ? (
-		<div ref={ itemRef } className={ dynamicCssClasses }>
-			{ blocks && blocks.length ? <BlockPreview blocks={ blocks } viewportWidth={ 800 } /> : null }
-		</div>
-	) : (
-		<img
-			className="template-selector-control__media"
-			src={ preview }
-			alt={ previewAlt }
-		/>
-	);
-
-	return (
-		<button
-			type="button"
-			id={ `${ id }-${ value }` }
-			className="template-selector-control__label"
-			value={ value }
-			onClick={ () => onSelect( value, label, parseBlocks( rawBlocks ) ) }
-			onMouseEnter={ () => onFocus( value, label, dynamicPreview ? blocks : parseBlocks( rawBlocks ) ) }
-			aria-describedby={ help ? `${ id }__help` : undefined }
-		>
-			<div className="template-selector-control__preview-wrap">
-				{ innerPreview }
-			</div>
-			{ label }
-		</button>
-	);
-};
 
 function TemplateSelectorControl( {
 	label,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -41,14 +41,13 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 			const el = itemRef ? itemRef.current : null;
 
 			if ( ! el ) {
-				console.time( `tpl-${ value }` );
+				console.timeEnd( `tpl-${ value }` );
 				setCssClasses( '' );
 				return;
 			}
 
 			// Try to pick up the editor styles wrapper element.
 			const editorStylesWrapperEl = el.querySelector( '.editor-styles-wrapper' );
-
 			if ( editorStylesWrapperEl ) {
 				setTimeout( () => {
 					editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
@@ -65,7 +64,7 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 				window.clearTimeout( timerId );
 			}
 		};
-	}, [ blocks.length ] );
+	}, [ blocks, value ] );
 
 	const itemClasses = classnames(
 		"template-selector-control__preview-wrap",
@@ -81,7 +80,7 @@ const TemplateSelectorItem = ( { id, value, help, onSelect, label, rawBlocks } )
 			onClick={ () => onSelect( value, label, parseBlocks( rawBlocks ) ) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
-			<div className={ itemClasses }>
+			<div ref={ itemRef } className={ itemClasses }>
 				{ blocks && blocks.length ? (
 					<BlockPreview blocks={ blocks } viewportWidth={ 800 } />
 				) : null }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -28,7 +28,7 @@ const { siteInformation = {} } = window.starterPageTemplatesConfig;
  */
 const TemplateDynamicPreview = ( { value, rawBlocks } ) => {
 	const itemRef = useRef( null );
-	const [ cssClasses, setCssClasses ] = useState( 'is-rendering' );
+	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
 
 	const blocks = useMemo( () => parseBlocks( rawBlocks ).slice( 0, 10 ), [ rawBlocks ] );
 
@@ -38,7 +38,7 @@ const TemplateDynamicPreview = ( { value, rawBlocks } ) => {
 
 			if ( ! el ) {
 				console.timeEnd( `tpl-${ value }` );
-				setCssClasses( '' );
+				setDynamicCssClasses( '' );
 				return;
 			}
 
@@ -48,7 +48,7 @@ const TemplateDynamicPreview = ( { value, rawBlocks } ) => {
 				setTimeout( () => {
 					editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
 				}, 0 );
-				setCssClasses( 'editor-styles-wrapper' );
+				setDynamicCssClasses( 'editor-styles-wrapper' );
 			}
 		}, 0 );
 
@@ -62,10 +62,8 @@ const TemplateDynamicPreview = ( { value, rawBlocks } ) => {
 		};
 	}, [ blocks, value ] );
 
-	const itemClasses = classnames( 'template-selector-control__preview-wrap', cssClasses );
-
 	return (
-		<div ref={ itemRef } className={ itemClasses }>
+		<div ref={ itemRef } className={ dynamicCssClasses }>
 			{ blocks && blocks.length ? <BlockPreview blocks={ blocks } viewportWidth={ 800 } /> : null }
 		</div>
 	);
@@ -93,7 +91,11 @@ const TemplateSelectorItem = ( {
 			rawBlocks={ replacePlaceholders( rawBlocks, siteInformation ) }
 		/>
 	) : (
-		<img src={ preview } alt={ previewAlt || '' } />
+		<img
+			className="template-selector-control__media"
+			src={ preview }
+			alt={ previewAlt || '' }
+		/>
 	);
 
 	return (
@@ -105,7 +107,9 @@ const TemplateSelectorItem = ( {
 			onClick={ () => onSelect( value, label, parseBlocks( rawBlocks ) ) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
-			{ innerPreview }
+			<div className="template-selector-control__preview-wrap">
+				{ innerPreview }
+			</div>
 			{ label }
 		</button>
 	);
@@ -118,6 +122,7 @@ function TemplateSelectorControl( {
 	instanceId,
 	onTemplateSelect = noop,
 	templates = [],
+	dynamicPreview = false,
 } ) {
 	if ( isEmpty( templates ) ) {
 		return null;
@@ -144,6 +149,7 @@ function TemplateSelectorControl( {
 							preview={ preview }
 							previewAlt={ previewAlt }
 							rawBlocks={ replacePlaceholders( content, siteInformation ) }
+							dynamicPreview={ dynamicPreview }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, noop, each, filter } from 'lodash';
+import { isEmpty, each } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -35,13 +35,7 @@ class TemplateSelectorControl extends Component {
 			const blocks = {};
 			each( props.templates, ( { content, slug } ) => {
 				if ( content ) {
-					const parsedBlocks = parseBlocks( content );
-					blocks[ slug ] = {
-						parsed: props.blocksInPreview ?
-							parsedBlocks.slice( 0, props.blocksInPreview ) :
-							parsedBlocks,
-						full: ! props.blocksInPreview,
-					}
+					blocks[ slug ] = parseBlocks( content );
 				}
 			} );
 			this.state.blocks = blocks;
@@ -51,33 +45,17 @@ class TemplateSelectorControl extends Component {
 		this.onFocusHandler = this.onFocusHandler.bind( this );
 	}
 
-	getParsedBlocks ( slug, forceFullParsing = false ) {
+	getParsedBlocks ( slug, fullParsing = false ) {
 		const { blocks } = this.state;
-		const alreadyFullParsed = blocks && blocks[ slug ] && blocks[ slug ].full;
-		// Return parsed blocks from the state if it isn't a force-full-parsing,
-		// or if it's already full parsed.
-		if ( ! forceFullParsing || alreadyFullParsed ) {
-			return blocks && blocks[ slug ] ? blocks[ slug ].parsed : null;
-		}
-
-		// Pick up the template from the properties, according to the given slug,
-		// in order to get its content.
-		let template = filter( this.props.templates, { slug } );
-		template = template.length ? template[ 0 ] : null;
-		if ( ! template || ! template.content ) {
+		if ( ! blocks || ! blocks[ slug ] ) {
 			return null;
 		}
 
-		// Always parse the blocks in static preview
-		if ( ! this.props.dynamicPreview && ! forceFullParsing ) {
-			return parseBlocks( template.content );
+		if ( fullParsing || ! this.props.blocksInPreview ) {
+			return blocks[ slug ];
 		}
 
-		// proceed to parse all blocks for this template
-		const allParsed = parseBlocks( template.content );
-		this.setState( { blocks: { ...blocks, [ slug ]: { parsed: allParsed, full: true } } } );
-
-		return allParsed;
+		return blocks[ slug ].slice( 0, this.props.blocksInPreview );
 	}
 
 	onSelectHandler( slug, title ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -29,16 +29,16 @@ class TemplateSelectorControl extends Component {
 	constructor( props ) {
 		super();
 
-		// Populate the state with the parsed blocks,
+		this.blocks = {};
+
+		// Populate this.blocks with the parsed blocks,
 		// only in the dynamic preview mode.
 		if ( props.templates && props.dynamicPreview ) {
-			const blocks = {};
 			each( props.templates, ( { content, slug } ) => {
 				if ( content ) {
-					blocks[ slug ] = parseBlocks( content );
+					this.blocks[ slug ] = parseBlocks( content );
 				}
 			} );
-			this.state.blocks = blocks;
 		}
 
 		this.onSelectHandler = this.onSelectHandler.bind( this );
@@ -46,12 +46,11 @@ class TemplateSelectorControl extends Component {
 	}
 
 	getParsedBlocks ( slug ) {
-		const { blocks } = this.state;
-		if ( ! blocks || ! blocks[ slug ] ) {
+		if ( ! this.blocks || ! this.blocks[ slug ] ) {
 			return [];
 		}
 
-		return blocks[ slug ];
+		return this.blocks[ slug ];
 	}
 
 	onSelectHandler( slug, title ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -52,10 +52,6 @@ class TemplateSelectorControl extends Component {
 		}
 
 		return blocks[ slug ];
-		// if ( fullParsing || ! this.props.blocksInPreview ) {
-		// }
-		//
-		// return blocks[ slug ].slice( 0, this.props.blocksInPreview );
 	}
 
 	onSelectHandler( slug, title ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -7,9 +7,9 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { withInstanceId } from '@wordpress/compose';
+import { withInstanceId, compose } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
-
+import { memo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
@@ -64,4 +64,7 @@ function TemplateSelectorControl( {
 	);
 }
 
-export default withInstanceId( TemplateSelectorControl );
+export default compose(
+	memo,
+	withInstanceId
+)( TemplateSelectorControl );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, each } from 'lodash';
+import { isEmpty, noop } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -9,8 +9,7 @@ import classnames from 'classnames';
  */
 import { withInstanceId, compose } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
-import { memo, Component } from '@wordpress/element';
-import { parse as parseBlocks } from '@wordpress/blocks';
+import { memo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,93 +20,52 @@ import replacePlaceholders from '../utils/replace-placeholders';
 // Load config passed from backend.
 const { siteInformation = {} } = window.starterPageTemplatesConfig;
 
-class TemplateSelectorControl extends Component {
-	state = {
-		blocks: {},
-	};
-
-	constructor( props ) {
-		super();
-
-		this.blocks = {};
-
-		// Populate this.blocks with the parsed blocks,
-		// only in the dynamic preview mode.
-		if ( props.templates && props.dynamicPreview ) {
-			each( props.templates, ( { content, slug } ) => {
-				if ( content ) {
-					this.blocks[ slug ] = parseBlocks( content );
-				}
-			} );
-		}
-
-		this.onSelectHandler = this.onSelectHandler.bind( this );
-		this.onFocusHandler = this.onFocusHandler.bind( this );
+const TemplateSelectorControl = ( {
+	 label,
+	 className,
+	 help,
+	 instanceId,
+	 templates = [],
+	 dynamicPreview = false,
+	 blocksInPreview,
+	 onTemplateSelect = noop,
+	 onTemplateFocus = noop,
+ } ) => {
+	if ( isEmpty( templates ) ) {
+		return null;
 	}
 
-	getParsedBlocks ( slug ) {
-		if ( ! this.blocks || ! this.blocks[ slug ] ) {
-			return [];
-		}
+	const id = `template-selector-control-${instanceId}`;
 
-		return this.blocks[ slug ];
-	}
-
-	onSelectHandler( slug, title ) {
-		this.props.onTemplateSelect( slug, title, this.getParsedBlocks( slug, true ) );
-	}
-
-	onFocusHandler( slug, title ) {
-		this.props.onTemplateFocus( slug, title, this.getParsedBlocks( slug, true ) );
-	}
-
-	render() {
-		const {
-			label,
-			className,
-			help,
-			instanceId,
-			templates = [],
-			dynamicPreview = false,
-			blocksInPreview,
-		} = this.props;
-
-		if ( isEmpty( templates ) ) {
-			return null;
-		}
-
-		const id = `template-selector-control-${instanceId}`;
-
-		return (
-			<BaseControl
-				label={ label }
-				id={ id }
-				help={ help }
-				className={ classnames( className, 'template-selector-control' ) }
-			>
-				<ul className="template-selector-control__options">
-					{ templates.map( ( { slug, title, preview, previewAlt, value } ) => (
-						<li key={ `${id}-${value}` } className="template-selector-control__template">
-							<TemplateSelectorItem
-								id={ id }
-								value={ slug }
-								label={ replacePlaceholders( title, siteInformation ) }
-								help={ help }
-								onSelect={ this.onSelectHandler }
-								onFocus={ this.onFocusHandler }
-								preview={ preview }
-								previewAlt={ previewAlt }
-								blocks={ this.getParsedBlocks( slug ) }
-								dynamicPreview={ dynamicPreview }
-								blocksInPreview={ blocksInPreview }
-							/>
-						</li>
-					) ) }
-				</ul>
-			</BaseControl>
-		);
-	}
-}
+	return (
+		<BaseControl
+			label={ label }
+			id={ id }
+			help={ help }
+			className={ classnames( className, 'template-selector-control' ) }
+		>
+			<ul className="template-selector-control__options">
+				{ templates.map( ( { slug, title, content, preview, previewAlt, value } ) => (
+					<li key={ `${id}-${value}` } className="template-selector-control__template">
+						<TemplateSelectorItem
+							id={ id }
+							value={ slug }
+							label={ replacePlaceholders( title, siteInformation ) }
+							help={ help }
+							onSelect={ onTemplateSelect }
+							onFocus={ onTemplateFocus }
+							preview={ preview }
+							previewAlt={ previewAlt }
+							rawContent={ content }
+							dynamicPreview={ dynamicPreview }
+							blocksInPreview={ blocksInPreview }
+						/>
+					</li>
+				) ) }
+			</ul>
+		</BaseControl>
+	);
+};
 
 export default compose(
 	memo,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -21,21 +21,21 @@ import replacePlaceholders from '../utils/replace-placeholders';
 const { siteInformation = {} } = window.starterPageTemplatesConfig;
 
 const TemplateSelectorControl = ( {
-	 label,
-	 className,
-	 help,
-	 instanceId,
-	 templates = [],
-	 dynamicPreview = false,
-	 blocksInPreview,
-	 onTemplateSelect = noop,
-	 onTemplateFocus = noop,
- } ) => {
+	label,
+	className,
+	help,
+	instanceId,
+	templates = [],
+	useDynamicPreview = false,
+	numBlocksInPreview,
+	onTemplateSelect = noop,
+	onTemplateFocus = noop,
+} ) => {
 	if ( isEmpty( templates ) ) {
 		return null;
 	}
 
-	const id = `template-selector-control-${instanceId}`;
+	const id = `template-selector-control-${ instanceId }`;
 
 	return (
 		<BaseControl
@@ -46,7 +46,7 @@ const TemplateSelectorControl = ( {
 		>
 			<ul className="template-selector-control__options">
 				{ templates.map( ( { slug, title, content, preview, previewAlt, value } ) => (
-					<li key={ `${id}-${value}` } className="template-selector-control__template">
+					<li key={ `${ id }-${ value }` } className="template-selector-control__template">
 						<TemplateSelectorItem
 							id={ id }
 							value={ slug }
@@ -54,11 +54,11 @@ const TemplateSelectorControl = ( {
 							help={ help }
 							onSelect={ onTemplateSelect }
 							onFocus={ onTemplateFocus }
-							preview={ preview }
-							previewAlt={ previewAlt }
+							staticPreviewImg={ preview }
+							staticPreviewImgAlt={ previewAlt }
 							rawContent={ content }
-							dynamicPreview={ dynamicPreview }
-							blocksInPreview={ blocksInPreview }
+							useDynamicPreview={ useDynamicPreview }
+							numBlocksInPreview={ numBlocksInPreview }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -45,17 +45,17 @@ class TemplateSelectorControl extends Component {
 		this.onFocusHandler = this.onFocusHandler.bind( this );
 	}
 
-	getParsedBlocks ( slug, fullParsing = false ) {
+	getParsedBlocks ( slug ) {
 		const { blocks } = this.state;
 		if ( ! blocks || ! blocks[ slug ] ) {
-			return null;
+			return [];
 		}
 
-		if ( fullParsing || ! this.props.blocksInPreview ) {
-			return blocks[ slug ];
-		}
-
-		return blocks[ slug ].slice( 0, this.props.blocksInPreview );
+		return blocks[ slug ];
+		// if ( fullParsing || ! this.props.blocksInPreview ) {
+		// }
+		//
+		// return blocks[ slug ].slice( 0, this.props.blocksInPreview );
 	}
 
 	onSelectHandler( slug, title ) {
@@ -74,6 +74,7 @@ class TemplateSelectorControl extends Component {
 			instanceId,
 			templates = [],
 			dynamicPreview = false,
+			blocksInPreview,
 		} = this.props;
 
 		if ( isEmpty( templates ) ) {
@@ -103,6 +104,7 @@ class TemplateSelectorControl extends Component {
 								previewAlt={ previewAlt }
 								blocks={ this.getParsedBlocks( slug ) }
 								dynamicPreview={ dynamicPreview }
+								blocksInPreview={ blocksInPreview }
 							/>
 						</li>
 					) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -26,11 +26,11 @@ const { siteInformation = {} } = window.starterPageTemplatesConfig;
  * It the templates blocks are not ready yet or not exist,
  * it tries to render a static image, or simply return null.
  */
-const TemplateDynamicPreview = ( { value, rawBlocks } ) => {
+const TemplateDynamicPreview = ( { value, rawBlocks, blocksInPreview = 10 } ) => {
 	const itemRef = useRef( null );
 	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
 
-	const blocks = useMemo( () => parseBlocks( rawBlocks ).slice( 0, 10 ), [ rawBlocks ] );
+	const blocks = useMemo( () => parseBlocks( rawBlocks ).slice( 0, blocksInPreview ), [ rawBlocks ] );
 
 	useLayoutEffect( () => {
 		const timerId = setTimeout( () => {
@@ -79,6 +79,7 @@ const TemplateSelectorItem = ( {
 	dynamicPreview = false,
 	preview,
 	previewAlt = '',
+	blocksInPreview,
 } ) => {
 	const innerPreview = dynamicPreview ? (
 		<TemplateDynamicPreview
@@ -89,6 +90,7 @@ const TemplateSelectorItem = ( {
 			onSelect={ onSelect }
 			preview={ preview }
 			rawBlocks={ replacePlaceholders( rawBlocks, siteInformation ) }
+			blocksInPreview={ blocksInPreview }
 		/>
 	) : (
 		<img

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, noop } from 'lodash';
+import { isEmpty, noop, each, filter } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -9,7 +9,9 @@ import classnames from 'classnames';
  */
 import { withInstanceId, compose } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
-import { memo } from '@wordpress/element';
+import { memo, Component } from '@wordpress/element';
+import { parse as parseBlocks } from '@wordpress/blocks';
+
 /**
  * Internal dependencies
  */
@@ -19,49 +21,117 @@ import replacePlaceholders from '../utils/replace-placeholders';
 // Load config passed from backend.
 const { siteInformation = {} } = window.starterPageTemplatesConfig;
 
-function TemplateSelectorControl( {
-	label,
-	className,
-	help,
-	instanceId,
-	onTemplateSelect = noop,
-	onTemplateFocus = noop,
-	templates = [],
-	dynamicPreview = false,
-} ) {
-	if ( isEmpty( templates ) ) {
-		return null;
+class TemplateSelectorControl extends Component {
+	state = {
+		blocks: {},
+	};
+
+	constructor( props ) {
+		super();
+
+		// Populate the state with the parsed blocks,
+		// only in the dynamic preview mode.
+		if ( props.templates && props.dynamicPreview ) {
+			const blocks = {};
+			each( props.templates, ( { content, slug } ) => {
+				if ( content ) {
+					const parsedBlocks = parseBlocks( content );
+					blocks[ slug ] = {
+						parsed: props.blocksInPreview ?
+							parsedBlocks.slice( 0, props.blocksInPreview ) :
+							parsedBlocks,
+						full: ! props.blocksInPreview,
+					}
+				}
+			} );
+			this.state.blocks = blocks;
+		}
+
+		this.onSelectHandler = this.onSelectHandler.bind( this );
+		this.onFocusHandler = this.onFocusHandler.bind( this );
 	}
 
-	const id = `template-selector-control-${ instanceId }`;
+	getParsedBlocks ( slug, forceFullParsing = false ) {
+		const { blocks } = this.state;
+		const alreadyFullParsed = blocks && blocks[ slug ] && blocks[ slug ].full;
+		// Return parsed blocks from the state if it isn't a force-full-parsing,
+		// or if it's already full parsed.
+		if ( ! forceFullParsing || alreadyFullParsed ) {
+			return blocks && blocks[ slug ] ? blocks[ slug ].parsed : null;
+		}
 
-	return (
-		<BaseControl
-			label={ label }
-			id={ id }
-			help={ help }
-			className={ classnames( className, 'template-selector-control' ) }
-		>
-			<ul className="template-selector-control__options">
-				{ templates.map( ( { slug, title, content, preview, previewAlt, value } ) => (
-					<li key={ `${ id }-${ value }` } className="template-selector-control__template">
-						<TemplateSelectorItem
-							id={ id }
-							value={ slug }
-							label={ replacePlaceholders( title, siteInformation ) }
-							help={ help }
-							onSelect={ onTemplateSelect }
-							onFocus={ onTemplateFocus }
-							preview={ preview }
-							previewAlt={ previewAlt }
-							rawBlocks={ replacePlaceholders( content, siteInformation ) }
-							dynamicPreview={ dynamicPreview }
-						/>
-					</li>
-				) ) }
-			</ul>
-		</BaseControl>
-	);
+		// Pick up the template from the properties, according to the given slug,
+		// in order to get its content.
+		let template = filter( this.props.templates, { slug } );
+		template = template.length ? template[ 0 ] : null;
+		if ( ! template || ! template.content ) {
+			return null;
+		}
+
+		// Always parse the blocks in static preview
+		if ( ! this.props.dynamicPreview && ! forceFullParsing ) {
+			return parseBlocks( template.content );
+		}
+
+		// proceed to parse all blocks for this template
+		const allParsed = parseBlocks( template.content );
+		this.setState( { blocks: { ...blocks, [ slug ]: { parsed: allParsed, full: true } } } );
+
+		return allParsed;
+	}
+
+	onSelectHandler( slug, title ) {
+		this.props.onTemplateSelect( slug, title, this.getParsedBlocks( slug, true ) );
+	}
+
+	onFocusHandler( slug, title ) {
+		this.props.onTemplateFocus( slug, title, this.getParsedBlocks( slug, true ) );
+	}
+
+	render() {
+		const {
+			label,
+			className,
+			help,
+			instanceId,
+			templates = [],
+			dynamicPreview = false,
+		} = this.props;
+
+		if ( isEmpty( templates ) ) {
+			return null;
+		}
+
+		const id = `template-selector-control-${instanceId}`;
+
+		return (
+			<BaseControl
+				label={ label }
+				id={ id }
+				help={ help }
+				className={ classnames( className, 'template-selector-control' ) }
+			>
+				<ul className="template-selector-control__options">
+					{ templates.map( ( { slug, title, preview, previewAlt, value } ) => (
+						<li key={ `${id}-${value}` } className="template-selector-control__template">
+							<TemplateSelectorItem
+								id={ id }
+								value={ slug }
+								label={ replacePlaceholders( title, siteInformation ) }
+								help={ help }
+								onSelect={ this.onSelectHandler }
+								onFocus={ this.onFocusHandler }
+								preview={ preview }
+								previewAlt={ previewAlt }
+								blocks={ this.getParsedBlocks( slug ) }
+								dynamicPreview={ dynamicPreview }
+							/>
+						</li>
+					) ) }
+				</ul>
+			</BaseControl>
+		);
+	}
 }
 
 export default compose(

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -1,0 +1,96 @@
+/**
+ * External dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useMemo, useRef, useLayoutEffect, useState } from '@wordpress/element';
+import { parse as parseBlocks } from '@wordpress/blocks';
+import { BlockPreview } from '@wordpress/block-editor';
+
+const TemplateSelectorItem = props => {
+	const {
+		id,
+		value,
+		help,
+		onFocus,
+		onSelect,
+		label,
+		rawBlocks,
+		dynamicPreview = false,
+		preview,
+		previewAlt = '',
+		blocksInPreview = 10,
+	} = props;
+
+	const itemRef = useRef( null );
+	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
+	const [ blocksAmount, setBlocksAmount ] = useState( blocksInPreview );
+
+	const blocks = useMemo(
+		() => ( dynamicPreview ? parseBlocks( rawBlocks ).slice( 0, blocksAmount ) : [] ),
+		[ rawBlocks, blocksAmount, dynamicPreview ]
+	);
+
+	useLayoutEffect( () => {
+		const timerId = setTimeout( () => {
+			const el = itemRef ? itemRef.current : null;
+
+			if ( ! el ) {
+				setDynamicCssClasses( '' );
+				return;
+			}
+
+			// Try to pick up the editor styles wrapper element.
+			const editorStylesWrapperEl = el.querySelector( '.editor-styles-wrapper' );
+			if ( editorStylesWrapperEl ) {
+				setTimeout( () => {
+					editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
+				}, 0 );
+				setDynamicCssClasses( 'editor-styles-wrapper' );
+			}
+
+			// experimental.
+			setBlocksAmount( 100 );
+		}, 0 );
+
+		// Cleanup
+		return () => {
+			if ( timerId ) {
+				window.clearTimeout( timerId );
+			}
+		};
+	}, [ blocks ] );
+
+	const innerPreview = dynamicPreview ? (
+		<div ref={ itemRef } className={ dynamicCssClasses }>
+			{ blocks && blocks.length ? <BlockPreview blocks={ blocks } viewportWidth={ 800 } /> : null }
+		</div>
+	) : (
+		<img className="template-selector-item__media" src={ preview } alt={ previewAlt } />
+	);
+
+	return (
+		<button
+			type="button"
+			id={ `${ id }-${ value }` }
+			className="template-selector-item__label"
+			value={ value }
+			onClick={ () => onSelect( value, label, parseBlocks( rawBlocks ) ) }
+			onMouseEnter={ () =>
+				onFocus( value, label, dynamicPreview ? blocks : parseBlocks( rawBlocks ) )
+			}
+			aria-describedby={ help ? `${ id }__help` : undefined }
+		>
+			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
+			{ label }
+		</button>
+	);
+};
+
+export default TemplateSelectorItem;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -25,10 +25,12 @@ const TemplateSelectorItem = props => {
 		preview,
 		previewAlt = '',
 		blocks,
+		blocksInPreview,
 	} = props;
 
 	const itemRef = useRef( null );
 	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
+	const [ blocksLimit, setBlockLimit ] = useState( blocksInPreview );
 
 	useLayoutEffect( () => {
 		const timerId = setTimeout( () => {
@@ -58,9 +60,23 @@ const TemplateSelectorItem = props => {
 		};
 	}, [ blocks ] );
 
+	const onFocusHandler = () => {
+		if ( blocks.length > blocksLimit ) {
+			setBlockLimit( null ); // not blocks limit to template preview
+		}
+
+		throttle( () => onFocus( value, label ), 300 );
+	};
+
 	const innerPreview = dynamicPreview ? (
 		<div ref={ itemRef } className={ dynamicCssClasses }>
-			{ blocks && blocks.length ? <BlockPreview blocks={ blocks } viewportWidth={ 800 } /> : null }
+			{ blocks && blocks.length ?
+				<BlockPreview
+					blocks={ blocksLimit ? blocks.slice( 0, blocksLimit ) : blocks }
+					viewportWidth={ 800 }
+				/> :
+				null
+			}
 		</div>
 	) : (
 		<img className="template-selector-item__media" src={ preview } alt={ previewAlt } />
@@ -73,7 +89,7 @@ const TemplateSelectorItem = props => {
 			className="template-selector-item__label"
 			value={ value }
 			onClick={ () => onSelect( value, label ) }
-			onMouseEnter={ throttle( () => onFocus( value, label ), 300) }
+			onMouseEnter={ onFocusHandler }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
 			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -41,7 +41,7 @@ const TemplateSelectorItem = props => {
 	const innerPreview = dynamicPreview ? (
 		<BlockPreview
 			blocks={ blocksLimit ? blocks.slice( 0, blocksLimit ) : blocks }
-			viewportWidth={ 800 }
+			viewportWidth={ 960 }
 		/>
 	) : (
 		<img className="template-selector-item__media" src={ preview } alt={ previewAlt } />

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -22,31 +22,35 @@ const TemplateSelectorItem = props => {
 		onFocus,
 		onSelect,
 		label,
-		dynamicPreview = false,
-		preview,
-		previewAlt = '',
+		useDynamicPreview = false,
+		staticPreviewImg,
+		staticPreviewImgAlt = '',
 		rawContent,
-		blocksInPreview,
+		numBlocksInPreview,
 	} = props;
 
-	const [ blocksLimit, setBlockLimit ] = useState( blocksInPreview );
-	const blocks = useMemo( () => rawContent ? parseBlocks( rawContent ) : null, [ rawContent ] );
+	const [ blocksLimit, setBlockLimit ] = useState( numBlocksInPreview );
+	const blocks = useMemo( () => ( rawContent ? parseBlocks( rawContent ) : null ), [ rawContent ] );
 
 	const onFocusHandler = () => {
-		if ( blocks.length > blocksLimit ) {
+		if ( blocks && blocks.length > blocksLimit ) {
 			setBlockLimit( null ); // not blocks limit to template preview
 		}
 
 		throttle( () => onFocus( value, label, blocks ), 300 );
 	};
 
-	const innerPreview = dynamicPreview ? (
+	const innerPreview = useDynamicPreview ? (
 		<BlockPreview
 			blocks={ blocksLimit && blocks ? blocks.slice( 0, blocksLimit ) : blocks }
 			viewportWidth={ 960 }
 		/>
 	) : (
-		<img className="template-selector-item__media" src={ preview } alt={ previewAlt } />
+		<img
+			className="template-selector-item__media"
+			src={ staticPreviewImg }
+			alt={ staticPreviewImgAlt }
+		/>
 	);
 
 	return (

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -66,6 +66,7 @@ const TemplateSelectorItem = props => {
 			value={ value }
 			// onFocus={ onFocusHandler }
 			onMouseEnter={ onFocusHandler }
+			onMouseLeave={ onFocusHandler.cancel }
 			onClick={ () => onSelect( value, label, blocks ) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -81,7 +81,9 @@ const TemplateSelectorItem = props => {
 			id={ `${ id }-${ value }` }
 			className="template-selector-item__label"
 			value={ value }
-			onClick={ () => onSelect( value, label, parseBlocks( rawBlocks ) ) }
+			onClick={ () =>
+				onSelect( value, label, blocksInPreview ? parseBlocks( rawBlocks ) : blocks )
+			}
 			onMouseEnter={ () =>
 				onFocus( value, label, dynamicPreview ? blocks : parseBlocks( rawBlocks ) )
 			}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -10,8 +10,9 @@ import { throttle } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 import BlockPreview from './block-template-preview';
+import { parse as parseBlocks } from '@wordpress/blocks';
 
 const TemplateSelectorItem = props => {
 	const {
@@ -24,23 +25,24 @@ const TemplateSelectorItem = props => {
 		dynamicPreview = false,
 		preview,
 		previewAlt = '',
-		blocks,
+		rawContent,
 		blocksInPreview,
 	} = props;
 
 	const [ blocksLimit, setBlockLimit ] = useState( blocksInPreview );
+	const blocks = useMemo( () => rawContent ? parseBlocks( rawContent ) : null, [ rawContent ] );
 
 	const onFocusHandler = () => {
 		if ( blocks.length > blocksLimit ) {
 			setBlockLimit( null ); // not blocks limit to template preview
 		}
 
-		throttle( () => onFocus( value, label ), 300 );
+		throttle( () => onFocus( value, label, blocks ), 300 );
 	};
 
 	const innerPreview = dynamicPreview ? (
 		<BlockPreview
-			blocks={ blocksLimit ? blocks.slice( 0, blocksLimit ) : blocks }
+			blocks={ blocksLimit && blocks ? blocks.slice( 0, blocksLimit ) : blocks }
 			viewportWidth={ 960 }
 		/>
 	) : (
@@ -53,7 +55,7 @@ const TemplateSelectorItem = props => {
 			id={ `${ id }-${ value }` }
 			className="template-selector-item__label"
 			value={ value }
-			onClick={ () => onSelect( value, label ) }
+			onClick={ () => onSelect( value, label, blocks ) }
 			onMouseEnter={ onFocusHandler }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -10,8 +10,7 @@ import { throttle } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useMemo, useRef, useLayoutEffect, useState } from '@wordpress/element';
-import { parse as parseBlocks } from '@wordpress/blocks';
+import { useRef, useLayoutEffect, useState } from '@wordpress/element';
 import { BlockPreview } from '@wordpress/block-editor';
 
 const TemplateSelectorItem = props => {
@@ -22,33 +21,14 @@ const TemplateSelectorItem = props => {
 		onFocus,
 		onSelect,
 		label,
-		rawBlocks,
 		dynamicPreview = false,
 		preview,
 		previewAlt = '',
-		blocksInPreview,
+		blocks,
 	} = props;
 
 	const itemRef = useRef( null );
 	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
-
-	/**
-	 * Memoize parsed blocks.
-	 * Use blocksInPreview property to limit the amount of blocks to memoize.
-	 */
-	const blocks = useMemo( () => {
-		if ( ! dynamicPreview ) {
-			return [];
-		}
-
-		const parsedBlocks = parseBlocks( rawBlocks );
-		if ( blocksInPreview ) {
-			return parsedBlocks.slice( 0, blocksInPreview );
-		}
-
-		return parsedBlocks;
-
-	}, [ rawBlocks, blocksInPreview, dynamicPreview ] );
 
 	useLayoutEffect( () => {
 		const timerId = setTimeout( () => {
@@ -78,35 +58,6 @@ const TemplateSelectorItem = props => {
 		};
 	}, [ blocks ] );
 
-
-	/**
-	 * onClick button handler function.
-	 * It call the onSelect() function property.
-	 *
-	 * If it isn't a dynamic preview,
-	 * or the blocks amount in the preview is defined (blocksInPreview),
-	 * it parses the raw block contents.
-	 *
-	 * @return {null} Null
-	 */
-		const onSelectHandler = () => (
-			( blocksInPreview || ! dynamicPreview ) ?
-				onSelect( value, label, parseBlocks( rawBlocks ) ) :
-				onSelect( value, label, blocks )
-		);
-
-		/**
-		 * onMouseEnter button handler function.
-		 * It call the onFocus() function property.
-		 *
-		 * @return {null} Null
-		 */
-	const onFocusHandler = () => (
-		( blocksInPreview || ! dynamicPreview ) ?
-			onFocus( value, label, parseBlocks( rawBlocks ) ) :
-			onFocus( value, label, blocks )
-	);
-
 	const innerPreview = dynamicPreview ? (
 		<div ref={ itemRef } className={ dynamicCssClasses }>
 			{ blocks && blocks.length ? <BlockPreview blocks={ blocks } viewportWidth={ 800 } /> : null }
@@ -121,8 +72,8 @@ const TemplateSelectorItem = props => {
 			id={ `${ id }-${ value }` }
 			className="template-selector-item__label"
 			value={ value }
-			onClick={ onSelectHandler }
-			onMouseEnter={ throttle( onFocusHandler, 300) }
+			onClick={ () => onSelect( value, label ) }
+			onMouseEnter={ throttle( () => onFocus( value, label ), 300) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
 			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { throttle } from 'lodash';
-
+import { throttle, noop } from 'lodash';
+import HoverIntent from 'react-hoverintent';
 /**
  * Internal dependencies
  */
@@ -53,20 +53,28 @@ const TemplateSelectorItem = props => {
 		/>
 	);
 
+	// We're disabling this rule because `HoverIntent` requires a handler for
+	// onMouseOut but it doesn't actually do anything so there's no need need
+	// to provide a matching keyboard handler for this event
+
+	/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 	return (
-		<button
-			type="button"
-			id={ `${ id }-${ value }` }
-			className="template-selector-item__label"
-			value={ value }
-			onClick={ () => onSelect( value, label, blocks ) }
-			onMouseEnter={ onFocusHandler }
-			aria-describedby={ help ? `${ id }__help` : undefined }
-		>
-			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
-			{ label }
-		</button>
+		<HoverIntent onMouseOver={ onFocusHandler } onMouseOut={ noop }>
+			<button
+				type="button"
+				id={ `${ id }-${ value }` }
+				className="template-selector-item__label"
+				value={ value }
+				onFocus={ onFocusHandler }
+				onClick={ () => onSelect( value, label, blocks ) }
+				aria-describedby={ help ? `${ id }__help` : undefined }
+			>
+				<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
+				{ label }
+			</button>
+		</HoverIntent>
 	);
+	/* eslint-enable jsx-a11y/mouse-events-have-key-events */
 };
 
 export default TemplateSelectorItem;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -91,8 +91,8 @@ const TemplateSelectorItem = props => {
 	 */
 		const onSelectHandler = () => (
 			( blocksInPreview || ! dynamicPreview ) ?
-				onFocus( value, label, parseBlocks( rawBlocks ) ) :
-				onFocus( value, label, blocks )
+				onSelect( value, label, parseBlocks( rawBlocks ) ) :
+				onSelect( value, label, blocks )
 		);
 
 		/**

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -35,7 +35,7 @@ const TemplateSelectorItem = props => {
 	const [ blocksLimit, setBlockLimit ] = useState( numBlocksInPreview );
 	const blocks = useMemo( () => ( rawContent ? parseBlocks( rawContent ) : null ), [ rawContent ] );
 
-	const onFocusHandler = debounce(() => {
+	const onFocusHandler = debounce( () => {
 		if ( blocks && blocks.length > blocksLimit ) {
 			setBlockLimit( null ); // not blocks limit to template preview
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { throttle, noop } from 'lodash';
-import HoverIntent from 'react-hoverintent';
+import { debounce } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -29,16 +29,18 @@ const TemplateSelectorItem = props => {
 		numBlocksInPreview,
 	} = props;
 
+	const ON_FOCUS_DELAY = 500;
+
 	const [ blocksLimit, setBlockLimit ] = useState( numBlocksInPreview );
 	const blocks = useMemo( () => ( rawContent ? parseBlocks( rawContent ) : null ), [ rawContent ] );
 
-	const onFocusHandler = () => {
+	const onFocusHandler = debounce(() => {
 		if ( blocks && blocks.length > blocksLimit ) {
 			setBlockLimit( null ); // not blocks limit to template preview
 		}
 
-		throttle( () => onFocus( value, label, blocks ), 300 );
-	};
+		onFocus( value, label, blocks );
+	}, ON_FOCUS_DELAY );
 
 	const innerPreview = useDynamicPreview ? (
 		<BlockPreview
@@ -53,28 +55,21 @@ const TemplateSelectorItem = props => {
 		/>
 	);
 
-	// We're disabling this rule because `HoverIntent` requires a handler for
-	// onMouseOut but it doesn't actually do anything so there's no need need
-	// to provide a matching keyboard handler for this event
-
-	/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 	return (
-		<HoverIntent onMouseOver={ onFocusHandler } onMouseOut={ noop }>
-			<button
-				type="button"
-				id={ `${ id }-${ value }` }
-				className="template-selector-item__label"
-				value={ value }
-				onFocus={ onFocusHandler }
-				onClick={ () => onSelect( value, label, blocks ) }
-				aria-describedby={ help ? `${ id }__help` : undefined }
-			>
-				<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
-				{ label }
-			</button>
-		</HoverIntent>
+		<button
+			type="button"
+			id={ `${ id }-${ value }` }
+			className="template-selector-item__label"
+			value={ value }
+			// onFocus={ onFocusHandler }
+			onMouseEnter={ onFocusHandler }
+			onClick={ () => onSelect( value, label, blocks ) }
+			aria-describedby={ help ? `${ id }__help` : undefined }
+		>
+			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
+			{ label }
+		</button>
 	);
-	/* eslint-enable jsx-a11y/mouse-events-have-key-events */
 };
 
 export default TemplateSelectorItem;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -26,17 +26,29 @@ const TemplateSelectorItem = props => {
 		dynamicPreview = false,
 		preview,
 		previewAlt = '',
-		blocksInPreview = 10,
+		blocksInPreview,
 	} = props;
 
 	const itemRef = useRef( null );
 	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
-	const [ blocksAmount, setBlocksAmount ] = useState( blocksInPreview );
 
-	const blocks = useMemo(
-		() => ( dynamicPreview ? parseBlocks( rawBlocks ).slice( 0, blocksAmount ) : [] ),
-		[ rawBlocks, blocksAmount, dynamicPreview ]
-	);
+	/**
+	 * Memoize parsed blocks.
+	 * Use blocksInPreview property to limit the amount of blocks to memoize.
+	 */
+	const blocks = useMemo( () => {
+		if ( ! dynamicPreview ) {
+			return [];
+		}
+
+		const parsedBlocks = parseBlocks( rawBlocks );
+		if ( blocksInPreview ) {
+			return parsedBlocks.slice( 0, blocksInPreview );
+		}
+
+		return parsedBlocks;
+
+	}, [ rawBlocks, blocksInPreview, dynamicPreview ] );
 
 	useLayoutEffect( () => {
 		const timerId = setTimeout( () => {
@@ -47,7 +59,8 @@ const TemplateSelectorItem = props => {
 				return;
 			}
 
-			// Try to pick up the editor styles wrapper element.
+			// Try to pick up the editor styles wrapper element,
+			// and move its `.editor-styles-wrapper` class out of the preview.
 			const editorStylesWrapperEl = el.querySelector( '.editor-styles-wrapper' );
 			if ( editorStylesWrapperEl ) {
 				setTimeout( () => {
@@ -55,9 +68,6 @@ const TemplateSelectorItem = props => {
 				}, 0 );
 				setDynamicCssClasses( 'editor-styles-wrapper' );
 			}
-
-			// experimental.
-			setBlocksAmount( 100 );
 		}, 0 );
 
 		// Cleanup

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -78,6 +78,35 @@ const TemplateSelectorItem = props => {
 		};
 	}, [ blocks ] );
 
+
+	/**
+	 * onClick button handler function.
+	 * It call the onSelect() function property.
+	 *
+	 * If it isn't a dynamic preview,
+	 * or the blocks amount in the preview is defined (blocksInPreview),
+	 * it parses the raw block contents.
+	 *
+	 * @return {null} Null
+	 */
+		const onSelectHandler = () => (
+			( blocksInPreview || ! dynamicPreview ) ?
+				onFocus( value, label, parseBlocks( rawBlocks ) ) :
+				onFocus( value, label, blocks )
+		);
+
+		/**
+		 * onMouseEnter button handler function.
+		 * It call the onFocus() function property.
+		 *
+		 * @return {null} Null
+		 */
+	const onFocusHandler = () => (
+		( blocksInPreview || ! dynamicPreview ) ?
+			onFocus( value, label, parseBlocks( rawBlocks ) ) :
+			onFocus( value, label, blocks )
+	);
+
 	const innerPreview = dynamicPreview ? (
 		<div ref={ itemRef } className={ dynamicCssClasses }>
 			{ blocks && blocks.length ? <BlockPreview blocks={ blocks } viewportWidth={ 800 } /> : null }
@@ -92,12 +121,8 @@ const TemplateSelectorItem = props => {
 			id={ `${ id }-${ value }` }
 			className="template-selector-item__label"
 			value={ value }
-			onClick={ () =>
-				onSelect( value, label, ( blocksInPreview || ! dynamicPreview ) ? parseBlocks( rawBlocks ) : blocks )
-			}
-			onMouseEnter={ throttle( () =>
-				onFocus( value, label, dynamicPreview ? blocks : parseBlocks( rawBlocks ) )
-			, 300) }
+			onClick={ onSelectHandler }
+			onMouseEnter={ throttle( onFocusHandler, 300) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
 			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -11,7 +11,7 @@ import { throttle } from 'lodash';
  * WordPress dependencies
  */
 import { useRef, useLayoutEffect, useState } from '@wordpress/element';
-import { BlockPreview } from '@wordpress/block-editor';
+import BlockPreview from './block-template-preview';
 
 const TemplateSelectorItem = props => {
 	const {
@@ -70,13 +70,10 @@ const TemplateSelectorItem = props => {
 
 	const innerPreview = dynamicPreview ? (
 		<div ref={ itemRef } className={ dynamicCssClasses }>
-			{ blocks && blocks.length ?
-				<BlockPreview
-					blocks={ blocksLimit ? blocks.slice( 0, blocksLimit ) : blocks }
-					viewportWidth={ 800 }
-				/> :
-				null
-			}
+			<BlockPreview
+				blocks={ blocksLimit ? blocks.slice( 0, blocksLimit ) : blocks }
+				viewportWidth={ 800 }
+			/>
 		</div>
 	) : (
 		<img className="template-selector-item__media" src={ preview } alt={ previewAlt } />

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -10,7 +10,7 @@ import { throttle } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useRef, useLayoutEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import BlockPreview from './block-template-preview';
 
 const TemplateSelectorItem = props => {
@@ -28,37 +28,7 @@ const TemplateSelectorItem = props => {
 		blocksInPreview,
 	} = props;
 
-	const itemRef = useRef( null );
-	const [ dynamicCssClasses, setDynamicCssClasses ] = useState( 'is-rendering' );
 	const [ blocksLimit, setBlockLimit ] = useState( blocksInPreview );
-
-	useLayoutEffect( () => {
-		const timerId = setTimeout( () => {
-			const el = itemRef ? itemRef.current : null;
-
-			if ( ! el ) {
-				setDynamicCssClasses( '' );
-				return;
-			}
-
-			// Try to pick up the editor styles wrapper element,
-			// and move its `.editor-styles-wrapper` class out of the preview.
-			const editorStylesWrapperEl = el.querySelector( '.editor-styles-wrapper' );
-			if ( editorStylesWrapperEl ) {
-				setTimeout( () => {
-					editorStylesWrapperEl.classList.remove( 'editor-styles-wrapper' );
-				}, 0 );
-				setDynamicCssClasses( 'editor-styles-wrapper' );
-			}
-		}, 0 );
-
-		// Cleanup
-		return () => {
-			if ( timerId ) {
-				window.clearTimeout( timerId );
-			}
-		};
-	}, [ blocks ] );
 
 	const onFocusHandler = () => {
 		if ( blocks.length > blocksLimit ) {
@@ -69,12 +39,10 @@ const TemplateSelectorItem = props => {
 	};
 
 	const innerPreview = dynamicPreview ? (
-		<div ref={ itemRef } className={ dynamicCssClasses }>
-			<BlockPreview
-				blocks={ blocksLimit ? blocks.slice( 0, blocksLimit ) : blocks }
-				viewportWidth={ 800 }
-			/>
-		</div>
+		<BlockPreview
+			blocks={ blocksLimit ? blocks.slice( 0, blocksLimit ) : blocks }
+			viewportWidth={ 800 }
+		/>
 	) : (
 		<img className="template-selector-item__media" src={ preview } alt={ previewAlt } />
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -43,6 +43,7 @@ const TemplateSelectorItem = props => {
 		onFocus( value, label, blocks );
 	}, ON_FOCUS_DELAY );
 
+	// Define static or dynamic preview.
 	const innerPreview = useDynamicPreview ? (
 		<Disabled>
 			<BlockPreview

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -83,7 +83,7 @@ const TemplateSelectorItem = props => {
 			className="template-selector-item__label"
 			value={ value }
 			onClick={ () =>
-				onSelect( value, label, blocksInPreview ? parseBlocks( rawBlocks ) : blocks )
+				onSelect( value, label, ( blocksInPreview || ! dynamicPreview ) ? parseBlocks( rawBlocks ) : blocks )
 			}
 			onMouseEnter={ throttle( () =>
 				onFocus( value, label, dynamicPreview ? blocks : parseBlocks( rawBlocks ) )

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { throttle } from 'lodash';
 
 /**
  * Internal dependencies
@@ -84,9 +85,9 @@ const TemplateSelectorItem = props => {
 			onClick={ () =>
 				onSelect( value, label, blocksInPreview ? parseBlocks( rawBlocks ) : blocks )
 			}
-			onMouseEnter={ () =>
+			onMouseEnter={ throttle( () =>
 				onFocus( value, label, dynamicPreview ? blocks : parseBlocks( rawBlocks ) )
-			}
+			, 300) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
 			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -1,3 +1,5 @@
-const TemplateSelectorPreview = () => <div className="template-selector-preview" />;
+const TemplateSelectorPreview = ( { children } ) => <div className="template-selector-preview">
+	{ children }
+</div>;
 
 export default TemplateSelectorPreview;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -1,0 +1,3 @@
+const TemplateSelectorPreview = () => <div className="template-selector-preview" />;
+
+export default TemplateSelectorPreview;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -1,5 +1,14 @@
-const TemplateSelectorPreview = ( { children } ) => <div className="template-selector-preview">
-	{ children }
-</div>;
+/**
+ * External dependencies
+ */
+import { BlockPreview } from '@wordpress/block-editor';
+
+const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
+	return (
+		<div className="template-selector-preview">
+			<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+		</div>
+	);
+};
 
 export default TemplateSelectorPreview;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 
@@ -30,6 +35,10 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 		};
 	}, [ blocks, viewportWidth ] );
 
+	const loadingClasses = classnames( 'template-selector-preview__loading', {
+		'is-loading': isLoading,
+	} );
+
 	if ( isEmpty( blocks ) ) {
 		return (
 			<div className="template-selector-preview">
@@ -42,9 +51,9 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 
 	return (
 		<div className="template-selector-preview">
-			{ isLoading && (
-				<div className="template-selector-preview__loading">Loading preview...</div>
-			) }
+			<div aria-hidden={ ! isLoading } className={ loadingClasses }>
+				Loading preview...
+			</div>
 			<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
 		</div>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -1,12 +1,12 @@
 /**
  * External dependencies
  */
-import { BlockPreview } from '@wordpress/block-editor';
+import BlockPreview from './block-template-preview';
 
 const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 	return (
 		<div className="template-selector-preview">
-			{ blocks && <BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } /> }
+			<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
 		</div>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -8,7 +8,7 @@ import { isEmpty } from 'lodash';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,9 +21,13 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 	// this but there isn't.
 	const artificialLoadingDelay = 800;
 
+	const previewContainerRef = useRef();
+
 	const [ isLoading, setIsLoading ] = useState( false );
 
 	useEffect( () => {
+		// Reset scroll first to avoid flicker
+		previewContainerRef.current.scrollTop = 0;
 		setIsLoading( true );
 		const timer = setTimeout( () => {
 			setIsLoading( false );
@@ -45,7 +49,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 
 	if ( isEmpty( blocks ) ) {
 		return (
-			<div className="template-selector-preview">
+			<div ref={ previewContainerRef } className="template-selector-preview">
 				<div className="template-selector-preview__placeholder">
 					{ __( 'Select a page template to preview.', 'full-site-editing' ) }
 				</div>
@@ -54,7 +58,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 	}
 
 	return (
-		<div className={ previewElClasses }>
+		<div ref={ previewContainerRef } className={ previewElClasses }>
 			<div aria-hidden={ ! isLoading } className={ loadingElClasses }>
 				Loading preview...
 			</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -39,13 +39,6 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 		};
 	}, [ blocks, viewportWidth ] );
 
-	const loadingElClasses = classnames(
-		'template-selector-preview__loading',
-		'editor-styles-wrapper', {
-			'is-loading': isLoading,
-		}
-	);
-
 	const previewElClasses = classnames(
 		'template-selector-preview',
 		'editor-styles-wrapper', {
@@ -65,7 +58,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 
 	return (
 		<div ref={ previewContainerRef } className={ previewElClasses }>
-			<div aria-hidden={ ! isLoading } className={ loadingElClasses }>
+			<div aria-hidden={ ! isLoading } className="template-selector-preview__loading editor-styles-wrapper">
 				{ __( 'Loading preview…', 'full-site-editing' ) }
 			</div>
 			<Disabled>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -3,6 +3,7 @@
  */
 import { isEmpty } from 'lodash';
 import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -10,6 +11,25 @@ import { __ } from '@wordpress/i18n';
 import BlockPreview from './block-template-preview';
 
 const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
+	// Used to hide the `BlockPreview` until we're confident
+	// it's completed rendering. Ideally there would a way to detect
+	// this but there isn't.
+	const artificialLoadingDelay = 800;
+
+	const [ isLoading, setIsLoading ] = useState( false );
+
+	useEffect( () => {
+		setIsLoading( true );
+		const timer = setTimeout( () => {
+			setIsLoading( false );
+		}, artificialLoadingDelay );
+
+		return () => {
+			setIsLoading( false );
+			clearTimeout( timer );
+		};
+	}, [ blocks, viewportWidth ] );
+
 	return (
 		<div className="template-selector-preview">
 			{ isEmpty( blocks ) ? (
@@ -17,7 +37,12 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 					{ __( 'Select a page template to preview.', 'full-site-editing' ) }
 				</div>
 			) : (
-				<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+				<>
+					{ isLoading && (
+						<div className="template-selector-preview__loading">Loading preview...</div>
+					) }
+					<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+				</>
 			) }
 		</div>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -6,7 +6,7 @@ import { BlockPreview } from '@wordpress/block-editor';
 const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 	return (
 		<div className="template-selector-preview">
-			<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+			{ blocks && <BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } /> }
 		</div>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -37,12 +37,12 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 					{ __( 'Select a page template to preview.', 'full-site-editing' ) }
 				</div>
 			) : (
-				<>
+				<div>
 					{ isLoading && (
 						<div className="template-selector-preview__loading">Loading preview...</div>
 					) }
 					<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
-				</>
+				</div>
 			) }
 		</div>
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -39,17 +39,23 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 		};
 	}, [ blocks, viewportWidth ] );
 
-	const loadingElClasses = classnames( 'template-selector-preview__loading', {
-		'is-loading': isLoading,
-	} );
+	const loadingElClasses = classnames(
+		'template-selector-preview__loading',
+		'editor-styles-wrapper', {
+			'is-loading': isLoading,
+		}
+	);
 
-	const previewElClasses = classnames( 'template-selector-preview', {
-		'is-loaded': ! isLoading,
-	} );
+	const previewElClasses = classnames(
+		'template-selector-preview',
+		'editor-styles-wrapper', {
+			'is-loaded': ! isLoading,
+		}
+	);
 
 	if ( isEmpty( blocks ) ) {
 		return (
-			<div ref={ previewContainerRef } className="template-selector-preview">
+			<div ref={ previewContainerRef } className={ previewElClasses }>
 				<div className="template-selector-preview__placeholder">
 					{ __( 'Select a page template to preview.', 'full-site-editing' ) }
 				</div>
@@ -60,7 +66,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 	return (
 		<div ref={ previewContainerRef } className={ previewElClasses }>
 			<div aria-hidden={ ! isLoading } className={ loadingElClasses }>
-				Loading preview...
+				{ __( 'Loading preview…', 'full-site-editing' ) }
 			</div>
 			<Disabled>
 				<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -1,12 +1,24 @@
 /**
  * External dependencies
  */
+import { isEmpty } from 'lodash';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import BlockPreview from './block-template-preview';
 
 const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 	return (
 		<div className="template-selector-preview">
-			<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+			{ isEmpty( blocks ) ? (
+				<div className="template-selector-preview__placeholder">
+					{ __( 'Select a page template to preview.', 'full-site-editing' ) }
+				</div>
+			) : (
+				<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+			) }
 		</div>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -35,8 +35,12 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 		};
 	}, [ blocks, viewportWidth ] );
 
-	const loadingClasses = classnames( 'template-selector-preview__loading', {
+	const loadingElClasses = classnames( 'template-selector-preview__loading', {
 		'is-loading': isLoading,
+	} );
+
+	const previewElClasses = classnames( 'template-selector-preview', {
+		'is-loaded': ! isLoading,
 	} );
 
 	if ( isEmpty( blocks ) ) {
@@ -50,8 +54,8 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 	}
 
 	return (
-		<div className="template-selector-preview">
-			<div aria-hidden={ ! isLoading } className={ loadingClasses }>
+		<div className={ previewElClasses }>
+			<div aria-hidden={ ! isLoading } className={ loadingElClasses }>
 				Loading preview...
 			</div>
 			<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -30,20 +30,22 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 		};
 	}, [ blocks, viewportWidth ] );
 
-	return (
-		<div className="template-selector-preview">
-			{ isEmpty( blocks ) ? (
+	if ( isEmpty( blocks ) ) {
+		return (
+			<div className="template-selector-preview">
 				<div className="template-selector-preview__placeholder">
 					{ __( 'Select a page template to preview.', 'full-site-editing' ) }
 				</div>
-			) : (
-				<div>
-					{ isLoading && (
-						<div className="template-selector-preview__loading">Loading preview...</div>
-					) }
-					<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
-				</div>
+			</div>
+		);
+	}
+
+	return (
+		<div className="template-selector-preview">
+			{ isLoading && (
+				<div className="template-selector-preview__loading">Loading preview...</div>
 			) }
+			<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
 		</div>
 	);
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -75,7 +75,7 @@ class PageTemplateModal extends Component {
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
 								onTemplateSelect={ ( slug, title, blocks ) => this.selectTemplate( slug, title, blocks ) }
-								dynamicPreview={ false }
+								dynamicPreview={ true }
 							/>
 						</fieldset>
 					</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -15,6 +15,7 @@ import '@wordpress/nux';
  */
 import './styles/starter-page-templates-editor.scss';
 import TemplateSelectorControl from './components/template-selector-control';
+import TemplateSelectorPreview from './components/template-selector-preview';
 import { trackDismiss, trackSelection, trackView, initializeWithIdentity } from './utils/tracking';
 
 class PageTemplateModal extends Component {
@@ -78,6 +79,7 @@ class PageTemplateModal extends Component {
 							/>
 						</fieldset>
 					</form>
+					<TemplateSelectorPreview />
 				</div>
 			</Modal>
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -86,7 +86,7 @@ class PageTemplateModal extends Component {
 								onTemplateFocus={ ( slug, title, blocks ) =>
 									this.focusTemplate( slug, title, blocks )
 								}
-								dynamicPreview={ true }
+								dynamicPreview={ false }
 							/>
 						</fieldset>
 					</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -86,7 +86,7 @@ class PageTemplateModal extends Component {
 								onTemplateFocus={ ( slug, title, blocks ) =>
 									this.focusTemplate( slug, title, blocks )
 								}
-								dynamicPreview={ false }
+								dynamicPreview={ true }
 							/>
 						</fieldset>
 					</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -9,6 +9,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
 import '@wordpress/nux';
+import { BlockPreview } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -21,6 +22,7 @@ import { trackDismiss, trackSelection, trackView, initializeWithIdentity } from 
 class PageTemplateModal extends Component {
 	state = {
 		isLoading: false,
+		previewBlocks: [],
 	};
 
 	constructor( props ) {
@@ -38,7 +40,7 @@ class PageTemplateModal extends Component {
 	}
 
 	selectTemplate = ( slug, title, blocks ) => {
-		this.setState( { isOpen: false } );
+		// this.setState( { isOpen: false } );
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 
 		this.props.saveTemplateChoice( slug );
@@ -51,8 +53,12 @@ class PageTemplateModal extends Component {
 		this.props.insertTemplate( title, blocks );
 	};
 
+	focusTemplate = ( slug, title, blocks ) => {
+		this.setState( { previewBlocks: blocks } );
+	};
+
 	closeModal = () => {
-		this.setState( { isOpen: false } );
+		// this.setState( { isOpen: false } );
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 
@@ -75,11 +81,14 @@ class PageTemplateModal extends Component {
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
 								onTemplateSelect={ ( slug, title, blocks ) => this.selectTemplate( slug, title, blocks ) }
+								onTemplateFocus={ ( slug, title, blocks ) => this.focusTemplate( slug, title, blocks ) }
 								dynamicPreview={ true }
 							/>
 						</fieldset>
 					</form>
-					<TemplateSelectorPreview />
+					<TemplateSelectorPreview>
+						<BlockPreview blocks={ this.state.previewBlocks } viewportWidth={ 800 } />
+					</TemplateSelectorPreview>
 				</div>
 			</Modal>
 		);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -9,7 +9,6 @@ import { registerPlugin } from '@wordpress/plugins';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Component } from '@wordpress/element';
 import '@wordpress/nux';
-import { BlockPreview } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -26,6 +25,7 @@ class PageTemplateModal extends Component {
 	};
 
 	constructor( props ) {
+		// eslint-disable-next-line no-console
 		console.time( 'PageTemplateModal' );
 		super();
 		this.state.isOpen = ! isEmpty( props.templates );
@@ -35,7 +35,7 @@ class PageTemplateModal extends Component {
 		if ( this.state.isOpen ) {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}
-
+		// eslint-disable-next-line no-console
 		console.timeEnd( 'PageTemplateModal' );
 	}
 
@@ -80,15 +80,17 @@ class PageTemplateModal extends Component {
 							<TemplateSelectorControl
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
-								onTemplateSelect={ ( slug, title, blocks ) => this.selectTemplate( slug, title, blocks ) }
-								onTemplateFocus={ ( slug, title, blocks ) => this.focusTemplate( slug, title, blocks ) }
+								onTemplateSelect={ ( slug, title, blocks ) =>
+									this.selectTemplate( slug, title, blocks )
+								}
+								onTemplateFocus={ ( slug, title, blocks ) =>
+									this.focusTemplate( slug, title, blocks )
+								}
 								dynamicPreview={ true }
 							/>
 						</fieldset>
 					</form>
-					<TemplateSelectorPreview>
-						<BlockPreview blocks={ this.state.previewBlocks } viewportWidth={ 800 } />
-					</TemplateSelectorPreview>
+					<TemplateSelectorPreview blocks={ this.state.previewBlocks } viewportWidth={ 800 } />
 				</div>
 			</Modal>
 		);
@@ -136,12 +138,7 @@ const PageTemplatesPlugin = compose(
 )( PageTemplateModal );
 
 // Load config passed from backend.
-const {
-	templates = [],
-	vertical,
-	segment,
-	tracksUserData,
-} = window.starterPageTemplatesConfig;
+const { templates = [], vertical, segment, tracksUserData } = window.starterPageTemplatesConfig;
 
 if ( tracksUserData ) {
 	initializeWithIdentity( tracksUserData );
@@ -150,11 +147,7 @@ if ( tracksUserData ) {
 registerPlugin( 'page-templates', {
 	render: () => {
 		return (
-			<PageTemplatesPlugin
-				templates={ templates }
-				vertical={ vertical }
-				segment={ segment }
-			/>
+			<PageTemplatesPlugin templates={ templates } vertical={ vertical } segment={ segment } />
 		);
 	},
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -40,7 +40,7 @@ class PageTemplateModal extends Component {
 	}
 
 	selectTemplate = ( slug, title, blocks ) => {
-		// this.setState( { isOpen: false } );
+		this.setState( { isOpen: false } );
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 
 		this.props.saveTemplateChoice( slug );
@@ -58,7 +58,7 @@ class PageTemplateModal extends Component {
 	};
 
 	closeModal = () => {
-		// this.setState( { isOpen: false } );
+		this.setState( { isOpen: false } );
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -41,22 +41,28 @@ class PageTemplateModal extends Component {
 		console.timeEnd( 'PageTemplateModal' );
 	}
 
-	selectTemplate = () => {
+	setTemplate = ( slug, title, previewBlocks ) => {
 		this.setState( { isOpen: false } );
-		trackSelection( this.props.segment.id, this.props.vertical.id, this.state.slug );
+		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 
-		this.props.saveTemplateChoice( this.state.slug );
+		this.props.saveTemplateChoice( slug );
 
 		// Skip inserting if there's nothing to insert.
-		if ( this.state.previewBlocks.length === 0 ) {
+		if ( previewBlocks.length === 0 ) {
 			return;
 		}
 
-		this.props.insertTemplate( this.state.title, this.state.previewBlocks );
+		this.props.insertTemplate( title, previewBlocks );
 	};
+
+	selectTemplate = () =>
+		this.setTemplate( this.state.slug, this.state.title, this.state.previewBlocks );
 
 	focusTemplate = ( slug, title, previewBlocks ) => {
 		this.setState( { slug, title, previewBlocks } );
+		if ( slug === 'blank' ) {
+			this.setTemplate( slug, title, previewBlocks );
+		}
 	};
 
 	closeModal = event => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -74,6 +74,7 @@ class PageTemplateModal extends Component {
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
 								onTemplateSelect={ ( slug, title, blocks ) => this.selectTemplate( slug, title, blocks ) }
+								dynamicPreview={ false }
 							/>
 						</fieldset>
 					</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -83,6 +83,7 @@ class PageTemplateModal extends Component {
 								onTemplateSelect={ this.selectTemplate }
 								onTemplateFocus={ this.focusTemplate }
 								dynamicPreview={ true }
+								blocksInPreview={ 2 }
 							/>
 						</fieldset>
 					</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -80,12 +80,8 @@ class PageTemplateModal extends Component {
 							<TemplateSelectorControl
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
-								onTemplateSelect={ ( slug, title, blocks ) =>
-									this.selectTemplate( slug, title, blocks )
-								}
-								onTemplateFocus={ ( slug, title, blocks ) =>
-									this.focusTemplate( slug, title, blocks )
-								}
+								onTemplateSelect={ this.selectTemplate }
+								onTemplateFocus={ this.focusTemplate }
 								dynamicPreview={ true }
 							/>
 						</fieldset>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -42,7 +42,7 @@ class PageTemplateModal extends Component {
 	}
 
 	setTemplate = ( slug, title, previewBlocks ) => {
-		this.setState( { isOpen: false } );
+		// this.setState( { isOpen: false } );
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 
 		this.props.saveTemplateChoice( slug );
@@ -71,7 +71,7 @@ class PageTemplateModal extends Component {
 		if ( event.target.matches( 'button.template-selector-item__label' ) ) {
 			return false;
 		}
-		this.setState( { isOpen: false } );
+		// this.setState( { isOpen: false } );
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -94,7 +94,7 @@ class PageTemplateModal extends Component {
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
 								onTemplateSelect={ this.focusTemplate }
-								onTemplateFocus={ this.focusTemplate }
+								// onTemplateFocus={ this.focusTemplate }
 								useDynamicPreview={ true }
 								numBlocksInPreview={ 10 }
 							/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { isEmpty } from 'lodash';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Button, Modal } from '@wordpress/components';
 import { registerPlugin } from '@wordpress/plugins';
@@ -105,7 +105,7 @@ class PageTemplateModal extends Component {
 						disabled={ isEmpty( this.state.slug ) }
 						onClick={ this.selectTemplate }
 					>
-						{ __( 'Use this template', 'full-site-editing' ) }
+						{ sprintf( __( 'Use %s template', 'full-site-editing' ), this.state.title ) }
 					</Button>
 				</div>
 			</Modal>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -84,7 +84,7 @@ class PageTemplateModal extends Component {
 								templates={ this.props.templates }
 								onTemplateSelect={ this.focusTemplate }
 								dynamicPreview={ true }
-								blocksInPreview={ 2 }
+								blocksInPreview={ 10 }
 							/>
 						</fieldset>
 					</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -42,7 +42,7 @@ class PageTemplateModal extends Component {
 	}
 
 	setTemplate = ( slug, title, previewBlocks ) => {
-		// this.setState( { isOpen: false } );
+		this.setState( { isOpen: false } );
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 
 		this.props.saveTemplateChoice( slug );
@@ -71,7 +71,7 @@ class PageTemplateModal extends Component {
 		if ( event.target.matches( 'button.template-selector-item__label' ) ) {
 			return false;
 		}
-		// this.setState( { isOpen: false } );
+		this.setState( { isOpen: false } );
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -94,6 +94,7 @@ class PageTemplateModal extends Component {
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
 								onTemplateSelect={ this.focusTemplate }
+								onTemplateFocus={ this.focusTemplate }
 								dynamicPreview={ true }
 								blocksInPreview={ 10 }
 							/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -95,8 +95,8 @@ class PageTemplateModal extends Component {
 								templates={ this.props.templates }
 								onTemplateSelect={ this.focusTemplate }
 								onTemplateFocus={ this.focusTemplate }
-								dynamicPreview={ true }
-								blocksInPreview={ 10 }
+								useDynamicPreview={ true }
+								numBlocksInPreview={ 10 }
 							/>
 						</fieldset>
 					</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -42,7 +42,7 @@ class PageTemplateModal extends Component {
 	}
 
 	selectTemplate = () => {
-		this.setState( { isOpen: false } );
+		// this.setState( { isOpen: false } );
 		trackSelection( this.props.segment.id, this.props.vertical.id, this.state.slug );
 
 		this.props.saveTemplateChoice( this.state.slug );
@@ -60,7 +60,7 @@ class PageTemplateModal extends Component {
 	};
 
 	closeModal = () => {
-		this.setState( { isOpen: false } );
+		// this.setState( { isOpen: false } );
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -53,8 +53,8 @@ class PageTemplateModal extends Component {
 		this.props.insertTemplate( title, blocks );
 	};
 
-	focusTemplate = ( slug, title, blocks ) => {
-		this.setState( { previewBlocks: blocks } );
+	focusTemplate = ( slug, title, previewBlocks ) => {
+		this.setState( { previewBlocks } );
 	};
 
 	closeModal = () => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -42,7 +42,7 @@ class PageTemplateModal extends Component {
 	}
 
 	selectTemplate = () => {
-		// this.setState( { isOpen: false } );
+		this.setState( { isOpen: false } );
 		trackSelection( this.props.segment.id, this.props.vertical.id, this.state.slug );
 
 		this.props.saveTemplateChoice( this.state.slug );
@@ -60,7 +60,7 @@ class PageTemplateModal extends Component {
 	};
 
 	closeModal = () => {
-		// this.setState( { isOpen: false } );
+		this.setState( { isOpen: false } );
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 
@@ -88,7 +88,7 @@ class PageTemplateModal extends Component {
 							/>
 						</fieldset>
 					</form>
-					<TemplateSelectorPreview blocks={ this.state.previewBlocks } viewportWidth={ 800 } />
+					<TemplateSelectorPreview blocks={ this.state.previewBlocks } viewportWidth={ 960 } />
 				</div>
 				<div className="page-template-modal__buttons">
 					<Button isDefault isLarge onClick={ this.closeModal }>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -59,7 +59,12 @@ class PageTemplateModal extends Component {
 		this.setState( { slug, title, previewBlocks } );
 	};
 
-	closeModal = () => {
+	closeModal = event => {
+		// Check to see if the Blur event occured on the buttons inside of the Modal.
+		// If it did then we don't want to dismiss the Modal for this type of Blur.
+		if ( event.target.matches( 'button.template-selector-item__label' ) ) {
+			return false;
+		}
 		this.setState( { isOpen: false } );
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -48,7 +48,7 @@ class PageTemplateModal extends Component {
 		this.props.saveTemplateChoice( slug );
 
 		// Skip inserting if there's nothing to insert.
-		if ( previewBlocks.length === 0 ) {
+		if ( ! previewBlocks || previewBlocks.length === 0 ) {
 			return;
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -204,6 +204,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	border: 1px solid $template-selector-border-color;
 	border-radius: 6px;
 	pointer-events: none;
+	overflow-x: hidden;
+	overflow-y: auto;
 }
 
 // Preview adjustments.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -11,6 +11,9 @@
 	word-wrap: normal !important;
 }
 
+$template-selector-border-color: #a1aab2;
+$template-selector-empty-background: #f6f6f6;
+
 // Modal Overlay
 .page-template-modal-screen-overlay {
 	animation: none;
@@ -78,7 +81,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			// stylelint-disable unit-whitelist
 			grid-template-columns: repeat(
 				auto-fit,
-				minmax( 200px, 1fr )
+				minmax( 110px, 1fr )
 			); // allow grid to take over number of cols on large screens
 			// stylelint-enable unit-whitelist
 		}
@@ -93,7 +96,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		width: 100%;
 		font-size: 14px;
 		text-align: center;
-		border: 1px solid #a1aab2;
+		border: 1px solid $template-selector-border-color;
 		border-radius: 6px;
 		cursor: pointer;
 		background: none;
@@ -115,7 +118,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		display: block;
 		margin: 0 auto 14px;
 		border-bottom: 1px solid #a1aab2;
-		background: #f6f6f6;
+		background: $template-selector-empty-background;
 		border-radius: 0;
 		overflow: hidden;
 		padding-bottom: 110%;
@@ -159,6 +162,29 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	@media screen and ( min-width: 960px ) {
 		margin-right: 1em;
 	}
+}
+
+.page-template-modal__form {
+	@media screen and ( min-width: 660px ) {
+		max-width: 50%;
+	}
+}
+
+// Template Selector Preview
+.template-selector-preview {
+	@media screen and ( max-width: 659px ) {
+		display: none;
+	}
+
+	position: fixed;
+	top: 93px;
+	bottom: 25px;
+	right: 32px;
+	width: calc( 50% - 50px );
+	background: $template-selector-empty-background;
+	border: 1px solid $template-selector-border-color;
+	border-radius: 6px;
+	pointer-events: none;
 }
 
 // Preview adjustments.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -110,7 +110,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		margin-bottom: 4px;
 	}
 
-	.template-selector-control__label {
+	.template-selector-item__label {
 		display: block;
 		width: 100%;
 		font-size: 14px;
@@ -132,7 +132,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 	}
 
-	.template-selector-control__preview-wrap {
+	.template-selector-item__preview-wrap {
 		width: 100%;
 		display: block;
 		margin: 0 auto 14px;
@@ -151,7 +151,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 	}
 
-	.template-selector-control__media {
+	.template-selector-item__media {
 		width: 100%;
 		display: block;
 		position: absolute;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -78,6 +78,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		grid-gap: 1.75em;
 
 		@media screen and ( min-width: 660px ) {
+			margin-top: 0;
 			// stylelint-disable unit-whitelist
 			grid-template-columns: repeat(
 				auto-fit,
@@ -177,7 +178,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	position: fixed;
-	top: 93px;
+	top: 80px;
 	bottom: 25px;
 	right: 32px;
 	width: calc( 50% - 50px );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -45,6 +45,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	height: 100vh;
 	max-width: 800px;
 	animation: none;
+
+	@media screen and ( min-width: 1200px ) {
+		width: 80%;
+		max-width: 1200px;
+	}
 }
 
 .page-template-modal .components-modal__header-heading-container {
@@ -63,6 +68,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 	@media screen and ( max-width: 659px ) {
 		padding-bottom: 3em;
+	}
+
+	@media screen and ( min-width: 1200px ) {
+		max-width: 100%;
 	}
 }
 
@@ -83,6 +92,15 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			grid-template-columns: repeat(
 				auto-fit,
 				minmax( 110px, 1fr )
+			); // allow grid to take over number of cols on large screens
+			// stylelint-enable unit-whitelist
+		}
+
+		@media screen and ( min-width: 1200px ) {
+			// stylelint-disable unit-whitelist
+			grid-template-columns: repeat(
+				auto-fit,
+				minmax( 150px, 1fr )
 			); // allow grid to take over number of cols on large screens
 			// stylelint-enable unit-whitelist
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -254,9 +254,9 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
     display: flex;
     align-items: center;
     justify-content: center;
-    
+
     // Retaining the element in the render tree (ie: avoiding display: none)
-    // avoids reflow/repaint cycle which makes UI more responsive when 
+    // avoids reflow/repaint cycle which makes UI more responsive when
     // loading state is toggled rapidly.
     // See: https://www.phpied.com/rendering-repaint-reflowrelayout-restyle/.
     transform: translate( -9999px, -9999px );
@@ -306,14 +306,13 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 }
 
+// Set full height to preview container to inherits styles defined for themes.
 .template-selector-preview .edit-post-visual-editor,
+.template-selector-item__preview-wrap .components-disabled,
 .template-selector-item__preview-wrap .edit-post-visual-editor {
-	// Set full height to preview container to inherits styles defined for themes.
 	height: 100%;
 
 	.editor-styles-wrapper {
 		height: 100%;
-		// remove background as it doesn't fill 100% of scrollable preview container
-		background: none;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -255,8 +255,12 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 // Tweak styles which are inside of the preview container.
 .block-editor-block-preview__container {
 	.editor-styles-wrapper {
+		.wp-block {
+			width: 100%;
+		}
+
 		.wp-block[data-align='wide'] {
-			max-width: 960px; // same width tha the viewportWidth
+			//max-width: 800px;
 		}
 
 		// `core/cover`
@@ -264,7 +268,18 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			padding: 0;
 		}
 
-	.block-editor-block-list__block {
+		// `core/columns`
+		.wp-block-columns > .editor-inner-blocks > .editor-block-list__layout > [data-type='core/column'] {
+			//margin-left: -14px;
+			//margin-right: -14px;
+
+			& > .editor-block-list__block-edit > div > .block-core-columns > .editor-inner-blocks {
+				margin-top: 0;
+				margin-bottom: 0;
+			}
+		}
+
+		.block-editor-block-list__block {
 			.block-editor-block-list__block-edit {
 				@media screen and ( min-width: 600px ) {
 					margin: 0;
@@ -272,11 +287,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			}
 		}
 
-		// grid.
-		.wp-block-columns > .editor-inner-blocks > .editor-block-list__layout > [data-type='core/column'] > .editor-block-list__block-edit > div > .block-core-columns > .editor-inner-blocks {
-			margin-top: 0;
-			margin-bottom: 0;
-		}
 	}
 }
 
@@ -291,6 +301,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 	// editor-writing-flow
 	.editor-writing-flow {
-		width: 100%;
+		//width: 100%;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -249,6 +249,17 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
     display: flex;
     align-items: center;
     justify-content: center;
+    
+    // Retaining the element in the render tree (ie: avoiding display: none)
+    // avoids reflow/repaint cycle which makes UI more responsive when 
+    // loading state is toggled rapidly.
+    // See: https://www.phpied.com/rendering-repaint-reflowrelayout-restyle/.
+    transform: translate( -9999px, -9999px );
+    will-change: transform; // tell the browser to expect a change here
+
+    &.is-loading {
+    	transform: translate( 0, 0 );
+    }
 }
 
 // Preview adjustments.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -231,7 +231,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	overflow-y: auto;
 
 	&.is-loaded {
-		background: #fff; // restore white as the default background behind entire preview
 		pointer-events: auto; // reset to allow scrolling loaded previews
 	}
 }
@@ -307,6 +306,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 // Set full height to preview container to inherits styles defined for themes.
+.template-selector-preview .components-disabled,
 .template-selector-preview .edit-post-visual-editor,
 .template-selector-item__preview-wrap .components-disabled,
 .template-selector-item__preview-wrap .edit-post-visual-editor {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -262,6 +262,8 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	top: 50%;
 	left: 50%;
 	transform: translate3d( -50%, -50%, 0 );
+	width: 80%;
+	text-align: center;
 }
 
 // Preview adjustments.
@@ -277,8 +279,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 
 		// `core/cover`
-		.wp-block[data-type='core/cover'][data-align='full'] .wp-block-cover {
-			padding: 0;
+		.wp-block[data-type='core/cover'][data-align='full'] {
+			margin: 0;
+			.wp-block-cover {
+				padding: 0;
+			}
 		}
 
 		// `core/columns`
@@ -293,6 +298,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		}
 
 		.block-editor-block-list__block {
+			&[data-align='full'] {
+				margin: 0;
+			}
+
 			.block-editor-block-list__block-edit {
 				@media screen and ( min-width: 600px ) {
 					margin: 0;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -142,7 +142,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		background: $template-selector-empty-background;
 		border-radius: 0;
 		overflow: hidden;
-		padding-bottom: 110%;
+		height: 170px;
 		box-sizing: content-box;
 		position: relative;
 		pointer-events: none;
@@ -232,8 +232,29 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 // Preview adjustments.
-.editor-styles-wrapper .block-editor-block-preview__container {
-	.block-editor-block-list__block[data-type='core/cover'] {
-		width: 100%;
+.edit-post-visual-editor .editor-styles-wrapper .block-editor-block-preview__container {
+	.wp-block[data-align='wide'] {
+		max-width: 800px; // same width tha the viewportWidth
+	}
+
+	.block-editor-block-list__block {
+		.block-editor-block-list__block-edit {
+			@media screen and ( min-width: 600px ) {
+				margin: 0;
+			}
+		}
+	}
+
+	.wp-block-columns > .editor-inner-blocks > .editor-block-list__layout > [data-type='core/column'] > .editor-block-list__block-edit > div > .block-core-columns > .editor-inner-blocks {
+		margin-top: 0;
+		margin-bottom: 0;
+	}
+}
+.template-selector-preview .edit-post-visual-editor,
+.template-selector-item__preview-wrap .edit-post-visual-editor {
+	height: 100%;
+
+	.editor-styles-wrapper {
+		height: 100%;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -231,6 +231,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	overflow-y: auto;
 
 	&.is-loaded {
+		background: #fff; // restore white as the default background behind entire preview
 		pointer-events: auto; // reset to allow scrolling loaded previews
 	}
 }
@@ -312,10 +313,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 
 	.editor-styles-wrapper {
 		height: 100%;
-	}
-
-	// editor-writing-flow
-	.editor-writing-flow {
-		//width: 100%;
+		// remove background as it doesn't fill 100% of scrollable preview container
+		background: none;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -231,6 +231,13 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	overflow-y: auto;
 }
 
+.template-selector-preview__placeholder {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate3d( -50%, -50%, 0 );
+}
+
 // Preview adjustments.
 .edit-post-visual-editor .editor-styles-wrapper .block-editor-block-preview__container {
 	.wp-block[data-align='wide'] {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -252,29 +252,45 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 }
 
 // Preview adjustments.
-.edit-post-visual-editor .editor-styles-wrapper .block-editor-block-preview__container {
-	.wp-block[data-align='wide'] {
-		max-width: 800px; // same width tha the viewportWidth
-	}
+// Tweak styles which are inside of the preview container.
+.block-editor-block-preview__container {
+	.editor-styles-wrapper {
+		.wp-block[data-align='wide'] {
+			max-width: 960px; // same width tha the viewportWidth
+		}
+
+		// `core/cover`
+		.wp-block[data-type='core/cover'][data-align='full'] .wp-block-cover {
+			padding: 0;
+		}
 
 	.block-editor-block-list__block {
-		.block-editor-block-list__block-edit {
-			@media screen and ( min-width: 600px ) {
-				margin: 0;
+			.block-editor-block-list__block-edit {
+				@media screen and ( min-width: 600px ) {
+					margin: 0;
+				}
 			}
 		}
-	}
 
-	.wp-block-columns > .editor-inner-blocks > .editor-block-list__layout > [data-type='core/column'] > .editor-block-list__block-edit > div > .block-core-columns > .editor-inner-blocks {
-		margin-top: 0;
-		margin-bottom: 0;
+		// grid.
+		.wp-block-columns > .editor-inner-blocks > .editor-block-list__layout > [data-type='core/column'] > .editor-block-list__block-edit > div > .block-core-columns > .editor-inner-blocks {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
 	}
 }
+
 .template-selector-preview .edit-post-visual-editor,
 .template-selector-item__preview-wrap .edit-post-visual-editor {
+	// Set full height to preview container to inherits styles defined for themes.
 	height: 100%;
 
 	.editor-styles-wrapper {
 		height: 100%;
+	}
+
+	// editor-writing-flow
+	.editor-writing-flow {
+		width: 100%;
 	}
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -238,6 +238,20 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	transform: translate3d( -50%, -50%, 0 );
 }
 
+.template-selector-preview__loading {
+    top: 0;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: #000;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+}
+
 // Preview adjustments.
 .edit-post-visual-editor .editor-styles-wrapper .block-editor-block-preview__container {
 	.wp-block[data-align='wide'] {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -229,6 +229,10 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	pointer-events: none;
 	overflow-x: hidden;
 	overflow-y: auto;
+
+	&.is-loaded {
+		pointer-events: auto; // reset to allow scrolling loaded previews
+	}
 }
 
 .template-selector-preview__placeholder {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -265,8 +265,3 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		height: 100%;
 	}
 }
-
-.page-template-modal .block-editor-block-preview__container {
-	max-width: 80%;
-	margin: 0 auto;
-}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -230,8 +230,30 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	overflow-x: hidden;
 	overflow-y: auto;
 
+	.template-selector-preview__loading {
+		top: 0;
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		z-index: 10;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		// Retaining the element in the render tree (ie: avoiding display: none)
+		// avoids reflow/repaint cycle which makes UI more responsive when
+		// loading state is toggled rapidly.
+		// See: https://www.phpied.com/rendering-repaint-reflowrelayout-restyle/.
+		will-change: transform; // tell the browser to expect a change here
+		transform: translate( 0, 0 );
+	}
+
 	&.is-loaded {
 		pointer-events: auto; // reset to allow scrolling loaded previews
+		.template-selector-preview__loading {
+			transform: translate( -9999px, -9999px );
+		}
 	}
 }
 
@@ -240,29 +262,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	top: 50%;
 	left: 50%;
 	transform: translate3d( -50%, -50%, 0 );
-}
-
-.template-selector-preview__loading {
-    top: 0;
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    z-index: 10;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    // Retaining the element in the render tree (ie: avoiding display: none)
-    // avoids reflow/repaint cycle which makes UI more responsive when
-    // loading state is toggled rapidly.
-    // See: https://www.phpied.com/rendering-repaint-reflowrelayout-restyle/.
-    transform: translate( -9999px, -9999px );
-    will-change: transform; // tell the browser to expect a change here
-
-    &.is-loading {
-    	transform: translate( 0, 0 );
-    }
 }
 
 // Preview adjustments.

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -111,14 +111,14 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	}
 
 	.template-selector-control__preview-wrap {
-		width: 90%;
+		width: 100%;
 		display: block;
 		margin: 0 auto 14px;
 		border-bottom: 1px solid #a1aab2;
-		//background: #f6f6f6;
+		background: #f6f6f6;
 		border-radius: 0;
 		overflow: hidden;
-		padding: 0 5% 110%;
+		padding-bottom: 110%;
 		box-sizing: content-box;
 		position: relative;
 		pointer-events: none;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -248,7 +248,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
     left: 0;
     right: 0;
     bottom: 0;
-    background: $template-selector-empty-background;
     z-index: 10;
     display: flex;
     align-items: center;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -244,12 +244,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
     left: 0;
     right: 0;
     bottom: 0;
-    background: #000;
+    background: $template-selector-empty-background;
     z-index: 10;
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #fff;
 }
 
 // Preview adjustments.

--- a/apps/full-site-editing/package-lock.json
+++ b/apps/full-site-editing/package-lock.json
@@ -85,63 +85,133 @@
 			}
 		},
 		"@wordpress/block-editor": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-2.2.0.tgz",
-			"integrity": "sha512-gpqg81l8Inq3qLALSzN3UG9v9KQ2f6z1FZnGRKnlcQCHqcuScDPiScpspZEZEDHsEj/wAdDtzNlJrpwCMSUNCA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-3.0.0.tgz",
+			"integrity": "sha512-ooEBV8kf1mnShUNLYSAZNiAZNFDoy9Eg9wihtfSDzc89431iFeClIw49dYEy3GFn84MNOHiCqXWHD7Ew2RR8iQ==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"@wordpress/a11y": "^2.4.0",
-				"@wordpress/blob": "^2.4.0",
-				"@wordpress/blocks": "^6.4.0",
-				"@wordpress/components": "^8.0.0",
-				"@wordpress/compose": "^3.4.0",
-				"@wordpress/data": "^4.6.0",
-				"@wordpress/dom": "^2.3.0",
-				"@wordpress/element": "^2.5.0",
-				"@wordpress/hooks": "^2.4.0",
-				"@wordpress/html-entities": "^2.4.0",
-				"@wordpress/i18n": "^3.5.0",
-				"@wordpress/is-shallow-equal": "^1.4.0",
-				"@wordpress/keycodes": "^2.4.0",
-				"@wordpress/rich-text": "^3.4.0",
-				"@wordpress/token-list": "^1.4.0",
-				"@wordpress/url": "^2.6.0",
-				"@wordpress/viewport": "^2.5.0",
-				"@wordpress/wordcount": "^2.4.0",
+				"@wordpress/a11y": "^2.5.0",
+				"@wordpress/blob": "^2.5.0",
+				"@wordpress/blocks": "^6.5.0",
+				"@wordpress/components": "^8.1.0",
+				"@wordpress/compose": "^3.5.0",
+				"@wordpress/data": "^4.7.0",
+				"@wordpress/deprecated": "^2.5.0",
+				"@wordpress/dom": "^2.4.0",
+				"@wordpress/element": "^2.6.0",
+				"@wordpress/hooks": "^2.5.0",
+				"@wordpress/html-entities": "^2.5.0",
+				"@wordpress/i18n": "^3.6.0",
+				"@wordpress/is-shallow-equal": "^1.5.0",
+				"@wordpress/keycodes": "^2.5.0",
+				"@wordpress/rich-text": "^3.5.0",
+				"@wordpress/token-list": "^1.5.0",
+				"@wordpress/url": "^2.7.0",
+				"@wordpress/viewport": "^2.6.0",
+				"@wordpress/wordcount": "^2.5.0",
 				"classnames": "^2.2.5",
 				"dom-scroll-into-view": "^1.2.1",
 				"lodash": "^4.17.10",
+				"react-spring": "^8.0.19",
 				"redux-multi": "^0.1.12",
 				"refx": "^3.0.0",
 				"rememo": "^3.0.0",
 				"tinycolor2": "^1.4.1"
 			},
 			"dependencies": {
-				"@wordpress/components": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.0.0.tgz",
-					"integrity": "sha512-8Lo9VHcNME+0s8RGQ0FaTYbSw7UdoIPZYK8+OB+jZgwM88kbVW6SkgCM45QdxSLtaxkCYdWX1IF/DRJzI22WyQ==",
+				"@wordpress/a11y": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-2.5.0.tgz",
+					"integrity": "sha512-KY+Z0NFQUH6cNbFnP9P58fTCLS93zBz+SIEDA633yG46u1NHOBfWDS4lIrx52fihFdaakSTS0f2OH6yeRb41HQ==",
 					"requires": {
 						"@babel/runtime": "^7.4.4",
-						"@wordpress/a11y": "^2.4.0",
-						"@wordpress/compose": "^3.4.0",
-						"@wordpress/dom": "^2.3.0",
-						"@wordpress/element": "^2.5.0",
-						"@wordpress/hooks": "^2.4.0",
-						"@wordpress/i18n": "^3.5.0",
-						"@wordpress/is-shallow-equal": "^1.4.0",
-						"@wordpress/keycodes": "^2.4.0",
-						"@wordpress/rich-text": "^3.4.0",
-						"@wordpress/url": "^2.6.0",
+						"@wordpress/dom-ready": "^2.5.0"
+					}
+				},
+				"@wordpress/autop": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-2.4.0.tgz",
+					"integrity": "sha512-QapmHuXN3daJpfBDVmKLAVIy97xmqoeBbAKT4sfhZGwR3NIv9fmiKrM8XKWSDAGAqNF1lYN2KkrFieXM7lDU4Q==",
+					"requires": {
+						"@babel/runtime": "^7.4.4"
+					}
+				},
+				"@wordpress/blob": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-2.5.0.tgz",
+					"integrity": "sha512-Eze4O8XivI8Xw4ol3l2TIPUk+K/FVT3GDOuYnwykNXKf19AwOrc51rfX7bqKqonsoGpEQ3TZTIsMfj6+l4k95g==",
+					"requires": {
+						"@babel/runtime": "^7.4.4"
+					}
+				},
+				"@wordpress/block-serialization-default-parser": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-3.3.0.tgz",
+					"integrity": "sha512-fTUS/LEvvwyMcy1VvPl4I8c49GrmtFz5/5h9peaRJdk+jCFD0OsXhpXN1bdHC+0CAoJRz5j8Nf0k8FdFqj6uMg==",
+					"requires": {
+						"@babel/runtime": "^7.4.4"
+					}
+				},
+				"@wordpress/block-serialization-spec-parser": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-serialization-spec-parser/-/block-serialization-spec-parser-3.2.0.tgz",
+					"integrity": "sha512-Qce6P7hBI4PBb1nqzJHcyQ4IMa5i0weBDmfGrDNE1EHoJJZ4zfBnzkUqVVnYNDH5al896y6OzLcQoEKk6SDW9Q==",
+					"requires": {
+						"pegjs": "^0.10.0"
+					}
+				},
+				"@wordpress/blocks": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-6.5.0.tgz",
+					"integrity": "sha512-0luBvWl8IvQwBkbKLuKg6enBvumxwVexR7gIQ6M9CaptUuVNmTheJIdg1EUUft/srRGyEwsQICDk/D9Pmx6nNw==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/autop": "^2.4.0",
+						"@wordpress/blob": "^2.5.0",
+						"@wordpress/block-serialization-default-parser": "^3.3.0",
+						"@wordpress/block-serialization-spec-parser": "^3.2.0",
+						"@wordpress/data": "^4.7.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/html-entities": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/shortcode": "^2.4.0",
+						"hpq": "^1.3.0",
+						"lodash": "^4.17.14",
+						"rememo": "^3.0.0",
+						"showdown": "^1.8.6",
+						"simple-html-tokenizer": "^0.5.7",
+						"tinycolor2": "^1.4.1",
+						"uuid": "^3.3.2"
+					}
+				},
+				"@wordpress/components": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.1.0.tgz",
+					"integrity": "sha512-V35ZyDIVadVQQhKB6IyGULdMfi+44KLL6K0FL2gVihLxHq1P0g3sC6kE26DmYNcYXYfhyGMZT440nkUi1jEo3A==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/a11y": "^2.5.0",
+						"@wordpress/compose": "^3.5.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/i18n": "^3.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/keycodes": "^2.5.0",
+						"@wordpress/rich-text": "^3.5.0",
+						"@wordpress/url": "^2.7.0",
 						"classnames": "^2.2.5",
 						"clipboard": "^2.0.1",
 						"diff": "^3.5.0",
 						"dom-scroll-into-view": "^1.2.1",
-						"lodash": "^4.17.11",
+						"lodash": "^4.17.14",
 						"memize": "^1.0.5",
 						"moment": "^2.22.1",
 						"mousetrap": "^1.6.2",
-						"re-resizable": "^4.7.1",
+						"re-resizable": "^5.0.1",
 						"react-click-outside": "^3.0.0",
 						"react-dates": "^17.1.1",
 						"react-spring": "^8.0.20",
@@ -150,20 +220,187 @@
 						"uuid": "^3.3.2"
 					}
 				},
-				"@wordpress/hooks": {
+				"@wordpress/compose": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-3.5.0.tgz",
+					"integrity": "sha512-X9Qe7gq5+SNvT5yZXSEEgEz5UwUwYh52SBe8WlW59/t182NBBUy9FICEnmx7DRjMugZcSRDwFX39L6tuwo7cnA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"lodash": "^4.17.14"
+					}
+				},
+				"@wordpress/data": {
+					"version": "4.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-4.7.0.tgz",
+					"integrity": "sha512-6ytvrcvg6otalvFNA26gnHv0GQkQT0h9/a780IKl0wyUqAYdKbn1J52CcJWopyfZ53HDq816NCZng1a4tWxHjQ==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/compose": "^3.5.0",
+						"@wordpress/deprecated": "^2.5.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/priority-queue": "^1.3.0",
+						"@wordpress/redux-routine": "^3.5.0",
+						"equivalent-key-map": "^0.2.2",
+						"is-promise": "^2.1.0",
+						"lodash": "^4.17.14",
+						"redux": "^4.0.0",
+						"turbo-combine-reducers": "^1.0.2"
+					}
+				},
+				"@wordpress/dom": {
 					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.4.0.tgz",
-					"integrity": "sha512-z3+8Yq4IQ3DOvUF4VsXOfntdyk1fJ8RZBYlZTW8WfmHV7VKTDbX3LfHXmC2VCjXhVkeWQVKozi2weoEYopfGKA==",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.4.0.tgz",
+					"integrity": "sha512-8hcHi5iHgi1Z/1G6ti04bgsiYBDNlR05X7MiosjwP8U/iTmcRwKrmtA1X6qzsMlOgvJ3MetoLqGZb3lCjLtXmw==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"lodash": "^4.17.14"
+					}
+				},
+				"@wordpress/dom-ready": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.5.0.tgz",
+					"integrity": "sha512-1CXRTZcQ0yn9Aj5x3e0xwYJeRv81NyuwoQUD2ZvDXRXCvaNq33fm79MDvpW5E2uYoo0t9jPHTCwadVXt7bzhwQ==",
 					"requires": {
 						"@babel/runtime": "^7.4.4"
 					}
 				},
-				"@wordpress/is-shallow-equal": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.4.0.tgz",
-					"integrity": "sha512-cghwkh4Ui4o52zdiMCD10dyR0y1K5rf7Cb92J8rF1+DhyoNgYRYWo2OtYLN8RPpsHdo4KPW8noL4SIuKse+Zkw==",
+				"@wordpress/element": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.6.0.tgz",
+					"integrity": "sha512-t7BgD+gRvC0gOubElsiXhp0H5Dq1yAu2/J8aeok4Fcg1anUXcmjo9M7uL/C17e1AbDVIFQvCyhgOg9ltc/rgEA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/escape-html": "^1.5.0",
+						"lodash": "^4.17.14",
+						"react": "^16.8.4",
+						"react-dom": "^16.8.4"
+					}
+				},
+				"@wordpress/hooks": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.5.0.tgz",
+					"integrity": "sha512-+nsYv5AdX7Oj9gVHvtDIQSE9gntrJwA5FpXSEVlZ2u2E5lhjGQS+a+IrRhxZL/7f2eKby5zvQV6vYCrqMtKxYg==",
 					"requires": {
 						"@babel/runtime": "^7.4.4"
+					}
+				},
+				"@wordpress/html-entities": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.5.0.tgz",
+					"integrity": "sha512-7TKaJKkOX2Tas0OyXNPz1kA2my1Z804weBf2RsPLiNXm593JDsf6Em8z1TA4mXtn7FO2ZAKTj/3yRemKK4PhnA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-3.6.0.tgz",
+					"integrity": "sha512-/fkc5OoUCrIyHAaBEKIsXKl+UWj2kKjquhMSSHu3eVqLv/WKrKAzypPPAZC9UXfdSVBY8MrORYLh7vUy9Ic3Vw==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"gettext-parser": "^1.3.1",
+						"lodash": "^4.17.14",
+						"memize": "^1.0.5",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.1.0"
+					}
+				},
+				"@wordpress/is-shallow-equal": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-1.5.0.tgz",
+					"integrity": "sha512-6GjIDZlwcgLmnt1uexUgnIj3zbzCPCtqe5vTqmsQeexC4zCIzgFJgzilOuuW/4kdwF/XB3jex91L9EImc5HTcw==",
+					"requires": {
+						"@babel/runtime": "^7.4.4"
+					}
+				},
+				"@wordpress/keycodes": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-2.5.0.tgz",
+					"integrity": "sha512-4SMN3pmJnNBexpd3/6JB6gJw+wcahBaVZaeMcHyF+Uw7bKcG6hDkzEAN6dWFJuifpdxmvilDE4H5JS/Ex9C6sA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/i18n": "^3.6.0",
+						"lodash": "^4.17.14"
+					}
+				},
+				"@wordpress/priority-queue": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-1.3.0.tgz",
+					"integrity": "sha512-HlhHZUCnKW56b2KFg2cZcn6fnGdi6mrmfOn2lE3cBOibjQLYfOY3pe3TCd+AxS4GdfkgXFA7BHfAinaWCBpAyg==",
+					"requires": {
+						"@babel/runtime": "^7.4.4"
+					}
+				},
+				"@wordpress/rich-text": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.5.0.tgz",
+					"integrity": "sha512-2Pi56SGcao0M0OjZtpwdIyYIXganIDg054InPpdE7zeJRUxf8gKvTGSXA2bYLdDJC0RgCLTtWp+45ItV6byZDg==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/compose": "^3.5.0",
+						"@wordpress/data": "^4.7.0",
+						"@wordpress/deprecated": "^2.5.0",
+						"@wordpress/dom": "^2.4.0",
+						"@wordpress/element": "^2.6.0",
+						"@wordpress/escape-html": "^1.5.0",
+						"@wordpress/hooks": "^2.5.0",
+						"@wordpress/is-shallow-equal": "^1.5.0",
+						"@wordpress/keycodes": "^2.5.0",
+						"classnames": "^2.2.5",
+						"lodash": "^4.17.14",
+						"memize": "^1.0.5",
+						"rememo": "^3.0.0"
+					}
+				},
+				"@wordpress/shortcode": {
+					"version": "2.4.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-2.4.0.tgz",
+					"integrity": "sha512-v9x7KPD39dxmnz9rn9LatrfP3SjWYBPnNVrEmLACXTGOe4XCmx1jfKdE4NlplJ5POq5tvCxcqG07bsKYfj4Dyw==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"lodash": "^4.17.14",
+						"memize": "^1.0.5"
+					}
+				},
+				"@wordpress/url": {
+					"version": "2.7.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-2.7.0.tgz",
+					"integrity": "sha512-W1KEyllal8YWbLMyqfbPw7pQzVsJh73RQyqElrPwZ84TPeH/1JilKVMgKb2RXgJw8q8I+gZIXi6GmVY0+WNAxg==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"qs": "^6.5.2"
+					}
+				},
+				"@wordpress/viewport": {
+					"version": "2.6.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-2.6.0.tgz",
+					"integrity": "sha512-mnUu/SbwrW949AgOODDFLcbLUM/Qhlbi0qZ4JN5c/nOEukru5NRuktvyPPzcd9wWAeNVlqTSpq6E8ES+65ureg==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/compose": "^3.5.0",
+						"@wordpress/data": "^4.7.0",
+						"@wordpress/element": "^2.6.0",
+						"lodash": "^4.17.14"
+					}
+				},
+				"@wordpress/wordcount": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-2.5.0.tgz",
+					"integrity": "sha512-Du/O50ZBpl5Pq/MevUZHQg0FBpT6v/SRhSV8lF5ByjZfXelUcQGN+gQ6RmNdasQ33KVPmspdCQHnQ+sThm4/iA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"lodash": "^4.17.14"
+					}
+				},
+				"re-resizable": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-5.0.1.tgz",
+					"integrity": "sha512-Iy8v5li7bhNBDxCN1DbA4l6G2Hk8NCZtcExoI1D+5pfvKyQcH8LH2P5h3DGoEfHhs0uyyRC1Qx8bHBomfrmxgA==",
+					"requires": {
+						"fast-memoize": "^2.5.1"
 					}
 				}
 			}
@@ -197,6 +434,39 @@
 				"url": "^0.11.0"
 			},
 			"dependencies": {
+				"@wordpress/block-editor": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-2.2.0.tgz",
+					"integrity": "sha512-gpqg81l8Inq3qLALSzN3UG9v9KQ2f6z1FZnGRKnlcQCHqcuScDPiScpspZEZEDHsEj/wAdDtzNlJrpwCMSUNCA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/a11y": "^2.4.0",
+						"@wordpress/blob": "^2.4.0",
+						"@wordpress/blocks": "^6.4.0",
+						"@wordpress/components": "^8.0.0",
+						"@wordpress/compose": "^3.4.0",
+						"@wordpress/data": "^4.6.0",
+						"@wordpress/dom": "^2.3.0",
+						"@wordpress/element": "^2.5.0",
+						"@wordpress/hooks": "^2.4.0",
+						"@wordpress/html-entities": "^2.4.0",
+						"@wordpress/i18n": "^3.5.0",
+						"@wordpress/is-shallow-equal": "^1.4.0",
+						"@wordpress/keycodes": "^2.4.0",
+						"@wordpress/rich-text": "^3.4.0",
+						"@wordpress/token-list": "^1.4.0",
+						"@wordpress/url": "^2.6.0",
+						"@wordpress/viewport": "^2.5.0",
+						"@wordpress/wordcount": "^2.4.0",
+						"classnames": "^2.2.5",
+						"dom-scroll-into-view": "^1.2.1",
+						"lodash": "^4.17.10",
+						"redux-multi": "^0.1.12",
+						"refx": "^3.0.0",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.1"
+					}
+				},
 				"@wordpress/components": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.0.0.tgz",
@@ -481,6 +751,25 @@
 				"moment-timezone": "^0.5.16"
 			}
 		},
+		"@wordpress/deprecated": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-2.5.0.tgz",
+			"integrity": "sha512-bryhXZZ9dZ8DlMQ2liDAV3CQV7wEiftJ9UAOB7X32X4MPZoPqvk3IGiKgHFs3/pEr4Ums0CCckgUlnY7AI+hxQ==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"@wordpress/hooks": "^2.5.0"
+			},
+			"dependencies": {
+				"@wordpress/hooks": {
+					"version": "2.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-2.5.0.tgz",
+					"integrity": "sha512-+nsYv5AdX7Oj9gVHvtDIQSE9gntrJwA5FpXSEVlZ2u2E5lhjGQS+a+IrRhxZL/7f2eKby5zvQV6vYCrqMtKxYg==",
+					"requires": {
+						"@babel/runtime": "^7.4.4"
+					}
+				}
+			}
+		},
 		"@wordpress/dom": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-2.3.0.tgz",
@@ -527,6 +816,39 @@
 				"refx": "^3.0.0"
 			},
 			"dependencies": {
+				"@wordpress/block-editor": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-2.2.0.tgz",
+					"integrity": "sha512-gpqg81l8Inq3qLALSzN3UG9v9KQ2f6z1FZnGRKnlcQCHqcuScDPiScpspZEZEDHsEj/wAdDtzNlJrpwCMSUNCA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/a11y": "^2.4.0",
+						"@wordpress/blob": "^2.4.0",
+						"@wordpress/blocks": "^6.4.0",
+						"@wordpress/components": "^8.0.0",
+						"@wordpress/compose": "^3.4.0",
+						"@wordpress/data": "^4.6.0",
+						"@wordpress/dom": "^2.3.0",
+						"@wordpress/element": "^2.5.0",
+						"@wordpress/hooks": "^2.4.0",
+						"@wordpress/html-entities": "^2.4.0",
+						"@wordpress/i18n": "^3.5.0",
+						"@wordpress/is-shallow-equal": "^1.4.0",
+						"@wordpress/keycodes": "^2.4.0",
+						"@wordpress/rich-text": "^3.4.0",
+						"@wordpress/token-list": "^1.4.0",
+						"@wordpress/url": "^2.6.0",
+						"@wordpress/viewport": "^2.5.0",
+						"@wordpress/wordcount": "^2.4.0",
+						"classnames": "^2.2.5",
+						"dom-scroll-into-view": "^1.2.1",
+						"lodash": "^4.17.10",
+						"redux-multi": "^0.1.12",
+						"refx": "^3.0.0",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.1"
+					}
+				},
 				"@wordpress/components": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.0.0.tgz",
@@ -617,6 +939,39 @@
 				"traverse": "^0.6.6"
 			},
 			"dependencies": {
+				"@wordpress/block-editor": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-2.2.0.tgz",
+					"integrity": "sha512-gpqg81l8Inq3qLALSzN3UG9v9KQ2f6z1FZnGRKnlcQCHqcuScDPiScpspZEZEDHsEj/wAdDtzNlJrpwCMSUNCA==",
+					"requires": {
+						"@babel/runtime": "^7.4.4",
+						"@wordpress/a11y": "^2.4.0",
+						"@wordpress/blob": "^2.4.0",
+						"@wordpress/blocks": "^6.4.0",
+						"@wordpress/components": "^8.0.0",
+						"@wordpress/compose": "^3.4.0",
+						"@wordpress/data": "^4.6.0",
+						"@wordpress/dom": "^2.3.0",
+						"@wordpress/element": "^2.5.0",
+						"@wordpress/hooks": "^2.4.0",
+						"@wordpress/html-entities": "^2.4.0",
+						"@wordpress/i18n": "^3.5.0",
+						"@wordpress/is-shallow-equal": "^1.4.0",
+						"@wordpress/keycodes": "^2.4.0",
+						"@wordpress/rich-text": "^3.4.0",
+						"@wordpress/token-list": "^1.4.0",
+						"@wordpress/url": "^2.6.0",
+						"@wordpress/viewport": "^2.5.0",
+						"@wordpress/wordcount": "^2.4.0",
+						"classnames": "^2.2.5",
+						"dom-scroll-into-view": "^1.2.1",
+						"lodash": "^4.17.10",
+						"redux-multi": "^0.1.12",
+						"refx": "^3.0.0",
+						"rememo": "^3.0.0",
+						"tinycolor2": "^1.4.1"
+					}
+				},
 				"@wordpress/components": {
 					"version": "8.0.0",
 					"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-8.0.0.tgz",
@@ -697,6 +1052,14 @@
 						"@babel/runtime": "^7.4.4"
 					}
 				}
+			}
+		},
+		"@wordpress/escape-html": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.5.0.tgz",
+			"integrity": "sha512-9jGwPbpdJ309EP4Acf6/zwHWeuYi0Bi5RAZx9q+BIYC7bjxLs3oFDS5QkEAi2mzrVAhIz+BbEWBGRg70U1RLlA==",
+			"requires": {
+				"@babel/runtime": "^7.4.4"
 			}
 		},
 		"@wordpress/hooks": {
@@ -866,6 +1229,16 @@
 				"@babel/runtime": "^7.4.4"
 			}
 		},
+		"@wordpress/redux-routine": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-3.5.0.tgz",
+			"integrity": "sha512-fssGjVcXlNFbAIjv6VhCWZYgsv51sugxxCgxAqgSIexsDVnOphDODo5V5bhcgwiZeL3/n5rzqvFQ7Dv4agvc/A==",
+			"requires": {
+				"@babel/runtime": "^7.4.4",
+				"is-promise": "^2.1.0",
+				"rungen": "^0.3.2"
+			}
+		},
 		"@wordpress/rich-text": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-3.4.0.tgz",
@@ -975,12 +1348,12 @@
 			}
 		},
 		"@wordpress/token-list": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-1.4.0.tgz",
-			"integrity": "sha512-QWXL8JlXTXMSfU/nvypfrKaZNeD8S3jUnib239JbloIdOPkYBTp+IMtg9mXXSd7S6wVr/ccnhZ57vmpmoZ222A==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-1.5.0.tgz",
+			"integrity": "sha512-JamANQZLdv2WgmPd0ZumjzmzPoPjbZTWef2W2kuvNHvoLNO9yVulR754qdR/wGPBYEf5sDC3E2D3Vb/zgVEw7A==",
 			"requires": {
 				"@babel/runtime": "^7.4.4",
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.14"
 			}
 		},
 		"@wordpress/url": {
@@ -1229,6 +1602,11 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-4.3.0.tgz",
 			"integrity": "sha512-k8FXd6+JeXoItmdNqB3hMwFgArryjdYBLuzEM8fRY/oztd/051yhSHU6GUrMOfIQU9dDHyFDcIAkGrQKlYtpDA=="
+		},
+		"fast-memoize": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.1.tgz",
+			"integrity": "sha512-xdmw296PCL01tMOXx9mdJSmWY29jQgxyuZdq0rEHMu+Tpe1eOEtCycoG6chzlcrWsNgpZP7oL8RiQr7+G6Bl6g=="
 		},
 		"fbjs": {
 			"version": "0.8.17",

--- a/apps/full-site-editing/package-lock.json
+++ b/apps/full-site-editing/package-lock.json
@@ -1492,6 +1492,16 @@
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
 			"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
 		},
+		"create-react-class": {
+			"version": "15.6.3",
+			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.3.tgz",
+			"integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
+			"requires": {
+				"fbjs": "^0.8.9",
+				"loose-envify": "^1.3.1",
+				"object-assign": "^4.1.1"
+			}
+		},
 		"cross-spawn": {
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
@@ -2113,6 +2123,42 @@
 				"scheduler": "^0.13.6"
 			}
 		},
+		"react-hoverintent": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/react-hoverintent/-/react-hoverintent-0.0.10.tgz",
+			"integrity": "sha1-rNl1wghF9kD9tfZS8ucY/oQzu1Y=",
+			"requires": {
+				"prop-types": "^15.5.10",
+				"react": "^15.4.1",
+				"react-dom": "^15.4.1",
+				"xtend": "^4.0.1"
+			},
+			"dependencies": {
+				"react": {
+					"version": "15.6.2",
+					"resolved": "https://registry.npmjs.org/react/-/react-15.6.2.tgz",
+					"integrity": "sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=",
+					"requires": {
+						"create-react-class": "^15.6.0",
+						"fbjs": "^0.8.9",
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.0",
+						"prop-types": "^15.5.10"
+					}
+				},
+				"react-dom": {
+					"version": "15.6.2",
+					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.6.2.tgz",
+					"integrity": "sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=",
+					"requires": {
+						"fbjs": "^0.8.9",
+						"loose-envify": "^1.1.0",
+						"object-assign": "^4.1.0",
+						"prop-types": "^15.5.10"
+					}
+				}
+			}
+		},
 		"react-is": {
 			"version": "16.8.6",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
@@ -2447,6 +2493,11 @@
 					}
 				}
 			}
+		},
+		"xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "3.2.1",

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -30,6 +30,7 @@
 	},
 	"dependencies": {
 		"@wordpress/api-fetch": "^3.1.2",
+		"@wordpress/block-editor": "^3.0.0",
 		"@wordpress/blocks": "^6.2.3",
 		"@wordpress/components": "^7.3.0",
 		"@wordpress/compose": "^3.2.0",

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -46,6 +46,7 @@
 		"@wordpress/plugins": "^2.2.0",
 		"@wordpress/url": "^2.5.0",
 		"classnames": "^2.2.6",
-		"lodash": "^4.17.14"
+		"lodash": "^4.17.14",
+		"react-hoverintent": "0.0.10"
 	}
 }

--- a/apps/full-site-editing/package.json
+++ b/apps/full-site-editing/package.json
@@ -46,7 +46,6 @@
 		"@wordpress/plugins": "^2.2.0",
 		"@wordpress/url": "^2.5.0",
 		"classnames": "^2.2.6",
-		"lodash": "^4.17.14",
-		"react-hoverintent": "0.0.10"
+		"lodash": "^4.17.14"
 	}
 }


### PR DESCRIPTION
The goal of this PR is to implement the new alternate template selector design suggested in https://github.com/Automattic/wp-calypso/issues/35232

### Creative

We're using the following mockup as a reference

<img width="1163" alt="62886512-16129400-bcf0-11e9-8430-ca1225e5e0b9 (1)" src="https://user-images.githubusercontent.com/1562646/62942456-9a404680-bdd8-11e9-9f46-adf4df66104c.png">

### How it looks (2019-08-14)

![image (5)](https://user-images.githubusercontent.com/77539/63056004-802c6400-bebd-11e9-84c1-4e8acb196d72.png)

![image (4)](https://user-images.githubusercontent.com/77539/63056005-80c4fa80-bebd-11e9-8b21-565c604305dc.png)

### Templates Preview approach

Some lines about the current approach for the preview

* All blocks for all templates are parsed once, in the `<TemplateSelectorControl />` constructor
* Initially, only 10 blocks are rendered by templates in the thumbnails
* When hovering thumbnail happens, it re-renders all blocks for the templates right there if it's needed.
* All parsed blocks are rendered in the Large Preview.
* It doesn't re-parse the blocks either when it injects them into the Editor or in the large preview. It simply uses which were parsed in the beginning.

### Tasks:
- [x] Turn on dynamic rendering of the “thumbnails”
- [x]  Make the large preview render dynamically on hover
- [x] Styles tweak

~-[ ] Performance tuning (note at x4 CPU throttle it takes over 2s to load the PageTemplate modal)~
