### PR TITLE
Jetpack Scan: Disable persistent alerts for Atomic sites

### DIFF
--- a/client/my-sites/activity/activity-log/index.jsx
+++ b/client/my-sites/activity/activity-log/index.jsx
@@ -62,6 +62,7 @@ import getRestoreProgress from 'state/selectors/get-restore-progress';
 import getRewindState from 'state/selectors/get-rewind-state';
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
+import isAtomicSite from 'state/selectors/is-site-automated-transfer';
 import isVipSite from 'state/selectors/is-vip-site';
 import { requestActivityLogs } from 'state/data-getters';
 import { emptyFilter } from 'state/activity-log/reducer';
@@ -362,6 +363,7 @@ class ActivityLog extends Component {
 			siteIsOnFreePlan,
 			slug,
 			translate,
+			isAtomic,
 			isJetpack,
 			isIntroDismissed,
 		} = this.props;
@@ -408,7 +410,7 @@ class ActivityLog extends Component {
 				<QuerySiteSettings siteId={ siteId } />
 				<SidebarNavigation />
 
-				{ config.isEnabled( 'rewind-alerts' ) && siteId && isJetpack && (
+				{ config.isEnabled( 'rewind-alerts' ) && siteId && isJetpack && ! isAtomic && (
 					<RewindAlerts siteId={ siteId } />
 				) }
 				{ siteId && 'unavailable' === rewindState.state && (
@@ -589,6 +591,7 @@ export default connect(
 				'active' === rewindState.state &&
 				! ( 'queued' === restoreStatus || 'running' === restoreStatus ),
 			filter,
+			isAtomic: isAtomicSite( state, siteId ),
 			isJetpack,
 			logs: ( siteId && logs.data ) || emptyList,
 			logLoadingState: logs && logs.state,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Jetpack Scan persistent notices, which are currently behind the feature flag `rewind-alerts`, should not show for Atomic sites because scan results on those sites are managed by support rather than the site owners. This PR disables the notices for Atomic sites.

**Before**

<img width="400" alt="Screenshot 2019-08-13 at 17 01 03" src="https://user-images.githubusercontent.com/7767559/62958200-1ee98f80-bdee-11e9-924b-5b003d17ebb0.png">

**After**

<img width="400" alt="Screenshot 2019-08-13 at 17 01 18" src="https://user-images.githubusercontent.com/7767559/62958190-185b1800-bdee-11e9-9933-5983470577c4.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://calypso.live/?branch=update/disable-rewind-threat-alerts-atomic&flags=rewind-alerts (note the `rewind-alerts` flag)
* Navigate to the activity log for an Atomic site with active threats

Expected: you should not see the security alerts at the top of the page.

