### PR TITLE
Stats: Increase Specificity of Month Control

### DIFF
--- a/client/my-sites/stats/stats-views/style.scss
+++ b/client/my-sites/stats/stats-views/style.scss
@@ -63,7 +63,7 @@
 	}
 }
 
-.stats-views__month-control {
+.segmented-control.stats-views__month-control {
 	max-width: 280px;
 	margin: 0 auto 10px;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

The margin of `stats-views__month-control` is being overriden after #35051 causing it not to be aligned properly. Similar fix to #35607, where the specificity needs to be increased.

#### Testing instructions

Visit `/stats/insights/` and scroll to "All Time Views".

**Before:**

<img width="1333" alt="Screenshot 2019-08-21 at 16 43 17" src="https://user-images.githubusercontent.com/43215253/63447332-bb85e000-c433-11e9-94f8-8ea9598b4f18.png">

**After:**

<img width="1372" alt="Screenshot 2019-08-21 at 16 43 32" src="https://user-images.githubusercontent.com/43215253/63447343-c0e32a80-c433-11e9-8dc9-c4b5c1b2cb2e.png">

cc @jsnajdr, @simison 