### PR TITLE
Revert "Update signup progress state to a keyed object"

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import Gridicon from 'gridicons';
-import { capitalize, findLast, get, includes, isEmpty } from 'lodash';
+import { capitalize, findLast, get, includes, isArray } from 'lodash';
 import { localize } from 'i18n-calypso';
 import page from 'page';
 import classNames from 'classnames';
@@ -146,7 +146,7 @@ class Login extends Component {
 				window.location.href = url;
 			} );
 		} else {
-			if ( ! isEmpty( this.props.signupProgress ) ) {
+			if ( isArray( this.props.signupProgress ) ) {
 				const lastStep = findLast( this.props.signupProgress, step => step.stepName !== 'user' );
 				if ( lastStep ) {
 					this.props.setResumeAfterLogin( lastStep );

--- a/client/lib/signup/flow-controller.js
+++ b/client/lib/signup/flow-controller.js
@@ -16,7 +16,6 @@ import {
 	keys,
 	pick,
 	reject,
-	reduce,
 } from 'lodash';
 import page from 'page';
 
@@ -291,8 +290,7 @@ assign( SignupFlowController.prototype, {
 			get( steps, [ stepName, 'providesDependencies' ], [] )
 		);
 
-		return reduce(
-			getSignupProgress( this._reduxStore.getState() ),
+		return getSignupProgress( this._reduxStore.getState() ).reduce(
 			( current, step ) => ( {
 				...current,
 				...pick( step.providedDependencies, requiredDependencies ),

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -451,11 +451,11 @@ class Signup extends React.Component {
 	// `nextFlowName` is an optional parameter used to redirect to another flow, i.e., from `main`
 	// to `ecommerce`. If not specified, the current flow (`this.props.flowName`) continues.
 	goToNextStep = ( nextFlowName = this.props.flowName ) => {
-		const flowSteps = flows.getFlow( nextFlowName ).steps;
-		const currentStepIndex = indexOf( flowSteps, this.props.stepName );
-		const nextStepName = flowSteps[ currentStepIndex + 1 ];
-		const nextProgressItem = get( this.props.progress, nextStepName );
-		const nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
+		const flowSteps = flows.getFlow( nextFlowName ).steps,
+			currentStepIndex = indexOf( flowSteps, this.props.stepName ),
+			nextStepName = flowSteps[ currentStepIndex + 1 ],
+			nextProgressItem = this.props.progress[ currentStepIndex + 1 ],
+			nextStepSection = ( nextProgressItem && nextProgressItem.stepSectionName ) || '';
 
 		if ( nextFlowName !== this.props.flowName ) {
 			this.props.removeUnneededSteps( nextFlowName );

--- a/client/signup/navigation-link/test/index.jsx
+++ b/client/signup/navigation-link/test/index.jsx
@@ -12,14 +12,11 @@ import { noop } from 'lodash';
 import { NavigationLink } from '../';
 import EMPTY_COMPONENT from 'components/empty-component';
 
-jest.mock( 'signup/utils', () => ( {
-	getStepUrl: jest.fn(),
-	getFilteredSteps: jest.fn(),
-} ) );
+jest.mock( 'signup/utils', () => ( { getStepUrl: jest.fn() } ) );
 jest.mock( 'gridicons', () => require( 'components/empty-component' ) );
 
 const signupUtils = require( 'signup/utils' );
-const { getStepUrl, getFilteredSteps } = signupUtils;
+const { getStepUrl } = signupUtils;
 
 describe( 'NavigationLink', () => {
 	const Gridicon = EMPTY_COMPONENT;
@@ -28,20 +25,16 @@ describe( 'NavigationLink', () => {
 		stepName: 'test:step2',
 		positionInFlow: 1,
 		stepSectionName: 'test:section',
-		signupProgress: {
-			'test:step1': { stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
-			'test:step2': { stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: false },
-			'test:step3': { stepName: 'test:step3', stepSectionName: 'test:section3', wasSkipped: false },
-		},
+		signupProgress: [
+			{ stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
+			{ stepName: 'test:step2', stepSectionName: 'test:section2', wasSkipped: false },
+			{ stepName: 'test:step3', stepSectionName: 'test:section3', wasSkipped: false },
+		],
 		recordTracksEvent: noop,
 		submitSignupStep: noop,
 		goToNextStep: jest.fn(),
 		translate: str => `translated:${ str }`,
 	};
-
-	beforeEach( () => {
-		getFilteredSteps.mockReturnValue( Object.values( props.signupProgress ) );
-	} );
 
 	afterEach( () => {
 		getStepUrl.mockReset();
@@ -92,9 +85,6 @@ describe( 'NavigationLink', () => {
 
 		// when it is the first step
 		getStepUrl.mockReset();
-		getFilteredSteps.mockReturnValue( [
-			{ stepName: 'test:step1', stepSectionName: 'test:section1', wasSkipped: false },
-		] );
 		wrapper.setProps( { stepName: 'test:step1' } ); // set the first step
 		expect( getStepUrl ).toHaveBeenCalled();
 		expect( getStepUrl ).toHaveBeenCalledWith( 'test:flow', null, '', 'en' );

--- a/client/signup/test/utils.js
+++ b/client/signup/test/utils.js
@@ -17,7 +17,6 @@ import {
 	getStepName,
 	getLocale,
 	getFlowName,
-	getFilteredSteps,
 } from '../utils';
 import flows from 'signup/config/flows';
 
@@ -70,71 +69,6 @@ describe( 'utils', () => {
 
 		test( 'should return the default flow if the flow is missing', () => {
 			expect( getFlowName( {} ) ).toBe( defaultFlowName );
-		} );
-	} );
-
-	describe( 'getFilteredSteps', () => {
-		describe( 'when the given flow is found in the config', () => {
-			const exampleFlowName = 'onboarding';
-
-			describe( 'when there are a number of steps in the progress state', () => {
-				describe( 'and some of them match that flow', () => {
-					const userStep = { stepName: 'user' };
-					const siteTypeStep = { stepName: 'site-type' };
-					const someOtherStep = { stepName: 'some-other-step' };
-					const exampleSteps = {
-						user: userStep,
-						'site-type': siteTypeStep,
-						'some-other-step': someOtherStep,
-					};
-
-					const result = getFilteredSteps( exampleFlowName, exampleSteps );
-
-					test( 'it returns an array', () => {
-						expect( Array.isArray( result ) ).toBe( true );
-					} );
-
-					test( 'it should return only the step objects that match the flow', () => {
-						expect( result ).toEqual( [ userStep, siteTypeStep ] );
-					} );
-				} );
-
-				describe( 'but none of them match that flow', () => {
-					const exampleSteps = {
-						'some-step': { stepName: 'some-step' },
-						'some-other-step': { stepName: 'some-other-step' },
-					};
-					const result = getFilteredSteps( exampleFlowName, exampleSteps );
-
-					test( 'it should return an empty array', () => {
-						expect( result ).toHaveLength( 0 );
-						expect( Array.isArray( result ) ).toBe( true );
-					} );
-				} );
-			} );
-
-			describe( 'when there are no steps in the progress state', () => {
-				const result = getFilteredSteps( exampleFlowName, {} );
-
-				test( 'it should return an empty array', () => {
-					expect( result ).toHaveLength( 0 );
-					expect( Array.isArray( result ) ).toBe( true );
-				} );
-			} );
-		} );
-
-		describe( 'when the given flow is not found in the config', () => {
-			const exampleFlowName = 'some-bad-flow';
-			const exampleSteps = {
-				user: { stepName: 'user' },
-				'site-type': { stepName: 'site-type' },
-			};
-			const result = getFilteredSteps( exampleFlowName, exampleSteps );
-
-			test( 'it should return an empty array', () => {
-				expect( result ).toHaveLength( 0 );
-				expect( Array.isArray( result ) ).toBe( true );
-			} );
 		} );
 	} );
 

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -3,7 +3,7 @@
  * Exernal dependencies
  */
 import cookie from 'cookie';
-import { filter, find, includes, indexOf, isEmpty, pick, sortBy } from 'lodash';
+import { filter, find, includes, indexOf, isEmpty, pick } from 'lodash';
 import { translate } from 'i18n-calypso';
 
 /**
@@ -177,17 +177,7 @@ export function getDesignTypeForSiteGoals( siteGoals, flow ) {
 
 export function getFilteredSteps( flowName, progress ) {
 	const flow = flows.getFlow( flowName );
-
-	if ( ! flow ) {
-		return [];
-	}
-
-	return sortBy(
-		// filter steps...
-		filter( progress, step => includes( flow.steps, step.stepName ) ),
-		// then order according to the flow definition...
-		( { stepName } ) => flow.steps.indexOf( stepName )
-	);
+	return filter( progress, step => includes( flow.steps, step.stepName ) );
 }
 
 export function getFirstInvalidStep( flowName, progress ) {

--- a/client/state/signup/progress/reducer.js
+++ b/client/state/signup/progress/reducer.js
@@ -3,120 +3,132 @@
 /**
  * External dependencies
  */
-import { has, keyBy, get } from 'lodash';
+import { get, find, map } from 'lodash';
 import debugFactory from 'debug';
 
 /**
  * Internal dependencies
  */
 import stepsConfig from 'signup/config/steps-pure';
+import flows from 'signup/config/flows-pure';
 import {
 	SIGNUP_COMPLETE_RESET,
 	SIGNUP_PROGRESS_COMPLETE_STEP,
 	SIGNUP_PROGRESS_INVALIDATE_STEP,
 	SIGNUP_PROGRESS_PROCESS_STEP,
+	SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
 	SIGNUP_PROGRESS_RESUME_AFTER_LOGIN_SET,
 	SIGNUP_PROGRESS_SAVE_STEP,
 	SIGNUP_PROGRESS_SUBMIT_STEP,
 } from 'state/action-types';
 import { createReducer } from 'state/utils';
 import { schema } from './schema';
+import userFactory from 'lib/user';
 
 const debug = debugFactory( 'calypso:state:signup:progress:reducer' );
 
 //
-// Helper Functions
-//
-const addStep = ( state, step ) => {
-	debug( `Adding step ${ step.stepName }` );
-
-	return {
-		...state,
-		[ step.stepName ]: step,
-	};
-};
-
-const updateStep = ( state, newStepState ) => {
-	const { stepName, status } = newStepState;
-	const stepState = get( state, stepName );
-
-	if ( ! stepState ) {
-		return state;
-	}
-
-	debug( `Updating step ${ stepName }` );
-
-	if ( status === 'pending' || status === 'completed' ) {
-		// This can only happen when submitting a step
-		//
-		// Steps that are resubmitted may decide to omit the `wasSkipped` status of a step if e.g.
-		// the user goes back and chooses to not skip a step. If a step is submitted without it,
-		// we explicitly remove it from the step data.
-		const { wasSkipped, ...commonStepArgs } = stepState;
-
-		return {
-			...state,
-			[ stepName ]: {
-				...commonStepArgs,
-				...newStepState,
-			},
-		};
-	}
-
-	return {
-		...state,
-		[ stepName ]: {
-			...stepState,
-			...newStepState,
-		},
-	};
-};
-
-//
 // Action handlers
 //
+function overwriteSteps( state, { steps = [] } ) {
+	// When called without action.steps, this is basically a state reset function.
+	return Array.isArray( steps ) ? steps : [];
+}
 
-// When called without action.steps, this is basically a state reset function.
-const overwriteSteps = ( state, { steps = {} } ) => keyBy( steps, 'stepName' );
+function completeStep( state, { step } ) {
+	return updateStep( state, { ...step, status: 'completed' } );
+}
 
-const completeStep = ( state, { step } ) => updateStep( state, { ...step, status: 'completed' } );
+function invalidateStep( state, { step, errors } ) {
+	const newStep = { ...step, errors, status: 'invalid' };
+	if ( find( state, { stepName: newStep.stepName } ) ) {
+		return updateStep( state, newStep );
+	}
+	return addStep( state, newStep );
+}
 
-const invalidateStep = ( state, { step, errors } ) => {
-	const newStepState = { ...step, errors, status: 'invalid' };
+function processStep( state, { step } ) {
+	return updateStep( state, { ...step, status: 'processing' } );
+}
 
-	return has( state, step.stepName )
-		? updateStep( state, newStepState )
-		: addStep( state, newStepState );
-};
+function removeUnneededSteps( state, { flowName } ) {
+	let flowSteps = [];
+	const user = userFactory();
 
-const processStep = ( state, { step } ) => updateStep( state, { ...step, status: 'processing' } );
+	flowSteps = get( flows, [ flowName, 'steps' ], [] );
 
-const saveStep = ( state, { step } ) =>
-	has( state, step.stepName )
-		? updateStep( state, step )
-		: addStep( state, { ...step, status: 'in-progress' } );
+	if ( user && user.get() ) {
+		flowSteps = flowSteps.filter( item => item !== 'user' );
+	}
+
+	return state.filter( step => flowSteps.includes( step.stepName ) );
+}
+
+function saveStep( state, { step } ) {
+	if ( find( state, { stepName: step.stepName } ) ) {
+		return updateStep( state, step );
+	}
+
+	return addStep( state, { ...step, status: 'in-progress' } );
+}
 
 function setResumeAfterLogin( state, { resumeStep } ) {
 	debug( `Setting resume after login for step ${ resumeStep.stepName }` );
 	return updateStep( state, { ...resumeStep, status: 'in-progress' } );
 }
 
-const submitStep = ( state, { step } ) => {
+function submitStep( state, { step } ) {
 	const stepHasApiRequestFunction = get( stepsConfig, [ step.stepName, 'apiRequestFunction' ] );
 	const status = stepHasApiRequestFunction ? 'pending' : 'completed';
 
-	return has( state, step.stepName )
-		? updateStep( state, { ...step, status } )
-		: addStep( state, { ...step, status } );
-};
+	if ( find( state, { stepName: step.stepName } ) ) {
+		return updateStep( state, { ...step, status } );
+	}
 
+	return addStep( state, { ...step, status } );
+}
+
+//
+// Helper Functions
+//
+function addStep( state, step ) {
+	debug( `Adding step ${ step.stepName }` );
+	return [ ...state, step ];
+}
+
+function updateStep( state, newStep ) {
+	debug( `Updating step ${ newStep.stepName }` );
+	return map( state, function( step ) {
+		if ( step.stepName === newStep.stepName ) {
+			const { status } = newStep;
+			if ( status === 'pending' || status === 'completed' ) {
+				// This can only happen when submitting a step
+				//
+				// Steps that are resubmitted may decide to omit the `wasSkipped` status of a step if e.g.
+				// the user goes back and chooses to not skip a step. If a step is submitted without it,
+				// we explicitly remove it from the step data.
+				const { wasSkipped, ...commonStepArgs } = step;
+				return { ...commonStepArgs, ...newStep };
+			}
+
+			return { ...step, ...newStep };
+		}
+
+		return step;
+	} );
+}
+
+//
+// Reducer export
+//
 export default createReducer(
-	{},
+	[],
 	{
 		[ SIGNUP_COMPLETE_RESET ]: overwriteSteps,
 		[ SIGNUP_PROGRESS_COMPLETE_STEP ]: completeStep,
 		[ SIGNUP_PROGRESS_INVALIDATE_STEP ]: invalidateStep,
 		[ SIGNUP_PROGRESS_PROCESS_STEP ]: processStep,
+		[ SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS ]: removeUnneededSteps,
 		[ SIGNUP_PROGRESS_RESUME_AFTER_LOGIN_SET ]: setResumeAfterLogin,
 		[ SIGNUP_PROGRESS_SAVE_STEP ]: saveStep,
 		[ SIGNUP_PROGRESS_SUBMIT_STEP ]: submitStep,

--- a/client/state/signup/progress/schema.js
+++ b/client/state/signup/progress/schema.js
@@ -1,21 +1,19 @@
 /** @format */
 export const schema = {
-	type: 'object',
-	patternProperties: {
-		'^[w-]+$': {
-			type: 'object',
-			properties: {
-				formData: {
-					type: 'object',
-					properties: {
-						url: { type: 'string' },
-					},
+	type: 'array',
+	items: {
+		type: 'object',
+		properties: {
+			formData: {
+				type: 'object',
+				properties: {
+					url: { type: 'string' },
 				},
-				lastUpdated: { type: 'number' },
-				// Valid status values: 'completed', 'processing', 'pending', 'in-progress' and 'invalid'
-				status: { type: 'string' },
-				stepName: { type: 'string' },
 			},
+			lastUpdated: { type: 'number' },
+			// Valid status values: 'completed', 'processing', 'pending', 'in-progress' and 'invalid'
+			status: { type: 'string' },
+			stepName: { type: 'string' },
 		},
 	},
 };

--- a/client/state/signup/progress/selectors.js
+++ b/client/state/signup/progress/selectors.js
@@ -6,7 +6,7 @@
 
 import { get } from 'lodash';
 
-const initialState = {};
+const initialState = [];
 export function getSignupProgress( state ) {
 	return get( state, 'signup.progress', initialState );
 }

--- a/client/state/signup/progress/test/reducer.js
+++ b/client/state/signup/progress/test/reducer.js
@@ -9,6 +9,7 @@ import {
 	SIGNUP_PROGRESS_COMPLETE_STEP,
 	SIGNUP_PROGRESS_INVALIDATE_STEP,
 	SIGNUP_PROGRESS_PROCESS_STEP,
+	SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS,
 	SIGNUP_PROGRESS_RESUME_AFTER_LOGIN_SET,
 	SIGNUP_PROGRESS_SAVE_STEP,
 	SIGNUP_PROGRESS_SUBMIT_STEP,
@@ -28,12 +29,12 @@ jest.mock( 'signup/config/steps-pure', () => ( {
 } ) );
 
 describe( 'reducer', () => {
-	test( 'should return an empty object at first', () => {
-		expect( Object.keys( reducer( undefined, { type: 'init' } ) ) ).toHaveLength( 0 );
+	test( 'should return an empty at first', () => {
+		expect( reducer( undefined, { type: 'init' } ) ).toHaveLength( 0 );
 	} );
 
 	test( 'should store a new step', () => {
-		const initialState = {};
+		const initialState = [];
 		const action = {
 			type: SIGNUP_PROGRESS_SUBMIT_STEP,
 			step: {
@@ -42,54 +43,52 @@ describe( 'reducer', () => {
 			},
 		};
 		const finalState = reducer( initialState, action );
-		expect( Object.keys( finalState ) ).toHaveLength( 1 );
-		expect( finalState[ 'site-selection' ].stepName ).toBe( 'site-selection' );
+		expect( finalState ).toHaveLength( 1 );
+		expect( finalState[ 0 ].stepName ).toBe( 'site-selection' );
 	} );
 
 	test( 'should not store the same step twice', () => {
-		const actions = [
-			{
-				type: SIGNUP_PROGRESS_SUBMIT_STEP,
-				step: {
-					stepName: 'site-selection',
-					formData: { url: 'my-site.wordpress.com' },
-				},
-			},
-			{
-				type: SIGNUP_PROGRESS_SUBMIT_STEP,
-				step: {
-					stepName: 'site-selection',
-				},
-			},
-		];
+		let state = [];
 
-		const state = actions.reduce( reducer, [] );
+		state = reducer( state, {
+			type: SIGNUP_PROGRESS_SUBMIT_STEP,
+			step: {
+				stepName: 'site-selection',
+				formData: { url: 'my-site.wordpress.com' },
+			},
+		} );
 
-		expect( Object.keys( state ) ).toHaveLength( 1 );
-		expect( state[ 'site-selection' ] ).toMatchObject( {
+		state = reducer( state, {
+			type: SIGNUP_PROGRESS_SUBMIT_STEP,
+			step: {
+				stepName: 'site-selection',
+			},
+		} );
+
+		expect( state ).toHaveLength( 1 );
+		expect( state[ 0 ] ).toMatchObject( {
 			stepName: 'site-selection',
 			formData: { url: 'my-site.wordpress.com' },
 			status: 'completed',
 		} );
 	} );
 
-	test( 'should store multiple steps', () => {
-		const actions = [
-			{
-				type: SIGNUP_PROGRESS_SUBMIT_STEP,
-				step: { stepName: 'site-selection' },
-			},
-			{
-				type: SIGNUP_PROGRESS_SUBMIT_STEP,
-				step: { stepName: 'theme-selection' },
-			},
-		];
+	test( 'should store multiple steps in order', () => {
+		let state = [];
 
-		const state = actions.reduce( reducer, [] );
+		state = reducer( state, {
+			type: SIGNUP_PROGRESS_SUBMIT_STEP,
+			step: { stepName: 'site-selection' },
+		} );
 
-		expect( Object.keys( state ) ).toHaveLength( 2 );
-		expect( state[ 'site-selection' ].stepName ).toBe( 'site-selection' );
-		expect( state[ 'theme-selection' ].stepName ).toBe( 'theme-selection' );
+		state = reducer( state, {
+			type: SIGNUP_PROGRESS_SUBMIT_STEP,
+			step: { stepName: 'theme-selection' },
+		} );
+
+		expect( state ).toHaveLength( 2 );
+		expect( state[ 0 ].stepName ).toBe( 'site-selection' );
+		expect( state[ 1 ].stepName ).toBe( 'theme-selection' );
 	} );
 
 	test( 'should mark only new saved steps as in-progress', () => {
@@ -112,49 +111,49 @@ describe( 'reducer', () => {
 
 		const state = actions.reduce( reducer, [] );
 
-		expect( state[ 'site-selection' ].status ).not.toBe( 'in-progress' );
-		expect( state[ 'last-step' ].status ).toBe( 'in-progress' );
+		expect( state[ 0 ].status ).not.toBe( 'in-progress' );
+		expect( state[ 1 ].status ).toBe( 'in-progress' );
 	} );
 
 	test( 'should set the status of a signup step', () => {
-		let state = {};
+		let state = [];
 
 		state = reducer( state, {
 			type: SIGNUP_PROGRESS_SUBMIT_STEP,
 			step: { stepName: 'site-selection' },
 		} );
-		expect( state[ 'site-selection' ].status ).toBe( 'completed' );
+		expect( state[ 0 ].status ).toBe( 'completed' );
 
 		state = reducer( state, {
 			type: SIGNUP_PROGRESS_COMPLETE_STEP,
 			step: { stepName: 'site-selection' },
 		} );
-		expect( state[ 'site-selection' ].status ).toBe( 'completed' );
+		expect( state[ 0 ].status ).toBe( 'completed' );
 	} );
 
 	describe( 'setting and resetting the state', () => {
 		test( 'should handle resetting the state', () => {
-			const initialState = { test: { test: 123 } };
+			const initialState = [ { test: 123 } ];
 			const action = { type: SIGNUP_COMPLETE_RESET };
-			const finalState = {};
+			const finalState = [];
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 	} );
 
 	describe( 'completing a step', () => {
 		test( 'should mark the new step with the "completed" status', () => {
-			const initialState = { example: { stepName: 'example', status: 'something' } };
+			const initialState = [ { stepName: 'example', status: 'something' } ];
 			const action = {
 				type: SIGNUP_PROGRESS_COMPLETE_STEP,
 				step: { stepName: 'example', exampleValue: 'some value' },
 			};
-			const finalState = {
-				example: { stepName: 'example', exampleValue: 'some value', status: 'completed' },
-			};
+			const finalState = [
+				{ stepName: 'example', exampleValue: 'some value', status: 'completed' },
+			];
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 		test( 'should not add a new step if no steps match by name', () => {
-			const initialState = { example: { stepName: 'example', status: 'something' } };
+			const initialState = [ { stepName: 'example', status: 'something' } ];
 			const action = {
 				type: SIGNUP_PROGRESS_COMPLETE_STEP,
 				step: { stepName: 'differentName', exampleValue: 'some value' },
@@ -164,72 +163,54 @@ describe( 'reducer', () => {
 	} );
 
 	describe( 'invalidating a step', () => {
-		test( "should add a step with error data and 'invalid' status if the step's name is unique", () => {
-			const initialState = { whatever: { stepName: 'whatever' } };
+		test( "should append a step with error data and 'invalid' status if the step's name is unique", () => {
+			const initialState = [ { stepName: 'whatever' } ];
 			const action = {
 				type: SIGNUP_PROGRESS_INVALIDATE_STEP,
 				step: { stepName: 'something' },
 				errors: [ new Error( 'something' ) ],
 			};
-			const finalState = {
-				whatever: { stepName: 'whatever' },
-				something: {
-					stepName: 'something',
-					status: 'invalid',
-					errors: [ new Error( 'something' ) ],
-				},
-			};
+			const finalState = [
+				{ stepName: 'whatever' },
+				{ stepName: 'something', status: 'invalid', errors: [ new Error( 'something' ) ] },
+			];
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 
 		test( "should update a step with error data and 'invalid' status if the step's name is not unique", () => {
-			const initialState = {
-				something: {
-					stepName: 'something',
-				},
-			};
+			const initialState = [ { stepName: 'something' } ];
 			const action = {
 				type: SIGNUP_PROGRESS_INVALIDATE_STEP,
 				step: { stepName: 'something', value: 'example' },
 				errors: [ new Error( 'something' ) ],
 			};
-			const finalState = {
-				something: {
+			const finalState = [
+				{
 					errors: [ new Error( 'something' ) ],
 					status: 'invalid',
 					stepName: 'something',
 					value: 'example',
 				},
-			};
+			];
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 	} );
 
 	describe( 'processing a step', () => {
 		test( 'should update the step with a "processing" status', () => {
-			const initialState = {
-				example: {
-					stepName: 'example',
-					status: 'something',
-				},
-			};
+			const initialState = [ { stepName: 'example', status: 'something' } ];
 			const action = {
 				type: SIGNUP_PROGRESS_PROCESS_STEP,
 				step: { stepName: 'example', exampleValue: 'some value' },
 			};
-			const finalState = {
-				example: { stepName: 'example', exampleValue: 'some value', status: 'processing' },
-			};
+			const finalState = [
+				{ stepName: 'example', exampleValue: 'some value', status: 'processing' },
+			];
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 
 		test( 'should not add a new step if no steps match by name', () => {
-			const initialState = {
-				example: {
-					stepName: 'example',
-					status: 'something',
-				},
-			};
+			const initialState = [ { stepName: 'example', status: 'something' } ];
 			const action = {
 				type: SIGNUP_PROGRESS_PROCESS_STEP,
 				step: { stepName: 'differentName', exampleValue: 'some value' },
@@ -238,42 +219,59 @@ describe( 'reducer', () => {
 		} );
 	} );
 
+	describe( 'removing unneded steps', () => {
+		test( 'should remove steps that are not in the new flow', () => {
+			const initialState = [
+				{ stepName: 'something', value: 'great something' },
+				{ stepName: 'everything', value: 'great everything' },
+				{ stepName: 'nothing', value: 'great nothing' },
+				{ stepName: 'one', value: 'great one' },
+			];
+
+			const action = { type: SIGNUP_PROGRESS_REMOVE_UNNEEDED_STEPS, flowName: 'new-flow' };
+
+			const finalState = [
+				{ stepName: 'something', value: 'great something' },
+				{ stepName: 'everything', value: 'great everything' },
+			];
+
+			expect( reducer( initialState, action ) ).toEqual( finalState );
+		} );
+	} );
+
 	describe( 'saving a step', () => {
 		describe( 'saving a new step', () => {
-			test( 'should add a new step to the state if step name is unique', () => {
-				const initialState = { whatever: { stepName: 'whatever' } };
+			test( 'should append a new step to the state if step name is unique', () => {
+				const initialState = [ { stepName: 'whatever' } ];
 				const action = {
 					type: SIGNUP_PROGRESS_SAVE_STEP,
 					step: { stepName: 'something' },
 				};
 				const state = reducer( initialState, action );
-				expect( Object.keys( state ) ).toHaveLength( 2 );
-				expect( state.something ).toBeTruthy();
-				expect( state.whatever ).toBeTruthy();
+				expect( state ).toHaveLength( 2 );
+				expect( state[ 1 ].stepName ).toEqual( 'something' );
 			} );
 			test( 'should mark the new step with an "in-progress" status', () => {
-				const initialState = { whatever: { stepName: 'whatever' } };
+				const initialState = [ { stepName: 'whatever' } ];
 				const action = {
 					type: SIGNUP_PROGRESS_SAVE_STEP,
 					step: { stepName: 'something' },
 				};
-				const finalState = {
-					whatever: { stepName: 'whatever' },
-					something: { stepName: 'something', status: 'in-progress' },
-				};
+				const finalState = [
+					{ stepName: 'whatever' },
+					{ stepName: 'something', status: 'in-progress' },
+				];
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 		} );
 		describe( 'saving an existing step', () => {
 			test( 'should update the existing step with the provided data', () => {
-				const initialState = { whatever: { stepName: 'whatever', oldValue: 'example' } };
+				const initialState = [ { stepName: 'whatever', oldValue: 'example' } ];
 				const action = {
 					type: SIGNUP_PROGRESS_SAVE_STEP,
 					step: { stepName: 'whatever', newValue: 'example' },
 				};
-				const finalState = {
-					whatever: { newValue: 'example', oldValue: 'example', stepName: 'whatever' },
-				};
+				const finalState = [ { newValue: 'example', oldValue: 'example', stepName: 'whatever' } ];
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 		} );
@@ -282,43 +280,39 @@ describe( 'reducer', () => {
 	describe( 'submitting a step', () => {
 		describe( 'saving a new step', () => {
 			test( 'should update the step with a "pending" status if the step has a corresponding API request function', () => {
-				const initialState = { 'some-step': { stepName: 'some-step' } };
+				const initialState = [ { stepName: 'some-step' } ];
 				const action = {
 					type: SIGNUP_PROGRESS_SUBMIT_STEP,
 					step: { stepName: 'stepWithAPI', updateValue: 'some value' },
 				};
-				const finalState = {
-					'some-step': { stepName: 'some-step' },
-					stepWithAPI: { stepName: 'stepWithAPI', updateValue: 'some value', status: 'pending' },
-				};
+				const finalState = [
+					{ stepName: 'some-step' },
+					{ stepName: 'stepWithAPI', updateValue: 'some value', status: 'pending' },
+				];
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 			test( 'should update the step with a "completed" status if the step does not have a corresponding API request function', () => {
-				const initialState = { 'some-step': { stepName: 'some-step' } };
+				const initialState = [ { stepName: 'some-step' } ];
 				const action = {
 					type: SIGNUP_PROGRESS_SUBMIT_STEP,
 					step: { stepName: 'stepWithoutAPI', updateValue: 'some value' },
 				};
-				const finalState = {
-					'some-step': { stepName: 'some-step' },
-					stepWithoutAPI: {
-						stepName: 'stepWithoutAPI',
-						updateValue: 'some value',
-						status: 'completed',
-					},
-				};
+				const finalState = [
+					{ stepName: 'some-step' },
+					{ stepName: 'stepWithoutAPI', updateValue: 'some value', status: 'completed' },
+				];
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 		} );
 		describe( 'saving an existing step', () => {
 			test( 'should update the step with a "pending" status if the step has a corresponding API request function', () => {
 				// It should also drop the wasSkipped value
-				const initialState = {
-					stepWithAPI: {
+				const initialState = [
+					{
 						stepName: 'stepWithAPI',
 						wasSkipped: true,
 					},
-				};
+				];
 				const action = {
 					type: SIGNUP_PROGRESS_SUBMIT_STEP,
 					step: {
@@ -326,30 +320,26 @@ describe( 'reducer', () => {
 						updateValue: 'some value',
 					},
 				};
-				const finalState = {
-					stepWithAPI: { stepName: 'stepWithAPI', updateValue: 'some value', status: 'pending' },
-				};
+				const finalState = [
+					{ stepName: 'stepWithAPI', updateValue: 'some value', status: 'pending' },
+				];
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 			test( 'should update the step with a "completed" status if the step does not have a corresponding API request function', () => {
 				// It should also drop the wasSkipped value
-				const initialState = {
-					stepWithoutAPI: {
+				const initialState = [
+					{
 						stepName: 'stepWithoutAPI',
 						wasSkipped: true,
 					},
-				};
+				];
 				const action = {
 					type: SIGNUP_PROGRESS_SUBMIT_STEP,
 					step: { stepName: 'stepWithoutAPI', updateValue: 'some value' },
 				};
-				const finalState = {
-					stepWithoutAPI: {
-						stepName: 'stepWithoutAPI',
-						updateValue: 'some value',
-						status: 'completed',
-					},
-				};
+				const finalState = [
+					{ stepName: 'stepWithoutAPI', updateValue: 'some value', status: 'completed' },
+				];
 				expect( reducer( initialState, action ) ).toEqual( finalState );
 			} );
 		} );
@@ -357,12 +347,12 @@ describe( 'reducer', () => {
 
 	describe( 'resuming a step', () => {
 		test( 'should update the step with an "in-progress" status', () => {
-			const initialState = { example: { stepName: 'example', status: 'completed' } };
+			const initialState = [ { stepName: 'example', status: 'completed' } ];
 			const action = {
 				type: SIGNUP_PROGRESS_RESUME_AFTER_LOGIN_SET,
 				resumeStep: { stepName: 'example' },
 			};
-			const finalState = { example: { stepName: 'example', status: 'in-progress' } };
+			const finalState = [ { stepName: 'example', status: 'in-progress' } ];
 			expect( reducer( initialState, action ) ).toEqual( finalState );
 		} );
 	} );

--- a/client/state/signup/progress/test/selectors.js
+++ b/client/state/signup/progress/test/selectors.js
@@ -11,20 +11,27 @@ import { expect } from 'chai';
 import { getSignupProgress } from '../selectors';
 
 describe( 'selectors', () => {
-	test( 'should return empty, plain object as a default state', () => {
+	test( 'should return empty array as a default state', () => {
 		const state = { signup: undefined };
-		expect( getSignupProgress( state ) ).to.be.eql( {} );
+		expect( getSignupProgress( state, [] ) ).to.be.eql( [] );
 	} );
 
-	test( 'should select progress from the state', () => {
-		const progress = {
-			'site-selection': {
+	test( 'should return signupDependencyStore instance from the state', () => {
+		const state = {
+			signup: {
+				progress: [
+					{
+						status: 'completed',
+						stepName: 'site-selection',
+					},
+				],
+			},
+		};
+		expect( getSignupProgress( state, [] ) ).to.be.eql( [
+			{
 				status: 'completed',
 				stepName: 'site-selection',
 			},
-		};
-		const state = { signup: { progress } };
-
-		expect( getSignupProgress( state ) ).to.be.eql( progress );
+		] );
 	} );
 } );

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -383,12 +383,12 @@ describe( 'initial-state', () => {
 							siteType: 'blog',
 							siteTitle: 'Logged out test title',
 						},
-						progress: {
-							'logged-out-step': {
+						progress: [
+							{
 								stepName: 'logged-out-step',
 								status: 'completed',
 							},
-						},
+						],
 						_timestamp,
 					},
 				};
@@ -440,12 +440,12 @@ describe( 'initial-state', () => {
 							siteType: 'blog',
 							siteTitle: 'Logged in test title',
 						},
-						progress: {
-							'logged-in-step': {
+						progress: [
+							{
 								stepName: 'logged-in-step',
 								status: 'completed',
 							},
-						},
+						],
 						_timestamp,
 					},
 					'redux-state-logged-out:signup': {
@@ -453,12 +453,12 @@ describe( 'initial-state', () => {
 							siteType: 'blog',
 							siteTitle: 'Logged out test title',
 						},
-						progress: {
-							'logged-out-step': {
+						progress: [
+							{
 								stepName: 'logged-out-step',
 								status: 'completed',
 							},
-						},
+						],
 						_timestamp,
 					},
 				};


### PR DESCRIPTION
Hopefully everything will go smoothly and we won't need this PR - I've opened it just in case we see issues over the next hour or so.

Reverts Automattic/wp-calypso#35049