### PR TITLE
Migrate DatePicker style to Webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -10,7 +10,6 @@
 
 @import 'components/button/style';
 @import 'components/card/style';
-@import 'components/date-picker/style';
 @import 'components/dialog/style';
 @import 'components/main/style';
 @import 'components/segmented-control/style';

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -14,8 +14,8 @@ import classNames from 'classnames';
 /**
  * Internal dependencies
  */
-import DayItem from 'components/date-picker/day';
-import DatePickerNavBar from 'components/date-picker/nav-bar';
+import DayItem from './day';
+import DatePickerNavBar from './nav-bar';
 
 /**
  * Style dependencies

--- a/client/components/date-picker/index.jsx
+++ b/client/components/date-picker/index.jsx
@@ -17,6 +17,11 @@ import classNames from 'classnames';
 import DayItem from 'components/date-picker/day';
 import DatePickerNavBar from 'components/date-picker/nav-bar';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 class DatePicker extends PureComponent {
 	static propTypes = {
 		calendarViewDate: PropTypes.object,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Migrate DatePicker style to Webpack

#### Testing instructions

- Test `/devdocs/design/date-picker`
- Test `/devdocs/design/date-range`
- Test `/devdocs/blocks/post-schedule`
- Test `/store/promotion`
  ![](https://cld.wthms.co/PyMgde+)
