### PR TITLE
File download stats: update availability start date

### DIFF
--- a/client/my-sites/stats/stats-module/availability-warning.tsx
+++ b/client/my-sites/stats/stats-module/availability-warning.tsx
@@ -11,9 +11,9 @@ interface Props {
 	startOfPeriod?: moment.Moment;
 }
 
-// File downloads were only recorded from 28th June 2019 onwards,
+// File downloads were only recorded from 1st July 2019 onwards,
 // so we want to warn the user if the start date is earlier
-const fileDownloadsRecordingStartDate = '2019-06-29T00:00:00Z';
+const fileDownloadsRecordingStartDate = '2019-07-01T00:00:00Z';
 
 const StatsModuleAvailabilityWarning: FunctionComponent< Props & LocalizeProps > = ( {
 	statType,
@@ -32,7 +32,7 @@ const StatsModuleAvailabilityWarning: FunctionComponent< Props & LocalizeProps >
 		<div className="stats-module__availability-warning">
 			<Gridicon icon="info-outline" size="24" />
 			<p className="stats-module__availability-warning-message">
-				{ translate( 'File download counts were not recorded before June 28th 2019.' ) }
+				{ translate( 'File download counts were not recorded before July 2019.' ) }
 			</p>
 		</div>
 	);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We are about to launch file download stats, and had previously added a warning to users that we were not counting downloads before 28th June 2019.

This PR adjusts the start date to 1st July 2019. This was the first date we were capturing download stats for all users.

#### Testing instructions

Try viewing the file download stats module for a period that starts before 2019-06-29, for example:

http://calypso.localhost:3000/stats/year/example.com

The info message should appear in the stats module:

<img width="1072" alt="Screen Shot 2019-08-19 at 14 14 29" src="https://user-images.githubusercontent.com/17325/63235114-5c399b80-c28c-11e9-9961-e1f1dd3ed3db.png">
<img width="390" alt="Screen Shot 2019-08-19 at 14 14 35" src="https://user-images.githubusercontent.com/17325/63235116-5c399b80-c28c-11e9-8b51-dc6ebcc1f428.png">

