### PR TITLE
Jetpack installer: Remove Jetpack product install on checkout

### DIFF
--- a/client/jetpack-connect/plans.jsx
+++ b/client/jetpack-connect/plans.jsx
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -124,7 +123,7 @@ class Plans extends Component {
 
 	getMyPlansDestination() {
 		const redirectTo = CALYPSO_MY_PLAN_PAGE + this.props.selectedSiteSlug;
-		const args = { 'thank-you': '', install: 'all' };
+		const args = { 'thank-you': '' };
 
 		return addQueryArgs( args, redirectTo );
 	}

--- a/client/my-sites/checkout/checkout-thank-you/index.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.jsx
@@ -444,7 +444,7 @@ export class CheckoutThankYou extends React.Component {
 				</Main>
 			);
 		} else if ( wasJetpackPlanPurchased ) {
-			page( `/plans/my-plan/${ this.props.siteId }?thank-you&install=all` );
+			page( `/plans/my-plan/${ this.props.siteId }?thank-you` );
 			return null;
 		}
 

--- a/client/my-sites/checkout/checkout/index.jsx
+++ b/client/my-sites/checkout/checkout/index.jsx
@@ -478,7 +478,7 @@ export class Checkout extends React.Component {
 			// Do not use the fallback `/` route after checkout
 			if ( selectedSiteSlug && signupDestination === '/' ) {
 				// Matches route from client/my-sites/checkout/checkout-thank-you/index.jsx:445
-				return `/plans/my-plan/${ selectedSiteSlug }?thank-you&install=all`;
+				return `/plans/my-plan/${ selectedSiteSlug }?thank-you`;
 			}
 			return signupDestination;
 		}


### PR DESCRIPTION
Second time: #35471

The backend installer seems to suffer from race conditions provisioning the VaultPress key. When those issues have improved we can land this to eliminate redundancy.

#### Changes proposed in this Pull Request

* Disable the client initiated product install after checkout

This is to remove potential conflicts with ~D31588-code~ (merged)

#### Testing instructions

* Purchase a plan on a Jetpack site on the free plan.
* After checkout, Akismet and VaultPress should _not_ be installed and provisioned with a key.
