### PR TITLE
Marketing: Do not depend on Publicize module being active to load the connections/ route. 

### DIFF
--- a/client/my-sites/marketing/controller.js
+++ b/client/my-sites/marketing/controller.js
@@ -18,12 +18,7 @@ import SharingConnections from './connections/connections';
 import Traffic from './traffic/';
 import { getSelectedSiteId } from 'state/ui/selectors';
 import canCurrentUser from 'state/selectors/can-current-user';
-import {
-	isJetpackSite,
-	isJetpackModuleActive,
-	getSiteSlug,
-	getSiteOption,
-} from 'state/sites/selectors';
+import { isJetpackSite, isJetpackModuleActive, getSiteOption } from 'state/sites/selectors';
 import versionCompare from 'lib/version-compare';
 
 export const redirectConnections = context => {
@@ -57,23 +52,7 @@ export const connections = ( context, next ) => {
 		);
 	}
 
-	if (
-		siteId &&
-		isJetpackSite( state, siteId ) &&
-		! isJetpackModuleActive( state, siteId, 'publicize' )
-	) {
-		const siteSlug = getSiteSlug( state, siteId );
-
-		// Redirect to sharing buttons if Jetpack Publicize module is not
-		// active, but ShareDaddy is active
-		page.redirect(
-			isJetpackModuleActive( state, siteId, 'sharedaddy' )
-				? `/marketing/sharing-buttons/${ siteSlug }`
-				: '/stats'
-		);
-	} else {
-		context.contentComponent = createElement( SharingConnections );
-	}
+	context.contentComponent = createElement( SharingConnections );
 
 	next();
 };


### PR DESCRIPTION
#### Changes proposed in this Pull Request
The controller no longer checks for status of modules (Publicize/Sharing) to load the `https://wordpress.com/marketing/connections/{siteUrl}` page. 

Before, it was redirecting to `/stats/day`, and was a problem when the site [navigated there directly after activating the Jetpack module](https://github.com/Automattic/jetpack/issues/12937). 

Even with those modules inactive, there are still some things you can do on that page: 

![image](https://user-images.githubusercontent.com/7129409/63370464-41305f80-c350-11e9-861a-37d4834f2699.png)


#### Testing instructions
- Connect a Jetpack site 
- Navigate to `/wp-admin/admin.php?page=jetpack#/sharing` in wp-admin, and toggle publicize on. 
- Click the link there to "Connect your social media accounts"
- You should successfully land on `/marketing/connections/dereksmart.wpsandbox.me` in calypso. 

**Todo in another PR**: Have an acceptable UI for when Publicize is not deemed active on that page. 
