### PR TITLE
SPT: fix replacing placeholder bug

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -56,7 +56,7 @@ const TemplateSelectorControl = ( {
 							onFocus={ onTemplateFocus }
 							staticPreviewImg={ preview }
 							staticPreviewImgAlt={ previewAlt }
-							rawContent={ content }
+							rawContent={ replacePlaceholders( content, siteInformation ) }
 							useDynamicPreview={ useDynamicPreview }
 							numBlocksInPreview={ numBlocksInPreview }
 						/>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR fixes a bug introduced in https://github.com/Automattic/wp-calypso/pull/35333.
It simply replaces the raw content before to parse the blocks

#### Testing instructions

Confirm that it doesn't replace the placeholders, for instance, testing in the `blog` template.

<img src="https://user-images.githubusercontent.com/77539/63284201-69a15680-c289-11e9-84f0-71971a3a551c.png" width="400px" />

After applying the patch, you should see the title rightly.

<img src="https://user-images.githubusercontent.com/77539/63283887-cc462280-c288-11e9-9f89-0f71984a972e.png" width="400px" />
