### PR TITLE
Convert `media-library/list-item` to TypeScript

### DIFF
--- a/client/lib/media/utils.js
+++ b/client/lib/media/utils.js
@@ -1,4 +1,3 @@
-/** @format */
 /**
  * External dependencies
  */
@@ -139,7 +138,7 @@ export function getFileExtension( media ) {
  * getMimeType( { mime_type: 'image/gif' } );
  * // All examples return 'image'
  *
- * @param  {string} media Media object or mime type string
+ * @param  {(string|File|Object)} media Media object or mime type string
  * @return {string}       The MIME type prefix
  */
 export function getMimePrefix( media ) {
@@ -149,7 +148,7 @@ export function getMimePrefix( media ) {
 		return;
 	}
 
-	const mimePrefixMatch = mimeType.match( /^([^\/]+)\// );
+	const mimePrefixMatch = mimeType.match( /^([^/]+)\// );
 
 	if ( mimePrefixMatch ) {
 		return mimePrefixMatch[ 1 ];

--- a/client/my-sites/media-library/list-item.jsx
+++ b/client/my-sites/media-library/list-item.jsx
@@ -1,10 +1,7 @@
-/** @format */
-
 /**
  * External dependencies
  */
-
-import { assign, isEqual, noop, omit } from 'lodash';
+import { isEqual, noop } from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
@@ -25,9 +22,7 @@ import EditorMediaModalGalleryHelp from 'post-editor/media-modal/gallery-help';
  */
 import './list-item.scss';
 
-export default class extends React.Component {
-	static displayName = 'MediaLibraryListItem';
-
+export default class MediaLibraryListItem extends React.Component {
 	static propTypes = {
 		media: PropTypes.object,
 		scale: PropTypes.number.isRequired,
@@ -102,41 +97,52 @@ export default class extends React.Component {
 	render() {
 		let title, selectedNumber;
 
+		const {
+			media,
+			scale,
+			maxImageWidth,
+			thumbnailType,
+			showGalleryHelp,
+			selectedIndex,
+			onToggle,
+			onEditItem,
+			style,
+			...otherProps
+		} = this.props;
+
 		const classes = classNames( 'media-library__list-item', {
-			'is-placeholder': ! this.props.media,
-			'is-selected': -1 !== this.props.selectedIndex,
-			'is-transient': this.props.media && this.props.media.transient,
-			'is-small': this.props.scale <= 0.125,
+			'is-placeholder': ! media,
+			'is-selected': -1 !== selectedIndex,
+			'is-transient': media && media.transient,
+			'is-small': scale <= 0.125,
 		} );
 
-		const props = omit( this.props, Object.keys( this.constructor.propTypes ) );
+		const styleWithDefaults = { width: scale * 100 + '%', ...style };
 
-		const style = assign(
-			{
-				width: this.props.scale * 100 + '%',
-			},
-			this.props.style
-		);
-
-		if ( this.props.media ) {
-			title = this.props.media.file;
+		if ( media ) {
+			title = media.file;
 		}
 
-		if ( -1 !== this.props.selectedIndex ) {
-			selectedNumber = this.props.selectedIndex + 1;
-			props[ 'data-selected-number' ] = selectedNumber > 99 ? '99+' : selectedNumber;
+		if ( -1 !== selectedIndex ) {
+			selectedNumber = selectedIndex + 1;
+			otherProps[ 'data-selected-number' ] = selectedNumber > 99 ? '99+' : selectedNumber;
 		}
 
 		return (
 			/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
-			<div className={ classes } style={ style } onClick={ this.clickItem } { ...props }>
+			<div
+				className={ classes }
+				style={ styleWithDefaults }
+				onClick={ this.clickItem }
+				{ ...otherProps }
+			>
 				<span className="media-library__list-item-selected-icon">
 					<Gridicon icon="checkmark" size={ 18 } />
 				</span>
 				<figure className="media-library__list-item-figure" title={ title }>
 					{ this.renderItem() }
 					{ this.renderSpinner() }
-					{ this.props.showGalleryHelp && <EditorMediaModalGalleryHelp /> }
+					{ showGalleryHelp && <EditorMediaModalGalleryHelp /> }
 				</figure>
 			</div>
 			/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -95,22 +95,6 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 		return React.createElement( component, this.props );
 	};
 
-	renderSpinner = () => {
-		if ( ! this.props.media ) {
-			return;
-		}
-
-		if ( ! ( this.props.media as MediaObject ).transient ) {
-			return;
-		}
-
-		return (
-			<div className="media-library__list-item-spinner">
-				<Spinner />
-			</div>
-		);
-	};
-
 	render() {
 		let title, selectedNumber;
 
@@ -161,7 +145,11 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 				</span>
 				<figure className="media-library__list-item-figure" title={ title }>
 					{ this.renderItem() }
-					{ this.renderSpinner() }
+					{ media && ( media as MediaObject ).transient && (
+						<div className="media-library__list-item-spinner">
+							<Spinner />
+						</div>
+					) }
 					{ showGalleryHelp && <EditorMediaModalGalleryHelp /> }
 				</figure>
 			</div>

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -38,7 +38,7 @@ interface Props {
 	thumbnailType?: string;
 	showGalleryHelp?: boolean;
 	selectedIndex?: number;
-	onToggle?: ( media: Media | undefined, shiftKey: boolean ) => any;
+	onToggle?: ( media: Media | undefined, shiftKey: boolean ) => void;
 	onEditItem?: any; // Unused. Appears to have been left here for compatibility reasons.
 	style?: React.CSSProperties;
 }

--- a/client/my-sites/media-library/list-item.tsx
+++ b/client/my-sites/media-library/list-item.tsx
@@ -43,7 +43,7 @@ interface Props {
 	style?: React.CSSProperties;
 }
 
-type DivProps = Omit< React.ComponentProps< 'div' >, 'style' | 'onClick' >;
+type DivProps = Omit< React.ComponentProps< 'button' >, 'style' | 'onClick' >;
 
 export default class MediaLibraryListItem extends React.Component< Props & DivProps > {
 	static defaultProps = {
@@ -132,8 +132,7 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 		}
 
 		return (
-			/* eslint-disable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
-			<div
+			<button
 				className={ classes }
 				style={ styleWithDefaults }
 				onClick={ this.clickItem }
@@ -152,8 +151,7 @@ export default class MediaLibraryListItem extends React.Component< Props & DivPr
 					) }
 					{ showGalleryHelp && <EditorMediaModalGalleryHelp /> }
 				</figure>
-			</div>
-			/* eslint-enable jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions */
+			</button>
 		);
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Remove render-time access to `propTypes` in `media-library/list-item`
* Add types to `media-library/list-item` and remove `propTypes` altogether
* Minor fixes to `lib/media/utils` to avoid linting and TypeScript errors

This PR fixes one of the issues in #35695.

#### Testing instructions

* Use the media gallery
* Ensure there are no errors and everything works normally