### PR TITLE
FSE: Always render actual block container divs in Template

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -61,10 +61,7 @@ const TemplateEdit = compose(
 				}
 
 				const templateBlocks = parse( get( template, [ 'content', 'raw' ], '' ) );
-				const templateBlock =
-					templateBlocks.length === 1
-						? templateBlocks[ 0 ]
-						: createBlock( 'core/template', {}, templateBlocks );
+				const templateBlock = createBlock( 'core/template', {}, templateBlocks );
 
 				receiveBlocks( [ templateBlock ] );
 				setState( { templateClientId: templateBlock.clientId } );


### PR DESCRIPTION
Previously, if there was only one block in the template, we sent it to be rendered just with its.... I suppose you could call it raw output? It rendered without any of the outer block UI div stuffs.

That's a problem because our editor CSS styles RELY on there being outer block div things like "data-align="full"". If there was only one block, that outer wrapper div did not show up!

In the new approach, we do what we did with multiple blocks. In essence, we have been using this approach for every time there are multiple blocks in the top level of the template. Which is how it is set up by default. Now we also do it if there is a single block there.

**Note: this only fixes the bug where the block wouldn't take up the full width of the screen. The other bugs like inner content not rendering are tracked in the issue below**

|  No outer block div | Yes outer block div |
| ------------- | ------------- |
|  <img width="990" alt="Screen Shot 2019-08-15 at 4 29 41 PM" src="https://user-images.githubusercontent.com/6265975/63136173-9d2c6a00-bf85-11e9-9665-ca07f3386b75.png">| <img width="989" alt="Screen Shot 2019-08-15 at 4 28 52 PM" src="https://user-images.githubusercontent.com/6265975/63136125-60607300-bf85-11e9-8f87-7e0ad9972faf.png">   |

|  Before | After |
| ------------- | ------------- |
| ![](https://cld.wthms.co/h2fsZZ+)| <img width="1895" alt="Screen Shot 2019-08-15 at 5 52 52 PM" src="https://user-images.githubusercontent.com/6265975/63136216-c8af5480-bf85-11e9-9b54-f3e93052b859.png">| 

#### Changes proposed in this Pull Request
* Use createBlock for even single instances of blocks.

#### Testing instructions
1. Pull this PR to your local FSE testing environment
2. Edit the header template and add a cover block.
3. Make the cover block full width, and add a picture to it.
4.  Make sure that this is the only outer block in your header. Make sure that even the placeholder paragraph underneath is gone.
3. Update the header and go back to the page editor.
4. In the page editor, the cover block should extend the full width of the page editor.

First part of a fix for #35429, but not quite everything.