### PR TITLE
Import in Signup: Limit path domain suggestsions to Wix / Medium

### DIFF
--- a/client/lib/importer/test/utils.js
+++ b/client/lib/importer/test/utils.js
@@ -10,6 +10,12 @@ describe( 'suggestDomainFromImportUrl', () => {
 		expect( suggestedDomain ).toEqual( 'mysite' );
 	} );
 
+	it( 'should suggest the path name, for medium sites, if present', () => {
+		const suggestedDomain = suggestDomainFromImportUrl( 'https://medium.com/mysite' );
+
+		expect( suggestedDomain ).toEqual( 'mysite' );
+	} );
+
 	it( 'should suggest the domain for WordPress.com sites', () => {
 		const suggestedDomain = suggestDomainFromImportUrl( 'https://mysite.wordpress.com' );
 

--- a/client/lib/importer/test/utils.js
+++ b/client/lib/importer/test/utils.js
@@ -4,7 +4,7 @@
 import { suggestDomainFromImportUrl } from '../utils';
 
 describe( 'suggestDomainFromImportUrl', () => {
-	it( 'should suggest the path name, if present', () => {
+	it( 'should suggest the path name, for wix sites, if present', () => {
 		const suggestedDomain = suggestDomainFromImportUrl( 'https://user.wixsite.com/mysite' );
 
 		expect( suggestedDomain ).toEqual( 'mysite' );

--- a/client/lib/importer/utils.ts
+++ b/client/lib/importer/utils.ts
@@ -14,11 +14,16 @@ export function suggestDomainFromImportUrl( siteUrl: string ): string | null {
 		/squarespace\.com\/?$/,
 		/tumblr\.com\/?$/,
 	];
+	const usePathMatchers = [ /wixsite\.com\/?$/, /medium\.com\/?$/ ];
 
 	// Site name is sometimes the path, as in the case of Wix and Medium sites,
 	// such as `medium.com/my-blog`.
 	if ( pathname ) {
-		return pathname.replace( '/', '-' );
+		for ( const pathMatcher of usePathMatchers ) {
+			if ( parsedUrl.hostname.match( pathMatcher ) ) {
+				return pathname.replace( '/', '-' );
+			}
+		}
 	}
 
 	if ( parsedUrl.hostname ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates domain suggestions such that path is only used for Wix and Medium URLs

In #35175 we introduced a utility to use the URL provided during an import in signup to suggest a domain on the domain step. If a path was present in the URL that was given, it was used to make the suggestion.

In #35409, @mattsherman pointed out that the behavior isn't always ideal when we're not dealing with a Wix or Medium site. He gave the example `https://www.rohrbachs.com/home`, which yielded the suggestion "home".

This PR limits path recommendations to Wix, and Mediums URLs, as those are the only URLs where the pattern is known to produce good results.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start from `/start` in Calypso.live or with this branch applied locally
* Select "Already have a website?"
* Enter a wixsite.com url (such as `example.wixsite.com/somethingelse`)
* Continue, and verify that on the domain step, `somethingelse` is used to suggest a domain
* Go back to the `import-url` step and enter a non-wix, non-medium url with a path (such as `https://www.rohrbachs.com/home`)
* Continue (selecting an engine first, if prompted) and verify that the hostname was used to make the suggestion.

