### PR TITLE
FSE: Fix navigation to and back from templates in Calypso

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -14,7 +14,7 @@ import { BlockEdit } from '@wordpress/editor';
 import { Button, Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { compose, withState } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Fragment, useEffect, useState } from '@wordpress/element';
+import { Fragment, useEffect, useState, createRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
@@ -97,10 +97,15 @@ const TemplateEdit = compose(
 				</Placeholder>
 			);
 		}
+		const navButton = createRef();
 		const [ navigateToTemplate, setNavigateToTemplate ] = useState( false );
 		useEffect( () => {
 			if ( navigateToTemplate && ! isDirty ) {
-				window.location.href = editTemplateUrl;
+				// Since we cancelled the click event to save the post
+				// we trigger it again here. We do this instead of setting
+				// window.location.href because in WordPress.com, the navigation
+				// scheme is different and not available to us here.
+				navButton.current.click();
 			}
 			receiveTemplateBlocks();
 		} );
@@ -150,7 +155,7 @@ const TemplateEdit = compose(
 						</Disabled>
 						{ isSelected && (
 							<Placeholder className="template-block__overlay">
-								<Button href={ editTemplateUrl } onClick={ save } isDefault>
+								<Button href={ editTemplateUrl } onClick={ save } isDefault ref={ navButton }>
 									{ navigateToTemplate ? <Spinner /> : sprintf( __( 'Edit %s' ), templateTitle ) }
 								</Button>
 							</Placeholder>

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -595,6 +595,7 @@ const mapStateToProps = (
 		action: postId && 'edit', // If postId is set, open edit view.
 		post_type: postType !== 'post' && postType, // Use postType if it's different than post.
 		calypsoify: 1,
+		fse_parent_post: fseParentPageId != null && fseParentPageId,
 		'block-editor': 1,
 		'frame-nonce': getSiteOption( state, siteId, siteOption ) || '',
 		'jetpack-copy': duplicatePostId,


### PR DESCRIPTION
Because of a few changes to some other parts of FSE, we ended up breaking a few parts of navigation in wpcom including in the following situations:
- Clicking "Edit Header/Footer" would not take you to the Calypso URL
- Using the back button from the Template took you to the pages list instead of the page you were on.
- When you had an unsaved draft, clicking "Edit header/footer" would not take you to the calypso URL after saving, even after fixing the above issue.
- When you visited the Calypso template URL, the back button with the text didn't show up, just the "x".

This PR resolves all of those issues.

#### Changes proposed in this Pull Request
1. The first issue was caused by a change in when we show the edit buttons. Previously, we expected those buttons to be on the DOM all the time. Now that they are shown while focusing the template block, our code which replaced their hrefs could not find them. I changed that code to now look for those buttons and update their URLs when the template blocks are selected.
2. The second issue was caused by our calypso nav logic still using `wp_template_part` to determine if we should perform a certain type of navigation. I changed that to the new `wp_template`, as well as renamed all the functions and variables in the iframe which referenced template parts.
3. The third issue was caused by the code which autosaves the post when you navigate to edit a template. The autosave code, if the post was dirty, cancelled the default click event, saved the post, then manually set the window's location. To fix this, I used a ref to re-click the button after the save finishes. The effect of this is "pausing" the event until the save finishes, then "resuming it". It's needed because we manually override that button's href from the bridge server to use our calypso URLs, which are not available in FSE.
4. The fourth issue was caused by the parent page ID not being passed down as a query param into the iframe context.

I now see that this could have been broken into a few pieces, but it was all pretty intertwined as I was debugging it.

#### Setup instructions
This is a doozy! You'll need all three environments running to test this.

1. Pull this branch.
1. You'll want to sandbox a site for testing, `public-api.wordpress.com`, and `widgets.wp.com`.
2. You'll want to run calypso locally: `nvm use && npm i && npm start`, then go to `calypso.localhost:3000`
3. You'll need to build the bridge server: `nvm use && npx lerna run build --scope='@automattic/wpcom-block-editor'` then sync it to your sandbox.
4. You'll need to build the FSE code: `nvm use && npx lerna run dev --scope='@automattic/full-site-editing'` then sync it to your sandbox.

#### Testing instructions
Now that everything is running, 
1. Go to your sandbox site's pages list in the local calypso setup.
2. Click on an existing page. It should load and you should see the templates.
3. Once on the existing page, select the header and click "Edit Header". It should take you to the template editor for the header **and the URL should change to match the calypso template editor route** (`http://calypso.localhost:3000/block-editor/edit/wp_template/{sandbox-site}/{template-id}?fse_parent_post={parent-page-id}`)
3. Make sure the template editor page **uses the "Back to Page" button** from this Calypso URL
4. Click the "Back to Page" button. It should take you to the page you were just on.
5. Now make a few changes to the page without saving it.
6. Select the header and click "Edit Header". It should save the page, and then take you to the template editor for the header, and the URL should change.
7. Click the back button again and it should take you back to that page. And your new changes should still be there.
8. Now, go back to the pages list and create a new page. Select a template, but don't publish anything.
9. Select the header and click "Edit Header". It should create a draft for the page, save it, and then take you to the template editor for the header. Click the back button. It should take you back to the page you just created.
10. Also try these steps with the footer.

Fixes #35345, #35355

For followup:
- In wpadmin, "Back to Page" button takes you to the calypso flows even if you started in wpadmin flows. (https://github.com/Automattic/wp-calypso/issues/35105)