### PR TITLE
Coupons: add RBC to auto-apply list

### DIFF
--- a/client/lib/upgrades/actions/cart.js
+++ b/client/lib/upgrades/actions/cart.js
@@ -155,16 +155,17 @@ export function getRememberedCoupon() {
 	}
 	const COUPON_CODE_WHITELIST = [
 		'ALT',
+		'FBSAVE15',
 		'FIVERR',
 		'GENEA',
 		'KITVISA',
 		'LINKEDIN',
 		'PATREON',
 		'ROCKETLAWYER',
+		'RBC',
 		'SAFE',
 		'SBDC',
 		'TXAM',
-		'FBSAVE15',
 	];
 	const THIRTY_DAYS_MILLISECONDS = 30 * 24 * 60 * 60 * 1000;
 	const now = Date.now();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* add `RBC` coupon code to auto-apply whitelist
* sort coupon code whitelist alphabetically

#### Testing instructions

* checkout branch locally or use calypso.live
* use an incognito window
* visit a URL like http://calypso.localhost:3000/start/user?coupon=RBC_XXXX (use current code from https://wordpress.com/rebrandcities)
* ensure that `localStorage.getItem( 'marketing-coupons' )` returns an object that has RBC_XXX as a key and for that key an integer number as its value (should be the current timestamp in ms)
* go through signup and on the plans selection page, select a paid plan
* ensure that in checkout the coupon is automatically applied
* ensure no errors in the JavaScript console 
