### PR TITLE
Guided Tours: stop using Redux store from legacy context

### DIFF
--- a/client/layout/guided-tours/component.jsx
+++ b/client/layout/guided-tours/component.jsx
@@ -37,17 +37,14 @@ class GuidedToursComponent extends Component {
 
 	UNSAFE_componentWillReceiveProps( nextProps ) {
 		if ( nextProps.requestedTour === 'reset' && this.props.requestedTour !== 'reset' ) {
-			this.props.resetGuidedToursHistory();
+			this.props.dispatch( resetGuidedToursHistory() );
 		}
 	}
 
 	start = ( { step, tour, tourVersion: tour_version } ) => {
 		if ( tour && tour_version ) {
-			this.props.nextGuidedTourStep( { step, tour } );
-			tracks.recordEvent( 'calypso_guided_tours_start', {
-				tour,
-				tour_version,
-			} );
+			this.props.dispatch( nextGuidedTourStep( { step, tour } ) );
+			tracks.recordEvent( 'calypso_guided_tours_start', { tour, tour_version } );
 		}
 	};
 
@@ -61,10 +58,7 @@ class GuidedToursComponent extends Component {
 		}
 
 		defer( () => {
-			this.props.nextGuidedTourStep( {
-				tour,
-				stepName: nextStepName,
-			} );
+			this.props.dispatch( nextGuidedTourStep( { tour, stepName: nextStepName } ) );
 		} );
 	};
 
@@ -83,11 +77,7 @@ class GuidedToursComponent extends Component {
 			tour_version,
 		} );
 
-		this.props.quitGuidedTour( {
-			tour,
-			stepName: step,
-			finished: isLastStep,
-		} );
+		this.props.dispatch( quitGuidedTour( { tour, stepName: step, finished: isLastStep } ) );
 	};
 
 	render() {
@@ -111,6 +101,7 @@ class GuidedToursComponent extends Component {
 						next={ this.next }
 						quit={ this.quit }
 						start={ this.start }
+						dispatch={ this.props.dispatch }
 					/>
 				</div>
 			</RootChild>
@@ -120,22 +111,15 @@ class GuidedToursComponent extends Component {
 
 const getTourWhenState = state => when => !! when( state );
 
-export default connect(
-	state => {
-		const tourState = getGuidedTourState( state );
-		const shouldPause = isSectionLoading( state ) || tourState.isPaused;
-		return {
-			sectionName: getSectionName( state ),
-			shouldPause,
-			tourState,
-			isValid: getTourWhenState( state ),
-			lastAction: getLastAction( state ),
-			requestedTour: getInitialQueryArguments( state ).tour,
-		};
-	},
-	{
-		nextGuidedTourStep,
-		quitGuidedTour,
-		resetGuidedToursHistory,
-	}
-)( GuidedToursComponent );
+export default connect( state => {
+	const tourState = getGuidedTourState( state );
+	const shouldPause = isSectionLoading( state ) || tourState.isPaused;
+	return {
+		sectionName: getSectionName( state ),
+		shouldPause,
+		tourState,
+		isValid: getTourWhenState( state ),
+		lastAction: getLastAction( state ),
+		requestedTour: getInitialQueryArguments( state ).tour,
+	};
+} )( GuidedToursComponent );

--- a/client/layout/guided-tours/config-elements/make-tour.js
+++ b/client/layout/guided-tours/config-elements/make-tour.js
@@ -13,7 +13,7 @@ import debugFactory from 'debug';
  * Internal dependencies
  */
 import { tourBranching } from '../tour-branching';
-import { childContextTypes } from '../context-types';
+import { contextTypes } from '../context-types';
 
 const debug = debugFactory( 'calypso:guided-tours' );
 
@@ -30,7 +30,7 @@ const makeTour = tree => {
 			dispatch: PropTypes.func.isRequired,
 		};
 
-		static childContextTypes = childContextTypes;
+		static childContextTypes = contextTypes;
 
 		static meta = omit( tree.props, 'children' );
 

--- a/client/layout/guided-tours/config-elements/make-tour.js
+++ b/client/layout/guided-tours/config-elements/make-tour.js
@@ -27,6 +27,7 @@ const makeTour = tree => {
 			shouldPause: PropTypes.bool.isRequired,
 			sectionName: PropTypes.string,
 			stepName: PropTypes.string.isRequired,
+			dispatch: PropTypes.func.isRequired,
 		};
 
 		static childContextTypes = childContextTypes;
@@ -42,7 +43,17 @@ const makeTour = tree => {
 		}
 
 		static getDerivedStateFromProps( props ) {
-			const { isValid, lastAction, next, quit, start, sectionName, shouldPause, stepName } = props;
+			const {
+				isValid,
+				lastAction,
+				next,
+				quit,
+				start,
+				sectionName,
+				shouldPause,
+				stepName,
+				dispatch,
+			} = props;
 			const step = stepName;
 			const branching = tourBranching( tree );
 
@@ -59,6 +70,7 @@ const makeTour = tree => {
 				isLastStep: isEmpty( branching[ step ] ),
 				tour: tree.props.name,
 				tourVersion: tree.props.version,
+				dispatch,
 			};
 
 			debug( 'makeTour#getDerivedStateFromProps computed new context', props, tourContext );

--- a/client/layout/guided-tours/config-elements/step.tsx
+++ b/client/layout/guided-tours/config-elements/step.tsx
@@ -3,7 +3,7 @@
  */
 import React, { Component, CSSProperties, FunctionComponent } from 'react';
 import classNames from 'classnames';
-import { defer, get, isFunction } from 'lodash';
+import { defer, isFunction } from 'lodash';
 import debugFactory from 'debug';
 import { translate } from 'i18n-calypso';
 
@@ -160,15 +160,10 @@ export default class Step extends Component< Props, State > {
 		start( { step, tour, tourVersion } );
 	}
 
-	wait( props: Props, context ) {
+	async wait( props: Props, context ) {
 		if ( isFunction( props.wait ) ) {
-			const ret = props.wait( { reduxStore: context.store } );
-			if ( isFunction( get( ret, 'then' ) ) ) {
-				return ret;
-			}
+			await context.dispatch( props.wait() );
 		}
-
-		return Promise.resolve();
 	}
 
 	safeSetState( state: State ) {

--- a/client/layout/guided-tours/context-types.js
+++ b/client/layout/guided-tours/context-types.js
@@ -1,13 +1,11 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 
-// Shape of context provided by the `makeTour` context provider
-export const childContextTypes = Object.freeze( {
+// Shape of context provided by the `makeTour` context provider.
+// The same shape is expected by the context consumers, too.
+export const contextTypes = Object.freeze( {
 	branching: PropTypes.object.isRequired,
 	next: PropTypes.func.isRequired,
 	quit: PropTypes.func.isRequired,
@@ -21,11 +19,4 @@ export const childContextTypes = Object.freeze( {
 	step: PropTypes.string.isRequired,
 	lastAction: PropTypes.object,
 	dispatch: PropTypes.func.isRequired,
-} );
-
-// Shape of context expected by the consumers: in addition to the context from the
-// `makeTour` context provider, they expect also `store` from Redux.
-export const contextTypes = Object.freeze( {
-	...childContextTypes,
-	store: PropTypes.object.isRequired,
 } );

--- a/client/layout/guided-tours/context-types.js
+++ b/client/layout/guided-tours/context-types.js
@@ -20,6 +20,7 @@ export const childContextTypes = Object.freeze( {
 	shouldPause: PropTypes.bool.isRequired,
 	step: PropTypes.string.isRequired,
 	lastAction: PropTypes.object,
+	dispatch: PropTypes.func.isRequired,
 } );
 
 // Shape of context expected by the consumers: in addition to the context from the

--- a/client/layout/guided-tours/tours/checklist-publish-post-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-publish-post-tour/index.js
@@ -35,29 +35,37 @@ function isFeaturedImageSet() {
 	return !! query( '.editor-featured-image.is-assigned' ).length;
 }
 
-function openSidebar( { reduxStore } ) {
-	if ( getCurrentLayoutFocus( reduxStore.getState() ) !== 'sidebar' ) {
-		reduxStore.dispatch( setLayoutFocus( 'sidebar' ) );
+// Open the sidebar with a Redux action dispatch and then wait 200ms before proceeding.
+// This function is a Redux action creator. The returned thunk will be dispatched and the
+// returned promise waited for.
+const openSidebar = () => async ( dispatch, getState ) => {
+	if ( getCurrentLayoutFocus( getState() ) !== 'sidebar' ) {
+		dispatch( setLayoutFocus( 'sidebar' ) );
 	}
 
-	return new Promise( function( resolve, reject ) {
-		getCurrentLayoutFocus( reduxStore.getState() ) === 'sidebar' ? delay( resolve, 200 ) : reject();
-	} );
-}
-
-function openFeatureImageUploadDialog() {
-	if ( ! query( '.editor-media-modal' ).length ) {
-		const buttons = query(
-			'[data-tip-target="accordion-featured-image"] .editor-drawer-well__placeholder, ' +
-				'[data-tip-target="accordion-featured-image"] .editor-featured-image__preview .image-preloader'
-		);
-		if ( buttons.length ) {
-			buttons[ 0 ].click();
-		}
+	if ( getCurrentLayoutFocus( getState() ) !== 'sidebar' ) {
+		throw new Error( 'Could not open sidebar' );
 	}
 
-	return true;
-}
+	await new Promise( resolve => delay( resolve, 200 ) );
+};
+
+// Open the image upload dialog by finding the open button in DOM and clicking it.
+// This function is a Redux action thunk, hence the two arrows (and unused `dispatch` param).
+const openFeatureImageUploadDialog = () => () => {
+	if ( query( '.editor-media-modal' ).length ) {
+		return;
+	}
+
+	const buttons = query(
+		'[data-tip-target="accordion-featured-image"] .editor-drawer-well__placeholder, ' +
+			'[data-tip-target="accordion-featured-image"] .editor-featured-image__preview .image-preloader'
+	);
+
+	if ( buttons.length ) {
+		buttons[ 0 ].click();
+	}
+};
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const ChecklistPublishPostTour = makeTour(

--- a/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
+++ b/client/layout/guided-tours/tours/jetpack-plugin-updates-tour/index.tsx
@@ -22,6 +22,14 @@ import {
 
 const JETPACK_TOGGLE_SELECTOR = '.plugin-item-jetpack .form-toggle__switch';
 
+// Wait until the desired DOM element appears. Check every 125ms.
+// This function is a Redux action creator, hence the two arrows.
+const waitForJetpackToggle = () => async () => {
+	while ( ! document.querySelector( JETPACK_TOGGLE_SELECTOR ) ) {
+		await new Promise( resolve => setTimeout( resolve, 125 ) );
+	}
+};
+
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const JetpackPluginUpdatesTour = makeTour(
 	<Tour
@@ -38,22 +46,7 @@ export const JetpackPluginUpdatesTour = makeTour(
 			target={ JETPACK_TOGGLE_SELECTOR }
 			arrow="top-left"
 			placement="below"
-			wait={ () =>
-				new Promise( resolve => {
-					if ( document.querySelector( JETPACK_TOGGLE_SELECTOR ) ) {
-						return resolve();
-					}
-
-					const waitForElement = () => {
-						if ( document.querySelector( JETPACK_TOGGLE_SELECTOR ) ) {
-							return resolve();
-						}
-						setTimeout( waitForElement, 125 );
-					};
-
-					waitForElement();
-				} )
-			}
+			wait={ waitForJetpackToggle }
 			style={ {
 				animationDelay: '0.7s',
 				zIndex: 1,


### PR DESCRIPTION
Spinoff from #32129 (React Redux upgrade) that stops accessing the Redux store in the legacy React context in Guided Tours. That implementation detail is changed in React Redux v7 to use the modern `React.createContext`.

The usage is replaced by making the `dispatch` function a part of the GT context that's available to all `Step` components.

The store was used by the `<Step wait={ ... } />` functions that do something (usually activate some UI) and then wait for a DOM element to appear before proceeding with displaying a GT bubble aligned to that element.

I changed the API of the `wait` function from a regular Promise-returning function to an action thunk creator. That thunk will be dispatched by the `Step.wait` method and the return value waited for. That's flexible enough to implement everything we need.

The already existing `<Tour when={ ... } />` prop is a Redux selector, so there's a prior art for using Redux concepts for implementing Tour flows.
