### PR TITLE
Domains: Fix an availability precheck regression

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1114,9 +1114,7 @@ class RegisterDomainStep extends React.Component {
 						this.showAvailabilityErrorMessage( domain, status, {
 							availabilityPreCheck: true,
 						} );
-					}
-
-					if ( trademarkClaimsNoticeInfo ) {
+					} else if ( trademarkClaimsNoticeInfo ) {
 						this.setState( {
 							trademarkClaimsNoticeInfo: trademarkClaimsNoticeInfo,
 							selectedSuggestion: suggestion,


### PR DESCRIPTION
It seems that we've introduced a regression in the availabilty precheck code when we introduced TMCH. This should fix the issue - if a domain is not available we should not add it to the cart.

see: p99Zz8-Jf-p2

#### Changes proposed in this Pull Request

* don't add domain to the cart if it's not available

#### Testing instructions

* search for a premium domain (ex. pizza) and try to add it to the cart. With this PR it should fail with an error message. Without you don't see the error message, so it looks like the domain was added to the cart (even though it wasn't)

