### PR TITLE
Show notice when user tries to purchase or transfer domain in redemption

### DIFF
--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -33,6 +33,7 @@ export const domainAvailability = {
 	EMPTY_RESULTS: 'empty_results',
 	FORBIDDEN: 'forbidden_domain',
 	FORBIDDEN_SUBDOMAIN: 'forbidden_subdomain',
+	IN_REDEMPTION: 'in_redemption',
 	INVALID: 'invalid_domain',
 	INVALID_QUERY: 'invalid_query',
 	INVALID_TLD: 'invalid_tld',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -75,6 +75,29 @@ function getAvailabilityNotice( domain, error, errorData ) {
 				}
 			);
 			break;
+		case domainAvailability.IN_REDEMPTION:
+			message = translate(
+				'{{strong}}%(domain)s{{/strong}} is not eligible to register or transfer since it is in {{redemptionLink}}redemption{{/redemptionLink}}. If you own this domain, please contact your current registrar to {{aboutRenewingLink}}redeem the domain{{/aboutRenewingLink}}.',
+				{
+					args: { domain },
+					components: {
+						strong: <strong />,
+						redemptionLink: (
+							<a
+								rel="noopener noreferrer"
+								href="https://www.icann.org/resources/pages/grace-2013-05-03-en"
+							/>
+						),
+						aboutRenewingLink: (
+							<a
+								rel="noopener noreferrer"
+								href="https://www.icann.org/news/blog/do-you-have-a-domain-name-here-s-what-you-need-to-know-part-5"
+							/>
+						),
+					},
+				}
+			);
+			break;
 		case domainAvailability.MAPPED_SAME_SITE_TRANSFERRABLE:
 			message = translate(
 				'{{strong}}%(domain)s{{/strong}} is already connected to this site, but registered somewhere else. Do you want to move ' +


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We need to check whether a domain is in redemption before allowing a user to purchase an inbound transfer and let them know what they need to do in the case where they want to transfer in a domain in this state.

#### Testing instructions

Depends on D31498-code

Follow the instructions on the backend patch to find a suitable domain for testing.

Use this domain as the query in the domain search page. You should see something like the following:

<img width="1085" alt="Screen Shot 2019-08-14 at 11 18 12 AM" src="https://user-images.githubusercontent.com/1379730/63033221-45a6d500-be85-11e9-88fa-47851c06cb6e.png">

Try to select the same domain on the inbound transfers page. You should see the same error notice:

<img width="1085" alt="Screen Shot 2019-08-14 at 11 18 22 AM" src="https://user-images.githubusercontent.com/1379730/63033264-56efe180-be85-11e9-99fc-4cbec00a2d37.png">

