### PR TITLE
Update copy in notice

### DIFF
--- a/client/my-sites/current-site/stale-cart-items-notice.js
+++ b/client/my-sites/current-site/stale-cart-items-notice.js
@@ -40,7 +40,7 @@ class StaleCartItemsNotice extends React.Component {
 				id: staleCartItemNoticeId,
 				isPersistent: false,
 				duration: 10000,
-				button: this.props.translate( 'Complete your purchase' ),
+				button: this.props.translate( 'View your cart' ),
 				href: '/checkout/' + this.props.selectedSiteSlug,
 				onClick: this.clickStaleCartItemsNotice,
 			} );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

While surveying our Happiness team about improvements to our checkout flow, a number of folks pointed out that the wording for an upgrade nudge causes some anxiety and confusion with our customers. I have update the copy in this PR to more of a gentle nudge. Once the update ships, I plan keep an eye on the engagement metrics with this nudge to see what kind of impact it has. 

**Before**
<img width="1599" alt="Screen Shot 2019-08-23 at 2 49 21 PM" src="https://user-images.githubusercontent.com/6981253/63616526-b8b2f880-c5b5-11e9-8338-44813c6cc2ef.png">


**After**
<img width="1599" alt="Screen Shot 2019-08-23 at 2 49 09 PM" src="https://user-images.githubusercontent.com/6981253/63616539-bf417000-c5b5-11e9-8729-cd395fae3d9b.png">


#### Testing instructions
You can look at the screenshots I shared above or:
- For any existing site try add something to your cart (either by upgrading your plan or adding a new domain).
- Leave before checking out by closing your browser window. 
- Return back to your site after some time and see the copy in the nudge that shows.

 
