### PR TITLE
Environment badge: only display bar when mouse is exactly over the badge

### DIFF
--- a/client/components/environment-badge/style.scss
+++ b/client/components/environment-badge/style.scss
@@ -1,7 +1,7 @@
 .environment-badge {
-	padding: 16px 0;
+	padding: 0;
 	position: fixed;
-	bottom: 0;
+	bottom: 27px;
 	right: 86px;
 	z-index: z-index( 'root', '.environment-badge' );
 


### PR DESCRIPTION
This is so the bar is not displayed when the user hovers near the badge. One issue with this was for example that the OK button to consent to cookies is in the footer, and the badge overlapped it, so whenever someone wanted to click the OK button, the bar was unfolded.

<img width="389" alt="Screen Shot 2019-08-16 at 15 49 15" src="https://user-images.githubusercontent.com/1041600/63191088-17202a00-c03e-11e9-902f-8bfd796b8cfb.png">

#### Changes proposed in this Pull Request

* remove padding so the bar isn't displayed when the mouse is near the badge and so it overlaps other controls as less as possible

#### Testing instructions

* check that it works as before, and that if the mouse is near the badge but not exactly over the badge, the control bar is not displayed
