### PR TITLE
Update to 4.0.0-alpha.2

### DIFF
--- a/packages/i18n-calypso/CHANGELOG.md
+++ b/packages/i18n-calypso/CHANGELOG.md
@@ -5,9 +5,8 @@
 * Refactor i18n-calypso to Calypso standards.
 * Add TypeScript type definitions to package.
 * Add support for extracting strings from TypeScript.
-* Update lodash to ^4.17.11
-* Update xgettext-js to ^3.0.0
-
+* Update dependency `lodash` to `^4.17.11`
+* Update `xgettext-js` to `^3.0.0`
 
 3.0.0
 ------

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "i18n-calypso",
-	"version": "4.0.0-alpha.1",
+	"version": "4.0.0-alpha.2",
 	"description": "i18n JavaScript library on top of Jed originally used in Calypso",
 	"main": "dist/cjs/index.js",
 	"module": "dist/esm/index.js",


### PR DESCRIPTION
Update i18n-calypso to 4.0.0-alpha.2 for another pre-release.

There are some deprecations I'd like to remove before the final 4.0.0 release.