### PR TITLE
AddCardDetails: Refactor as functional component

### DIFF
--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -33,12 +33,12 @@ function AddCardDetails( props ) {
 	const isDataLoading = ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
 	const isDataValid = ( { purchase, selectedSite } ) => purchase && selectedSite;
 
-	if ( isDataLoading && ! isDataValid( props ) ) {
+	if ( ! isDataLoading && ! isDataValid( props ) ) {
 		// Redirect if invalid data
 		page( purchasesRoot );
 	}
 
-	if ( isDataLoading( props ) ) {
+	if ( isDataLoading ) {
 		return (
 			<Fragment>
 				<QueryUserPurchases userId={ props.userId } />
@@ -49,14 +49,14 @@ function AddCardDetails( props ) {
 	}
 
 	const recordFormSubmitEvent = () =>
-		void this.props.recordTracksEvent( 'calypso_purchases_credit_card_form_submit', {
-			product_slug: this.props.purchase.productSlug,
+		void props.recordTracksEvent( 'calypso_purchases_credit_card_form_submit', {
+			product_slug: props.purchase.productSlug,
 		} );
 
 	const successCallback = () => {
-		const { id } = this.props.purchase;
-		this.props.clearPurchases();
-		page( managePurchase( this.props.siteSlug, id ) );
+		const { id } = props.purchase;
+		props.clearPurchases();
+		page( managePurchase( props.siteSlug, id ) );
 	};
 
 	return (

--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -5,7 +5,7 @@
  */
 import page from 'page';
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 
 /**
@@ -24,99 +24,77 @@ import { createCardToken } from 'lib/store-transactions';
 import { getByPurchaseId, hasLoadedUserPurchasesFromServer } from 'state/purchases/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import { isDataLoading } from 'me/purchases/utils';
 import { isRequestingSites } from 'state/sites/selectors';
 import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-class AddCardDetails extends Component {
-	static propTypes = {
-		clearPurchases: PropTypes.func.isRequired,
-		hasLoadedSites: PropTypes.bool.isRequired,
-		hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
-		purchaseId: PropTypes.number.isRequired,
-		purchase: PropTypes.object,
-		selectedSite: PropTypes.object,
-		siteSlug: PropTypes.string.isRequired,
-		userId: PropTypes.number,
-	};
+function AddCardDetails( props ) {
+	const createCardUpdateToken = ( ...args ) => createCardToken( 'card_update', ...args );
+	const isDataLoading = ! props.hasLoadedSites || ! props.hasLoadedUserPurchasesFromServer;
+	const isDataValid = ( { purchase, selectedSite } ) => purchase && selectedSite;
 
-	createCardToken = ( ...args ) => createCardToken( 'card_update', ...args );
-
-	redirectIfDataIsInvalid( props = this.props ) {
-		if ( isDataLoading( props ) ) {
-			return true;
-		}
-
-		if ( ! this.isDataValid( props ) ) {
-			page( purchasesRoot );
-		}
+	if ( isDataLoading && ! isDataValid( props ) ) {
+		// Redirect if invalid data
+		page( purchasesRoot );
 	}
 
-	isDataValid( props = this.props ) {
-		const { purchase, selectedSite } = props;
+	if ( isDataLoading( props ) ) {
+		return (
+			<Fragment>
+				<QueryUserPurchases userId={ props.userId } />
 
-		return purchase && selectedSite;
+				<CreditCardFormLoadingPlaceholder title={ titles.addCardDetails } />
+			</Fragment>
+		);
 	}
 
-	recordFormSubmitEvent = () =>
+	const recordFormSubmitEvent = () =>
 		void this.props.recordTracksEvent( 'calypso_purchases_credit_card_form_submit', {
 			product_slug: this.props.purchase.productSlug,
 		} );
 
-	successCallback = () => {
+	const successCallback = () => {
 		const { id } = this.props.purchase;
-
 		this.props.clearPurchases();
-
 		page( managePurchase( this.props.siteSlug, id ) );
 	};
 
-	componentWillMount() {
-		this.redirectIfDataIsInvalid();
-	}
+	return (
+		<Main>
+			<TrackPurchasePageView
+				eventName="calypso_add_card_details_purchase_view"
+				purchaseId={ props.purchaseId }
+			/>
+			<PageViewTracker
+				path="/me/purchases/:site/:purchaseId/payment/add"
+				title="Purchases > Add Card Details"
+			/>
+			<HeaderCake backHref={ managePurchase( props.siteSlug, props.purchaseId ) }>
+				{ titles.addCardDetails }
+			</HeaderCake>
 
-	componentWillReceiveProps( nextProps ) {
-		this.redirectIfDataIsInvalid( nextProps );
-	}
-
-	render() {
-		if ( isDataLoading( this.props ) ) {
-			return (
-				<Fragment>
-					<QueryUserPurchases userId={ this.props.userId } />
-
-					<CreditCardFormLoadingPlaceholder title={ titles.addCardDetails } />
-				</Fragment>
-			);
-		}
-
-		return (
-			<Main>
-				<TrackPurchasePageView
-					eventName="calypso_add_card_details_purchase_view"
-					purchaseId={ this.props.purchaseId }
-				/>
-				<PageViewTracker
-					path="/me/purchases/:site/:purchaseId/payment/add"
-					title="Purchases > Add Card Details"
-				/>
-				<HeaderCake backHref={ managePurchase( this.props.siteSlug, this.props.purchaseId ) }>
-					{ titles.addCardDetails }
-				</HeaderCake>
-
-				<CreditCardForm
-					apiParams={ { purchaseId: this.props.purchase.id } }
-					createCardToken={ this.createCardToken }
-					purchase={ this.props.purchase }
-					recordFormSubmitEvent={ this.recordFormSubmitEvent }
-					siteSlug={ this.props.siteSlug }
-					successCallback={ this.successCallback }
-				/>
-			</Main>
-		);
-	}
+			<CreditCardForm
+				apiParams={ { purchaseId: props.purchase.id } }
+				createCardToken={ createCardUpdateToken }
+				purchase={ props.purchase }
+				recordFormSubmitEvent={ recordFormSubmitEvent }
+				siteSlug={ props.siteSlug }
+				successCallback={ successCallback }
+			/>
+		</Main>
+	);
 }
+
+AddCardDetails.propTypes = {
+	clearPurchases: PropTypes.func.isRequired,
+	hasLoadedSites: PropTypes.bool.isRequired,
+	hasLoadedUserPurchasesFromServer: PropTypes.bool.isRequired,
+	purchaseId: PropTypes.number.isRequired,
+	purchase: PropTypes.object,
+	selectedSite: PropTypes.object,
+	siteSlug: PropTypes.string.isRequired,
+	userId: PropTypes.number,
+};
 
 const mapStateToProps = ( state, { purchaseId } ) => ( {
 	hasLoadedSites: ! isRequestingSites( state ),


### PR DESCRIPTION
In preparation to upgrade the `AddCardDetails` component to use Stripe Elements and Payment Intents (see previous work in #34848), this PR just reorganizes the component into a stateless functional component instead of a class. Previously this was done for `EditCardDetails` in #35237 which is nearly identical to this component.

There wasn't much present that required a class in the first place; there was no state, and I think the redirect-on-invalid behavior is actually easier to understand happening on every render than using the lifecycle methods.

#### Testing instructions

1. Sandbox the store.
2. Make sure you have purchased something, then visit http://calypso.localhost:3000/me/purchases, click on a purchase, and then click on "Change Payment Method".
2. Change the resulting url so that instead of ending with `/payment/edit/123456` it reads `/payment/add`. It is possible to get to this page without editing the url but this is much simpler.
3. Fill out all the fields with a test card (eg: `4242424242424242`) and submit the form. It will help to use a unique name for the cardholder name.
4. Click the "Payment method" text/icon (you may need to reload the page if the data is cached).
5. Be sure that the cardholder name shown is the same as the one you entered above.