### PR TITLE
FSE: Remove unwanted editor panels from settings

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/index.js
@@ -7,3 +7,4 @@ import './image-block-keywords';
 import './style.scss';
 import './suppress-trash-action';
 import './suppress-draft-action';
+import './remove-editor-panels';

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/remove-editor-panels/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/remove-editor-panels/index.js
@@ -3,7 +3,7 @@
 /**
  * External dependencies
  */
-import { dispatch, select, subscribe } from '@wordpress/data';
+import { dispatch, subscribe } from '@wordpress/data';
 
 /**
  * Disables specific sidebar editor panels in the FSE context.
@@ -15,31 +15,17 @@ import { dispatch, select, subscribe } from '@wordpress/data';
  * in the redux state.
  */
 const unsubscribe = subscribe( () => {
-	const { getActiveGeneralSidebarName } = select( 'core/edit-post' );
 	const { removeEditorPanel } = dispatch( 'core/edit-post' );
-
 	if ( 'page' === fullSiteEditing.editorPostType ) {
 		removeEditorPanel( 'featured-image' );
-		return unsubscribe();
 	}
 
+	// @TODO Since the post status component doesn't check to see if it is removed, the
+	// removeEditorPanel action won't have the desired effect. See:
+	// https://github.com/WordPress/gutenberg/pull/17117
+	// When support is added, we should remove the CSS hack at '../style.scss'
 	if ( 'wp_template' === fullSiteEditing.editorPostType ) {
-		// @TODO Since the post status component doesn't check to see if it is removed, the
-		// removeEditorPanel action won't have the desired effect. See:
-		// https://github.com/WordPress/gutenberg/pull/17117
-		// When support is added, we should add this line back in and remove the DOM manipulation hack:
-		// removeEditorPanel( 'post-status' );
-
-		// Only run the hack when the document sidebar is opened:
-		if ( 'edit-post/document' === getActiveGeneralSidebarName() ) {
-			const impendingElement = setInterval( () => {
-				const postStatusElement = document.querySelector(
-					'.components-panel__body.edit-post-post-status'
-				);
-				postStatusElement && postStatusElement.classList.add( 'hidden' );
-				clearInterval( impendingElement );
-				// We cannot unsubscribe since the element can be recreated by React.
-			} );
-		}
+		removeEditorPanel( 'post-status' );
 	}
+	return unsubscribe();
 } );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/remove-editor-panels/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/remove-editor-panels/index.js
@@ -1,0 +1,45 @@
+/* global fullSiteEditing */
+
+/**
+ * External dependencies
+ */
+import { dispatch, select, subscribe } from '@wordpress/data';
+
+/**
+ * Disables specific sidebar editor panels in the FSE context.
+ *
+ * In particular, we remove the featured image panel for pages,
+ * and we remove the post status panel for templates.
+ *
+ * Note that we only need to remove the panel once as it is persisted
+ * in the redux state.
+ */
+const unsubscribe = subscribe( () => {
+	const { getActiveGeneralSidebarName } = select( 'core/edit-post' );
+	const { removeEditorPanel } = dispatch( 'core/edit-post' );
+
+	if ( 'page' === fullSiteEditing.editorPostType ) {
+		removeEditorPanel( 'featured-image' );
+		return unsubscribe();
+	}
+
+	if ( 'wp_template' === fullSiteEditing.editorPostType ) {
+		// @TODO Since the post status component doesn't check to see if it is removed, the
+		// removeEditorPanel action won't have the desired effect. See:
+		// https://github.com/WordPress/gutenberg/pull/17117
+		// When support is added, we should add this line back in and remove the DOM manipulation hack:
+		// removeEditorPanel( 'post-status' );
+
+		// Only run the hack when the document sidebar is opened:
+		if ( 'edit-post/document' === getActiveGeneralSidebarName() ) {
+			const impendingElement = setInterval( () => {
+				const postStatusElement = document.querySelector(
+					'.components-panel__body.edit-post-post-status'
+				);
+				postStatusElement && postStatusElement.classList.add( 'hidden' );
+				clearInterval( impendingElement );
+				// We cannot unsubscribe since the element can be recreated by React.
+			} );
+		}
+	}
+} );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/editor/style.scss
@@ -4,6 +4,12 @@
 		display: none;
 	}
 
+	// @TODO: Remove this when Gutenberg support is added for
+	// removing the PostStatus panel:
+	.edit-post-post-status {
+		display: none;
+	}
+
 	.edit-post-visual-editor {
 		margin-top: 20px;
 		padding-top: 0;


### PR DESCRIPTION
This removes the featured image panel on pages and the post status panel on templates.

Note: we had to use a hack for the post status panel since the gutenberg component doesn't respect the settings correctly. We can revisit once that is fixed to add support for the "right" way of doing things. I have a PR up on Gutenberg for the fix here: https://github.com/WordPress/gutenberg/pull/17117

#### Changes proposed in this Pull Request
* Disable featured image panel in settings while editing a page.
* Disable post status panel in settings while editing templates.

| Before  | After |
| ------------- | ------------- |
| <img width="356" alt="Screen Shot 2019-08-20 at 3 23 16 PM" src="https://user-images.githubusercontent.com/6265975/63393177-b743bf00-c36e-11e9-8d1d-455c85051b47.png"> | <img width="400" alt="Screen Shot 2019-08-20 at 3 24 09 PM" src="https://user-images.githubusercontent.com/6265975/63393178-b743bf00-c36e-11e9-8fdf-baa77989db72.png">  |
| <img width="293" alt="Screen Shot 2019-08-20 at 5 23 50 PM" src="https://user-images.githubusercontent.com/6265975/63393308-51a40280-c36f-11e9-8db2-ac7c19609efe.png"> | <img width="346" alt="Screen Shot 2019-08-20 at 5 13 26 PM" src="https://user-images.githubusercontent.com/6265975/63393179-b743bf00-c36e-11e9-9529-793ee60acabc.png">|

#### Testing instructions
1. Pull this branch and run it on your local FSE environment
2. Open the page editor and open the right-hand settings panel. Go to the "Document" settings. There _should not_ be a place to set your featured image.
3. Open the template editor and open the right-hand settings panel. Go to the "Document" settings. There _should not_ be a "Status & Visibility" heading at the top. That panel should be gone.
4. Mess around with the pages - close the side bar, reopen it, switch tabs, etc. Make sure those panels do not show up in those contexts.
5. Make sure that the "Status & Visibility" panel still shows up for the page editor.

Fixes #35485, Fixes #35574

**NOTE:** This does not "fix" issues with featured images, it just does not allow the user to set one. Please let me know if I should leave that issue open and also investigate actually fixing featured images. I imagine we do not want to support featured images in the sidebar for FSE, since it's a confusing experience. i.e. it changes the UI but doesn't show up in the editor.