### PR TITLE
FormTextInputWithAction: add className prop and other improvements

### DIFF
--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -7,7 +7,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { keys, omit, noop } from 'lodash';
+import { noop } from 'lodash';
 
 /**
  * Internal dependencies
@@ -88,34 +88,51 @@ export default class FormTextInputWithAction extends Component {
 	};
 
 	render() {
+		const {
+			className,
+			action,
+			inputRef,
+			onFocus,
+			onBlur,
+			onKeyDown,
+			onChange,
+			onAction,
+			defaultValue,
+			disabled,
+			isError,
+			isValid,
+			...props
+		} = this.props;
+		const { focused, value } = this.state;
+
 		return (
 			<div
-				className={ classNames( 'form-text-input-with-action', this.props.className, {
-					'is-focused': this.state.focused,
-					'is-disabled': this.props.disabled,
-					'is-error': this.props.isError,
-					'is-valid': this.props.isValid,
+				className={ classNames( 'form-text-input-with-action', className, {
+					'is-focused': focused,
+					'is-disabled': disabled,
+					'is-error': isError,
+					'is-valid': isValid,
 				} ) }
 				role="group"
 			>
 				<FormTextInput
+					{ ...props }
 					className="form-text-input-with-action__input"
-					ref={ this.props.inputRef }
-					disabled={ this.props.disabled }
-					defaultValue={ this.props.defaultValue }
-					value={ this.state.value }
+					ref={ inputRef }
+					disabled={ disabled }
+					value={ value }
+					defaultValue={ defaultValue }
 					onChange={ this.handleChange }
 					onFocus={ this.handleFocus }
 					onBlur={ this.handleBlur }
 					onKeyDown={ this.handleKeyDown }
-					{ ...omit( this.props, keys( this.constructor.propTypes ) ) }
 				/>
 				<FormButton
 					className="form-text-input-with-action__button is-compact"
-					disabled={ this.props.disabled || ! this.state.value }
+					disabled={ disabled || ! value }
 					onClick={ this.handleAction }
 				>
-					{ this.props.action }
+					{ action }
 				</FormButton>
 			</div>
 		);

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -4,7 +4,7 @@
  * External dependencies
  */
 
-import React, { Component } from 'react';
+import React, { useState, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { noop } from 'lodash';
@@ -20,121 +20,111 @@ import FormButton from 'components/forms/form-button';
  */
 import './style.scss';
 
-export default class FormTextInputWithAction extends Component {
-	static propTypes = {
-		className: PropTypes.string,
-		action: PropTypes.node,
-		inputRef: PropTypes.func,
-		onFocus: PropTypes.func,
-		onBlur: PropTypes.func,
-		onKeyDown: PropTypes.func,
-		onChange: PropTypes.func,
-		onAction: PropTypes.func,
-		defaultValue: PropTypes.string,
-		disabled: PropTypes.bool,
-		isError: PropTypes.bool,
-		isValid: PropTypes.bool,
-	};
+function FormTextInputWithAction( {
+	className,
+	action,
+	inputRef,
+	onFocus = noop,
+	onBlur = noop,
+	onKeyDown = noop,
+	onChange = noop,
+	onAction = noop,
+	defaultValue = '',
+	disabled,
+	isError,
+	isValid,
+	...props
+} ) {
+	const [ focused, setFocused ] = useState( false );
+	const [ value, setValue ] = useState( defaultValue );
 
-	static defaultProps = {
-		defaultValue: '',
-		onFocus: noop,
-		onBlur: noop,
-		onKeyDown: noop,
-		onChange: noop,
-		onAction: noop,
-		isError: false,
-		isValid: false,
-	};
+	const handleFocus = useCallback(
+		e => {
+			setFocused( true );
+			onFocus( e );
+		},
+		[ onFocus ]
+	);
 
-	state = {
-		focused: false,
-		value: String( this.props.defaultValue ),
-	};
+	const handleBlur = useCallback(
+		e => {
+			setFocused( false );
+			onBlur( e );
+		},
+		[ onBlur ]
+	);
 
-	handleFocus = e => {
-		this.setState( {
-			focused: true,
-		} );
+	const handleChange = useCallback(
+		e => {
+			setValue( e.target.value );
+			onChange( e.target.value, e );
+		},
+		[ onChange ]
+	);
 
-		this.props.onFocus( e );
-	};
+	const handleAction = useCallback(
+		e => {
+			onAction( value, e );
+		},
+		[ onAction, value ]
+	);
 
-	handleBlur = e => {
-		this.setState( {
-			focused: false,
-		} );
+	const handleKeyDown = useCallback(
+		e => {
+			onKeyDown( e );
+			if ( e.which === 13 && value ) {
+				handleAction( e );
+			}
+		},
+		[ handleAction, onKeyDown, value ]
+	);
 
-		this.props.onBlur( e );
-	};
-
-	handleKeyDown = e => {
-		this.props.onKeyDown( e );
-		if ( e.which === 13 && this.state.value ) {
-			this.handleAction( e );
-		}
-	};
-
-	handleChange = e => {
-		this.setState( {
-			value: e.target.value,
-		} );
-
-		this.props.onChange( e.target.value, e );
-	};
-
-	handleAction = e => {
-		this.props.onAction( this.state.value, e );
-	};
-
-	render() {
-		const {
-			className,
-			action,
-			inputRef,
-			onFocus,
-			onBlur,
-			onKeyDown,
-			onChange,
-			onAction,
-			defaultValue,
-			disabled,
-			isError,
-			isValid,
-			...props
-		} = this.props;
-		const { focused, value } = this.state;
-
-		return (
-			<div
-				className={ classNames( 'form-text-input-with-action', className, {
-					'is-focused': focused,
-					'is-disabled': disabled,
-					'is-error': isError,
-					'is-valid': isValid,
-				} ) }
-				role="group"
+	return (
+		<div
+			className={ classNames( 'form-text-input-with-action', className, {
+				'is-focused': focused,
+				'is-disabled': disabled,
+				'is-error': isError,
+				'is-valid': isValid,
+			} ) }
+			role="group"
+		>
+			<FormTextInput
+				{ ...props }
+				className="form-text-input-with-action__input"
+				ref={ inputRef }
+				disabled={ disabled }
+				value={ value }
+				defaultValue={ defaultValue }
+				onChange={ handleChange }
+				onFocus={ handleFocus }
+				onBlur={ handleBlur }
+				onKeyDown={ handleKeyDown }
+			/>
+			<FormButton
+				className="form-text-input-with-action__button is-compact"
+				disabled={ disabled || ! value }
+				onClick={ handleAction }
 			>
-				<FormTextInput
-					{ ...props }
-					className="form-text-input-with-action__input"
-					ref={ inputRef }
-					disabled={ disabled }
-					value={ value }
-					defaultValue={ defaultValue }
-					onChange={ this.handleChange }
-					onFocus={ this.handleFocus }
-					onBlur={ this.handleBlur }
-					onKeyDown={ this.handleKeyDown }
-				/>
-				<FormButton
-					className="form-text-input-with-action__button is-compact"
-					disabled={ disabled || ! value }
-					onClick={ this.handleAction }
-				>
-					{ action }
-				</FormButton>
-			</div>
-		);
-	}
+				{ action }
+			</FormButton>
+		</div>
+	);
 }
+
+FormTextInputWithAction.propTypes = {
+	className: PropTypes.string,
+	action: PropTypes.node,
+	inputRef: PropTypes.func,
+	onFocus: PropTypes.func,
+	onBlur: PropTypes.func,
+	onKeyDown: PropTypes.func,
+	onChange: PropTypes.func,
+	onAction: PropTypes.func,
+	defaultValue: PropTypes.string,
+	disabled: PropTypes.bool,
+	isError: PropTypes.bool,
+	isValid: PropTypes.bool,
+};
+
+export default FormTextInputWithAction;

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -47,13 +47,10 @@ export default class FormTextInputWithAction extends Component {
 		isValid: false,
 	};
 
-	constructor() {
-		super();
-		this.state = {
-			focused: false,
-			value: null,
-		};
-	}
+	state = {
+		focused: false,
+		value: String( this.props.defaultValue ),
+	};
 
 	handleFocus = e => {
 		this.setState( {
@@ -73,7 +70,7 @@ export default class FormTextInputWithAction extends Component {
 
 	handleKeyDown = e => {
 		this.props.onKeyDown( e );
-		if ( e.which === 13 && this.getValue() !== '' ) {
+		if ( e.which === 13 && this.state.value ) {
 			this.handleAction( e );
 		}
 	};
@@ -87,15 +84,8 @@ export default class FormTextInputWithAction extends Component {
 	};
 
 	handleAction = e => {
-		this.props.onAction( this.getValue(), e );
+		this.props.onAction( this.state.value, e );
 	};
-
-	getValue() {
-		if ( this.state.value === null ) {
-			return this.props.defaultValue;
-		}
-		return this.state.value;
-	}
 
 	render() {
 		return (
@@ -113,6 +103,7 @@ export default class FormTextInputWithAction extends Component {
 					ref={ this.props.inputRef }
 					disabled={ this.props.disabled }
 					defaultValue={ this.props.defaultValue }
+					value={ this.state.value }
 					onChange={ this.handleChange }
 					onFocus={ this.handleFocus }
 					onBlur={ this.handleBlur }
@@ -121,7 +112,7 @@ export default class FormTextInputWithAction extends Component {
 				/>
 				<FormButton
 					className="form-text-input-with-action__button is-compact"
-					disabled={ this.props.disabled || this.getValue() === '' }
+					disabled={ this.props.disabled || ! this.state.value }
 					onClick={ this.handleAction }
 				>
 					{ this.props.action }

--- a/client/components/forms/form-text-input-with-action/index.jsx
+++ b/client/components/forms/form-text-input-with-action/index.jsx
@@ -22,6 +22,7 @@ import './style.scss';
 
 export default class FormTextInputWithAction extends Component {
 	static propTypes = {
+		className: PropTypes.string,
 		action: PropTypes.node,
 		inputRef: PropTypes.func,
 		onFocus: PropTypes.func,
@@ -99,7 +100,7 @@ export default class FormTextInputWithAction extends Component {
 	render() {
 		return (
 			<div
-				className={ classNames( 'form-text-input-with-action', {
+				className={ classNames( 'form-text-input-with-action', this.props.className, {
 					'is-focused': this.state.focused,
 					'is-disabled': this.props.disabled,
 					'is-error': this.props.isError,


### PR DESCRIPTION
This PR implements two improvements for `FormTextInputWithAction`:
- add a `className` prop to pass a custom CSS class to the wrapper `div` element. This is extracted from @shaunandrews' #34051, where `FormTextInputWithAction` is used to implement adding tags in Reader sidebar.
- remove the usage of `this.constructor.propTypes` to filter props passed to the inner `FormTextInput`. This fixes one of the tasks in #35695.

After replacing `omit` with destructuring, it became clear that the component would benefit from rewriting it as functional component with hooks, so that's the last commit.

**How to test:**
The component is used in `/start/rebrand-cities` to enter a business' name.