### PR TITLE
Media Library: Enable Access for Contributors

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -1,14 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import { connect } from 'react-redux';
 import { groupBy, head, isEmpty, map, noop, size, values } from 'lodash';
 import PropTypes from 'prop-types';
 import page from 'page';
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 
 /**
@@ -26,6 +24,7 @@ import {
 	MEDIA_IMAGE_RESIZER,
 	MEDIA_IMAGE_THUMBNAIL,
 } from 'lib/media/constants';
+import canCurrentUser from 'state/selectors/can-current-user';
 import { getSiteSlug } from 'state/sites/selectors';
 import MediaLibraryHeader from './header';
 import MediaLibraryExternalHeader from './external-media-header';
@@ -407,8 +406,12 @@ export class MediaLibraryContent extends React.Component {
 	}
 
 	render() {
+		const classNames = classnames( 'media-library__content', {
+			'has-no-upload-button': ! this.props.displayUploadMediaButton,
+		} );
+		
 		return (
-			<div className="media-library__content">
+			<div className={ classNames }>
 				{ this.renderHeader() }
 				{ this.renderErrors() }
 				{ this.renderMediaList() }
@@ -428,6 +431,7 @@ export default connect(
 		return {
 			siteSlug: ownProps.site ? getSiteSlug( state, ownProps.site.ID ) : '',
 			isRequesting: isKeyringConnectionsFetching( state ),
+			displayUploadMediaButton: canCurrentUser( state, ownProps.site.ID, 'publish_posts' ),
 			mediaValidationErrorTypes,
 			shouldPauseGuidedTour,
 			googleConnection: googleConnection.length === 1 ? googleConnection[ 0 ] : null, // There can be only one

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -1,3 +1,5 @@
+/** @format */
+
 /**
  * External dependencies
  */

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -37,6 +37,8 @@ class MediaLibraryListItem extends React.Component {
 		thumbnailType: PropTypes.string,
 		showGalleryHelp: PropTypes.bool,
 		selectedIndex: PropTypes.number,
+		isMediaLibrary: PropTypes.bool,
+		isContributor: PropTypes.bool,
 		onToggle: PropTypes.func,
 		onEditItem: PropTypes.func,
 		style: PropTypes.object,
@@ -103,9 +105,10 @@ class MediaLibraryListItem extends React.Component {
 
 	render() {
 		let title, selectedNumber;
-		
-		const selectMedia = ! this.props.isMediaLibrary || ( this.props.isMediaLibrary && ! this.props.isContributor );
-		
+
+		const selectMedia =
+			! this.props.isMediaLibrary || ( this.props.isMediaLibrary && ! this.props.isContributor );
+
 		const classes = classNames( 'media-library__list-item', {
 			'is-placeholder': ! this.props.media,
 			'is-selected': -1 !== this.props.selectedIndex && selectMedia,
@@ -148,9 +151,14 @@ class MediaLibraryListItem extends React.Component {
 	}
 }
 
-export default connect( state => {
-	return {
-		isContributor: ! canCurrentUser( state, getSelectedSiteId( state ), 'publish_posts' ),
-		isMediaLibrary: getSectionName( state ) === 'media',
-	};
-} )( MediaLibraryListItem );
+const mapStateToProps = state => ( {
+	isContributor: ! canCurrentUser( state, getSelectedSiteId( state ), 'publish_posts' ),
+	isMediaLibrary: getSectionName( state ) === 'media',
+} );
+
+const mapDispatchToProps = {};
+
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)( MediaLibraryListItem );

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -7,6 +5,7 @@
 import { assign, isEqual, noop, omit } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { connect } from 'react-redux';
 import classNames from 'classnames';
 
 /**
@@ -20,12 +19,15 @@ import ListItemAudio from './list-item-audio';
 import ListItemDocument from './list-item-document';
 import { getMimePrefix } from 'lib/media/utils';
 import EditorMediaModalGalleryHelp from 'post-editor/media-modal/gallery-help';
+import canCurrentUser from 'state/selectors/can-current-user';
+import { getSelectedSite, getSelectedSiteId, getSectionName } from 'state/ui/selectors';
+
 /**
  * Style dependencies
  */
 import './list-item.scss';
 
-export default class extends React.Component {
+class MediaLibraryListItem extends React.Component {
 	static displayName = 'MediaLibraryListItem';
 
 	static propTypes = {
@@ -101,10 +103,12 @@ export default class extends React.Component {
 
 	render() {
 		let title, selectedNumber;
-
+		
+		const selectMedia = ! this.props.isMediaLibrary || ( this.props.isMediaLibrary && ! this.props.isContributor );
+		
 		const classes = classNames( 'media-library__list-item', {
 			'is-placeholder': ! this.props.media,
-			'is-selected': -1 !== this.props.selectedIndex,
+			'is-selected': -1 !== this.props.selectedIndex && selectMedia,
 			'is-transient': this.props.media && this.props.media.transient,
 			'is-small': this.props.scale <= 0.125,
 		} );
@@ -143,3 +147,10 @@ export default class extends React.Component {
 		);
 	}
 }
+
+export default connect( state => {
+	return {
+		isContributor: ! canCurrentUser( state, getSelectedSiteId( state ), 'publish_posts' ),
+		isMediaLibrary: getSectionName( state ) === 'media',
+	};
+} )( MediaLibraryListItem );

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -20,7 +20,7 @@ import ListItemDocument from './list-item-document';
 import { getMimePrefix } from 'lib/media/utils';
 import EditorMediaModalGalleryHelp from 'post-editor/media-modal/gallery-help';
 import canCurrentUser from 'state/selectors/can-current-user';
-import { getSelectedSite, getSelectedSiteId, getSectionName } from 'state/ui/selectors';
+import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
 
 /**
  * Style dependencies

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -5,7 +5,6 @@
 import { assign, isEqual, noop, omit } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { connect } from 'react-redux';
 import classNames from 'classnames';
 
 /**
@@ -19,15 +18,12 @@ import ListItemAudio from './list-item-audio';
 import ListItemDocument from './list-item-document';
 import { getMimePrefix } from 'lib/media/utils';
 import EditorMediaModalGalleryHelp from 'post-editor/media-modal/gallery-help';
-import canCurrentUser from 'state/selectors/can-current-user';
-import { getSelectedSiteId, getSectionName } from 'state/ui/selectors';
-
 /**
  * Style dependencies
  */
 import './list-item.scss';
 
-class MediaLibraryListItem extends React.Component {
+export default class extends React.Component {
 	static displayName = 'MediaLibraryListItem';
 
 	static propTypes = {
@@ -37,8 +33,6 @@ class MediaLibraryListItem extends React.Component {
 		thumbnailType: PropTypes.string,
 		showGalleryHelp: PropTypes.bool,
 		selectedIndex: PropTypes.number,
-		isMediaLibrary: PropTypes.bool,
-		isContributor: PropTypes.bool,
 		onToggle: PropTypes.func,
 		onEditItem: PropTypes.func,
 		style: PropTypes.object,
@@ -106,12 +100,9 @@ class MediaLibraryListItem extends React.Component {
 	render() {
 		let title, selectedNumber;
 
-		const selectMedia =
-			! this.props.isMediaLibrary || ( this.props.isMediaLibrary && ! this.props.isContributor );
-
 		const classes = classNames( 'media-library__list-item', {
 			'is-placeholder': ! this.props.media,
-			'is-selected': -1 !== this.props.selectedIndex && selectMedia,
+			'is-selected': -1 !== this.props.selectedIndex,
 			'is-transient': this.props.media && this.props.media.transient,
 			'is-small': this.props.scale <= 0.125,
 		} );
@@ -150,15 +141,3 @@ class MediaLibraryListItem extends React.Component {
 		);
 	}
 }
-
-const mapStateToProps = state => ( {
-	isContributor: ! canCurrentUser( state, getSelectedSiteId( state ), 'publish_posts' ),
-	isMediaLibrary: getSectionName( state ) === 'media',
-} );
-
-const mapDispatchToProps = {};
-
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( MediaLibraryListItem );

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -25,7 +25,8 @@
 	}
 	
 	.media__main-section .media-library__content.has-no-upload-button & {
-		cursor: default;
+		// In the Media Library, don't allow contributors to click images.
+		pointer-events: none;
 	}
 }
 
@@ -64,10 +65,6 @@
 
 .media-library__list-item:hover .media-library__list-item-figure {
 	box-shadow: 0 0 0 1px var( --color-neutral-light ), 0 2px 4px var( --color-neutral-100 );
-	
-	.media__main-section .media-library__content.has-no-upload-button & {
-		box-shadow: none;
-	}
 }
 
 .media-library__list-item.is-selected .media-library__list-item-figure {

--- a/client/my-sites/media-library/list-item.scss
+++ b/client/my-sites/media-library/list-item.scss
@@ -23,6 +23,10 @@
 		text-align: center;
 		color: var( --color-white );
 	}
+	
+	.media__main-section .media-library__content.has-no-upload-button & {
+		cursor: default;
+	}
 }
 
 .media-library__list-item-selected-icon {
@@ -60,6 +64,10 @@
 
 .media-library__list-item:hover .media-library__list-item-figure {
 	box-shadow: 0 0 0 1px var( --color-neutral-light ), 0 2px 4px var( --color-neutral-100 );
+	
+	.media__main-section .media-library__content.has-no-upload-button & {
+		box-shadow: none;
+	}
 }
 
 .media-library__list-item.is-selected .media-library__list-item-figure {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -155,7 +155,7 @@
 
 .media-library__source-button.is-borderless {
 	padding: 5px;
-	padding-left: 12px;
+	padding-left: 9px;
 	height: 38px;
 
 	img {

--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -42,6 +42,18 @@
 	}
 }
 
+.media-library__content.has-no-upload-button .media-library {	
+	&__header.card {
+		padding-bottom: 36px;
+	}
+	
+	&__scale-range.range {
+		right: 50%;
+		margin: 0;
+		transform: translateX( 50% );
+	}
+}
+
 .media-library__filter-bar {
 	display: flex;
 	flex-flow: row nowrap;

--- a/client/my-sites/media/main.jsx
+++ b/client/my-sites/media/main.jsx
@@ -3,7 +3,7 @@
  */
 
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import page from 'page';
 import { localize } from 'i18n-calypso';
@@ -13,14 +13,12 @@ import { localize } from 'i18n-calypso';
  */
 import MediaLibrary from 'my-sites/media-library';
 import QueryMedia from 'components/data/query-media';
-import EmptyContent from 'components/empty-content';
 import SidebarNavigation from 'my-sites/sidebar-navigation';
 import EditorMediaModalDialog from 'post-editor/media-modal/dialog';
 import { EditorMediaModalDetail } from 'post-editor/media-modal/detail';
 import { getSelectedSite, getSelectedSiteId } from 'state/ui/selectors';
 import getMediaItem from 'state/selectors/get-media-item';
 import getPreviousRoute from 'state/selectors/get-previous-route';
-import canCurrentUser from 'state/selectors/can-current-user';
 import ImageEditor from 'blocks/image-editor';
 import VideoEditor from 'blocks/video-editor';
 import MediaActions from 'lib/media/actions';
@@ -363,80 +361,69 @@ class Media extends Component {
 	};
 
 	render() {
-		const { selectedSite: site, mediaId, previousRoute, canAccessMedia, translate } = this.props;
-
+		const { selectedSite: site, mediaId, previousRoute, translate } = this.props;
 		return (
 			<div ref={ this.containerRef } className="main main-column media" role="main">
 				{ mediaId && site && site.ID && <QueryMedia siteId={ site.ID } mediaId={ mediaId } /> }
 				<PageViewTracker path={ this.getAnalyticsPath() } title="Media" />
 				<SidebarNavigation />
-				{ ! canAccessMedia && (
-					<EmptyContent
-						illustration="/calypso/images/illustrations/illustration-404.svg"
-						title={ translate( 'You are not authorized to view this page' ) }
-					/>
+				{ this.showDialog() && (
+					<EditorMediaModalDialog
+						isVisible
+						additionalClassNames="media__item-dialog"
+						buttons={ this.getModalButtons() }
+						onClose={ this.closeDetailsModal }
+					>
+						{ this.showDialog( 'detail' ) && (
+							<EditorMediaModalDetail
+								site={ site }
+								items={ this.getSelectedItems() }
+								selectedIndex={ this.getSelectedIndex() }
+								onReturnToList={ this.closeDetailsModal }
+								backButtonText={
+									previousRoute ? translate( 'Back' ) : translate( 'Media Library' )
+								}
+								onEditImageItem={ this.editImage }
+								onEditVideoItem={ this.editVideo }
+								onRestoreItem={ this.restoreOriginalMedia }
+								onSelectedIndexChange={ this.setDetailSelectedIndex }
+							/>
+						) }
+						{ this.state.editedImageItem !== null && (
+							<ImageEditor
+								siteId={ site && site.ID }
+								media={ this.getSelectedItem( this.state.editedImageItem ) }
+								onDone={ this.onImageEditorDone }
+								onCancel={ this.onImageEditorCancel }
+							/>
+						) }
+						{ this.state.editedVideoItem !== null && (
+							<VideoEditor
+								media={ this.getSelectedItem( this.state.editedVideoItem ) }
+								onCancel={ this.onVideoEditorCancel }
+								onUpdatePoster={ this.onVideoEditorUpdatePoster }
+							/>
+						) }
+					</EditorMediaModalDialog>
 				) }
-				{ canAccessMedia && (
-					<Fragment>
-						{ this.showDialog() && (
-							<EditorMediaModalDialog
-								isVisible
-								additionalClassNames="media__item-dialog"
-								buttons={ this.getModalButtons() }
-								onClose={ this.closeDetailsModal }
-							>
-								{ this.showDialog( 'detail' ) && (
-									<EditorMediaModalDetail
-										site={ site }
-										items={ this.getSelectedItems() }
-										selectedIndex={ this.getSelectedIndex() }
-										onReturnToList={ this.closeDetailsModal }
-										backButtonText={
-											previousRoute ? translate( 'Back' ) : translate( 'Media Library' )
-										}
-										onEditImageItem={ this.editImage }
-										onEditVideoItem={ this.editVideo }
-										onRestoreItem={ this.restoreOriginalMedia }
-										onSelectedIndexChange={ this.setDetailSelectedIndex }
-									/>
-								) }
-								{ this.state.editedImageItem !== null && (
-									<ImageEditor
-										siteId={ site && site.ID }
-										media={ this.getSelectedItem( this.state.editedImageItem ) }
-										onDone={ this.onImageEditorDone }
-										onCancel={ this.onImageEditorCancel }
-									/>
-								) }
-								{ this.state.editedVideoItem !== null && (
-									<VideoEditor
-										media={ this.getSelectedItem( this.state.editedVideoItem ) }
-										onCancel={ this.onVideoEditorCancel }
-										onUpdatePoster={ this.onVideoEditorUpdatePoster }
-									/>
-								) }
-							</EditorMediaModalDialog>
-						) }
-						{ site && site.ID && (
-							<MediaLibrarySelectedData siteId={ site.ID }>
-								<MediaLibrary
-									{ ...this.props }
-									className="media__main-section"
-									onFilterChange={ this.onFilterChange }
-									site={ site }
-									single={ false }
-									filter={ this.props.filter }
-									source={ this.state.source }
-									onEditItem={ this.openDetailsModalForASingleImage }
-									onViewDetails={ this.openDetailsModalForAllSelected }
-									onDeleteItem={ this.handleDeleteMediaEvent }
-									onSourceChange={ this.handleSourceChange }
-									modal={ false }
-									containerWidth={ this.state.containerWidth }
-								/>
-							</MediaLibrarySelectedData>
-						) }
-					</Fragment>
+				{ site && site.ID && (
+					<MediaLibrarySelectedData siteId={ site.ID }>
+						<MediaLibrary
+							{ ...this.props }
+							className="media__main-section"
+							onFilterChange={ this.onFilterChange }
+							site={ site }
+							single={ false }
+							filter={ this.props.filter }
+							source={ this.state.source }
+							onEditItem={ this.openDetailsModalForASingleImage }
+							onViewDetails={ this.openDetailsModalForAllSelected }
+							onDeleteItem={ this.handleDeleteMediaEvent }
+							onSourceChange={ this.handleSourceChange }
+							modal={ false }
+							containerWidth={ this.state.containerWidth }
+						/>
+					</MediaLibrarySelectedData>
 				) }
 			</div>
 		);
@@ -447,7 +434,6 @@ const mapStateToProps = ( state, { mediaId } ) => ( {
 	selectedSite: getSelectedSite( state ),
 	previousRoute: getPreviousRoute( state ),
 	media: getMediaItem( state, getSelectedSiteId( state ), mediaId ),
-	canAccessMedia: canCurrentUser( state, getSelectedSiteId( state ), 'publish_posts' ),
 } );
 
 export default connect( mapStateToProps )( localize( Media ) );

--- a/client/my-sites/sidebar/site-menu.jsx
+++ b/client/my-sites/sidebar/site-menu.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -98,7 +96,7 @@ class SiteMenu extends PureComponent {
 			{
 				name: 'media',
 				label: translate( 'Media' ),
-				capability: 'upload_files',
+				capability: 'edit_posts',
 				queryable: true,
 				link: '/media',
 				wpAdminLink: 'upload.php',

--- a/client/post-editor/media-modal/secondary-actions.jsx
+++ b/client/post-editor/media-modal/secondary-actions.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -17,6 +15,7 @@ import { localize } from 'i18n-calypso';
  */
 import { canUserDeleteItem } from 'lib/media/utils';
 import { getCurrentUser } from 'state/current-user/selectors';
+import canCurrentUser from 'state/selectors/can-current-user';
 import { getSiteSlug } from 'state/sites/selectors';
 import { getMediaModalView } from 'state/ui/media-modal/selectors';
 import { setEditorMediaModalView } from 'state/ui/editor/actions';
@@ -86,6 +85,11 @@ class MediaModalSecondaryActions extends Component {
 	}
 
 	render() {
+		
+		if ( this.props.hideButton ) {
+			return null;
+		}
+		
 		return (
 			<div>
 				{ this.getButtons().map( button => (
@@ -109,6 +113,7 @@ export default connect(
 		view: getMediaModalView( state ),
 		user: getCurrentUser( state ),
 		siteSlug: ownProps.site ? getSiteSlug( state, ownProps.site.ID ) : '',
+		hideButton: ! canCurrentUser( state, ownProps.site.ID, 'publish_posts' ),
 	} ),
 	{
 		onViewDetails: flow(


### PR DESCRIPTION
After some discussion below, this PR will now open access to the Media Library for contributors, granting access from the sidebar.

Please try testing as both a contributor and another role, then spot any issues. In the Media Library, it should only be possible to view the images, which means that the Edit button is hidden. There should be no differences in the Media Modal. 

<img width="1254" alt="Screenshot 2019-08-21 at 10 12 05" src="https://user-images.githubusercontent.com/43215253/63420008-bb6aed80-c3fd-11e9-8e1b-943c236e6263.png">

Fixes #35530
