### PR TITLE
Signup: Show "Related" topics when searching in site topic step

### DIFF
--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -108,6 +108,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		id: `${ uuid().replace( /-/g, '' ) }-site-vertical-suggestion`,
 		fetch_algo: '/verticals',
 		action: 'site_vertical_selected',
+		ui_algo: 'signup/site-topic/related_1',
 	} );
 
 	/**

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -180,9 +180,9 @@ export class SiteVerticalsSuggestionSearch extends Component {
 		return verticals
 			.map( vertical => ( {
 				label: vertical.verticalName,
-				category: vertical.verticalName.toLowerCase().includes( normalizedInput )
-					? undefined
-					: this.props.translate( 'Related' ),
+				category: isRelatedVertical( vertical, normalizedInput )
+					? this.props.translate( 'Related' )
+					: undefined,
 			} ) )
 			.filter( suggestion => includeRelated || ! suggestion.category );
 	}
@@ -224,6 +224,13 @@ export class SiteVerticalsSuggestionSearch extends Component {
 			</>
 		);
 	}
+}
+
+function isRelatedVertical( vertical, normalizedInput ) {
+	return (
+		! vertical.isUserInputVertical &&
+		! vertical.verticalName.toLowerCase().includes( normalizedInput )
+	);
 }
 
 export default localize(

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -94,7 +94,8 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	 */
 	setSearchResults = results => {
 		if ( results && results.length ) {
-			this.setState( { candidateVerticals: results }, () =>
+			const candidateVerticals = this.getSuggestionsWithCategories( results );
+			this.setState( { candidateVerticals }, () =>
 				this.updateVerticalData(
 					this.searchForVerticalMatches( this.state.inputValue ),
 					this.state.inputValue
@@ -168,13 +169,23 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	 * We use the `this.state.candidateVerticals` array instead of `this.props.verticals`
 	 * so `<SuggestionSearch />` has a list to filter in between requests.
 	 *
+	 * @param {Array} verticals verticals to be categorized
 	 * @returns {Array} The array of vertical values.
 	 */
-	getSuggestions = () => this.state.candidateVerticals.map( vertical => vertical.verticalName );
+	getSuggestionsWithCategories( verticals ) {
+		const normalizedInput = this.state.inputValue.toLowerCase();
+
+		return verticals.map( vertical => ( {
+			label: vertical.verticalName,
+			category: vertical.verticalName.toLowerCase().includes( normalizedInput )
+				? undefined
+				: this.props.translate( 'Related' ),
+		} ) );
+	}
 
 	render() {
 		const { autoFocus, defaultVerticalSearchTerm, placeholder, siteType, translate } = this.props;
-		const { inputValue, railcar } = this.state;
+		const { candidateVerticals, inputValue, railcar } = this.state;
 		const shouldShowPopularTopics = this.shouldShowPopularTopics();
 		const placeholderText = shouldShowPopularTopics
 			? translate( 'Enter a topic or select from below.', {
@@ -185,6 +196,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 					comment:
 						'Text input field placeholder. Should be fewer than 35 chars to fit mobile width.',
 			  } );
+
 		return (
 			<>
 				<QueryVerticals
@@ -197,7 +209,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 					id="siteTopic"
 					placeholder={ placeholder || placeholderText }
 					onChange={ this.onSiteTopicChange }
-					suggestions={ this.getSuggestions() }
+					suggestions={ candidateVerticals }
 					value={ inputValue }
 					autoFocus={ autoFocus } // eslint-disable-line jsx-a11y/no-autofocus
 					isSearching={ this.isVerticalSearchPending() }

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -174,7 +174,7 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	 * @returns {Array} The array of vertical values.
 	 */
 	getSuggestionsWithCategories( verticals ) {
-		const normalizedInput = this.state.inputValue.toLowerCase();
+		const normalizedInput = this.state.inputValue.toLowerCase().trim();
 		const includeRelated = normalizedInput.length > 2;
 
 		return verticals

--- a/client/components/site-verticals-suggestion-search/index.jsx
+++ b/client/components/site-verticals-suggestion-search/index.jsx
@@ -174,13 +174,16 @@ export class SiteVerticalsSuggestionSearch extends Component {
 	 */
 	getSuggestionsWithCategories( verticals ) {
 		const normalizedInput = this.state.inputValue.toLowerCase();
+		const includeRelated = normalizedInput.length > 2;
 
-		return verticals.map( vertical => ( {
-			label: vertical.verticalName,
-			category: vertical.verticalName.toLowerCase().includes( normalizedInput )
-				? undefined
-				: this.props.translate( 'Related' ),
-		} ) );
+		return verticals
+			.map( vertical => ( {
+				label: vertical.verticalName,
+				category: vertical.verticalName.toLowerCase().includes( normalizedInput )
+					? undefined
+					: this.props.translate( 'Related' ),
+			} ) )
+			.filter( suggestion => includeRelated || ! suggestion.category );
 	}
 
 	render() {

--- a/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
+++ b/client/components/site-verticals-suggestion-search/test/__snapshots__/index.js.snap
@@ -23,6 +23,7 @@ exports[`<SiteVerticalsSuggestionSearch /> should render 1`] = `
         "action": "site_vertical_selected",
         "fetch_algo": "/verticals",
         "id": "fakeuuid-site-vertical-suggestion",
+        "ui_algo": "signup/site-topic/related_1",
       }
     }
     suggestions={Array []}

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -72,6 +72,24 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 		expect( wrapper.find( PopularTopics ) ).toHaveLength( 1 );
 	} );
 
+	test( 'should hide popular topics if showPopular is false', () => {
+		const wrapper = shallow(
+			<SiteVerticalsSuggestionSearch { ...defaultProps } showPopular={ false } />
+		);
+		expect( wrapper.find( PopularTopics ) ).toHaveLength( 0 );
+	} );
+
+	test( 'should hide popular topics if user has typed a query', () => {
+		const wrapper = shallow(
+			<SiteVerticalsSuggestionSearch
+				{ ...defaultProps }
+				searchValue={ 'Dogs' }
+				showPopular={ true }
+			/>
+		);
+		expect( wrapper.find( PopularTopics ) ).toHaveLength( 0 );
+	} );
+
 	test( 'should pass default vertical search term to <QueryVerticals />', () => {
 		const wrapper = shallow(
 			<SiteVerticalsSuggestionSearch { ...defaultProps } showPopular={ true } />

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -167,6 +167,25 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 		] );
 	} );
 
+	test( 'user input vertical is never shown in Related category', () => {
+		const wrapper = shallow(
+			<SiteVerticalsSuggestionSearch { ...defaultProps } searchValue="dog" />
+		);
+		wrapper.setProps( {
+			verticals: [
+				{ verticalName: 'Dogs' },
+				{ verticalName: 'Doggo' },
+				{ verticalName: 'Cats', isUserInputVertical: true },
+			],
+		} );
+
+		expect( wrapper.find( SuggestionSearch ).prop( 'suggestions' ) ).toEqual( [
+			{ label: 'Dogs' },
+			{ label: 'Doggo' },
+			{ label: 'Cats' },
+		] );
+	} );
+
 	test( "don't show any related topics if query length is less than 3", () => {
 		const wrapper = shallow(
 			<SiteVerticalsSuggestionSearch { ...defaultProps } searchValue="do" />

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -156,4 +156,19 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 			expect( defaultProps.onChange ).toHaveBeenLastCalledWith( { deal: 'nodeal' } );
 		} );
 	} );
+
+	test( "show verticals that don't match searchValue in the Related category", () => {
+		const wrapper = shallow(
+			<SiteVerticalsSuggestionSearch { ...defaultProps } searchValue="dog" />
+		);
+		wrapper.setProps( {
+			verticals: [ { verticalName: 'Dogs' }, { verticalName: 'Doggo' }, { verticalName: 'Cats' } ],
+		} );
+
+		expect( wrapper.find( SuggestionSearch ).prop( 'suggestions' ) ).toEqual( [
+			{ label: 'Dogs' },
+			{ label: 'Doggo' },
+			{ category: 'Related', label: 'Cats' },
+		] );
+	} );
 } );

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -171,4 +171,31 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 			{ category: 'Related', label: 'Cats' },
 		] );
 	} );
+
+	test( "don't show any related topics if query length is less than 3", () => {
+		const wrapper = shallow(
+			<SiteVerticalsSuggestionSearch { ...defaultProps } searchValue="do" />
+		);
+		wrapper.setProps( {
+			verticals: [ { verticalName: 'Dogs' }, { verticalName: 'Doggo' }, { verticalName: 'Cats' } ],
+		} );
+
+		expect( wrapper.find( SuggestionSearch ).prop( 'suggestions' ) ).toEqual( [
+			{ label: 'Dogs' },
+			{ label: 'Doggo' },
+		] );
+
+		wrapper.instance().onSiteTopicChange( 'dog' );
+		// Need to re-set the verticals prop again because `cDU` does reference equality
+		// check before updating candidateVerticals
+		wrapper.setProps( {
+			verticals: [ { verticalName: 'Dogs' }, { verticalName: 'Doggo' }, { verticalName: 'Cats' } ],
+		} );
+
+		expect( wrapper.find( SuggestionSearch ).prop( 'suggestions' ) ).toEqual( [
+			{ label: 'Dogs' },
+			{ label: 'Doggo' },
+			{ label: 'Cats', category: 'Related' },
+		] );
+	} );
 } );

--- a/client/components/site-verticals-suggestion-search/test/index.js
+++ b/client/components/site-verticals-suggestion-search/test/index.js
@@ -1,9 +1,4 @@
 /**
- * @format
- * @jest-environment jsdom
- */
-
-/**
  * External dependencies
  */
 import React from 'react';
@@ -197,5 +192,14 @@ describe( '<SiteVerticalsSuggestionSearch />', () => {
 			{ label: 'Doggo' },
 			{ label: 'Cats', category: 'Related' },
 		] );
+	} );
+
+	test( 'specifies which fetch_algo and ui_algo are being used for traintracks events', () => {
+		const wrapper = shallow( <SiteVerticalsSuggestionSearch { ...defaultProps } /> );
+
+		expect( wrapper.find( SuggestionSearch ).prop( 'railcar' ) ).toMatchObject( {
+			fetch_algo: expect.any( String ),
+			ui_algo: expect.any( String ),
+		} );
 	} );
 } );

--- a/client/components/suggestion-search/README.md
+++ b/client/components/suggestion-search/README.md
@@ -1,11 +1,10 @@
-SuggestionSearch
-================
+# SuggestionSearch
 
 SuggestionSearch is a bundled component of FormTextInput and Suggestions which encapsulates the common boilerplate code for pairing them.
 
 ## Usage
 
-```es6
+```jsx
 import SuggestionSearch from 'components/suggestion-search';
 
 onChange( newValue, isNavigating ) {
@@ -17,11 +16,10 @@ render() {
 		<SuggestionSearch
 			placeholder={ 'Type here to search' }
 			onChange={ onChange }
-			suggestions={ [ 'foo', 'bar' ] }
+			suggestions={ [ { label: 'foo' }, { label: 'bar' } ] }
 		/>
 	);
 }
-
 ```
 
 See the [example](./example/example.jsx).
@@ -29,20 +27,25 @@ See the [example](./example/example.jsx).
 ## Props
 
 ### `{String} id`
+
 It's common that this component is used in a form. This `id` prop is passed to the underlying FormTextInput so that you can associate a FormLabel with it easily.
 
-
 ### `{String} placeholder`
+
 The placeholder text to show if nothing has been entered yet.
 
 ### `{Func} onChange`
+
 The callback function for receiving updated value, whether it's by typing, autocompletion, or suggestion picking. If a user is navigating through the list, it will pass an additional `true` as the 2nd argument.
 
-### `{Func} sortResults` 
+### `{Func} sortResults`
+
 An optional method for sorting the results that we display in the suggestion list.
 
 #### Returns
+
 `Array` A sorted array
 
 ### `{Array} suggestions`
+
 A list of candidate strings that a user can pick from upon typing.

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -26,7 +26,12 @@ class SuggestionSearch extends Component {
 		placeholder: PropTypes.string,
 		onChange: PropTypes.func,
 		onSelect: PropTypes.func,
-		suggestions: PropTypes.array,
+		suggestions: PropTypes.arrayOf(
+			PropTypes.shape( {
+				label: PropTypes.string.isRequired,
+				category: PropTypes.string,
+			} )
+		),
 		value: PropTypes.string,
 		autoFocus: PropTypes.bool,
 		railcar: PropTypes.object,
@@ -87,7 +92,7 @@ class SuggestionSearch extends Component {
 			return [];
 		}
 
-		return this.props.suggestions.map( hint => ( { label: hint } ) );
+		return this.props.suggestions;
 	}
 
 	getSuggestionLabel( suggestionPosition ) {

--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -6,12 +6,12 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { escapeRegExp, noop } from 'lodash';
-import Gridicon from 'components/gridicon';
 
 /**
  * Internal dependencies
  */
 import FormTextInput from 'components/forms/form-text-input';
+import Gridicon from 'components/gridicon';
 import Suggestions from 'components/suggestions';
 import Spinner from 'components/spinner';
 

--- a/client/components/suggestions/README.md
+++ b/client/components/suggestions/README.md
@@ -62,7 +62,26 @@ class SuggestionsExample extends Component {
 		);
 	}
 }
+```
 
+The suggestion list also supports headings by adding a category field to the suggestions. Suggestions with the same category value are grouped together under the heading. Suggestions with no category will always appear at the top of the list.
+
+For example:
+
+```jsx
+const FoodSuggestions = React.forwardRef( ( props, ref ) => (
+	<Suggestions
+		ref={ ref }
+		query=""
+		suggest={ props.suggest }
+		suggestions={ [
+			{ label: 'Oats' },
+			{ label: 'Apple', category: 'Fruit' },
+			{ label: 'Orange', category: 'Fruit' },
+			{ label: 'Carrot', category: 'Vegetable' },
+		] }
+	/>
+) );
 ```
 
 ## Props
@@ -70,5 +89,5 @@ class SuggestionsExample extends Component {
 The following props are available:
 
 - `query`: (string) The search query that the suggestions are based on. Will be highlighted in the suggestions.
-- `suggestions`: (arry) An array of possible suggestions that match the query, made of objects of the shape `{ label: 'Label' }
+- `suggestions`: (arry) An array of possible suggestions that match the query, made of objects of the shape `{ label: 'Label', category: 'This is optional' }
 - `suggest`: A function that is called when the suggestion is selected.

--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -154,6 +154,8 @@ class Suggestions extends Component {
 									<div className="suggestions__category-heading">{ category }</div>
 								) }
 								{ suggestions.map( ( { index, label, originalIndex } ) => (
+									// The parent component should handle key events and forward them to
+									// this component. See ./README.md for details.
 									// eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
 									<Item
 										key={ originalIndex }

--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -153,7 +153,7 @@ class Suggestions extends Component {
 				{ showSuggestions && (
 					<div className="suggestions__wrapper">
 						{ this.getCategories().map( ( { category, suggestions }, categoryIndex ) => (
-							<>
+							<React.Fragment key={ category }>
 								{ ! categoryIndex ? null : (
 									<div className="suggestions__category-heading">{ category }</div>
 								) }
@@ -180,7 +180,7 @@ class Suggestions extends Component {
 										} }
 									/>
 								) ) }
-							</>
+							</React.Fragment>
 						) ) }
 					</div>
 				) }

--- a/client/components/suggestions/index.jsx
+++ b/client/components/suggestions/index.jsx
@@ -36,17 +36,21 @@ class Suggestions extends Component {
 	};
 
 	state = {
+		lastSuggestions: null,
 		suggestionPosition: 0,
 	};
 
 	refsCollection = {};
 
-	UNSAFE_componentWillReceiveProps( nextProps ) {
-		if ( isEqual( nextProps.suggestions, this.props.suggestions ) ) {
-			return;
+	static getDerivedStateFromProps( props, state ) {
+		if ( isEqual( props.suggestions, state.lastSuggestions ) ) {
+			return null;
 		}
 
-		this.setState( { suggestionPosition: 0 } );
+		return {
+			lastSuggestions: props.suggestions,
+			suggestionPosition: 0,
+		};
 	}
 
 	getSuggestionsCount = () => this.props.suggestions.length;

--- a/client/components/suggestions/item.jsx
+++ b/client/components/suggestions/item.jsx
@@ -69,7 +69,7 @@ class Item extends PureComponent {
 		event.stopPropagation();
 		event.preventDefault();
 
-		this.props.onMouseDown( this.props.label );
+		this.props.onMouseDown();
 		if ( railcar ) {
 			tracks.recordEvent(
 				'calypso_traintracks_interact',
@@ -79,7 +79,7 @@ class Item extends PureComponent {
 	};
 
 	handleMouseOver = () => {
-		this.props.onMouseOver( this.props.label );
+		this.props.onMouseOver();
 	};
 
 	render() {

--- a/client/components/suggestions/item.jsx
+++ b/client/components/suggestions/item.jsx
@@ -33,7 +33,7 @@ class Item extends PureComponent {
 		if ( railcar ) {
 			tracks.recordEvent(
 				'calypso_traintracks_render',
-				pick( railcar, [ 'railcar', 'fetch_algo', 'fetch_position' ] )
+				pick( railcar, [ 'railcar', 'fetch_algo', 'fetch_position', 'ui_algo', 'ui_position' ] )
 			);
 		}
 	}

--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -26,3 +26,12 @@
 		font-weight: bold;
 	}
 }
+
+.suggestions__category-heading {
+	font-size: 10px;
+	font-weight: 500;
+	text-transform: uppercase;
+	padding: 12px 24px 8px 42px;
+	color: var( --color-neutral-400 );
+	border-bottom: 1px solid var( --color-neutral-50 );
+}

--- a/client/components/suggestions/style.scss
+++ b/client/components/suggestions/style.scss
@@ -33,5 +33,5 @@
 	text-transform: uppercase;
 	padding: 12px 24px 8px 42px;
 	color: var( --color-neutral-400 );
-	border-bottom: 1px solid var( --color-neutral-50 );
+	border-bottom: 1px solid var( --color-border-subtle );
 }

--- a/client/components/suggestions/test/__snapshots__/index.js.snap
+++ b/client/components/suggestions/test/__snapshots__/index.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Suggestions> render basic list of suggestions 1`] = `
+<div>
+  <div
+    className="suggestions__wrapper"
+  >
+    <Item
+      hasHighlight={true}
+      key="0"
+      label="Apple"
+      onMouseDown={[Function]}
+      onMouseOver={[Function]}
+      query=""
+    />
+    <Item
+      hasHighlight={false}
+      key="1"
+      label="Pear"
+      onMouseDown={[Function]}
+      onMouseOver={[Function]}
+      query=""
+    />
+    <Item
+      hasHighlight={false}
+      key="2"
+      label="Orange"
+      onMouseDown={[Function]}
+      onMouseOver={[Function]}
+      query=""
+    />
+  </div>
+</div>
+`;

--- a/client/components/suggestions/test/index.js
+++ b/client/components/suggestions/test/index.js
@@ -1,14 +1,25 @@
 /**
+ * @jest-environment jsdom
+ */
+
+/**
  * External dependencies
  */
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 
 /**
  * Internal dependencies
  */
 import Suggestions from '..';
 import Item from '../item';
+import { tracks } from 'lib/analytics';
+
+jest.mock( 'lib/analytics', () => ( {
+	tracks: {
+		recordEvent: jest.fn(),
+	},
+} ) );
 
 const defaultProps = {
 	suggest: jest.fn(),
@@ -42,5 +53,121 @@ describe( '<Suggestions>', () => {
 		expect( wrapper.find( { label: 'Orange' } ).prop( 'hasHighlight' ) ).toBe( false );
 		expect( wrapper.find( { label: 'Apple' } ).prop( 'hasHighlight' ) ).toBe( true );
 		expect( wrapper.find( { label: 'Apple' } ).prop( 'query' ) ).toBe( 'LE' );
+	} );
+
+	test( 'uncategorized suggestions always appear first', () => {
+		const wrapper = shallow(
+			<Suggestions
+				{ ...defaultProps }
+				suggestions={ [ { label: 'Carrot', category: 'Vegetable' }, ...defaultProps.suggestions ] }
+			/>
+		);
+
+		const suggestions = wrapper.find( Item );
+
+		expect( suggestions.at( 0 ).prop( 'label' ) ).toBe( 'Apple' );
+		expect( suggestions.at( 1 ).prop( 'label' ) ).toBe( 'Pear' );
+		expect( suggestions.at( 2 ).prop( 'label' ) ).toBe( 'Orange' );
+		expect( suggestions.at( 3 ).prop( 'label' ) ).toBe( 'Carrot' );
+	} );
+
+	test( 'rendering fires traintracks render events', () => {
+		mount(
+			<Suggestions
+				{ ...defaultProps }
+				railcar={ {
+					id: 'abcd',
+					fetch_algo: 'fetch_algo',
+					ui_algo: 'ui_algo',
+				} }
+			/>
+		);
+
+		expect( tracks.recordEvent ).toHaveBeenCalledWith( 'calypso_traintracks_render', {
+			railcar: 'abcd-0',
+			fetch_algo: 'fetch_algo',
+			fetch_position: 0,
+			ui_algo: 'ui_algo',
+			ui_position: 0,
+		} );
+		expect( tracks.recordEvent ).toHaveBeenCalledWith( 'calypso_traintracks_render', {
+			railcar: 'abcd-1',
+			fetch_algo: 'fetch_algo',
+			fetch_position: 1,
+			ui_algo: 'ui_algo',
+			ui_position: 1,
+		} );
+		expect( tracks.recordEvent ).toHaveBeenCalledWith( 'calypso_traintracks_render', {
+			railcar: 'abcd-2',
+			fetch_algo: 'fetch_algo',
+			fetch_position: 2,
+			ui_algo: 'ui_algo',
+			ui_position: 2,
+		} );
+	} );
+
+	test( 'traintrack events use correct ui_position when suggestions have re-ordered into categories', () => {
+		mount(
+			<Suggestions
+				{ ...defaultProps }
+				suggestions={ [ { label: 'Carrot', category: 'Vegetable' }, ...defaultProps.suggestions ] }
+				railcar={ {
+					id: 'abcd',
+					fetch_algo: 'fetch_algo',
+					ui_algo: 'ui_algo',
+				} }
+			/>
+		);
+
+		expect( tracks.recordEvent ).toHaveBeenCalledWith( 'calypso_traintracks_render', {
+			railcar: 'abcd-0',
+			fetch_algo: 'fetch_algo',
+			fetch_position: 0,
+			ui_algo: 'ui_algo',
+			ui_position: 3,
+		} );
+		expect( tracks.recordEvent ).toHaveBeenCalledWith( 'calypso_traintracks_render', {
+			railcar: 'abcd-1',
+			fetch_algo: 'fetch_algo',
+			fetch_position: 1,
+			ui_algo: 'ui_algo',
+			ui_position: 0,
+		} );
+		expect( tracks.recordEvent ).toHaveBeenCalledWith( 'calypso_traintracks_render', {
+			railcar: 'abcd-2',
+			fetch_algo: 'fetch_algo',
+			fetch_position: 2,
+			ui_algo: 'ui_algo',
+			ui_position: 1,
+		} );
+		expect( tracks.recordEvent ).toHaveBeenCalledWith( 'calypso_traintracks_render', {
+			railcar: 'abcd-3',
+			fetch_algo: 'fetch_algo',
+			fetch_position: 3,
+			ui_algo: 'ui_algo',
+			ui_position: 2,
+		} );
+	} );
+
+	test( 'mousedown fires traintracks interact event', () => {
+		const wrapper = mount(
+			<Suggestions
+				{ ...defaultProps }
+				railcar={ {
+					id: 'abcd',
+					action: 'action-name',
+				} }
+			/>
+		);
+
+		wrapper
+			.find( Item )
+			.at( 0 )
+			.simulate( 'mousedown' );
+
+		expect( tracks.recordEvent ).toHaveBeenCalledWith( 'calypso_traintracks_interact', {
+			railcar: 'abcd-0',
+			action: 'action-name',
+		} );
 	} );
 } );

--- a/client/components/suggestions/test/index.js
+++ b/client/components/suggestions/test/index.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import React from 'react';
+import { shallow } from 'enzyme';
+
+/**
+ * Internal dependencies
+ */
+import Suggestions from '..';
+import Item from '../item';
+
+const defaultProps = {
+	suggest: jest.fn(),
+	suggestions: [
+		{
+			label: 'Apple',
+		},
+		{
+			label: 'Pear',
+		},
+		{
+			label: 'Orange',
+		},
+	],
+};
+
+describe( '<Suggestions>', () => {
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	test( 'render basic list of suggestions', () => {
+		const wrapper = shallow( <Suggestions { ...defaultProps } /> );
+		expect( wrapper.find( Item ) ).toHaveLength( 3 );
+		expect( wrapper ).toMatchSnapshot();
+	} );
+
+	test( 'highlights the query inside the suggestions', () => {
+		const wrapper = shallow( <Suggestions { ...defaultProps } query="LE" /> );
+		expect( wrapper.find( { label: 'Pear' } ).prop( 'hasHighlight' ) ).toBe( false );
+		expect( wrapper.find( { label: 'Orange' } ).prop( 'hasHighlight' ) ).toBe( false );
+		expect( wrapper.find( { label: 'Apple' } ).prop( 'hasHighlight' ) ).toBe( true );
+		expect( wrapper.find( { label: 'Apple' } ).prop( 'query' ) ).toBe( 'LE' );
+	} );
+} );

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -77,7 +77,7 @@ body.is-section-signup .layout.gravatar {
 		top: 42px;
 		left: 0;
 		right: 0;
-		max-height: 300px;
+		max-height: 350px;
 		overflow: auto;
 		@include elevation ( 2dp );
 	}

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -31,6 +31,7 @@ export const requestVerticals = action =>
 				...( action.siteTypeId && { site_type: action.siteTypeId } ),
 				limit: action.limit,
 				include_preview: true,
+				synonyms: true,
 			},
 		},
 		action

--- a/client/state/data-layer/wpcom/signup/verticals/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/index.js
@@ -31,7 +31,7 @@ export const requestVerticals = action =>
 				...( action.siteTypeId && { site_type: action.siteTypeId } ),
 				limit: action.limit,
 				include_preview: true,
-				synonyms: true,
+				allow_synonyms: true,
 			},
 		},
 		action

--- a/client/state/data-layer/wpcom/signup/verticals/test/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/test/index.js
@@ -27,7 +27,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 						site_type: mockAction.siteTypeId,
 						limit: mockAction.limit,
 						include_preview: true,
-						synonyms: true,
+						allow_synonyms: true,
 					},
 				},
 				mockAction

--- a/client/state/data-layer/wpcom/signup/verticals/test/index.js
+++ b/client/state/data-layer/wpcom/signup/verticals/test/index.js
@@ -27,6 +27,7 @@ describe( 'data-layer/wpcom/signup/verticals', () => {
 						site_type: mockAction.siteTypeId,
 						limit: mockAction.limit,
 						include_preview: true,
+						synonyms: true,
 					},
 				},
 				mockAction


### PR DESCRIPTION
![Aug-23-2019 18-19-09](https://user-images.githubusercontent.com/1500769/63571801-64b80c00-c5d5-11e9-9730-24f163ee2e16.gif)

#### Changes proposed in this Pull Request

* Adds headings to the `<Suggestions>` component by adding an optional "category" to suggestions, which will be grouped together in the list.
* Adds a "Related" category to the site topic suggestions. Anything vertical that doesn't "string match" query typed by the user will be shown as a "Related" topic.

These changes should have no effect if the vertical search API doesn't return synonyms in the results. **This change should be shipped before D31114-code.**

Some more discussion: paObgF-qR-p2

Feedback welcome on whether "category" is the best term to use for the new `<Suggestions>` feature.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apply D32511-code.

Follow instructions in D31114-code to add yourself to the 'synonymns' or 'original' test variation.

* Try original variation: vertical picker should work as before, no **Related** header should appear.
* Try synonymns variation:
  * synonyms should only appear in the business segment
  * synonyms that don't match the query value should appear under the **Related** header
  * no related matches appear if the query is less than 3 characters long
  * mouse hover, mouse clicks, and keyboard events should work with the items under the **Related** header.

Fixes Automattic/zelda-private#117
