### PR TITLE
Jetpack premium blocks: Pass plan_upgraded param to iframeUrl

### DIFF
--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -594,6 +594,7 @@ const mapStateToProps = (
 
 	let queryArgs = pickBy( {
 		// plan_upgraded required by a JP premium blocks extension (currently known as upgrade nudge).
+		// Respective JP PR: https://github.com/Automattic/jetpack/pull/13281.
 		plan_upgraded: initialQueryArguments && initialQueryArguments.plan_upgraded,
 		post: postId,
 		action: postId && 'edit', // If postId is set, open edit view.

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -593,6 +593,7 @@ const mapStateToProps = (
 	const initialQueryArguments = getInitialQueryArguments( state );
 
 	let queryArgs = pickBy( {
+		// plan_upgraded required by a JP premium blocks extension (currently known as upgrade nudge).
 		plan_upgraded: initialQueryArguments && initialQueryArguments.plan_upgraded,
 		post: postId,
 		action: postId && 'edit', // If postId is set, open edit view.

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -581,6 +581,8 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	}
 }
 
+import { parse as parseUrl } from 'url';
+
 const mapStateToProps = (
 	state,
 	{ postId, postType, duplicatePostId, fseParentPageId }: Props
@@ -590,7 +592,17 @@ const mapStateToProps = (
 	const postTypeTrashUrl = getPostTypeTrashUrl( state, postType );
 	const siteOption = isJetpackSite( state, siteId ) ? 'jetpack_frame_nonce' : 'frame_nonce';
 
+	let plan_upgraded;
+	if ( undefined !== typeof window && window.location ) {
+		const { query } = parseUrl( window.location.href, true );
+
+		if ( query.plan_upgraded ) {
+			plan_upgraded = query.plan_upgraded;
+		}
+	}
+
 	let queryArgs = pickBy( {
+		plan_upgraded,
 		post: postId,
 		action: postId && 'edit', // If postId is set, open edit view.
 		post_type: postType !== 'post' && postType, // Use postType if it's different than post.

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -28,6 +28,7 @@ import { addQueryArgs } from 'lib/route';
 import { getEnabledFilters, getDisabledDataSources, mediaCalypsoToGutenberg } from './media-utils';
 import { replaceHistory, setRoute, navigate } from 'state/ui/actions';
 import getCurrentRoute from 'state/selectors/get-current-route';
+import getInitialQueryArguments from 'state/selectors/get-initial-query-arguments';
 import getPostTypeTrashUrl from 'state/selectors/get-post-type-trash-url';
 import getPostTypeAllPostsUrl from 'state/selectors/get-post-type-all-posts-url';
 import getGutenbergEditorUrl from 'state/selectors/get-gutenberg-editor-url';
@@ -581,8 +582,6 @@ class CalypsoifyIframe extends Component< Props & ConnectedProps & ProtectedForm
 	}
 }
 
-import { parse as parseUrl } from 'url';
-
 const mapStateToProps = (
 	state,
 	{ postId, postType, duplicatePostId, fseParentPageId }: Props
@@ -591,18 +590,10 @@ const mapStateToProps = (
 	const currentRoute = getCurrentRoute( state );
 	const postTypeTrashUrl = getPostTypeTrashUrl( state, postType );
 	const siteOption = isJetpackSite( state, siteId ) ? 'jetpack_frame_nonce' : 'frame_nonce';
-
-	let plan_upgraded;
-	if ( undefined !== typeof window && window.location ) {
-		const { query } = parseUrl( window.location.href, true );
-
-		if ( query.plan_upgraded ) {
-			plan_upgraded = query.plan_upgraded;
-		}
-	}
+	const initialQueryArguments = getInitialQueryArguments( state );
 
 	let queryArgs = pickBy( {
-		plan_upgraded,
+		plan_upgraded: initialQueryArguments && initialQueryArguments.plan_upgraded,
 		post: postId,
 		action: postId && 'edit', // If postId is set, open edit view.
 		post_type: postType !== 'post' && postType, // Use postType if it's different than post.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Related to https://github.com/Automattic/jetpack/pull/13281

Passes the `plan_upgraded` url param to the iframe url, such that it can be processed from the Jetpack extensions that expect it to show a notice (see "testing instructions" below).

**Note:** The solution feels more of a working prototype right now (hopefully). If we agree on the approach, then we can move the logic to own selector, or something of that nature.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test the whole process:

- Apply https://github.com/Automattic/jetpack/pull/13281 to your sandbox
- Start calypso on this branch
- Open the editor and pass the `plan_upgraded=1` param e.g. http://calypso.localhost:3000/block-editor/post/chriskmnds.wordpress.com/3?plan_upgraded=1

The result should be a notice "Plan Upgraded..." shown:

<img width="1427" alt="Screenshot 2019-08-22 at 1 38 04 PM" src="https://user-images.githubusercontent.com/1705499/63508229-3c9bb080-c4e2-11e9-87c7-1abc3acd3c31.png">