### PR TITLE
Threat Alerts: Add tracks events on fix and ignore buttons

### DIFF
--- a/client/my-sites/activity/activity-log/threat-alert.jsx
+++ b/client/my-sites/activity/activity-log/threat-alert.jsx
@@ -25,6 +25,7 @@ import SplitButton from 'components/split-button';
 import { fixThreatAlert, ignoreThreatAlert } from 'state/jetpack/site-alerts/actions';
 import { requestRewindState } from 'state/rewind/actions';
 import { getSelectedSiteSlug } from 'state/ui/selectors';
+import { recordTracksEvent, withAnalytics } from 'state/analytics/actions';
 
 /**
  * Style dependencies
@@ -36,12 +37,12 @@ export class ThreatAlert extends Component {
 
 	handleFix = () => {
 		this.setState( { requesting: true } );
-		this.props.fixThreatAlert( this.props.siteId, this.props.threat.id );
+		this.props.fixThreat( this.props.siteId, this.props.threat.id );
 	};
 
 	handleIgnore = () => {
 		this.setState( { requesting: true } );
-		this.props.ignoreThreatAlert( this.props.siteId, this.props.threat.id );
+		this.props.ignoreThreat( this.props.siteId, this.props.threat.id );
 	};
 
 	refreshRewindState = () => this.props.requestRewindState( this.props.siteId );
@@ -395,8 +396,16 @@ const mapStateToProps = state => ( {
 export default connect(
 	mapStateToProps,
 	{
-		fixThreatAlert,
-		ignoreThreatAlert,
+		fixThreat: ( siteId, threatId ) =>
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_threat_fix', { threat_id: threatId } ),
+				fixThreatAlert( siteId, threatId )
+			),
+		ignoreThreat: ( siteId, threatId ) =>
+			withAnalytics(
+				recordTracksEvent( 'calypso_activitylog_threat_ignore', { threat_id: threatId } ),
+				ignoreThreatAlert( siteId, threatId )
+			),
 		requestRewindState,
 	}
 )( localize( ThreatAlert ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR will fire two new tracks events on button click, titled `calypso_activitylog_threat_fix` and `calypso_activitylog_threat_ignore`. The tracks will carry the threat ID.

#### Testing instructions

* For a site with active threats, ensure that the tracks events described above fire when the `Ignore` or `Fix Threat` buttons are clicked.
