### PR TITLE
Importer: Decode Characters of Author Name

### DIFF
--- a/client/my-sites/importer/author-mapping-item.jsx
+++ b/client/my-sites/importer/author-mapping-item.jsx
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import Gridicon from 'gridicons';
@@ -16,6 +13,7 @@ import { defer } from 'lodash';
 import AuthorSelector from 'blocks/author-selector';
 import User from 'components/user';
 import { getCurrentUser } from 'state/current-user/selectors';
+import { decodeEntities } from 'lib/formatting';
 
 /**
  * Style dependencies
@@ -80,7 +78,7 @@ class ImporterAuthorMapping extends React.Component {
 
 		return (
 			<div className="importer__author-mapping">
-				<span className="importer__source-author">{ name }</span>
+				<span className="importer__source-author">{ decodeEntities( name ) }</span>
 				<Gridicon className="importer__mapping-relation" icon="arrow-right" />
 				{ ! hasSingleAuthor ? (
 					<AuthorSelector siteId={ siteId } onSelect={ onSelect }>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Prevents `&amp;` appearing instead of `&` etc.

#### Testing instructions

With an import with multiple authors, ensure that one of the authors has some characters such as `&` in their name. 

**Before:**

<img width="942" alt="Screenshot 2019-08-23 at 14 12 06" src="https://user-images.githubusercontent.com/43215253/63595220-4c81c600-c5b0-11e9-8752-47a8143729f2.png">

**After:**

<img width="900" alt="Screenshot 2019-08-23 at 14 12 23" src="https://user-images.githubusercontent.com/43215253/63595257-615e5980-c5b0-11e9-814e-033375d683c5.png">

Fixes #35730
