### PR TITLE
(0P) SPT: Use slug in selector key

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -43,8 +43,8 @@ const TemplateSelectorControl = ( {
 			className={ classnames( className, 'template-selector-control' ) }
 		>
 			<ul className="template-selector-control__options">
-				{ map( templates, ( { slug, title, preview, previewAlt, value } ) => (
-					<li key={ `${ id }-${ value }` } className="template-selector-control__template">
+				{ map( templates, ( { slug, title, preview, previewAlt } ) => (
+					<li key={ `${ id }-${ slug }` } className="template-selector-control__template">
 						<TemplateSelectorItem
 							id={ id }
 							value={ slug }


### PR DESCRIPTION
Fixes an error where multiple children have the same key because `value` was undefined.

See p1566491297048300-slack-ajax


#### Testing instructions

* Load the template selector and make sure the error doesn't show up.