### PR TITLE
Fix SSR in themes.

### DIFF
--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -228,9 +225,11 @@ class ThemeShowcase extends React.Component {
 				) }
 				<div className="themes__content">
 					<QueryThemeFilters />
-					{ showBanners && abtest( 'builderReferralThemesBanner' ) === 'builderReferralBanner' && (
-						<UpworkBanner location={ 'theme-banner' } />
-					) }
+					{ showBanners &&
+						abtest &&
+						abtest( 'builderReferralThemesBanner' ) === 'builderReferralBanner' && (
+							<UpworkBanner location={ 'theme-banner' } />
+						) }
 					<ThemesSearchCard
 						onSearch={ this.doSearch }
 						search={ filterString + search }


### PR DESCRIPTION
SSR is failing because `lib/abtests` is aliased to a noop on the server, but we still try to make use of it in the theme showcase.

This fixes the issue by checking if the imported function is valid (it will be `undefined` if the module was replaced with a noop).

#### Changes proposed in this Pull Request

* Check if `abtest` is present before calling it.

#### Testing instructions

* Ensure you're logged out
* Disable JS on your browser
* Open `/themes`
* Ensure that you get the initial page of themes rendered, not just a skeleton render.
