### PR TITLE
Importer: Improve Handling of Long Author Names

### DIFF
--- a/client/my-sites/importer/author-mapping-item.scss
+++ b/client/my-sites/importer/author-mapping-item.scss
@@ -15,13 +15,14 @@
 
 .importer__source-author {
 	width: 45%;
-	height: 18px;
 	padding-top: 7px;
 	float: left;
 	display: inline-block;
 	color: var( --color-neutral-700 );
-
 	text-align: left;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	white-space: nowrap;
 	font-size: 14px;
 	font-weight: 600;
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* This is a potential solution to improve the handling of long author names. 

#### Testing instructions

Import a file which has multiple authors, ideally with long names, or alternatively just use Developer Tools to make the text super long. 

**Before:**

<img width="845" alt="Screenshot 2019-08-23 at 14 01 11" src="https://user-images.githubusercontent.com/43215253/63594580-b8632f00-c5ae-11e9-96af-47d6bf8806fb.png">

**After:**

<img width="1029" alt="Screenshot 2019-08-23 at 14 00 48" src="https://user-images.githubusercontent.com/43215253/63594586-bd27e300-c5ae-11e9-8bf4-ef61838f0d10.png">

Fixes #35731
