### PR TITLE
Customer Home: Update links when the site displays posts on the homepage

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -153,7 +153,7 @@ class Home extends Component {
 	}
 
 	renderCustomerHome = () => {
-		const { translate, customizeUrl, site, siteSlug, trackAction } = this.props;
+		const { translate, customizeUrl, site, siteSlug, trackAction, isStaticHomePage } = this.props;
 		return (
 			<div className="customer-home__layout">
 				<div className="customer-home__layout-col">
@@ -170,12 +170,23 @@ class Home extends Component {
 							>
 								{ translate( 'View Site' ) }
 							</Button>
-							<Button
-								href={ customizeUrl }
-								onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
-							>
-								{ translate( 'Edit Homepage' ) }
-							</Button>
+							{ isStaticHomePage ? (
+								<Button
+									href={ customizeUrl }
+									onClick={ () => trackAction( 'my_site', 'edit_homepage' ) }
+								>
+									{ translate( 'Edit Homepage' ) }
+								</Button>
+							) : (
+								<Button
+									onClick={ () => {
+										trackAction( 'my_site', 'write_post' );
+										page( `/post/${ siteSlug }` );
+									} }
+								>
+									{ translate( 'Write Blog Post' ) }
+								</Button>
+							) }
 						</div>
 					</Card>
 					<Card className="customer-home__card-boxes">
@@ -188,14 +199,25 @@ class Home extends Component {
 								label={ translate( 'Add a page' ) }
 								iconSrc="/calypso/images/customer-home/page.svg"
 							/>
-							<ActionBox
-								onClick={ () => {
-									trackAction( 'my_site', 'write_post' );
-									page( `/post/${ siteSlug }` );
-								} }
-								label={ translate( 'Write blog post' ) }
-								iconSrc="/calypso/images/customer-home/post.svg"
-							/>
+							{ isStaticHomePage ? (
+								<ActionBox
+									onClick={ () => {
+										trackAction( 'my_site', 'write_post' );
+										page( `/post/${ siteSlug }` );
+									} }
+									label={ translate( 'Write blog post' ) }
+									iconSrc="/calypso/images/customer-home/post.svg"
+								/>
+							) : (
+								<ActionBox
+									onClick={ () => {
+										trackAction( 'my_site', 'manage_comments' );
+										page( `/comments/${ siteSlug }` );
+									} }
+									label={ translate( 'Manage comments' ) }
+									iconSrc="/calypso/images/customer-home/comment.svg"
+								/>
+							) }
 							<ActionBox
 								href={ customizeUrl }
 								onClick={ () => trackAction( 'my_site', 'customize_theme' ) }

--- a/static/images/customer-home/comment.svg
+++ b/static/images/customer-home/comment.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="20px" height="21px" viewBox="0 0 20 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
+    <title>outline-mode_comment-24px</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Customer-Home-Design-v1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="outline-mode_comment-24px" transform="translate(-2.000000, -1.500000)">
+            <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
+            <path d="M20,17.17 L18.83,16 L4,16 L4,4 L20,4 L20,17.17 Z M20,2 L4,2 C2.9,2 2,2.9 2,4 L2,16 C2,17.1 2.9,18 4,18 L18,18 L22,22 L22,4 C22,2.9 21.1,2 20,2 Z" id="Shape" fill="#8F9194" fill-rule="nonzero"></path>
+        </g>
+    </g>
+</svg>

--- a/static/images/customer-home/comment.svg
+++ b/static/images/customer-home/comment.svg
@@ -1,12 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="20px" height="21px" viewBox="0 0 20 21" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
-    <title>outline-mode_comment-24px</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Customer-Home-Design-v1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="outline-mode_comment-24px" transform="translate(-2.000000, -1.500000)">
-            <polygon id="Path" points="0 0 24 0 24 24 0 24"></polygon>
-            <path d="M20,17.17 L18.83,16 L4,16 L4,4 L20,4 L20,17.17 Z M20,2 L4,2 C2.9,2 2,2.9 2,4 L2,16 C2,17.1 2.9,18 4,18 L18,18 L22,22 L22,4 C22,2.9 21.1,2 20,2 Z" id="Shape" fill="#8F9194" fill-rule="nonzero"></path>
-        </g>
-    </g>
-</svg>
+<svg width="20" height="21" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><path d="M-2-1.5h24v24H-2z"/><path d="M18 15.67l-1.17-1.17H2v-12h16v13.17zM18 .5H2c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h14l4 4v-18c0-1.1-.9-2-2-2z" fill="#8F9194" fill-rule="nonzero"/></g></svg>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When a site sets the option to display posts on the homepage, the
buttons to edit the homepage are not appropriate. This change checks the
value of the option for the site and swaps the two of the buttons, so
the user additionally has a link to manage their comments.

#### Testing instructions

View the customer home screen with a site that has its homepage option set to display a static page (this is the default for most new sites)

This is the option in Design -> Customize -> Homepage Settings

<img width="283" alt="image" src="https://user-images.githubusercontent.com/96462/63292462-98392480-c2bd-11e9-84b7-730c82eea761.png">

With the option set to 'A static page' the My Sites section should look like this:

<img width="538" alt="image" src="https://user-images.githubusercontent.com/96462/63292349-5b6d2d80-c2bd-11e9-8efa-3fad7d422ac5.png">

And with the option set to 'Your latest posts' the My Sites section should look like this:

<img width="538" alt="image" src="https://user-images.githubusercontent.com/96462/63292395-76d83880-c2bd-11e9-9844-77b8d71cd476.png">
