### PR TITLE
Media Library: Fix Toggle Overlapping Slider

### DIFF
--- a/client/my-sites/media-library/style.scss
+++ b/client/my-sites/media-library/style.scss
@@ -198,10 +198,10 @@
 	}
 }
 
-.media-library__scale-toggle {
+.media-library__scale-toggle.segmented-control {
 	position: absolute;
 	right: 16px;
-	&.segmented-control.is-compact .segmented-control__link {
+	&.is-compact .segmented-control__link {
 		padding: 2px 4px;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Segmented Control toggle should be hidden on desktop displays in the Media Library to prevent an overlap with the slider. It previously was, but I think #35051 caused the CSS that was initially hiding it to be overridden. cc @jsnajdr 

#### Testing instructions

Visit the Media Library and compare.

**Before:**

<img width="586" alt="Screenshot 2019-08-20 at 08 40 26" src="https://user-images.githubusercontent.com/43215253/63327509-3b258900-c326-11e9-8a0f-2d8af960d649.png">

**After:**

<img width="553" alt="Screenshot 2019-08-20 at 08 41 19" src="https://user-images.githubusercontent.com/43215253/63327621-7031db80-c326-11e9-9e4e-5454c8863a78.png">

Should still appear on mobile though.

