### PR TITLE
Customer Home: Update the redirects for the checklist

### DIFF
--- a/client/my-sites/checklist/controller.jsx
+++ b/client/my-sites/checklist/controller.jsx
@@ -5,15 +5,39 @@
  */
 import React from 'react';
 import { get } from 'lodash';
+import page from 'page';
+import { isEnabled } from 'config';
 
 /**
  * Internal Dependencies
  */
 
 import ChecklistMain from './main';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
+import {
+	canCurrentUserUseCustomerHome,
+	canCurrentUserUseChecklistMenu,
+} from 'state/sites/selectors';
 
 export function show( context, next ) {
 	const displayMode = get( context, 'query.d' );
 	context.primary = <ChecklistMain displayMode={ displayMode } />;
+	next();
+}
+
+export function maybeRedirect( context, next ) {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+	const slug = getSelectedSiteSlug( state );
+	if ( isEnabled( 'customer-home' ) && canCurrentUserUseCustomerHome( state, siteId ) ) {
+		page.redirect( `/home/${ slug }` );
+		return;
+	}
+
+	if ( ! canCurrentUserUseChecklistMenu( state, siteId ) ) {
+		page.redirect( `/plans/my-plan/${ slug }` );
+		return;
+	}
+
 	next();
 }

--- a/client/my-sites/checklist/index.js
+++ b/client/my-sites/checklist/index.js
@@ -10,10 +10,18 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import { show } from './controller';
+import { show, maybeRedirect } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page( '/checklist', siteSelection, sites, makeLayout, clientRender );
-	page( '/checklist/:site_id', siteSelection, navigation, show, makeLayout, clientRender );
+	page(
+		'/checklist/:site_id',
+		siteSelection,
+		maybeRedirect,
+		navigation,
+		show,
+		makeLayout,
+		clientRender
+	);
 }


### PR DESCRIPTION
Previously the checklist would redirect to 'my-plan' for Jetpack sites.
This change moves that behaviour in to the controller. It also redirects
the checklist to `/home/` for sites that are eligible.

#### Testing instructions

With this branch (and the feature flag `?flags=customer-home` set if not in development, like calypso.live for example) visit the `/checklist/` page with a variety of sites and confirm that:

* A Jetpack but not Atomic site redirects to `/plans/my-plan`
* Atomic and .com sites redirect to `/home`
* Without the feature flag, Atomic and .com sites (created after the 6th August 2019) aren't redirected and see the checklist at `/checklist`. Older Atomic and .com sites are redirected to `/plans/my-plan` as is the case for Jetpack sites.

Fixes #35374
