### PR TITLE
Signup: Use forEach to iterate over elements in signup preview

### DIFF
--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -128,6 +128,9 @@ export default class SignupSitePreviewIframe extends Component {
 		}
 		const elements = this.iframe.current.contentWindow.document.querySelectorAll( selector );
 
+		// Using `_.forEach` instead of a for-of loop to fix environments that need
+		// polyfilled. This is probably required because the node list is being
+		// pulled out of the iframe environment which hasn't been polyfilled.
 		forEach( elements, element => {
 			element.textContent = content;
 		} );

--- a/client/components/signup-site-preview/iframe.jsx
+++ b/client/components/signup-site-preview/iframe.jsx
@@ -6,7 +6,7 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { debounce } from 'lodash';
+import { debounce, forEach } from 'lodash';
 import shallowEqual from 'react-pure-render/shallowEqual';
 
 /**
@@ -128,9 +128,9 @@ export default class SignupSitePreviewIframe extends Component {
 		}
 		const elements = this.iframe.current.contentWindow.document.querySelectorAll( selector );
 
-		for ( const element of elements ) {
+		forEach( elements, element => {
 			element.textContent = content;
-		}
+		} );
 	}
 
 	setOnPreviewClick = () => {


### PR DESCRIPTION
After choosing a site type in IE the `site-topic-with-preview` page fails to render. I think this is happening because we're iterating over a `NodeList` using a `for-of` expression. Normally polyfilling will take care of this, but I think the issue is we're grabbing the `NodeList` out of an `<iframe>` environment that hasn't been polyfilled.

Spinning up live branch to test this out in browserstack. 

#### Changes proposed in this Pull Request

* Use `_.forEach` to iterate over elements in signup preview instead of a `for-of` expression.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In IE start from `/start` and do the onboarding flow
* It should correctly show the site preview
* Updating the site title should update the preview

Fixes #35634
