### PR TITLE
Add linting to check we don't use for-of loops with iframe elements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,7 +87,7 @@ module.exports = {
 		// this is when Webpack last built the bundle
 		BUILD_TIMESTAMP: true,
 	},
-	plugins: [ 'jest', 'jsx-a11y', 'import' ],
+	plugins: [ 'jest', 'jsx-a11y', 'import', 'no-for-of-loops' ],
 	settings: {
 		react: {
 			version: reactVersion,
@@ -134,5 +134,8 @@ module.exports = {
 		// Disallow importing or requiring packages that are not listed in package.json
 		// This prevents us from depending on transitive dependencies, which could break in unexpected ways.
 		'import/no-extraneous-dependencies': [ 'error', { packageDir: './' } ],
+
+		// We only want to prevent for-of loops in specific situations
+		'no-for-of-loops/no-for-of-loops': 0,
 	},
 };

--- a/client/components/signup-site-preview/iframe-utils.ts
+++ b/client/components/signup-site-preview/iframe-utils.ts
@@ -1,0 +1,127 @@
+// This module is for dealing with DOM elements from inside the the site preview
+// iframe. This means that not every modern JS feature will be available to use
+// because they won't have been polyfilled e.g. a NodeList from the iframe isn't
+// iterable using a for-of loop.
+/* eslint no-for-of-loops/no-for-of-loops: 2 */
+
+/**
+ * External dependencies
+ */
+import { forEach } from 'lodash';
+import { RefObject } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { isIE, getIframeSource, revokeObjectURL } from './utils';
+
+type IFrameRef = RefObject< HTMLIFrameElement >;
+
+/**
+ * @param iframe frame in which to set the content
+ * @param html html content to set in iframe
+ * @returns true if innerHTML was set successfully
+ */
+export function setEntryContentInnerHTML( iframe: IFrameRef, html: string ): boolean {
+	if ( ! iframe.current || ! iframe.current.contentWindow ) {
+		return false;
+	}
+	const element = iframe.current.contentWindow.document.querySelector( '.entry-content' );
+	if ( ! element ) {
+		return false;
+	}
+
+	element.innerHTML = html;
+	return true;
+}
+
+export function setIframeElementContent(
+	iframe: IFrameRef,
+	selector: string,
+	textContent: string
+) {
+	if ( ! iframe.current || ! iframe.current.contentWindow ) {
+		return;
+	}
+	const elements = iframe.current.contentWindow.document.querySelectorAll( selector );
+
+	forEach( elements, element => {
+		element.textContent = textContent;
+	} );
+}
+
+export function setBodyOnClick( iframe: IFrameRef, onClick: GlobalEventHandlers['onclick'] ) {
+	if ( ! iframe.current || ! iframe.current.contentWindow ) {
+		return;
+	}
+	const element = iframe.current.contentWindow.document.body;
+
+	if ( element ) {
+		element.onclick = onClick;
+	}
+}
+
+export function setIframeIsLoading( iframe: IFrameRef ) {
+	if ( ! iframe.current || ! iframe.current.contentWindow ) {
+		return;
+	}
+	const element = iframe.current.contentWindow.document.querySelector( '.home' );
+
+	if ( element ) {
+		element.classList.remove( 'is-loading' );
+	}
+}
+
+export function getPageScrollHeight( iframe: IFrameRef ): number | null {
+	if ( ! iframe.current || ! iframe.current.contentWindow ) {
+		return null;
+	}
+
+	const element = iframe.current.contentWindow.document.querySelector( '#page' );
+	if ( ! element ) {
+		return null;
+	}
+
+	return element.scrollHeight;
+}
+
+interface PreviewContent {
+	body: string;
+	params: Record< string, string >;
+	title: string;
+	tagline: string;
+}
+
+export function setIframeSource(
+	iframe: IFrameRef,
+	content: PreviewContent,
+	cssUrl: string,
+	fontUrl: string,
+	gutenbergStylesUrl: string,
+	isRtl: boolean,
+	langSlug: string,
+	scrolling: boolean
+) {
+	if ( ! iframe.current || ! iframe.current.contentWindow ) {
+		return;
+	}
+
+	const iframeSrc = getIframeSource(
+		content,
+		cssUrl,
+		fontUrl,
+		gutenbergStylesUrl,
+		isRtl,
+		langSlug,
+		scrolling
+	);
+
+	if ( isIE() ) {
+		iframe.current.contentWindow.document.open();
+		iframe.current.contentWindow.document.write( iframeSrc );
+		iframe.current.contentWindow.document.close();
+	} else {
+		revokeObjectURL( iframe.current.src );
+		iframe.current.contentWindow.location.replace( iframeSrc );
+	}
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9614,6 +9614,12 @@
 				}
 			}
 		},
+		"eslint-plugin-no-for-of-loops": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-no-for-of-loops/-/eslint-plugin-no-for-of-loops-1.0.1.tgz",
+			"integrity": "sha512-uCotzBHt2W+HbLw2srRmqDJHOPbJGzeVLstKh8YyxS3ppduq2P50qdpJfHKoD+UGbnqA/zhy8NRgPH6p0y8bnA==",
+			"dev": true
+		},
 		"eslint-plugin-react": {
 			"version": "7.12.4",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",

--- a/package.json
+++ b/package.json
@@ -301,6 +301,7 @@
 		"eslint-plugin-import": "2.17.2",
 		"eslint-plugin-jest": "22.6.4",
 		"eslint-plugin-jsx-a11y": "6.2.3",
+		"eslint-plugin-no-for-of-loops": "1.0.1",
 		"eslint-plugin-react": "7.12.4",
 		"eslint-plugin-wpcalypso": "file:./packages/eslint-plugin-wpcalypso",
 		"glob": "7.1.3",


### PR DESCRIPTION
Adding a lint to prevent the sort of issue that caught us out in #35638

Discussion here: p1566332337028600-slack-C04S2FRPA

#### Changes proposed in this Pull Request

* Adds `eslint-plugin-no-for-of-loops` dependency
* Configured so errors only occur for for-of when opting in to that behaviour
* Refactor `<SignupSitePreviewIframe>` so the code for dealing with DOM elements fom the iframe are in their own module
* Enable lint rule in new module

Using eslint's inline comments like `/* eslint-enable no-for-of-loops */` and `/* eslint-disable no-for-of-loops */` to just enable the warning in a particular region of code didn't work. It could be that "enabling" falls back to the default config, but the default config is off. But I'm not really sure why it didn't work. The only style of comment that worked was `/* eslint */`, which only works on a per file basis.

Part of me doesn't think the refactor is worth it. The `iframe-utils.ts` file doesn't seem like a good abstraction, a lot of it seems like code that really should just be written in-line. Is it better just to rely on the automatted tests catching this sort of issue?

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run `node_modules/.bin/eslint bin/categorize-component-styles.js` and get no errors (this file already has a for-of loop)
* Run `node_modules/.bin/eslint client/components/signup-site-preview/iframe-utils.ts` and get no errors (this file has regions where for-of loops aren't allowed)
* Edit `client/components/signup-site-preview/iframe-utils.ts` so there is a for-of loop somewhere. Re-run the command above and see that there is an error