### PR TITLE
FSE: Add front-end scripts for headers and footers containing CoBlocks gallery blocks.

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -115,3 +115,32 @@ function populate_wp_template_data() {
 	$fse->insert_default_data();
 }
 register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data' );
+
+/**
+ * Add front-end CoBlocks gallery block scripts.
+ *
+ * This function performs the same enqueueing duties as `CoBlocks_Block_Assets::frontend_scripts`,
+ * but for our FSE header and footer content. `frontend_scripts` uses `has_block` to determine
+ * if gallery blocks are present, and `has_block` is not aware of content sections outside of
+ * post_content yet.
+ */
+function enqueue_coblocks_gallery_scripts() {
+	if ( ! is_plugin_active( 'coblocks' ) ) {
+		return;
+	}
+
+	$template = new WP_Template();
+	$header   = $template->get_template_content( 'header' );
+	$footer   = $template->get_template_content( 'footer' );
+
+	if ( has_block( 'coblocks/gallery-masonry', $header . $footer ) ) {
+		wp_enqueue_script(
+			'coblocks-masonry',
+			WP_PLUGINS_DIR . 'coblocks/dist/js/coblocks-masonry.min.js',
+			array( 'jquery', 'masonry', 'imagesloaded' ),
+			filemtime( plugin_dir_path( __FILE__ ) . 'full-site-editing-plugin.php' ),
+			true
+		);
+	}
+}
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\enqueue_coblocks_gallery_scripts' );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing-plugin.php
@@ -125,7 +125,7 @@ register_activation_hook( __FILE__, __NAMESPACE__ . '\populate_wp_template_data'
  * post_content yet.
  */
 function enqueue_coblocks_gallery_scripts() {
-	if ( ! is_plugin_active( 'coblocks' ) ) {
+	if ( ! function_exists( 'CoBlocks' ) ) {
 		return;
 	}
 
@@ -133,12 +133,30 @@ function enqueue_coblocks_gallery_scripts() {
 	$header   = $template->get_template_content( 'header' );
 	$footer   = $template->get_template_content( 'footer' );
 
+	// Define where the asset is loaded from.
+	$dir = CoBlocks()->asset_source( 'js' );
+
+	// Define where the vendor asset is loaded from.
+	$vendors_dir = CoBlocks()->asset_source( 'js', 'vendors' );
+
+	// Masonry block.
 	if ( has_block( 'coblocks/gallery-masonry', $header . $footer ) ) {
 		wp_enqueue_script(
 			'coblocks-masonry',
-			WP_PLUGINS_DIR . 'coblocks/dist/js/coblocks-masonry.min.js',
+			$dir . 'coblocks-masonry' . COBLOCKS_ASSET_SUFFIX . '.js',
 			array( 'jquery', 'masonry', 'imagesloaded' ),
-			filemtime( plugin_dir_path( __FILE__ ) . 'full-site-editing-plugin.php' ),
+			COBLOCKS_VERSION,
+			true
+		);
+	}
+
+	// Carousel block.
+	if ( has_block( 'coblocks/gallery-carousel', $header . $footer ) ) {
+		wp_enqueue_script(
+			'coblocks-flickity',
+			$vendors_dir . '/flickity' . COBLOCKS_ASSET_SUFFIX . '.js',
+			array( 'jquery' ),
+			COBLOCKS_VERSION,
 			true
 		);
 	}


### PR DESCRIPTION
Because CoBlocks is unaware of FSE and its header+footer sections, CoBlocks only enqueues front-end scripts when its blocks are found in `post_content`. This PR also checks for CoBlocks gallery blocks in FSE headers and footers, enqueuing the scripts if necessary.

#### Testing instructions

* Install the CoBlocks plugin on your FSE dev environment.
* Create a new FSE page with a Masonry block in the header and footer.
* Verify the `coblocks-masonry.min.js` script is enqueued on the front-end.

Fixes #35509.
