### PR TITLE
Site Alerts: Send alerts to staging

### DIFF
--- a/config/stage.json
+++ b/config/stage.json
@@ -98,6 +98,7 @@
 		"reader/user-mention-suggestions": true,
 		"resume-editing": true,
 		"republicize": true,
+		"rewind-alerts": true,
 		"rewind/clone-site": true,
 		"rewind/partial-restores": true,
 		"rubberband-scroll-disable": false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR enables rewind alerts in staging for testing.

#### Testing instructions

Load up staging and ensure the rewind alerts module appears at the top of the Activity Log for a site with active threats.
