### PR TITLE
Jetpack Scan: Fix support link from threat notices

### DIFF
--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -4,7 +4,6 @@
  */
 import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
-import debugFactory from 'debug';
 import { connect } from 'react-redux';
 import Spinner from 'components/spinner';
 import Interval, { EVERY_TEN_SECONDS } from 'lib/interval';
@@ -15,6 +14,7 @@ import Interval, { EVERY_TEN_SECONDS } from 'lib/interval';
 import ActivityIcon from '../activity-log-item/activity-icon';
 import DiffViewer from 'components/diff-viewer';
 import FoldableCard from 'components/foldable-card';
+import { JETPACK_CONTACT_SUPPORT } from 'lib/url/support';
 import MarkedLines from 'components/marked-lines';
 import TimeSince from 'components/time-since';
 import PopoverMenuItem from 'components/popover/menu-item';
@@ -26,11 +26,6 @@ import { requestRewindState } from 'state/rewind/actions';
  * Style dependencies
  */
 import './threat-alert.scss';
-
-/**
- * Module variables
- */
-const debug = debugFactory( 'calypso:activity-log' );
 
 const detailType = threat => {
 	if ( threat.hasOwnProperty( 'diff' ) ) {
@@ -186,16 +181,10 @@ export class ThreatAlert extends Component {
 										disabled={ inProgress }
 									>
 										<PopoverMenuItem
-											onClick={ () => debug( 'documentation clicked' ) }
-											className="activity-log__threat-menu-item"
-											icon="help"
-										>
-											<span>{ translate( 'Documentation' ) }</span>
-										</PopoverMenuItem>
-										<PopoverMenuItem
-											onClick={ () => debug( 'get help clicked' ) }
+											href={ JETPACK_CONTACT_SUPPORT }
 											className="activity-log__threat-menu-item"
 											icon="chat"
+											isExternalLink
 										>
 											<span>{ translate( 'Get help' ) }</span>
 										</PopoverMenuItem>

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -184,7 +184,7 @@ export class ThreatAlert extends Component {
 											href={ JETPACK_CONTACT_SUPPORT }
 											className="activity-log__threat-menu-item"
 											icon="chat"
-											isExternalLink
+											target="_blank"
 										>
 											<span>{ translate( 'Get help' ) }</span>
 										</PopoverMenuItem>


### PR DESCRIPTION
Tidy up the support/doc links in the Jetpack Scan persistent notices which appear at the top of the Activity log. Note that these threats only show in dev environment currently.

<img width="954" alt="Screenshot 2019-08-14 at 13 48 12" src="https://user-images.githubusercontent.com/7767559/63022196-45650480-be9a-11e9-85eb-81d1628378ab.png">

#### Changes proposed in this Pull Request

* Remove the _Documentation_ link until we have a doc to link to
* Give the _Get Help_ link a URL

**Before**

<img width="240" alt="Screenshot 2019-08-14 at 13 18 46" src="https://user-images.githubusercontent.com/7767559/63023075-31220700-be9c-11e9-9c22-02395a898e90.png">

**After**
<img width="239" alt="Screenshot 2019-08-14 at 13 18 55" src="https://user-images.githubusercontent.com/7767559/63026848-cd9bd780-bea3-11e9-8788-b45435357294.png">


#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://calypso.live/?branch=update/jetpack-scan-alert-help-links&flags=rewind-alerts (note the rewind-alerts flag)
* Navigate to the activity log for an Atomic site with active threats
Expected: the _Get Help_ link should open the Jetpack support page


