### PR TITLE
Improve infinite list: propTypes and string refs

### DIFF
--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -50,6 +50,8 @@ export default class InfiniteList extends React.Component {
 	isScrolling = false;
 	_isMounted = false;
 	smartSetState = smartSetState;
+	topPlaceholderRef = React.createRef();
+	bottomPlaceholderRef = React.createRef();
 
 	componentWillMount() {
 		const url = page.current;
@@ -65,7 +67,11 @@ export default class InfiniteList extends React.Component {
 			newState.scrollTop = scrollTop;
 		}
 
-		this.scrollHelper = new ScrollHelper( this.boundsForRef );
+		this.scrollHelper = new ScrollHelper(
+			this.boundsForRef,
+			this.getTopPlaceholderBounds,
+			this.getBottomPlaceholderBounds
+		);
 		this.scrollHelper.props = this.props;
 		if ( this._contextLoaded() ) {
 			this._scrollContainer = this.props.context || window;
@@ -163,7 +169,11 @@ export default class InfiniteList extends React.Component {
 	reset() {
 		this.cancelAnimationFrame();
 
-		this.scrollHelper = new ScrollHelper( this.boundsForRef );
+		this.scrollHelper = new ScrollHelper(
+			this.boundsForRef,
+			this.getTopPlaceholderBounds,
+			this.getBottomPlaceholderBounds
+		);
 		this.scrollHelper.props = this.props;
 		if ( this._contextLoaded() ) {
 			this._scrollContainer = this.props.context || window;
@@ -298,6 +308,12 @@ export default class InfiniteList extends React.Component {
 		return null;
 	};
 
+	getTopPlaceholderBounds = () =>
+		this.topPlaceholderRef.current && this.topPlaceholderRef.current.getBoundingClientRect();
+
+	getBottomPlaceholderBounds = () =>
+		this.bottomPlaceholderRef.current && this.bottomPlaceholderRef.current.getBoundingClientRect();
+
 	/**
 	 * Returns a list of visible item indexes. This includes any items that are
 	 * partially visible in the viewport. Instance method that is called externally
@@ -388,14 +404,14 @@ export default class InfiniteList extends React.Component {
 		return (
 			<div { ...propsToTransfer }>
 				<div
-					ref="topPlaceholder"
+					ref={ this.topPlaceholderRef }
 					className={ spacerClassName }
 					style={ { height: this.state.topPlaceholderHeight } }
 				/>
 				{ itemsToRender }
 				{ renderTrailingItems() }
 				<div
-					ref="bottomPlaceholder"
+					ref={ this.bottomPlaceholderRef }
 					className={ spacerClassName }
 					style={ { height: this.state.bottomPlaceholderHeight } }
 				/>

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-string-refs */
+// TODO: remove string ref usage.
 /**
  * External dependencies
  */

--- a/client/components/infinite-list/index.jsx
+++ b/client/components/infinite-list/index.jsx
@@ -1,9 +1,8 @@
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
-import { noop, omit } from 'lodash';
+import { noop } from 'lodash';
 import page from 'page';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -344,21 +343,34 @@ export default class InfiniteList extends React.Component {
 	}
 
 	render() {
-		const propsToTransfer = omit( this.props, Object.keys( this.constructor.propTypes ) ),
-			spacerClassName = 'infinite-list__spacer';
+		const {
+			items,
+			fetchingNextPage,
+			lastPage,
+			guessedItemHeight,
+			itemsPerRow,
+			fetchNextPage,
+			getItemRef,
+			renderItem,
+			renderLoadingPlaceholders,
+			renderTrailingItems,
+			context,
+			...propsToTransfer
+		} = this.props;
+		const spacerClassName = 'infinite-list__spacer';
 		let i,
 			lastRenderedIndex = this.state.lastRenderedIndex,
 			itemsToRender = [];
 
-		if ( lastRenderedIndex === -1 || lastRenderedIndex > this.props.items.length - 1 ) {
+		if ( lastRenderedIndex === -1 || lastRenderedIndex > items.length - 1 ) {
 			debug(
 				'resetting lastRenderedIndex, currently at %s, %d items',
 				lastRenderedIndex,
-				this.props.items.length
+				items.length
 			);
 			lastRenderedIndex = Math.min(
 				this.state.firstRenderedIndex + this.scrollHelper.initialLastRenderedIndex(),
-				this.props.items.length - 1
+				items.length - 1
 			);
 			debug( 'reset lastRenderedIndex to %s', lastRenderedIndex );
 		}
@@ -366,11 +378,11 @@ export default class InfiniteList extends React.Component {
 		debug( 'rendering %d to %d', this.state.firstRenderedIndex, lastRenderedIndex );
 
 		for ( i = this.state.firstRenderedIndex; i <= lastRenderedIndex; i++ ) {
-			itemsToRender.push( this.props.renderItem( this.props.items[ i ], i ) );
+			itemsToRender.push( renderItem( items[ i ], i ) );
 		}
 
-		if ( this.props.fetchingNextPage ) {
-			itemsToRender = itemsToRender.concat( this.props.renderLoadingPlaceholders() );
+		if ( fetchingNextPage ) {
+			itemsToRender = itemsToRender.concat( renderLoadingPlaceholders() );
 		}
 
 		return (
@@ -381,7 +393,7 @@ export default class InfiniteList extends React.Component {
 					style={ { height: this.state.topPlaceholderHeight } }
 				/>
 				{ itemsToRender }
-				{ this.props.renderTrailingItems() }
+				{ renderTrailingItems() }
 				<div
 					ref="bottomPlaceholder"
 					className={ spacerClassName }

--- a/client/components/infinite-list/scroll-helper.js
+++ b/client/components/infinite-list/scroll-helper.js
@@ -69,7 +69,7 @@ class ScrollHelper {
 			index,
 			function( item ) {
 				const itemKey = this.props.getItemRef( item );
-				const	itemBounds = this.boundsForRef( itemKey );
+				const itemBounds = this.boundsForRef( itemKey );
 				let height;
 
 				if ( itemBounds ) {

--- a/client/components/infinite-list/scroll-helper.js
+++ b/client/components/infinite-list/scroll-helper.js
@@ -1,9 +1,6 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
 import debugFactory from 'debug';
 const debug = debugFactory( 'calypso:infinite-list:helper' );
 
@@ -11,8 +8,10 @@ const debug = debugFactory( 'calypso:infinite-list:helper' );
 // The purpose of extracting it is to make it testable and help the methods
 // to be shorter and readable.
 class ScrollHelper {
-	constructor( boundsForRef ) {
+	constructor( boundsForRef, getTopPlaceholderBounds, getBottomPlaceholderBounds ) {
 		this.boundsForRef = boundsForRef;
+		this.getTopPlaceholderBounds = getTopPlaceholderBounds;
+		this.getBottomPlaceholderBounds = getBottomPlaceholderBounds;
 		this.itemHeights = {};
 
 		// Hide levels and context height
@@ -69,8 +68,8 @@ class ScrollHelper {
 		this.forEachInRow(
 			index,
 			function( item ) {
-				const itemKey = this.props.getItemRef( item ),
-					itemBounds = this.boundsForRef( itemKey );
+				const itemKey = this.props.getItemRef( item );
+				const	itemBounds = this.boundsForRef( itemKey );
 				let height;
 
 				if ( itemBounds ) {
@@ -146,8 +145,8 @@ class ScrollHelper {
 	}
 
 	updatePlaceholderDimensions() {
-		const topPlaceholderRect = this.boundsForRef( 'topPlaceholder' ),
-			bottomPlaceholderRect = this.boundsForRef( 'bottomPlaceholder' );
+		const topPlaceholderRect = this.getTopPlaceholderBounds();
+		const bottomPlaceholderRect = this.getBottomPlaceholderBounds();
 
 		this.topPlaceholderHeight = topPlaceholderRect.height;
 		this.containerTop = topPlaceholderRect.top;

--- a/client/components/infinite-list/test/scroll-helper.js
+++ b/client/components/infinite-list/test/scroll-helper.js
@@ -1,5 +1,3 @@
-/** @format */
-
 /**
  * External dependencies
  */
@@ -69,19 +67,10 @@ describe( 'scroll-helper', () => {
 	} );
 
 	describe( 'Container and placeholder positioning', () => {
-		let preparedBounds = {
-				topPlaceholder: {
-					top: -2000,
-					height: 1000,
-				},
-				bottomPlaceholder: {
-					bottom: 4000,
-					height: 2000,
-				},
-			},
-			helper = new ScrollHelper( function( ref ) {
-				return preparedBounds[ ref ];
-			} );
+		const topPlaceholderBounds = () => ( { top: -2000, height: 1000 } );
+		const bottomPlaceholderBounds = () => ( { bottom: 4000, height: 2000 } );
+
+		const helper = new ScrollHelper( () => null, topPlaceholderBounds, bottomPlaceholderBounds );
 
 		helper.updatePlaceholderDimensions();
 
@@ -135,7 +124,7 @@ describe( 'scroll-helper', () => {
 		} );
 
 		describe( 'Hiding batch of items', () => {
-			let preparedBounds = {
+			const preparedBounds = {
 					i0: {
 						bottom: -1850,
 					},
@@ -190,7 +179,7 @@ describe( 'scroll-helper', () => {
 		} );
 
 		describe( 'Completely above context', () => {
-			let preparedBounds = {
+			const preparedBounds = {
 					i0: {
 						bottom: -1850,
 					},
@@ -349,7 +338,7 @@ describe( 'scroll-helper', () => {
 		} );
 
 		describe( 'Hiding batch of items', () => {
-			let preparedBounds = {
+			const preparedBounds = {
 					i5: {
 						top: 1900,
 					},


### PR DESCRIPTION
This PR adds two small improvements to `InfiniteList`:
* Don't use `propTypes` during render. This avoids a hard dependency on `propTypes` at runtime, fixing one of the issues in #35695.
* Use `createRef` instead of string refs for placeholders. This doesn't remove all usage of string refs in `InfiniteList`, however, as it still uses them for its items. This will be a bigger change, however, involving modifications to all consumers of `InfiniteList`.

This PR also removes the string ref-related linting warnings for now.

#### Testing instructions

* Try the various infinite lists in Calypso (e.g. Reader, media library), and ensure they continue working normally.
