### PR TITLE
Customer Home: Add an ABTest and associated logic to display the customer home

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -28,6 +28,7 @@ import isNotificationsOpen from 'state/selectors/is-notifications-open';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import { getSiteSlug } from 'state/sites/selectors';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import { getStatsPathForTab } from 'lib/route';
 import { domainManagementList } from 'my-sites/domains/paths';
 
@@ -82,10 +83,17 @@ class MasterbarLoggedIn extends React.Component {
 	};
 
 	renderMySites() {
-		const { domainOnlySite, hasMoreThanOneSite, siteSlug, translate } = this.props,
-			mySitesUrl = domainOnlySite
-				? domainManagementList( siteSlug )
-				: getStatsPathForTab( 'day', siteSlug );
+		const {
+				domainOnlySite,
+				hasMoreThanOneSite,
+				siteSlug,
+				translate,
+				isCustomerHomeEnabled,
+			} = this.props,
+			homeUrl = isCustomerHomeEnabled
+				? `/home/${ siteSlug }`
+				: getStatsPathForTab( 'day', siteSlug ),
+			mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
 
 		return (
 			<Item
@@ -176,6 +184,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state ) || getPrimarySiteId( state );
 
 		return {
+			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
 			siteSlug: getSiteSlug( state, siteId ),
 			domainOnlySite: isDomainOnlySite( state, siteId ),

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -161,4 +161,13 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	customerHomePage: {
+		datestamp: '20190820',
+		variations: {
+			show: 50,
+			hide: 50,
+		},
+		defaultVariation: 'hide',
+		assignmentMethod: 'userId',
+	},
 };

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -53,6 +53,8 @@ jest.mock( 'state/help/courses/selectors', () => ( {
 	getHelpCourses: jest.fn( () => [] ),
 } ) );
 
+jest.mock( 'state/selectors/is-site-eligible-for-customer-home', () => jest.fn( () => false ) );
+
 jest.mock( 'i18n-calypso', () => ( {
 	localize: Comp => props => (
 		<Comp

--- a/client/me/help/help-courses/test/index.jsx
+++ b/client/me/help/help-courses/test/index.jsx
@@ -53,8 +53,6 @@ jest.mock( 'state/help/courses/selectors', () => ( {
 	getHelpCourses: jest.fn( () => [] ),
 } ) );
 
-jest.mock( 'state/selectors/is-site-eligible-for-customer-home', () => jest.fn( () => false ) );
-
 jest.mock( 'i18n-calypso', () => ( {
 	localize: Comp => props => (
 		<Comp

--- a/client/my-sites/checklist/controller.jsx
+++ b/client/my-sites/checklist/controller.jsx
@@ -14,10 +14,8 @@ import { isEnabled } from 'config';
 
 import ChecklistMain from './main';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import {
-	canCurrentUserUseCustomerHome,
-	canCurrentUserUseChecklistMenu,
-} from 'state/sites/selectors';
+import { canCurrentUserUseChecklistMenu } from 'state/sites/selectors';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 
 export function show( context, next ) {
 	const displayMode = get( context, 'query.d' );

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -5,11 +5,15 @@
  */
 import React from 'react';
 import { get } from 'lodash';
+import page from 'page';
 
 /**
  * Internal Dependencies
  */
+import { isEnabled } from 'config';
+import { abtest } from 'lib/abtest';
 import CustomerHome from './main';
+import { getSelectedSiteSlug } from 'state/ui/selectors';
 
 export default function( context, next ) {
 	// Scroll to the top
@@ -19,5 +23,15 @@ export default function( context, next ) {
 
 	context.primary = <CustomerHome checklistMode={ get( context, 'query.d' ) } />;
 
+	next();
+}
+
+export function maybeRedirect( context, next ) {
+	const state = context.store.getState();
+	const slug = getSelectedSiteSlug( state );
+	if ( ! isEnabled( 'customer-home' ) || 'hide' === abtest( 'customerHomePage' ) ) {
+		page.redirect( `/stats/day/${ slug }` );
+		return;
+	}
 	next();
 }

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -27,8 +27,7 @@ export default function( context, next ) {
 }
 
 export function maybeRedirect( context, next ) {
-	const state = context.store.getState();
-	const slug = getSelectedSiteSlug( state );
+	const slug = getSelectedSiteSlug( context.store.getState() );
 	if ( ! isEnabled( 'customer-home' ) || 'hide' === abtest( 'customerHomePage' ) ) {
 		page.redirect( `/stats/day/${ slug }` );
 		return;

--- a/client/my-sites/customer-home/index.js
+++ b/client/my-sites/customer-home/index.js
@@ -8,11 +8,11 @@ import page from 'page';
  * Internal dependencies
  */
 import { navigation, siteSelection, sites } from 'my-sites/controller';
-import home from './controller';
+import home, { maybeRedirect } from './controller';
 import { makeLayout, render as clientRender } from 'controller';
 
 export default function() {
 	page( '/home', siteSelection, sites, makeLayout, clientRender );
 
-	page( '/home/:siteId', siteSelection, navigation, home, makeLayout, clientRender );
+	page( '/home/:siteId', siteSelection, maybeRedirect, navigation, home, makeLayout, clientRender );
 }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -27,9 +27,9 @@ import SidebarNavigation from 'my-sites/sidebar-navigation';
 import { getSelectedSite, getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
 import {
 	getCustomizerUrl,
-	canCurrentUserUseCustomerHome,
 	getSiteOption,
 } from 'state/sites/selectors';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import isSiteEligibleForCustomerHome from 'state/selectors/is-site-eligible-for-customer-home';
 import PageViewTracker from 'lib/analytics/page-view-tracker';
 import DocumentHead from 'components/data/document-head';

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -44,10 +44,10 @@ import {
 	isJetpackSite,
 	canCurrentUserUseAds,
 	canCurrentUserUseEarn,
-	canCurrentUserUseCustomerHome,
 	canCurrentUserUseStore,
 	canCurrentUserUseChecklistMenu,
 } from 'state/sites/selectors';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import canCurrentUserManagePlugins from 'state/selectors/can-current-user-manage-plugins';
 import { getStatsPathForTab } from 'lib/route';
 import { itemLinkMatches } from './utils';

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -184,18 +184,22 @@ export class MySitesSidebar extends Component {
 			return null;
 		}
 
+		const itemProps = isCustomerHomeEnabled
+			? {
+					label: translate( 'Home' ),
+					selected: itemLinkMatches( [ '/home' ], path ),
+					link: '/home' + siteSuffix,
+					materialIcon: 'home',
+			  }
+			: {
+					label: translate( 'Checklist' ),
+					selected: itemLinkMatches( [ '/checklist' ], path ),
+					link: '/checklist' + siteSuffix,
+					materialIcon: 'check_circle',
+			  };
+
 		return (
-			<SidebarItem
-				tipTarget="menus"
-				label={ isCustomerHomeEnabled ? translate( 'Home' ) : translate( 'Checklist' ) }
-				selected={ itemLinkMatches(
-					isEnabled( 'customer-home' ) ? [ '/home' ] : [ '/checklist' ],
-					path
-				) }
-				link={ isCustomerHomeEnabled ? '/home' + siteSuffix : '/checklist' + siteSuffix }
-				onNavigate={ this.trackCustomerHomeClick }
-				materialIcon={ isCustomerHomeEnabled ? 'home' : 'check_circle' }
-			/>
+			<SidebarItem tipTarget="menus" onNavigate={ this.trackCustomerHomeClick } { ...itemProps } />
 		);
 	}
 

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -14,6 +14,7 @@ import { memoize } from 'lodash';
  * Internal dependencies
  */
 import { isEnabled } from 'config';
+import { abtest } from 'lib/abtest';
 import Button from 'components/button';
 import CurrentSite from 'my-sites/current-site';
 import ExpandableSidebarMenu from 'layout/sidebar/expandable';
@@ -159,7 +160,7 @@ export class MySitesSidebar extends Component {
 	}
 
 	trackCustomerHomeClick = () => {
-		this.trackMenuItemClick( isEnabled( 'customer-home' ) ? 'customer-home' : 'checklist' );
+		this.trackMenuItemClick( this.props.isCustomerHomeEnabled ? 'customer-home' : 'checklist' );
 		this.onNavigate();
 	};
 
@@ -171,10 +172,11 @@ export class MySitesSidebar extends Component {
 			siteSuffix,
 			siteId,
 			translate,
+			isCustomerHomeEnabled,
 		} = this.props;
 
 		// This will be eventually removed when Customer Home is finally live
-		const canUserViewChecklistOrCustomerHome = isEnabled( 'customer-home' )
+		const canUserViewChecklistOrCustomerHome = isCustomerHomeEnabled
 			? canUserUseCustomerHome
 			: canUserUseChecklistMenu;
 
@@ -185,12 +187,12 @@ export class MySitesSidebar extends Component {
 		return (
 			<SidebarItem
 				tipTarget="menus"
-				label={ isEnabled( 'customer-home' ) ? translate( 'Home' ) : translate( 'Checklist' ) }
+				label={ isCustomerHomeEnabled ? translate( 'Home' ) : translate( 'Checklist' ) }
 				selected={ itemLinkMatches(
 					isEnabled( 'customer-home' ) ? [ '/home' ] : [ '/checklist' ],
 					path
 				) }
-				link={ isEnabled( 'customer-home' ) ? '/home' + siteSuffix : '/checklist' + siteSuffix }
+				link={ isCustomerHomeEnabled ? '/home' + siteSuffix : '/checklist' + siteSuffix }
 				onNavigate={ this.trackCustomerHomeClick }
 				materialIcon={ isEnabled( 'customer-home' ) ? 'home' : 'check_circle' }
 			/>
@@ -767,6 +769,8 @@ function mapStateToProps( state ) {
 	const isDesignSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_DESIGN );
 	const isToolsSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_TOOLS );
 	const isManageSectionOpen = isSidebarSectionOpen( state, SIDEBAR_SECTION_MANAGE );
+	const isCustomerHomeEnabled =
+		'show' === abtest( 'customerHomePage' ) && isEnabled( 'customer-home' );
 
 	return {
 		canUserEditThemeOptions: canCurrentUser( state, siteId, 'edit_theme_options' ),
@@ -780,6 +784,7 @@ function mapStateToProps( state ) {
 		canUserUseStore: canCurrentUserUseStore( state, siteId ),
 		canUserUseEarn: canCurrentUserUseEarn( state, siteId ),
 		canUserUseCustomerHome: canCurrentUserUseCustomerHome( state, siteId ),
+		isCustomerHomeEnabled,
 		canUserUseAds: canCurrentUserUseAds( state, siteId ),
 		canUserUpgradeSite: canCurrentUserUpgradeSite( state, siteId ),
 		currentUser,

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -194,7 +194,7 @@ export class MySitesSidebar extends Component {
 				) }
 				link={ isCustomerHomeEnabled ? '/home' + siteSuffix : '/checklist' + siteSuffix }
 				onNavigate={ this.trackCustomerHomeClick }
-				materialIcon={ isEnabled( 'customer-home' ) ? 'home' : 'check_circle' }
+				materialIcon={ isCustomerHomeEnabled ? 'home' : 'check_circle' }
 			/>
 		);
 	}

--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -189,17 +189,20 @@ export class MySitesSidebar extends Component {
 					label: translate( 'Home' ),
 					selected: itemLinkMatches( [ '/home' ], path ),
 					link: '/home' + siteSuffix,
-					materialIcon: 'home',
 			  }
 			: {
 					label: translate( 'Checklist' ),
 					selected: itemLinkMatches( [ '/checklist' ], path ),
 					link: '/checklist' + siteSuffix,
-					materialIcon: 'check_circle',
 			  };
 
 		return (
-			<SidebarItem tipTarget="menus" onNavigate={ this.trackCustomerHomeClick } { ...itemProps } />
+			<SidebarItem
+				materialIcon="home"
+				tipTarget="menus"
+				onNavigate={ this.trackCustomerHomeClick }
+				{ ...itemProps }
+			/>
 		);
 	}
 

--- a/client/state/selectors/is-site-eligible-for-customer-home.js
+++ b/client/state/selectors/is-site-eligible-for-customer-home.js
@@ -2,8 +2,9 @@
  * Internal dependencies
  */
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { isJetpackSite } from 'state/sites/selectors';
-import isAtomicSite from 'state/selectors/is-site-automated-transfer';
+import { abtest } from 'lib/abtest';
+import { canCurrentUserUseChecklistMenu } from 'state/sites/selectors';
+import { isEnabled } from 'config';
 
 /**
  * Returns true if the current should be able to use the customer home screen
@@ -13,9 +14,12 @@ import isAtomicSite from 'state/selectors/is-site-automated-transfer';
  * @return {?Boolean}        Whether the site can use the customer home screen
  */
 export default function isSiteEligibleForCustomerHome( state, siteId = null ) {
-	//TODO Add A/B test and new site logic
 	if ( ! siteId ) {
 		siteId = getSelectedSiteId( state );
 	}
-	return ! ( isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId ) );
+	return (
+		isEnabled( 'customer-home' ) &&
+		'show' === abtest( 'customerHomePage' ) &&
+		canCurrentUserUseChecklistMenu( state, siteId )
+	);
 }

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -2,7 +2,6 @@ export { default as buildSeoTitle } from './build-seo-title';
 export { default as canCurrentUserUpgradeSite } from './can-current-user-upgrade-site';
 export { default as canCurrentUserUseAds } from './can-current-user-use-ads';
 export { default as canCurrentUserUseEarn } from './can-current-user-use-earn';
-export { default as canCurrentUserUseCustomerHome } from './can-current-user-use-customer-home';
 export { default as canCurrentUserUseStore } from './can-current-user-use-store';
 export { default as canCurrentUserUseChecklistMenu } from './can-current-user-use-checklist-menu';
 export { default as canJetpackSiteAutoUpdateCore } from './can-jetpack-site-auto-update-core';

--- a/config/stage.json
+++ b/config/stage.json
@@ -23,6 +23,7 @@
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
+		"customer-home": true,
 		"desktop-promo": true,
 		"domains/cctlds": true,
 		"domains/cctlds/ca": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -25,6 +25,7 @@
 		"calypsoify/plugins": true,
 		"catch-js-errors": true,
 		"code-splitting": true,
+		"customer-home": true,
 		"desktop-promo": true,
 		"devdocs": true,
 		"devdocs/redirect-loggedout-homepage": false,


### PR DESCRIPTION
This updates the logic for the displaying the customer home to be the
same as displaying the checklist sidebar menu item, as well as being
part of the AB test. By default only new users with an English locale
are eligible for the test, so that covers part of our criteria.

**I think this covers everything, but I'm not 100% if all the logic is correct yet**

#### Testing instructions

With various sites, set your `customerHomePage` test variation to `show` or `hide`. If it's hidden and the site is eligible to see the checklist sidebar item, then you should see the checklist item still in the sidebar. Otherwise, you will see nothing and `/home` should redirect to `/stats`.

With `show` as the variation, and the site should see the checklist sidebar item, then this should be replaced with 'Home', and `/checklist` should redirect to `/home`. Otherwise, again you will see nothing in the sidebar and `/home` should redirect to `/stats`.
