### PR TITLE
Checkout: Add phone number field

### DIFF
--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -418,14 +418,16 @@ export class CreditCardFormFields extends React.Component {
 						} )
 					) }
 
-					{ this.createField( 'phone-number', FormPhoneMediaInput, {
-						onChange: this.handlePhoneFieldChange,
-						countriesList,
-						countryCode: this.state.userSelectedPhoneCountryCode || this.getFieldValue( 'country' ),
-						label: translate( 'Phone Number {{span}}(Optional){{/span}}', {
-							components: { span: <span className="credit-card-form-fields__explainer" /> },
-						} ),
-					} ) }
+					{ countryDetailsRequired ||
+						this.createField( 'phone-number', FormPhoneMediaInput, {
+							onChange: this.handlePhoneFieldChange,
+							countriesList,
+							countryCode:
+								this.state.userSelectedPhoneCountryCode || this.getFieldValue( 'country' ),
+							label: translate( 'Phone Number {{span}}(Optional){{/span}}', {
+								components: { span: <span className="credit-card-form-fields__explainer" /> },
+							} ),
+						} ) }
 				</div>
 			</div>
 		);

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -418,20 +418,38 @@ export class CreditCardFormFields extends React.Component {
 						} )
 					) }
 
-					{ countryDetailsRequired ||
-						this.createField( 'phone-number', FormPhoneMediaInput, {
-							onChange: this.handlePhoneFieldChange,
-							countriesList,
-							countryCode:
-								this.state.userSelectedPhoneCountryCode || this.getFieldValue( 'country' ) || 'US',
-							label: translate( 'Phone Number {{span}}(Optional){{/span}}', {
-								components: { span: <span className="credit-card-form-fields__explainer" /> },
-							} ),
-						} ) }
+					{ countryDetailsRequired || (
+						<PhoneNumberField
+							countriesList={ countriesList }
+							onChange={ this.handlePhoneFieldChange }
+							createField={ this.createField }
+							countryCode={
+								this.state.userSelectedPhoneCountryCode || this.getFieldValue( 'country' )
+							}
+							translate={ translate }
+						/>
+					) }
 				</div>
 			</div>
 		);
 	}
+}
+
+function PhoneNumberField( { countriesList, translate, createField, onChange, countryCode } ) {
+	return (
+		<React.Fragment>
+			{ createField( 'phone-number', FormPhoneMediaInput, {
+				onChange,
+				countriesList,
+				countryCode: countryCode || 'US',
+				label: translate( 'Phone Number {{span}}(Optional){{/span}}', {
+					components: {
+						span: <span className="credit-card-form-fields__explainer" />,
+					},
+				} ),
+			} ) }
+		</React.Fragment>
+	);
 }
 
 export default localize( CreditCardFormFields );

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -21,6 +21,7 @@ import InfoPopover from 'components/info-popover';
 import { maskField, unmaskField, getCreditCardType } from 'lib/checkout';
 import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
 import FormInputValidation from 'components/forms/form-input-validation';
+import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
 
 const CardNumberElementWithValidation = withStripeElementValidation( CardNumberElement );
 const CardExpiryElementWithValidation = withStripeElementValidation( CardExpiryElement );
@@ -406,6 +407,13 @@ export class CreditCardFormFields extends React.Component {
 							placeholder: ' ',
 						} )
 					) }
+
+					{ this.createField( 'phone-number', FormPhoneMediaInput, {
+						onChange: this.updateFieldValues,
+						countriesList,
+						countryCode: this.getFieldValue( 'country' ),
+						label: translate( 'Phone' ),
+					} ) }
 				</div>
 			</div>
 		);

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -279,6 +279,11 @@ export class CreditCardFormFields extends React.Component {
 		isNewTransaction: false,
 	};
 
+	constructor( props ) {
+		super( props );
+		this.state = { userSelectedPhoneCountryCode: '' };
+	}
+
 	createField = ( fieldName, componentClass, props ) => {
 		const errorMessage = this.props.getErrorMessage( fieldName ) || [];
 		return React.createElement(
@@ -329,6 +334,11 @@ export class CreditCardFormFields extends React.Component {
 
 	handleFieldChange = event => {
 		this.updateFieldValues( event.target.name, event.target.value );
+	};
+
+	handlePhoneFieldChange = ( { value, countryCode } ) => {
+		this.updateFieldValues( 'phone-number', value );
+		this.setState( { userSelectedPhoneCountryCode: countryCode } );
 	};
 
 	shouldRenderCountrySpecificFields() {
@@ -409,10 +419,12 @@ export class CreditCardFormFields extends React.Component {
 					) }
 
 					{ this.createField( 'phone-number', FormPhoneMediaInput, {
-						onChange: this.updateFieldValues,
+						onChange: this.handlePhoneFieldChange,
 						countriesList,
-						countryCode: this.getFieldValue( 'country' ),
-						label: translate( 'Phone' ),
+						countryCode: this.state.userSelectedPhoneCountryCode || this.getFieldValue( 'country' ),
+						label: translate( 'Phone Number {{span}}(Optional){{/span}}', {
+							components: { span: <span className="credit-card-form-fields__explainer" /> },
+						} ),
 					} ) }
 				</div>
 			</div>

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -423,7 +423,7 @@ export class CreditCardFormFields extends React.Component {
 							onChange: this.handlePhoneFieldChange,
 							countriesList,
 							countryCode:
-								this.state.userSelectedPhoneCountryCode || this.getFieldValue( 'country' ),
+								this.state.userSelectedPhoneCountryCode || this.getFieldValue( 'country' ) || 'US',
 							label: translate( 'Phone Number {{span}}(Optional){{/span}}', {
 								components: { span: <span className="credit-card-form-fields__explainer" /> },
 							} ),

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -22,6 +22,7 @@ import { maskField, unmaskField, getCreditCardType } from 'lib/checkout';
 import { shouldRenderAdditionalCountryFields } from 'lib/checkout/processor-specific';
 import FormInputValidation from 'components/forms/form-input-validation';
 import FormPhoneMediaInput from 'components/forms/form-phone-media-input';
+import { abtest } from 'lib/abtest';
 
 const CardNumberElementWithValidation = withStripeElementValidation( CardNumberElement );
 const CardExpiryElementWithValidation = withStripeElementValidation( CardExpiryElement );
@@ -358,6 +359,7 @@ export class CreditCardFormFields extends React.Component {
 			'credit-card-form-fields__extras': true,
 			'ebanx-details-required': countryDetailsRequired,
 		} );
+		const shouldShowPhoneField = ! countryDetailsRequired && abtest( 'checkoutCollectPhoneNumber' ) === 'show';
 
 		return (
 			<div className="credit-card-form-fields">
@@ -418,7 +420,7 @@ export class CreditCardFormFields extends React.Component {
 						} )
 					) }
 
-					{ countryDetailsRequired || (
+					{ shouldShowPhoneField && (
 						<PhoneNumberField
 							countriesList={ countriesList }
 							onChange={ this.handlePhoneFieldChange }

--- a/client/components/credit-card-form-fields/index.jsx
+++ b/client/components/credit-card-form-fields/index.jsx
@@ -359,7 +359,8 @@ export class CreditCardFormFields extends React.Component {
 			'credit-card-form-fields__extras': true,
 			'ebanx-details-required': countryDetailsRequired,
 		} );
-		const shouldShowPhoneField = ! countryDetailsRequired && abtest( 'checkoutCollectPhoneNumber' ) === 'show';
+		const shouldShowPhoneField =
+			! countryDetailsRequired && abtest( 'checkoutCollectPhoneNumber' ) === 'show';
 
 		return (
 			<div className="credit-card-form-fields">
@@ -438,17 +439,20 @@ export class CreditCardFormFields extends React.Component {
 }
 
 function PhoneNumberField( { countriesList, translate, createField, onChange, countryCode } ) {
+	const label = (
+		<React.Fragment>
+			{ translate( 'Phone Number' ) }
+			<span className="credit-card-form-fields__explainer">{ translate( 'Optional' ) }</span>
+		</React.Fragment>
+	);
+
 	return (
 		<React.Fragment>
 			{ createField( 'phone-number', FormPhoneMediaInput, {
 				onChange,
 				countriesList,
 				countryCode: countryCode || 'US',
-				label: translate( 'Phone Number {{span}}(Optional){{/span}}', {
-					components: {
-						span: <span className="credit-card-form-fields__explainer" />,
-					},
-				} ),
+				label: label,
 			} ) }
 		</React.Fragment>
 	);

--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -24,6 +24,7 @@ export default function FormPhoneMediaInput( props ) {
 		disabled,
 		errorMessage,
 		isError = 'false',
+		children,
 	} = props;
 
 	return (
@@ -31,12 +32,13 @@ export default function FormPhoneMediaInput( props ) {
 			<div>
 				<FormLabel htmlFor={ name }>{ label }</FormLabel>
 				<PhoneInput
-					{ ...omit( props, [ 'className', 'countryCode' ] ) }
+					{ ...omit( props, [ 'className', 'countryCode', 'children' ] ) }
 					countryCode={ countryCode.toUpperCase() }
 					className={ className }
 					isError={ isError }
 					disabled={ disabled }
 				/>
+				{ children }
 			</div>
 			{ errorMessage && <FormInputValidation text={ errorMessage } isError /> }
 		</div>

--- a/client/components/forms/form-phone-media-input/index.jsx
+++ b/client/components/forms/form-phone-media-input/index.jsx
@@ -15,35 +15,30 @@ import PhoneInput from 'components/phone-input';
 import FormLabel from 'components/forms/form-label';
 import FormInputValidation from 'components/forms/form-input-validation';
 
-export default class extends React.Component {
-	static displayName = 'FormPhoneMediaInput';
+export default function FormPhoneMediaInput( props ) {
+	const {
+		additionalClasses,
+		label,
+		countryCode,
+		className,
+		disabled,
+		errorMessage,
+		isError = 'false',
+	} = props;
 
-	static defaultProps = {
-		isError: false,
-	};
-
-	focus = () => this.phoneInput.numberInput.focus();
-
-	setPhoneInput = ref => ( this.phoneInput = ref );
-
-	render() {
-		return (
-			<div className={ classnames( this.props.additionalClasses, 'phone' ) }>
-				<div>
-					<FormLabel htmlFor={ this.props.name }>{ this.props.label }</FormLabel>
-					<PhoneInput
-						{ ...omit( this.props, [ 'className', 'countryCode' ] ) }
-						setComponentReference={ this.setPhoneInput }
-						countryCode={ this.props.countryCode.toUpperCase() }
-						className={ this.props.className }
-						isError={ this.props.isError }
-						disabled={ this.props.disabled }
-					/>
-				</div>
-				{ this.props.errorMessage && (
-					<FormInputValidation text={ this.props.errorMessage } isError />
-				) }
+	return (
+		<div className={ classnames( additionalClasses, 'phone' ) }>
+			<div>
+				<FormLabel htmlFor={ name }>{ label }</FormLabel>
+				<PhoneInput
+					{ ...omit( props, [ 'className', 'countryCode' ] ) }
+					countryCode={ countryCode.toUpperCase() }
+					className={ className }
+					isError={ isError }
+					disabled={ disabled }
+				/>
 			</div>
-		);
-	}
+			{ errorMessage && <FormInputValidation text={ errorMessage } isError /> }
+		</div>
+	);
 }

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -143,7 +143,7 @@ export default {
 		allowExistingUsers: true,
 	},
 	checkoutCollectPhoneNumber: {
-		datestamp: '2019-09-03',
+		datestamp: '20191003',
 		variations: {
 			show: 50,
 			hide: 50,

--- a/client/lib/abtest/active-tests.js
+++ b/client/lib/abtest/active-tests.js
@@ -142,4 +142,14 @@ export default {
 		defaultVariation: 'control',
 		allowExistingUsers: true,
 	},
+	checkoutCollectPhoneNumber: {
+		datestamp: '2019-09-03',
+		variations: {
+			show: 50,
+			hide: 50,
+		},
+		defaultVariation: 'hide',
+		allowExistingUsers: true,
+		localeTargets: 'any',
+	},
 };

--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -191,7 +191,7 @@ TransactionFlow.prototype._paymentHandlers = {
 		this._pushStep( { name: INPUT_VALIDATION, first: true } );
 		debug( 'submitting transaction with new stripe elements card' );
 
-		const { name, country, 'postal-code': zip } = newCardDetails;
+		const { name, country, 'postal-code': zip, 'phone-number': phone } = newCardDetails;
 		const paymentDetailsForStripe = {
 			name,
 			address: {
@@ -199,6 +199,10 @@ TransactionFlow.prototype._paymentHandlers = {
 				postal_code: zip,
 			},
 		};
+
+		if ( phone ) {
+			paymentDetailsForStripe.phone = phone;
+		}
 
 		try {
 			const stripePaymentMethod = await createStripePaymentMethod(


### PR DESCRIPTION
This adds an optional phone number field to the checkout page. 

See p8hgLy-1Dg-p2 for discussion and design.

<img width="518" alt="Screen Shot 2019-08-26 at 1 45 21 PM" src="https://user-images.githubusercontent.com/2036909/63710836-19d20a80-c808-11e9-9f8b-6f8805e09011.png">

#### Testing instructions

- Add a plan to your cart.
- Visit the checkout page and (if necessary) click the link to add a new card.
- From the "bug" icon in the lower right corner, select "ABTESTS" and make sure "show" is selected for `checkoutCollectPhoneNumber`. 
- Be sure the phone number field is visible and that changing the country works as expected (default is US, but will use country field if set, but will override that with the phone input country field if set).
- Bonus: use one of our mag 16 languages, and make sure that both the "Phone number" label, and it's "optional" explainer are translated.
- Check that the field isn't visible if the Abtest variation is "hide"

