### PR TITLE
Full Site Editing: Add an hover transition to the Template block overlay

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/edit.js
@@ -80,7 +80,6 @@ const TemplateEdit = compose(
 		templateTitle,
 		isDirty,
 		savePost,
-		isSelected,
 		isEditorSidebarOpened,
 		openGeneralSidebar,
 		isAnyTemplateBlockSelected,
@@ -136,6 +135,7 @@ const TemplateEdit = compose(
 			<div
 				className={ classNames( 'template-block', {
 					[ `align${ align }` ]: align,
+					'is-navigating-to-template': navigateToTemplate,
 				} ) }
 			>
 				{ templateBlock && (
@@ -152,24 +152,23 @@ const TemplateEdit = compose(
 								/>
 							</div>
 						</Disabled>
-						{ isSelected && (
-							<Placeholder className="template-block__overlay">
-								{ navigateToTemplate && (
-									<div className="template-block__loading">
-										<Spinner /> { sprintf( __( 'Loading %s Editor' ), templateTitle ) }
-									</div>
-								) }
-								<Button
-									className={ navigateToTemplate ? 'hidden' : null }
-									href={ editTemplateUrl }
-									onClick={ save }
-									isDefault
-									ref={ navButton }
-								>
-									{ sprintf( __( 'Edit %s' ), templateTitle ) }
-								</Button>
-							</Placeholder>
-						) }
+						<Placeholder className="template-block__overlay">
+							{ navigateToTemplate && (
+								<div className="template-block__loading">
+									<Spinner /> { sprintf( __( 'Loading %s Editor' ), templateTitle ) }
+								</div>
+							) }
+							<Button
+								className={ navigateToTemplate ? 'hidden' : null }
+								href={ editTemplateUrl }
+								onClick={ save }
+								isDefault
+								isLarge
+								ref={ navButton }
+							>
+								{ sprintf( __( 'Edit %s' ), templateTitle ) }
+							</Button>
+						</Placeholder>
 					</Fragment>
 				) }
 			</div>

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -10,8 +10,24 @@
 		cursor: pointer;
 	}
 
-	&.is-selected .components-disabled {
-		filter: blur( 2px );
+	&.is-hovered, &.is-selected, .is-navigating-to-template {
+		.components-disabled {
+			filter: blur( 2px );
+			transition: filter 0.2s linear 0.7s;
+		}
+		.template-block__overlay {
+			opacity: 1;
+			transition: opacity 0.2s linear;
+			.components-button {
+				opacity: 1;
+				transition: opacity 0.2s linear 0.7s;
+			}
+		}
+	}
+
+	.components-disabled {
+		filter: blur( 0 );
+		transition: filter 0.2s linear 0s;
 	}
 
 	// Hide the block toolbar and border
@@ -38,14 +54,20 @@
 	bottom: 0;
 	left: 0;
 	margin: 0;
+	opacity: 0;
 	padding: 0;
 	position: absolute;
 	right: 0;
+	transition: opacity 0.2s linear 0s;
 	top: 0;
 	z-index: 2;
 
-	.components-button.hidden {
-		display: none;
+	.components-button {
+		opacity: 0;
+		transition: opacity 0.2s linear 0s;
+		&.hidden {
+			display: none;
+		}
 	}
 }
 

--- a/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/full-site-editing/blocks/template/style.scss
@@ -50,7 +50,8 @@
 }
 
 .template-block__overlay {
-	background: rgba( #f5f5f5, 0.8 );
+	background: rgba( #ffffff, 0.8 );
+	border: 0 solid rgba( #7b86a2, 0.3 ); // Gutenberg $dark-opacity-light-600
 	bottom: 0;
 	left: 0;
 	margin: 0;
@@ -61,6 +62,21 @@
 	transition: opacity 0.2s linear 0s;
 	top: 0;
 	z-index: 2;
+
+	.is-selected & {
+		border-color: rgba( #425863, 0.4 ); // Gutenberg $dark-opacity-light-800
+	}
+
+	.editor-block-list__block:first-child & {
+		border-bottom-width: 1px;
+	}
+	.editor-block-list__block:last-child & {
+		border-top-width: 1px;
+	}
+
+	@media only screen and ( min-width: 768px ) {
+		border-width: 1px;
+	}
 
 	.components-button {
 		opacity: 0;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add an hover transition to the Template block overlay.
  * The overlay appears in 0.2 seconds.
  * The button and the blur effect in 0.2 seconds, delayed by 0.7 seconds (as in: 0.5 seconds after the overlay appeared).
* Selecting the block makes the overlay "stick": it doesn't disappear on mouse out.
* Clicking on the "Edit" button makes the overlay "stick" too while the template editor loads.

| Before | After |
| - | - |
| ![Aug-22-2019 16-05-27](https://user-images.githubusercontent.com/2070010/63526634-9c508680-c4f7-11e9-9025-28a640c4c942.gif) | ![Aug-22-2019 18-24-37](https://user-images.githubusercontent.com/2070010/63535851-5650ee00-c50a-11e9-9c5b-4a198bc38fe0.gif) |

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Edit a page on an FSE site.
* Poke around a template part to see if everything works as expected, and the effect feels good.

Fixes #35437
