### PR TITLE
Full Site Editing: Remove the Content and Template blocks from the Inserter

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/post-content/index.js
@@ -22,6 +22,7 @@ registerBlockType( 'a8c/post-content', {
 		anchor: false,
 		customClassName: false,
 		html: false,
+		inserter: false,
 		multiple: false,
 		reusable: false,
 	},

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/index.js
@@ -28,6 +28,7 @@ if ( 'wp_template' !== fullSiteEditing.editorPostType ) {
 			anchor: false,
 			customClassName: false,
 			html: false,
+			inserter: false,
 			reusable: false,
 		},
 		edit,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

We can only have one Content block in pages (pre-filled), and none in templates.
We can only have two Template blocks in pages (pre-filled), and none in templates.

So there is no reason to have them available in the Inserter!

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an FSE site, try editing both a page and a template.
* Make sure in neither case it's possible to add both the Content and Template blocks.
  * It shouldn't appear in the Inserter menu in the top bar.
  * It shouldn't appear in the Inserter menu between blocks.
  * It shouldn't appear in the Inserter menu triggered with the `/` character.

Fixes #35436