### PR TITLE
Traffic: Remove check at the controller level for sharing activation state on Jetpack sites

### DIFF
--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -116,25 +116,6 @@ export const sharingButtons = ( context, next ) => {
 };
 
 export const traffic = ( context, next ) => {
-	const { store } = context;
-	const state = store.getState();
-	const siteId = getSelectedSiteId( state );
-
-	const siteJetpackVersion = getSiteOption( state, siteId, 'jetpack_version' );
-
-	if (
-		siteId &&
-		isJetpackSite( state, siteId ) &&
-		( ! isJetpackModuleActive( state, siteId, 'sharedaddy' ) ||
-			versionCompare( siteJetpackVersion, '3.4-dev', '<' ) )
-	) {
-		notices.error(
-			translate(
-				'This page is only available to Jetpack sites running version 3.4 or higher with the Sharing module activated.'
-			)
-		);
-	}
-
 	context.contentComponent = createElement( Traffic );
 
 	next();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Removes the check for Jetpack version and activation state of the sharing module from the marketing/traffic controller.

#### Testing instructions

1. Connect a Jetpack site
2. Visit `https://wordpress.com/marketing/traffic/your-site-slug` and confirm you don't get a red notice stating that  Sharing is not active.
3. Visit `https://wordpress.com/marketing/sharing-buttons/bleeding.jurassic.ninja` and expect to be redirected to the stats page

![image](https://user-images.githubusercontent.com/746152/63368191-cb2df780-c353-11e9-8549-62fba201d025.png)


### Why

Doing the check at a controller level is an old pattern that causes issues when the module's activation state is changed in the sites' Jetpack admin page and immediately followed by a flow that leaves the user in Calypso with its cache populalted by old data (old activation state)
