### PR TITLE
Checkout: Fix recording stripe payment method errors

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -333,9 +333,10 @@ TransactionFlow.prototype.stripeModalAuth = async function( stripeConfiguration,
 			} );
 		}
 	} catch ( error ) {
+		debug( 'error during stripeModalAuth', error );
 		this._pushStep( {
 			name: RECEIVED_AUTHORIZATION_RESPONSE,
-			error: error.message,
+			error: error.stripeError ? error.stripeError : error.message,
 			last: true,
 		} );
 	}

--- a/client/lib/stripe/index.js
+++ b/client/lib/stripe/index.js
@@ -55,6 +55,20 @@ StripeSetupIntentError.prototype = new Error();
 export { StripeSetupIntentError };
 
 /**
+ * An error related to a Stripe PaymentMethod
+ *
+ * The object will include the original stripe error in the stripeError prop.
+ *
+ * @param {object} stripeError - The original Stripe error object
+ */
+function StripePaymentMethodError( stripeError ) {
+	this.stripeError = stripeError;
+	this.message = stripeError.message;
+}
+StripePaymentMethodError.prototype = new Error();
+export { StripePaymentMethodError };
+
+/**
  * Create a Stripe PaymentMethod using Stripe Elements
  *
  * paymentDetails should include data not gathered by Stripe Elements. For
@@ -141,8 +155,9 @@ export async function confirmStripePaymentIntent( stripeConfiguration, paymentIn
 		{}
 	);
 	if ( error ) {
+		debug( 'Confirming paymentIntent failed', error );
 		// Note that this is a promise rejection
-		throw new Error( error );
+		throw new StripePaymentMethodError( error );
 	}
 
 	return paymentIntent;

--- a/client/my-sites/checkout/checkout/secure-payment-form.jsx
+++ b/client/my-sites/checkout/checkout/secure-payment-form.jsx
@@ -306,8 +306,9 @@ export class SecurePaymentForm extends Component {
 			case RECEIVED_AUTHORIZATION_RESPONSE:
 			case RECEIVED_WPCOM_RESPONSE:
 				if ( step.error ) {
+					debug( 'authorization error', step.error );
 					analytics.tracks.recordEvent( 'calypso_checkout_payment_error', {
-						error_code: step.error.error,
+						error_code: step.error.code || step.error.error,
 						reason: this.formatError( step.error ),
 					} );
 
@@ -394,6 +395,14 @@ export class SecurePaymentForm extends Component {
 
 		if ( error.error ) {
 			formatedMessage = error.error + ': ' + formatedMessage;
+		}
+
+		if ( error.decline_code ) {
+			formatedMessage = error.decline_code + ': ' + formatedMessage;
+		}
+
+		if ( error.code ) {
+			formatedMessage = error.code + ': ' + formatedMessage;
 		}
 
 		return formatedMessage;


### PR DESCRIPTION
When checking out using the (newly added in #34469) Stripe Payment Intent system, if the card is declined, the error response from Stripe will be lost as it is passed up the call stack and the user will receive a generic failure message.

With this change, the Stripe error message will be preserved and displayed to the user. We will also record the error message, the error code, and the decline code in our analytics as was originally intended.

Before:

<img width="423" alt="Screen Shot 2019-08-19 at 7 39 14 PM" src="https://user-images.githubusercontent.com/2036909/63306574-219a2800-c2b9-11e9-8a72-b9fc42948dcc.png">

After:

<img width="354" alt="Screen Shot 2019-08-19 at 7 32 24 PM" src="https://user-images.githubusercontent.com/2036909/63306577-252daf00-c2b9-11e9-944c-d858a888c6eb.png">


#### Testing instructions

1. Sandbox the store.
2. Add a plan to your cart.
3. Verify that you see number placeholders (not dots) in the credit card field.
4. Fill out the checkout form with the test card `4000008260003178`.
5. Submit the form. Then click "Complete Authentication" in the 3DSecure modal.
6. Verify that you see the error "Your card has insufficient funds."