### PR TITLE
Revert "Main: migrate CSS styles to webpack"

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -11,4 +11,5 @@
 @import 'components/button/style';
 @import 'components/card/style';
 @import 'components/dialog/style';
+@import 'components/main/style';
 @import 'layout/sidebar/style';

--- a/client/components/main/README.md
+++ b/client/components/main/README.md
@@ -1,16 +1,16 @@
 Main (jsx)
 ==========
 
-Component used to declare the main area of any given section —- it's the main wrapper that gets rendered first inside `#primary`.
+Component used to declare the main area of any given section — it's the main wrapper that gets render first inside `#primary`.
 
 #### How to use:
 
-```jsx
+```js
 import Main from 'components/main';
 
 render() {
 	return (
-		<Main className="your-component">
+		<Main (optional) className="your-component">
 			Your section content...
 		</Main>
 	);
@@ -19,5 +19,4 @@ render() {
 
 #### Props
 
-* `className`: Add your own CSS class to the wrapper.
-* `wideLayout`: Use wide layout (larger `max-width`) for the section.
+* `className`: Add your own class to the wrapper.

--- a/client/components/main/index.jsx
+++ b/client/components/main/index.jsx
@@ -1,13 +1,11 @@
+/** @format */
+
 /**
  * External dependencies
  */
+
 import React from 'react';
 import classNames from 'classnames';
-
-/**
- * Style dependencies
- */
-import './style.scss';
 
 export default function Main( { className, children, wideLayout = false } ) {
 	const classes = classNames( className, 'main', {

--- a/client/components/main/style.scss
+++ b/client/components/main/style.scss
@@ -8,6 +8,20 @@
 		max-width: 100%;
 	}
 
+	&.sites {
+		max-width: 320px;
+	}
+
+	// The customizer is full-width
+	&.customize {
+		max-width: 100%;
+	}
+
+	&.preview {
+		height: 100%;
+		max-width: none;
+	}
+
 	&.is-wide-layout {
 		max-width: 1040px;
 	}

--- a/client/my-sites/customize/style.scss
+++ b/client/my-sites/customize/style.scss
@@ -1,8 +1,3 @@
-// The customizer is full-width
-.main.customize {
-	max-width: 100%;
-}
-
 .main.customize.is-iframe {
 	background-color: var( --color-neutral-0 );
 	margin: 0;

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -29,11 +29,6 @@ import {
 import WebPreview from 'components/web-preview';
 import { recordTracksEvent } from 'state/analytics/actions';
 
-/**
- * Internal dependencies
- */
-import './style.scss';
-
 const debug = debugFactory( 'calypso:my-sites:preview' );
 
 class PreviewMain extends React.Component {

--- a/client/my-sites/preview/style.scss
+++ b/client/my-sites/preview/style.scss
@@ -1,4 +1,0 @@
-.main.preview {
-	height: 100%;
-	max-width: none;
-}

--- a/client/my-sites/sites/style.scss
+++ b/client/my-sites/sites/style.scss
@@ -1,7 +1,3 @@
-.main.sites {
-	max-width: 320px;
-}
-
 .sites__select-header {
 	text-align: center;
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#35554. This PR caused display issues in the theme profile page:

<img width="1500" alt="Screen Shot 2019-08-20 at 15 13 14" src="https://user-images.githubusercontent.com/17325/63314862-1e587800-c35d-11e9-8139-296b422910fc.png">

Reverting until we can identify the cause.

### Testing instructions

Visit https://wpcalypso.wordpress.com/theme/stow on a desktop browser and verify that the layout appears at the correct width.

cc @sgomes @jsnajdr 