### PR TITLE
FSE - Show loading indicator on ever navigation to template editor

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -127,11 +127,11 @@ const TemplateEdit = compose(
 		const { align, className } = attributes;
 
 		const save = event => {
+			setNavigateToTemplate( true );
 			if ( ! isDirty ) {
 				return;
 			}
 			event.preventDefault();
-			setNavigateToTemplate( true );
 			savePost();
 		};
 
@@ -156,7 +156,13 @@ const TemplateEdit = compose(
 						{ isSelected && (
 							<Placeholder className="template-block__overlay">
 								<Button href={ editTemplateUrl } onClick={ save } isDefault ref={ navButton }>
-									{ navigateToTemplate ? <Spinner /> : sprintf( __( 'Edit %s' ), templateTitle ) }
+									{ navigateToTemplate ? (
+										<Fragment>
+											<Spinner /> { sprintf( __( 'Loading %s Editor' ), templateTitle ) }
+										</Fragment>
+									) : (
+										sprintf( __( 'Edit %s' ), templateTitle )
+									) }
 								</Button>
 							</Placeholder>
 						) }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -155,14 +155,19 @@ const TemplateEdit = compose(
 						</Disabled>
 						{ isSelected && (
 							<Placeholder className="template-block__overlay">
-								<Button href={ editTemplateUrl } onClick={ save } isDefault ref={ navButton }>
-									{ navigateToTemplate ? (
-										<Fragment>
-											<Spinner /> { sprintf( __( 'Loading %s Editor' ), templateTitle ) }
-										</Fragment>
-									) : (
-										sprintf( __( 'Edit %s' ), templateTitle )
-									) }
+								{ navigateToTemplate && (
+									<div className="template-block__loading">
+										<Spinner /> { sprintf( __( 'Loading %s Editor' ), templateTitle ) }
+									</div>
+								) }
+								<Button
+									className={ navigateToTemplate ? 'hidden' : null }
+									href={ editTemplateUrl }
+									onClick={ save }
+									isDefault
+									ref={ navButton }
+								>
+									{ sprintf( __( 'Edit %s' ), templateTitle ) }
 								</Button>
 							</Placeholder>
 						) }

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -39,6 +39,16 @@
 	align-items: center;
 	background: rgba( #f5f5f5, 0.8 );
 	z-index: 2;
+
+	.components-button.hidden {
+		display: none;
+	}
+}
+
+.template-block__loading {
+	display: flex;
+	align-items: center;
+	color: #191e23;
 }
 
 .block-editor-block-list__layout {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adds the loading indicator to the template edit button on every navigation instead of just on page saves
* Add message as well as loading indicator

#### Testing instructions

* Apply the patch to FSE test env
* Click on Edit Header and Edit Footer buttons and ensure loading indicator and correct message ('Loading Header Editor' for Header and 'Loading Footer Editor' for Footer) shows on button - simulate slow network connection if needed.

**Before**

![before-nav](https://user-images.githubusercontent.com/3629020/63132762-589cdf00-c016-11e9-8f44-b05fc5ac3354.gif)

**After**

![header-after](https://user-images.githubusercontent.com/3629020/63294065-825b4c00-c31d-11e9-82d7-4ed07f0788fa.gif)

Fixes #35422
