### PR TITLE
Woo: Shipping Labels: Use Stripe Elements for Add Credit Card Dialog

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
@@ -19,6 +19,9 @@ import CreditCardForm from 'blocks/credit-card-form';
 import { addStoredCard } from 'state/stored-cards/actions';
 import { createCardToken } from 'lib/store-transactions';
 import analytics from 'lib/analytics';
+import { withStripe } from 'lib/stripe';
+
+const CreditCardFormWithStripe = withStripe( CreditCardForm, { needs_intent: true } );
 
 function AddCardDialog( {
 	siteId,
@@ -38,7 +41,7 @@ function AddCardDialog( {
 			isVisible={ isVisible }
 			onClose={ onClose }
 		>
-			<CreditCardForm
+			<CreditCardFormWithStripe
 				createCardToken={ createCardAddToken }
 				recordFormSubmitEvent={ recordFormSubmitEvent }
 				saveStoredCard={ saveStoredCard }

--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/label-payment-method.js
@@ -72,6 +72,13 @@ const PaymentMethod = ( {
 	const typeId = typeTitle ? type : 'placeholder';
 	const typeName = typeTitle || type;
 
+	const expiryText = expiry
+		? translate( 'Expires %(date)s', {
+				args: { date: expiry },
+				context: 'date is of the form MM/YY',
+		  } )
+		: '';
+
 	return (
 		<CompactCard className="label-settings__card" onClick={ onSelect }>
 			<FormCheckbox
@@ -84,12 +91,7 @@ const PaymentMethod = ( {
 				<p className="label-settings__card-number">{ typeName }</p>
 				<p className="label-settings__card-name">{ name }</p>
 			</div>
-			<div className="label-settings__card-date">
-				{ translate( 'Expires %(date)s', {
-					args: { date: expiry },
-					context: 'date is of the form MM/YY',
-				} ) }
-			</div>
+			<div className="label-settings__card-date">{ expiryText }</div>
 		</CompactCard>
 	);
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This updates the `AddCardDialog` Woo component to use Stripe Elements and Payment Intents (see previous work in #34848, #35262, and #35351).

- [x] Depends on #35414

#### Testing instructions

- Sandbox the store.
- Purchase a Business plan.
- Create a Store (further instructions are needed here).
- Visit http://calypso.localhost:3000/store/settings/shipping/ and choose the site with the Store.
- Click "Settings" in the sidebar.
- Click the "Shipping" tab.
- In the "Shipping Labels" section, click "Add credit card" or "Add another credit card".
- Verify that the resulting form's credit card field has numbers as placeholders rather than dots. This proves that you are seeing the Stripe fields.
- Fill out the form with a Stripe test card (see https://stripe.com/docs/testing#cards) and press "Save Card".
- Verify that the card was successfully added and appears in the list (it will have no expiry date until the page is reloaded; this is expected behavior).
- Repeat the above steps with a new card that requires 3DS.
