### PR TITLE
Signup: Fix keyboard nav in site topic suggestion list

### DIFF
--- a/client/components/suggestion-search/index.jsx
+++ b/client/components/suggestion-search/index.jsx
@@ -69,40 +69,8 @@ class SuggestionSearch extends Component {
 	};
 
 	handleSuggestionKeyDown = event => {
-		if ( this.suggestionsRef.props.suggestions.length > 0 ) {
-			let suggestionPosition = this.suggestionsRef.state.suggestionPosition;
-
-			switch ( event.key ) {
-				case 'ArrowRight':
-					this.updateFieldFromSuggestion( this.getSuggestionLabel( suggestionPosition ) );
-
-					break;
-				case 'ArrowUp':
-					if ( suggestionPosition === 0 ) {
-						suggestionPosition = this.suggestionsRef.props.suggestions.length;
-					}
-
-					this.updateFieldFromSuggestion( this.getSuggestionLabel( suggestionPosition - 1 ) );
-
-					break;
-				case 'ArrowDown':
-					suggestionPosition++;
-
-					if ( suggestionPosition === this.suggestionsRef.props.suggestions.length ) {
-						suggestionPosition = 0;
-					}
-
-					this.updateFieldFromSuggestion( this.getSuggestionLabel( suggestionPosition ) );
-
-					break;
-				case 'Tab':
-					this.updateFieldFromSuggestion( this.getSuggestionLabel( suggestionPosition ) );
-
-					break;
-				case 'Enter':
-					event.preventDefault();
-					break;
-			}
+		if ( this.suggestionsRef.props.suggestions.length > 0 && event.key === 'Enter' ) {
+			event.preventDefault();
 		}
 
 		this.suggestionsRef.handleKeyEvent( event );


### PR DESCRIPTION
The site topic suggestion list should be following the [Combo Box pattern as described by aria](https://www.w3.org/TR/wai-aria-practices-1.1/#combobox). But when the user presses up or down the suggestion list is shrinking.

![Aug-26-2019 15-06-01](https://user-images.githubusercontent.com/1500769/63662569-0bd5b700-c813-11e9-9ea0-8b082580edb4.gif)

This basically makes the topic suggestions impossible to use for keyboard only users.

It should behave more like [Example 3 from aria's example combo box implementations](https://www.w3.org/TR/wai-aria-practices-1.1/examples/combobox/aria1.1pattern/listbox-combo.html).

`<SuggestionSearch>` now works like this when using the up+down keys:
![Aug-26-2019 15-11-45](https://user-images.githubusercontent.com/1500769/63662823-03ca4700-c814-11e9-827c-96e6a191a309.gif)
[video where the selected topic's background colour is "clearer"](https://cld.wthms.co/5X7ar6)

#### Changes proposed in this Pull Request

* Up and down navigate the site topic suggestion list
* Enter selects the suggestion under the cursor
* (Pressing enter when the suggestion list is dismissed will submit the step as before)

The change was basically to remove most of the custom key handling from `<SuggestionSearch>` since `<Suggestion>` was already doing the right thing.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This changes the behaviour of the `<SuggestionSearch>` component, which afaict is only used during signup.

Test the site topic suggestion control in the `onboarding` and `main` flow.

Be aware that the "popular" topics in the `site-topic` step aren't navigable with up+down keys because they're (confusingly) not part of the `<SuggestionSearch>` control.