### PR TITLE
Checklist: Stop redirecting eligible sites to /plan

### DIFF
--- a/client/my-sites/checklist/controller.jsx
+++ b/client/my-sites/checklist/controller.jsx
@@ -14,7 +14,7 @@ import { isEnabled } from 'config';
 
 import ChecklistMain from './main';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'state/ui/selectors';
-import { canCurrentUserUseChecklistMenu } from 'state/sites/selectors';
+import isEligibleForDotcomChecklist from 'state/selectors/is-eligible-for-dotcom-checklist';
 import canCurrentUserUseCustomerHome from 'state/sites/selectors/can-current-user-use-customer-home';
 
 export function show( context, next ) {
@@ -34,7 +34,7 @@ export function maybeRedirect( context, next ) {
 		return;
 	}
 
-	if ( ! canCurrentUserUseChecklistMenu( state, siteId ) ) {
+	if ( ! isEligibleForDotcomChecklist( state, siteId ) ) {
 		page.redirect( `/plans/my-plan/${ slug }` );
 		return;
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

A change as part of the new Customer Home page meant that we were
incorrectly redirecting from the checklist to /plan for some sites that
were previously eligible for it.

#### Testing instructions

With a simple site that was registered after the 1st February 2018, and before 6th August 2019, make sure that the `customer-home` feature is off and visit `/checklist/DOMAIN`. With this patch you should see the site checklist, and without it you will be redirected to `/plan`