### PR TITLE
FSE: Strip empty blocks from being display in the template part block

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -23,6 +23,35 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import './style.scss';
 
+const stripEmptyBlocks = blocks =>
+	blocks.filter( ( { name, attributes } ) => {
+		switch ( name ) {
+			case 'core/verse':
+			case 'core/preformatted':
+			case 'core/html':
+			case 'core/code':
+			case 'core/heading':
+			case 'core/paragraph':
+				return attributes.content.length > 0;
+			case 'core/image':
+			case 'core/audio':
+			case 'core/file':
+			case 'core/video':
+				return attributes.hasOwnProperty( 'id' );
+			case 'core/pullquote':
+			case 'core/quote':
+				return attributes.value !== '<p></p>';
+			case 'core/list':
+				return attributes.values !== '<li></li>';
+			case 'core/table':
+				return attributes.body.length > 0;
+			case 'core/gallery':
+				return attributes.images.length > 0;
+			default:
+				return true;
+		}
+	} );
+
 const TemplateEdit = compose(
 	withState( { templateClientId: null, shouldCloseSidebarOnSelect: true } ),
 	withSelect( ( select, { attributes, templateClientId } ) => {
@@ -60,7 +89,9 @@ const TemplateEdit = compose(
 					return;
 				}
 
-				const templateBlocks = parse( get( template, [ 'content', 'raw' ], '' ) );
+				const templateBlocks = stripEmptyBlocks(
+					parse( get( template, [ 'content', 'raw' ], '' ) )
+				);
 				const templateBlock =
 					templateBlocks.length === 1
 						? templateBlocks[ 0 ]


### PR DESCRIPTION
### Summary

This PR aims to fix an issue where empty blocks - not stripped out on save by Gutenberg, by design - were being displayed in the template part blocks when editing a page. The concern was that the existing block placeholders imply immediate action, which isn't possible until clicking into editing the header (or other template part) itself.

![fse-header-placeholder](https://user-images.githubusercontent.com/8892849/63112174-8bcf6780-bf5d-11e9-953b-2e572e12a5a9.gif)

<hr>

### Specifics

This is a bit of an interesting problem, as Gutenberg itself does not aim to strip out "empty" blocks on save. In fact, looking through similar issues in the Gberg repo, the rhetoric is often "what defines an empty block" - which is fair, given how the definition of empty for each different block type varies.

Based on what I've seen while looking into this, there are three main directions that are possible here:

**1. Actually strip out blocks that are "empty" that are passed to the template part block.**
The historically noted downside to this is that the "empty" state is variable depending on different block types. 3rd party blocks also infinitely expand the possible differing cases here, meaning we wouldn't be able to ever unify placeholder handling for _all_ blocks.

**2. Use styling to target and hide placeholders.**
The biggest downside to this is accessibility and hackiness.

**3. Don't use the BlockEdit component, rather use a different component that renders blocks like the frontend.**
This won't work with our current implementation of placeholders (ie, for the site logo) and I imagine that we will have to display placeholders in the future. (Or, more aptly, "pre-placeholders" as opposed to the placeholders insinuating direct action that Gberg currently displays for blank blocks. See: the implementation of the site logo block.) There also doesn't seem to be a simple solution for this given the components that Gutenberg currently provides.

**4. Strip empty blocks on save from template parts.**
The biggest downside to this is the same as the downsides to option 1, in addition to going against how Gutenberg currently operates (and potentially expected behavior for the block editor for users).

Ultimately, I ended up implementing option 1 at this point -> limited in scope to the core blocks present in the "Common" and "Formatting" categories. This should cover enough cases in the meantime that this won't be as jarring, but feedback is much appreciated.

<hr>

### Testing

* Spin up a local instance of your FSE environment and build/activate the FSE app.
* Edit the header (by editing a page and then clicking the "Edit Header" button overlaying the Header template part block). Add a paragraph block, but do not edit it.
* Go back to editing a page and notice that the placeholder is not visible.
* Try this for any core block in the "Common Blocks" and "Formatting" categories.

Fixes #35040, Fixes #35425