### PR TITLE
Checkout: Refactor WebPaymentBox (Apple Pay) as a functional component

### DIFF
--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -572,11 +572,9 @@ export class SecurePaymentForm extends Component {
 			>
 				<WebPaymentBox
 					cart={ this.props.cart }
-					transaction={ this.props.transaction }
 					transactionStep={ this.props.transaction.step }
 					countriesList={ this.props.countriesList }
 					onSubmit={ this.handlePaymentBoxSubmit }
-					translate={ this.props.translate }
 					presaleChatAvailable={ this.props.presaleChatAvailable }
 				>
 					{ this.props.children }

--- a/client/my-sites/checkout/checkout/test/web-payment-box.js
+++ b/client/my-sites/checkout/checkout/test/web-payment-box.js
@@ -53,7 +53,6 @@ describe( 'WebPaymentBox', () => {
 		countriesList: [ 'TEST_COUNTRY_CODE' ],
 		onSubmit: jest.fn(),
 		transactionStep: { name: BEFORE_SUBMIT },
-		transaction: {},
 	};
 
 	const context = {

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -233,7 +233,7 @@ function WebPayButton( {
 										translate( 'Please specify a country and postal code.' ),
 										event
 								  )
-								: submitButton( {
+								: submitForm( {
 										paymentMethod,
 										event,
 										processorCountry,
@@ -264,7 +264,7 @@ function WebPayButton( {
 					type="submit"
 					className="button is-primary button-pay pay-button__button" // eslint-disable-line wpcalypso/jsx-classname-namespace
 					onClick={ event =>
-						submitButton( { paymentMethod, event, processorCountry, cart, onSubmit, translate } )
+						submitForm( { paymentMethod, event, processorCountry, cart, onSubmit, translate } )
 					}
 					busy={ buttonState.disabled }
 					disabled={ buttonState.disabled }
@@ -378,97 +378,77 @@ function getPaymentTypeFromPaymentMethod( paymentMethod ) {
 	}
 }
 
-function submitButton( { paymentMethod, event, processorCountry, cart, onSubmit, translate } ) {
+async function submitForm( { paymentMethod, event, processorCountry, cart, onSubmit, translate } ) {
 	event.persist();
 	event.preventDefault();
 
-	switch ( paymentMethod ) {
-		case WEB_PAYMENT_APPLE_PAY_METHOD:
-			{
-				const is_renewal = hasRenewalItem( cart );
-				analytics.tracks.recordEvent( 'calypso_checkout_apple_pay_open_payment_sheet', {
-					is_renewal,
-				} );
-
-				const paymentRequest = getPaymentRequestForApplePay( {
-					processorCountry,
-					cart,
-					translate,
-				} );
-
-				try {
-					paymentRequest
-						.show()
-						.then( paymentResponse => {
-							analytics.tracks.recordEvent( 'calypso_checkout_apple_pay_submit_payment_sheet', {
-								is_renewal,
-							} );
-
-							const { payerName, details } = paymentResponse;
-							const { token } = details;
-
-							if ( 'EC_v1' !== token.paymentData.version ) {
-								return; // Not supported yet.
-							}
-
-							const cardRawDetails = {
-								tokenized_payment_data: token.paymentData,
-								name: payerName,
-								country: getTaxCountryCode( cart ),
-								'postal-code': getTaxPostalCode( cart ),
-								card_brand: token.paymentMethod.network,
-								card_display_name: token.paymentMethod.displayName,
-							};
-
-							setPayment( newCardPayment( cardRawDetails ) );
-							onSubmit( event );
-							paymentResponse.complete( 'success' );
-						} )
-						.catch( error => {
-							debug( 'Error while showing the payment request', error );
-						} );
-				} catch ( error ) {
-					debug( 'Error while running the payment request', error );
-				}
-			}
-			break;
-
-		case WEB_PAYMENT_BASIC_CARD_METHOD:
-			{
-				const paymentRequest = getPaymentRequestForBasicCard( cart, translate );
-
-				try {
-					paymentRequest
-						.show()
-						.then( paymentResponse => {
-							const { details } = paymentResponse;
-							const { billingAddress } = details;
-
-							const cardRawDetails = {
-								number: details.cardNumber,
-								cvv: details.cardSecurityCode,
-								'expiration-date': details.expiryMonth + '/' + details.expiryYear.substr( 2 ),
-								name: details.cardholderName,
-								country: billingAddress.country,
-								'postal-code': billingAddress.postalCode,
-							};
-
-							setPayment( newCardPayment( cardRawDetails ) );
-							onSubmit( event );
-							paymentResponse.complete();
-						} )
-						.catch( error => {
-							debug( 'Error while showing the payment request', error );
-						} );
-				} catch ( error ) {
-					debug( 'Error while running the payment request', error );
-				}
-			}
-			break;
-
-		default:
-			debug( `Unknown or unhandled payment method ${ paymentMethod }.` );
+	try {
+		switch ( paymentMethod ) {
+			case WEB_PAYMENT_APPLE_PAY_METHOD:
+				return submitFormWithApplePayMethod( { cart, processorCountry, translate, onSubmit } );
+			case WEB_PAYMENT_BASIC_CARD_METHOD:
+				return submitFormWithBasicCardMethod( { cart, translate, onSubmit } );
+			default:
+				debug( `Unknown or unhandled payment method ${ paymentMethod }.` );
+		}
+	} catch ( error ) {
+		debug( 'Error while running the payment request', error );
 	}
+}
+
+async function submitFormWithApplePayMethod( { cart, processorCountry, translate, onSubmit } ) {
+	const is_renewal = hasRenewalItem( cart );
+	analytics.tracks.recordEvent( 'calypso_checkout_apple_pay_open_payment_sheet', {
+		is_renewal,
+	} );
+
+	const paymentResponse = await getPaymentRequestForApplePay( {
+		processorCountry,
+		cart,
+		translate,
+	} ).show();
+	analytics.tracks.recordEvent( 'calypso_checkout_apple_pay_submit_payment_sheet', {
+		is_renewal,
+	} );
+
+	const { payerName, details } = paymentResponse;
+	const { token } = details;
+
+	if ( 'EC_v1' !== token.paymentData.version ) {
+		return; // Not supported yet.
+	}
+
+	const cardRawDetails = {
+		tokenized_payment_data: token.paymentData,
+		name: payerName,
+		country: getTaxCountryCode( cart ),
+		'postal-code': getTaxPostalCode( cart ),
+		card_brand: token.paymentMethod.network,
+		card_display_name: token.paymentMethod.displayName,
+	};
+
+	setPayment( newCardPayment( cardRawDetails ) );
+	onSubmit( event );
+	paymentResponse.complete( 'success' );
+}
+
+async function submitFormWithBasicCardMethod( { cart, translate, onSubmit } ) {
+	const paymentResponse = await getPaymentRequestForBasicCard( cart, translate ).show();
+	const { details } = paymentResponse;
+	const { billingAddress } = details;
+
+	const cardRawDetails = {
+		number: details.cardNumber,
+		cvv: details.cardSecurityCode,
+		'expiration-date': details.expiryMonth + '/' + details.expiryYear.substr( 2 ),
+		name: details.cardholderName,
+		country: billingAddress.country,
+		'postal-code': billingAddress.postalCode,
+	};
+
+	setPayment( newCardPayment( cardRawDetails ) );
+	onSubmit( event );
+	paymentResponse.complete();
 }
 
 function updateSelectedCountry( { selectedCountryCode, setProcessorCountry } ) {
@@ -508,9 +488,6 @@ function updateSelectedCountry( { selectedCountryCode, setProcessorCountry } ) {
 	);
 }
 
-/**
- * @return {PaymentRequest} A configured payment request object.
- */
 function getPaymentRequestForApplePay( { processorCountry, cart, translate } ) {
 	const supportedPaymentMethods = [
 		{

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { localize } from 'i18n-calypso';
 import config from 'config';
 import Gridicon from 'gridicons';
@@ -68,508 +68,543 @@ const PAYMENT_REQUEST_OPTIONS = {
 	requestShipping: false,
 };
 
-/**
- * The `<WebPaymentBox />` component.
- */
-export class WebPaymentBox extends React.Component {
-	static propTypes = {
-		cart: PropTypes.shape( {
-			currency: PropTypes.string.isRequired,
-			total_cost: PropTypes.number.isRequired,
-			products: PropTypes.array.isRequired,
-		} ).isRequired,
-		transaction: PropTypes.shape( {
-			payment: PropTypes.object,
-		} ).isRequired,
-		transactionStep: PropTypes.shape( {
-			name: PropTypes.string.isRequired,
-			error: PropTypes.object,
-		} ).isRequired,
-		countriesList: PropTypes.array.isRequired,
-		onSubmit: PropTypes.func.isRequired,
-		translate: PropTypes.func.isRequired,
-	};
+export function WebPaymentBox( {
+	cart,
+	transactionStep,
+	countriesList,
+	onSubmit,
+	presaleChatAvailable,
+	translate,
+	children,
+} ) {
+	const [ processorCountry, setProcessorCountry ] = useState( 'US' );
+	const paymentMethod = useDetectedPaymentMethod();
 
-	state = { processorCountry: 'US' };
+	const countryCode = getTaxCountryCode( cart );
+	const postalCode = getTaxPostalCode( cart );
 
-	constructor() {
-		super();
-		this.detectedPaymentMethod = detectWebPaymentMethod();
-	}
-
-	/**
-	 * @return {object} A dictionary containing `default`, `disabled` and `text` keys.
-	 */
-	getButtonState = () => {
-		const { transactionStep, translate } = this.props;
-
-		const defaultState = () => {
-			return {
-				default: true,
-				disabled: false,
-				text: translate( 'Select a payment card', {
-					context: 'Loading state on /checkout',
-				} ),
-			};
-		};
-		const ongoingState = () => {
-			return {
-				default: false,
-				disabled: true,
-				text: translate( 'Sending your purchase', {
-					context: 'Loading state on /checkout',
-				} ),
-			};
-		};
-		const completingState = () => {
-			return {
-				default: false,
-				disabled: true,
-				text: translate( 'Completing your purchase', {
-					context: 'Loading state on /checkout',
-				} ),
-			};
-		};
-
-		switch ( transactionStep.name ) {
-			case BEFORE_SUBMIT:
-				return defaultState();
-
-			case INPUT_VALIDATION:
-				if ( transactionStep.error ) {
-					return defaultState();
-				}
-
-				return ongoingState();
-
-			case SUBMITTING_PAYMENT_KEY_REQUEST:
-				return ongoingState();
-
-			case RECEIVED_PAYMENT_KEY_RESPONSE:
-				if ( transactionStep.error ) {
-					return defaultState();
-				}
-
-				return ongoingState();
-
-			case SUBMITTING_WPCOM_REQUEST:
-			case REDIRECTING_FOR_AUTHORIZATION:
-				return completingState();
-
-			case RECEIVED_WPCOM_RESPONSE:
-				if ( transactionStep.error || ! transactionStep.data.success ) {
-					return defaultState();
-				}
-
-				return completingState();
-
-			default:
-				throw new Error( `Unknown transaction step: ${ transactionStep.name }.` );
-		}
-	};
-
-	/**
-	 * @return {PaymentRequest} A configured payment request object.
-	 */
-	getPaymentRequestForApplePay = () => {
-		const { cart } = this.props;
-
-		const supportedPaymentMethods = [
-			{
-				supportedMethods: WEB_PAYMENT_APPLE_PAY_METHOD,
-				data: {
-					version: 2,
-					merchantIdentifier: APPLE_PAY_MERCHANT_IDENTIFIER,
-					merchantCapabilities: [ 'supports3DS', 'supportsCredit', 'supportsDebit' ],
-					supportedNetworks: SUPPORTED_NETWORKS,
-					countryCode: this.state.processorCountry,
-				},
-			},
-		];
-
-		const paymentDetails = this.getPaymentDetails( cart );
-
-		const paymentRequest = new PaymentRequest(
-			supportedPaymentMethods,
-			paymentDetails,
-			PAYMENT_REQUEST_OPTIONS
-		);
-
-		paymentRequest.onmerchantvalidation = event => {
-			wpcom
-				.undocumented()
-				.applePayMerchantValidation( event.validationURL )
-				.then( json => event.complete( json ) )
-				.catch( error => {
-					debug( 'onmerchantvalidation error', error );
-				} );
-		};
-
-		return paymentRequest;
-	};
-
-	/**
-	 * @return {PaymentRequest} A configured payment request object.
-	 */
-	getPaymentRequestForBasicCard = () => {
-		const { cart } = this.props;
-
-		const supportedPaymentMethods = [
-			{
-				supportedMethods: WEB_PAYMENT_BASIC_CARD_METHOD,
-				data: {
-					supportedNetworks: SUPPORTED_NETWORKS,
-				},
-			},
-		];
-
-		const paymentDetails = this.getPaymentDetails( cart );
-
-		return new PaymentRequest( supportedPaymentMethods, paymentDetails, PAYMENT_REQUEST_OPTIONS );
-	};
-
-	/**
-	 * Returns line items to display on the payment sheet during purchase authorization.
-	 *
-	 * @param {object} cart The cart object.
-	 * @return {object} A dictionary containing `displayItems` and `total` keys.
-	 */
-	getPaymentDetails = cart => {
-		const { translate } = this.props;
-
-		let displayItems = [];
-		if ( shouldShowTax( cart ) ) {
-			displayItems = [
-				{
-					label: translate( 'Subtotal' ),
-					amount: {
-						currency: cart.currency,
-						value: cart.sub_total,
-					},
-				},
-				{
-					label: translate( 'Tax', { comment: 'The tax amount line-item in payment request' } ),
-					amount: {
-						currency: cart.currency,
-						value: cart.total_tax,
-					},
-				},
-			];
-		}
-
-		return {
-			displayItems: displayItems,
-			total: {
-				label: translate( 'WordPress.com' ),
-				amount: {
-					currency: cart.currency,
-					value: cart.total_cost,
-				},
-			},
-		};
-	};
-
-	/**
-	 * @param {string} paymentMethod  Payment method.
-	 * @param {DOMEvent} event        Button event.
-	 */
-	submit = ( paymentMethod, event ) => {
-		event.persist();
-		event.preventDefault();
-
-		switch ( paymentMethod ) {
-			case WEB_PAYMENT_APPLE_PAY_METHOD:
-				{
-					const is_renewal = hasRenewalItem( this.props.cart );
-					analytics.tracks.recordEvent( 'calypso_checkout_apple_pay_open_payment_sheet', {
-						is_renewal,
-					} );
-
-					const paymentRequest = this.getPaymentRequestForApplePay();
-
-					try {
-						paymentRequest
-							.show()
-							.then( paymentResponse => {
-								analytics.tracks.recordEvent( 'calypso_checkout_apple_pay_submit_payment_sheet', {
-									is_renewal,
-								} );
-
-								const { payerName, details } = paymentResponse;
-								const { token } = details;
-
-								if ( 'EC_v1' !== token.paymentData.version ) {
-									return; // Not supported yet.
-								}
-
-								const cardRawDetails = {
-									tokenized_payment_data: token.paymentData,
-									name: payerName,
-									country: getTaxCountryCode( this.props.cart ),
-									'postal-code': getTaxPostalCode( this.props.cart ),
-									card_brand: token.paymentMethod.network,
-									card_display_name: token.paymentMethod.displayName,
-								};
-
-								setPayment( newCardPayment( cardRawDetails ) );
-								this.props.onSubmit( event );
-								paymentResponse.complete( 'success' );
-							} )
-							.catch( error => {
-								debug( 'Error while showing the payment request', error );
-							} );
-					} catch ( error ) {
-						debug( 'Error while running the payment request', error );
-					}
-				}
-				break;
-
-			case WEB_PAYMENT_BASIC_CARD_METHOD:
-				{
-					const paymentRequest = this.getPaymentRequestForBasicCard();
-
-					try {
-						paymentRequest
-							.show()
-							.then( paymentResponse => {
-								const { details } = paymentResponse;
-								const { billingAddress } = details;
-
-								const cardRawDetails = {
-									number: details.cardNumber,
-									cvv: details.cardSecurityCode,
-									'expiration-date': details.expiryMonth + '/' + details.expiryYear.substr( 2 ),
-									name: details.cardholderName,
-									country: billingAddress.country,
-									'postal-code': billingAddress.postalCode,
-								};
-
-								setPayment( newCardPayment( cardRawDetails ) );
-								this.props.onSubmit( event );
-								paymentResponse.complete();
-							} )
-							.catch( error => {
-								debug( 'Error while showing the payment request', error );
-							} );
-					} catch ( error ) {
-						debug( 'Error while running the payment request', error );
-					}
-				}
-				break;
-
-			default:
-				debug( `Unknown or unhandled payment method ${ paymentMethod }.` );
-		}
-	};
-
-	/**
-	 * @param {string} errorMessage  Error message.
-	 * @param {DOMEvent} event       Button event.
-	 */
-	displaySubmissionError = ( errorMessage, event ) => {
-		event.preventDefault();
-		notices.error( errorMessage );
-	};
-
-	/**
-	 * @param {string} fieldName The name of the country select field.
-	 * @param {string} selectedCountryCode The selected country.
-	 */
-	updateSelectedCountry = ( fieldName, selectedCountryCode ) => {
-		setTaxCountryCode( selectedCountryCode );
-
-		// Apple Pay needs the country where the payment will be processed
-		// (https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951833-countrycode),
-		// so call the Paygate configuration API endpoint to get that. This
-		// information is only needed when the user clicks the button to buy
-		// something and opens the Apple Pay payment sheet, so it is somewhat
-		// wasteful to call it here (every time a new country is selected);
-		// however, it is necessary because browsers will only open a payment
-		// sheet in direct response to user input (see
-		// https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/show),
-		// so we can't delay the opening of the payment sheet on waiting for
-		// the response to this API call.
-		wpcom.undocumented().paygateConfiguration(
-			{
-				request_type: 'new_purchase',
-				country: selectedCountryCode,
-				// The endpoint also accepts an optional credit card brand in
-				// cases where the processor country might depend on the card
-				// brand used, but unfortunately we can't send that because we
-				// don't know it yet (it's a chicken and egg problem; the user
-				// only selects a credit card once the Apple Pay payment sheet
-				// is open, but we need to send Apple Pay the processor country
-				// in order to open the payment sheet). Fortunately, in most
-				// cases this won't have a practical effect.
-			},
-			function( configError, configuration ) {
-				let processorCountry = 'US';
-				if ( ! configError && configuration.processor === 'stripe_ie' ) {
-					processorCountry = 'IE';
-				}
-				this.setState( { processorCountry } );
-			}.bind( this )
-		);
-	};
-
-	/**
-	 * @param {object} event  Event object.
-	 */
-	updateSelectedPostalCode = event => {
+	const updateSelectedPostalCode = event => {
 		const { name: key, value } = event.target;
-
 		if ( 'postal-code' === key ) {
 			setTaxPostalCode( value );
 		}
 	};
 
-	render() {
-		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		const paymentMethod = this.detectedPaymentMethod;
-		const { cart, countriesList, presaleChatAvailable, translate } = this.props;
-		const countryCode = getTaxCountryCode( cart );
-		const postalCode = getTaxPostalCode( cart );
+	if ( ! paymentMethod ) {
+		return null;
+	}
+	const paymentType = getPaymentTypeFromPaymentMethod( paymentMethod );
 
-		if ( ! paymentMethod ) {
-			return null;
-		}
+	const hasBusinessPlanInCart = some( cart.products, ( { product_slug } ) =>
+		overSome( isWpComBusinessPlan, isWpComEcommercePlan )( product_slug )
+	);
+	const showPaymentChatButton = presaleChatAvailable && hasBusinessPlanInCart;
 
-		const hasBusinessPlanInCart = some( cart.products, ( { product_slug } ) =>
-			overSome( isWpComBusinessPlan, isWpComEcommercePlan )( product_slug )
-		);
-		const showPaymentChatButton = presaleChatAvailable && hasBusinessPlanInCart;
+	const testSealsCopy = 'variant' === abtest( 'checkoutSealsCopyBundle' ),
+		moneyBackGuarantee = ! hasOnlyDomainProducts( cart ) && testSealsCopy,
+		paymentButtonClasses = classNames( 'payment-box__payment-buttons', {
+			'payment-box__payment-buttons-variant': testSealsCopy,
+		} ),
+		secureText = testSealsCopy
+			? translate( 'This is a secure 128-SSL encrypted connection' )
+			: translate( 'Secure Payment' );
 
-		const testSealsCopy = 'variant' === abtest( 'checkoutSealsCopyBundle' ),
-			moneyBackGuarantee = ! hasOnlyDomainProducts( cart ) && testSealsCopy,
-			paymentButtonClasses = classNames( 'payment-box__payment-buttons', {
-				'payment-box__payment-buttons-variant': testSealsCopy,
-			} ),
-			secureText = testSealsCopy
-				? translate( 'This is a secure 128-SSL encrypted connection' )
-				: translate( 'Secure Payment' );
-
-		const buttonState = this.getButtonState();
-		const buttonDisabled = buttonState.disabled;
-		let button;
-		let paymentType;
-
-		switch ( paymentMethod ) {
-			case WEB_PAYMENT_APPLE_PAY_METHOD:
-				if ( buttonState.default ) {
-					button = (
-						<button
-							type="submit"
-							onClick={ event =>
-								! countryCode || ! postalCode
-									? this.displaySubmissionError(
-											translate( 'Please specify a country and postal code.' ),
-											event
-									  )
-									: this.submit( paymentMethod, event )
+	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	return (
+		<React.Fragment>
+			<form>
+				<div className="checkout__payment-box-sections">
+					<div className="checkout__payment-box-section">
+						<PaymentCountrySelect
+							additionalClasses="checkout-field"
+							name="country"
+							label={ translate( 'Country', { textOnly: true } ) }
+							countriesList={ countriesList }
+							onCountrySelected={ ( fieldName, selectedCountryCode ) =>
+								updateSelectedCountry( { selectedCountryCode, setProcessorCountry } )
 							}
-							disabled={ buttonDisabled }
-							className="web-payment-box__apple-pay-button"
+							value={ countryCode }
+							eventFormName="Checkout Form"
 						/>
-					);
-				} else {
-					button = (
-						<Button
-							type="button"
-							className="button is-primary button-pay pay-button__button"
-							busy={ buttonState.disabled }
-							disabled={ buttonDisabled }
-						>
-							{ buttonState.text }
-						</Button>
-					);
-				}
-				paymentType = 'apple-pay';
-				break;
+						<Input
+							additionalClasses="checkout-field"
+							name="postal-code"
+							label={ translate( 'Postal Code', { textOnly: true } ) }
+							onChange={ updateSelectedPostalCode }
+							value={ postalCode }
+							eventFormName="Checkout Form"
+						/>
+					</div>
+				</div>
 
-			case WEB_PAYMENT_BASIC_CARD_METHOD:
-				button = (
-					<Button
-						type="submit"
-						className="button is-primary button-pay pay-button__button"
-						onClick={ event => this.submit( paymentMethod, event ) }
-						busy={ buttonState.disabled }
-						disabled={ buttonDisabled }
-					>
-						{ buttonState.text }
-					</Button>
-				);
-				paymentType = 'web-payment';
-				break;
+				{ children }
 
-			default:
-				debug( `Unknown payment method ${ paymentMethod }.` );
-		}
+				<RecentRenewals cart={ cart } />
 
-		return (
-			<React.Fragment>
-				<form>
-					<div className="checkout__payment-box-sections">
-						<div className="checkout__payment-box-section">
-							<PaymentCountrySelect
-								additionalClasses="checkout-field"
-								name="country"
-								label={ translate( 'Country', { textOnly: true } ) }
-								countriesList={ countriesList }
-								onCountrySelected={ this.updateSelectedCountry }
-								value={ countryCode }
-								eventFormName="Checkout Form"
+				<CheckoutTerms cart={ cart } />
+
+				<span className={ paymentButtonClasses }>
+					<span className="pay-button">
+						<span className="payment-request-button">
+							<WebPayButton
+								paymentMethod={ paymentMethod }
+								transactionStep={ transactionStep }
+								countryCode={ countryCode }
+								postalCode={ postalCode }
+								processorCountry={ processorCountry }
+								cart={ cart }
+								onSubmit={ onSubmit }
+								translate={ translate }
 							/>
-							<Input
-								additionalClasses="checkout-field"
-								name="postal-code"
-								label={ translate( 'Postal Code', { textOnly: true } ) }
-								onChange={ this.updateSelectedPostalCode }
-								value={ postalCode }
-								eventFormName="Checkout Form"
-							/>
+						</span>
+						<SubscriptionText cart={ cart } />
+					</span>
+					{ moneyBackGuarantee && (
+						<div className="checkout__secure-payment-content">
+							<Gridicon icon="refresh" />
+							<div className="checkout__money-back-guarantee">
+								<div>{ translate( '30-day Money Back Guarantee' ) }</div>
+								{ hasDomainRegistration( cart ) && (
+									<div>{ translate( '(96 hrs for domains)' ) }</div>
+								) }
+							</div>
+						</div>
+					) }
+					<div className="checkout__secure-payment">
+						<div className="checkout__secure-payment-content">
+							<Gridicon icon="lock" />
+							{ secureText }
 						</div>
 					</div>
 
-					{ this.props.children }
+					{ showPaymentChatButton && (
+						<PaymentChatButton paymentType={ paymentType } cart={ cart } />
+					) }
+				</span>
+			</form>
+			<CartCoupon cart={ cart } />
+			<CartToggle />
+		</React.Fragment>
+	);
+	/* eslint-enable wpcalypso/jsx-classname-namespace */
+}
 
-					<RecentRenewals cart={ cart } />
+WebPaymentBox.propTypes = {
+	cart: PropTypes.shape( {
+		currency: PropTypes.string.isRequired,
+		total_cost: PropTypes.number.isRequired,
+		products: PropTypes.array.isRequired,
+	} ).isRequired,
+	transactionStep: PropTypes.shape( {
+		name: PropTypes.string.isRequired,
+		error: PropTypes.object,
+	} ).isRequired,
+	countriesList: PropTypes.array.isRequired,
+	onSubmit: PropTypes.func.isRequired,
+	presaleChatAvailable: PropTypes.bool,
+	translate: PropTypes.func.isRequired,
+};
 
-					<CheckoutTerms cart={ cart } />
+function WebPayButton( {
+	paymentMethod,
+	transactionStep,
+	countryCode,
+	postalCode,
+	processorCountry,
+	cart,
+	onSubmit,
+	translate,
+} ) {
+	const buttonState = getButtonStateFromTransactionStep( { transactionStep, translate } );
+	const displaySubmissionError = ( errorMessage, event ) => {
+		event.preventDefault();
+		notices.error( errorMessage );
+	};
 
-					<span className={ paymentButtonClasses }>
-						<span className="pay-button">
-							<span className="payment-request-button">{ button }</span>
-							<SubscriptionText cart={ cart } />
-						</span>
-						{ moneyBackGuarantee && (
-							<div className="checkout__secure-payment-content">
-								<Gridicon icon="refresh" />
-								<div className="checkout__money-back-guarantee">
-									<div>{ translate( '30-day Money Back Guarantee' ) }</div>
-									{ hasDomainRegistration( cart ) && (
-										<div>{ translate( '(96 hrs for domains)' ) }</div>
-									) }
-								</div>
-							</div>
-						) }
-						<div className="checkout__secure-payment">
-							<div className="checkout__secure-payment-content">
-								<Gridicon icon="lock" />
-								{ secureText }
-							</div>
-						</div>
+	switch ( paymentMethod ) {
+		case WEB_PAYMENT_APPLE_PAY_METHOD:
+			if ( buttonState.default ) {
+				return (
+					<button
+						type="submit"
+						onClick={ event =>
+							! countryCode || ! postalCode
+								? displaySubmissionError(
+										translate( 'Please specify a country and postal code.' ),
+										event
+								  )
+								: submitButton( {
+										paymentMethod,
+										event,
+										processorCountry,
+										cart,
+										onSubmit,
+										translate,
+								  } )
+						}
+						disabled={ buttonState.disabled }
+						className="web-payment-box__apple-pay-button"
+					/>
+				);
+			}
+			return (
+				<Button
+					type="button"
+					className="button is-primary button-pay pay-button__button" // eslint-disable-line wpcalypso/jsx-classname-namespace
+					busy={ buttonState.disabled }
+					disabled={ buttonState.disabled }
+				>
+					{ buttonState.text }
+				</Button>
+			);
 
-						{ showPaymentChatButton && (
-							<PaymentChatButton paymentType={ paymentType } cart={ cart } />
-						) }
-					</span>
-				</form>
-				<CartCoupon cart={ cart } />
-				<CartToggle />
-			</React.Fragment>
-		);
-		/* eslint-enable wpcalypso/jsx-classname-namespace */
+		case WEB_PAYMENT_BASIC_CARD_METHOD:
+			return (
+				<Button
+					type="submit"
+					className="button is-primary button-pay pay-button__button" // eslint-disable-line wpcalypso/jsx-classname-namespace
+					onClick={ event =>
+						submitButton( { paymentMethod, event, processorCountry, cart, onSubmit, translate } )
+					}
+					busy={ buttonState.disabled }
+					disabled={ buttonState.disabled }
+				>
+					{ buttonState.text }
+				</Button>
+			);
+
+		default:
+			debug( `Unknown payment method ${ paymentMethod }.` );
 	}
+}
+
+WebPayButton.propTypes = {
+	paymentMethod: PropTypes.string.isRequired,
+	transactionStep: PropTypes.shape( {
+		name: PropTypes.string.isRequired,
+		error: PropTypes.object,
+	} ).isRequired,
+	countryCode: PropTypes.string,
+	postalCode: PropTypes.string,
+	processorCountry: PropTypes.string,
+	cart: PropTypes.shape( {
+		currency: PropTypes.string.isRequired,
+		total_cost: PropTypes.number.isRequired,
+		products: PropTypes.array.isRequired,
+	} ).isRequired,
+	onSubmit: PropTypes.func.isRequired,
+	translate: PropTypes.func.isRequired,
+};
+
+function useDetectedPaymentMethod() {
+	const [ detectedPaymentMethod, setDetectedPaymentMethod ] = useState();
+	useEffect( () => {
+		setDetectedPaymentMethod( detectWebPaymentMethod() );
+	}, [] );
+	return detectedPaymentMethod;
+}
+
+const getDefaultButtonState = translate => {
+	return {
+		default: true,
+		disabled: false,
+		text: translate( 'Select a payment card', {
+			context: 'Loading state on /checkout',
+		} ),
+	};
+};
+
+const getOngoingButtonState = translate => {
+	return {
+		default: false,
+		disabled: true,
+		text: translate( 'Sending your purchase', {
+			context: 'Loading state on /checkout',
+		} ),
+	};
+};
+
+const getCompletingButtonState = translate => {
+	return {
+		default: false,
+		disabled: true,
+		text: translate( 'Completing your purchase', {
+			context: 'Loading state on /checkout',
+		} ),
+	};
+};
+
+function getButtonStateFromTransactionStep( { transactionStep, translate } ) {
+	switch ( transactionStep.name ) {
+		case BEFORE_SUBMIT:
+			return getDefaultButtonState( translate );
+
+		case INPUT_VALIDATION:
+			if ( transactionStep.error ) {
+				return getDefaultButtonState( translate );
+			}
+
+			return getOngoingButtonState( translate );
+
+		case SUBMITTING_PAYMENT_KEY_REQUEST:
+			return getOngoingButtonState( translate );
+
+		case RECEIVED_PAYMENT_KEY_RESPONSE:
+			if ( transactionStep.error ) {
+				return getDefaultButtonState( translate );
+			}
+
+			return getOngoingButtonState( translate );
+
+		case SUBMITTING_WPCOM_REQUEST:
+		case REDIRECTING_FOR_AUTHORIZATION:
+			return getCompletingButtonState( translate );
+
+		case RECEIVED_WPCOM_RESPONSE:
+			if ( transactionStep.error || ! transactionStep.data.success ) {
+				return getDefaultButtonState( translate );
+			}
+
+			return getCompletingButtonState( translate );
+
+		default:
+			throw new Error( `Unknown transaction step: ${ transactionStep.name }.` );
+	}
+}
+
+function getPaymentTypeFromPaymentMethod( paymentMethod ) {
+	switch ( paymentMethod ) {
+		case WEB_PAYMENT_APPLE_PAY_METHOD:
+			return 'apple-pay';
+
+		case WEB_PAYMENT_BASIC_CARD_METHOD:
+			return 'web-payment';
+
+		default:
+			debug( `Unknown payment method ${ paymentMethod }.` );
+			return '';
+	}
+}
+
+function submitButton( { paymentMethod, event, processorCountry, cart, onSubmit, translate } ) {
+	event.persist();
+	event.preventDefault();
+
+	switch ( paymentMethod ) {
+		case WEB_PAYMENT_APPLE_PAY_METHOD:
+			{
+				const is_renewal = hasRenewalItem( cart );
+				analytics.tracks.recordEvent( 'calypso_checkout_apple_pay_open_payment_sheet', {
+					is_renewal,
+				} );
+
+				const paymentRequest = getPaymentRequestForApplePay( {
+					processorCountry,
+					cart,
+					translate,
+				} );
+
+				try {
+					paymentRequest
+						.show()
+						.then( paymentResponse => {
+							analytics.tracks.recordEvent( 'calypso_checkout_apple_pay_submit_payment_sheet', {
+								is_renewal,
+							} );
+
+							const { payerName, details } = paymentResponse;
+							const { token } = details;
+
+							if ( 'EC_v1' !== token.paymentData.version ) {
+								return; // Not supported yet.
+							}
+
+							const cardRawDetails = {
+								tokenized_payment_data: token.paymentData,
+								name: payerName,
+								country: getTaxCountryCode( cart ),
+								'postal-code': getTaxPostalCode( cart ),
+								card_brand: token.paymentMethod.network,
+								card_display_name: token.paymentMethod.displayName,
+							};
+
+							setPayment( newCardPayment( cardRawDetails ) );
+							onSubmit( event );
+							paymentResponse.complete( 'success' );
+						} )
+						.catch( error => {
+							debug( 'Error while showing the payment request', error );
+						} );
+				} catch ( error ) {
+					debug( 'Error while running the payment request', error );
+				}
+			}
+			break;
+
+		case WEB_PAYMENT_BASIC_CARD_METHOD:
+			{
+				const paymentRequest = getPaymentRequestForBasicCard( cart, translate );
+
+				try {
+					paymentRequest
+						.show()
+						.then( paymentResponse => {
+							const { details } = paymentResponse;
+							const { billingAddress } = details;
+
+							const cardRawDetails = {
+								number: details.cardNumber,
+								cvv: details.cardSecurityCode,
+								'expiration-date': details.expiryMonth + '/' + details.expiryYear.substr( 2 ),
+								name: details.cardholderName,
+								country: billingAddress.country,
+								'postal-code': billingAddress.postalCode,
+							};
+
+							setPayment( newCardPayment( cardRawDetails ) );
+							onSubmit( event );
+							paymentResponse.complete();
+						} )
+						.catch( error => {
+							debug( 'Error while showing the payment request', error );
+						} );
+				} catch ( error ) {
+					debug( 'Error while running the payment request', error );
+				}
+			}
+			break;
+
+		default:
+			debug( `Unknown or unhandled payment method ${ paymentMethod }.` );
+	}
+}
+
+function updateSelectedCountry( { selectedCountryCode, setProcessorCountry } ) {
+	setTaxCountryCode( selectedCountryCode );
+
+	// Apple Pay needs the country where the payment will be processed
+	// (https://developer.apple.com/documentation/apple_pay_on_the_web/applepayrequest/2951833-countrycode),
+	// so call the Paygate configuration API endpoint to get that. This
+	// information is only needed when the user clicks the button to buy
+	// something and opens the Apple Pay payment sheet, so it is somewhat
+	// wasteful to call it here (every time a new country is selected);
+	// however, it is necessary because browsers will only open a payment
+	// sheet in direct response to user input (see
+	// https://developer.mozilla.org/en-US/docs/Web/API/PaymentRequest/show),
+	// so we can't delay the opening of the payment sheet on waiting for
+	// the response to this API call.
+	wpcom.undocumented().paygateConfiguration(
+		{
+			request_type: 'new_purchase',
+			country: selectedCountryCode,
+			// The endpoint also accepts an optional credit card brand in
+			// cases where the processor country might depend on the card
+			// brand used, but unfortunately we can't send that because we
+			// don't know it yet (it's a chicken and egg problem; the user
+			// only selects a credit card once the Apple Pay payment sheet
+			// is open, but we need to send Apple Pay the processor country
+			// in order to open the payment sheet). Fortunately, in most
+			// cases this won't have a practical effect.
+		},
+		function( configError, configuration ) {
+			let processorCountry = 'US';
+			if ( ! configError && configuration.processor === 'stripe_ie' ) {
+				processorCountry = 'IE';
+			}
+			setProcessorCountry( processorCountry );
+		}
+	);
+}
+
+/**
+ * @return {PaymentRequest} A configured payment request object.
+ */
+function getPaymentRequestForApplePay( { processorCountry, cart, translate } ) {
+	const supportedPaymentMethods = [
+		{
+			supportedMethods: WEB_PAYMENT_APPLE_PAY_METHOD,
+			data: {
+				version: 2,
+				merchantIdentifier: APPLE_PAY_MERCHANT_IDENTIFIER,
+				merchantCapabilities: [ 'supports3DS', 'supportsCredit', 'supportsDebit' ],
+				supportedNetworks: SUPPORTED_NETWORKS,
+				countryCode: processorCountry,
+			},
+		},
+	];
+
+	const paymentDetails = getPaymentDetails( cart, translate );
+
+	const paymentRequest = new PaymentRequest(
+		supportedPaymentMethods,
+		paymentDetails,
+		PAYMENT_REQUEST_OPTIONS
+	);
+
+	paymentRequest.onmerchantvalidation = event => {
+		wpcom
+			.undocumented()
+			.applePayMerchantValidation( event.validationURL )
+			.then( json => event.complete( json ) )
+			.catch( error => {
+				debug( 'onmerchantvalidation error', error );
+			} );
+	};
+
+	return paymentRequest;
+}
+
+function getPaymentRequestForBasicCard( cart, translate ) {
+	const supportedPaymentMethods = [
+		{
+			supportedMethods: WEB_PAYMENT_BASIC_CARD_METHOD,
+			data: {
+				supportedNetworks: SUPPORTED_NETWORKS,
+			},
+		},
+	];
+	const paymentDetails = getPaymentDetails( cart, translate );
+	return new PaymentRequest( supportedPaymentMethods, paymentDetails, PAYMENT_REQUEST_OPTIONS );
+}
+
+/**
+ * Returns line items to display on the payment sheet during purchase authorization.
+ *
+ * @param {object} cart The cart object.
+ * @param {function} translate The translate function
+ * @return {object} A dictionary containing `displayItems` and `total` keys.
+ */
+function getPaymentDetails( cart, translate ) {
+	let displayItems = [];
+	if ( shouldShowTax( cart ) ) {
+		displayItems = [
+			{
+				label: translate( 'Subtotal' ),
+				amount: {
+					currency: cart.currency,
+					value: cart.sub_total,
+				},
+			},
+			{
+				label: translate( 'Tax', { comment: 'The tax amount line-item in payment request' } ),
+				amount: {
+					currency: cart.currency,
+					value: cart.total_tax,
+				},
+			},
+		];
+	}
+
+	return {
+		displayItems: displayItems,
+		total: {
+			label: translate( 'WordPress.com' ),
+			amount: {
+				currency: cart.currency,
+				value: cart.total_cost,
+			},
+		},
+	};
 }
 
 export default localize( WebPaymentBox );

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -5,7 +5,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useMemo } from 'react';
 import { localize } from 'i18n-calypso';
 import config from 'config';
 import Gridicon from 'gridicons';
@@ -78,7 +78,7 @@ export function WebPaymentBox( {
 	children,
 } ) {
 	const [ processorCountry, setProcessorCountry ] = useState( 'US' );
-	const paymentMethod = useDetectedPaymentMethod();
+	const paymentMethod = useMemo( () => detectWebPaymentMethod(), [] );
 
 	const countryCode = getTaxCountryCode( cart );
 	const postalCode = getTaxPostalCode( cart );
@@ -295,14 +295,6 @@ WebPayButton.propTypes = {
 	onSubmit: PropTypes.func.isRequired,
 	translate: PropTypes.func.isRequired,
 };
-
-function useDetectedPaymentMethod() {
-	const [ detectedPaymentMethod, setDetectedPaymentMethod ] = useState();
-	useEffect( () => {
-		setDetectedPaymentMethod( detectWebPaymentMethod() );
-	}, [] );
-	return detectedPaymentMethod;
-}
 
 const getDefaultButtonState = translate => {
 	return {

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -428,7 +428,7 @@ async function submitFormWithApplePayMethod( { cart, processorCountry, translate
 	};
 
 	setPayment( newCardPayment( cardRawDetails ) );
-	onSubmit( event );
+	onSubmit();
 	paymentResponse.complete( 'success' );
 }
 
@@ -447,7 +447,7 @@ async function submitFormWithBasicCardMethod( { cart, translate, onSubmit } ) {
 	};
 
 	setPayment( newCardPayment( cardRawDetails ) );
-	onSubmit( event );
+	onSubmit();
 	paymentResponse.complete();
 }
 

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -82,11 +82,12 @@ export function WebPaymentBox( {
 
 	const countryCode = getTaxCountryCode( cart );
 	const postalCode = getTaxPostalCode( cart );
+	const postalCodeValue =
+		typeof postalCode === 'undefined' || postalCode === null ? '' : postalCode;
 
 	const updateSelectedPostalCode = event => {
-		const { name: key, value } = event.target;
-		if ( 'postal-code' === key ) {
-			setTaxPostalCode( value );
+		if ( 'postal-code' === event.target.name ) {
+			setTaxPostalCode( event.target.value.toString() );
 		}
 	};
 
@@ -99,15 +100,14 @@ export function WebPaymentBox( {
 		overSome( isWpComBusinessPlan, isWpComEcommercePlan )( product_slug )
 	);
 	const showPaymentChatButton = presaleChatAvailable && hasBusinessPlanInCart;
-
-	const testSealsCopy = 'variant' === abtest( 'checkoutSealsCopyBundle' ),
-		moneyBackGuarantee = ! hasOnlyDomainProducts( cart ) && testSealsCopy,
-		paymentButtonClasses = classNames( 'payment-box__payment-buttons', {
-			'payment-box__payment-buttons-variant': testSealsCopy,
-		} ),
-		secureText = testSealsCopy
-			? translate( 'This is a secure 128-SSL encrypted connection' )
-			: translate( 'Secure Payment' );
+	const testSealsCopy = 'variant' === abtest( 'checkoutSealsCopyBundle' );
+	const moneyBackGuarantee = ! hasOnlyDomainProducts( cart ) && testSealsCopy;
+	const paymentButtonClasses = classNames( 'payment-box__payment-buttons', {
+		'payment-box__payment-buttons-variant': testSealsCopy,
+	} );
+	const secureText = testSealsCopy
+		? translate( 'This is a secure 128-SSL encrypted connection' )
+		: translate( 'Secure Payment' );
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
@@ -131,7 +131,7 @@ export function WebPaymentBox( {
 							name="postal-code"
 							label={ translate( 'Postal Code', { textOnly: true } ) }
 							onChange={ updateSelectedPostalCode }
-							value={ postalCode }
+							value={ postalCodeValue }
 							eventFormName="Checkout Form"
 						/>
 					</div>

--- a/client/my-sites/checkout/checkout/web-payment-box.jsx
+++ b/client/my-sites/checkout/checkout/web-payment-box.jsx
@@ -216,11 +216,6 @@ function WebPayButton( {
 	translate,
 } ) {
 	const buttonState = getButtonStateFromTransactionStep( { transactionStep, translate } );
-	const displaySubmissionError = ( errorMessage, event ) => {
-		event.preventDefault();
-		notices.error( errorMessage );
-	};
-
 	switch ( paymentMethod ) {
 		case WEB_PAYMENT_APPLE_PAY_METHOD:
 			if ( buttonState.default ) {
@@ -228,19 +223,16 @@ function WebPayButton( {
 					<button
 						type="submit"
 						onClick={ event =>
-							! countryCode || ! postalCode
-								? displaySubmissionError(
-										translate( 'Please specify a country and postal code.' ),
-										event
-								  )
-								: submitForm( {
-										paymentMethod,
-										event,
-										processorCountry,
-										cart,
-										onSubmit,
-										translate,
-								  } )
+							submitForm( {
+								event,
+								paymentMethod,
+								countryCode,
+								postalCode,
+								processorCountry,
+								cart,
+								onSubmit,
+								translate,
+							} )
 						}
 						disabled={ buttonState.disabled }
 						className="web-payment-box__apple-pay-button"
@@ -378,13 +370,26 @@ function getPaymentTypeFromPaymentMethod( paymentMethod ) {
 	}
 }
 
-async function submitForm( { paymentMethod, event, processorCountry, cart, onSubmit, translate } ) {
+async function submitForm( {
+	paymentMethod,
+	postalCode,
+	countryCode,
+	event,
+	processorCountry,
+	cart,
+	onSubmit,
+	translate,
+} ) {
 	event.persist();
 	event.preventDefault();
 
 	try {
 		switch ( paymentMethod ) {
 			case WEB_PAYMENT_APPLE_PAY_METHOD:
+				if ( ! countryCode || ! postalCode ) {
+					notices.error( translate( 'Please specify a country and postal code.' ) );
+					return;
+				}
 				return submitFormWithApplePayMethod( { cart, processorCountry, translate, onSubmit } );
 			case WEB_PAYMENT_BASIC_CARD_METHOD:
 				return submitFormWithBasicCardMethod( { cart, translate, onSubmit } );


### PR DESCRIPTION
As part of an experiment to replace the Apple Pay implementation we currently use (which requires Paygate) with a Stripe solution instead (see #35636), this diff cleans up the rather complex `WebPaymentBox` component to make it easier to follow and to make bugs more apparent.

#### Testing instructions

1. Sandbox the store.
2. Use a proxy to forward requests from `https://wordpress.com` to localhost. This can be a complex step. Let me know if you have any questions about doing this. It's necessary because the button will only appear on a secure connection and on a verified url.
3. Make sure you have a real credit card added to Apple Pay in your local Safari. Look online for how to do this if you don't have it set up already or let me know and I can help.
3. Add a plan to your cart. Make sure you see the "dev" logo in the lower right of the screen.
4. Visit the checkout page in Safari. Apple Pay exists only in Safari on Mac OS.
5. Click the Apple Pay tab above the checkout form.
6. Fill out the form and click the Pay button.
7. When the Apple Pay sheet appears, authorize the payment. Don't worry, you won't be charged as long as you are sandboxing the store.
8. Verify that the transaction goes through correctly and that you are redirected to the next step of the checkout process (which may be a special offer).
