### PR TITLE
Button: remove 'block' prop and its usage in 2FA login UI

### DIFF
--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -68,13 +68,13 @@ class TwoFactorActions extends Component {
 		return (
 			<Card className="two-factor-authentication__actions">
 				{ isSmsAvailable && (
-					<Button block data-e2e-link="2fa-sms-link" onClick={ this.sendSmsCode }>
+					<Button data-e2e-link="2fa-sms-link" onClick={ this.sendSmsCode }>
 						{ translate( 'Send code via\u00A0text\u00A0message' ) }
 					</Button>
 				) }
 
 				{ isAuthenticatorAvailable && (
-					<Button block data-e2e-link="2fa-otp-link" onClick={ this.recordAuthenticatorLinkClick }>
+					<Button data-e2e-link="2fa-otp-link" onClick={ this.recordAuthenticatorLinkClick }>
 						{ translate( 'Continue with your authenticator\u00A0app' ) }
 					</Button>
 				) }

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.scss
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.scss
@@ -1,7 +1,11 @@
 .two-factor-authentication__actions.card {
 	margin-bottom: 0;
 
-	.button:not( :first-child ) {
-		margin-top: 20px;
+	.button {
+		width: 100%;
+
+		&:not( :first-child ) {
+			margin-top: 20px;
+		}
 	}
 }

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -143,7 +143,7 @@ class VerificationCodeForm extends Component {
 
 		return (
 			<form onSubmit={ this.onSubmitForm }>
-				<Card compact>
+				<Card compact className="two-factor-authentication__verification-code-form">
 					<p>{ helpText }</p>
 
 					<FormFieldset>
@@ -164,7 +164,7 @@ class VerificationCodeForm extends Component {
 						) }
 					</FormFieldset>
 
-					<FormButton block primary disabled={ this.state.isDisabled }>
+					<FormButton primary disabled={ this.state.isDisabled }>
 						{ translate( 'Continue' ) }
 					</FormButton>
 

--- a/client/blocks/login/two-factor-authentication/verification-code-form.scss
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.scss
@@ -3,3 +3,7 @@
 	font-size: 11px;
 	padding: 1em 0;
 }
+
+.two-factor-authentication__verification-code-form .button {
+	width: 100%;
+}

--- a/client/components/button/docs/example.jsx
+++ b/client/components/button/docs/example.jsx
@@ -171,19 +171,6 @@ class Buttons extends React.PureComponent {
 						<span>Primary scary busy button</span>
 					</Button>
 				</div>
-				<div className="docs__design-button-row">
-					<Button block>Button</Button>
-					<Button block>
-						<Gridicon icon="heart" />
-						<span>Icon button</span>
-					</Button>
-					<Button block>
-						<Gridicon icon="plugins" />
-					</Button>
-					<Button block disabled>
-						Disabled button
-					</Button>
-				</div>
 			</Card>
 		),
 	};

--- a/client/components/button/index.jsx
+++ b/client/components/button/index.jsx
@@ -29,7 +29,6 @@ export default class Button extends PureComponent {
 			'is-primary': this.props.primary,
 			'is-scary': this.props.scary,
 			'is-busy': this.props.busy,
-			'is-block': this.props.block,
 			'is-borderless': this.props.borderless,
 		} );
 

--- a/client/components/button/style.scss
+++ b/client/components/button/style.scss
@@ -127,11 +127,6 @@ button {
 			var( --color-neutral-0 ) 72%
 		);
 	}
-
-	&.is-block {
-		display: block;
-		width: 100%;
-	}
 }
 
 // Primary buttons


### PR DESCRIPTION
The `block` prop was added in #33940 while working in 2FA UI improvements. But the `@wordpress/components` button doesn't support `block` and it's not a good fit for `Button` either: it doesn't style the `Button` internals, but rather its external layout (i.e., how it's positioned in the parent element)

This PR removes the `block` prop and replaces its usage with `width: 100%` at a few places in the 2FA UI. In the end, the `display: block` wasn't even necessary.

**How to test:**
Verify that the buttons have full width in the 2FA UI:

Alt actions in the "waiting for mobile notification" screen:
<img width="406" alt="Screenshot 2019-08-21 at 11 58 33" src="https://user-images.githubusercontent.com/664258/63459447-d452bd80-c454-11e9-899c-afd570f457af.png">

"Continue" button in the OTP code form:
<img width="406" alt="Screenshot 2019-08-21 at 11 58 16" src="https://user-images.githubusercontent.com/664258/63459496-ef253200-c454-11e9-9929-0cc615247148.png">
