### PR TITLE
Full Site Editing: suppress trash template action

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -63,6 +63,7 @@ class Full_Site_Editing {
 		add_filter( 'post_row_actions', [ $this, 'remove_trash_row_action_for_template_post_types' ], 10, 2 );
 		add_filter( 'bulk_actions-edit-wp_template', [ $this, 'remove_trash_bulk_action_for_template_post_type' ] );
 		add_action( 'wp_trash_post', [ $this, 'restrict_template_deletion' ] );
+		add_action( 'before_delete_post', [ $this, 'restrict_template_deletion' ] );
 		add_filter( 'wp_template_type_row_actions', [ $this, 'remove_delete_row_action_for_template_taxonomy' ], 10, 2 );
 		add_filter( 'bulk_actions-edit-wp_template_type', [ $this, 'remove_delete_bulk_action_for_template_taxonomy' ] );
 		add_action( 'pre_delete_term', [ $this, 'restrict_template_taxonomy_deletion' ], 10, 2 );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js
@@ -5,4 +5,5 @@ import './block-inserter';
 import './template-validity-override';
 import './image-block-keywords';
 import './style.scss';
+import './suppress-trash-action';
 import './suppress-draft-action';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/suppress-trash-action/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/suppress-trash-action/index.js
@@ -1,0 +1,22 @@
+/* global fullSiteEditing */
+
+/**
+ * External dependencies
+ */
+import { use } from '@wordpress/data';
+
+// The purpose of this override is to prevent trash action from deleting template CPTs.
+use( registry => {
+	return {
+		dispatch: namespace => {
+			const actions = { ...registry.dispatch( namespace ) };
+			const { editorPostType } = fullSiteEditing;
+
+			if ( namespace === 'core/editor' && actions.trashPost && editorPostType === 'wp_template' ) {
+				actions.trashPost = () => {};
+			}
+
+			return actions;
+		},
+	};
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In addition to hiding the Trash button on templates, let's also make sure that the Trash action is a no-op. Follow up to handle @gwwar's suggestion from https://github.com/Automattic/wp-calypso/pull/35278#discussion_r312660678

#### Testing instructions

1. Remove this line https://github.com/Automattic/wp-calypso/blob/master/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss#L3 to make Trash button visible for testing purposes.
2. Navigate to header/footer editing view.
3. Click on Trash and verify that nothing happens.
4. Comment out the trash suppression script import.
5. Try to trash again and verify that backend safeguards prevent it.
6. Smoke test the plugin.