### PR TITLE
Import in Signup: persist siteTitle for display and add sensible fallback.

### DIFF
--- a/client/lib/signup/step-actions.js
+++ b/client/lib/signup/step-actions.js
@@ -185,6 +185,9 @@ export function createSiteWithCart( callback, dependencies, stepData, reduxStore
 	}
 
 	if ( 'import' === lastKnownFlow || 'import-onboarding' === lastKnownFlow ) {
+		// If `siteTitle` wasn't inferred by the site detection api, use
+		// the `siteUrl` until an import replaces it with an actual title.
+		newSiteParams.blog_title = siteTitle || siteUrl;
 		newSiteParams.options.nux_import_engine = getSelectedImportEngine( state );
 		newSiteParams.options.nux_import_from_url = getNuxUrlInputValue( state );
 	}

--- a/client/my-sites/importer/importer-blogger.jsx
+++ b/client/my-sites/importer/importer-blogger.jsx
@@ -34,7 +34,7 @@ class ImporterBlogger extends React.PureComponent {
 
 	render() {
 		const importerData = importerConfig( {
-			siteTitle: this.props.site.title,
+			siteTitle: this.props.siteTitle,
 		} ).blogger;
 
 		return <FileImporter importerData={ importerData } { ...this.props } />;

--- a/client/my-sites/importer/importer-medium.jsx
+++ b/client/my-sites/importer/importer-medium.jsx
@@ -18,7 +18,7 @@ class ImporterMedium extends React.PureComponent {
 
 	render() {
 		const importerData = importerConfig( {
-			siteTitle: this.props.site.title,
+			siteTitle: this.props.siteTitle,
 		} ).medium;
 
 		return <FileImporter importerData={ importerData } { ...this.props } />;

--- a/client/my-sites/importer/importer-squarespace.jsx
+++ b/client/my-sites/importer/importer-squarespace.jsx
@@ -32,7 +32,7 @@ class ImporterSquarespace extends React.PureComponent {
 
 	render() {
 		const importerData = importerConfig( {
-			siteTitle: this.props.site.title,
+			siteTitle: this.props.siteTitle,
 		} ).squarespace;
 
 		return <FileImporter importerData={ importerData } { ...this.props } />;

--- a/client/my-sites/importer/importer-wordpress.jsx
+++ b/client/my-sites/importer/importer-wordpress.jsx
@@ -31,7 +31,7 @@ class ImporterWordPress extends React.PureComponent {
 
 	render() {
 		const importerData = importerConfig( {
-			siteTitle: this.props.site.title,
+			siteTitle: this.props.siteTitle,
 		} ).wordpress;
 
 		return <FileImporter importerData={ importerData } { ...this.props } />;

--- a/client/my-sites/importer/section-import.jsx
+++ b/client/my-sites/importer/section-import.jsx
@@ -27,6 +27,7 @@ import { appStates } from 'state/imports/constants';
 
 import EmailVerificationGate from 'components/email-verification/email-verification-gate';
 import { getSelectedSite, getSelectedSiteSlug, getSelectedSiteId } from 'state/ui/selectors';
+import { getSiteTitle } from 'state/sites/selectors';
 import { getSelectedImportEngine, getImporterSiteUrl } from 'state/importer-nux/temp-selectors';
 import Main from 'components/main';
 import FormattedHeader from 'components/formatted-header';
@@ -129,6 +130,7 @@ class SectionImport extends Component {
 				<ImporterComponent
 					key={ engine }
 					site={ site }
+					siteTitle={ siteTitle }
 					importerStatus={ {
 						importerState: state,
 						siteTitle,
@@ -178,6 +180,7 @@ class SectionImport extends Component {
 					<ImporterComponent
 						key={ importItem.type + idx }
 						site={ importItem.site }
+						siteTitle={ importItem.siteTitle || this.props.siteTitle }
 						fromSite={ this.props.fromSite }
 						importerStatus={ importItem }
 					/>
@@ -196,9 +199,7 @@ class SectionImport extends Component {
 			api: { isHydrated },
 			importers: imports,
 		} = this.state;
-		const { engine, site } = this.props;
-		const { slug, title } = site;
-		const siteTitle = title.length ? title : slug;
+		const { engine, site, siteTitle } = this.props;
 
 		if ( engine && importerComponents[ engine ] ) {
 			return this.renderActiveImporters( filterImportsForSite( site.ID, imports ) );
@@ -282,12 +283,16 @@ class SectionImport extends Component {
 }
 
 export default flow(
-	connect( state => ( {
-		engine: getSelectedImportEngine( state ),
-		fromSite: getImporterSiteUrl( state ),
-		site: getSelectedSite( state ),
-		siteSlug: getSelectedSiteSlug( state ),
-		canImport: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
-	} ) ),
+	connect( state => {
+		const siteID = getSelectedSiteId( state );
+		return {
+			engine: getSelectedImportEngine( state ),
+			fromSite: getImporterSiteUrl( state ),
+			site: getSelectedSite( state ),
+			siteSlug: getSelectedSiteSlug( state ),
+			siteTitle: getSiteTitle( state, siteID ),
+			canImport: canCurrentUser( state, siteID, 'manage_options' ),
+		};
+	} ),
 	localize
 )( SectionImport );

--- a/client/signup/steps/import-url-onboarding/index.jsx
+++ b/client/signup/steps/import-url-onboarding/index.jsx
@@ -18,6 +18,7 @@ import FormLabel from 'components/forms/form-label';
 import FormTextInput from 'components/forms/form-text-input';
 import ScreenReaderText from 'components/screen-reader-text';
 import { setImportOriginSiteDetails, setNuxUrlInputValue } from 'state/importer-nux/actions';
+import { setSiteTitle } from 'state/signup/steps/site-title/actions';
 import { getNuxUrlInputValue } from 'state/importer-nux/temp-selectors';
 import { validateImportUrl } from 'lib/importer/url-validation';
 import { recordTracksEvent } from 'state/analytics/actions';
@@ -76,6 +77,8 @@ class ImportURLOnboardingStepComponent extends Component {
 			siteFavicon,
 			siteTitle,
 		} );
+
+		this.props.setSiteTitle( siteTitle );
 
 		this.props.submitSignupStep(
 			{ stepName },
@@ -177,6 +180,8 @@ class ImportURLOnboardingStepComponent extends Component {
 						siteFavicon,
 						siteTitle,
 					} );
+
+					this.props.setSiteTitle( siteTitle );
 
 					this.props.submitSignupStep(
 						{ stepName },
@@ -377,6 +382,7 @@ export default flow(
 			saveSignupStep,
 			setImportOriginSiteDetails,
 			setNuxUrlInputValue,
+			setSiteTitle,
 		}
 	),
 	localize


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Calls `setSiteTitle` to persist site title.
* Uses the `getSiteTitle` selector to display site title within importer components.
* Adds a fallback (`siteUrl`) for when site title cannot be inferred by detection API

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Recreate issue in #35582.
* Apply PR and run locally or test via calypso.live.
* Visit `/start` and select "Already have a website? Import your content here."
* Select "Have an import file?"
* Select one of the importers from the list.
* Choose a domain, and complete signup.
* Verify that after signup, your site title is generated based on the domain you selected.
* Start again from `/start` and select  "Already have a website? Import your content here."
* Enter any URL belonging to a page that has a title and continue.
* If the engine wasn't detected, select any engine (it shouldn't matter, the title should still be persisted).
* Complete signup and verify that your site title is generated based on the URL you entered in the importing step.

Fixes #35582 
