### PR TITLE
Import in Signup: Fix occasional mis-sizing of service icon in import preview

### DIFF
--- a/client/signup/steps/import-preview/style.scss
+++ b/client/signup/steps/import-preview/style.scss
@@ -12,6 +12,7 @@
 	.importer__service-icon {
 		align-self: flex-start;
 		object-fit: contain;
+		min-width: 48px;
 		width: 48px;
 		height: 48px;
 		border-radius: 0;


### PR DESCRIPTION
A rendering issue causes the GoDaddy icon in the import preview occasionally to be rendered narrower than its proper width. The icon pops back into shape after some time, and also as soon as you inspect it in dev tools.

#### Changes proposed in this Pull Request

* Add a `min-width` rule to force the icon to be at least 48px wide.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the PR and go to http://calypso.localhost:3000/start/import-onboarding/, or use `calypso.live`.
* Click the Already have a website? link on the `site-type` step to go to the `from-url` step.
* Enter the URL of a GoDaddy or Wix site to import from, for example `https://omowale.org`, `https://rochesternypilates.com` or `https://www.totalsportswomensrace.com`.
* The preview should load. The GoDaddy or Wix icon should be the correct 48px square shape.
* Try this test several times, as the issue is intermittent.

Fixes https://github.com/Automattic/wp-calypso/issues/35560
