### PR TITLE
CalendarButton: move CalendarPopover out of button markup

### DIFF
--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -80,29 +80,26 @@ class CalendarButton extends Component {
 			return null;
 		}
 
-		const calendarProperties = Object.assign(
-			{},
-			pick( this.props, [
-				'autoPosition',
-				'closeOnEsc',
-				'disabledDays',
-				'events',
-				'showOutsideDays',
-				'ignoreContext',
-				'isVisible',
-				'modifiers',
-				'rootClassName',
-				'selectedDay',
-				'showDelay',
-				'siteId',
-				'onDateChange',
-				'onMonthChange',
-				'onDayMouseEnter',
-				'onDayMouseLeave',
-				'onShow',
-				'onClose',
-			] )
-		);
+		const calendarProperties = pick( this.props, [
+			'autoPosition',
+			'closeOnEsc',
+			'disabledDays',
+			'events',
+			'showOutsideDays',
+			'ignoreContext',
+			'isVisible',
+			'modifiers',
+			'rootClassName',
+			'selectedDay',
+			'showDelay',
+			'siteId',
+			'onDateChange',
+			'onMonthChange',
+			'onDayMouseEnter',
+			'onDayMouseLeave',
+			'onShow',
+			'onClose',
+		] );
 
 		return (
 			<AsyncLoad
@@ -122,20 +119,17 @@ class CalendarButton extends Component {
 	}
 
 	render() {
-		const buttonsProperties = Object.assign(
-			{},
-			pick( this.props, [
-				'compact',
-				'disabled',
-				'primary',
-				'scary',
-				'busy',
-				'href',
-				'borderless',
-				'target',
-				'rel',
-			] )
-		);
+		const buttonsProperties = pick( this.props, [
+			'compact',
+			'disabled',
+			'primary',
+			'scary',
+			'busy',
+			'href',
+			'borderless',
+			'target',
+			'rel',
+		] );
 
 		return (
 			<Button

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -1,14 +1,12 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import Gridicon from 'gridicons';
 import classNames from 'classnames';
 import { noop, pick } from 'lodash';
+
 /**
  * Internal dependencies
  */
@@ -74,9 +72,7 @@ class CalendarButton extends Component {
 	buttonRef = React.createRef();
 
 	renderCalendarPopover() {
-		const { showPopover } = this.state;
-
-		if ( ! showPopover ) {
+		if ( ! this.state.showPopover ) {
 			return null;
 		}
 
@@ -105,11 +101,11 @@ class CalendarButton extends Component {
 			<AsyncLoad
 				{ ...calendarProperties }
 				require="blocks/calendar-popover"
+				placeholder={ null }
+				isVisible
 				context={ this.buttonRef.current }
-				isVisible={ showPopover }
 				position={ this.props.popoverPosition }
 				onClose={ this.closePopover }
-				placeholder={ null }
 			/>
 		);
 	}
@@ -132,15 +128,17 @@ class CalendarButton extends Component {
 		] );
 
 		return (
-			<Button
-				{ ...buttonsProperties }
-				className={ classNames( 'calendar-button', this.props.className ) }
-				ref={ this.buttonRef }
-				onClick={ this.togglePopover }
-			>
-				{ this.renderCalendarContent() }
+			<Fragment>
+				<Button
+					{ ...buttonsProperties }
+					className={ classNames( 'calendar-button', this.props.className ) }
+					ref={ this.buttonRef }
+					onClick={ this.togglePopover }
+				>
+					{ this.renderCalendarContent() }
+				</Button>
 				{ this.renderCalendarPopover() }
-			</Button>
+			</Fragment>
 		);
 	}
 }

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -65,10 +65,10 @@ class CalendarButton extends Component {
 
 	togglePopover = () => {
 		if ( this.props.disabled ) {
-			return null;
+			return;
 		}
 
-		return this.setState( { showPopover: ! this.state.showPopover } );
+		this.setState( { showPopover: ! this.state.showPopover } );
 	};
 
 	setPopoverReference = calendarButtonRef => ( this.reference = calendarButtonRef );

--- a/client/blocks/calendar-button/index.jsx
+++ b/client/blocks/calendar-button/index.jsx
@@ -71,7 +71,7 @@ class CalendarButton extends Component {
 		this.setState( { showPopover: ! this.state.showPopover } );
 	};
 
-	setPopoverReference = calendarButtonRef => ( this.reference = calendarButtonRef );
+	buttonRef = React.createRef();
 
 	renderCalendarPopover() {
 		const { showPopover } = this.state;
@@ -105,7 +105,7 @@ class CalendarButton extends Component {
 			<AsyncLoad
 				{ ...calendarProperties }
 				require="blocks/calendar-popover"
-				context={ this.reference }
+				context={ this.buttonRef.current }
 				isVisible={ showPopover }
 				position={ this.props.popoverPosition }
 				onClose={ this.closePopover }
@@ -135,7 +135,7 @@ class CalendarButton extends Component {
 			<Button
 				{ ...buttonsProperties }
 				className={ classNames( 'calendar-button', this.props.className ) }
-				ref={ this.setPopoverReference }
+				ref={ this.buttonRef }
 				onClick={ this.togglePopover }
 			>
 				{ this.renderCalendarContent() }

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -66,21 +66,18 @@ class CalendarPopover extends Component {
 	};
 
 	renderScheduler() {
-		const schedulerProps = Object.assign(
-			{},
-			pick( this.props, [
-				'events',
-				'posts',
-				'site',
-				'disabledDays',
-				'showOutsideDays',
-				'modifiers',
-				'onDateChange',
-				'onMonthChange',
-				'onDayMouseEnter',
-				'onDayMouseLeave',
-			] )
-		);
+		const schedulerProps = pick( this.props, [
+			'events',
+			'posts',
+			'site',
+			'disabledDays',
+			'showOutsideDays',
+			'modifiers',
+			'onDateChange',
+			'onMonthChange',
+			'onDayMouseEnter',
+			'onDayMouseLeave',
+		] );
 
 		return (
 			<PostSchedule
@@ -95,21 +92,18 @@ class CalendarPopover extends Component {
 	}
 
 	render() {
-		const popoverProps = Object.assign(
-			{},
-			pick( this.props, [
-				'autoPosition',
-				'closeOnEsc',
-				'context',
-				'ignoreContext',
-				'isVisible',
-				'position',
-				'rootClassName',
-				'showDelay',
-				'onClose',
-				'onShow',
-			] )
-		);
+		const popoverProps = pick( this.props, [
+			'autoPosition',
+			'closeOnEsc',
+			'context',
+			'ignoreContext',
+			'isVisible',
+			'position',
+			'rootClassName',
+			'showDelay',
+			'onClose',
+			'onShow',
+		] );
 
 		return (
 			<div className="calendar-popover">

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -106,11 +106,9 @@ class CalendarPopover extends Component {
 		] );
 
 		return (
-			<div className="calendar-popover">
-				<Popover { ...popoverProps } className="calendar-popover__popover">
-					{ this.renderScheduler() }
-				</Popover>
-			</div>
+			<Popover { ...popoverProps } className="calendar-popover__popover">
+				{ this.renderScheduler() }
+			</Popover>
 		);
 	}
 }

--- a/client/blocks/calendar-popover/index.jsx
+++ b/client/blocks/calendar-popover/index.jsx
@@ -13,7 +13,6 @@ import { noop, pick } from 'lodash';
  * Internal dependencies
  */
 import getSiteGmtOffset from 'state/selectors/get-site-gmt-offset';
-
 import getSiteTimezoneValue from 'state/selectors/get-site-timezone-value';
 import Popover from 'components/popover';
 import PostSchedule from 'components/post-schedule';
@@ -57,13 +56,9 @@ class CalendarPopover extends Component {
 		onDayMouseLeave: noop,
 	};
 
-	state = { date: null };
-
-	componentWillMount() {
-		if ( this.props.selectedDay ) {
-			this.setState( { date: this.props.selectedDay } );
-		}
-	}
+	state = {
+		date: this.props.selectedDay || null,
+	};
 
 	setDate = date => {
 		this.setState( { date } );


### PR DESCRIPTION
Fixes a bug in the Post Share sheet where `CalendarButton` would change size when toggled:

![Screen Capture on 2019-08-20 at 16-03-29](https://user-images.githubusercontent.com/664258/63357388-a04e9e00-c369-11e9-8cbc-38acf0266ba5.gif)

The cause of the bug was:
- `CalendarPopover`, a `RootChild` that is located at the root of the DOM, is rendered inside as `CalendarButton` child. I'm changing it to be a sibling
- `CalendarPopover` renders a redundant `<div className="calendar-popover" />` as a parent of the `RootChild`. Unneeded always-empty element

There is also a drive-by cleanup that removes unneeded `Object.assign` calls and modernizes one ref to `React.createRef`.