### PR TITLE
Fix/e2e/remove purchase

### DIFF
--- a/test/e2e/lib/components/notices-component.js
+++ b/test/e2e/lib/components/notices-component.js
@@ -51,7 +51,11 @@ export default class NoticesComponent extends AsyncBaseContainer {
 
 	async dismissNotice() {
 		const selector = By.css( '.notice.is-dismissable .notice__dismiss' );
-		await driverHelper.waitTillPresentAndDisplayed( this.driver, selector );
+		await driverHelper.waitTillPresentAndDisplayed(
+			this.driver,
+			selector,
+			this.explicitWaitMS * 3
+		);
 		return await driverHelper.clickWhenClickable( this.driver, selector );
 	}
 }

--- a/test/e2e/lib/flows/delete-plan-flow.js
+++ b/test/e2e/lib/flows/delete-plan-flow.js
@@ -41,7 +41,13 @@ export default class DeletePlanFlow {
 				await cancelPurchasePage.chooseCancelPlanAndDomain();
 			}
 			await cancelPurchasePage.clickCancelPurchase();
-			await cancelPurchasePage.completeCancellationSurvey();
+
+			if ( planName === 'theme' ) {
+				await cancelPurchasePage.completeThemeCancellation();
+			} else {
+				await cancelPurchasePage.completeCancellationSurvey();
+			}
+
 			const noticesComponent = await NoticesComponent.Expect( this.driver );
 			return await noticesComponent.dismissNotice();
 		} )().catch( err => {

--- a/test/e2e/lib/pages/cancel-purchase-page.js
+++ b/test/e2e/lib/pages/cancel-purchase-page.js
@@ -70,4 +70,12 @@ export default class CancelPurchasePage extends AsyncBaseContainer {
 			by.css( `${ buttonDialogClass } button[data-e2e-button="cancel"]` )
 		);
 	}
+
+	async completeThemeCancellation() {
+		const buttonDialogClass = '.dialog__action-buttons';
+		const cancelButtonSelector = by.css(
+			`${ buttonDialogClass } button[data-e2e-button="cancel"]`
+		);
+		return await driverHelper.clickWhenClickable( this.driver, cancelButtonSelector );
+	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Some errors in delete plan flow are still happening after https://github.com/Automattic/wp-calypso/pull/35603 has been merged. I tried locally Sign up tests and addressed two issues:
- After canceling purchase sometimes more time is needed to finish the process. [Increase timeout to 60s](https://github.com/Automattic/wp-calypso/commit/530bf3a9c849772689b672f8d8c26c94af4c4fcc) should resolve this issue 
- At the end of the test `Sign up while purchasing premium theme in AUD currency @parallel @email` purchased theme should be canceled. The flow here is a little bit different than canceling a plan, and we used the same flow for both things. That's why canceling theme purchase didn't work and we didn't catch it since we are raising a warning if it fails on this step. [`completeThemeCancellation()`](https://github.com/Automattic/wp-calypso/commit/0343e7a36918ffa84bf0e9fd7fa6423b7f9df630) should resolve this issue. 

#### Testing instructions

Make sure that tests are green in CircleCI. If you're running locally Sign up tests make sure that there are no errors when canceling plans and accounts. 

