### PR TITLE
FSE: Apply filter to template content before front end render

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -177,6 +177,7 @@ class WP_Template {
 		}
 
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo do_blocks( $this->get_template_content( $template_type ) );
+		$content = do_blocks( $this->get_template_content( $template_type ) );
+		echo apply_filters( 'the_content', $content );
 	}
 }


### PR DESCRIPTION
It turns out that quite a bit of functionality happens behind 'the_content' filter. For example, all shortcodes and autoembeds happen during this filter. As a result, we need to apply it before rendering the template content. This makes embeds/shortcodes work in the header/footer.

#### Changes proposed in this Pull Request
* Apply `'the_content'` filter before rendering header/footer content on the frontend.

This will fix issues rendering embeds/shortcodes in the header/footer on the frontend.

| | Before  | After |
| ------------- | ------------- | ------------- |
| Youtube embed | ![](https://cld.wthms.co/2qy30G+)(Image link: https://cld.wthms.co/2qy30G ) | <img width="1472" alt="Screen Shot 2019-08-19 at 6 16 41 PM" src="https://user-images.githubusercontent.com/6265975/63309952-851e5880-c2ad-11e9-9b88-3929e0d0277a.png">  |
| Subscription form |<img width="843" alt="Screenshot 2019-08-18 at 18 34 51" src="https://user-images.githubusercontent.com/18581859/63224809-12e34080-c1e7-11e9-93d9-a36255c560ce.png">| <img width="826" alt="Screen Shot 2019-08-19 at 6 27 52 PM" src="https://user-images.githubusercontent.com/6265975/63310322-12ae7800-c2af-11e9-8ac7-15d362e9eb8f.png">  |


#### Testing instructions
1. Pull this branch and sync it to your sandbox.
2. Follow these instructions on your sandboxed site:
2. Add a youtube video, or any other embed, to your header. Also add the jetpack subscription form to your header.
3. Update the header and navigate to the front end of your site.
4. The embedded content should render correctly. Previously it only displayed the text URL of the content without rendering anything. Also make sure that the "subscribe" button displays for the subscription form. 
5. Feel free to try other embed or shortcode-based blocks and make sure they render correctly on the front end.

Fixes #35537, Fixes #35446