### PR TITLE
Move file download stats to more prominent spot in site stats

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -224,7 +224,6 @@ class StatsSite extends Component {
 								showSummaryLink
 							/>
 							{ fileDownloadList }
-							{ videoList }
 						</div>
 						<div className="stats__module-column">
 							<Countries
@@ -260,6 +259,7 @@ class StatsSite extends Component {
 								className="stats__author-views"
 								showSummaryLink
 							/>
+							{ videoList }
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -13,7 +11,6 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-
 import DocumentHead from 'components/data/document-head';
 import StatsPeriodNavigation from './stats-period-navigation';
 import Main from 'components/main';
@@ -226,6 +223,7 @@ class StatsSite extends Component {
 								statType="statsSearchTerms"
 								showSummaryLink
 							/>
+							{ fileDownloadList }
 							{ videoList }
 						</div>
 						<div className="stats__module-column">
@@ -262,7 +260,6 @@ class StatsSite extends Component {
 								className="stats__author-views"
 								showSummaryLink
 							/>
-							{ fileDownloadList }
 						</div>
 					</div>
 				</div>

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In the site stats screen, move the File Downloads panel to a more prominent spot by swapping its position with the Videos panel.

<img width="1103" alt="Screen Shot 2019-08-19 at 15 13 42" src="https://user-images.githubusercontent.com/17325/63236994-3fa16180-c294-11e9-880a-9c489bbaaca1.png">
<img width="764" alt="Screen Shot 2019-08-19 at 15 13 53" src="https://user-images.githubusercontent.com/17325/63236995-3fa16180-c294-11e9-935b-97c8f9037f24.png">
<img width="434" alt="Screen Shot 2019-08-19 at 15 14 00" src="https://user-images.githubusercontent.com/17325/63236996-3fa16180-c294-11e9-9ace-c5ebd359ad0b.png">


#### Testing instructions

Try viewing a site's stats, for example:

http://calypso.localhost:3000/stats/year/example.com

Change the viewport's width to see 1, 2 and 3 column layouts.

#### Future plans

I think this page could benefit from a Masonry-style layout to better fill the columns, especially on the 2-column view: https://w3bits.com/css-masonry/