### PR TITLE
Draggable: Add types, remove propTypes and lodash

### DIFF
--- a/client/components/draggable/index.tsx
+++ b/client/components/draggable/index.tsx
@@ -83,13 +83,14 @@ export default class Draggable extends Component< Props & DivProps, State > {
 	relativePos: { x: number; y: number } | null = null;
 	mousePos: { x: number; y: number } | null = null;
 
-	componentWillReceiveProps( newProps: Draggable['props'] ) {
-		if ( this.state.x !== newProps.x || this.state.y !== newProps.y ) {
-			this.setState( {
-				x: newProps.x,
-				y: newProps.y,
-			} );
+	static getDerivedStateFromProps( props: Draggable['props'], state: State ) {
+		if ( state.x !== props.x || state.y !== props.y ) {
+			return {
+				x: props.x,
+				y: props.y,
+			};
 		}
+		return null;
 	}
 
 	componentWillUnmount() {

--- a/client/components/draggable/index.tsx
+++ b/client/components/draggable/index.tsx
@@ -1,33 +1,33 @@
-/** @format */
-
 /**
  * External dependencies
  */
+import React, { Component, CSSProperties } from 'react';
 
-import PropTypes from 'prop-types';
-import React, { Component } from 'react';
-import { noop, omit } from 'lodash';
+interface Props {
+	onDrag: ( x: number, y: number ) => void;
+	onStop: () => void;
+	width?: number;
+	height?: number;
+	x: number;
+	y: number;
+	controlled: boolean;
+	bounds: {
+		top: number;
+		left: number;
+		bottom: number;
+		right: number;
+	} | null;
+}
 
-export default class Draggable extends Component {
-	static propTypes = {
-		onDrag: PropTypes.func,
-		onStop: PropTypes.func,
-		width: PropTypes.number,
-		height: PropTypes.number,
-		x: PropTypes.number,
-		y: PropTypes.number,
-		controlled: PropTypes.bool,
-		bounds: PropTypes.shape( {
-			top: PropTypes.number,
-			left: PropTypes.number,
-			bottom: PropTypes.number,
-			right: PropTypes.number,
-		} ),
-	};
+interface State {
+	x: number;
+	y: number;
+}
 
-	static defaultProps = {
-		onDrag: noop,
-		onStop: noop,
+export default class Draggable extends Component< Props, State > {
+	static defaultProps: Props = {
+		onDrag: () => {},
+		onStop: () => {},
 		width: 0,
 		height: 0,
 		x: 0,
@@ -36,7 +36,7 @@ export default class Draggable extends Component {
 		bounds: null,
 	};
 
-	constructor( props ) {
+	constructor( props: Props ) {
 		super( props );
 
 		this.state = {
@@ -53,7 +53,7 @@ export default class Draggable extends Component {
 		this.update = this.update.bind( this );
 	}
 
-	componentWillReceiveProps( newProps ) {
+	componentWillReceiveProps( newProps: Props ) {
 		if ( this.state.x !== newProps.x || this.state.y !== newProps.y ) {
 			this.setState( {
 				x: newProps.x,
@@ -161,16 +161,15 @@ export default class Draggable extends Component {
 	removeListeners() {
 		document.removeEventListener( 'mousemove', this.draggingHandler );
 		document.removeEventListener( 'mouseup', this.draggingEndedHandler );
-
 		document.removeEventListener( 'touchmove', this.draggingHandler );
 		document.removeEventListener( 'touchend', this.draggingEndedHandler );
 	}
 
 	render() {
-		const elementProps = omit( this.props, Object.keys( this.constructor.propTypes ) ),
-			style = {
-				transform: 'translate(' + this.state.x + 'px, ' + this.state.y + 'px)',
-			};
+		const { onDrag, onStop, width, height, x, y, controlled, bounds, ...elementProps } = this.props;
+		const style: CSSProperties = {
+			transform: 'translate(' + this.state.x + 'px, ' + this.state.y + 'px)',
+		};
 
 		if ( this.props.width || this.props.height ) {
 			style.width = this.props.width + 'px';

--- a/client/components/draggable/index.tsx
+++ b/client/components/draggable/index.tsx
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import React, { Component, CSSProperties, TouchEventHandler, MouseEventHandler } from 'react';
+import React, {
+	Component,
+	ComponentProps,
+	CSSProperties,
+	MouseEventHandler,
+	TouchEventHandler,
+} from 'react';
 
 interface Props {
 	onDrag: ( x: number, y: number ) => void;
@@ -53,8 +59,10 @@ function isEventWithTouches( event: HasTouches | HasPageCoords ): event is HasTo
 	);
 }
 
-export default class Draggable extends Component< Props, State > {
-	static defaultProps: Props = {
+type DivProps = Omit< ComponentProps< 'div' >, 'style' | 'onMouseDown' | 'onTouchStart' >;
+
+export default class Draggable extends Component< Props & DivProps, State > {
+	static defaultProps = {
 		onDrag: () => {},
 		onStop: () => {},
 		width: 0,
@@ -75,7 +83,7 @@ export default class Draggable extends Component< Props, State > {
 	relativePos: { x: number; y: number } | null = null;
 	mousePos: { x: number; y: number } | null = null;
 
-	componentWillReceiveProps( newProps: Props ) {
+	componentWillReceiveProps( newProps: Draggable['props'] ) {
 		if ( this.state.x !== newProps.x || this.state.y !== newProps.y ) {
 			this.setState( {
 				x: newProps.x,
@@ -184,7 +192,8 @@ export default class Draggable extends Component< Props, State > {
 	}
 
 	render() {
-		const { onDrag, onStop, width, height, x, y, controlled, bounds, ...elementProps } = this.props;
+		// Discard "our" props and leave divProps for the div
+		const { onDrag, onStop, width, height, x, y, controlled, bounds, ...divProps } = this.props;
 		const style: CSSProperties = {
 			transform: 'translate(' + this.state.x + 'px, ' + this.state.y + 'px)',
 		};
@@ -197,7 +206,7 @@ export default class Draggable extends Component< Props, State > {
 		return (
 			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 			<div
-				{ ...elementProps }
+				{ ...divProps }
 				style={ style }
 				onMouseDown={ this.onMouseDownHandler }
 				onTouchStart={ this.onTouchStartHandler }

--- a/client/components/draggable/index.tsx
+++ b/client/components/draggable/index.tsx
@@ -72,7 +72,7 @@ export default class Draggable extends Component< Props, State > {
 
 	dragging: boolean = false;
 	frameRequestId: ReturnType< typeof requestAnimationFrame > | null = null;
-	relativePos?: { x: number; y: number };
+	relativePos: { x: number; y: number } | null = null;
 	mousePos: { x: number; y: number } | null = null;
 
 	componentWillReceiveProps( newProps: Props ) {
@@ -115,8 +115,9 @@ export default class Draggable extends Component< Props, State > {
 	draggingHandler = ( event: TouchEvent | MouseEvent ) => {
 		const coords = isEventWithTouches( event ) ? event.touches[ 0 ] : event;
 
-		const x = coords.pageX - this.relativePos.x;
-		const y = coords.pageY - this.relativePos.y;
+		// draggingStartedHandler populates `relativePos` and it should not be undefined.
+		const x = coords.pageX - ( this.relativePos as NonNullable< Draggable['relativePos'] > ).x;
+		const y = coords.pageY - ( this.relativePos as NonNullable< Draggable['relativePos'] > ).y;
 
 		this.mousePos = { x, y };
 	};
@@ -124,6 +125,7 @@ export default class Draggable extends Component< Props, State > {
 	draggingEndedHandler = () => {
 		this.dragging = false;
 		this.mousePos = null;
+		this.relativePos = null;
 
 		this.cancelRaf();
 		this.removeListeners();
@@ -133,19 +135,19 @@ export default class Draggable extends Component< Props, State > {
 	onTouchStartHandler: TouchEventHandler< HTMLDivElement > = event => {
 		event.preventDefault();
 
+		// Call draggingStartedHandler first
+		this.draggingStartedHandler( event );
 		document.addEventListener( 'touchmove', this.draggingHandler );
 		document.addEventListener( 'touchend', this.draggingEndedHandler );
-
-		this.draggingStartedHandler( event );
 	};
 
 	onMouseDownHandler: MouseEventHandler< HTMLDivElement > = event => {
 		event.preventDefault();
 
+		// Call draggingStartedHandler first
+		this.draggingStartedHandler( event );
 		document.addEventListener( 'mousemove', this.draggingHandler );
 		document.addEventListener( 'mouseup', this.draggingEndedHandler );
-
-		this.draggingStartedHandler( event );
 	};
 
 	update = () => {

--- a/client/components/draggable/index.tsx
+++ b/client/components/draggable/index.tsx
@@ -195,6 +195,7 @@ export default class Draggable extends Component< Props, State > {
 		}
 
 		return (
+			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 			<div
 				{ ...elementProps }
 				style={ style }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Convert `Draggable` component to TypeScript
* Add necessary typings and address issues that surfaced
* Remove lodash usage
* Remove direct access to `propTypes`
* Replace `componentWillUpdate` with `static getDerivedStateFromProps`

#### Testing instructions

* The Draggable component should work exactly as before. No functional changes.
* `Draggable` appears to be used exclusively in the image editor, specifically image editor crop:
  https://github.com/Automattic/wp-calypso/blob/6eecb98efbedb46b07057067719ef8d4001738c2/client/blocks/image-editor/image-editor-crop.jsx#L402-L477
* You can test the image editor
  * via devdocs: https://calypso.live/devdocs/blocks/image-editor?branch=type/draggable
  * By editing media https://calypso.live/media?branch=type/draggable
