### PR TITLE
Append the query string to customer home redirect

### DIFF
--- a/client/my-sites/checklist/controller.jsx
+++ b/client/my-sites/checklist/controller.jsx
@@ -29,8 +29,10 @@ export function maybeRedirect( context, next ) {
 	const state = context.store.getState();
 	const siteId = getSelectedSiteId( state );
 	const slug = getSelectedSiteSlug( state );
+	const queryString = context.querystring ? `?${ context.querystring }` : '';
+
 	if ( isEnabled( 'customer-home' ) && canCurrentUserUseCustomerHome( state, siteId ) ) {
-		page.redirect( `/home/${ slug }` );
+		page.redirect( `/home/${ slug }${ queryString }` );
 		return;
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* https://github.com/Automattic/wp-calypso/pull/35392 introduces a redirect for /checklist URLs to /home URLs. It doesn't, however, include query params in the redirect URL. So, /checklist/{SITE_SLUG}?d=gsuite will redirect /home/{SITE_SLUG} losing the query parameter.
This PR fixes the issue.
* For context, we append query params to the /checklist URL in a few cases:
  - in the signup flow, when GSuite is purchased([#](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checkout/checkout/index.jsx#L498))
  - in the signup flow, when a Quick Start(concierge) session is purchased in the upsell nudge([#](https://github.com/Automattic/wp-calypso/blob/master/client/my-sites/checkout/checkout/index.jsx#L543))

The query param helps display a contextual message in the sub-header, like so:
<img src="https://user-images.githubusercontent.com/1269602/63174172-0f24b200-c05f-11e9-8164-2f0e140c9375.png">

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit /checklist/{SITE_SLUG}?some=var and verify that you are redirect /home/{SITE_SLUG}?some=var.
* Go through the signup flow and purchase a Personal plan. Post checkout, purchase the Quick Start session on the upsell nudge. Verify that you are finally redirected to customer home with the quick start sub-header text as shown in the screenshot in the PR description.
