### PR TITLE
FSE: Fix header and footer template styling

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Full Site Editing
  * Description: Enhances your page creation workflow within the Block Editor.
- * Version: 0.6
+ * Version: 0.6.1
  * Author: Automattic
  * Author URI: https://automattic.com/wordpress-plugins/
  * License: GPLv2 or later
@@ -20,7 +20,7 @@ namespace A8C\FSE;
  *
  * @var string
  */
-define( 'PLUGIN_VERSION', '0.6' );
+define( 'PLUGIN_VERSION', '0.6.1' );
 
 /**
  * Load Full Site Editing.

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
@@ -39,8 +39,10 @@ const addContentSlotClassname = createHigherOrderComponent( BlockListBlock => {
 	};
 }, 'addContentSlotClassname' );
 
+// Must be 9 or this breaks on Simple Sites
 addFilter(
 	'editor.BlockListBlock',
 	'full-site-editing/blocks/post-content',
-	addContentSlotClassname
+	addContentSlotClassname,
+	9
 );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -48,4 +48,10 @@ const addFSETemplateClassname = createHigherOrderComponent( BlockListBlock => {
 	};
 }, 'addFSETemplateClassname' );
 
-addFilter( 'editor.BlockListBlock', 'full-site-editing/blocks/template', addFSETemplateClassname );
+// Must be 9 or this breaks on Simple Sites
+addFilter(
+	'editor.BlockListBlock',
+	'full-site-editing/blocks/template',
+	addFSETemplateClassname,
+	9
+);

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -40,6 +40,9 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 
+= 0.6.1=
+* Updates priority of filter so classnames are added properly to the template blocks.
+
 = 0.6 =
 * Fix issues with Edit template and Back to Page functionality.
 

--- a/apps/full-site-editing/full-site-editing-plugin/readme.txt
+++ b/apps/full-site-editing/full-site-editing-plugin/readme.txt
@@ -40,7 +40,7 @@ This plugin is experimental, so we don't provide any support for it outside of w
 
 == Changelog ==
 
-= 0.6.1=
+= 0.6.1 =
 * Updates priority of filter so classnames are added properly to the template blocks.
 
 = 0.6 =


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Add Filter has a default priority of 10. This PR updates priority so we can add needed classnames to template blocks.

| Before| After |
| ------------- | ------------- |
| <img width="1190" alt="62986315-e054d480-bdef-11e9-9f4f-05c0e2569f8a" src="https://user-images.githubusercontent.com/1270189/63047833-13e43d00-be8a-11e9-8666-caf9e4d2793a.png"> | <img width="975" alt="Screen Shot 2019-08-14 at 12 24 52 PM" src="https://user-images.githubusercontent.com/1270189/63049866-92db7480-be8e-11e9-981f-e2fc8b993132.png"> |

#### Testing instructions

- Apply this to the sandbox
- Visit a site with FSE flows
- Verify that editing a page looks like the after shot

Fixes https://github.com/Automattic/wp-calypso/pull/35386
