### PR TITLE
For redirect payments, respect destination

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -56,13 +56,7 @@ class CheckoutPending extends PureComponent {
 			const { processingStatus } = transaction;
 
 			if ( ORDER_TRANSACTION_STATUS.SUCCESS === processingStatus ) {
-				const { receiptId } = transaction;
-
-				page(
-					receiptId
-						? `/checkout/thank-you/${ siteSlug }/${ receiptId }`
-						: `/checkout/thank-you/${ siteSlug }`
-				);
+				page( this.props.redirectTo );
 
 				return;
 			}

--- a/client/my-sites/checkout/checkout-thank-you/pending.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending.jsx
@@ -40,7 +40,7 @@ class CheckoutPending extends PureComponent {
 
 	componentWillReceiveProps( nextProps ) {
 		const { transaction, error } = nextProps;
-		const { translate, showErrorNotice, siteSlug } = this.props;
+		const { translate, showErrorNotice, siteSlug, redirectTo } = this.props;
 
 		const retryOnError = () => {
 			page( `/checkout/${ siteSlug }` );
@@ -56,7 +56,10 @@ class CheckoutPending extends PureComponent {
 			const { processingStatus } = transaction;
 
 			if ( ORDER_TRANSACTION_STATUS.SUCCESS === processingStatus ) {
-				page( this.props.redirectTo );
+				const { receiptId } = transaction;
+
+				const redirectPath = redirectTo.replace( 'pending', receiptId );
+				page( redirectPath );
 
 				return;
 			}

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -565,9 +565,7 @@ export class Checkout extends React.Component {
 			displayModeParam = { d: 'concierge' };
 		}
 
-		// pendingOrReceiptId takes a value of ':receiptId' if a redirect payment has been selected,
-		// in which case we want to go to a thank you page.
-		if ( ':receiptId' !== pendingOrReceiptId && this.props.isEligibleForSignupDestination ) {
+		if ( this.props.isEligibleForSignupDestination ) {
 			return this.getUrlWithQueryParam( signupDestination, displayModeParam );
 		}
 

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -145,12 +145,21 @@ export class RedirectPaymentBox extends PureComponent {
 			disabled: true,
 		} );
 
-		let cancelUrl = origin + '/checkout/';
+		let cancelUrl = origin + '/checkout/',
+			successUrl;
+		const redirectTo = this.props.redirectTo();
+		const redirectPath = redirectTo.includes( 'https://' ) ? redirectTo : origin + redirectTo;
 
 		if ( this.props.selectedSite ) {
 			cancelUrl += this.props.selectedSite.slug;
+			successUrl =
+				origin +
+				`/checkout/thank-you/${
+					this.props.selectedSite.slug
+				}/pending?redirectTo=${ redirectPath }`;
 		} else {
 			cancelUrl += 'no-site';
+			successUrl = origin + this.props.redirectTo();
 		}
 
 		// unmask form values
@@ -161,7 +170,7 @@ export class RedirectPaymentBox extends PureComponent {
 		const dataForApi = {
 			payment: Object.assign( {}, paymentDetails, {
 				paymentMethod: this.paymentMethodByType( this.props.paymentType ),
-				successUrl: origin + this.props.redirectTo(),
+				successUrl: successUrl,
 				cancelUrl,
 			} ),
 			cart: this.props.cart,

--- a/client/my-sites/checkout/checkout/redirect-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/redirect-payment-box.jsx
@@ -159,7 +159,7 @@ export class RedirectPaymentBox extends PureComponent {
 				}/pending?redirectTo=${ redirectPath }`;
 		} else {
 			cancelUrl += 'no-site';
-			successUrl = origin + this.props.redirectTo();
+			successUrl = origin + `/checkout/thank-you/no-site/pending?redirectTo=${ redirectPath }`;
 		}
 
 		// unmask form values

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -77,7 +77,13 @@ export function checkoutPending( context, next ) {
 
 	context.store.dispatch( setSection( { name: 'checkout-thank-you' }, { hasSidebar: false } ) );
 
-	context.primary = <CheckoutPendingComponent orderId={ orderId } siteSlug={ siteSlug } />;
+	context.primary = (
+		<CheckoutPendingComponent
+			orderId={ orderId }
+			siteSlug={ siteSlug }
+			redirectTo={ context.query.redirectTo }
+		/>
+	);
 
 	next();
 }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -95,14 +95,6 @@ export default function() {
 	);
 
 	if ( config.isEnabled( 'upsell/concierge-session' ) ) {
-		page(
-			'/checkout/(add|offer)-support-session/pending/:site/:orderId',
-			siteSelection,
-			checkoutPending,
-			makeLayout,
-			clientRender
-		);
-
 		// For backwards compatibility, retaining the old URL structure.
 		page( '/checkout/:site/add-support-session/:receiptId?', redirectToSupportSession );
 
@@ -118,14 +110,6 @@ export default function() {
 			'/checkout/offer-support-session/:receiptId/:site',
 			siteSelection,
 			upsellNudge,
-			makeLayout,
-			clientRender
-		);
-
-		page(
-			'/checkout/offer-quickstart-session/pending/:site/:orderId',
-			siteSelection,
-			checkoutPending,
 			makeLayout,
 			clientRender
 		);
@@ -177,14 +161,6 @@ export default function() {
 		'/checkout/:site/offer-plan-upgrade/:upgradeItem/:receiptId?',
 		siteSelection,
 		upsellNudge,
-		makeLayout,
-		clientRender
-	);
-
-	page(
-		'/checkout/:site/offer-plan-upgrade/:upgradeItem/pending/:receiptId?',
-		siteSelection,
-		checkoutPending,
 		makeLayout,
 		clientRender
 	);


### PR DESCRIPTION
Depends on D31513-code

#### Changes proposed in this Pull Request

* There are situations when using a redirect payment type, such as Giropay or Ebanx, leads to signup destination not being respected.

Fixes the following issues:
  - Going through the signup flow, Business plan paid for with a redirect payment always shows 
       the Thank You page. 
  - Checkout pending page always redirects to Thank You page.
  - We no longer need `/pending` routes to be defined for new checkout routes.

#### Fixes the following bugs:
 https://github.com/Automattic/wp-calypso/issues/34434 
 https://github.com/Automattic/wp-calypso/issues/31061 
 https://github.com/Automattic/wp-calypso/issues/34333


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apply patch D31513-code before proceeding to test.

**Scenario 1**

* Go through the signup flow starting from /start. Add a Business plan to cart, and pay with a redirect payment such as Giropay (proxy through Germany).
* Verify that you are taken to flow destination

**Scenario 2**
(this test verifies that the removal of the `/pending` route(`/checkout/offer-quickstart-session/pending/:site/:orderId`) for the quick start session does not prevent the upsell nudge from being shown)

* Go through the signup flow and add a Personal plan to cart. 
* Pay with Giropay or Sofort
* You will be taken to checkout pending page. Verify that it then redirects you to the Quick Start offer page.

**Scenario 3**
(this test is verify that a redirect payment works on a purchase made outside the signup flow. Also, the `/pending` route for support session should not be required)

* On an existing account, purchase a support session by going to /checkout/offer-support-session
* Pay with Giropay or Sofort
* Verify that you are taken to thank you page for the support session

**Scenario 4**
(Domain only flow uses a  thank you page without a site slug, /checkout/thank-you/no-site, so we have this as a separate test case)

* Begin at /start/domain and go through the domain only flow
* Select `Just buy a domain` option and complete checkout. Pay with Giropay or Sofort
* Verify that the checkout pending page `/checkout/thank-you/no-site/pending/:orderId` redirects you to the flow destination.

**Scenario 5**

* Verify that the following bugs are all fixed: 
https://github.com/Automattic/wp-calypso/issues/34434 
 https://github.com/Automattic/wp-calypso/issues/31061 
 https://github.com/Automattic/wp-calypso/issues/34333


**Scenario 6**
(Ebanx uses a different backend callback, so we have this as a separate test case.

* Proxy through Brazil, and then beginning from /start, purchase a plan and pay with Ebanx. Check p8hgLy-1zx#comment-2817-p2 for sandbox testing instructions with Ebanx.
* Verify that you are taken to the appropriate destination.

