### PR TITLE
FSE - Add a forced autosave call to preview method in iframe bridge

### DIFF
--- a/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
+++ b/apps/wpcom-block-editor/src/calypso/iframe-bridge-server.js
@@ -455,11 +455,11 @@ function handlePreview( calypsoPort ) {
 
 		const isAutosaveable = select( 'core/editor' ).isEditedPostAutosaveable();
 
-		// We need to retry the save/autosave in some instances:
-		// * In simple sites a post may be not autosaveable but a preview link may not have been generated yet
+		// In specific instances we will need to  need to force an autosave if previewUrl is null:
+		// * In simple sites if autosave exists then autosave is not called on first preview load
 		// * In Atomic sites where an autosave already exists the call to autosave to generate preview link will
-		//   result in a 400 from due to https://core.trac.wordpress.org/browser/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L357
-		let retryCount = 0;
+		//   result in a 400 due to https://core.trac.wordpress.org/browser/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L357
+		let autosaveForced = false;
 
 		// If we don't need to autosave the post before previewing, then we simply
 		// generate the preview.
@@ -491,8 +491,8 @@ function handlePreview( calypsoPort ) {
 
 		function sendPreviewData() {
 			const previewUrl = select( 'core/editor' ).getEditedPostPreviewLink();
-			if ( ! previewUrl && retryCount < 3 ) {
-				retryCount++;
+			if ( ! previewUrl && ! autosaveForced ) {
+				autosaveForced = true;
 				savePost();
 				return;
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Adds a retry to the post save/autosave call in the preview method in iframe bridge. This is a workaround to prevent the following issues

* In simple sites a post may be flagged as not autosaveable but a preview link may not have been generated yet
 * In Atomic sites where an autosave already exists the call to autosave to generate preview link will result in a 400 from due to https://core.trac.wordpress.org/browser/trunk/src/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php#L357 but a second call to autosave works as the first call deletes the existing autosave.

#### Testing instructions

* Check out branch
* Build the block editor with `npx lerna run build --scope='@automattic/wpcom-block-editor' -- -- --watch`
* Sync the new block editor build with your sandbox
* Sandbox widgets.wp.com
* Open a page  in the block editor and click the preview button. This will generate autosave.
* Close the preview window and reload the editor window
* You should now see the yellow autosave banner at the top of the page
* Open the Network dev tools panel and filter for autosaves
* Click the preview button and preview should load successful. In Atomic sites  you will probably see two calls to autosaves endpoint, a first failing with a 400 and second successful 200. For Simple sites you will just see single Autosave call. 

**before - Atomic site**

![preview-before](https://user-images.githubusercontent.com/3629020/63555527-62ce5880-c595-11e9-8b1e-ad2fe150704b.gif)

**after - Atomic site**

![preview-after](https://user-images.githubusercontent.com/3629020/63555539-695cd000-c595-11e9-9879-e2cf8d7f6b76.gif)

**before - Simple site**

![simplesite-before](https://user-images.githubusercontent.com/3629020/63657039-69a4d780-c7f0-11e9-99bb-7d66e59dcc37.gif)

**after - Simple site**

![simplesite-after](https://user-images.githubusercontent.com/3629020/63657047-732e3f80-c7f0-11e9-8ef2-72dc02f65849.gif)

Fixes #35484 
Fixes #33799
