### PR TITLE
Plugins: Redirect plugins/setup/:site to /plans/my-plan/:site

### DIFF
--- a/client/my-sites/plugins/index.js
+++ b/client/my-sites/plugins/index.js
@@ -24,14 +24,22 @@ export default function() {
 			clientRender
 		);
 
-		page(
-			'/plugins/setup/:site',
-			pluginsController.scrollTopIfNoHash,
-			siteSelection,
-			pluginsController.setupPlugins,
-			makeLayout,
-			clientRender
-		);
+		page( '/plugins/setup/:site', context => {
+			let install = 'all';
+			if ( context.query.only ) {
+				if ( context.query.only === 'akismet' ) {
+					install = 'akismet';
+				}
+				if (
+					context.query.only === 'vaultpress' ||
+					context.query.only === 'backups' ||
+					context.query.only === 'scan'
+				) {
+					install = 'vaultpress';
+				}
+			}
+			page.redirect( `/plans/my-plan/${ context.params.site }?install=${ install }` );
+		} );
 	}
 
 	if ( config.isEnabled( 'manage/plugins' ) ) {


### PR DESCRIPTION
With a flexible product installer available elsewhere in Calypso, we can remove the plugin setup routes and associated components.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/87168/63413531-8f9e3680-c402-11e9-8959-d8d006ecd614.png">

<img width="500" alt="Screenshot 2019-08-21 at 10 46 49" src="https://user-images.githubusercontent.com/87168/63412823-2833b700-c401-11e9-919a-d8d1f36940b8.png">

This is a minimal first pass which handles redirection. The following `only` arguments must be handled correctly:

- `akismet` -> `/plans/my-plan?install=akismet`
- `vaultpress` -> `/plans/my-plan?install=vaultpress`
- `scan` -> `/plans/my-plan?install=vaultpress`
- `backups` -> `/plans/my-plan?install=vaultpress`
- none  -> `/plans/my-plan?install=all`

Justification for the above: If you follow the code, you should see that `only` ends up here:

https://github.com/Automattic/wp-calypso/blob/20a8d2f4fd8adeea79b472c56702927c33ae765d/client/state/plugins/premium/selectors.js#L36-L38

This will make is possible to remove components and parts of state.

## Testing instructions

- For a Jetpack site on a paid plan, the following should behave as expected.
- Verify that `/plugins/setup/SITE_SLUG` redirects to `/plans/my-plan/SITE_SLUG?install=all`
- Verify that `/plugins/setup/SITE_SLUG?only=ONLY` redirects appropriately (see above).
- Akismet and/or VaultPress should be installed as expected.