### PR TITLE
FSE Tooling: Streamline webpack output

### DIFF
--- a/apps/full-site-editing/webpack.config.js
+++ b/apps/full-site-editing/webpack.config.js
@@ -55,6 +55,7 @@ function getWebpackConfig( env = {}, argv = {} ) {
 		},
 		watch: isDevelopment,
 		devtool: isDevelopment ? 'inline-cheap-source-map' : false,
+		stats: 'minimal',
 	};
 }
 


### PR DESCRIPTION
Previously, it was impossible to find errors in the build from webpack output. This displays only a "minimal" amount of information, making the output much easier to parse.

If anyone knows how to get the colors to work, I'd love to add it. It seems that some tool along the line suppresses error colors. It'd be great if errors were red for added readability.

#### Changes proposed in this Pull Request
Before: (Can you find where the error is? Hint: it's near the top.)
<img width="1916" alt="Screen Shot 2019-08-23 at 2 52 07 PM" src="https://user-images.githubusercontent.com/6265975/63626280-4e9b5300-c5b7-11e9-9216-75890acf974f.png">

After:
<img width="1091" alt="Screen Shot 2019-08-23 at 2 53 00 PM" src="https://user-images.githubusercontent.com/6265975/63626291-6246b980-c5b7-11e9-85c7-1844f8c02b83.png">

Gif to show how easy it is to see errors in the build now:
![2019-08-23 14 53 35](https://user-images.githubusercontent.com/6265975/63626308-72f72f80-c5b7-11e9-81c1-f51f42ec7972.gif)

#### Testing instructions
1. Pull this branch and run `npx lerna run dev --scope='@automattic/full-site-editing' --stream`
2. In an FSE file, import something that doesn't exist, like `import { noah } from 'noah';`
3. Verify that you can easily see the build error at the end of the webpack output after saving the file.
4. Remove the import and save the file. Verify that the output updates to reflect that.