### PR TITLE
Fix typo ("acessing" => "accessing") when cancelling a domain and a plan

### DIFF
--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -118,7 +118,7 @@ const CancelPurchaseRefundInformation = ( {
 						i18n.translate(
 							'Your plan included the custom domain %(domain)s. You can cancel your domain as well as the plan, but keep ' +
 								'in mind that when you cancel a domain you risk losing it forever, and visitors to your site may ' +
-								'experience difficulties acessing it.',
+								'experience difficulties accessing it.',
 							{
 								args: {
 									domain: includedDomainPurchase.meta,


### PR DESCRIPTION
There is a typo in one of the paragraphs of text you see when cancelling a plan for a site that also has a domain.

As you can see in this screenshot, it says "acessing" when it should say "accessing" instead:

![screenshot-from-2019-08-15-18-28-37](https://user-images.githubusercontent.com/235183/63131483-e1bb0400-bf8b-11e9-810d-efe2a99a7e1d.png)

This pull request fixes it.  Pretty trivial fix, although I guess it might (temporarily) break some translations because it changes a string.