### PR TITLE
FSE: Remove data-type selectors

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -55,7 +55,7 @@
 		display: block;
 	}
 
-	.wp-block[data-type='a8c/template'] [data-block] {
+	.wp-block.template__block-container [data-block] {
 		margin: 0;
 	}
 }


### PR DESCRIPTION
Removes the data-type selector in favor of the new classname

#### Changes proposed in this Pull Request

* Switch selector for our new outer block selector. Note that the `[data-block]` selector is still needed because those divs do not have other classes or IDs to grab, but they have a lot of margin.

#### Testing instructions
* Run FSE in your local environment on an FSE enabled site
* Open the page editor
* Make sure the spacing of the header inner blocks matches what they are on master. If the selector does not work, the spaces around the blocks will be larger than what they are in master.

Partial fix for #35246

After this, I'll also change the data type selectors in the theme stylesheets.