### PR TITLE
GSuite nudge purchase/skip flow to respect destination

### DIFF
--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -494,8 +494,6 @@ export class Checkout extends React.Component {
 			selectedSiteSlug,
 			transaction: { step: { data: stepResult = null } = {} } = {},
 		} = this.props;
-		const domainReceiptId = get( getGoogleApps( cart ), '[0].extra.receipt_for_domain', 0 );
-		const siteDesignType = get( selectedSite, 'options.design_type' );
 
 		const adminUrl = get( selectedSite, [ 'options', 'admin_url' ] );
 
@@ -595,6 +593,10 @@ export class Checkout extends React.Component {
 
 		if ( hasConciergeSession( cart ) ) {
 			displayModeParam = { d: 'concierge' };
+		}
+
+		if ( hasGoogleApps( cart ) ) {
+			displayModeParam = { d: 'gsuite' };
 		}
 
 		if ( this.props.isEligibleForSignupDestination ) {

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -437,7 +437,7 @@ export class Checkout extends React.Component {
 			}
 
 			// If atomic site, then replace wordpress.com with wpcomstaging.com
-			if ( selectedSiteSlug.includes( '.wpcomstaging.com' ) ) {
+			if ( selectedSiteSlug && selectedSiteSlug.includes( '.wpcomstaging.com' ) ) {
 				const wpcomStagingDestination = signupDestination.replace(
 					/\b.wordpress.com/,
 					'.wpcomstaging.com'

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -416,7 +416,8 @@ export class Checkout extends React.Component {
 	}
 
 	/**
-	 * If there is an ecommerce plan in cart, saves the destination cookie as Thank You page along with the receipt id.
+	 * If there is an ecommerce plan in cart, then irrespective of the signup flow destination, the final destination
+	 * will always be "Thank You" page for the eCommerce plan. This is because the ecommerce store setup happens in this page.
 	 * If the user purchases additional products via upsell nudges, the original saved receipt ID will be used to
 	 * display the Thank You page for the eCommerce plan purchase.
 	 *
@@ -424,15 +425,10 @@ export class Checkout extends React.Component {
 	 */
 
 	setDestinationIfEcommPlan( pendingOrReceiptId ) {
-		const { cart } = this.props;
+		const { cart, selectedSiteSlug } = this.props;
 
 		if ( hasEcommercePlan( cart ) ) {
-			const ecommDestination = this.getUrlWithQueryParam(
-				this.getFallbackDestination( pendingOrReceiptId ),
-				{ fReceiptId: pendingOrReceiptId }
-			);
-
-			persistSignupDestination( ecommDestination );
+			persistSignupDestination( this.getFallbackDestination( pendingOrReceiptId ) );
 		} else {
 			const signupDestination = retrieveSignupDestination();
 
@@ -440,13 +436,13 @@ export class Checkout extends React.Component {
 				return;
 			}
 
-			const { query } = parseUrl( signupDestination, true );
-
-			if ( query && query.fReceiptId ) {
-				const ecommDestination = this.getUrlWithQueryParam(
-					this.getFallbackDestination( query.fReceiptId )
+			// If atomic site, then replace wordpress.com with wpcomstaging.com
+			if ( selectedSiteSlug.includes( '.wpcomstaging.com' ) ) {
+				const wpcomStagingDestination = signupDestination.replace(
+					/\b.wordpress.com/,
+					'.wpcomstaging.com'
 				);
-				persistSignupDestination( ecommDestination );
+				persistSignupDestination( wpcomStagingDestination );
 			}
 		}
 	}
@@ -624,7 +620,6 @@ export class Checkout extends React.Component {
 
 		// Display mode is used to show purchase specific messaging, for e.g. the Schedule Session button
 		// when purchasing a concierge session.
-
 		if ( hasConciergeSession( cart ) ) {
 			displayModeParam = { d: 'concierge' };
 		}

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -564,17 +564,6 @@ export class Checkout extends React.Component {
 			return `${ signupDestination }/${ pendingOrReceiptId }`;
 		}
 
-		// Handle the redirect path after a purchase of GSuite
-		// The onboarding checklist currently supports the blog type only.
-		if ( hasGoogleApps( cart ) && domainReceiptId && 'store' !== siteDesignType ) {
-			analytics.tracks.recordEvent( 'calypso_checklist_assign', {
-				site: selectedSiteSlug,
-				plan: 'paid',
-			} );
-
-			return `${ signupDestination }?d=gsuite`;
-		}
-
 		const redirectPathForGSuiteUpsell = this.maybeRedirectToGSuiteNudge(
 			pendingOrReceiptId,
 			stepResult

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -415,6 +415,14 @@ export class Checkout extends React.Component {
 		return '/';
 	}
 
+	/**
+	 * If there is an ecommerce plan in cart, saves the destination cookie as Thank You page along with the receipt id.
+	 * If the user purchases additional products via upsell nudges, the original saved receipt ID will be used to
+	 * display the Thank You page for the eCommerce plan purchase.
+	 *
+	 * @param {String} pendingOrReceiptId The receipt id for the transaction
+	 */
+
 	setDestinationIfEcommPlan( pendingOrReceiptId ) {
 		const { cart } = this.props;
 
@@ -423,9 +431,15 @@ export class Checkout extends React.Component {
 				this.getFallbackDestination( pendingOrReceiptId ),
 				{ fReceiptId: pendingOrReceiptId }
 			);
+
 			persistSignupDestination( ecommDestination );
 		} else {
 			const signupDestination = retrieveSignupDestination();
+
+			if ( ! signupDestination ) {
+				return;
+			}
+
 			const { query } = parseUrl( signupDestination, true );
 
 			if ( query && query.fReceiptId ) {
@@ -609,7 +623,7 @@ export class Checkout extends React.Component {
 		}
 
 		// Display mode is used to show purchase specific messaging, for e.g. the Schedule Session button
-		// when purchasing a concierge session. We do not want to show it if there's an eCommerce plan
+		// when purchasing a concierge session.
 
 		if ( hasConciergeSession( cart ) ) {
 			displayModeParam = { d: 'concierge' };
@@ -652,8 +666,6 @@ export class Checkout extends React.Component {
 
 		// Removes the destination cookie only if redirecting to the signup destination.
 		// (e.g. if the destination is an upsell nudge, it does not remove the cookie).
-		// An exception is when we have an eCommerce plan in cart, in which case we always
-		// take to the thank you page so destination cookie can be cleared.
 		if ( redirectPath.includes( destinationFromCookie ) ) {
 			clearSignupDestinationCookie();
 		}

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -355,7 +355,7 @@ export class Checkout extends React.Component {
 	 * Purchases are of the format { [siteId]: [ { productId: ... } ] }
 	 * so we need to flatten them to get a list of purchases
 	 *
-	 * @param {Object} purchases keyed by siteId { [siteId]: [ { productId: ... } ] }
+	 * @param {object} purchases keyed by siteId { [siteId]: [ { productId: ... } ] }
 	 * @returns {Array} of product objects [ { productId: ... }, ... ]
 	 */
 	flattenPurchases( purchases ) {
@@ -420,7 +420,7 @@ export class Checkout extends React.Component {
 	 * If the user purchases additional products via upsell nudges, the original saved receipt ID will be used to
 	 * display the Thank You page for the eCommerce plan purchase.
 	 *
-	 * @param {String} pendingOrReceiptId The receipt id for the transaction
+	 * @param {string} pendingOrReceiptId The receipt id for the transaction
 	 */
 
 	setDestinationIfEcommPlan( pendingOrReceiptId ) {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -15,7 +15,6 @@ import { getSiteBySlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
 import GSuiteNudge from './gsuite-nudge';
 import CheckoutContainer from './checkout/checkout-container';
-import CartData from 'components/data/cart';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
 import CheckoutThankYouComponent from './checkout-thank-you';
 import UpsellNudge from './upsell-nudge';

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -13,7 +13,7 @@ import { setDocumentHeadTitle as setTitle } from 'state/document-head/actions';
 import { setSection } from 'state/ui/actions';
 import { getSiteBySlug } from 'state/sites/selectors';
 import { getSelectedSite } from 'state/ui/selectors';
-import GSuiteNudge from 'my-sites/checkout/gsuite-nudge';
+import GSuiteNudge from './gsuite-nudge';
 import CheckoutContainer from './checkout/checkout-container';
 import CartData from 'components/data/cart';
 import CheckoutPendingComponent from './checkout-thank-you/pending';
@@ -139,13 +139,17 @@ export function gsuiteNudge( context, next ) {
 	}
 
 	context.primary = (
-		<CartData>
+		<CheckoutContainer
+			shouldShowCart={ false }
+			clearTransaction={ true }
+			purchaseId={ Number( receiptId ) }
+		>
 			<GSuiteNudge
 				domain={ domain }
 				receiptId={ Number( receiptId ) }
 				selectedSiteId={ selectedSite.ID }
 			/>
-		</CartData>
+		</CheckoutContainer>
 	);
 
 	next();
@@ -166,6 +170,7 @@ export function upsellNudge( context, next ) {
 		upsellType = 'plan-upgrade-upsell';
 		upgradeItem = context.params.upgradeItem;
 	}
+
 	context.store.dispatch( setSection( { name: upsellType }, { hasSidebar: false } ) );
 
 	context.primary = (

--- a/client/my-sites/checkout/gsuite-nudge/index.jsx
+++ b/client/my-sites/checkout/gsuite-nudge/index.jsx
@@ -36,12 +36,7 @@ export class GSuiteNudge extends React.Component {
 	};
 
 	handleSkipClick = () => {
-		const { siteSlug, receiptId, isEligibleForChecklist } = this.props;
-		page(
-			isEligibleForChecklist
-				? `/checklist/${ siteSlug }`
-				: `/checkout/thank-you/${ siteSlug }/${ receiptId }`
-		);
+		this.props.handleCheckoutCompleteRedirect();
 	};
 
 	handleAddEmailClick = cartItems => {

--- a/client/my-sites/checkout/gsuite-nudge/style.scss
+++ b/client/my-sites/checkout/gsuite-nudge/style.scss
@@ -1,3 +1,7 @@
+main.gsuite-nudge.main {
+	margin:auto;
+}
+
 .gsuite-nudge {
 	box-sizing: border-box;
 	position: static;

--- a/client/state/selectors/is-eligible-for-signup-destination.js
+++ b/client/state/selectors/is-eligible-for-signup-destination.js
@@ -1,7 +1,11 @@
 /**
+ * External dependencies
+ */
+import { get } from 'lodash';
+/**
  * Internal dependencies
  */
-import { hasEcommercePlan } from 'lib/cart-values/cart-items';
+import { hasEcommercePlan, getGoogleApps, hasGoogleApps } from 'lib/cart-values/cart-items';
 import isEligibleForDotcomChecklist from './is-eligible-for-dotcom-checklist';
 import { retrieveSignupDestination } from 'signup/utils';
 

--- a/client/state/selectors/is-eligible-for-signup-destination.js
+++ b/client/state/selectors/is-eligible-for-signup-destination.js
@@ -5,7 +5,7 @@ import { get } from 'lodash';
 /**
  * Internal dependencies
  */
-import { hasEcommercePlan, getGoogleApps, hasGoogleApps } from 'lib/cart-values/cart-items';
+import { getGoogleApps, hasGoogleApps } from 'lib/cart-values/cart-items';
 import isEligibleForDotcomChecklist from './is-eligible-for-dotcom-checklist';
 import { retrieveSignupDestination } from 'signup/utils';
 
@@ -16,10 +16,6 @@ import { retrieveSignupDestination } from 'signup/utils';
  * @return {Boolean} True if current user is able to see the checklist after checkout
  */
 export default function isEligibleForSignupDestination( state, siteId, cart ) {
-	if ( hasEcommercePlan( cart ) ) {
-		return false;
-	}
-
 	if ( hasGoogleApps( cart ) ) {
 		const domainReceiptId = get( getGoogleApps( cart ), '[0].extra.receipt_for_domain', 0 );
 

--- a/client/state/selectors/is-eligible-for-signup-destination.js
+++ b/client/state/selectors/is-eligible-for-signup-destination.js
@@ -16,6 +16,14 @@ export default function isEligibleForSignupDestination( state, siteId, cart ) {
 		return false;
 	}
 
+	if ( hasGoogleApps( cart ) ) {
+		const domainReceiptId = get( getGoogleApps( cart ), '[0].extra.receipt_for_domain', 0 );
+
+		if ( ! domainReceiptId ) {
+			return false;
+		}
+	}
+
 	const destination = retrieveSignupDestination();
 
 	if ( ! destination ) {

--- a/client/state/selectors/is-eligible-for-signup-destination.js
+++ b/client/state/selectors/is-eligible-for-signup-destination.js
@@ -10,10 +10,10 @@ import isEligibleForDotcomChecklist from './is-eligible-for-dotcom-checklist';
 import { retrieveSignupDestination } from 'signup/utils';
 
 /**
- * @param {Object} state Global state tree
- * @param {Number} siteId Site ID
- * @param {Object} cart object
- * @return {Boolean} True if current user is able to see the checklist after checkout
+ * @param {object} state Global state tree
+ * @param {number} siteId Site ID
+ * @param {object} cart object
+ * @returns {boolean} True if current user is able to see the checklist after checkout
  */
 export default function isEligibleForSignupDestination( state, siteId, cart ) {
 	if ( hasGoogleApps( cart ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Wrap the GSuite Nudge component in `<CheckoutContainer>`, so that clicking the Skip button on the nudge will use `handleCheckoutCompleteRedirect()` to take the user to signup destination. Presently, the Skip button action is hardcoded to a checklist destination for all scenarios.

Fixes #
https://github.com/Automattic/wp-calypso/issues/35406

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Scenario 1**
* Go through the signup flow and add a plan(other than eCommerce) and domain to cart.
* Verify that you see the GSuite nudge and are able to complete the purchase.
* You should then be taken to flow destination.

**Scenario 2**
* On an existing account, add a new domain and GSuite subscription, and complete checkout. Verify the purchase completes. You should see the following thank you page:

<img width="804" alt="Screenshot 2019-09-03 at 11 08 36 AM" src="https://user-images.githubusercontent.com/1269602/64147874-65576a80-ce3f-11e9-8693-3046274362ee.png">


**Scenario 3**
* Verify that https://github.com/Automattic/wp-calypso/issues/35406 is fixed.

