### PR TITLE
Checklist: use always the home icon

### DIFF
--- a/client/my-sites/sidebar/sidebar.jsx
+++ b/client/my-sites/sidebar/sidebar.jsx
@@ -192,7 +192,7 @@ export class MySitesSidebar extends Component {
 				) }
 				link={ isEnabled( 'customer-home' ) ? '/home' + siteSuffix : '/checklist' + siteSuffix }
 				onNavigate={ this.trackCustomerHomeClick }
-				materialIcon={ isEnabled( 'customer-home' ) ? 'home' : 'check_circle' }
+				materialIcon={ 'home' }
 			/>
 		);
 	}


### PR DESCRIPTION
The home icon will be the only icon used, regardless of whether the user sees checklist or home.
This also helps differentiating it from the Followed Sites icon in the Reader.

#### Changes proposed in this Pull Request

* always use the home icon

#### Testing instructions

* verify that the Checklist for any site uses the Home icon, not the checklist icon.

Fixes #35635
