### PR TITLE
Use requestExternalAccess to login with Apple external service

### DIFF
--- a/client/blocks/keyring-connect-button/index.js
+++ b/client/blocks/keyring-connect-button/index.js
@@ -108,7 +108,7 @@ class KeyringConnectButton extends Component {
 		if ( this.props.service ) {
 			// Attempt to create a new connection. If a Keyring connection ID
 			// is not provided, the user will need to authorize the app
-			requestExternalAccess( this.props.service.connect_URL, keyringId => {
+			requestExternalAccess( this.props.service.connect_URL, ( { keyring_id: keyringId } ) => {
 				if ( ! keyringId ) {
 					this.setState( { isConnecting: false } );
 					return;

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -113,10 +113,13 @@ class SocialLoginForm extends Component {
 			return;
 		}
 
+		const user = response.user || {};
+
 		const socialInfo = {
 			service: 'apple',
 			id_token: response.id_token,
-			keyring_id: response.keyring_id,
+			user_name: user.name,
+			user_email: user.email,
 		};
 
 		this.props.loginSocialUser( socialInfo, redirectTo ).then(

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -116,7 +116,7 @@ class SocialLoginForm extends Component {
 		const socialInfo = {
 			service: 'apple',
 			id_token: response.id_token,
-			//keyring_id: response.keyring_id,
+			keyring_id: response.keyring_id,
 		};
 
 		this.props.loginSocialUser( socialInfo, redirectTo ).then(

--- a/client/components/social-buttons/apple.js
+++ b/client/components/social-buttons/apple.js
@@ -13,12 +13,16 @@ import { localize } from 'i18n-calypso';
  * Internal dependencies
  */
 import { isFormDisabled } from 'state/login/selectors';
+import requestExternalAccess from 'lib/sharing';
 
 /**
  * Style dependencies
  */
 import './style.scss';
 import AppleIcon from 'components/social-icons/apple';
+
+const connectUrl =
+	'https://public-api.wordpress.com/connect/?magic=keyring&service=apple&action=request&for=connect';
 
 class AppleLoginButton extends Component {
 	static propTypes = {
@@ -63,17 +67,9 @@ class AppleLoginButton extends Component {
 		this.setState( { error: '' } );
 
 		this.initialized = this.loadDependency()
-			.then( AppleID => {
-					AppleID.auth.init( {
-						clientId: this.props.clientId,
-						scope: 'name email',
-						redirectURI: this.props.redirectUri,
-						state: '1',
-					} );
-
-					this.setState( { isDisabled: false } );
-				}
-			)
+			.then( () => {
+				this.setState( { isDisabled: false } );
+			} )
 			.catch( error => {
 				this.initialized = null;
 
@@ -83,20 +79,18 @@ class AppleLoginButton extends Component {
 		return this.initialized;
 	}
 
-	handleClick = ( event ) => {
+	handleClick = event => {
 		event.preventDefault();
 
 		if ( this.state.isDisabled ) {
 			return;
 		}
 
-		window.AppleID.auth.signIn();
+		requestExternalAccess( connectUrl, this.props.responseHandler );
 	};
 
 	render() {
-		const isDisabled = Boolean(
-			this.state.isDisabled || this.props.isFormDisabled
-		);
+		const isDisabled = Boolean( this.state.isDisabled || this.props.isFormDisabled );
 
 		if ( ! config.isEnabled( 'sign-in-with-apple' ) ) {
 			return null;

--- a/client/lib/sharing/index.js
+++ b/client/lib/sharing/index.js
@@ -21,6 +21,7 @@ const requestExternalAccess = ( url, cb ) => {
 		if ( lastMessage && lastMessage.keyring_id ) {
 			result.keyring_id = Number( lastMessage.keyring_id );
 			result.id_token = lastMessage.id_token;
+			result.user = lastMessage.user;
 		}
 		cb( result );
 	} );

--- a/client/lib/sharing/index.js
+++ b/client/lib/sharing/index.js
@@ -17,11 +17,12 @@ const requestExternalAccess = ( url, cb ) => {
 	);
 
 	popupMonitor.once( 'close', () => {
-		let keyringId = null;
+		const result = {};
 		if ( lastMessage && lastMessage.keyring_id ) {
-			keyringId = Number( lastMessage.keyring_id );
+			result.keyring_id = Number( lastMessage.keyring_id );
+			result.id_token = lastMessage.id_token;
 		}
-		cb( keyringId );
+		cb( result );
 	} );
 
 	popupMonitor.on( 'message', message => ( lastMessage = message ) );

--- a/client/my-sites/marketing/connections/service.jsx
+++ b/client/my-sites/marketing/connections/service.jsx
@@ -173,7 +173,7 @@ export class SharingService extends Component {
 			} else {
 				// Attempt to create a new connection. If a Keyring connection ID
 				// is not provided, the user will need to authorize the app
-				requestExternalAccess( service.connect_URL, newKeyringId => {
+				requestExternalAccess( service.connect_URL, ( { keyring_id: newKeyringId } ) => {
 					// When the user has finished authorizing the connection
 					// (or otherwise closed the window), force a refresh
 					this.props.requestKeyringConnections();


### PR DESCRIPTION
Requires server side patch D30973

WIP

#### Changes proposed in this Pull Request

This change reuses the apple external service to add "Sign In with Apple". This does not support sign up with apple though so one must create a valid keyring connection first to be able to login using this service afterwards.

#### Testing instructions

Incoming
