### PR TITLE
Import in Signup: Add track event when user submits URL form in  step.

### DIFF
--- a/client/signup/steps/import-url-onboarding/index.jsx
+++ b/client/signup/steps/import-url-onboarding/index.jsx
@@ -110,13 +110,19 @@ class ImportURLOnboardingStepComponent extends Component {
 
 	handleSubmit = event => {
 		event.preventDefault();
+
+		const { flowName, stepName, translate, urlInputValue } = this.props;
 		const isValid = this.validateUrl();
+
+		this.props.recordTracksEvent( 'calypso_signup_import_url_submit', {
+			flow: flowName,
+			url: urlInputValue,
+			isValid: isValid,
+		} );
 
 		if ( ! isValid ) {
 			return;
 		}
-
-		const { stepName, translate, urlInputValue } = this.props;
 
 		this.setState( {
 			fallbackSiteDetails: {

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -68,13 +68,17 @@ class ImportURLStepComponent extends Component {
 
 	handleSubmit = event => {
 		event.preventDefault();
-		const isValid = this.validateUrl();
+		const { flowName, stepName, translate, urlInputValue } = this.props;
 
+		this.props.recordTracksEvent( 'calypso_signup_import_url', {
+			flow: flowName,
+			url: urlInputValue,
+		} );
+
+		const isValid = this.validateUrl();
 		if ( ! isValid ) {
 			return;
 		}
-
-		const { stepName, translate, urlInputValue } = this.props;
 
 		this.setState( {
 			isLoading: true,

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -69,13 +69,14 @@ class ImportURLStepComponent extends Component {
 	handleSubmit = event => {
 		event.preventDefault();
 		const { flowName, stepName, translate, urlInputValue } = this.props;
+		const isValid = this.validateUrl();
 
 		this.props.recordTracksEvent( 'calypso_signup_import_url', {
 			flow: flowName,
 			url: urlInputValue,
+			isValid: isValid,
 		} );
 
-		const isValid = this.validateUrl();
 		if ( ! isValid ) {
 			return;
 		}

--- a/client/signup/steps/import-url/index.jsx
+++ b/client/signup/steps/import-url/index.jsx
@@ -68,18 +68,13 @@ class ImportURLStepComponent extends Component {
 
 	handleSubmit = event => {
 		event.preventDefault();
-		const { flowName, stepName, translate, urlInputValue } = this.props;
 		const isValid = this.validateUrl();
-
-		this.props.recordTracksEvent( 'calypso_signup_import_url', {
-			flow: flowName,
-			url: urlInputValue,
-			isValid: isValid,
-		} );
 
 		if ( ! isValid ) {
 			return;
 		}
+
+		const { stepName, translate, urlInputValue } = this.props;
 
 		this.setState( {
 			isLoading: true,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add a client-side Tracks event when the user clicks the "Continue" button after entering a website URL in the `import-url` step of signup flow.
* The component validates the contents of the input on blur, so this track will miss some attempts to insert an invalid URL. But it should record invalid URLs people submit.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out the branch, run Calypso and go to a signup flow which uses the `import-url-onboarding` step, for example http://calypso.localhost:3000/start/import-onboarding/ (Click on the bug icon and set the A/B test value `showImportFlowInSiteTypeStep` to `show` to see the "Already have a website?" link.)
* Open the network tab of dev tools and filter by `pixel.wp.com`.
* Enter an invalid URL in the input and - without blurring the input - click on the "Continue" button.
* The page should make a request to the tracking pixel `http://pixel.wp.com/t.gif`. The request params should include the flow name and the URL you entered.
* Enter a valid URL in the input and click "Continue" again.
* The page should make another request to the tracking pixel, passing similar params.

Fixes Samus issue 216
