### PR TITLE
File Download Stats: show full relative URL in summary view and CSV download

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -156,6 +156,7 @@ class StatsSite extends Component {
 						query={ query }
 						statType="statsFileDownloads"
 						showSummaryLink
+						useShortLabel={ true }
 					/>
 				);
 			}

--- a/client/my-sites/stats/stats-list/index.jsx
+++ b/client/my-sites/stats/stats-list/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -15,7 +13,7 @@ const debug = debugFactory( 'calypso:stats:list' );
 import StatsListItem from './stats-list-item';
 
 /**
- * Style Dependencies
+ * Style dependencies
  */
 import './style.scss';
 
@@ -71,6 +69,7 @@ export default class extends React.Component {
 						key={ groupKey }
 						itemClickHandler={ clickHandler }
 						followList={ this.props.followList }
+						useShortLabel={ this.props.useShortLabel }
 					/>
 				);
 			}, this );

--- a/client/my-sites/stats/stats-list/stats-list-item.jsx
+++ b/client/my-sites/stats/stats-list/stats-list-item.jsx
@@ -230,6 +230,12 @@ class StatsListItem extends React.Component {
 				icon = <span className="stats-list__flag-icon" style={ style } />;
 			}
 
+			let labelText = labelItem.label;
+
+			if ( this.props.useShortLabel && labelItem.shortLabel ) {
+				labelText = labelItem.shortLabel;
+			}
+
 			if ( data.link ) {
 				const href = data.link;
 				let onClickHandler = this.preventDefaultOnClick;
@@ -256,13 +262,14 @@ class StatsListItem extends React.Component {
 						page( `/read/blogs/${ siteId }` );
 					};
 				}
+
 				itemLabel = (
 					<a onClick={ onClickHandler } href={ href } title={ labelItem.linkTitle }>
-						<Emojify>{ decodeEntities( labelItem.label ) }</Emojify>
+						<Emojify>{ decodeEntities( labelText ) }</Emojify>
 					</a>
 				);
 			} else {
-				itemLabel = <Emojify>{ decodeEntities( labelItem.label ) }</Emojify>;
+				itemLabel = <Emojify>{ decodeEntities( labelText ) }</Emojify>;
 			}
 
 			return (

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -136,6 +136,7 @@ class StatsModule extends Component {
 			query,
 			period,
 			translate,
+			useShortLabel,
 		} = this.props;
 
 		const noData = data && this.state.loaded && ! data.length;
@@ -192,7 +193,7 @@ class StatsModule extends Component {
 					{ this.props.children }
 					<StatsListLegend value={ moduleStrings.value } label={ moduleStrings.item } />
 					<StatsModulePlaceholder isLoading={ isLoading } />
-					<StatsList moduleName={ path } data={ data } />
+					<StatsList moduleName={ path } data={ data } useShortLabel={ useShortLabel } />
 					{ this.props.showSummaryLink && displaySummaryLink && (
 						<StatsModuleExpand href={ summaryLink } />
 					) }

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -1823,7 +1823,8 @@ describe( 'utils', () => {
 								'2017-01-12': {
 									files: [
 										{
-											filename: '/2019/01/awesome.mov',
+											filename: 'awesome.mov',
+											relative_url: '/2019/01/awesome.mov',
 											downloads: 3939,
 										},
 									],
@@ -1843,6 +1844,7 @@ describe( 'utils', () => {
 					{
 						value: 3939,
 						label: '/2019/01/awesome.mov',
+						shortLabel: 'awesome.mov',
 						labelIcon: 'external',
 					},
 				] );

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -977,7 +977,8 @@ export const normalizers = {
 
 		return statsData.map( item => {
 			return {
-				label: item.filename,
+				label: item.relative_url,
+				shortLabel: item.filename,
 				page: null,
 				value: item.downloads,
 				link: item.download_url,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

During testing, we received feedback about the filename display in the CSV download:

> It would be good if the download CSV contains the path instead of just the name.
> Filenames can duplicate when uploaded in different months and the path will be helpful information in analyzing which month’s file was downloaded.

This PR leaves the short version of the filename in the Sites view, but switches to show the full filename in Summary view and in the CSV download.

#### Testing instructions

On a site with recent file downloads, go to My Sites > Stats. The panel shown there should just show the filename:

<img width="371" alt="Screen Shot 2019-08-15 at 12 35 23" src="https://user-images.githubusercontent.com/17325/63065188-3c873800-bf59-11e9-98f8-931fa339afbf.png">

If you click on the panel header to go to the Summary view, you should see the full relative URL including date prefix:

<img width="1065" alt="Screen Shot 2019-08-15 at 12 35 32" src="https://user-images.githubusercontent.com/17325/63065203-4d37ae00-bf59-11e9-9c36-b6cf3f708c7b.png">

You should also see the full relative URL including date prefix in the CSV download:

<img width="688" alt="Screen Shot 2019-08-15 at 12 35 41" src="https://user-images.githubusercontent.com/17325/63065211-588ad980-bf59-11e9-9364-024a567662a3.png">


