### PR TITLE
Re-enable ie11 canaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -673,13 +673,13 @@ workflows:
           requires:
             - wait-calypso-live
           test-flags: '-C -S $CIRCLE_SHA1'
-#      - test-e2e-canary:
-#          name: test-e2e-canary-ie
-#          requires:
-#            - wait-calypso-live
-#          test-flags: '-z -S $CIRCLE_SHA1'
-#          test-target: 'IE11'
-#          slack-webhook: '$SLACK_IE'
+      - test-e2e-canary:
+          name: test-e2e-canary-ie
+          requires:
+            - wait-calypso-live
+          test-flags: '-z -S $CIRCLE_SHA1'
+          test-target: 'IE11'
+          slack-webhook: '$SLACK_IE'
       - test-e2e-canary:
           name: test-e2e-canary-safari
           requires:


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This PR turns the ie11 canary back on to running on every PR. This will make it easier to have some confidence that changes will run in ie11

#### Testing instructions

* Ensure that ie11 canaries run and pass for this branch