### PR TITLE
Full Site Editing: suppress switch to draft action for templates

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js
@@ -5,3 +5,4 @@ import './block-inserter';
 import './template-validity-override';
 import './image-block-keywords';
 import './style.scss';
+import './suppress-draft-action';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/suppress-draft-action/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/suppress-draft-action/index.js
@@ -1,0 +1,34 @@
+/* global fullSiteEditing */
+
+/**
+ * External dependencies
+ */
+import { use } from '@wordpress/data';
+
+// The purpose of this override is to prevent Switch to Draft action for template CPTs.
+use( registry => {
+	return {
+		dispatch: namespace => {
+			const actions = { ...registry.dispatch( namespace ) };
+			const { editorPostType } = fullSiteEditing;
+
+			if ( namespace === 'core/editor' && actions.editPost && editorPostType === 'wp_template' ) {
+				const originalEditPost = actions.editPost;
+
+				actions.editPost = edits => {
+					const { status } = edits;
+
+					// Bail if editPost is attempting to set draft as status.
+					if ( status === 'draft' ) {
+						return;
+					}
+
+					// Proceed with the usual call otherwise.
+					originalEditPost( edits );
+				};
+			}
+
+			return actions;
+		},
+	};
+} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Prevent templates from being switched to drafts. Follow up to handle @gwwar's suggestion here https://github.com/Automattic/wp-calypso/pull/35277#discussion_r312664100.

Here is the core action for reference: https://github.com/WordPress/gutenberg/blob/89bd6b124bd8930307e92dbb6b3157eb8bc0c833/packages/editor/src/store/actions.js#L407

#### Testing instructions

1. Remove this line to make `Switch to Draft` button visible again https://github.com/Automattic/wp-calypso/blob/master/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss#L12.
2. Navigate to header or footer editing view.
3. Click on `Switch to Draft`.
4. Verify that the status hasn't been changed.
5. Comment out the draft suppression script and verify that backend safeguards kick in.
6. Smoke test the plugin.