### PR TITLE
Import in Signup: Allow detection of all engines and display fallbacks

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -280,7 +280,7 @@ export function generateFlows( {
 		pageTitle: translate( 'Launch your site' ),
 	};
 
-	const importSteps = [ 'from-url', 'domains', 'plans-import' ];
+	const importSteps = [ 'domains', 'plans-import' ];
 
 	const importDestination = ( { importSiteEngine, importSiteUrl, siteSlug } ) =>
 		addQueryArgs(
@@ -293,7 +293,7 @@ export function generateFlows( {
 		);
 
 	flows.import = {
-		steps: [ 'user', ...importSteps ],
+		steps: [ 'user', 'from-url', ...importSteps ],
 		destination: importDestination,
 		description: 'A flow to kick off an import during signup',
 		disallowResume: true,
@@ -303,7 +303,7 @@ export function generateFlows( {
 	flows[ 'import-onboarding' ] = {
 		// IMPORTANT: steps should match the onboarding flow through the `site-type` step to prevent issues
 		// when switching from the onboarding flow.
-		steps: [ 'user', 'site-type', ...importSteps ],
+		steps: [ 'user', 'site-type', 'import-url', ...importSteps ],
 		destination: importDestination,
 		description: 'Import flow that can be used from the onboarding flow',
 		disallowResume: true,

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -15,7 +15,9 @@ const stepNameToModuleName = {
 	'domain-only': 'domains',
 	'domains-theme-preselected': 'domains',
 	'domains-launch': 'domains',
+	/* import-url will eventually replace from-url step. Forgive temporary naming. */
 	'from-url': 'import-url',
+	'import-url': 'import-url-onboarding',
 	launch: 'launch-site',
 	plans: 'plans',
 	'plans-business': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -439,6 +439,19 @@ export function generateSteps( {
 			],
 		},
 
+		/* Import onboarding */
+		'import-url': {
+			stepName: 'import-url',
+			providesDependencies: [
+				'importSiteEngine',
+				'importSiteFavicon',
+				'importSiteUrl',
+				'siteTitle',
+				'suggestedDomain',
+				'themeSlugWithRepo',
+			],
+		},
+
 		'reader-landing': {
 			stepName: 'reader-landing',
 			providesDependencies: [],

--- a/client/signup/steps/import-url-onboarding/index.jsx
+++ b/client/signup/steps/import-url-onboarding/index.jsx
@@ -1,0 +1,277 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { Component, Fragment } from 'react';
+import { localize } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import { flow, get, includes, invoke } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import StepWrapper from 'signup/step-wrapper';
+import FormButton from 'components/forms/form-button';
+import FormLabel from 'components/forms/form-label';
+import FormTextInput from 'components/forms/form-text-input';
+import ScreenReaderText from 'components/screen-reader-text';
+import { setImportOriginSiteDetails, setNuxUrlInputValue } from 'state/importer-nux/actions';
+import { getNuxUrlInputValue } from 'state/importer-nux/temp-selectors';
+import { validateImportUrl } from 'lib/importer/url-validation';
+import { recordTracksEvent } from 'state/analytics/actions';
+import Notice from 'components/notice';
+import wpcom from 'lib/wp';
+import { saveSignupStep } from 'state/signup/progress/actions';
+import { suggestDomainFromImportUrl } from 'lib/importer/utils';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+class ImportURLOnboardingStepComponent extends Component {
+	state = {
+		isLoading: false,
+		// Url message could be client-side validation or server-side error.
+		urlValidationMessage: '',
+	};
+
+	componentDidMount() {
+		this.props.saveSignupStep( { stepName: this.props.stepName } );
+		this.setInputValueFromProps();
+		this.focusInput();
+	}
+
+	handleInputChange = event => {
+		this.props.setNuxUrlInputValue( event.target.value );
+	};
+
+	handleInputBlur = event => {
+		if ( event.target.value ) {
+			this.validateUrl();
+		}
+	};
+
+	handleInputRef = el => ( this.inputRef = el );
+
+	focusInput = () => invoke( this.inputRef, 'focus' );
+
+	setUrlError = urlValidationMessage => this.setState( { urlValidationMessage }, this.focusInput );
+
+	handleSubmit = event => {
+		event.preventDefault();
+		const isValid = this.validateUrl();
+
+		if ( ! isValid ) {
+			return;
+		}
+
+		const { stepName, translate, urlInputValue } = this.props;
+
+		this.setState( {
+			isLoading: true,
+			urlValidationMessage: '',
+		} );
+
+		wpcom
+			.undocumented()
+			.isSiteImportable( urlInputValue )
+			.then(
+				( {
+					site_engine: siteEngine,
+					site_favicon: siteFavicon,
+					site_status: siteStatus,
+					site_title: siteTitle,
+					site_url: siteUrl,
+					importer_types: importerTypes,
+				} ) => {
+					if ( ! includes( importerTypes, 'url' ) ) {
+						return this.setUrlError(
+							translate(
+								"That doesn't seem to be a Wix or GoDaddy site. Please check the URL and try again."
+							)
+						);
+					}
+
+					if ( 404 === siteStatus ) {
+						return this.setUrlError(
+							translate( 'That site was not found. Please check the URL and try again.' )
+						);
+					}
+
+					// We need a successful response for url importers to work.
+					if ( includes( importerTypes, 'url' ) && 200 !== siteStatus ) {
+						return this.setUrlError(
+							translate( 'That site responded with an error. Please check the URL and try again.' )
+						);
+					}
+
+					this.props.setImportOriginSiteDetails( {
+						importerTypes,
+						siteUrl,
+						siteEngine,
+						siteFavicon,
+						siteTitle,
+					} );
+
+					this.props.submitSignupStep(
+						{ stepName },
+						{
+							importSiteEngine: siteEngine,
+							importSiteFavicon: siteFavicon,
+							importSiteUrl: siteUrl,
+							siteTitle,
+							suggestedDomain: suggestDomainFromImportUrl( siteUrl ),
+							themeSlugWithRepo: 'pub/modern-business',
+						}
+					);
+					this.props.goToNextStep();
+				},
+				error => {
+					switch ( error.code ) {
+						case 'rest_invalid_param':
+							return this.setUrlError(
+								translate( "We couldn't reach that site. Please check the URL and try again." )
+							);
+					}
+					return this.setUrlError(
+						translate( 'Something went wrong. Please check the URL and try again.' )
+					);
+				}
+			)
+			.finally( () =>
+				this.setState( {
+					isLoading: false,
+				} )
+			);
+	};
+
+	setInputValueFromProps = () => {
+		const { queryObject, urlInputValue } = this.props;
+		const inputValue = urlInputValue || get( queryObject, 'url', '' );
+		this.props.setNuxUrlInputValue( inputValue );
+	};
+
+	validateUrl = () => {
+		const validationMessage = validateImportUrl( this.props.urlInputValue );
+		const isValid = ! validationMessage;
+
+		if ( ! isValid ) {
+			this.setUrlError( validationMessage );
+		}
+
+		return isValid;
+	};
+
+	exitFlow = () => {
+		const target = '/start';
+		this.props.recordTracksEvent( 'calypso_signup_flow_exit', {
+			flow: this.props.flowName,
+			step: this.props.stepName,
+			target,
+		} );
+
+		// Exit to main signup flow.
+		this.props.goToNextStep( 'main' );
+	};
+
+	renderNotice = () => {
+		const { urlValidationMessage } = this.state;
+
+		if ( urlValidationMessage ) {
+			return (
+				<Notice
+					className="import-url-onboarding__url-input-message"
+					status="is-error"
+					showDismiss={ false }
+				>
+					{ urlValidationMessage }
+				</Notice>
+			);
+		}
+
+		return <div className="import-url-onboarding__notice-placeholder" />;
+	};
+
+	renderContent = () => {
+		const { urlInputValue, translate } = this.props;
+		const { isLoading, urlValidationMessage } = this.state;
+
+		return (
+			<Fragment>
+				<div className="import-url-onboarding__wrapper">
+					<form className="import-url-onboarding__form" onSubmit={ this.handleSubmit }>
+						<ScreenReaderText>
+							<FormLabel htmlFor="url-input">Site URL</FormLabel>
+						</ScreenReaderText>
+
+						<FormTextInput
+							id="url-input"
+							className="import-url-onboarding__url-input"
+							placeholder={ translate( 'Website URL' ) }
+							disabled={ isLoading }
+							defaultValue={ urlInputValue }
+							onChange={ this.handleInputChange }
+							onBlur={ this.handleInputBlur }
+							inputRef={ this.handleInputRef }
+							isError={ !! urlValidationMessage }
+						/>
+
+						<FormButton
+							className="import-url-onboarding__submit-button"
+							disabled={ isLoading }
+							busy={ isLoading }
+							type="submit"
+						>
+							{ isLoading
+								? translate( 'Checking{{ellipsis/}}', {
+										components: { ellipsis: <Fragment>&hellip;</Fragment> },
+										comment: 'Indicates user input is being processed.',
+								  } )
+								: translate( 'Continue' ) }
+						</FormButton>
+					</form>
+					{ this.renderNotice() }
+				</div>
+			</Fragment>
+		);
+	};
+
+	render() {
+		const { flowName, positionInFlow, stepName, translate } = this.props;
+
+		const headerText = translate( 'Where can we find your old site?' );
+		const subHeaderText = translate(
+			"We'll check your website to see what content we can bring to your new WordPress site."
+		);
+
+		return (
+			<StepWrapper
+				className="import-url-onboarding"
+				flowName={ flowName }
+				stepName={ stepName }
+				positionInFlow={ positionInFlow }
+				headerText={ headerText }
+				fallbackHeaderText={ headerText }
+				subHeaderText={ subHeaderText }
+				fallbackSubHeaderText={ subHeaderText }
+				stepContent={ this.renderContent() }
+			/>
+		);
+	}
+}
+
+export default flow(
+	connect(
+		state => ( {
+			urlInputValue: getNuxUrlInputValue( state ),
+		} ),
+		{
+			recordTracksEvent,
+			saveSignupStep,
+			setImportOriginSiteDetails,
+			setNuxUrlInputValue,
+		}
+	),
+	localize
+)( ImportURLOnboardingStepComponent );

--- a/client/signup/steps/import-url-onboarding/style.scss
+++ b/client/signup/steps/import-url-onboarding/style.scss
@@ -46,3 +46,21 @@
 	height: 47px;
 	margin: 16px auto;
 }
+
+.import-url-onboarding__service-info {
+	margin-bottom: 1.5em;
+
+	@include breakpoint( '>480px' ) {
+		margin-left: 60px;
+	}
+}
+
+.import-url-onboarding__service-title {
+	font-size: 21px;
+	font-weight: 300;
+	color: var( --color-text-subtle );
+
+	@include breakpoint( '>480px' ) {
+		clear: none;
+	}
+}

--- a/client/signup/steps/import-url-onboarding/style.scss
+++ b/client/signup/steps/import-url-onboarding/style.scss
@@ -1,0 +1,48 @@
+
+// The containing element
+.import-url-onboarding__wrapper {
+	padding: 0;
+	@include elevation ( 0 );
+	border-radius: 3px;
+	max-width: 640px;
+	margin: auto;
+}
+
+// Actual form input for typing the URL
+.import-url-onboarding__wrapper .import-url-onboarding__url-input {
+	border: none;
+	border-radius: 3px;
+	padding: 10px 14px;
+
+	@include breakpoint( '<660px' ) {
+		padding: 14px;
+	}
+}
+
+.import-url-onboarding__wrapper .import-url-onboarding__url-input-message {
+	max-width: 640px;
+	margin: 16px auto;
+}
+
+
+.import-url {
+	&__form {
+		position: relative;
+	}
+
+	&__submit-button {
+		position: absolute;
+		top: 2px;
+		right: 2px;
+
+		@include breakpoint( '<660px' ) {
+			top: 1px;
+			right: 1px;
+		}
+	}
+}
+
+.import-url-onboarding__notice-placeholder {
+	height: 47px;
+	margin: 16px auto;
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR expands the current engine detection from Wix and GoDaddy to all supported engines (additionally: WordPress, Blogger, Medium, Squarespace)
* If the engine cannot be detected, a list of fallbacks is displayed, and one can be chosen manually

Note: These changes are behind the feature-flag `signup/import-flow`, and therefore, this change shouldn't affect any environment where that is not enabled.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Verify that the existing import flow at `/start/import` isn't affected by these changes.
* Verify that the new step `import-url` is only used in the `import-onboarding` flow.