### PR TITLE
Migrate CSS of Tooltip and Popover to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -13,7 +13,5 @@
 @import 'components/date-picker/style';
 @import 'components/dialog/style';
 @import 'components/main/style';
-@import 'components/popover/style';
 @import 'components/segmented-control/style';
-@import 'components/tooltip/style';
 @import 'layout/sidebar/style';

--- a/client/components/popover/index.jsx
+++ b/client/components/popover/index.jsx
@@ -26,6 +26,11 @@ import {
 import isRtlSelector from 'state/selectors/is-rtl';
 
 /**
+ * Style dependencies
+ */
+import './style.scss';
+
+/**
  * Module variables
  */
 const noop = () => {};

--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -14,6 +14,11 @@ import classnames from 'classnames';
 import Popover from 'components/popover';
 import { useMobileBreakpoint } from 'lib/viewport/react';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 function Tooltip( props ) {
 	const isMobile = useMobileBreakpoint();
 

--- a/client/components/tooltip/index.jsx
+++ b/client/components/tooltip/index.jsx
@@ -27,7 +27,6 @@ function Tooltip( props ) {
 	}
 
 	const classes = classnames(
-		'popover',
 		'tooltip',
 		`is-${ props.status }`,
 		`is-${ props.position }`,

--- a/client/components/tooltip/style.scss
+++ b/client/components/tooltip/style.scss
@@ -160,8 +160,3 @@
 		}
 	}
 }
-
-.tooltip__hr {
-	margin: 8px 0;
-	background: var( --color-neutral-light );
-}


### PR DESCRIPTION
Straightforward migration of `Tooltip` and `Popover` components. Plus few little drive-by cleanups.

**How to test:**

The components are used for info popovers:

<img width="316" alt="Screenshot 2019-08-16 at 14 59 07" src="https://user-images.githubusercontent.com/664258/63169194-7712d280-c036-11e9-8428-e5c40093841f.png">

ellipsis menus:

<img width="213" alt="Screenshot 2019-08-16 at 15 00 56" src="https://user-images.githubusercontent.com/664258/63169287-b17c6f80-c036-11e9-8246-c9ad5a47520a.png">

stats chart tooltips:

<img width="260" alt="Screenshot 2019-08-16 at 15 02 08" src="https://user-images.githubusercontent.com/664258/63169344-d96bd300-c036-11e9-84c7-a4add7b7ce85.png">

and other tooltips:

<img width="204" alt="Screenshot 2019-08-16 at 15 02 51" src="https://user-images.githubusercontent.com/664258/63169506-44b5a500-c037-11e9-98b9-0ef4dba94542.png">
