### PR TITLE
Card: migrate CSS to webpack

### DIFF
--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -9,6 +9,5 @@
 @import 'layout/style';
 
 @import 'components/button/style';
-@import 'components/card/style';
 @import 'components/dialog/style';
 @import 'layout/sidebar/style';

--- a/client/components/card/README.md
+++ b/client/components/card/README.md
@@ -36,11 +36,11 @@ Name | Type | Default | Description
 `displayAsLink` | `bool` | false | Used for cards without a `href` that need to display as a link. Primarily intended for use when `tagName` is "button" and when an `onClick` attribute is set. The corresponding button will render with the same visual appearance as a link (including the right chevron icon).
 `target` | `string` | null | If used with `href`, this specifies where the link opens. Changes the icon to `external`.
 `compact` | `bool` | false | Decreases the size of the card.
-`highlight` | `string` | `false` | Displays a colored highlight. Can be `false` (no highlight, default), `info`, `success`, `error`, or `warning`.
+`highlight` | `string` | null | Displays a colored highlight. If specified (default is no highlight), can be one of `info`, `success`, `error`, or `warning`.
 
 ### Additional usage information
 
-* **Compact**: Use to save vertical space when displaying many consecutive cards in a list. The `CompactCard` component slightly modifies the `Card` component.
+* **Compact**: Use to save vertical space when displaying many consecutive cards in a list. The `CompactCard` component slightly modifies the `Card` component (and is equivalent to using `<Card compact />`).
 * **Highlight**: Use when you need to highlight information that is neither a `Notice` or `Banner`.
 
 ### General guidelines

--- a/client/components/card/compact.jsx
+++ b/client/components/card/compact.jsx
@@ -1,9 +1,7 @@
-/** @format */
 /**
  * External dependencies
  */
 import React from 'react';
-import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -11,9 +9,5 @@ import classnames from 'classnames';
 import Card from 'components/card';
 
 export default function CompactCard( props ) {
-	return (
-		<Card { ...props } className={ classnames( props.className, 'is-compact' ) }>
-			{ props.children }
-		</Card>
-	);
+	return <Card { ...props } compact />;
 }

--- a/client/components/card/index.jsx
+++ b/client/components/card/index.jsx
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -8,13 +6,18 @@ import classNames from 'classnames';
 import Gridicon from 'gridicons';
 import PropTypes from 'prop-types';
 
+/**
+ * Style dependencies
+ */
+import './style.scss';
+
 const getClassName = ( { className, compact, displayAsLink, highlight, href, onClick } ) =>
 	classNames(
 		'card',
 		className,
 		{
-			'is-card-link': displayAsLink || !! href,
-			'is-clickable': !! onClick,
+			'is-card-link': displayAsLink || href,
+			'is-clickable': onClick,
 			'is-compact': compact,
 			'is-highlight': highlight,
 		},
@@ -26,15 +29,10 @@ class Card extends PureComponent {
 		className: PropTypes.string,
 		displayAsLink: PropTypes.bool,
 		href: PropTypes.string,
-		tagName: PropTypes.oneOfType( [ PropTypes.func, PropTypes.string ] ).isRequired,
+		tagName: PropTypes.elementType,
 		target: PropTypes.string,
 		compact: PropTypes.bool,
-		highlight: PropTypes.oneOf( [ false, 'error', 'info', 'success', 'warning' ] ),
-	};
-
-	static defaultProps = {
-		tagName: 'div',
-		highlight: false,
+		highlight: PropTypes.oneOf( [ 'error', 'info', 'success', 'warning' ] ),
 	};
 
 	render() {
@@ -43,7 +41,7 @@ class Card extends PureComponent {
 			compact,
 			displayAsLink,
 			highlight,
-			tagName: TagName,
+			tagName: TagName = 'div',
 			href,
 			target,
 			...props

--- a/client/components/card/test/__snapshots__/index.js.snap
+++ b/client/components/card/test/__snapshots__/index.js.snap
@@ -48,27 +48,22 @@ exports[`Card should render children 1`] = `
 </div>
 `;
 
-exports[`CompactCard should have \`is-compact\` class 1`] = `
+exports[`CompactCard should have \`compact\` prop 1`] = `
 <Card
-  className="is-compact"
-  highlight={false}
-  tagName="div"
+  compact={true}
 />
 `;
 
 exports[`CompactCard should have custom class of \`test__ace\` 1`] = `
 <Card
-  className="test__ace is-compact"
-  highlight={false}
-  tagName="div"
+  className="test__ace"
+  compact={true}
 />
 `;
 
 exports[`CompactCard should render children 1`] = `
 <Card
-  className="is-compact"
-  highlight={false}
-  tagName="div"
+  compact={true}
 >
   This is a compact card
 </Card>
@@ -76,8 +71,6 @@ exports[`CompactCard should render children 1`] = `
 
 exports[`CompactCard should use the card component 1`] = `
 <Card
-  className="is-compact"
-  highlight={false}
-  tagName="div"
+  compact={true}
 />
 `;

--- a/client/components/card/test/index.js
+++ b/client/components/card/test/index.js
@@ -57,10 +57,10 @@ describe( 'Card', () => {
 } );
 
 describe( 'CompactCard', () => {
-	// it should have a class of `is-compact`
-	test( 'should have `is-compact` class', () => {
+	// the inner `Card` should have a `compact` prop
+	test( 'should have `compact` prop', () => {
 		const compactCard = shallow( <CompactCard /> );
-		expect( compactCard.find( '.is-compact' ) ).toHaveLength( 1 );
+		expect( compactCard.prop( 'compact' ) ).toBe( true );
 		expect( compactCard ).toMatchSnapshot();
 	} );
 

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -4,8 +4,6 @@ exports[`Theme rendering with default display buttonContents should match snapsh
 <Card
   className="theme is-actionable"
   data-e2e-theme="twenty-seventeen"
-  highlight={false}
-  tagName="div"
 >
   <div
     className="theme__content"

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -39,8 +39,6 @@ exports[`JetpackAuthorize renders as expected 1`] = `
       />
       <Card
         className="jetpack-connect__logged-in-card"
-        highlight={false}
-        tagName="div"
       >
         <Connect(Gravatar)
           size={64}


### PR DESCRIPTION
Straightforward migration, plus several drive-by cleanups:
- simplify `CompactCard` by just passing `compact` prop to `Card`
- use `PropTypes.elementType` for `tagName` (string tag name or React constructor fn)
- remove usage of double negation (`!!`) -- unneeded for `className` params
- remove default `false` value for `highlight`. The prop is optional, `undefined` value is OK

**How to test:**
There are many usages of `Card` and the main risk are CSS selectors with ambiguous specificity.