### PR TITLE
Blocks: add docs for upgrade-nudge block

### DIFF
--- a/client/blocks/upgrade-nudge-expanded/README.md
+++ b/client/blocks/upgrade-nudge-expanded/README.md
@@ -1,7 +1,8 @@
 # Upgrade Nudge Expanded
 
 UpgradeNudgeExpanded displays a huge upgrade nudge, containing PlanCompare card, reasons to upgrade, highlighted feature and benefits of it.
-It's meant to comprehensivly describe a plan and give enough reasons to upgrade. It uses `plans/constants` information to figure out what features to present and how to direct to checkout.
+
+It's meant to comprehensively describe a plan and give enough reasons to upgrade. It uses `plans/constants` information to figure out what features to present and how to direct to checkout.
 
 ## Props
 

--- a/client/blocks/upgrade-nudge/README.md
+++ b/client/blocks/upgrade-nudge/README.md
@@ -1,0 +1,64 @@
+# Upgrade Nudge
+
+UpgradeNudge is a visual "nudge" which encourages users to upgrade their plan for a site, usually by offering a new feature that is part of the upgraded plan. It indicates the name of the plan that the user can upgrade to, and displays a simple message describing the benefits or a feature of upgrading to that plan.
+
+## Usage
+
+```jsx
+import UpgradeNudge from 'my-sites/upgrade-nudge';
+
+export default function ShowUpgradeNudge() {
+	return (
+		<div>
+			<UpgradeNudge
+				title="This is a title"
+				message="This is a custom message"
+			/>
+		</div>
+	);
+}
+```
+
+To set the UpgradeNudge to be always visibly displayed (mostly for debugging use), `shouldDisplay` can be used:
+
+```jsx
+import { stubTrue } from 'lodash';
+import UpgradeNudge from 'my-sites/upgrade-nudge';
+
+export default function ShowUpgradeNudgeAlways() {
+	return (
+		<div>
+			<UpgradeNudge
+				title="This is a title"
+				message="This is a custom message"
+				shouldDisplay={ stubTrue }
+			/>
+		</div>
+	);
+}
+```
+
+## Props
+
+Name | Type | Default | Description
+--- | --- | --- | ---
+`className` | `string` | `null` | An additional `className` for the Card (or Button if compact) component inside the UpgradeNudge.
+`compact` | `bool` | `false` | Decreases the size of the UpgradeNudge.
+`event` | `string` | `null` | An event to distinguish the nudge in tracks. Will be set as the `cta_name` event property.
+`feature` | `string` from `FEATURES_LIST` keys | `null` | The slug of the feature that will be provided as part of the proposed upgrade.
+`href` | `string` | `null` | The URL/path that the UpgradeNudge redirects to if clicked.
+`icon` | `string` | `'star'` | The slug of the icon used on the UpgradeNudge.
+`jetpack` | `bool` | `false` | Indicates whether the proposed upgrade feature is a Jetpack feature.
+`message` | `string` | `'And you get your own domain address.'` | The displayed message on the UpgradeNudge.
+`onClick` | `func` | `noop` | The function to run when the UpgradeNudge is clicked.
+`plan` | `string` from `PLANS_LIST` keys | `null` | The slug of the plan that the proposed upgrade would provide.
+`shouldDisplay` | `func` or `bool` | `null` | A `bool` (or `func` that returns a `bool`) that indicates whether the UpgradeNudge should be displayed.
+`site` | `object` | `null` | The site that is proposed to be upgraded.
+`title` | `string` | `'Upgrade to Premium'` | The displayed title on the UpgradeNudge.
+`translate` | `func` | `identity` | The translation function to use for translatable strings visible on the UpgradeNudge.
+
+# Additional usage information
+
+* **shouldDisplay**: If `shouldDisplay` is left unspecified, the `shouldDisplay()` function in `index.jsx` will be used to determine whether the UpgradeNudge should display in certain conditions.
+* **feature**: See `client/lib/plans/constants.js` for `FEATURES_LIST`.
+* **plan**: See `client/lib/plans/constants.js` for `PLANS_LIST`.

--- a/client/blocks/upgrade-nudge/README.md
+++ b/client/blocks/upgrade-nudge/README.md
@@ -19,25 +19,6 @@ export default function ShowUpgradeNudge() {
 }
 ```
 
-To set the UpgradeNudge to be always visibly displayed (mostly for debugging use), `shouldDisplay` can be used:
-
-```jsx
-import { stubTrue } from 'lodash';
-import UpgradeNudge from 'my-sites/upgrade-nudge';
-
-export default function ShowUpgradeNudgeAlways() {
-	return (
-		<div>
-			<UpgradeNudge
-				title="This is a title"
-				message="This is a custom message"
-				shouldDisplay={ stubTrue }
-			/>
-		</div>
-	);
-}
-```
-
 ## Props
 
 Name | Type | Default | Description
@@ -52,13 +33,11 @@ Name | Type | Default | Description
 `message` | `string` | `'And you get your own domain address.'` | The displayed message on the UpgradeNudge.
 `onClick` | `func` | `noop` | The function to run when the UpgradeNudge is clicked.
 `plan` | `string` from `PLANS_LIST` keys | `null` | The slug of the plan that the proposed upgrade would provide.
-`shouldDisplay` | `func` or `bool` | `null` | A `bool` (or `func` that returns a `bool`) that indicates whether the UpgradeNudge should be displayed.
 `site` | `object` | `null` | The site that is proposed to be upgraded.
 `title` | `string` | `'Upgrade to Premium'` | The displayed title on the UpgradeNudge.
 `translate` | `func` | `identity` | The translation function to use for translatable strings visible on the UpgradeNudge.
 
 # Additional usage information
 
-* **shouldDisplay**: If `shouldDisplay` is left unspecified, the `shouldDisplay()` function in `index.jsx` will be used to determine whether the UpgradeNudge should display in certain conditions.
 * **feature**: See `client/lib/plans/constants.js` for `FEATURES_LIST`.
 * **plan**: See `client/lib/plans/constants.js` for `PLANS_LIST`.

--- a/client/blocks/upgrade-nudge/README.md
+++ b/client/blocks/upgrade-nudge/README.md
@@ -5,7 +5,7 @@ UpgradeNudge is a visual "nudge" which encourages users to upgrade their plan fo
 ## Usage
 
 ```jsx
-import UpgradeNudge from 'my-sites/upgrade-nudge';
+import UpgradeNudge from 'blocks/upgrade-nudge';
 
 export default function ShowUpgradeNudge() {
 	return (

--- a/client/blocks/upgrade-nudge/index.jsx
+++ b/client/blocks/upgrade-nudge/index.jsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -91,14 +90,14 @@ export class UpgradeNudge extends React.Component {
 			title,
 			translate,
 		} = this.props;
-		
-		const shouldNotDisplay = 
-			  ! canManageSite || 
-			  ( ! site || typeof site !== 'object' || typeof site.jetpack !== 'boolean' ) ||
-			  ( feature && planHasFeature ) ||
-			  ( ! feature && ! isFreePlan( site.plan ) ) ||
-			  ( feature === FEATURE_NO_ADS && site.options.wordads ) ||
-			  ( ( ! jetpack && site.jetpack ) || ( jetpack && ! site.jetpack ) );
+
+		const shouldNotDisplay =
+			! canManageSite ||
+			( ! site || typeof site !== 'object' || typeof site.jetpack !== 'boolean' ) ||
+			( feature && planHasFeature ) ||
+			( ! feature && ! isFreePlan( site.plan ) ) ||
+			( feature === FEATURE_NO_ADS && site.options.wordads ) ||
+			( ( ! jetpack && site.jetpack ) || ( jetpack && ! site.jetpack ) );
 
 		if ( shouldNotDisplay ) {
 			return null;

--- a/client/blocks/upgrade-nudge/index.jsx
+++ b/client/blocks/upgrade-nudge/index.jsx
@@ -41,7 +41,6 @@ export class UpgradeNudge extends React.Component {
 		compact: PropTypes.bool,
 		plan: PropTypes.string,
 		feature: PropTypes.string,
-		shouldDisplay: PropTypes.oneOfType( [ PropTypes.func, PropTypes.bool ] ),
 		site: PropTypes.object,
 		translate: PropTypes.func,
 	};
@@ -55,7 +54,6 @@ export class UpgradeNudge extends React.Component {
 		plan: null,
 		feature: null,
 		compact: false,
-		shouldDisplay: null,
 		site: null,
 		translate: identity,
 	};


### PR DESCRIPTION
#### Changes proposed in this Pull Request

In https://github.com/Automattic/wp-calypso/pull/27202, @mirrory wrote an excellent README for the `upgrade-nudge` block. The PR has now been closed, but I wanted to preserve their documentation work and get this README shipped.

#### Testing instructions

Peruse the README and check the documentation is accurate.
