### PR TITLE
Full Site Editing: account for `-wpcom` suffixes on dotorg installs

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -94,6 +94,7 @@ class Full_Site_Editing {
 	 * @return bool True if passed theme supports FSE, false otherwise.
 	 */
 	public function is_supported_theme( $theme_slug ) {
+		$theme_slug = $this->normalize_theme_slug( $theme_slug );
 		return in_array( $theme_slug, self::SUPPORTED_THEMES, true );
 	}
 
@@ -132,6 +133,9 @@ class Full_Site_Editing {
 	public function normalize_theme_slug( $theme_slug ) {
 		if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
 			$theme_slug = str_replace( 'pub/', '', $theme_slug );
+		}
+		if ( '-wpcom' === substr( $theme_slug, -6, 6 ) ) {
+			$theme_slug = preg_replace( '#-wpcom$#', '', $theme_slug );
 		}
 
 		return $theme_slug;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -123,7 +123,7 @@ class Full_Site_Editing {
 	 * Returns normalized theme slug for the current theme.
 	 *
 	 * Normalize WP.com theme slugs that differ from those that we'll get on self hosted sites.
-	 * For example, we will get 'modern-business' when retrieving theme slug on self hosted sites,
+	 * For example, we will get 'modern-business-wpcom' when retrieving theme slug on self hosted sites,
 	 * but due to WP.com setup, on Simple sites we'll get 'pub/modern-business' for the theme.
 	 *
 	 * @param string $theme_slug Theme slug to check support for.
@@ -132,10 +132,11 @@ class Full_Site_Editing {
 	 */
 	public function normalize_theme_slug( $theme_slug ) {
 		if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
-			$theme_slug = str_replace( 'pub/', '', $theme_slug );
+			$theme_slug = substr( $theme_slug, 4 );
 		}
+
 		if ( '-wpcom' === substr( $theme_slug, -6, 6 ) ) {
-			$theme_slug = preg_replace( '#-wpcom$#', '', $theme_slug );
+			$theme_slug = substr( $theme_slug, 0, -6 );
 		}
 
 		return $theme_slug;

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/templates/class-wp-template.php
@@ -50,7 +50,7 @@ class WP_Template {
 	 * Returns normalized theme slug for the current theme.
 	 *
 	 * Normalize WP.com theme slugs that differ from those that we'll get on self hosted sites.
-	 * For example, we will get 'modern-business' when retrieving theme slug on self hosted sites,
+	 * For example, we will get 'modern-business-wpcom' when retrieving theme slug on self hosted sites,
 	 * but due to WP.com setup, on Simple sites we'll get 'pub/modern-business' for the theme.
 	 *
 	 * @param string $theme_slug Theme slug to check support for.
@@ -59,7 +59,11 @@ class WP_Template {
 	 */
 	public function normalize_theme_slug( $theme_slug ) {
 		if ( 'pub/' === substr( $theme_slug, 0, 4 ) ) {
-			$theme_slug = str_replace( 'pub/', '', $theme_slug );
+			$theme_slug = substr( $theme_slug, 4 );
+		}
+
+		if ( '-wpcom' === substr( $theme_slug, -6, 6 ) ) {
+			$theme_slug = substr( $theme_slug, 0, -6 );
 		}
 
 		return $theme_slug;


### PR DESCRIPTION
Themes installed from wpcom on dotorg installs will receive a `-wpcom` suffix and fail this check. Now they won't.

#### Testing instructions

1. Get this branch installed and activated as a plugin on a dotorg site.
1. Download Modern Business to your dotorg site. [direct link](https://public-api.wordpress.com/rest/v1/themes/download/modern-business.zip)
2. Activate Modern Business in wp-admin
3. In a `wp shell` session on your dotorg site, verify that the following returns `true`:

```
\A8C\FSE\Full_Site_Editing::get_instance()->is_supported_theme( get_stylesheet() )
```

This is needed for https://github.com/Automattic/jetpack/pull/13196