### PR TITLE
Check if there is a valid `selectedSite` before assembling the marketing survey data.

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/index.jsx
+++ b/client/components/marketing-survey/cancel-purchase-form/index.jsx
@@ -206,7 +206,7 @@ class CancelPurchaseForm extends React.Component {
 	onSubmit = () => {
 		const { purchase, selectedSite } = this.props;
 
-		if ( ! isGoogleApps( purchase ) ) {
+		if ( ! isGoogleApps( purchase ) && selectedSite ) {
 			this.setState( {
 				isSubmitting: true,
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR attempts to resolve https://github.com/Automattic/wp-calypso/issues/35380.

Ideally we would still want to submit the survey data in this case. However, it is currently designed with valid site data in mind, so there is not much we can do if it's just not there, e.g. a disconnected Jetpack site like reported in the above issue.

#### Testing instructions

Follow the instructions in #35380 and make sure it is fixed.
