### PR TITLE
Migrate button style to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -8,5 +8,4 @@
 
 @import 'layout/style';
 
-@import 'components/button/style';
 @import 'layout/sidebar/style';

--- a/client/components/button/index.jsx
+++ b/client/components/button/index.jsx
@@ -6,6 +6,11 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 export default class Button extends PureComponent {
 	static propTypes = {
 		compact: PropTypes.bool,


### PR DESCRIPTION
Migrate `Button` style to webpack

Tried to refactor the component into a functional component using `React.forwardRef` and `React.memo`, but the PR got too complex and tests were failing due to the current usage of enzyme (testing implementation details), which would need further changes. So, let's try it in another PR later.

#### Testing instructions

- Test `Button` (appearance and behavior) in several pages