### PR TITLE
SPT: immediately render modal with empty thumbnails

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
@@ -14,16 +14,14 @@ import { BlockPreview } from '@wordpress/block-editor';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const BlockTemplatePreview = ( { blocks = [], viewportWidth } ) => {
-	if ( ! blocks || ! blocks.length ) {
-		return null;
-	}
-
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<div className="edit-post-visual-editor">
 			<div className="editor-styles-wrapper">
 				<div className="editor-writing-flow">
-					<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+					<div className="template-selector-item__preview-wrap">
+						<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+					</div>
 				</div>
 			</div>
 		</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
@@ -20,7 +20,11 @@ const BlockTemplatePreview = ( { blocks = [], viewportWidth } ) => {
 			<div className="editor-styles-wrapper">
 				<div className="editor-writing-flow">
 					<div className="template-selector-item__preview-wrap">
-						<BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } />
+						<BlockPreview
+							blocks={ blocks }
+							viewportWidth={ viewportWidth }
+							__experimentalScalingDelay={ 0 }
+						/>
 					</div>
 				</div>
 			</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/block-template-preview.js
@@ -11,23 +11,26 @@
  */
 /* eslint-disable import/no-extraneous-dependencies */
 import { BlockPreview } from '@wordpress/block-editor';
+import { Disabled } from '@wordpress/components';
 /* eslint-enable import/no-extraneous-dependencies */
 
 const BlockTemplatePreview = ( { blocks = [], viewportWidth } ) => {
 	return (
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
-		<div className="edit-post-visual-editor">
-			<div className="editor-styles-wrapper">
-				<div className="editor-writing-flow">
-					<div className="template-selector-item__preview-wrap">
-						<BlockPreview
-							blocks={ blocks }
-							viewportWidth={ viewportWidth }
-							__experimentalScalingDelay={ 0 }
-						/>
+		<div className="template-selector-item__preview-wrap">
+			<Disabled>
+				<div className="editor-styles-wrapper">
+					<div className="edit-post-visual-editor">
+						<div className="editor-writing-flow">
+							<BlockPreview
+								blocks={ blocks }
+								viewportWidth={ viewportWidth }
+								__experimentalScalingDelay={ 0 }
+							/>
+						</div>
 					</div>
 				</div>
-			</div>
+			</Disabled>
 		</div>
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -20,6 +20,7 @@ import { memo } from '@wordpress/element';
  */
 import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
+import { getTemplateBySlug, hasTemplates } from '../utils/templates-parser';
 
 export const TemplateSelectorControl = ( {
 	label,
@@ -27,7 +28,6 @@ export const TemplateSelectorControl = ( {
 	help,
 	instanceId,
 	templates = [],
-	blocksByTemplates = {},
 	useDynamicPreview = false,
 	onTemplateSelect = noop,
 	siteInformation = {},
@@ -38,7 +38,7 @@ export const TemplateSelectorControl = ( {
 		return null;
 	}
 
-	if ( true === useDynamicPreview && isEmpty( blocksByTemplates ) ) {
+	if ( true === useDynamicPreview && ! hasTemplates() ) {
 		return null;
 	}
 
@@ -65,14 +65,11 @@ export const TemplateSelectorControl = ( {
 							onSelect={ onTemplateSelect }
 							staticPreviewImg={ preview }
 							staticPreviewImgAlt={ previewAlt }
-							blocks={ get( blocksByTemplates, [ slug, 'blocks' ], [] ) }
 							useDynamicPreview={ useDynamicPreview }
 							isSelected={ slug === selectedTemplate }
-<<<<<<< HEAD
 							handleTemplateConfirmation={ handleTemplateConfirmation }
-=======
 							isParsing={ get( blocksByTemplates, [ slug, 'isParsing' ], false ) }
->>>>>>> a1f7085... show spinner when still parsing
+							template={ getTemplateBySlug( slug ) }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 /* eslint-disable import/no-extraneous-dependencies */
-import { isEmpty, isArray, noop, map } from 'lodash';
+import { isEmpty, isArray, noop, map, get } from 'lodash';
 /* eslint-enable import/no-extraneous-dependencies */
 import classnames from 'classnames';
 
@@ -65,10 +65,14 @@ export const TemplateSelectorControl = ( {
 							onSelect={ onTemplateSelect }
 							staticPreviewImg={ preview }
 							staticPreviewImgAlt={ previewAlt }
-							blocks={ blocksByTemplates.hasOwnProperty( slug ) ? blocksByTemplates[ slug ] : [] }
+							blocks={ get( blocksByTemplates, [ slug, 'blocks' ], [] ) }
 							useDynamicPreview={ useDynamicPreview }
 							isSelected={ slug === selectedTemplate }
+<<<<<<< HEAD
 							handleTemplateConfirmation={ handleTemplateConfirmation }
+=======
+							isParsing={ get( blocksByTemplates, [ slug, 'isParsing' ], false ) }
+>>>>>>> a1f7085... show spinner when still parsing
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 /* eslint-disable import/no-extraneous-dependencies */
-import { isEmpty, isArray, noop, map, get } from 'lodash';
+import { isEmpty, isArray, noop, map } from 'lodash';
 /* eslint-enable import/no-extraneous-dependencies */
 import classnames from 'classnames';
 
@@ -20,7 +20,6 @@ import { memo } from '@wordpress/element';
  */
 import TemplateSelectorItem from './template-selector-item';
 import replacePlaceholders from '../utils/replace-placeholders';
-import { getTemplateBySlug, hasTemplates } from '../utils/templates-parser';
 
 export const TemplateSelectorControl = ( {
 	label,
@@ -35,10 +34,6 @@ export const TemplateSelectorControl = ( {
 	handleTemplateConfirmation = noop,
 } ) => {
 	if ( isEmpty( templates ) || ! isArray( templates ) ) {
-		return null;
-	}
-
-	if ( true === useDynamicPreview && ! hasTemplates() ) {
 		return null;
 	}
 
@@ -68,8 +63,6 @@ export const TemplateSelectorControl = ( {
 							useDynamicPreview={ useDynamicPreview }
 							isSelected={ slug === selectedTemplate }
 							handleTemplateConfirmation={ handleTemplateConfirmation }
-							isParsing={ get( blocksByTemplates, [ slug, 'isParsing' ], false ) }
-							template={ getTemplateBySlug( slug ) }
 						/>
 					</li>
 				) ) }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-control.js
@@ -38,7 +38,6 @@ export const TemplateSelectorControl = ( {
 	}
 
 	const id = `template-selector-control-${ instanceId }`;
-
 	return (
 		<BaseControl
 			label={ label }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 /* eslint-disable import/no-extraneous-dependencies */
-import { isNil, isEmpty } from 'lodash';
+import { isNil } from 'lodash';
 /* eslint-enable import/no-extraneous-dependencies */
 import classnames from 'classnames';
 
@@ -22,7 +22,7 @@ const TemplateSelectorItem = props => {
 		value,
 		onSelect,
 		label,
-		useDynamicPreview = false,
+		useDynamicPreview,
 		staticPreviewImg,
 		staticPreviewImgAlt = '',
 		blocks = [],
@@ -38,8 +38,12 @@ const TemplateSelectorItem = props => {
 	const renderInnerPreview = () => {
 		if ( isParsing ) {
 			return (
-				<div className="template-selector-item__preview-wrap is-parsing">
-					<Spinner />;
+				<div className="edit-post-visual-editor">
+					<div className="editor-styles-wrapper">
+						<div className="template-selector-item__preview-wrap is-parsing">
+							<Spinner />;
+						</div>
+					</div>
 				</div>
 			);
 		}
@@ -61,6 +65,7 @@ const TemplateSelectorItem = props => {
 				/>
 			</div>
 		);
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	};
 
 	const labelId = `label-${ id }-${ value }`;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -9,10 +9,12 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { Disabled, Spinner } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import BlockPreview from './block-template-preview';
-/* eslint-disable import/no-extraneous-dependencies */
-import { Disabled } from '@wordpress/components';
-/* eslint-enable import/no-extraneous-dependencies */
 
 const TemplateSelectorItem = props => {
 	const {
@@ -26,28 +28,40 @@ const TemplateSelectorItem = props => {
 		blocks = [],
 		isSelected,
 		handleTemplateConfirmation,
+		isParsing,
 	} = props;
 
 	if ( isNil( id ) || isNil( label ) || isNil( value ) ) {
 		return null;
 	}
 
-	if ( useDynamicPreview && ( isNil( blocks ) || isEmpty( blocks ) ) ) {
-		return null;
-	}
+	const renderInnerPreview = () => {
+		if ( isParsing ) {
+			return (
+				<div className="template-selector-item__preview-wrap is-parsing">
+					<Spinner />;
+				</div>
+			);
+		}
 
-	// Define static or dynamic preview.
-	const innerPreview = useDynamicPreview ? (
-		<Disabled>
-			<BlockPreview blocks={ blocks } viewportWidth={ 960 } />
-		</Disabled>
-	) : (
-		<img
-			className="template-selector-item__media"
-			src={ staticPreviewImg }
-			alt={ staticPreviewImgAlt }
-		/>
-	);
+		if ( useDynamicPreview ) {
+			return (
+				<Disabled>
+					<BlockPreview blocks={blocks} viewportWidth={960}/>
+				</Disabled>
+			);
+		}
+
+		return (
+			<div className="template-selector-item__preview-wrap">
+				<img
+					className="template-selector-item__media"
+					src={ staticPreviewImg }
+					alt={ staticPreviewImgAlt }
+				/>
+			</div>
+		);
+	};
 
 	const labelId = `label-${ id }-${ value }`;
 
@@ -76,7 +90,7 @@ const TemplateSelectorItem = props => {
 			onClick={ handleLabelClick }
 			aria-labelledby={ `${ id } ${ labelId }` }
 		>
-			<div className="template-selector-item__preview-wrap">{ innerPreview }</div>
+			{ renderInnerPreview() }
 			<span className="template-selector-item__template-title" id={ labelId }>
 				{ label }
 			</span>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -31,14 +31,14 @@ const TemplateSelectorItem = props => {
 		handleTemplateConfirmation,
 	} = props;
 	const template = getTemplateBySlug( value );
-	const [ isParsing, setIsParsing ] = useState( template.isParsing );
+	const [ isParsing, setIsParsing ] = useState( true );
 
 	const onTemplatesParseListener = event => {
 		const parsedTemplate = get( event, [ 'detail', 'template' ] );
 		if ( value !== parsedTemplate.slug ) {
 			return;
 		}
-		setIsParsing( parsedTemplate.isParsing );
+		setIsParsing( false );
 	};
 	window.addEventListener( 'onTemplateParse', onTemplatesParseListener );
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -25,24 +25,23 @@ const TemplateSelectorItem = props => {
 		useDynamicPreview,
 		staticPreviewImg,
 		staticPreviewImgAlt = '',
-		blocks = [],
 		isSelected,
 		handleTemplateConfirmation,
-		isParsing,
+		template,
 	} = props;
 
 	if ( isNil( id ) || isNil( label ) || isNil( value ) ) {
 		return null;
 	}
 
+	const { isParsing, isEmpty, blocks } = template;
+
 	const renderInnerPreview = () => {
-		if ( isParsing ) {
+		if ( isParsing && ! isEmpty ) {
 			return (
-				<div className="edit-post-visual-editor">
-					<div className="editor-styles-wrapper">
-						<div className="template-selector-item__preview-wrap is-parsing">
-							<Spinner />;
-						</div>
+				<div className="editor-styles-wrapper">
+					<div className="template-selector-item__preview-wrap is-parsing">
+						<Spinner />;
 					</div>
 				</div>
 			);
@@ -51,7 +50,7 @@ const TemplateSelectorItem = props => {
 		if ( useDynamicPreview ) {
 			return (
 				<Disabled>
-					<BlockPreview blocks={blocks} viewportWidth={960}/>
+					<BlockPreview blocks={ blocks } viewportWidth={ 960 } />
 				</Disabled>
 			);
 		}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-item.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Disabled, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 /* eslint-enable import/no-extraneous-dependencies */
 
@@ -68,11 +68,7 @@ const TemplateSelectorItem = props => {
 		/* eslint-enable wpcalypso/jsx-classname-namespace */
 
 		if ( useDynamicPreview ) {
-			return (
-				<Disabled>
-					<BlockPreview blocks={ getBlocksByTemplateSlug( value ) } viewportWidth={ 960 } />
-				</Disabled>
-			);
+			return <BlockPreview blocks={ getBlocksByTemplateSlug( value ) } viewportWidth={ 960 } />;
 		}
 
 		return (
@@ -105,6 +101,7 @@ const TemplateSelectorItem = props => {
 	};
 
 	return (
+		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		<button
 			type="button"
 			className={ classnames( 'template-selector-item__label', {
@@ -117,9 +114,10 @@ const TemplateSelectorItem = props => {
 		>
 			{ renderInnerPreview() }
 			<span className="template-selector-item__template-title" id={ labelId }>
-				{ label }
+				<div className="editor-styles-wrapper">{ label }</div>
 			</span>
 		</button>
+		/* eslint-enable wpcalypso/jsx-classname-namespace */
 	);
 };
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/components/template-selector-preview.js
@@ -104,7 +104,12 @@ const TemplateSelectorPreview = ( { blocks, viewportWidth, title } ) => {
 					<div className="editor-styles-wrapper" style={ { visibility } }>
 						<div className="editor-writing-flow">
 							<PreviewTemplateTitle title={ title } transform={ transform } />
-							<BlockPreview key={ recompute } blocks={ blocks } viewportWidth={ viewportWidth } />
+							<BlockPreview
+								key={ recompute }
+								blocks={ blocks }
+								viewportWidth={ viewportWidth }
+								__experimentalScalingDelay={ 0 }
+							/>
 						</div>
 					</div>
 				</div>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -42,20 +42,10 @@ const {
 class PageTemplateModal extends Component {
 	state = {
 		isLoading: false,
-		previewedTemplate: null,
+		previewedTemplate: getFirstTemplateSlug(),
 		error: null,
-		isOpen: false,
+		isOpen: hasTemplates(),
 	};
-
-	constructor( props ) {
-		super();
-		this.state.isOpen = hasTemplates();
-
-		if ( this.state.isOpen ) {
-			// Select the first template automatically.
-			this.state.previewedTemplate = getFirstTemplateSlug();
-		}
-	}
 
 	componentDidMount() {
 		if ( this.state.isOpen ) {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -25,6 +25,7 @@ import {
 	getBlocksByTemplateSlug,
 	getTitleByTemplateSlug,
 	hasTemplates,
+	getFirstTemplateSlug,
 } from  './utils/templates-parser';
 
 /* eslint-enable import/no-extraneous-dependencies */
@@ -52,7 +53,7 @@ class PageTemplateModal extends Component {
 
 		if ( this.state.isOpen ) {
 			// Select the first template automatically.
-			this.state.previewedTemplate = get( props.templates, [ 0, 'slug' ] );
+			this.state.previewedTemplate = getFirstTemplateSlug();
 		}
 	}
 

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -33,6 +33,8 @@ const {
 	siteInformation = {},
 } = window.starterPageTemplatesConfig;
 
+const PARSING_TEMPLATE_DELAY = 50;
+
 class PageTemplateModal extends Component {
 	state = {
 		isLoading: false,
@@ -86,7 +88,7 @@ class PageTemplateModal extends Component {
 						}
 					} );
 				} ).bind( null, templates[ i ] ),
-				100 * i
+				PARSING_TEMPLATE_DELAY * i
 			);
 		}
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -60,20 +60,28 @@ class PageTemplateModal extends Component {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}
 
-		// Parse templates blocks and store them into the state.
-		const blocksByTemplateSlug = reduce(
-			templates,
-			( prev, { slug, content } ) => {
-				prev[ slug ] = content
-					? parseBlocks( replacePlaceholders( content, siteInformation ) )
-					: [];
-				return prev;
-			},
-			{}
-		);
+		// Populate the state with parsed blocks
+		// immediately after the modal has been rendered.
+		// Wrapping it in a setTimeout() call,
+		// allows showing the modal with empty thumbnails
+		// before to start to parser and render them
+		// into their preview spots. It reduces the time considerably.
+		setTimeout( () => {
+			// Parse templates blocks and store them into the state.
+			const blocksByTemplateSlug = reduce(
+				templates,
+				( prev, { slug, content } ) => {
+					prev[ slug ] = content
+						? parseBlocks( replacePlaceholders( content, siteInformation ) )
+						: [];
+					return prev;
+				},
+				{}
+			);
 
-		// eslint-disable-next-line react/no-did-mount-set-state
-		this.setState( { blocksByTemplateSlug } );
+			// eslint-disable-next-line react/no-did-mount-set-state
+			this.setState( { blocksByTemplateSlug } );
+		}, 0 );
 	}
 
 	setTemplate = slug => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, reduce, get, keyBy, mapValues } from 'lodash';
+import { isEmpty, get, keyBy, mapValues } from 'lodash';
 import classnames from 'classnames';
 import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
@@ -66,31 +66,29 @@ class PageTemplateModal extends Component {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}
 
-		// Populate the state with parsed blocks
+		// Populate the state with parsed blocks, template by template,
 		// immediately after the modal has been rendered.
 		// Wrapping it in a setTimeout() call,
 		// allows showing the modal with empty thumbnails
 		// before to start to parser and render them
 		// into their preview spots. It reduces the time considerably.
-		setTimeout( () => {
-			// Parse templates blocks and store them into the state.
-			const blocksByTemplateSlug = reduce(
-				templates,
-				( prev, { slug, content } ) => {
-					prev[ slug ] = content
-						? ( {
-							blocks: parseBlocks( replacePlaceholders( content, siteInformation ) ),
-							isParsing: false,
-						} )
-						: ( { blocks: [], isParsing: false } );
-					return prev;
-				},
-				{}
-			);
+		for ( const i in templates ) {
+			setTimeout(
+				( ( { slug, content } ) => {
+					const blocks = content
+						? parseBlocks( replacePlaceholders( content, siteInformation ) )
+						: [];
+					this.setState( {
+						blocksByTemplateSlug: {
+							...this.state.blocksByTemplateSlug,
+							[ slug ]: { blocks, isParsing: false }
+						}
+					} );
 
-			// eslint-disable-next-line react/no-did-mount-set-state
-			this.setState( { blocksByTemplateSlug } );
-		}, 0 );
+				} ).bind( null, templates[ i ] ),
+				50 * i
+			);
+		}
 	}
 
 	setTemplate = slug => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -78,15 +78,15 @@ class PageTemplateModal extends Component {
 					const blocks = content
 						? parseBlocks( replacePlaceholders( content, siteInformation ) )
 						: [];
+
 					this.setState( {
 						blocksByTemplateSlug: {
 							...this.state.blocksByTemplateSlug,
 							[ slug ]: { blocks, isParsing: false }
 						}
 					} );
-
 				} ).bind( null, templates[ i ] ),
-				50 * i
+				100 * i
 			);
 		}
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -39,6 +39,7 @@ class PageTemplateModal extends Component {
 		previewedTemplate: null,
 		blocksByTemplateSlug: {},
 		titlesByTemplateSlug: {},
+		isTemplateParsingBySlug: {},
 		error: null,
 		isOpen: false,
 	};
@@ -52,6 +53,11 @@ class PageTemplateModal extends Component {
 			this.state.previewedTemplate = get( props.templates, [ 0, 'slug' ] );
 			// Extract titles for faster lookup.
 			this.state.titlesByTemplateSlug = mapValues( keyBy( props.templates, 'slug' ), 'title' );
+			// Set initially parsing by slug to `false`.
+			this.state.blocksByTemplateSlug = mapValues(
+				this.state.titlesByTemplateSlug,
+				() => ( { blocks: [], isParsing: true } )
+			);
 		}
 	}
 
@@ -72,8 +78,11 @@ class PageTemplateModal extends Component {
 				templates,
 				( prev, { slug, content } ) => {
 					prev[ slug ] = content
-						? parseBlocks( replacePlaceholders( content, siteInformation ) )
-						: [];
+						? ( {
+							blocks: parseBlocks( replacePlaceholders( content, siteInformation ) ),
+							isParsing: false,
+						} )
+						: ( { blocks: [], isParsing: false } );
 					return prev;
 				},
 				{}
@@ -144,7 +153,7 @@ class PageTemplateModal extends Component {
 	};
 
 	getBlocksByTemplateSlug( slug ) {
-		return get( this.state.blocksByTemplateSlug, [ slug ], [] );
+		return get( this.state.blocksByTemplateSlug, [ slug, 'blocks' ], [] );
 	}
 
 	getTitleByTemplateSlug( slug ) {
@@ -153,6 +162,7 @@ class PageTemplateModal extends Component {
 
 	render() {
 		const { previewedTemplate, isOpen, isLoading, blocksByTemplateSlug } = this.state;
+
 		/* eslint-disable no-shadow */
 		const { templates } = this.props;
 		/* eslint-enable no-shadow */
@@ -186,10 +196,12 @@ class PageTemplateModal extends Component {
 										templates={ templates }
 										blocksByTemplates={ blocksByTemplateSlug }
 										onTemplateSelect={ this.previewTemplate }
-										useDynamicPreview={ false }
+										useDynamicPreview={ true }
 										siteInformation={ siteInformation }
 										selectedTemplate={ previewedTemplate }
 										handleTemplateConfirmation={ this.handleConfirmation }
+										isLoading={ isLoading }
+										isTemplateParsingBySlug={ isTemplateParsingBySlug }
 									/>
 								</fieldset>
 							</form>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -1,8 +1,16 @@
 /* eslint-disable import/no-extraneous-dependencies */
+import {
+	getBlocksByTemplateSlug,
+	getTitleByTemplateSlug,
+	hasTemplates,
+	getFirstTemplateSlug,
+	getTemplates,
+} from './utils/templates-parser';
+
 /**
  * External dependencies
  */
-import { isEmpty, get } from 'lodash';
+import { isEmpty } from 'lodash';
 import classnames from 'classnames';
 import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
@@ -20,19 +28,9 @@ import TemplateSelectorControl from './components/template-selector-control';
 import TemplateSelectorPreview from './components/template-selector-preview';
 import { trackDismiss, trackSelection, trackView, initializeWithIdentity } from './utils/tracking';
 import ensureAssets from './utils/ensure-assets';
-import {
-	getAllTemplatesBlocks,
-	getBlocksByTemplateSlug,
-	getTitleByTemplateSlug,
-	hasTemplates,
-	getFirstTemplateSlug,
-} from  './utils/templates-parser';
-
-/* eslint-enable import/no-extraneous-dependencies */
 
 // Load config passed from backend.
 const {
-	templates = [],
 	vertical,
 	segment,
 	tracksUserData,
@@ -145,7 +143,6 @@ class PageTemplateModal extends Component {
 									<TemplateSelectorControl
 										label={ __( 'Template', 'full-site-editing' ) }
 										templates={ templates }
-										blocksByTemplates={ getAllTemplatesBlocks() }
 										onTemplateSelect={ this.previewTemplate }
 										useDynamicPreview={ true }
 										siteInformation={ siteInformation }
@@ -234,7 +231,7 @@ registerPlugin( 'page-templates', {
 		return (
 			<PageTemplatesPlugin
 				shouldPrefetchAssets={ false }
-				templates={ templates }
+				templates={ getTemplates() }
 				vertical={ vertical }
 				segment={ segment }
 			/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -4,7 +4,7 @@ import {
 	getTitleByTemplateSlug,
 	hasTemplates,
 	getFirstTemplateSlug,
-	getTemplates,
+	getAllTemplateSlugs,
 } from './utils/templates-parser';
 
 /**
@@ -96,7 +96,7 @@ class PageTemplateModal extends Component {
 		return this.props.shouldPrefetchAssets ? ensureAssets( blocks ) : Promise.resolve( blocks );
 	};
 
-	handleConfirmation = ( slug = this.state.previewedTemplate ) => this.setTemplate( slug );
+	// handleConfirmation = ( slug = this.state.previewedTemplate ) => this.setTemplate( slug );
 
 	previewTemplate = previewedTemplate => this.setState( { previewedTemplate } );
 
@@ -231,7 +231,7 @@ registerPlugin( 'page-templates', {
 		return (
 			<PageTemplatesPlugin
 				shouldPrefetchAssets={ false }
-				templates={ getTemplates() }
+				templates={ getAllTemplateSlugs() }
 				vertical={ vertical }
 				segment={ segment }
 			/>

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { isEmpty, get, keyBy, mapValues } from 'lodash';
+import { isEmpty, reduce, get, keyBy, mapValues } from 'lodash';
 import classnames from 'classnames';
 import '@wordpress/nux';
 import { __, sprintf } from '@wordpress/i18n';
@@ -33,8 +33,6 @@ const {
 	siteInformation = {},
 } = window.starterPageTemplatesConfig;
 
-const PARSING_TEMPLATE_DELAY = 50;
-
 class PageTemplateModal extends Component {
 	state = {
 		isLoading: false,
@@ -53,13 +51,16 @@ class PageTemplateModal extends Component {
 		if ( hasTemplates ) {
 			// Select the first template automatically.
 			this.state.previewedTemplate = get( props.templates, [ 0, 'slug' ] );
+
+			// Organize templates in an object, by slug key.
+			const templatesBySlug = keyBy( props.templates, 'slug' );
 			// Extract titles for faster lookup.
-			this.state.titlesByTemplateSlug = mapValues( keyBy( props.templates, 'slug' ), 'title' );
+			this.state.titlesByTemplateSlug = mapValues( templatesBySlug, 'title' );
 			// Set initially parsing by slug to `false`.
-			this.state.blocksByTemplateSlug = mapValues(
-				this.state.titlesByTemplateSlug,
-				() => ( { blocks: [], isParsing: true } )
-			);
+			this.state.blocksByTemplateSlug = mapValues( templatesBySlug, ( { content } ) => ( {
+				blocks: [],
+				isParsing: !! content,
+			} ) );
 		}
 	}
 
@@ -68,29 +69,30 @@ class PageTemplateModal extends Component {
 			trackView( this.props.segment.id, this.props.vertical.id );
 		}
 
-		// Populate the state with parsed blocks, template by template,
+		// Populate the state with parsed blocks,
 		// immediately after the modal has been rendered.
 		// Wrapping it in a setTimeout() call,
-		// allows showing the modal with empty thumbnails
-		// before to start to parser and render them
-		// into their preview spots. It reduces the time considerably.
-		for ( const i in templates ) {
-			setTimeout(
-				( ( { slug, content } ) => {
-					const blocks = content
-						? parseBlocks( replacePlaceholders( content, siteInformation ) )
-						: [];
+		// allows showing the templates selector with empty thumbnails
+		// before to start to parser and render them.
+		setTimeout( () => {
+			// Parse templates blocks and store them into the state.
+			const blocksByTemplateSlug = reduce(
+				templates,
+				( prev, { slug, content } ) => {
+					prev[ slug ] = content
+						? {
+								blocks: parseBlocks( replacePlaceholders( content, siteInformation ) ),
+								isParsing: false,
+						  }
+						: { blocks: [], isParsing: false };
 
-					this.setState( {
-						blocksByTemplateSlug: {
-							...this.state.blocksByTemplateSlug,
-							[ slug ]: { blocks, isParsing: false }
-						}
-					} );
-				} ).bind( null, templates[ i ] ),
-				PARSING_TEMPLATE_DELAY * i
+					return prev;
+				},
+				{}
 			);
-		}
+
+			this.setState( { blocksByTemplateSlug } );
+		}, 0 );
 	}
 
 	setTemplate = slug => {

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -311,23 +311,18 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 	overflow-y: auto;
 	box-shadow: 0 2px 2px 0 rgba( 0, 0, 0, 0.14 ), 0 3px 1px -2px rgba( 0, 0, 0, 0.12 ), 0 1px 5px 0 rgba( 0, 0, 0, 0.2 );
 
-	.edit-post-visual-editor {
-		margin-top: 20px;
-	}
-
-
 	.editor-styles-wrapper {
 		.editor-post-title {
 			transform-origin: top left;
 			width: 960px;
 			display: block;
-			position: absolute;
-			top: 0;
 		}
 
 		.editor-post-title,
-		.editor-post-title__block {
+		.editor-post-title__block,
+		.editor-post-title__block .editor-post-title__input {
 			height: $template-large-preview-title-height;
+			line-height: $template-large-preview-title-height !important;
 			margin-top: 0;
 			margin-bottom: 0;
 			padding-top: 0;
@@ -361,8 +356,8 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 
 // Preview adjustments.
 // Tweak styles which are inside of the preview container.
-.block-editor-block-preview__container,
-.template-selector-preview {
+.template-selector-item__label, 	// thumbnail
+.template-selector-preview {		// Large Preview
 	.editor-styles-wrapper {
 		.wp-block {
 			width: 100%;
@@ -382,8 +377,6 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 
 		// `core/columns`
 		.wp-block-columns > .editor-inner-blocks > .editor-block-list__layout > [data-type='core/column'] {
-			//margin-left: -14px;
-			//margin-right: -14px;
 
 			& > .editor-block-list__block-edit > div > .block-core-columns > .editor-inner-blocks {
 				margin-top: 0;
@@ -421,6 +414,7 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 	}
 }
 
+.template-selector-preview .edit-post-visual-editor,
 .template-selector-item__label .edit-post-visual-editor {
 	padding: 0;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -21,6 +21,8 @@ $template-large-preview-title-height: 117px;
 $wp-org-sidebar-reduced: 36px;
 $wp-org-sidebar-full: 160px;
 
+$spinner-width: 18px;
+
 // Modal Overlay
 .page-template-modal-screen-overlay {
 	animation: none;
@@ -197,8 +199,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			position: absolute;
 			top: 50%;
 			left: 50%;
-			margin: -9px 0 0 -9px;
-			padding: 0;
+			margin: -#{$spinner-width / 2} 0 0 -#{$spinner-width / 2}; // Center the spinner.
 		}
 
         .block-editor-block-list__layout,

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -183,15 +183,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		position: relative;
 		pointer-events: none;
 
-<<<<<<< HEAD
 		@media screen and ( max-width: 659px ) {
 			padding-top: 120%;
 		}
 
-		&.is-rendering {
-=======
 		&.is-parsing {
->>>>>>> a1f7085... show spinner when still parsing
 			opacity: 0.5;
 		}
 
@@ -279,7 +275,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
     display: flex;
     align-items: center;
 	padding-right: 24px;
-	
+
 	@media screen and ( max-width: 659px ) {
 		display: none;
 	}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -180,14 +180,25 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		box-sizing: content-box;
 		position: relative;
 		pointer-events: none;
-		opacity: 1;
 
+<<<<<<< HEAD
 		@media screen and ( max-width: 659px ) {
 			padding-top: 120%;
 		}
 
 		&.is-rendering {
+=======
+		&.is-parsing {
+>>>>>>> a1f7085... show spinner when still parsing
 			opacity: 0.5;
+		}
+
+		.components-spinner {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			margin: -9px 0 0 -9px;
+			padding: 0;
 		}
 
         .block-editor-block-list__layout,
@@ -400,8 +411,6 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 }
 
 // Set full height to preview container to inherits styles defined for themes.
-.template-selector-preview .components-disabled,
-.template-selector-preview .edit-post-visual-editor,
 .template-selector-item__preview-wrap .components-disabled,
 .template-selector-item__preview-wrap .edit-post-visual-editor {
 	height: 100%;
@@ -411,15 +420,11 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 	}
 }
 
-.page-template-modal__loading {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-	transform: translate( -50%, -50% );
-	display: flex;
-    align-items: flex-end;
+.template-selector-item__label .edit-post-visual-editor {
+	padding: 0;
+}
 
-	.components-spinner {
-		float: none;
-	}
+.template-selector-item__label .block-editor-block-preview__container {
+	position: absolute;
+	top: 0;
 }

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/styles/starter-page-templates-editor.scss
@@ -155,6 +155,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 			height: 40px;
 			line-height: 40px;
 			background-color: #fff;
+			.editor-styles-wrapper {
+				font-size: 14px;
+				height: 40px;
+				line-height: 40px;
+			}
 		}
 
 		&:hover,
@@ -174,7 +179,7 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		width: 100%;
 		display: block;
 		margin: 0 auto;
-		background: $template-selector-empty-background;
+		//background: $template-selector-empty-background;
 		border-radius: 0;
 		overflow: hidden;
 		height: 0;
@@ -182,6 +187,11 @@ body.admin-bar:not( .is-fullscreen-mode ) .page-template-modal-screen-overlay {
 		box-sizing: content-box;
 		position: relative;
 		pointer-events: none;
+
+		.edit-post-visual-editor {
+			padding-top: 100%;
+			margin-top: -100%;
+		}
 
 		@media screen and ( max-width: 659px ) {
 			padding-top: 120%;
@@ -419,3 +429,10 @@ body:not( .is-fullscreen-mode ) .template-selector-preview {
 	position: absolute;
 	top: 0;
 }
+//
+//.template-selector-control__template {
+//	.editor-styles-wrapper .editor-writing-flow {
+//		max-width: 80%;
+//		margin: 0 10%;
+//	}
+//}

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/templates-parser.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/templates-parser.js
@@ -50,6 +50,6 @@ export const getTitleByTemplateSlug = slug => get ( allTemplatesBlockBySlug, [ s
 
 export const getTemplateBySlug = slug => get( allTemplatesBlockBySlug, [ slug ], {} );
 
-export const getFirstTemplateSlug = () => get( templates, [ 0, 'slug' ] );
+export const getFirstTemplateSlug = () => get( templates, [ 0, 'slug' ], null );
 
 export default allTemplatesBlockBySlug;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/templates-parser.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/templates-parser.js
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { keyBy, mapValues, get } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { parse as parseBlocks } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import replacePlaceholders from "./replace-placeholders";
+
+const { templates = [],  siteInformation = {} } = window.starterPageTemplatesConfig;
+
+let allTemplatesBlockBySlug = mapValues( keyBy( templates, 'slug' ), ( { content, title } ) => ( {
+	blocks: [],
+	content,
+	count: 0,
+	isEmpty: ! content,
+	isParsing: !! content,
+	title,
+} ) );
+
+setTimeout( () => {
+	allTemplatesBlockBySlug = mapValues( allTemplatesBlockBySlug, ( { content, title } ) => {
+		const blocks = content ? parseBlocks( replacePlaceholders( content, siteInformation ) ) : [];
+
+		return {
+			blocks,
+			count: blocks.length,
+			isParsing: false,
+			isEmpty: ! content,
+			title,
+		};
+	} );
+
+	// Clean up templates from window object.
+}, 0 );
+
+export const getAllTemplatesBlocks= () => allTemplatesBlockBySlug;
+
+export const hasTemplates = () => !! Object.keys( allTemplatesBlockBySlug ).length;
+
+export const getBlocksByTemplateSlug = slug => get( allTemplatesBlockBySlug, [ slug, 'blocks' ], [] );
+
+export const getTitleByTemplateSlug = slug => get ( allTemplatesBlockBySlug, [ slug, 'title' ], [] );
+
+export const getTemplateBySlug = slug => get( allTemplatesBlockBySlug, [ slug ], {} );
+
+export default allTemplatesBlockBySlug;

--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/templates-parser.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/utils/templates-parser.js
@@ -42,12 +42,14 @@ setTimeout( () => {
 
 export const getAllTemplatesBlocks= () => allTemplatesBlockBySlug;
 
-export const hasTemplates = () => !! Object.keys( allTemplatesBlockBySlug ).length;
+export const hasTemplates = () => !! templates.length;
 
 export const getBlocksByTemplateSlug = slug => get( allTemplatesBlockBySlug, [ slug, 'blocks' ], [] );
 
 export const getTitleByTemplateSlug = slug => get ( allTemplatesBlockBySlug, [ slug, 'title' ], [] );
 
 export const getTemplateBySlug = slug => get( allTemplatesBlockBySlug, [ slug ], {} );
+
+export const getFirstTemplateSlug = () => get( templates, [ 0, 'slug' ] );
 
 export default allTemplatesBlockBySlug;


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR changes slightly the approach in how the thumbnails are dynamically previewed.

_Although it doesn't depend strictly on https://github.com/WordPress/gutenberg/pull/17242, it will improve reduce the previewing time even for all thumbnails and as well as the large preview (100ms)_

#### Overview

The current behavior waits to get the templates parsed before to start to render and mount the components. It produces a delay when the template modal appears. In order to improve the performance and the user perception, I purpose the following more important changes in this PR:

* `Disengage` the parsing process from the react component, starting to process as fast as possible without waiting for the component lifecycle.
* `Do not update the state` with the parsed templates blocks. Update the state[ seems to take considerable time.](https://github.com/Automattic/wp-calypso/pull/35713#issuecomment-536676899)
* Add a `templates-parser.js` which acts as a data store and global event dispatcher. It contains selectors in order to get the desired data.

* `Dispatch onTemplateParse` global event to communicate with the component. The event dispatcher sends all data about templates in the event object argument:

```es6
window.addEventListener( 'onTemplateParse', event => console.log ( event ) );
```

![image](https://user-images.githubusercontent.com/77539/66085323-41bf3700-e547-11e9-8a5d-dbafb3c050b7.png)

The event detail object contains the following fields:

* `blocks`: list of the parsed blocks
* `count`: the number of blocks
* `isEmpty`: `true` is the template doesn't have content.
* `isParsing`: defines if the template is being parsed or not.
* `title`: template title.
* `slug`: template slug.

#### Testing instructions

Apply the patch and confirm that you see the spinners in the thumbnails when the templates are being parsed.

#### Static vs Dynamic


#### Tests


##### Parsing One By One
```
time - blank: 0.005126953125ms
time - about: 46.718017578125ms
time - contact: 19.9072265625ms
time - portfolio: 28.283935546875ms
time - services: 51.375ms
time - team: 37.27197265625ms
time - blog: 29.65673828125ms
time - menu: 51.2978515625ms
time - total: 6304.18798828125ms
```