### PR TITLE
lib/interval: Add useInterval, use it in Interval

### DIFF
--- a/client/blocks/comments/index.jsx
+++ b/client/blocks/comments/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -12,7 +10,7 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import PostCommentsList from './post-comment-list';
-import Interval, { EVERY_MINUTE } from 'lib/interval';
+import { Interval, EVERY_MINUTE } from 'lib/interval';
 import { requestPostComments } from 'state/comments/actions';
 
 class PostComments extends React.Component {

--- a/client/components/data/query-post-likes/index.jsx
+++ b/client/components/data/query-post-likes/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -13,7 +11,7 @@ import { connect } from 'react-redux';
 import { requestPostLikes } from 'state/posts/likes/actions';
 import getPostLikeLastUpdated from 'state/selectors/get-post-like-last-updated';
 import getPostLikes from 'state/selectors/get-post-likes';
-import Interval from 'lib/interval';
+import { Interval } from 'lib/interval';
 
 class QueryPostLikes extends Component {
 	static propTypes = {

--- a/client/components/data/query-rewind-backup-status/index.js
+++ b/client/components/data/query-rewind-backup-status/index.js
@@ -1,8 +1,6 @@
-/** @format */
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -10,7 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Interval, { EVERY_SECOND } from 'lib/interval';
+import { Interval, EVERY_SECOND } from 'lib/interval';
 import { getRewindBackupProgress } from 'state/activity-log/actions';
 
 class QueryRewindBackupStatus extends Component {

--- a/client/components/data/query-rewind-restore-status/index.js
+++ b/client/components/data/query-rewind-restore-status/index.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -9,7 +8,7 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import Interval, { EVERY_SECOND } from 'lib/interval';
+import { Interval, EVERY_SECOND } from 'lib/interval';
 import { getRewindRestoreProgress } from 'state/activity-log/actions';
 
 class QueryRewindRestoreStatus extends Component {

--- a/client/components/time-since/index.jsx
+++ b/client/components/time-since/index.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -9,7 +8,7 @@ import moment from 'moment';
  * Internal dependencies
  */
 import humanDate from 'lib/human-date';
-import Interval, { EVERY_TEN_SECONDS } from 'lib/interval';
+import { Interval, EVERY_TEN_SECONDS } from 'lib/interval';
 import smartSetState from 'lib/react-smart-set-state';
 
 export default class TimeSince extends PureComponent {

--- a/client/lib/interval/README.md
+++ b/client/lib/interval/README.md
@@ -1,43 +1,41 @@
 # Interval
 
-An interface into a global timer coalescing interval runner.
-
-_**An interface**_ because this component handles registering and un-registering the given `onTick` action with the global runner.
-
-_**timer coalescing**_ because the global runner will run at the same time all of the actions registered for a given interval period. For example, if four actions are registered for running once per minute, they will all run at one point in time every minute instead of having four different run times, each time repeating every minute. This is better for things like battery life because it allows for longer and deeper periods of sleep between actions.
-
-_**interval runner**_ because the global runner will execute the given action every interval on the interval.
+A React-oriented, declarative interval runner.
 
 This component can be used to easily trigger a polling, looping, or interval action in the background. Such usages could include polling an API endpoint for updates, sweeping over user input such as in the post editor at intervals, or updating an on-screen timer.
 
-It only requires two inputs: an action to perform and an interval between which runs of the action should occur. The action is simply a function and the interval is a named constant representing the interval period. These interval periods are intentionally limited to prevent sprawl of timers.
-
-The action will only be executed as long as the React component is mounted, as the component un-registers the action on unmount. Additionally, the default behavior is to stop executing the action when the browser document is hidden, though this can be overwritten. "Hidden" means that another browser tab is selected or the browser is minimized.
-
-Wrapped components will be transferred all additional props not consumed by the `<Interval />` itself.
+It only requires two inputs: a callback to perform and an interval between which runs of the action should occur. The action is simply a function and the interval is a timeout in ms.
+Notice how this interface closely matches `setInterval`.
 
 ## Usage
 
-```jsx
-import Interval, { EVERY_FIVE_SECONDS, EVERY_MINUTE } from 'lib/interval';
+### `useInterval`
 
-<Interval onTick={ doSomething } period={ EVERY_FIVE_SECONDS } />
+```tsx
+import { useInterval, EVERY_MINUTE } from 'react';
 
-// Wrapping a component
-<Interval onTick={ fetchNewReaderPosts } period={ EVERY_MINUTE }>
-	<Reader {...readerProps} />
-</Interval>
+function Counter() {
+	let [ count, setCount ] = useState( 0 );
 
-// Wrapping passes down props
-const CounterDisplay = counter => <div>{ counter }</div>;
+	useInterval( () => {
+		setCount( count + 1 );
+	}, EVERY_MINUTE );
 
-<Interval onTick={ updateCounter } period={ EVERY_MINUTE } counter={ counter }>
-	<CounterDisplay />
-</Interval>
+	return <h1>Minutes: { count }</h1>;
+}
 ```
 
-## Props
+### `<Interval />`
 
- - `onTick`: Function to run on interval, _required_
- - `period`: Constant specifying interval period, _required_
- - `pauseWhenHidden`: _[true]_ Boolean indicating whether or not to stop executing the action when the browser document is hidden from view.
+This is a Component wrapping `useInterval`, intended for use in classic React Components where hooks are unavailable.
+
+```tsx
+import { Interval, EVERY_FIVE_SECONDS } from 'lib/interval';
+
+<Interval onTick={ doSomething } period={ EVERY_FIVE_SECONDS } />;
+```
+
+#### Props
+
+- `onTick`: Function to run on interval, _required_
+- `period`: Constant specifying interval period, _required_

--- a/client/lib/interval/index.ts
+++ b/client/lib/interval/index.ts
@@ -1,52 +1,13 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import { Component } from 'react';
-import PropTypes from 'prop-types';
+import { TimeoutMS } from 'client/types';
 
-export const EVERY_SECOND = 1000;
-export const EVERY_FIVE_SECONDS = 5 * 1000;
-export const EVERY_TEN_SECONDS = 10 * 1000;
-export const EVERY_THIRTY_SECONDS = 30 * 1000;
-export const EVERY_MINUTE = 60 * 1000;
+export { Interval } from './interval';
+export { useInterval } from './use-interval';
 
-/**
- * Calls a given function on a given interval
- */
-export default class Interval extends Component {
-	static propTypes = {
-		onTick: PropTypes.func.isRequired,
-		period: PropTypes.number.isRequired,
-	};
-
-	tick = () => {
-		this.props.onTick();
-	};
-
-	start = ( props = this.props ) => {
-		this.interval = setInterval( this.tick, props.period );
-	};
-
-	stop = () => {
-		this.interval = clearInterval( this.interval );
-	};
-
-	componentDidMount() {
-		this.start();
-	}
-
-	componentWillUnmount() {
-		this.stop();
-	}
-
-	componentWillReceiveProps( nextProps ) {
-		if ( nextProps.period !== this.props.period ) {
-			this.stop();
-			this.start( nextProps );
-		}
-	}
-
-	render() {
-		return null;
-	}
-}
+export const EVERY_SECOND: TimeoutMS = 1000;
+export const EVERY_FIVE_SECONDS: TimeoutMS = 5 * 1000;
+export const EVERY_TEN_SECONDS: TimeoutMS = 10 * 1000;
+export const EVERY_THIRTY_SECONDS: TimeoutMS = 30 * 1000;
+export const EVERY_MINUTE: TimeoutMS = 60 * 1000;

--- a/client/lib/interval/index.ts
+++ b/client/lib/interval/index.ts
@@ -1,9 +1,3 @@
-/** @format */
-
-/**
- * External dependencies
- */
-
 /**
  * External dependencies
  */

--- a/client/lib/interval/interval.ts
+++ b/client/lib/interval/interval.ts
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { FunctionComponent } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { TimeoutMS } from 'client/types';
+import { useInterval } from './use-interval';
+
+interface Props {
+	onTick: () => void;
+	period: TimeoutMS;
+}
+
+export const Interval: FunctionComponent< Props > = props => {
+	useInterval( props.onTick, props.period );
+	return null;
+};

--- a/client/lib/interval/test/interval.tsx
+++ b/client/lib/interval/test/interval.tsx
@@ -6,7 +6,8 @@
  * External dependencies
  */
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
 
 /**
  * Internal dependencies
@@ -16,64 +17,117 @@ import { Interval, EVERY_SECOND, EVERY_MINUTE } from '../index';
 jest.useFakeTimers();
 
 describe( 'Interval', () => {
-	describe( 'Running actions', () => {
-		test( 'Does not run onTick() on mount', () => {
-			const spy = jest.fn();
-			mount( <Interval onTick={ spy } period={ EVERY_SECOND } /> );
-			expect( spy ).not.toHaveBeenCalled();
+	let container;
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+	} );
+
+	afterEach( () => {
+		unmountComponentAtNode( container );
+		container.remove();
+		container = null;
+	} );
+
+	test( 'Does not run onTick() on mount', () => {
+		const spy = jest.fn();
+		act( () => {
+			render( <Interval onTick={ spy } period={ EVERY_SECOND } />, container );
+		} );
+		expect( spy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'Runs onTick() on the intervals', () => {
+		const spy = jest.fn();
+		act( () => {
+			render( <Interval onTick={ spy } period={ EVERY_SECOND } />, container );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'Respects the period passed', () => {
+		const spy = jest.fn();
+		act( () => {
+			render( <Interval onTick={ spy } period={ EVERY_MINUTE } />, container );
+		} );
+		act( () => {
+			jest.advanceTimersByTime( 1000 * 60 );
+		} );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'Stops running the interval on unmount', () => {
+		const spy = jest.fn();
+		act( () => {
+			render( <Interval onTick={ spy } period={ EVERY_SECOND } />, container );
+			jest.advanceTimersByTime( 1000 );
 		} );
 
-		test( 'Runs onTick() on the intervals', () => {
-			const spy = jest.fn();
-			mount( <Interval onTick={ spy } period={ EVERY_SECOND } /> );
-			jest.runTimersToTime( 1000 );
-			expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+
+		act( () => {
+			unmountComponentAtNode( container );
+			jest.advanceTimersByTime( 2000 );
 		} );
 
-		test( 'Respects the period passed', () => {
-			const spy = jest.fn();
-			mount( <Interval onTick={ spy } period={ EVERY_MINUTE } /> );
-			jest.runTimersToTime( 1000 * 60 );
-			expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'Changes the interval when the period changes', () => {
+		const spy = jest.fn();
+
+		act( () => {
+			render( <Interval onTick={ spy } period={ EVERY_SECOND } />, container );
+			jest.advanceTimersByTime( 1000 );
 		} );
 
-		test( 'Stops running the interval on unmount', () => {
-			const spy = jest.fn();
-			const wrapper = mount( <Interval onTick={ spy } period={ EVERY_SECOND } /> );
-			jest.runTimersToTime( 1000 );
-			expect( spy ).toHaveBeenCalledTimes( 1 );
-			wrapper.unmount();
-			jest.runTimersToTime( 2000 );
-			expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+
+		act( () => {
+			render( <Interval onTick={ spy } period={ EVERY_MINUTE } />, container );
 		} );
 
-		test( 'Changes the interval when the period changes', () => {
-			const spy = jest.fn();
-			const wrapper = mount( <Interval onTick={ spy } period={ EVERY_SECOND } /> );
-			jest.runTimersToTime( 1000 );
-			expect( spy ).toHaveBeenCalledTimes( 1 );
-			wrapper.setProps( { onTick: spy, period: EVERY_MINUTE } );
-			jest.runTimersToTime( 1000 );
-			expect( spy ).toHaveBeenCalledTimes( 1 );
-			jest.runTimersToTime( 60 * 1000 );
-			expect( spy ).toHaveBeenCalledTimes( 2 );
+		// Separate `act` to ensure props are updated before advancing timers
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
 		} );
 
-		test( 'Picks up a new ticker even if the period does not change', () => {
-			const spy = jest.fn();
-			const otherSpy = jest.fn();
+		expect( spy ).toHaveBeenCalledTimes( 1 );
 
-			const wrapper = mount( <Interval onTick={ spy } period={ EVERY_SECOND } /> );
-
-			jest.runTimersToTime( 1000 );
-			expect( spy ).toHaveBeenCalledTimes( 1 );
-
-			wrapper.setProps( { onTick: otherSpy, period: EVERY_SECOND } );
-			expect( spy ).toHaveBeenCalledTimes( 1 );
-			expect( otherSpy ).not.toHaveBeenCalled();
-
-			jest.runTimersToTime( 1000 );
-			expect( spy ).toHaveBeenCalledTimes( 1 );
+		act( () => {
+			jest.advanceTimersByTime( 60 * 1000 );
 		} );
+
+		expect( spy ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'Picks up a new ticker even if the period does not change', () => {
+		const spy = jest.fn();
+		const otherSpy = jest.fn();
+
+		act( () => {
+			render( <Interval onTick={ spy } period={ EVERY_SECOND } />, container );
+			jest.advanceTimersByTime( 1000 );
+		} );
+
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+
+		act( () => {
+			render( <Interval onTick={ otherSpy } period={ EVERY_SECOND } />, container );
+		} );
+
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( otherSpy ).not.toHaveBeenCalled();
+
+		act( () => {
+			jest.advanceTimersByTime( 1000 );
+		} );
+
+		expect( spy ).toHaveBeenCalledTimes( 1 );
+		expect( otherSpy ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/client/lib/interval/test/interval.tsx
+++ b/client/lib/interval/test/interval.tsx
@@ -1,18 +1,17 @@
 /**
- * @format
  * @jest-environment jsdom
  */
 
 /**
  * External dependencies
  */
-import { mount } from 'enzyme';
 import React from 'react';
+import { mount } from 'enzyme';
 
 /**
  * Internal dependencies
  */
-import Interval, { EVERY_SECOND, EVERY_MINUTE } from '../index';
+import { Interval, EVERY_SECOND, EVERY_MINUTE } from '../index';
 
 jest.useFakeTimers();
 
@@ -21,42 +20,43 @@ describe( 'Interval', () => {
 		test( 'Does not run onTick() on mount', () => {
 			const spy = jest.fn();
 			mount( <Interval onTick={ spy } period={ EVERY_SECOND } /> );
-			expect( spy.mock.calls.length ).toBe( 0 );
+			expect( spy ).not.toHaveBeenCalled();
 		} );
 
 		test( 'Runs onTick() on the intervals', () => {
 			const spy = jest.fn();
 			mount( <Interval onTick={ spy } period={ EVERY_SECOND } /> );
 			jest.runTimersToTime( 1000 );
-			expect( spy.mock.calls.length ).toBe( 1 );
+			expect( spy ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		test( 'Respects the period passed', () => {
 			const spy = jest.fn();
 			mount( <Interval onTick={ spy } period={ EVERY_MINUTE } /> );
 			jest.runTimersToTime( 1000 * 60 );
-			expect( spy.mock.calls.length ).toBe( 1 );
+			expect( spy ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		test( 'Stops running the interval on unmount', () => {
 			const spy = jest.fn();
 			const wrapper = mount( <Interval onTick={ spy } period={ EVERY_SECOND } /> );
 			jest.runTimersToTime( 1000 );
-			expect( spy.mock.calls.length ).toBe( 1 );
+			expect( spy ).toHaveBeenCalledTimes( 1 );
 			wrapper.unmount();
 			jest.runTimersToTime( 2000 );
-			expect( spy.mock.calls.length ).toBe( 1 );
+			expect( spy ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		test( 'Changes the interval when the period changes', () => {
 			const spy = jest.fn();
 			const wrapper = mount( <Interval onTick={ spy } period={ EVERY_SECOND } /> );
 			jest.runTimersToTime( 1000 );
-			expect( spy.mock.calls.length ).toBe( 1 );
+			expect( spy ).toHaveBeenCalledTimes( 1 );
 			wrapper.setProps( { onTick: spy, period: EVERY_MINUTE } );
-			expect( spy.mock.calls.length ).toBe( 1 );
+			jest.runTimersToTime( 1000 );
+			expect( spy ).toHaveBeenCalledTimes( 1 );
 			jest.runTimersToTime( 60 * 1000 );
-			expect( spy.mock.calls.length ).toBe( 2 );
+			expect( spy ).toHaveBeenCalledTimes( 2 );
 		} );
 
 		test( 'Picks up a new ticker even if the period does not change', () => {
@@ -66,14 +66,14 @@ describe( 'Interval', () => {
 			const wrapper = mount( <Interval onTick={ spy } period={ EVERY_SECOND } /> );
 
 			jest.runTimersToTime( 1000 );
-			expect( spy.mock.calls.length ).toBe( 1 );
+			expect( spy ).toHaveBeenCalledTimes( 1 );
 
 			wrapper.setProps( { onTick: otherSpy, period: EVERY_SECOND } );
-			expect( spy.mock.calls.length ).toBe( 1 );
-			expect( otherSpy.mock.calls.length ).toBe( 0 );
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( otherSpy ).not.toHaveBeenCalled();
 
 			jest.runTimersToTime( 1000 );
-			expect( spy.mock.calls.length ).toBe( 1 );
+			expect( spy ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 } );

--- a/client/lib/interval/use-interval.ts
+++ b/client/lib/interval/use-interval.ts
@@ -16,8 +16,10 @@ import { TimeoutMS } from 'client/types';
  * https://github.com/gaearon/overreacted.io/blob/80c0a314c5d855891220852788f662c2e8ecc7d4/src/pages/making-setinterval-declarative-with-react-hooks/index.md
  */
 
-export function useInterval( callback: () => void, delay: TimeoutMS ) {
-	const savedCallback = useRef< typeof callback >();
+type Callback = () => void;
+
+export function useInterval( callback: Callback, delay: TimeoutMS ) {
+	const savedCallback = useRef< Callback >();
 
 	// Remember the latest callback.
 	useEffect( () => {
@@ -27,7 +29,7 @@ export function useInterval( callback: () => void, delay: TimeoutMS ) {
 	// Set up the interval.
 	useEffect( () => {
 		function tick() {
-			( savedCallback.current as /* savedCallback ref should never be `undefined` */ typeof callback )();
+			( savedCallback.current as /* savedCallback ref should never be `undefined` */ Callback )();
 		}
 		if ( delay !== null ) {
 			const id = setInterval( tick, delay );

--- a/client/lib/interval/use-interval.ts
+++ b/client/lib/interval/use-interval.ts
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { TimeoutMS } from 'client/types';
+
+/**
+ * useInterval implementation from @see https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+ *
+ * Used with explicit permission:
+ * > Feel free to copy paste it in your project or put it on npm.
+ * https://github.com/gaearon/overreacted.io/blob/80c0a314c5d855891220852788f662c2e8ecc7d4/src/pages/making-setinterval-declarative-with-react-hooks/index.md
+ */
+
+export function useInterval( callback: () => void, delay: TimeoutMS ) {
+	const savedCallback = useRef< typeof callback >();
+
+	// Remember the latest callback.
+	useEffect( () => {
+		savedCallback.current = callback;
+	}, [ callback ] );
+
+	// Set up the interval.
+	useEffect( () => {
+		function tick() {
+			( savedCallback.current as /* savedCallback ref should never be `undefined` */ typeof callback )();
+		}
+		if ( delay !== null ) {
+			const id = setInterval( tick, delay );
+			return () => clearInterval( id );
+		}
+	}, [ delay ] );
+}

--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -6,7 +5,7 @@ import React, { Component, Fragment } from 'react';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import Spinner from 'components/spinner';
-import Interval, { EVERY_TEN_SECONDS } from 'lib/interval';
+import { Interval, EVERY_TEN_SECONDS } from 'lib/interval';
 import classNames from 'classnames';
 
 /**

--- a/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/atomic-store-thank-you-card.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
@@ -14,7 +11,7 @@ import classNames from 'classnames';
  */
 import Button from 'components/button';
 import PlanThankYouCard from 'blocks/plan-thank-you-card';
-import Interval, { EVERY_FIVE_SECONDS } from 'lib/interval';
+import { Interval, EVERY_FIVE_SECONDS } from 'lib/interval';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import { getCurrentPlan } from 'state/sites/plans/selectors';
 import { getPlanClass } from 'lib/plans';

--- a/client/my-sites/exporter/export-card/index.jsx
+++ b/client/my-sites/exporter/export-card/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import React, { Component } from 'react';
@@ -14,7 +11,7 @@ import { connect } from 'react-redux';
  */
 import SpinnerButton from 'components/spinner-button';
 import FoldableCard from 'components/foldable-card';
-import Interval, { EVERY_SECOND } from 'lib/interval';
+import { Interval, EVERY_SECOND } from 'lib/interval';
 import AdvancedSettings from './advanced-settings';
 import { withAnalytics, recordTracksEvent } from 'state/analytics/actions';
 import {

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -15,7 +14,7 @@ import CompactCard from 'components/card/compact';
 import DocumentHead from 'components/data/document-head';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import ImporterStore, { getState as getImporterState } from 'lib/importer/store';
-import Interval, { EVERY_FIVE_SECONDS } from 'lib/interval';
+import { Interval, EVERY_FIVE_SECONDS } from 'lib/interval';
 import WordPressImporter from 'my-sites/importer/importer-wordpress';
 import MediumImporter from 'my-sites/importer/importer-medium';
 import BloggerImporter from 'my-sites/importer/importer-blogger';

--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -11,7 +11,7 @@ import { localize, LocalizeProps } from 'i18n-calypso';
 import { recordTracksEvent } from 'state/analytics/actions';
 import getJetpackProductInstallProgress from 'state/selectors/get-jetpack-product-install-progress';
 import getJetpackProductInstallStatus from 'state/selectors/get-jetpack-product-install-status';
-import Interval, { EVERY_SECOND, EVERY_FIVE_SECONDS } from 'lib/interval';
+import { Interval, EVERY_SECOND, EVERY_FIVE_SECONDS } from 'lib/interval';
 import Notice from 'components/notice';
 import NoticeAction from 'components/notice/notice-action';
 import { JETPACK_CONTACT_SUPPORT } from 'lib/url/support';

--- a/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
+++ b/client/my-sites/site-settings/jetpack-sync-panel/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -20,7 +17,7 @@ import ProgressBar from 'components/progress-bar';
 import { getSelectedSite } from 'state/ui/selectors';
 import syncSelectors from 'state/jetpack-sync/selectors';
 import { getSyncStatus, scheduleJetpackFullysync } from 'state/jetpack-sync/actions';
-import Interval, { EVERY_TEN_SECONDS } from 'lib/interval';
+import { Interval, EVERY_TEN_SECONDS } from 'lib/interval';
 import NoticeAction from 'components/notice/notice-action';
 import analytics from 'lib/analytics';
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -186,7 +186,7 @@ class ReaderStream extends React.Component {
 		// only toggle a like on a x-post if we have the appropriate metadata,
 		// and original post is full screen
 		const xPostMetadata = XPostHelper.getXPostMetadata( post );
-		if ( !! xPostMetadata.postURL ) {
+		if ( xPostMetadata.postURL ) {
 			return;
 		}
 

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -45,7 +44,7 @@ import { resetCardExpansions } from 'state/ui/reader/card-expansions/actions';
 import { reduxGetState } from 'lib/redux-bridge';
 import { getPostByKey } from 'state/reader/posts/selectors';
 import { viewStream } from 'state/reader/watermarks/actions';
-import Interval, { EVERY_MINUTE } from 'lib/interval';
+import { Interval, EVERY_MINUTE } from 'lib/interval';
 import { PER_FETCH, INITIAL_FETCH } from 'state/data-layer/wpcom/read/streams';
 
 /**

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
 	transformIgnorePatterns: [
 		'node_modules[\\/\\\\](?!flag-icon-css|redux-form|simple-html-tokenizer|draft-js|social-logos|gridicons)',
 	],
-	testMatch: [ '<rootDir>/client/**/test/*.js?(x)', '!**/.eslintrc.*' ],
+	testMatch: [ '<rootDir>/client/**/test/*.[jt]s?(x)', '!**/.eslintrc.*' ],
 	testURL: 'https://example.com',
 	setupFiles: [ 'regenerator-runtime/runtime' ], // some NPM-published packages depend on the global
 	setupFilesAfterEnv: [ '<rootDir>/test/client/setup-test-framework.js' ],

--- a/test/integration/jest.config.js
+++ b/test/integration/jest.config.js
@@ -1,5 +1,3 @@
-/** @format */
-
 module.exports = {
 	modulePaths: [
 		'<rootDir>/test/',
@@ -10,10 +8,10 @@ module.exports = {
 	rootDir: './../../',
 	testEnvironment: 'node',
 	testMatch: [
-		'<rootDir>/bin/**/integration/*.js',
-		'<rootDir>/client/**/integration/*.js',
-		'<rootDir>/server/**/integration/*.js',
-		'<rootDir>/test/test/helpers/**/integration/*.js',
+		'<rootDir>/bin/**/integration/*.[jt]s',
+		'<rootDir>/client/**/integration/*.[jt]s',
+		'<rootDir>/server/**/integration/*.[jt]s',
+		'<rootDir>/test/test/helpers/**/integration/*.[jt]s',
 		'!**/.eslintrc.*',
 	],
 	verbose: false,

--- a/test/server/jest.config.js
+++ b/test/server/jest.config.js
@@ -1,7 +1,5 @@
-/** @format */
-
 module.exports = {
-	collectCoverageFrom: [ 'server/**/*.js?(x)' ],
+	collectCoverageFrom: [ 'server/**/*.[jt]s?(x)' ],
 	coveragePathIgnorePatterns: [ '<rootDir>/server/devdocs/search-index.js' ],
 	modulePaths: [
 		'<rootDir>/test/',
@@ -19,7 +17,7 @@ module.exports = {
 		),
 	},
 	transformIgnorePatterns: [ 'node_modules[\\/\\\\](?!redux-form|draft-js)' ],
-	testMatch: [ '<rootDir>/server/**/test/*.js?(x)', '!**/.eslintrc.*' ],
+	testMatch: [ '<rootDir>/server/**/test/*.[jt]s?(x)', '!**/.eslintrc.*' ],
 	timers: 'fake',
 	setupFiles: [ 'regenerator-runtime/runtime' ], // some NPM-published packages depend on the global
 	setupFilesAfterEnv: [ '<rootDir>/test/server/setup-test-framework.js' ],


### PR DESCRIPTION
- Adds `useInterval` hook inspired by https://overreacted.io/making-setinterval-declarative-with-react-hooks/
- Convert `Interval` component to functional component using `useInterval` internally.
- Update `lib/interval` README - **!!** This made claims that were inaccurate and the current and new implementations do not implement. There were interesting ideas in the README, so I don't know if they were a placeholder for planned work or inaccurate for other reasons.
- Type all interfaces in `lib/interval` with TypeScript.
- Update `Interval` imports throughout the application. Must use named `{ Interval }` or `{ useInterval }` now.
- Add `ts` and `tsx` Jest test matching, tests can be written in TypeScript.

#### Testing instructions

* Intervals continue to work as expected.
* Tests should pass
* `<Interval />` appears to be used to [poll Reader streams](https://github.com/Automattic/wp-calypso/blob/77a105de508c1068b1172cf119dbd96b4f5bdbb1/client/reader/stream/index.jsx#L428). From `/`, you should see a request like the following every minute: `https://public-api.wordpress.com/rest/v1.2/read/following?…`