### PR TITLE
Stats: launch file download stats

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -26,7 +26,6 @@ import PageViewTracker from 'lib/analytics/page-view-tracker';
 import StatsBanners from './stats-banners';
 import StickyPanel from 'components/sticky-panel';
 import JetpackColophon from 'components/jetpack-colophon';
-import config from 'config';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import { isJetpackSite, getSitePlanSlug } from 'state/sites/selectors';
 import { recordGoogleEvent } from 'state/analytics/actions';
@@ -144,19 +143,17 @@ class StatsSite extends Component {
 				/>
 			);
 
-			if ( config.isEnabled( 'manage/stats/file-downloads' ) ) {
-				fileDownloadList = (
-					<StatsModule
-						path="filedownloads"
-						moduleStrings={ moduleStrings.filedownloads }
-						period={ this.props.period }
-						query={ query }
-						statType="statsFileDownloads"
-						showSummaryLink
-						useShortLabel={ true }
-					/>
-				);
-			}
+			fileDownloadList = (
+				<StatsModule
+					path="filedownloads"
+					moduleStrings={ moduleStrings.filedownloads }
+					period={ this.props.period }
+					query={ query }
+					statType="statsFileDownloads"
+					showSummaryLink
+					useShortLabel={ true }
+				/>
+			);
 		}
 
 		return (

--- a/config/desktop-development.json
+++ b/config/desktop-development.json
@@ -78,7 +78,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/stats": true,
-		"manage/stats/file-downloads": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/development.json
+++ b/config/development.json
@@ -97,7 +97,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/stats": true,
-		"manage/stats/file-downloads": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/test.json
+++ b/config/test.json
@@ -57,7 +57,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/stats": true,
-		"manage/stats/file-downloads": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -76,7 +76,6 @@
 		"manage/site-settings/analytics": true,
 		"manage/site-settings/categories": true,
 		"manage/stats": true,
-		"manage/stats/file-downloads": true,
 		"manage/themes-jetpack": true,
 		"manage/themes/details": true,
 		"manage/themes/details/jetpack": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Remove the feature flag `manage/stats/file-downloads` and launch the file download stats feature to everyone.

#### Testing instructions

Visit My Sites and ensure that you see the File Downloads panel.

<img width="356" alt="screen-shot-2019-08-16-at-15 41 07" src="https://user-images.githubusercontent.com/17325/63144858-0f19b780-c049-11e9-8bc8-c4f124eaacec.png">
