### PR TITLE
Stats: ensure consistent week data on site and summary views

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -8,7 +7,7 @@ import i18n from 'i18n-calypso';
 import { find, pick, get } from 'lodash';
 
 /**
- * Internal Dependencies
+ * Internal dependencies
  */
 import { getSiteFragment, getStatsDefaultSitePage } from 'lib/route';
 import analytics from 'lib/analytics';
@@ -335,8 +334,8 @@ export default {
 		const isValidStartDate =
 			queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid();
 		const date = isValidStartDate
-			? i18n.moment( queryOptions.startDate )
-			: momentSiteZone.endOf( activeFilter.period );
+			? i18n.moment( queryOptions.startDate ).locale( 'en' )
+			: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
 		const period = rangeOfPeriod( activeFilter.period, date );
 
 		const extraProps =

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -335,7 +335,7 @@ export default {
 			queryOptions.startDate && i18n.moment( queryOptions.startDate ).isValid();
 		const date = isValidStartDate
 			? i18n.moment( queryOptions.startDate ).locale( 'en' )
-			: rangeOfPeriod( activeFilter.period, momentSiteZone.locale( 'en' ) ).startOf;
+			: momentSiteZone.endOf( activeFilter.period ).locale( 'en' );
 		const period = rangeOfPeriod( activeFilter.period, date );
 
 		const extraProps =


### PR DESCRIPTION
I noticed while testing File Download Stats that different data was being fetched for the Site and Summary views when browsing by week in the UTC+12 timezone. The API requests looked like this:

<img width="522" alt="Screen Shot 2019-08-14 at 14 05 28" src="https://user-images.githubusercontent.com/17325/62993010-cd063f80-bea9-11e9-84ae-93acaf54c8d9.png">

Note that the Site view was fetching data for a week ending 2019-08-18, which seemed right. In this case, it meant the Site view was showing data:

<img width="373" alt="Screen Shot 2019-08-14 at 15 42 02" src="https://user-images.githubusercontent.com/17325/62993080-1787bc00-beaa-11e9-9418-2475444150fe.png">

Meanwhile, the Summary view was requesting data for the week ending *2019-08-19* and the data was empty 🤔

<img width="1072" alt="Screen Shot 2019-08-14 at 15 42 06" src="https://user-images.githubusercontent.com/17325/62993093-29695f00-beaa-11e9-907b-cb08cb49a3a3.png">

(Note: my site is in UTC+12, so the dates displayed in the UI are one day ahead. The API endpoint deals with UTC dates.)

#### Changes proposed in this Pull Request

I have changed the Summary view to use the 'en' locale when figuring out the query date. The two views now fetch the same data:

<img width="567" alt="Screen Shot 2019-08-14 at 15 44 13" src="https://user-images.githubusercontent.com/17325/62993155-60d80b80-beaa-11e9-80c0-ae6bb442291b.png">

#### Testing instructions

In your browser console, open the 'Network' tab and filter requests by "file-downloads":

<img width="830" alt="Screen Shot 2019-08-14 at 15 46 12" src="https://user-images.githubusercontent.com/17325/62993264-c88e5680-beaa-11e9-9058-d115165ca619.png">

Using a site that has some file downloads, select the 'Weeks' view:

https://wpcalypso.wordpress.com/stats/week/example.com

<img width="392" alt="Screen Shot 2019-08-14 at 15 45 58" src="https://user-images.githubusercontent.com/17325/62993239-aac0f180-beaa-11e9-8f04-8a27c57ffd99.png">

Click on the heading of the File Downloads panel and you should be taken to Summary view. 

You should now have two API requests in your console, and they should both have requested the same date.

<img width="567" alt="Screen Shot 2019-08-14 at 15 44 13" src="https://user-images.githubusercontent.com/17325/62993296-f378aa80-beaa-11e9-9e5f-0a17d17c1167.png">

The data shown in both views should be identical.

Site view:

<img width="379" alt="Screen Shot 2019-08-14 at 15 51 32" src="https://user-images.githubusercontent.com/17325/62993446-7437a680-beab-11e9-997a-06a7023ea95b.png">

Summary view:

<img width="1071" alt="Screen Shot 2019-08-14 at 15 51 26" src="https://user-images.githubusercontent.com/17325/62993450-77cb2d80-beab-11e9-98f8-4b72fd3e2f52.png">

