### PR TITLE
DevDocs: Fix broken links on certain pages

### DIFF
--- a/client/devdocs/blocks/README.md
+++ b/client/devdocs/blocks/README.md
@@ -3,4 +3,4 @@ Blocks
 
 Blocks are React components created from combining UI Components into more complex entities.
 
-Read the [blocks documentation](../client/blocks/README.md) for more in-depth information.
+Read the [blocks documentation](https://github.com/Automattic/wp-calypso/blob/master/client/blocks/README.md) for more in-depth information.

--- a/client/devdocs/design/README.md
+++ b/client/devdocs/design/README.md
@@ -3,4 +3,4 @@ UI Components
 
 These UI Components are simple React components used for composing the UI of Calypso.
 
-Read the [component documentation](../../../docs/components.md) for more in-depth information.
+Read the [component documentation](https://github.com/Automattic/wp-calypso/blob/master/docs/components.md) for more in-depth information.


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* On affected devdocs pages, replace relative urls (on devdocs pages) of markdown files with absolute urls so they do not break when these pages are viewed via https://wpcalypso.wordpress.com/devdocs. For precedent, see [State Selectors README](https://github.com/Automattic/wp-calypso/blob/master/client/devdocs/docs-selectors/README.md).

#### Testing instructions

* Visit the [UI Components](https://wpcalypso.wordpress.com/devdocs/design) page and click **component documentation** link. Currently it redirects to a 404 page, but after the fix it will redirect to the intended page.

* Visit the [Blocks](https://wpcalypso.wordpress.com/devdocs/blocks) page and click **blocks documentation** link. Currently it redirects to a 404 page, but after the fix it will redirect to the intended page.

Fixes #35690

CC @sirreal @retrofox 
