### PR TITLE
Full Site Editing: Add Varia and Maywood support

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/class-full-site-editing.php
@@ -44,7 +44,11 @@ class Full_Site_Editing {
 	 *
 	 * @var array
 	 */
-	const SUPPORTED_THEMES = [ 'modern-business' ];
+	const SUPPORTED_THEMES = [
+		'maywood',
+		'modern-business',
+		'varia',
+	];
 
 	/**
 	 * Full_Site_Editing constructor.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Depends on D31833-code

* Add Varia and Maywood themes support for Full Site Editing.

Note: we probably won't need to have Varia here, but only its children themes (like Maywood).
Though, it's easier to test if FSE works on Varia while Maywood is still in development.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D31833-code and sandbox the API.
* Apply https://github.com/Automattic/themes/pull/1309 to the Varia theme on an FSE site.
* On that site, change theme from Modern Business to Varia.
* Edit a page and make sure the template parts are still there in the editor.
* Check `edit.php?post_type=wp_template` and make sure that there are new Header and Footer template parts (although, virtually identical to the Modern Business ones).
* View a page in the front end. It should have the FSE Header and Footer instead of the original Varia template parts.