### PR TITLE
Reader: cleanup unused feature flags

### DIFF
--- a/client/reader/following/main.jsx
+++ b/client/reader/following/main.jsx
@@ -19,7 +19,6 @@ import { recordTrack } from 'reader/stats';
 import Suggestion from 'reader/search-stream/suggestion';
 import SuggestionProvider from 'reader/search-stream/suggestion-provider';
 import FollowingIntro from './intro';
-import config from 'config';
 import { getSearchPlaceholderText } from 'reader/search/utils';
 import Banner from 'components/banner';
 import { getCurrentUserCountryCode } from 'state/current-user/selectors';
@@ -60,9 +59,7 @@ const FollowingStream = props => {
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
 		<Stream { ...props }>
-			{ config.isEnabled( 'reader/following-intro' ) && ! showRegistrationMsg && (
-				<FollowingIntro />
-			) }
+			{ ! showRegistrationMsg && <FollowingIntro /> }
 			{ showRegistrationMsg && (
 				<Banner
 					className="following__reader-vote"

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -110,7 +110,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/high-watermark": true,
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -114,7 +114,6 @@
 		"reader/list-management": false,
 		"reader/new-post-notifications": true,
 		"reader/recommendations/posts": true,
-		"reader/related-posts": true,
 		"reader/high-watermark": true,
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -109,7 +109,6 @@
 		"publicize-preview": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/new-post-notifications": true,

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -110,7 +110,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,
 		"republicize": true,
 		"rubberband-scroll-disable": false,

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -111,7 +111,6 @@
 		"reader": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
-		"reader/new-post-notifications": true,
 		"reader/high-watermark": true,
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -112,7 +112,6 @@
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/new-post-notifications": true,
-		"reader/recommendations/posts": true,
 		"reader/high-watermark": true,
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -110,7 +110,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/list-management": false,
 		"reader/high-watermark": true,
 		"reader/tags-with-elasticsearch": false,
 		"resume-editing": true,

--- a/config/desktop.json
+++ b/config/desktop.json
@@ -73,7 +73,6 @@
 		"post-editor/image-editor": true,
 		"press-this": false,
 		"reader": true,
-		"reader/following-intro": true,
 		"reader/full-errors": false,
 		"reader/user-mention-suggestions": false,
 		"resume-editing": true,

--- a/config/development.json
+++ b/config/development.json
@@ -131,7 +131,6 @@
 		"reader/comment-polling": true,
 		"reader/full-errors": true,
 		"reader/likes-hover": true,
-		"reader/list-management": false,
 		"reader/paste-to-link": true,
 		"reader/high-watermark": true,
 		"reader/user-mention-suggestions": true,

--- a/config/development.json
+++ b/config/development.json
@@ -132,7 +132,6 @@
 		"reader/full-errors": true,
 		"reader/likes-hover": true,
 		"reader/paste-to-link": true,
-		"reader/high-watermark": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,
 		"resume-editing": true,

--- a/config/development.json
+++ b/config/development.json
@@ -135,7 +135,6 @@
 		"reader/list-management": false,
 		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
-		"reader/related-posts": true,
 		"reader/high-watermark": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,

--- a/config/development.json
+++ b/config/development.json
@@ -129,7 +129,6 @@
 		"push-notifications": true,
 		"reader": true,
 		"reader/comment-polling": true,
-		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/likes-hover": true,
 		"reader/list-management": false,

--- a/config/development.json
+++ b/config/development.json
@@ -133,7 +133,6 @@
 		"reader/likes-hover": true,
 		"reader/list-management": false,
 		"reader/paste-to-link": true,
-		"reader/recommendations/posts": true,
 		"reader/high-watermark": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -83,7 +83,6 @@
 		"press-this": true,
 		"privacy-policy": true,
 		"reader": true,
-		"reader/following-intro": true,
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,
 		"republicize": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -84,7 +84,6 @@
 		"privacy-policy": true,
 		"reader": true,
 		"reader/following-intro": true,
-		"reader/related-posts": true,
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,
 		"republicize": true,

--- a/config/production.json
+++ b/config/production.json
@@ -93,7 +93,6 @@
 		"reader": true,
 		"reader/following-intro": true,
 		"reader/full-errors": false,
-		"reader/related-posts": true,
 		"reader/user-mention-suggestions": false,
 		"resume-editing": true,
 		"republicize": true,

--- a/config/production.json
+++ b/config/production.json
@@ -91,7 +91,6 @@
 		"publicize-preview": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/following-intro": true,
 		"reader/full-errors": false,
 		"reader/user-mention-suggestions": false,
 		"resume-editing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -93,7 +93,6 @@
 		"publicize-preview": true,
 		"push-notifications": true,
 		"reader": true,
-		"reader/following-intro": true,
 		"reader/full-errors": false,
 		"reader/likes-hover": true,
 		"reader/paste-to-link": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,7 +96,6 @@
 		"reader/full-errors": false,
 		"reader/likes-hover": true,
 		"reader/paste-to-link": true,
-		"reader/search": true,
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,
 		"republicize": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -98,7 +98,6 @@
 		"reader/likes-hover": true,
 		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
-		"reader/related-posts": true,
 		"reader/search": true,
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -96,7 +96,6 @@
 		"reader/full-errors": false,
 		"reader/likes-hover": true,
 		"reader/paste-to-link": true,
-		"reader/recommendations/posts": true,
 		"reader/search": true,
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,

--- a/config/test.json
+++ b/config/test.json
@@ -80,7 +80,6 @@
 		"publicize-preview": true,
 		"reader": true,
 		"reader/full-errors": true,
-		"reader/list-management": false,
 		"reader/paste-to-link": true,
 		"reader/user-mention-suggestions": true,
 		"republicize": true,

--- a/config/test.json
+++ b/config/test.json
@@ -79,7 +79,6 @@
 		"press-this": true,
 		"publicize-preview": true,
 		"reader": true,
-		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/list-management": false,
 		"reader/paste-to-link": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -108,7 +108,6 @@
 		"reader/likes-hover": true,
 		"reader/full-errors": true,
 		"reader/paste-to-link": true,
-		"reader/high-watermark": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,
 		"resume-editing": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -110,7 +110,6 @@
 		"reader/full-errors": true,
 		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,
-		"reader/related-posts": true,
 		"reader/high-watermark": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -108,7 +108,6 @@
 		"reader/likes-hover": true,
 		"reader/full-errors": true,
 		"reader/paste-to-link": true,
-		"reader/recommendations/posts": true,
 		"reader/high-watermark": true,
 		"reader/user-mention-suggestions": true,
 		"recommend-plugins": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -106,7 +106,6 @@
 		"publicize-preview": true,
 		"reader": true,
 		"reader/likes-hover": true,
-		"reader/following-intro": true,
 		"reader/full-errors": true,
 		"reader/paste-to-link": true,
 		"reader/recommendations/posts": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Cleans up a bunch of old Reader feature flags, nearly all of which are no longer referenced in the codebase.

#### Testing instructions

Load up Reader Following at http://calypso.localhost:3000 and make sure your following stream loads as normal.