### PR TITLE
Login: Fix display issues with Sign In With Apple button

### DIFF
--- a/client/blocks/login/social.scss
+++ b/client/blocks/login/social.scss
@@ -3,17 +3,10 @@
 }
 
 .login__social-buttons {
-	margin-top: 10px;
+	display: flex;
+	flex-direction: column;
 
-	button {
-		width: 100%;
-	}
-
-	svg {
-		margin-top: -2px;
-
-		&.disabled {
-			display: none;
-		}
+	.social-buttons__button:not(:first-of-type) {
+		margin-top: 10px;
 	}
 }

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -160,8 +160,9 @@
 }
 
 .login__form-signup-link {
+	clear: both;
 	font-size: 13px;
-	margin-top: 20px;
+	padding-top: 20px;
 
 	&.disabled {
 		a,

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -27,6 +27,16 @@ class AppleLoginButton extends Component {
 		redirectUri: PropTypes.string.isRequired,
 	};
 
+	state = {
+		isDisabled: true,
+	};
+
+	constructor( props ) {
+		super( props );
+
+		this.initialized = null;
+	}
+
 	componentDidMount() {
 		this.initialize();
 	}
@@ -53,13 +63,16 @@ class AppleLoginButton extends Component {
 		this.setState( { error: '' } );
 
 		this.initialized = this.loadDependency()
-			.then( AppleID =>
-				AppleID.auth.init( {
-					clientId: this.props.clientId,
-					scope: 'name email',
-					redirectURI: this.props.redirectUri,
-					state: '1',
-				} )
+			.then( AppleID => {
+					AppleID.auth.init( {
+						clientId: this.props.clientId,
+						scope: 'name email',
+						redirectURI: this.props.redirectUri,
+						state: '1',
+					} );
+
+					this.setState( { isDisabled: false } );
+				}
 			)
 			.catch( error => {
 				this.initialized = null;
@@ -70,8 +83,20 @@ class AppleLoginButton extends Component {
 		return this.initialized;
 	}
 
+	handleClick = ( event ) => {
+		event.preventDefault();
+
+		if ( this.state.isDisabled ) {
+			return;
+		}
+
+		window.AppleID.auth.signIn();
+	};
+
 	render() {
-		const { isFormDisabled } = this.props;
+		const isDisabled = Boolean(
+			this.state.isDisabled || this.props.isFormDisabled
+		);
 
 		if ( ! config.isEnabled( 'sign-in-with-apple' ) ) {
 			return null;
@@ -79,9 +104,10 @@ class AppleLoginButton extends Component {
 
 		return (
 			<button
-				className={ classNames( 'social-buttons__button button', { disabled: isFormDisabled } ) }
+				className={ classNames( 'social-buttons__button button', { disabled: isDisabled } ) }
+				onClick={ this.handleClick }
 			>
-				<AppleIcon isDisabled={ isFormDisabled } />
+				<AppleIcon isDisabled={ isDisabled } />
 
 				<span className="social-buttons__service-name">
 					{ this.props.translate( 'Sign in with %(service)s', {

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import config from 'config';
+import classNames from 'classnames';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -17,6 +18,7 @@ import { isFormDisabled } from 'state/login/selectors';
  * Style dependencies
  */
 import './style.scss';
+import AppleIcon from 'components/social-icons/apple';
 
 class AppleLoginButton extends Component {
 	static propTypes = {
@@ -35,6 +37,7 @@ class AppleLoginButton extends Component {
 				'https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js'
 			);
 		}
+
 		return window.AppleID;
 	}
 
@@ -48,6 +51,7 @@ class AppleLoginButton extends Component {
 		}
 
 		this.setState( { error: '' } );
+
 		this.initialized = this.loadDependency()
 			.then( AppleID =>
 				AppleID.auth.init( {
@@ -59,6 +63,7 @@ class AppleLoginButton extends Component {
 			)
 			.catch( error => {
 				this.initialized = null;
+
 				return Promise.reject( error );
 			} );
 
@@ -66,18 +71,26 @@ class AppleLoginButton extends Component {
 	}
 
 	render() {
+		const { isFormDisabled } = this.props;
+
+		if ( ! config.isEnabled( 'sign-in-with-apple' ) ) {
+			return null;
+		}
+
 		return (
-			<div>
-				{ ! this.props.isFormDisabled && config.isEnabled( 'sign-in-with-apple' ) && (
-					<div
-						className="social-buttons__apple-button"
-						id="appleid-signin"
-						data-color="white"
-						data-border="false"
-						data-type="sign in"
-					/>
-				) }
-			</div>
+			<button
+				className={ classNames( 'social-buttons__button button', { disabled: isFormDisabled } ) }
+			>
+				<AppleIcon isDisabled={ isFormDisabled } />
+
+				<span className="social-buttons__service-name">
+					{ this.props.translate( 'Sign in with %(service)s', {
+						args: { service: 'Apple' },
+						comment:
+							'%(service)s is the name of a third-party provider, e.g. "Google", "Facebook", "Apple" ...',
+					} ) }
+				</span>
+			</button>
 		);
 	}
 }

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -25,15 +25,15 @@ import './style.scss';
 
 class GoogleLoginButton extends Component {
 	static propTypes = {
-		isFormDisabled: PropTypes.bool,
 		clientId: PropTypes.string.isRequired,
-		scope: PropTypes.string,
 		fetchBasicProfile: PropTypes.bool,
-		uxMode: PropTypes.string,
+		isFormDisabled: PropTypes.bool,
+		onClick: PropTypes.func,
 		recordTracksEvent: PropTypes.func.isRequired,
 		responseHandler: PropTypes.func.isRequired,
+		scope: PropTypes.string,
 		translate: PropTypes.func.isRequired,
-		onClick: PropTypes.func,
+		uxMode: PropTypes.string,
 	};
 
 	static defaultProps = {

--- a/client/components/social-buttons/style.scss
+++ b/client/components/social-buttons/style.scss
@@ -1,5 +1,17 @@
 /*rtl:ignore*/
 
+.social-buttons__button {
+	width: 100%;
+
+	svg {
+		margin-top: -2px;
+
+		&.disabled {
+			display: none;
+		}
+	}
+}
+
 .social-buttons__service-name {
 	margin-left: 9px;
 }
@@ -8,20 +20,5 @@
 	.popover__inner {
 		padding: 10px;
 		max-width: 200px;
-	}
-}
-
-.social-buttons__apple-button div {
-	border-style: solid;
-	border-width: 1px 1px 2px;
-	border-color: var( --color-neutral-100 );
-	border-radius: 4px;
-	color: var( --color-neutral-700 );
-	margin-top: 10px;
-	padding: 10px 80px;
-
-	svg {
-		font-weight: 400;
-		padding: 0 75px;
 	}
 }

--- a/client/components/social-icons/apple.jsx
+++ b/client/components/social-icons/apple.jsx
@@ -1,0 +1,45 @@
+/** @format */
+
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { omit } from 'lodash';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
+export default class AppleIcon extends PureComponent {
+	static propTypes = {
+		isDisabled: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		isDisabled: false,
+	};
+
+	render() {
+		const props = omit( this.props, [ 'isDisabled' ] );
+
+		return (
+			<svg
+				className={ classNames( 'social-icons social-icons__apple', {
+					'social-icons--enabled': ! this.props.isDisabled,
+					'social-icons--disabled': !! this.props.isDisabled,
+				} ) }
+				width="20"
+				height="20"
+				viewBox="0 0 170 170"
+				xmlns="http://www.w3.org/2000/svg"
+				{ ...props }
+			>
+				<path
+					d="m150.37 130.25c-2.45 5.66-5.35 10.87-8.71 15.66-4.58 6.53-8.33 11.05-11.22 13.56-4.48 4.12-9.28 6.23-14.42 6.35-3.69 0-8.14-1.05-13.32-3.18-5.197-2.12-9.973-3.17-14.34-3.17-4.58 0-9.492 1.05-14.746 3.17-5.262 2.13-9.501 3.24-12.742 3.35-4.929 0.21-9.842-1.96-14.746-6.52-3.13-2.73-7.045-7.41-11.735-14.04-5.032-7.08-9.169-15.29-12.41-24.65-3.471-10.11-5.211-19.9-5.211-29.378 0-10.857 2.346-20.221 7.045-28.068 3.693-6.303 8.606-11.275 14.755-14.925s12.793-5.51 19.948-5.629c3.915 0 9.049 1.211 15.429 3.591 6.362 2.388 10.447 3.599 12.238 3.599 1.339 0 5.877-1.416 13.57-4.239 7.275-2.618 13.415-3.702 18.445-3.275 13.63 1.1 23.87 6.473 30.68 16.153-12.19 7.386-18.22 17.731-18.1 31.002 0.11 10.337 3.86 18.939 11.23 25.769 3.34 3.17 7.07 5.62 11.22 7.36-0.9 2.61-1.85 5.11-2.86 7.51zm-31.26-123.01c0 8.1021-2.96 15.667-8.86 22.669-7.12 8.324-15.732 13.134-25.071 12.375-0.119-0.972-0.188-1.995-0.188-3.07 0-7.778 3.386-16.102 9.399-22.908 3.002-3.446 6.82-6.3113 11.45-8.597 4.62-2.2516 8.99-3.4968 13.1-3.71 0.12 1.0831 0.17 2.1663 0.17 3.2409z" />
+			</svg>
+		);
+	}
+}

--- a/client/components/social-icons/facebook.jsx
+++ b/client/components/social-icons/facebook.jsx
@@ -3,7 +3,6 @@
 /**
  * External dependencies
  */
-
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -25,6 +24,7 @@ export default class FacebookIcon extends PureComponent {
 
 	render() {
 		const props = omit( this.props, [ 'isDisabled' ] );
+
 		return (
 			<svg
 				className={ classNames( 'social-icons social-icons__facebook', {

--- a/client/components/social-icons/google.jsx
+++ b/client/components/social-icons/google.jsx
@@ -24,6 +24,7 @@ export default class GoogleIcon extends PureComponent {
 
 	render() {
 		const props = omit( this.props, [ 'isDisabled' ] );
+
 		return (
 			<svg
 				className={ classNames( 'social-icons social-icons__google', {

--- a/client/layout/masterbar/oauth-client.scss
+++ b/client/layout/masterbar/oauth-client.scss
@@ -316,7 +316,10 @@
 		.social-buttons__button {
 			border: 1px solid #cecfd1;
 			border-radius: 0;
-			margin-bottom: 40px;
+
+			&:last-of-type {
+				margin-bottom: 40px;
+			}
 		}
 
 		.translator-invite {
@@ -531,9 +534,20 @@
 	}
 
 	.login__form-action,
-	.login__social-buttons,
 	.magic-login__form-action {
 		text-align: center;
+	}
+
+	.login__social-buttons {
+		margin-top: 0;
+
+		@include breakpoint( '>660px' ) {
+			flex-direction: row;
+
+			button:not(:first-of-type) {
+				margin-top: 0;
+			}
+		}
 	}
 
 	.wp-login__main.main,

--- a/server/pages/index.js
+++ b/server/pages/index.js
@@ -530,6 +530,7 @@ function setUpCSP( req, res, next ) {
 			'https://widgets.wp.com',
 			'*.wordpress.com',
 			'https://apis.google.com',
+			'https://appleid.cdn-apple.com',
 			`'nonce-${ req.context.inlineScriptNonce }'`,
 			'www.google-analytics.com',
 			...inlineScripts.map( hash => `'${ hash }'` ),


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/35137 that seeks to fix many display issues around the `Sign in with Apple` button displayed on the `Login` page. The inconsistencies observed were indeed caused by the Apple library injecting its own button in the code of this page, thus offering [limited flexibility](https://developer.apple.com/documentation/signinwithapplejs/displaying_and_configuring_sign_in_with_apple_buttons) regarding its look and feel. With this pull request we'll be using our own button that follows our design conventions, and triggers the same authentication flow at Apple:

##### WordPress.com

Before | After
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/63115193-ed5ff800-bf96-11e9-9e9f-9d931552d8aa.png) | ![screenshot](https://user-images.githubusercontent.com/594356/63115215-fd77d780-bf96-11e9-8d24-9da095a49784.png)

##### WooCommerce

Before | After
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/63115268-1a140f80-bf97-11e9-8f16-7756b7e94860.png) | ![screenshot](https://user-images.githubusercontent.com/594356/63115314-3021d000-bf97-11e9-9506-e5abaa788e1a.png)

##### Crowdsignal

Before | After
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/63115356-4760bd80-bf97-11e9-87bd-1ffaabcbab45.png) | ![screenshot](https://user-images.githubusercontent.com/594356/63115383-59426080-bf97-11e9-89b5-f2e2664d2314.png)

##### Akismet

Before | After
------ | -----
![screenshot](https://user-images.githubusercontent.com/594356/63115455-81ca5a80-bf97-11e9-841a-2d69741d2dd3.png) | ![screenshot](https://user-images.githubusercontent.com/594356/63115481-90b10d00-bf97-11e9-867c-9f685f47c3ff.png)

#### Testing instructions

Do not hesitate to check how the `Login` page looks when the width of the browser changes:

1. Run `git checkout fix/sign-in-with-apple-button` and start your server, or open a [live branch](https://calypso.live/?branch=fix/sign-in-with-apple-button)

##### WordPress.com

2. Open the [`Login` page](http://calypso.localhost:3000/log-in) in an incognito window
3. Assert that the page looks like the screenshot above
4. Assert that you can still log in

##### WooCommerce

2. Open the WooCommerce [`Home` page](https://woocommerce.com/) in an incognito window
3. Click the `LOG IN WITH WORDPRESS.COM` link in the header
4. Replace https://wordpress.com with http://calypso.localhost:3000 in the address bar, and reload
5. Assert that the page looks like the screenshot above
6. Assert that you can still log in

##### Crowdsignal

2. Open the Crowdsignal [`Home` page](https://crowdsignal.com/) in an incognito window
3. Click the `LOGIN` link in the header
4. Replace https://wordpress.com with http://calypso.localhost:3000 in the address bar, and reload
5. Assert that the page looks like the screenshot above
6. Assert that you can still log in

##### Other OAuth apps

2. Open the Akismet [`Home` page](https://akismet.com/) in an incognito window
3. Click the `Sign In` button in the header
4. Replace https://wordpress.com with http://calypso.localhost:3000 in the address bar, and reload
5. Assert that the page looks like the screenshot above
6. Assert that you can still log in