### PR TITLE
Increment diff api version to pick up new endpoint with FSE compatiblity

### DIFF
--- a/client/state/data-layer/wpcom/posts/revisions/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/index.js
@@ -38,7 +38,7 @@ export const fetchPostRevisionsDiffs = action => {
 	const { siteId, postId, postType, comparisons } = action;
 	return http(
 		{
-			apiVersion: '1.1',
+			apiVersion: '1.2',
 			path: `/sites/${ siteId }/${ postType }/${ postId }/diffs`,
 			method: 'GET',
 			query: { comparisons },

--- a/client/state/data-layer/wpcom/posts/revisions/test/index.js
+++ b/client/state/data-layer/wpcom/posts/revisions/test/index.js
@@ -67,7 +67,7 @@ describe( '#fetchPostRevisionsDiffs', () => {
 		expect( fetchPostRevisionsDiffs( action ) ).toMatchObject(
 			http(
 				{
-					apiVersion: '1.1',
+					apiVersion: '1.2',
 					method: 'GET',
 					path: '/sites/12345678/post/10/diffs',
 					query: {
@@ -85,7 +85,7 @@ describe( '#fetchPostRevisionsDiffs', () => {
 		expect( fetchPostRevisionsDiffs( action ) ).toMatchObject(
 			http(
 				{
-					apiVersion: '1.1',
+					apiVersion: '1.2',
 					method: 'GET',
 					path: '/sites/12345678/page/10/diffs',
 					query: {
@@ -103,7 +103,7 @@ describe( '#fetchPostRevisionsDiffs', () => {
 		expect( fetchPostRevisionsDiffs( action ) ).toMatchObject(
 			http(
 				{
-					apiVersion: '1.1',
+					apiVersion: '1.2',
 					method: 'GET',
 					path: '/sites/12345678/jetpack-portfolio/10/diffs',
 					query: {


### PR DESCRIPTION
**N.B.** This patch is needed for testing D31750-code and #35647 but should not be merged until both of these patches have been landed first

#### Changes proposed in this Pull Request

* Increment the diff endpoint version to utilise change implemented in  D31750-code

#### Testing instructions

* see #35647

Part of fix for #35483
