### PR TITLE
SPT: set static preview as default

### DIFF
--- a/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
+++ b/apps/full-site-editing/full-site-editing-plugin/starter-page-templates/page-template-modal/index.js
@@ -130,7 +130,7 @@ class PageTemplateModal extends Component {
 								templates={ this.props.templates }
 								blocksByTemplates={ this.state.blocks }
 								onTemplateSelect={ this.previewTemplate }
-								useDynamicPreview={ true }
+								useDynamicPreview={ false }
 								siteInformation={ siteInformation }
 							/>
 						</fieldset>


### PR DESCRIPTION
This PR sets static preview for thumbnails as default.

#### Testing instructions

1) Apply these changes
2) Confirm that the templates thumbnails are images:

<img width="1132" alt="Screen Shot 2019-08-26 at 5 02 57 PM" src="https://user-images.githubusercontent.com/77539/63719520-72fb6780-c823-11e9-820e-75fbe508e46f.png">

Fixes https://github.com/Automattic/wp-calypso/issues/35790
