### PR TITLE
Show proper availability notices for premium domains.

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -733,8 +733,10 @@ class RegisterDomainStep extends React.Component {
 
 					const {
 						AVAILABLE,
+						AVAILABLE_PREMIUM,
 						MAPPED_SAME_SITE_TRANSFERRABLE,
 						TRANSFERRABLE,
+						TRANSFERRABLE_PREMIUM,
 						UNKNOWN,
 					} = domainAvailability;
 					const isDomainAvailable = includes( [ AVAILABLE, UNKNOWN ], status );
@@ -753,7 +755,12 @@ class RegisterDomainStep extends React.Component {
 						} );
 					} else {
 						let site = get( result, 'other_site_domain', null );
-						if ( MAPPED_SAME_SITE_TRANSFERRABLE === status ) {
+						if (
+							includes(
+								[ MAPPED_SAME_SITE_TRANSFERRABLE, AVAILABLE_PREMIUM, TRANSFERRABLE_PREMIUM ],
+								status
+							)
+						) {
 							site = get( this.props, 'selectedSite.slug', null );
 						}
 						this.showAvailabilityErrorMessage( domain, status, {

--- a/client/lib/domains/constants.js
+++ b/client/lib/domains/constants.js
@@ -25,6 +25,7 @@ export const registrar = {
 
 export const domainAvailability = {
 	AVAILABLE: 'available',
+	AVAILABLE_PREMIUM: 'available_premium',
 	AVAILABILITY_CHECK_ERROR: 'availability_check_error',
 	BLACKLISTED: 'blacklisted_domain',
 	DOMAIN_SUGGESTIONS_THROTTLED: 'domain_suggestions_throttled',
@@ -58,6 +59,7 @@ export const domainAvailability = {
 	TRANSFER_PENDING: 'transfer_pending',
 	TRANSFER_PENDING_SAME_USER: 'transfer_pending_same_user',
 	TRANSFERRABLE: 'transferrable',
+	TRANSFERRABLE_PREMIUM: 'transferrable_premium',
 	UNKNOWN: 'unknown',
 	UNKOWN_ACTIVE: 'unknown_active_domain_with_wpcom',
 	WPCOM_STAGING_DOMAIN: 'wpcom_staging_domain',

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -22,6 +22,7 @@ import { domainAvailability } from 'lib/domains/constants';
 import {
 	domainManagementTransferToOtherSite,
 	domainManagementTransferIn,
+	domainMapping,
 	domainTransferIn,
 } from 'my-sites/domains/paths';
 
@@ -345,6 +346,32 @@ function getAvailabilityNotice( domain, error, errorData ) {
 					'Sorry, the domain name you selected is not available. Please choose another domain.'
 				);
 			}
+			break;
+
+		case domainAvailability.AVAILABLE_PREMIUM:
+			message = translate(
+				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support purchases of premium domains on WordPress.com, but if you purchase this domain elsewhere, you can {{a}}map it to your site{{/a}}.",
+				{
+					args: { domain },
+					components: {
+						strong: <strong />,
+						a: <a rel="noopener noreferrer" href={ domainMapping( site, domain ) } />,
+					},
+				}
+			);
+			break;
+
+		case domainAvailability.TRANSFERRABLE_PREMIUM:
+			message = translate(
+				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support transfers of premium domains on WordPress.com, but if you already own this domain, you can {{a}}map it to your site{{/a}}.",
+				{
+					args: { domain },
+					components: {
+						strong: <strong />,
+						a: <a rel="noopener noreferrer" href={ domainMapping( site, domain ) } />,
+					},
+				}
+			);
 			break;
 
 		default:

--- a/client/lib/domains/registration/availability-messages.js
+++ b/client/lib/domains/registration/availability-messages.js
@@ -363,7 +363,7 @@ function getAvailabilityNotice( domain, error, errorData ) {
 
 		case domainAvailability.TRANSFERRABLE_PREMIUM:
 			message = translate(
-				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support transfers of premium domains on WordPress.com, but if you already own this domain, you can {{a}}map it to your site{{/a}}.",
+				"Sorry, {{strong}}%(domain)s{{/strong}} is a premium domain. We don't support transfers of premium domains on WordPress.com, but if you are the owner of this domain, you can {{a}}map it to your site{{/a}}.",
 				{
 					args: { domain },
 					components: {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Showing premium domains as not available can be confusing for users since they can appear as available on platforms that support premium domains.  We should show a better notice for these domains and provide an option to map them.

#### Testing instructions

Depends on D31694-code and D31704-code.

Apply the back-end patches and build this branch.  Then try to search for premium domains that are both available (try labinsk.live) and not available (try yes.academy).

Make sure that the proper notices and links to the mapping pages are shown:

<img width="1070" alt="Screen Shot 2019-08-20 at 3 24 20 PM" src="https://user-images.githubusercontent.com/1379730/63377717-9ffcd580-c35e-11e9-86b8-9b41ed442f4e.png">

<img width="1070" alt="Screen Shot 2019-08-20 at 3 24 09 PM" src="https://user-images.githubusercontent.com/1379730/63377727-a2f7c600-c35e-11e9-924c-c351c37a6ee4.png">

Also, make sure that non-premium available and not-available domains work as expected.
