### PR TITLE
Restore AMP anon ID tracking.

### DIFF
--- a/client/lib/analytics/sem.js
+++ b/client/lib/analytics/sem.js
@@ -104,6 +104,11 @@ export function updateQueryParamsTracking() {
 		}
 	} );
 
+	// Cross domain tracking for AMP.
+	if ( query.amp_client_id ) {
+		window._tkq.push( [ 'identifyAnonUser', query.amp_client_id ] );
+	}
+
 	// Drop SEM cookie update if either of these is missing
 	if ( ! sanitized_query.utm_source || ! sanitized_query.utm_campaign ) {
 		debug( 'Missing utm_source or utm_campaign.' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Reverts https://github.com/Automattic/wp-calypso/pull/34116/files#diff-e86700baab556b800419339b1ce432fe
* Except this time use `amp_client_id` to avoid OAuth conflicts.

see: p4qSXL-38P-p2#comment-10855

#### Testing instructions

* ... wip
