### PR TITLE
Main: migrate CSS styles to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -12,5 +12,4 @@
 @import 'components/card/style';
 @import 'components/date-picker/style';
 @import 'components/dialog/style';
-@import 'components/main/style';
 @import 'layout/sidebar/style';

--- a/client/components/main/README.md
+++ b/client/components/main/README.md
@@ -1,16 +1,16 @@
 Main (jsx)
 ==========
 
-Component used to declare the main area of any given section — it's the main wrapper that gets render first inside `#primary`.
+Component used to declare the main area of any given section —- it's the main wrapper that gets rendered first inside `#primary`.
 
 #### How to use:
 
-```js
+```jsx
 import Main from 'components/main';
 
 render() {
 	return (
-		<Main (optional) className="your-component">
+		<Main className="your-component">
 			Your section content...
 		</Main>
 	);
@@ -19,4 +19,5 @@ render() {
 
 #### Props
 
-* `className`: Add your own class to the wrapper.
+* `className`: Add your own CSS class to the wrapper.
+* `wideLayout`: Use wide layout (larger `max-width`) for the section.

--- a/client/components/main/index.jsx
+++ b/client/components/main/index.jsx
@@ -1,11 +1,13 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import React from 'react';
 import classNames from 'classnames';
+
+/**
+ * Style dependencies
+ */
+import './style.scss';
 
 export default function Main( { className, children, wideLayout = false } ) {
 	const classes = classNames( className, 'main', {

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -8,11 +8,6 @@
 		max-width: 100%;
 	}
 
-	&.preview {
-		height: 100%;
-		max-width: none;
-	}
-
 	&.is-wide-layout {
 		max-width: 1040px;
 	}

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -8,10 +8,6 @@
 		max-width: 100%;
 	}
 
-	&.sites {
-		max-width: 320px;
-	}
-
 	&.preview {
 		height: 100%;
 		max-width: none;

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -12,11 +12,6 @@
 		max-width: 320px;
 	}
 
-	// The customizer is full-width
-	&.customize {
-		max-width: 100%;
-	}
-
 	&.preview {
 		height: 100%;
 		max-width: none;

--- a/client/my-sites/customize/style.scss
+++ b/client/my-sites/customize/style.scss
@@ -1,3 +1,8 @@
+// The customizer is full-width
+.main.customize {
+	max-width: 100%;
+}
+
 .main.customize.is-iframe {
 	background-color: var( --color-neutral-0 );
 	margin: 0;

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -29,6 +29,11 @@ import {
 import WebPreview from 'components/web-preview';
 import { recordTracksEvent } from 'state/analytics/actions';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 const debug = debugFactory( 'calypso:my-sites:preview' );
 
 class PreviewMain extends React.Component {

--- a/client/my-sites/preview/style.scss
+++ b/client/my-sites/preview/style.scss
@@ -1,0 +1,4 @@
+.main.preview {
+	height: 100%;
+	max-width: none;
+}

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -1,3 +1,7 @@
+.main.sites {
+	max-width: 320px;
+}
+
 .sites__select-header {
 	text-align: center;
 


### PR DESCRIPTION
Very straightforward CSS migration and docs update of the `Main` component used as the root element of every section.

I also moved the custom styles for Customize, Preview and Sites sections to their respective stylesheets. I gave up on Themes, as there's no good single place for the `.main.themes` style in the `themes` section. Opportunity for a followup cleanup PR.

**How to test:**
Test that the width of the section's primary area is as expected: some are narrow, some have `wideLayout=true` (e.g., Plans), some take 100% of the available width (e.g., the iframed sections like Customizer or Gutenberg, or Themes).