### PR TITLE
Docs: update guides about adding new sections and CSS

### DIFF
--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -1,7 +1,7 @@
 CSS/Sass Coding Guidelines
 ==========================
 
-Every stylesheet should be easy to read, scan, add to, and collaborate on. Our current system and nomenclature builds on top of _components_, where CSS files live alongside the component they are styling: `component/style.scss`. These files are all imported via `stylesheets/_components.scss`.
+Every stylesheet should be easy to read, scan, add to, and collaborate on. Our current system and nomenclature builds on top of _components_, where CSS files live alongside the component they are styling: `component/style.scss`. These files are all imported into the components' JavaScript/React sources and then bundled by webpack to the production CSS files.
 
 This is an example of a declaration:
 
@@ -92,10 +92,9 @@ Calypso already provides helpers for many common solutions. Please, use them! We
 
 ## Sass Guidelines
 
-Currently, all component based Sass files are imported in `assets/stylesheets/_components`. They are compiled as part of `npm run build-css` into a single file together with the other general purpose stylesheets: `public/style.css`. Remember that all styles end up in a single file, so **all styles will apply to every page, all the time**. Make sure you namespace your styles for the page you are working on.
-Under the hood, we are using `node-sass` to handle the compiling of Sass, which is working on parity with the reference ruby implementation.
+Currently, all component based Sass files are imported into the respective JavaScript/React sources. They are compiled by webpack as part of the bundling process into CSS chunks that are then loaded into the browser at runtime. Remember that all styles, even when loaded at different times, eventually end up on one page as part of a single HTML document. Make sure you namespace your styles for the page you are working on.
 
-The structure of files will be changing as we move remaining section-specific code to their relevant components. In the end, the only Sass files living in a general assets folder would be style-guide related.
+Under the hood, we are using webpack and its `sass-loader`, for compiling the styles with `node-sass` (a C++ implementation of the Sass compiler which is working on parity with the reference Ruby implementation) and `mini-css-extract-plugin`, for creating the CSS chunks to be loaded as `<style>` tags into the browser.
 
 ## Media Queries
 
@@ -149,7 +148,7 @@ Adding additional breakpoints should not be undertaken lightly.
 
 ### Adding a new Sass file
 
-If you are adding a new Sass file to `assets/stylesheets` you will need to reference the file in `assets/stylesheets/style.scss` for it to load. If you're adding a new component reference it in `assets/stylesheets/_components.scss` instead.
+If you are adding a new Sass file (global or component-specific), you need to import it in some JavaScript source file. Try to avoid creating global styles and favor of styling particular components. JS and CSS code is async-loaded just in time when a particular section or an async-loaded React component is loaded.
 
 ### Imports
 

--- a/docs/coding-guidelines/css.md
+++ b/docs/coding-guidelines/css.md
@@ -1,7 +1,7 @@
 CSS/Sass Coding Guidelines
 ==========================
 
-Every stylesheet should be easy to read, scan, add to, and collaborate on. Our current system and nomenclature builds on top of _components_, where CSS files live alongside the component they are styling: `component/style.scss`. These files are all imported into the components' JavaScript/React sources and then bundled by webpack to the production CSS files.
+Every stylesheet should be easy to read, scan, add to, and collaborate on. Our current system and nomenclature builds on top of _components_, where CSS files live alongside the component they are styling: `component/style.scss`. These files are all imported into the React components' JavaScript sources and then bundled by webpack to the production CSS files.
 
 This is an example of a declaration:
 
@@ -92,7 +92,7 @@ Calypso already provides helpers for many common solutions. Please, use them! We
 
 ## Sass Guidelines
 
-Currently, all component based Sass files are imported into the respective JavaScript/React sources. They are compiled by webpack as part of the bundling process into CSS chunks that are then loaded into the browser at runtime. Remember that all styles, even when loaded at different times, eventually end up on one page as part of a single HTML document. Make sure you namespace your styles for the page you are working on.
+Currently, all component based Sass files are imported into the respective JavaScript sources (using `import './style.scss'` statements). They are compiled by webpack as part of the bundling process into CSS chunks that are then loaded into the browser at runtime. Remember that all styles, even when loaded at different times, eventually end up on one page as part of a single HTML document. Make sure you namespace your styles for the page you are working on.
 
 Under the hood, we are using webpack and its `sass-loader`, for compiling the styles with `node-sass` (a C++ implementation of the Sass compiler which is working on parity with the reference Ruby implementation) and `mini-css-extract-plugin`, for creating the CSS chunks to be loaded as `<style>` tags into the browser.
 

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -122,6 +122,11 @@ if ( config.isEnabled( 'hello-world' ) ) {
 
 This checks for our feature in the current environment to figure out whether it needs to register a new section. The section is defined by a name, an array with the relevant paths, and the main module.
 
+You might need to import the `config` module at the top of the `sections.js` file if it's not already there:
+```js
+import config from 'config';
+```
+
 ### Run the server!
 
 Restart the server doing:
@@ -219,10 +224,13 @@ export default class HelloWorld extends React.Component {
 }
 ```
 
-We need to do one more step to include the component's style file in the main application style file. It's done by importing `style.scss` in `assets/stylesheets/_components.scss`, add following line at the end of `_components.scss`:
+We need to do one more step to import the component's style file in the component's JavaScript source file. It's done by adding an import statement block to the `main.jsx` file:
 
-```scss
-@import 'my-sites/hello-world/style';
+```jsx
+/**
+ * Style dependencies
+ */
+import './style.scss';
 ```
 
 That's it. Please check out the [CSS/Sass Coding Guidelines](../coding-guidelines/css.md) to learn more about working with stylesheets in the project.

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -122,10 +122,11 @@ if ( config.isEnabled( 'hello-world' ) ) {
 
 This checks for our feature in the current environment to figure out whether it needs to register a new section. The section is defined by a name, an array with the relevant paths, and the main module.
 
-You might need to import the `config` module at the top of the `sections.js` file if it's not already there:
+You might need to `require` the `config` module at the top of the `sections.js` file if your code uses it and if it's not already imported there:
 ```js
-import config from 'config';
+const config = require( 'config' );
 ```
+The `sections.js` module needs to be a CommonJS module that uses `require` calls, because it's run by Node.js. ESM imports won't work there at this moment.
 
 ### Run the server!
 

--- a/docs/guide/hello-world.md
+++ b/docs/guide/hello-world.md
@@ -85,7 +85,7 @@ import { helloWorld } from './controller';
 
 export default () => {
 	page(
-		'/hello-world/:domain?',
+		'/hello-world/:site?',
 		siteSelection,
 		navigation,
 		helloWorld,
@@ -96,7 +96,7 @@ export default () => {
 ```
 
 * `page()` will set up the route `/hello-world` and run some functions when it's matched.
-* The `:domain?` is because we want to support site specific pages for our hello-world route.
+* The `:site?` is because we want to support site specific pages for our hello-world route.
 * Each function is invoked with `context` and `next` arguments.
 * We are passing the `siteSelection` function from the main "My Sites" controller, which handles the site selection process.
 * Next, we are passing the `navigation` function, also from the main "My Sites" controller, which inserts the sidebar navigation into `context.secondary`.
@@ -122,11 +122,13 @@ if ( config.isEnabled( 'hello-world' ) ) {
 
 This checks for our feature in the current environment to figure out whether it needs to register a new section. The section is defined by a name, an array with the relevant paths, and the main module.
 
-You might need to `require` the `config` module at the top of the `sections.js` file if your code uses it and if it's not already imported there:
+You also need to `require` the `config` module at the top of the `client/sections.js` file (in case the `require` statement is not already there):
 ```js
 const config = require( 'config' );
 ```
 The `sections.js` module needs to be a CommonJS module that uses `require` calls, because it's run by Node.js. ESM imports won't work there at this moment.
+
+Through the use of the `config` module, we are conditionally loading our section only in development environment. All existing sections in `client/sections.js` will load in all environments.
 
 ### Run the server!
 


### PR DESCRIPTION
- update docs about styles to mention the new webpack pipeline, instead of the legacy `assets/stylesheets` one
- mention that `sections.js` might need a `config` module import if not present (fixes #35691)
