### PR TITLE
Update skippableDomainStep test datestamp so no users are assigned for now

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -98,7 +98,7 @@ export default {
 		defaultVariation: 'siteType',
 	},
 	skippableDomainStep: {
-		datestamp: '20190717',
+		datestamp: '20290717',
 		variations: {
 			skippable: 0,
 			notSkippable: 100,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

What is this task about?

The `skippableDomainStep` test has been disabled, but it's been pointed out that we're still collecting events, which creates a large number of unnecessary records.

We'll want the skipping behaviour again soon so we should keep the code there for now. Hence, this PR only updates the date to a distant future so no test group is assigned.

#### Testing instructions

* Go to /start as a new user in private mode
* After finishing the flow, confirm you were not assigned to any test variation in AB test picker

Fixes Automattic/zelda-private#111
