### PR TITLE
Offer mapping when user requests a transfer for an unsupported TLD

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -514,7 +514,8 @@ class TransferDomainStep extends React.Component {
 							break;
 						case domainAvailability.MAPPABLE:
 						case domainAvailability.TLD_NOT_SUPPORTED:
-						case domainAvailability.TLD_NOT_SUPPORTED_TEMPORARILY: {
+						case domainAvailability.TLD_NOT_SUPPORTED_TEMPORARILY:
+						case domainAvailability.TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE: {
 							const tld = getTld( domain );
 
 							this.setState( {

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -512,8 +512,26 @@ class TransferDomainStep extends React.Component {
 								supportsPrivacy: get( result, 'supports_privacy', false ),
 							} );
 							break;
+						case domainAvailability.TLD_NOT_SUPPORTED: {
+							const tld = getTld( domain );
+
+							this.setState( {
+								notice: this.props.translate(
+									"This domain is available to be registered, but we don't support transfers for domains ending with {{strong}}.%(tld)s{{/strong}}. " +
+										'If you register it elsewhere, you can {{a}}map it{{/a}} instead.',
+									{
+										args: { tld },
+										components: {
+											strong: <strong />,
+											a: <a href="#" onClick={ this.goToMapDomainStep } />, // eslint-disable-line jsx-a11y/anchor-is-valid
+										},
+									}
+								),
+								noticeSeverity: 'info',
+							} );
+							break;
+						}
 						case domainAvailability.MAPPABLE:
-						case domainAvailability.TLD_NOT_SUPPORTED:
 						case domainAvailability.TLD_NOT_SUPPORTED_TEMPORARILY:
 						case domainAvailability.TLD_NOT_SUPPORTED_AND_DOMAIN_NOT_AVAILABLE: {
 							const tld = getTld( domain );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

Offer mapping for domains with unsupported TLDs when user requests a transfer for these domains.

#### Testing instructions

Depends on D31885-code

Visit http://calypso.localhost:3000/domains/add/transfer and http://calypso.localhost:3000/domains/add. Try searching for FQDNs with unsupported TLDs that are both available and unavailable. (Try google.it and googlezzzzzzzzz.it, for example.)
