### PR TITLE
Signup: update `domain_item` tracking value so it's actually recorded

### DIFF
--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -51,7 +51,10 @@ function recordSubmitStep( stepName, providedDependencies ) {
 				propValue = !! propValue;
 			}
 
-			if ( propName === 'cart_item' && typeof propValue !== 'string' ) {
+			if (
+				( propName === 'cart_item' || propName === 'domain_item' ) &&
+				typeof propValue !== 'string'
+			) {
 				propValue = toPairs( propValue )
 					.map( pair => pair.join( ':' ) )
 					.join( ',' );


### PR DESCRIPTION
Related: #34704

#### Changes proposed in this Pull Request

Converts the `domain_item` property (which is an object) to a string so it can be recorded as a property of the `calypso_signup_actions_submit_step` event.

The `domain_item` is serialised so that keys are separated from values by `":"` and key/value pairs are separated by `","`. This matches how the `cart_item` value is serialised.

I'm pretty sure domain names can't contain semicolons or commas so I think this should be fine.

#### Testing instructions

1. Fire up the branch
2. Open you network console
3. Filter by `calypso_signup_actions_submit_step`
4. Go through a flow and choose a domain that requires a purchase
5. Look at the network event for submitting the domain step.

The query parameter `domain_item` should have a value like `product_slug:dotlive_domain,meta:thedomainyoupicked.live,is_domain_registration:true`