### PR TITLE
Allow post to be passed in to is_full_site_page to allow checking post type of revisions

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -351,13 +351,6 @@ class Full_Site_Editing {
 		if ( ! $this->should_merge_template_and_post( $post ) ) {
 			return;
 		}
-        
-        $this->theme_slug = $this->normalize_theme_slug( get_stylesheet() );
-        // Bail if theme doesn't support FSE.
-        if ( ! $this->is_supported_theme( $this->theme_slug ) ) {
-            return;
-        }
-        
 
 		$template         = new WP_Template();
 		$template_content = $template->get_page_template_content();
@@ -374,14 +367,20 @@ class Full_Site_Editing {
 	 * Detects if we are in a context where the template and post should be merged.
 	 *
 	 * Conditions:
-	 * 1. in a REST API request (either flavour)
-	 * 2. OR on a block editor screen (inlined requests using `rest_preload_api_request` )
-	 * 3. AND editing a post_type that supports full site editing
+	 * 1. Current theme supports it
+	 * 2. AND in a REST API request (either flavour)
+	 * 3. OR on a block editor screen (inlined requests using `rest_preload_api_request` )
+	 * 4. AND editing a post_type that supports full site editing
 	 *
-     * @param WP_Post post object for the check
+   * @param \WP_Post post object for the check
 	 * @return bool
 	 */
 	private function should_merge_template_and_post( $post ) {
+		$current_theme = $this->normalize_theme_slug( get_stylesheet() );
+		if ( ! $this->is_supported_theme( $current_theme ) ) {
+			return false;
+		}
+
 		$is_rest_api_wpcom = ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST );
 		$is_rest_api_core = ( defined( 'REST_REQUEST' ) && REST_REQUEST );
 		$is_block_editor_screen = ( function_exists( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor() );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -348,7 +348,7 @@ class Full_Site_Editing {
 	 */
 	public function merge_template_and_post( $post ) {
 		// Bail if not a REST API Request and not in the editor.
-		if ( ! $this->should_merge_template_and_post() ) {
+		if ( ! $this->should_merge_template_and_post( $post ) ) {
 			return;
 		}
 
@@ -371,9 +371,10 @@ class Full_Site_Editing {
 	 * 2. OR on a block editor screen (inlined requests using `rest_preload_api_request` )
 	 * 3. AND editing a post_type that supports full site editing
 	 *
+     * @param WP_Post post object for the check
 	 * @return bool
 	 */
-	private function should_merge_template_and_post() {
+	private function should_merge_template_and_post( $post ) {
 		$is_rest_api_wpcom = ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST );
 		$is_rest_api_core = ( defined( 'REST_REQUEST' ) && REST_REQUEST );
 		$is_block_editor_screen = ( function_exists( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor() );
@@ -381,7 +382,7 @@ class Full_Site_Editing {
 		if ( ! ( $is_block_editor_screen || $is_rest_api_core || $is_rest_api_wpcom ) ) {
 			return false;
 		}
-		return $this->is_full_site_page();
+		return $this->is_full_site_page( $post );
 	}
 
 	/**
@@ -458,10 +459,12 @@ class Full_Site_Editing {
 	 * Determine if the current edited post is a full site page.
 	 * So far we only support static pages.
 	 *
+	 * @param object $post optional post object, if not passed in then current post is checked.
 	 * @return boolean
 	 */
-	public function is_full_site_page() {
-		return 'page' === get_post_type();
+	public function is_full_site_page( $post = null ) {
+		$post_type = get_post_type( $post );
+		return 'page' === $post_type || ( 'revision' === $post_type && 'page' === get_post_type( $post->post_parent ) );
 	}
 
 	/**

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -376,11 +376,6 @@ class Full_Site_Editing {
 	 * @return bool
 	 */
 	private function should_merge_template_and_post( $post ) {
-		$current_theme = $this->normalize_theme_slug( get_stylesheet() );
-		if ( ! $this->is_supported_theme( $current_theme ) ) {
-			return false;
-		}
-
 		$is_rest_api_wpcom = ( defined( 'REST_API_REQUEST' ) && REST_API_REQUEST );
 		$is_rest_api_core = ( defined( 'REST_REQUEST' ) && REST_REQUEST );
 		$is_block_editor_screen = ( function_exists( 'get_current_screen' ) && get_current_screen() && get_current_screen()->is_block_editor() );

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -351,6 +351,13 @@ class Full_Site_Editing {
 		if ( ! $this->should_merge_template_and_post( $post ) ) {
 			return;
 		}
+        
+        $this->theme_slug = $this->normalize_theme_slug( get_stylesheet() );
+        // Bail if theme doesn't support FSE.
+        if ( ! $this->is_supported_theme( $this->theme_slug ) ) {
+            return;
+        }
+        
 
 		$template         = new WP_Template();
 		$template_content = $template->get_page_template_content();

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -146,22 +146,14 @@ class WP_Template {
 	 *
 	 * We only support one page template for now with header at the top and footer at the bottom.
 	 *
-	 * @param string $post_content String representing the post content that needs to be wrapped.
-	 *
 	 * @return null|string
 	 */
-	public function get_page_template_content( $post_content = '<!-- wp:a8c/post-content /-->' ) {
+	public function get_page_template_content() {
 		$header_id = $this->get_template_id( self::HEADER );
 		$footer_id = $this->get_template_id( self::FOOTER );
 
-		if ( false === strpos( $post_content, '<!-- wp:a8c/post-content /-->' ) ) {
-			$post_content = '<!-- wp:a8c/post-content -->' .
-							$post_content .
-							'<!-- /wp:a8c/post-content -->';
-		}
-
 		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"className\":\"site-header site-branding\"} /-->" .
-				$post_content .
+				'<!-- wp:a8c/post-content /-->' .
 				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"className\":\"site-footer\"} /-->";
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -154,6 +154,12 @@ class WP_Template {
 		$header_id = $this->get_template_id( self::HEADER );
 		$footer_id = $this->get_template_id( self::FOOTER );
 
+		if ( false === strpos( $post_content, '<!-- wp:a8c/post-content /-->' ) ) {
+			$post_content = '<!-- wp:a8c/post-content -->' .
+							$post_content .
+							'<!-- /wp:a8c/post-content -->';
+		}
+
 		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"className\":\"site-header site-branding\"} /-->" .
 				$post_content .
 				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"className\":\"site-footer\"} /-->";

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -146,14 +146,16 @@ class WP_Template {
 	 *
 	 * We only support one page template for now with header at the top and footer at the bottom.
 	 *
+	 * @param string $post_content String representing the post content that needs to be wrapped.
+	 *
 	 * @return null|string
 	 */
-	public function get_page_template_content() {
+	public function get_page_template_content( $post_content = '<!-- wp:a8c/post-content /-->' ) {
 		$header_id = $this->get_template_id( self::HEADER );
 		$footer_id = $this->get_template_id( self::FOOTER );
 
 		return "<!-- wp:a8c/template {\"templateId\":$header_id,\"className\":\"site-header site-branding\"} /-->" .
-				'<!-- wp:a8c/post-content /-->' .
+				$post_content .
 				"<!-- wp:a8c/template {\"templateId\":$footer_id,\"className\":\"site-footer\"} /-->";
 	}
 


### PR DESCRIPTION
This PR is part of the fix for #35483

#### Changes proposed in this Pull Request

* Allow post content to be optionally passed in to is_full_site_page method. This is to allow post_type to be checked when the merge_template_and_post method is used by the diff endpoint to merge templates into revisions
* Add check for FSE valid theme before merging templates with post content

#### Testing instructions

* Apply D31750-code to your sandbox
* Check out this PR, build FSE plugin and apply to your sandbox
* Check out #35648 and apply to your local calypso dev environment
* Sandbox the api
* In an FSE enabled site open up a Page with revisions. 
* Open dev tools network inspector and filter for /diff
* Select the Revisions option from right hand Document details panel
* Check the api response payload and make sure revisions post_content property is wrapped with FSE template data, eg. `<!-- wp:a8c/template {"templateId":15,"className":"site-header site-branding"} /-->" <p>Some stuff</p><!-- wp:a8c/template {"templateId":16,"className""site-footer"} /-->"`
* Select a revision and make sure the FSE header and footer are correctly added in editor
* Repeat the above steps for a Post rather than a page and make sure this time the api response does not wrap the post_content in fse templates.
* Repeat the above steps for a non-fse site and make sure this time the api response does not wrap the post_content in fse templates for either Pages or Posts.

** Before **

![revisions-before](https://user-images.githubusercontent.com/3629020/63403179-52ea3380-c432-11e9-9f33-131b8edc67e6.gif)

** After **

![revisions-after](https://user-images.githubusercontent.com/3629020/63403185-58e01480-c432-11e9-82c5-1b4f43f3b235.gif)
