### PR TITLE
Domains: Recommend dotblog for signup flows

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -317,31 +317,8 @@ class DomainsStep extends React.Component {
 	};
 
 	shouldIncludeDotBlogSubdomain() {
-		const { flowName, isDomainOnly, siteGoals, signupDependencies } = this.props;
-		const siteGoalsArray = siteGoals ? siteGoals.split( ',' ) : [];
-
-		// 'subdomain' flow coming from .blog landing pages
-		if ( flowName === 'subdomain' ) {
-			return true;
-		}
-
-		// 'blog' flow, starting with blog themes
-		if ( flowName === 'blog' ) {
-			return true;
-		}
-
 		// No .blog subdomains for domain only sites
-		if ( isDomainOnly ) {
-			return false;
-		}
-
-		// If we detect a 'blog' site type from Signup data
-		return (
-			// All flows where 'about' step is before 'domains' step, user picked only 'share' on the `about` step
-			( siteGoalsArray.length === 1 && siteGoalsArray.indexOf( 'share' ) !== -1 ) ||
-			// Users choose `Blog` as their site type
-			'blog' === get( signupDependencies, 'siteType' )
-		);
+		return ! this.props.isDomainOnly;
 	}
 
 	domainForm = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change enables dotblog suggestions for all signup verticals except for `/domains`. 

Context: p2MSmN-7db#comment-37130. cc @kelliepeterson.

#### Testing instructions

1. Spin up this branch locally or in a live branch.
2. Navigate to `/start`.

3a. Select `Blog` and advance to the domain selection process.
4a. Enter something like `greatest.food.blog` and ensure that a dotblog suggestion is recommended.

3b. Select `Business` and advance to the domain selection process.
4b. Enter something like `greatest.food.blog` and ensure that a dotblog suggestion is recommended.

3b. Select `Professional` and advance to the domain selection process.
4b. Enter something like `greatest.food.blog` and ensure that a dotblog suggestion is recommended.
