### PR TITLE
Jetpack Backup: ensure login before server creds entry

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -181,6 +181,7 @@ export function generateFlows( {
 			disallowResume: true,
 			allowContinue: false,
 			hideFlowProgress: true,
+			forceLogin: true,
 		},
 
 		'rewind-auto-config': {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -23,12 +23,14 @@ import {
 	getStepSectionName,
 	getValidPath,
 	getFlowPageTitle,
+	shouldForceLogin,
 } from './utils';
 import { setLayoutFocus } from 'state/ui/layout-focus/actions';
 import store from 'store';
 import { setCurrentFlowName } from 'state/signup/flow/actions';
 import { isUserLoggedIn } from 'state/current-user/selectors';
 import { getSignupProgress } from 'state/signup/progress/selectors';
+import { login } from 'lib/paths';
 
 /**
  * Constants
@@ -84,6 +86,10 @@ export default {
 
 		const userLoggedIn = isUserLoggedIn( context.store.getState() );
 		const signupProgress = getSignupProgress( context.store.getState() );
+
+		if ( ! userLoggedIn && shouldForceLogin( flowName ) ) {
+			return page.redirect( login( { isNative: true, redirectTo: context.path } ) );
+		}
 
 		// if flow can be resumed, use saved locale
 		if (

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -224,3 +224,8 @@ export const clearSignupDestinationCookie = () => {
 
 	document.cookie = cookie.serialize( 'wpcom_signup_complete_destination', '', options );
 };
+
+export const shouldForceLogin = flowName => {
+	const flow = flows.getFlow( flowName );
+	return !! flow.forceLogin;
+};

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -227,5 +227,5 @@ export const clearSignupDestinationCookie = () => {
 
 export const shouldForceLogin = flowName => {
 	const flow = flows.getFlow( flowName );
-	return !! flow.forceLogin;
+	return !! flow && flow.forceLogin;
 };


### PR DESCRIPTION
For Jetpack Backup server credentials entry to work, the user must be logged in to wordpress.com (for the APIs to be authorized). Force logged-out visitors to the start/rewind-setup route to be logged in by redirecting through the login form.

This PR adds a `forceLogin` property to the signup flow definitions, which will redirect through the login form is set.

It is unfortunate that the signup flow, which is supposed to be for logged-out users, needs a `forceLogin` property, but these rewind setup flows already exist.

#### Testing instructions

* visit http://calypso.localhost:3000/start/rewind-setup in an new incognito browser

Expected: you should be redirected to the login form, then back to /start/rewind-setup after login.

* visit http://calypso.localhost:3000/start in a new incognito browser

Expected: flow should be the same as on `master`.

