### PR TITLE
Themes: fix theme sheet width

### DIFF
--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -1,4 +1,4 @@
-.theme__sheet {
+.main.theme__sheet {
 	max-width: none;
 }
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Fixes an issue introduced in #35554 causing the theme page to be artificially limited in width:

<img width="1500" alt="Screen Shot 2019-08-20 at 15 13 14" src="https://user-images.githubusercontent.com/17325/63317377-bd35a200-c366-11e9-967f-53e585180681.png">

The CSS changes in the above PR caused the max-width rule to be overridden:

<img width="334" alt="Screen Shot 2019-08-20 at 16 03 20" src="https://user-images.githubusercontent.com/17325/63317394-d0e10880-c366-11e9-91cb-d994e578028d.png">


#### Testing instructions

Visit http://calypso.localhost:3000/theme/stow on a desktop browser and verify that the theme sheet appears at the correct width:

<img width="1397" alt="Screen Shot 2019-08-20 at 16 24 41" src="https://user-images.githubusercontent.com/17325/63317455-084fb500-c367-11e9-947f-10bc8ccdea56.png">
