### PR TITLE
SPT: do not rendering preview with zero blocks

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
@@ -12,6 +12,10 @@
 import { BlockPreview } from '@wordpress/block-editor';
 
 const BlockTemplatePreview = ( { blocks, viewportWidth } ) => {
+	if ( ! blocks || ! blocks.length ) {
+		return null;
+	}
+
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<div className="edit-post-visual-editor">


### PR DESCRIPTION
This PR avoids rendering the preview template component when the blocks are not defined or the length is zero.

Issues: https://github.com/Automattic/wp-calypso/issues/35233

### How to test.

Apply the changes and confirm it stills preview the templates in the templates selector modal.