### PR TITLE
Remove moveUserStepPosition A/B test

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -143,15 +143,6 @@ export default {
 		defaultVariation: 'show',
 		allowExistingUsers: true,
 	},
-	moveUserStepPosition: {
-		datestamp: '20190719',
-		variations: {
-			first: 50,
-			last: 50,
-		},
-		defaultVariation: 'first',
-		allowExistingUsers: true,
-	},
 	removeBlogFlow: {
 		datestamp: '20190813',
 		variations: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -334,30 +334,6 @@ export function generateFlows( {
 		lastModified: '2018-12-12',
 	};
 
-	// Used by moveUserStepPosition A/B test.
-	flows[ 'onboarding-user-last' ] = {
-		steps: [
-			'site-type',
-			'site-topic-with-preview',
-			'site-title-with-preview',
-			'site-style-with-preview',
-			'domains-with-preview',
-			'plans',
-			'user',
-		],
-		destination: getSignupDestination,
-		description: 'Variant of the onboarding flow, but with the user step in the last position.',
-		lastModified: '2019-07-19',
-	};
-
-	// Used by moveUserStepPosition A/B test.
-	flows[ 'ecommerce-store-onboarding' ] = {
-		steps: [ 'site-type', 'domains', 'plans-ecommerce', 'user' ],
-		destination: getSiteDestination,
-		description: 'Signup flow for creating an online store, with user step in last position',
-		lastModified: '2019-07-19',
-	};
-
 	if ( isEnabled( 'signup/full-site-editing' ) ) {
 		flows[ 'test-fse' ] = {
 			steps: [

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -11,7 +11,6 @@ import { assign, get, includes, indexOf, reject } from 'lodash';
 import config from 'config';
 import stepConfig from './steps';
 import userFactory from 'lib/user';
-import { abtest } from 'lib/abtest';
 import { generateFlows } from 'signup/config/flows-pure';
 
 const user = userFactory();
@@ -164,9 +163,5 @@ const Flows = {
 		return flows;
 	},
 };
-
-if ( abtest( 'moveUserStepPosition' ) === 'last' && Flows.defaultFlowName === 'onboarding' ) {
-	Flows.defaultFlowName = 'onboarding-user-last';
-}
 
 export default Flows;

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -40,24 +40,13 @@ class SiteType extends Component {
 	submitStep = siteTypeValue => {
 		this.props.submitSiteType( siteTypeValue );
 
-		// This hack ensures that users in the moveUserStepPosition A/B Test
-		// reach a compatible flow when selecting the online-store site type.
-		if (
-			abtest( 'moveUserStepPosition' ) === 'last' &&
-			this.props.flowName === 'onboarding-user-last' &&
-			siteTypeValue === 'online-store'
-		) {
-			this.props.goToNextStep( 'ecommerce-store-onboarding' );
-		} else {
-			// Modify the flowname if the site type matches an override.
-			this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
-		}
+		// Modify the flowname if the site type matches an override.
+		this.props.goToNextStep( siteTypeToFlowname[ siteTypeValue ] || this.props.flowName );
 	};
 
 	renderImportButton() {
 		if (
 			! isEnabled( 'signup/import-flow' ) ||
-			'last' === abtest( 'moveUserStepPosition' ) ||
 			'show' !== abtest( 'showImportFlowInSiteTypeStep' )
 		) {
 			return null;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove `moveUserStepPosition` A/B test and associated flows (reverts the A/B tests from https://github.com/Automattic/wp-calypso/pull/34770 but preserves the improvements to logged out -> logged in behaviour)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `http://calypso.localhost:3000/start` and you should no longer be able to see the `moveUserStepPosition` A/B test in the list of tests in the local development environment.
* You should be directed to the `user` step as step 1
* Complete signing up for a site, to ensure that the normal onboarding flow is unaffected

Check that the importer A/B test works correctly

* On the `site-type` step set the `showImportFlowInSiteTypeStep` A/B test to `show`, and you should see the `Already have a website?` link on the `site-type` step. Clicking this link should take you to `http://calypso.localhost:3000/start/import-onboarding/import-url`