### PR TITLE
SPT: Abstract item route

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-wp-rest-sideload-image-controller.php
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/class-wp-rest-sideload-image-controller.php
@@ -160,7 +160,7 @@ class WP_REST_Sideload_Image_Controller extends \WP_REST_Attachments_Controller 
 
 		// Foreach request specified in the requests param, run the endpoint.
 		foreach ( $request['resources'] as $resource ) {
-			$request = new \WP_REST_Request( 'POST', "/{$this->namespace}/{$this->rest_base}" );
+			$request = new \WP_REST_Request( 'POST', $this->get_item_route() );
 
 			// Add specified request parameters into the request.
 			foreach ( $resource as $param_name => $param_value ) {
@@ -282,5 +282,14 @@ class WP_REST_Sideload_Image_Controller extends \WP_REST_Attachments_Controller 
 				'default'     => 0,
 			],
 		];
+	}
+
+	/**
+	 * Returns the route to sideload a single image.
+	 *
+	 * @return string
+	 */
+	public function get_item_route() {
+		return "/{$this->namespace}/{$this->rest_base}";
 	}
 }


### PR DESCRIPTION
Allow subclasses to overwrite the route.

See D31603-code

### Testing
Send a POST request to this endpoint on your test site. It should continue to respond with two image resources.

`POST /wp-json/fse/v1/sideload/image/batch?resources[0][url]=https://a8ctm1.files.wordpress.com/2019/06/phone-table.jpg&resources[1][url]=https://a8ctm1.files.wordpress.com/2019/06/phone-table.jpg`
