### PR TITLE
Pin the mini-css-extract-plugin RTL fork to exact commit

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -41,7 +41,7 @@
 				"enzyme": "3.10.0",
 				"enzyme-adapter-react-16": "1.14.0",
 				"file-loader": "3.0.1",
-				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
+				"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300d",
 				"node-sass": "4.11.0",
 				"postcss-custom-properties": "8.0.9",
 				"postcss-loader": "3.0.0",
@@ -14902,7 +14902,7 @@
 		},
 		"mini-css-extract-plugin-with-rtl": {
 			"version": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300db7027af8caa9a3015f54a34aec545cc54",
-			"from": "github:Automattic/mini-css-extract-plugin-with-rtl",
+			"from": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300d",
 			"dev": true,
 			"requires": {
 				"loader-utils": "^1.1.0",

--- a/packages/calypso-build/package.json
+++ b/packages/calypso-build/package.json
@@ -55,7 +55,7 @@
 		"enzyme": "3.10.0",
 		"enzyme-adapter-react-16": "1.14.0",
 		"file-loader": "3.0.1",
-		"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl",
+		"mini-css-extract-plugin-with-rtl": "github:Automattic/mini-css-extract-plugin-with-rtl#af1300d",
 		"node-sass": "4.11.0",
 		"postcss-custom-properties": "8.0.9",
 		"postcss-loader": "3.0.0",


### PR DESCRIPTION
Unties our hands to push updates to the forked [Automattic/mini-css-extract-plugin-with-rtl](https://github.com/Automattic/mini-css-extract-plugin-with-rtl) repo and then make a controlled upgrade in Calypso.

**How to test:**
Verify that this PR doesn't change anything at all 😄 The `mini-css-extract-plugin-with-rtl` is already resolved (in the lockfile) to the same commit as we are pinning it to.