### PR TITLE
Pages: Denote template-first theme homepage templates

### DIFF
--- a/client/lib/post-metadata/index.js
+++ b/client/lib/post-metadata/index.js
@@ -5,6 +5,7 @@
  */
 
 import { find } from 'lodash';
+import { getThemeIdFromStylesheet } from 'state/themes/utils';
 
 /**
  * Module variables
@@ -81,6 +82,21 @@ PostMetadata = {
 		}
 
 		return getConnectionIdsByPattern( post.metadata, REGEXP_PUBLICIZE_SERVICE_SKIPPED );
+	},
+
+	/**
+	 * Given a post object, returns the theme id of a template-first theme, or `undefined` if the value
+	 * cannot be determined.
+	 *
+	 * @param  {Object} post Post object
+	 * @return {Array}       Array of Publicize service IDs
+	 */
+	homepageTemplate: function( post ) {
+		if ( ! post ) {
+			return;
+		}
+
+		return getThemeIdFromStylesheet( getValueByKey( post.metadata, '_tft_homepage_template' ) );
 	},
 
 	/**

--- a/client/my-sites/pages/page-card-info/index.jsx
+++ b/client/my-sites/pages/page-card-info/index.jsx
@@ -16,6 +16,9 @@ import { isFrontPage, isPostsPage } from 'state/pages/selectors';
 import PostRelativeTimeStatus from 'my-sites/post-relative-time-status';
 import canCurrentUser from 'state/selectors/can-current-user';
 import getEditorUrl from 'state/selectors/get-editor-url';
+import PostMetadata from 'lib/post-metadata';
+import { getTheme } from 'state/themes/selectors';
+import QueryThemes from 'components/data/query-themes';
 
 /**
  * Style dependencies
@@ -47,6 +50,7 @@ function PageCardInfo( {
 	isPosts,
 	siteUrl,
 	contentLink,
+	theme,
 } ) {
 	const renderTimestamp = function() {
 		if ( page.status === 'future' ) {
@@ -70,6 +74,7 @@ function PageCardInfo( {
 
 	return (
 		<div className="page-card-info">
+			<QueryThemes siteId="wpcom" />
 			{ siteUrl && <div className="page-card-info__site-url">{ siteUrl }</div> }
 			<div>
 				{ showTimestamp && renderTimestamp() }
@@ -85,15 +90,25 @@ function PageCardInfo( {
 						<span className="page-card-info__item-text">{ translate( 'Your latest posts' ) }</span>
 					</span>
 				) }
+				{ ! isFront && theme && (
+					<span className="page-card-info__item">
+						<Gridicon icon="themes" size={ ICON_SIZE } className="page-card-info__item-icon" />
+						<span className="page-card-info__item-text">
+							{ translate( '%(title)s Theme Homepage', { args: { title: theme.name } } ) }
+						</span>
+					</span>
+				) }
 			</div>
 		</div>
 	);
 }
 
 export default connect( ( state, props ) => {
+	const themeTemplate = PostMetadata.homepageTemplate( props.page );
 	return {
 		isFront: isFrontPage( state, props.page.site_ID, props.page.ID ),
 		isPosts: isPostsPage( state, props.page.site_ID, props.page.ID ),
+		theme: getTheme( state, props.page.site_ID, getThemeIdFromStylesheet( themeTemplate ) ),
 		contentLink: getContentLink( state, props.page.site_ID, props.page ),
 	};
 } )( localize( PageCardInfo ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This depends on D31499-code.

Gives context to pages that were derived from template-first themes' homepage templates.
After switching between a few themes, users can be left with a multitude of pages titled "Home".
This change adds some context around that.

#### Testing instructions

* Apply D31499-code and go through the testing steps there
* Checkout this PR and navigate to `http://calypso.localhost:3000/pages/drafts/` and select the site you used for testing ^
* It should show a label similar to what you see in the below screenshot

### Screenshot
![Screen Shot 2019-08-15 at 3 55 42 PM](https://user-images.githubusercontent.com/1398304/63132316-89790780-bf75-11e9-845c-debaee585fd0.png)

See #35255.