### PR TITLE
Checkout: Fix inline errors in domain contact form

### DIFF
--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/eu-address-fieldset.jsx
@@ -17,8 +17,8 @@ const EuAddressFieldset = props => {
 	const { getFieldProps, translate } = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields eu-address-fieldset">
-			<Input label={ translate( 'Postal Code' ) } { ...getFieldProps( 'postal-code', true ) } />
-			<Input label={ translate( 'City' ) } { ...getFieldProps( 'city', true ) } />
+			<Input label={ translate( 'Postal Code' ) } { ...getFieldProps( 'postal-code' ) } />
+			<Input label={ translate( 'City' ) } { ...getFieldProps( 'city' ) } />
 		</div>
 	);
 };

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/region-address-fieldsets.jsx
@@ -68,7 +68,7 @@ export class RegionAddressFieldsets extends Component {
 						ref={ shouldAutoFocusAddressField ? this.inputRefCallback : noop }
 						label={ translate( 'Address' ) }
 						maxLength={ 40 }
-						{ ...getFieldProps( 'address-1', true ) }
+						{ ...getFieldProps( 'address-1' ) }
 					/>
 
 					<HiddenInput

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/uk-address-fieldset.jsx
@@ -17,8 +17,8 @@ const UkAddressFieldset = props => {
 	const { getFieldProps, translate } = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields uk-address-fieldset">
-			<Input label={ translate( 'City' ) } { ...getFieldProps( 'city', true ) } />
-			<Input label={ translate( 'Postal Code' ) } { ...getFieldProps( 'postal-code', true ) } />
+			<Input label={ translate( 'City' ) } { ...getFieldProps( 'city' ) } />
+			<Input label={ translate( 'Postal Code' ) } { ...getFieldProps( 'postal-code' ) } />
 		</div>
 	);
 };

--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/us-address-fieldset.jsx
@@ -18,17 +18,14 @@ const UsAddressFieldset = props => {
 	const { getFieldProps, translate, countryCode } = props;
 	return (
 		<div className="custom-form-fieldsets__address-fields us-address-fieldset">
-			<Input label={ translate( 'City' ) } { ...getFieldProps( 'city', true ) } />
+			<Input label={ translate( 'City' ) } { ...getFieldProps( 'city' ) } />
 			<StateSelect
 				label={ getStateLabelText( countryCode ) }
 				countryCode={ countryCode }
 				selectText={ STATE_SELECT_TEXT[ countryCode ] }
 				{ ...getFieldProps( 'state', true ) }
 			/>
-			<Input
-				label={ getPostCodeLabelText( countryCode ) }
-				{ ...getFieldProps( 'postal-code', true ) }
-			/>
+			<Input label={ getPostCodeLabelText( countryCode ) } { ...getFieldProps( 'postal-code' ) } />
 		</div>
 	);
 };

--- a/client/components/domains/contact-details-form-fields/index.jsx
+++ b/client/components/domains/contact-details-form-fields/index.jsx
@@ -431,7 +431,7 @@ export class ContactDetailsFormFields extends Component {
 
 				<Input
 					label={ getPostCodeLabelText( countryCode ) }
-					{ ...this.getFieldProps( 'postal-code', true ) }
+					{ ...this.getFieldProps( 'postal-code' ) }
 				/>
 			</div>
 		);

--- a/client/my-sites/domains/components/form/hidden-input.jsx
+++ b/client/my-sites/domains/components/form/hidden-input.jsx
@@ -35,6 +35,9 @@ export class HiddenInput extends PureComponent {
 
 	assignInputFieldRef = input => {
 		this.inputField = input;
+		if ( this.props.inputRef ) {
+			this.props.inputRef( input );
+		}
 	};
 
 	render() {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While working on #34940, I've discovered that for some fields (Organization and the address fields, like address1/2, city, postal code...) if there's a validation error, we show the inline error (good) and a generic, confusing notice (baaaaad). Seems the root cause is that the logic cannot find the ref to focus on.

#### Testing instructions

Go to checkout with a domain in cart. Try to trigger a validation error for each of the fields (for example, by inputing forbidden characters, like `(*&(*&(*`). Hit `Submit`. Make sure that the first field with the error gets focus. Rinse and repeat for each field.
Note: seems the State select is not getting the focus correctly, looks to be broken in the component itself.

Before:

<img width="1209" alt="Screenshot 2019-08-15 at 15 21 00" src="https://user-images.githubusercontent.com/3392497/63107389-66018d00-bf74-11e9-98d1-c72e03dd065f.png">

After:

<img width="751" alt="Screenshot 2019-08-15 at 15 51 02" src="https://user-images.githubusercontent.com/3392497/63107460-816c9800-bf74-11e9-902a-043c55610640.png">

(no notice in the up right corner and the field is focused)
