### PR TITLE
Import in Signup: enable test to show import on site type step

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -135,12 +135,12 @@ export default {
 		//localeTargets: 'any',
 	},
 	showImportFlowInSiteTypeStep: {
-		datestamp: '20991231',
+		datestamp: '20190820',
 		variations: {
 			show: 50,
 			hide: 50,
 		},
-		defaultVariation: 'show',
+		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
 	removeBlogFlow: {

--- a/client/signup/steps/site-type/index.jsx
+++ b/client/signup/steps/site-type/index.jsx
@@ -13,7 +13,6 @@ import hasInitializedSites from 'state/selectors/has-initialized-sites';
 import Button from 'components/button';
 import SiteTypeForm from './form';
 import StepWrapper from 'signup/step-wrapper';
-import { isEnabled } from 'config';
 import { getSiteType } from 'state/signup/steps/site-type/selectors';
 import { submitSiteType } from 'state/signup/steps/site-type/actions';
 import { saveSignupStep } from 'state/signup/progress/actions';
@@ -52,10 +51,7 @@ class SiteType extends Component {
 	};
 
 	renderImportButton() {
-		if (
-			! isEnabled( 'signup/import-flow' ) ||
-			'show' !== abtest( 'showImportFlowInSiteTypeStep' )
-		) {
+		if ( 'show' !== abtest( 'showImportFlowInSiteTypeStep' ) ) {
 			return null;
 		}
 

--- a/config/development.json
+++ b/config/development.json
@@ -148,7 +148,6 @@
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": true,
 		"signup/full-site-editing": true,
-		"signup/import-flow": true,
 		"signup/onboarding-flow": true,
 		"signup/social": true,
 		"signup/social-management": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -123,7 +123,6 @@
 		"signup/social-management": true,
 		"signup/atomic-store-flow": true,
 		"signup/ecommerce-flow": false,
-		"signup/import-flow": true,
 		"signup/wpcc": true,
 		"support-user": true,
 		"try/preconnect": true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Enable the a/b test to show import in site type step. See p3Ex-3u7-p2

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confidence check

