### PR TITLE
Update Refer platform referral link.

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -167,7 +167,8 @@ const Home: FunctionComponent< ConnectedProps > = ( {
 						onClick: () => trackCtaButton( 'referral-jetpack' ),
 				  }
 				: {
-						url: 'https://refer.wordpress.com/',
+						url:
+							'https://refer.wordpress.com/?utm_source=calypso&utm_campaign=calypso_earn&utm_medium=automattic_referred&atk=341b381c971a0631a88f080f598faafb25c344db',
 						onClick: () => trackCtaButton( 'referral-wpcom' ),
 				  },
 		};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Updates Refer platform link for affiliate recruiting.
* Add UTMs and `atk` token.

#### Testing instructions

* Use Calypso.live link below.
* Go to Tools -> Earn
* Click the affiliate link.

![Screen Shot 2019-08-22 at 20 40 11](https://user-images.githubusercontent.com/1563559/63558959-28c17000-c51d-11e9-8d9f-0ba277ca68e1.png)

Confirm link is: https://refer.wordpress.com/?utm_source=calypso&utm_campaign=calypso_earn&utm_medium=automattic_referred&atk=341b381c971a0631a88f080f598faafb25c344db
