### PR TITLE
Experiment: make schema validation explicit.

### DIFF
--- a/client/extensions/wp-super-cache/state/plugins/reducer.js
+++ b/client/extensions/wp-super-cache/state/plugins/reducer.js
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
 
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_PLUGINS,
@@ -78,7 +76,7 @@ export const toggling = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated plugins
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ WP_SUPER_CACHE_RECEIVE_PLUGINS ]: ( state, { siteId, plugins } ) => ( {

--- a/client/extensions/wp-super-cache/state/settings/reducer.js
+++ b/client/extensions/wp-super-cache/state/settings/reducer.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_PRELOAD_CACHE_SUCCESS,
@@ -117,7 +114,7 @@ export const restoring = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated settings
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ WP_SUPER_CACHE_RECEIVE_SETTINGS ]: ( state, { siteId, settings } ) => ( {

--- a/client/extensions/wp-super-cache/state/stats/reducer.js
+++ b/client/extensions/wp-super-cache/state/stats/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { statsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_DELETE_CACHE_SUCCESS,
@@ -74,7 +71,7 @@ const deleting = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated stats
  */
-const items = createReducer(
+const items = createReducerWithValidation(
 	{},
 	{
 		[ WP_SUPER_CACHE_GENERATE_STATS_SUCCESS ]: ( state, { siteId, stats } ) => ( {

--- a/client/extensions/wp-super-cache/state/status/reducer.js
+++ b/client/extensions/wp-super-cache/state/status/reducer.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	WP_SUPER_CACHE_RECEIVE_STATUS,
@@ -39,7 +36,7 @@ const requesting = createReducer(
  * @param  {Object} action Action object
  * @return {Object} Updated status
  */
-const items = createReducer(
+const items = createReducerWithValidation(
 	{},
 	{
 		[ WP_SUPER_CACHE_RECEIVE_STATUS ]: ( state, action ) => ( {

--- a/client/extensions/zoninator/state/zones/reducer.js
+++ b/client/extensions/zoninator/state/zones/reducer.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	ZONINATOR_REQUEST_ERROR,
@@ -22,7 +19,7 @@ export const requesting = createReducer(
 	}
 );
 
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ ZONINATOR_UPDATE_ZONES ]: ( state, { siteId, data } ) => ( { ...state, [ siteId ]: data } ),

--- a/client/state/active-promotions/reducer.js
+++ b/client/state/active-promotions/reducer.js
@@ -1,16 +1,13 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
 	ACTIVE_PROMOTIONS_RECEIVE,
 	ACTIVE_PROMOTIONS_REQUEST,
 	ACTIVE_PROMOTIONS_REQUEST_SUCCESS,
 	ACTIVE_PROMOTIONS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -22,15 +19,14 @@ import { itemsSchema } from './schema';
  * @param {Object} action - activePromotions action
  * @return {Object} updated state
  */
-export const items = ( state = [], action ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = [], action ) => {
 	switch ( action.type ) {
 		case ACTIVE_PROMOTIONS_RECEIVE:
 			return [ ...action.activePromotions ];
 	}
 
 	return state;
-};
-items.schema = itemsSchema;
+} );
 
 /**
  * `Reducer` function which handles request/response actions

--- a/client/state/active-promotions/test/reducer.js
+++ b/client/state/active-promotions/test/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -16,16 +14,13 @@ import {
 	requestActivePromotions,
 } from '../actions';
 import activePromotionsReducer, {
-	items,
+	items as itemsReducer,
 	requesting as requestReducer,
 	error as errorReducer,
 } from '../reducer';
 
 import { WPCOM_RESPONSE } from './fixture';
-import { withSchemaValidation } from 'state/utils';
 import { useSandbox } from 'test/helpers/use-sinon';
-
-const itemsReducer = withSchemaValidation( items.schema, items );
 
 describe( 'reducer', () => {
 	let sandbox;

--- a/client/state/activity-log/restore/reducer.js
+++ b/client/state/activity-log/restore/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * Internal dependencies
  */
@@ -10,7 +9,7 @@ import {
 	REWIND_RESTORE_REQUEST,
 	REWIND_RESTORE_UPDATE_PROGRESS,
 } from 'state/action-types';
-import { createReducer, keyedReducer } from 'state/utils';
+import { createReducer, keyedReducer, withSchemaValidation } from 'state/utils';
 
 const stubNull = () => null;
 
@@ -39,19 +38,21 @@ const updateProgress = (
 	context,
 } );
 
-export const restoreProgress = keyedReducer(
-	'siteId',
-	createReducer(
-		{},
-		{
-			[ REWIND_RESTORE ]: startProgress,
-			[ REWIND_RESTORE_DISMISS_PROGRESS ]: stubNull,
-			[ REWIND_RESTORE_UPDATE_PROGRESS ]: updateProgress,
-			[ REWIND_RESTORE_DISMISS ]: stubNull,
-		}
+export const restoreProgress = withSchemaValidation(
+	restoreProgressSchema,
+	keyedReducer(
+		'siteId',
+		createReducer(
+			{},
+			{
+				[ REWIND_RESTORE ]: startProgress,
+				[ REWIND_RESTORE_DISMISS_PROGRESS ]: stubNull,
+				[ REWIND_RESTORE_UPDATE_PROGRESS ]: updateProgress,
+				[ REWIND_RESTORE_DISMISS ]: stubNull,
+			}
+		)
 	)
 );
-restoreProgress.schema = restoreProgressSchema;
 
 export const restoreRequest = keyedReducer(
 	'siteId',

--- a/client/state/application-passwords/reducer.js
+++ b/client/state/application-passwords/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -14,10 +12,10 @@ import {
 	APPLICATION_PASSWORD_NEW_CLEAR,
 	APPLICATION_PASSWORDS_RECEIVE,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 
-export const items = ( state = [], action ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = [], action ) => {
 	switch ( action.type ) {
 		case APPLICATION_PASSWORD_DELETE_SUCCESS:
 			return reject( state, { ID: action.appPasswordId } );
@@ -26,8 +24,7 @@ export const items = ( state = [], action ) => {
 		default:
 			return state;
 	}
-};
-items.schema = itemsSchema;
+} );
 
 export const newPassword = ( state = null, action ) => {
 	switch ( action.type ) {

--- a/client/state/atomic-transfer/reducer.js
+++ b/client/state/atomic-transfer/reducer.js
@@ -1,9 +1,12 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-import { combineReducers, keyedReducer, createReducer } from 'state/utils';
+import {
+	combineReducers,
+	keyedReducer,
+	createReducer,
+	createReducerWithValidation,
+} from 'state/utils';
 import { atomicTransfer as schema } from './schema';
 import {
 	ATOMIC_TRANSFER_REQUEST,
@@ -12,7 +15,7 @@ import {
 	ATOMIC_TRANSFER_COMPLETE,
 } from 'state/action-types';
 
-export const atomicTransfer = createReducer(
+export const atomicTransfer = createReducerWithValidation(
 	{},
 	{
 		[ ATOMIC_TRANSFER_SET ]: ( state, { transfer } ) => ( { ...state, ...transfer } ),

--- a/client/state/billing-transactions/reducer.js
+++ b/client/state/billing-transactions/reducer.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
 	BILLING_RECEIPT_EMAIL_SEND,
 	BILLING_RECEIPT_EMAIL_SEND_FAILURE,
@@ -13,7 +10,7 @@ import {
 	BILLING_TRANSACTIONS_REQUEST_FAILURE,
 	BILLING_TRANSACTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { billingTransactionsSchema } from './schema';
 import individualTransactions from './individual-transactions/reducer';
 
@@ -25,7 +22,7 @@ import individualTransactions from './individual-transactions/reducer';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ BILLING_TRANSACTIONS_RECEIVE ]: ( state, { past, upcoming } ) => ( { past, upcoming } ),

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -1,11 +1,7 @@
 /**
- * External dependencies
- */
-
-/**
  * Internal dependencies
  */
-import { combineReducers, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
 import {
 	JETPACK_MODULE_ACTIVATE_SUCCESS,
 	JETPACK_MODULE_DEACTIVATE_SUCCESS,
@@ -31,7 +27,7 @@ const moduleTaskMap = {
 	videopress: 'jetpack_video_hosting',
 };
 
-function items( state = {}, action ) {
+const items = withSchemaValidation( itemSchemas, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_CHECKLIST_RECEIVE:
 			return action.checklist;
@@ -55,8 +51,7 @@ function items( state = {}, action ) {
 			break;
 	}
 	return state;
-}
-items.schema = itemSchemas;
+} );
 
 const reducer = combineReducers( {
 	items,

--- a/client/state/connected-applications/reducer.js
+++ b/client/state/connected-applications/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -12,6 +10,7 @@ import {
 	CONNECTED_APPLICATION_DELETE_SUCCESS,
 	CONNECTED_APPLICATIONS_RECEIVE,
 } from 'state/action-types';
+import { withSchemaValidation } from 'state/utils';
 import schema from './schema';
 
 const reducer = ( state = null, action ) => {
@@ -24,6 +23,5 @@ const reducer = ( state = null, action ) => {
 			return state;
 	}
 };
-reducer.schema = schema;
 
-export default reducer;
+export default withSchemaValidation( schema, reducer );

--- a/client/state/country-states/reducer.js
+++ b/client/state/country-states/reducer.js
@@ -1,20 +1,17 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
 	COUNTRY_STATES_RECEIVE,
 	COUNTRY_STATES_REQUEST,
 	COUNTRY_STATES_REQUEST_FAILURE,
 	COUNTRY_STATES_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemSchema } from './schema';
 
 // Stores the complete list of states, indexed by locale key
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ COUNTRY_STATES_RECEIVE ]: ( state, action ) => ( {

--- a/client/state/current-user/reducer.js
+++ b/client/state/current-user/reducer.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { get, isEqual, reduce, keys, first } from 'lodash';
 
 /**
@@ -17,7 +14,7 @@ import {
 	PLANS_RECEIVE,
 	PRODUCTS_LIST_RECEIVE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation, withSchemaValidation } from 'state/utils';
 import { idSchema, capabilitiesSchema, currencyCodeSchema, flagsSchema } from './schema';
 import gravatarStatus from './gravatar-status/reducer';
 import emailVerification from './email-verification/reducer';
@@ -35,7 +32,7 @@ import emailVerification from './email-verification/reducer';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const id = createReducer(
+export const id = createReducerWithValidation(
 	null,
 	{
 		[ CURRENT_USER_RECEIVE ]: ( state, action ) => action.user.ID,
@@ -43,7 +40,7 @@ export const id = createReducer(
 	idSchema
 );
 
-export const flags = createReducer(
+export const flags = createReducerWithValidation(
 	[],
 	{
 		[ CURRENT_USER_RECEIVE ]: ( state, action ) =>
@@ -60,7 +57,7 @@ export const flags = createReducer(
  * @return {Object}        Updated state
  *
  */
-export const currencyCode = createReducer(
+export const currencyCode = createReducerWithValidation(
 	null,
 	{
 		[ PRODUCTS_LIST_RECEIVE ]: ( state, action ) => {
@@ -89,7 +86,7 @@ export const currencyCode = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function capabilities( state = {}, action ) {
+export const capabilities = withSchemaValidation( capabilitiesSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_RECEIVE:
 		case SITES_RECEIVE: {
@@ -114,8 +111,7 @@ export function capabilities( state = {}, action ) {
 	}
 
 	return state;
-}
-capabilities.schema = capabilitiesSchema;
+} );
 
 export default combineReducers( {
 	id,

--- a/client/state/current-user/test/reducer.js
+++ b/client/state/current-user/test/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,7 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import reducer, { id, capabilities as unwrappedCapabilities, currencyCode } from '../reducer';
+import reducer, { id, capabilities, currencyCode } from '../reducer';
 import {
 	CURRENT_USER_RECEIVE,
 	DESERIALIZE,
@@ -19,9 +17,7 @@ import {
 	SITE_PLANS_FETCH_COMPLETED,
 	SITES_RECEIVE,
 } from 'state/action-types';
-import { withSchemaValidation } from 'state/utils';
 import { useSandbox } from 'test/helpers/use-sinon';
-const capabilities = withSchemaValidation( unwrappedCapabilities.schema, unwrappedCapabilities );
 
 describe( 'reducer', () => {
 	useSandbox( sandbox => {

--- a/client/state/document-head/reducer.js
+++ b/client/state/document-head/reducer.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import {
 	DOCUMENT_HEAD_LINK_SET,
 	DOCUMENT_HEAD_META_SET,
@@ -19,7 +16,7 @@ import { titleSchema, unreadCountSchema, linkSchema, metaSchema } from './schema
  */
 export const DEFAULT_META_STATE = [ { property: 'og:site_name', content: 'WordPress.com' } ];
 
-export const title = createReducer(
+export const title = createReducerWithValidation(
 	'',
 	{
 		[ DOCUMENT_HEAD_TITLE_SET ]: ( state, action ) => action.title,
@@ -27,7 +24,7 @@ export const title = createReducer(
 	titleSchema
 );
 
-export const unreadCount = createReducer(
+export const unreadCount = createReducerWithValidation(
 	0,
 	{
 		[ DOCUMENT_HEAD_UNREAD_COUNT_SET ]: ( state, action ) => action.count,
@@ -36,7 +33,7 @@ export const unreadCount = createReducer(
 	unreadCountSchema
 );
 
-export const meta = createReducer(
+export const meta = createReducerWithValidation(
 	DEFAULT_META_STATE,
 	{
 		[ DOCUMENT_HEAD_META_SET ]: ( state, action ) => action.meta,
@@ -44,7 +41,7 @@ export const meta = createReducer(
 	metaSchema
 );
 
-export const link = createReducer(
+export const link = createReducerWithValidation(
 	[],
 	{
 		[ DOCUMENT_HEAD_LINK_SET ]: ( state, action ) => action.link,

--- a/client/state/domains/management/reducer.js
+++ b/client/state/domains/management/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -7,7 +6,12 @@ import { get, isArray, merge, omit, stubFalse, stubTrue } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducers, keyedReducer } from 'state/utils';
+import {
+	createReducer,
+	createReducerWithValidation,
+	combineReducers,
+	keyedReducer,
+} from 'state/utils';
 import { validationSchemas } from './validation-schemas/reducer';
 import { domainWhoisSchema } from './schema';
 import {
@@ -103,7 +107,7 @@ function mergeDomainRegistrantContactDetails( domainState, registrantContactDeta
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ DOMAIN_MANAGEMENT_CONTACT_DETAILS_CACHE_RECEIVE ]: ( state, { data } ) => ( {

--- a/client/state/domains/suggestions/reducer.js
+++ b/client/state/domains/suggestions/reducer.js
@@ -1,16 +1,14 @@
-/** @format */
-
+/* eslint-disable no-case-declarations */
 /**
  * Internal dependencies
  */
-
 import {
 	DOMAINS_SUGGESTIONS_RECEIVE,
 	DOMAINS_SUGGESTIONS_REQUEST,
 	DOMAINS_SUGGESTIONS_REQUEST_FAILURE,
 	DOMAINS_SUGGESTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 import { getSerializedDomainsSuggestionsQuery } from './utils';
 
@@ -21,7 +19,7 @@ import { getSerializedDomainsSuggestionsQuery } from './utils';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function items( state = {}, action ) {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case DOMAINS_SUGGESTIONS_RECEIVE:
 			const serializedQuery = getSerializedDomainsSuggestionsQuery( action.queryObject );
@@ -33,8 +31,7 @@ export function items( state = {}, action ) {
 			return state;
 	}
 	return state;
-}
-items.schema = itemsSchema;
+} );
 
 /**
  * Tracks domains suggestions request state, indexed by a serialized query.

--- a/client/state/domains/suggestions/test/reducer.js
+++ b/client/state/domains/suggestions/test/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,7 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import reducer, { items as unwrappedItems, requesting, errors } from '../reducer';
+import reducer, { items, requesting, errors } from '../reducer';
 import {
 	DOMAINS_SUGGESTIONS_RECEIVE,
 	DOMAINS_SUGGESTIONS_REQUEST,
@@ -18,10 +16,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
-import { withSchemaValidation } from 'state/utils';
 import { useSandbox } from 'test/helpers/use-sinon';
-
-const items = withSchemaValidation( unwrappedItems.schema, unwrappedItems );
 
 describe( 'reducer', () => {
 	let sandbox;
@@ -402,7 +397,7 @@ describe( 'reducer', () => {
 			} );
 		} );
 
-		test( 'should update errors on failure', () => {
+		test( 'should update errors on error', () => {
 			const originalState = deepFreeze( {
 				'{"query":"example","quantity":2,"vendor":"domainsbot","include_wordpressdotcom":false}': true,
 			} );

--- a/client/state/domains/transfer/reducer.js
+++ b/client/state/domains/transfer/reducer.js
@@ -1,8 +1,7 @@
-/** @format */
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducers } from 'state/utils';
+import { createReducerWithValidation, combineReducers } from 'state/utils';
 import { domainTransferSchema } from './schema';
 import { DOMAIN_TRANSFER_UPDATE } from 'state/action-types';
 
@@ -14,7 +13,7 @@ import { DOMAIN_TRANSFER_UPDATE } from 'state/action-types';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ DOMAIN_TRANSFER_UPDATE ]: ( state, { domain, options } ) => ( {

--- a/client/state/email-forwarding/reducer.js
+++ b/client/state/email-forwarding/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -8,7 +6,12 @@ import { orderBy } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import {
+	combineReducers,
+	createReducer,
+	createReducerWithValidation,
+	keyedReducer,
+} from 'state/utils';
 import {
 	EMAIL_FORWARDING_REQUEST,
 	EMAIL_FORWARDING_REQUEST_SUCCESS,
@@ -84,7 +87,7 @@ const changeMailBoxTemporary = temporary => ( forwards, { mailbox } ) => {
 	} );
 };
 
-export const typeReducer = createReducer(
+export const typeReducer = createReducerWithValidation(
 	null,
 	{
 		[ EMAIL_FORWARDING_REQUEST ]: () => null,
@@ -94,7 +97,7 @@ export const typeReducer = createReducer(
 	typeSchema
 );
 
-export const mxServersReducer = createReducer(
+export const mxServersReducer = createReducerWithValidation(
 	null,
 	{
 		[ EMAIL_FORWARDING_REQUEST ]: () => null,
@@ -105,7 +108,7 @@ export const mxServersReducer = createReducer(
 	mxSchema
 );
 
-export const forwardsReducer = createReducer(
+export const forwardsReducer = createReducerWithValidation(
 	null,
 	{
 		[ EMAIL_FORWARDING_REQUEST ]: () => null,

--- a/client/state/gsuite-users/reducer.js
+++ b/client/state/gsuite-users/reducer.js
@@ -1,9 +1,12 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import {
+	combineReducers,
+	createReducerWithValidation,
+	createReducer,
+	keyedReducer,
+} from 'state/utils';
 import {
 	GSUITE_USERS_REQUEST,
 	GSUITE_USERS_REQUEST_FAILURE,
@@ -11,7 +14,7 @@ import {
 } from 'state/action-types';
 import { usersSchema } from './schema';
 
-export const usersReducer = createReducer(
+export const usersReducer = createReducerWithValidation(
 	null,
 	{
 		[ GSUITE_USERS_REQUEST ]: () => null,

--- a/client/state/happiness-engineers/reducer.js
+++ b/client/state/happiness-engineers/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { map } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	HAPPINESS_ENGINEERS_FETCH,
@@ -41,7 +38,7 @@ export const requesting = createReducer( false, {
  * @param  {Object} action Action object
  * @return {Array}         Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	null,
 	{
 		[ HAPPINESS_ENGINEERS_RECEIVE ]: ( state, { happinessEngineers } ) => {

--- a/client/state/happychat/chat/reducer.js
+++ b/client/state/happychat/chat/reducer.js
@@ -1,7 +1,4 @@
-/** @format */
-
-/** @format */
-
+/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
@@ -22,7 +19,7 @@ import {
 	HAPPYCHAT_CHAT_STATUS_DEFAULT,
 	HAPPYCHAT_MAX_STORED_MESSAGES,
 } from 'state/happychat/constants';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { timelineSchema } from './schema';
 
 // We compare incoming timestamps against a known future Unix time in seconds date
@@ -34,15 +31,18 @@ const UNIX_TIMESTAMP_2023_IN_SECONDS = 1700000000;
 export const maybeUpscaleTimePrecision = time =>
 	time < UNIX_TIMESTAMP_2023_IN_SECONDS ? time * 1000 : time;
 
-export const lastActivityTimestamp = ( state = null, action ) => {
-	switch ( action.type ) {
-		case HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE:
-		case HAPPYCHAT_IO_RECEIVE_MESSAGE:
-			return Date.now();
+const lastActivityTimestampSchema = { type: 'number' };
+export const lastActivityTimestamp = withSchemaValidation(
+	lastActivityTimestampSchema,
+	( state = null, action ) => {
+		switch ( action.type ) {
+			case HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE:
+			case HAPPYCHAT_IO_RECEIVE_MESSAGE:
+				return Date.now();
+		}
+		return state;
 	}
-	return state;
-};
-lastActivityTimestamp.schema = { type: 'number' };
+);
 
 /**
  * Tracks the state of the happychat chat. Valid states are:
@@ -105,7 +105,7 @@ const sortTimeline = timeline => sortBy( timeline, event => parseInt( event.time
  * @return {Object}        Updated state
  *
  */
-export const timeline = ( state = [], action ) => {
+export const timeline = withSchemaValidation( timelineSchema, ( state = [], action ) => {
 	switch ( action.type ) {
 		case SERIALIZE:
 			return takeRight( state, HAPPYCHAT_MAX_STORED_MESSAGES );
@@ -149,8 +149,7 @@ export const timeline = ( state = [], action ) => {
 			);
 	}
 	return state;
-};
-timeline.schema = timelineSchema;
+} );
 
 export default combineReducers( {
 	status,

--- a/client/state/happychat/ui/reducer.js
+++ b/client/state/happychat/ui/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
@@ -12,7 +10,7 @@ import {
 	HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE,
 	HAPPYCHAT_SET_CURRENT_MESSAGE,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 
 /**
  * Tracks the current message the user has typed into the happychat client
@@ -32,6 +30,7 @@ export const currentMessage = ( state = '', action ) => {
 	return state;
 };
 
+const lostFocusAtSchema = { type: 'number' };
 /**
  * Tracks the last time Happychat had focus. This lets us determine things like
  * whether the user has unread messages. A numerical value is the timestamp where focus
@@ -40,7 +39,7 @@ export const currentMessage = ( state = '', action ) => {
  * @param {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const lostFocusAt = ( state = null, action ) => {
+export const lostFocusAt = withSchemaValidation( lostFocusAtSchema, ( state = null, action ) => {
 	switch ( action.type ) {
 		case SERIALIZE:
 			// If there's already a timestamp set, use that. Otherwise treat a SERIALIZE as a
@@ -55,8 +54,7 @@ export const lostFocusAt = ( state = null, action ) => {
 			return null;
 	}
 	return state;
-};
-lostFocusAt.schema = { type: 'number' };
+} );
 
 const isOpen = ( state = false, action ) => {
 	switch ( action.type ) {

--- a/client/state/happychat/ui/test/index.js
+++ b/client/state/happychat/ui/test/index.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -16,14 +14,8 @@ import {
 	HAPPYCHAT_IO_SEND_MESSAGE_MESSAGE,
 	HAPPYCHAT_SET_CURRENT_MESSAGE,
 } from 'state/action-types';
-import { lostFocusAt as lostFocusAtWithoutValidation, currentMessage } from '../reducer';
-import { withSchemaValidation } from 'state/utils';
+import { lostFocusAt, currentMessage } from '../reducer';
 jest.mock( 'lib/warn', () => () => {} );
-
-const lostFocusAt = withSchemaValidation(
-	lostFocusAtWithoutValidation.schema,
-	lostFocusAtWithoutValidation
-);
 
 // Simulate the time Feb 27, 2017 05:25 UTC
 const NOW = 1488173100125;

--- a/client/state/happychat/user/reducer.js
+++ b/client/state/happychat/user/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
@@ -8,7 +6,7 @@ import {
 	HAPPYCHAT_ELIGIBILITY_SET,
 	PRESALE_PRECANCELLATION_CHAT_AVAILABILITY_SET,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import {
 	geoLocationSchema,
 	isEligibleSchema,
@@ -23,7 +21,7 @@ import {
  * @param {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const geoLocation = createReducer(
+export const geoLocation = createReducerWithValidation(
 	null,
 	{
 		[ HAPPYCHAT_IO_RECEIVE_INIT ]: ( state, action ) => {
@@ -39,7 +37,7 @@ export const geoLocation = createReducer(
 	geoLocationSchema
 );
 
-export const isEligible = createReducer(
+export const isEligible = createReducerWithValidation(
 	null,
 	{
 		[ HAPPYCHAT_ELIGIBILITY_SET ]: ( state, action ) => action.isEligible,
@@ -47,7 +45,7 @@ export const isEligible = createReducer(
 	isEligibleSchema
 );
 
-export const isPresalesPrecancellationEligible = createReducer(
+export const isPresalesPrecancellationEligible = createReducerWithValidation(
 	null,
 	{
 		[ PRESALE_PRECANCELLATION_CHAT_AVAILABILITY_SET ]: ( state, action ) => action.availability,

--- a/client/state/invites/reducer.js
+++ b/client/state/invites/reducer.js
@@ -1,5 +1,4 @@
-/** @format */
-
+/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
@@ -8,7 +7,7 @@ import { includes, map, pick, zipObject } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import {
 	INVITES_DELETE_REQUEST,
 	INVITES_DELETE_REQUEST_FAILURE,
@@ -52,7 +51,7 @@ export function requesting( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ INVITES_REQUEST_SUCCESS ]: ( state, action ) => {

--- a/client/state/jetpack-connect/reducer/jetpack-auth-attempts.js
+++ b/client/state/jetpack-connect/reducer/jetpack-auth-attempts.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * Internal dependencies
  */
@@ -6,7 +5,7 @@ import { AUTH_ATTEMPS_TTL } from '../constants';
 import { isStale } from '../utils';
 import { JETPACK_CONNECT_COMPLETE_FLOW, JETPACK_CONNECT_RETRY_AUTH } from 'state/action-types';
 import { jetpackAuthAttemptsSchema } from './schema';
-import { keyedReducer } from 'state/utils';
+import { keyedReducer, withSchemaValidation } from 'state/utils';
 
 export function authAttempts( state = undefined, { type, attemptNumber } ) {
 	switch ( type ) {
@@ -28,7 +27,9 @@ export function authAttempts( state = undefined, { type, attemptNumber } ) {
 	return state;
 }
 
-export const reducer = keyedReducer( 'slug', authAttempts );
-reducer.schema = jetpackAuthAttemptsSchema;
+export const reducer = withSchemaValidation(
+	jetpackAuthAttemptsSchema,
+	keyedReducer( 'slug', authAttempts )
+);
 
 export default reducer;

--- a/client/state/jetpack/credentials/reducer.js
+++ b/client/state/jetpack/credentials/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * Internal dependencies
  */
@@ -8,17 +7,19 @@ import {
 	JETPACK_CREDENTIALS_UPDATE_SUCCESS,
 	JETPACK_CREDENTIALS_UPDATE_FAILURE,
 } from 'state/action-types';
-import { combineReducers, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 
-export const items = keyedReducer( 'siteId', ( state, { type, credentials } ) => {
-	if ( JETPACK_CREDENTIALS_STORE === type ) {
-		return 'object' === typeof credentials ? credentials : {};
-	}
+export const items = withSchemaValidation(
+	itemsSchema,
+	keyedReducer( 'siteId', ( state, { type, credentials } ) => {
+		if ( JETPACK_CREDENTIALS_STORE === type ) {
+			return 'object' === typeof credentials ? credentials : {};
+		}
 
-	return state;
-} );
-items.schema = itemsSchema;
+		return state;
+	} )
+);
 
 export const requestStatus = keyedReducer( 'siteId', ( state, { type } ) => {
 	switch ( type ) {

--- a/client/state/jetpack/onboarding/reducer.js
+++ b/client/state/jetpack/onboarding/reducer.js
@@ -1,9 +1,7 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducers, keyedReducer } from 'state/utils';
+import { createReducerWithValidation, combineReducers, keyedReducer } from 'state/utils';
 import credentialsSchema from './schema';
 import {
 	JETPACK_CONNECT_AUTHORIZE_RECEIVE,
@@ -12,7 +10,7 @@ import {
 
 const credentialsReducer = keyedReducer(
 	'siteId',
-	createReducer(
+	createReducerWithValidation(
 		{},
 		{
 			[ JETPACK_ONBOARDING_CREDENTIALS_RECEIVE ]: ( state, { credentials } ) => credentials,

--- a/client/state/jetpack/settings/reducer.js
+++ b/client/state/jetpack/settings/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -8,7 +6,7 @@ import { mapValues, merge } from 'lodash';
 /**
  * Internal dependencies
  */
-import { createReducer, combineReducers, keyedReducer } from 'state/utils';
+import { createReducerWithValidation, combineReducers, keyedReducer } from 'state/utils';
 import { jetpackSettingsSchema } from './schema';
 import { normalizeSettings } from './utils';
 import {
@@ -21,7 +19,7 @@ import {
 
 export const settingsReducer = keyedReducer(
 	'siteId',
-	createReducer(
+	createReducerWithValidation(
 		{},
 		{
 			[ JETPACK_MODULE_ACTIVATE_SUCCESS ]: ( state, { moduleSlug } ) => ( {

--- a/client/state/memberships/product-list/reducer.js
+++ b/client/state/memberships/product-list/reducer.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import productListSchema from './schema';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import {
 	MEMBERSHIPS_PRODUCTS_RECEIVE,
 	MEMBERSHIPS_PRODUCT_RECEIVE,
@@ -41,7 +38,7 @@ function addOrEditProduct( list = [], newProduct ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ MEMBERSHIPS_PRODUCTS_RECEIVE ]: ( state, { siteId, products } ) => ( {

--- a/client/state/my-sites/reducer.js
+++ b/client/state/my-sites/reducer.js
@@ -1,12 +1,10 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import sidebar from './sidebar/reducer';
 
-sidebar.schema = {
+const schema = {
 	type: 'object',
 	patternProperties: {
 		// Sidebar section key, e.g. `site`.
@@ -17,4 +15,4 @@ sidebar.schema = {
 	additionalProperties: false,
 };
 
-export default combineReducers( { sidebarSections: sidebar } );
+export default combineReducers( { sidebarSections: withSchemaValidation( schema, sidebar ) } );

--- a/client/state/my-sites/sidebar/reducer.js
+++ b/client/state/my-sites/sidebar/reducer.js
@@ -1,17 +1,18 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
 	MY_SITES_SIDEBAR_SECTION_TOGGLE,
 	MY_SITES_SIDEBAR_SECTION_EXPAND,
 	MY_SITES_SIDEBAR_SECTION_COLLAPSE,
 } from 'state/action-types';
-import { combineReducers, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
 
-function expansionReducer( state = false, action ) {
+const schema = {
+	type: 'boolean',
+};
+
+const expansionReducer = withSchemaValidation( schema, ( state = false, action ) => {
 	switch ( action.type ) {
 		case MY_SITES_SIDEBAR_SECTION_TOGGLE:
 			return ! state;
@@ -22,11 +23,7 @@ function expansionReducer( state = false, action ) {
 		default:
 			return state;
 	}
-}
-
-expansionReducer.schema = {
-	type: 'boolean',
-};
+} );
 
 const sectionReducer = combineReducers( { isOpen: expansionReducer } );
 

--- a/client/state/page-templates/reducer.js
+++ b/client/state/page-templates/reducer.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 import {
 	PAGE_TEMPLATES_RECEIVE,
@@ -45,7 +42,7 @@ export const requesting = createReducer(
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ PAGE_TEMPLATES_RECEIVE ]: ( state, { siteId, templates } ) => {

--- a/client/state/plans/reducer.js
+++ b/client/state/plans/reducer.js
@@ -1,16 +1,13 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
 	PLANS_RECEIVE,
 	PLANS_REQUEST,
 	PLANS_REQUEST_SUCCESS,
 	PLANS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -22,15 +19,14 @@ import { itemsSchema } from './schema';
  * @param {Object} action - plans action
  * @return {Object} updated state
  */
-export const items = ( state = [], action ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = [], action ) => {
 	switch ( action.type ) {
 		case PLANS_RECEIVE:
 			return action.plans.slice( 0 );
 	}
 
 	return state;
-};
-items.schema = itemsSchema;
+} );
 
 /**
  * `Reducer` function which handles request/response actions

--- a/client/state/plans/test/reducer.js
+++ b/client/state/plans/test/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -16,16 +14,13 @@ import {
 	requestPlans,
 } from '../actions';
 import plansReducer, {
-	items,
+	items as itemsReducer,
 	requesting as requestReducer,
 	error as errorReducer,
 } from '../reducer';
 
 import { WPCOM_RESPONSE } from './fixture';
-import { withSchemaValidation } from 'state/utils';
 import { useSandbox } from 'test/helpers/use-sinon';
-
-const itemsReducer = withSchemaValidation( items.schema, items );
 
 describe( 'reducer', () => {
 	let sandbox;

--- a/client/state/plugins/installed/reducer.js
+++ b/client/state/plugins/installed/reducer.js
@@ -1,15 +1,13 @@
-/** @format */
-
+/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
-
 import { omit, findIndex } from 'lodash';
 /**
  * Internal dependencies
  */
 import status from './status/reducer';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import {
 	PLUGINS_RECEIVE,
 	PLUGINS_REQUEST,
@@ -56,7 +54,7 @@ const updatePlugin = function( state, action ) {
 /*
  * Tracks all known installed plugin objects indexed by site ID.
  */
-export const plugins = createReducer(
+export const plugins = createReducerWithValidation(
 	{},
 	{
 		[ PLUGINS_RECEIVE ]: ( state, action ) => {

--- a/client/state/plugins/premium/reducer.js
+++ b/client/state/plugins/premium/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -18,7 +16,7 @@ import {
 	PLUGIN_SETUP_ERROR,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { pluginInstructionSchema } from './schema';
 
 /*
@@ -53,7 +51,7 @@ export function hasRequested( state = {}, action ) {
  * Tracks all known premium plugin objects (plugin meta and install status),
  * indexed by site ID.
  */
-export function plugins( state = {}, action ) {
+export const plugins = withSchemaValidation( pluginInstructionSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case PLUGIN_SETUP_INSTRUCTIONS_RECEIVE:
 			return Object.assign( {}, state, { [ action.siteId ]: action.data } );
@@ -81,8 +79,7 @@ export function plugins( state = {}, action ) {
 		default:
 			return state;
 	}
-}
-plugins.schema = pluginInstructionSchema;
+} );
 
 /*
  * Tracks the list of premium plugin objects for a single site

--- a/client/state/post-formats/reducer.js
+++ b/client/state/post-formats/reducer.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { postFormatsItemsSchema } from './schema';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import {
 	POST_FORMATS_RECEIVE,
 	POST_FORMATS_REQUEST,
@@ -38,7 +35,7 @@ export const requesting = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ POST_FORMATS_RECEIVE ]: ( state, { siteId, formats } ) => {

--- a/client/state/post-types/reducer.js
+++ b/client/state/post-types/reducer.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { keyBy } from 'lodash';
 
 /**

--- a/client/state/posts/counts/reducer.js
+++ b/client/state/posts/counts/reducer.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { get, merge, omit, pick } from 'lodash';
 
 /**
@@ -20,7 +17,7 @@ import {
 	POST_SAVE,
 	POSTS_RECEIVE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import { countsSchema } from './schema';
 
 /**
@@ -136,7 +133,7 @@ export const counts = ( () => {
 		} );
 	}
 
-	return createReducer(
+	return createReducerWithValidation(
 		{},
 		{
 			[ POST_COUNTS_RESET_INTERNAL_STATE ]: state => {

--- a/client/state/posts/likes/reducer.js
+++ b/client/state/posts/likes/reducer.js
@@ -1,16 +1,13 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { dropWhile, some } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import itemSchema from './schema';
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation, keyedReducer } from 'state/utils';
 import {
 	POST_LIKES_ADD_LIKER,
 	POST_LIKES_RECEIVE,
@@ -27,7 +24,7 @@ import {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const itemReducer = createReducer(
+export const itemReducer = createReducerWithValidation(
 	{ likes: undefined, iLike: false, found: 0, lastUpdated: undefined },
 	{
 		[ POST_LIKES_RECEIVE ]: ( state, { likes, iLike, found } ) => {

--- a/client/state/posts/reducer.js
+++ b/client/state/posts/reducer.js
@@ -1,5 +1,4 @@
-/** @format */
-
+/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
@@ -21,7 +20,7 @@ import {
  * Internal dependencies
  */
 import PostQueryManager from 'lib/query-manager/post';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import {
 	EDITOR_SAVE,
 	EDITOR_START,
@@ -69,7 +68,7 @@ import { getFeaturedImageId } from 'state/posts/utils';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ POSTS_RECEIVE ]: ( state, action ) => {
@@ -192,7 +191,7 @@ export const queries = ( () => {
 		};
 	}
 
-	return createReducer(
+	return createReducerWithValidation(
 		{},
 		{
 			[ POSTS_REQUEST_SUCCESS ]: ( state, { siteId, query, posts, found } ) => {
@@ -323,7 +322,7 @@ export const allSitesQueries = ( () => {
 		);
 	}
 
-	return createReducer(
+	return createReducerWithValidation(
 		new PostQueryManager( {}, { itemKey: 'global_ID' } ),
 		{
 			[ POSTS_REQUEST_SUCCESS ]: ( state, { siteId, query, posts, found } ) => {

--- a/client/state/preferences/reducer.js
+++ b/client/state/preferences/reducer.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { omit } from 'lodash';
 
 /**
@@ -17,7 +14,7 @@ import {
 	PREFERENCES_FETCH_FAILURE,
 	PREFERENCES_SAVE_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { remoteValuesSchema } from './schema';
 
 /**
@@ -55,7 +52,7 @@ export const localValues = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const remoteValues = createReducer(
+export const remoteValues = createReducerWithValidation(
 	null,
 	{
 		[ PREFERENCES_RECEIVE ]: ( state, { values } ) => values,

--- a/client/state/products-list/reducer.js
+++ b/client/state/products-list/reducer.js
@@ -1,19 +1,16 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
 	PRODUCTS_LIST_RECEIVE,
 	PRODUCTS_LIST_REQUEST,
 	PRODUCTS_LIST_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { productsListSchema } from './schema';
 
 // Stores the complete list of products, indexed by the product key
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ PRODUCTS_LIST_RECEIVE ]: ( state, action ) => action.productsList,

--- a/client/state/push-notifications/reducer.js
+++ b/client/state/push-notifications/reducer.js
@@ -1,16 +1,13 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 import { omit } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { settingsSchema, systemSchema } from './schema';
 
 import {
@@ -29,7 +26,7 @@ const debug = debugFactory( 'calypso:push-notifications' );
 
 // If you change this, also change the corresponding test
 const UNPERSISTED_SYSTEM_NODES = [ 'apiReady', 'authorized', 'authorizationLoaded', 'blocked' ];
-function system( state = {}, action ) {
+const system = withSchemaValidation( systemSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		// System state is not persisted
 		case DESERIALIZE:
@@ -97,8 +94,7 @@ function system( state = {}, action ) {
 	}
 
 	return state;
-}
-system.schema = systemSchema;
+} );
 
 // If you change this, also change the corresponding test
 const UNPERSISTED_SETTINGS_NODES = [
@@ -106,7 +102,7 @@ const UNPERSISTED_SETTINGS_NODES = [
 	'showingUnblockInstructions',
 ];
 
-function settings( state = { enabled: false }, action ) {
+const settings = withSchemaValidation( settingsSchema, ( state = { enabled: false }, action ) => {
 	switch ( action.type ) {
 		case DESERIALIZE: {
 			return omit( state, UNPERSISTED_SETTINGS_NODES );
@@ -136,8 +132,7 @@ function settings( state = { enabled: false }, action ) {
 	}
 
 	return state;
-}
-settings.schema = settingsSchema;
+} );
 
 export default combineReducers( {
 	settings,

--- a/client/state/reader/conversations/reducer.js
+++ b/client/state/reader/conversations/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -14,14 +13,14 @@ import {
 	READER_POSTS_RECEIVE,
 } from 'state/action-types';
 import { CONVERSATION_FOLLOW_STATUS } from './follow-status';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 import { key } from './utils';
 
 /**
  * Tracks all known conversation following statuses.
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ READER_CONVERSATION_FOLLOW ]: ( state, action ) => {

--- a/client/state/reader/feeds/reducer.js
+++ b/client/state/reader/feeds/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External Dependencies
  */
@@ -14,7 +13,7 @@ import {
 	READER_FEED_UPDATE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { decodeEntities, stripHTML } from 'lib/formatting';
 import { itemsSchema } from './schema';
 import { safeLink } from 'lib/post-normalizer/utils';
@@ -64,7 +63,7 @@ function handleFeedUpdate( state, action ) {
 	return assign( {}, state, keyBy( feeds, 'feed_ID' ) );
 }
 
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ SERIALIZE ]: handleSerialize,

--- a/client/state/reader/follows/reducer.js
+++ b/client/state/reader/follows/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -26,7 +25,7 @@ import {
 	READER_UNSUBSCRIBE_TO_NEW_POST_NOTIFICATIONS,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { prepareComparableUrl } from './utils';
 import { items as itemsSchema } from './schema';
 
@@ -107,7 +106,7 @@ function updateNotificationSubscription( state, { payload, type } ) {
 	};
 }
 
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ READER_RECORD_FOLLOW ]: ( state, action ) => {
@@ -257,7 +256,7 @@ export const items = createReducer(
 
 export const itemsCount = createReducer( 0, {
 	[ READER_FOLLOWS_RECEIVE ]: ( state, action ) => {
-		return !! action.payload.totalCount ? action.payload.totalCount : state;
+		return action.payload.totalCount ? action.payload.totalCount : state;
 	},
 } );
 

--- a/client/state/reader/lists/reducer.js
+++ b/client/state/reader/lists/reducer.js
@@ -1,4 +1,4 @@
-/** @format */
+/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
@@ -23,7 +23,7 @@ import {
 	READER_LISTS_FOLLOW_SUCCESS,
 	READER_LISTS_UNFOLLOW_SUCCESS,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema, subscriptionsSchema, updatedListsSchema, errorsSchema } from './schema';
 
 /**
@@ -33,7 +33,7 @@ import { itemsSchema, subscriptionsSchema, updatedListsSchema, errorsSchema } fr
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function items( state = {}, action ) {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case READER_LISTS_RECEIVE:
 			return Object.assign( {}, state, keyBy( action.lists, 'ID' ) );
@@ -56,8 +56,7 @@ export function items( state = {}, action ) {
 			return Object.assign( {}, state, keyBy( [ listForDescriptionChange ], 'ID' ) );
 	}
 	return state;
-}
-items.schema = itemsSchema;
+} );
 
 /**
  * Tracks which list IDs the current user is subscribed to.
@@ -66,25 +65,27 @@ items.schema = itemsSchema;
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function subscribedLists( state = [], action ) {
-	switch ( action.type ) {
-		case READER_LISTS_RECEIVE:
-			return map( action.lists, 'ID' );
-		case READER_LISTS_FOLLOW_SUCCESS:
-			const newListId = get( action, [ 'data', 'list', 'ID' ] );
-			if ( ! newListId || includes( state, newListId ) ) {
-				return state;
-			}
-			return [ ...state, newListId ];
-		case READER_LISTS_UNFOLLOW_SUCCESS:
-			// Remove the unfollowed list ID from subscribedLists
-			return filter( state, listId => {
-				return listId !== action.data.list.ID;
-			} );
+export const subscribedLists = withSchemaValidation(
+	subscriptionsSchema,
+	( state = [], action ) => {
+		switch ( action.type ) {
+			case READER_LISTS_RECEIVE:
+				return map( action.lists, 'ID' );
+			case READER_LISTS_FOLLOW_SUCCESS:
+				const newListId = get( action, [ 'data', 'list', 'ID' ] );
+				if ( ! newListId || includes( state, newListId ) ) {
+					return state;
+				}
+				return [ ...state, newListId ];
+			case READER_LISTS_UNFOLLOW_SUCCESS:
+				// Remove the unfollowed list ID from subscribedLists
+				return filter( state, listId => {
+					return listId !== action.data.list.ID;
+				} );
+		}
+		return state;
 	}
-	return state;
-}
-subscribedLists.schema = subscriptionsSchema;
+);
 
 /**
  * Tracks which list IDs have been updated recently. Used to show the correct success message.
@@ -93,7 +94,7 @@ subscribedLists.schema = subscriptionsSchema;
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function updatedLists( state = [], action ) {
+export const updatedLists = withSchemaValidation( updatedListsSchema, ( state = [], action ) => {
 	switch ( action.type ) {
 		case READER_LIST_UPDATE_SUCCESS:
 			const newListId = get( action, 'data.list.ID' );
@@ -108,8 +109,8 @@ export function updatedLists( state = [], action ) {
 			} );
 	}
 	return state;
-}
-updatedLists.schema = updatedListsSchema;
+} );
+
 /**
  * Returns the updated requests state after an action has been dispatched.
  *
@@ -153,7 +154,7 @@ export function isRequestingLists( state = false, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function errors( state = {}, action ) {
+export const errors = withSchemaValidation( errorsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case READER_LIST_UPDATE_FAILURE:
 			const newError = {};
@@ -166,8 +167,7 @@ export function errors( state = {}, action ) {
 	}
 
 	return state;
-}
-errors.schema = errorsSchema;
+} );
 
 /**
  * A missing list is one that's been requested, but we couldn't find (API response 404-ed).

--- a/client/state/reader/posts/reducer.js
+++ b/client/state/reader/posts/reducer.js
@@ -1,4 +1,4 @@
-/** @format */
+/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
@@ -36,7 +36,7 @@ export function seen( state = {}, action ) {
 }
 // @TODO: evaluate serialization later
 // import { itemsSchema } from './schema';
-// items.schema = itemsSchema;
+// export const items = withSchemaValidation( itemsSchema, itemsReducer );
 
 export default combineReducers( {
 	items,

--- a/client/state/reader/sites/reducer.js
+++ b/client/state/reader/sites/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External Dependencies
  */
@@ -15,7 +14,7 @@ import {
 	READER_SITE_UPDATE,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { readerSitesSchema } from './schema';
 import { withoutHttp } from 'lib/url';
 import { decodeEntities } from 'lib/formatting';
@@ -84,7 +83,7 @@ function handleSiteUpdate( state, action ) {
 	return assign( {}, state, keyBy( sites, 'ID' ) );
 }
 
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ SERIALIZE ]: handleSerialize,

--- a/client/state/reader/teams/reducer.js
+++ b/client/state/reader/teams/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External Dependencies
  */
@@ -8,10 +7,10 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { READER_TEAMS_REQUEST, READER_TEAMS_RECEIVE } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	[],
 	{
 		[ READER_TEAMS_RECEIVE ]: ( state, action ) => {

--- a/client/state/reader/watermarks/reducer.js
+++ b/client/state/reader/watermarks/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External Dependencies
  */
@@ -9,12 +7,12 @@ import { max } from 'lodash';
  * Internal dependencies
  */
 import { READER_VIEW_STREAM } from 'state/action-types';
-import { createReducer, keyedReducer } from 'state/utils';
+import { createReducerWithValidation, keyedReducer } from 'state/utils';
 import schema from './watermark-schema';
 
 export const watermarks = keyedReducer(
 	'streamKey',
-	createReducer(
+	createReducerWithValidation(
 		{},
 		{
 			[ READER_VIEW_STREAM ]: ( state, action ) => max( [ +state, +action.mark ] ),

--- a/client/state/sharing/keyring/reducer.js
+++ b/client/state/sharing/keyring/reducer.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { keyBy, omit, without } from 'lodash';
 
 /**
@@ -18,7 +15,7 @@ import {
 	PUBLICIZE_CONNECTION_CREATE,
 	PUBLICIZE_CONNECTION_DELETE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemSchema } from './schema';
 
 // Tracks fetching state for keyring connections
@@ -29,7 +26,7 @@ export const isFetching = createReducer( false, {
 } );
 
 // Stores the list of available keyring connections
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ KEYRING_CONNECTIONS_RECEIVE ]: ( state, { connections } ) => ( {

--- a/client/state/sharing/publicize/publicize-actions/reducer.js
+++ b/client/state/sharing/publicize/publicize-actions/reducer.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { omit, get } from 'lodash';
 
 /**
@@ -27,7 +24,7 @@ import {
 	PUBLICIZE_SHARE_ACTION_SCHEDULE_SUCCESS,
 	PUBLICIZE_SHARE_ACTION_SCHEDULE_FAILURE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { publicizeActionsSchema } from './schema';
 
 /**
@@ -55,7 +52,7 @@ export function updateDataForPost( newValue, state, siteId, postId, actionId ) {
 	};
 }
 
-export const scheduled = createReducer(
+export const scheduled = createReducerWithValidation(
 	{},
 	{
 		[ PUBLICIZE_SHARE_ACTIONS_SCHEDULED_REQUEST_SUCCESS ]: ( state, { siteId, postId, actions } ) =>
@@ -79,7 +76,7 @@ export const scheduled = createReducer(
 	publicizeActionsSchema
 );
 
-export const published = createReducer(
+export const published = createReducerWithValidation(
 	{},
 	{
 		[ PUBLICIZE_SHARE_ACTIONS_PUBLISHED_REQUEST_SUCCESS ]: ( state, { siteId, postId, actions } ) =>

--- a/client/state/sharing/publicize/reducer.js
+++ b/client/state/sharing/publicize/reducer.js
@@ -1,10 +1,8 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { keyBy, omit, omitBy } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -24,7 +22,7 @@ import {
 	PUBLICIZE_SHARE_FAILURE,
 	PUBLICIZE_SHARE_DISMISS,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { connectionsSchema } from './schema';
 import sharePostActions from './publicize-actions/reducer';
 
@@ -115,7 +113,7 @@ export const fetchedConnections = createReducer(
 );
 
 // Tracks all known connection objects, indexed by connection ID.
-export const connections = createReducer(
+export const connections = createReducerWithValidation(
 	{},
 	{
 		[ PUBLICIZE_CONNECTIONS_RECEIVE ]: ( state, action ) => ( {

--- a/client/state/sharing/services/reducer.js
+++ b/client/state/sharing/services/reducer.js
@@ -1,20 +1,17 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
 	KEYRING_SERVICES_RECEIVE,
 	KEYRING_SERVICES_REQUEST,
 	KEYRING_SERVICES_REQUEST_FAILURE,
 	KEYRING_SERVICES_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemSchema } from './schema';
 
 // Stores the list of available keyring services
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ KEYRING_SERVICES_RECEIVE ]: ( state, action ) => action.services,

--- a/client/state/shortcodes/reducer.js
+++ b/client/state/shortcodes/reducer.js
@@ -1,16 +1,13 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { intersection, merge, pickBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { shortcodesSchema } from './schema';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import {
 	SHORTCODE_RECEIVE,
 	SHORTCODE_REQUEST,
@@ -89,7 +86,7 @@ function mediaItemsReducer( state, { siteId, data } ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		FLUX_RECEIVE_MEDIA_ITEM: mediaItemsReducer,

--- a/client/state/signup/dependency-store/reducer.js
+++ b/client/state/signup/dependency-store/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
@@ -10,6 +8,7 @@ import {
 	SIGNUP_COMPLETE_RESET,
 } from 'state/action-types';
 import { dependencyStoreSchema } from './schema';
+import { withSchemaValidation } from 'state/utils';
 
 const EMPTY = {};
 
@@ -35,6 +34,4 @@ function reducer( state = EMPTY, action ) {
 	}
 }
 
-reducer.schema = dependencyStoreSchema;
-
-export default reducer;
+export default withSchemaValidation( dependencyStoreSchema, reducer );

--- a/client/state/signup/optional-dependencies/reducer.js
+++ b/client/state/signup/optional-dependencies/reducer.js
@@ -1,14 +1,11 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import { suggestedUsernameSchema } from './schema';
 
-const suggestedUsername = createReducer(
+const suggestedUsername = createReducerWithValidation(
 	'',
 	{
 		[ SIGNUP_OPTIONAL_DEPENDENCY_SUGGESTED_USERNAME_SET ]: ( state, action ) => {

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -19,7 +17,7 @@ import {
 	SIGNUP_PROGRESS_SAVE_STEP,
 	SIGNUP_PROGRESS_SUBMIT_STEP,
 } from 'state/action-types';
-import { createReducer } from 'state/utils';
+import { createReducerWithValidation } from 'state/utils';
 import { schema } from './schema';
 
 const debug = debugFactory( 'calypso:state:signup:progress:reducer' );
@@ -110,7 +108,7 @@ const submitStep = ( state, { step } ) => {
 		: addStep( state, { ...step, status } );
 };
 
-export default createReducer(
+export default createReducerWithValidation(
 	{},
 	{
 		[ SIGNUP_COMPLETE_RESET ]: overwriteSteps,

--- a/client/state/signup/steps/design-type/reducer.js
+++ b/client/state/signup/steps/design-type/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_DESIGN_TYPE_SET } from 'state/action-types';
 
-import { createReducer } from 'state/utils';
+import { createReducerWithValidation } from 'state/utils';
 import { designTypeSchema } from './schema';
 
-export default createReducer(
+export default createReducerWithValidation(
 	'',
 	{
 		[ SIGNUP_STEPS_DESIGN_TYPE_SET ]: ( state, action ) => {

--- a/client/state/signup/steps/site-goals/reducer.js
+++ b/client/state/signup/steps/site-goals/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_SITE_GOALS_SET } from 'state/action-types';
 
-import { createReducer } from 'state/utils';
+import { createReducerWithValidation } from 'state/utils';
 import { siteGoalsSchema } from './schema';
 
-export default createReducer(
+export default createReducerWithValidation(
 	'',
 	{
 		[ SIGNUP_STEPS_SITE_GOALS_SET ]: ( state, action ) => {

--- a/client/state/signup/steps/site-style/reducer.js
+++ b/client/state/signup/steps/site-style/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_SITE_STYLE_SET } from 'state/action-types';
 
-import { createReducer } from 'state/utils';
+import { createReducerWithValidation } from 'state/utils';
 import { siteStyleSchema } from './schema';
 
-export default createReducer(
+export default createReducerWithValidation(
 	'',
 	{
 		[ SIGNUP_STEPS_SITE_STYLE_SET ]: ( state, action ) => {

--- a/client/state/signup/steps/site-title/reducer.js
+++ b/client/state/signup/steps/site-title/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_SITE_TITLE_SET } from 'state/action-types';
 
-import { createReducer } from 'state/utils';
+import { createReducerWithValidation } from 'state/utils';
 import { siteTitleSchema } from './schema';
 
-export default createReducer(
+export default createReducerWithValidation(
 	'',
 	{
 		[ SIGNUP_STEPS_SITE_TITLE_SET ]: ( state, action ) => {

--- a/client/state/signup/steps/site-type/reducer.js
+++ b/client/state/signup/steps/site-type/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_SITE_TYPE_SET } from 'state/action-types';
 
-import { createReducer } from 'state/utils';
+import { createReducerWithValidation } from 'state/utils';
 import { siteTypeSchema } from './schema';
 
-export default createReducer(
+export default createReducerWithValidation(
 	'',
 	{
 		[ SIGNUP_STEPS_SITE_TYPE_SET ]: ( state, action ) => {

--- a/client/state/signup/steps/site-vertical/reducer.js
+++ b/client/state/signup/steps/site-vertical/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -12,7 +11,7 @@ import {
 	SIGNUP_COMPLETE_RESET,
 	SIGNUP_STEPS_SITE_VERTICAL_SET,
 } from 'state/action-types';
-import { createReducer } from 'state/utils';
+import { createReducerWithValidation } from 'state/utils';
 import { siteVerticalSchema } from './schema';
 
 const initialState = {
@@ -27,7 +26,7 @@ const initialState = {
 // TODO:
 // This reducer can be further simplify since the verticals data can be
 // found in `signup.verticals`, so it only needs to store the site vertical name.
-export default createReducer(
+export default createReducerWithValidation(
 	initialState,
 	{
 		[ SIGNUP_STEPS_SITE_VERTICAL_SET ]: ( state, siteVerticalData ) => {

--- a/client/state/signup/steps/survey/reducer.js
+++ b/client/state/signup/steps/survey/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_STEPS_SURVEY_SET, SIGNUP_COMPLETE_RESET } from 'state/action-types';
 
-import { createReducer } from 'state/utils';
+import { createReducerWithValidation } from 'state/utils';
 import { surveyStepSchema } from './schema';
 
-export default createReducer(
+export default createReducerWithValidation(
 	{},
 	{
 		[ SIGNUP_STEPS_SURVEY_SET ]: ( state = {}, action ) => {

--- a/client/state/signup/steps/user-experience/reducer.js
+++ b/client/state/signup/steps/user-experience/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { SIGNUP_COMPLETE_RESET, SIGNUP_STEPS_USER_EXPERIENCE_SET } from 'state/action-types';
 
-import { createReducer } from 'state/utils';
+import { createReducerWithValidation } from 'state/utils';
 import { userExperienceSchema } from './schema';
 
-export default createReducer(
+export default createReducerWithValidation(
 	'',
 	{
 		[ SIGNUP_STEPS_USER_EXPERIENCE_SET ]: ( state, action ) => {

--- a/client/state/simple-payments/product-list/reducer.js
+++ b/client/state/simple-payments/product-list/reducer.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import productListSchema from './schema';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import {
 	SIMPLE_PAYMENTS_PRODUCT_RECEIVE,
 	SIMPLE_PAYMENTS_PRODUCTS_LIST_RECEIVE,
@@ -43,7 +40,7 @@ function addOrEditProduct( list = [], newProduct ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ SIMPLE_PAYMENTS_PRODUCT_RECEIVE ]: ( state, { siteId, product } ) => ( {

--- a/client/state/site-keyrings/reducer.js
+++ b/client/state/site-keyrings/reducer.js
@@ -1,9 +1,7 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { siteKeyrings as siteKeyringsSchema } from './schema';
 import {
 	SITE_KEYRINGS_REQUEST,
@@ -67,7 +65,7 @@ export const saveRequests = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-const items = createReducer(
+const items = createReducerWithValidation(
 	{},
 	{
 		[ SITE_KEYRINGS_REQUEST_SUCCESS ]: ( state, { siteId, keyrings } ) => ( {

--- a/client/state/site-roles/reducer.js
+++ b/client/state/site-roles/reducer.js
@@ -1,11 +1,8 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { siteRolesSchema } from './schema';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import {
 	SITE_ROLES_RECEIVE,
 	SITE_ROLES_REQUEST,
@@ -39,7 +36,7 @@ export const requesting = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ SITE_ROLES_RECEIVE ]: ( state, { siteId, roles } ) => ( { ...state, [ siteId ]: roles } ),

--- a/client/state/site-settings/reducer.js
+++ b/client/state/site-settings/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { includes } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	MEDIA_DELETE,
@@ -74,7 +71,7 @@ export const saveRequests = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ SITE_SETTINGS_RECEIVE ]: ( state, { siteId, settings } ) => ( {

--- a/client/state/sites/domains/reducer.js
+++ b/client/state/sites/domains/reducer.js
@@ -1,4 +1,4 @@
-/** @format */
+/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
@@ -14,7 +14,7 @@ import {
 	SITE_DOMAINS_REQUEST_SUCCESS,
 	SITE_DOMAINS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -24,7 +24,7 @@ import { itemsSchema } from './schema';
  * @param {Object} action - domains action
  * @return {Object} updated state
  */
-export const items = ( state = {}, action ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
 	const { siteId } = action;
 	switch ( action.type ) {
 		case SITE_DOMAINS_RECEIVE:
@@ -52,8 +52,7 @@ export const items = ( state = {}, action ) => {
 	}
 
 	return state;
-};
-items.schema = itemsSchema;
+} );
 
 /**
  * `Reducer` function which handles request/response actions

--- a/client/state/sites/domains/test/reducer.js
+++ b/client/state/sites/domains/test/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -14,7 +13,7 @@ import {
 	domainsRequestFailureAction,
 } from '../actions';
 import domainsReducer, {
-	items,
+	items as itemsReducer,
 	requesting as requestReducer,
 	errors as errorsReducer,
 } from '../reducer';
@@ -35,13 +34,10 @@ import {
 	SITE_DOMAINS_REQUEST_FAILURE,
 } from 'state/action-types';
 
-import { withSchemaValidation } from 'state/utils';
 import { useSandbox } from 'test/helpers/use-sinon';
 
 // Gets rid of warnings such as 'UnhandledPromiseRejectionWarning: Error: No available storage method found.'
 jest.mock( 'lib/user', () => () => {} );
-
-const itemsReducer = withSchemaValidation( items.schema, items );
 
 describe( 'reducer', () => {
 	let sandbox;

--- a/client/state/sites/guided-transfer/reducer.js
+++ b/client/state/sites/guided-transfer/reducer.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE,
 	GUIDED_TRANSFER_HOST_DETAILS_SAVE_FAILURE,
@@ -13,11 +10,11 @@ import {
 	GUIDED_TRANSFER_STATUS_REQUEST_FAILURE,
 	GUIDED_TRANSFER_STATUS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { guidedTransferStatusSchema } from './schema';
 
 // Stores the status of guided transfers per site
-export const status = createReducer(
+export const status = createReducerWithValidation(
 	{},
 	{
 		[ GUIDED_TRANSFER_STATUS_RECEIVE ]: ( state, action ) => ( {

--- a/client/state/sites/media-storage/reducer.js
+++ b/client/state/sites/media-storage/reducer.js
@@ -1,9 +1,7 @@
-/** @format */
-
+/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
-
 import { pick } from 'lodash';
 
 /**
@@ -15,7 +13,7 @@ import {
 	SITE_MEDIA_STORAGE_REQUEST_SUCCESS,
 	SITE_MEDIA_STORAGE_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -25,7 +23,7 @@ import { itemsSchema } from './schema';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function items( state = {}, action ) {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_MEDIA_STORAGE_RECEIVE:
 			const mediaStorage = pick( action.mediaStorage, [
@@ -37,8 +35,7 @@ export function items( state = {}, action ) {
 			} );
 	}
 	return state;
-}
-items.schema = itemsSchema;
+} );
 
 /**
  * Tracks media-storage fetching state, indexed by site ID.

--- a/client/state/sites/media-storage/test/reducer.js
+++ b/client/state/sites/media-storage/test/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,7 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import reducer, { items as unwrappedItems, fetchingItems } from '../reducer';
+import reducer, { items, fetchingItems } from '../reducer';
 import {
 	SITE_MEDIA_STORAGE_RECEIVE,
 	SITE_MEDIA_STORAGE_REQUEST,
@@ -18,10 +16,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
-import { withSchemaValidation } from 'state/utils';
 import { useSandbox } from 'test/helpers/use-sinon';
-
-const items = withSchemaValidation( unwrappedItems.schema, unwrappedItems );
 
 describe( 'reducer', () => {
 	let sandbox;

--- a/client/state/sites/reducer.js
+++ b/client/state/sites/reducer.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -39,7 +38,13 @@ import {
 	SITE_FRONT_PAGE_UPDATE,
 } from 'state/action-types';
 import { sitesSchema, hasAllSitesListSchema } from './schema';
-import { combineReducers, createReducer, keyedReducer } from 'state/utils';
+import {
+	combineReducers,
+	createReducer,
+	createReducerWithValidation,
+	keyedReducer,
+	withSchemaValidation,
+} from 'state/utils';
 
 /**
  * Tracks all known site objects, indexed by site ID.
@@ -48,7 +53,7 @@ import { combineReducers, createReducer, keyedReducer } from 'state/utils';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function items( state = null, action ) {
+export const items = withSchemaValidation( sitesSchema, ( state = null, action ) => {
 	if ( state === null && action.type !== SITE_RECEIVE && action.type !== SITES_RECEIVE ) {
 		return null;
 	}
@@ -241,8 +246,7 @@ export function items( state = null, action ) {
 	}
 
 	return state;
-}
-items.schema = sitesSchema;
+} );
 
 /**
  * Returns the updated requesting state after an action has been dispatched.
@@ -309,7 +313,7 @@ export const deleting = keyedReducer(
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const hasAllSitesList = createReducer(
+export const hasAllSitesList = createReducerWithValidation(
 	false,
 	{
 		[ SITES_RECEIVE ]: () => true,

--- a/client/state/sites/sharing-buttons/reducer.js
+++ b/client/state/sites/sharing-buttons/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { uniqBy } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	SHARING_BUTTONS_RECEIVE,
@@ -79,7 +76,7 @@ export const saveRequests = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ SHARING_BUTTONS_RECEIVE ]: ( state, { siteId, settings } ) => ( {

--- a/client/state/sites/test/reducer.js
+++ b/client/state/sites/test/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,13 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import reducer, {
-	items as unwrappedItems,
-	requestingAll,
-	requesting,
-	deleting,
-	hasAllSitesList,
-} from '../reducer';
+import reducer, { items, requestingAll, requesting, deleting, hasAllSitesList } from '../reducer';
 import {
 	MEDIA_DELETE,
 	SITE_DELETE,
@@ -39,10 +31,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
-import { withSchemaValidation } from 'state/utils';
 import { useSandbox } from 'test/helpers/use-sinon';
-
-const items = withSchemaValidation( unwrappedItems.schema, unwrappedItems );
 
 describe( 'reducer', () => {
 	useSandbox( sandbox => {

--- a/client/state/sites/vouchers/reducer.js
+++ b/client/state/sites/vouchers/reducer.js
@@ -1,9 +1,7 @@
-/** @format */
-
+/* eslint-disable no-case-declarations */
 /**
  * Internal dependencies
  */
-
 import {
 	SITE_VOUCHERS_ASSIGN_RECEIVE,
 	SITE_VOUCHERS_ASSIGN_REQUEST,
@@ -14,7 +12,7 @@ import {
 	SITE_VOUCHERS_REQUEST_SUCCESS,
 	SITE_VOUCHERS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -24,7 +22,7 @@ import { itemsSchema } from './schema';
  * @param {Object} action - vouchers action
  * @return {Object} updated state
  */
-export const items = ( state = {}, action ) => {
+export const items = withSchemaValidation( itemsSchema, ( state = {}, action ) => {
 	const { siteId, type, voucher, vouchers, serviceType } = action;
 
 	switch ( type ) {
@@ -44,8 +42,7 @@ export const items = ( state = {}, action ) => {
 	}
 
 	return state;
-};
-items.schema = itemsSchema;
+} );
 
 /**
  * `Reducer` function which handles request/response actions

--- a/client/state/sites/vouchers/test/reducer.js
+++ b/client/state/sites/vouchers/test/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -10,7 +8,7 @@ import deepFreeze from 'deep-freeze';
  * Internal dependencies
  */
 import vouchersReducer, {
-	items,
+	items as itemsReducer,
 	requesting as requestReducer,
 	errors as errorsReducer,
 } from '../reducer';
@@ -36,10 +34,7 @@ import {
 	SITE_VOUCHERS_REQUEST_FAILURE,
 } from 'state/action-types';
 
-import { withSchemaValidation } from 'state/utils';
 import { useSandbox } from 'test/helpers/use-sinon';
-
-const itemsReducer = withSchemaValidation( items.schema, items );
 
 describe( 'reducer', () => {
 	let sandbox;

--- a/client/state/stats/chart-tabs/reducer.js
+++ b/client/state/stats/chart-tabs/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -8,7 +6,7 @@ import { pick, set, isEqual } from 'lodash';
 /**
  * Internal dependencies
  */
-import { combineReducers, keyedReducer } from 'state/utils';
+import { combineReducers, keyedReducer, withSchemaValidation } from 'state/utils';
 import { STATS_CHART_COUNTS_REQUEST, STATS_CHART_COUNTS_RECEIVE } from 'state/action-types';
 import { countsSchema } from './schema';
 import { QUERY_FIELDS } from './constants';
@@ -19,39 +17,41 @@ import { QUERY_FIELDS } from './constants';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const counts = keyedReducer(
-	'siteId',
-	keyedReducer( 'period', ( state = [], action ) => {
-		switch ( action.type ) {
-			case STATS_CHART_COUNTS_RECEIVE: {
-				let areThereChanges = false;
+export const counts = withSchemaValidation(
+	countsSchema,
+	keyedReducer(
+		'siteId',
+		keyedReducer( 'period', ( state = [], action ) => {
+			switch ( action.type ) {
+				case STATS_CHART_COUNTS_RECEIVE: {
+					let areThereChanges = false;
 
-				const newState = action.data.reduce(
-					( nextState, recordFromApi ) => {
-						const index = nextState.findIndex( entry => entry.period === recordFromApi.period );
-						if ( index >= 0 ) {
-							const newRecord = { ...nextState[ index ], ...recordFromApi };
-							if ( ! isEqual( nextState[ index ], newRecord ) ) {
+					const newState = action.data.reduce(
+						( nextState, recordFromApi ) => {
+							const index = nextState.findIndex( entry => entry.period === recordFromApi.period );
+							if ( index >= 0 ) {
+								const newRecord = { ...nextState[ index ], ...recordFromApi };
+								if ( ! isEqual( nextState[ index ], newRecord ) ) {
+									areThereChanges = true;
+									nextState[ index ] = newRecord;
+								}
+							} else {
 								areThereChanges = true;
-								nextState[ index ] = newRecord;
+								nextState.push( recordFromApi );
 							}
-						} else {
-							areThereChanges = true;
-							nextState.push( recordFromApi );
-						}
-						return nextState;
-					},
-					[ ...state ]
-				);
+							return nextState;
+						},
+						[ ...state ]
+					);
 
-				// Avoid changing state if nothing's changed.
-				return areThereChanges ? newState : state;
+					// Avoid changing state if nothing's changed.
+					return areThereChanges ? newState : state;
+				}
 			}
-		}
-		return state;
-	} )
+			return state;
+		} )
+	)
 );
-counts.schema = countsSchema;
 
 /**
  * Returns the loading state after an action has been dispatched.

--- a/client/state/stats/lists/reducer.js
+++ b/client/state/stats/lists/reducer.js
@@ -1,15 +1,13 @@
-/** @format */
-
+/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
-
 import { merge, get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, withSchemaValidation } from 'state/utils';
 import { getSerializedStatsQuery } from './utils';
 import { itemSchema } from './schema';
 import {
@@ -70,7 +68,7 @@ export const requests = createReducer(
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function items( state = {}, action ) {
+export const items = withSchemaValidation( itemSchema, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case SITE_STATS_RECEIVE:
 			const { siteId, statType, query, data } = action;
@@ -91,8 +89,7 @@ export function items( state = {}, action ) {
 	}
 
 	return state;
-}
-items.schema = itemSchema;
+} );
 
 export default combineReducers( {
 	requests,

--- a/client/state/stats/lists/test/reducer.js
+++ b/client/state/stats/lists/test/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,7 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import reducer, { items as unwrappedItems, requests } from '../reducer';
+import reducer, { items, requests } from '../reducer';
 import {
 	DESERIALIZE,
 	SERIALIZE,
@@ -17,10 +15,7 @@ import {
 	SITE_STATS_REQUEST,
 	SITE_STATS_REQUEST_FAILURE,
 } from 'state/action-types';
-import { withSchemaValidation } from 'state/utils';
 import { useSandbox } from 'test/helpers/use-sinon';
-
-const items = withSchemaValidation( unwrappedItems.schema, unwrappedItems );
 
 /**
  * Test Data

--- a/client/state/stats/posts/reducer.js
+++ b/client/state/stats/posts/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { get, merge } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { items as itemSchemas } from './schema';
 import {
 	POST_STATS_RECEIVE,
@@ -51,7 +48,7 @@ export function requesting( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function items( state = {}, action ) {
+export const items = withSchemaValidation( itemSchemas, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case POST_STATS_RECEIVE:
 			return {
@@ -67,8 +64,7 @@ export function items( state = {}, action ) {
 	}
 
 	return state;
-}
-items.schema = itemSchemas;
+} );
 
 export default combineReducers( {
 	requesting,

--- a/client/state/stats/posts/test/reducer.js
+++ b/client/state/stats/posts/test/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,7 +7,7 @@ import deepFreeze from 'deep-freeze';
 /**
  * Internal dependencies
  */
-import { requesting, items as unwrappedItems } from '../reducer';
+import { requesting, items } from '../reducer';
 import {
 	POST_STATS_RECEIVE,
 	POST_STATS_REQUEST,
@@ -18,10 +16,7 @@ import {
 	SERIALIZE,
 	DESERIALIZE,
 } from 'state/action-types';
-import { withSchemaValidation } from 'state/utils';
 import { useSandbox } from 'test/helpers/use-sinon';
-
-const items = withSchemaValidation( unwrappedItems.schema, unwrappedItems );
 
 describe( 'reducer', () => {
 	useSandbox( sandbox => {

--- a/client/state/stats/recent-post-views/reducer.js
+++ b/client/state/stats/recent-post-views/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import { get } from 'lodash';
 
 /**
  * Internal dependencies
  */
-import { combineReducers } from 'state/utils';
+import { combineReducers, withSchemaValidation } from 'state/utils';
 import { items as itemsSchemas } from './schema';
 import { STATS_RECENT_POST_VIEWS_RECEIVE } from 'state/action-types';
 
@@ -21,7 +18,7 @@ import { STATS_RECENT_POST_VIEWS_RECEIVE } from 'state/action-types';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export function items( state = {}, action ) {
+export const items = withSchemaValidation( itemsSchemas, ( state = {}, action ) => {
 	switch ( action.type ) {
 		case STATS_RECENT_POST_VIEWS_RECEIVE: {
 			const viewsForState = {};
@@ -40,8 +37,7 @@ export function items( state = {}, action ) {
 	}
 
 	return state;
-}
-items.schema = itemsSchemas;
+} );
 
 export default combineReducers( {
 	items,

--- a/client/state/stored-cards/reducer.js
+++ b/client/state/stored-cards/reducer.js
@@ -1,9 +1,7 @@
-/** @format */
-
+/* eslint-disable no-case-declarations */
 /**
  * Internal dependencies
  */
-
 import {
 	STORED_CARDS_ADD_COMPLETED,
 	STORED_CARDS_FETCH,
@@ -13,7 +11,7 @@ import {
 	STORED_CARDS_DELETE_COMPLETED,
 	STORED_CARDS_DELETE_FAILED,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import { storedCardsSchema } from './schema';
 
 /**
@@ -24,7 +22,7 @@ import { storedCardsSchema } from './schema';
  * @param  {Object} action storeCard action
  * @return {Array}         Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	[],
 	{
 		[ STORED_CARDS_ADD_COMPLETED ]: ( state, { item } ) => [ ...state, item ],

--- a/client/state/terms/reducer.js
+++ b/client/state/terms/reducer.js
@@ -1,9 +1,7 @@
-/** @format */
-
+/* eslint-disable no-case-declarations */
 /**
  * External dependencies
  */
-
 import { mapValues, merge } from 'lodash';
 
 /**
@@ -18,7 +16,7 @@ import {
 	TERMS_REQUEST_SUCCESS,
 	SERIALIZE,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import TermQueryManager from 'lib/query-manager/term';
 import { getSerializedTermsQuery } from './utils';
 import { queriesSchema } from './schema';
@@ -55,7 +53,7 @@ export function queryRequests( state = {}, action ) {
  * The state reflects a mapping of serialized query key to an array of term IDs
  * for the query, if a query response was successfully received.
  */
-export const queries = createReducer(
+export const queries = createReducerWithValidation(
 	{},
 	{
 		[ TERMS_RECEIVE ]: ( state, action ) => {

--- a/client/state/themes/reducer.js
+++ b/client/state/themes/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,7 +7,7 @@ import { mapValues, omit, map } from 'lodash';
  * Internal dependencies
  */
 import ThemeQueryManager from 'lib/query-manager/theme';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import {
 	ACTIVE_THEME_REQUEST,
 	ACTIVE_THEME_REQUEST_SUCCESS,
@@ -54,7 +52,7 @@ import { decodeEntities } from 'lib/formatting';
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const activeThemes = createReducer(
+export const activeThemes = createReducerWithValidation(
 	{},
 	{
 		[ THEME_ACTIVATE_SUCCESS ]: ( state, { siteId, themeStylesheet } ) => ( {
@@ -195,7 +193,7 @@ export function themeInstalls( state = {}, action ) {
  * @param  {Object} action Action payload
  * @return {Object}        Updated state
  */
-export const themeRequestErrors = createReducer(
+export const themeRequestErrors = createReducerWithValidation(
 	{},
 	{
 		[ THEME_REQUEST_FAILURE ]: ( state, { siteId, themeId, error } ) => ( {
@@ -315,7 +313,7 @@ export const queries = ( () => {
 	// days * hours_in_day * minutes_in_hour * seconds_in_minute * miliseconds_in_second
 	const MAX_THEMES_AGE = 1 * 24 * 60 * 60 * 1000;
 
-	return createReducer(
+	return createReducerWithValidation(
 		{},
 		{
 			[ THEMES_REQUEST_SUCCESS ]: ( state, { siteId, query, themes, found } ) => {
@@ -400,7 +398,7 @@ export const themePreviewVisibility = createReducer( null, {
 	[ THEME_PREVIEW_STATE ]: ( state, { themeId } ) => themeId,
 } );
 
-export const themeFilters = createReducer(
+export const themeFilters = createReducerWithValidation(
 	{},
 	{
 		[ THEME_FILTERS_ADD ]: ( state, { filters } ) => filters,

--- a/client/state/timezones/reducer.js
+++ b/client/state/timezones/reducer.js
@@ -1,15 +1,12 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import { TIMEZONES_RECEIVE } from 'state/action-types';
 
 import { rawOffsetsSchema, labelsSchema, continentsSchema } from './schema';
 
-export const rawOffsets = createReducer(
+export const rawOffsets = createReducerWithValidation(
 	{},
 	{
 		[ TIMEZONES_RECEIVE ]: ( state, actions ) => actions.rawOffsets,
@@ -17,7 +14,7 @@ export const rawOffsets = createReducer(
 	rawOffsetsSchema
 );
 
-export const labels = createReducer(
+export const labels = createReducerWithValidation(
 	{},
 	{
 		[ TIMEZONES_RECEIVE ]: ( state, actions ) => actions.labels,
@@ -25,7 +22,7 @@ export const labels = createReducer(
 	labelsSchema
 );
 
-export const byContinents = createReducer(
+export const byContinents = createReducerWithValidation(
 	{},
 	{
 		[ TIMEZONES_RECEIVE ]: ( state, actions ) => actions.byContinents,

--- a/client/state/ui/language/reducer.js
+++ b/client/state/ui/language/reducer.js
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import { LOCALE_SET } from 'state/action-types';
 import { localeSlugSchema, localeVariantSchema, isRtlSchema } from './schema';
 import { getLanguage } from 'lib/i18n-utils/utils';
@@ -17,7 +14,7 @@ import { getLanguage } from 'lib/i18n-utils/utils';
  * @return {Object}        Updated state
  *
  */
-export const localeSlug = createReducer(
+export const localeSlug = createReducerWithValidation(
 	null,
 	{
 		[ LOCALE_SET ]: ( state, action ) => action.localeSlug,
@@ -33,7 +30,7 @@ export const localeSlug = createReducer(
  * @return {Object}        Updated or default state
  *
  */
-export const localeVariant = createReducer(
+export const localeVariant = createReducerWithValidation(
 	null,
 	{
 		[ LOCALE_SET ]: ( state, action ) => action.localeVariant || state,
@@ -49,7 +46,7 @@ export const localeVariant = createReducer(
  * @return {Object}        Updated state
  *
  */
-export const isRtl = createReducer(
+export const isRtl = createReducerWithValidation(
 	null,
 	{
 		[ LOCALE_SET ]: ( state, action ) => {

--- a/client/state/ui/payment/reducer.js
+++ b/client/state/ui/payment/reducer.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -9,7 +7,7 @@ import { find, get, has } from 'lodash';
  * Internal dependencies
  */
 import { PAYMENT_COUNTRY_CODE_SET, PAYMENT_POSTAL_CODE_SET } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducerWithValidation } from 'state/utils';
 import { paymentCountryCodeSchema, paymentPostalCodeSchema } from './schema';
 
 /**
@@ -32,7 +30,7 @@ export const extractStoredCardMetaValue = ( action, meta_key ) =>
  * @param  {Object} action - The action object containing the new country code.
  * @return {Object} - The updated global state.
  */
-export const countryCode = createReducer(
+export const countryCode = createReducerWithValidation(
 	null,
 	{
 		[ PAYMENT_COUNTRY_CODE_SET ]: ( state, action ) => action.countryCode,
@@ -59,7 +57,7 @@ export const countryCode = createReducer(
  * @param  {Object} action - The action object containing the new postalCode.
  * @return {Object} - The updated global state.
  */
-export const postalCode = createReducer(
+export const postalCode = createReducerWithValidation(
 	null,
 	{
 		[ PAYMENT_POSTAL_CODE_SET ]: ( state, action ) => action.postalCode,

--- a/client/state/users/suggestions/reducer.js
+++ b/client/state/users/suggestions/reducer.js
@@ -1,16 +1,13 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import {
 	USER_SUGGESTIONS_RECEIVE,
 	USER_SUGGESTIONS_REQUEST,
 	USER_SUGGESTIONS_REQUEST_FAILURE,
 	USER_SUGGESTIONS_REQUEST_SUCCESS,
 } from 'state/action-types';
-import { combineReducers, createReducer } from 'state/utils';
+import { combineReducers, createReducer, createReducerWithValidation } from 'state/utils';
 import { itemsSchema } from './schema';
 
 /**
@@ -45,7 +42,7 @@ export const requesting = createReducer(
  * @param  {Object} action Action object
  * @return {Object}        Updated state
  */
-export const items = createReducer(
+export const items = createReducerWithValidation(
 	{},
 	{
 		[ USER_SUGGESTIONS_RECEIVE ]: ( state, { siteId, suggestions } ) => {

--- a/client/state/utils/create-base-reducer.js
+++ b/client/state/utils/create-base-reducer.js
@@ -1,0 +1,19 @@
+// Utility method used by createReducer and createReducerWithValidation.
+export function createBaseReducer( initialState, handlers ) {
+	return ( state = initialState, action ) => {
+		const { type } = action;
+
+		if ( 'production' !== process.env.NODE_ENV && 'type' in action && ! type ) {
+			throw new TypeError(
+				'Reducer called with undefined type.' +
+					' Verify that the action type is defined in state/action-types.js'
+			);
+		}
+
+		if ( handlers.hasOwnProperty( type ) ) {
+			return handlers[ type ]( state, action );
+		}
+
+		return state;
+	};
+}

--- a/client/state/utils/create-reducer-with-validation.js
+++ b/client/state/utils/create-reducer-with-validation.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { withSchemaValidation } from './schema-utils';
+import { createBaseReducer } from './create-base-reducer';
+
+/**
+ * Returns a reducer function with state calculation determined by the result
+ * of invoking the handler key corresponding with the dispatched action type,
+ * passing both the current state and action object. Defines default
+ * serialization (persistence) handlers based on the presence of a schema.
+ *
+ * @param  {*}        initialState   Initial state
+ * @param  {Object}   handlers       Object mapping action types to state action handlers
+ * @param  {?Object}  schema         JSON schema object for deserialization validation
+ * @return {Function}                Reducer function
+ */
+export function createReducerWithValidation( initialState, handlers, schema ) {
+	if ( ! schema ) {
+		throw new Error( 'Missing schema in call to createReducerWithValidation.' );
+	}
+
+	const reducer = createBaseReducer( initialState, handlers );
+	return withSchemaValidation( schema, reducer );
+}

--- a/client/state/utils/create-reducer.js
+++ b/client/state/utils/create-reducer.js
@@ -5,6 +5,7 @@ import { DESERIALIZE, SERIALIZE } from 'state/action-types';
 import { withoutPersistence } from './without-persistence';
 import { createBaseReducer } from './create-base-reducer';
 
+// eslint-disable-next-line valid-jsdoc
 /**
  * Returns a reducer function with state calculation determined by the result
  * of invoking the handler key corresponding with the dispatched action type,
@@ -14,8 +15,8 @@ import { createBaseReducer } from './create-base-reducer';
  * @param  {Object}   handlers       Object mapping action types to state action handlers
  * @return {Function}                Reducer function
  */
-export function createReducer( initialState, handlers, ...args ) {
-	if ( args && args.length > 0 ) {
+export function createReducer( initialState, handlers, __deprecatedArg__ ) {
+	if ( __deprecatedArg__ !== undefined ) {
 		throw new Error(
 			'Schema support in createReducer is no longer available. Please use createReducerWithValidation instead.'
 		);

--- a/client/state/utils/create-reducer.js
+++ b/client/state/utils/create-reducer.js
@@ -3,40 +3,24 @@
  */
 import { DESERIALIZE, SERIALIZE } from 'state/action-types';
 import { withoutPersistence } from './without-persistence';
-import { withSchemaValidation } from './schema-utils';
+import { createBaseReducer } from './create-base-reducer';
 
 /**
  * Returns a reducer function with state calculation determined by the result
  * of invoking the handler key corresponding with the dispatched action type,
- * passing both the current state and action object. Defines default
- * serialization (persistence) handlers based on the presence of a schema.
+ * passing both the current state and action object.
  *
  * @param  {*}        initialState   Initial state
  * @param  {Object}   handlers       Object mapping action types to state action handlers
- * @param  {?Object}  schema         JSON schema object for deserialization validation
  * @return {Function}                Reducer function
  */
-export function createReducer( initialState, handlers, schema ) {
-	const reducer = ( state = initialState, action ) => {
-		const { type } = action;
-
-		if ( 'production' !== process.env.NODE_ENV && 'type' in action && ! type ) {
-			throw new TypeError(
-				'Reducer called with undefined type.' +
-					' Verify that the action type is defined in state/action-types.js'
-			);
-		}
-
-		if ( handlers.hasOwnProperty( type ) ) {
-			return handlers[ type ]( state, action );
-		}
-
-		return state;
-	};
-
-	if ( schema ) {
-		return withSchemaValidation( schema, reducer );
+export function createReducer( initialState, handlers, ...args ) {
+	if ( args && args.length > 0 ) {
+		throw new Error(
+			'Schema support in createReducer is no longer available. Please use createReducerWithValidation instead.'
+		);
 	}
+	const reducer = createBaseReducer( initialState, handlers );
 
 	if ( ! handlers[ SERIALIZE ] && ! handlers[ DESERIALIZE ] ) {
 		return withoutPersistence( reducer );

--- a/client/state/utils/index.ts
+++ b/client/state/utils/index.ts
@@ -3,6 +3,7 @@
  */
 export { cachingActionCreatorFactory } from './caching-action-creator-factory';
 export { createReducer } from './create-reducer';
+export { createReducerWithValidation } from './create-reducer-with-validation';
 export { extendAction } from './extend-action';
 export { isValidStateWithSchema, withSchemaValidation } from './schema-utils';
 export { keyedReducer } from './keyed-reducer';

--- a/client/state/utils/package.json
+++ b/client/state/utils/package.json
@@ -1,0 +1,3 @@
+{
+	"sideEffects": false
+}

--- a/client/state/utils/reducer-utils.js
+++ b/client/state/utils/reducer-utils.js
@@ -8,7 +8,6 @@ import { combineReducers as combine } from 'redux'; // eslint-disable-line wpcal
  * Internal dependencies
  */
 import { APPLY_STORED_STATE, SERIALIZE } from 'state/action-types';
-import { withSchemaValidation } from './schema-utils';
 import { SerializationResult } from 'state/serialization-result';
 import { withoutPersistence } from './without-persistence';
 
@@ -75,10 +74,7 @@ export function addReducer( origReducer, reducers ) {
  * Returns a single reducing function that ensures that persistence is opt-in.
  * If you don't need state to be stored, simply use this method instead of
  * combineReducers from redux. This function uses the same interface.
- *
- * To mark that a reducer's state should be persisted, add the related JSON
- * schema as a property on the reducer.
- *
+ * *
  * @example
  * const age = ( state = 0, action ) =>
  *     GROW === action.type
@@ -88,9 +84,6 @@ export function addReducer( origReducer, reducers ) {
  *     GROW === action.type
  *         ? state + 1
  *         : state
- * const schema = { type: 'number', minimum: 0 };
- *
- * age.schema = schema;
  *
  * const combinedReducer = combineReducers( {
  *     age,
@@ -238,8 +231,6 @@ function serializeState( reducers, state, action ) {
 /*
  * Wrap the reducer with appropriate persistence code. If it has the `hasCustomPersistence` flag,
  * it means it's already set up and we don't need to make any changes.
- * If the reducer has a `schema` property, it means that persistence is requested and we
- * wrap it with code that validates the schema when loading persisted state.
  */
 function setupReducerPersistence( reducer ) {
 	if ( reducer.hasCustomPersistence ) {
@@ -247,7 +238,10 @@ function setupReducerPersistence( reducer ) {
 	}
 
 	if ( reducer.schema ) {
-		return withSchemaValidation( reducer.schema, reducer );
+		throw new Error(
+			'`schema` properties in reducers are no longer supported.' +
+				'Please use createReducerWithValidation or wrap reducers with withSchemaValidation.'
+		);
 	}
 
 	return withoutPersistence( reducer );

--- a/client/state/wordads/status/reducer.js
+++ b/client/state/wordads/status/reducer.js
@@ -1,22 +1,20 @@
-/** @format */
-
 /**
  * Internal dependencies
  */
-
 import { WORDADS_STATUS_RECEIVE } from 'state/action-types';
-import { keyedReducer } from 'state/utils';
+import { keyedReducer, withSchemaValidation } from 'state/utils';
 import { wordadsStatusSchema } from './schema';
 
-export const items = keyedReducer( 'siteId', ( state, action ) => {
-	switch ( action.type ) {
-		case WORDADS_STATUS_RECEIVE:
-			return action.status;
-		default:
-			return state;
-	}
-} );
-
-items.schema = wordadsStatusSchema;
+export const items = withSchemaValidation(
+	wordadsStatusSchema,
+	keyedReducer( 'siteId', ( state, action ) => {
+		switch ( action.type ) {
+			case WORDADS_STATUS_RECEIVE:
+				return action.status;
+			default:
+				return state;
+		}
+	} )
+);
 
 export default items;

--- a/docs/data-persistence.md
+++ b/docs/data-persistence.md
@@ -103,9 +103,10 @@ export const itemsSchema = {
 A JSON Schema must be provided if the subtree chooses to persist state. If we find that our persisted data doesn't
 match our described data shape, we should throw it out and rebuild that section of the tree with our default state.
 
-When using `createReducer` util you can pass a schema as a third param and all that will be handled for you.
+You can use `createReducerWithValidation` similarly to `createReducer`, passing the schema as the third param, and all
+that will be handled for you.
 ```javascript
-export const items = createReducer( defaultState, {
+export const items = createReducerWithValidation( defaultState, {
 	[THEMES_RECEIVE]: ( state, action ) => // ...
 }, itemsSchema );
 ```
@@ -160,11 +161,10 @@ return combineReducers( {
 } );
 ```
 
-To persist, we add the schema as a property on the reducer:
+To persist, we add the schema by wrapping the reducer with the `withValidation` util:
 ```javascript
-age.schema = ageSchema;
 return combineReducers( {
-    age,
+    age: withValidation( ageSchema, age ),
     height,
 } );
 ```


### PR DESCRIPTION
Sorry for the large changeset in this PR, but most of it is mechanical.

**Background:** The state utils confusingly allowed for schema validation to be added to reducers in a number of ways:
- Passing a third parameter to `createReducer`
- Adding a `schema` property to a plain reducer function
- Wrapping a plain reducer function with `withSchemaValidation`

The first two, in particular, were implicit and hard to determine at compile time, leading to some strong coupling in the state utils, and requiring validation code to always be present, even if none of the reducers use it.

**Proposed solution:** This change makes schema validation explicit, by allowing for schema validation to be added to reducers via two methods:
- Using `createReducerWithValidation` (instead of `createReducer`, which loses schema support)
- Wrapping a plain reducer function with `withSchemaValidation`

This makes it possible to tree-shake effectively at compile time, should we ever drop enough schemas, and it makes state utils less coupled, by e.g. making `combineReducers` no longer depend on validation code. It may also benefit PRs like #33642 

This change should also make it easier to add types to Calypso reducers, by standardising how schemas are attached to reducers.

#### Changes proposed in this Pull Request

* Add `createReducerWithValidation`
* Remove support for the third parameter in `createReducer`
* Extract common code from `createReducer` and `createReducerWithValidation` into a utility method
* Remove support for `schema` property in plain reducer functions
* Add `package.json` with `sideEffects: false` to `state/utils` to enable tree-shaking
* Refactor all reducers to use `createReducerWithValidation` instead of `createReducer` as needed
* Refactor all reducers that were using the `schema` property to instead explicitly call `withSchemaValidation`

#### Testing instructions

I don't really have any specific testing instructions for this. The unit tests should largely cover all of this, and I added E2E tests for good measure. Also, the errors the reworked utils methods throw when unexpected usage is detected would have made most problems visible, since this all mostly happens on boot.

Take Calypso for a spin and see if anything breaks, I suppose :)