### PR TITLE
Change Jetpack default plan period back to yearly

### DIFF
--- a/client/jetpack-connect/plans-grid.jsx
+++ b/client/jetpack-connect/plans-grid.jsx
@@ -53,7 +53,7 @@ class JetpackPlansGrid extends Component {
 
 	render() {
 		const { interval } = this.props;
-		const defaultInterval = 'monthly';
+		const defaultInterval = 'yearly';
 
 		return (
 			<MainWrapper isWide className="jetpack-connect__hide-plan-icons">


### PR DESCRIPTION
After discussing with @robertbpugh we decided to go back to yearly pricing for now.

#### Changes proposed in this Pull Request

* Change Jetpack default plan interval to yearly

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Connect a new Jetpack site
* At plans page, prices should be yearly

