### PR TITLE
Revert A/B tests that removed `/start/blog` and `/start/website/` flows

### DIFF
--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -143,22 +143,4 @@ export default {
 		defaultVariation: 'hide',
 		allowExistingUsers: true,
 	},
-	removeBlogFlow: {
-		datestamp: '20190813',
-		variations: {
-			remove: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
-	removeWebsiteFlow: {
-		datestamp: '20190813',
-		variations: {
-			remove: 50,
-			control: 50,
-		},
-		defaultVariation: 'control',
-		allowExistingUsers: true,
-	},
 };

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -38,7 +38,6 @@ import SignupHeader from 'signup/signup-header';
 import QuerySiteDomains from 'components/data/query-site-domains';
 
 // Libraries
-import { abtest } from 'lib/abtest';
 import analytics from 'lib/analytics';
 import * as oauthToken from 'lib/oauth-token';
 import { isDomainRegistration, isDomainTransfer, isDomainMapping } from 'lib/products-values';
@@ -161,18 +160,6 @@ class Signup extends React.Component {
 			const destinationStep = flows.getFlow( this.props.flowName ).steps[ 0 ];
 			this.setState( { resumingStep: destinationStep } );
 			return page.redirect( getStepUrl( this.props.flowName, destinationStep, this.props.locale ) );
-		}
-
-		if ( 'remove' === abtest( 'removeBlogFlow' ) && 'blog' === this.props.flowName ) {
-			const destinationStep = flows.getFlow( 'onboarding' ).steps[ 0 ];
-			this.setState( { resumingStep: destinationStep } );
-			return page.redirect( getStepUrl( 'onboarding', destinationStep, this.props.locale ) );
-		}
-
-		if ( 'remove' === abtest( 'removeWebsiteFlow' ) && 'website' === this.props.flowName ) {
-			const destinationStep = flows.getFlow( 'onboarding' ).steps[ 0 ];
-			this.setState( { resumingStep: destinationStep } );
-			return page.redirect( getStepUrl( 'onboarding', destinationStep, this.props.locale ) );
 		}
 
 		this.recordStep();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Revert A/B tests that effectively removed the `/start/blog` and `/start/website` flows by redirecting those flows to the main onboarding flow (#35321)

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/start/blog and after logging in you should see the older `blog-themes` step, e.g. http://calypso.localhost:3000/start/blog/blog-themes
* Complete a signup and the site should be created with one of the older themes (e.g. Independent Publisher)
* Go to http://calypso.localhost:3000/start/website and after logging in you should see the older `website-themes` step, e.g. http://calypso.localhost:3000/start/website/website-themes
* Complete a signup and the site should be created with one of the older themes (e.g. Radcliffe 2)

Reverts #35321
