### PR TITLE
Customer Home: Add MC stats and tracks events to all the links

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -322,7 +322,7 @@ class Home extends Component {
 	};
 }
 
-const connectHome = connect( 
+const connectHome = connect(
 	state => {
 		const siteId = getSelectedSiteId( state );
 		const siteChecklist = getSiteChecklist( state, siteId );
@@ -346,7 +346,7 @@ const connectHome = connect(
 			dispatch(
 				composeAnalytics(
 					recordTracksEvent( `calypso_customer_home_${ section }_${ action }_click`, {
-						isStaticHomePage,
+						is_static_home_page: isStaticHomePage,
 					} ),
 					bumpStat( 'calypso_customer_home', `${ section }_${ action }` )
 				)

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -153,7 +153,7 @@ class Home extends Component {
 	}
 
 	renderCustomerHome = () => {
-		const { translate, customizeUrl, site, siteSlug, trackAction } = this.props;
+		const { translate, customizeUrl, site, siteSlug, trackAction, isStaticHomePage } = this.props;
 		return (
 			<div className="customer-home__layout">
 				<div className="customer-home__layout-col">
@@ -170,12 +170,23 @@ class Home extends Component {
 							>
 								{ translate( 'View Site' ) }
 							</Button>
-							<Button
-								href={ customizeUrl }
-								onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
-							>
-								{ translate( 'Edit Homepage' ) }
-							</Button>
+							{ isStaticHomePage ? (
+								<Button
+									href={ customizeUrl }
+									onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
+								>
+									{ translate( 'Edit Homepage' ) }
+								</Button>
+							) : (
+								<Button
+									onClick={ () => {
+										trackAction( 'my_site', 'write_post' );
+										page( `/post/${ siteSlug }` );
+									} }
+								>
+									{ translate( 'Write Blog Post' ) }
+								</Button>
+							) }
 						</div>
 					</Card>
 					<Card className="customer-home__card-boxes">
@@ -188,14 +199,25 @@ class Home extends Component {
 								label={ translate( 'Add a page' ) }
 								iconSrc="/calypso/images/customer-home/page.svg"
 							/>
-							<ActionBox
-								onClick={ () => {
-									trackAction( 'my_site', 'write_post' );
-									page( `/post/${ siteSlug }` );
-								} }
-								label={ translate( 'Write blog post' ) }
-								iconSrc="/calypso/images/customer-home/post.svg"
-							/>
+							{ isStaticHomePage ? (
+								<ActionBox
+									onClick={ () => {
+										trackAction( 'my_site', 'write_post' );
+										page( `/post/${ siteSlug }` );
+									} }
+									label={ translate( 'Write blog post' ) }
+									iconSrc="/calypso/images/customer-home/post.svg"
+								/>
+							) : (
+								<ActionBox
+									onClick={ () => {
+										trackAction( 'my_site', 'manage_comments' );
+										page( `/comments/${ siteSlug }` );
+									} }
+									label={ translate( 'Manage comments' ) }
+									iconSrc="/calypso/images/customer-home/comment.svg"
+								/>
+							) }
 							<ActionBox
 								href={ customizeUrl }
 								onClick={ () => trackAction( 'my_site', 'customize_theme' ) }

--- a/static/images/customer-home/comment.svg
+++ b/static/images/customer-home/comment.svg
@@ -1,0 +1,1 @@
+<svg width="20" height="21" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M-2-1.5h24v24H-2z"/><path d="M18 15.67l-1.17-1.17H2v-12h16v13.17zM18 .5H2c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4v-18c0-1.1-.9-2-2-2z" fill="#8F9194" fill-rule="nonzero"/></g></svg>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This change adds Tracks events and bumps MC stats for each link on the
page. It passes whether the site is using a static homepage to the
Tracks events, because we are planning on showing different links to
people based on this option, and we may want to segment the data by it.

#### Testing instructions

Turn on debug for analytics using:

`localStorage.setItem('debug', "calypso:analytics:mc,calypso:analytics:tracks")`

in your browser console.

Click on the various links on the customer home page and check the logs in the console. You should see events being tracked of the form

```
calypso:analytics:tracks Recording event "calypso_customer_home_earn_share_site_click" with actual props 
Object { isStaticHomePage: true, environment: "development", environment_id: "development", site_count: 155, site_id_label: "wpcom", client: "browser" }
calypso:analytics:mc Bumping stat calypso_customer_home:earn_share_site +1h
```

