### PR TITLE
Full Site Editing: update render_template usage for namespaces

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/posts-list.php
+++ b/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/posts-list.php
@@ -33,7 +33,7 @@ if ( $posts_list instanceof WP_Query && $posts_list->have_posts() ) :
 	<?php
 else :
 	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-	echo a8c_pl_render_template( 'no-posts' );
+	echo A8C\FSE\render_template( 'no-posts' );
 endif;
 
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

During the namespacing refactor `render_template` function has been renamed (https://github.com/Automattic/wp-calypso/pull/35074/files#diff-96ec6417465e02120f56037809f27faeL19) but we didn't update its usage in https://github.com/Automattic/wp-calypso/blob/3344c559da4fe605f74cdfc3e6b05e8f569c32b2/apps/full-site-editing/full-site-editing-plugin/posts-list-block/templates/posts-list.php#L36.

This caused the following fatals when we tried to sync FSE on Dotcom:

```
Uncaught Error: Call to undefined function a8c_pl_render_template() in /home/wpcom/public_html/wp-content/plugins/full-site-editing-plugin/posts-list-block/templates/posts-list.php:36
```

#### Testing instructions

* cc @Automattic/ajax for help with testing.
