### PR TITLE
Domains: Update email verification landing page

### DIFF
--- a/client/landing/domains/registrant-verification/index.jsx
+++ b/client/landing/domains/registrant-verification/index.jsx
@@ -4,6 +4,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { localize } from 'i18n-calypso';
+import { get, join } from 'lodash';
 
 /**
  * Internal dependencies
@@ -37,8 +38,8 @@ class RegistrantVerificationPage extends Component {
 	componentWillMount() {
 		const { domain, email, token } = this.props;
 		wpcom.domainsVerifyRegistrantEmail( domain, email, token ).then(
-			() => {
-				this.setState( this.getVerificationSuccessState() );
+			response => {
+				this.setState( this.getVerificationSuccessState( get( response, 'domains', [ domain ] ) ) );
 			},
 			error => {
 				this.setErrorState( error );
@@ -58,15 +59,18 @@ class RegistrantVerificationPage extends Component {
 		};
 	};
 
-	getVerificationSuccessState = () => {
-		const { domain, translate } = this.props;
+	getVerificationSuccessState = domains => {
+		const { translate } = this.props;
+
+		const verifiedDomains = join( domains, ', ' );
+
 		return {
 			title: translate( 'Success!' ),
 			message: translate(
 				'Thank your for verifying your contact information for:{{br /}}{{strong}}%(domain)s{{/strong}}.',
 				{
 					args: {
-						domain: domain,
+						domain: verifiedDomains,
 					},
 					components: {
 						strong: <strong />,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR updates the email verification landing page to correctly reflect that the user has successfully verified their contact for multiple domains, and not just one, if that is the case.

Depends on D31580-code

#### Testing instructions

* Update the contact info for two or more domains by changing the email address to an unverified email address
* Click the link you receive in your email to verify your updated contact info
* After verification succeeds, make sure that all domains with updated contact info are listed, similar to the screenshot below:

<img width="738" alt="Screenshot 2019-08-15 at 17 22 03" src="https://user-images.githubusercontent.com/13062352/63106581-6b1a0880-bf83-11e9-8fc3-06e03fa363cc.png">