### PR TITLE
Plugins/Themes: replace upload eligibility error message with upsell

### DIFF
--- a/client/blocks/eligibility-warnings/index.jsx
+++ b/client/blocks/eligibility-warnings/index.jsx
@@ -47,6 +47,7 @@ export const EligibilityWarnings = ( {
 	siteId,
 	siteSlug,
 	translate,
+	upsell,
 } ) => {
 	const warnings = get( eligibilityData, 'eligibilityWarnings', [] );
 
@@ -124,34 +125,36 @@ export const EligibilityWarnings = ( {
 				</Card>
 			) }
 
-			<Card className="eligibility-warnings__confirm-box">
-				<div className="eligibility-warnings__confirm-text">
-					{ ! isEligible && translate( 'Please clear all issues above to proceed.' ) }
-					{ isEligible &&
-						warnings.length > 0 &&
-						translate( 'If you proceed you will no longer be able to use these features. ' ) }
-					{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
-						components: {
-							a: (
-								<a
-									href="https://wordpress.com/help/contact"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						},
-					} ) }
-				</div>
-				<div className="eligibility-warnings__confirm-buttons">
-					<Button href={ backUrl } onClick={ onCancel }>
-						{ translate( 'Cancel' ) }
-					</Button>
+			{ isEligible && (
+				<Card className="eligibility-warnings__confirm-box">
+					<div className="eligibility-warnings__confirm-text">
+						{ isEligible &&
+							warnings.length > 0 &&
+							translate( 'If you proceed you will no longer be able to use these features. ' ) }
+						{ translate( 'Questions? {{a}}Contact support{{/a}} for help.', {
+							components: {
+								a: (
+									<a
+										href="https://wordpress.com/help/contact"
+										target="_blank"
+										rel="noopener noreferrer"
+									/>
+								),
+							},
+						} ) }
+					</div>
+					<div className="eligibility-warnings__confirm-buttons">
+						<Button href={ backUrl } onClick={ onCancel }>
+							{ translate( 'Cancel' ) }
+						</Button>
 
-					<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
-						{ translate( 'Proceed' ) }
-					</Button>
-				</div>
-			</Card>
+						<Button primary={ true } disabled={ ! isEligible } onClick={ onProceed }>
+							{ translate( 'Proceed' ) }
+						</Button>
+					</div>
+				</Card>
+			) }
+			{ ! isEligible && upsell }
 		</div>
 	);
 };

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -526,3 +526,29 @@ $feature-upsell-break-at: '1040px';
 		margin-left: 0;
 	}
 }
+
+.eligibility-warnings {
+	.card {
+		h1 {
+			font-size: 20px;
+			font-weight: 400;
+		}
+		h2 {
+			font-size: 18px;
+			font-weight: 300;
+		}
+		h3 {
+			font-size: 15px;
+		}
+		.feature-upsell__feature-icon {
+			transform: scale( 0.6 );
+		}
+		.feature-upsell__feature-content {
+			padding-top: 10px;
+			padding-bottom: 25px;
+		}
+		.feature-upsell__cta-button {
+			font-size: 16px;
+		}
+	}
+}

--- a/client/my-sites/feature-upsell/style.scss
+++ b/client/my-sites/feature-upsell/style.scss
@@ -529,6 +529,9 @@ $feature-upsell-break-at: '1040px';
 
 .eligibility-warnings {
 	.card {
+		.feature-upsell__main {
+			margin-top: 0;
+		}
 		h1 {
 			font-size: 20px;
 			font-weight: 400;

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -23,6 +23,7 @@ import EligibilityWarnings from 'blocks/eligibility-warnings';
 import EmptyContent from 'components/empty-content';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import QueryEligibility from 'components/data/query-atat-eligibility';
+import { PluginsUpsellComponent } from 'my-sites/feature-upsell/main';
 import { uploadPlugin, clearPluginUpload } from 'state/plugins/upload/actions';
 import { initiateAutomatedTransferWithPluginZip } from 'state/automated-transfer/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
@@ -143,7 +144,11 @@ class PluginUpload extends React.Component {
 	render() {
 		const { translate, isJetpackMultisite, upgradeJetpack, siteId, siteSlug } = this.props;
 		const { showEligibility } = this.state;
-
+		const upsell = (
+			<Card>
+				<PluginsUpsellComponent />
+			</Card>
+		);
 		return (
 			<Main>
 				<PageViewTracker path="/plugins/upload/:site" title="Plugins > Upload" />
@@ -162,6 +167,7 @@ class PluginUpload extends React.Component {
 					<EligibilityWarnings
 						backUrl={ `/plugins/${ siteSlug }` }
 						onProceed={ this.onProceedClick }
+						upsell={ upsell }
 					/>
 				) }
 				{ ! upgradeJetpack && ! isJetpackMultisite && ! showEligibility && this.renderUploadCard() }

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -47,6 +47,7 @@ import {
 import { getCanonicalTheme } from 'state/themes/selectors';
 import { connectOptions } from 'my-sites/themes/theme-options';
 import EligibilityWarnings from 'blocks/eligibility-warnings';
+import { ThemesUpsellComponent } from 'my-sites/feature-upsell/main';
 import JetpackManageErrorPage from 'my-sites/jetpack-manage-error-page';
 import { getBackPath } from 'state/themes/themes-ui/selectors';
 import { hasFeature } from 'state/sites/plans/selectors';
@@ -260,7 +261,11 @@ class Upload extends React.Component {
 		if ( isMultisite ) {
 			return this.renderNotAvailableForMultisite();
 		}
-
+		const upsell = (
+			<Card>
+				<ThemesUpsellComponent />
+			</Card>
+		);
 		return (
 			<Main>
 				<QueryEligibility siteId={ siteId } />
@@ -277,7 +282,11 @@ class Upload extends React.Component {
 					/>
 				) }
 				{ showEligibility && (
-					<EligibilityWarnings backUrl={ backPath } onProceed={ this.onProceedClick } />
+					<EligibilityWarnings
+						backUrl={ backPath }
+						onProceed={ this.onProceedClick }
+						upsell={ upsell }
+					/>
 				) }
 				{ ! upgradeJetpack && ! showEligibility && this.renderUploadCard() }
 			</Main>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When site lacks business plan, both plugin and theme upload pages currently display confusing error messages.

This patch adds upsell support to `EligibilityWarnings` class and specifies:

- `PluginsUpsellComponent` as `upsell` component in plugins upload page.
- `ThemesUpsellComponent` as `upsell` component in themes upload page.
- Tweaks upsell components' CSS styles to fit overall page style.

#### Design

Both `PluginsUpsellComponent` and `ThemesUpsellComponent` appear to have been designed for different use-case than plugins/themes upload pages so their styles had to be tweaked to be less _loud_.

#### Testing instructions

1. Test with a Simple site without Business plan.
2. Navigate to http://calypso.localhost:3000/plugins/upload/{site_slug}

*Before:*
![](https://user-images.githubusercontent.com/2124984/57792024-0cd35480-770c-11e9-9aec-5d16d8d6ac82.png)

*After:*
<img width="1095" alt="screenshot_863" src="https://user-images.githubusercontent.com/127594/63190624-7751a480-c01b-11e9-846d-5a515c6c2730.png">


3. Navigate to http://calypso.localhost:3000/themes/upload/{site_slug}

*After:*
<img width="978" alt="screenshot_865" src="https://user-images.githubusercontent.com/127594/63190636-7b7dc200-c01b-11e9-82de-8619ec53809c.png">


*

Fixes #33063
Fixes #33069
