### PR TITLE
Signup: Add "site created" notice checkout after signup

### DIFF
--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -45,7 +45,7 @@ class CheckoutContainer extends React.Component {
 	componentDidMount() {
 		if ( this.state.shouldDisplaySiteCreatedNotice ) {
 			this.setHeaderText(
-				this.props.translate( 'Your WordPress.com site is ready! Finalize your upgrade to get the most out of it.' )
+				this.props.translate( 'Your WordPress.com site is ready! Finish your purchase to get the most out of it.' )
 			);
 		}
 	}

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import React from 'react';
+import moment from 'moment';
+import { get } from 'lodash';
 
 /**
  * Internal dependencies
@@ -23,6 +25,10 @@ class CheckoutContainer extends React.Component {
 		headerText: '',
 	};
 
+	componentDidMount() {
+		this.setSiteCreatedNotice();
+	}
+
 	renderCheckoutHeader() {
 		return this.state.headerText && <FormattedHeader headerText={ this.state.headerText } />;
 	}
@@ -30,6 +36,27 @@ class CheckoutContainer extends React.Component {
 	setHeaderText = newHeaderText => {
 		this.setState( { headerText: newHeaderText } );
 	};
+
+	setSiteCreatedNotice() {
+		// TODO:
+		// Add this as a child of TransactionData so we can grab the cart details
+		// Once we have the cart details we can tweak the copy depending on what's the in the cart,
+		// e.g., once you've purchased xyz.com, your new site address will be xyz.com
+		// or
+		// once you've upgraded to the X plan you'll be able to add a domain
+		// Do we need to set data in the signup state to validate that this site has been created via the onboarding flow?
+		// Probably, as the root cause is users  clicking back in the onboarding flow, not knowing that a site has already been created.
+		const createdAt = get( this.props.selectedSite, 'options.created_at', '' );
+		const isSelectedSiteNew = moment( createdAt ).isAfter( moment().subtract( 10, 'minutes' ) );
+		if ( ! isSelectedSiteNew ) {
+			return;
+		}
+
+		this.setHeaderText(
+			`Your site, ${ this.props.selectedSite.slug }, is created and ready to upgrade!`,
+			'Continue with your purchase to access your upgrade benefits.'
+		);
+	}
 
 	render() {
 		const {

--- a/client/my-sites/checkout/checkout/checkout-container.jsx
+++ b/client/my-sites/checkout/checkout/checkout-container.jsx
@@ -22,30 +22,30 @@ import SignupSiteCreatedNotice from 'my-sites/checkout/checkout/signup-site-crea
 import './checkout-container.scss';
 
 /**
- * Returns whether given site has been created in the last `n` minutes
+ * Returns whether a given site creation date is "new", that is whether the date falls in the last `n` minutes
  *
  * @param  {String}  createdAt               The site creation date stamp
- * @param  {Number}  creationWindowInMinutes A site is considered 'new' if it's been created in this time window (in minutes)
- * @return {Boolean}                         If the site is 'new'. Default `false`
+ * @param  {Number}  creationWindowInMinutes A site creation date is considered 'new' if it's been created in this time window (in minutes)
+ * @return {Boolean}                         If the creation date is 'new'. Default `false`
  */
-function isSelectedSiteNew( createdAt, creationWindowInMinutes = 5 ) {
+function isSiteCreatedDateNew( createdAt, creationWindowInMinutes = 5 ) {
 	return moment( createdAt ).isAfter( moment().subtract( creationWindowInMinutes, 'minutes' ) );
 }
 
 class CheckoutContainer extends React.Component {
-	constructor( props ) {
-		super( props );
-		this.state = {
-			headerText: '',
-			shouldDisplaySiteCreatedNotice:
-				props.isComingFromSignup && isSelectedSiteNew( get( props.selectedSite, 'options.created_at', '' ) ),
-		};
-	}
+	state = {
+		headerText: '',
+		shouldDisplaySiteCreatedNotice:
+			this.props.isComingFromSignup &&
+			isSiteCreatedDateNew( get( this.props, 'selectedSite.options.created_at', '' ) ),
+	};
 
 	componentDidMount() {
 		if ( this.state.shouldDisplaySiteCreatedNotice ) {
 			this.setHeaderText(
-				this.props.translate( 'Your WordPress.com site is ready! Finish your purchase to get the most out of it.' )
+				this.props.translate(
+					'Your WordPress.com site is ready! Finish your purchase to get the most out of it.'
+				)
 			);
 		}
 	}

--- a/client/my-sites/checkout/checkout/signup-site-created-notice.jsx
+++ b/client/my-sites/checkout/checkout/signup-site-created-notice.jsx
@@ -1,0 +1,59 @@
+/** @format */
+/**
+ * External dependencies
+ */
+import React, { PureComponent } from 'react';
+import { localize } from 'i18n-calypso';
+
+/**
+ * Internal dependencies
+ */
+import { hasPlan } from 'lib/cart-values/cart-items';
+
+export class SignupSiteCreatedNotice extends PureComponent {
+	getUpgradeText() {
+		const { cart, translate } = this.props;
+		const hasPlanInCart = hasPlan( cart );
+		const bundledDomain = cart && cart.bundled_domain;
+		let hintText = 'Continue with your purchase to access your upgrade benefits.';
+
+		if ( hasPlanInCart ) {
+			hintText = translate( 'Continue with your plan purchase to upgrade.' );
+		}
+		if ( hasPlanInCart && bundledDomain ) {
+			hintText = translate(
+				"Once you've upgraded, your new site address will be {{strong}}%(bundledDomain)s{{/strong}}",
+				{
+					components: { strong: <strong /> },
+					args: { bundledDomain },
+					comment: '`bundledDomain` is the domain name at checkout',
+				}
+			);
+		}
+
+		return hintText;
+	}
+
+	render() {
+		const { selectedSite } = this.props;
+
+		return (
+			<div className="checkout__site-created-notice-wrapper">
+				<img
+					src="/calypso/images/signup/confetti.svg"
+					aria-hidden="true"
+					className="checkout__site-created-image"
+					alt=""
+				/>
+				<div className="checkout__site-created-copy">
+					<div>
+						<em>{ selectedSite.slug }</em> has been created!
+					</div>
+					<div>{ this.getUpgradeText() }</div>
+				</div>
+			</div>
+		);
+	}
+}
+
+export default localize( SignupSiteCreatedNotice );

--- a/client/my-sites/checkout/checkout/signup-site-created-notice.jsx
+++ b/client/my-sites/checkout/checkout/signup-site-created-notice.jsx
@@ -15,10 +15,10 @@ export class SignupSiteCreatedNotice extends PureComponent {
 		const { cart, translate } = this.props;
 		const hasPlanInCart = hasPlan( cart );
 		const bundledDomain = cart && cart.bundled_domain;
-		let hintText = 'Continue with your purchase to access your upgrade benefits.';
+		let hintText = 'Complete your purchase to access your upgrade benefits.';
 
 		if ( hasPlanInCart ) {
-			hintText = translate( 'Continue with your plan purchase to upgrade.' );
+			hintText = translate( 'Complete your plan purchase to upgrade.' );
 		}
 		if ( hasPlanInCart && bundledDomain ) {
 			hintText = translate(
@@ -35,7 +35,7 @@ export class SignupSiteCreatedNotice extends PureComponent {
 	}
 
 	render() {
-		const { selectedSite } = this.props;
+		const { selectedSite, translate } = this.props;
 
 		return (
 			<div className="checkout__site-created-notice-wrapper">
@@ -47,7 +47,14 @@ export class SignupSiteCreatedNotice extends PureComponent {
 				/>
 				<div className="checkout__site-created-copy">
 					<div>
-						<em>{ selectedSite.slug }</em> has been created!
+						{ translate(
+							"{{em}}%(siteSlug)s{{/em}} is up and running!",
+							{
+								components: { em: <em /> },
+								args: { siteSlug: selectedSite.slug },
+								comment: '`siteSlug` is the WordPress.com site, e.g., testsite.wordpress.com',
+							} )
+						}
 					</div>
 					<div>{ this.getUpgradeText() }</div>
 				</div>

--- a/client/my-sites/checkout/checkout/signup-site-created-notice.jsx
+++ b/client/my-sites/checkout/checkout/signup-site-created-notice.jsx
@@ -15,11 +15,12 @@ export class SignupSiteCreatedNotice extends PureComponent {
 		const { cart, translate } = this.props;
 		const hasPlanInCart = hasPlan( cart );
 		const bundledDomain = cart && cart.bundled_domain;
-		let hintText = 'Complete your purchase to access your upgrade benefits.';
+		let hintText = translate( 'Complete your purchase to access your upgrade benefits.' );
 
 		if ( hasPlanInCart ) {
 			hintText = translate( 'Complete your plan purchase to upgrade.' );
 		}
+		
 		if ( hasPlanInCart && bundledDomain ) {
 			hintText = translate(
 				"Once you've upgraded, your new site address will be {{strong}}%(bundledDomain)s{{/strong}}",

--- a/client/my-sites/checkout/checkout/style.scss
+++ b/client/my-sites/checkout/checkout/style.scss
@@ -1139,3 +1139,22 @@
 		box-shadow: none;
 	}
 }
+
+.checkout__site-created-notice-wrapper {
+	overflow: hidden;
+	float: none;
+	clear: both;
+	margin: 0 auto 20px;
+	width: 100%;
+	display: flex;
+	justify-content: center;
+	@include breakpoint( '<660px' ) {
+		display: none;
+	}
+	.checkout__site-created-copy {
+		margin: 0 20px;
+	}
+	.checkout__site-created-image {
+		height: 40px;
+	}
+}

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -58,7 +58,7 @@ export function checkout( context, next ) {
 			selectedFeature={ feature }
 			// NOTE: `context.query.code` is deprecated in favor of `context.query.coupon`.
 			couponCode={ context.query.coupon || context.query.code || getRememberedCoupon() }
-			// NOTE: `context.query.code` is deprecated in favor of `context.query.coupon`.
+			// Are we being redirected from the signup flow?
 			isComingFromSignup={ !! context.query.signup }
 			plan={ plan }
 			selectedSite={ selectedSite }

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -58,6 +58,8 @@ export function checkout( context, next ) {
 			selectedFeature={ feature }
 			// NOTE: `context.query.code` is deprecated in favor of `context.query.coupon`.
 			couponCode={ context.query.coupon || context.query.code || getRememberedCoupon() }
+			// NOTE: `context.query.code` is deprecated in favor of `context.query.coupon`.
+			isComingFromSignup={ !! context.query.signup }
 			plan={ plan }
 			selectedSite={ selectedSite }
 			reduxStore={ context.store }

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -16,7 +16,7 @@ import { generateFlows } from 'signup/config/flows-pure';
 const user = userFactory();
 
 function getCheckoutUrl( dependencies ) {
-	return '/checkout/' + dependencies.siteSlug;
+	return `/checkout/${ dependencies.siteSlug }?signup=1`;
 }
 
 function dependenciesContainCartItem( dependencies ) {

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -54,7 +54,7 @@ export class SignupProcessingScreen extends Component {
 
 	getTitle() {
 		return this.props.translate(
-			'{{strong}}Awesome!{{/strong}} Give us one minute and {{br/}}we’ll move right along.',
+			'{{strong}}Awesome!{{/strong}} Give us one minute to {{br/}}to create your site.',
 			{
 				components: { strong: <strong />, br: <br /> },
 				comment:

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -54,7 +54,7 @@ export class SignupProcessingScreen extends Component {
 
 	getTitle() {
 		return this.props.translate(
-			'{{strong}}Awesome!{{/strong}} Give us one minute to {{br/}}to create your site.',
+			"{{strong}}Hooray!{{/strong}} We're creating your site.{{br/}}It'll be ready shortly...",
 			{
 				components: { strong: <strong />, br: <br /> },
 				comment:

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -54,7 +54,7 @@ export class SignupProcessingScreen extends Component {
 
 	getTitle() {
 		return this.props.translate(
-			"{{strong}}Hooray!{{/strong}} We're creating your site.{{br/}}It'll be ready shortly...",
+			"{{strong}}Hooray!{{/strong}} Your site will be ready shortly.",
 			{
 				components: { strong: <strong />, br: <br /> },
 				comment:

--- a/client/signup/processing-screen/index.jsx
+++ b/client/signup/processing-screen/index.jsx
@@ -3,10 +3,13 @@
 /**
  * External dependencies
  */
-
 import React, { Component } from 'react';
 import { localize } from 'i18n-calypso';
-import Gridicon from 'gridicons';
+
+/**
+ * Internal dependencies
+ */
+import Gridicon from 'components/gridicon';
 
 /**
  * Style dependencies
@@ -53,14 +56,11 @@ export class SignupProcessingScreen extends Component {
 	}
 
 	getTitle() {
-		return this.props.translate(
-			"{{strong}}Hooray!{{/strong}} Your site will be ready shortly.",
-			{
-				components: { strong: <strong />, br: <br /> },
-				comment:
-					'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
-			}
-		);
+		return this.props.translate( '{{strong}}Hooray!{{/strong}} Your site will be ready shortly.', {
+			components: { strong: <strong />, br: <br /> },
+			comment:
+				'The second line after the breaking tag {{br/}} should fit unbroken in 384px and greater and have a max of 30 characters.',
+		} );
 	}
 
 	render() {


### PR DESCRIPTION
## Changes proposed in this Pull Request

During signup, once you have selected a plan or free site, your WordPress.com site is created.

Our favourite signup user (the one who makes it through signup with something in the cart) arrives at the checkout, but clicks the browser's back button thinking that if they abandon checkout, that also cancel the site creation.

The site, however, has already been created.

Background: paObgF-7A-p2#comment-302

This PR adds copy to:

### ...the processing screen to say that a site is being created (which it is)
<img width="500" alt="Screen Shot 2019-08-25 at 8 02 44 pm" src="https://user-images.githubusercontent.com/6458278/63648468-818a4600-c773-11e9-8e81-7f7645fe8c5b.png">

### ...the checkout page to make it clear that a site has been created, naming that site and, if the user has selected a domain name, explains that the selected domain will be their site URL
<img width="500" alt="Screen Shot 2019-08-25 at 7 51 08 pm" src="https://user-images.githubusercontent.com/6458278/63648471-8949ea80-c773-11e9-84bb-2dac34a35687.png">

<img width="500" alt="Screen Shot 2019-08-25 at 7 51 51 pm" src="https://user-images.githubusercontent.com/6458278/63648472-8949ea80-c773-11e9-8d61-04c3ab9a5726.png">

Until we knock out a better layout, I've hidden the subtitle for narrower screen widths:

<img width="500" alt="Screen Shot 2019-08-25 at 7 51 57 pm" src="https://user-images.githubusercontent.com/6458278/63648634-e5157300-c775-11e9-948c-6ba26c51856a.png">


## Testing instructions

Go through `/start`, add a plan to your cart and proceed to checkout
Go through `/start`, add a domain and a plan to your cart and proceed to checkout

Fixes https://github.com/Automattic/zelda-private/issues/101
