### PR TITLE
AddCardDetails: Switch to Stripe Elements

### DIFF
--- a/client/me/purchases/payment/add-card-details/index.jsx
+++ b/client/me/purchases/payment/add-card-details/index.jsx
@@ -27,6 +27,9 @@ import { getSelectedSite } from 'state/ui/selectors';
 import { isRequestingSites } from 'state/sites/selectors';
 import { managePurchase, purchasesRoot } from 'me/purchases/paths';
 import { recordTracksEvent } from 'state/analytics/actions';
+import { withStripe } from 'lib/stripe';
+
+const CreditCardFormWithStripe = withStripe( CreditCardForm, { needs_intent: true } );
 
 function AddCardDetails( props ) {
 	const createCardUpdateToken = ( ...args ) => createCardToken( 'card_update', ...args );
@@ -73,7 +76,7 @@ function AddCardDetails( props ) {
 				{ titles.addCardDetails }
 			</HeaderCake>
 
-			<CreditCardForm
+			<CreditCardFormWithStripe
 				apiParams={ { purchaseId: props.purchase.id } }
 				createCardToken={ createCardUpdateToken }
 				purchase={ props.purchase }


### PR DESCRIPTION
This updates the `AddCardDetails` component to use Stripe Elements and Payment Intents (see previous work in #34848 and #35262).

Depends on #35350

#### Testing instructions

1. Sandbox the store.
2. Make sure you have purchased something, then visit http://calypso.localhost:3000/me/purchases, click on a purchase, and then click on "Change Payment Method".
2. Change the resulting url so that instead of ending with `/payment/edit/123456` it reads `/payment/add`. It is possible to get to this page without editing the url but this is much simpler.
4. Verify that the placeholder for the card number field is numbers and not dots (this verifies that you are seeing the Stripe field).
3. Fill out all the fields with a test card (eg: `4242424242424242`) and submit the form. It will help to use a unique name for the cardholder name.
4. Click the "Payment method" text/icon (you may need to reload the page if the data is cached).
5. Be sure that the cardholder name shown is the same as the one you entered above.