### PR TITLE
Signup: Reuse the site title for the domains search

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -201,7 +201,11 @@ class RegisterDomainStep extends React.Component {
 				this.state.subdomainSearchResults = props.initialState.subdomainSearchResults;
 			}
 
-			if ( this.state.searchResults || this.state.subdomainSearchResults ) {
+			if (
+				this.state.searchResults ||
+				this.state.subdomainSearchResults ||
+				! props.initialState.isInitialQueryActive
+			) {
 				this.state.lastQuery = props.initialState.lastQuery;
 			} else {
 				this.state.railcarId = this.getNewRailcarId();

--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -243,6 +243,7 @@ class RegisterDomainStep extends React.Component {
 			unavailableDomains: [],
 			trademarkClaimsNoticeInfo: null,
 			selectedSuggestion: null,
+			isInitialQueryActive: !! this.props.suggestion,
 		};
 	}
 
@@ -484,7 +485,7 @@ class RegisterDomainStep extends React.Component {
 	};
 
 	acceptTrademarkClaim = () => {
-		this.props.onAddDomain( this.state.selectedSuggestion );
+		this.props.onAddDomain( this.state.selectedSuggestion, this.state.isInitialQueryActive );
 	};
 
 	renderTrademarkClaimsNotice() {
@@ -672,9 +673,11 @@ class RegisterDomainStep extends React.Component {
 
 		const cleanedQuery = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
 		const loadingResults = Boolean( cleanedQuery );
+		const isInitialQueryActive = searchQuery === this.props.suggestion;
 
 		this.setState(
 			{
+				isInitialQueryActive,
 				availabilityError: null,
 				availabilityErrorData: null,
 				exactMatchDomain: null,
@@ -1130,11 +1133,11 @@ class RegisterDomainStep extends React.Component {
 							selectedSuggestion: suggestion,
 						} );
 					} else {
-						this.props.onAddDomain( suggestion );
+						this.props.onAddDomain( suggestion, this.state.isInitialQueryActive );
 					}
 				} );
 		} else {
-			this.props.onAddDomain( suggestion );
+			this.props.onAddDomain( suggestion, this.state.isInitialQueryActive );
 		}
 	};
 

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -124,4 +124,13 @@ export default {
 		},
 		defaultVariation: 'original',
 	},
+	prefillDomainStepValue: {
+		datestamp: '20190929',
+		variations: {
+			test: 50,
+			control: 50,
+		},
+		defaultVariation: 'control',
+		allowExistingUsers: true,
+	},
 };

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -90,7 +90,7 @@ class DomainsStep extends React.Component {
 			return queryValue || suggestedDomain;
 		}
 
-		if ( abtest( 'prefilDomainStepValue' ) === 'test' ) {
+		if ( abtest( 'prefillDomainStepValue' ) === 'test' ) {
 			return get( this.props, 'signupDependencies.siteTitle', '' );
 		}
 
@@ -103,7 +103,7 @@ class DomainsStep extends React.Component {
 	// between cases where the site title was used vs cases where the initial
 	// query was set by some other method. Remove this once the A/B test is finished.
 	hasMadeSuggestion = !! (
-		abtest( 'prefilDomainStepValue' ) === 'test' &&
+		abtest( 'prefillDomainStepValue' ) === 'test' &&
 		get( this.props, 'signupDependencies.siteTitle' ) &&
 		get( this.props, 'signupDependencies.siteTitle' ) === this.getInitialQuery()
 	);
@@ -190,7 +190,7 @@ class DomainsStep extends React.Component {
 			suggestion,
 		};
 
-		if ( abtest( 'prefilDomainStepValue' ) === 'test' ) {
+		if ( abtest( 'prefillDomainStepValue' ) === 'test' ) {
 			stepData.usedSuggestedDomain = usedSuggestedDomain;
 		}
 
@@ -633,8 +633,8 @@ const submitDomainStepSelection = ( suggestion, section, usedSuggestedDomain ) =
 	if ( suggestion.isBestAlternative ) {
 		tracksObjects.label = 'best-alternative';
 	}
-	if ( abtest( 'prefilDomainStepValue' ) === 'test' && isBoolean( usedSuggestedDomain ) ) {
-		tracksObjects.usedSuggestedDomain = usedSuggestedDomain;
+	if ( abtest( 'prefillDomainStepValue' ) === 'test' && isBoolean( usedSuggestedDomain ) ) {
+		tracksObjects.used_suggested_domain = usedSuggestedDomain;
 	}
 
 	return composeAnalytics(

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -117,7 +117,12 @@ class DomainsStep extends React.Component {
 
 		// If we landed anew from `/domains` and it's the `new-flow` variation
 		// or there's a suggestedDomain from previous steps, always rerun the search.
-		if ( ( search && props.path.indexOf( '?' ) !== -1 ) || suggestedDomain ) {
+		if (
+			( search && props.path.indexOf( '?' ) !== -1 ) ||
+			suggestedDomain ||
+			( this.hasMadeSuggestion &&
+				get( this.props.step, 'domainForm.isInitialQueryActive' ) === true )
+		) {
 			this.searchOnInitialRender = true;
 		}
 

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -323,6 +323,30 @@ class DomainsStep extends React.Component {
 		return typeof lastQuery === 'string' && lastQuery.includes( '.blog' );
 	}
 
+	getInitialQuery = () => {
+		const fromQueryObject = get( this.props, 'queryObject.new', '' );
+
+		if ( fromQueryObject ) {
+			return fromQueryObject;
+		}
+
+		const initialQuery =
+			get( this.props, 'queryObject.new', '' ) ||
+			get( this.props, 'signupDependencies.suggestedDomain' );
+
+		`We want to favour the above ^
+		But how do we really track the effectiveness of the split?
+		If they never make it down below here then thats no good - though most are likely to fall through here
+		`
+
+		if ( abtest( 'thingy' ) ===  ) {}
+			const siteTitle = get( this.props, 'signupDependencies.siteTitle', '' );
+
+			return siteTitle;
+
+		return;
+	};
+
 	domainForm = () => {
 		let initialState = {};
 		if ( this.state ) {
@@ -332,10 +356,7 @@ class DomainsStep extends React.Component {
 			initialState = this.props.step.domainForm;
 		}
 
-		// If it's the first load, rerun the search with whatever we get from the query param or signup dependencies.
-		const initialQuery =
-			get( this.props, 'queryObject.new', '' ) ||
-			get( this.props, 'signupDependencies.suggestedDomain' );
+		const initialQuery = this.getInitialQuery();
 
 		if (
 			// If we landed here from /domains Search or with a suggested domain.

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { defer, endsWith, get, includes, isBoolean, isEmpty } from 'lodash';
+import { defer, endsWith, get, includes, isEmpty } from 'lodash';
 import { localize, getLocaleSlug } from 'i18n-calypso';
 
 /**
@@ -638,7 +638,7 @@ const submitDomainStepSelection = ( suggestion, section, usedSuggestedDomain ) =
 	if ( suggestion.isBestAlternative ) {
 		tracksObjects.label = 'best-alternative';
 	}
-	if ( abtest( 'prefillDomainStepValue' ) === 'test' && isBoolean( usedSuggestedDomain ) ) {
+	if ( abtest( 'prefillDomainStepValue' ) === 'test' && typeof usedSuggestedDomain === 'boolean' ) {
 		tracksObjects.used_suggested_domain = usedSuggestedDomain;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Look for the given `siteTitle` property in the `signupDependencies` object. If it's found, search for domain suggestions based on this input.
* A/B test this behaviour and add a tracking param to support this A/B test.

#### A/B Test Hypothesis

Our hypothesise that we can present our onboarding customers with relevant domain suggestions, based on the information that they have already given us, earlier. In doing so we would save the customer having to interact with the step at all before seeing any domains, helping them to get through the signup flow with less effort and with less waiting.
As part of this PR we're adding a new param (`usedSuggestedDomain`) to an existing tracking event (`calypso_domain_search_submit_step`). In cases where we present a suggestion this param will either be `true` or `false` depending on whether or not the customer selects a domain based on that suggestion.

#### Questions

* Is a 50/50 split ideal here? Should we have a smaller control segment, or larger?
* Do we want to include the other suggestion (`new` param) in this test? I'd guess not as I don't think we're so interested in suggestions in general, rather this latest change.

#### Testing instructions

The tricky part of this work is in making sure we search only in the right situations - we shouldn't be making a new request when navigating back to the domains step from a later step for instance. Let's make sure we're testing this by navigating through the domains step in a few different situations. 
Let's also check that everything works as expected, without the extra tracking param, when we're passing a `new` url param or when we're on the import flow, as they already do an eager search.


#### Onboarding flow
- When a site title is given
  - Make sure to give a value in the site title step
  - Progress through to the domains step.
    -  You should notice that the site title is pre-filled and the step begins in a fetching state.
    -  After some time you should see results relevant to your site title.
  - Make a selection
    - Look for the `calypso_domain_search_submit_step` event in the network tab, look for the `usedSuggestedDomain` param in the query string params.
       - It should be `true`, as you were given a selection and decided to use it.
  - carry on to the next step (you'll need to be on a flow that has a step after domains)
  - use the back button to navigate back to the domains step
    - This time it should look exactly as you left it - with the site title pre-filled, but this time it's not fetching.
- When no site title is given
  - Make sure the site title step is clear of input
  - Progress through to the domains step.
    -  You should notice that there's nothing pre-filled in the input and the step is not fetching, instead it should be waiting for your input.
  - Enter something in to the input and select an option when it's done loading.
    - The `calypso_domain_search_submit_step` event should have been fired
    - Look for the `usedSuggestedDomain` param in the query string params.
    - Because no suggestion was given the param should not be present (neither true or false)

#### When the `new` param is supplied
In this case, we don't want to track whether the suggestion was used or not, so continue through the above but check that the tracking event doesn't include the `usedSuggestedDomain` param at all.
	
#### When in the import signup flow
 In this case, we don't want to track whether the suggestion was used or not, so continue through the above but check that the tracking event doesn't include the `usedSuggestedDomain` param at all.

Fixes # https://github.com/Automattic/wp-calypso/issues/35032
