### PR TITLE
Woo: AddCardDialog: Refactor as functional component

### DIFF
--- a/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
+++ b/client/extensions/woocommerce/woocommerce-services/views/label-settings/add-credit-card-modal.js
@@ -3,12 +3,11 @@
 /**
  * External dependencies
  */
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { localize } from 'i18n-calypso';
-import { curry } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,47 +20,44 @@ import { addStoredCard } from 'state/stored-cards/actions';
 import { createCardToken } from 'lib/store-transactions';
 import analytics from 'lib/analytics';
 
-class AddCardDialog extends Component {
-	static propTypes = {
-		siteId: PropTypes.number.isRequired,
-		isVisible: PropTypes.bool,
-		addStoredCard: PropTypes.func.isRequired,
-		closeAddCardDialog: PropTypes.func.isRequired,
-	};
-
-	constructor( props ) {
-		super( props );
-		this.createCardToken = curry( createCardToken )( 'card_add' );
-	}
-
-	recordFormSubmitEvent() {
+function AddCardDialog( {
+	siteId,
+	isVisible,
+	translate,
+	closeAddCardDialog: closeDialog,
+	addStoredCard: saveStoredCard,
+} ) {
+	const createCardAddToken = ( ...args ) => createCardToken( 'card_add', ...args );
+	const recordFormSubmitEvent = () =>
 		analytics.tracks.recordEvent( 'calypso_add_credit_card_form_submit' );
-	}
+	const onClose = () => closeDialog( siteId );
 
-	render() {
-		const { siteId, isVisible, translate } = this.props;
-
-		const onClose = () => this.props.closeAddCardDialog( siteId );
-
-		return (
-			<Dialog
-				additionalClassNames="add-credit-card-modal woocommerce wcc-root"
-				isVisible={ isVisible }
-				onClose={ onClose }
-			>
-				<CreditCardForm
-					createCardToken={ this.createCardToken }
-					recordFormSubmitEvent={ this.recordFormSubmitEvent }
-					saveStoredCard={ this.props.addStoredCard }
-					successCallback={ onClose }
-					showUsedForExistingPurchasesInfo={ true }
-					heading={ translate( 'Add credit card' ) }
-					onCancel={ onClose }
-				/>
-			</Dialog>
-		);
-	}
+	return (
+		<Dialog
+			additionalClassNames="add-credit-card-modal woocommerce wcc-root"
+			isVisible={ isVisible }
+			onClose={ onClose }
+		>
+			<CreditCardForm
+				createCardToken={ createCardAddToken }
+				recordFormSubmitEvent={ recordFormSubmitEvent }
+				saveStoredCard={ saveStoredCard }
+				successCallback={ onClose }
+				showUsedForExistingPurchasesInfo={ true }
+				heading={ translate( 'Add credit card' ) }
+				onCancel={ onClose }
+			/>
+		</Dialog>
+	);
 }
+
+AddCardDialog.propTypes = {
+	siteId: PropTypes.number.isRequired,
+	isVisible: PropTypes.bool,
+	translate: PropTypes.func.isRequired,
+	addStoredCard: PropTypes.func.isRequired,
+	closeAddCardDialog: PropTypes.func.isRequired,
+};
 
 const mapStateToProps = ( state, { siteId } ) => {
 	const form = getLabelSettingsForm( state, siteId );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In preparation to upgrade the `AddCardDialog` component to use Stripe Elements and Payment Intents (see #35237 for a similar PR), this PR just reorganizes the component into a stateless functional component instead of a class.

This is required for #35390

#### Testing instructions

- Sandbox the store.
- Purchase a Business plan.
- Create a Store (further instructions are needed here).
- Visit http://calypso.localhost:3000/store/settings/shipping/ and choose the site with the Store.
- Click "Settings" in the sidebar.
- Click the "Shipping" tab.
- In the "Shipping Labels" section, click "Add credit card" or "Add another credit card".
- Fill out the form with a Stripe test card (see https://stripe.com/docs/testing#cards) and press "Save Card".
- Verify that the card was successfully added and appears in the list.