### PR TITLE
Full Site Editing: Disable the Block sidebar when a Template block is selected

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -47,7 +47,7 @@ const TemplateEdit = compose(
 			templateTitle: get( template, [ 'title', 'rendered' ], '' ),
 			isDirty: isEditedPostDirty(),
 			isEditorSidebarOpened: !! isEditorSidebarOpened(),
-			isTemplateBlockSelected: selectedBlock && 'a8c/template' === selectedBlock.name,
+			isAnyTemplateBlockSelected: selectedBlock && 'a8c/template' === selectedBlock.name,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
@@ -83,7 +83,7 @@ const TemplateEdit = compose(
 		isSelected,
 		isEditorSidebarOpened,
 		openGeneralSidebar,
-		isTemplateBlockSelected,
+		isAnyTemplateBlockSelected,
 	} ) => {
 		if ( ! template ) {
 			return (
@@ -112,13 +112,12 @@ const TemplateEdit = compose(
 				'.edit-post-sidebar__panel-tabs ul li:last-child'
 			);
 			if ( isEditorSidebarOpened && blockSidebarButton ) {
-				if ( isTemplateBlockSelected ) {
+				if ( isAnyTemplateBlockSelected ) {
 					openGeneralSidebar( 'edit-post/document' );
 					blockSidebarButton.classList.add( 'hidden' );
+					return;
 				}
-				if ( ! isTemplateBlockSelected ) {
-					blockSidebarButton.classList.remove( 'hidden' );
-				}
+				blockSidebarButton.classList.remove( 'hidden' );
 			}
 		} );
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -119,7 +119,7 @@ const TemplateEdit = compose(
 				}
 				blockSidebarButton.classList.remove( 'hidden' );
 			}
-		} );
+		}, [ isAnyTemplateBlockSelected, isEditorSidebarOpened, openGeneralSidebar ] );
 
 		const { align, className } = attributes;
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -4,13 +4,12 @@
  * External dependencies
  */
 import classNames from 'classnames';
-import { debounce, get, noop } from 'lodash';
+import { get, noop } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { parse, createBlock } from '@wordpress/blocks';
-import domReady from '@wordpress/dom-ready';
 import { BlockEdit } from '@wordpress/editor';
 import { Button, Placeholder, Spinner, Disabled } from '@wordpress/components';
 import { compose, withState } from '@wordpress/compose';
@@ -24,33 +23,12 @@ import { addQueryArgs } from '@wordpress/url';
  */
 import './style.scss';
 
-// Hide the Block Sidebar when the Template block is selected
-domReady( () => {
-	const debouncedFunction = debounce( () => {
-		const templateBlock = document.querySelector( '.template__block-container' );
-		const blockSidebarButton = document.querySelector(
-			'.edit-post-sidebar__panel-tabs ul li:last-child'
-		);
-
-		if ( ! templateBlock || ! blockSidebarButton ) {
-			return;
-		}
-
-		if ( templateBlock.classList.contains( 'is-selected' ) ) {
-			blockSidebarButton.classList.add( 'hidden' );
-		} else {
-			blockSidebarButton.classList.remove( 'hidden' );
-		}
-	}, 50 );
-	setInterval( debouncedFunction, 100 );
-} );
-
 const TemplateEdit = compose(
 	withState( { templateClientId: null } ),
 	withSelect( ( select, { attributes, templateClientId } ) => {
 		const { getEntityRecord } = select( 'core' );
 		const { getCurrentPostId, isEditedPostDirty } = select( 'core/editor' );
-		const { getBlock } = select( 'core/block-editor' );
+		const { getBlock, getSelectedBlock } = select( 'core/block-editor' );
 		const { isEditorSidebarOpened } = select( 'core/edit-post' );
 		const { templateId } = attributes;
 		const currentPostId = getCurrentPostId();
@@ -59,6 +37,7 @@ const TemplateEdit = compose(
 			post: templateId,
 			fse_parent_post: currentPostId,
 		} );
+		const selectedBlock = getSelectedBlock();
 
 		return {
 			currentPostId,
@@ -68,6 +47,7 @@ const TemplateEdit = compose(
 			templateTitle: get( template, [ 'title', 'rendered' ], '' ),
 			isDirty: isEditedPostDirty(),
 			isEditorSidebarOpened: !! isEditorSidebarOpened(),
+			isTemplateBlockSelected: selectedBlock && 'a8c/template' === selectedBlock.name,
 		};
 	} ),
 	withDispatch( ( dispatch, ownProps ) => {
@@ -103,6 +83,7 @@ const TemplateEdit = compose(
 		isSelected,
 		isEditorSidebarOpened,
 		openGeneralSidebar,
+		isTemplateBlockSelected,
 	} ) => {
 		if ( ! template ) {
 			return (
@@ -126,9 +107,18 @@ const TemplateEdit = compose(
 
 		useEffect( () => {
 			// Since the Block Sidebar (`edit-post/block`) is not available for the Template block,
-			// if the sidebar is open, we force toggle to the Document Sidebar.
-			if ( isSelected && isEditorSidebarOpened ) {
-				openGeneralSidebar( 'edit-post/document' );
+			// if the sidebar is open, we force toggle to the Document Sidebar, and hide the Block button.
+			const blockSidebarButton = document.querySelector(
+				'.edit-post-sidebar__panel-tabs ul li:last-child'
+			);
+			if ( isEditorSidebarOpened && blockSidebarButton ) {
+				if ( isTemplateBlockSelected ) {
+					openGeneralSidebar( 'edit-post/document' );
+					blockSidebarButton.classList.add( 'hidden' );
+				}
+				if ( ! isTemplateBlockSelected ) {
+					blockSidebarButton.classList.remove( 'hidden' );
+				}
 			}
 		} );
 


### PR DESCRIPTION
In Full Site Editing, the Template block does not have any options, and so we are disabling the Block sidebar when it's selected to avoid a possibly confusing UX.

In #35387 I've merged a stop-gap solution reliant on `domReady` and `setInterval`, which wasn't really the most elegant possible.

This PR replaces that approach with one using the Template block's effect hook, letting Redux look at the state changes, waiting for when a Template block is selected and the sidebar is open to hide the Block button.

Props to @gwwar for making me realize how much I was overthinking this! 🙇 

#### Testing instructions

* On an FSE site, edit a page.
* Open the sidebar and observe that the Block button is visible.
* Select the header or the footer Template block: make sure the Block button in the sidebar is now hidden.
* Select any other block: make sure the Block button shows up again.
* Close the sidebar.
* Select a Template block and open the sidebar: make sure the Block button disappears (although, just a fraction of second too late).
* Close the sidebar again.
* Select any non Template block and open the sidebar: make sure the Block button is visible.

Fixes #35608