### PR TITLE
Start replacing 'url' and 'qs' with standard APIs.

### DIFF
--- a/client/blocks/reader-share/index.jsx
+++ b/client/blocks/reader-share/index.jsx
@@ -1,15 +1,12 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
 import { connect } from 'react-redux';
-import url from 'url';
 import { defer } from 'lodash';
 import config from 'config';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { stringify } from 'qs';
 import page from 'page';
 import { localize } from 'i18n-calypso';
 
@@ -39,32 +36,26 @@ function preloadEditor() {
  */
 const actionMap = {
 	twitter( post ) {
-		const twitterUrlProperties = {
-			scheme: 'https',
-			hostname: 'twitter.com',
-			pathname: '/intent/tweet',
-			query: {
-				text: post.title,
-				url: post.URL,
-			},
-		};
+		const baseUrl = new URL( 'https://twitter.com/intent/tweet' );
+		const params = new URLSearchParams( {
+			text: post.title,
+			url: post.URL,
+		} );
+		baseUrl.search = params.toString();
 
-		const twitterUrl = url.format( twitterUrlProperties );
+		const twitterUrl = baseUrl.href;
 
 		window.open( twitterUrl, 'twitter', 'width=550,height=420,resizeable,scrollbars' );
 	},
 	facebook( post ) {
-		const facebookUrlProperties = {
-			scheme: 'https',
-			hostname: 'www.facebook.com',
-			pathname: '/sharer.php',
-			query: {
-				u: post.URL,
-				app_id: config( 'facebook_api_key' ),
-			},
-		};
+		const baseUrl = new URL( 'https://www.facebook.com/sharer.php' );
+		const params = new URLSearchParams( {
+			u: post.URL,
+			app_id: config( 'facebook_api_key' ),
+		} );
+		baseUrl.search = params.toString();
 
-		const facebookUrl = url.format( facebookUrlProperties );
+		const facebookUrl = baseUrl.href;
 
 		window.open( facebookUrl, 'facebook', 'width=626,height=436,resizeable,scrollbars' );
 	},
@@ -84,7 +75,8 @@ function buildQuerystringForPost( post ) {
 	args.text = post.excerpt;
 	args.url = post.URL;
 
-	return stringify( args );
+	const params = new URLSearchParams( args );
+	return params.toString();
 }
 
 class ReaderShare extends React.Component {

--- a/client/boot/polyfills.js
+++ b/client/boot/polyfills.js
@@ -1,10 +1,10 @@
-/** @format */
 /**
  * External dependencies
  */
 import '@babel/polyfill';
 import svg4everybody from 'svg4everybody';
 import 'isomorphic-fetch';
+import '@webcomponents/url';
 
 /**
  * Internal dependencies

--- a/client/boot/polyfills.js
+++ b/client/boot/polyfills.js
@@ -3,13 +3,13 @@
  */
 import '@babel/polyfill';
 import svg4everybody from 'svg4everybody';
-import 'isomorphic-fetch';
 import '@webcomponents/url';
+import URLSearchParamsPolyfill from '@ungap/url-search-params';
+import 'isomorphic-fetch';
 
 /**
  * Internal dependencies
  */
-
 import localStoragePolyfill from 'lib/local-storage-polyfill';
 
 localStoragePolyfill();
@@ -18,4 +18,6 @@ const isBrowser = typeof window !== 'undefined';
 if ( isBrowser ) {
 	// Polyfill SVG external content support. Noop in the evergreen build.
 	svg4everybody();
+	// Polyfill URLSearchParams.
+	window.URLSearchParams = window.URLSearchParams || URLSearchParamsPolyfill;
 }

--- a/client/lib/build-url/index.ts
+++ b/client/lib/build-url/index.ts
@@ -1,26 +1,21 @@
 /**
- * External dependencies
- */
-import { pick } from 'lodash';
-import url from 'url';
-
-/**
- * Given a URL or path and search terms, returns a path including the search
- * query parameter and preserving existing parameters.
+ * Given an absolute or relative URL and search terms, returns a relative URL including
+ * the search query parameter and preserving existing parameters.
  *
  * @param  uri    URL or path to modify
  * @param  search Search terms
  * @return        Path including search terms
  */
-export default function( uri: string, search: string ): string {
-	let parsedUrl = url.parse( uri, true );
+export function buildRelativeSearchUrl( uri: string, search: string ): string {
+	// We only care about the relative part, but the URL API only deals with absolute URLs,
+	// so we need to provide a dummy domain.
+	const parsedUrl = new URL( uri, 'http://dummy.example' );
 
 	if ( search ) {
-		parsedUrl.query.s = search;
+		parsedUrl.searchParams.set( 's', search );
 	} else {
-		delete parsedUrl.query.s;
+		parsedUrl.searchParams.delete( 's' );
 	}
 
-	parsedUrl = pick( parsedUrl, 'pathname', 'hash', 'query' );
-	return url.format( parsedUrl ).replace( /%20/g, '+' );
+	return `${ parsedUrl.pathname }${ parsedUrl.search }${ parsedUrl.hash }`.replace( /%20/g, '+' );
 }

--- a/client/lib/build-url/test/index.js
+++ b/client/lib/build-url/test/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -8,41 +6,41 @@ import { expect } from 'chai';
 /**
  * Internal dependencies
  */
-import buildUrl from '..';
+import { buildRelativeSearchUrl } from '..';
 
-describe( 'build-url', () => {
+describe( 'buildRelativeSearchUrl', () => {
 	test( 'should accept a path without existing query parameters', () => {
-		const url = buildUrl( '/path', 'terms' );
+		const url = buildRelativeSearchUrl( '/path', 'terms' );
 
 		expect( url ).to.equal( '/path?s=terms' );
 	} );
 
 	test( 'should return only the path, even if a full URL is passed', () => {
-		const url = buildUrl( 'https://wordpress.com/path#hash', 'terms' );
+		const url = buildRelativeSearchUrl( 'https://wordpress.com/path#hash', 'terms' );
 
 		expect( url ).to.equal( '/path?s=terms#hash' );
 	} );
 
 	test( 'should preserve existing query parameters', () => {
-		const url = buildUrl( '/path?param=1', 'terms' );
+		const url = buildRelativeSearchUrl( '/path?param=1', 'terms' );
 
 		expect( url ).to.equal( '/path?param=1&s=terms' );
 	} );
 
 	test( 'should override the previous search term', () => {
-		const url = buildUrl( '/path?s=terms', 'newterms' );
+		const url = buildRelativeSearchUrl( '/path?s=terms', 'newterms' );
 
 		expect( url ).to.equal( '/path?s=newterms' );
 	} );
 
 	test( 'should remove the previous search term if not searching', () => {
-		const url = buildUrl( '/path?s=terms', '' );
+		const url = buildRelativeSearchUrl( '/path?s=terms', '' );
 
 		expect( url ).to.equal( '/path' );
 	} );
 
 	test( 'should replace encoded spaces with `+`', () => {
-		const url = buildUrl( '/path', 'new terms' );
+		const url = buildRelativeSearchUrl( '/path', 'new terms' );
 
 		expect( url ).to.equal( '/path?s=new+terms' );
 	} );

--- a/client/lib/search-url/index.js
+++ b/client/lib/search-url/index.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import page from 'page';
 
 /**
  * Internal dependencies
  */
-import buildUrl from 'lib/build-url';
+import { buildRelativeSearchUrl } from 'lib/build-url';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'calypso:search-url' );
@@ -20,7 +17,7 @@ export default function searchUrl( keywords, initialSearch, onSearch ) {
 		return;
 	}
 
-	const searchURL = buildUrl( window.location.href, keywords );
+	const searchURL = buildRelativeSearchUrl( window.location.href, keywords );
 
 	debug( 'search posts for:', keywords );
 	if ( initialSearch && keywords ) {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -19,7 +19,7 @@ import SubMasterbarNav from 'components/sub-masterbar-nav';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import { addTracking, trackClick } from './helpers';
 import DocumentHead from 'components/data/document-head';
-import buildUrl from 'lib/build-url';
+import { buildRelativeSearchUrl } from 'lib/build-url';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getCurrentUserId } from 'state/current-user/selectors';
 import ThemePreview from './theme-preview';
@@ -132,7 +132,7 @@ class ThemeShowcase extends React.Component {
 		filterSection = filterSection.replace( /\s/g, '+' );
 
 		const url = `/themes${ verticalSection }${ tierSection }${ filterSection }${ siteIdSection }`;
-		return buildUrl( url, searchString );
+		return buildRelativeSearchUrl( url, searchString );
 	};
 
 	onTierSelect = ( { value: tier } ) => {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3150,6 +3150,11 @@
 				}
 			}
 		},
+		"@ungap/url-search-params": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@ungap/url-search-params/-/url-search-params-0.1.2.tgz",
+			"integrity": "sha512-WVk5+lJ+AoNLh2sIDMhnEAgLsVQuI067hWLJCzirErH1GYiy1gs09q4+XZxYWSvdAsslKsaO4q1iXXMx2c72dA=="
+		},
 		"@webassemblyjs/ast": {
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
@@ -3325,6 +3330,11 @@
 				"@webassemblyjs/wast-parser": "1.8.5",
 				"@xtuc/long": "4.2.2"
 			}
+		},
+		"@webcomponents/url": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/@webcomponents/url/-/url-0.7.3.tgz",
+			"integrity": "sha512-lGyV8yEbVGiQHr7MT+Xi04piZ5b80dj5HaAiL2KFuEHxi6w0l/zQ9hUJffBhg/0ZaQ2IikIp0LDxx4QqJkKfIQ=="
 		},
 		"@wordpress/a11y": {
 			"version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"@babel/cli": "7.5.5",
 		"@babel/polyfill": "7.4.4",
 		"@babel/runtime": "7.5.5",
+		"@webcomponents/url": "0.7.3",
 		"@wordpress/api-fetch": "3.3.0",
 		"@wordpress/block-editor": "2.2.0",
 		"@wordpress/block-library": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 		"@babel/cli": "7.5.5",
 		"@babel/polyfill": "7.4.4",
 		"@babel/runtime": "7.5.5",
+		"@ungap/url-search-params": "0.1.2",
 		"@webcomponents/url": "0.7.3",
 		"@wordpress/api-fetch": "3.3.0",
 		"@wordpress/block-editor": "2.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -341,6 +341,8 @@ const polyfillsSkippedInEvergreen = [
 	/^isomorphic-fetch$/,
 	// All modern browsers support the URL API.
 	/^@webcomponents[/\\]url$/,
+	// All evergreen browsers support the URLSearchParams API.
+	/^@ungap[/\\]url-search-params$/,
 ];
 
 if ( browserslistEnv === 'evergreen' ) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -339,6 +339,8 @@ const polyfillsSkippedInEvergreen = [
 	/^svg4everybody$/,
 	// The fetch polyfill isn't needed for evergreen browsers, as they all support it.
 	/^isomorphic-fetch$/,
+	// All modern browsers support the URL API.
+	/^@webcomponents[/\\]url$/,
 ];
 
 if ( browserslistEnv === 'evergreen' ) {


### PR DESCRIPTION
We currently make use of `node`'s deprecated `'url'` API in Calypso client, imported as a browserified module. We also make use of a 3rd party `'qs'` library to parse and format URL query strings.

This PR starts the process of replacing them both (in client code) with native functionality provided by `URL` and `URLSearchParams`.

It uses polyfills for browsers that don't include native support, and since modern browsers don't need these polyfills, they're explicitly excluded from the `evergreen` build. No server-side polyfills are needed, as `node` already includes this functionality natively in the minimum supported version for Calypso (`^10.15.2`).

In addition, the PR tweaks `lib/build-url` (one of the example usages) to use a more semantic name for its single export, preparing it also for future extension.

**Note:** this PR will make the `fallback` build grow by about 4.7KB, which is the size of the polyfills being added. Once every usage of `'url'` and `'qs'` is removed, however, we should recoup those bytes and more over. The `evergreen` build should not change in size significantly until every usage of `'url'` and `'qs'` is removed, at which point it will also shrink.

#### Changes proposed in this Pull Request

* Add `@webcomponents/url` and `@ungap/url-search-params` polyfills. Can be replaced by `CoreJS` polyfills once we upgrade to `CoreJS` 3.
* Replace some example usage of `'url'` and `'qs'`.
* Rename default export in `lib/build-url` to a more semantic named export: `buildRelativeSearchUrl`.

#### Testing instructions

* Open Reader
* Choose a post and click on the share icon
* Choose Twitter
* Ensure that the tweet contents in the popup window are auto-filled with the title and URL

The changes are similar for Facebook but are harder to test, as it requires logging in. You could also just analyse the URL in the popup window and ensure it includes the right query string (made harder by the fact that it's behind a login URL).

`lib/build-url` already includes some extensive unit tests, so it shouldn't need any manual testing.