### PR TITLE
Customer Home: Update My Sites link to /home where appropriate 

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -27,7 +27,8 @@ import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug, canCurrentUserUseCustomerHome } from 'state/sites/selectors';
+import { getSiteSlug } from 'state/sites/selectors';
+import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 import { getStatsPathForTab } from 'lib/route';
 import { domainManagementList } from 'my-sites/domains/paths';
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -27,7 +27,7 @@ import isDomainOnlySite from 'state/selectors/is-domain-only-site';
 import isNotificationsOpen from 'state/selectors/is-notifications-open';
 import { setNextLayoutFocus } from 'state/ui/layout-focus/actions';
 import { getSelectedSiteId } from 'state/ui/selectors';
-import { getSiteSlug } from 'state/sites/selectors';
+import { getSiteSlug, canCurrentUserUseCustomerHome } from 'state/sites/selectors';
 import { getStatsPathForTab } from 'lib/route';
 import { domainManagementList } from 'my-sites/domains/paths';
 
@@ -82,10 +82,17 @@ class MasterbarLoggedIn extends React.Component {
 	};
 
 	renderMySites() {
-		const { domainOnlySite, hasMoreThanOneSite, siteSlug, translate } = this.props,
-			mySitesUrl = domainOnlySite
-				? domainManagementList( siteSlug )
-				: getStatsPathForTab( 'day', siteSlug );
+		const {
+				domainOnlySite,
+				hasMoreThanOneSite,
+				siteSlug,
+				translate,
+				isCustomerHomeEnabled,
+			} = this.props,
+			homeUrl = isCustomerHomeEnabled
+				? `/home/${ siteSlug }`
+				: getStatsPathForTab( 'day', siteSlug ),
+			mySitesUrl = domainOnlySite ? domainManagementList( siteSlug ) : homeUrl;
 
 		return (
 			<Item
@@ -176,6 +183,7 @@ export default connect(
 		const siteId = getSelectedSiteId( state ) || getPrimarySiteId( state );
 
 		return {
+			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
 			siteSlug: getSiteSlug( state, siteId ),
 			domainOnlySite: isDomainOnlySite( state, siteId ),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

When it's available, the 'My Sites' link should now go to the customer home page, rather than the stats page as it does currently

#### Testing instructions

With sites both eligible for the customer home page and not, check that the 'My Sites' link is set to '/home/<site slug` for eligible sites, and `/stats/day/<site slug>` otherwise. 