### PR TITLE
Double MAX_RETRIES for Jetpack product install

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -55,7 +55,7 @@ const PLUGINS: PluginSlug[] = [ 'akismet', 'vaultpress' ];
 /**
  * Maximum number of attempts to refetch installation status in the event of a recoverable error.
  */
-const MAX_RETRIES = 3;
+const MAX_RETRIES = 6;
 
 const PLUGIN_KEY_REFETCH_INTERVAL: TimeoutMS = 300;
 


### PR DESCRIPTION
`vaultpress_error` appears to be the most common installer error. It is
a "recoverable" error. Increase the number of retries to allow slower
hosting to recover from `vaultpress_error` state.

#### Testing instructions

* Jetpack installer flow (purchase a plan for a Jetpack site) works as expected.

Akismet and Vaultpress should be installed and set up with keys after purchasing a plan.
