### PR TITLE
Jetpack installer: Skip install status requests if no installs

### DIFF
--- a/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
+++ b/client/my-sites/plans/current-plan/jetpack-product-install/index.tsx
@@ -235,8 +235,15 @@ export class JetpackProductInstall extends Component< Props, State > {
 	 * or by a retry if we discover we have a recoverable error.
 	 */
 	requestInstallationStatus = (): void => {
-		const { siteId } = this.props;
+		const { requestedInstalls, siteId } = this.props;
+
+		// We require a siteId to get install status
 		if ( ! siteId ) {
+			return;
+		}
+
+		// Don't do anything if we haven't requested any installs
+		if ( ! requestedInstalls.length ) {
 			return;
 		}
 


### PR DESCRIPTION
Don't check install status if the installer doesn't need to install
anything. Saves repeated API calls.

Reported by @tyxla, thanks!

#### Testing instructions

* Connect a Jetpack site on the free plan
* After connecting, at `/plans/my-plan/SITE_SLUG`, you should see no requests to an endpoint like `/jetpack-blogs/SITE_ID/product-install-status`. Without this change, you would see a request sent every second.
* Subsequently purchasing a paid plan or purchasing a paid plan during the connection flow should work as before (plugins installed as expected).

