### PR TITLE
FSE - change placeholder text for site title and description and hide when field focused

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/edit.js
@@ -52,7 +52,7 @@ function SiteDescriptionEdit( {
 				value={ option }
 				onChange={ value => handleChange( value ) }
 				onKeyDown={ onKeyDown }
-				placeholder={ __( 'Site Description' ) }
+				placeholder={ __( 'Add a Site Description' ) }
 				aria-label={ __( 'Site Description' ) }
 			/>
 		</Fragment>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
@@ -1,6 +1,7 @@
 .block-editor {
 	.wp-block-a8c-site-description {
-		&,&:focus {
+		&,
+		&:focus {
 			display: inline;
 			color: #767676;
 			font-size: 1.125em;
@@ -11,6 +12,29 @@
 			background-color: transparent;
 		}
 	}
+
+	.wp-block {
+		&.is-selected {
+			.wp-block-a8c-site-description {
+				&::-webkit-input-placeholder {
+					color: transparent;
+				}
+
+				&:-moz-placeholder {
+					color: transparent;
+				}
+
+				&::-moz-placeholder {
+					color: transparent;
+				}
+
+				&:-ms-input-placeholder {
+					color: transparent;
+				}
+			}
+		}
+	}
+
 	.site-description__save-button {
 		margin-left: auto;
 		display: block;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-description/style.scss
@@ -1,3 +1,5 @@
+@import '../../sass/mixins';
+
 .block-editor {
 	.wp-block-a8c-site-description {
 		&,
@@ -16,21 +18,7 @@
 	.wp-block {
 		&.is-selected {
 			.wp-block-a8c-site-description {
-				&::-webkit-input-placeholder {
-					color: transparent;
-				}
-
-				&:-moz-placeholder {
-					color: transparent;
-				}
-
-				&::-moz-placeholder {
-					color: transparent;
-				}
-
-				&:-ms-input-placeholder {
-					color: transparent;
-				}
+				@include hide-input-placeholder;
 			}
 		}
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/edit.js
@@ -56,7 +56,7 @@ function SiteTitleEdit( {
 				value={ option }
 				onChange={ value => handleChange( value ) }
 				onKeyDown={ onKeyDown }
-				placeholder={ __( 'Site Title' ) }
+				placeholder={ __( 'Add a Site Title' ) }
 				aria-label={ __( 'Site Title' ) }
 			/>
 		</Fragment>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
@@ -1,6 +1,7 @@
 .block-editor {
 	.wp-block-a8c-site-title {
-		&, &:focus {
+		&,
+		&:focus {
 			display: inline;
 			color: #111111;
 			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
@@ -14,6 +15,29 @@
 			background-color: transparent;
 		}
 	}
+
+	.wp-block {
+		&.is-selected {
+			.wp-block-a8c-site-title {
+				&::-webkit-input-placeholder {
+					color: transparent;
+				}
+
+				&:-moz-placeholder {
+					color: transparent;
+				}
+
+				&::-moz-placeholder {
+					color: transparent;
+				}
+
+				&:-ms-input-placeholder {
+					color: transparent;
+				}
+			}
+		}
+	}
+
 	.site-title__save-button {
 		margin-left: auto;
 		display: block;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/site-title/style.scss
@@ -1,3 +1,5 @@
+@import '../../sass/mixins';
+
 .block-editor {
 	.wp-block-a8c-site-title {
 		&,
@@ -19,21 +21,7 @@
 	.wp-block {
 		&.is-selected {
 			.wp-block-a8c-site-title {
-				&::-webkit-input-placeholder {
-					color: transparent;
-				}
-
-				&:-moz-placeholder {
-					color: transparent;
-				}
-
-				&::-moz-placeholder {
-					color: transparent;
-				}
-
-				&:-ms-input-placeholder {
-					color: transparent;
-				}
+				@include hide-input-placeholder;
 			}
 		}
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/sass/_mixins.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/sass/_mixins.scss
@@ -1,0 +1,17 @@
+@mixin hide-input-placeholder {
+	&::-webkit-input-placeholder {
+		color: transparent;
+	}
+
+	&:-moz-placeholder {
+		color: transparent;
+	}
+
+	&::-moz-placeholder {
+		color: transparent;
+	}
+
+	&:-ms-input-placeholder {
+		color: transparent;
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change placeholder text for site title and description to make it clearer it is a placeholder
* Hide the placeholder text when the field is selected

#### Testing instructions

* Apply patch to your FSE test environment
* Remove the site title and description from site settings
* Edit the header template and check that placeholders are `Add a Site Description` and `Add a Site Title`
* Check the placeholder disappears when each block is focused

**Before**

![placeholder-before](https://user-images.githubusercontent.com/3629020/62996232-034abb80-beb8-11e9-828a-9f238f327e3e.gif)

**After**

![placeholder-after](https://user-images.githubusercontent.com/3629020/62996234-0776d900-beb8-11e9-8dee-95932210cbf2.gif)

Fixes #34852
