### PR TITLE
[e2e] Fix "Delete plan" flow

### DIFF
--- a/test/e2e/lib/pages/cancel-purchase-page.js
+++ b/test/e2e/lib/pages/cancel-purchase-page.js
@@ -36,7 +36,7 @@ export default class CancelPurchasePage extends AsyncBaseContainer {
 
 	async completeCancellationSurvey() {
 		const e2eReason = 'e2e testing';
-		const dialogClass = '.cancel-purchase__button-warning-dialog';
+		const dialogClass = '.cancel-purchase-form__dialog';
 		const buttonDialogClass = '.dialog__action-buttons';
 		const nextButtonSelector = by.css( `${ buttonDialogClass } button[data-e2e-button="next"]` );
 		await driverHelper.clickWhenClickable(


### PR DESCRIPTION
#### Changes proposed in this Pull Request

After PR https://github.com/Automattic/wp-calypso/pull/34393 landed [`dialogClass`](https://github.com/Automattic/wp-calypso/pull/35603/files#diff-937cb984ac0a915f9423dc3579d84eddL39) selector has changed. This result in _delete plan flow_ couldn't finish and after that deleting account didn't pass also. We didn't see this as urgent thing since tests won't fail because of that. Instead, only warnings are present in e2e notification slack channel:

<img width="748" alt="Screen Shot 2019-08-20 at 12 40 22" src="https://user-images.githubusercontent.com/7116222/63345931-2e1f8e80-c354-11e9-9c9d-cdfd80572bf5.png">

With this fix, delete plan flow should work as expected. 

#### Testing instructions

Run any of sign up tests which have `Can delete the plan` step and make sure that plan is removed and an account is canceled. 