### PR TITLE
Recurring Payments: Reword Stripe fees

### DIFF
--- a/client/my-sites/earn/memberships/index.jsx
+++ b/client/my-sites/earn/memberships/index.jsx
@@ -96,13 +96,22 @@ class MembershipsSection extends Component {
 					</div>
 					<div className="memberships__earnings-breakdown-notes">
 						{ translate(
-							'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Stripe charges are typically %(stripe)s.',
+							'On your current plan, WordPress.com charges {{em}}%(commission)s{{/em}}.{{br/}} Additionally, Stripe charges are typically %(stripe)s. {{a}}Learn more{{/a}}',
 							{
 								args: {
 									commission: '' + parseFloat( this.props.commission ) * 100 + '%',
 									stripe: '2.9%+30c',
 								},
-								components: { em: <em />, br: <br /> },
+								components: {
+									em: <em />,
+									br: <br />,
+									a: (
+										<ExternalLink
+											href="https://en.support.wordpress.com/recurring-payments-button/#related-fees"
+											icon={ true }
+										/>
+									),
+								},
 							}
 						) }
 					</div>


### PR DESCRIPTION
Previously, there was some confusion if stripe fees are on top of wpcom or in comparison.
See p1565795952411800-slack-C03TY6J1A
- I added the word "Additionally"
- I added a link

#### Testing instructions
- If you never tested recurring payments, you will need a site for that, or just see the screenshot
- Go to /earn/payments/ , notice clear explanation.

![Zrzut ekranu 2019-08-23 o 16 03 42](https://user-images.githubusercontent.com/3775068/63598643-44318700-c5c0-11e9-88bb-9bea3f05a5db.png)


