### PR TITLE
Import in Signup: Link to appropriate step when exiting flow

### DIFF
--- a/client/signup/steps/import-url-onboarding/index.jsx
+++ b/client/signup/steps/import-url-onboarding/index.jsx
@@ -229,8 +229,8 @@ class ImportURLOnboardingStepComponent extends Component {
 			target,
 		} );
 
-		// Exit to main signup flow.
-		this.props.goToNextStep( 'main' );
+		// Exit to main signup flow. Skip to the about step.
+		this.props.goToStep( 'about', '', 'main' );
 	};
 
 	renderNotice = () => {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changes the destination for exiting the import flow to the `about` step of `main`

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start with a new user.
* Visit `/start`.
* Create a user.
* Select "Already have a website?"
* Select "Have an import file?"
* Select "Don't see your service?"
* You should be taken to `/start/main/about` and be able to continue creating a site (there are known issues with the back button).

Prior to this change, instead of being taken to `/start/main/about`, you'd see the user step, which was already completed.

