### PR TITLE
SPT: remove artificial previewing time

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -16,39 +16,14 @@ import { Disabled } from '@wordpress/components';
 import BlockPreview from './block-template-preview';
 
 const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
-	// Used to hide the `BlockPreview` until we're confident
-	// it's completed rendering. Ideally there would a way to detect
-	// this but there isn't.
-	const artificialLoadingDelay = 800;
-
-	const previewContainerRef = useRef();
-
-	const [ isLoading, setIsLoading ] = useState( false );
-
-	useEffect( () => {
-		// Reset scroll first to avoid flicker
-		previewContainerRef.current.scrollTop = 0;
-		setIsLoading( true );
-		const timer = setTimeout( () => {
-			setIsLoading( false );
-		}, artificialLoadingDelay );
-
-		return () => {
-			setIsLoading( false );
-			clearTimeout( timer );
-		};
-	}, [ blocks, viewportWidth ] );
-
 	const previewElClasses = classnames(
 		'template-selector-preview',
-		'editor-styles-wrapper', {
-			'is-loaded': ! isLoading,
-		}
+		'editor-styles-wrapper',
 	);
 
 	if ( isEmpty( blocks ) ) {
 		return (
-			<div ref={ previewContainerRef } className={ previewElClasses }>
+			<div className={ previewElClasses }>
 				<div className="template-selector-preview__placeholder">
 					{ __( 'Select a page template to preview.', 'full-site-editing' ) }
 				</div>
@@ -57,10 +32,7 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth } ) => {
 	}
 
 	return (
-		<div ref={ previewContainerRef } className={ previewElClasses }>
-			<div aria-hidden={ ! isLoading } className="template-selector-preview__loading editor-styles-wrapper">
-				{ __( 'Loading preview…', 'full-site-editing' ) }
-			</div>
+		<div className={ previewElClasses }>
 			<Disabled>
 				<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
 			</Disabled>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -229,32 +229,6 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	pointer-events: none;
 	overflow-x: hidden;
 	overflow-y: auto;
-
-	.template-selector-preview__loading {
-		top: 0;
-		position: absolute;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		z-index: 10;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-
-		// Retaining the element in the render tree (ie: avoiding display: none)
-		// avoids reflow/repaint cycle which makes UI more responsive when
-		// loading state is toggled rapidly.
-		// See: https://www.phpied.com/rendering-repaint-reflowrelayout-restyle/.
-		will-change: transform; // tell the browser to expect a change here
-		transform: translate( 0, 0 );
-	}
-
-	&.is-loaded {
-		pointer-events: auto; // reset to allow scrolling loaded previews
-		.template-selector-preview__loading {
-			transform: translate( -9999px, -9999px );
-		}
-	}
 }
 
 .template-selector-preview__placeholder {


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR removes the delay added artificially when it shows the template in the Large preview.

#### Testing

1) Apply the changes
2) create a new page
3) Switch the template clicking on the thumbnails
4) Check the Large preview is rendered faster without showing the `Loading preview…` message.

Issues: https://github.com/Automattic/wp-calypso/issues/35233