### PR TITLE
ABTest Library: Change the ABTest helper to save the variation on the server

### DIFF
--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -55,6 +55,16 @@ export const getABTestVariation = name => new ABTest( name ).getVariation();
  */
 export const getSavedVariations = () => store.get( ABTEST_LOCALSTORAGE_KEY ) || {};
 
+/**
+ * Set the variation for a test - useful for testing!
+ *
+ * @param {String} name - The name of the A/B test
+ * @param {String} variation - The test variation to set
+ * @returns {undefined}
+ */
+export const setABTestVariation = ( name, variation ) =>
+	new ABTest( name ).saveVariation( variation );
+
 export const getAllTests = () => keys( activeTests ).map( ABTest );
 
 const isUserSignedIn = () => user && user.get() !== false;

--- a/client/lib/abtest/index.js
+++ b/client/lib/abtest/index.js
@@ -56,13 +56,13 @@ export const getABTestVariation = name => new ABTest( name ).getVariation();
 export const getSavedVariations = () => store.get( ABTEST_LOCALSTORAGE_KEY ) || {};
 
 /**
- * Set the variation for a test - useful for testing!
+ * Save the variation for a test - useful for testing!
  *
  * @param {String} name - The name of the A/B test
- * @param {String} variation - The test variation to set
+ * @param {String} variation - The test variation to save
  * @returns {undefined}
  */
-export const setABTestVariation = ( name, variation ) =>
+export const saveABTestVariation = ( name, variation ) =>
 	new ABTest( name ).saveVariation( variation );
 
 export const getAllTests = () => keys( activeTests ).map( ABTest );

--- a/client/lib/abtest/test-helper/index.js
+++ b/client/lib/abtest/test-helper/index.js
@@ -14,7 +14,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Card from 'components/card';
-import { getAllTests, setABTestVariation } from 'lib/abtest';
+import { getAllTests, saveABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -79,7 +79,7 @@ export default function injectTestHelper( element ) {
 			tests: getAllTests(),
 			onChangeVariant: function( test, variation ) {
 				debug( 'Switching test variant', test.experimentId, variation );
-				setABTestVariation( test.name, variation );
+				saveABTestVariation( test.name, variation );
 				window.location.reload();
 			},
 		} ),

--- a/client/lib/abtest/test-helper/index.js
+++ b/client/lib/abtest/test-helper/index.js
@@ -14,8 +14,7 @@ import classNames from 'classnames';
  * Internal dependencies
  */
 import Card from 'components/card';
-import { getAllTests } from 'lib/abtest';
-import { ABTEST_LOCALSTORAGE_KEY } from 'lib/abtest/utility';
+import { getAllTests, setABTestVariation } from 'lib/abtest';
 
 /**
  * Style dependencies
@@ -79,10 +78,8 @@ export default function injectTestHelper( element ) {
 		React.createElement( TestList, {
 			tests: getAllTests(),
 			onChangeVariant: function( test, variation ) {
-				const testSettings = JSON.parse( localStorage.getItem( ABTEST_LOCALSTORAGE_KEY ) ) || {};
-				testSettings[ test.experimentId ] = variation;
 				debug( 'Switching test variant', test.experimentId, variation );
-				localStorage.setItem( ABTEST_LOCALSTORAGE_KEY, JSON.stringify( testSettings ) );
+				setABTestVariation( test.name, variation );
 				window.location.reload();
 			},
 		} ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Currently the ABTest helper changes the value in local storage, but
leaves the value on the server (stored in a user attribute) unchanged.
This updates the code in the helper to use the same save mechanism as
the main ABTest library, and so the variation is updated on the server
if possible.

This is necessary so that we can determine the test group on the server.

#### Testing instructions

With this branch, change a value in the ABTest helper. Observe that a POST request is made to `/me/abtest` for each change with the attribute name. 

You can also confirm that a call to `get_user_attribute( <USER ID>, 'abtest_<TEST NAME>_<TEST DATE>' )` gives the correct variation. For instance, the attribute `abtest_removeBlogFlow_20190813` should have the value `remove` or `control` as appropriate.