### PR TITLE
Jetpack connect: enforce top-scroll after plan purchase

### DIFF
--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -30,6 +30,12 @@ export function currentPlan( context, next ) {
 
 	const requestThankYou = context.query.hasOwnProperty( 'thank-you' );
 
+	// On plans grid page we might've scrolled down.
+	// Ensure we're scrolled to top when "thank you" modal is shown.
+	if ( requestThankYou ) {
+		window.scrollTo( 0, 0 );
+	}
+
 	context.primary = <CurrentPlan path={ context.path } requestThankYou={ requestThankYou } />;
 
 	next();

--- a/client/my-sites/plans/current-plan/controller.jsx
+++ b/client/my-sites/plans/current-plan/controller.jsx
@@ -30,12 +30,6 @@ export function currentPlan( context, next ) {
 
 	const requestThankYou = context.query.hasOwnProperty( 'thank-you' );
 
-	// On plans grid page we might've scrolled down.
-	// Ensure we're scrolled to top when "thank you" modal is shown.
-	if ( requestThankYou ) {
-		window.scrollTo( 0, 0 );
-	}
-
 	context.primary = <CurrentPlan path={ context.path } requestThankYou={ requestThankYou } />;
 
 	next();

--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -59,6 +59,12 @@ class CurrentPlan extends Component {
 		showThankYou: PropTypes.bool,
 	};
 
+	componentDidMount() {
+		if ( typeof window !== 'undefined' ) {
+			window.scrollTo( 0, 0 );
+		}
+	}
+
 	isLoading() {
 		const { selectedSite, isRequestingSitePlans: isRequestingPlans } = this.props;
 


### PR DESCRIPTION
When the page scrolling down at plans view, the scroll position is maintained over to checklist page: 

<img width="600" alt="Screenshot 2019-08-16 at 12 34 19" src="https://user-images.githubusercontent.com/87168/63415970-3dabdf80-c407-11e9-9ef6-8b0173cff3f6.png">
<img width="600" alt="Screenshot 2019-08-16 at 12 34 27" src="https://user-images.githubusercontent.com/87168/63415915-21a83e00-c407-11e9-95cd-522bdd067b34.png">
<img width="600" alt="Screenshot 2019-08-16 at 12 34 33" src="https://user-images.githubusercontent.com/87168/63415916-21a83e00-c407-11e9-8f99-89dfcdd81835.png">



#### Changes proposed in this Pull Request

* Scroll checklist page to top when "thank you" modal is shown

#### Testing instructions

- Create a new Jetpack site (https://jurassic.ninja/)
- Connect the site — on plan selection, scroll the page down and choose "free plan"
- Note how before the PR, the checklist under "thank you" modal is scrolled down
- With the PR, you're scrolled to the top 
