### PR TITLE
Checkout: Fix layout for mobile devices

### DIFF
--- a/client/blocks/subscription-length-picker/style.scss
+++ b/client/blocks/subscription-length-picker/style.scss
@@ -15,21 +15,17 @@
 	}
 
 	&__option-container {
-		&:first-child:nth-last-child( 2 ),
-		&:first-child:nth-last-child( 2 ) ~ div {
-			flex-basis: calc( 50% - 10px );
-			margin-top: 0;
-		}
-
 		flex-basis: calc( 100% );
+
 		&:not( :first-child ) {
 			margin-top: 20px;
 		}
 
-		@include breakpoint( '<960px' ) {
-			flex-basis: calc( 100% );
-			&:not( :first-child ) {
-				margin-top: 20px;
+		@include breakpoint( '>960px' ) {
+			&:first-child:nth-last-child( 2 ),
+			&:first-child:nth-last-child( 2 ) ~ div {
+				flex-basis: calc( 50% - 10px );
+				margin-top: 0;
 			}
 		}
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The two-column layout of the subscription length in checkout does not work well on small screens because it swishes everything together. This PR updates the layout so that it displays as a single column on small screens. 

**Before**
![image](https://user-images.githubusercontent.com/6981253/63182254-22645d00-c020-11e9-82d8-d5524a7ba164.png)

**After**
![image](https://user-images.githubusercontent.com/6981253/63182217-137daa80-c020-11e9-927b-389be2a5ca24.png)



#### Testing instructions
* Make your way to the cart by starting a site or upgrading an existing site
* Make sure the layout doesn't look broken on any size
