### PR TITLE
Jetpack Backups: Clean up partial restore interface, make available to all customers

### DIFF
--- a/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
+++ b/client/my-sites/activity/activity-log-confirm-dialog/index.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 /**
  * Internal dependencies
  */
-import config from 'config';
 import ActivityIcon from '../activity-log-item/activity-icon';
 import Button from 'components/button';
 import Card from 'components/card';
@@ -28,6 +27,7 @@ import './style.scss';
 const ActivityLogConfirmDialog = ( {
 	children,
 	confirmTitle,
+	disableButton,
 	icon = 'history',
 	notice,
 	onClose,
@@ -47,46 +47,37 @@ const ActivityLogConfirmDialog = ( {
 
 			<div className="activity-log-confirm-dialog__highlight">{ children }</div>
 
-			{ config.isEnabled( 'rewind/partial-restores' ) && (
-				<Card className="activity-log-confirm-dialog__partial-restore-settings">
-					<p>
-						<strong>
-							{ notice
-								? translate( 'Partial Restore Settings (A8C Only)' )
-								: translate( 'Partial Download Settings (A8C Only)' ) }
-						</strong>
-					</p>
-					<p>
-						{ notice
-							? translate( 'Include the following things in this restore:' )
-							: translate( 'Include the following things in this download:' ) }
-					</p>
-					<FormLabel>
-						<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'WordPress Themes' ) }
-					</FormLabel>
-					<FormLabel>
-						<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'WordPress Plugins' ) }
-					</FormLabel>
-					<FormLabel>
-						<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'Media Uploads' ) }
-					</FormLabel>
-					<FormLabel>
-						<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'WordPress Root (includes wp-config.php and any non-WordPress files)' ) }
-					</FormLabel>
-					<FormLabel>
-						<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'WP-Content Directory (excluding themes, plugins, and uploads)' ) }
-					</FormLabel>
-					<FormLabel>
-						<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
-						{ translate( 'Site Database (SQL)' ) }
-					</FormLabel>
-				</Card>
-			) }
+			<div className="activity-log-confirm-dialog__partial-restore-settings">
+				<p>
+					{ notice
+						? translate( 'Choose the items you wish to rewind:' )
+						: translate( 'Choose the items you wish to include in the download:' ) }
+				</p>
+				<FormLabel>
+					<FormCheckbox name="themes" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'WordPress Themes' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox name="plugins" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'WordPress Plugins' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox name="uploads" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'Media Uploads' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox name="roots" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'WordPress Root (includes wp-config.php and any non-WordPress files)' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox name="contents" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'WP-Content Directory (excluding themes, plugins, and uploads)' ) }
+				</FormLabel>
+				<FormLabel>
+					<FormCheckbox name="sqls" onChange={ onSettingsChange } defaultChecked />
+					{ translate( 'Site Database (SQL)' ) }
+				</FormLabel>
+			</div>
 
 			{ notice && (
 				<div className="activity-log-confirm-dialog__notice">
@@ -98,7 +89,7 @@ const ActivityLogConfirmDialog = ( {
 			<div className="activity-log-confirm-dialog__button-wrap">
 				<div className="activity-log-confirm-dialog__primary-actions">
 					<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
-					<Button primary onClick={ onConfirm }>
+					<Button primary disabled={ disableButton } onClick={ onConfirm }>
 						{ confirmTitle }
 					</Button>
 				</div>

--- a/client/my-sites/activity/activity-log-confirm-dialog/style.scss
+++ b/client/my-sites/activity/activity-log-confirm-dialog/style.scss
@@ -185,5 +185,4 @@
 
 .activity-log-confirm-dialog__partial-restore-settings .form-checkbox {
 	margin-right: 0.5rem;
-	margin-left: 1.5rem;
 }

--- a/client/my-sites/activity/activity-log-item/index.jsx
+++ b/client/my-sites/activity/activity-log-item/index.jsx
@@ -77,6 +77,8 @@ class ActivityLogItem extends Component {
 			roots: true,
 			contents: true,
 		},
+		disableRestoreButton: false,
+		disableDownloadButton: false,
 	};
 
 	confirmBackup = () =>
@@ -89,15 +91,56 @@ class ActivityLogItem extends Component {
 			this.state.restoreArgs
 		);
 
-	restoreSettingsChange = ( { target: { name, checked } } ) =>
+	restoreSettingsChange = ( { target: { name, checked } } ) => {
 		this.setState( {
 			restoreArgs: Object.assign( this.state.restoreArgs, { [ name ]: checked } ),
+			disableRestoreButton: Object.keys( this.state.restoreArgs ).every(
+				k => ! this.state.restoreArgs[ k ]
+			),
 		} );
+	};
 
-	downloadSettingsChange = ( { target: { name, checked } } ) =>
+	downloadSettingsChange = ( { target: { name, checked } } ) => {
 		this.setState( {
 			downloadArgs: Object.assign( this.state.downloadArgs, { [ name ]: checked } ),
+			disableDownloadButton: Object.keys( this.state.downloadArgs ).every(
+				k => ! this.state.downloadArgs[ k ]
+			),
 		} );
+	};
+
+	cancelRewindIntent = () => {
+		this.props.dismissRewind();
+		this.cancelIntent();
+	};
+
+	cancelDownloadIntent = () => {
+		this.props.dismissBackup();
+		this.cancelIntent();
+	};
+
+	cancelIntent = () => {
+		this.setState( {
+			restoreArgs: {
+				themes: true,
+				plugins: true,
+				uploads: true,
+				sqls: true,
+				roots: true,
+				contents: true,
+			},
+			downloadArgs: {
+				themes: true,
+				plugins: true,
+				uploads: true,
+				sqls: true,
+				roots: true,
+				contents: true,
+			},
+			disableRestoreButton: false,
+			disableDownloadButton: false,
+		} );
+	};
 
 	sizeChanged = () => {
 		this.forceUpdate();
@@ -277,8 +320,6 @@ class ActivityLogItem extends Component {
 		const {
 			activity,
 			className,
-			dismissBackup,
-			dismissRewind,
 			gmtOffset,
 			mightBackup,
 			mightRewind,
@@ -298,41 +339,42 @@ class ActivityLogItem extends Component {
 					<ActivityLogConfirmDialog
 						key="activity-rewind-dialog"
 						confirmTitle={ translate( 'Confirm Rewind' ) }
-						notice={ translate(
-							'This will remove all content and options created or changed since then.'
-						) }
-						onClose={ dismissRewind }
+						notice={
+							this.state.disableRestoreButton
+								? translate( 'Please select at least one item to rewind.' )
+								: translate(
+										'This will remove all content and options created or changed since then.'
+								  )
+						}
+						onClose={ this.cancelRewindIntent }
 						onConfirm={ this.confirmRewind }
 						onSettingsChange={ this.restoreSettingsChange }
 						supportLink="https://jetpack.com/support/how-to-rewind"
 						title={ translate( 'Rewind Site' ) }
+						disableButton={ this.satet.disableRestoreButton }
 					>
-						{ translate(
-							'This is the selected point for your site Rewind. ' +
-								'Are you sure you want to rewind your site back to {{time/}}?',
-							{
-								components: {
-									time: <b>{ adjustedTime.format( 'LLL' ) }</b>,
-								},
-							}
-						) }
+						{ translate( '{{time/}} is the selected point for your site Rewind.', {
+							components: {
+								time: <b>{ adjustedTime.format( 'LLL' ) }</b>,
+							},
+						} ) }
 					</ActivityLogConfirmDialog>
 				) }
 				{ mightBackup && (
 					<ActivityLogConfirmDialog
 						key="activity-backup-dialog"
 						confirmTitle={ translate( 'Create download' ) }
-						onClose={ dismissBackup }
+						onClose={ this.cancelBackupIntent }
 						onConfirm={ this.confirmBackup }
 						onSettingsChange={ this.downloadSettingsChange }
 						supportLink="https://jetpack.com/support/backups"
 						title={ translate( 'Create downloadable backup' ) }
 						type={ 'backup' }
 						icon={ 'cloud-download' }
+						disableButton={ this.state.disableDownloadButton }
 					>
 						{ translate(
-							'We will build a downloadable backup of your site at {{time/}}. ' +
-								'You will get a notification when the backup is ready to download.',
+							'{{time/}} is the selected point to create a download backup of. You will get a notification when the backup is ready to download.',
 							{
 								components: {
 									time: <b>{ adjustedTime.format( 'LLL' ) }</b>,
@@ -423,6 +465,7 @@ const mapDispatchToProps = ( dispatch, { activity: { activityId }, siteId } ) =>
 				recordTracksEvent( 'calypso_activitylog_restore_confirm', {
 					action_id: rewindId,
 					activity_name: activityName,
+					restore_types: JSON.stringify( restoreArgs ),
 				} ),
 				rewindRestore( siteId, rewindId, restoreArgs )
 			)

--- a/config/development.json
+++ b/config/development.json
@@ -138,7 +138,6 @@
 		"republicize": true,
 		"rewind-alerts": true,
 		"rewind/clone-site": true,
-		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -87,7 +87,6 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rewind/clone-site": true,
-		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -99,7 +99,6 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rewind/clone-site": true,
-		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -112,7 +112,6 @@
 		"resume-editing": true,
 		"republicize": true,
 		"rewind/clone-site": true,
-		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,


### PR DESCRIPTION
This PR cleans up the partial restore interface contained in the `ActivityLogItem` component, and makes it available to all Rewind users.

**Testing instructions**
- Test a full restore, make sure everything is restored.
- Test any combination that you want of plugins/themes/uploads/sqls/roots. They should all restore the specified types.

This is redux of https://github.com/Automattic/wp-calypso/pull/34188 which is now closed.