### PR TITLE
If FSE is enabled, disable switch to classic in Help menu

### DIFF
--- a/client/blocks/inline-help/popover.jsx
+++ b/client/blocks/inline-help/popover.jsx
@@ -44,6 +44,7 @@ import WpcomChecklist from 'my-sites/checklist/wpcom-checklist';
 import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
 import { getSelectedSiteId, getSection } from 'state/ui/selectors';
 import getCurrentRoute from 'state/selectors/get-current-route';
+import isSiteUsingFullSiteEditing from 'state/selectors/is-site-using-full-site-editing';
 import { setSelectedEditor } from 'state/selected-editor/actions';
 import {
 	composeAnalytics,
@@ -381,6 +382,10 @@ function mapStateToProps( state, { moment } ) {
 		].includes( getActiveTheme( state, siteId ) ) &&
 		moment( getSiteOption( state, siteId, 'created_at' ) ).isAfter( '20190314' );
 
+	const isAllowedToUseClassic =
+		! isSiteUsingFullSiteEditing( state, siteId ) && ! isUsingGutenbergPageTemplates;
+	const showOptOut = optInEnabled && isGutenbergEditor && isAllowedToUseClassic;
+
 	return {
 		isOnboardingWelcomeVisible: isEligibleForChecklist && isOnboardingWelcomePromptVisible( state ),
 		isChecklistPromptVisible: isInlineHelpChecklistPromptVisible( state ),
@@ -390,7 +395,7 @@ function mapStateToProps( state, { moment } ) {
 		selectedResult: getInlineHelpCurrentlySelectedResult( state ),
 		classicUrl: `/${ classicRoute }`,
 		siteId,
-		showOptOut: optInEnabled && isGutenbergEditor && ! isUsingGutenbergPageTemplates,
+		showOptOut,
 		showOptIn: optInEnabled && isCalypsoClassic,
 		gutenbergUrl,
 	};


### PR DESCRIPTION
This shores up the logic around opt out in the help menu. If FSE is active on the site, it will never show the opt out button there. I also renamed the variable to read a bit better.

#### Changes proposed in this Pull Request
* Always disable help menu "Switch to Classic" option if FSE is active on the site.

#### Testing instructions
- pull this PR
- `nvm use && npm i && npm start` then go to `calypso.localhost:3000`.
- On a site with FSE active, open the page editor.
- Open the inline help menu and verify that the option does not show up:
<img width="563" alt="Screen Shot 2019-08-14 at 4 34 15 PM" src="https://user-images.githubusercontent.com/6265975/63063523-e14e3a80-beb1-11e9-8437-5214d52abea5.png">

Since your site likely already did not show this opt out for other reasons, feel free to edit [this line](https://github.com/Automattic/wp-calypso/pull/35398/files#diff-b2ae3263b3e683457c5a595eb649294fR387) to

`const showOptOut = ! isSiteUsingFullSiteEditing( state, siteId );`

and then verify that the opt out menu still does not show up, just to double check that this selector is working correctly.

Fixes #32833 partially, along with some more backend logic improvements in D31361-code.