### PR TITLE
Plan Storage Bar: Hide Nudge for Non-Admins

### DIFF
--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -1,11 +1,9 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import filesize from 'filesize';
@@ -16,6 +14,8 @@ import filesize from 'filesize';
 import ProgressBar from 'components/progress-bar';
 import { planHasFeature } from 'lib/plans';
 import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
+import canCurrentUser from 'state/selectors/can-current-user';
+import { getSelectedSiteId } from 'state/ui/selectors';
 
 const ALERT_PERCENT = 80;
 const WARN_PERCENT = 60;
@@ -33,7 +33,7 @@ export class PlanStorageBar extends Component {
 	};
 
 	render() {
-		const { className, mediaStorage, sitePlanSlug, siteSlug, translate } = this.props;
+		const { canUserUpgrade, className, mediaStorage, sitePlanSlug, siteSlug, translate } = this.props;
 
 		if ( planHasFeature( sitePlanSlug, FEATURE_UNLIMITED_STORAGE ) ) {
 			return null;
@@ -69,9 +69,10 @@ export class PlanStorageBar extends Component {
 					} ) }
 				</span>
 
-				<a className="plan-storage__storage-link" href={ `/plans/${ siteSlug }` }>
+				{ canUserUpgrade && ( <a className="plan-storage__storage-link" href={ `/plans/${ siteSlug }` }>
 					{ translate( 'Upgrade' ) }
 				</a>
+				) }
 
 				{ this.props.children }
 			</div>
@@ -79,4 +80,8 @@ export class PlanStorageBar extends Component {
 	}
 }
 
-export default localize( PlanStorageBar );
+export default connect( ( state ) => {
+	return {
+		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
+	};
+} )( localize( PlanStorageBar ) );

--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -14,8 +14,6 @@ import filesize from 'filesize';
 import ProgressBar from 'components/progress-bar';
 import { planHasFeature } from 'lib/plans';
 import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
-import canCurrentUser from 'state/selectors/can-current-user';
-import { getSelectedSiteId } from 'state/ui/selectors';
 
 const ALERT_PERCENT = 80;
 const WARN_PERCENT = 60;
@@ -24,6 +22,7 @@ export class PlanStorageBar extends Component {
 	static propTypes = {
 		className: PropTypes.string,
 		mediaStorage: PropTypes.object,
+		displayUpgradeLink: PropTypes.bool,
 		siteSlug: PropTypes.string.isRequired,
 		sitePlanSlug: PropTypes.string.isRequired,
 	};
@@ -34,8 +33,8 @@ export class PlanStorageBar extends Component {
 
 	render() {
 		const {
-			canUserUpgrade,
 			className,
+			displayUpgradeLink,
 			mediaStorage,
 			sitePlanSlug,
 			siteSlug,
@@ -76,7 +75,7 @@ export class PlanStorageBar extends Component {
 					} ) }
 				</span>
 
-				{ canUserUpgrade && (
+				{ displayUpgradeLink && (
 					<a className="plan-storage__storage-link" href={ `/plans/${ siteSlug }` }>
 						{ translate( 'Upgrade' ) }
 					</a>
@@ -88,8 +87,4 @@ export class PlanStorageBar extends Component {
 	}
 }
 
-export default connect( state => {
-	return {
-		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
-	};
-} )( localize( PlanStorageBar ) );
+export default localize( PlanStorageBar );

--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -33,7 +33,14 @@ export class PlanStorageBar extends Component {
 	};
 
 	render() {
-		const { canUserUpgrade, className, mediaStorage, sitePlanSlug, siteSlug, translate } = this.props;
+		const {
+			canUserUpgrade,
+			className,
+			mediaStorage,
+			sitePlanSlug,
+			siteSlug,
+			translate,
+		} = this.props;
 
 		if ( planHasFeature( sitePlanSlug, FEATURE_UNLIMITED_STORAGE ) ) {
 			return null;
@@ -69,9 +76,10 @@ export class PlanStorageBar extends Component {
 					} ) }
 				</span>
 
-				{ canUserUpgrade && ( <a className="plan-storage__storage-link" href={ `/plans/${ siteSlug }` }>
-					{ translate( 'Upgrade' ) }
-				</a>
+				{ canUserUpgrade && (
+					<a className="plan-storage__storage-link" href={ `/plans/${ siteSlug }` }>
+						{ translate( 'Upgrade' ) }
+					</a>
 				) }
 
 				{ this.props.children }
@@ -80,7 +88,7 @@ export class PlanStorageBar extends Component {
 	}
 }
 
-export default connect( ( state ) => {
+export default connect( state => {
 	return {
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 	};

--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -3,7 +3,6 @@
  */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { localize } from 'i18n-calypso';
 import classNames from 'classnames';
 import filesize from 'filesize';

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -15,6 +12,7 @@ import { connect } from 'react-redux';
 import QueryMediaStorage from 'components/data/query-media-storage';
 import { getMediaStorage } from 'state/sites/media-storage/selectors';
 import { getSitePlanSlug, getSiteSlug, isJetpackSite } from 'state/sites/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import { planHasFeature } from 'lib/plans';
 import { FEATURE_UNLIMITED_STORAGE } from 'lib/plans/constants';
 import PlanStorageBar from './bar';
@@ -34,9 +32,18 @@ export class PlanStorage extends Component {
 	};
 
 	render() {
-		const { className, jetpackSite, siteId, sitePlanSlug, siteSlug } = this.props;
+		const {
+			canUserUpgrade,
+			canViewBar,
+			className,
+			displayUpgradeLink,
+			jetpackSite,
+			siteId,
+			sitePlanSlug,
+			siteSlug,
+		} = this.props;
 
-		if ( jetpackSite || ! sitePlanSlug ) {
+		if ( jetpackSite || ! canViewBar || ! sitePlanSlug ) {
 			return null;
 		}
 
@@ -51,6 +58,7 @@ export class PlanStorage extends Component {
 					siteSlug={ siteSlug }
 					sitePlanSlug={ sitePlanSlug }
 					mediaStorage={ this.props.mediaStorage }
+					displayUpgradeLink={ canUserUpgrade }
 				>
 					{ this.props.children }
 				</PlanStorageBar>
@@ -66,5 +74,7 @@ export default connect( ( state, ownProps ) => {
 		jetpackSite: isJetpackSite( state, siteId ),
 		sitePlanSlug: getSitePlanSlug( state, siteId ),
 		siteSlug: getSiteSlug( state, siteId ),
+		canUserUpgrade: canCurrentUser( state, siteId, 'manage_options' ),
+		canViewBar: canCurrentUser( state, siteId, 'publish_posts' ),
 	};
 } )( PlanStorage );

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -36,7 +36,6 @@ export class PlanStorage extends Component {
 			canUserUpgrade,
 			canViewBar,
 			className,
-			displayUpgradeLink,
 			jetpackSite,
 			siteId,
 			sitePlanSlug,

--- a/client/blocks/plan-storage/test/plan-storage.jsx
+++ b/client/blocks/plan-storage/test/plan-storage.jsx
@@ -29,6 +29,7 @@ import { PlanStorage } from '../index';
 
 describe( 'PlanStorage basic tests', () => {
 	const props = {
+		canViewBar: true,
 		mediaStorage: {
 			max_storage_bytes: 1000,
 		},
@@ -88,6 +89,11 @@ describe( 'PlanStorage basic tests', () => {
 
 	test( 'should not render for jetpack sites', () => {
 		const storage = shallow( <PlanStorage { ...props } jetpackSite={ true } /> );
+		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
+	} );
+	
+	test( 'should not render for contributors', () => {
+		const storage = shallow( <PlanStorage { ...props } canViewBar={ false } /> );
 		assert.lengthOf( storage.find( '.plan-storage' ), 0 );
 	} );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This should hopefully be the last upgrade nudge visible for non-admins as I missed this once in #34597, but only administrators should be able to see the nudge.

#### Testing instructions

Visit a site's Media Library. Verify that the bar is always there, but the "Upgrade" link is only visible for administrators. cc @donpark 

<img width="288" alt="Screenshot 2019-08-18 at 09 33 37" src="https://user-images.githubusercontent.com/43215253/63222132-45ffe280-c19b-11e9-888f-366915850ff4.png">

Fixes #35528
