### PR TITLE
Jetpack Plans Price Toggle: CSS selector that sets margin should be more specific

### DIFF
--- a/client/my-sites/plan-features/style.scss
+++ b/client/my-sites/plan-features/style.scss
@@ -518,7 +518,7 @@ $plan-features-sidebar-width: 272px;
 
 // This is used for the monthly/yearly billing
 // which is currently us in the Jetpack flow.
-.price-toggle {
+.segmented-control.price-toggle {
 	width: 250px;
 	margin: 0 auto 20px;
 


### PR DESCRIPTION
Turn the `.price-toggle` CSS selector into `.segmented-control.price-control`, to make sure
that it always overrides the base `.segmented-control` styles.

Fixes a regression introduced in #35051 and reported by @simison in https://github.com/Automattic/wp-calypso/pull/35051#issuecomment-522885496

**How to test:**
Verify that the bug reported by @simison no longer happens. I.e., the placement of the Monthly/Yearly toggle is not broken like here:

<img width="1588" alt="Screenshot 2019-08-20 at 10 06 28" src="https://user-images.githubusercontent.com/87168/63325198-58605480-c332-11e9-8af3-abf75b884126.png">

Note that the bug is non-deterministic: depends on the exact order of how CSS chunks are loaded, which depends on navigation history etc.