### PR TITLE
Only show the auto-renewal toggle for eligible payment methods.

### DIFF
--- a/client/lib/purchases/assembler.js
+++ b/client/lib/purchases/assembler.js
@@ -43,6 +43,7 @@ function createPurchaseObject( purchase ) {
 		includedDomainPurchaseAmount: purchase.included_domain_purchase_amount,
 		isCancelable: Boolean( purchase.is_cancelable ),
 		isDomainRegistration: Boolean( purchase.is_domain_registration ),
+		isRechargeable: Boolean( purchase.is_rechargable ),
 		isRefundable: Boolean( purchase.is_refundable ),
 		isRenewable: Boolean( purchase.is_renewable ),
 		isRenewal: Boolean( purchase.is_renewal ),

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -217,6 +217,10 @@ function maybeWithinRefundPeriod( purchase ) {
 	);
 }
 
+function isRechargeable( purchase ) {
+	return purchase.isRechargeable;
+}
+
 /**
  * Checks if a purchase can be canceled and refunded via the WordPress.com API.
  * Purchases usually can be refunded up to 30 days after purchase.
@@ -427,6 +431,7 @@ export {
 	isExpiring,
 	isIncludedWithPlan,
 	isOneTimePurchase,
+	isRechargeable,
 	isRefundable,
 	isRemovable,
 	isRenewable,

--- a/client/lib/purchases/index.js
+++ b/client/lib/purchases/index.js
@@ -217,6 +217,13 @@ function maybeWithinRefundPeriod( purchase ) {
 	);
 }
 
+/**
+ * Checks if a purchase have a bound payment method that we can recharge.
+ * This ties to the auto-renewal. At the moment, the only eligble methods are credit cards and Paypal.
+ *
+ * @param {Object} purchase - the purchase with which we are concerned
+ * @return {boolean} if the purchase can be recharged by us through the bound payment method.
+ */
 function isRechargeable( purchase ) {
 	return purchase.isRechargeable;
 }

--- a/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
+++ b/client/me/purchases/manage-purchase/auto-renew-toggle/index.jsx
@@ -31,7 +31,6 @@ class AutoRenewToggle extends Component {
 		isAtomicSite: PropTypes.bool.isRequired,
 		fetchingUserPurchases: PropTypes.bool,
 		recordTracksEvent: PropTypes.func.isRequired,
-		errorNotice: PropTypes.func.isRequired,
 	};
 
 	static defaultProps = {

--- a/client/me/purchases/manage-purchase/notices.jsx
+++ b/client/me/purchases/manage-purchase/notices.jsx
@@ -23,6 +23,7 @@ import {
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isRenewable,
+	isRechargeable,
 	hasPaymentMethod,
 	showCreditCardExpiringWarning,
 	isPaidWithCredits,
@@ -64,9 +65,22 @@ class PurchaseNotice extends Component {
 			}
 
 			if ( hasPaymentMethod( purchase ) ) {
+				if ( isRechargeable( purchase ) ) {
+					return translate(
+						'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
+							"Please enable auto-renewal so you don't lose out on your paid features!",
+						{
+							args: {
+								purchaseName: getName( purchase ),
+								expiry: moment( purchase.expiryMoment ).fromNow(),
+							},
+						}
+					);
+				}
+
 				return translate(
 					'%(purchaseName)s will expire and be removed from your site %(expiry)s. ' +
-						"Please enable auto-renewal so you don't lose out on your paid features!",
+						"Please renew before expiry so you don't lose out on your paid features!",
 					{
 						args: {
 							purchaseName: getName( purchase ),
@@ -127,9 +141,8 @@ class PurchaseNotice extends Component {
 			);
 		}
 
-		// In case of `manualRenew`, the text encouraging users to enable auto-renewal through the toggle will be presented.
 		return (
-			purchase.expiryStatus !== 'manualRenew' && (
+			! isRechargeable( purchase ) && (
 				<NoticeAction onClick={ onClick }>{ translate( 'Renew Now' ) }</NoticeAction>
 			)
 		);

--- a/client/me/purchases/manage-purchase/purchase-meta.jsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.jsx
@@ -23,6 +23,7 @@ import {
 	isPaidWithCredits,
 	cardProcessorSupportsUpdates,
 	isPaidWithPayPalDirect,
+	isRechargeable,
 	isRenewing,
 	isSubscription,
 	paymentLogoType,
@@ -299,8 +300,7 @@ class PurchaseMeta extends Component {
 
 		if (
 			( isDomainRegistration( purchase ) || isPlan( purchase ) ) &&
-			hasPaymentMethod( purchase ) &&
-			! isPaidWithCredits( purchase ) &&
+			isRechargeable( purchase ) &&
 			! isExpired( purchase )
 		) {
 			const dateSpan = <span className="manage-purchase__detail-date-span" />;

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -60,7 +60,7 @@ describe( 'selectors', () => {
 				purchases: {
 					data: [
 						{ ID: 1, product_name: 'domain registration', blog_id: 1337 },
-						{ ID: 2, product_name: 'premium plan', blog_id: 1337 },
+						{ ID: 2, product_name: 'premium plan', blog_id: 1337, is_rechargable: true },
 					],
 					error: null,
 					isFetchingSitePurchases: false,
@@ -94,6 +94,7 @@ describe( 'selectors', () => {
 				includedDomainPurchaseAmount: undefined,
 				isCancelable: false,
 				isDomainRegistration: false,
+				isRechargeable: true,
 				isRefundable: false,
 				isRenewable: false,
 				isRenewal: false,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR attempts to resolve https://github.com/Automattic/wp-calypso/issues/35405.

The only recurring payments method we have now are credit cards and Paypal. Thus, any other means, e.g. Giropay, Sofort, dotcom credits, iDEAL, etc., shouldn't have the toggle available. In this PR, we exploit the `is_rechargable`(yes, it's a long-standing typo) property to implement a general solution.

Before:
<img width="792" alt="螢幕快照 2019-08-23 下午2 11 41" src="https://user-images.githubusercontent.com/1842898/63570544-3411ab80-c5b0-11e9-9d5e-dee0894080ec.png">

After:
<img width="790" alt="螢幕快照 2019-08-23 下午2 13 08" src="https://user-images.githubusercontent.com/1842898/63570548-383dc900-c5b0-11e9-8f2f-35b2d61cf63e.png">

#### Testing instructions

For a plan subscription of a domain registration:

1. If bound to a credit card or Paypal, the toggle should be available.
1. If bound to any other means, the toggle shouldn't be available.
