### PR TITLE
Jetpack Checkout: Improve Confirmation Text Contrast

### DIFF
--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1180,6 +1180,10 @@
 	.formatted-header {
 		color: var( --color-jetpack-onboarding-text );
 	}
+	
+	.formatted-header__subtitle {
+		color: var( --color-primary-100 );
+	}
 
 	.card {
 		box-shadow: none;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When the Jetpack colour scheme is used in Checkout, it's difficult to see the text against the dark background. This improves that, taking the variable of --color-primary-100 from here. 

https://github.com/Automattic/wp-calypso/blob/a2c890e499127bc74f0734488cdf76829f4d58d3/client/jetpack-connect/style.scss#L789-#L792

#### Testing instructions

Activate the variant A/B test for the Checkout Seal (checkoutSealsCopyBundle), add a Jetpack plan to your site and visit the Checkout, then compare the two texts.

**Before:**

<img width="587" alt="Screenshot 2019-08-17 at 08 55 53" src="https://user-images.githubusercontent.com/43215253/63208556-6b261f80-c0cd-11e9-81c9-c4191958f8d3.png">

**After:**

<img width="631" alt="Screenshot 2019-08-17 at 08 55 49" src="https://user-images.githubusercontent.com/43215253/63208557-74af8780-c0cd-11e9-9a9e-3f063f067bff.png">

Fixes #35503
