### PR TITLE
SPT: move storing to higher component

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -15,7 +15,6 @@ import { memo } from '@wordpress/element';
  * Internal dependencies
  */
 import TemplateSelectorItem from './template-selector-item';
-import replacePlaceholders from '../utils/replace-placeholders';
 
 // Load config passed from backend.
 const { siteInformation = {} } = window.starterPageTemplatesConfig;
@@ -26,6 +25,7 @@ const TemplateSelectorControl = ( {
 	help,
 	instanceId,
 	templates = {},
+	blocksByTemplates = {},
 	useDynamicPreview = false,
 	numBlocksInPreview,
 	onTemplateSelect = noop,
@@ -45,18 +45,18 @@ const TemplateSelectorControl = ( {
 			className={ classnames( className, 'template-selector-control' ) }
 		>
 			<ul className="template-selector-control__options">
-				{ map( templates, ( { slug, title, blocks, preview, previewAlt, value } ) => (
+				{ map( templates, ( { slug, title, preview, previewAlt, value } ) => (
 					<li key={ `${ id }-${ value }` } className="template-selector-control__template">
 						<TemplateSelectorItem
 							id={ id }
 							value={ slug }
-							label={ replacePlaceholders( title, siteInformation ) }
+							label={ title }
 							help={ help }
 							onSelect={ onTemplateSelect }
 							onFocus={ onTemplateFocus }
 							staticPreviewImg={ preview }
 							staticPreviewImgAlt={ previewAlt }
-							blocks={ blocks }
+							blocks={ blocksByTemplates[ slug ] }
 							useDynamicPreview={ useDynamicPreview }
 							numBlocksInPreview={ numBlocksInPreview }
 						/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -16,9 +16,6 @@ import { memo } from '@wordpress/element';
  */
 import TemplateSelectorItem from './template-selector-item';
 
-// Load config passed from backend.
-const { siteInformation = {} } = window.starterPageTemplatesConfig;
-
 const TemplateSelectorControl = ( {
 	label,
 	className,
@@ -27,7 +24,6 @@ const TemplateSelectorControl = ( {
 	templates = {},
 	blocksByTemplates = {},
 	useDynamicPreview = false,
-	numBlocksInPreview,
 	onTemplateSelect = noop,
 	onTemplateFocus = noop,
 } ) => {
@@ -58,7 +54,6 @@ const TemplateSelectorControl = ( {
 							staticPreviewImgAlt={ previewAlt }
 							blocks={ blocksByTemplates[ slug ] }
 							useDynamicPreview={ useDynamicPreview }
-							numBlocksInPreview={ numBlocksInPreview }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -15,6 +15,8 @@ import { memo } from '@wordpress/element';
  * Internal dependencies
  */
 import TemplateSelectorItem from './template-selector-item';
+import replacePlaceholders from '../utils/replace-placeholders';
+const { siteInformation = {} } = window.starterPageTemplatesConfig;
 
 const TemplateSelectorControl = ( {
 	label,
@@ -46,7 +48,7 @@ const TemplateSelectorControl = ( {
 						<TemplateSelectorItem
 							id={ id }
 							value={ slug }
-							label={ title }
+							label={ replacePlaceholders( title, siteInformation ) }
 							help={ help }
 							onSelect={ onTemplateSelect }
 							onFocus={ onTemplateFocus }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, noop } from 'lodash';
+import { isEmpty, noop, map } from 'lodash';
 import classnames from 'classnames';
 
 /**
@@ -25,7 +25,7 @@ const TemplateSelectorControl = ( {
 	className,
 	help,
 	instanceId,
-	templates = [],
+	templates = {},
 	useDynamicPreview = false,
 	numBlocksInPreview,
 	onTemplateSelect = noop,
@@ -45,7 +45,7 @@ const TemplateSelectorControl = ( {
 			className={ classnames( className, 'template-selector-control' ) }
 		>
 			<ul className="template-selector-control__options">
-				{ templates.map( ( { slug, title, content, preview, previewAlt, value } ) => (
+				{ map( templates, ( { slug, title, blocks, preview, previewAlt, value } ) => (
 					<li key={ `${ id }-${ value }` } className="template-selector-control__template">
 						<TemplateSelectorItem
 							id={ id }
@@ -56,7 +56,7 @@ const TemplateSelectorControl = ( {
 							onFocus={ onTemplateFocus }
 							staticPreviewImg={ preview }
 							staticPreviewImgAlt={ previewAlt }
-							rawContent={ replacePlaceholders( content, siteInformation ) }
+							blocks={ blocks }
 							useDynamicPreview={ useDynamicPreview }
 							numBlocksInPreview={ numBlocksInPreview }
 						/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -52,7 +52,9 @@ const TemplateSelectorControl = ( {
 							onFocus={ onTemplateFocus }
 							staticPreviewImg={ preview }
 							staticPreviewImgAlt={ previewAlt }
-							blocks={ blocksByTemplates[ slug ] }
+							blocks={
+								slug && blocksByTemplates.hasOwnProperty( slug ) ? blocksByTemplates[ slug ] : []
+							}
 							useDynamicPreview={ useDynamicPreview }
 						/>
 					</li>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -16,7 +16,6 @@ import { memo } from '@wordpress/element';
  */
 import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
-const { siteInformation = {} } = window.starterPageTemplatesConfig;
 
 const TemplateSelectorControl = ( {
 	label,
@@ -28,6 +27,7 @@ const TemplateSelectorControl = ( {
 	useDynamicPreview = false,
 	onTemplateSelect = noop,
 	onTemplateFocus = noop,
+	siteInformation = {},
 } ) => {
 	if ( isEmpty( templates ) ) {
 		return null;
@@ -54,9 +54,7 @@ const TemplateSelectorControl = ( {
 							onFocus={ onTemplateFocus }
 							staticPreviewImg={ preview }
 							staticPreviewImgAlt={ previewAlt }
-							blocks={
-								slug && blocksByTemplates.hasOwnProperty( slug ) ? blocksByTemplates[ slug ] : []
-							}
+							blocks={ blocksByTemplates.hasOwnProperty( slug ) ? blocksByTemplates[ slug ] : [] }
 							useDynamicPreview={ useDynamicPreview }
 						/>
 					</li>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -63,7 +63,6 @@ const TemplateSelectorItem = props => {
 			id={ `${ id }-${ value }` }
 			className="template-selector-item__label"
 			value={ value }
-			// onFocus={ onFocusHandler }
 			onMouseEnter={ onFocusHandler }
 			onMouseLeave={ onFocusHandler.cancel }
 			onClick={ () => onSelect( value, label, blocks ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { debounce } from 'lodash';
 
 /**
  * Internal dependencies
@@ -10,7 +9,6 @@ import { debounce } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
 import BlockPreview from './block-template-preview';
 import { Disabled } from '@wordpress/components';
 
@@ -25,29 +23,13 @@ const TemplateSelectorItem = props => {
 		useDynamicPreview = false,
 		staticPreviewImg,
 		staticPreviewImgAlt = '',
-		numBlocksInPreview,
 		blocks = [],
 	} = props;
-
-	const ON_FOCUS_DELAY = 500;
-
-	const [ blocksLimit, setBlockLimit ] = useState( numBlocksInPreview );
-
-	const onFocusHandler = debounce( () => {
-		if ( blocks && blocks.length > blocksLimit ) {
-			setBlockLimit( null ); // not blocks limit to template preview
-		}
-
-		onFocus( value, label, blocks );
-	}, ON_FOCUS_DELAY );
 
 	// Define static or dynamic preview.
 	const innerPreview = useDynamicPreview ? (
 		<Disabled>
-			<BlockPreview
-				blocks={ blocksLimit && blocks ? blocks.slice( 0, blocksLimit ) : blocks }
-				viewportWidth={ 960 }
-			/>
+			<BlockPreview blocks={ blocks } viewportWidth={ 960 } />
 		</Disabled>
 	) : (
 		<img
@@ -63,9 +45,8 @@ const TemplateSelectorItem = props => {
 			id={ `${ id }-${ value }` }
 			className="template-selector-item__label"
 			value={ value }
-			onMouseEnter={ onFocusHandler }
-			onMouseLeave={ onFocusHandler.cancel }
-			onClick={ () => onSelect( value, label, blocks ) }
+			onMouseEnter={ () => onFocus( value, label ) }
+			onClick={ () => onSelect( value, label ) }
 			aria-describedby={ help ? `${ id }__help` : undefined }
 		>
 			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -10,9 +10,8 @@ import { debounce } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { useState, useMemo } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import BlockPreview from './block-template-preview';
-import { parse as parseBlocks } from '@wordpress/blocks';
 import { Disabled } from '@wordpress/components';
 
 const TemplateSelectorItem = props => {
@@ -26,14 +25,13 @@ const TemplateSelectorItem = props => {
 		useDynamicPreview = false,
 		staticPreviewImg,
 		staticPreviewImgAlt = '',
-		rawContent,
 		numBlocksInPreview,
+		blocks = [],
 	} = props;
 
 	const ON_FOCUS_DELAY = 500;
 
 	const [ blocksLimit, setBlockLimit ] = useState( numBlocksInPreview );
-	const blocks = useMemo( () => ( rawContent ? parseBlocks( rawContent ) : null ), [ rawContent ] );
 
 	const onFocusHandler = debounce( () => {
 		if ( blocks && blocks.length > blocksLimit ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, each } from 'lodash';
+import { isEmpty, reduce } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Button, Modal } from '@wordpress/components';
@@ -43,13 +43,14 @@ class PageTemplateModal extends Component {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}
 
-		// Populate blocks state parsing the raw content for each template.
+		// Populate blocks state field, parsing the raw content for each template.
 		const blocks = {};
-		for( const slug in this.props.templates ) {
+		for ( const slug in this.props.templates ) {
 			const template = this.props.templates[ slug ];
 			blocks[ slug ] = template.content ? parseBlocks( template.content ) : [];
 		}
 
+		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { blocks } );
 
 		// eslint-disable-next-line no-console
@@ -62,7 +63,7 @@ class PageTemplateModal extends Component {
 
 		this.props.saveTemplateChoice( slug );
 
-		const previewBlocks = this.state.blocks [ slug ];
+		const previewBlocks = this.state.blocks[ slug ];
 
 		// Skip inserting if there's nothing to insert.
 		if ( ! previewBlocks || previewBlocks.length === 0 ) {
@@ -72,8 +73,7 @@ class PageTemplateModal extends Component {
 		this.props.insertTemplate( title, previewBlocks );
 	};
 
-	selectTemplate = () =>
-		this.setTemplate( this.state.slug, this.state.title );
+	selectTemplate = () => this.setTemplate( this.state.slug, this.state.title );
 
 	focusTemplate = ( slug, title ) => {
 		this.setState( { slug, title } );
@@ -83,7 +83,7 @@ class PageTemplateModal extends Component {
 	};
 
 	closeModal = event => {
-		// Check to see if the Blur event occured on the buttons inside of the Modal.
+		// Check to see if the Blur event occurred on the buttons inside of the Modal.
 		// If it did then we don't want to dismiss the Modal for this type of Blur.
 		if ( event.target.matches( 'button.template-selector-item__label' ) ) {
 			return false;
@@ -117,7 +117,10 @@ class PageTemplateModal extends Component {
 							/>
 						</fieldset>
 					</form>
-					<TemplateSelectorPreview blocks={ this.state.blocks[ this.state.slug ] } viewportWidth={ 960 } />
+					<TemplateSelectorPreview
+						blocks={ this.state.blocks[ this.state.slug ] }
+						viewportWidth={ 960 }
+					/>
 				</div>
 				<div className="page-template-modal__buttons">
 					<Button isDefault isLarge onClick={ this.closeModal }>
@@ -191,11 +194,7 @@ const prepareTemplatesForPlugin = ( templatesBySlug, template ) => {
 
 	return {
 		...templatesBySlug,
-		[ template.slug ]: {
-			...template,
-			title,
-			content,
-		},
+		[ template.slug ]: { ...template, title, content },
 	};
 };
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -131,6 +131,7 @@ class PageTemplateModal extends Component {
 								blocksByTemplates={ this.state.blocks }
 								onTemplateSelect={ this.focusTemplate }
 								useDynamicPreview={ true }
+								siteInformation={ siteInformation }
 							/>
 						</fieldset>
 					</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -26,7 +26,6 @@ const { siteInformation = {} } = window.starterPageTemplatesConfig;
 class PageTemplateModal extends Component {
 	state = {
 		isLoading: false,
-		previewBlocks: [],
 		slug: '',
 		title: '',
 		blocks: {},
@@ -57,11 +56,13 @@ class PageTemplateModal extends Component {
 		console.timeEnd( 'PageTemplateModal' );
 	}
 
-	setTemplate = ( slug, title, previewBlocks ) => {
+	setTemplate = ( slug, title ) => {
 		this.setState( { isOpen: false } );
 		trackSelection( this.props.segment.id, this.props.vertical.id, slug );
 
 		this.props.saveTemplateChoice( slug );
+
+		const previewBlocks = this.state.blocks [ slug ];
 
 		// Skip inserting if there's nothing to insert.
 		if ( ! previewBlocks || previewBlocks.length === 0 ) {
@@ -72,12 +73,12 @@ class PageTemplateModal extends Component {
 	};
 
 	selectTemplate = () =>
-		this.setTemplate( this.state.slug, this.state.title, this.state.previewBlocks );
+		this.setTemplate( this.state.slug, this.state.title );
 
-	focusTemplate = ( slug, title, previewBlocks ) => {
-		this.setState( { slug, title, previewBlocks } );
+	focusTemplate = ( slug, title ) => {
+		this.setState( { slug, title } );
 		if ( slug === 'blank' ) {
-			this.setTemplate( slug, title, previewBlocks );
+			this.setTemplate( slug, title );
 		}
 	};
 
@@ -116,7 +117,7 @@ class PageTemplateModal extends Component {
 							/>
 						</fieldset>
 					</form>
-					<TemplateSelectorPreview blocks={ this.state.previewBlocks } viewportWidth={ 960 } />
+					<TemplateSelectorPreview blocks={ this.state.blocks[ this.state.slug ] } viewportWidth={ 960 } />
 				</div>
 				<div className="page-template-modal__buttons">
 					<Button isDefault isLarge onClick={ this.closeModal }>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -21,7 +21,6 @@ import { parse as parseBlocks } from '@wordpress/blocks';
 import replacePlaceholders from './utils/replace-placeholders';
 
 // Load config passed from backend.
-// Load config passed from backend.
 const {
 	templates = [],
 	vertical,
@@ -202,24 +201,10 @@ if ( tracksUserData ) {
 	initializeWithIdentity( tracksUserData );
 }
 
-// Reorganizing templates as an object, processing title and content on the fly.
-const getTemplatesBySlug = reduce(
-	templates,
-	( templatesBySlug, template ) => {
-		const title = replacePlaceholders( template.title, siteInformation );
-		return { ...templatesBySlug, [ template.slug ]: { ...template, title } };
-	},
-	{}
-);
-
 registerPlugin( 'page-templates', {
 	render: () => {
 		return (
-			<PageTemplatesPlugin
-				templates={ getTemplatesBySlug }
-				vertical={ vertical }
-				segment={ segment }
-			/>
+			<PageTemplatesPlugin templates={ templates } vertical={ vertical } segment={ segment } />
 		);
 	},
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -97,6 +97,18 @@ class PageTemplateModal extends Component {
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 
+	getBlocksByTemplateSlug( slug = this.state.slug ) {
+		if ( ! slug ) {
+			return [];
+		}
+
+		if ( ! this.state.blocks.hasOwnProperty( slug ) ) {
+			return [];
+		}
+
+		return this.state.blocks[ slug ];
+	}
+
 	render() {
 		if ( ! this.state.isOpen ) {
 			return null;
@@ -122,7 +134,7 @@ class PageTemplateModal extends Component {
 						</fieldset>
 					</form>
 					<TemplateSelectorPreview
-						blocks={ this.state.blocks[ this.state.slug ] }
+						blocks={ this.getBlocksByTemplateSlug() }
 						viewportWidth={ 960 }
 					/>
 				</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -71,7 +71,7 @@ class PageTemplateModal extends Component {
 		const previewBlocks = this.state.blocks[ slug ];
 
 		// Skip inserting if there's nothing to insert.
-		if ( ! previewBlocks || previewBlocks.length === 0 ) {
+		if ( ! previewBlocks || ! previewBlocks.length ) {
 			return;
 		}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -48,12 +48,15 @@ class PageTemplateModal extends Component {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}
 
-		// Populate blocks state field, parsing the raw content for each template.
-		const blocks = {};
-		for ( const slug in this.props.templates ) {
-			const template = this.props.templates[ slug ];
-			blocks[ slug ] = template.content ? parseBlocks( template.content ) : [];
-		}
+		// Parse templates blocks and store them into the state.
+		const blocks = reduce(
+			templates,
+			( prev, { slug, content } ) => {
+				prev[ slug ] = content ? parseBlocks( content ) : [];
+				return prev;
+			},
+			{}
+		);
 
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { blocks } );
@@ -185,7 +188,7 @@ if ( tracksUserData ) {
 	initializeWithIdentity( tracksUserData );
 }
 
-// Enhance templates with their parsed blocks and processed titles. Key by their slug.
+// Reorganizing templates as an object, processing title and content on the fly.
 const prepareTemplatesForPlugin = ( templatesBySlug, template ) => {
 	const content = replacePlaceholders( template.content, siteInformation );
 	const title = replacePlaceholders( template.title, siteInformation );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce } from 'lodash';
+import { isEmpty, reduce, each } from 'lodash';
 import { __, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { Button, Modal } from '@wordpress/components';
@@ -29,6 +29,7 @@ class PageTemplateModal extends Component {
 		previewBlocks: [],
 		slug: '',
 		title: '',
+		blocks: {},
 	};
 
 	constructor( props ) {
@@ -42,6 +43,16 @@ class PageTemplateModal extends Component {
 		if ( this.state.isOpen ) {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}
+
+		// Populate blocks state parsing the raw content for each template.
+		const blocks = {};
+		for( const slug in this.props.templates ) {
+			const template = this.props.templates[ slug ];
+			blocks[ slug ] = template.content ? parseBlocks( template.content ) : [];
+		}
+
+		this.setState( { blocks } );
+
 		// eslint-disable-next-line no-console
 		console.timeEnd( 'PageTemplateModal' );
 	}
@@ -98,6 +109,7 @@ class PageTemplateModal extends Component {
 							<TemplateSelectorControl
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
+								blocksByTemplates={ this.state.blocks }
 								onTemplateSelect={ this.focusTemplate }
 								useDynamicPreview={ true }
 								numBlocksInPreview={ 10 }
@@ -174,13 +186,14 @@ if ( tracksUserData ) {
 // Enhance templates with their parsed blocks and processed titles. Key by their slug.
 const prepareTemplatesForPlugin = ( templatesBySlug, template ) => {
 	const content = replacePlaceholders( template.content, siteInformation );
+	const title = replacePlaceholders( template.title, siteInformation );
+
 	return {
 		...templatesBySlug,
 		[ template.slug ]: {
 			...template,
-			title: replacePlaceholders( template.title, siteInformation ),
+			title,
 			content,
-			blocks: parseBlocks( content ),
 		},
 	};
 };

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -39,8 +39,6 @@ class PageTemplateModal extends Component {
 	};
 
 	constructor( props ) {
-		// eslint-disable-next-line no-console
-		console.time( 'PageTemplateModal' );
 		super();
 		this.state.isOpen = ! isEmpty( props.templates );
 	}
@@ -59,9 +57,6 @@ class PageTemplateModal extends Component {
 
 		// eslint-disable-next-line react/no-did-mount-set-state
 		this.setState( { blocks } );
-
-		// eslint-disable-next-line no-console
-		console.timeEnd( 'PageTemplateModal' );
 	}
 
 	setTemplate = ( slug, title ) => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -52,7 +52,9 @@ class PageTemplateModal extends Component {
 		const blocks = reduce(
 			templates,
 			( prev, { slug, content } ) => {
-				prev[ slug ] = content ? parseBlocks( content ) : [];
+				prev[ slug ] = content
+					? parseBlocks( replacePlaceholders( content, siteInformation ) )
+					: [];
 				return prev;
 			},
 			{}
@@ -204,13 +206,8 @@ if ( tracksUserData ) {
 const getTemplatesBySlug = reduce(
 	templates,
 	( templatesBySlug, template ) => {
-		const content = replacePlaceholders( template.content, siteInformation );
 		const title = replacePlaceholders( template.title, siteInformation );
-
-		return {
-			...templatesBySlug,
-			[ template.slug ]: { ...template, title, content },
-		};
+		return { ...templatesBySlug, [ template.slug ]: { ...template, title } };
 	},
 	{}
 );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -21,7 +21,14 @@ import { parse as parseBlocks } from '@wordpress/blocks';
 import replacePlaceholders from './utils/replace-placeholders';
 
 // Load config passed from backend.
-const { siteInformation = {} } = window.starterPageTemplatesConfig;
+// Load config passed from backend.
+const {
+	templates = [],
+	vertical,
+	segment,
+	tracksUserData,
+	siteInformation = {},
+} = window.starterPageTemplatesConfig;
 
 class PageTemplateModal extends Component {
 	state = {
@@ -113,7 +120,6 @@ class PageTemplateModal extends Component {
 								blocksByTemplates={ this.state.blocks }
 								onTemplateSelect={ this.focusTemplate }
 								useDynamicPreview={ true }
-								numBlocksInPreview={ 10 }
 							/>
 						</fieldset>
 					</form>
@@ -179,9 +185,6 @@ const PageTemplatesPlugin = compose(
 		};
 	} )
 )( PageTemplateModal );
-
-// Load config passed from backend.
-const { templates = [], vertical, segment, tracksUserData } = window.starterPageTemplatesConfig;
 
 if ( tracksUserData ) {
 	initializeWithIdentity( tracksUserData );

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -79,9 +79,9 @@ class PageTemplateModal extends Component {
 		this.props.insertTemplate( title, previewBlocks );
 	};
 
-	selectTemplate = () => this.setTemplate( this.state.slug, this.state.title );
+	handleConfirmation = () => this.setTemplate( this.state.slug, this.state.title );
 
-	focusTemplate = ( slug, title ) => {
+	previewTemplate = ( slug, title ) => {
 		this.setState( { slug, title } );
 		if ( slug === 'blank' ) {
 			this.setTemplate( slug, title );
@@ -129,7 +129,7 @@ class PageTemplateModal extends Component {
 								label={ __( 'Template', 'full-site-editing' ) }
 								templates={ this.props.templates }
 								blocksByTemplates={ this.state.blocks }
-								onTemplateSelect={ this.focusTemplate }
+								onTemplateSelect={ this.previewTemplate }
 								useDynamicPreview={ true }
 								siteInformation={ siteInformation }
 							/>
@@ -148,7 +148,7 @@ class PageTemplateModal extends Component {
 						isPrimary
 						isLarge
 						disabled={ isEmpty( this.state.slug ) }
-						onClick={ this.selectTemplate }
+						onClick={ this.handleConfirmation }
 					>
 						{ sprintf( __( 'Use %s template', 'full-site-editing' ), this.state.title ) }
 					</Button>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -189,21 +189,25 @@ if ( tracksUserData ) {
 }
 
 // Reorganizing templates as an object, processing title and content on the fly.
-const prepareTemplatesForPlugin = ( templatesBySlug, template ) => {
-	const content = replacePlaceholders( template.content, siteInformation );
-	const title = replacePlaceholders( template.title, siteInformation );
+const getTemplatesBySlug = reduce(
+	templates,
+	( templatesBySlug, template ) => {
+		const content = replacePlaceholders( template.content, siteInformation );
+		const title = replacePlaceholders( template.title, siteInformation );
 
-	return {
-		...templatesBySlug,
-		[ template.slug ]: { ...template, title, content },
-	};
-};
+		return {
+			...templatesBySlug,
+			[ template.slug ]: { ...template, title, content },
+		};
+	},
+	{}
+);
 
 registerPlugin( 'page-templates', {
 	render: () => {
 		return (
 			<PageTemplatesPlugin
-				templates={ reduce( templates, prepareTemplatesForPlugin, {} ) }
+				templates={ getTemplatesBySlug }
 				vertical={ vertical }
 				segment={ segment }
 			/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -88,7 +88,7 @@ class PageTemplateModal extends Component {
 		if ( event.target.matches( 'button.template-selector-item__label' ) ) {
 			return false;
 		}
-		// this.setState( { isOpen: false } );
+		this.setState( { isOpen: false } );
 		trackDismiss( this.props.segment.id, this.props.vertical.id );
 	};
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR move the logic which parses the template content from the `<TemplateSelectorItem />` to the `<PageTemplateModal />`.

Right now we are processing each template content into its own component (<TemplateSelectorItem />). With processing I mean to get the raw template content (from a component property), parse this content in order to get the blocks, to finally preview them using the <BlockPreview /> component.

In this PR, the templates are re-ordered as an Object which each field is the template slug. This `templates` property is passed to the `<PageTemplateModal />` component, and once the component did mount it starts the parsing process, template by template and storing the blocks into the component state (blocks).

The blocks state is passed to the `<TemplateSelectorControl />` component through of the `blocksByTemplates` property, and this component takes over of iterating for all templates in order to perform the preview (thumbnails).

All templates are parsed once, and also we are avoiding storing the blocks for the current preview (large preview) since now we just need the current template slug.

Related Issues: #35233

### Test

Apply the patch and check that everything is working as expected.
Maybe use the developer tools to check the props and state of the components.