### PR TITLE
 Private by Default: make selectors based solely on global signup state & use default exports

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -37,7 +37,7 @@ import { getSignupDependencyStore } from 'state/signup/dependency-store/selector
 import { requestSites } from 'state/sites/actions';
 import { getProductsList } from 'state/products-list/selectors';
 import { getSelectedImportEngine, getNuxUrlInputValue } from 'state/importer-nux/temp-selectors';
-import { getNewSitePublicSetting } from 'state/selectors/get-new-site-public-setting';
+import getNewSitePublicSetting from 'state/selectors/get-new-site-public-setting';
 
 // Current directory dependencies
 import { isValidLandingPageVertical } from './verticals';

--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -164,7 +164,7 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 				title: siteTitle,
 			},
 		},
-		public: getNewSitePublicSetting( state, siteType ),
+		public: getNewSitePublicSetting( state ),
 		validate: false,
 	};
 
@@ -485,12 +485,11 @@ export function createSite( callback, dependencies, stepData, reduxStore ) {
 	const { themeSlugWithRepo } = dependencies;
 	const { site } = stepData;
 	const state = reduxStore.getState();
-	const siteType = getSiteType( state ).trim();
 
 	const data = {
 		blog_name: site,
 		blog_title: '',
-		public: getNewSitePublicSetting( state, siteType ),
+		public: getNewSitePublicSetting( state ),
 		options: { theme: themeSlugWithRepo },
 		validate: false,
 	};

--- a/client/state/selectors/get-new-site-public-setting.ts
+++ b/client/state/selectors/get-new-site-public-setting.ts
@@ -1,23 +1,13 @@
 /**
- * External dependencies
- */
-import debugFactory from 'debug';
-
-/**
  * Internal dependencies
  */
 import { shouldNewSiteBePrivateByDefault } from './should-new-site-be-private-by-default';
 
-const debug = debugFactory( 'calypso:signup:private-by-default' );
-
 /**
  * Get the numeric value that should be provided to the "new site" endpoint
  * @param state The current client state
- * @param siteType The selected site type / segment. Corresponds with the `slug` in ./site-type.js
  * @returns `-1` for private by default & `1` for public
  */
-export function getNewSitePublicSetting( state, siteType: string = '' ): number {
-	debug( 'getNewSitePublicSetting input', { siteType } );
-
-	return shouldNewSiteBePrivateByDefault( state, siteType ) ? -1 : 1;
+export function getNewSitePublicSetting( state: object ): number {
+	return shouldNewSiteBePrivateByDefault( state ) ? -1 : 1;
 }

--- a/client/state/selectors/get-new-site-public-setting.ts
+++ b/client/state/selectors/get-new-site-public-setting.ts
@@ -1,13 +1,13 @@
 /**
  * Internal dependencies
  */
-import { shouldNewSiteBePrivateByDefault } from './should-new-site-be-private-by-default';
+import shouldNewSiteBePrivateByDefault from './should-new-site-be-private-by-default';
 
 /**
  * Get the numeric value that should be provided to the "new site" endpoint
  * @param state The current client state
  * @returns `-1` for private by default & `1` for public
  */
-export function getNewSitePublicSetting( state: object ): number {
+export default function getNewSitePublicSetting( state: object ): number {
 	return shouldNewSiteBePrivateByDefault( state ) ? -1 : 1;
 }

--- a/client/state/selectors/should-new-site-be-private-by-default.ts
+++ b/client/state/selectors/should-new-site-be-private-by-default.ts
@@ -3,20 +3,19 @@
  */
 import { abtest } from 'lib/abtest';
 import { getSiteTypePropertyValue } from 'lib/signup/site-type';
+import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { getCurrentFlowName } from 'state/signup/flow/selectors';
 
 /**
  * Should the site be private by default
  * @param state The current client state
- * @param siteType The selected site type / segment. Corresponds with the `slug` in ./site-type.js
  * @returns `true` for private by default & `false` for not
  */
-export function shouldNewSiteBePrivateByDefault( state, siteType: string = '' ): boolean {
+export function shouldNewSiteBePrivateByDefault( state: object ): boolean {
 	if ( getCurrentFlowName( state ) === 'test-fse' ) {
 		return true;
 	}
-
-	if ( getSiteTypePropertyValue( 'slug', siteType, 'forcePublicSite' ) ) {
+	if ( getSiteTypePropertyValue( 'slug', getSiteType( state ).trim(), 'forcePublicSite' ) ) {
 		return false;
 	}
 

--- a/client/state/selectors/should-new-site-be-private-by-default.ts
+++ b/client/state/selectors/should-new-site-be-private-by-default.ts
@@ -11,7 +11,7 @@ import { getCurrentFlowName } from 'state/signup/flow/selectors';
  * @param state The current client state
  * @returns `true` for private by default & `false` for not
  */
-export function shouldNewSiteBePrivateByDefault( state: object ): boolean {
+export default function shouldNewSiteBePrivateByDefault( state: object ): boolean {
 	if ( getCurrentFlowName( state ) === 'test-fse' ) {
 		return true;
 	}

--- a/client/state/selectors/test/get-new-site-public-setting.js
+++ b/client/state/selectors/test/get-new-site-public-setting.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { getNewSitePublicSetting } from '../get-new-site-public-setting';
+import getNewSitePublicSetting from '../get-new-site-public-setting';
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: testName => ( testName === 'privateByDefault' ? 'selected' : '' ),

--- a/client/state/selectors/test/get-new-site-public-setting.js
+++ b/client/state/selectors/test/get-new-site-public-setting.js
@@ -13,27 +13,34 @@ describe( 'getNewSitePublicSetting()', () => {
 	} );
 
 	test( 'should return `-1` if on test-fse flow', () => {
-		const mockState = { signup: { flow: { currentFlowName: 'test-fse' } } };
-		expect( getNewSitePublicSetting( mockState, 'someOtherSiteType' ) ).toBe( -1 );
+		const mockState = {
+			signup: { flow: { currentFlowName: 'test-fse' }, steps: { siteType: 'online-store' } },
+		};
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 
 	test( 'should return `-1` for invalid siteType', () => {
-		expect( getNewSitePublicSetting( {}, 'someOtherSiteType' ) ).toBe( -1 );
+		const mockState = { signup: { steps: { siteType: 'someOtherSiteType' } } };
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 
 	test( 'should return `-1` for business segment', () => {
-		expect( getNewSitePublicSetting( {}, 'business' ) ).toBe( -1 );
+		const mockState = { signup: { steps: { siteType: 'business' } } };
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 
 	test( 'should return `-1` for blog segment', () => {
-		expect( getNewSitePublicSetting( {}, 'blog' ) ).toBe( -1 );
+		const mockState = { signup: { steps: { siteType: 'blog' } } };
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 
 	test( 'should return `1` for online-store segment', () => {
-		expect( getNewSitePublicSetting( {}, 'online-store' ) ).toBe( 1 );
+		const mockState = { signup: { steps: { siteType: 'online-store' } } };
+		expect( getNewSitePublicSetting( mockState ) ).toBe( 1 );
 	} );
 
 	test( 'should return `-1` for professional segment', () => {
-		expect( getNewSitePublicSetting( {}, 'professional' ) ).toBe( -1 );
+		const mockState = { signup: { steps: { siteType: 'professional' } } };
+		expect( getNewSitePublicSetting( mockState ) ).toBe( -1 );
 	} );
 } );

--- a/client/state/selectors/test/should-new-site-be-private-by-default.js
+++ b/client/state/selectors/test/should-new-site-be-private-by-default.js
@@ -13,27 +13,34 @@ describe( 'shouldNewSiteBePrivateByDefault()', () => {
 	} );
 
 	test( 'should return `true` if on test-fse flow', () => {
-		const mockState = { signup: { flow: { currentFlowName: 'test-fse' } } };
-		expect( shouldNewSiteBePrivateByDefault( mockState, 'someOtherSiteType' ) ).toBe( true );
+		const mockState = {
+			signup: { flow: { currentFlowName: 'test-fse' }, steps: { siteType: 'online-store' } },
+		};
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 
 	test( 'should return `true` for invalid siteType', () => {
-		expect( shouldNewSiteBePrivateByDefault( {}, 'someOtherSiteType' ) ).toBe( true );
+		const mockState = { signup: { steps: { siteType: 'someOtherSiteType' } } };
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 
 	test( 'should return `true` for business segment', () => {
-		expect( shouldNewSiteBePrivateByDefault( {}, 'business' ) ).toBe( true );
+		const mockState = { signup: { steps: { siteType: 'business' } } };
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 
 	test( 'should return `true` for blog segment', () => {
-		expect( shouldNewSiteBePrivateByDefault( {}, 'blog' ) ).toBe( true );
+		const mockState = { signup: { steps: { siteType: 'blog' } } };
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 
 	test( 'should return `false` for online-store segment', () => {
-		expect( shouldNewSiteBePrivateByDefault( {}, 'online-store' ) ).toBe( false );
+		const mockState = { signup: { steps: { siteType: 'online-store' } } };
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( false );
 	} );
 
 	test( 'should return `true` for professional segment', () => {
-		expect( shouldNewSiteBePrivateByDefault( {}, 'professional' ) ).toBe( true );
+		const mockState = { signup: { steps: { siteType: 'professional' } } };
+		expect( shouldNewSiteBePrivateByDefault( mockState ) ).toBe( true );
 	} );
 } );

--- a/client/state/selectors/test/should-new-site-be-private-by-default.js
+++ b/client/state/selectors/test/should-new-site-be-private-by-default.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { shouldNewSiteBePrivateByDefault } from '../should-new-site-be-private-by-default';
+import shouldNewSiteBePrivateByDefault from '../should-new-site-be-private-by-default';
 
 jest.mock( 'lib/abtest', () => ( {
 	abtest: testName => ( testName === 'privateByDefault' ? 'selected' : '' ),


### PR DESCRIPTION
~~Based on branch in #35320~~ Rebased & retargeted on master

#### Changes proposed in this Pull Request

* Don't pass `siteType` into the selectors -- extract it from the state tree instead
* Export the selector functions as default (so you don't have to destructure on import
* Update tests to match changes above

#### Testing instructions

* npm run test-client client/state/selectors/test/should-new-site-be-private-by-default.js client/state/selectors/test/get-new-site-public-setting.js
* Test to make sure all new site signups are subject to the abtest for Private by Defualt except:
  * The `test-fse` flow
  * When purchasing an "online store" / ecommerce plan